### PR TITLE
[codex] Route PHP kit through LSP daemon

### DIFF
--- a/implementations/php/bin/provekit-lsp-php
+++ b/implementations/php/bin/provekit-lsp-php
@@ -1,0 +1,7 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec php "$SCRIPT_DIR/../provekit-lift/src/lspd.php" "$@"

--- a/implementations/php/composer.json
+++ b/implementations/php/composer.json
@@ -2,6 +2,7 @@
     "name": "provekit/php-kit",
     "description": "Provekit PHP kit — IR library + self-contracts lifter",
     "type": "project",
+    "bin": ["bin/provekit-lsp-php"],
     "autoload": {
         "psr-4": {
             "Provekit\\Ir\\": "provekit-ir-symbolic/src/Ir/",

--- a/implementations/php/provekit-lift/src/lspd.php
+++ b/implementations/php/provekit-lift/src/lspd.php
@@ -83,7 +83,7 @@ class AnnotationScanner
                         'sourceContractCid' => 'pending-php:' . $funcName,
                         'targetContractCid' => null,
                         'targetSymbol' => $cid,
-                        'callSiteLocus' => ['file' => $path, 'line' => $i + 1, 'col' => 0],
+                        'callSiteLocus' => ['file' => $path, 'line' => $i + 1, 'column' => 0],
                         'evidenceTerm' => ['kind' => 'atomic', 'name' => 'true', 'args' => []],
                     ];
                 }
@@ -98,7 +98,7 @@ class AnnotationScanner
                         'sourceContractCid' => 'pending-php:' . $funcName,
                         'targetContractCid' => null,
                         'targetSymbol' => $target,
-                        'callSiteLocus' => ['file' => $path, 'line' => $i + 1, 'col' => 0],
+                        'callSiteLocus' => ['file' => $path, 'line' => $i + 1, 'column' => 0],
                         'evidenceTerm' => ['kind' => 'atomic', 'name' => 'true', 'args' => []],
                     ];
                 }
