### PR TITLE
fix(materialize): infer targets from realize manifests

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -1252,21 +1252,8 @@ fn resolve_library_surface(
         }
         return Ok((target.to_string(), Some(tag.to_string())));
     }
-    for language in ["typescript", "python", "rust", "java"] {
-        // Same manifest-aware preference as the `--target` arm: a tag that
-        // literally starts with `{language}-` (e.g. `java-io`) must not be
-        // truncated when it names a real manifest.
-        if library.starts_with(&format!("{language}-"))
-            && realize_tag_exists(project_root, language, library)
-        {
-            return Ok((language.to_string(), Some(library.to_string())));
-        }
-        if let Some(tag) = library.strip_prefix(&format!("{language}-")) {
-            if tag.is_empty() {
-                return Err(format!("library surface `{library}` has empty library tag"));
-            }
-            return Ok((language.to_string(), Some(tag.to_string())));
-        }
+    if let Some((language, tag)) = resolve_registered_library_surface(project_root, library)? {
+        return Ok((language, Some(tag)));
     }
     let language = detect_project_language(project_root).ok_or_else(|| {
         format!(
@@ -1274,6 +1261,43 @@ fn resolve_library_surface(
         )
     })?;
     Ok((language, Some(library.to_string())))
+}
+
+fn resolve_registered_library_surface(
+    project_root: &Path,
+    library: &str,
+) -> Result<Option<(String, String)>, String> {
+    use crate::kit_dispatch::registry_realize_language_candidates;
+
+    let candidates = registry_realize_language_candidates(project_root)?;
+    let mut matches = candidates
+        .into_iter()
+        .filter_map(|candidate| {
+            let prefixed = format!("{}-{}", candidate.language, candidate.tag);
+            if candidate.tag == library || prefixed == library {
+                Some((candidate.language, candidate.tag, candidate.source))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    matches.sort();
+    matches.dedup();
+
+    match matches.as_slice() {
+        [] => Ok(None),
+        [(language, tag, _source)] => Ok(Some((language.clone(), tag.clone()))),
+        _ => {
+            let registered = matches
+                .iter()
+                .map(|(language, tag, source)| format!("{language}/{tag} from {source}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(format!(
+                "ambiguous target language for library `{library}`; pass --target=<language>. registered matches: {registered}"
+            ))
+        }
+    }
 }
 
 /// True when a realize manifest registered for `target_lang` declares exactly

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -698,6 +698,63 @@ pub(crate) fn registry_realize_candidates(
     Ok(candidates)
 }
 
+#[allow(dead_code)] // used by the CLI binary's cmd_materialize module; lib target exposes kit_dispatch alone
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct RealizeLanguageCandidate {
+    pub(crate) language: String,
+    pub(crate) tag: String,
+    pub(crate) source: String,
+}
+
+#[allow(dead_code)] // used by the CLI binary's cmd_materialize module; lib target exposes kit_dispatch alone
+pub(crate) fn registry_realize_language_candidates(
+    workspace_root: &Path,
+) -> Result<Vec<RealizeLanguageCandidate>, String> {
+    let registry = run_plugin_registry_for_project(workspace_root)?;
+    let mut candidates = registry
+        .plugins
+        .iter()
+        .filter(|plugin| registry_authorizes_plugin(&registry, plugin))
+        .filter(|plugin| plugin.kind == "realize")
+        .filter_map(|plugin| {
+            let tag = plugin
+                .parsed
+                .library_tag
+                .clone()
+                .unwrap_or_else(|| DEFAULT_LIBRARY_TAG.to_string());
+            let language = infer_realize_language_from_surface(&plugin.surface)?;
+            Some(RealizeLanguageCandidate {
+                language,
+                tag,
+                source: plugin.source.clone(),
+            })
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by(|a, b| {
+        a.language
+            .cmp(&b.language)
+            .then(a.tag.cmp(&b.tag))
+            .then(a.source.cmp(&b.source))
+    });
+    candidates.dedup();
+    Ok(candidates)
+}
+
+#[allow(dead_code)] // used by the CLI binary's cmd_materialize module; lib target exposes kit_dispatch alone
+fn infer_realize_language_from_surface(surface: &str) -> Option<String> {
+    let surface = surface.trim();
+    if surface.is_empty() {
+        return None;
+    }
+    Some(
+        surface
+            .split_once('-')
+            .map(|(language, _)| language)
+            .unwrap_or(surface)
+            .to_string(),
+    )
+}
+
 fn registry_exam_manifest_command(
     workspace_root: &Path,
     plugin_name: &str,

--- a/implementations/rust/provekit-cli/tests/go_realize_materialize.rs
+++ b/implementations/rust/provekit-cli/tests/go_realize_materialize.rs
@@ -462,6 +462,64 @@ fn go_materialize_cli_rewrites_carrier_and_asks_go_kit_to_compile_check() {
     );
 }
 
+#[test]
+fn go_materialize_infers_target_from_registered_go_manifest() {
+    if !go_available() {
+        eprintln!("go not on PATH: skipping go manifest-inference materialize test");
+        return;
+    }
+    let bin = build_go_realize();
+    let workspace = tempfile::tempdir().expect("tempdir");
+    install_go_realize_manifest(workspace.path(), &bin);
+    write_external_go_dependency_with_identity_body(workspace.path());
+    let src_dir = workspace.path().join("src");
+    fs::create_dir_all(&src_dir).expect("mkdir src");
+    write_go_identity_carrier(&src_dir);
+
+    let out_dir = workspace.path().join("materialized");
+    fs::create_dir_all(&out_dir).expect("mkdir out");
+    fs::write(
+        out_dir.join("go.mod"),
+        "module example.com/provekit_go_materialized\n\ngo 1.22\n",
+    )
+    .expect("write output go.mod");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("materialize")
+        .arg("--library")
+        .arg("go")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--compile-check")
+        .output()
+        .expect("spawn provekit materialize for inferred Go target");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "Go materialize should infer target from the registered Go manifest, without --target\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("assembled by go kit via RPC"),
+        "inferred Go materialize must still assemble through the Go kit\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("compile-check: go test ./... passed"),
+        "inferred Go materialize must still ask the Go kit to run its native check\nstderr:\n{stderr}"
+    );
+
+    let emitted = fs::read_to_string(out_dir.join("id.go")).expect("read materialized Go");
+    assert!(
+        emitted.contains("func Id(x int) int") && emitted.contains("return x"),
+        "materialized Go should contain the Go kit's realized identity body:\n{emitted}"
+    );
+}
+
 /// The shim supplies REAL Go sugar (`func Id(x int) int { return x }`),
 /// dispatched through the substrate realize protocol, and that Go compiles.
 #[test]


### PR DESCRIPTION
## Summary
- replace materialize's hardcoded no-target language table with realize-manifest-driven target/tag inference
- add a Go materialize regression proving a registered Go realize manifest routes without --target
- keep ambiguous manifest matches loud instead of guessing a language

## Verification
- cargo test -p provekit-cli --test go_realize_materialize --manifest-path implementations/rust/Cargo.toml -- --nocapture
- cargo test -p provekit-cli --test cmd_materialize_integration --manifest-path implementations/rust/Cargo.toml -- --nocapture
- PATH="/usr/local/Cellar/openjdk/25.0.2/libexec/openjdk.jdk/Contents/Home/bin:$PATH" cargo test -p provekit-cli --test cmd_materialize_proof_load --manifest-path implementations/rust/Cargo.toml -- --nocapture
- cargo fmt --manifest-path implementations/rust/provekit-cli/Cargo.toml --check
- git diff --check