### PR TITLE
feat(python): add implication lift RPC surface

### DIFF
--- a/implementations/python/.provekit/lift/python-implications/manifest.toml
+++ b/implementations/python/.provekit/lift/python-implications/manifest.toml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# PEP 1.7.0 lift plugin manifest for Python implication lifting.
+#
+# The Python kit owns Python AST/source semantics. This consumer-phase route
+# walks Python function bodies and emits kind:bridge IR for call expressions,
+# resolving targets from contract_bindings by the callee prefix in
+# "<callee>@..." contract names.
+name = "python-implications-lift"
+command = ["provekit-lift-python", "--rpc"]
+working_dir = "."
+method = "provekit.plugin.lift_implications"
+phase = "consumer"

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lsp.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lsp.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 import sys
@@ -277,6 +278,196 @@ def handle_lift(msg_id: Any, params: dict) -> None:
         )
 
 
+def _contract_bindings_by_callee(contract_bindings: List[Any]) -> Dict[str, Dict[str, Any]]:
+    contracts_by_callee: Dict[str, Dict[str, Any]] = {}
+    for binding in contract_bindings:
+        if not isinstance(binding, dict):
+            continue
+        name = binding.get("name")
+        if not isinstance(name, str):
+            continue
+        stem = name.split("@", 1)[0].split("(", 1)[0].strip()
+        if stem:
+            contracts_by_callee.setdefault(stem, binding)
+            simple = stem.rsplit(".", 1)[-1]
+            if simple:
+                contracts_by_callee.setdefault(simple, binding)
+    return contracts_by_callee
+
+
+def _binding_contract_cid(binding: Dict[str, Any]) -> Optional[str]:
+    cid = binding.get("contract_cid", binding.get("contractCid"))
+    if isinstance(cid, str) and cid:
+        return cid
+    return None
+
+
+def _call_callee_name(node: ast.AST) -> Optional[str]:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _collect_python_callsites(source: str, source_path: str) -> List[Dict[str, Any]]:
+    tree = ast.parse(source, filename=source_path)
+    callsites: List[Dict[str, Any]] = []
+
+    class FunctionBodyCallVisitor(ast.NodeVisitor):
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            for stmt in node.body:
+                self.visit(stmt)
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            for stmt in node.body:
+                self.visit(stmt)
+
+        def visit_Lambda(self, node: ast.Lambda) -> None:
+            self.visit(node.body)
+
+        def visit_Call(self, node: ast.Call) -> None:
+            callee = _call_callee_name(node.func)
+            if callee:
+                callsites.append(
+                    {
+                        "callee": callee,
+                        "file": source_path,
+                        "line": node.lineno,
+                        "col": node.col_offset,
+                    }
+                )
+            self.generic_visit(node)
+
+    FunctionBodyCallVisitor().visit(tree)
+    return callsites
+
+
+def _rel_python_path(workspace_root: str, path: str) -> str:
+    try:
+        rel = os.path.relpath(path, os.path.abspath(workspace_root or "."))
+    except ValueError:
+        rel = path
+    return rel.replace(os.sep, "/")
+
+
+def _lift_implications_result(params: dict) -> Dict[str, Any]:
+    workspace_root = str(params.get("workspace_root", "."))
+    source_paths = params.get("source_paths", ["."])
+    contract_bindings = params.get("contract_bindings", [])
+    if not isinstance(contract_bindings, list):
+        contract_bindings = []
+
+    contracts_by_callee = _contract_bindings_by_callee(contract_bindings)
+    ir: List[Dict[str, Any]] = []
+    diagnostics: List[Dict[str, Any]] = []
+
+    for path in _iter_python_files(workspace_root, source_paths):
+        rel_path = _rel_python_path(workspace_root, path)
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                source = f.read()
+        except OSError as e:
+            diagnostics.append(
+                {
+                    "kind": "lift-gap",
+                    "reason": f"read-failed: {e}",
+                    "file": rel_path,
+                }
+            )
+            continue
+
+        try:
+            callsites = _collect_python_callsites(source, rel_path)
+        except SyntaxError as e:
+            diagnostics.append(
+                {
+                    "kind": "lift-gap",
+                    "reason": "parse-failed",
+                    "file": rel_path,
+                    "message": str(e),
+                }
+            )
+            continue
+
+        for callsite in callsites:
+            callee = callsite["callee"]
+            binding = contracts_by_callee.get(callee)
+            if binding is None:
+                diagnostics.append(
+                    {
+                        "kind": "lift-gap",
+                        "reason": "no-contract-for-callee",
+                        "callee": callee,
+                        "file": callsite["file"],
+                        "line": callsite["line"],
+                        "col": callsite["col"],
+                    }
+                )
+                continue
+
+            target_cid = _binding_contract_cid(binding)
+            if target_cid is None:
+                diagnostics.append(
+                    {
+                        "kind": "lift-gap",
+                        "reason": "binding-missing-contract-cid",
+                        "callee": callee,
+                        "file": callsite["file"],
+                        "line": callsite["line"],
+                        "col": callsite["col"],
+                    }
+                )
+                continue
+
+            ir.append(
+                {
+                    "kind": "bridge",
+                    "name": (
+                        f"intra-body:python:{callee}@{callsite['file']}:"
+                        f"{callsite['line']}:{callsite['col']}"
+                    ),
+                    "schemaVersion": "1",
+                    "sourceContractCid": target_cid,
+                    "sourceLayer": "python",
+                    "sourceSymbol": callee,
+                    "target": {"cid": target_cid, "kind": "contract"},
+                    "targetContractCid": target_cid,
+                    "targetLayer": "python-tests",
+                    "callsite": {
+                        "file": callsite["file"],
+                        "start_line": callsite["line"],
+                        "start_col": callsite["col"],
+                    },
+                }
+            )
+
+    return {"kind": "ir-document", "ir": ir, "diagnostics": diagnostics}
+
+
+def handle_lift_implications(msg_id: Any, params: dict) -> None:
+    try:
+        _send(
+            {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": _lift_implications_result(params),
+            }
+        )
+    except Exception as e:
+        _send(
+            {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "error": {
+                    "code": -32603,
+                    "message": str(e),
+                    "data": traceback.format_exc(),
+                },
+            }
+        )
+
+
 def _try_lift_pydantic(source: str) -> List[ContractDecl]:
     """Attempt to exec the source and lift any Pydantic BaseModels."""
     try:
