### PR TITLE
Lift more native Python unittest assertions

### DIFF
--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/layer2.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/layer2.py
@@ -329,6 +329,20 @@ def _classify_and_lift(
     if _classify_value_scope(body, test_name, source_path, out):
         return
 
+    unsupported_unittest_asserts = _unsupported_unittest_assertions(body)
+    if unsupported_unittest_asserts:
+        out.claimed_tests.add(test_name)
+        out.seen += 1
+        for name in unsupported_unittest_asserts:
+            out.warnings.append(
+                LiftWarning(
+                    source_path,
+                    test_name,
+                    f"layer2 unittest lift-gap: unsupported assertion method `{name}`",
+                )
+            )
+        return
+
     # No Layer 2 pattern claimed it. Leave for Layer 0.
 
 
@@ -349,6 +363,13 @@ _UNITTEST_BINARY_PREDICATES = {
     "assertIsNot": "≠",
 }
 
+_UNITTEST_NONE_PREDICATES = {
+    "assertIsNone": "=",
+    "assertIsNotNone": "≠",
+}
+
+_UNITTEST_TRUTH_PREDICATES = {"assertTrue", "assertFalse"}
+
 
 def _is_assertion_stmt(stmt: ast.stmt) -> bool:
     """Return True iff ``stmt`` looks like a liftable assertion in either
@@ -364,7 +385,9 @@ def _is_assertion_stmt(stmt: ast.stmt) -> bool:
             name = _attr_method_name(call.func)
             if name is not None and name in _UNITTEST_BINARY_PREDICATES:
                 return True
-            if name in ("assertTrue", "assertFalse"):
+            if name is not None and name in _UNITTEST_NONE_PREDICATES:
+                return True
+            if name in _UNITTEST_TRUTH_PREDICATES:
                 return True
     return False
 
@@ -376,6 +399,29 @@ def _attr_method_name(func: ast.expr) -> Optional[str]:
     if isinstance(func, ast.Attribute):
         return func.attr
     return None
+
+
+def _unsupported_unittest_assertions(stmts: Sequence[ast.stmt]) -> List[str]:
+    out: List[str] = []
+    for stmt in stmts:
+        if not isinstance(stmt, ast.Expr):
+            continue
+        call = stmt.value
+        if not isinstance(call, ast.Call):
+            continue
+        name = _attr_method_name(call.func)
+        if name is None:
+            continue
+        if not name.startswith("assert"):
+            continue
+        if (
+            name in _UNITTEST_BINARY_PREDICATES
+            or name in _UNITTEST_NONE_PREDICATES
+            or name in _UNITTEST_TRUTH_PREDICATES
+        ):
+            continue
+        out.append(name)
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -475,18 +521,33 @@ def _lift_assertion_stmt(stmt: ast.stmt) -> Formula:
             r = _translate_term(call.args[1])
             sym = _UNITTEST_BINARY_PREDICATES[name]
             return atomic(sym, [l, r])
+        if name in _UNITTEST_NONE_PREDICATES:
+            if len(call.args) < 1:
+                raise ValueError(f"{name} expects 1 positional arg")
+            t = _translate_term(call.args[0])
+            return atomic(_UNITTEST_NONE_PREDICATES[name], [t, ctor("None", [])])
         if name == "assertTrue":
             if len(call.args) < 1:
                 raise ValueError("assertTrue expects 1 positional arg")
-            t = _translate_term(call.args[0])
-            return eq(t, bool_const(True))
+            return _translate_truth_assertion(call.args[0], True)
         if name == "assertFalse":
             if len(call.args) < 1:
                 raise ValueError("assertFalse expects 1 positional arg")
-            t = _translate_term(call.args[0])
-            return eq(t, bool_const(False))
+            return _translate_truth_assertion(call.args[0], False)
         raise ValueError(f"unrecognized assertion method: {name!r}")
     raise ValueError("statement is not a liftable assertion")
+
+
+def _translate_truth_assertion(node: ast.expr, expected: bool) -> Formula:
+    try:
+        formula = _translate_bool_expr(node)
+    except ValueError as bool_error:
+        try:
+            t = _translate_term(node)
+        except ValueError:
+            raise bool_error
+        return eq(t, bool_const(expected))
+    return formula if expected else not_(formula)
 
 
 # ---------------------------------------------------------------------------
@@ -1263,7 +1324,9 @@ def _assertion_value_exprs(stmt: ast.stmt) -> List[ast.expr]:
         name = _attr_method_name(stmt.value.func)
         if name in _UNITTEST_BINARY_PREDICATES:
             exprs.extend(stmt.value.args[:2])
-        elif name in ("assertTrue", "assertFalse") and stmt.value.args:
+        elif name in _UNITTEST_NONE_PREDICATES and stmt.value.args:
+            exprs.append(stmt.value.args[0])
+        elif name in _UNITTEST_TRUTH_PREDICATES and stmt.value.args:
             exprs.append(stmt.value.args[0])
     return exprs
 
@@ -1344,6 +1407,11 @@ def _lift_assertion_stmt_scoped(
             l = _translate_term_scoped(call.args[0], scope, call_vars)
             r = _translate_term_scoped(call.args[1], scope, call_vars)
             return atomic(_UNITTEST_BINARY_PREDICATES[name], [l, r])
+        if name in _UNITTEST_NONE_PREDICATES:
+            if len(call.args) < 1:
+                raise ValueError(f"{name} expects 1 positional arg")
+            t = _translate_term_scoped(call.args[0], scope, call_vars)
+            return atomic(_UNITTEST_NONE_PREDICATES[name], [t, ctor("None", [])])
         if name == "assertTrue":
             if len(call.args) < 1:
                 raise ValueError("assertTrue expects 1 positional arg")

--- a/implementations/python/provekit-lift-py-tests/tests/test_daemon_protocol.py
+++ b/implementations/python/provekit-lift-py-tests/tests/test_daemon_protocol.py
@@ -59,12 +59,17 @@ _FIXTURE_PATH = "test_fixture.py"
 def _run_lsp(ndjson_input: str) -> List[dict]:
     """Spawn the LSP binary, feed ndjson_input, return parsed response lines."""
     cmd = _lsp_cmd()
+    src_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "src"))
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = src_dir if not existing else os.pathsep.join([src_dir, existing])
     result = subprocess.run(
         cmd,
         input=ndjson_input,
         capture_output=True,
         text=True,
         timeout=10,
+        env=env,
     )
     assert result.returncode == 0, (
         f"LSP binary exited {result.returncode}; stderr: {result.stderr!r}"
@@ -172,3 +177,55 @@ class TestDaemonProtocol:
         parse_resp = next(r for r in responses if r.get("id") == 2)
         assert "error" in parse_resp, "Expected error for unsupported language"
         assert parse_resp["error"]["code"] == -32602
+
+    def test_parse_plain_unittest_testcase_assertions_as_normalized_contract(self):
+        """Plain unittest.TestCase assertions lift through RPC as one contract."""
+        source = """\
+import unittest
+
+class ParserTest(unittest.TestCase):
+    def test_native_assertions(self):
+        self.assertEqual(parse_int("42"), 42)
+        self.assertNotEqual(parse_int("0"), 1)
+        self.assertTrue(parse_int("5") > 0)
+        self.assertIsNone(maybe_none())
+        self.assertIsNotNone(maybe_value())
+"""
+        responses = _run_lsp(_build_session(source=source, path="test_parser.py"))
+        parse_resp = next(r for r in responses if r.get("id") == 2)
+        assert "error" not in parse_resp, f"parse returned error: {parse_resp}"
+        decls = parse_resp["result"]["declarations"]
+        assert len(decls) == 1
+        decl = decls[0]
+        assert decl["kind"] == "contract"
+        assert decl["name"] == "test_native_assertions"
+        inv = decl["inv"]
+        assert inv["kind"] == "and"
+        assert [op["name"] for op in inv["operands"]] == ["=", "≠", ">", "=", "≠"]
+        none_atoms = [
+            op for op in inv["operands"]
+            if op["name"] in {"=", "≠"}
+            and len(op["args"]) == 2
+            and op["args"][1].get("kind") == "ctor"
+            and op["args"][1].get("name") == "None"
+        ]
+        assert len(none_atoms) == 2
+
+    def test_parse_unsupported_unittest_assertion_reports_lift_gap_warning(self):
+        """Unsupported unittest forms report a gap and do not mint a contract."""
+        source = """\
+import unittest
+
+class RegexTest(unittest.TestCase):
+    def test_regex(self):
+        self.assertRegex("abc", "a.*")
+"""
+        responses = _run_lsp(_build_session(source=source, path="test_regex.py"))
+        parse_resp = next(r for r in responses if r.get("id") == 2)
+        assert "error" not in parse_resp, f"parse returned error: {parse_resp}"
+        result = parse_resp["result"]
+        assert result["declarations"] == []
+        assert any(
+            "assertRegex" in warning["reason"] and "lift-gap" in warning["reason"]
+            for warning in result["warnings"]
+        )

--- a/implementations/python/provekit-lift-py-tests/tests/test_layer2.py
+++ b/implementations/python/provekit-lift-py-tests/tests/test_layer2.py
@@ -186,6 +186,47 @@ def test_pattern3_unittest_assertEqual_recognized():
     assert out.decls[0].name == "test_three"
 
 
+def test_pattern3_plain_unittest_testcase_assertions_lift_to_contract_atoms():
+    out = _lift("""
+        import unittest
+
+        class ParserTest(unittest.TestCase):
+            def test_native_assertions(self):
+                self.assertEqual(parse_int("42"), 42)
+                self.assertNotEqual(parse_int("0"), 1)
+                self.assertTrue(parse_int("5") > 0)
+                self.assertIsNone(maybe_none())
+                self.assertIsNotNone(maybe_value())
+    """)
+    assert out.characterization_lifted == 1, f"warnings: {out.warnings}"
+    assert out.decls[0].name == "test_native_assertions"
+    inv = out.decls[0].inv
+    assert isinstance(inv, _Connective)
+    assert inv.kind == "and"
+    atoms = list(inv.operands)
+    assert len(atoms) == 5
+    assert [atom.name for atom in atoms] == ["=", "≠", ">", "=", "≠"]
+    none_atoms = [
+        atom
+        for atom in atoms
+        if atom.name in {"=", "≠"} and isinstance(atom.args[1], _Ctor)
+    ]
+    assert [atom.args[1].name for atom in none_atoms] == ["None", "None"]
+
+
+def test_unittest_unsupported_assertion_warns_without_fake_contract():
+    out = _lift("""
+        import unittest
+
+        class RegexTest(unittest.TestCase):
+            def test_regex(self):
+                self.assertRegex("abc", "a.*")
+    """)
+    assert out.lifted == 0
+    assert "test_regex" in out.claimed_tests
+    assert any("assertRegex" in w.reason and "lift-gap" in w.reason for w in out.warnings)
+
+
 # --- Pattern 4: parametrize ---------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- expand the existing Python `py-tests` lifter surface for native `unittest.TestCase` assertions
- lift `assertIsNone`, `assertIsNotNone`, `assertTrue`, and `assertFalse` into normalized contracts
- emit structured lift-gap warnings for unsupported unittest assertions instead of fake contracts
- add package and RPC protocol coverage for normalized output and gaps

## Verification
- `python3 -m pytest implementations/python/provekit-lift-py-tests/tests -q`
- `cargo test -p provekit-cli --test cmd_mint_python_project_implications --manifest-path implementations/rust/Cargo.toml python_implication_consumer_mints_bridge_from_manifest_rpc -- --nocapture`
- `git diff --check`