### PR TITLE
[codex] Route Python kit through linkerd LSP dispatch

### DIFF
--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lsp.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lsp.py
@@ -25,12 +25,17 @@ from typing import Any, Dict, List, Optional
 from .ir import (
     ContractDecl,
     BridgeDecl,
+    CallEdgeDecl,
+    Locus,
+    atomic,
+    make_var,
     contract_decl_to_value,
     declarations_to_value,
     call_edges_to_value,
     formula_to_value,
 )
 from .canonicalizer import encode_jcs, jcs_hash
+from .canonicalizer import vobj, vstr
 from .layer2 import lift_file_layer2
 from .walk import lift_production_walk
 from .decorators import collect_module
@@ -113,7 +118,10 @@ def _lift_source(path: str, source: str) -> Dict[str, Any]:
     # Try to load the source as a module to collect @provekit.contract
     # decorators. This only works when the source is importable; for
     # standalone files we skip this path.
-    # TODO: use importlib.util to load from source string.
+    try:
+        decls.extend(_try_lift_decorated_contracts(source))
+    except Exception:
+        pass
 
     # Pydantic lift: if the file defines BaseModel subclasses, walk them.
     # We do this by exec-ing the source in a clean namespace and
@@ -129,12 +137,13 @@ def _lift_source(path: str, source: str) -> Dict[str, Any]:
     contract_index: Dict[str, str] = {}
     for d in decls:
         if isinstance(d, ContractDecl):
-            cid = jcs_hash(contract_decl_to_value(d))
+            cid = _linkerd_contract_cid(d)
             contract_index[d.name] = cid
 
     # Emit ctypes call-edge stream per spec #114 R1.
     ctypes_result = resolve_ctypes_calls(source, path, contract_index)
-    call_edges = ctypes_result.call_edges
+    same_kit_edges = _resolve_same_kit_calls(source, path, contract_index)
+    call_edges = ctypes_result.call_edges + same_kit_edges
     call_edges_value = call_edges_to_value(call_edges)
     call_edges_array = json.loads(encode_jcs(call_edges_value))
 
@@ -310,6 +319,90 @@ def _call_callee_name(node: ast.AST) -> Optional[str]:
     return None
 
 
+def _contract_index_with_simple_names(contract_index: Dict[str, str]) -> Dict[str, str]:
+    out = dict(contract_index)
+    for name, cid in contract_index.items():
+        simple = name.rsplit(".", 1)[-1]
+        if simple:
+            out.setdefault(simple, cid)
+    return out
+
+
+def _linkerd_contract_cid(decl: ContractDecl) -> str:
+    pairs = [
+        ("name", vstr(decl.name)),
+        ("outBinding", vstr(decl.out_binding)),
+    ]
+    if decl.pre is not None:
+        pairs.append(("pre", formula_to_value(decl.pre)))
+    if decl.post is not None:
+        pairs.append(("post", formula_to_value(decl.post)))
+    if decl.inv is not None:
+        pairs.append(("inv", formula_to_value(decl.inv)))
+    return jcs_hash(vobj(pairs))
+
+
+def _resolve_same_kit_calls(
+    source: str,
+    path: str,
+    contract_index: Dict[str, str],
+) -> List[CallEdgeDecl]:
+    try:
+        tree = ast.parse(source, filename=path)
+    except SyntaxError:
+        return []
+
+    contracts_by_name = _contract_index_with_simple_names(contract_index)
+    if not contracts_by_name:
+        return []
+
+    edges: List[CallEdgeDecl] = []
+    seen: set[tuple[str, str, int, int]] = set()
+
+    class SameKitCallVisitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.function_stack: List[str] = []
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            self.function_stack.append(node.name)
+            self.generic_visit(node)
+            self.function_stack.pop()
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            self.function_stack.append(node.name)
+            self.generic_visit(node)
+            self.function_stack.pop()
+
+        def visit_Call(self, node: ast.Call) -> None:
+            if self.function_stack:
+                caller = self.function_stack[-1]
+                source_cid = contracts_by_name.get(caller)
+                callee = _call_callee_name(node.func)
+                if source_cid and callee and callee in contracts_by_name:
+                    line = getattr(node, "lineno", 1)
+                    column = getattr(node, "col_offset", 0)
+                    target_symbol = f"python-kit:{callee}"
+                    key = (source_cid, target_symbol, line, column)
+                    if key not in seen:
+                        seen.add(key)
+                        edges.append(
+                            CallEdgeDecl(
+                                source_contract_cid=source_cid,
+                                target_contract_cid=None,
+                                target_symbol=target_symbol,
+                                call_site_locus=Locus(file=path, line=line, column=column),
+                                evidence_term=atomic(
+                                    "call-site-obligation",
+                                    [make_var(caller)],
+                                ),
+                            )
+                        )
+            self.generic_visit(node)
+
+    SameKitCallVisitor().visit(tree)
+    return edges
+
+
 def _collect_python_callsites(source: str, source_path: str) -> List[Dict[str, Any]]:
     tree = ast.parse(source, filename=source_path)
     callsites: List[Dict[str, Any]] = []