@@ -109,50 +109,127 @@ class AnnotationScanner
     }
 
     /**
-     * Walk function bodies for potential call expressions
-     * (emits call edges for same-kit and cross-kit resolution).
+     * Walk function bodies for same-kit PHP call expressions.
      */
     public static function walkCallEdges(string $source, string $path, array $decls): array
     {
-        $callEdges = [];
-
+        $declaredNames = [];
         foreach ($decls as $decl) {
-            if (($decl['kind'] ?? '') !== 'contract') continue;
-            $name = $decl['name'] ?? '';
-            if (!$name) continue;
+            if (($decl['kind'] ?? '') === 'contract' && !empty($decl['name'])) {
+                $declaredNames[$decl['name']] = true;
+            }
+        }
+        if ($declaredNames === []) {
+            return [];
+        }
 
-            // Find call expressions in the function body: `ClassName::method()`
-            // For same-kit: `$this->otherMethod()`
-            if (preg_match_all('/\$this->(\w+)\(/', $source, $matches)) {
-                foreach ($matches[1] as $called) {
-                    $callEdges[] = [
+        $tokens = token_get_all($source);
+        $callEdges = [];
+        $seen = [];
+        $line = 1;
+        $column = 0;
+        $braceDepth = 0;
+        $pendingFunction = null;
+        $functionStack = [];
+        $declarationNameIndexes = [];
+
+        for ($i = 0; $i < count($tokens); $i++) {
+            $token = $tokens[$i];
+            $text = self::tokenText($token);
+            $startLine = $line;
+            $startColumn = $column;
+
+            if (is_array($token) && $token[0] === T_FUNCTION) {
+                $nameIndex = self::nextNamedFunctionIndex($tokens, $i + 1);
+                if ($nameIndex !== null) {
+                    $pendingFunction = self::tokenText($tokens[$nameIndex]);
+                    $declarationNameIndexes[$nameIndex] = true;
+                }
+            } elseif ($text === '{') {
+                $braceDepth++;
+                if ($pendingFunction !== null) {
+                    $functionStack[] = ['name' => $pendingFunction, 'braceDepth' => $braceDepth];
+                    $pendingFunction = null;
+                }
+            } elseif ($text === '}') {
+                while ($functionStack !== [] && end($functionStack)['braceDepth'] === $braceDepth) {
+                    array_pop($functionStack);
+                }
+                $braceDepth = max(0, $braceDepth - 1);
+            } elseif (
+                is_array($token)
+                && $token[0] === T_STRING
+                && !isset($declarationNameIndexes[$i])
+                && $functionStack !== []
+            ) {
+                $callee = $text;
+                $nextIndex = self::nextNonTriviaIndex($tokens, $i + 1);
+                if (isset($declaredNames[$callee]) && $nextIndex !== null && self::tokenText($tokens[$nextIndex]) === '(') {
+                    $caller = end($functionStack)['name'];
+                    $edge = [
                         'kind' => 'call-edge',
-                        'sourceContractCid' => 'pending-php:' . $name,
+                        'sourceContractCid' => 'pending-php:' . $caller,
                         'targetContractCid' => null,
-                        'targetSymbol' => 'php:' . $called,
-                        'callSiteLocus' => ['file' => $path, 'line' => 0, 'col' => 0],
+                        'targetSymbol' => 'php-kit:' . $callee,
+                        'callSiteLocus' => ['file' => $path, 'line' => $startLine, 'column' => $startColumn],
                         'evidenceTerm' => ['kind' => 'atomic', 'name' => 'true', 'args' => []],
                     ];
+                    $key = $edge['sourceContractCid'] . '|' . $edge['targetSymbol'] . '|' . $startLine . '|' . $startColumn;
+                    if (!isset($seen[$key])) {
+                        $callEdges[] = $edge;
+                        $seen[$key] = true;
+                    }
                 }
             }
 
-            // Cross-kit: `C\function()` → cgo-like resolution
-            if (preg_match_all('/(?:new\s+)?(\w+)\s*\(/', $source, $matches)) {
-                foreach ($matches[1] as $called) {
-                    if (in_array(strtolower($called), ['if', 'for', 'while', 'function', 'return', 'echo', 'new', 'array', 'list'])) continue;
-                    $callEdges[] = [
-                        'kind' => 'call-edge',
-                        'sourceContractCid' => 'pending-php:' . $name,
-                        'targetContractCid' => null,
-                        'targetSymbol' => 'php:' . $called,
-                        'callSiteLocus' => ['file' => $path, 'line' => 0, 'col' => 0],
-                        'evidenceTerm' => ['kind' => 'atomic', 'name' => 'true', 'args' => []],
-                    ];
-                }
-            }
+            self::advancePosition($text, $line, $column);
         }
 
         return $callEdges;
+    }
+
+    private static function tokenText(mixed $token): string
+    {
+        return is_array($token) ? $token[1] : $token;
+    }
+
+    private static function nextNamedFunctionIndex(array $tokens, int $start): ?int
+    {
+        for ($i = $start; $i < count($tokens); $i++) {
+            $token = $tokens[$i];
+            if (self::isTrivia($token) || self::tokenText($token) === '&') {
+                continue;
+            }
+            return is_array($token) && $token[0] === T_STRING ? $i : null;
+        }
+        return null;
+    }
+
+    private static function nextNonTriviaIndex(array $tokens, int $start): ?int
+    {
+        for ($i = $start; $i < count($tokens); $i++) {
+            if (!self::isTrivia($tokens[$i])) {
+                return $i;
+            }
+        }
+        return null;
+    }
+
+    private static function isTrivia(mixed $token): bool
+    {
+        return is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true);
+    }
+
+    private static function advancePosition(string $text, int &$line, int &$column): void
+    {
+        for ($i = 0; $i < strlen($text); $i++) {
+            if ($text[$i] === "\n") {
+                $line++;
+                $column = 0;
+            } else {
+                $column++;
+            }
+        }
     }
 }
 

--- a/implementations/php/provekit-lift/tests/integration_lsp.sh
+++ b/implementations/php/provekit-lift/tests/integration_lsp.sh
@@ -47,6 +47,10 @@ cat > "$FIXTURE" << 'EOF'
 function add_numbers(int $a, int $b): int {
     return $a + $b;
 }
+// @provekit-contract
+function compute_total(int $a, int $b): int {
+    return add_numbers($a, $b);
+}
 EOF
 
 printf "Running provekit-lsp-php integration tests...\n"
@@ -97,6 +101,11 @@ PARSE2=$(printf '%s\n' "$PARSE_RESPONSES" | sed -n '2p')
 
 check "T12 parse: declarations key"    "$PARSE2" '"declarations":'
 check "T13 parse: contract add_numbers" "$PARSE2" '"name":"add_numbers"'
+check "T14 parse: call edge source"    "$PARSE2" '"sourceContractCid":"pending-php:compute_total"'
+check "T15 parse: call edge target"    "$PARSE2" '"targetSymbol":"php-kit:add_numbers"'
+check "T16 parse: call edge locus file" "$PARSE2" '"file":"fixture.php"'
+check "T17 parse: call edge locus line" "$PARSE2" '"line":8'
+check "T18 parse: call edge locus column" "$PARSE2" '"column":11'
 
 # Cleanup
 rm -rf "$TMPDIR_PATH"

--- a/implementations/rust/provekit-linkerd/src/methods.rs
+++ b/implementations/rust/provekit-linkerd/src/methods.rs
@@ -10,7 +10,7 @@
 //
 // Lifting strategy for parseFile:
 //   For `rust` sources: call `provekit_lift::lift_path` in-process (fast).
-//   For `go`, `csharp`, `ruby`, `java`, `swift`, `ts`, `cpp`, `c`, `zig`:
+//   For `go`, `csharp`, `ruby`, `java`, `swift`, `ts`, `cpp`, `c`, `zig`, `php`:
 //     spawn the kit's LSP plugin binary, send a JSON-RPC `parse` request,
 //     read the `{declarations, callEdges}` response, and map into
 //     `LinkerContract`/`LinkerCallEdge` (see `spawn_kit_lifter`).
@@ -29,6 +29,8 @@
 //     Binary built via `g++ -std=c++17 -o provekit-lsp-cpp main.cpp`.
 //   For `c`: spawn `provekit-lsp-c --rpc` (requires --rpc flag).
 //     Binary built via `cc -std=c11 -o provekit-lsp-c main.c`.
+//   For `php`: spawn `provekit-lsp-php` (no args: reads stdin directly).
+//     Binary is installed from implementations/php/bin.
 //
 // Binary discovery order (for subprocess kits):
 //   1. Check PATH for the named binary.
@@ -252,6 +254,7 @@ enum LiftError {
 /// - `ts`: subprocess `provekit-lsp-ts` (no args), method `parse`.
 /// - `cpp`: subprocess `provekit-lsp-cpp` (no args), method `parse`.
 /// - `c`: subprocess `provekit-lsp-c --rpc`, method `parse`.
+/// - `php`: subprocess `provekit-lsp-php` (no args), method `parse`.
 async fn lift_source(
     kit_id: &str,
     file: &str,
@@ -386,8 +389,20 @@ async fn lift_source(
             spawn_kit_lifter(&binary, &["--rpc"], file, source, "c-kit").await
         }
 
+        "php" => {
+            let binary = find_binary("provekit-lsp-php").ok_or_else(|| {
+                LiftError::LifterUnavailable(
+                    "kit 'php' binary not found on PATH; install via: \
+                     cd implementations/php && composer install && \
+                     cp bin/provekit-lsp-php ~/.local/bin/"
+                        .to_string(),
+                )
+            })?;
+            spawn_kit_lifter(&binary, &[], file, source, "php-kit").await
+        }
+
         other => Err(LiftError::KitNotInManifest(format!(
-            "unknown kitId '{other}'; valid kits: rust, go, cpp, csharp, python, ruby, swift, ts, zig, java, c"
+            "unknown kitId '{other}'; valid kits: rust, go, cpp, csharp, python, ruby, swift, ts, zig, java, c, php"
         ))),
     }
 }

--- a/implementations/rust/provekit-linkerd/tests/multi_kit.rs
+++ b/implementations/rust/provekit-linkerd/tests/multi_kit.rs
@@ -33,6 +33,9 @@
 //          Uses a fixture binary on PATH so the test is not coupled to the
 //          developer machine's Python package installation state.
 //
+// Test 11: parseFile(kit="php", ...) dispatches to the php lifter and returns
+//          a result with a diagnostics array when provekit-lsp-php is on PATH.
+//
 // These tests communicate with the daemon over its Unix socket.
 
 use std::io::{BufRead, BufReader, Write};
@@ -137,6 +140,47 @@ fn binary_path(name: &str) -> Option<PathBuf> {
         }
     }
     None
