### PR TITLE
Add Python unittest emit kit

### DIFF
--- a/implementations/python/provekit-emit-python-unittest/README.md
+++ b/implementations/python/provekit-emit-python-unittest/README.md
@@ -1,0 +1,9 @@
+# provekit-emit-python-unittest
+
+PEP 1.7.0 Python emitter kit for native `unittest` assertions.
+
+The kit accepts normalized proof predicate data over the ProveKit plugin RPC
+protocol and emits a standalone Python `unittest.TestCase` module. Predicate
+spelling is Python framework knowledge and stays in this Python package; the
+Rust CLI only dispatches through `.provekit/config.toml` and the emit manifest.
+

--- a/implementations/python/provekit-emit-python-unittest/pyproject.toml
+++ b/implementations/python/provekit-emit-python-unittest/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "provekit-emit-python-unittest"
+version = "0.1.0"
+description = "PEP 1.7.0 Python unittest emitter kit: materializes neutral predicates as native unittest assertions"
+requires-python = ">=3.11"
+dependencies = ["blake3>=1.0.0"]
+
+[project.scripts]
+provekit-emit-python-unittest = "provekit_emit_python_unittest.__main__:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+

--- a/implementations/python/provekit-emit-python-unittest/src/provekit_emit_python_unittest/__init__.py
+++ b/implementations/python/provekit-emit-python-unittest/src/provekit_emit_python_unittest/__init__.py
@@ -1,0 +1,2 @@
+"""Python unittest emitter kit (PEP 1.7.0 emit plugin, framework = unittest)."""
+

