### PR TITLE
[codex] Surface solver diagnostics at LSP callsites

### DIFF
--- a/docs/superpowers/plans/2026-05-29-lsp-solver-callsite-diagnostics.md
+++ b/docs/superpowers/plans/2026-05-29-lsp-solver-callsite-diagnostics.md
@@ -1,0 +1,397 @@
+# LSP Solver Callsite Diagnostics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make solver/verifier failures from the Rust daemon path publish LSP diagnostics at the broken contract callsite instead of file start.
+
+**Architecture:** Keep language analysis inside the owning kit. The Rust CLI/LSP/linkerd path remains language-agnostic infrastructure that routes kit facts, runs solver obligations, and projects verifier results into editor diagnostics. The vertical slice preserves `callSiteLocus` from Rust kit call edges through `LinkerError`, linkerd JSON, and LSP range conversion.
+
+**Tech Stack:** Rust workspace crates `provekit-linker`, `provekit-linkerd`, `provekit-lsp`; `serde_json`; `tower_lsp`; existing verifier `StubSolver` test utilities.
+
+---
+
+## File Structure
+
+- Modify `implementations/rust/provekit-linker/src/lib.rs`
+  - Add `call_site_locus_json: Option<Json>` to `LinkerError`.
+  - Populate it from `LinkerCallEdge.call_site_locus_json` for unresolved symbols and solver failures.
+- Modify `implementations/rust/provekit-linker/tests/discharge_obligation.rs`
+  - Prove unsatisfied solver obligations preserve the original callsite locus.
+- Modify `implementations/rust/provekit-linkerd/src/methods.rs`
+  - Include `callSiteLocus` in `parseFile` diagnostic JSON.
+- Modify `implementations/rust/provekit-linkerd/src/state.rs`
+  - Include `callSiteLocus` in cached `getDiagnostics` JSON.
+  - Add a focused state test using an unresolved call edge to prove cached diagnostics preserve the locus.
+- Modify `implementations/rust/provekit-lsp/src/main.rs`
+  - Accept `callSiteLocus` on daemon diagnostics.
+  - Convert 1-based line / 0-based column source loci to 0-based LSP ranges.
+  - Map solver failure kinds to stable `provekit.lsp.*` diagnostic codes.
+- Modify `implementations/rust/provekit-lsp/tests/daemon_routed.rs`
+  - Add or extend coverage proving published daemon diagnostics use the daemon-provided callsite range.
+
+### Task 1: Preserve Callsite Locus In Linker Errors
+
+**Files:**
+- Modify: `implementations/rust/provekit-linker/src/lib.rs`
+- Test: `implementations/rust/provekit-linker/tests/discharge_obligation.rs`
+
+- [ ] **Step 1: Write the failing linker test**
+
+Add this assertion to `logically_incompatible_emits_implication_unprovable` after the existing `let err = &out.linker_errors[0];` block, or create the `err` binding if absent:
+
+```rust
+    assert_eq!(
+        err.call_site_locus_json.as_ref(),
+        Some(&json!({
+            "file": "caller.rs",
+            "line": 1,
+            "column": 1
+        })),
+        "solver failure must preserve the callsite locus for LSP diagnostics"
+    );
+```
+
+- [ ] **Step 2: Run the failing linker test**
+
+Run:
+
+```bash
+cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linker --test discharge_obligation logically_incompatible_emits_implication_unprovable
+```
+
+Expected: FAIL to compile because `LinkerError` has no `call_site_locus_json` field.
+
+- [ ] **Step 3: Add the minimal linker field and propagation**
+
+In `implementations/rust/provekit-linker/src/lib.rs`, change `LinkerError`:
+
+```rust
+pub struct LinkerError {
+    pub kind: String,
+    pub target_symbol: String,
+    pub source_contract_cid: String,
+    pub reason: String,
+    pub file: Option<String>,
+    pub call_site_locus_json: Option<Json>,
+}
+```
+
+In the unresolved-symbol construction inside `derive_link_bundle_inner`, add:
+
+```rust
+call_site_locus_json: Some(edge.call_site_locus_json.clone()),
+```
+
+After `discharge_obligation(...)` returns `Some(mut err)`, set:
+
+```rust
+err.file = locus_file;
+err.call_site_locus_json = Some(edge.call_site_locus_json.clone());
+```
+
+Inside `discharge_obligation`, add `call_site_locus_json: None` to every `LinkerError` literal.
+
+- [ ] **Step 4: Run the linker test**
+
+Run:
+
+```bash
+cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linker --test discharge_obligation logically_incompatible_emits_implication_unprovable
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the linker slice**
+
+```bash
+git add implementations/rust/provekit-linker/src/lib.rs implementations/rust/provekit-linker/tests/discharge_obligation.rs
+git commit -m "Propagate linker callsite loci"
+```
+
+### Task 2: Include Callsite Locus In Linkerd Diagnostics
+
+**Files:**
+- Modify: `implementations/rust/provekit-linkerd/src/methods.rs`
+- Modify: `implementations/rust/provekit-linkerd/src/state.rs`
+
+- [ ] **Step 1: Write the failing state test**
+
+Append this test module to `implementations/rust/provekit-linkerd/src/state.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use provekit_linker::{LinkerCallEdge, LinkerContract};
+    use serde_json::json;
+
+    const SOURCE_CID: &str = "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    #[test]
+    fn diagnostics_for_file_preserve_callsite_locus() {
+        let mut state = ProjectState::new(4);
+        let locus = json!({
+            "file": "/tmp/caller.rs",
+            "line": 7,
+            "column": 13
+        });
+
+        state.update_and_link(
+            "rust",
+            "/tmp/caller.rs",
+            vec![LinkerContract {
+                name: "caller".into(),
+                kit: "rust-kit".into(),
+                contract_cid: SOURCE_CID.into(),
+                pre_json: None,
+                post_json: Some(json!({"kind": "atomic", "name": "true", "args": []})),
+            }],
+            vec![LinkerCallEdge {
+                source_contract_cid: SOURCE_CID.into(),
+                target_contract_cid: None,
+                target_symbol: "rust-kit:missing".into(),
+                call_site_locus_json: locus.clone(),
+                evidence_term_json: json!({"kind": "Atomic", "name": "obligation", "args": []}),
+            }],
+        );
+
+        let diagnostics = state.diagnostics_for_file("/tmp/caller.rs");
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0]["callSiteLocus"], locus);
+    }
+}
+```
+
+- [ ] **Step 2: Run the failing linkerd state test**
+
+Run:
+
+```bash
+cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd diagnostics_for_file_preserve_callsite_locus
+```
+
+Expected: FAIL because diagnostic JSON omits `callSiteLocus`.
+
+- [ ] **Step 3: Add `callSiteLocus` to linkerd JSON responses**
+
+In `handle_parse_file`, update the diagnostic JSON:
+
+```rust
+"callSiteLocus": e.call_site_locus_json,
+```
+
+In `ProjectState::diagnostics_for_file`, update the diagnostic JSON:
+
+```rust
+"callSiteLocus": e.call_site_locus_json,
+```
+
+- [ ] **Step 4: Run the linkerd state test**
+
+Run:
+
+```bash
+cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd diagnostics_for_file_preserve_callsite_locus
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the daemon JSON slice**
+
+```bash
+git add implementations/rust/provekit-linkerd/src/methods.rs implementations/rust/provekit-linkerd/src/state.rs
+git commit -m "Return callsite loci from linkerd diagnostics"
+```
+
+### Task 3: Convert Daemon Callsite Loci To LSP Ranges
+
+**Files:**
+- Modify: `implementations/rust/provekit-lsp/src/main.rs`
+
+- [ ] **Step 1: Write failing LSP conversion tests**
+
+In `implementations/rust/provekit-lsp/src/main.rs`, update the test helper:
+
+```rust
+fn make_diag_with_locus(error_kind: &str, target_symbol: &str, reason: &str, locus: serde_json::Value) -> DaemonDiagnostic {
+    DaemonDiagnostic {
+        error_kind: error_kind.to_string(),
+        target_symbol: target_symbol.to_string(),
+        reason: reason.to_string(),
+        call_site_locus: Some(locus),
+    }
+}
+```
+
+Add this test:
+
+```rust
+#[test]
+fn callsite_locus_maps_to_lsp_range() {
+    let d = make_diag_with_locus(
+        "implication-unprovable",
+        "checkPositive",
+        "solver found a counterexample",
+        serde_json::json!({"file": "/tmp/test.rs", "line": 20, "column": 17}),
+    );
+
+    let lsp = daemon_diag_to_lsp(&d);
+    assert_eq!(lsp.range.start.line, 19);
+    assert_eq!(lsp.range.start.character, 17);
+    assert_eq!(lsp.range.end.line, 19);
+    assert_eq!(lsp.range.end.character, 18);
+    assert_eq!(
+        lsp.code,
+        Some(NumberOrString::String("provekit.lsp.implication_failed".to_string()))
+    );
+}
+```
+
+- [ ] **Step 2: Run the failing LSP unit test**
+
+Run:
+
+```bash
+cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-lsp callsite_locus_maps_to_lsp_range
+```
+
+Expected: FAIL to compile because `DaemonDiagnostic` has no `call_site_locus` field.
+
+- [ ] **Step 3: Add daemon diagnostic locus parsing and range conversion**
+
+In `DaemonDiagnostic`, add:
+
+```rust
+#[serde(rename = "callSiteLocus", default)]
+call_site_locus: Option<serde_json::Value>,
+```
+
+Add a helper near `daemon_diag_to_lsp`:
+
+```rust
+fn locus_to_lsp_range(locus: Option<&serde_json::Value>) -> Range {
+    let Some(locus) = locus else {
+        return file_start_range();
+    };
+    let line = locus.get("line").and_then(|v| v.as_u64()).unwrap_or(1);
+    let column = locus
+        .get("column")
+        .or_else(|| locus.get("col"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let end_line = locus
+        .get("endLine")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(line);
+    let end_column = locus
+        .get("endColumn")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(column + 1);
+
+    Range {
+        start: Position {
+            line: line.saturating_sub(1) as u32,
+            character: column as u32,
+        },
+        end: Position {
+            line: end_line.saturating_sub(1) as u32,
+            character: end_column as u32,
+        },
+    }
+}
+
+fn file_start_range() -> Range {
+    Range {
+        start: Position { line: 0, character: 0 },
+        end: Position { line: 0, character: 1 },
+    }
+}
+```
+
+Replace the hardcoded range in `daemon_diag_to_lsp`:
+
+```rust
+let range = locus_to_lsp_range(d.call_site_locus.as_ref());
+```
+
+Map codes:
+
+```rust
+let code = match d.error_kind.as_str() {
+    "implication-unprovable" => "provekit.lsp.implication_failed",
+    "unprovable-obligation" => "provekit.lsp.implication_failed",
+    "unresolved-symbol" => "provekit.lsp.unresolved_symbol",
+    "implication-undecidable" => "provekit.lsp.unprovable_obligation",
+    _ => "provekit.lsp.unprovable_obligation",
+};
+```
+
+Use `code` in the diagnostic.
+
+- [ ] **Step 4: Run the LSP unit tests**
+
+Run:
+
+```bash
+cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-lsp callsite_locus_maps_to_lsp_range
+cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-lsp range_is_file_start_marker
+```
+
+Expected: PASS. The fallback test should still prove missing loci use `(0,0)..(0,1)`.
+
+- [ ] **Step 5: Commit the LSP conversion slice**
+
+```bash
+git add implementations/rust/provekit-lsp/src/main.rs
+git commit -m "Map solver diagnostics to callsite ranges"
+```
+
+### Task 4: Run Focused Regression Set
+
+**Files:**
+- No code changes unless a focused test exposes a real issue.
+
+- [ ] **Step 1: Run focused crate tests**
+
+Run:
+
+```bash
+cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linker --test discharge_obligation
+cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd diagnostics_for_file_preserve_callsite_locus
+cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-lsp callsite_locus_maps_to_lsp_range
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run formatting/checks for touched Rust crates**
+
+Run:
+
+```bash
+cargo fmt --manifest-path implementations/rust/Cargo.toml --check
+cargo check --manifest-path implementations/rust/Cargo.toml -p provekit-linker -p provekit-linkerd -p provekit-lsp
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --check origin/main...HEAD
+```
+
+Expected: no whitespace errors; diff limited to the approved spec/plan and Rust/linkerd/LSP vertical slice.
+
+- [ ] **Step 4: Final commit if needed**
+
+If Task 4 required fixes:
+
+```bash
+git add <fixed-files>
+git commit -m "Stabilize LSP callsite diagnostics"
+```
+
+If Task 4 required no fixes, do not create an empty commit.

--- a/docs/superpowers/specs/2026-05-29-lsp-solver-callsite-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-05-29-lsp-solver-callsite-diagnostics-design.md
@@ -1,0 +1,140 @@
+# LSP Solver Callsite Diagnostics Design
+
+Date: 2026-05-29
+
+## Goal
+
+Make the first LSP product slice show solver failures at the source callsite of the broken contract.
+
+The gap is not contract discovery and not more lifting. The project already has
+the pieces up through solver results. The missing product path is taking a
+failed verifier obligation and projecting it into the IDE as a precise
+diagnostic.
+
+This PR is limited to the Rust/linkerd/LSP vertical slice. Per-language kit sweeps come after this proves the end-to-end diagnostic path.
+
+Language ownership is strict:
+
+- the Rust kit produces Rust facts from Rust source;
+- the Python kit produces Python facts from Python source;
+- the Java kit produces Java facts from Java source, in Java;
+- the Rust CLI is language-agnostic coordinator/verifier infrastructure;
+- the shared coordinator and linkerd do not parse host-language source or learn host-language framework semantics.
+
+## Problem
+
+The current architecture has the right upstream data, but drops the location before it reaches the editor:
+
+- kit/lift output can emit `callSiteLocus` on call edges;
+- `provekit-linker` receives that locus in `LinkerCallEdge.call_site_locus_json`;
+- the solver verdict is converted into `LinkerError`;
+- `LinkerError` preserves only `file`;
+- `provekit-lsp` therefore publishes daemon diagnostics at `(0,0)..(0,1)`.
+
+That produces a file-level marker, not the red squiggle users expect.
+
+## Chosen Approach
+
+Propagate the callsite locus through the existing Rust daemon path.
+
+1. Extend `LinkerError` with an optional callsite range/locus payload derived from `LinkerCallEdge.call_site_locus_json`.
+2. Include that range in `parseFile` and `getDiagnostics` JSON responses from `provekit-linkerd`.
+3. Teach `provekit-lsp` to convert daemon ranges into LSP ranges instead of using the file-start fallback.
+4. Map solver implication failures to `provekit.lsp.implication_failed` with source `provekit` and severity error.
+5. Keep parse/lift failures, unresolved symbols, and undecidable solver results on their own diagnostic codes.
+
+The design keeps lifting as upstream fact production. The product signal is the
+solver/verifier result projected back to a source call expression.
+
+This does not move Rust parsing into linkerd as a general pattern. The Rust
+vertical slice uses the existing Rust kit path because this PR proves the
+diagnostic last mile. Follow-on kit work keeps each language's analysis inside
+that kit's implementation language.
+
+## Alternatives Considered
+
+1. Add a separate LSP-side callsite index.
+
+   This would let the editor repair missing daemon locations, but it duplicates routing and risks divergence from linkerd's solver input.
+
+2. Push all diagnostic construction into each language kit.
+
+   This would give kits maximum control, but it would make solver diagnostics inconsistent and force every kit to understand verifier result shaping.
+
+3. Propagate solver diagnostic loci through linkerd.
+
+   This is the selected approach. The same component that owns the solver decision also owns the call edge that caused it, so it can preserve the source span without inventing a second lookup surface.
+
+## Data Flow
+
+```text
+source call expression
+  -> Rust lifter call edge with callSiteLocus
+  -> linkerd project union
+  -> linker solver obligation: caller post implies callee pre
+  -> LinkerError with callsite locus
+  -> parseFile/getDiagnostics JSON
+  -> provekit-lsp Diagnostic at the callsite range
+  -> editor red squiggle
+```
+
+## Range Rules
+
+The initial accepted locus shape is:
+
+```json
+{"file": "/abs/path/src/lib.rs", "line": 20, "column": 17}
+```
+
+The linker treats `line` as 1-based and `column` as 0-based, matching the existing Rust lifter locus. The LSP server converts to 0-based LSP positions.
+
+If the locus also carries `endLine`/`endColumn`, the LSP uses it. If it only carries a start point, the LSP marks a one-character range. If no usable locus exists, the LSP may fall back to `(0,0)..(0,1)`, but tests for this PR must prove the solver-failure path does not use that fallback.
+
+## Diagnostic Rules
+
+Solver-rejected implication:
+
+- code: `provekit.lsp.implication_failed`
+- source: `provekit`
+- severity: error
+- range: callsite expression or callee token
+- message: explains that the callee precondition is not established at this callsite
+- data: includes at least target symbol, source contract CID, reason, and raw callsite locus
+
+Unresolved symbol:
+
+- code: `provekit.lsp.unresolved_symbol`
+- severity: warning
+- range: callsite if available
+
+Undecidable implication:
+
+- code: `provekit.lsp.unprovable_obligation`
+- severity: warning
+- range: callsite if available
+
+## Testing
+
+Add tests at the narrowest useful layers:
+
+1. `provekit-linker` unit test: an unsatisfied solver obligation preserves callsite locus in `LinkerError`.
+2. `provekit-linkerd` test: `parseFile` returns a diagnostic containing the callsite locus/range.
+3. `provekit-lsp` test: daemon diagnostic range converts to the expected LSP line/character instead of `(0,0)`.
+
+The end-to-end fixture should use the existing floor shape: a satisfied call, a violated call such as `checkPositive(-1)`, and a loop/top fallback that does not emit a false positive.
+
+## Out Of Scope
+
+- Implementing all per-language kit call-edge emitters.
+- Replacing legacy `parse` with `analyzeDocument`.
+- Building a VS Code extension.
+- Changing solver semantics.
+- Treating lift gaps as solver failures.
+- Adding Java, Python, TypeScript, or any other host-language parsing to the Rust coordinator or linkerd.
+
+## Success Criteria
+
+- A broken Rust contract implication produces a red squiggle at the callsite.
+- The LSP diagnostic no longer uses the file-start fallback for solver implication failures.
+- The diagnostic code is stable and matches the shared LSP protocol.
+- Existing daemon and LSP tests still pass.

--- a/implementations/rust/provekit-linker/src/lib.rs
+++ b/implementations/rust/provekit-linker/src/lib.rs
@@ -129,6 +129,9 @@ pub struct LinkerError {
     /// Source file where the call site is located.  Derived from
     /// `call_site_locus_json.file`; `None` if the locus has no file field.
     pub file: Option<String>,
+    /// Original call-site locus emitted by the owning kit. Used by linkerd/LSP
+    /// to place solver diagnostics at the source call expression.
+    pub call_site_locus_json: Option<Json>,
 }
 
 /// Input bundle for a single `link()` invocation.
@@ -288,6 +291,7 @@ fn derive_link_bundle_inner(
                         edge.target_symbol
                     ),
                     file: locus_file,
+                    call_site_locus_json: Some(edge.call_site_locus_json.clone()),
                 });
             }
             Some(target_cid) => {
@@ -317,6 +321,7 @@ fn derive_link_bundle_inner(
                     plan,
                 ) {
                     err.file = locus_file;
+                    err.call_site_locus_json = Some(edge.call_site_locus_json.clone());
                     linker_errors_out.push(err);
                 }
             }
@@ -515,6 +520,7 @@ fn discharge_obligation(
                     "caller post-condition is absent; cannot discharge `post_caller \u{2283} pre_callee` for target `{target_cid}`"
                 ),
                 file: None, // populated by caller from locus
+                call_site_locus_json: None, // populated by caller from locus
             });
         }
         Some(p) => p,
@@ -557,6 +563,7 @@ fn discharge_obligation(
                     "compile post-implies-pre to SMT-LIB failed for target `{target_cid}`: {e}"
                 ),
                 file: None,
+                call_site_locus_json: None,
             });
         }
     };
@@ -573,6 +580,7 @@ fn discharge_obligation(
                 "solver reports `post_caller \u{2283} pre_callee` is violated for target `{target_cid}`: {reason}"
             ),
             file: None,
+            call_site_locus_json: None,
         }),
         ObligationVerdict::Undecidable | ObligationVerdict::Disagreement => Some(LinkerError {
             kind: "implication-undecidable".into(),
@@ -582,6 +590,7 @@ fn discharge_obligation(
                 "solver could not decide `post_caller \u{2283} pre_callee` for target `{target_cid}`: {reason}"
             ),
             file: None,
+            call_site_locus_json: None,
         }),
     }
 }

--- a/implementations/rust/provekit-linker/tests/discharge_obligation.rs
+++ b/implementations/rust/provekit-linker/tests/discharge_obligation.rs
@@ -225,8 +225,18 @@ fn logically_incompatible_emits_implication_unprovable() {
         "weak-post case must surface implication-unprovable, got {:?}",
         out.linker_errors[0]
     );
-    assert_eq!(out.linker_errors[0].target_symbol, "rust-kit:callee");
-    assert_eq!(out.linker_errors[0].file.as_deref(), Some("caller.rs"));
+    let err = &out.linker_errors[0];
+    assert_eq!(err.target_symbol, "rust-kit:callee");
+    assert_eq!(err.file.as_deref(), Some("caller.rs"));
+    assert_eq!(
+        err.call_site_locus_json.as_ref(),
+        Some(&json!({
+            "file": "caller.rs",
+            "line": 1,
+            "column": 1
+        })),
+        "solver failure must preserve the callsite locus for LSP diagnostics"
+    );
 }
 
 // -------------------------------------------------------------------

--- a/implementations/rust/provekit-linkerd/src/methods.rs
+++ b/implementations/rust/provekit-linkerd/src/methods.rs
@@ -131,6 +131,7 @@ pub async fn handle_parse_file(state: Arc<Mutex<ProjectState>>, params: &Json, i
                     "sourceContractCid": e.source_contract_cid,
                     "reason": e.reason,
                     "file": e.file,
+                    "callSiteLocus": e.call_site_locus_json,
                 })
             })
             .collect::<Vec<_>>()

--- a/implementations/rust/provekit-linkerd/src/state.rs
+++ b/implementations/rust/provekit-linkerd/src/state.rs
@@ -173,6 +173,7 @@ impl ProjectState {
                     "sourceContractCid": e.source_contract_cid,
                     "reason": e.reason,
                     "file": e.file,
+                    "callSiteLocus": e.call_site_locus_json,
                 })
             })
             .collect()
@@ -319,6 +320,48 @@ mod tests {
         assert!(state.project_status().is_some());
         state.flush_cache();
         assert!(state.project_status().is_none());
+    }
+
+    #[test]
+    fn diagnostics_for_file_preserve_callsite_locus() {
+        let mut state = ProjectState::new(4);
+        let source_cid = "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let locus = serde_json::json!({
+            "file": "/tmp/caller.rs",
+            "line": 7,
+            "column": 13
+        });
+
+        state.update_and_link(
+            "rust",
+            "/tmp/caller.rs",
+            vec![LinkerContract {
+                name: "caller".into(),
+                kit: "rust-kit".into(),
+                contract_cid: source_cid.into(),
+                pre_json: None,
+                post_json: Some(serde_json::json!({
+                    "kind": "atomic",
+                    "name": "true",
+                    "args": []
+                })),
+            }],
+            vec![LinkerCallEdge {
+                source_contract_cid: source_cid.into(),
+                target_contract_cid: None,
+                target_symbol: "rust-kit:missing".into(),
+                call_site_locus_json: locus.clone(),
+                evidence_term_json: serde_json::json!({
+                    "kind": "Atomic",
+                    "name": "obligation",
+                    "args": []
+                }),
+            }],
+        );
+
+        let diagnostics = state.diagnostics_for_file("/tmp/caller.rs");
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0]["callSiteLocus"], locus);
     }
 
     #[test]

--- a/implementations/rust/provekit-lsp/src/main.rs
+++ b/implementations/rust/provekit-lsp/src/main.rs
@@ -83,16 +83,14 @@ enum LanguageHandle {
 /// ```json
 /// {
 ///   "kind":              "linker-error",