+}
+
+fn install_fixture_php_lsp() {
+    let dir = std::env::temp_dir().join(format!(
+        "provekit-linkerd-php-fixture-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0)
+    ));
+    std::fs::create_dir_all(&dir).expect("create php fixture dir");
+
+    let binary = dir.join("provekit-lsp-php");
+    std::fs::write(
+        &binary,
+        r#"#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*|*'"method": "initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"name":"fixture-php","protocol_version":"provekit-lift/1"}}'
+      ;;
+    *'"method":"parse"'*|*'"method": "parse"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"declarations":[{"kind":"contract","name":"add_numbers","outBinding":"out","post":{"kind":"atomic","name":"true","args":[]}}],"callEdges":[],"diagnostics":[]}}'
+      ;;
+    *'"method":"shutdown"'*|*'"method": "shutdown"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":null}'
+      exit 0
+      ;;
+  esac
+done
+"#,
+    )
+    .expect("write php fixture lsp");
+    let mut permissions = std::fs::metadata(&binary)
+        .expect("stat php fixture lsp")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&binary, permissions).expect("chmod php fixture lsp");
+
+    let current_path = std::env::var("PATH").unwrap_or_default();
+    std::env::set_var("PATH", format!("{}:{current_path}", dir.display()));
 }
 
 fn rpc_binary_accepts_initialize(name: &str, args: &[&str]) -> Result<PathBuf, String> {
@@ -999,4 +1043,63 @@ def test_positive():
     child.wait().ok();
     std::fs::remove_file(&sock).ok();
     std::fs::remove_dir_all(fixture_bin_dir).ok();
+}
+
+// -------------------------------------------------------------------
+// Test 11: php kit dispatch returns diagnostics when provekit-lsp-php is on PATH.
+// -------------------------------------------------------------------
+
+/// Test 11: parseFile with kit="php" dispatches to the php lifter.
+///
+/// Installs a fixture `provekit-lsp-php` binary on PATH for this process so the
+/// assertion covers linkerd's kit dispatch contract, independent of local PHP
+/// package installation state.
+#[test]
+fn test11_php_kit_dispatch() {
+    install_fixture_php_lsp();
+
+    let sock = unique_sock_path("t11");
+    let _ = std::fs::remove_file(&sock);
+
+    let mut child = spawn_daemon(&sock);
+
+    assert!(
+        wait_for_socket(&sock, Duration::from_secs(5)),
+        "daemon socket did not appear"
+    );
+
+    let php_source = r#"<?php
+// @provekit-contract
+function add_numbers(int $a, int $b): int {
+    return $a + $b;
+}
+"#;
+
+    let req = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "parseFile",
+        "params": {
+            "kitId": "php",
+            "file": "/tmp/test_add.php",
+            "source": php_source
+        }
+    });
+
+    let resp = send_recv(&sock, &req);
+
+    assert!(
+        resp.get("error").is_none(),
+        "php kit parseFile returned unexpected error: {:?}",
+        resp
+    );
+    assert!(
+        resp["result"]["diagnostics"].is_array(),
+        "php kit parseFile result must have diagnostics array: {:?}",
+        resp
+    );
+
+    shutdown(&sock);
+    child.wait().ok();
+    std::fs::remove_file(&sock).ok();
 }


