### PR TITLE
Add Java AssertJ emit and lift kits

### DIFF
--- a/implementations/java/.provekit/config.toml
+++ b/implementations/java/.provekit/config.toml
@@ -17,3 +17,15 @@ name = "java-testng-lifter"
 kind = "lift"
 surface = "java-testng"
 emit = "ir-document"
+
+[[plugins]]
+name = "java-assertj-emitter"
+kind = "emit"
+surface = "java-assertj"
+emit = "assertj"
+
+[[plugins]]
+name = "java-assertj-lifter"
+kind = "lift"
+surface = "java-assertj"
+emit = "ir-document"

--- a/implementations/java/.provekit/emit/java-assertj/manifest.toml
+++ b/implementations/java/.provekit/emit/java-assertj/manifest.toml
@@ -1,0 +1,6 @@
+name = "java-assertj"
+version = "0.1.0"
+protocol_versions = ["pep/1.7.0"]
+kind = "emit"
+command = ["java", "-jar", "provekit-emit-java-assertj/target/provekit-emit-java-assertj.jar", "--rpc"]
+working_dir = "."

--- a/implementations/java/.provekit/lift/java-assertj/manifest.toml
+++ b/implementations/java/.provekit/lift/java-assertj/manifest.toml
@@ -1,0 +1,11 @@
+name = "java-assertj"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["java", "-jar", "provekit-lift-java-assertj/target/provekit-lift-java-assertj.jar", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["java-assertj"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false

--- a/implementations/java/pom.xml
+++ b/implementations/java/pom.xml
@@ -27,6 +27,7 @@
         <module>provekit-lift-java-provekit-native</module>
         <module>provekit-lift-java-junit</module>
         <module>provekit-lift-java-testng</module>
+        <module>provekit-lift-java-assertj</module>
         <module>provekit-lift-java-jml</module>
         <module>provekit-lift-java-cofoja</module>
         <module>provekit-lift-java-spring-web</module>
@@ -39,6 +40,7 @@
         <module>provekit-realize-java-core</module>
         <module>provekit-emit-java-junit</module>
         <module>provekit-emit-java-testng</module>
+        <module>provekit-emit-java-assertj</module>
         <module>provekit-lift-java-integration-tests</module>
     </modules>
 

--- a/implementations/java/provekit-emit-java-assertj/pom.xml
+++ b/implementations/java/provekit-emit-java-assertj/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.provekit</groupId>
+        <artifactId>provekit-lift-java-parent</artifactId>
+        <version>0.1.0</version>
+    </parent>
+    <artifactId>provekit-emit-java-assertj</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.provekit</groupId>
+            <artifactId>provekit-ir</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.26.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals><goal>shade</goal></goals>
+                        <configuration>
+                            <outputFile>${project.build.directory}/provekit-emit-java-assertj.jar</outputFile>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.provekit.emit.assertj.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/implementations/java/provekit-emit-java-assertj/src/main/java/com/provekit/emit/assertj/AssertJEmitter.java
+++ b/implementations/java/provekit-emit-java-assertj/src/main/java/com/provekit/emit/assertj/AssertJEmitter.java
@@ -1,0 +1,269 @@
+package com.provekit.emit.assertj;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import com.provekit.ir.Blake3;
+import com.provekit.ir.Jcs;
+
+/**
+ * Emits an AssertJ-backed JUnit test class from an {@link EmitPlan}.
+ *
+ * <p>The output is a self-contained java compilation unit: imports for
+ * {@code org.junit.jupiter.api.Test} and a static import of AssertJ's
+ * {@code assertThat}, a {@code <Function>ContractTest} class, and one
+ * {@code @Test} method per supported predicate whose body asserts that
+ * predicate via the inline {@link PredicateAssertionTable} mapping.
+ *
+ * <p>Substrate-honest: predicates this kit cannot spell are NOT emitted as
+ * vacuously-passing tests. They are collected as {@code unsupported}
+ * diagnostics so the substrate can record an honest "emit-assertion-gap"
+ * per unhandled predicate.
+ */
+public final class AssertJEmitter {
+
+    /** The emission result: source text, per-predicate gaps, and a CID. */
+    public record Emission(
+        String source,
+        String path,
+        String artifactCid,
+        List<String> emittedPredicates,
+        List<String> unsupportedPredicates
+    ) {
+        public Emission {
+            emittedPredicates = List.copyOf(emittedPredicates);
+            unsupportedPredicates = List.copyOf(unsupportedPredicates);
+        }
+
+        public boolean isComplete() {
+            return unsupportedPredicates.isEmpty() && !emittedPredicates.isEmpty();
+        }
+
+        public String toJson() {
+            StringBuilder sb = new StringBuilder("{");
+            sb.append("\"kind\":\"assertj-test-emission\"");
+            sb.append(",\"source\":").append(jsonString(source));
+            sb.append(",\"path\":").append(jsonString(path));
+            sb.append(",\"extension\":\"java\"");
+            sb.append(",\"emitted_artifact_cid\":").append(jsonString(artifactCid));
+            sb.append(",\"emitted_predicates\":").append(jsonStringArray(emittedPredicates));
+            sb.append(",\"unsupported_predicates\":").append(jsonStringArray(unsupportedPredicates));
+            sb.append(",\"is_complete\":").append(isComplete());
+            return sb.append('}').toString();
+        }
+    }
+
+    /** Emit an AssertJ-backed test class for the contract described by {@code plan}. */
+    public Emission emit(EmitPlan plan) {
+        String className = toPascalCase(plan.function()) + "ContractTest";
+
+        // Map declared formal -> java type, parallel arrays from the plan.
+        Map<String, String> declaredTypes = new LinkedHashMap<>();
+        List<String> formals = plan.params();
+        List<String> formalTypes = plan.paramTypes();
+        for (int i = 0; i < formals.size(); i++) {
+            String t = i < formalTypes.size() ? formalTypes.get(i) : "int";
+            declaredTypes.put(formals.get(i), t == null || t.isBlank() ? "int" : t);
+        }
+
+        List<String> emitted = new ArrayList<>();
+        List<String> unsupported = new ArrayList<>();
+        List<String> methods = new ArrayList<>();
+
+        int idx = 0;
+        for (Jcs.Obj predicate : plan.predicates()) {
+            String head = PredicateAssertionTable.headOf(predicate);
+            Optional<String> assertion = PredicateAssertionTable.render(predicate);
+            if (assertion.isEmpty()) {
+                unsupported.add(head == null ? "<malformed>" : head);
+                continue;
+            }
+            emitted.add(head);
+            // Each emitted @Test method is self-contained: it declares
+            // placeholder locals for every free variable the predicate
+            // references so the assertion compiles standalone. The catalog
+            // contract is about the SHAPE of the assertion, not runtime
+            // values; placeholders are the type-correct stand-ins.
+            List<String> declarations = freeVarDeclarations(predicate, head, declaredTypes);
+            methods.add(renderTestMethod(methodName(head, idx), declarations, assertion.get()));
+            idx++;
+        }
+
+        String source = renderClass(className, methods);
+        String cid = Blake3.blake3_512(source.getBytes(StandardCharsets.UTF_8));
+        return new Emission(source, className + ".java", cid, emitted, unsupported);
+    }
+
+    /**
+     * Build placeholder local-variable declarations for every free variable
+     * referenced by the predicate term, in deterministic encounter order.
+     * Type resolution, in priority order:
+     * <ol>
+     *   <li>the declared formal type from the function signature, if the
+     *       variable is a known parameter;</li>
+     *   <li>a per-predicate default driven by the assertion's java surface:
+     *       reference type ({@code Object}) for nullness predicates,
+     *       {@code int} for ordering/equality comparisons.</li>
+     * </ol>
+     */
+    private List<String> freeVarDeclarations(
+            Jcs.Obj predicate, String head, Map<String, String> declaredTypes) {
+        Set<String> vars = new LinkedHashSet<>();
+        collectVars(predicate, vars);
+        String fallbackType = defaultTypeFor(head);
+        List<String> decls = new ArrayList<>();
+        for (String v : vars) {
+            String type = declaredTypes.getOrDefault(v, fallbackType);
+            decls.add(type + " " + v + " = " + defaultValueFor(type) + ";");
+        }
+        return decls;
+    }
+
+    /** Walk a term tree collecting {@code kind:"var"} names in encounter order. */
+    private static void collectVars(Jcs.Json term, Set<String> out) {
+        if (!(term instanceof Jcs.Obj obj)) return;
+        String kind = obj.stringFieldOrNull("kind");
+        if ("var".equals(kind)) {
+            String name = obj.stringFieldOrNull("name");
+            if (name != null && !name.isBlank()) out.add(name);
+            return;
+        }
+        Jcs.Json args = obj.get("args");
+        if (args instanceof Jcs.Arr arr) {
+            for (Jcs.Json a : arr.values()) collectVars(a, out);
+        }
+    }
+
+    /** Default placeholder type when a variable is not a declared formal. */
+    private static String defaultTypeFor(String head) {
+        if (head == null) return "int";
+        switch (head) {
+            case "option-is-some":
+            case "option-is-none":
+            case "not-null":
+                return "Object";
+            default:
+                return "int"; // eq/ne/lt/gt/le/ge: numeric comparison surface
+        }
+    }
+
+    private static String defaultValueFor(String type) {
+        switch (type) {
+            case "int":
+            case "long":
+            case "short":
+            case "byte":
+                return "0";
+            case "double":
+            case "float":
+                return "0.0";
+            case "boolean":
+                return "false";
+            case "char":
+                return "'\\0'";
+            default:
+                return "null"; // reference types: Object, String, etc.
+        }
+    }
+
+    private String renderClass(String className, List<String> methods) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("import org.junit.jupiter.api.Test;\n");
+        sb.append("import static org.assertj.core.api.Assertions.assertThat;\n");
+        sb.append('\n');
+        sb.append("public class ").append(className).append(" {\n");
+        for (int i = 0; i < methods.size(); i++) {
+            if (i > 0) sb.append('\n');
+            sb.append(methods.get(i));
+        }
+        sb.append("}\n");
+        return sb.toString();
+    }
+
+    private String renderTestMethod(
+            String methodName, List<String> declarations, String assertionStmt) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("    @Test\n");
+        sb.append("    void ").append(methodName).append("() {\n");
+        for (String decl : declarations) {
+            sb.append("        ").append(decl).append('\n');
+        }
+        sb.append("        ").append(assertionStmt).append('\n');
+        sb.append("    }\n");
+        return sb.toString();
+    }
+
+    private String methodName(String head, int idx) {
+        // verifies<Head>[_<idx>] in camelCase; idx disambiguates repeats.
+        String safe = head == null ? "predicate" : head.replace('-', '_');
+        StringBuilder sb = new StringBuilder("verifies");
+        boolean up = true;
+        for (int i = 0; i < safe.length(); i++) {
+            char c = safe.charAt(i);
+            if (c == '_') {
+                up = true;
+            } else if (up) {
+                sb.append(Character.toUpperCase(c));
+                up = false;
+            } else {
+                sb.append(c);
+            }
+        }
+        sb.append('_').append(idx);
+        return sb.toString();
+    }
+
+    /** PascalCase from a snake/camel/kebab function name. */
+    static String toPascalCase(String name) {
+        if (name == null || name.isBlank()) return "Contract";
+        StringBuilder sb = new StringBuilder();
+        boolean up = true;
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+            if (c == '_' || c == '-' || c == '.') {
+                up = true;
+            } else if (up) {
+                sb.append(Character.toUpperCase(c));
+                up = false;
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.length() == 0 ? "Contract" : sb.toString();
+    }
+
+    private static String jsonString(String s) {
+        if (s == null) return "null";
+        StringBuilder sb = new StringBuilder("\"");
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"' -> sb.append("\\\"");
+                case '\\' -> sb.append("\\\\");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                default -> {
+                    if (c < 0x20) sb.append(String.format("\\u%04x", (int) c));
+                    else sb.append(c);
+                }
+            }
+        }
+        return sb.append('"').toString();
+    }
+
+    private static String jsonStringArray(List<String> items) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < items.size(); i++) {
+            if (i > 0) sb.append(',');
+            sb.append(jsonString(items.get(i)));
+        }
+        return sb.append(']').toString();
+    }
+}