@@ -483,6 +576,17 @@ def _try_lift_pydantic(source: str) -> List[ContractDecl]:
         if isinstance(obj, type) and hasattr(obj, "model_fields"):
             decls.extend(lift_pydantic_model(obj))
     return decls
+
+
+def _try_lift_decorated_contracts(source: str) -> List[ContractDecl]:
+    """Exec the source in an isolated namespace and collect @contract metadata."""
+    import types
+
+    namespace: dict = {"__name__": "_provekit_lsp_source"}
+    exec(source, namespace)
+    module = types.ModuleType("_provekit_lsp_source")
+    module.__dict__.update(namespace)
+    return collect_module(module)
 
 
 def handle_shutdown(msg_id: Any) -> None:

--- a/implementations/python/provekit-lift-py-tests/tests/test_daemon_protocol.py
+++ b/implementations/python/provekit-lift-py-tests/tests/test_daemon_protocol.py
@@ -125,6 +125,35 @@ class TestDaemonProtocol:
             f"{result['callEdges']!r}"
         )
 
+    def test_parse_emits_same_language_call_edge_locus(self):
+        """Decorated Python functions emit same-kit call edges at call sites."""
+        source = """\
+from provekit_lift_py_tests.decorators import contract
+
+@contract(pre="x >= 0")
+def add(x: int) -> int:
+    return x
+
+@contract(post="out >= 0")
+def compute(x: int) -> int:
+    return add(x)
+"""
+        responses = _run_lsp(_build_session(source=source, path="fixture.py"))
+        parse_resp = next(r for r in responses if r.get("id") == 2)
+        assert "error" not in parse_resp, f"parse returned error: {parse_resp}"
+        edges = parse_resp["result"]["callEdges"]
+        assert any(
+            edge.get("targetSymbol") == "python-kit:add"
+            and isinstance(edge.get("sourceContractCid"), str)
+            and edge["sourceContractCid"].startswith("blake3-512:")
+            and edge.get("callSiteLocus") == {
+                "column": 11,
+                "file": "fixture.py",
+                "line": 9,
+            }
+            for edge in edges
+        ), f"expected compute -> python-kit:add call edge, got {edges!r}"
+
     def test_declarations_contain_contracts(self):
         """With a contract-bearing fixture, each declaration has kind=='contract'."""
         responses = _run_lsp(_build_session())

--- a/implementations/rust/provekit-linkerd/src/methods.rs
+++ b/implementations/rust/provekit-linkerd/src/methods.rs
@@ -16,11 +16,8 @@
 //     `LinkerContract`/`LinkerCallEdge` (see `spawn_kit_lifter`).
 //   For `zig`: spawn `provekit-lsp-zig` (no args: reads stdin directly).
 //     `callEdges` may be omitted from the response and is treated as empty.
-//   For `python`: the LSP module has no installed binary (it's a Python module,
-//     invoked as `python -m provekit_lift_py_tests.lsp`); additionally, its
-//     `declarations` field is a JSON-encoded string rather than a JSON array
-//     (shape divergence from go/csharp/ruby). Documented gap; returns
-//     LifterUnavailable until a proper installed binary ships.
+//   For `python`: spawn `provekit-lsp-python` (no args), method `parse`.
+//     Binary is installed from implementations/python/provekit-lift-py-tests.
 //   For `java`: spawn `provekit-lsp-java --rpc`, same protocol as go/csharp/ruby.
 //     Requires `mvn package` in implementations/java/provekit-lift-java-core first;
 //     returns LifterUnavailable if the binary is not on PATH.