@@ -326,6 +517,8 @@ def main() -> None:
             handle_parse(msg_id, params)
         elif method == "lift":
             handle_lift(msg_id, params)
+        elif method == "provekit.plugin.lift_implications":
+            handle_lift_implications(msg_id, params)
         elif method == "shutdown":
             handle_shutdown(msg_id)
         else:

--- a/implementations/python/provekit-lift-py-tests/tests/test_lift_implications.py
+++ b/implementations/python/provekit-lift-py-tests/tests/test_lift_implications.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import List
+
+
+_CID_A = "blake3-512:" + "a" * 128
+_CID_B = "blake3-512:" + "b" * 128
+_CID_C = "blake3-512:" + "c" * 128
+
+
+def _lsp_cmd() -> List[str]:
+    return [sys.executable, "-m", "provekit_lift_py_tests.lsp"]
+
+
+def _run_lsp(ndjson_input: str) -> List[dict]:
+    src_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "src"))
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = src_dir if not existing else os.pathsep.join([src_dir, existing])
+    result = subprocess.run(
+        _lsp_cmd(),
+        input=ndjson_input,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    return [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
+
+
+def _run_lift_implications(tmp_path, source: str, *, source_paths=None, contract_bindings=None):
+    (tmp_path / "example.py").write_text(source, encoding="utf-8")
+    msgs = [
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "provekit.plugin.lift_implications",
+            "params": {
+                "workspace_root": str(tmp_path),
+                "source_paths": source_paths or ["example.py"],
+                "contract_bindings": contract_bindings or [],
+            },
+        },
+        {"jsonrpc": "2.0", "id": 3, "method": "shutdown"},
+    ]
+    responses = _run_lsp("\n".join(json.dumps(m) for m in msgs) + "\n")
+    return next(r for r in responses if r.get("id") == 2)
+
+
+def test_lift_implications_rpc_emits_bridge_per_call_expression(tmp_path):
+    response = _run_lift_implications(
+        tmp_path,
+        """\
+def caller(value):
+    parsed = parse_input(value)
+    return parsed.normalize_value()
+""",
+        contract_bindings=[
+            {"name": "parse_input@example.py:10:4", "contract_cid": _CID_A},
+            {"name": "normalize_value@example.py:20:4", "contract_cid": _CID_B},
+        ],
+    )
+
+    assert "error" not in response, response
+    result = response["result"]
+    assert result["kind"] == "ir-document"
+    ir = result["ir"]
+    assert len(ir) == 2
+
+    parse_bridge = next(entry for entry in ir if entry["sourceSymbol"] == "parse_input")
+    assert parse_bridge["kind"] == "bridge"
+    assert parse_bridge["sourceLayer"] == "python"
+    assert parse_bridge["targetLayer"] == "python-tests"
+    assert parse_bridge["targetContractCid"] == _CID_A
+    assert parse_bridge["target"] == {"kind": "contract", "cid": _CID_A}
+    assert parse_bridge["name"].startswith("intra-body:python:parse_input@example.py:")
+
+    method_bridge = next(entry for entry in ir if entry["sourceSymbol"] == "normalize_value")
+    assert method_bridge["kind"] == "bridge"
+    assert method_bridge["targetContractCid"] == _CID_B
+
+
+def test_lift_implications_emits_lift_gap_for_unmatched_callee(tmp_path):
+    response = _run_lift_implications(
+        tmp_path,
+        """\
+def caller():
+    return completely_unknown_function(0)
+"""
+    )
+
+    assert "error" not in response, response
+    assert response["result"]["ir"] == []
+    diagnostics = response["result"]["diagnostics"]
+    assert len(diagnostics) == 1
+    assert diagnostics[0]["kind"] == "lift-gap"
+    assert diagnostics[0]["reason"] == "no-contract-for-callee"
+    assert diagnostics[0]["callee"] == "completely_unknown_function"
+
+
+def test_lift_implications_uses_last_attribute_segment_as_callee_name(tmp_path):
+    response = _run_lift_implications(
+        tmp_path,
+        """\
+def caller(payload):
+    return json.loads(payload)
+""",
+        contract_bindings=[
+            {"name": "loads@json.py:1:1", "contract_cid": _CID_C},
+        ],
+    )
+
+    assert "error" not in response, response
+    ir = response["result"]["ir"]
+    assert [entry["sourceSymbol"] for entry in ir] == ["loads"]
+    assert ir[0]["targetContractCid"] == _CID_C
+
+
+def test_lift_implications_matches_module_qualified_producer_contract_name(tmp_path):
+    response = _run_lift_implications(
+        tmp_path,
+        """\
+def caller(value):
+    return callee(value)
+""",
+        contract_bindings=[
+            {"name": "app.callee", "contract_cid": _CID_A},
+        ],
+    )
+
+    assert "error" not in response, response
+    ir = response["result"]["ir"]
+    assert [entry["sourceSymbol"] for entry in ir] == ["callee"]
+    assert ir[0]["targetContractCid"] == _CID_A
+    assert response["result"]["diagnostics"] == []

--- a/implementations/rust/provekit-cli/tests/cmd_mint_python_project_implications.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_python_project_implications.rs
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn python_available() -> bool {
+    Command::new("python3")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-py-implications-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+fn write_executable(path: &Path, body: &str) {
+    use std::io::Write as _;
+    {
+        let mut file = fs::File::create(path).expect("create script");
+        file.write_all(body.as_bytes()).expect("write script");
+        file.sync_all().expect("sync script");
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(path).expect("stat script").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).expect("chmod script");
+    }
+}
+
+fn python_wrapper(module: &str, function: &str, src_dir: PathBuf) -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let script = std::env::temp_dir().join(format!(
+        "provekit-python-implication-{}-{}.sh",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    let body = format!(
+        "#!/bin/sh\nexec python3 -c \"import sys; sys.path.insert(0, '{}'); from {module} import {function}; {function}()\"\n",
+        src_dir.display()
+    );
+    write_executable(&script, &body);
+    script
+}
+
+fn python_verify_wrapper() -> PathBuf {
+    python_wrapper(
+        "provekit_lift_python_source.verify_rpc",
+        "run_rpc",
+        repo_root()
+            .join("implementations")
+            .join("python")
+            .join("provekit-lift-python-source")
+            .join("src"),
+    )
+}
+
+fn python_implications_wrapper() -> PathBuf {
+    python_wrapper(
+        "provekit_lift_py_tests.lsp",
+        "main",
+        repo_root()
+            .join("implementations")
+            .join("python")
+            .join("provekit-lift-py-tests")
+            .join("src"),
+    )
+}
+
+fn stage_python_project(producer: &Path, consumer: &Path) -> PathBuf {
+    let project = unique_dir("project");
+    fs::write(
+        project.join("app.py"),
+        r#"def caller(x: int) -> int:
+    return callee(x)
+
+
+def callee(x: int) -> int:
+    return x + 1
+"#,
+    )
+    .expect("write app.py");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("python-contracts")).unwrap();
+    fs::create_dir_all(provekit.join("lift").join("python-implications")).unwrap();
+    fs::write(
+        provekit.join("config.toml"),
+        r#"[[plugins]]
+name = "python-contracts"
+surface = "python-contracts"
+
+[[plugins]]
+name = "python-implications"
+surface = "python-implications"
+"#,
+    )
+    .expect("write config.toml");
+
+    fs::write(
+        provekit
+            .join("lift")
+            .join("python-contracts")
+            .join("manifest.toml"),
+        format!(
+            "name = \"python-contracts\"\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
+            producer.display()
+        ),
+    )
+    .expect("write python-contracts manifest");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("python-implications")
+            .join("manifest.toml"),
+        format!(
+            "name = \"python-implications\"\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\nmethod = \"provekit.plugin.lift_implications\"\nphase = \"consumer\"\n",
+            consumer.display()
+        ),
+    )
+    .expect("write python-implications manifest");
+
+    project
+}
+
+#[test]
+fn python_implication_consumer_mints_bridge_from_manifest_rpc() {
+    if !python_available() {
+        eprintln!("python3 not on PATH: skipping Python implication consumer test");
+        return;
+    }
+    let producer = python_verify_wrapper();
+    let consumer = python_implications_wrapper();
+    let project = stage_python_project(&producer, &consumer);
+    let out_dir = unique_dir("out");
+
+    let output = Command::new(provekit_bin())
+        .arg("mint")
+        .arg("--project")
+        .arg(&project)
+        .arg("--out")
+        .arg(&out_dir)
+        .arg("--no-attest")
+        .arg("--quiet")
+        .arg("--json")
+        .output()
+        .expect("spawn provekit mint");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "python implication mint should dispatch producer lift then consumer lift_implications\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("no-contract-for-callee"),
+        "matched callee call should not surface a lift-gap\nstdout:\n{stdout}"
+    );
+
+    let proof_files: Vec<PathBuf> = fs::read_dir(&out_dir)
+        .expect("read out dir")
+        .filter_map(|entry| {
+            let path = entry.expect("out dir entry").path();
+            (path.extension().and_then(|s| s.to_str()) == Some("proof")).then_some(path)
+        })
+        .collect();
+    assert_eq!(
+        proof_files.len(),
+        1,
+        "producer + Python implication consumer should conjoin into one proof"
+    );
+
+    let pool = provekit_verifier::load_all_proofs::run_with_files(
+        Path::new("/no-such-project"),
+        &proof_files,
+    );
+    assert!(
+        pool.load_errors.is_empty(),
+        "conjoined Python proof must load cleanly: {:?}",
+        pool.load_errors
+    );
+    let saw_implication_bridge = pool.mementos.values().any(|env| {
+        provekit_verifier::types::memento_kind(env).as_deref() == Some("bridge")
+            && provekit_verifier::types::memento_body_field(env, "sourceSymbol")
+                .and_then(|v| v.as_str())
+                == Some("callee")
+            && provekit_verifier::types::memento_body_field(env, "notes").and_then(|v| v.as_str())
+                == Some("implication-lifted callsite bridge")
+    });
+    assert!(
+        saw_implication_bridge,
+        "Python consumer must contribute the implication-lifted callsite bridge"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+    let _ = fs::remove_dir_all(&out_dir);
+}


### PR DESCRIPTION
## Summary
- add Python-owned provekit.plugin.lift_implications RPC handling in provekit-lift-py-tests
- index producer contract bindings by full and simple callee names so module-qualified contracts resolve to native callsite symbols
- add python-implications manifest and Rust CLI mint integration proving producer + consumer conjoin through config/manifest/RPC

## Verification
- python3 -m pytest implementations/python/provekit-lift-py-tests/tests/test_lift_implications.py -q
- cargo test -p provekit-cli --test cmd_mint_python_project_implications --manifest-path implementations/rust/Cargo.toml -- --nocapture

Refs #1601