--- a/implementations/java/provekit-emit-java-assertj/src/main/java/com/provekit/emit/assertj/EmitPlan.java
+++ b/implementations/java/provekit-emit-java-assertj/src/main/java/com/provekit/emit/assertj/EmitPlan.java
@@ -1,0 +1,90 @@
+package com.provekit.emit.assertj;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.provekit.ir.Jcs;
+
+/**
+ * The emit request: a contract's neutral predicates plus the target function
+ * signature. Mirrors the {@code RealizerPlan} shape in
+ * {@code provekit-realize-java-core} but is SMALLER: this kit emits test
+ * assertions, not function bodies.
+ *
+ * <p>JSON shape (the RPC {@code params} object):
+ * <pre>
+ * {
+ *   "contract_id":   "concept:eq",          // concept name OR CID; informational
+ *   "function":      "clamp",               // target function name (snake/camel)
+ *   "params":        ["x", "lo", "hi"],     // formal parameter names
+ *   "param_types":   ["int", "int", "int"], // java parameter types (parallel to params)
+ *   "predicates": [                          // neutral predicate terms (catalog form)
+ *     {"kind":"op","name":"concept:ge","args":[
+ *        {"kind":"var","name":"x"},{"kind":"var","name":"lo"}]},
+ *     {"kind":"op","name":"concept:le","args":[
+ *        {"kind":"var","name":"x"},{"kind":"var","name":"hi"}]}
+ *   ]
+ * }
+ * </pre>
+ *
+ * <p>The {@code predicates} array carries the neutral form that flows between
+ * languages: {@code kind:"op"}, {@code name:"concept:<head>"}, {@code args}
+ * = term subtrees. This kit also tolerates the harvester's internal
+ * {@code kind:"atomic"} / bare-name form. The kit reads ONLY which predicate
+ * it is emitting from the catalog concept name; the AssertJ spelling is
+ * inline java in {@link PredicateAssertionTable}.
+ */
+public record EmitPlan(
+    String contractId,
+    String function,
+    List<String> params,
+    List<String> paramTypes,
+    List<Jcs.Obj> predicates
+) {
+    public EmitPlan {
+        params = List.copyOf(params);
+        paramTypes = List.copyOf(paramTypes);
+        predicates = List.copyOf(predicates);
+    }
+
+    /** Parse an EmitPlan from the RPC params object (a JSON object string). */
+    public static EmitPlan fromParams(String paramsJson) {
+        Jcs.Json doc = Jcs.parse(paramsJson);
+        if (!(doc instanceof Jcs.Obj obj)) {
+            return new EmitPlan("", "test", List.of(), List.of(), List.of());
+        }
+        String contractId = orEmpty(obj.stringFieldOrNull("contract_id"),
+            obj.stringFieldOrNull("concept_name"));
+        String function = orEmpty(obj.stringFieldOrNull("function"),
+            obj.stringFieldOrNull("function_name"));
+        if (function.isBlank()) function = "test";
+
+        List<String> params = stringArray(obj.get("params"));
+        List<String> paramTypes = stringArray(obj.get("param_types"));
+
+        List<Jcs.Obj> predicates = new ArrayList<>();
+        Jcs.Json preds = obj.get("predicates");
+        if (preds instanceof Jcs.Arr arr) {
+            for (Jcs.Json p : arr.values()) {
+                if (p instanceof Jcs.Obj po) predicates.add(po);
+            }
+        }
+        return new EmitPlan(contractId, function, params, paramTypes, predicates);
+    }
+
+    private static List<String> stringArray(Jcs.Json json) {
+        List<String> out = new ArrayList<>();
+        if (json instanceof Jcs.Arr arr) {
+            for (Jcs.Json v : arr.values()) {
+                if (v instanceof Jcs.Str s) out.add(s.value());
+            }
+        }
+        return out;
+    }
+
+    private static String orEmpty(String first, String second) {
+        if (first != null && !first.isBlank()) return first;
+        if (second != null && !second.isBlank()) return second;
+        return "";
+    }
+}

--- a/implementations/java/provekit-emit-java-assertj/src/main/java/com/provekit/emit/assertj/Main.java
+++ b/implementations/java/provekit-emit-java-assertj/src/main/java/com/provekit/emit/assertj/Main.java
@@ -1,0 +1,28 @@
+package com.provekit.emit.assertj;
+
+/**
+ * Entry point for the provekit-emit-java-assertj PEP 1.7.0 emit-plugin.
+ *
+ * <p>Usage: {@code provekit-emit-java-assertj --rpc}
+ *
+ * <p>Runs a newline-delimited JSON-RPC server on stdin/stdout (see
+ * {@link RpcServer}).
+ */
+public final class Main {
+    private Main() {}
+
+    public static void main(String[] args) {
+        boolean rpc = false;
+        for (String arg : args) {
+            if ("--rpc".equals(arg)) {
+                rpc = true;
+                break;
+            }
+        }
+        if (!rpc) {
+            System.err.println("Usage: provekit-emit-java-assertj --rpc");
+            System.exit(1);
+        }
+        new RpcServer().run();
+    }
+}