-///   "errorKind":         "unresolved-symbol" | "unprovable-obligation",
+///   "errorKind":         "unresolved-symbol" | "unprovable-obligation" | "implication-unprovable" | "implication-undecidable",
 ///   "targetSymbol":      "<string>",
 ///   "sourceContractCid": "<string>",
 ///   "reason":            "<string>",
-///   "file":              "<string | null>"
+///   "file":              "<string | null>",
+///   "callSiteLocus":     {"file": "<string>", "line": 1, "column": 0}
 /// }
 /// ```
-///
-/// Note: no per-line locus data in this daemon MVP.  Diagnostics are attached
-/// at (0,0) until `LinkerError` gains locus propagation upstream.
 #[derive(Debug, serde::Deserialize)]
 struct DaemonDiagnostic {
     /// Discriminator for the linker-error category; maps to LSP severity.
@@ -104,33 +102,27 @@ struct DaemonDiagnostic {
     /// Human-readable explanation from the linker.
     #[serde(default)]
     reason: String,
+    /// Original kit-owned callsite locus. The LSP adapter only translates
+    /// source coordinates; it does not interpret host-language syntax.
+    #[serde(rename = "callSiteLocus", default)]
+    call_site_locus: Option<serde_json::Value>,
 }
 
 /// Convert a single daemon `DaemonDiagnostic` into an LSP `Diagnostic`.
-///
-/// Range is (0,0)..(0,1): whole-file marker: because the daemon MVP does
-/// not yet propagate call-site locus from `LinkerCallEdge` into `LinkerError`.
-/// Once that propagation is added upstream, this function should read locus
-/// fields and produce a precise range.
 fn daemon_diag_to_lsp(d: &DaemonDiagnostic) -> Diagnostic {
-    let range = Range {
-        start: Position {
-            line: 0,
-            character: 0,
-        },
-        end: Position {
-            line: 0,
-            character: 1,
-        },
-    };
+    let range = locus_to_lsp_range(d.call_site_locus.as_ref());
     let severity = match d.error_kind.as_str() {
-        "unprovable-obligation" => Some(DiagnosticSeverity::ERROR),
-        "unresolved-symbol" => Some(DiagnosticSeverity::WARNING),
+        "implication-unprovable" | "unprovable-obligation" => Some(DiagnosticSeverity::ERROR),
+        "unresolved-symbol" | "implication-undecidable" => Some(DiagnosticSeverity::WARNING),
         _ => Some(DiagnosticSeverity::INFORMATION),
     };
     let message = match d.error_kind.as_str() {
-        "unprovable-obligation" => format!(
+        "implication-unprovable" | "unprovable-obligation" => format!(
             "cannot verify {}'s precondition; postcondition at call site does not establish it ({})",
+            d.target_symbol, d.reason
+        ),
+        "implication-undecidable" => format!(
+            "cannot prove {}'s precondition from this call site ({})",
             d.target_symbol, d.reason
         ),
         "unresolved-symbol" => format!(
@@ -142,10 +134,75 @@ fn daemon_diag_to_lsp(d: &DaemonDiagnostic) -> Diagnostic {
     Diagnostic {
         range,
         severity,
-        code: Some(NumberOrString::String(format!("provekit:{}", d.error_kind))),
+        code: Some(NumberOrString::String(
+            diagnostic_code(&d.error_kind).to_string(),
+        )),
         source: Some("provekit".to_string()),
         message,
         ..Default::default()
+    }
+}
+
+fn file_start_range() -> Range {
+    Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 1,
+        },
+    }
+}
+
+fn locus_to_lsp_range(locus: Option<&serde_json::Value>) -> Range {
+    let Some(locus) = locus else {
+        return file_start_range();
+    };
+
+    let Some(line) = json_u32(locus, "line") else {
+        return file_start_range();
+    };
+    let Some(column) = json_u32(locus, "column").or_else(|| json_u32(locus, "col")) else {
+        return file_start_range();
+    };
+
+    let start_line = line.saturating_sub(1);
+    let start = Position {
+        line: start_line,
+        character: column,
+    };
+
+    let end_line = json_u32(locus, "endLine")
+        .map(|n| n.saturating_sub(1))
+        .unwrap_or(start_line);
+    let mut end_character = json_u32(locus, "endColumn")
+        .or_else(|| json_u32(locus, "endCol"))
+        .unwrap_or(column.saturating_add(1));
+    if end_line == start_line && end_character <= column {
+        end_character = column.saturating_add(1);
+    }
+
+    Range {
+        start,
+        end: Position {
+            line: end_line,
+            character: end_character,
+        },
+    }
+}
+
+fn json_u32(value: &serde_json::Value, key: &str) -> Option<u32> {
+    value.get(key)?.as_u64().and_then(|n| u32::try_from(n).ok())
+}
+
+fn diagnostic_code(error_kind: &str) -> &'static str {
+    match error_kind {
+        "implication-unprovable" | "unprovable-obligation" => "provekit.lsp.implication_failed",
+        "unresolved-symbol" => "provekit.lsp.unresolved_symbol",
+        "implication-undecidable" => "provekit.lsp.unprovable_obligation",
+        _ => "provekit.lsp.unprovable_obligation",
     }
 }
 
@@ -627,7 +684,49 @@ mod tests {
             error_kind: error_kind.to_string(),
             target_symbol: target_symbol.to_string(),
             reason: reason.to_string(),
+            call_site_locus: None,
         }
+    }
+
+    fn make_diag_with_locus(
+        error_kind: &str,
+        target_symbol: &str,
+        reason: &str,
+        locus: serde_json::Value,
+    ) -> DaemonDiagnostic {
+        DaemonDiagnostic {
+            error_kind: error_kind.to_string(),
+            target_symbol: target_symbol.to_string(),
+            reason: reason.to_string(),
+            call_site_locus: Some(locus),
+        }
+    }
+
+    #[test]
+    fn callsite_locus_maps_to_lsp_range() {
+        let d = make_diag_with_locus(
+            "implication-unprovable",
+            "checkPositive",
+            "solver found a counterexample",
+            serde_json::json!({
+                "file": "/tmp/caller.rs",
+                "line": 20,
+                "column": 17,
+            }),
+        );
+        let lsp = daemon_diag_to_lsp(&d);
+
+        assert_eq!(lsp.severity, Some(DiagnosticSeverity::ERROR));
+        assert_eq!(lsp.range.start.line, 19);
+        assert_eq!(lsp.range.start.character, 17);
+        assert_eq!(lsp.range.end.line, 19);
+        assert_eq!(lsp.range.end.character, 18);
+        assert_eq!(
+            lsp.code,
+            Some(NumberOrString::String(
+                "provekit.lsp.implication_failed".to_string()
+            ))
+        );
     }
 
     #[test]
@@ -643,7 +742,7 @@ mod tests {
         assert_eq!(
             lsp.code,
             Some(NumberOrString::String(
-                "provekit:unprovable-obligation".to_string()
+                "provekit.lsp.implication_failed".to_string()
             ))
         );
         assert_eq!(lsp.source, Some("provekit".to_string()));
@@ -673,7 +772,7 @@ mod tests {
         assert_eq!(
             lsp.code,
             Some(NumberOrString::String(
-                "provekit:unresolved-symbol".to_string()
+                "provekit.lsp.unresolved_symbol".to_string()
             ))
         );
         assert_eq!(lsp.source, Some("provekit".to_string()));
@@ -698,7 +797,7 @@ mod tests {
         assert_eq!(
             lsp.code,
             Some(NumberOrString::String(
-                "provekit:some-future-kind".to_string()
+                "provekit.lsp.unprovable_obligation".to_string()
             ))
         );
         assert_eq!(lsp.source, Some("provekit".to_string()));


### PR DESCRIPTION
## Summary

- Preserve linker callsite loci on solver/linker errors so verifier failures keep the owning kit's source location.
- Return `callSiteLocus` from linkerd `parseFile` and cached diagnostics responses.
- Convert daemon `callSiteLocus` payloads into LSP ranges and stable `provekit.lsp.*` diagnostic codes.

## Notes

- This stays in Rust/linkerd/LSP infrastructure: the coordinator translates kit-owned loci but does not parse host-language semantics.
- Per-language kits remain responsible for their own source analysis and callsite emission.

## Validation

- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linker --test discharge_obligation`
- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd diagnostics_for_file_preserve_callsite_locus`
- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-lsp`
- `cargo check --manifest-path implementations/rust/Cargo.toml -p provekit-linker -p provekit-linkerd -p provekit-lsp`
- `cargo fmt --manifest-path implementations/rust/Cargo.toml -p provekit-linker -p provekit-linkerd -p provekit-lsp -- --check`