### PR DESCRIPTION
## Summary

- route `kitId=php` in `provekit-linkerd` through `provekit-lsp-php`
- add an executable PHP LSP wrapper and expose it through Composer `bin`
- emit caller-scoped PHP same-kit call edges as `pending-php:<caller>` to `php-kit:<callee>` with concrete call-site locus data
- add linkerd dispatch coverage and PHP daemon integration coverage for the call-edge shape

## Why

The PHP kit already had a stdio LSP daemon, but the language-agnostic Rust daemon rejected `php` before it could invoke the kit-owned parser. This wires PHP into the same LSP/linkerd path as the other subprocess kits, and makes PHP emit the call-edge shape that linkerd can resolve into solver diagnostics at the source call site.

## Validation

- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd --test multi_kit test10_php_kit_dispatch -- --nocapture` failed before the original dispatch implementation with `unknown kitId 'php'`
- `sh implementations/php/provekit-lift/tests/integration_lsp.sh` failed before the call-edge scanner fix on `php-kit:add_numbers`, `line`, and `column`
- `sh implementations/php/provekit-lift/tests/integration_lsp.sh`
- `php provekit-lift/tests/ForwardPropagatorTest.php`
- `php provekit-lift-php-source/tests/PhpSourceLifterTest.php`
- `php -l provekit-lift/src/lspd.php`
- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd --test multi_kit test10_php_kit_dispatch -- --nocapture`
- manual linkerd probe for `compute_total -> add_numbers` returned an `unprovable-obligation` diagnostic with `targetSymbol: php-kit:add_numbers`, `sourceContractCid: pending-php:compute_total`, and `file: /tmp/call-edge.php`
- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd --test multi_kit`
- `cargo check --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd`
- `cargo fmt --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd -- --check`
- `git diff --check`
- `php -r '$s=file_get_contents("implementations/php/composer.json"); json_decode($s, true, 512, JSON_THROW_ON_ERROR); echo "composer.json valid JSON\n";'`

Composer CLI was not installed in this shell, so `composer test` could not run; its two configured PHP test commands were run directly.