--- a/implementations/java/provekit-emit-java-assertj/src/main/java/com/provekit/emit/assertj/PredicateAssertionTable.java
+++ b/implementations/java/provekit-emit-java-assertj/src/main/java/com/provekit/emit/assertj/PredicateAssertionTable.java
@@ -1,0 +1,142 @@
+package com.provekit.emit.assertj;
+
+import java.util.Optional;
+
+import com.provekit.ir.Jcs;
+
+/**
+ * INLINE predicate -> AssertJ assertion mapping.
+ *
+ * <p>This is the heart of the emitter: the fact that {@code concept:eq}
+ * spells as AssertJ's fluent
+ * {@code assertThat(a).isEqualTo(b)}
+ * is JAVA FRAMEWORK KNOWLEDGE, written here in java code. It is NOT substrate
+ * data. There is no catalog memento family for this mapping and no catalog
+ * read for the framework spelling.
+ *
+ * <p>The mapping is the inverse of {@code provekit-lift-java-assertj}'s
+ * {@code AssertJExtractor}, which recognizes these same assertions and lifts
+ * them back to neutral predicates. If the two ever want to share the table
+ * it becomes a normal java module dependency, never a substrate catalog
+ * memento.
+ *
+ * <p>Supported neutral predicates (catalog spelling, with the {@code concept:}
+ * prefix stripped by {@link AssertJEmitter}):
+ * <ul>
+ *   <li>{@code eq(a, b)}            -> {@code assertThat(a).isEqualTo(b)}</li>
+ *   <li>{@code ne(a, b)}            -> {@code assertThat(a).isNotEqualTo(b)}</li>
+ *   <li>{@code lt(a, b)}            -> {@code assertThat(a).isLessThan(b)}</li>
+ *   <li>{@code gt(a, b)}            -> {@code assertThat(a).isGreaterThan(b)}</li>
+ *   <li>{@code le(a, b)}            -> {@code assertThat(a).isLessThanOrEqualTo(b)}</li>
+ *   <li>{@code ge(a, b)}            -> {@code assertThat(a).isGreaterThanOrEqualTo(b)}</li>
+ *   <li>{@code option-is-some(x)}   -> {@code assertThat(x).isNotNull()}</li>
+ *   <li>{@code option-is-none(x)}   -> {@code assertThat(x).isNull()}</li>
+ * </ul>
+ */
+final class PredicateAssertionTable {
+    private PredicateAssertionTable() {}
+
+    /**
+     * Render a single neutral predicate term as one AssertJ assertion statement
+     * (no trailing newline, no indentation). The term is the catalog-form
+     * op node: {@code {"kind":"op"|"atomic","name":"concept:eq","args":[...]}}.
+     *
+     * <p>Returns {@code Optional.empty()} if the predicate head is not in this
+     * kit's table or the arity is wrong — substrate-honest: an unsupported
+     * predicate is NOT silently dropped into a passing assertion; the caller
+     * surfaces it as an unemitted gap.
+     */
+    static Optional<String> render(Jcs.Obj predicate) {
+        String head = headOf(predicate);
+        if (head == null) return Optional.empty();
+        java.util.List<Jcs.Json> args = argsOf(predicate);
+
+        switch (head) {
+            case "eq":
+                return binary(args, (a, b) -> "assertThat(" + a + ").isEqualTo(" + b + ");");
+            case "ne":
+            case "neq": // extractor internal spelling; accept both
+                return binary(args, (a, b) -> "assertThat(" + a + ").isNotEqualTo(" + b + ");");
+            case "lt":
+                return binary(args, (a, b) -> "assertThat(" + a + ").isLessThan(" + b + ");");
+            case "gt":
+                return binary(args, (a, b) -> "assertThat(" + a + ").isGreaterThan(" + b + ");");
+            case "le":
+            case "lte":
+                return binary(args, (a, b) -> "assertThat(" + a + ").isLessThanOrEqualTo(" + b + ");");
+            case "ge":
+            case "gte":
+                return binary(args, (a, b) -> "assertThat(" + a + ").isGreaterThanOrEqualTo(" + b + ");");
+            case "option-is-some":
+            case "not-null":
+                return unary(args, x -> "assertThat(" + x + ").isNotNull();");
+            case "option-is-none":
+                return unary(args, x -> "assertThat(" + x + ").isNull();");
+            default:
+                return Optional.empty();
+        }
+    }
+
+    /** True if this kit can emit an assertion for the given predicate head. */
+    static boolean supports(String head) {
+        if (head == null) return false;
+        switch (head) {
+            case "eq":
+            case "ne":
+            case "neq":
+            case "lt":
+            case "gt":
+            case "le":
+            case "lte":
+            case "ge":
+            case "gte":
+            case "option-is-some":
+            case "not-null":
+            case "option-is-none":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * The predicate head with the {@code concept:} prefix stripped, or
+     * {@code null} if the node is malformed. Accepts both the catalog form
+     * ({@code kind:"op"}, {@code name:"concept:eq"}) and the harvester's
+     * internal form ({@code kind:"atomic"}, {@code name:"eq"}).
+     */
+    static String headOf(Jcs.Obj predicate) {
+        String name = predicate.stringFieldOrNull("name");
+        if (name == null || name.isBlank()) return null;
+        return name.startsWith("concept:") ? name.substring("concept:".length()) : name;
+    }
+
+    private static java.util.List<Jcs.Json> argsOf(Jcs.Obj predicate) {
+        Jcs.Json args = predicate.get("args");
+        if (args instanceof Jcs.Arr arr) return arr.values();
+        return java.util.List.of();
+    }
+
+    private interface Binary {
+        String render(String a, String b);
+    }
+
+    private interface Unary {
+        String render(String x);
+    }
+
+    private static Optional<String> binary(java.util.List<Jcs.Json> args, Binary f) {
+        if (args.size() != 2) return Optional.empty();
+        Optional<String> a = TermRenderer.render(args.get(0));
+        Optional<String> b = TermRenderer.render(args.get(1));
+        if (a.isEmpty() || b.isEmpty()) return Optional.empty();
+        return Optional.of(f.render(a.get(), b.get()));
+    }
+
+    private static Optional<String> unary(java.util.List<Jcs.Json> args, Unary f) {
+        if (args.size() != 1) return Optional.empty();
+        Optional<String> x = TermRenderer.render(args.get(0));
+        if (x.isEmpty()) return Optional.empty();
+        return Optional.of(f.render(x.get()));
+    }
+}

--- a/implementations/java/provekit-emit-java-assertj/src/main/java/com/provekit/emit/assertj/RpcServer.java
+++ b/implementations/java/provekit-emit-java-assertj/src/main/java/com/provekit/emit/assertj/RpcServer.java
@@ -1,0 +1,295 @@
+package com.provekit.emit.assertj;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import com.provekit.ir.Blake3;
+import com.provekit.ir.Jcs;
+
+/**
+ * PEP 1.7.0 newline-delimited JSON-RPC server for the AssertJ emitter plugin.
+ *
+ * <p>Reads one JSON-RPC request per line on stdin, writes one response per
+ * line to stdout. Supported methods:
+ * <ul>
+ *   <li>{@code provekit.plugin.describe}  - plugin self-description.</li>
+ *   <li>{@code provekit.plugin.invoke}    - emit an AssertJ test class from an
+ *       {@link EmitPlan} carried in {@code params}; returns an
+ *       {@link AssertJEmitter.Emission}.</li>
+ *   <li>{@code provekit.plugin.shutdown}  - exit.</li>
+ * </ul>
+ *
+ * <p>Mirrors the RpcServer shape in {@code provekit-realize-java-core} but is
+ * deliberately smaller: there is no body-emit, no assembly, no platform
+ * semantics. The emitter is a predicate -> assertion table plus a
+ * test-class shell.
+ */
+public final class RpcServer {
+
+    /**
+     * The plugin-memento {@code header.content} payload (§4.2.1) for this
+     * kit's {@code provekit.plugin.describe} response. This is the kit's
+     * capability self-description: which neutral predicates it can emit
+     * AssertJ assertions for. It is INLINE plugin self-description, NOT a
+     * substrate catalog memento; framework knowledge stays in the kit.
+     *
+     * <p>It is the single source of truth for both the describe response and
+     * the {@link #PLUGIN_CID} computation. JCS-canonicalizing this exact
+     * object (with the surrounding header fields, {@code cid} elided) and
+     * BLAKE3-512 hashing it MUST reproduce {@link #PLUGIN_CID} — enforced by
+     * {@code RpcServerDescribeTest}. Changing it requires re-minting the CID
+     * (via {@code mint-plugin-cid}) and updating the constant.
+     */
+    static final String CONTENT_JSON =
+        "{"
+        + "\"emits\":\"assertj-assertions\","
+        + "\"predicates\":["
+        + "\"concept:eq\",\"concept:ne\",\"concept:lt\",\"concept:gt\","
+        + "\"concept:le\",\"concept:ge\",\"concept:option-is-some\","
+        + "\"concept:option-is-none\""
+        + "],"
+        + "\"target_framework\":\"assertj\","
+        + "\"target_language\":\"java\""
+        + "}";
+
+    static final String KIND = "emit";
+    static final boolean CRITICAL = false;
+    static final String VERSION = "0.1.0";
+    static final List<String> PROTOCOL_VERSIONS = List.of("pep/1.7.0");
+    static final String PROVENANCE_CID =
+        "blake3-512:00000000000000000000000000000000000000000000000000000000"
+        + "00000000000000000000000000000000000000000000000000000000000000000000000000";
+
+    /**
+     * PEP 1.7.0 plugin CID for this kit's describe header. Pre-computed by
+     * {@code mint-plugin-cid} over the §6.1 cid-input
+     * (JCS of {@code {content, critical, kind, protocol_versions,
+     * provenance_cid, schemaVersion, version}}; the {@code cid} field is
+     * elided). The strict loader ({@code provekit-plugin-loader/src/loader.rs})
+     * recomputes and compares this; a mismatch refuses the load. Kept in lockstep
+     * with {@link #CONTENT_JSON} by {@code RpcServerDescribeTest}, which recomputes
+     * the CID in java (provekit-ir Jcs + Blake3, which are byte-identical to the
+     * rust canonicalizer) and asserts equality.
+     */
+    static final String PLUGIN_CID =
+        "blake3-512:be588f510c4af01b068e2925246d84a766cc2e01e64039ccd1311669fb51"
+        + "f15791b2a0da8d8ddc07791e77e76b333c062860af00d7dceaa9cf98dfbcf0294032";
+
+    private final BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+    private final PrintWriter out = new PrintWriter(System.out, true);
+    private final AssertJEmitter emitter = new AssertJEmitter();
+
+    public void run() {
+        try {
+            String line;
+            while ((line = in.readLine()) != null) {
+                String trimmed = line.trim();
+                if (!trimmed.isEmpty()) handle(trimmed);
+            }
+        } catch (IOException e) {
+            System.err.println("emit-java-assertj RPC read error: " + e.getMessage());
+        }
+    }
+
+    private void handle(String line) {
+        String id = "null";
+        String method = "";
+        String params = "{}";
+        try {
+            Jcs.Json doc = Jcs.parse(line);
+            if (doc instanceof Jcs.Obj obj) {
+                Jcs.Json idJson = obj.get("id");
+                if (idJson instanceof Jcs.Num n) id = Long.toString(n.value());
+                else if (idJson instanceof Jcs.Str s) id = "\"" + s.value() + "\"";
+                method = obj.stringFieldOrNull("method");
+                if (method == null) method = "";
+                Jcs.Json p = obj.get("params");
+                if (p instanceof Jcs.Obj) params = Jcs.encode(p);
+            }
+        } catch (RuntimeException e) {
+            sendError(id, -32700, "parse error: " + e.getMessage());
+            return;
+        }
+
+        try {
+            switch (method) {
+                case "provekit.plugin.describe" -> sendResponse(id, describeResult());
+                case "provekit.plugin.invoke" -> {
+                    EmitPlan plan = EmitPlan.fromParams(params);
+                    AssertJEmitter.Emission emission = emitter.emit(plan);
+                    sendResponse(id, emission.toJson());
+                }
+                case "provekit.plugin.check" -> sendResponse(id, checkResult(params));
+                case "provekit.plugin.shutdown" -> {
+                    sendResponse(id, "null");
+                    System.exit(0);
+                }
+                default -> sendError(id, -32601, "unknown method: " + method);
+            }
+        } catch (Exception e) {
+            sendError(id, -32000,
+                e.getMessage() != null ? e.getMessage() : e.getClass().getName());
+        }
+    }
+
+    /**
+     * Plugin self-description per PEP 1.7.0 §4.2.1: the JSON-RPC {@code result}
+     * IS the plugin-memento body, an enveloped {@code {envelope, header,
+     * metadata}} object. The strict loader
+     * ({@code provekit-plugin-loader/src/loader.rs}) shape-validates these three
+     * keys, deserializes the header, checks {@code schemaVersion == "1"},
+     * checks {@code protocol_versions} intersects the runtime set, and
+     * recomputes {@code header.cid} via §6.1 — refusing the load on any
+     * mismatch. This response satisfies all of those so the kit loads through
+     * the standard plugin loader (required by the #1436 retirement gauntlet,
+     * which invokes this emitter through that loader).
+     *
+     * <p>Mirrors the enveloped shape of {@code provekit-realize-java-core}'s
+     * {@code describeResult()}. The envelope signature is the all-zero
+     * placeholder (the v0 loader parses but does not yet verify signatures).
+     */
+    String describeResult() {
+        return "{"
+            + "\"envelope\":{"
+            + "\"declaredAt\":\"2026-05-23T00:00:00.000Z\","
+            + "\"signature\":\"ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\","
+            + "\"signer\":\"ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\""
+            + "},"
+            + "\"header\":{"
+            + "\"cid\":\"" + PLUGIN_CID + "\","
+            + "\"content\":" + CONTENT_JSON + ","
+            + "\"critical\":" + CRITICAL + ","
+            + "\"kind\":\"" + KIND + "\","
+            + "\"protocol_versions\":[\"pep/1.7.0\"],"
+            + "\"provenance_cid\":\"" + PROVENANCE_CID + "\","
+            + "\"schemaVersion\":\"1\","
+            + "\"version\":\"" + VERSION + "\""
+            + "},"
+            + "\"metadata\":{"
+            + "\"note\":\"Emits AssertJ assertions that verify a contract's neutral predicates. Predicate->assertion mapping is inline Java framework knowledge.\""
+            + "}"
+            + "}";
+    }
+
+    /**
+     * Recompute this kit's plugin CID exactly as the rust loader does (§6.1):
+     * BLAKE3-512 of the JCS encoding of the cid-input map
+     * {@code {content, critical, kind, protocol_versions, provenance_cid,
+     * schemaVersion, version}} (the {@code cid} field is elided;
+     * {@code protocol_versions} sorted ascending). provekit-ir's {@link Jcs}
+     * encoder is byte-identical to rust's {@code provekit_canonicalizer}
+     * (lexicographic codepoint key sort, integer rendering, RFC 8259 string
+     * escaping), so this reproduces {@link #PLUGIN_CID}.
+     */
+    static String computePluginCid() {
+        Jcs.Json content = Jcs.parse(CONTENT_JSON);
+        List<String> pv = new ArrayList<>(PROTOCOL_VERSIONS);
+        Collections.sort(pv);
+        List<Jcs.Json> pvJson = new ArrayList<>();
+        for (String v : pv) pvJson.add(Jcs.string(v));
+
+        LinkedHashMap<String, Jcs.Json> fields = new LinkedHashMap<>();
+        fields.put("content", content);
+        fields.put("critical", Jcs.bool(CRITICAL));
+        fields.put("kind", Jcs.string(KIND));
+        fields.put("protocol_versions", Jcs.array(pvJson));
+        fields.put("provenance_cid", Jcs.string(PROVENANCE_CID));
+        fields.put("schemaVersion", Jcs.string("1"));
+        fields.put("version", Jcs.string(VERSION));
+
+        List<Jcs.Field> fieldList = new ArrayList<>();
+        for (var e : fields.entrySet()) fieldList.add(new Jcs.Field(e.getKey(), e.getValue()));
+        Jcs.Obj input = new Jcs.Obj(fieldList);
+        return Blake3.blake3_512(Jcs.encodeUtf8(input));
+    }
+
+    private String checkResult(String paramsJson) throws IOException, InterruptedException {
+        Jcs.Json parsed = Jcs.parse(paramsJson);
+        if (!(parsed instanceof Jcs.Obj obj)) {
+            throw new IllegalArgumentException("params must be an object");
+        }
+        String outDir = obj.stringFieldOrNull("out_dir");
+        if (outDir == null || outDir.isBlank()) {
+            throw new IllegalArgumentException("missing out_dir");
+        }
+        File projectRoot = findAncestorFile(new File(outDir), "pom.xml");
+        if (projectRoot == null) {
+            throw new IllegalArgumentException(
+                "assertj check requires a pom.xml at or above " + outDir);
+        }
+
+        Process process = new ProcessBuilder("mvn", "-q", "test")
+            .directory(projectRoot)
+            .start();
+        CompletableFuture<byte[]> stdoutFuture = readAllBytesAsync(process.getInputStream());
+        CompletableFuture<byte[]> stderrFuture = readAllBytesAsync(process.getErrorStream());
+        int exitCode = process.waitFor();
+        byte[] stdout = joinBytes(stdoutFuture);
+        byte[] stderr = joinBytes(stderrFuture);
+
+        Jcs.Obj result = Jcs.object(
+            "ok", Jcs.bool(exitCode == 0),
+            "command", Jcs.string("mvn -q test"),
+            "cwd", Jcs.string(projectRoot.getPath()),
+            "stdout", Jcs.string(new String(stdout, StandardCharsets.UTF_8)),
+            "stderr", Jcs.string(new String(stderr, StandardCharsets.UTF_8)),
+            "exitCode", Jcs.integer(exitCode)
+        );
+        return Jcs.encode(result);
+    }
+
+    private static CompletableFuture<byte[]> readAllBytesAsync(InputStream stream) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return stream.readAllBytes();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+    }
+
+    private static byte[] joinBytes(CompletableFuture<byte[]> future) throws IOException {
+        try {
+            return future.join();
+        } catch (CompletionException e) {
+            if (e.getCause() instanceof UncheckedIOException io) throw io.getCause();
+            throw e;
+        }
+    }
+
+    private static File findAncestorFile(File start, String filename) {
+        File cursor = start;
+        while (cursor != null) {
+            if (new File(cursor, filename).exists()) return cursor;
+            cursor = cursor.getParentFile();
+        }
+        return null;
+    }
+
+    private void sendResponse(String id, String result) {
+        out.println("{\"jsonrpc\":\"2.0\",\"id\":" + id + ",\"result\":" + result + "}");
+    }
+
+    private void sendError(String id, int code, String message) {
+        out.println("{\"jsonrpc\":\"2.0\",\"id\":" + id
+            + ",\"error\":{\"code\":" + code + ",\"message\":\"" + escape(message) + "\"}}");
+    }
+
+    private static String escape(String s) {
+        if (s == null) return "";
+        return s.replace("\\", "\\\\").replace("\"", "\\\"")
+            .replace("\n", "\\n").replace("\r", "\\r");
+    }
+}

--- a/implementations/java/provekit-emit-java-assertj/src/main/java/com/provekit/emit/assertj/TermRenderer.java
+++ b/implementations/java/provekit-emit-java-assertj/src/main/java/com/provekit/emit/assertj/TermRenderer.java
@@ -1,0 +1,112 @@
+package com.provekit.emit.assertj;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.provekit.ir.Jcs;
+
+/**
+ * Render a neutral term subtree (the {@code args} of a predicate) into a java
+ * expression string.
+ *
+ * <p>The neutral term forms are the catalog's:
+ * <ul>
+ *   <li>{@code {"kind":"var","name":"x"}}            -> {@code x}</li>
+ *   <li>{@code {"kind":"const","value":7,"sort":{...}}} -> {@code 7}</li>
+ *   <li>{@code {"kind":"const","value":"hi",...}}     -> {@code "hi"}</li>
+ *   <li>{@code {"kind":"const","value":null,...}}     -> {@code null}</li>
+ *   <li>{@code {"kind":"ctor"|"op","name":"+","args":[a,b]}} (arithmetic)
+ *       -> {@code (a + b)}</li>
+ *   <li>{@code {"kind":"ctor"|"op","name":"foo","args":[a]}} (call)
+ *       -> {@code foo(a)}</li>
+ * </ul>
+ *
+ * <p>Substrate-honest: a term shape this renderer does not understand yields
+ * {@code Optional.empty()} so the caller can refuse rather than emit a
+ * silently-wrong expression.
+ */
+final class TermRenderer {
+    private TermRenderer() {}
+
+    private static final java.util.Set<String> ARITHMETIC =
+        java.util.Set.of("+", "-", "*", "/", "%");
+
+    static Optional<String> render(Jcs.Json term) {
+        if (!(term instanceof Jcs.Obj obj)) return Optional.empty();
+        String kind = obj.stringFieldOrNull("kind");
+        if (kind == null) return Optional.empty();
+        switch (kind) {
+            case "var":
+                return renderVar(obj);
+            case "const":
+                return renderConst(obj);
+            case "ctor":
+            case "op":
+                return renderApplication(obj);
+            default:
+                return Optional.empty();
+        }
+    }
+
+    private static Optional<String> renderVar(Jcs.Obj obj) {
+        String name = obj.stringFieldOrNull("name");
+        return (name == null || name.isBlank()) ? Optional.empty() : Optional.of(name);
+    }
+
+    private static Optional<String> renderConst(Jcs.Obj obj) {
+        Jcs.Json value = obj.get("value");
+        if (value == null) return Optional.empty();
+        if (value instanceof Jcs.Null) return Optional.of("null");
+        if (value instanceof Jcs.Bool b) return Optional.of(Boolean.toString(b.value()));
+        if (value instanceof Jcs.Num n) return Optional.of(Long.toString(n.value()));
+        if (value instanceof Jcs.Str s) return Optional.of(quote(s.value()));
+        return Optional.empty();
+    }
+
+    private static Optional<String> renderApplication(Jcs.Obj obj) {
+        String name = obj.stringFieldOrNull("name");
+        if (name == null || name.isBlank()) return Optional.empty();
+        // Strip a concept: prefix if a nested op carries one (defensive).
+        if (name.startsWith("concept:")) name = name.substring("concept:".length());
+
+        List<String> args = new ArrayList<>();
+        Jcs.Json rawArgs = obj.get("args");
+        if (rawArgs instanceof Jcs.Arr arr) {
+            for (Jcs.Json a : arr.values()) {
+                Optional<String> r = render(a);
+                if (r.isEmpty()) return Optional.empty();
+                args.add(r.get());
+            }
+        }
+
+        // Infix arithmetic operators.
+        if (ARITHMETIC.contains(name) && args.size() == 2) {
+            return Optional.of("(" + args.get(0) + " " + name + " " + args.get(1) + ")");
+        }
+
+        // Otherwise: a method/constructor call expression.
+        StringBuilder sb = new StringBuilder(name).append('(');
+        for (int i = 0; i < args.size(); i++) {
+            if (i > 0) sb.append(", ");
+            sb.append(args.get(i));
+        }
+        return Optional.of(sb.append(')').toString());
+    }
+
+    private static String quote(String s) {
+        StringBuilder sb = new StringBuilder("\"");
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"' -> sb.append("\\\"");
+                case '\\' -> sb.append("\\\\");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                default -> sb.append(c);
+            }
+        }
+        return sb.append('"').toString();
+    }
+}

