### PR TITLE
feat(java): add implication lift RPC surface

### DIFF
--- a/implementations/java/.provekit/lift/java-implications/manifest.toml
+++ b/implementations/java/.provekit/lift/java-implications/manifest.toml
@@ -1,0 +1,13 @@
+name = "java-implications"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["java", "-jar", "provekit-lift-java-core/target/provekit-lsp-java.jar", "--rpc"]
+working_dir = "."
+method = "provekit.plugin.lift_implications"
+phase = "consumer"
+
+[capabilities]
+authoring_surfaces = ["java-implications"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false

--- a/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/JavaImplicationLifter.java
+++ b/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/JavaImplicationLifter.java
@@ -1,0 +1,199 @@
+package com.provekit.lift;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.provekit.ir.Jcs;
+
+public final class JavaImplicationLifter {
+    private JavaImplicationLifter() {}
+
+    private record ContractBinding(String contractCid) {}
+
+    private record SourceFile(String relPath, Path fullPath) {}
+
+    private record Callsite(String callee, String file, int line, int col) {}
+
+    public static Jcs.Obj lift(Jcs.Obj params) {
+        Path workspaceRoot = Paths.get(orDefault(params.stringFieldOrNull("workspace_root"), "."));
+        List<String> sourcePaths = sourcePaths(params.get("source_paths"));
+        Map<String, ContractBinding> contractsByCallee = contractBindings(params.get("contract_bindings"));
+
+        List<Jcs.Json> ir = new ArrayList<>();
+        List<Jcs.Json> diagnostics = new ArrayList<>();
+        for (SourceFile sourceFile : resolveJavaSourceFiles(workspaceRoot, sourcePaths)) {
+            CompilationUnit cu = parseSource(sourceFile.fullPath());
+            if (cu == null) continue;
+            for (Callsite callsite : collectCallsites(cu, sourceFile.relPath())) {
+                ContractBinding binding = contractsByCallee.get(callsite.callee());
+                if (binding == null) {
+                    diagnostics.add(liftGap("no-contract-for-callee", callsite));
+                    continue;
+                }
+                if (binding.contractCid() == null || binding.contractCid().isBlank()) {
+                    diagnostics.add(liftGap("binding-missing-contract-cid", callsite));
+                    continue;
+                }
+                ir.add(bridge(callsite, binding.contractCid()));
+            }
+        }
+
+        return Jcs.object(
+            "diagnostics", Jcs.array(diagnostics),
+            "ir", Jcs.array(ir),
+            "kind", Jcs.string("ir-document")
+        );
+    }
+
+    private static List<String> sourcePaths(Jcs.Json json) {
+        List<String> paths = new ArrayList<>();
+        if (json instanceof Jcs.Arr arr) {
+            for (Jcs.Json item : arr.values()) {
+                if (item instanceof Jcs.Str s && !s.value().isBlank()) {
+                    paths.add(s.value());
+                }
+            }
+        }
+        if (paths.isEmpty()) paths.add(".");
+        return paths;
+    }
+
+    private static Map<String, ContractBinding> contractBindings(Jcs.Json json) {
+        Map<String, ContractBinding> bindings = new LinkedHashMap<>();
+        if (!(json instanceof Jcs.Arr arr)) return bindings;
+        for (Jcs.Json item : arr.values()) {
+            if (!(item instanceof Jcs.Obj obj)) continue;
+            String name = obj.stringFieldOrNull("name");
+            if (name == null || name.isBlank()) continue;
+            String callee = name.split("@", 2)[0].trim();
+            if (callee.isEmpty()) continue;
+            bindings.putIfAbsent(callee, new ContractBinding(obj.stringFieldOrNull("contract_cid")));
+        }
+        return bindings;
+    }
+
+    private static List<SourceFile> resolveJavaSourceFiles(Path workspaceRoot, List<String> sourcePaths) {
+        Path root = workspaceRoot.toAbsolutePath().normalize();
+        List<SourceFile> files = new ArrayList<>();
+        for (String sourcePath : sourcePaths) {
+            Path fullPath = root.resolve(sourcePath).normalize();
+            if (Files.isDirectory(fullPath)) {
+                Path scanRoot = ".".equals(sourcePath) && Files.isDirectory(fullPath.resolve("src"))
+                    ? fullPath.resolve("src")
+                    : fullPath;
+                collectJavaFiles(root, scanRoot, files);
+            } else if (Files.isRegularFile(fullPath) && fullPath.toString().endsWith(".java")) {
+                files.add(new SourceFile(relativePath(root, fullPath), fullPath));
+            }
+        }
+        files.sort(Comparator.comparing(SourceFile::relPath));
+        return files;
+    }
+
+    private static void collectJavaFiles(Path root, Path scanRoot, List<SourceFile> out) {
+        try (var paths = Files.walk(scanRoot)) {
+            paths
+                .filter(Files::isRegularFile)
+                .filter(path -> path.toString().endsWith(".java"))
+                .forEach(path -> out.add(new SourceFile(relativePath(root, path), path)));
+        } catch (IOException ignored) {
+            // Missing or unreadable source roots are not implication lift errors.
+        }
+    }
+
+    private static String relativePath(Path root, Path path) {
+        Path rel = root.relativize(path.toAbsolutePath().normalize());
+        return rel.toString().replace('\\', '/');
+    }
+
+    private static CompilationUnit parseSource(Path path) {
+        try {
+            ParseResult<CompilationUnit> result = new JavaParser().parse(path);
+            return result.isSuccessful() && result.getResult().isPresent()
+                ? result.getResult().get()
+                : null;
+        } catch (IOException ignored) {
+            return null;
+        }
+    }
+
+    private static List<Callsite> collectCallsites(CompilationUnit cu, String relPath) {
+        List<Callsite> callsites = new ArrayList<>();
+        for (MethodDeclaration method : cu.findAll(MethodDeclaration.class)) {
+            if (isTestMethod(method) || method.getBody().isEmpty()) continue;
+            for (MethodCallExpr call : method.getBody().get().findAll(MethodCallExpr.class)) {
+                call.getName().getRange().ifPresent(range ->
+                    callsites.add(new Callsite(
+                        call.getNameAsString(),
+                        relPath,
+                        range.begin.line,
+                        range.begin.column
+                    ))
+                );
+            }
+        }
+        return callsites;
+    }
+
+    private static boolean isTestMethod(MethodDeclaration method) {
+        for (AnnotationExpr ann : method.getAnnotations()) {
+            String name = ann.getNameAsString();
+            if (name.equals("Test")
+                    || name.equals("RepeatedTest")
+                    || name.equals("ParameterizedTest")
+                    || name.endsWith(".Test")
+                    || name.endsWith(".ParameterizedTest")) {
+                return true;
+            }
+        }
+        return method.getNameAsString().startsWith("test");
+    }
+
+    private static Jcs.Obj bridge(Callsite callsite, String targetCid) {
+        return Jcs.object(
+            "callsite", Jcs.object(
+                "file", Jcs.string(callsite.file()),
+                "start_col", Jcs.integer(callsite.col()),
+                "start_line", Jcs.integer(callsite.line())
+            ),
+            "kind", Jcs.string("bridge"),
+            "name", Jcs.string("intra-body:java:" + callsite.callee() + "@"
+                + callsite.file() + ":" + callsite.line() + ":" + callsite.col()),
+            "schemaVersion", Jcs.string("1"),
+            "sourceContractCid", Jcs.string(targetCid),
+            "sourceLayer", Jcs.string("java"),
+            "sourceSymbol", Jcs.string(callsite.callee()),
+            "target", Jcs.object("cid", Jcs.string(targetCid), "kind", Jcs.string("contract")),
+            "targetContractCid", Jcs.string(targetCid),
+            "targetLayer", Jcs.string("java-tests")
+        );
+    }
+
+    private static Jcs.Obj liftGap(String reason, Callsite callsite) {
+        return Jcs.object(
+            "callee", Jcs.string(callsite.callee()),
+            "col", Jcs.integer(callsite.col()),
+            "file", Jcs.string(callsite.file()),
+            "kind", Jcs.string("lift-gap"),
+            "line", Jcs.integer(callsite.line()),
+            "reason", Jcs.string(reason)
+        );
+    }
+
+    private static String orDefault(String value, String fallback) {
+        return value == null || value.isBlank() ? fallback : value;
+    }
+}

--- a/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/RpcServer.java
+++ b/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/RpcServer.java
@@ -53,6 +53,14 @@ public class RpcServer {
                         sendResponse(id, Jcs.encode(RecognizeHandler.recognizeImpl(params)));
                     }
                 }