@@ -248,7 +245,7 @@ enum LiftError {
 /// - `ruby`: subprocess `provekit-lsp-ruby --rpc`, method `parse`.
 /// - `zig`: subprocess `provekit-lsp-zig` (no args), method `parse`; `callEdges`
 ///   field may be absent from response and is treated as empty.
-/// - `python`: no installed binary + shape divergence in response. LifterUnavailable.
+/// - `python`: subprocess `provekit-lsp-python` (no args), method `parse`.
 /// - `java`: subprocess `provekit-lsp-java --rpc`, method `parse`; binary must be
 ///   installed via `mvn package` in implementations/java/provekit-lift-java-core.
 /// - `swift`: subprocess `provekit-lsp-swift` (no args), method `parse`.
@@ -309,13 +306,17 @@ async fn lift_source(
             spawn_kit_lifter(&binary, &[], file, source, "zig-kit").await
         }
 
-        "python" => Err(LiftError::LifterUnavailable(
-            "kit 'python' lifter has no installed binary (it ships as a Python module, \
-             not a standalone executable) and its RPC response uses a non-standard \
-             shape (declarations encoded as a JSON string rather than a JSON array). \
-             Gap documented in spec §3 R5 commentary. Follow-up required."
-                .to_string(),
-        )),
+        "python" => {
+            let binary = find_binary("provekit-lsp-python").ok_or_else(|| {
+                LiftError::LifterUnavailable(
+                    "kit 'python' binary not found on PATH; install via: \
+                     cd implementations/python && \
+                     pip install -e provekit-lift-py-tests"
+                        .to_string(),
+                )
+            })?;
+            spawn_kit_lifter(&binary, &[], file, source, "python-kit").await
+        }
 
         "java" => {
             let binary = find_binary("provekit-lsp-java").ok_or_else(|| {

--- a/implementations/rust/provekit-linkerd/tests/multi_kit.rs
+++ b/implementations/rust/provekit-linkerd/tests/multi_kit.rs
@@ -29,9 +29,14 @@
 // Test 9: parseFile(kit="zig", ...) dispatches to the zig lifter.
 //         Skipped if provekit-lsp-zig is not installed.
 //
+// Test 10: parseFile(kit="python", ...) dispatches to the python lifter.
+//          Uses a fixture binary on PATH so the test is not coupled to the
+//          developer machine's Python package installation state.
+//
 // These tests communicate with the daemon over its Unix socket.
 
 use std::io::{BufRead, BufReader, Write};
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
@@ -216,6 +221,78 @@ fn rpc_binary_accepts_initialize(name: &str, args: &[&str]) -> Result<PathBuf, S
     let _ = child.wait();
 
     Ok(path)
+}
+
+fn install_fixture_python_lsp() -> PathBuf {
+    let bin_dir = std::env::temp_dir().join(format!(
+        "provekit-linkerd-python-bin-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0)
+    ));
+    std::fs::create_dir_all(&bin_dir).expect("create python fixture bin dir");
+    let binary = bin_dir.join("provekit-lsp-python");
+    std::fs::write(
+        &binary,
+        r#"#!/usr/bin/env python3
+import json
+import sys
+
+for line in sys.stdin:
+    if not line.strip():
+        continue
+    request = json.loads(line)
+    method = request.get("method")
+    msg_id = request.get("id")
+    if method == "initialize":
+        response = {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": {
+                "name": "provekit-lsp-python",
+                "version": "fixture",
+                "capabilities": ["parse"],
+            },
+        }
+    elif method == "parse":
+        response = {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": {
+                "declarations": [],
+                "callEdges": [],
+                "warnings": [],
+            },
+        }
+    elif method == "shutdown":
+        response = {"jsonrpc": "2.0", "id": msg_id, "result": None}
+        print(json.dumps(response, separators=(",", ":")), flush=True)
+        break
+    else:
+        response = {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "error": {"code": -32601, "message": f"unknown method: {method}"},
+        }
+    print(json.dumps(response, separators=(",", ":")), flush=True)
+"#,
+    )
+    .expect("write python fixture lsp");
+    let mut perms = std::fs::metadata(&binary)
+        .expect("stat python fixture lsp")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&binary, perms).expect("chmod python fixture lsp");
+
+    let current_path = std::env::var("PATH").unwrap_or_default();
+    let new_path = if current_path.is_empty() {
+        bin_dir.display().to_string()
+    } else {
+        format!("{}:{}", bin_dir.display(), current_path)
+    };
+    std::env::set_var("PATH", new_path);
+    bin_dir
 }
 
 // -------------------------------------------------------------------