--- a/implementations/java/provekit-emit-java-assertj/src/test/java/com/provekit/emit/assertj/AssertJEmitterTest.java
+++ b/implementations/java/provekit-emit-java-assertj/src/test/java/com/provekit/emit/assertj/AssertJEmitterTest.java
@@ -1,0 +1,181 @@
+package com.provekit.emit.assertj;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import javax.tools.JavaCompiler;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.ToolProvider;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.provekit.ir.Jcs;
+
+class AssertJEmitterTest {
+    @TempDir
+    Path tmp;
+
+    @Test
+    void emitsAssertJFluentAssertionsForNeutralPredicates() throws Exception {
+        Object emission = emit(plan(List.of(
+            predicate("concept:eq", var("a"), var("b")),
+            predicate("concept:ne", var("a"), var("b")),
+            predicate("concept:lt", var("a"), var("b")),
+            predicate("concept:gt", var("a"), var("b")),
+            predicate("concept:option-is-some", var("o")),
+            predicate("concept:option-is-none", var("o"))
+        )));
+
+        String source = source(emission);
+
+        assertTrue(source.contains("import org.junit.jupiter.api.Test;"), source);
+        assertTrue(source.contains("import static org.assertj.core.api.Assertions.assertThat;"), source);
+        assertTrue(source.contains("assertThat(a).isEqualTo(b);"), source);
+        assertTrue(source.contains("assertThat(a).isNotEqualTo(b);"), source);
+        assertTrue(source.contains("assertThat(a).isLessThan(b);"), source);
+        assertTrue(source.contains("assertThat(a).isGreaterThan(b);"), source);
+        assertTrue(source.contains("assertThat(o).isNotNull();"), source);
+        assertTrue(source.contains("assertThat(o).isNull();"), source);
+        assertEquals(List.of("eq", "ne", "lt", "gt", "option-is-some", "option-is-none"),
+            emittedPredicates(emission));
+        assertTrue(unsupportedPredicates(emission).isEmpty());
+        assertTrue(isComplete(emission));
+    }
+
+    @Test
+    void unsupportedPredicatesAreReportedAndNotEmittedAsPassingTests() throws Exception {
+        Object emission = emit(plan(List.of(
+            predicate("concept:eq", var("a"), var("b")),
+            predicate("concept:mystery", var("a"))
+        )));
+
+        String source = source(emission);
+
+        assertEquals(List.of("eq"), emittedPredicates(emission));
+        assertEquals(List.of("mystery"), unsupportedPredicates(emission));
+        assertFalse(isComplete(emission));
+        assertFalse(source.contains("mystery"), source);
+    }
+
+    @Test
+    void emittedAssertJSourceCompilesWithJUnitRunnerAndAssertJApi() throws Exception {
+        Object emission = emit(plan(List.of(
+            predicate("concept:eq", cInt(2), cInt(2)),
+            predicate("concept:option-is-some", cStr("present"))
+        )));
+
+        compileGenerated(source(emission), path(emission).replace(".java", ""));
+    }
+
+    private Object emit(Object plan) throws Exception {
+        Class<?> emitterClass = Class.forName("com.provekit.emit.assertj.AssertJEmitter");
+        Object emitter = emitterClass.getConstructor().newInstance();
+        Method emit = emitterClass.getMethod("emit", plan.getClass());
+        return emit.invoke(emitter, plan);
+    }
+
+    private Object plan(List<Jcs.Obj> predicates) throws Exception {
+        Class<?> planClass = Class.forName("com.provekit.emit.assertj.EmitPlan");
+        Constructor<?> ctor = planClass.getConstructor(
+            String.class, String.class, List.class, List.class, List.class);
+        return ctor.newInstance(
+            "concept:eq",
+            "compare",
+            List.of("a", "b", "o"),
+            List.of("int", "int", "Object"),
+            predicates
+        );
+    }
+
+    private String source(Object emission) throws Exception {
+        return (String) emission.getClass().getMethod("source").invoke(emission);
+    }
+
+    private String path(Object emission) throws Exception {
+        return (String) emission.getClass().getMethod("path").invoke(emission);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> emittedPredicates(Object emission) throws Exception {
+        return (List<String>) emission.getClass().getMethod("emittedPredicates").invoke(emission);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> unsupportedPredicates(Object emission) throws Exception {
+        return (List<String>) emission.getClass().getMethod("unsupportedPredicates").invoke(emission);
+    }
+
+    private boolean isComplete(Object emission) throws Exception {
+        return (boolean) emission.getClass().getMethod("isComplete").invoke(emission);
+    }
+
+    private void compileGenerated(String source, String className) throws IOException {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        assertNotNull(compiler, "system java compiler unavailable; run tests on a JDK");
+        Path out = tmp.resolve("classes");
+        Files.createDirectories(out);
+        int rc = compiler.getTask(
+            null,
+            null,
+            null,
+            List.of("-classpath", System.getProperty("java.class.path"), "-d", out.toString()),
+            null,
+            List.of(new SourceFile(className, source))
+        ).call() ? 0 : 1;
+        assertEquals(0, rc, "emitted AssertJ source failed to compile:\n" + source);
+        assertTrue(Files.exists(out.resolve(className + ".class")));
+    }
+
+    private static Jcs.Obj predicate(String name, Jcs.Json... args) {
+        return Jcs.object(
+            "kind", Jcs.string("op"),
+            "name", Jcs.string(name),
+            "args", Jcs.array(List.of(args))
+        );
+    }
+
+    private static Jcs.Obj var(String name) {
+        return Jcs.object("kind", Jcs.string("var"), "name", Jcs.string(name));
+    }
+
+    private static Jcs.Obj cInt(long value) {
+        return Jcs.object(
+            "kind", Jcs.string("const"),
+            "value", Jcs.integer(value),
+            "sort", Jcs.object("kind", Jcs.string("primitive"), "name", Jcs.string("Int"))
+        );
+    }
+
+    private static Jcs.Obj cStr(String value) {
+        return Jcs.object(
+            "kind", Jcs.string("const"),
+            "value", Jcs.string(value),
+            "sort", Jcs.object("kind", Jcs.string("primitive"), "name", Jcs.string("String"))
+        );
+    }
+
+    private static final class SourceFile extends SimpleJavaFileObject {
+        private final String source;
+
+        SourceFile(String className, String source) {
+            super(URI.create("string:///" + className + ".java"), Kind.SOURCE);
+            this.source = source;
+        }
+
+        @Override
+        public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+            return source;
+        }
+    }
+}

--- a/implementations/java/provekit-emit-java-assertj/src/test/java/com/provekit/emit/assertj/RpcServerDescribeTest.java
+++ b/implementations/java/provekit-emit-java-assertj/src/test/java/com/provekit/emit/assertj/RpcServerDescribeTest.java
@@ -1,0 +1,30 @@
+package com.provekit.emit.assertj;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.provekit.ir.Jcs;
+
+class RpcServerDescribeTest {
+    @Test
+    void pluginCidMatchesInlineAssertJCapabilityDocument() {
+        assertEquals(RpcServer.computePluginCid(), RpcServer.PLUGIN_CID);
+    }
+
+    @Test
+    void describeAdvertisesAssertJOnly() {
+        Jcs.Json parsed = Jcs.parse(new RpcServer().describeResult());
+        assertTrue(parsed instanceof Jcs.Obj);
+        Jcs.Obj obj = (Jcs.Obj) parsed;
+        Jcs.Obj header = (Jcs.Obj) obj.get("header");
+        Jcs.Obj content = (Jcs.Obj) header.get("content");
+
+        assertEquals("emit", header.stringFieldOrNull("kind"));
+        assertEquals("assertj", content.stringFieldOrNull("target_framework"));
+        assertEquals("java", content.stringFieldOrNull("target_language"));
+        assertTrue(Jcs.encode(content).contains("\"concept:eq\""));
+        assertTrue(Jcs.encode(content).contains("\"concept:option-is-none\""));
+    }
+}

--- a/implementations/java/provekit-lift-java-assertj/pom.xml
+++ b/implementations/java/provekit-lift-java-assertj/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.provekit</groupId>
+        <artifactId>provekit-lift-java-parent</artifactId>
+        <version>0.1.0</version>
+    </parent>
+    <artifactId>provekit-lift-java-assertj</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.provekit</groupId>
+            <artifactId>provekit-lift-java-core</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals><goal>shade</goal></goals>
+                        <configuration>
+                            <outputFile>${project.build.directory}/provekit-lift-java-assertj.jar</outputFile>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.provekit.lift.Main</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/implementations/java/provekit-lift-java-assertj/src/main/java/com/provekit/lift/assertj/AssertJExtractor.java
+++ b/implementations/java/provekit-lift-java-assertj/src/main/java/com/provekit/lift/assertj/AssertJExtractor.java
@@ -1,0 +1,695 @@
+package com.provekit.lift.assertj;
+
+import java.util.*;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.body.BodyDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.IfStmt;
+import com.github.javaparser.ast.stmt.Statement;
+import com.provekit.lift.AnnotationSupport;
+import com.provekit.lift.ContractDecl;
+import com.provekit.lift.Extractor;
+
+public class AssertJExtractor implements Extractor {
+    private static final Set<String> JUPITER_TESTS = Set.of("Test", "RepeatedTest");
+    private static final Set<String> JUPITER_PARAM_TESTS = Set.of("ParameterizedTest");
+    private static final Set<String> ASSERTIONS = Set.of(
+        "isEqualTo", "isNotEqualTo", "isLessThan", "isGreaterThan",
+        "isLessThanOrEqualTo", "isGreaterThanOrEqualTo", "isNull", "isNotNull"
+    );
+
+    public String name() { return "assertj"; }
+
+    public List<ContractDecl> extract(CompilationUnit cu, String rawSource) {
+        List<ContractDecl> out = new ArrayList<>();
+        String sourceFile = sourceFileName(cu);
+        for (TypeDeclaration<?> type : cu.getTypes()) {
+            for (BodyDeclaration<?> member : type.getMembers()) {
+                if (member instanceof MethodDeclaration method && isAssertJTest(cu, method)) {
+                    extractMethod(cu, method, sourceFile, out);
+                }
+            }
+        }
+        return out;
+    }
+
+    private boolean isAssertJTest(CompilationUnit cu, MethodDeclaration method) {
+        for (AnnotationExpr ann : method.getAnnotations()) {
+            if (AnnotationSupport.belongsToFamily(
+                    cu, ann, "org.junit.jupiter.api", JUPITER_TESTS, Set.of())) {
+                return true;
+            }
+            if (AnnotationSupport.belongsToFamily(
+                    cu, ann, "org.junit.jupiter.params", JUPITER_PARAM_TESTS, Set.of())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void extractMethod(
+            CompilationUnit cu,
+            MethodDeclaration method,
+            String sourceFile,
+            List<ContractDecl> out) {
+        if (method.getBody().isEmpty()) return;
+
+        Map<String, Integer> versions = new LinkedHashMap<>();
+        List<ValueScope> scopes = List.of(new ValueScope());
+
+        for (Statement stmt : method.getBody().get().getStatements()) {
+            List<LiftedAssertion> assertions = liftAssertion(cu, stmt, scopes, sourceFile);
+            for (LiftedAssertion assertion : assertions) {
+                out.add(new ContractDecl(
+                    assertion.symbol(),
+                    List.of(),
+                    List.of(),
+                    List.of(assertion.formula())
+                ));
+            }
+            if (!assertions.isEmpty()) continue;
+            scopes = applyStatement(stmt, scopes, versions);
+        }
+    }
+
+    private List<LiftedAssertion> liftAssertion(
+            CompilationUnit cu,
+            Statement stmt,
+            List<ValueScope> scopes,
+            String sourceFile) {
+        if (!stmt.isExpressionStmt()) return List.of();
+        Expression expr = stmt.asExpressionStmt().getExpression();
+        if (!(expr instanceof MethodCallExpr call)) return List.of();
+        Optional<Expression> subject = assertThatSubject(cu, call);
+        if (subject.isEmpty()) return List.of();
+
+        String name = call.getNameAsString();
+        Map<String, List<String>> scopedByCallsite = new LinkedHashMap<>();
+        for (ValueScope scope : scopes) {
+            Optional<ObservedCall> observedCall = observedCallForAssertion(subject.get(), scope);
+            if (observedCall.isEmpty()) return List.of();
+            Optional<String> symbol = callsiteSymbol(sourceFile, observedCall.get().call());
+            if (symbol.isEmpty()) return List.of();
+            ValueScope assertionScope = scope.withTermOverrides(observedCall.get().termOverrides());
+            Optional<String> consequent = switch (name) {
+                case "isEqualTo" -> liftBinaryAssertion(call, subject.get(), assertionScope, "eq");
+                case "isNotEqualTo" -> liftBinaryAssertion(call, subject.get(), assertionScope, "neq");
+                case "isLessThan" -> liftBinaryAssertion(call, subject.get(), assertionScope, "lt");
+                case "isGreaterThan" -> liftBinaryAssertion(call, subject.get(), assertionScope, "gt");
+                case "isLessThanOrEqualTo" -> liftBinaryAssertion(call, subject.get(), assertionScope, "lte");
+                case "isGreaterThanOrEqualTo" -> liftBinaryAssertion(call, subject.get(), assertionScope, "gte");
+                case "isNull" -> liftNullnessAssertion(call, subject.get(), assertionScope, false);
+                case "isNotNull" -> liftNullnessAssertion(call, subject.get(), assertionScope, true);
+                default -> Optional.empty();
+            };
+            if (consequent.isEmpty()) return List.of();
+            scopedByCallsite
+                .computeIfAbsent(symbol.get(), ignored -> new ArrayList<>())
+                .add(assertionScope.wrapExcluding(observedCall.get().sourceLocals(), consequent.get()));
+        }
+        List<LiftedAssertion> lifted = new ArrayList<>();
+        for (Map.Entry<String, List<String>> entry : scopedByCallsite.entrySet()) {
+            List<String> scoped = entry.getValue();
+            if (!scoped.isEmpty()) {
+                lifted.add(new LiftedAssertion(
+                    entry.getKey(),
+                    scoped.size() == 1 ? scoped.get(0) : and(scoped)
+                ));
+            }
+        }
+        return lifted;
+    }
+
+    private Optional<String> liftBinaryAssertion(
+            MethodCallExpr call,
+            Expression subject,
+            ValueScope scope,
+            String op) {
+        if (call.getArguments().size() != 1) return Optional.empty();
+        Optional<String> actual = liftTerm(subject, scope);
+        Optional<String> expected = liftTerm(call.getArgument(0), scope);
+        if (expected.isEmpty() || actual.isEmpty()) return Optional.empty();
+        return Optional.of(atom(op, actual.get(), expected.get()));
+    }
+
+    private Optional<String> liftNullnessAssertion(
+            MethodCallExpr call,
+            Expression subject,
+            ValueScope scope,
+            boolean notNull) {
+        if (!call.getArguments().isEmpty()) return Optional.empty();
+        Optional<String> actual = liftTerm(subject, scope);
+        if (actual.isEmpty()) return Optional.empty();
+        return Optional.of(atom(notNull ? "neq" : "eq", actual.get(), cNull()));
+    }
+
+    private Optional<Expression> assertThatSubject(CompilationUnit cu, MethodCallExpr call) {
+        String name = call.getNameAsString();
+        if (!ASSERTIONS.contains(name)) return Optional.empty();
+        if (call.getScope().isEmpty()) return Optional.empty();
+
+        Expression scope = unwrap(call.getScope().get());
+        if (!(scope instanceof MethodCallExpr assertThat)) return Optional.empty();
+        if (!"assertThat".equals(assertThat.getNameAsString())) return Optional.empty();
+        if (assertThat.getArguments().size() != 1) return Optional.empty();
+        if (!isAssertThatCall(cu, assertThat)) return Optional.empty();
+        return Optional.of(assertThat.getArgument(0));
+    }
+
+    private boolean isAssertThatCall(CompilationUnit cu, MethodCallExpr call) {
+        if (call.getScope().isEmpty()) {
+            return hasStaticAssertThatImport(cu);
+        }
+
+        String scope = call.getScope().get().toString();
+        if (scope.equals("org.assertj.core.api.Assertions")) {
+            return true;
+        }
+        if (scope.equals("Assertions")) {
+            return hasAssertJAssertionsImport(cu);
+        }
+        return scope.endsWith(".Assertions") && scope.contains("assertj");
+    }
+
+    private boolean hasStaticAssertThatImport(CompilationUnit cu) {
+        for (ImportDeclaration importDecl : cu.getImports()) {
+            if (!importDecl.isStatic()) continue;
+            String imported = importDecl.getNameAsString();
+            if (importDecl.isAsterisk() && imported.equals("org.assertj.core.api.Assertions")) {
+                return true;
+            }
+            if (!importDecl.isAsterisk()
+                    && imported.equals("org.assertj.core.api.Assertions.assertThat")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasAssertJAssertionsImport(CompilationUnit cu) {
+        for (ImportDeclaration importDecl : cu.getImports()) {
+            if (importDecl.isStatic()) continue;
+            if (importDecl.getNameAsString().equals("org.assertj.core.api.Assertions")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<ValueScope> applyStatement(
+            Statement stmt,
+            List<ValueScope> scopes,
+            Map<String, Integer> versions) {
+        if (stmt.isBlockStmt()) {
+            return applyBlock(stmt.asBlockStmt(), scopes, versions);
+        }
+        if (stmt.isIfStmt()) {
+            return applyIf(stmt.asIfStmt(), scopes, versions);
+        }
+        if (!stmt.isExpressionStmt()) {
+            return scopes;
+        }
+
+        Expression expr = stmt.asExpressionStmt().getExpression();
+        if (expr instanceof VariableDeclarationExpr decl) {
+            return applyVariableDeclaration(decl, scopes, versions);
+        }
+        if (expr instanceof AssignExpr assign && assign.getOperator() == AssignExpr.Operator.ASSIGN) {
+            return applyAssignment(assign, scopes, versions);
+        }
+        return scopes;
+    }
+
+    private List<ValueScope> applyBlock(
+            BlockStmt block,
+            List<ValueScope> scopes,
+            Map<String, Integer> versions) {
+        List<ValueScope> current = scopes;
+        for (Statement child : block.getStatements()) {
+            current = applyStatement(child, current, versions);
+        }
+        return current;
+    }
+
+    private List<ValueScope> applyIf(
+            IfStmt stmt,
+            List<ValueScope> scopes,
+            Map<String, Integer> versions) {
+        List<ValueScope> out = new ArrayList<>();
+
+        for (ValueScope scope : scopes) {
+            String guard = liftFormula(stmt.getCondition(), scope)
+                .orElseGet(() -> opaqueBranchCondition(stmt.getCondition()));
+            ValueScope thenScope = scope.copy();
+            thenScope.facts.add(new ScopeFact(guard, null));
+            out.addAll(applyStatement(stmt.getThenStmt(), List.of(thenScope), versions));
+
+            ValueScope elseScope = scope.copy();
+            elseScope.facts.add(new ScopeFact(not(guard), null));
+            if (stmt.getElseStmt().isPresent()) {
+                out.addAll(applyStatement(stmt.getElseStmt().get(), List.of(elseScope), versions));
+            } else {
+                out.add(elseScope);
+            }
+        }
+
+        return out;
+    }
+
+    private List<ValueScope> applyVariableDeclaration(
+            VariableDeclarationExpr decl,
+            List<ValueScope> scopes,
+            Map<String, Integer> versions) {
+        List<ValueScope> out = new ArrayList<>();
+        for (ValueScope scope : scopes) {
+            ValueScope next = scope.copy();
+            for (VariableDeclarator varDecl : decl.getVariables()) {
+                String name = varDecl.getNameAsString();
+                next.locals.add(name);
+                if (varDecl.getInitializer().isPresent()) {
+                    bind(next, name, varDecl.getInitializer().get(), versions);
+                } else {
+                    next.current.remove(name);
+                    next.calls.remove(name);
+                }
+            }
+            out.add(next);
+        }
+        return out;
+    }
+
+    private List<ValueScope> applyAssignment(
+            AssignExpr assign,
+            List<ValueScope> scopes,
+            Map<String, Integer> versions) {
+        if (!(assign.getTarget() instanceof NameExpr target)) return scopes;
+
+        List<ValueScope> out = new ArrayList<>();
+        for (ValueScope scope : scopes) {
+            ValueScope next = scope.copy();
+            bind(next, target.getNameAsString(), assign.getValue(), versions);
+            out.add(next);
+        }
+        return out;
+    }
+
+    private void bind(
+            ValueScope scope,
+            String name,
+            Expression expr,
+            Map<String, Integer> versions) {
+        scope.locals.add(name);
+        Optional<String> lifted = liftTerm(expr, scope);
+        if (lifted.isEmpty()) {
+            scope.current.remove(name);
+            scope.calls.remove(name);
+            return;
+        }
+
+        int version = versions.getOrDefault(name, 0);
+        versions.put(name, version + 1);
+        String ssaName = name + "$" + version;
+        String ssaVar = var(ssaName);
+        scope.current.put(name, ssaVar);
+        scope.calls.remove(name);
+        Expression unwrapped = unwrap(expr);
+        if (unwrapped instanceof MethodCallExpr call) {
+            scope.calls.put(name, new ObservedCall(call, lifted.get(), Map.of(), Set.of()));
+        }
+        scope.facts.add(new ScopeFact(atom("eq", ssaVar, lifted.get()), name));
+    }
+
+    private Optional<String> liftFormula(Expression expr, ValueScope scope) {
+        expr = unwrap(expr);
+        if (expr instanceof BinaryExpr binary) {
+            Optional<String> op = binaryFormulaOp(binary.getOperator());
+            if (op.isPresent()) {
+                Optional<String> left = liftTerm(binary.getLeft(), scope);
+                Optional<String> right = liftTerm(binary.getRight(), scope);
+                if (left.isEmpty() || right.isEmpty()) return Optional.empty();
+                return Optional.of(atom(op.get(), left.get(), right.get()));
+            }
+            if (binary.getOperator() == BinaryExpr.Operator.AND) {
+                Optional<String> left = liftFormula(binary.getLeft(), scope);
+                Optional<String> right = liftFormula(binary.getRight(), scope);
+                if (left.isEmpty() || right.isEmpty()) return Optional.empty();
+                return Optional.of(and(List.of(left.get(), right.get())));
+            }
+            if (binary.getOperator() == BinaryExpr.Operator.OR) {
+                Optional<String> left = liftFormula(binary.getLeft(), scope);
+                Optional<String> right = liftFormula(binary.getRight(), scope);
+                if (left.isEmpty() || right.isEmpty()) return Optional.empty();
+                return Optional.of(or(List.of(left.get(), right.get())));
+            }
+        }
+        Optional<String> term = liftTerm(expr, scope);
+        return term.map(t -> atom("eq", t, cBool(true)));
+    }
+
+    private Optional<String> liftTerm(Expression expr, ValueScope scope) {
+        expr = unwrap(expr);
+        if (expr instanceof NameExpr name) {
+            String simple = name.getNameAsString();
+            if (scope.termOverrides.containsKey(simple)) {
+                return Optional.of(scope.termOverrides.get(simple));
+            }
+            if (scope.locals.contains(simple)) {
+                return Optional.ofNullable(scope.current.get(simple));
+            }
+            return Optional.of(var(simple));
+        }
+        if (expr instanceof IntegerLiteralExpr intLit) {
+            return Optional.of(cInt(intLit.asNumber().longValue()));
+        }
+        if (expr instanceof LongLiteralExpr longLit) {
+            return Optional.of(cInt(longLit.asNumber().longValue()));
+        }
+        if (expr instanceof StringLiteralExpr strLit) {
+            return Optional.of(cStr(strLit.getValue()));
+        }
+        if (expr instanceof BooleanLiteralExpr boolLit) {
+            return Optional.of(cBool(boolLit.getValue()));
+        }
+        if (expr instanceof NullLiteralExpr) {
+            return Optional.of(cNull());
+        }
+        if (expr instanceof UnaryExpr unary
+                && unary.getOperator() == UnaryExpr.Operator.MINUS
+                && unary.getExpression() instanceof IntegerLiteralExpr intLit) {
+            return Optional.of(cInt(-intLit.asNumber().longValue()));
+        }
+        if (expr instanceof MethodCallExpr call) {
+            return liftMethodCallTerm(call, scope);
+        }
+        if (expr instanceof FieldAccessExpr field) {
+            return Optional.of(ctor(field.toString()));
+        }
+        if (expr instanceof BinaryExpr binary) {
+            Optional<String> op = binaryTermOp(binary.getOperator());
+            if (op.isEmpty()) return Optional.empty();
+            Optional<String> left = liftTerm(binary.getLeft(), scope);
+            Optional<String> right = liftTerm(binary.getRight(), scope);
+            if (left.isEmpty() || right.isEmpty()) return Optional.empty();
+            return Optional.of(ctor(op.get(), left.get(), right.get()));
+        }
+        return Optional.empty();
+    }
+
+    private Optional<ObservedCall> observedCallForAssertion(Expression subject, ValueScope scope) {
+        return observedCallForValue(subject, scope);
+    }
+
+    private Optional<ObservedCall> observedCallForValue(Expression expr, ValueScope scope) {
+        expr = unwrap(expr);
+        if (expr instanceof MethodCallExpr call) {
+            Optional<String> term = liftTerm(call, scope);
+            return term.map(t -> new ObservedCall(call, t, Map.of(), Set.of()));
+        }
+        if (expr instanceof NameExpr name) {
+            ObservedCall bound = scope.calls.get(name.getNameAsString());
+            if (bound != null) return Optional.of(bound.withLocalOverride(name.getNameAsString()));
+        }
+        return Optional.empty();
+    }
+
+    private List<ObservedCall> observedCallsInFormula(Expression expr, ValueScope scope) {
+        Optional<ObservedCall> direct = observedCallForValue(expr, scope);
+        if (direct.isPresent()) return List.of(direct.get());
+
+        expr = unwrap(expr);
+        if (expr instanceof UnaryExpr unary) {
+            return observedCallsInFormula(unary.getExpression(), scope);
+        }
+        if (expr instanceof BinaryExpr binary) {
+            List<ObservedCall> calls = new ArrayList<>();
+            calls.addAll(observedCallsInFormula(binary.getLeft(), scope));
+            calls.addAll(observedCallsInFormula(binary.getRight(), scope));
+            return calls;
+        }
+        return List.of();
+    }
+
+    private Optional<String> callsiteSymbol(String sourceFile, MethodCallExpr call) {
+        return call.getRange().map(range ->
+            call.getNameAsString()
+                + "@"
+                + sourceFile
+                + ":"
+                + range.begin.line
+                + ":"
+                + range.begin.column
+        );
+    }
+
+    private String sourceFileName(CompilationUnit cu) {
+        if (cu.getStorage().isPresent()) {
+            return cu.getStorage().get().getPath().getFileName().toString();
+        }
+        return cu.getPrimaryTypeName()
+            .or(() -> cu.getTypes().stream().findFirst().map(type -> type.getNameAsString()))
+            .map(name -> name + ".java")
+            .orElse("<unknown>.java");
+    }
+
+    private Expression unwrap(Expression expr) {
+        while (expr instanceof EnclosedExpr enclosed) {
+            expr = enclosed.getInner();
+        }
+        return expr;
+    }
+
+    private Optional<String> liftMethodCallTerm(MethodCallExpr call, ValueScope scope) {
+        List<String> args = new ArrayList<>();
+        String name = call.getNameAsString();
+
+        if (call.getScope().isPresent()) {
+            Expression recv = call.getScope().get();
+            if (recv instanceof NameExpr nameExpr && startsUppercase(nameExpr.getNameAsString())) {
+                name = nameExpr.getNameAsString() + "." + name;
+            } else if (recv instanceof FieldAccessExpr fieldAccess) {
+                name = fieldAccess.toString() + "." + name;
+            } else {
+                Optional<String> recvTerm = liftTerm(recv, scope);
+                if (recvTerm.isEmpty()) return Optional.empty();
+                args.add(recvTerm.get());
+            }
+        }
+
+        for (Expression arg : call.getArguments()) {
+            Optional<String> lifted = liftTerm(arg, scope);
+            if (lifted.isEmpty()) return Optional.empty();
+            args.add(lifted.get());
+        }
+        return Optional.of(ctor(name, args));
+    }
+
+    private Optional<String> binaryFormulaOp(BinaryExpr.Operator op) {
+        return switch (op) {
+            case EQUALS -> Optional.of("eq");
+            case NOT_EQUALS -> Optional.of("neq");
+            case GREATER -> Optional.of("gt");
+            case GREATER_EQUALS -> Optional.of("gte");
+            case LESS -> Optional.of("lt");
+            case LESS_EQUALS -> Optional.of("lte");
+            default -> Optional.empty();
+        };
+    }
+
+    private Optional<String> binaryTermOp(BinaryExpr.Operator op) {
+        return switch (op) {
+            case PLUS -> Optional.of("+");
+            case MINUS -> Optional.of("-");
+            case MULTIPLY -> Optional.of("*");
+            case DIVIDE -> Optional.of("/");
+            case REMAINDER -> Optional.of("%");
+            default -> Optional.empty();
+        };
+    }
+
+    private String opaqueBranchCondition(Expression expr) {
+        return atom("assertj_branch_condition", cStr(expr.toString()));
+    }
+
+    private boolean startsUppercase(String s) {
+        return !s.isEmpty() && Character.isUpperCase(s.charAt(0));
+    }
+
+    private static final class ValueScope {
+        final Map<String, String> current;
+        final Set<String> locals;
+        final List<ScopeFact> facts;
+        final Map<String, ObservedCall> calls;
+        final Map<String, String> termOverrides;
+
+        ValueScope() {
+            this(
+                new LinkedHashMap<>(),
+                new LinkedHashSet<>(),
+                new ArrayList<>(),
+                new LinkedHashMap<>(),
+                new LinkedHashMap<>()
+            );
+        }
+
+        private ValueScope(
+                Map<String, String> current,
+                Set<String> locals,
+                List<ScopeFact> facts,
+                Map<String, ObservedCall> calls,
+                Map<String, String> termOverrides) {
+            this.current = current;
+            this.locals = locals;
+            this.facts = facts;
+            this.calls = calls;
+            this.termOverrides = termOverrides;
+        }
+
+        ValueScope copy() {
+            return new ValueScope(
+                new LinkedHashMap<>(current),
+                new LinkedHashSet<>(locals),
+                new ArrayList<>(facts),
+                new LinkedHashMap<>(calls),
+                new LinkedHashMap<>(termOverrides)
+            );
+        }
+
+        String wrap(String consequent) {
+            return wrapExcluding(Set.of(), consequent);
+        }
+
+        String wrapExcluding(Set<String> excludedLocals, String consequent) {
+            List<String> formulas = new ArrayList<>();
+            for (ScopeFact fact : facts) {
+                if (fact.localName() == null || !excludedLocals.contains(fact.localName())) {
+                    formulas.add(fact.formula());
+                }
+            }
+            if (formulas.isEmpty()) return consequent;
+            return implies(formulas.size() == 1 ? formulas.get(0) : and(formulas), consequent);
+        }
+
+        ValueScope withTermOverrides(Map<String, String> overrides) {
+            ValueScope next = copy();
+            next.termOverrides.putAll(overrides);
+            return next;
+        }
+    }
+
+    private static String var(String name) {
+        return "{\"kind\":\"var\",\"name\":\"" + esc(name) + "\"}";
+    }
+
+    private static String cInt(long value) {
+        return "{\"kind\":\"const\",\"value\":" + value
+            + ",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"}}";
+    }
+
+    private static String cStr(String value) {
+        return "{\"kind\":\"const\",\"value\":\"" + esc(value)
+            + "\",\"sort\":{\"kind\":\"primitive\",\"name\":\"String\"}}";
+    }
+
+    private static String cBool(boolean value) {
+        return "{\"kind\":\"const\",\"value\":" + value
+            + ",\"sort\":{\"kind\":\"primitive\",\"name\":\"Bool\"}}";
+    }
+
+    private static String cNull() {
+        return "{\"kind\":\"const\",\"value\":null,\"sort\":{\"kind\":\"primitive\",\"name\":\"Ref\"}}";
+    }
+
+    private static String ctor(String name, String... args) {
+        return ctor(name, Arrays.asList(args));
+    }
+
+    private static String ctor(String name, List<String> args) {
+        StringBuilder sb = new StringBuilder("{\"kind\":\"ctor\",\"name\":\"")
+            .append(esc(name))
+            .append("\",\"args\":[");
+        for (int i = 0; i < args.size(); i++) {
+            if (i > 0) sb.append(",");
+            sb.append(args.get(i));
+        }
+        return sb.append("]}").toString();
+    }
+
+    private static String atom(String name, String... args) {
+        return atom(name, Arrays.asList(args));
+    }
+
+    private static String atom(String name, List<String> args) {
+        StringBuilder sb = new StringBuilder("{\"kind\":\"atomic\",\"name\":\"")
+            .append(esc(name))
+            .append("\",\"args\":[");
+        for (int i = 0; i < args.size(); i++) {
+            if (i > 0) sb.append(",");
+            sb.append(args.get(i));
+        }
+        return sb.append("]}").toString();
+    }
+
+    private static String and(List<String> operands) {
+        return connective("and", operands);
+    }
+
+    private static String and(String... operands) {
+        return connective("and", Arrays.asList(operands));
+    }
+
+    private static String or(List<String> operands) {
+        return connective("or", operands);
+    }
+
+    private static String not(String operand) {
+        return connective("not", List.of(operand));
+    }
+
+    private static String implies(String antecedent, String consequent) {
+        return connective("implies", List.of(antecedent, consequent));
+    }
+
+    private static String connective(String kind, List<String> operands) {
+        StringBuilder sb = new StringBuilder("{\"kind\":\"")
+            .append(kind)
+            .append("\",\"operands\":[");
+        for (int i = 0; i < operands.size(); i++) {
+            if (i > 0) sb.append(",");
+            sb.append(operands.get(i));
+        }
+        return sb.append("]}").toString();
+    }
+
+    private static String esc(String s) {
+        return s
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t");
+    }
+
+    private record LiftedAssertion(String symbol, String formula) {}
+
+    private record ObservedCall(
+            MethodCallExpr call,
+            String term,
+            Map<String, String> termOverrides,
+            Set<String> sourceLocals) {
+        ObservedCall withLocalOverride(String localName) {
+            Map<String, String> nextOverrides = new LinkedHashMap<>(termOverrides);
+            nextOverrides.put(localName, term);
+            Set<String> nextLocals = new LinkedHashSet<>(sourceLocals);
+            nextLocals.add(localName);
+            return new ObservedCall(call, term, nextOverrides, nextLocals);
+        }
+    }
+
+    private record ScopeFact(String formula, String localName) {}
+}

--- a/implementations/java/provekit-lift-java-assertj/src/main/resources/META-INF/services/com.provekit.lift.Extractor
+++ b/implementations/java/provekit-lift-java-assertj/src/main/resources/META-INF/services/com.provekit.lift.Extractor
@@ -1,0 +1,1 @@
+com.provekit.lift.assertj.AssertJExtractor

--- a/implementations/java/provekit-lift-java-assertj/src/test/java/com/provekit/lift/assertj/AssertJExtractorTest.java
+++ b/implementations/java/provekit-lift-java-assertj/src/test/java/com/provekit/lift/assertj/AssertJExtractorTest.java
@@ -1,0 +1,167 @@
+package com.provekit.lift.assertj;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ast.CompilationUnit;
+import com.provekit.lift.ContractDecl;
+
+class AssertJExtractorTest {
+    @Test
+    void directAssertThatCallLiftsEqualityByProductionCallsite() {
+        String source = """
+            import org.junit.jupiter.api.Test;
+            import static org.assertj.core.api.Assertions.assertThat;
+
+            public class ParseTest {
+                @Test
+                void testFoo() {
+                    assertThat(foo(5)).isEqualTo(10);
+                }
+            }
+            """;
+
+        ContractDecl decl = liftOne(source);
+
+        assertEquals(callsiteSymbol(source, "foo", "foo(5)"), decl.symbol);
+        assertEquals(List.of(atom("eq", ctor("foo", cInt(5)), cInt(10))), decl.invariants);
+    }
+
+    @Test
+    void variableBoundAssertThatCallLiftsComparisonByBindingCallsite() {
+        String source = """
+            import org.junit.jupiter.api.Test;
+            import static org.assertj.core.api.Assertions.assertThat;
+
+            public class ParseTest {
+                @Test
+                void testFoo() {
+                    int r = foo(5);
+                    assertThat(r).isLessThan(10);
+                }
+            }
+            """;
+
+        ContractDecl decl = liftOne(source);
+
+        assertEquals(callsiteSymbol(source, "foo", "foo(5)"), decl.symbol);
+        assertEquals(List.of(atom("lt", ctor("foo", cInt(5)), cInt(10))), decl.invariants);
+    }
+
+    @Test
+    void qualifiedAssertJAssertionsLiftNullnessAndInequality() {
+        String source = """
+            import org.junit.jupiter.api.Test;
+            import org.assertj.core.api.Assertions;
+
+            public class ParseTest {
+                @Test
+                void testFoo() {
+                    Assertions.assertThat(name()).isNotNull();
+                    Assertions.assertThat(count()).isNotEqualTo(0);
+                }
+            }
+            """;
+
+        List<ContractDecl> decls = lift(source);
+
+        assertEquals(2, decls.size(), "Expected two lifted AssertJ assertions");
+        assertEquals(callsiteSymbol(source, "name", "name()"), decls.get(0).symbol);
+        assertEquals(List.of(atom("neq", ctor("name"), cNull())), decls.get(0).invariants);
+        assertEquals(callsiteSymbol(source, "count", "count()"), decls.get(1).symbol);
+        assertEquals(List.of(atom("neq", ctor("count"), cInt(0))), decls.get(1).invariants);
+    }
+
+    @Test
+    void unsupportedAssertJFluentFormsDoNotLiftFakeContracts() {
+        String source = """
+            import org.junit.jupiter.api.Test;
+            import static org.assertj.core.api.Assertions.assertThat;
+
+            public class ParseTest {
+                @Test
+                void testFoo() {
+                    assertThat(foo(5)).contains("5");
+                }
+            }
+            """;
+
+        assertTrue(lift(source).isEmpty());
+    }
+
+    private ContractDecl liftOne(String source) {
+        List<ContractDecl> decls = lift(source);
+        assertEquals(1, decls.size(), "Expected exactly one lifted AssertJ assertion");
+        return decls.get(0);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<ContractDecl> lift(String source) {
+        ParseResult<CompilationUnit> result = new JavaParser().parse(source);
+        assertTrue(result.isSuccessful() && result.getResult().isPresent(),
+            "Failed to parse: " + result.getProblems());
+        try {
+            Class<?> extractorClass = Class.forName("com.provekit.lift.assertj.AssertJExtractor");
+            Object extractor = extractorClass.getConstructor().newInstance();
+            Method extract = extractorClass.getMethod("extract", CompilationUnit.class, String.class);
+            return (List<ContractDecl>) extract.invoke(extractor, result.getResult().get(), source);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("AssertJ extractor is not available", e);
+        }
+    }
+
+    private static String callsiteSymbol(String source, String callee, String snippet) {
+        int offset = source.indexOf(snippet);
+        assertTrue(offset >= 0, "Missing call snippet: " + snippet);
+        int line = 1;
+        int col = 1;
+        for (int i = 0; i < offset; i++) {
+            if (source.charAt(i) == '\n') {
+                line++;
+                col = 1;
+            } else {
+                col++;
+            }
+        }
+        return callee + "@ParseTest.java:" + line + ":" + col;
+    }
+
+    private static String cInt(long value) {
+        return "{\"kind\":\"const\",\"value\":" + value
+            + ",\"sort\":{\"kind\":\"primitive\",\"name\":\"Int\"}}";
+    }
+
+    private static String cNull() {
+        return "{\"kind\":\"const\",\"value\":null,\"sort\":{\"kind\":\"primitive\",\"name\":\"Ref\"}}";
+    }
+
+    private static String ctor(String name, String... args) {
+        StringBuilder sb = new StringBuilder("{\"kind\":\"ctor\",\"name\":\"")
+            .append(name)
+            .append("\",\"args\":[");
+        for (int i = 0; i < args.length; i++) {
+            if (i > 0) sb.append(",");
+            sb.append(args[i]);
+        }
+        return sb.append("]}").toString();
+    }
+
+    private static String atom(String name, String... args) {
+        StringBuilder sb = new StringBuilder("{\"kind\":\"atomic\",\"name\":\"")
+            .append(name)
+            .append("\",\"args\":[");
+        for (int i = 0; i < args.length; i++) {
+            if (i > 0) sb.append(",");
+            sb.append(args[i]);
+        }
+        return sb.append("]}").toString();
+    }
+}


### PR DESCRIPTION
## Summary
- add `provekit-emit-java-assertj` and `provekit-lift-java-assertj` as separate Java artifacts
- register AssertJ emit and lift surfaces through project config and manifests
- emit native AssertJ fluent assertions from normalized predicates
- lift ordinary AssertJ fluent assertions from JUnit tests without ProveKit markers
- keep unsupported predicates/forms honest instead of minting fake contracts

## Verification
- `mvn -B -ntp -pl provekit-emit-java-assertj,provekit-lift-java-assertj -am -Dtest=AssertJEmitterTest,RpcServerDescribeTest,AssertJExtractorTest package`
- TOML parse check for Java project config and AssertJ emit/lift manifests
- `git diff --check`

Notes:
- No Rust CLI code is changed in this PR.
- Maven prints existing shade warnings; the targeted reactor build passes.