--- a/implementations/python/provekit-emit-python-unittest/src/provekit_emit_python_unittest/__main__.py
+++ b/implementations/python/provekit-emit-python-unittest/src/provekit_emit_python_unittest/__main__.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import argparse
+
+from .rpc import run_rpc
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="provekit-emit-python-unittest",
+        description="PEP 1.7.0 unittest emitter kit (predicate -> unittest assertion).",
+    )
+    parser.add_argument("--rpc", action="store_true", help="run PEP 1.7.0 JSON-RPC over stdio")
+    args = parser.parse_args(argv)
+    if args.rpc:
+        run_rpc()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/implementations/python/provekit-emit-python-unittest/src/provekit_emit_python_unittest/emitter.py
+++ b/implementations/python/provekit-emit-python-unittest/src/provekit_emit_python_unittest/emitter.py
@@ -1,0 +1,150 @@
+"""Emit a unittest test module from a contract's neutral predicates."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+import blake3
+
+from . import predicate_table as pt
+
+
+@dataclass(frozen=True)
+class EmitPlan:
+    """The emit request: neutral predicates plus target function metadata."""
+
+    contract_id: str = ""
+    function: str = "test"
+    params: list[str] = field(default_factory=list)
+    param_types: list[str] = field(default_factory=list)
+    predicates: list[dict[str, Any]] = field(default_factory=list)
+
+    @staticmethod
+    def from_params(params: dict[str, Any]) -> "EmitPlan":
+        if not isinstance(params, dict):
+            return EmitPlan()
+        contract_id = _first_str(params.get("contract_id"), params.get("concept_name"))
+        function = _first_str(params.get("function"), params.get("function_name")) or "test"
+        formals = _string_list(params.get("params"))
+        formal_types = _string_list(params.get("param_types"))
+        predicates = [p for p in _list(params.get("predicates")) if isinstance(p, dict)]
+        return EmitPlan(contract_id, function, formals, formal_types, predicates)
+
+
+@dataclass(frozen=True)
+class Emission:
+    """The emission result: source text, per-predicate gaps, and a CID."""
+
+    source: str
+    path: str
+    artifact_cid: str
+    emitted_predicates: list[str]
+    unsupported_predicates: list[str]
+
+    @property
+    def is_complete(self) -> bool:
+        return not self.unsupported_predicates and bool(self.emitted_predicates)
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "kind": "unittest-test-emission",
+            "source": self.source,
+            "path": self.path,
+            "extension": "py",
+            "emitted_artifact_cid": self.artifact_cid,
+            "emitted_predicates": list(self.emitted_predicates),
+            "unsupported_predicates": list(self.unsupported_predicates),
+            "is_complete": self.is_complete,
+        }
+
+
+def emit(plan: EmitPlan) -> Emission:
+    """Emit a native unittest module for the contract described by ``plan``."""
+    emitted: list[str] = []
+    unsupported: list[str] = []
+    methods: list[str] = []
+
+    for idx, predicate in enumerate(plan.predicates):
+        head = pt.head_of(predicate)
+        assertion = pt.render(predicate)
+        if assertion is None:
+            unsupported.append(head if head is not None else "<malformed>")
+            continue
+        emitted.append(head)
+        declarations = _free_var_declarations(predicate, head)
+        methods.append(_render_test_method(_method_name(head, idx), declarations, assertion))
+
+    class_name = _class_name(plan.function)
+    source = _render_module(class_name, methods)
+    cid = "blake3-512:" + blake3.blake3(source.encode("utf-8")).digest(length=64).hex()
+    return Emission(source, _module_path(plan.function), cid, emitted, unsupported)
+
+
+def _module_path(function: str) -> str:
+    safe = _snake(function)
+    if not safe:
+        safe = "contract"
+    return f"test_{safe}_contract.py"
+
+
+def _class_name(function: str) -> str:
+    safe = _snake(function)
+    parts = [part for part in safe.split("_") if part]
+    if not parts:
+        parts = ["contract"]
+    return "Test" + "".join(part.capitalize() for part in parts) + "Contract"
+
+
+def _snake(value: str) -> str:
+    return re.sub(r"[^0-9A-Za-z_]+", "_", value or "").strip("_").lower()
+
+
+def _free_var_declarations(predicate: dict[str, Any], head: str | None) -> list[str]:
+    variables = pt.free_vars(predicate)
+    decls: list[str] = []
+    for var_index, name in enumerate(variables):
+        value = pt.placeholder_value(head, var_index)
+        decls.append(f"{name} = {value}")
+    return decls
+
+
+def _render_test_method(name: str, declarations: list[str], assertion: str) -> str:
+    lines = [f"    def {name}(self):"]
+    for declaration in declarations:
+        lines.append(f"        {declaration}")
+    lines.extend(_indent(assertion, "        "))
+    return "\n".join(lines) + "\n"
+
+
+def _render_module(class_name: str, methods: list[str]) -> str:
+    body = "\n".join(methods) if methods else "    pass\n"
+    return f"import unittest\n\n\nclass {class_name}(unittest.TestCase):\n{body}"
+
+
+def _method_name(head: str | None, idx: int) -> str:
+    safe = (head or "predicate").replace("-", "_")
+    return f"test_verifies_{safe}_{idx}"
+
+
+def _indent(block: str, prefix: str) -> list[str]:
+    return [prefix + line if line else line for line in block.split("\n")]
+
+
+def _first_str(*candidates: Any) -> str:
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate
+    return ""
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+

--- a/implementations/python/provekit-emit-python-unittest/src/provekit_emit_python_unittest/plugin_memento.py
+++ b/implementations/python/provekit-emit-python-unittest/src/provekit_emit_python_unittest/plugin_memento.py
@@ -1,0 +1,88 @@
+"""Plugin-memento minting for the PEP 1.7.0 unittest emitter."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import blake3
+
+from . import predicate_table as pt
+
+PLUGIN_KIND = "emit"
+PLUGIN_VERSION = "0.1.0"
+PROTOCOL_VERSIONS = ["pep/1.7.0"]
+PROVENANCE_CID = "blake3-512:provenance-provekit-emit-python-unittest-0.1.0"
+
+_ZERO_SIGNATURE = "ed25519:" + ("A" * 86 + "==")
+_ZERO_SIGNER = "ed25519:" + ("A" * 43 + "=")
+
+
+def _jcs(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def compute_plugin_cid(header: dict[str, Any]) -> str:
+    protocol_versions = sorted(header["protocol_versions"])
+    cid_input = {
+        "content": header["content"],
+        "critical": header["critical"],
+        "kind": header["kind"],
+        "protocol_versions": protocol_versions,
+        "provenance_cid": header["provenance_cid"],
+        "schemaVersion": header["schemaVersion"],
+        "version": header["version"],
+    }
+    return "blake3-512:" + blake3.blake3(_jcs(cid_input).encode("utf-8")).digest(length=64).hex()
+
+
+def plugin_content() -> dict[str, Any]:
+    return {
+        "name": "provekit-emit-python-unittest",
+        "version": PLUGIN_VERSION,
+        "kind": PLUGIN_KIND,
+        "target_language": "python",
+        "target_framework": "unittest",
+        "capabilities": {
+            "kits": ["python"],
+            "emits": "unittest-assertions",
+            "predicates": pt.supported_predicates(),
+        },
+    }
+
+
+def plugin_header() -> dict[str, Any]:
+    header = {
+        "content": plugin_content(),
+        "critical": False,
+        "kind": PLUGIN_KIND,
+        "protocol_versions": list(PROTOCOL_VERSIONS),
+        "provenance_cid": PROVENANCE_CID,
+        "schemaVersion": "1",
+        "version": PLUGIN_VERSION,
+    }
+    header["cid"] = compute_plugin_cid(header)
+    return header
+
+
+def plugin_memento() -> dict[str, Any]:
+    return {
+        "envelope": {
+            "declaredAt": "2026-05-29T00:00:00.000Z",
+            "signature": _ZERO_SIGNATURE,
+            "signer": _ZERO_SIGNER,
+        },
+        "header": plugin_header(),
+        "metadata": {
+            "maintainer": "T Savo <evilgenius@nefariousplan.com>",
+            "note": (
+                "PEP 1.7.0 unittest emitter: materializes neutral predicates as "
+                "native unittest assertions. Mapping is inline python."
+            ),
+            "source_url": "implementations/python/provekit-emit-python-unittest",
+        },
+    }
+
+
+PLUGIN_MEMENTO: dict[str, Any] = plugin_memento()
+

--- a/implementations/python/provekit-emit-python-unittest/src/provekit_emit_python_unittest/predicate_table.py
+++ b/implementations/python/provekit-emit-python-unittest/src/provekit_emit_python_unittest/predicate_table.py
@@ -1,0 +1,196 @@
+"""INLINE predicate -> unittest assertion mapping.
+
+The mapping from neutral predicates to ``unittest`` assertion methods is Python
+framework knowledge, so it belongs in this Python kit rather than in the Rust
+CLI or a substrate catalog template.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+_CONCEPT_PREFIX = "concept:"
+_ARITHMETIC = {"+", "-", "*", "/", "%"}
+
+
+def head_of(predicate: dict[str, Any]) -> Optional[str]:
+    """Return the predicate head with any ``concept:`` prefix stripped."""
+    if not isinstance(predicate, dict):
+        return None
+    name = predicate.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return None
+    if name.startswith(_CONCEPT_PREFIX):
+        return name[len(_CONCEPT_PREFIX):]
+    return name
+
+
+def supports(head: Optional[str]) -> bool:
+    """True if this kit can spell an assertion for ``head``."""
+    return head in _HANDLERS
+
+
+def render(predicate: dict[str, Any]) -> Optional[str]:
+    """Render one neutral predicate as a unittest assertion statement.
+
+    Returns ``None`` for unsupported predicate heads, wrong arity, malformed
+    terms, or term shapes this emitter cannot safely spell.
+    """
+    head = head_of(predicate)
+    if head is None:
+        return None
+    handler = _HANDLERS.get(head)
+    if handler is None:
+        return None
+    return handler(_args_of(predicate))
+
+
+def placeholder_value(head: Optional[str], var_index: int) -> str:
+    """Return a placeholder value that makes the standalone emitted test pass."""
+    if head == "option-is-none":
+        return "None"
+    if head in ("option-is-some", "not-null"):
+        return "object()"
+    if head == "fallible-err":
+        return "lambda: (_ for _ in ()).throw(ValueError('contract error'))"
+    if head == "lt":
+        return "0" if var_index == 0 else "1"
+    if head == "gt":
+        return "1" if var_index == 0 else "0"
+    if head == "ne":
+        return "0" if var_index == 0 else "1"
+    return "0"
+
+
+def render_term(term: Any) -> Optional[str]:
+    """Render a neutral term subtree to a Python expression."""
+    if not isinstance(term, dict):
+        return None
+    kind = term.get("kind")
+    if kind == "var":
+        name = term.get("name")
+        return name if isinstance(name, str) and name.strip() else None
+    if kind == "const":
+        return _render_const(term)
+    if kind in ("op", "ctor"):
+        return _render_application(term)
+    return None
+
+
+def free_vars(term: Any, out: Optional[list[str]] = None) -> list[str]:
+    """Collect ``kind:"var"`` names in deterministic encounter order."""
+    if out is None:
+        out = []
+    if not isinstance(term, dict):
+        return out
+    if term.get("kind") == "var":
+        name = term.get("name")
+        if isinstance(name, str) and name.strip() and name not in out:
+            out.append(name)
+        return out
+    args = term.get("args")
+    if isinstance(args, list):
+        for arg in args:
+            free_vars(arg, out)
+    return out
+
+
+def supported_predicates() -> list[str]:
+    """Catalog-form names of every predicate this kit can emit."""
+    return [
+        "concept:eq",
+        "concept:ne",
+        "concept:lt",
+        "concept:gt",
+        "concept:le",
+        "concept:ge",
+        "concept:option-is-some",
+        "concept:option-is-none",
+        "concept:fallible-err",
+    ]
+
+
+def _render_const(obj: dict[str, Any]) -> Optional[str]:
+    if "value" not in obj:
+        return None
+    value = obj["value"]
+    if value is None:
+        return "None"
+    if isinstance(value, bool):
+        return "True" if value else "False"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return repr(value)
+    if isinstance(value, str):
+        return repr(value)
+    return None
+
+
+def _render_application(obj: dict[str, Any]) -> Optional[str]:
+    name = obj.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return None
+    if name.startswith(_CONCEPT_PREFIX):
+        name = name[len(_CONCEPT_PREFIX):]
+
+    rendered_args: list[str] = []
+    raw_args = obj.get("args")
+    if isinstance(raw_args, list):
+        for arg in raw_args:
+            rendered = render_term(arg)
+            if rendered is None:
+                return None
+            rendered_args.append(rendered)
+
+    if name in _ARITHMETIC and len(rendered_args) == 2:
+        return f"({rendered_args[0]} {name} {rendered_args[1]})"
+    return f"{name}({', '.join(rendered_args)})"
+
+
+def _args_of(predicate: dict[str, Any]) -> list[Any]:
+    args = predicate.get("args")
+    return args if isinstance(args, list) else []
+
+
+def _binary(make: Callable[[str, str], str]) -> Callable[[list[Any]], Optional[str]]:
+    def handler(args: list[Any]) -> Optional[str]:
+        if len(args) != 2:
+            return None
+        left = render_term(args[0])
+        right = render_term(args[1])
+        if left is None or right is None:
+            return None
+        return make(left, right)
+
+    return handler
+
+
+def _unary(make: Callable[[str], str]) -> Callable[[list[Any]], Optional[str]]:
+    def handler(args: list[Any]) -> Optional[str]:
+        if len(args) != 1:
+            return None
+        value = render_term(args[0])
+        if value is None:
+            return None
+        return make(value)
+
+    return handler
+
+
+_HANDLERS: dict[str, Callable[[list[Any]], Optional[str]]] = {
+    "eq": _binary(lambda a, b: f"self.assertEqual({a}, {b})"),
+    "ne": _binary(lambda a, b: f"self.assertNotEqual({a}, {b})"),
+    "neq": _binary(lambda a, b: f"self.assertNotEqual({a}, {b})"),
+    "lt": _binary(lambda a, b: f"self.assertTrue({a} < {b})"),
+    "gt": _binary(lambda a, b: f"self.assertTrue({a} > {b})"),
+    "le": _binary(lambda a, b: f"self.assertTrue({a} <= {b})"),
+    "lte": _binary(lambda a, b: f"self.assertTrue({a} <= {b})"),
+    "ge": _binary(lambda a, b: f"self.assertTrue({a} >= {b})"),
+    "gte": _binary(lambda a, b: f"self.assertTrue({a} >= {b})"),
+    "option-is-some": _unary(lambda x: f"self.assertIsNotNone({x})"),
+    "not-null": _unary(lambda x: f"self.assertIsNotNone({x})"),
+    "option-is-none": _unary(lambda x: f"self.assertIsNone({x})"),
+    "fallible-err": _unary(lambda x: f"with self.assertRaises(Exception):\n    {x}()"),
+}
+

--- a/implementations/python/provekit-emit-python-unittest/src/provekit_emit_python_unittest/rpc.py
+++ b/implementations/python/provekit-emit-python-unittest/src/provekit_emit_python_unittest/rpc.py
@@ -1,0 +1,92 @@
+"""PEP 1.7.0 newline-delimited JSON-RPC server for the unittest emitter."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import traceback
+from typing import Any
+
+from .emitter import EmitPlan, emit
+from .plugin_memento import PLUGIN_MEMENTO
+
+
+def run_rpc() -> None:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        method = ""
+        try:
+            request = json.loads(line)
+            method = str(request.get("method", ""))
+            response = dispatch(request)
+        except json.JSONDecodeError as exc:
+            response = _error(None, -32700, f"PARSE_ERROR: {exc}")
+        except Exception as exc:  # noqa: BLE001 - surface plugin errors to the host
+            response = _error(None, -32603, f"{exc}\n{traceback.format_exc()}")
+        _send(response)
+        if method == "provekit.plugin.shutdown":
+            break
+
+
+def dispatch(request: dict[str, Any]) -> dict[str, Any]:
+    msg_id = request.get("id")
+    method = str(request.get("method", ""))
+    params = request.get("params")
+    if params is None:
+        params = {}
+
+    if method == "provekit.plugin.describe":
+        return {"jsonrpc": "2.0", "id": msg_id, "result": PLUGIN_MEMENTO}
+
+    if method == "provekit.plugin.invoke":
+        if not isinstance(params, dict):
+            return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        emission = emit(EmitPlan.from_params(params))
+        return {"jsonrpc": "2.0", "id": msg_id, "result": emission.to_json()}
+
+    if method == "provekit.plugin.check":
+        if not isinstance(params, dict):
+            return _error(msg_id, -32602, "INVALID_PARAMS: params must be an object")
+        out_dir = params.get("out_dir")
+        if not isinstance(out_dir, str) or not out_dir:
+            return _error(msg_id, -32602, "INVALID_PARAMS: missing out_dir")
+        return {"jsonrpc": "2.0", "id": msg_id, "result": _check_unittest(out_dir)}
+
+    if method == "provekit.plugin.shutdown":
+        return {"jsonrpc": "2.0", "id": msg_id, "result": None}
+
+    return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")
+
+
+def _check_unittest(out_dir: str) -> dict[str, Any]:
+    python = os.environ.get("PYTHON") or sys.executable or "python3"
+    completed = subprocess.run(
+        [python, "-m", "unittest", "discover", "-s", "."],
+        cwd=out_dir,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    return {
+        "ok": completed.returncode == 0,
+        "command": f"{python} -m unittest discover -s .",
+        "cwd": out_dir,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+        "exitCode": completed.returncode,
+    }
+
+
+def _send(obj: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(obj, separators=(",", ":"), ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+
+
+def _error(msg_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": msg_id, "error": {"code": code, "message": message}}
+

--- a/implementations/python/provekit-emit-python-unittest/tests/test_emitter.py
+++ b/implementations/python/provekit-emit-python-unittest/tests/test_emitter.py
@@ -1,0 +1,73 @@
+"""Module-level emission behavior for the unittest emitter."""
+
+from __future__ import annotations
+
+from provekit_emit_python_unittest.emitter import EmitPlan, emit
+
+
+def _atomic(name: str, *args: dict) -> dict:
+    return {"kind": "atomic", "name": name, "args": list(args)}
+
+
+def _var(name: str) -> dict:
+    return {"kind": "var", "name": name}
+
+
+def test_emits_unittest_case_class_and_native_assertions() -> None:
+    plan = EmitPlan(
+        contract_id="concept:eq",
+        function="identity",
+        params=["actual", "expected"],
+        param_types=["int", "int"],
+        predicates=[
+            _atomic("concept:eq", _var("actual"), _var("expected")),
+            _atomic("concept:option-is-none", _var("missing")),
+        ],
+    )
+
+    emission = emit(plan)
+
+    assert emission.path == "test_identity_contract.py"
+    assert emission.emitted_predicates == ["eq", "option-is-none"]
+    assert emission.unsupported_predicates == []
+    assert emission.is_complete
+    assert "import unittest" in emission.source
+    assert "class TestIdentityContract(unittest.TestCase):" in emission.source
+    assert "self.assertEqual(actual, expected)" in emission.source
+    assert "self.assertIsNone(missing)" in emission.source
+    assert emission.artifact_cid.startswith("blake3-512:")
+
+
+def test_unsupported_predicate_recorded_as_gap_not_emitted() -> None:
+    emission = emit(
+        EmitPlan(
+            function="f",
+            predicates=[
+                _atomic("concept:eq", _var("a"), _var("b")),
+                _atomic("concept:mystery", _var("a")),
+            ],
+        )
+    )
+
+    assert emission.emitted_predicates == ["eq"]
+    assert emission.unsupported_predicates == ["mystery"]
+    assert not emission.is_complete
+    assert "mystery" not in emission.source
+
+
+def test_from_params_accepts_rpc_shape_and_aliases() -> None:
+    plan = EmitPlan.from_params(
+        {
+            "concept_name": "concept:eq",
+            "function_name": "f",
+            "params": ["a", "b"],
+            "param_types": ["int", "int"],
+            "predicates": [_atomic("concept:eq", _var("a"), _var("b"))],
+        }
+    )
+
+    assert plan.contract_id == "concept:eq"
+    assert plan.function == "f"
+    assert plan.params == ["a", "b"]
+    assert len(plan.predicates) == 1
+

--- a/implementations/python/provekit-emit-python-unittest/tests/test_end_to_end.py
+++ b/implementations/python/provekit-emit-python-unittest/tests/test_end_to_end.py
@@ -1,0 +1,77 @@
+"""End-to-end: emit unittest source and run it with the stdlib test runner."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from provekit_emit_python_unittest.emitter import EmitPlan, emit
+
+
+def _atomic(name: str, *args: dict) -> dict:
+    return {"kind": "atomic", "name": name, "args": list(args)}
+
+
+def _var(name: str) -> dict:
+    return {"kind": "var", "name": name}
+
+
+def _run_unittest_on(source: str, tmp_path) -> subprocess.CompletedProcess:
+    module = tmp_path / "test_emitted_contract.py"
+    module.write_text(source, encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, "-m", "unittest", "discover", "-s", str(tmp_path)],
+        capture_output=True,
+        text=True,
+    )
+
+
+SUPPORTED_CASES = [
+    ("eq", _atomic("concept:eq", _var("a"), _var("b"))),
+    ("ne", _atomic("concept:ne", _var("a"), _var("b"))),
+    ("lt", _atomic("concept:lt", _var("a"), _var("b"))),
+    ("gt", _atomic("concept:gt", _var("a"), _var("b"))),
+    ("le", _atomic("concept:le", _var("a"), _var("b"))),
+    ("ge", _atomic("concept:ge", _var("a"), _var("b"))),
+    ("option-is-some", _atomic("concept:option-is-some", _var("x"))),
+    ("option-is-none", _atomic("concept:option-is-none", _var("x"))),
+    ("fallible-err", _atomic("concept:fallible-err", _var("f"))),
+]
+
+
+@pytest.mark.parametrize("name,predicate", SUPPORTED_CASES, ids=[c[0] for c in SUPPORTED_CASES])
+def test_each_supported_predicate_emits_green_unittest(name, predicate, tmp_path) -> None:
+    emission = emit(EmitPlan(function=name.replace("-", "_"), predicates=[predicate]))
+
+    assert emission.is_complete, emission.unsupported_predicates
+    result = _run_unittest_on(emission.source, tmp_path)
+    assert result.returncode == 0, (
+        f"emitted test for {name!r} failed:\n"
+        f"--- source ---\n{emission.source}\n--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+
+
+def test_multi_predicate_contract_emits_green(tmp_path) -> None:
+    emission = emit(
+        EmitPlan(
+            contract_id="concept:clamp",
+            function="clamp",
+            params=["x", "lo", "hi"],
+            param_types=["int", "int", "int"],
+            predicates=[
+                _atomic("concept:ge", _var("x"), _var("lo")),
+                _atomic("concept:le", _var("x"), _var("hi")),
+                _atomic("concept:option-is-some", _var("result")),
+            ],
+        )
+    )
+
+    assert emission.is_complete
+    result = _run_unittest_on(emission.source, tmp_path)
+    assert result.returncode == 0, (
+        f"--- source ---\n{emission.source}\n--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )

--- a/implementations/python/provekit-emit-python-unittest/tests/test_predicate_table.py
+++ b/implementations/python/provekit-emit-python-unittest/tests/test_predicate_table.py
@@ -1,0 +1,36 @@
+"""Unit tests for the inline predicate -> unittest assertion mapping."""
+
+from __future__ import annotations
+
+from provekit_emit_python_unittest import predicate_table as pt
+
+
+def _atomic(name: str, *args: dict) -> dict:
+    return {"kind": "atomic", "name": name, "args": list(args)}
+
+
+def _var(name: str) -> dict:
+    return {"kind": "var", "name": name}
+
+
+def test_binary_predicates_render_native_unittest_assertions() -> None:
+    assert pt.render(_atomic("concept:eq", _var("a"), _var("b"))) == "self.assertEqual(a, b)"
+    assert pt.render(_atomic("concept:ne", _var("a"), _var("b"))) == "self.assertNotEqual(a, b)"
+    assert pt.render(_atomic("concept:lt", _var("a"), _var("b"))) == "self.assertTrue(a < b)"
+    assert pt.render(_atomic("concept:ge", _var("a"), _var("b"))) == "self.assertTrue(a >= b)"
+
+
+def test_option_predicates_render_none_assertions() -> None:
+    assert pt.render(_atomic("concept:option-is-some", _var("x"))) == "self.assertIsNotNone(x)"
+    assert pt.render(_atomic("concept:option-is-none", _var("x"))) == "self.assertIsNone(x)"
+
+
+def test_fallible_err_renders_assert_raises_block() -> None:
+    rendered = pt.render(_atomic("concept:fallible-err", _var("call")))
+
+    assert rendered == "with self.assertRaises(Exception):\n    call()"
+
+
+def test_unsupported_predicate_or_bad_arity_returns_none() -> None:
+    assert pt.render(_atomic("concept:mystery", _var("x"))) is None
+    assert pt.render(_atomic("concept:eq", _var("x"))) is None

--- a/implementations/python/provekit-emit-python-unittest/tests/test_rpc.py
+++ b/implementations/python/provekit-emit-python-unittest/tests/test_rpc.py
@@ -1,0 +1,74 @@
+"""RPC dispatch conventions for the unittest emitter."""
+
+from __future__ import annotations
+
+import json
+
+from provekit_emit_python_unittest.rpc import dispatch
+
+
+def _atomic(name: str, *args: dict) -> dict:
+    return {"kind": "atomic", "name": name, "args": list(args)}
+
+
+def _var(name: str) -> dict:
+    return {"kind": "var", "name": name}
+
+
+def test_describe_returns_plugin_memento_shape() -> None:
+    response = dispatch({"jsonrpc": "2.0", "id": 1, "method": "provekit.plugin.describe"})
+    result = response["result"]
+    header = result["header"]
+
+    assert response["id"] == 1
+    assert set(result.keys()) == {"envelope", "header", "metadata"}
+    assert header["schemaVersion"] == "1"
+    assert "pep/1.7.0" in header["protocol_versions"]
+    assert header["content"]["target_language"] == "python"
+    assert header["content"]["target_framework"] == "unittest"
+    assert "concept:eq" in header["content"]["capabilities"]["predicates"]
+    json.dumps(response)
+
+
+def test_invoke_emits_unittest_module() -> None:
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "provekit.plugin.invoke",
+            "params": {
+                "contract_id": "concept:eq",
+                "function": "f",
+                "params": ["a", "b"],
+                "param_types": ["int", "int"],
+                "predicates": [_atomic("concept:eq", _var("a"), _var("b"))],
+            },
+        }
+    )
+    result = response["result"]
+
+    assert response["id"] == 2
+    assert result["kind"] == "unittest-test-emission"
+    assert result["path"] == "test_f_contract.py"
+    assert result["extension"] == "py"
+    assert "class TestFContract(unittest.TestCase):" in result["source"]
+    assert "self.assertEqual(a, b)" in result["source"]
+    assert result["emitted_predicates"] == ["eq"]
+    assert result["unsupported_predicates"] == []
+    assert result["is_complete"] is True
+    json.dumps(response)
+
+
+def test_invoke_reports_unsupported_gap() -> None:
+    response = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "provekit.plugin.invoke",
+            "params": {"function": "f", "predicates": [_atomic("concept:mystery", _var("a"))]},
+        }
+    )
+
+    assert response["result"]["unsupported_predicates"] == ["mystery"]
+    assert response["result"]["is_complete"] is False
+

--- a/implementations/rust/provekit-cli/tests/cmd_emit_python_unittest.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_emit_python_unittest.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn python_bin() -> String {
+    std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string())
+}
+
+fn python_available() -> bool {
+    Command::new(python_bin())
+        .args(["-c", "import blake3"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn install_emit_registration(project: &Path) {
+    let python_src = repo_root()
+        .join("implementations")
+        .join("python")
+        .join("provekit-emit-python-unittest")
+        .join("src");
+    let pythonpath = python_src
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let python = python_bin().replace('\\', "\\\\").replace('"', "\\\"");
+
+    let provekit_dir = project.join(".provekit");
+    fs::create_dir_all(&provekit_dir).expect("mkdir .provekit");
+    fs::write(
+        provekit_dir.join("config.toml"),
+        "exam_manifest_cid = \"blake3-512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"\n\
+         \n\
+         [[plugins]]\n\
+         name = \"python-unittest\"\n\
+         surface = \"python-unittest\"\n\
+         emit = \"unittest\"\n",
+    )
+    .expect("write project config");
+
+    let manifest = project
+        .join(".provekit")
+        .join("emit")
+        .join("python-unittest")
+        .join("manifest.toml");
+    fs::create_dir_all(manifest.parent().unwrap()).expect("mkdir manifest");
+    fs::write(
+        manifest,
+        format!(
+            "name = \"python-unittest\"\ncommand = [\"env\", \"PYTHONPATH={pythonpath}\", \"{python}\", \"-m\", \"provekit_emit_python_unittest\", \"--rpc\"]\nworking_dir = \".\"\nprotocol_versions = [\"pep/1.7.0\"]\n"
+        ),
+    )
+    .expect("write emit manifest");
+}
+
+#[test]
+fn emit_python_unittest_dispatches_real_emitter_and_unittest_checks_output() {
+    if !python_available() {
+        eprintln!("skipping: python3 cannot import blake3");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("project");
+    let out_dir = temp.path().join("out");
+    fs::create_dir_all(&project).expect("mkdir project");
+    fs::create_dir_all(&out_dir).expect("mkdir out");
+    install_emit_registration(&project);
+
+    let plan = project.join("plan.json");
+    fs::write(
+        &plan,
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "contract_id": "concept:eq",
+            "function": "identity",
+            "params": ["actual", "expected"],
+            "param_types": ["int", "int"],
+            "predicates": [{
+                "kind": "atomic",
+                "name": "concept:eq",
+                "args": [
+                    {"kind": "const", "value": 2, "sort": {"kind": "primitive", "name": "Int"}},
+                    {"kind": "const", "value": 2, "sort": {"kind": "primitive", "name": "Int"}}
+                ]
+            }]
+        }))
+        .expect("encode plan"),
+    )
+    .expect("write plan");
+
+    let output = Command::new(provekit_bin())
+        .arg("emit")
+        .arg("--project")
+        .arg(&project)
+        .arg("--target")
+        .arg("python")
+        .arg("--framework")
+        .arg("unittest")
+        .arg("--plan")
+        .arg(&plan)
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--compile-check")
+        .arg("--json")
+        .output()
+        .expect("spawn provekit emit python");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "provekit emit python unittest failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let receipt: Value = serde_json::from_str(&stdout).expect("emit stdout is JSON");
+    assert_eq!(receipt["ok"], true, "receipt: {receipt}");
+    assert_eq!(receipt["targetLanguage"], "python", "receipt: {receipt}");
+    assert_eq!(receipt["targetFramework"], "unittest", "receipt: {receipt}");
+    assert_eq!(receipt["isComplete"], true, "receipt: {receipt}");
+    assert_eq!(receipt["compileCheck"]["ok"], true, "receipt: {receipt}");
+
+    let emitted_path = out_dir.join("test_identity_contract.py");
+    let emitted = fs::read_to_string(&emitted_path)
+        .unwrap_or_else(|_| panic!("read emitted {}", emitted_path.display()));
+    assert!(emitted.contains("import unittest"), "emitted:\n{emitted}");
+    assert!(
+        emitted.contains("class TestIdentityContract(unittest.TestCase):"),
+        "emitted:\n{emitted}"
+    );
+    assert!(
+        emitted.contains("self.assertEqual(2, 2)"),
+        "emitted:\n{emitted}"
+    );
+}


### PR DESCRIPTION
## Summary
- add `provekit-emit-python-unittest` as a separate Python emitter artifact
- emit native `unittest.TestCase` tests and assertions from normalized predicates
- report unsupported predicates honestly with incomplete status
- add Rust CLI integration coverage for config/manifest/RPC dispatch only

## Verification
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=implementations/python/provekit-emit-python-unittest/src python3 -m pytest -p no:cacheprovider implementations/python/provekit-emit-python-unittest/tests -q`
- `PYTHONDONTWRITEBYTECODE=1 cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_emit_python_unittest -- --nocapture`
- `cargo fmt --manifest-path implementations/rust/provekit-cli/Cargo.toml --check`
- `git diff --check`