### PR TITLE
Split project plugin dispatch by kind

### DIFF
--- a/implementations/java/.provekit/config.toml
+++ b/implementations/java/.provekit/config.toml
@@ -2,5 +2,6 @@ exam_manifest_cid = "blake3-512:000000000000000000000000000000000000000000000000
 
 [[plugins]]
 name = "java-testng"
+kind = "emit"
 surface = "java-testng"
 emit = "testng"

--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -741,6 +741,7 @@ fn mint_input(
 ) -> MintPathInput {
     let entry = PluginEntry {
         name: None,
+        kind: Some("lift".to_string()),
         surface: surface.to_string(),
         workspace_override: None,
         emit: None,
@@ -1990,10 +1991,18 @@ pub fn run(args: MintArgs) -> u8 {
 
     let session = if let Some(path_file) = configured_path {
         dispatch_path(&project_root, Path::new(&path_file))
-    } else if args.surface.is_none() && derived_surface.is_none() && !project_cfg.plugins.is_empty()
+    } else if args.surface.is_none()
+        && derived_surface.is_none()
+        && project_cfg.plugins.iter().any(PluginEntry::is_lift_plugin)
     {
-        // Multi-plugin path: config.toml declared `[[plugins]]` and the
-        // user didn't override with a single `--surface` or `--kit`.
+        let lift_plugins = project_cfg
+            .plugins
+            .iter()
+            .filter(|plugin| plugin.is_lift_plugin())
+            .cloned()
+            .collect::<Vec<_>>();
+        // Multi-plugin path: config.toml declared lift `[[plugins]]` and
+        // the user didn't override with a single `--surface` or `--kit`.
         // Build a fan-in path with one lift step per declared plugin and
         // one terminal mint step depending on all of them. The path
         // executor walks each plugin's k(I)=t independently; mint merges
@@ -2002,9 +2011,8 @@ pub fn run(args: MintArgs) -> u8 {
             println!(
                 "{}: {} plugin(s) declared: {}",
                 "config".green().bold(),
-                project_cfg.plugins.len(),
-                project_cfg
-                    .plugins
+                lift_plugins.len(),
+                lift_plugins
                     .iter()
                     .map(|p| p.display_name().to_string())
                     .collect::<Vec<_>>()
@@ -2014,7 +2022,7 @@ pub fn run(args: MintArgs) -> u8 {
         let out_dir = args.out.clone().unwrap_or_else(|| project_root.clone());
         dispatch_multi(
             &project_root,
-            &project_cfg.plugins,
+            &lift_plugins,
             &out_dir,
             args.flags.quiet,
             args.library_bindings,

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -1662,6 +1662,7 @@ fn configured_emit_surface_names(workspace_root: &Path) -> BTreeSet<String> {
     read_project_config(workspace_root)
         .plugins
         .into_iter()
+        .filter(|plugin| plugin.is_emit_plugin())
         .filter_map(|plugin| {
             let surface = plugin.surface.trim().to_string();
             (!surface.is_empty()).then_some(surface)
@@ -1678,6 +1679,7 @@ fn configured_emit_surfaces(
     let mut surfaces = read_project_config(workspace_root)
         .plugins
         .into_iter()
+        .filter(|plugin| plugin.is_emit_plugin())
         .filter_map(|plugin| {
             let surface = plugin.surface.trim().to_string();
             if surface.is_empty() || !emit_surface_matches(&surface, target_lang, framework) {

--- a/implementations/rust/provekit-cli/src/project_config.rs
+++ b/implementations/rust/provekit-cli/src/project_config.rs
@@ -14,17 +14,19 @@ use std::path::{Path, PathBuf};
 
 /// One entry in `.provekit/config.toml`'s `[[plugins]]` array.
 ///
-/// Each entry declares one lift plugin this project enables. cmd_mint
-/// reads the full list and dispatches each plugin via its manifest at
-/// `.provekit/lift/<surface>/manifest.toml`, then merges all
-/// ir-documents into one envelope. The substrate's "config-driven
-/// multi-plugin orchestration" pattern: the user declares which kits
-/// are active; the CLI invokes them.
+/// Each entry declares one project-enabled plugin. `kind = "lift"` routes
+/// to `.provekit/lift/<surface>/manifest.toml`; `kind = "emit"` routes
+/// to `.provekit/emit/<surface>/manifest.toml`. Omitted kind preserves
+/// legacy dual-use registrations.
 #[derive(Debug, Clone, Default)]
 pub struct PluginEntry {
     /// Human label for diagnostics. Optional; falls back to `surface`.
     pub name: Option<String>,
-    /// Lift surface — resolves to `.provekit/lift/<surface>/manifest.toml`.
+    /// Plugin role in the project registry. Explicit values are
+    /// "lift" and "emit"; absent means legacy dual-use registration.
+    pub kind: Option<String>,
+    /// Plugin surface. The command decides whether this resolves under
+    /// `.provekit/lift` or `.provekit/emit` from `kind`.
     pub surface: String,
     /// Optional absolute path the plugin should treat as its
     /// `workspace_root`. Use case: a shim that lifts from a
@@ -51,6 +53,20 @@ pub struct PluginEntry {
 impl PluginEntry {
     pub fn display_name(&self) -> &str {
         self.name.as_deref().unwrap_or(self.surface.as_str())
+    }
+
+    pub fn is_lift_plugin(&self) -> bool {
+        self.kind
+            .as_deref()
+            .map(|kind| kind.eq_ignore_ascii_case("lift"))
+            .unwrap_or(true)
+    }
+
+    pub fn is_emit_plugin(&self) -> bool {
+        self.kind
+            .as_deref()
+            .map(|kind| kind.eq_ignore_ascii_case("emit"))
+            .unwrap_or(true)
     }
 }
 
@@ -242,6 +258,11 @@ fn parse_config(text: &str) -> ProjectConfig {
                     entry.name = Some(val);
                 }
             }
+            (Some("plugins.entry"), "kind") => {
+                if let Some(entry) = current_plugin.as_mut() {
+                    entry.kind = Some(val);
+                }
+            }
             (Some("plugins.entry"), "surface") => {
                 if let Some(entry) = current_plugin.as_mut() {
                     entry.surface = val;
@@ -422,6 +443,29 @@ family = "concept:family:hash"
             Some(".provekit/paths/mint.json")
         );
         assert_eq!(cfg.path_for("prove"), None);
+    }
+
+    #[test]
+    fn parses_plugin_kind_for_dispatch_filtering() {
+        let cfg = parse_config(
+            r#"[[plugins]]
+name = "java-testng-emitter"
+kind = "emit"
+surface = "java-testng"
+emit = "testng"
+
+[[plugins]]
+name = "java-testng-lifter"
+kind = "lift"
+surface = "java-testng"
+emit = "ir-document"
+"#,
+        );
+        assert_eq!(cfg.plugins.len(), 2);
+        assert!(cfg.plugins[0].is_emit_plugin());
+        assert!(!cfg.plugins[0].is_lift_plugin());
+        assert!(cfg.plugins[1].is_lift_plugin());
+        assert!(!cfg.plugins[1].is_emit_plugin());
     }
 
     #[test]

--- a/implementations/rust/provekit-cli/tests/cli_surface.rs
+++ b/implementations/rust/provekit-cli/tests/cli_surface.rs
@@ -621,6 +621,79 @@ done
 }
 
 #[test]
+fn mint_ignores_emit_only_plugin_registrations() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let project = dir.path().join("project");
+    let lift_manifest = project.join(".provekit/lift/test-lift");
+    let out_dir = dir.path().join("out");
+    fs::create_dir_all(&lift_manifest).expect("create lift manifest dir");
+    fs::write(
+        project.join(".provekit/config.toml"),
+        r#"[[plugins]]
+name = "java-testng-emitter"
+kind = "emit"
+surface = "java-testng"
+emit = "testng"
+
+[[plugins]]
+name = "test-lift"
+kind = "lift"
+surface = "test-lift"
+emit = "ir-document"
+"#,
+    )
+    .expect("write project config");
+
+    let plugin = dir.path().join("test-lift.sh");
+    write_executable(
+        &plugin,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+while IFS= read -r line; do
+  if [[ "$line" == *'"method":"initialize"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"name":"test-lift","protocol_version":"pep/1.7.0","capabilities":{}}}'
+  elif [[ "$line" == *'"method":"lift"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"kind":"ir-document","ir":[{"kind":"contract","name":"demo.contract","outBinding":"out","post":{"kind":"atomic","name":"demo_true","args":[]}}],"diagnostics":[]}}'
+  elif [[ "$line" == *'"method":"shutdown"'* ]]; then
+    printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":null}'
+    exit 0
+  fi
+done
+"#,
+    );
+    fs::write(
+        lift_manifest.join("manifest.toml"),
+        format!(
+            "name = \"test-lift\"\ncommand = [\"{}\"]\n",
+            plugin.display()
+        ),
+    )
+    .expect("write lift manifest");
+
+    let output = output_retrying_etxtbsy(
+        Command::new(provekit_bin())
+            .arg("mint")
+            .arg("--project")
+            .arg(&project)
+            .arg("--out")
+            .arg(&out_dir)
+            .arg("--no-attest")
+            .arg("--json")
+            .arg("--quiet"),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "mint should ignore kind=emit registrations instead of resolving .provekit/lift/java-testng\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let report: serde_json::Value = serde_json::from_str(&stdout).expect("mint JSON parses");
+    assert_eq!(report["surface"], "test-lift");
+    assert_eq!(report["lift"]["kind"], "ir-document");
+}
+
+#[test]
 fn mint_surfaces_structured_lift_gap_diagnostics_from_consumer_surfaces() {
     let dir = tempfile::tempdir().expect("create tempdir");
     let project = dir.path().join("project");


### PR DESCRIPTION
## Summary
- parse optional project plugin kind values for lift vs emit registrations
- make mint fan-in only lift plugins and emit dispatch only emit plugins
- mark the Java TestNG emitter registration as kind = "emit" so emitter registration does not leak into mint/lift dispatch

## Verification
- red: cargo test -p provekit-cli --manifest-path implementations/rust/Cargo.toml --test cli_surface mint_ignores_emit_only_plugin_registrations -- --nocapture failed before implementation by resolving .provekit/lift/java-testng from an emit-only entry
- cargo test -p provekit-cli --manifest-path implementations/rust/Cargo.toml --test cli_surface mint_ignores_emit_only_plugin_registrations -- --nocapture
- cargo test -p provekit-cli --manifest-path implementations/rust/Cargo.toml project_config::tests::parses_plugin_kind_for_dispatch_filtering -- --nocapture
- cargo test -p provekit-cli --manifest-path implementations/rust/Cargo.toml --test cmd_emit_java_testng -- --nocapture
- cargo test -p provekit-cli --manifest-path implementations/rust/Cargo.toml --test cli_surface mint_conjoins_producer_contracts_and_consumer_bridges_in_one_proof -- --nocapture
- cargo fmt --manifest-path implementations/rust/provekit-cli/Cargo.toml --check
- git diff --check