@@ -863,4 +940,63 @@ fn absValue(x: i64) i64 {
     shutdown(&sock);
     child.wait().ok();
     std::fs::remove_file(&sock).ok();
+}
+
+// -------------------------------------------------------------------
+// Test 10: python kit dispatch returns diagnostics when provekit-lsp-python is on PATH.
+// -------------------------------------------------------------------
+
+/// Test 10: parseFile with kit="python" dispatches to the Python lifter.
+///
+/// Unlike the other optional kit-dispatch tests, this test installs a tiny
+/// fixture `provekit-lsp-python` binary on PATH. The regression it pins is
+/// linkerd's dispatch arm: Python must be routed like any other per-language
+/// kit, not rejected inside Rust as unavailable.
+#[test]
+fn test10_python_kit_dispatch() {
+    let fixture_bin_dir = install_fixture_python_lsp();
+
+    let sock = unique_sock_path("t10");
+    let _ = std::fs::remove_file(&sock);
+
+    let mut child = spawn_daemon(&sock);
+
+    assert!(
+        wait_for_socket(&sock, Duration::from_secs(5)),
+        "daemon socket did not appear"
+    );
+
+    let python_source = r#"
+def test_positive():
+    assert 1 > 0
+"#;
+
+    let req = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "parseFile",
+        "params": {
+            "kitId": "python",
+            "file": "/tmp/test_positive.py",
+            "source": python_source
+        }
+    });
+
+    let resp = send_recv(&sock, &req);
+
+    assert!(
+        resp.get("error").is_none(),
+        "python kit parseFile returned unexpected error: {:?}",
+        resp
+    );
+    assert!(
+        resp["result"]["diagnostics"].is_array(),
+        "python kit parseFile result must have diagnostics array: {:?}",
+        resp
+    );
+
+    shutdown(&sock);
+    child.wait().ok();
+    std::fs::remove_file(&sock).ok();
+    std::fs::remove_dir_all(fixture_bin_dir).ok();
 }


### PR DESCRIPTION
## Summary

- Replace the stale Python `LifterUnavailable` branch in linkerd with subprocess dispatch to `provekit-lsp-python`.
- Keep Python source/lift semantics inside the existing Python LSP plugin; Rust only routes the daemon protocol.
- Collect decorated Python contracts from source strings and emit same-kit Python call edges as `python-kit:<callee>` with call-site locus data.
- Use the same pared-down contract CID formula as linkerd for call-edge source IDs, so solver diagnostics resolve the caller contract instead of treating it as absent.
- Add a linkerd multi-kit regression with a fixture `provekit-lsp-python` binary so Python dispatch is tested without depending on local package install state.

## Validation

- `PYTHONPATH=implementations/python/provekit-lift-py-tests/src pytest -q implementations/python/provekit-lift-py-tests/tests/test_daemon_protocol.py::TestDaemonProtocol::test_parse_emits_same_language_call_edge_locus` failed before implementation with `callEdges: []`.
- `PYTHONPATH=implementations/python/provekit-lift-py-tests/src pytest -q implementations/python/provekit-lift-py-tests/tests/test_daemon_protocol.py`
- `PYTHONPATH=implementations/python/provekit-lift-py-tests/src pytest -q implementations/python/provekit-lift-py-tests/tests/test_ctypes_resolver.py`
- `PYTHONPATH=implementations/python/provekit-lift-py-tests/src pytest -q implementations/python/provekit-lift-py-tests/tests/test_daemon_protocol.py implementations/python/provekit-lift-py-tests/tests/test_ctypes_resolver.py`
- `python3 -m compileall -q implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests`
- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd --test multi_kit test10_python_kit_dispatch -- --nocapture`
- manual linkerd probe for decorated `compute -> add` returned an `implication-undecidable` diagnostic with `targetSymbol: python-kit:add`, a resolved `blake3-512:` source contract CID, and `file: /tmp/call_edge.py`
- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd --test multi_kit`
- `cargo check --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd`
- `cargo fmt --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd -- --check`
- `git diff --check`