### PR TITLE
fix(materialize): require manifest-backed target inference

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -1255,12 +1255,9 @@ fn resolve_library_surface(
     if let Some((language, tag)) = resolve_registered_library_surface(project_root, library)? {
         return Ok((language, Some(tag)));
     }
-    let language = detect_project_language(project_root).ok_or_else(|| {
-        format!(
-            "could not infer target language for library `{library}`; pass --target=<language> or use a language-prefixed library surface"
-        )
-    })?;
-    Ok((language, Some(library.to_string())))
+    Err(format!(
+        "could not infer target language for library `{library}` from registered realize manifests; pass --target=<language> or register .provekit/realize/<surface>/manifest.toml"
+    ))
 }
 
 fn resolve_registered_library_surface(
@@ -1309,22 +1306,6 @@ fn realize_tag_exists(project_root: &Path, target_lang: &str, library_tag: &str)
     registry_realize_candidates(project_root, target_lang)
         .map(|cands| cands.iter().any(|c| c.tag == library_tag))
         .unwrap_or(false)
-}
-
-fn detect_project_language(project_root: &Path) -> Option<String> {
-    let markers = [
-        ("package.json", "typescript"),
-        ("Cargo.toml", "rust"),
-        ("pyproject.toml", "python"),
-        ("requirements.txt", "python"),
-        ("pom.xml", "java"),
-        ("build.gradle", "java"),
-        ("build.gradle.kts", "java"),
-    ];
-    markers
-        .iter()
-        .find(|(marker, _)| project_root.join(marker).exists())
-        .map(|(_, language)| (*language).to_string())
 }
 
 fn materialize_source_dir(

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -1125,6 +1125,41 @@ fn materialize_no_carriers_reports_zero_without_printing_dry_run_source() {
 }
 
 #[test]
+fn materialize_without_target_or_registered_manifest_refuses_project_marker_inference() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        workspace.path().join("Cargo.toml"),
+        "[package]\nname = \"marker-only\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+    )
+    .expect("write rust project marker");
+    let src_dir = workspace.path().join("src");
+    fs::create_dir_all(&src_dir).expect("create src dir");
+    let _source_path = write_no_carrier_source(&src_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("materialize")
+        .arg("--library")
+        .arg("reqwest")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .output()
+        .expect("spawn provekit materialize");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "marker-only materialize must not infer a target without a registered realize manifest\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("could not infer target language for library `reqwest`"),
+        "error should require explicit target or manifest-backed dispatch:\n{stderr}"
+    );
+}
+
+#[test]
 fn materialize_python_requests_example_uses_python_library_shim() {
     let workspace = tempfile::tempdir().expect("tempdir");
     let Some(src_dir) = write_python_requests_project_fixture(workspace.path()) else {


### PR DESCRIPTION
## Summary
- remove materialize target inference from project marker files like Cargo.toml/package.json/pom.xml
- require no-target materialize to resolve through registered realize manifests, or use an explicit --target
- add a regression proving marker-only projects do not silently dispatch through CLI language heuristics

## Verification
- cargo test -p provekit-cli --test cmd_materialize_integration --manifest-path implementations/rust/Cargo.toml materialize_without_target_or_registered_manifest_refuses_project_marker_inference -- --nocapture (red before fix, green after)
- cargo test -p provekit-cli --test cmd_materialize_integration --manifest-path implementations/rust/Cargo.toml -- --nocapture
- cargo test -p provekit-cli --test go_realize_materialize --manifest-path implementations/rust/Cargo.toml -- --nocapture
- PATH="/usr/local/Cellar/openjdk/25.0.2/libexec/openjdk.jdk/Contents/Home/bin:$PATH" cargo test -p provekit-cli --test cmd_materialize_proof_load --manifest-path implementations/rust/Cargo.toml -- --nocapture
- cargo fmt --manifest-path implementations/rust/provekit-cli/Cargo.toml --check
- git diff --check