+                case "provekit.plugin.lift_implications" -> {
+                    Jcs.Json doc = Jcs.parse(line);
+                    if (!(doc instanceof Jcs.Obj obj) || !(obj.get("params") instanceof Jcs.Obj params)) {
+                        sendError(id, -32602, "missing params object");
+                    } else {
+                        sendResponse(id, Jcs.encode(JavaImplicationLifter.lift(params)));
+                    }
+                }
                 case "shutdown" -> {
                     sendResponse(id, "null");
                     System.exit(0);
@@ -65,7 +73,7 @@ public class RpcServer {
     }
 
     private String initResult() {
-        return "{\"name\":\"provekit-lsp-java\",\"version\":\"0.1.0\",\"capabilities\":[\"parse\"]}";
+        return "{\"name\":\"provekit-lsp-java\",\"version\":\"0.1.0\",\"capabilities\":[\"parse\",\"provekit.plugin.lift_implications\"]}";
     }
 
     private void sendResponse(String id, String result) {

--- a/implementations/java/provekit-lift-java-core/src/test/java/com/provekit/lift/JavaImplicationLiftRpcTest.java
+++ b/implementations/java/provekit-lift-java-core/src/test/java/com/provekit/lift/JavaImplicationLiftRpcTest.java
@@ -1,0 +1,145 @@
+package com.provekit.lift;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class JavaImplicationLiftRpcTest {
+    private static final String PARSE_CID =
+        "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    private static final String NORMALIZE_CID =
+        "blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void rpcLiftImplicationsEmitsBridgePerMatchedJavaCallExpression() throws Exception {
+        Path src = write("src/App.java", """
+            class App {
+                int caller(String input) {
+                    int parsed = parseInput(input);
+                    return parsed.normalizeValue();
+                }
+            }
+            """);
+
+        String response = invokeRpc("""
+            {"jsonrpc":"2.0","id":7,"method":"provekit.plugin.lift_implications","params":{
+              "workspace_root":"%s",
+              "source_paths":["%s"],
+              "contract_bindings":[
+                {"name":"parseInput@src/App.java:9:8","contract_cid":"%s"},
+                {"name":"normalizeValue@src/App.java:12:8","contract_cid":"%s"}
+              ]
+            }}
+            """.formatted(json(tempDir), json(tempDir.relativize(src)), PARSE_CID, NORMALIZE_CID));
+
+        assertFalse(response.contains("\"error\""), response);
+        assertTrue(response.contains("\"kind\":\"ir-document\""), response);
+        assertTrue(response.contains("\"kind\":\"bridge\""), response);
+        assertTrue(response.contains("\"sourceLayer\":\"java\""), response);
+        assertTrue(response.contains("\"targetLayer\":\"java-tests\""), response);
+        assertTrue(response.contains("\"sourceSymbol\":\"parseInput\""), response);
+        assertTrue(response.contains("\"targetContractCid\":\"" + PARSE_CID + "\""), response);
+        assertTrue(response.contains("\"target\":{\"cid\":\"" + PARSE_CID + "\",\"kind\":\"contract\"}"), response);
+        assertTrue(response.contains("\"sourceSymbol\":\"normalizeValue\""), response);
+        assertEquals(2, countOccurrences(response, "\"kind\":\"bridge\""), response);
+    }
+
+    @Test
+    public void liftImplicationsScansSrcWhenSourcePathIsProjectRoot() throws Exception {
+        write("src/App.java", """
+            class App {
+                int caller(String input) {
+                    return parseInput(input);
+                }
+            }
+            """);
+
+        String response = invokeRpc("""
+            {"jsonrpc":"2.0","id":8,"method":"provekit.plugin.lift_implications","params":{
+              "workspace_root":"%s",
+              "source_paths":["."],
+              "contract_bindings":[{"name":"parseInput@src/App.java:9:8","contract_cid":"%s"}]
+            }}
+            """.formatted(json(tempDir), PARSE_CID));
+
+        assertFalse(response.contains("\"error\""), response);
+        assertTrue(response.contains("\"sourceSymbol\":\"parseInput\""), response);
+        assertEquals(1, countOccurrences(response, "\"kind\":\"bridge\""), response);
+    }
+
+    @Test
+    public void liftImplicationsEmitsLiftGapForUnmatchedCallee() throws Exception {
+        Path src = write("src/App.java", """
+            class App {
+                int caller() {
+                    return missingContract(0);
+                }
+            }
+            """);
+
+        String response = invokeRpc("""
+            {"jsonrpc":"2.0","id":9,"method":"provekit.plugin.lift_implications","params":{
+              "workspace_root":"%s",
+              "source_paths":["%s"],
+              "contract_bindings":[]
+            }}
+            """.formatted(json(tempDir), json(tempDir.relativize(src))));
+
+        assertFalse(response.contains("\"error\""), response);
+        assertTrue(response.contains("\"ir\":[]"), response);
+        assertTrue(response.contains("\"kind\":\"lift-gap\""), response);
+        assertTrue(response.contains("\"reason\":\"no-contract-for-callee\""), response);
+        assertTrue(response.contains("\"callee\":\"missingContract\""), response);
+    }
+
+    private Path write(String relative, String source) throws Exception {
+        Path path = tempDir.resolve(relative);
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, source, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    private static String invokeRpc(String request) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        try (PrintStream capture = new PrintStream(bytes, true, StandardCharsets.UTF_8)) {
+            System.setOut(capture);
+            RpcServer server = new RpcServer();
+            Method handle = RpcServer.class.getDeclaredMethod("handle", String.class);
+            handle.setAccessible(true);
+            handle.invoke(server, request.replace("\n", ""));
+        } finally {
+            System.setOut(original);
+        }
+        return bytes.toString(StandardCharsets.UTF_8);
+    }
+
+    private static String json(Path path) {
+        return json(path.toString());
+    }
+
+    private static String json(CharSequence value) {
+        return value.toString().replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int offset = 0;
+        while ((offset = haystack.indexOf(needle, offset)) >= 0) {
+            count++;
+            offset += needle.length();
+        }
+        return count;
+    }
+}

--- a/implementations/rust/provekit-cli/tests/cmd_mint_java_project_implications.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_java_project_implications.rs
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-java-implications-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+fn run_with_timeout(cmd: &mut Command, timeout: Duration) -> std::io::Result<std::process::Output> {
+    let mut child = cmd.spawn()?;
+    let started = Instant::now();
+    loop {
+        if child.try_wait()?.is_some() {
+            return child.wait_with_output();
+        }
+        if started.elapsed() >= timeout {
+            let _ = child.kill();
+            return child.wait_with_output();
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn java_bin() -> Option<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(java_home) = std::env::var_os("JAVA_HOME") {
+        candidates.push(PathBuf::from(java_home).join("bin").join("java"));
+    }
+    candidates.push(PathBuf::from("java"));
+    candidates.push(PathBuf::from(
+        "/usr/local/opt/openjdk/libexec/openjdk.jdk/Contents/Home/bin/java",
+    ));
+    candidates.push(PathBuf::from(
+        "/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home/bin/java",
+    ));
+
+    candidates.into_iter().find(|candidate| {
+        run_with_timeout(
+            Command::new(candidate).arg("-version"),
+            Duration::from_secs(5),
+        )
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+    })
+}
+
+fn maven_available() -> bool {
+    run_with_timeout(Command::new("mvn").arg("-version"), Duration::from_secs(8))
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn java_lift_command() -> Option<Vec<String>> {
+    static JAVA_LIFT_COMMAND: OnceLock<Option<Vec<String>>> = OnceLock::new();
+    JAVA_LIFT_COMMAND
+        .get_or_init(|| {
+            let Some(java) = java_bin() else {
+                eprintln!("no working java binary found: skipping Java implication consumer test");
+                return None;
+            };
+            if !maven_available() {
+                eprintln!("mvn unavailable: skipping Java implication consumer test");
+                return None;
+            }
+            let root = repo_root();
+            let mut mvn = Command::new("mvn");
+            mvn.current_dir(root.join("implementations").join("java"))
+                .args([
+                    "-B",
+                    "-ntp",
+                    "-pl",
+                    "provekit-lift-java-core",
+                    "-am",
+                    "-DskipTests",
+                    "package",
+                ]);
+            let out =
+                run_with_timeout(&mut mvn, Duration::from_secs(120)).expect("spawn mvn package");
+            assert!(
+                out.status.success(),
+                "mvn package provekit-lift-java-core failed\n  stdout: {}\n  stderr: {}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr)
+            );
+            let jar = root
+                .join("implementations")
+                .join("java")
+                .join("provekit-lift-java-core")
+                .join("target")
+                .join("provekit-lsp-java.jar");
+            assert!(
+                jar.exists(),
+                "maven build produced no jar at {}",
+                jar.display()
+            );
+            Some(vec![
+                java.display().to_string(),
+                "-jar".to_string(),
+                jar.display().to_string(),
+                "--rpc".to_string(),
+            ])
+        })
+        .clone()
+}
+
+fn toml_string_array(values: &[String]) -> String {
+    let quoted = values
+        .iter()
+        .map(|v| format!("\"{}\"", v.replace('\\', "\\\\").replace('"', "\\\"")))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("[{quoted}]")
+}
+
+fn stage_java_project(command: &[String]) -> PathBuf {
+    let project = unique_dir("project");
+    fs::write(
+        project.join("App.java"),
+        r#"public class App {
+    static int caller(int x) {
+        return callee(x);
+    }
+
+    static int callee(int x) {
+        return x + 1;
+    }
+}
+"#,
+    )
+    .expect("write App.java");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("java-contracts")).unwrap();
+    fs::create_dir_all(provekit.join("lift").join("java-implications")).unwrap();
+    fs::write(
+        provekit.join("config.toml"),
+        r#"[[plugins]]
+name = "java-contracts"
+surface = "java-contracts"
+emit = "ir-document"
+
+[[plugins]]
+name = "java-implications"
+surface = "java-implications"
+"#,
+    )
+    .expect("write config.toml");
+
+    fs::write(
+        provekit
+            .join("lift")
+            .join("java-contracts")
+            .join("manifest.toml"),
+        format!(
+            "name = \"java-contracts\"\ncommand = {}\nworking_dir = \".\"\n",
+            toml_string_array(command)
+        ),
+    )
+    .expect("write java-contracts manifest");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("java-implications")
+            .join("manifest.toml"),
+        format!(
+            "name = \"java-implications\"\ncommand = {}\nworking_dir = \".\"\nmethod = \"provekit.plugin.lift_implications\"\nphase = \"consumer\"\n",
+            toml_string_array(command)
+        ),
+    )
+    .expect("write java-implications manifest");
+
+    project
+}
+
+#[test]
+fn java_implication_consumer_mints_bridge_from_manifest_rpc() {
+    let Some(command) = java_lift_command() else {
+        return;
+    };
+    let project = stage_java_project(&command);
+    let out_dir = unique_dir("out");
+
+    let output = Command::new(provekit_bin())
+        .arg("mint")
+        .arg("--project")
+        .arg(&project)
+        .arg("--out")
+        .arg(&out_dir)
+        .arg("--no-attest")
+        .arg("--quiet")
+        .arg("--json")
+        .output()
+        .expect("spawn provekit mint");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "java implication mint should dispatch producer lift then consumer lift_implications\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("no-contract-for-callee"),
+        "matched callee call should not surface a lift-gap\nstdout:\n{stdout}"
+    );
+
+    let proof_files: Vec<PathBuf> = fs::read_dir(&out_dir)
+        .expect("read out dir")
+        .filter_map(|entry| {
+            let path = entry.expect("out dir entry").path();
+            (path.extension().and_then(|s| s.to_str()) == Some("proof")).then_some(path)
+        })
+        .collect();
+    assert_eq!(
+        proof_files.len(),
+        1,
+        "producer + Java implication consumer should conjoin into one proof"
+    );
+
+    let pool = provekit_verifier::load_all_proofs::run_with_files(
+        Path::new("/no-such-project"),
+        &proof_files,
+    );
+    assert!(
+        pool.load_errors.is_empty(),
+        "conjoined Java proof must load cleanly: {:?}",
+        pool.load_errors
+    );
+    let saw_implication_bridge = pool.mementos.values().any(|env| {
+        provekit_verifier::types::memento_kind(env).as_deref() == Some("bridge")
+            && provekit_verifier::types::memento_body_field(env, "sourceSymbol")
+                .and_then(|v| v.as_str())
+                == Some("callee")
+            && provekit_verifier::types::memento_body_field(env, "notes").and_then(|v| v.as_str())
+                == Some("implication-lifted callsite bridge")
+    });
+    assert!(
+        saw_implication_bridge,
+        "Java consumer must contribute the implication-lifted callsite bridge"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+    let _ = fs::remove_dir_all(&out_dir);
+}


### PR DESCRIPTION
## Summary
- add Java-owned provekit.plugin.lift_implications RPC handling in provekit-lift-java-core
- add JavaParser callsite bridge lifting and lift-gap diagnostics
- add java-implications manifest and Rust CLI mint integration proving producer + consumer conjoin through config/manifest/RPC

## Verification
- mvn -B -ntp -pl provekit-lift-java-core -am -Dtest=JavaImplicationLiftRpcTest test
- cargo test -p provekit-cli --test cmd_mint_java_project_implications --manifest-path implementations/rust/Cargo.toml -- --nocapture

Refs #1601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Java implications lifting now available in the provekit CLI. The feature scans Java projects to detect method callsites within source files, matches them against configured contract bindings, and generates corresponding bridge implications. Callsites without matching contracts are flagged as lift gaps for review.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->