### PR TITLE
Add recognizer parity for sugar lifters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -735,6 +735,7 @@ cross-language-proof-parity: build-java build-ts build-zig build-scala cross-lan
 		-p provekit-walk --bin provekit-walk-rpc \
 		recognize -- --nocapture
 	pnpm vitest run implementations/typescript/src/lift/typescript-source/index.test.ts
+	make test-swift-source-lift
 	(cd implementations/zig/provekit-lift-zig-source && zig build test)
 	$(SCALA_CLI) test implementations/scala/provekit-lift-scala-source --server=false
 	@echo "--- prove parity ---"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   make help: print this help
 #   make ci: Linux-profile gate (catalog + protocol + live mints + tests)
 #   make conformance: catalog + protocol + live mint CIDs + self-contract tests
-#   make cross-language-proof-parity: Java/Go/Python/Rust emit + materialize + prove gate,
+#   make cross-language-proof-parity: Java/Go/Python/Rust emit + materialize + recognize + prove gate,
 #                                      plus TypeScript/Zig/Scala parity lanes
 #   make all-mint: run all 11 Linux-profile mint commands; print CIDs
 #   make bootstrap-self-contracts: re-sign attestations from live artifacts
@@ -280,6 +280,7 @@ build-python:
 .PHONY: build-scala
 build-scala:
 	$(SCALA_CLI) compile implementations/scala/provekit-emit-scala-scalatest --server=false --scalac-option -deprecation
+	$(SCALA_CLI) compile implementations/scala/provekit-lift-scala-source --server=false --scalac-option -deprecation
 
 .PHONY: build-java-self-contracts
 build-java-self-contracts:
@@ -668,13 +669,13 @@ cross-language-proof-parity-python-env:
 		pytest \
 		-e examples/provekit-shim-python-requests \
 		-e implementations/python/provekit-emit-python-pytest \
-		-e implementations/python/provekit-lift-py-tests \
+		-e implementations/python/provekit-lift-python-source \
 		-e implementations/python/provekit-realize-python-core \
 		-e implementations/python/provekit-realize-python-requests
 
 .PHONY: cross-language-proof-parity
 cross-language-proof-parity: build-java build-ts build-zig build-scala cross-language-proof-parity-python-env
-	@echo "=== Cross-language proof parity: emit/materialize/prove lanes for Java, Go, Python, Rust, TypeScript, Zig, Scala ==="
+	@echo "=== Cross-language proof parity: emit/materialize/recognize/prove lanes for Java, Go, Python, Rust, TypeScript, Zig, Scala ==="
 	cargo build --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-realize-rust-core --bin provekit-realize-rust
 	@echo "--- emit parity ---"
@@ -718,6 +719,24 @@ cross-language-proof-parity: build-java build-ts build-zig build-scala cross-lan
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_materialize_integration \
 		materialize_rust_reqwest_example_uses_rust_library_shim
+	@echo "--- recognizer parity ---"
+	$(MVN) -q -f implementations/java/pom.xml \
+		-pl provekit-lift-java-source -am \
+		-Dtest=RecognizeHandlerTest,JavaSugarBindingLifterTest test
+	(cd implementations/go/provekit-lift-go && \
+		go test ./... -run 'Test(SugarBody|Recognize)')
+	$(PARITY_PYTHON) -m pytest \
+		implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py \
+		-q -k 'sugar_body or recognize'
+	cargo test --release --manifest-path implementations/rust/Cargo.toml \
+		-p provekit-walk --bin provekit-walk-rpc \
+		sugar_body -- --nocapture
+	cargo test --release --manifest-path implementations/rust/Cargo.toml \
+		-p provekit-walk --bin provekit-walk-rpc \
+		recognize -- --nocapture
+	pnpm vitest run implementations/typescript/src/lift/typescript-source/index.test.ts
+	(cd implementations/zig/provekit-lift-zig-source && zig build test)
+	$(SCALA_CLI) test implementations/scala/provekit-lift-scala-source --server=false
 	@echo "--- prove parity ---"
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_verify_java_production_bridge \
@@ -919,6 +938,7 @@ test-scala: build-scala
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_emit_scala_scalatest \
 		emit_scala_scalatest_dispatches_real_emitter_and_scala_cli_checks_output
+	$(SCALA_CLI) test implementations/scala/provekit-lift-scala-source --server=false
 
 .PHONY: test-swift
 test-swift: build-swift
@@ -926,6 +946,10 @@ test-swift: build-swift
 	cd implementations/swift && swift run conformance
 	cd implementations/swift && swift run test-swift-lsp
 	cd implementations/swift && swift run test-swift-crypto
+
+.PHONY: test-swift-source-lift
+test-swift-source-lift: build-swift
+	cd implementations/swift && swift run test-swift-source-lift
 
 .PHONY: test-zig
 test-zig:

--- a/implementations/rust/provekit-cli/src/report_fmt.rs
+++ b/implementations/rust/provekit-cli/src/report_fmt.rs
@@ -112,10 +112,10 @@ pub fn print_report_pretty(r: &Report, quiet: bool) {
     }
 }
 
-/// Decide an exit code from a report. Discharged or empty -> success;
-/// any violation or load error -> verification failure (exit 1).
+/// Decide an exit code from a proof report. A load-bearing `prove` run must
+/// have checked at least one callsite; zero-callsite reports are vacuous.
 pub fn report_exit_code(r: &Report) -> u8 {
-    if r.violations > 0 || !r.load_errors.is_empty() {
+    if r.violations > 0 || !r.load_errors.is_empty() || r.total_callsites == 0 {
         crate::EXIT_VERIFY_FAIL
     } else {
         crate::EXIT_OK
@@ -128,9 +128,9 @@ mod tests {
     use provekit_verifier::Report;
 
     #[test]
-    fn empty_report_is_clean() {
+    fn empty_report_is_not_a_successful_proof() {
         let r = Report::default();
-        assert_eq!(report_exit_code(&r), crate::EXIT_OK);
+        assert_eq!(report_exit_code(&r), crate::EXIT_VERIFY_FAIL);
         let j = report_to_json(&r);
         assert_eq!(j["totalCallsites"], 0);
         assert_eq!(j["violations"], 0);

--- a/implementations/rust/provekit-cli/tests/cli_surface.rs
+++ b/implementations/rust/provekit-cli/tests/cli_surface.rs
@@ -175,6 +175,27 @@ fn prove_cli_does_not_expose_manual_proofir_or_solver_text_flags() {
 }
 
 #[test]
+fn prove_empty_project_is_not_a_successful_proof() {
+    let project = tempfile::tempdir().expect("create tempdir");
+    let output = Command::new(provekit_bin())
+        .arg("prove")
+        .arg(project.path())
+        .arg("--json")
+        .output()
+        .expect("spawn provekit prove empty project");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let report: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("prove JSON parse failed: {e}\nstdout: {stdout}"));
+
+    assert_eq!(report["totalCallsites"], 0, "report: {report}");
+    assert_eq!(report["violations"], 0, "report: {report}");
+    assert!(
+        !output.status.success(),
+        "prove must not report success when it checked zero callsites: {report}"
+    );
+}
+
+#[test]
 fn provekit_cli_does_not_expose_legacy_witness_subcommand() {
     let help = Command::new(provekit_bin())
         .arg("--help")

--- a/implementations/scala/.provekit/config.toml
+++ b/implementations/scala/.provekit/config.toml
@@ -1,4 +1,14 @@
+[authoring]
+surface = "scala-source"
+
+[[plugins]]
+name = "scala-source"
+kind = "lift"
+surface = "scala-source"
+emit = "ir-document"
+
 [[plugins]]
 name = "scala-scalatest"
+kind = "emit"
 surface = "scala-scalatest"
 emit = "scalatest"

--- a/implementations/scala/.provekit/lift/scala-source/manifest.toml
+++ b/implementations/scala/.provekit/lift/scala-source/manifest.toml
@@ -1,0 +1,11 @@
+name = "scala-source"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["scala-cli", "run", "provekit-lift-scala-source", "--server=false", "--", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["scala-source"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false

--- a/implementations/scala/provekit-lift-scala-source/Main.scala
+++ b/implementations/scala/provekit-lift-scala-source/Main.scala
@@ -1,0 +1,577 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package provekit.lift.scala_source
+
+import java.io.{BufferedReader, InputStreamReader}
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+
+import org.bouncycastle.crypto.digests.Blake3Digest
+import scala.collection.mutable
+import scala.jdk.CollectionConverters.*
+import scala.meta.*
+
+object Main:
+  def main(args: Array[String]): Unit =
+    if args.contains("--rpc") then ScalaSourceRpc.run()
+    else System.err.println("provekit-lift-scala-source expects --rpc")
+
+final case class LiftResult(ir: Seq[ujson.Value], diagnostics: Seq[ujson.Value])
+
+final case class SourceSpan(
+    startLine: Int,
+    startCol: Int,
+    endLine: Int,
+    endCol: Int,
+):
+  def toJson: ujson.Obj =
+    ujson.Obj(
+      "start_line" -> startLine,
+      "start_col" -> startCol,
+      "end_line" -> endLine,
+      "end_col" -> endCol,
+    )
+
+final case class BindingTemplate(
+    conceptName: String,
+    libraryTag: String,
+    family: Option[ujson.Value],
+    astTemplate: ujson.Value,
+    templateCid: String,
+    paramNames: Seq[String],
+    contractCid: String,
+)
+
+final case class RecognizeParams(
+    projectRoot: String,
+    sourcePaths: Seq[String],
+    bindingTemplates: Seq[BindingTemplate],
+)
+
+final case class ParamBinding(index: Int, sourceText: String):
+  def toJson: ujson.Obj =
+    ujson.Obj("index" -> index, "source_text" -> sourceText)
+
+final case class RecognizeTag(
+    file: String,
+    span: SourceSpan,
+    functionName: String,
+    conceptName: String,
+    libraryTag: String,
+    family: Option[ujson.Value],
+    templateCid: String,
+    contractCid: String,
+    matchTier: String,
+    paramBindings: Seq[ParamBinding],
+):
+  def toJson: ujson.Obj =
+    val obj = ujson.Obj(
+      "file" -> file,
+      "span" -> span.toJson,
+      "function_name" -> functionName,
+      "concept_name" -> conceptName,
+      "library_tag" -> libraryTag,
+      "template_cid" -> templateCid,
+      "contract_cid" -> contractCid,
+      "match_tier" -> matchTier,
+      "param_bindings" -> ujson.Arr.from(paramBindings.map(_.toJson)),
+    )
+    family.foreach(value => obj("family") = value)
+    obj
+
+final case class RecognizeResponse(tags: Seq[RecognizeTag]):
+  def toJson: ujson.Obj =
+    ujson.Obj("tags" -> ujson.Arr.from(tags.map(_.toJson)))
+
+private final case class ParsedSource(tree: Source, diagnostics: Seq[ujson.Value])
+
+private final case class SugarBinding(
+    conceptName: String,
+    targetLibraryTag: String,
+    family: Option[String],
+    libraryVersion: Option[String],
+    observedDimension: Option[String],
+    loss: Seq[String],
+)
+
+object ScalaSourceLifter:
+  def liftSource(source: String, sourcePath: String, layer: String = "all"): LiftResult =
+    parseSource(source, sourcePath) match
+      case Left(diagnostic) => LiftResult(Seq.empty, Seq(diagnostic))
+      case Right(parsed) =>
+        val emitBindings = layer == "library-bindings" || layer == "all"
+        val ir =
+          if emitBindings then
+            ScalaTrees.definitions(parsed.tree).flatMap(defn => libraryBindingEntry(defn, sourcePath))
+          else Seq.empty
+        LiftResult(ir, parsed.diagnostics)
+
+  def liftPaths(workspaceRoot: String, sourcePaths: Seq[String], layer: String = "all"): LiftResult =
+    val root = Path.of(if workspaceRoot.nonEmpty then workspaceRoot else ".").toAbsolutePath.normalize()
+    val requested = if sourcePaths.nonEmpty then sourcePaths else Seq(".")
+    val ir = mutable.ArrayBuffer.empty[ujson.Value]
+    val diagnostics = mutable.ArrayBuffer.empty[ujson.Value]
+    for path <- expandScalaPaths(root, requested) do
+      val relPath =
+        try root.relativize(path).toString.replace('\\', '/')
+        catch case _: IllegalArgumentException => path.toString
+      try
+        val result = liftSource(Files.readString(path, StandardCharsets.UTF_8), relPath, layer)
+        ir ++= result.ir
+        diagnostics ++= result.diagnostics
+      catch
+        case e: Exception =>
+          diagnostics += ujson.Obj(
+            "kind" -> "io-error",
+            "message" -> s"cannot read '$relPath': ${e.getMessage}",
+          )
+    LiftResult(ir.toSeq, diagnostics.toSeq)
+
+  private def libraryBindingEntry(defn: Defn.Def, sourcePath: String): Option[ujson.Obj] =
+    sugarBinding(defn).map { binding =>
+      val paramNames = ScalaTemplate.functionParamNames(defn)
+      val paramTypes = defn.paramss.flatten.map(_.decltpe.map(_.syntax).getOrElse(""))
+      val returnType = defn.decltpe.map(_.syntax).getOrElse("")
+      val signatureShape = ujson.Obj(
+        "param_names" -> ujson.Arr.from(paramNames),
+        "param_types" -> ujson.Arr.from(paramTypes),
+        "return_type" -> returnType,
+      )
+      val termShape = ScalaTemplate.functionBodyTemplate(defn)
+      val bodyText = ScalaTemplate.bodyText(defn)
+      val bodySource = ujson.Obj(
+        "file" -> sourcePath,
+        "source_cid" -> ScalaTemplate.cidOfUtf8(bodyText),
+        "span" -> ScalaTrees.span(defn).toJson,
+        "body_text" -> bodyText,
+        "ast_template" -> termShape,
+        "template_cid" -> ScalaTemplate.templateCid(termShape),
+        "param_names" -> ujson.Arr.from(paramNames),
+      )
+      val entry = ujson.Obj(
+        "kind" -> "library-sugar-binding-entry",
+        "body_source" -> bodySource,
+        "concept_name" -> binding.conceptName,
+        "loss_record_contribution" -> ujson.Obj(
+          "form" -> "literal",
+          "value" -> ujson.Obj("entries" -> ujson.Arr.from(binding.loss)),
+        ),
+        "param_names" -> ujson.Arr.from(paramNames),
+        "param_types" -> ujson.Arr.from(paramTypes),
+        "return_type" -> returnType,
+        "signature_shape_cid" -> ScalaTemplate.templateCid(signatureShape),
+        "source_function_name" -> defn.name.value,
+        "target_language" -> "scala",
+        "target_library_tag" -> binding.targetLibraryTag,
+        "term_shape" -> termShape,
+        "term_shape_cid" -> ScalaTemplate.templateCid(termShape),
+      )
+      binding.family.foreach(value => entry("family") = value)
+      binding.libraryVersion.foreach(value => entry("library_version") = value)
+      binding.observedDimension.foreach(value => entry("observed_dimension") = value)
+      entry
+    }
+
+  private def sugarBinding(defn: Defn.Def): Option[SugarBinding] =
+    defn.mods.collectFirst {
+      case Mod.Annot(init) if isSugarBind(init) =>
+        val args = namedStringArgs(init)
+        val concept = args.getOrElse("concept", "")
+        val library = args.getOrElse("library", "")
+        if concept.nonEmpty && library.nonEmpty then
+          SugarBinding(
+            conceptName = concept,
+            targetLibraryTag = library,
+            family = args.get("family"),
+            libraryVersion = args.get("version"),
+            observedDimension = args.get("observed_dimension"),
+            loss = stringListArg(init, "loss").getOrElse(Seq.empty),
+          )
+        else null
+    }.filter(_ != null)
+
+  private def isSugarBind(init: Init): Boolean =
+    init.tpe.syntax == "sugar.bind" || init.tpe.syntax == "provekit.sugar.bind"
+
+  private def namedStringArgs(init: Init): Map[String, String] =
+    init.argss.flatMap(_.values).collect {
+      case Term.Assign(Term.Name(name), Lit.String(value)) => name -> value
+    }.toMap
+
+  private def stringListArg(init: Init, name: String): Option[Seq[String]] =
+    init.argss.flatMap(_.values).collectFirst {
+      case Term.Assign(Term.Name(`name`), Term.Apply(Term.Name("List"), values)) =>
+        values.collect { case Lit.String(value) => value }
+      case Term.Assign(Term.Name(`name`), Term.Apply(Term.Name("Seq"), values)) =>
+        values.collect { case Lit.String(value) => value }
+    }
+
+  private def parseSource(source: String, sourcePath: String): Either[ujson.Value, ParsedSource] =
+    dialects.Scala3(Input.VirtualFile(sourcePath, source)).parse[Source] match
+      case Parsed.Success(tree) => Right(ParsedSource(tree, Seq.empty))
+      case Parsed.Error(pos, message, _) =>
+        Left(
+          ujson.Obj(
+            "kind" -> "parse-error",
+            "message" -> message,
+            "path" -> sourcePath,
+            "line" -> (pos.startLine + 1),
+          ),
+        )
+
+  private def expandScalaPaths(root: Path, requested: Seq[String]): Seq[Path] =
+    val seen = mutable.LinkedHashSet.empty[Path]
+    for item <- requested do
+      val path = if Path.of(item).isAbsolute then Path.of(item) else root.resolve(item)
+      if Files.isDirectory(path) then
+        Files.walk(path).iterator().asScala
+          .filter(path => Files.isRegularFile(path) && path.toString.endsWith(".scala"))
+          .foreach(path => seen += path.toAbsolutePath.normalize())
+      else if Files.isRegularFile(path) && path.toString.endsWith(".scala") then
+        seen += path.toAbsolutePath.normalize()
+    seen.toSeq
+
+object ScalaRecognizer:
+  def recognize(params: RecognizeParams): RecognizeResponse =
+    if params.projectRoot.isEmpty then throw IllegalArgumentException("missing `project_root`")
+    val root = Path.of(params.projectRoot).toAbsolutePath.normalize()
+    val bindingsByCid = params.bindingTemplates
+      .filter(_.templateCid.nonEmpty)
+      .map(binding => binding.templateCid -> binding)
+      .toMap
+    val tags = mutable.ArrayBuffer.empty[RecognizeTag]
+    for path <- expandScalaPaths(root, params.sourcePaths) do
+      val relPath =
+        try root.relativize(path).toString.replace('\\', '/')
+        catch case _: IllegalArgumentException => path.toString
+      val source =
+        try Some(Files.readString(path, StandardCharsets.UTF_8))
+        catch case _: Exception => None
+      source.foreach { text =>
+        dialects.Scala3(Input.VirtualFile(relPath, text)).parse[Source] match
+          case Parsed.Success(tree) =>
+            for defn <- ScalaTrees.definitions(tree) do
+              recognizeDef(relPath, defn, bindingsByCid).foreach(tags += _)
+          case _: Parsed.Error => ()
+      }
+    RecognizeResponse(tags.toSeq)
+
+  private def recognizeDef(
+      relPath: String,
+      defn: Defn.Def,
+      bindingsByCid: Map[String, BindingTemplate],
+  ): Option[RecognizeTag] =
+    val template = ScalaTemplate.functionBodyTemplate(defn)
+    val cid = ScalaTemplate.templateCid(template)
+    bindingsByCid.get(cid).map { binding =>
+      val paramNames = ScalaTemplate.functionParamNames(defn)
+      RecognizeTag(
+        file = relPath,
+        span = ScalaTrees.span(defn),
+        functionName = defn.name.value,
+        conceptName = binding.conceptName,
+        libraryTag = binding.libraryTag,
+        family = binding.family,
+        templateCid = cid,
+        contractCid = binding.contractCid,
+        matchTier = "exact",
+        paramBindings = paramNames.zipWithIndex.map { case (name, index) =>
+          ParamBinding(index + 1, name)
+        },
+      )
+    }
+
+  private def expandScalaPaths(root: Path, requested: Seq[String]): Seq[Path] =
+    val seen = mutable.LinkedHashSet.empty[Path]
+    for item <- requested do
+      val path = if Path.of(item).isAbsolute then Path.of(item) else root.resolve(item)
+      if Files.isDirectory(path) then
+        Files.walk(path).iterator().asScala
+          .filter(path => Files.isRegularFile(path) && path.toString.endsWith(".scala"))
+          .foreach(path => seen += path.toAbsolutePath.normalize())
+      else if Files.isRegularFile(path) && path.toString.endsWith(".scala") then
+        seen += path.toAbsolutePath.normalize()
+    seen.toSeq
+
+object ScalaTemplate:
+  def functionParamNames(defn: Defn.Def): Seq[String] =
+    defn.paramss.flatten.map(_.name.value)
+
+  def bodyText(defn: Defn.Def): String =
+    defn.body match
+      case Term.Block(stats) => stats.map(_.syntax).mkString("\n").trim
+      case other => other.syntax.trim
+
+  def functionBodyTemplate(defn: Defn.Def): ujson.Obj =
+    blockTemplate(defn.body, functionParamNames(defn))
+
+  def blockTemplate(body: Term, params: Seq[String]): ujson.Obj =
+    val statements = body match
+      case Term.Block(stats) => stats
+      case other => Seq(other)
+    ujson.Obj(
+      "kind" -> "block",
+      "stmts" -> ujson.Arr.from(statements.map(stmtTemplate(_, params))),
+    )
+
+  def stmtTemplate(stat: Stat, params: Seq[String]): ujson.Obj =
+    stat match
+      case Defn.Val(_, pats, _, rhs) =>
+        ujson.Obj(
+          "kind" -> "let",
+          "pat" -> pats.headOption.map(patTemplate(_, params)).getOrElse(ujson.Obj("kind" -> "pat_other")),
+          "init" -> exprTemplate(rhs, params),
+        )
+      case term: Term =>
+        ujson.Obj(
+          "kind" -> "expr_stmt",
+          "expr" -> exprTemplate(term, params),
+          "trailing_semi" -> false,
+        )
+      case other =>
+        ujson.Obj("kind" -> "other", "variant" -> other.productPrefix)
+
+  def exprTemplate(term: Term, params: Seq[String]): ujson.Value =
+    term match
+      case Term.Apply(Term.Select(receiver, Term.Name(method)), args) =>
+        ujson.Obj(
+          "kind" -> "method_call",
+          "receiver" -> exprTemplate(receiver, params),
+          "method" -> method,
+          "args" -> ujson.Arr.from(args.map(exprTemplate(_, params))),
+        )
+      case Term.Apply(func, args) =>
+        ujson.Obj(
+          "kind" -> "call",
+          "func" -> exprTemplate(func, params),
+          "args" -> ujson.Arr.from(args.map(exprTemplate(_, params))),
+        )
+      case Term.ApplyInfix(left, Term.Name(op), _, args) =>
+        ujson.Obj(
+          "kind" -> "binary",
+          "op" -> op,
+          "left" -> exprTemplate(left, params),
+          "right" -> args.headOption.map(exprTemplate(_, params)).getOrElse(ujson.Null),
+        )
+      case Term.ApplyUnary(Term.Name(op), arg) =>
+        ujson.Obj("kind" -> "unary", "op" -> op, "expr" -> exprTemplate(arg, params))
+      case Term.Return(expr) =>
+        ujson.Obj("kind" -> "return", "expr" -> exprTemplate(expr, params))
+      case Term.Name(name) if params.contains(name) =>
+        ujson.Obj("kind" -> "param_ref", "index" -> (params.indexOf(name) + 1))
+      case Term.Name(name) =>
+        ujson.Obj("kind" -> "ident", "name" -> name)
+      case select: Term.Select =>
+        fieldTemplateIfParamRoot(select, params).getOrElse {
+          selectSegments(select) match
+            case Some(segments) => ujson.Obj("kind" -> "path", "segments" -> ujson.Arr.from(segments))
+            case None =>
+              ujson.Obj(
+                "kind" -> "field",
+                "base" -> exprTemplate(select.qual, params),
+                "member" -> select.name.value,
+              )
+        }
+      case Term.Tuple(values) =>
+        ujson.Obj("kind" -> "tuple", "elems" -> ujson.Arr.from(values.map(exprTemplate(_, params))))
+      case Lit.String(value) => lit("str", value)
+      case Lit.Int(value) => lit("int", value)
+      case Lit.Long(value) => lit("int", value)
+      case Lit.Float(value) => lit("float", value)
+      case Lit.Double(value) => lit("float", value)
+      case Lit.Boolean(value) => lit("bool", value)
+      case Lit.Unit() => ujson.Obj("kind" -> "lit", "ty" -> "unit", "value" -> ujson.Null)
+      case Lit.Null() => ujson.Obj("kind" -> "lit", "ty" -> "null", "value" -> ujson.Null)
+      case Term.Block(stats) =>
+        ujson.Obj("kind" -> "block", "stmts" -> ujson.Arr.from(stats.map(stmtTemplate(_, params))))
+      case other =>
+        ujson.Obj("kind" -> "other", "variant" -> other.productPrefix)
+
+  def patTemplate(pat: Pat, params: Seq[String]): ujson.Obj =
+    pat match
+      case Pat.Var(Term.Name(name)) if params.contains(name) =>
+        ujson.Obj("kind" -> "param_ref", "index" -> (params.indexOf(name) + 1))
+      case Pat.Var(Term.Name(name)) =>
+        ujson.Obj("kind" -> "binding", "name" -> name)
+      case Pat.Tuple(values) =>
+        ujson.Obj("kind" -> "pat_tuple", "elems" -> ujson.Arr.from(values.map(patTemplate(_, params))))
+      case _ =>
+        ujson.Obj("kind" -> "pat_other")
+
+  def templateCid(value: ujson.Value): String =
+    cidOfBytes(ujson.write(value).getBytes(StandardCharsets.UTF_8))
+
+  def cidOfUtf8(value: String): String =
+    cidOfBytes(value.getBytes(StandardCharsets.UTF_8))
+
+  def cidOfBytes(bytes: Array[Byte]): String =
+    val digest = Blake3Digest(512)
+    digest.update(bytes, 0, bytes.length)
+    val out = Array.ofDim[Byte](64)
+    digest.doFinal(out, 0, out.length)
+    "blake3-512:" + out.map(byte => f"${byte & 0xff}%02x").mkString
+
+  private def lit(ty: String, value: String): ujson.Obj =
+    ujson.Obj("kind" -> "lit", "ty" -> ty, "value" -> value)
+
+  private def lit(ty: String, value: Long): ujson.Obj =
+    ujson.Obj("kind" -> "lit", "ty" -> ty, "value" -> value)
+
+  private def lit(ty: String, value: Double): ujson.Obj =
+    ujson.Obj("kind" -> "lit", "ty" -> ty, "value" -> value)
+
+  private def lit(ty: String, value: Boolean): ujson.Obj =
+    ujson.Obj("kind" -> "lit", "ty" -> ty, "value" -> value)
+
+  private def fieldTemplateIfParamRoot(select: Term.Select, params: Seq[String]): Option[ujson.Obj] =
+    val parts = mutable.ArrayBuffer.empty[String]
+    var current: Term = select
+    while current.isInstanceOf[Term.Select] do
+      val s = current.asInstanceOf[Term.Select]
+      parts += s.name.value
+      current = s.qual
+    current match
+      case Term.Name(root) if params.contains(root) =>
+        var result: ujson.Value = ujson.Obj("kind" -> "param_ref", "index" -> (params.indexOf(root) + 1))
+        for member <- parts.reverse do
+          result = ujson.Obj("kind" -> "field", "base" -> result, "member" -> member)
+        Some(result.obj)
+      case _ => None
+
+  private def selectSegments(select: Term.Select): Option[Seq[String]] =
+    val parts = mutable.ArrayBuffer.empty[String]
+    var current: Term = select
+    while current.isInstanceOf[Term.Select] do
+      val s = current.asInstanceOf[Term.Select]
+      parts += s.name.value
+      current = s.qual
+    current match
+      case Term.Name(root) => Some((parts += root).reverse.toSeq)
+      case _ => None
+
+object ScalaTrees:
+  def definitions(tree: Tree): Seq[Defn.Def] =
+    tree.collect { case defn: Defn.Def => defn }
+
+  def span(tree: Tree): SourceSpan =
+    SourceSpan(
+      startLine = tree.pos.startLine + 1,
+      startCol = tree.pos.startColumn,
+      endLine = tree.pos.endLine + 1,
+      endCol = tree.pos.endColumn,
+    )
+
+object ScalaSourceRpc:
+  def run(): Unit =
+    val reader = BufferedReader(InputStreamReader(System.in, StandardCharsets.UTF_8))
+    var keepGoing = true
+    while keepGoing do
+      val line = reader.readLine()
+      if line == null then keepGoing = false
+      else if line.trim.nonEmpty then
+        val response =
+          try
+            val request = ujson.read(line)
+            val method = stringAt(request, "method")
+            if method == "shutdown" || method == "provekit.plugin.shutdown" then keepGoing = false
+            dispatch(request)
+          catch
+            case e: Throwable =>
+              ujson.Obj(
+                "jsonrpc" -> "2.0",
+                "id" -> ujson.Null,
+                "error" -> ujson.Obj("code" -> -32603, "message" -> e.getMessage),
+              )
+        println(ujson.write(response))
+        Console.out.flush()
+
+  def dispatch(request: ujson.Value): ujson.Obj =
+    val id = request.obj.getOrElse("id", ujson.Null)
+    val method = stringAt(request, "method")
+    val params = request.obj.getOrElse("params", ujson.Obj())
+    try
+      val result = method match
+        case "initialize" | "provekit.plugin.describe" => describe()
+        case "lift" => lift(params)
+        case "provekit.plugin.recognize" => recognize(params)
+        case "shutdown" | "provekit.plugin.shutdown" => ujson.Null
+        case other => throw RpcFailure(-32601, s"METHOD_NOT_FOUND: $other")
+      ujson.Obj("jsonrpc" -> "2.0", "id" -> id, "result" -> result)
+    catch
+      case e: RpcFailure =>
+        ujson.Obj(
+          "jsonrpc" -> "2.0",
+          "id" -> id,
+          "error" -> ujson.Obj("code" -> e.code, "message" -> e.getMessage),
+        )
+
+  private def describe(): ujson.Obj =
+    ujson.Obj(
+      "name" -> "provekit-lift-scala-source",
+      "version" -> "0.1.0",
+      "protocol_version" -> "pep/1.7.0",
+      "capabilities" -> ujson.Obj(
+        "authoring_surfaces" -> ujson.Arr("scala-source"),
+        "ir_version" -> "bind-ir/1.0.0",
+        "emits_signed_mementos" -> false,
+      ),
+    )
+
+  private def lift(params: ujson.Value): ujson.Obj =
+    val sourcePaths = stringArray(params.obj.getOrElse("source_paths", ujson.Arr()))
+    val options = params.obj.get("options").collect { case obj: ujson.Obj => obj }.getOrElse(ujson.Obj())
+    val layer = stringAt(options, "layer") match
+      case "" => "all"
+      case value => value
+    val result = ScalaSourceLifter.liftPaths(
+      stringAt(params, "workspace_root"),
+      sourcePaths,
+      layer,
+    )
+    ujson.Obj(
+      "kind" -> "ir-document",
+      "ir" -> ujson.Arr.from(result.ir),
+      "diagnostics" -> ujson.Arr.from(result.diagnostics),
+    )
+
+  private def recognize(params: ujson.Value): ujson.Obj =
+    ScalaRecognizer.recognize(parseRecognizeParams(params)).toJson
+
+  private def parseRecognizeParams(params: ujson.Value): RecognizeParams =
+    RecognizeParams(
+      projectRoot = stringAt(params, "project_root"),
+      sourcePaths = stringArray(params.obj.getOrElse("source_paths", ujson.Arr())),
+      bindingTemplates = params.obj
+        .get("binding_templates")
+        .collect { case arr: ujson.Arr => arr.value.collect { case obj: ujson.Obj => parseBindingTemplate(obj) }.toSeq }
+        .getOrElse(Seq.empty),
+    )
+
+  private def parseBindingTemplate(obj: ujson.Obj): BindingTemplate =
+    BindingTemplate(
+      conceptName = stringAt(obj, "concept_name"),
+      libraryTag = firstString(obj, "library_tag", "target_library_tag").getOrElse(""),
+      family = obj.obj.get("family"),
+      astTemplate = obj.obj.getOrElse("ast_template", ujson.Null),
+      templateCid = stringAt(obj, "template_cid"),
+      paramNames = stringArray(obj.obj.getOrElse("param_names", ujson.Arr())),
+      contractCid = stringAt(obj, "contract_cid"),
+    )
+
+  private def stringArray(value: ujson.Value): Seq[String] =
+    value match
+      case arr: ujson.Arr => arr.value.collect { case ujson.Str(text) => text }.toSeq
+      case _ => Seq.empty
+
+private final case class RpcFailure(code: Int, message: String) extends RuntimeException(message)
+
+private def stringAt(value: ujson.Value, field: String): String =
+  firstString(value, field).getOrElse("")
+
+private def firstString(value: ujson.Value, fields: String*): Option[String] =
+  value match
+    case obj: ujson.Obj =>
+      fields.view.flatMap(field => obj.obj.get(field).collect {
+        case ujson.Str(text) if text.trim.nonEmpty => text.trim
+      }).headOption
+    case _ => None

--- a/implementations/scala/provekit-lift-scala-source/Main.scala
+++ b/implementations/scala/provekit-lift-scala-source/Main.scala
@@ -46,6 +46,7 @@ final case class RecognizeParams(
     projectRoot: String,
     sourcePaths: Seq[String],
     bindingTemplates: Seq[BindingTemplate],
+    templateSourceFiles: Set[String] = Set.empty,
 )
 
 final case class ParamBinding(index: Int, sourceText: String):
@@ -244,16 +245,17 @@ object ScalaRecognizer:
       val relPath =
         try root.relativize(path).toString.replace('\\', '/')
         catch case _: IllegalArgumentException => path.toString
-      val source =
-        try Some(Files.readString(path, StandardCharsets.UTF_8))
-        catch case _: Exception => None
-      source.foreach { text =>
-        dialects.Scala3(Input.VirtualFile(relPath, text)).parse[Source] match
-          case Parsed.Success(tree) =>
-            for defn <- ScalaTrees.definitions(tree) do
-              recognizeDef(relPath, defn, bindingsByCid).foreach(tags += _)
-          case _: Parsed.Error => ()
-      }
+      if !params.templateSourceFiles.contains(relPath) then
+        val source =
+          try Some(Files.readString(path, StandardCharsets.UTF_8))
+          catch case _: Exception => None
+        source.foreach { text =>
+          dialects.Scala3(Input.VirtualFile(relPath, text)).parse[Source] match
+            case Parsed.Success(tree) =>
+              for defn <- ScalaTrees.definitions(tree) do
+                recognizeDef(relPath, defn, bindingsByCid).foreach(tags += _)
+            case _: Parsed.Error => ()
+        }
     RecognizeResponse(tags.toSeq)
 
   private def recognizeDef(
@@ -538,13 +540,29 @@ object ScalaSourceRpc:
     ScalaRecognizer.recognize(parseRecognizeParams(params)).toJson
 
   private def parseRecognizeParams(params: ujson.Value): RecognizeParams =
+    val projectRoot = stringAt(params, "project_root")
+    val sourcePaths = stringArray(params.obj.getOrElse("source_paths", ujson.Arr()))
+    val suppliedTemplates = params.obj
+      .get("binding_templates")
+      .collect { case arr: ujson.Arr => arr.value.collect { case obj: ujson.Obj => parseBindingTemplate(obj) }.toSeq }
+      .getOrElse(Seq.empty)
+    val selfResolved = if suppliedTemplates.nonEmpty then Seq.empty else
+      ScalaSourceLifter
+        .liftPaths(projectRoot, sourcePaths, "library-bindings")
+        .ir
+        .collect { case obj: ujson.Obj => obj }
+    val selfResolvedTemplates = selfResolved.map(parseSugarBindingTemplate)
+    val templateFiles = selfResolved.flatMap { entry =>
+      entry.obj
+        .get("body_source")
+        .collect { case body: ujson.Obj => stringAt(body, "file") }
+        .filter(_.nonEmpty)
+    }.toSet
     RecognizeParams(
-      projectRoot = stringAt(params, "project_root"),
-      sourcePaths = stringArray(params.obj.getOrElse("source_paths", ujson.Arr())),
-      bindingTemplates = params.obj
-        .get("binding_templates")
-        .collect { case arr: ujson.Arr => arr.value.collect { case obj: ujson.Obj => parseBindingTemplate(obj) }.toSeq }
-        .getOrElse(Seq.empty),
+      projectRoot = projectRoot,
+      sourcePaths = sourcePaths,
+      bindingTemplates = if suppliedTemplates.nonEmpty then suppliedTemplates else selfResolvedTemplates,
+      templateSourceFiles = templateFiles,
     )
 
   private def parseBindingTemplate(obj: ujson.Obj): BindingTemplate =
@@ -555,6 +573,18 @@ object ScalaSourceRpc:
       astTemplate = obj.obj.getOrElse("ast_template", ujson.Null),
       templateCid = stringAt(obj, "template_cid"),
       paramNames = stringArray(obj.obj.getOrElse("param_names", ujson.Arr())),
+      contractCid = stringAt(obj, "contract_cid"),
+    )
+
+  private def parseSugarBindingTemplate(obj: ujson.Obj): BindingTemplate =
+    val body = obj.obj.get("body_source").collect { case body: ujson.Obj => body }.getOrElse(ujson.Obj())
+    BindingTemplate(
+      conceptName = stringAt(obj, "concept_name"),
+      libraryTag = firstString(obj, "library_tag", "target_library_tag").getOrElse(""),
+      family = obj.obj.get("family"),
+      astTemplate = body.obj.getOrElse("ast_template", ujson.Null),
+      templateCid = stringAt(body, "template_cid"),
+      paramNames = stringArray(body.obj.getOrElse("param_names", ujson.Arr())),
       contractCid = stringAt(obj, "contract_cid"),
     )
 

--- a/implementations/scala/provekit-lift-scala-source/ScalaSourceLifterTest.scala
+++ b/implementations/scala/provekit-lift-scala-source/ScalaSourceLifterTest.scala
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package provekit.lift.scala_source
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import scala.jdk.CollectionConverters.*
+
+final class ScalaSourceLifterTest extends munit.FunSuite:
+  test("sugar body emits ast_template alongside body_text"):
+    val body = mustSugarBodySource(
+      """package shim
+        |
+        |@sugar.bind(concept = "concept:http-request", library = "provekit-shim-scala-http", family = "concept:family:http")
+        |def Fetch(url: String, headers: Header): Response = http.get(url, headers)
+        |""".stripMargin,
+      "Fetch",
+    )
+
+    assertEquals(body("body_text").str, "http.get(url, headers)")
+    assertEquals(body("source_cid").str, ScalaTemplate.cidOfUtf8("http.get(url, headers)"))
+    assertEquals(jsonStrings(body("param_names")), Seq("url", "headers"))
+
+    val template = body("ast_template").obj
+    assertEquals(template("kind").str, "block")
+    val stmt = template("stmts").arr.head.obj
+    assertEquals(stmt("kind").str, "expr_stmt")
+    val call = stmt("expr").obj
+    assertEquals(call("kind").str, "method_call")
+    assertEquals(call("method").str, "get")
+    assertEquals(call("receiver").obj("name").str, "http")
+    val args = call("args").arr.map(_.obj).toSeq
+    assertEquals(args(0)("kind").str, "param_ref")
+    assertEquals(args(0)("index").num.toInt, 1)
+    assertEquals(args(1)("kind").str, "param_ref")
+    assertEquals(args(1)("index").num.toInt, 2)
+    assertEquals(body("template_cid").str, ScalaTemplate.templateCid(template))
+
+  test("sugar body template_cid is stable under parameter renaming"):
+    val bodyA = mustSugarBodySource(
+      """package shim
+        |
+        |@sugar.bind(concept = "concept:http-request", library = "provekit-shim-scala-http")
+        |def Fetch(url: String, headers: Header): Response = http.get(url, headers)
+        |""".stripMargin,
+      "Fetch",
+    )
+    val bodyB = mustSugarBodySource(
+      """package shim
+        |
+        |@sugar.bind(concept = "concept:http-request", library = "provekit-shim-scala-http")
+        |def Fetch(addr: String, hdrs: Header): Response = http.get(addr, hdrs)
+        |""".stripMargin,
+      "Fetch",
+    )
+
+    assertEquals(bodyA("ast_template"), bodyB("ast_template"))
+    assertEquals(bodyA("template_cid").str, bodyB("template_cid").str)
+    assertNotEquals(bodyA("source_cid").str, bodyB("source_cid").str)
+
+  test("recognize emits exact tag for alpha-equivalent user function"):
+    val binding = mustBindingTemplate(
+      concept = "concept:http-request",
+      library = "provekit-shim-scala-http",
+      family = "concept:family:http",
+      source =
+        """package shim
+          |
+          |@sugar.bind(concept = "concept:http-request", library = "provekit-shim-scala-http", family = "concept:family:http")
+          |def Fetch(url: String, headers: Header): Response = http.get(url, headers)
+          |""".stripMargin,
+      functionName = "Fetch",
+    )
+    val root = Files.createTempDirectory("provekit-scala-recognize-")
+    val rel = Path.of("src", "main", "scala", "Fetch.scala")
+    write(root.resolve(rel),
+      """package app
+        |
+        |def FetchURL(u: String, h: Header): Response = http.get(u, h)
+        |""".stripMargin,
+    )
+
+    val response = ScalaRecognizer.recognize(
+      RecognizeParams(root.toString, Seq(rel.toString.replace('\\', '/')), Seq(binding)),
+    )
+
+    assertEquals(response.tags.length, 1)
+    val tag = response.tags.head
+    assertEquals(tag.file, rel.toString.replace('\\', '/'))
+    assertEquals(tag.functionName, "FetchURL")
+    assertEquals(tag.conceptName, "concept:http-request")
+    assertEquals(tag.libraryTag, "provekit-shim-scala-http")
+    assertEquals(tag.family, Some(ujson.Str("concept:family:http")))
+    assertEquals(tag.templateCid, binding.templateCid)
+    assertEquals(tag.contractCid, binding.contractCid)
+    assertEquals(tag.matchTier, "exact")
+    assertEquals(tag.paramBindings.map(_.sourceText), Seq("u", "h"))
+
+  test("rpc recognize dispatch emits exact tags from binding templates"):
+    val binding = mustBindingTemplate(
+      concept = "concept:http-request",
+      library = "provekit-shim-scala-http",
+      family = "concept:family:http",
+      source =
+        """package shim
+          |
+          |@sugar.bind(concept = "concept:http-request", library = "provekit-shim-scala-http", family = "concept:family:http")
+          |def Fetch(url: String, headers: Header): Response = http.get(url, headers)
+          |""".stripMargin,
+      functionName = "Fetch",
+    )
+    val root = Files.createTempDirectory("provekit-scala-recognize-rpc-")
+    val rel = Path.of("Fetch.scala")
+    write(root.resolve(rel),
+      """package app
+        |
+        |def FetchURL(u: String, h: Header): Response = http.get(u, h)
+        |""".stripMargin,
+    )
+
+    val response = ScalaSourceRpc.dispatch(
+      ujson.Obj(
+        "jsonrpc" -> "2.0",
+        "id" -> 7,
+        "method" -> "provekit.plugin.recognize",
+        "params" -> ujson.Obj(
+          "project_root" -> root.toString,
+          "source_paths" -> ujson.Arr(rel.toString),
+          "binding_templates" -> ujson.Arr(bindingTemplateJson(binding)),
+        ),
+      ),
+    )
+
+    assert(!response.obj.contains("error"))
+    assertEquals(response("id").num.toInt, 7)
+    val tags = response("result")("tags").arr
+    assertEquals(tags.length, 1)
+    assertEquals(tags.head("function_name").str, "FetchURL")
+    assertEquals(tags.head("match_tier").str, "exact")
+
+  test("recognize returns empty tags for non-matching source"):
+    val binding = mustBindingTemplate(
+      concept = "concept:http-request",
+      library = "provekit-shim-scala-http",
+      family = "",
+      source =
+        """package shim
+          |
+          |@sugar.bind(concept = "concept:http-request", library = "provekit-shim-scala-http")
+          |def Fetch(url: String, headers: Header): Response = http.get(url, headers)
+          |""".stripMargin,
+      functionName = "Fetch",
+    )
+    val root = Files.createTempDirectory("provekit-scala-recognize-")
+    val rel = Path.of("Fetch.scala")
+    write(root.resolve(rel),
+      """package app
+        |
+        |def FetchURL(u: String, h: Header): Response = completelyDifferent(u, h)
+        |""".stripMargin,
+    )
+
+    val response = ScalaRecognizer.recognize(
+      RecognizeParams(root.toString, Seq(rel.toString), Seq(binding)),
+    )
+
+    assert(response.tags.isEmpty)
+
+  test("recognize routes multiple bindings per call-site pool"):
+    val httpBinding = mustBindingTemplate(
+      concept = "concept:http-request",
+      library = "http-lib",
+      family = "concept:family:http",
+      source =
+        """package shim
+          |
+          |@sugar.bind(concept = "concept:http-request", library = "http-lib", family = "concept:family:http")
+          |def Fetch(url: String, headers: Header): Response = http.get(url, headers)
+          |""".stripMargin,
+      functionName = "Fetch",
+    )
+    val sqlBinding = mustBindingTemplate(
+      concept = "concept:sql-execute",
+      library = "sql-lib",
+      family = "concept:family:sql",
+      source =
+        """package shim
+          |
+          |@sugar.bind(concept = "concept:sql-execute", library = "sql-lib", family = "concept:family:sql")
+          |def Exec(conn: DB, sql: String, args: Args): Result = conn.execute(sql, args)
+          |""".stripMargin,
+      functionName = "Exec",
+    )
+    val root = Files.createTempDirectory("provekit-scala-recognize-")
+    val rel = Path.of("Calls.scala")
+    write(root.resolve(rel),
+      """package app
+        |
+        |def FetchURL(u: String, h: Header): Response = http.get(u, h)
+        |
+        |def RunQuery(db: DB, query: String, params: Args): Result = db.execute(query, params)
+        |""".stripMargin,
+    )
+
+    val response = ScalaRecognizer.recognize(
+      RecognizeParams(root.toString, Seq(rel.toString), Seq(httpBinding, sqlBinding)),
+    )
+
+    assertEquals(response.tags.length, 2)
+    val routed = response.tags.map(tag => tag.conceptName -> tag.functionName).toMap
+    assertEquals(routed("concept:http-request"), "FetchURL")
+    assertEquals(routed("concept:sql-execute"), "RunQuery")
+    assert(response.tags.forall(_.matchTier == "exact"))
+
+  private def mustSugarBodySource(source: String, functionName: String): ujson.Obj =
+    val result = ScalaSourceLifter.liftSource(source, "shim.scala", layer = "library-bindings")
+    assertEquals(result.diagnostics, Seq.empty)
+    val entry = result.ir.collectFirst {
+      case obj: ujson.Obj if obj("source_function_name").str == functionName => obj
+    }.getOrElse(fail(s"missing binding for $functionName in ${result.ir}"))
+    entry("body_source").obj
+
+  private def mustBindingTemplate(
+      concept: String,
+      library: String,
+      family: String,
+      source: String,
+      functionName: String,
+  ): BindingTemplate =
+    val result = ScalaSourceLifter.liftSource(source, "shim.scala", layer = "library-bindings")
+    val entry = result.ir.collectFirst {
+      case obj: ujson.Obj if obj("source_function_name").str == functionName => obj
+    }.getOrElse(fail(s"missing binding for $functionName in ${result.ir}"))
+    val body = entry("body_source").obj
+    BindingTemplate(
+      conceptName = concept,
+      libraryTag = library,
+      family = Option.when(family.nonEmpty)(ujson.Str(family)),
+      astTemplate = body("ast_template"),
+      templateCid = body("template_cid").str,
+      paramNames = jsonStrings(body("param_names")),
+      contractCid = "blake3-512:" + ("c" * 128),
+    )
+
+  private def jsonStrings(value: ujson.Value): Seq[String] =
+    value.arr.map(_.str).toSeq
+
+  private def bindingTemplateJson(binding: BindingTemplate): ujson.Obj =
+    val obj = ujson.Obj(
+      "concept_name" -> binding.conceptName,
+      "library_tag" -> binding.libraryTag,
+      "ast_template" -> binding.astTemplate,
+      "template_cid" -> binding.templateCid,
+      "param_names" -> ujson.Arr.from(binding.paramNames),
+      "contract_cid" -> binding.contractCid,
+    )
+    binding.family.foreach(value => obj("family") = value)
+    obj
+
+  private def write(path: Path, contents: String): Unit =
+    Files.createDirectories(path.getParent)
+    Files.writeString(path, contents, StandardCharsets.UTF_8)

--- a/implementations/scala/provekit-lift-scala-source/ScalaSourceLifterTest.scala
+++ b/implementations/scala/provekit-lift-scala-source/ScalaSourceLifterTest.scala
@@ -96,20 +96,16 @@ final class ScalaSourceLifterTest extends munit.FunSuite:
     assertEquals(tag.matchTier, "exact")
     assertEquals(tag.paramBindings.map(_.sourceText), Seq("u", "h"))
 
-  test("rpc recognize dispatch emits exact tags from binding templates"):
-    val binding = mustBindingTemplate(
-      concept = "concept:http-request",
-      library = "provekit-shim-scala-http",
-      family = "concept:family:http",
-      source =
-        """package shim
-          |
-          |@sugar.bind(concept = "concept:http-request", library = "provekit-shim-scala-http", family = "concept:family:http")
-          |def Fetch(url: String, headers: Header): Response = http.get(url, headers)
-          |""".stripMargin,
-      functionName = "Fetch",
-    )
+  test("rpc recognize dispatch self-resolves exact tags from sugar templates"):
     val root = Files.createTempDirectory("provekit-scala-recognize-rpc-")
+    val shim = Path.of("Shim.scala")
+    write(root.resolve(shim),
+      """package shim
+        |
+        |@sugar.bind(concept = "concept:http-request", library = "provekit-shim-scala-http", family = "concept:family:http")
+        |def Fetch(url: String, headers: Header): Response = http.get(url, headers)
+        |""".stripMargin,
+    )
     val rel = Path.of("Fetch.scala")
     write(root.resolve(rel),
       """package app
@@ -125,8 +121,7 @@ final class ScalaSourceLifterTest extends munit.FunSuite:
         "method" -> "provekit.plugin.recognize",
         "params" -> ujson.Obj(
           "project_root" -> root.toString,
-          "source_paths" -> ujson.Arr(rel.toString),
-          "binding_templates" -> ujson.Arr(bindingTemplateJson(binding)),
+          "source_paths" -> ujson.Arr(shim.toString, rel.toString),
         ),
       ),
     )

--- a/implementations/scala/provekit-lift-scala-source/project.scala
+++ b/implementations/scala/provekit-lift-scala-source/project.scala
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+//> using scala "3.8.3"
+//> using dep com.lihaoyi::upickle:4.4.3
+//> using dep org.scalameta::scalameta:4.17.0
+//> using dep org.bouncycastle:bcprov-jdk18on:1.84
+//> using dep org.scalameta::munit:1.3.1

--- a/implementations/swift/Package.swift
+++ b/implementations/swift/Package.swift
@@ -36,6 +36,7 @@ let package = Package(
         .executable(name: "provekit-lsp-swift", targets: ["ProveKitLSPSwift"]),
         .executable(name: "mint-swift-self-contracts", targets: ["MintSwiftSelfContracts"]),
         .executable(name: "provekit-lift-swift-source", targets: ["ProvekitLiftSwiftSourceCLI"]),
+        .executable(name: "test-swift-source-lift", targets: ["SwiftSourceLiftTests"]),
         .executable(name: "provekit-lift-swift-xctest-tests", targets: ["ProvekitLiftSwiftXCTestTests"]),
         .executable(name: "provekit-emit-swift-xctest", targets: ["ProvekitEmitSwiftXCTest"]),
         .executable(name: "test-swift-lsp", targets: ["LSPTests"]),
@@ -143,6 +144,10 @@ let package = Package(
         .executableTarget(
             name: "ProvekitLiftSwiftSourceCLI",
             dependencies: ["ProvekitLiftSwiftSource"]
+        ),
+        .executableTarget(
+            name: "SwiftSourceLiftTests",
+            dependencies: ["ProvekitLiftSwiftSource", "ProvekitCrypto"]
         ),
         .executableTarget(
             name: "ProvekitLiftSwiftXCTestTests",

--- a/implementations/swift/Sources/ProvekitLiftSwiftSource/SwiftSourceLifter.swift
+++ b/implementations/swift/Sources/ProvekitLiftSwiftSource/SwiftSourceLifter.swift
@@ -121,6 +121,559 @@ public enum SwiftSourceLifter {
         }
         return result
     }
+
+    public static func liftLibraryBindingsSource(_ source: String, path: String) -> SwiftSourceLiftResult {
+        let sourceFile = Parser.parse(source: source)
+        let converter = SourceLocationConverter(fileName: path, tree: sourceFile)
+        let collector = SwiftSugarFunctionCollector()
+        collector.walk(sourceFile)
+
+        var result = SwiftSourceLiftResult()
+        for function in collector.functions {
+            guard let entry = SwiftSugarBindingEntryBuilder.entry(
+                for: function,
+                sourcePath: path,
+                converter: converter
+            ) else {
+                continue
+            }
+            result.ir.append(entry)
+        }
+        return result
+    }
+
+    public static func liftLibraryBindingsPaths(workspaceRoot: String, sourcePaths: [String]) -> SwiftSourceLiftResult {
+        var result = SwiftSourceLiftResult()
+        let root = URL(fileURLWithPath: workspaceRoot.isEmpty ? "." : workspaceRoot).standardizedFileURL
+        let rootPath = root.path
+        let fileManager = FileManager.default
+
+        for requested in sourcePaths.isEmpty ? ["."] : sourcePaths {
+            let requestedURL = URL(fileURLWithPath: requested, relativeTo: root).standardizedFileURL
+            let fullPath = requestedURL.path
+            guard isPath(fullPath, inside: rootPath) else {
+                result.refusals.append(SwiftSourceIR.refusal(
+                    kind: "path-traversal",
+                    function: nil,
+                    line: nil,
+                    reason: "path '\(requested)' escapes workspace root '\(rootPath)'"
+                ))
+                continue
+            }
+
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: fullPath, isDirectory: &isDirectory) else {
+                result.diagnostics.append(.object([
+                    ("severity", .string("warning")),
+                    ("message", .string("path not found: \(fullPath)")),
+                ]))
+                continue
+            }
+
+            let files: [String]
+            if isDirectory.boolValue {
+                let enumerator = fileManager.enumerator(atPath: fullPath)
+                files = (enumerator?.compactMap { item -> String? in
+                    guard let rel = item as? String, rel.hasSuffix(".swift") else {
+                        return nil
+                    }
+                    return URL(fileURLWithPath: rel, relativeTo: requestedURL).standardizedFileURL.path
+                } ?? []).sorted()
+            } else if fullPath.hasSuffix(".swift") {
+                files = [fullPath]
+            } else {
+                files = []
+            }
+
+            for file in files {
+                do {
+                    let source = try String(contentsOfFile: file, encoding: .utf8)
+                    let displayPath = relativePath(file, root: rootPath)
+                    let fileResult = liftLibraryBindingsSource(source, path: displayPath)
+                    result.ir.append(contentsOf: fileResult.ir)
+                    result.diagnostics.append(contentsOf: fileResult.diagnostics)
+                    result.opacityReport.append(contentsOf: fileResult.opacityReport)
+                    result.refusals.append(contentsOf: fileResult.refusals)
+                } catch {
+                    result.refusals.append(SwiftSourceIR.refusal(
+                        kind: "io-error",
+                        function: nil,
+                        line: nil,
+                        reason: "cannot read '\(file)': \(error)"
+                    ))
+                }
+            }
+        }
+        return result
+    }
+
+    public static func recognizeSource(
+        _ source: String,
+        path: String,
+        bindingTemplates: [JcsCanonical]
+    ) -> [JcsCanonical] {
+        let sourceFile = Parser.parse(source: source)
+        let converter = SourceLocationConverter(fileName: path, tree: sourceFile)
+        let collector = SwiftSugarFunctionCollector()
+        collector.walk(sourceFile)
+
+        var bindingsByCID: [String: JcsCanonical] = [:]
+        for binding in bindingTemplates {
+            guard let cid = jcsField("template_cid", in: binding).stringValue, !cid.isEmpty else {
+                continue
+            }
+            bindingsByCID[cid] = binding
+        }
+
+        var tags: [JcsCanonical] = []
+        for function in collector.functions {
+            guard let body = function.body else {
+                continue
+            }
+            let paramNames = swiftParamNames(function)
+            let template = SwiftAstTemplateBuilder(paramNames: paramNames).block(body)
+            let templateCID = computeJcsCid(template)
+            guard let binding = bindingsByCID[templateCID] else {
+                continue
+            }
+            tags.append(SwiftSugarBindingEntryBuilder.recognizeTag(
+                function: function,
+                sourcePath: path,
+                converter: converter,
+                templateCID: templateCID,
+                binding: binding
+            ))
+        }
+        return tags
+    }
+
+    public static func recognizePaths(
+        workspaceRoot: String,
+        sourcePaths: [String],
+        bindingTemplates: [JcsCanonical]
+    ) -> [JcsCanonical] {
+        let root = URL(fileURLWithPath: workspaceRoot.isEmpty ? "." : workspaceRoot).standardizedFileURL
+        let rootPath = root.path
+        let fileManager = FileManager.default
+        var tags: [JcsCanonical] = []
+
+        for requested in sourcePaths.isEmpty ? ["."] : sourcePaths {
+            let requestedURL = URL(fileURLWithPath: requested, relativeTo: root).standardizedFileURL
+            let fullPath = requestedURL.path
+            guard isPath(fullPath, inside: rootPath) else {
+                continue
+            }
+
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: fullPath, isDirectory: &isDirectory) else {
+                continue
+            }
+
+            let files: [String]
+            if isDirectory.boolValue {
+                let enumerator = fileManager.enumerator(atPath: fullPath)
+                files = (enumerator?.compactMap { item -> String? in
+                    guard let rel = item as? String, rel.hasSuffix(".swift") else {
+                        return nil
+                    }
+                    return URL(fileURLWithPath: rel, relativeTo: requestedURL).standardizedFileURL.path
+                } ?? []).sorted()
+            } else if fullPath.hasSuffix(".swift") {
+                files = [fullPath]
+            } else {
+                files = []
+            }
+
+            for file in files {
+                guard let source = try? String(contentsOfFile: file, encoding: .utf8) else {
+                    continue
+                }
+                tags.append(contentsOf: recognizeSource(
+                    source,
+                    path: relativePath(file, root: rootPath),
+                    bindingTemplates: bindingTemplates
+                ))
+            }
+        }
+        return tags
+    }
+}
+
+private struct SwiftSugarBindingAnnotation {
+    let concept: String
+    let library: String
+    let family: String?
+    let version: String?
+}
+
+private final class SwiftSugarFunctionCollector: SyntaxVisitor {
+    var functions: [FunctionDeclSyntax] = []
+
+    init() {
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        functions.append(node)
+        return .skipChildren
+    }
+}
+
+private enum SwiftSugarBindingEntryBuilder {
+    static func entry(
+        for function: FunctionDeclSyntax,
+        sourcePath: String,
+        converter: SourceLocationConverter
+    ) -> JcsCanonical? {
+        guard let annotation = sugarAnnotation(function), let body = function.body else {
+            return nil
+        }
+        let paramNames = swiftParamNames(function)
+        let paramTypes = swiftParamTypes(function)
+        let returnType = cleanTypeName(function.signature.returnClause?.type.description ?? "Void")
+        let signatureShape = JcsCanonical.object([
+            ("param_names", .array(paramNames.map(JcsCanonical.string))),
+            ("param_types", .array(paramTypes.map(JcsCanonical.string))),
+            ("return_type", .string(returnType)),
+        ])
+        let bodyText = swiftBodyText(body)
+        let template = SwiftAstTemplateBuilder(paramNames: paramNames).block(body)
+        let span = swiftSpan(function, converter: converter)
+        let bodySource = JcsCanonical.object([
+            ("ast_template", template),
+            ("body_text", .string(bodyText)),
+            ("file", .string(sourcePath)),
+            ("param_names", .array(paramNames.map(JcsCanonical.string))),
+            ("source_cid", .string(Blake3.hex(Data(bodyText.utf8)))),
+            ("span", span),
+            ("template_cid", .string(computeJcsCid(template))),
+        ])
+
+        var fields: [(String, JcsCanonical)] = [
+            ("body_source", bodySource),
+            ("concept_name", .string(annotation.concept)),
+            ("kind", .string("library-sugar-binding-entry")),
+            ("loss_record_contribution", .object([
+                ("form", .string("literal")),
+                ("value", .object([("entries", .array([]))])),
+            ])),
+            ("param_names", .array(paramNames.map(JcsCanonical.string))),
+            ("param_types", .array(paramTypes.map(JcsCanonical.string))),
+            ("return_type", .string(returnType)),
+            ("signature_shape_cid", .string(computeJcsCid(signatureShape))),
+            ("source_function_name", .string(function.name.text)),
+            ("target_language", .string("swift")),
+            ("target_library_tag", .string(annotation.library)),
+            ("term_shape", .null),
+            ("term_shape_cid", .null),
+        ]
+        if let family = annotation.family {
+            fields.append(("family", .string(family)))
+        }
+        if let version = annotation.version {
+            fields.append(("library_version", .string(version)))
+        }
+        return .object(fields)
+    }
+
+    static func recognizeTag(
+        function: FunctionDeclSyntax,
+        sourcePath: String,
+        converter: SourceLocationConverter,
+        templateCID: String,
+        binding: JcsCanonical
+    ) -> JcsCanonical {
+        let paramNames = swiftParamNames(function)
+        let paramBindings = paramNames.enumerated().map { index, name in
+            JcsCanonical.object([
+                ("index", .int(Int64(index + 1))),
+                ("source_text", .string(name)),
+            ])
+        }
+        return .object([
+            ("concept_name", jcsField("concept_name", in: binding)),
+            ("contract_cid", jcsField("contract_cid", in: binding)),
+            ("family", jcsField("family", in: binding)),
+            ("file", .string(sourcePath)),
+            ("function_name", .string(function.name.text)),
+            ("library_tag", jcsField("library_tag", in: binding)),
+            ("match_tier", .string("exact")),
+            ("param_bindings", .array(paramBindings)),
+            ("span", swiftSpan(function, converter: converter)),
+            ("template_cid", .string(templateCID)),
+        ])
+    }
+}
+
+private struct SwiftAstTemplateBuilder {
+    let paramNames: [String]
+
+    func block(_ block: CodeBlockSyntax) -> JcsCanonical {
+        .object([
+            ("kind", .string("block")),
+            ("stmts", .array(block.statements.map(codeBlockItem))),
+        ])
+    }
+
+    private func codeBlockItem(_ item: CodeBlockItemSyntax) -> JcsCanonical {
+        switch item.item {
+        case .decl(let decl):
+            if let variable = decl.as(VariableDeclSyntax.self) {
+                return variableDecl(variable)
+            }
+            return other("decl", decl)
+        case .stmt(let stmt):
+            if let ret = stmt.as(ReturnStmtSyntax.self) {
+                return .object([
+                    ("kind", .string("return")),
+                    ("expr", ret.expression.map(expression) ?? .null),
+                ])
+            }
+            return other("stmt", stmt)
+        case .expr(let expr):
+            return .object([
+                ("kind", .string("expr_stmt")),
+                ("expr", expression(expr)),
+                ("trailing_semi", .bool(false)),
+            ])
+        }
+    }
+
+    private func variableDecl(_ node: VariableDeclSyntax) -> JcsCanonical {
+        let bindings = node.bindings.map { binding -> JcsCanonical in
+            .object([
+                ("kind", .string("let")),
+                ("pat", pattern(binding.pattern)),
+                ("init", binding.initializer.map { expression($0.value) } ?? .null),
+            ])
+        }
+        if bindings.count == 1 {
+            return bindings[0]
+        }
+        return .object([
+            ("kind", .string("decl_group")),
+            ("decls", .array(bindings)),
+        ])
+    }
+
+    private func expression(_ expr: ExprSyntax) -> JcsCanonical {
+        if let ref = expr.as(DeclReferenceExprSyntax.self) {
+            let name = ref.baseName.text
+            if let index = paramNames.firstIndex(of: name) {
+                return .object([
+                    ("kind", .string("param_ref")),
+                    ("index", .int(Int64(index + 1))),
+                ])
+            }
+            return .object([
+                ("kind", .string("ident")),
+                ("name", .string(name)),
+            ])
+        }
+        if let call = expr.as(FunctionCallExprSyntax.self) {
+            return functionCall(call)
+        }
+        if let member = expr.as(MemberAccessExprSyntax.self) {
+            return memberAccess(member)
+        }
+        if let literal = expr.as(IntegerLiteralExprSyntax.self) {
+            return .object([
+                ("kind", .string("lit")),
+                ("ty", .string("int")),
+                ("value", .string(literal.literal.text.replacingOccurrences(of: "_", with: ""))),
+            ])
+        }
+        if let literal = expr.as(BooleanLiteralExprSyntax.self) {
+            return .object([
+                ("kind", .string("lit")),
+                ("ty", .string("bool")),
+                ("value", .bool(literal.literal.text == "true")),
+            ])
+        }
+        if let literal = expr.as(StringLiteralExprSyntax.self) {
+            return .object([
+                ("kind", .string("lit")),
+                ("ty", .string("string")),
+                ("value", .string(literal.description.trimmingCharacters(in: .whitespacesAndNewlines))),
+            ])
+        }
+        if let sequence = expr.as(SequenceExprSyntax.self) {
+            return sequenceExpr(sequence)
+        }
+        if let tuple = expr.as(TupleExprSyntax.self), tuple.elements.count == 1, let first = tuple.elements.first {
+            return expression(first.expression)
+        }
+        return other("expr", expr)
+    }
+
+    private func functionCall(_ node: FunctionCallExprSyntax) -> JcsCanonical {
+        let args = node.arguments.map { expression($0.expression) }
+        if let member = node.calledExpression.as(MemberAccessExprSyntax.self), let base = member.base {
+            return .object([
+                ("kind", .string("method_call")),
+                ("receiver", expression(base)),
+                ("method", .string(member.declName.baseName.text)),
+                ("args", .array(args)),
+            ])
+        }
+        return .object([
+            ("kind", .string("call")),
+            ("func", expression(node.calledExpression)),
+            ("args", .array(args)),
+        ])
+    }
+
+    private func memberAccess(_ node: MemberAccessExprSyntax) -> JcsCanonical {
+        .object([
+            ("kind", .string("member")),
+            ("base", node.base.map(expression) ?? .null),
+            ("field", .string(node.declName.baseName.text)),
+        ])
+    }
+
+    private func sequenceExpr(_ node: SequenceExprSyntax) -> JcsCanonical {
+        let elements = Array(node.elements)
+        if elements.count == 3 {
+            return .object([
+                ("kind", .string("binary")),
+                ("op", .string(elements[1].description.trimmingCharacters(in: .whitespacesAndNewlines))),
+                ("left", expression(elements[0])),
+                ("right", expression(elements[2])),
+            ])
+        }
+        return other("sequence", node)
+    }
+
+    private func pattern(_ pattern: PatternSyntax) -> JcsCanonical {
+        if let ident = pattern.as(IdentifierPatternSyntax.self) {
+            return .object([
+                ("kind", .string("binding")),
+                ("name", .string(ident.identifier.text)),
+            ])
+        }
+        if pattern.is(WildcardPatternSyntax.self) {
+            return .object([("kind", .string("wildcard"))])
+        }
+        return other("pattern", pattern)
+    }
+
+    private func other<T: SyntaxProtocol>(_ kind: String, _ node: T) -> JcsCanonical {
+        .object([
+            ("kind", .string("other")),
+            ("variant", .string(kind)),
+            ("text", .string(node.description.trimmingCharacters(in: .whitespacesAndNewlines))),
+        ])
+    }
+}
+
+private func sugarAnnotation(_ function: FunctionDeclSyntax) -> SwiftSugarBindingAnnotation? {
+    let attributes = function.attributes.description
+    guard attributes.contains("ProveKitSugar") else {
+        return nil
+    }
+    guard let concept = quotedArgument("concept", in: attributes),
+          let library = quotedArgument("library", in: attributes)
+    else {
+        return nil
+    }
+    return SwiftSugarBindingAnnotation(
+        concept: concept,
+        library: library,
+        family: quotedArgument("family", in: attributes),
+        version: quotedArgument("version", in: attributes)
+    )
+}
+
+private func quotedArgument(_ name: String, in text: String) -> String? {
+    guard let label = text.range(of: "\(name):") else {
+        return nil
+    }
+    let rest = text[label.upperBound...]
+    guard let open = rest.firstIndex(of: "\"") else {
+        return nil
+    }
+    let afterOpen = rest.index(after: open)
+    guard let close = rest[afterOpen...].firstIndex(of: "\"") else {
+        return nil
+    }
+    return String(rest[afterOpen..<close])
+}
+
+private func swiftParamNames(_ node: FunctionDeclSyntax) -> [String] {
+    node.signature.parameterClause.parameters.map { parameter in
+        if let second = parameter.secondName {
+            return second.text
+        }
+        return parameter.firstName.text == "_" ? "_" : parameter.firstName.text
+    }
+}
+
+private func swiftParamTypes(_ node: FunctionDeclSyntax) -> [String] {
+    node.signature.parameterClause.parameters.map { parameter in
+        cleanTypeName(parameter.type.description)
+    }
+}
+
+private func swiftSpan(_ node: FunctionDeclSyntax, converter: SourceLocationConverter) -> JcsCanonical {
+    let start = node.startLocation(converter: converter)
+    let end = node.endLocation(converter: converter)
+    return .object([
+        ("end_col", .int(Int64(max(0, end.column)))),
+        ("end_line", .int(Int64(end.line))),
+        ("start_col", .int(Int64(max(0, start.column)))),
+        ("start_line", .int(Int64(start.line))),
+    ])
+}
+
+private func swiftBodyText(_ body: CodeBlockSyntax) -> String {
+    var text = body.description
+    if let open = text.firstIndex(of: "{"), let close = text.lastIndex(of: "}"), open < close {
+        text = String(text[text.index(after: open)..<close])
+    }
+    text = text.replacingOccurrences(of: #"^\r?\n"#, with: "", options: .regularExpression)
+    text = text.replacingOccurrences(of: #"\s+$"#, with: "", options: .regularExpression)
+    return dedentCommonIndent(text)
+}
+
+private func dedentCommonIndent(_ text: String) -> String {
+    let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    let indents = lines
+        .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        .map { line -> String in
+            String(line.prefix { $0 == " " || $0 == "\t" })
+        }
+    guard let shortest = indents.min(by: { $0.count < $1.count }), !shortest.isEmpty else {
+        return text
+    }
+    let common = indents.reduce(shortest) { prefix, indent in
+        var out = prefix
+        while !indent.hasPrefix(out), !out.isEmpty {
+            out.removeLast()
+        }
+        return out
+    }
+    guard !common.isEmpty else {
+        return text
+    }
+    return lines.map { line in
+        line.hasPrefix(common) ? String(line.dropFirst(common.count)) : line
+    }.joined(separator: "\n")
+}
+
+private func jcsField(_ name: String, in object: JcsCanonical) -> JcsCanonical {
+    guard case .object(let pairs) = object else {
+        return .null
+    }
+    return pairs.first(where: { $0.0 == name })?.1 ?? .null
+}
+
+private extension JcsCanonical {
+    var stringValue: String? {
+        if case .string(let value) = self {
+            return value
+        }
+        return nil
+    }
 }
 
 private struct SwiftFunctionInfo {

--- a/implementations/swift/Sources/ProvekitLiftSwiftSource/SwiftSourceLifter.swift
+++ b/implementations/swift/Sources/ProvekitLiftSwiftSource/SwiftSourceLifter.swift
@@ -252,6 +252,15 @@ public enum SwiftSourceLifter {
         sourcePaths: [String],
         bindingTemplates: [JcsCanonical]
     ) -> [JcsCanonical] {
+        let selfResolvedEntries = bindingTemplates.isEmpty
+            ? liftLibraryBindingsPaths(workspaceRoot: workspaceRoot, sourcePaths: sourcePaths).ir
+            : []
+        let resolvedTemplates = bindingTemplates.isEmpty
+            ? selfResolvedEntries.compactMap(bindingTemplateFromSugarEntry)
+            : bindingTemplates
+        let templateFiles = Set(selfResolvedEntries.compactMap { entry -> String? in
+            jcsField("body_source", in: entry).objectFields?["file"]?.stringValue
+        })
         let root = URL(fileURLWithPath: workspaceRoot.isEmpty ? "." : workspaceRoot).standardizedFileURL
         let rootPath = root.path
         let fileManager = FileManager.default
@@ -285,18 +294,38 @@ public enum SwiftSourceLifter {
             }
 
             for file in files {
+                let displayPath = relativePath(file, root: rootPath)
+                if templateFiles.contains(displayPath) {
+                    continue
+                }
                 guard let source = try? String(contentsOfFile: file, encoding: .utf8) else {
                     continue
                 }
                 tags.append(contentsOf: recognizeSource(
                     source,
-                    path: relativePath(file, root: rootPath),
-                    bindingTemplates: bindingTemplates
+                    path: displayPath,
+                    bindingTemplates: resolvedTemplates
                 ))
             }
         }
         return tags
     }
+}
+
+private func bindingTemplateFromSugarEntry(_ entry: JcsCanonical) -> JcsCanonical? {
+    guard let body = jcsField("body_source", in: entry).objectFields else {
+        return nil
+    }
+    let fields: [(String, JcsCanonical)] = [
+        ("ast_template", body["ast_template"] ?? .null),
+        ("concept_name", jcsField("concept_name", in: entry)),
+        ("contract_cid", jcsField("contract_cid", in: entry)),
+        ("family", jcsField("family", in: entry)),
+        ("library_tag", jcsField("target_library_tag", in: entry)),
+        ("param_names", body["param_names"] ?? .array([])),
+        ("template_cid", body["template_cid"] ?? .string("")),
+    ]
+    return .object(fields)
 }
 
 private struct SwiftSugarBindingAnnotation {
@@ -673,6 +702,13 @@ private extension JcsCanonical {
             return value
         }
         return nil
+    }
+
+    var objectFields: [String: JcsCanonical]? {
+        guard case .object(let pairs) = self else {
+            return nil
+        }
+        return Dictionary(uniqueKeysWithValues: pairs)
     }
 }
 

--- a/implementations/swift/Sources/ProvekitLiftSwiftSource/SwiftSourceRPC.swift
+++ b/implementations/swift/Sources/ProvekitLiftSwiftSource/SwiftSourceRPC.swift
@@ -109,12 +109,10 @@ public enum SwiftSourceRPC {
             return errorResponse(id: id, code: -32602, message: "source_paths must be an array")
         }
         let sourcePaths = sourcePathsAny.compactMap { $0 as? String }.filter { !$0.isEmpty }
-        let bindingValues = params["binding_templates"] as? [Any] ?? []
-        let bindings = try bindingValues.map(SwiftSourceIR.canonical(from:))
         let tags = SwiftSourceLifter.recognizePaths(
             workspaceRoot: workspaceRoot,
             sourcePaths: sourcePaths,
-            bindingTemplates: bindings
+            bindingTemplates: []
         )
         return response(id: id, result: [
             "tags": tags.map(SwiftSourceIR.anyValue),

--- a/implementations/swift/Sources/ProvekitLiftSwiftSource/SwiftSourceRPC.swift
+++ b/implementations/swift/Sources/ProvekitLiftSwiftSource/SwiftSourceRPC.swift
@@ -60,6 +60,8 @@ public enum SwiftSourceRPC {
             return try lift(id: id, params: params)
         case "compile":
             return try compile(id: id, params: params)
+        case "provekit.plugin.recognize":
+            return try recognize(id: id, params: params)
         case "shutdown":
             throw SwiftSourceRPCExit(response: response(id: id, result: NSNull()))
         case "exit":
@@ -83,7 +85,10 @@ public enum SwiftSourceRPC {
             return errorResponse(id: id, code: -32602, message: "source_paths must contain strings")
         }
         let workspaceRoot = params["workspace_root"] as? String ?? "."
-        var result = SwiftSourceLifter.liftPaths(workspaceRoot: workspaceRoot, sourcePaths: sourcePaths)
+        let layer = requestedLayer(params)
+        var result = layer == "library-bindings"
+            ? SwiftSourceLifter.liftLibraryBindingsPaths(workspaceRoot: workspaceRoot, sourcePaths: sourcePaths)
+            : SwiftSourceLifter.liftPaths(workspaceRoot: workspaceRoot, sourcePaths: sourcePaths)
         if requestedVerifyLayer(params) {
             result = SwiftSourceIR.verifyFacingResult(result)
         }
@@ -98,11 +103,33 @@ public enum SwiftSourceRPC {
         ])
     }
 
-    private static func requestedVerifyLayer(_ params: [String: Any]) -> Bool {
-        guard let options = params["options"] as? [String: Any] else {
-            return false
+    private static func recognize(id: Any, params: [String: Any]) throws -> [String: Any] {
+        let workspaceRoot = params["project_root"] as? String ?? params["workspace_root"] as? String ?? "."
+        guard let sourcePathsAny = params["source_paths"] as? [Any] else {
+            return errorResponse(id: id, code: -32602, message: "source_paths must be an array")
         }
-        return options["layer"] as? String == "verify"
+        let sourcePaths = sourcePathsAny.compactMap { $0 as? String }.filter { !$0.isEmpty }
+        let bindingValues = params["binding_templates"] as? [Any] ?? []
+        let bindings = try bindingValues.map(SwiftSourceIR.canonical(from:))
+        let tags = SwiftSourceLifter.recognizePaths(
+            workspaceRoot: workspaceRoot,
+            sourcePaths: sourcePaths,
+            bindingTemplates: bindings
+        )
+        return response(id: id, result: [
+            "tags": tags.map(SwiftSourceIR.anyValue),
+        ])
+    }
+
+    private static func requestedLayer(_ params: [String: Any]) -> String {
+        guard let options = params["options"] as? [String: Any] else {
+            return "all"
+        }
+        return options["layer"] as? String ?? "all"
+    }
+
+    private static func requestedVerifyLayer(_ params: [String: Any]) -> Bool {
+        requestedLayer(params) == "verify"
     }
 
     private static func compile(id: Any, params: [String: Any]) throws -> [String: Any] {

--- a/implementations/swift/Sources/SwiftSourceLiftTests/main.swift
+++ b/implementations/swift/Sources/SwiftSourceLiftTests/main.swift
@@ -18,6 +18,7 @@ struct SwiftSourceLiftTests {
             ("recognize emits exact tag", testRecognizeEmitsExactTag),
             ("recognize returns no tags for non-match", testRecognizeReturnsNoTagsForNonMatch),
             ("recognize routes multiple bindings", testRecognizeRoutesMultipleBindings),
+            ("recognize paths self-resolves sugar templates", testRecognizePathsSelfResolvesSugarTemplates),
         ]
 
         var failures: [String] = []
@@ -174,6 +175,40 @@ private func testRecognizeRoutesMultipleBindings() throws {
 
     let concepts = Set(try tags.map { try require(object($0)["concept_name"] as? String, "missing concept") })
     try expect(concepts == ["concept:http-request", "concept:sql-execute"], "wrong concepts: \(concepts)")
+}
+
+private func testRecognizePathsSelfResolvesSugarTemplates() throws {
+    let root = try FileManager.default.url(
+        for: .itemReplacementDirectory,
+        in: .userDomainMask,
+        appropriateFor: URL(fileURLWithPath: NSTemporaryDirectory()),
+        create: true
+    )
+    defer { try? FileManager.default.removeItem(at: root) }
+    try """
+    @ProveKitSugar(concept: "concept:http-request", library: "urlsession", family: "concept:family:http")
+    func fetch(_ url: String) -> Int {
+        return send(url)
+    }
+    """.write(to: root.appendingPathComponent("Shim.swift"), atomically: true, encoding: .utf8)
+    try """
+    func getStatus(_ endpoint: String) -> Int {
+        return send(endpoint)
+    }
+    """.write(to: root.appendingPathComponent("Client.swift"), atomically: true, encoding: .utf8)
+
+    let tags = SwiftSourceLifter.recognizePaths(
+        workspaceRoot: root.path,
+        sourcePaths: ["Shim.swift", "Client.swift"],
+        bindingTemplates: []
+    )
+
+    try expect(tags.count == 1, "expected one self-resolved tag, got \(tags.count)")
+    let tag = try object(tags[0])
+    try expect(tag["file"] as? String == "Client.swift", "wrong file: \(tag)")
+    try expect(tag["function_name"] as? String == "getStatus", "wrong function: \(tag)")
+    try expect(tag["concept_name"] as? String == "concept:http-request", "wrong concept: \(tag)")
+    try expect(tag["library_tag"] as? String == "urlsession", "wrong library: \(tag)")
 }
 
 private func sugarBodySource(_ source: String) throws -> [String: Any] {

--- a/implementations/swift/Sources/SwiftSourceLiftTests/main.swift
+++ b/implementations/swift/Sources/SwiftSourceLiftTests/main.swift
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+import ProvekitCrypto
+import ProvekitLiftSwiftSource
+
+private struct TestFailure: Error, CustomStringConvertible {
+    let message: String
+    var description: String { message }
+}
+
+@main
+struct SwiftSourceLiftTests {
+    static func main() {
+        let tests: [(String, () throws -> Void)] = [
+            ("sugar body emits ast_template alongside body_text", testSugarBodyEmitsAstTemplateAlongsideBodyText),
+            ("sugar template cid is stable under parameter renaming", testSugarBodyTemplateCidIsStableUnderParameterRenaming),
+            ("recognize emits exact tag", testRecognizeEmitsExactTag),
+            ("recognize returns no tags for non-match", testRecognizeReturnsNoTagsForNonMatch),
+            ("recognize routes multiple bindings", testRecognizeRoutesMultipleBindings),
+        ]
+
+        var failures: [String] = []
+        for (name, test) in tests {
+            do {
+                try test()
+                print("ok - \(name)")
+            } catch {
+                failures.append("\(name): \(error)")
+                print("not ok - \(name): \(error)", to: .standardError)
+            }
+        }
+
+        if !failures.isEmpty {
+            print("\nSwift source lift tests failed:", to: .standardError)
+            for failure in failures {
+                print("  - \(failure)", to: .standardError)
+            }
+            exit(1)
+        }
+    }
+}
+
+private func testSugarBodyEmitsAstTemplateAlongsideBodyText() throws {
+    let source = """
+    @ProveKitSugar(concept: "concept:http-request", library: "urlsession")
+    func fetchStatus(_ url: String, headers: String) -> Int {
+        let request = makeRequest(url, headers)
+        return send(request)
+    }
+    """
+
+    let entries = SwiftSourceLifter.liftLibraryBindingsSource(source, path: "Sources/Shim.swift").ir
+    try expect(entries.count == 1, "expected one sugar binding entry, got \(entries.count)")
+    let entry = try object(entries[0])
+    try expect(entry["kind"] as? String == "library-sugar-binding-entry", "wrong entry kind")
+    try expect(entry["target_language"] as? String == "swift", "wrong target language")
+    try expect(entry["target_library_tag"] as? String == "urlsession", "wrong library tag")
+    try expect(entry["concept_name"] as? String == "concept:http-request", "wrong concept")
+    try expect(entry["source_function_name"] as? String == "fetchStatus", "wrong source function")
+    try expect(entry["param_names"] as? [String] == ["url", "headers"], "wrong param names")
+
+    let body = try require(entry["body_source"] as? [String: Any], "missing body_source")
+    try expect((body["body_text"] as? String ?? "").contains("makeRequest(url, headers)"), "missing body_text")
+    try expect(body["ast_template"] != nil, "missing ast_template")
+    try expect((body["template_cid"] as? String ?? "").hasPrefix("blake3-512:"), "missing template_cid")
+    try expect(body["param_names"] as? [String] == ["url", "headers"], "wrong body param_names")
+}
+
+private func testSugarBodyTemplateCidIsStableUnderParameterRenaming() throws {
+    let sourceA = """
+    @ProveKitSugar(concept: "concept:http-request", library: "urlsession")
+    func fetchStatus(_ url: String) -> Int {
+        return send(url)
+    }
+    """
+    let sourceB = """
+    @ProveKitSugar(concept: "concept:http-request", library: "urlsession")
+    func fetchStatus(_ endpoint: String) -> Int {
+        return send(endpoint)
+    }
+    """
+
+    let bodyA = try sugarBodySource(sourceA)
+    let bodyB = try sugarBodySource(sourceB)
+    try expect(bodyA["template_cid"] as? String == bodyB["template_cid"] as? String, "template CID changed under parameter rename")
+    try expect(
+        try stableJSONString(bodyA["ast_template"] as Any) == stableJSONString(bodyB["ast_template"] as Any),
+        "AST template changed under parameter rename"
+    )
+    try expect(bodyA["body_text"] as? String != bodyB["body_text"] as? String, "body_text should preserve source spelling")
+}
+
+private func testRecognizeEmitsExactTag() throws {
+    let binding = try bindingTemplate(from: """
+    @ProveKitSugar(concept: "concept:http-request", library: "urlsession")
+    func fetchStatus(_ url: String) -> Int {
+        return send(url)
+    }
+    """)
+
+    let tags = SwiftSourceLifter.recognizeSource(
+        """
+        func getStatus(_ endpoint: String) -> Int {
+            return send(endpoint)
+        }
+        """,
+        path: "Sources/Client.swift",
+        bindingTemplates: [binding]
+    )
+
+    try expect(tags.count == 1, "expected one tag, got \(tags.count)")
+    let tag = try object(tags[0])
+    try expect(tag["file"] as? String == "Sources/Client.swift", "wrong file")
+    try expect(tag["function_name"] as? String == "getStatus", "wrong recognized function")
+    try expect(tag["concept_name"] as? String == "concept:http-request", "wrong concept")
+    try expect(tag["library_tag"] as? String == "urlsession", "wrong library")
+    try expect(tag["template_cid"] as? String == stringField("template_cid", in: binding), "wrong template CID")
+    try expect(tag["match_tier"] as? String == "exact", "wrong match tier")
+    let paramBindings = try require(tag["param_bindings"] as? [[String: Any]], "missing param bindings")
+    try expect(paramBindings.count == 1, "wrong param binding count")
+    try expect(paramBindings[0]["index"] as? Int == 1, "wrong binding index")
+    try expect(paramBindings[0]["source_text"] as? String == "endpoint", "wrong binding source text")
+}
+
+private func testRecognizeReturnsNoTagsForNonMatch() throws {
+    let binding = try bindingTemplate(from: """
+    @ProveKitSugar(concept: "concept:http-request", library: "urlsession")
+    func fetchStatus(_ url: String) -> Int {
+        return send(url)
+    }
+    """)
+
+    let tags = SwiftSourceLifter.recognizeSource(
+        """
+        func getStatus(_ endpoint: String) -> Int {
+            return 200
+        }
+        """,
+        path: "Sources/Client.swift",
+        bindingTemplates: [binding]
+    )
+
+    try expect(tags.isEmpty, "expected no tags, got \(tags.count)")
+}
+
+private func testRecognizeRoutesMultipleBindings() throws {
+    let httpBinding = try bindingTemplate(from: """
+    @ProveKitSugar(concept: "concept:http-request", library: "urlsession")
+    func fetchStatus(_ url: String) -> Int {
+        return send(url)
+    }
+    """)
+    let sqlBinding = try bindingTemplate(from: """
+    @ProveKitSugar(concept: "concept:sql-execute", library: "sqlite")
+    func execute(_ db: String, sql: String) -> Int {
+        return run(db, sql)
+    }
+    """)
+
+    let tags = SwiftSourceLifter.recognizeSource(
+        """
+        func getStatus(_ endpoint: String) -> Int {
+            return send(endpoint)
+        }
+
+        func save(_ conn: String, statement: String) -> Int {
+            return run(conn, statement)
+        }
+        """,
+        path: "Sources/Client.swift",
+        bindingTemplates: [httpBinding, sqlBinding]
+    )
+
+    let concepts = Set(try tags.map { try require(object($0)["concept_name"] as? String, "missing concept") })
+    try expect(concepts == ["concept:http-request", "concept:sql-execute"], "wrong concepts: \(concepts)")
+}
+
+private func sugarBodySource(_ source: String) throws -> [String: Any] {
+    let entries = SwiftSourceLifter.liftLibraryBindingsSource(source, path: "Sources/Shim.swift").ir
+    try expect(entries.count == 1, "expected one entry, got \(entries.count)")
+    let entry = try object(entries[0])
+    return try require(entry["body_source"] as? [String: Any], "missing body_source")
+}
+
+private func bindingTemplate(from source: String) throws -> JcsCanonical {
+    let entries = SwiftSourceLifter.liftLibraryBindingsSource(source, path: "Sources/Shim.swift").ir
+    try expect(entries.count == 1, "expected one entry, got \(entries.count)")
+    let entry = try object(entries[0])
+    let body = try require(entry["body_source"] as? [String: Any], "missing body_source")
+    let paramNames = (body["param_names"] as? [String] ?? []).map { JcsCanonical.string($0) }
+    return .object([
+        ("concept_name", .string(try require(entry["concept_name"] as? String, "missing concept"))),
+        ("library_tag", .string(try require(entry["target_library_tag"] as? String, "missing library"))),
+        ("family", stringOrNull(entry["family"])),
+        ("ast_template", try jcsCanonical(from: try require(body["ast_template"], "missing ast_template"))),
+        ("template_cid", .string(try require(body["template_cid"] as? String, "missing template_cid"))),
+        ("param_names", .array(paramNames)),
+        ("contract_cid", stringOrNull(entry["contract_cid"])),
+    ])
+}
+
+private func object(_ value: JcsCanonical) throws -> [String: Any] {
+    let data = JcsCanonicalizer.encode(value)
+    return try require(JSONSerialization.jsonObject(with: data) as? [String: Any], "not a JSON object")
+}
+
+private func stableJSONString(_ value: Any) throws -> String {
+    JcsCanonicalizer.encodeString(try jcsCanonical(from: value))
+}
+
+private func jcsCanonical(from value: Any) throws -> JcsCanonical {
+    if value is NSNull {
+        return .null
+    }
+    if let value = value as? Bool {
+        return .bool(value)
+    }
+    if let value = value as? Int {
+        return .int(Int64(value))
+    }
+    if let value = value as? Int64 {
+        return .int(value)
+    }
+    if let value = value as? String {
+        return .string(value)
+    }
+    if let value = value as? [Any] {
+        return .array(try value.map(jcsCanonical(from:)))
+    }
+    if let value = value as? [String: Any] {
+        return .object(try value.map { key, child in
+            (key, try jcsCanonical(from: child))
+        })
+    }
+    throw TestFailure(message: "unsupported JSON value: \(value)")
+}
+
+private func stringOrNull(_ value: Any?) -> JcsCanonical {
+    if let value = value as? String {
+        return .string(value)
+    }
+    return .null
+}
+
+private func stringField(_ name: String, in value: JcsCanonical) -> String? {
+    guard case .object(let pairs) = value,
+          let field = pairs.first(where: { $0.0 == name })?.1,
+          case .string(let string) = field
+    else {
+        return nil
+    }
+    return string
+}
+
+private func expect(_ condition: Bool, _ message: String) throws {
+    if !condition {
+        throw TestFailure(message: message)
+    }
+}
+
+private func require<T>(_ value: T?, _ message: String) throws -> T {
+    guard let value else {
+        throw TestFailure(message: message)
+    }
+    return value
+}
+
+private func print(_ value: String, to handle: FileHandle) {
+    handle.write((value + "\n").data(using: .utf8)!)
+}

--- a/implementations/typescript/src/lift/typescript-source/bin.ts
+++ b/implementations/typescript/src/lift/typescript-source/bin.ts
@@ -5,7 +5,9 @@ import {
   compileTypeScriptSourceIr,
   liftTypeScriptLibraryBindingsPaths,
   liftTypeScriptSourcePaths,
+  recognizeTypeScriptSources,
   type FunctionContractMemento,
+  type TypeScriptBindingTemplate,
 } from "./index.js";
 import { normalizeTypeScriptSourceVerifyDocument } from "./verify.js";
 
@@ -65,6 +67,8 @@ function dispatch(request: JsonRpcRequest): Record<string, unknown> | null {
       return liftRpc(request);
     case "compile":
       return compileRpc(request);
+    case "provekit.plugin.recognize":
+      return recognizeRpc(request);
     case "shutdown":
       return success(request.id, null);
     default:
@@ -120,6 +124,26 @@ function compileRpc(request: JsonRpcRequest): Record<string, unknown> {
   }
   const body = compileTypeScriptSourceIr(ir as FunctionContractMemento[]);
   return success(request.id, { kind: "compiled-formula", body });
+}
+
+function recognizeRpc(request: JsonRpcRequest): Record<string, unknown> {
+  const params = request.params ?? {};
+  const projectRoot = typeof params.project_root === "string" ? params.project_root : "";
+  const sourcePaths = Array.isArray(params.source_paths)
+    ? params.source_paths.filter((path): path is string => typeof path === "string")
+    : [];
+  const bindingTemplates = Array.isArray(params.binding_templates)
+    ? params.binding_templates.filter((item): item is TypeScriptBindingTemplate => !!item && typeof item === "object")
+    : [];
+  try {
+    return success(request.id, recognizeTypeScriptSources({
+      project_root: projectRoot,
+      source_paths: sourcePaths,
+      binding_templates: bindingTemplates,
+    }));
+  } catch (error) {
+    return errorResponse(request.id ?? null, -32602, (error as Error).message);
+  }
 }
 
 function success(id: unknown, result: unknown): Record<string, unknown> {

--- a/implementations/typescript/src/lift/typescript-source/bin.ts
+++ b/implementations/typescript/src/lift/typescript-source/bin.ts
@@ -7,7 +7,6 @@ import {
   liftTypeScriptSourcePaths,
   recognizeTypeScriptSources,
   type FunctionContractMemento,
-  type TypeScriptBindingTemplate,
 } from "./index.js";
 import { normalizeTypeScriptSourceVerifyDocument } from "./verify.js";
 
@@ -132,14 +131,10 @@ function recognizeRpc(request: JsonRpcRequest): Record<string, unknown> {
   const sourcePaths = Array.isArray(params.source_paths)
     ? params.source_paths.filter((path): path is string => typeof path === "string")
     : [];
-  const bindingTemplates = Array.isArray(params.binding_templates)
-    ? params.binding_templates.filter((item): item is TypeScriptBindingTemplate => !!item && typeof item === "object")
-    : [];
   try {
     return success(request.id, recognizeTypeScriptSources({
       project_root: projectRoot,
       source_paths: sourcePaths,
-      binding_templates: bindingTemplates,
     }));
   } catch (error) {
     return errorResponse(request.id ?? null, -32602, (error as Error).message);

--- a/implementations/typescript/src/lift/typescript-source/index.test.ts
+++ b/implementations/typescript/src/lift/typescript-source/index.test.ts
@@ -236,6 +236,44 @@ export function query(conn: Database, statement: string, values: unknown[]): Res
     expect(response.tags.every((tag: any) => tag.match_tier === "exact")).toBe(true);
   });
 
+  it("recognize RPC path self-resolves TypeScript sugar templates from source", () => {
+    const root = tempDir("provekit-ts-recognize-self-");
+    writeFileSync(
+      join(root, "shim.ts"),
+      `
+import { sugar } from "provekit";
+
+@sugar.bind({ concept: "concept:http-request", library: "fetch-lib", family: "concept:family:http" })
+function fetchUrl(url: string, headers: Headers): Response {
+  return client.execute(url, headers);
+}
+`,
+    );
+    writeFileSync(
+      join(root, "user.ts"),
+      `
+export function send(uri: string, h: Headers): Response {
+  return client.execute(uri, h);
+}
+`,
+    );
+
+    const response = (typeScriptSource as Record<string, any>).recognizeTypeScriptSources({
+      project_root: root,
+      source_paths: ["shim.ts", "user.ts"],
+    });
+
+    expect(response.tags).toHaveLength(1);
+    expect(response.tags[0]).toMatchObject({
+      file: "user.ts",
+      function_name: "send",
+      concept_name: "concept:http-request",
+      library_tag: "fetch-lib",
+      family: "concept:family:http",
+      match_tier: "exact",
+    });
+  });
+
   // -----------------------------------------------------------------
   // #1357 / #1355: family + version axes on @sugar.bind decorators.
   // Parallel to walk_rpc's rust-side tests. Both fields are optional;

--- a/implementations/typescript/src/lift/typescript-source/index.test.ts
+++ b/implementations/typescript/src/lift/typescript-source/index.test.ts
@@ -14,6 +14,7 @@ import {
   liftTypeScriptSourcePaths,
   liftTypeScriptSourceText,
 } from "./index.js";
+import * as typeScriptSource from "./index.js";
 
 function tempDir(prefix = "provekit-ts-source-"): string {
   return mkdtempSync(join(tmpdir(), prefix));
@@ -63,13 +64,182 @@ function selectRows(db: Database.Database, sql: string, args: unknown[]) {
     expect(binding.body_source.span).toEqual({ start_line: 5, start_col: 0, end_line: 8, end_col: 1 });
     const expectedSpan = source.split(/(?<=\n)/).slice(4, 8).join("").replace(/\n$/, "");
     expect(binding.body_source.source_cid).toBe(computeCid(Buffer.from(expectedSpan, "utf8")));
+    expect(binding.body_source.body_text).toBe("return db.prepare(sql).all(args);");
+    expect(binding.body_source.param_names).toEqual(["db", "sql", "args"]);
+    expect(binding.body_source.ast_template).toMatchObject({
+      kind: "block",
+      stmts: [
+        {
+          kind: "return",
+          expr: {
+            kind: "method_call",
+            method: "all",
+            args: [{ kind: "param_ref", index: 3 }],
+          },
+        },
+      ],
+    });
+    expect(binding.body_source.template_cid).toBe(canonicalCid(binding.body_source.ast_template));
     expect(canonicalJsonString(binding)).not.toContain("emission_template");
+  });
+
+  it("sugar body template cid is stable under parameter renaming", () => {
+    const sourceA = `
+import { sugar } from "provekit";
+
+@sugar.bind({ concept: "concept:http-request", library: "fetch-lib" })
+function fetchUrl(url: string, headers: Headers): Response {
+  return client.execute(url, headers);
+}
+`;
+    const sourceB = `
+import { sugar } from "provekit";
+
+@sugar.bind({ concept: "concept:http-request", library: "fetch-lib" })
+function fetchUrl(uri: string, h: Headers): Response {
+  return client.execute(uri, h);
+}
+`;
+
+    const bodyA = liftTypeScriptLibraryBindingsText(sourceA, "src/a.ts").libraryBindings[0]!.body_source;
+    const bodyB = liftTypeScriptLibraryBindingsText(sourceB, "src/b.ts").libraryBindings[0]!.body_source;
+
+    expect(bodyA.ast_template).toEqual(bodyB.ast_template);
+    expect(bodyA.template_cid).toBe(bodyB.template_cid);
+    expect(bodyA.source_cid).not.toBe(bodyB.source_cid);
+  });
+
+  it("recognizes exact alpha-equivalent TypeScript source from binding templates", () => {
+    const shim = `
+import { sugar } from "provekit";
+
+@sugar.bind({ concept: "concept:http-request", library: "fetch-lib", family: "concept:family:http" })
+function fetchUrl(url: string, headers: Headers): Response {
+  return client.execute(url, headers);
+}
+`;
+    const user = `
+export function send(uri: string, h: Headers): Response {
+  return client.execute(uri, h);
+}
+`;
+    const sugarEntry = liftTypeScriptLibraryBindingsText(shim, "src/shim.ts").libraryBindings[0]!;
+    const recognize = (typeScriptSource as Record<string, any>).recognizeTypeScriptSourcesText;
+
+    expect(typeof recognize).toBe("function");
+    const response = recognize(user, "src/user.ts", [
+      {
+        concept_name: sugarEntry.concept_name,
+        library_tag: sugarEntry.target_library_tag,
+        family: "concept:family:http",
+        ast_template: sugarEntry.body_source.ast_template,
+        template_cid: sugarEntry.body_source.template_cid,
+        param_names: sugarEntry.body_source.param_names,
+        contract_cid: "blake3-512:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      },
+    ]);
+
+    expect(response.tags).toHaveLength(1);
+    expect(response.tags[0]).toMatchObject({
+      file: "src/user.ts",
+      function_name: "send",
+      concept_name: "concept:http-request",
+      library_tag: "fetch-lib",
+      family: "concept:family:http",
+      template_cid: sugarEntry.body_source.template_cid,
+      match_tier: "exact",
+      param_bindings: [
+        { index: 1, source_text: "uri" },
+        { index: 2, source_text: "h" },
+      ],
+    });
+  });
+
+  it("returns no recognize tags for non-matching TypeScript source", () => {
+    const shim = `
+import { sugar } from "provekit";
+
+@sugar.bind({ concept: "concept:http-request", library: "fetch-lib" })
+function fetchUrl(url: string, headers: Headers): Response {
+  return client.execute(url, headers);
+}
+`;
+    const user = `
+export function send(uri: string, h: Headers): Response {
+  return other.execute(uri, h);
+}
+`;
+    const sugarEntry = liftTypeScriptLibraryBindingsText(shim, "src/shim.ts").libraryBindings[0]!;
+    const recognize = (typeScriptSource as Record<string, any>).recognizeTypeScriptSourcesText;
+
+    expect(typeof recognize).toBe("function");
+    expect(
+      recognize(user, "src/user.ts", [
+        {
+          concept_name: sugarEntry.concept_name,
+          library_tag: sugarEntry.target_library_tag,
+          ast_template: sugarEntry.body_source.ast_template,
+          template_cid: sugarEntry.body_source.template_cid,
+          param_names: sugarEntry.body_source.param_names,
+          contract_cid: null,
+        },
+      ]).tags,
+    ).toEqual([]);
+  });
+
+  it("routes multiple TypeScript binding templates by template cid", () => {
+    const shim = `
+import { sugar } from "provekit";
+
+@sugar.bind({ concept: "concept:http-request", library: "fetch-lib", family: "concept:family:http" })
+function fetchUrl(url: string, headers: Headers): Response {
+  return client.execute(url, headers);
+}
+
+@sugar.bind({ concept: "concept:sql-execute", library: "sql-lib", family: "concept:family:sql" })
+function runSql(db: Database, sql: string, args: unknown[]): Result {
+  return db.execute(sql, args);
+}
+`;
+    const user = `
+export function send(uri: string, h: Headers): Response {
+  return client.execute(uri, h);
+}
+
+export function query(conn: Database, statement: string, values: unknown[]): Result {
+  return conn.execute(statement, values);
+}
+`;
+    const entries = liftTypeScriptLibraryBindingsText(shim, "src/shim.ts").libraryBindings;
+    const recognize = (typeScriptSource as Record<string, any>).recognizeTypeScriptSourcesText;
+
+    expect(typeof recognize).toBe("function");
+    const response = recognize(
+      user,
+      "src/user.ts",
+      entries.map((entry) => ({
+        concept_name: entry.concept_name,
+        library_tag: entry.target_library_tag,
+        family: (entry as any).family,
+        ast_template: entry.body_source.ast_template,
+        template_cid: entry.body_source.template_cid,
+        param_names: entry.body_source.param_names,
+        contract_cid: `${entry.concept_name}:contract`,
+      })),
+    );
+
+    expect(response.tags).toHaveLength(2);
+    expect(Object.fromEntries(response.tags.map((tag: any) => [tag.concept_name, tag.function_name]))).toEqual({
+      "concept:http-request": "send",
+      "concept:sql-execute": "query",
+    });
+    expect(response.tags.every((tag: any) => tag.match_tier === "exact")).toBe(true);
   });
 
   // -----------------------------------------------------------------
   // #1357 / #1355: family + version axes on @sugar.bind decorators.
   // Parallel to walk_rpc's rust-side tests. Both fields are optional;
-  // absent on decorator ↔ absent in emitted JSON.
+  // absent on decorator means absent in emitted JSON.
   // -----------------------------------------------------------------
 
   it("lifts family + library_version when present on @sugar.bind", () => {

--- a/implementations/typescript/src/lift/typescript-source/index.ts
+++ b/implementations/typescript/src/lift/typescript-source/index.ts
@@ -100,6 +100,8 @@ export interface TypeScriptBindingTemplate {
 export interface TypeScriptRecognizeParams {
   project_root: string;
   source_paths: string[];
+  /// Direct templates are kept for focused kit tests. The manifest/RPC path
+  /// resolves templates inside the kit from project source/proof context.
   binding_templates?: TypeScriptBindingTemplate[];
 }
 
@@ -245,8 +247,16 @@ export function liftTypeScriptLibraryBindingsPaths(
 export function recognizeTypeScriptSources(params: TypeScriptRecognizeParams): TypeScriptRecognizeResponse {
   if (!params.project_root) throw new Error("missing `project_root`");
   if (!Array.isArray(params.source_paths)) throw new Error("missing `source_paths` array");
-  const bindingsByCid = bindingTemplatesByCid(params.binding_templates ?? []);
   const root = resolve(params.project_root);
+  const suppliedTemplates = params.binding_templates ?? [];
+  const selfResolvedBindings = suppliedTemplates.length > 0
+    ? []
+    : liftTypeScriptLibraryBindingsPaths(root, params.source_paths).libraryBindings;
+  const sugarTemplateFiles = new Set(selfResolvedBindings.map((entry) => entry.body_source.file));
+  const templatePool = suppliedTemplates.length > 0
+    ? suppliedTemplates
+    : selfResolvedBindings.map(bindingTemplateFromSugarEntry);
+  const bindingsByCid = bindingTemplatesByCid(templatePool);
   const tags: TypeScriptRecognizeTag[] = [];
 
   for (const sourcePath of params.source_paths) {
@@ -257,11 +267,24 @@ export function recognizeTypeScriptSources(params: TypeScriptRecognizeParams): T
     for (const file of files.sort()) {
       const sourceText = readFileSync(file, "utf8");
       const relPath = normalizePath(relative(root, file));
+      if (sugarTemplateFiles.has(relPath)) continue;
       tags.push(...recognizeTypeScriptSourcesText(sourceText, relPath, [...bindingsByCid.values()]).tags);
     }
   }
 
   return { tags };
+}
+
+function bindingTemplateFromSugarEntry(entry: TypeScriptLibrarySugarBindingEntry): TypeScriptBindingTemplate {
+  return {
+    concept_name: entry.concept_name,
+    library_tag: entry.target_library_tag,
+    family: (entry as unknown as { family?: unknown }).family,
+    ast_template: entry.body_source.ast_template,
+    template_cid: entry.body_source.template_cid,
+    param_names: entry.body_source.param_names,
+    contract_cid: (entry as unknown as { contract_cid?: unknown }).contract_cid ?? null,
+  };
 }
 
 export function recognizeTypeScriptSourcesText(
@@ -299,9 +322,22 @@ function bindingTemplatesByCid(bindingTemplates: readonly TypeScriptBindingTempl
 }
 
 function isRecognizableFunctionLike(node: ts.Node): node is RecognizableFunctionLike {
+  if (ts.canHaveDecorators(node) && (ts.getDecorators(node) ?? []).some(isSugarBindDecorator)) {
+    return false;
+  }
   if (ts.isFunctionDeclaration(node)) return !!node.name && !!node.body;
   if (ts.isMethodDeclaration(node)) return !!methodNameText(node.name) && !!node.body;
   return false;
+}
+
+function isSugarBindDecorator(decorator: ts.Decorator): boolean {
+  const expr = decorator.expression;
+  if (!ts.isCallExpression(expr)) return false;
+  const callee = expr.expression;
+  return ts.isPropertyAccessExpression(callee)
+    && callee.name.text === "bind"
+    && ts.isIdentifier(callee.expression)
+    && callee.expression.text === "sugar";
 }
 
 function recognizeFunctionLike(

--- a/implementations/typescript/src/lift/typescript-source/index.ts
+++ b/implementations/typescript/src/lift/typescript-source/index.ts
@@ -60,6 +60,9 @@ export interface TypeScriptLibrarySugarBindingEntry {
     span: { start_line: number; start_col: number; end_line: number; end_col: number };
     source_cid: string;
     body_text: string;
+    ast_template: unknown;
+    template_cid: string;
+    param_names: string[];
   };
 }
 
@@ -82,6 +85,39 @@ export interface TypeScriptSourceLiftResult {
   diagnostics: TypeScriptSourceDiagnostic[];
   opacityReport: unknown[];
   refusals: TypeScriptSourceRefusal[];
+}
+
+export interface TypeScriptBindingTemplate {
+  concept_name?: unknown;
+  library_tag?: unknown;
+  family?: unknown;
+  ast_template?: unknown;
+  template_cid?: unknown;
+  param_names?: unknown;
+  contract_cid?: unknown;
+}
+
+export interface TypeScriptRecognizeParams {
+  project_root: string;
+  source_paths: string[];
+  binding_templates?: TypeScriptBindingTemplate[];
+}
+
+export interface TypeScriptRecognizeTag {
+  file: string;
+  span: { start_line: number; start_col: number; end_line: number; end_col: number };
+  function_name: string;
+  concept_name: unknown;
+  library_tag: unknown;
+  family: unknown;
+  template_cid: string;
+  contract_cid: unknown;
+  match_tier: "exact";
+  param_bindings: { index: number; source_text: string }[];
+}
+
+export interface TypeScriptRecognizeResponse {
+  tags: TypeScriptRecognizeTag[];
 }
 
 interface LiftedFunction {
@@ -204,6 +240,100 @@ export function liftTypeScriptLibraryBindingsPaths(
     refusals.push(...lifted.refusals);
   }
   return { declarations: [], diagnostics, opacityReport: [], refusals, libraryBindings, libraryRefusals };
+}
+
+export function recognizeTypeScriptSources(params: TypeScriptRecognizeParams): TypeScriptRecognizeResponse {
+  if (!params.project_root) throw new Error("missing `project_root`");
+  if (!Array.isArray(params.source_paths)) throw new Error("missing `source_paths` array");
+  const bindingsByCid = bindingTemplatesByCid(params.binding_templates ?? []);
+  const root = resolve(params.project_root);
+  const tags: TypeScriptRecognizeTag[] = [];
+
+  for (const sourcePath of params.source_paths) {
+    const fullPath = resolve(root, sourcePath);
+    if (!isInsideRoot(root, fullPath) || !existsSync(fullPath)) continue;
+    const st = statSync(fullPath);
+    const files = st.isDirectory() ? enumerateSourceFiles(fullPath) : st.isFile() && isSourceFile(fullPath) ? [fullPath] : [];
+    for (const file of files.sort()) {
+      const sourceText = readFileSync(file, "utf8");
+      const relPath = normalizePath(relative(root, file));
+      tags.push(...recognizeTypeScriptSourcesText(sourceText, relPath, [...bindingsByCid.values()]).tags);
+    }
+  }
+
+  return { tags };
+}
+
+export function recognizeTypeScriptSourcesText(
+  sourceText: string,
+  fileName = "input.ts",
+  bindingTemplates: TypeScriptBindingTemplate[] = [],
+): TypeScriptRecognizeResponse {
+  const modulePath = normalizePath(fileName);
+  const sourceFile = ts.createSourceFile(modulePath, sourceText, ts.ScriptTarget.ES2022, true, scriptKind(modulePath));
+  const bindingsByCid = bindingTemplatesByCid(bindingTemplates);
+  const tags: TypeScriptRecognizeTag[] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (isRecognizableFunctionLike(node)) {
+      const tag = recognizeFunctionLike(sourceFile, modulePath, node, bindingsByCid);
+      if (tag) tags.push(tag);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+
+  return { tags };
+}
+
+type RecognizableFunctionLike = ts.FunctionDeclaration | ts.MethodDeclaration;
+
+function bindingTemplatesByCid(bindingTemplates: readonly TypeScriptBindingTemplate[]): Map<string, TypeScriptBindingTemplate> {
+  const out = new Map<string, TypeScriptBindingTemplate>();
+  for (const binding of bindingTemplates) {
+    if (!binding || typeof binding !== "object") continue;
+    const cid = binding.template_cid;
+    if (typeof cid === "string" && cid.length > 0) out.set(cid, binding);
+  }
+  return out;
+}
+
+function isRecognizableFunctionLike(node: ts.Node): node is RecognizableFunctionLike {
+  if (ts.isFunctionDeclaration(node)) return !!node.name && !!node.body;
+  if (ts.isMethodDeclaration(node)) return !!methodNameText(node.name) && !!node.body;
+  return false;
+}
+
+function recognizeFunctionLike(
+  sourceFile: ts.SourceFile,
+  modulePath: string,
+  node: RecognizableFunctionLike,
+  bindingsByCid: ReadonlyMap<string, TypeScriptBindingTemplate>,
+): TypeScriptRecognizeTag | null {
+  if (!node.body) return null;
+  const paramNames = node.parameters.map((param) => parameterName(param));
+  const astTemplate = functionBodyAstTemplate(node.body, paramNames);
+  const templateCid = cidOfValue(astTemplate);
+  const binding = bindingsByCid.get(templateCid);
+  if (!binding) return null;
+
+  return {
+    file: modulePath,
+    span: locatorForNode(node, sourceFile),
+    function_name: recognizableFunctionName(node),
+    concept_name: binding.concept_name ?? null,
+    library_tag: binding.library_tag ?? null,
+    family: binding.family ?? null,
+    template_cid: templateCid,
+    contract_cid: binding.contract_cid ?? null,
+    match_tier: "exact",
+    param_bindings: paramNames.map((name, index) => ({ index: index + 1, source_text: name })),
+  };
+}
+
+function recognizableFunctionName(node: RecognizableFunctionLike): string {
+  if (ts.isFunctionDeclaration(node)) return node.name?.text ?? "";
+  return methodNameText(node.name) ?? "";
 }
 
 export function functionContractCid(contract: FunctionContractMemento): string {
@@ -377,11 +507,12 @@ function libraryBindingEntryForFunction(
   // `@sugar.bind(...)` decorator + signature + braces are presentation/sugar.
   // The lifter has already read the decorator (concept/library/family/version)
   // and the signature (param_names/param_types/return_type) into typed fields.
-  // body_text carries only the remaining substance — the statements between the
+  // body_text carries only the remaining substance: the statements between the
   // function block's outermost `{` and matching `}`, with original indentation
   // preserved (the realizer does its own indentation pass). When no block body
   // is present, body_text is empty and the entry contributes no template.
   const bodyText = extractFunctionBodyStatements(body, sourceFile);
+  const astTemplate = functionBodyAstTemplate(body, paramNames);
   const entry: TypeScriptLibrarySugarBindingEntry = {
     kind: "library-sugar-binding-entry",
     target_language: "typescript",
@@ -403,12 +534,15 @@ function libraryBindingEntryForFunction(
       span,
       source_cid: computeCid(Buffer.from(spanText, "utf8")),
       body_text: bodyText,
+      ast_template: astTemplate,
+      template_cid: cidOfValue(astTemplate),
+      param_names: paramNames,
     },
   };
   if (binding.observed_dimension !== null) entry.observed_dimension = binding.observed_dimension;
   // #1357 / #1355: surface optional family + version pins on the binding
-  // entry. Absent on the @sugar.bind decorator → absent in emitted JSON
-  // (NOT empty strings — null/missing is the substrate signal for
+  // entry. Absent on the @sugar.bind decorator means absent in emitted JSON
+  // (NOT empty strings; null/missing is the substrate signal for
   // "this axis floats"). Parallel to walk_rpc's rust-side emission.
   if (binding.family !== null) (entry as unknown as Record<string, unknown>).family = binding.family;
   if (binding.version !== null) (entry as unknown as Record<string, unknown>).library_version = binding.version;
@@ -416,7 +550,7 @@ function libraryBindingEntryForFunction(
 }
 
 /**
- * Extract only the statements inside a function's block body — the text between
+ * Extract only the statements inside a function's block body: the text between
  * the block's outermost `{` and matching `}`, dedented to column 0. The
  * decorator + signature + braces are sugar already captured as typed fields;
  * body_text carries what the function DOES. Returns "" when there is no block
@@ -424,7 +558,7 @@ function libraryBindingEntryForFunction(
  *
  * Dedent rationale: the shim source indents method bodies (e.g. 2 spaces inside
  * the function block). That source-level indentation is presentation, not
- * substance — the realizer's functionSource / emission template owns body
+ * substance; the realizer's functionSource / emission template owns body
  * indentation and the materialize indent pass adds the carrier's column on top.
  * Capturing body_text at column 0 keeps it byte-equal to the canonical
  * de-indented emission template the central body-templates JSON shipped before
@@ -477,6 +611,236 @@ function dedentCommonIndent(text: string): string {
   return lines
     .map((line) => (line.startsWith(prefix) ? line.slice(prefix.length) : line))
     .join("\n");
+}
+
+function functionBodyAstTemplate(body: ts.Block | undefined, params: readonly string[]): unknown {
+  return {
+    kind: "block",
+    stmts: body ? body.statements.flatMap((stmt) => stmtToAstTemplates(stmt, params)) : [],
+  };
+}
+
+function stmtToAstTemplates(stmt: ts.Statement, params: readonly string[]): unknown[] {
+  if (ts.isVariableStatement(stmt)) {
+    return stmt.declarationList.declarations.map((decl) => ({
+      kind: "let",
+      pat: bindingNameToAstTemplate(decl.name, params),
+      init: decl.initializer ? exprToAstTemplate(decl.initializer, params) : null,
+    }));
+  }
+  if (ts.isExpressionStatement(stmt)) {
+    return [{
+      kind: "expr_stmt",
+      expr: exprToAstTemplate(stmt.expression, params),
+      trailing_semi: true,
+    }];
+  }
+  if (ts.isReturnStatement(stmt)) {
+    return [{
+      kind: "return",
+      expr: stmt.expression ? exprToAstTemplate(stmt.expression, params) : null,
+    }];
+  }
+  if (ts.isBlock(stmt)) {
+    return [functionBodyAstTemplate(stmt, params)];
+  }
+  return [otherAstTemplate(stmt)];
+}
+
+function exprToAstTemplate(expr: ts.Expression, params: readonly string[]): unknown {
+  if (ts.isIdentifier(expr)) return identifierAstTemplate(expr.text, params);
+  if (expr.kind === ts.SyntaxKind.ThisKeyword) return { kind: "ident", name: "this" };
+  if (expr.kind === ts.SyntaxKind.NullKeyword) return { kind: "lit", ty: "null", value: null };
+  if (expr.kind === ts.SyntaxKind.TrueKeyword) return { kind: "lit", ty: "bool", value: true };
+  if (expr.kind === ts.SyntaxKind.FalseKeyword) return { kind: "lit", ty: "bool", value: false };
+  if (ts.isStringLiteralLike(expr)) return { kind: "lit", ty: "str", value: expr.text };
+  if (ts.isNumericLiteral(expr)) return { kind: "lit", ty: "number", value: Number(expr.text) };
+  if (ts.isParenthesizedExpression(expr)) return exprToAstTemplate(expr.expression, params);
+  if (ts.isArrayLiteralExpression(expr)) {
+    return { kind: "array", elems: expr.elements.map((element) => exprToAstTemplate(element as ts.Expression, params)) };
+  }
+  if (ts.isObjectLiteralExpression(expr)) {
+    return {
+      kind: "object",
+      fields: expr.properties.map((prop) => objectPropertyAstTemplate(prop, params)),
+    };
+  }
+  if (ts.isCallExpression(expr)) {
+    const args = expr.arguments.map((arg) => exprToAstTemplate(arg, params));
+    if (ts.isPropertyAccessExpression(expr.expression)) {
+      return {
+        kind: "method_call",
+        receiver: exprToAstTemplate(expr.expression.expression, params),
+        method: expr.expression.name.text,
+        args,
+      };
+    }
+    return {
+      kind: "call",
+      func: exprToAstTemplate(expr.expression, params),
+      args,
+    };
+  }
+  if (ts.isPropertyAccessExpression(expr)) {
+    const field = fieldAstTemplateIfParamRoot(expr, params);
+    if (field) return field;
+    const segments = propertyAccessSegments(expr);
+    return segments ? { kind: "path", segments } : {
+      kind: "field",
+      base: exprToAstTemplate(expr.expression, params),
+      member: expr.name.text,
+    };
+  }
+  if (ts.isElementAccessExpression(expr)) {
+    return {
+      kind: "index",
+      base: exprToAstTemplate(expr.expression, params),
+      index: expr.argumentExpression ? exprToAstTemplate(expr.argumentExpression, params) : null,
+    };
+  }
+  if (ts.isBinaryExpression(expr)) {
+    const op = binaryOpTemplateName(expr.operatorToken.kind);
+    return op
+      ? {
+          kind: "binary",
+          op,
+          left: exprToAstTemplate(expr.left, params),
+          right: exprToAstTemplate(expr.right, params),
+        }
+      : otherAstTemplate(expr);
+  }
+  if (ts.isPrefixUnaryExpression(expr)) {
+    return {
+      kind: "unary",
+      op: ts.SyntaxKind[expr.operator] ?? String(expr.operator),
+      expr: exprToAstTemplate(expr.operand, params),
+    };
+  }
+  if (ts.isAsExpression(expr) || ts.isTypeAssertionExpression(expr) || ts.isNonNullExpression(expr)) {
+    return exprToAstTemplate(expr.expression, params);
+  }
+  return otherAstTemplate(expr);
+}
+
+function objectPropertyAstTemplate(prop: ts.ObjectLiteralElementLike, params: readonly string[]): unknown {
+  if (ts.isPropertyAssignment(prop)) {
+    return {
+      kind: "field",
+      name: propertyNameText(prop.name),
+      value: exprToAstTemplate(prop.initializer, params),
+    };
+  }
+  if (ts.isShorthandPropertyAssignment(prop)) {
+    return {
+      kind: "field",
+      name: prop.name.text,
+      value: identifierAstTemplate(prop.name.text, params),
+    };
+  }
+  return otherAstTemplate(prop);
+}
+
+function bindingNameToAstTemplate(name: ts.BindingName, params: readonly string[]): unknown {
+  if (ts.isIdentifier(name)) {
+    if (paramIndex(name.text, params) > 0) return { kind: "param_ref", index: paramIndex(name.text, params) };
+    return { kind: "binding", name: name.text };
+  }
+  return {
+    kind: "pat_tuple",
+    elems: name.elements.map((element) => {
+      if (ts.isOmittedExpression(element)) return { kind: "wildcard" };
+      return bindingNameToAstTemplate(element.name, params);
+    }),
+  };
+}
+
+function identifierAstTemplate(name: string, params: readonly string[]): unknown {
+  switch (name) {
+    case "undefined":
+      return { kind: "lit", ty: "undefined", value: null };
+    case "NaN":
+    case "Infinity":
+      return { kind: "ident", name };
+    default: {
+      const index = paramIndex(name, params);
+      return index > 0 ? { kind: "param_ref", index } : { kind: "ident", name };
+    }
+  }
+}
+
+function paramIndex(name: string, params: readonly string[]): number {
+  const index = params.indexOf(name);
+  return index < 0 ? 0 : index + 1;
+}
+
+function propertyAccessSegments(expr: ts.PropertyAccessExpression): string[] | null {
+  const segments: string[] = [expr.name.text];
+  let current: ts.Expression = expr.expression;
+  while (ts.isPropertyAccessExpression(current)) {
+    segments.unshift(current.name.text);
+    current = current.expression;
+  }
+  if (ts.isIdentifier(current)) {
+    segments.unshift(current.text);
+    return segments;
+  }
+  if (current.kind === ts.SyntaxKind.ThisKeyword) {
+    segments.unshift("this");
+    return segments;
+  }
+  return null;
+}
+
+function fieldAstTemplateIfParamRoot(expr: ts.PropertyAccessExpression, params: readonly string[]): unknown | null {
+  const members: string[] = [];
+  let current: ts.Expression = expr;
+  while (ts.isPropertyAccessExpression(current)) {
+    members.unshift(current.name.text);
+    current = current.expression;
+  }
+  if (!ts.isIdentifier(current)) return null;
+  const index = paramIndex(current.text, params);
+  if (index === 0) return null;
+  let result: unknown = { kind: "param_ref", index };
+  for (const member of members) {
+    result = { kind: "field", base: result, member };
+  }
+  return result;
+}
+
+function propertyNameText(name: ts.PropertyName): string {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) return name.text;
+  return name.getText();
+}
+
+function binaryOpTemplateName(kind: ts.SyntaxKind): string | null {
+  switch (kind) {
+    case ts.SyntaxKind.PlusToken: return "Add";
+    case ts.SyntaxKind.MinusToken: return "Sub";
+    case ts.SyntaxKind.AsteriskToken: return "Mul";
+    case ts.SyntaxKind.SlashToken: return "Div";
+    case ts.SyntaxKind.PercentToken: return "Rem";
+    case ts.SyntaxKind.AmpersandToken: return "BitAnd";
+    case ts.SyntaxKind.BarToken: return "BitOr";
+    case ts.SyntaxKind.CaretToken: return "BitXor";
+    case ts.SyntaxKind.LessThanLessThanToken: return "Shl";
+    case ts.SyntaxKind.GreaterThanGreaterThanToken: return "Shr";
+    case ts.SyntaxKind.AmpersandAmpersandToken: return "And";
+    case ts.SyntaxKind.BarBarToken: return "Or";
+    case ts.SyntaxKind.EqualsEqualsEqualsToken:
+    case ts.SyntaxKind.EqualsEqualsToken: return "Eq";
+    case ts.SyntaxKind.ExclamationEqualsEqualsToken:
+    case ts.SyntaxKind.ExclamationEqualsToken: return "Ne";
+    case ts.SyntaxKind.LessThanToken: return "Lt";
+    case ts.SyntaxKind.LessThanEqualsToken: return "Le";
+    case ts.SyntaxKind.GreaterThanEqualsToken: return "Ge";
+    case ts.SyntaxKind.GreaterThanToken: return "Gt";
+    default: return null;
+  }
+}
+
+function otherAstTemplate(node: ts.Node): unknown {
+  return { kind: "other", variant: syntaxKindName(node) };
 }
 
 function sugarBindingArgs(node: ts.FunctionDeclaration): {

--- a/implementations/zig/provekit-lift-zig-source/src/lift.zig
+++ b/implementations/zig/provekit-lift-zig-source/src/lift.zig
@@ -189,6 +189,208 @@ pub const FunctionContract = struct {
     }
 };
 
+pub const SourceSpan = struct {
+    start_line: usize,
+    start_col: usize,
+    end_line: usize,
+    end_col: usize,
+};
+
+pub const SugarAstTemplate = union(enum) {
+    block: struct { stmts: []const SugarAstTemplate },
+    let: struct { pat: *const SugarAstTemplate, init: ?*const SugarAstTemplate },
+    expr_stmt: struct { expr: *const SugarAstTemplate, trailing_semi: bool },
+    call: struct { func: *const SugarAstTemplate, args: []const SugarAstTemplate },
+    method_call: struct { receiver: *const SugarAstTemplate, method: []const u8, args: []const SugarAstTemplate },
+    ident: []const u8,
+    param_ref: usize,
+    path: []const []const u8,
+    lit: struct { ty: []const u8, value: []const u8 },
+    ref: struct { mutability: bool, expr: *const SugarAstTemplate },
+    @"return": ?*const SugarAstTemplate,
+    tuple: struct { elems: []const SugarAstTemplate },
+    array: struct { elems: []const SugarAstTemplate },
+    binary: struct { op: []const u8, left: *const SugarAstTemplate, right: *const SugarAstTemplate },
+    binding: []const u8,
+    wildcard,
+    pat_tuple: struct { elems: []const SugarAstTemplate },
+    other: []const u8,
+
+    pub fn jsonStringify(self: SugarAstTemplate, jws: anytype) !void {
+        try jws.beginObject();
+        switch (self) {
+            .block => |v| {
+                try jws.objectField("kind");
+                try jws.write("block");
+                try jws.objectField("stmts");
+                try jws.write(v.stmts);
+            },
+            .let => |v| {
+                try jws.objectField("kind");
+                try jws.write("let");
+                try jws.objectField("pat");
+                try jws.write(v.pat.*);
+                try jws.objectField("init");
+                if (v.init) |init| try jws.write(init.*) else try jws.write(null);
+            },
+            .expr_stmt => |v| {
+                try jws.objectField("kind");
+                try jws.write("expr_stmt");
+                try jws.objectField("expr");
+                try jws.write(v.expr.*);
+                try jws.objectField("trailing_semi");
+                try jws.write(v.trailing_semi);
+            },
+            .call => |v| {
+                try jws.objectField("kind");
+                try jws.write("call");
+                try jws.objectField("func");
+                try jws.write(v.func.*);
+                try jws.objectField("args");
+                try jws.write(v.args);
+            },
+            .method_call => |v| {
+                try jws.objectField("kind");
+                try jws.write("method_call");
+                try jws.objectField("receiver");
+                try jws.write(v.receiver.*);
+                try jws.objectField("method");
+                try jws.write(v.method);
+                try jws.objectField("args");
+                try jws.write(v.args);
+            },
+            .ident => |name| {
+                try jws.objectField("kind");
+                try jws.write("ident");
+                try jws.objectField("name");
+                try jws.write(name);
+            },
+            .param_ref => |index| {
+                try jws.objectField("kind");
+                try jws.write("param_ref");
+                try jws.objectField("index");
+                try jws.write(index);
+            },
+            .path => |segments| {
+                try jws.objectField("kind");
+                try jws.write("path");
+                try jws.objectField("segments");
+                try jws.write(segments);
+            },
+            .lit => |v| {
+                try jws.objectField("kind");
+                try jws.write("lit");
+                try jws.objectField("ty");
+                try jws.write(v.ty);
+                try jws.objectField("value");
+                try jws.write(v.value);
+            },
+            .ref => |v| {
+                try jws.objectField("kind");
+                try jws.write("ref");
+                try jws.objectField("mutability");
+                try jws.write(v.mutability);
+                try jws.objectField("expr");
+                try jws.write(v.expr.*);
+            },
+            .@"return" => |maybe_expr| {
+                try jws.objectField("kind");
+                try jws.write("return");
+                try jws.objectField("expr");
+                if (maybe_expr) |expr| try jws.write(expr.*) else try jws.write(null);
+            },
+            .tuple => |v| {
+                try jws.objectField("kind");
+                try jws.write("tuple");
+                try jws.objectField("elems");
+                try jws.write(v.elems);
+            },
+            .array => |v| {
+                try jws.objectField("kind");
+                try jws.write("array");
+                try jws.objectField("elems");
+                try jws.write(v.elems);
+            },
+            .binary => |v| {
+                try jws.objectField("kind");
+                try jws.write("binary");
+                try jws.objectField("op");
+                try jws.write(v.op);
+                try jws.objectField("left");
+                try jws.write(v.left.*);
+                try jws.objectField("right");
+                try jws.write(v.right.*);
+            },
+            .binding => |name| {
+                try jws.objectField("kind");
+                try jws.write("binding");
+                try jws.objectField("name");
+                try jws.write(name);
+            },
+            .wildcard => {
+                try jws.objectField("kind");
+                try jws.write("wildcard");
+            },
+            .pat_tuple => |v| {
+                try jws.objectField("kind");
+                try jws.write("pat_tuple");
+                try jws.objectField("elems");
+                try jws.write(v.elems);
+            },
+            .other => |variant| {
+                try jws.objectField("kind");
+                try jws.write("other");
+                try jws.objectField("variant");
+                try jws.write(variant);
+            },
+        }
+        try jws.endObject();
+    }
+};
+
+pub const SugarBodySource = struct {
+    file: []const u8,
+    span: SourceSpan,
+    source_cid: []const u8,
+    body_text: []const u8,
+    ast_template: SugarAstTemplate,
+    template_cid: []const u8,
+    param_names: []const []const u8,
+};
+
+pub const BindingTemplate = struct {
+    concept_name: ?[]const u8 = null,
+    library_tag: ?[]const u8 = null,
+    target_library_tag: ?[]const u8 = null,
+    family: ?[]const u8 = null,
+    ast_template: ?SugarAstTemplate = null,
+    template_cid: []const u8,
+    param_names: []const []const u8 = &.{},
+    contract_cid: ?[]const u8 = null,
+};
+
+pub const ParamBinding = struct {
+    index: usize,
+    source_text: []const u8,
+};
+
+pub const RecognizeTag = struct {
+    file: []const u8,
+    span: SourceSpan,
+    function_name: []const u8,
+    concept_name: ?[]const u8,
+    library_tag: ?[]const u8,
+    family: ?[]const u8,
+    template_cid: []const u8,
+    contract_cid: ?[]const u8,
+    match_tier: []const u8,
+    param_bindings: []const ParamBinding,
+};
+
+pub const RecognizeResponse = struct {
+    tags: []const RecognizeTag,
+};
+
 const Global = struct {
     name: []const u8,
     mutable: bool,
@@ -721,7 +923,7 @@ const Lifter = struct {
         }
         try out.append(self.alloc, '.');
         try out.appendSlice(self.alloc, name);
-        return out.toOwnedSlice(self.alloc);
+        return try out.toOwnedSlice(self.alloc);
     }
 
     fn exprName(self: *Lifter, node: Node.Index) anyerror!?[]const u8 {
@@ -809,6 +1011,397 @@ pub fn liftSource(alloc: std.mem.Allocator, source: []const u8, path: []const u8
         return .{ .declarations = &.{}, .refusals = try lifter.refusals.toOwnedSlice(alloc) };
     }
     return lifter.lift();
+}
+
+pub fn sugarBodySourceForFunc(
+    alloc: std.mem.Allocator,
+    source: []const u8,
+    path: []const u8,
+    fn_name: []const u8,
+) !?SugarBodySource {
+    const source_z = try alloc.allocSentinel(u8, source.len, 0);
+    @memcpy(source_z[0..source.len], source);
+    var tree = try Ast.parse(alloc, source_z, .zig);
+    defer tree.deinit(alloc);
+    if (tree.errors.len > 0) return null;
+
+    const fn_node = findFunctionByName(&tree, fn_name) orelse return null;
+    return try sugarBodySourceForNode(alloc, &tree, path, fn_node);
+}
+
+pub fn recognizeSourcePaths(
+    alloc: std.mem.Allocator,
+    io: std.Io,
+    project_root: []const u8,
+    source_paths: []const []const u8,
+    bindings: []const BindingTemplate,
+) !RecognizeResponse {
+    var tags: std.ArrayList(RecognizeTag) = .empty;
+    var root = try std.Io.Dir.openDir(std.Io.Dir.cwd(), io, project_root, .{});
+    defer root.close(io);
+    for (source_paths) |rel_path| {
+        const source = std.Io.Dir.readFileAlloc(root, io, rel_path, alloc, .unlimited) catch continue;
+        try recognizeSource(alloc, rel_path, source, bindings, &tags);
+    }
+    return .{ .tags = try tags.toOwnedSlice(alloc) };
+}
+
+pub fn recognizeSourceText(
+    alloc: std.mem.Allocator,
+    rel_path: []const u8,
+    source: []const u8,
+    bindings: []const BindingTemplate,
+) !RecognizeResponse {
+    var tags: std.ArrayList(RecognizeTag) = .empty;
+    try recognizeSource(alloc, rel_path, source, bindings, &tags);
+    return .{ .tags = try tags.toOwnedSlice(alloc) };
+}
+
+fn recognizeSource(
+    alloc: std.mem.Allocator,
+    rel_path: []const u8,
+    source: []const u8,
+    bindings: []const BindingTemplate,
+    tags: *std.ArrayList(RecognizeTag),
+) !void {
+    const source_z = try alloc.allocSentinel(u8, source.len, 0);
+    @memcpy(source_z[0..source.len], source);
+    var tree = try Ast.parse(alloc, source_z, .zig);
+    defer tree.deinit(alloc);
+    if (tree.errors.len > 0) return;
+
+    var functions: std.ArrayList(Node.Index) = .empty;
+    const roots = tree.rootDecls();
+    for (roots) |decl| try collectFunctionNodes(alloc, &tree, decl, &functions);
+    for (functions.items) |fn_node| {
+        const candidate = try sugarBodySourceForNode(alloc, &tree, rel_path, fn_node);
+        const binding = bindingByTemplateCid(bindings, candidate.template_cid) orelse continue;
+        const function_name = functionName(&tree, fn_node) orelse continue;
+        try tags.append(alloc, .{
+            .file = rel_path,
+            .span = candidate.span,
+            .function_name = try alloc.dupe(u8, function_name),
+            .concept_name = binding.concept_name,
+            .library_tag = binding.library_tag orelse binding.target_library_tag,
+            .family = binding.family,
+            .template_cid = candidate.template_cid,
+            .contract_cid = binding.contract_cid,
+            .match_tier = "exact",
+            .param_bindings = try paramBindings(alloc, candidate.param_names),
+        });
+    }
+}
+
+fn bindingByTemplateCid(bindings: []const BindingTemplate, template_cid: []const u8) ?BindingTemplate {
+    for (bindings) |binding| {
+        if (std.mem.eql(u8, binding.template_cid, template_cid)) return binding;
+    }
+    return null;
+}
+
+fn paramBindings(alloc: std.mem.Allocator, names: []const []const u8) ![]const ParamBinding {
+    var out: std.ArrayList(ParamBinding) = .empty;
+    for (names, 0..) |name, i| {
+        try out.append(alloc, .{ .index = i + 1, .source_text = name });
+    }
+    return out.toOwnedSlice(alloc);
+}
+
+fn sugarBodySourceForNode(
+    alloc: std.mem.Allocator,
+    tree: *const Ast,
+    path: []const u8,
+    fn_node: Node.Index,
+) !SugarBodySource {
+    const body_node = functionBodyNode(tree, fn_node).?;
+    const body_text = try alloc.dupe(u8, blockInnerSource(tree, body_node));
+    const param_names = try functionParamNames(alloc, tree, fn_node);
+    var builder = TemplateBuilder.init(alloc, tree, param_names);
+    const ast_template = try builder.block(body_node);
+    const template_bytes = try provekit.jcsStringify(alloc, ast_template);
+    return .{
+        .file = path,
+        .span = functionSpan(tree, fn_node),
+        .source_cid = try provekit.jcsHash(alloc, body_text),
+        .body_text = body_text,
+        .ast_template = ast_template,
+        .template_cid = try provekit.jcsHash(alloc, template_bytes),
+        .param_names = param_names,
+    };
+}
+
+const TemplateBuilder = struct {
+    alloc: std.mem.Allocator,
+    tree: *const Ast,
+    params: []const []const u8,
+
+    fn init(alloc: std.mem.Allocator, tree: *const Ast, params: []const []const u8) TemplateBuilder {
+        return .{ .alloc = alloc, .tree = tree, .params = params };
+    }
+
+    fn box(self: *TemplateBuilder, value: SugarAstTemplate) !*const SugarAstTemplate {
+        const ptr = try self.alloc.create(SugarAstTemplate);
+        ptr.* = value;
+        return ptr;
+    }
+
+    fn block(self: *TemplateBuilder, node: Node.Index) anyerror!SugarAstTemplate {
+        var buf: [2]Node.Index = undefined;
+        const stmts = self.tree.blockStatements(&buf, node) orelse return .{ .other = @tagName(self.tree.nodeTag(node)) };
+        var out: std.ArrayList(SugarAstTemplate) = .empty;
+        for (stmts) |stmt_node| try out.append(self.alloc, try self.stmt(stmt_node));
+        return .{ .block = .{ .stmts = try out.toOwnedSlice(self.alloc) } };
+    }
+
+    fn stmt(self: *TemplateBuilder, node: Node.Index) anyerror!SugarAstTemplate {
+        return switch (self.tree.nodeTag(node)) {
+            .block, .block_semicolon, .block_two, .block_two_semicolon => self.block(node),
+            .local_var_decl, .simple_var_decl, .aligned_var_decl => self.letStmt(node),
+            .@"return" => .{ .expr_stmt = .{ .expr = try self.box(try self.returnExpr(node)), .trailing_semi = false } },
+            else => .{ .expr_stmt = .{ .expr = try self.box(try self.expr(node)), .trailing_semi = true } },
+        };
+    }
+
+    fn letStmt(self: *TemplateBuilder, node: Node.Index) anyerror!SugarAstTemplate {
+        const var_decl = fullVarDeclFor(self.tree, node) orelse return .{ .other = @tagName(self.tree.nodeTag(node)) };
+        const name = varDeclNameFor(self.tree, var_decl) orelse "_";
+        const initializer = if (var_decl.ast.init_node.unwrap()) |init_node| try self.box(try self.expr(init_node)) else null;
+        return .{ .let = .{ .pat = try self.box(.{ .binding = name }), .init = initializer } };
+    }
+
+    fn returnExpr(self: *TemplateBuilder, node: Node.Index) anyerror!SugarAstTemplate {
+        const maybe_value = self.tree.nodeData(node).opt_node.unwrap();
+        const expr_template = if (maybe_value) |value| try self.box(try self.expr(value)) else null;
+        return .{ .@"return" = expr_template };
+    }
+
+    fn expr(self: *TemplateBuilder, node: Node.Index) anyerror!SugarAstTemplate {
+        const tag = self.tree.nodeTag(node);
+        return switch (tag) {
+            .identifier => self.ident(node),
+            .number_literal => .{ .lit = .{ .ty = "number", .value = self.tree.tokenSlice(self.tree.nodeMainToken(node)) } },
+            .string_literal, .multiline_string_literal => .{ .lit = .{ .ty = "string", .value = self.tree.getNodeSource(node) } },
+            .grouped_expression => self.expr(self.tree.nodeData(node).node_and_token[0]),
+            .add => self.binary(node, "+"),
+            .sub => self.binary(node, "-"),
+            .mul => self.binary(node, "*"),
+            .div => self.binary(node, "/"),
+            .mod => self.binary(node, "%"),
+            .equal_equal => self.binary(node, "=="),
+            .bang_equal => self.binary(node, "!="),
+            .less_than => self.binary(node, "<"),
+            .less_or_equal => self.binary(node, "<="),
+            .greater_than => self.binary(node, ">"),
+            .greater_or_equal => self.binary(node, ">="),
+            .bool_and => self.binary(node, "and"),
+            .bool_or => self.binary(node, "or"),
+            .bit_and => self.binary(node, "&"),
+            .bit_or => self.binary(node, "|"),
+            .bit_xor => self.binary(node, "^"),
+            .call, .call_comma, .call_one, .call_one_comma => self.call(node),
+            .field_access => self.fieldAccess(node),
+            .address_of => .{ .ref = .{ .mutability = false, .expr = try self.box(try self.expr(self.tree.nodeData(node).node)) } },
+            .@"return" => self.returnExpr(node),
+            .block, .block_semicolon, .block_two, .block_two_semicolon => self.block(node),
+            else => .{ .other = @tagName(tag) },
+        };
+    }
+
+    fn ident(self: *TemplateBuilder, node: Node.Index) SugarAstTemplate {
+        const name = self.tree.tokenSlice(self.tree.nodeMainToken(node));
+        for (self.params, 0..) |param, i| {
+            if (std.mem.eql(u8, param, name)) return .{ .param_ref = i + 1 };
+        }
+        return .{ .ident = name };
+    }
+
+    fn binary(self: *TemplateBuilder, node: Node.Index, op: []const u8) anyerror!SugarAstTemplate {
+        const lhs, const rhs = self.tree.nodeData(node).node_and_node;
+        return .{ .binary = .{
+            .op = op,
+            .left = try self.box(try self.expr(lhs)),
+            .right = try self.box(try self.expr(rhs)),
+        } };
+    }
+
+    fn call(self: *TemplateBuilder, node: Node.Index) anyerror!SugarAstTemplate {
+        var buffer: [1]Node.Index = undefined;
+        const call_data = self.tree.fullCall(&buffer, node) orelse return .{ .other = @tagName(self.tree.nodeTag(node)) };
+        var args: std.ArrayList(SugarAstTemplate) = .empty;
+        for (call_data.ast.params) |param| try args.append(self.alloc, try self.expr(param));
+        if (self.tree.nodeTag(call_data.ast.fn_expr) == .field_access) {
+            const base, const field_token = self.tree.nodeData(call_data.ast.fn_expr).node_and_token;
+            return .{ .method_call = .{
+                .receiver = try self.box(try self.expr(base)),
+                .method = self.tree.tokenSlice(field_token),
+                .args = try args.toOwnedSlice(self.alloc),
+            } };
+        }
+        return .{ .call = .{
+            .func = try self.box(try self.expr(call_data.ast.fn_expr)),
+            .args = try args.toOwnedSlice(self.alloc),
+        } };
+    }
+
+    fn fieldAccess(self: *TemplateBuilder, node: Node.Index) anyerror!SugarAstTemplate {
+        const base, const field_token = self.tree.nodeData(node).node_and_token;
+        return .{ .path = try self.pathSegments(base, self.tree.tokenSlice(field_token)) };
+    }
+
+    fn pathSegments(self: *TemplateBuilder, base: Node.Index, field: []const u8) ![]const []const u8 {
+        var out: std.ArrayList([]const u8) = .empty;
+        try self.collectPathSegments(base, &out);
+        try out.append(self.alloc, field);
+        return try out.toOwnedSlice(self.alloc);
+    }
+
+    fn collectPathSegments(self: *TemplateBuilder, node: Node.Index, out: *std.ArrayList([]const u8)) anyerror!void {
+        switch (self.tree.nodeTag(node)) {
+            .identifier => try out.append(self.alloc, self.tree.tokenSlice(self.tree.nodeMainToken(node))),
+            .field_access => {
+                const base, const field_token = self.tree.nodeData(node).node_and_token;
+                try self.collectPathSegments(base, out);
+                try out.append(self.alloc, self.tree.tokenSlice(field_token));
+            },
+            else => {},
+        }
+    }
+};
+
+fn findFunctionByName(tree: *const Ast, fn_name: []const u8) ?Node.Index {
+    const roots = tree.rootDecls();
+    for (roots) |decl| {
+        if (findFunctionByNameInNode(tree, decl, fn_name)) |node| return node;
+    }
+    return null;
+}
+
+fn findFunctionByNameInNode(tree: *const Ast, node: Node.Index, fn_name: []const u8) ?Node.Index {
+    switch (tree.nodeTag(node)) {
+        .fn_decl => {
+            const name = functionName(tree, node) orelse return null;
+            if (std.mem.eql(u8, name, fn_name)) return node;
+        },
+        .global_var_decl, .simple_var_decl, .aligned_var_decl => {
+            const var_decl = fullVarDeclFor(tree, node) orelse return null;
+            const init_node = var_decl.ast.init_node.unwrap() orelse return null;
+            if (!isContainerDeclFor(tree, init_node)) return null;
+            const members = containerMembersFor(tree, init_node) orelse return null;
+            for (members) |member| {
+                if (findFunctionByNameInNode(tree, member, fn_name)) |found| return found;
+            }
+        },
+        else => {},
+    }
+    return null;
+}
+
+fn collectFunctionNodes(
+    alloc: std.mem.Allocator,
+    tree: *const Ast,
+    node: Node.Index,
+    functions: *std.ArrayList(Node.Index),
+) !void {
+    switch (tree.nodeTag(node)) {
+        .fn_decl => try functions.append(alloc, node),
+        .global_var_decl, .simple_var_decl, .aligned_var_decl => {
+            const var_decl = fullVarDeclFor(tree, node) orelse return;
+            const init_node = var_decl.ast.init_node.unwrap() orelse return;
+            if (!isContainerDeclFor(tree, init_node)) return;
+            const members = containerMembersFor(tree, init_node) orelse return;
+            for (members) |member| try collectFunctionNodes(alloc, tree, member, functions);
+        },
+        else => {},
+    }
+}
+
+fn functionName(tree: *const Ast, fn_node: Node.Index) ?[]const u8 {
+    var buffer: [1]Node.Index = undefined;
+    const proto_node = tree.nodeData(fn_node).node_and_node[0];
+    const proto = tree.fullFnProto(&buffer, proto_node) orelse return null;
+    const name_token = proto.name_token orelse return null;
+    return tree.tokenSlice(name_token);
+}
+
+fn functionBodyNode(tree: *const Ast, fn_node: Node.Index) ?Node.Index {
+    if (tree.nodeTag(fn_node) != .fn_decl) return null;
+    return tree.nodeData(fn_node).node_and_node[1];
+}
+
+fn functionParamNames(alloc: std.mem.Allocator, tree: *const Ast, fn_node: Node.Index) ![]const []const u8 {
+    var buffer: [1]Node.Index = undefined;
+    const proto_node = tree.nodeData(fn_node).node_and_node[0];
+    const proto = tree.fullFnProto(&buffer, proto_node) orelse return &.{};
+    var names: std.ArrayList([]const u8) = .empty;
+    var it = proto.iterate(tree);
+    while (it.next()) |param| {
+        if (param.name_token) |tok| try names.append(alloc, tree.tokenSlice(tok));
+    }
+    return names.toOwnedSlice(alloc);
+}
+
+fn functionSpan(tree: *const Ast, fn_node: Node.Index) SourceSpan {
+    const start = tree.tokenLocation(0, tree.nodeMainToken(fn_node));
+    const body_node = functionBodyNode(tree, fn_node) orelse return .{
+        .start_line = start.line + 1,
+        .start_col = start.column,
+        .end_line = start.line + 1,
+        .end_col = start.column,
+    };
+    const block_src = tree.getNodeSource(body_node);
+    var line = start.line + 1;
+    var col = start.column;
+    for (block_src) |c| {
+        if (c == '\n') {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return .{
+        .start_line = start.line + 1,
+        .start_col = start.column,
+        .end_line = line,
+        .end_col = col,
+    };
+}
+
+fn blockInnerSource(tree: *const Ast, body_node: Node.Index) []const u8 {
+    const block_src = tree.getNodeSource(body_node);
+    const open = std.mem.indexOfScalar(u8, block_src, '{') orelse return "";
+    const close = std.mem.lastIndexOfScalar(u8, block_src, '}') orelse return "";
+    if (close <= open) return "";
+    return std.mem.trim(u8, block_src[open + 1 .. close], " \t\r\n");
+}
+
+fn fullVarDeclFor(tree: *const Ast, node: Node.Index) ?Ast.full.VarDecl {
+    return switch (tree.nodeTag(node)) {
+        .global_var_decl => tree.globalVarDecl(node),
+        .local_var_decl => tree.localVarDecl(node),
+        .simple_var_decl => tree.simpleVarDecl(node),
+        .aligned_var_decl => tree.alignedVarDecl(node),
+        else => null,
+    };
+}
+
+fn varDeclNameFor(tree: *const Ast, var_decl: Ast.full.VarDecl) ?[]const u8 {
+    const name_token = var_decl.ast.mut_token + 1;
+    if (tree.tokenTag(name_token) != .identifier) return null;
+    return tree.tokenSlice(name_token);
+}
+
+fn isContainerDeclFor(tree: *const Ast, node: Node.Index) bool {
+    return switch (tree.nodeTag(node)) {
+        .container_decl, .container_decl_trailing, .container_decl_two, .container_decl_two_trailing, .container_decl_arg, .container_decl_arg_trailing => true,
+        else => false,
+    };
+}
+
+fn containerMembersFor(tree: *const Ast, node: Node.Index) ?[]const Node.Index {
+    var buffer: [2]Node.Index = undefined;
+    const decl = tree.fullContainerDecl(&buffer, node) orelse return null;
+    return decl.ast.members;
 }
 
 pub fn verifyContracts(alloc: std.mem.Allocator, declarations: []const FunctionContract) ![]FunctionContract {
@@ -1504,4 +2097,210 @@ test "round trip compile then lift preserves canonical loop body term bytes" {
     const first_hash = try provekit.jcsHash(alloc, first_bytes);
     const second_hash = try provekit.jcsHash(alloc, second_bytes);
     try std.testing.expectEqualStrings(first_hash, second_hash);
+}
+
+test "sugar body emits ast template alongside body text" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const src =
+        \\pub fn fetch(url: []const u8, headers: []const u8) i32 {
+        \\    return http.get(url, headers);
+        \\}
+        \\
+    ;
+
+    const body = (try sugarBodySourceForFunc(alloc, src, "shim.zig", "fetch")).?;
+    try std.testing.expectEqualStrings("return http.get(url, headers);", body.body_text);
+    try std.testing.expect(std.mem.startsWith(u8, body.source_cid, "blake3-512:"));
+    try std.testing.expect(std.mem.startsWith(u8, body.template_cid, "blake3-512:"));
+    try std.testing.expectEqualStrings("url", body.param_names[0]);
+    try std.testing.expectEqualStrings("headers", body.param_names[1]);
+
+    const template_json = try provekit.jcsStringify(alloc, body.ast_template);
+    try std.testing.expect(std.mem.indexOf(u8, template_json, "\"kind\":\"block\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, template_json, "\"kind\":\"method_call\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, template_json, "\"method\":\"get\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, template_json, "\"kind\":\"param_ref\"") != null);
+}
+
+test "sugar body template cid is stable under parameter renaming" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const src_a =
+        \\pub fn fetch(url: []const u8, headers: []const u8) i32 {
+        \\    return http.get(url, headers);
+        \\}
+        \\
+    ;
+    const src_b =
+        \\pub fn fetch(uri: []const u8, hdrs: []const u8) i32 {
+        \\    return http.get(uri, hdrs);
+        \\}
+        \\
+    ;
+
+    const body_a = (try sugarBodySourceForFunc(alloc, src_a, "a.zig", "fetch")).?;
+    const body_b = (try sugarBodySourceForFunc(alloc, src_b, "b.zig", "fetch")).?;
+    try std.testing.expectEqualStrings(body_a.template_cid, body_b.template_cid);
+    try std.testing.expect(!std.mem.eql(u8, body_a.body_text, body_b.body_text));
+    try std.testing.expect(!std.mem.eql(u8, body_a.source_cid, body_b.source_cid));
+}
+
+test "recognize emits exact tag for alpha-equivalent user function" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const sugar =
+        \\pub fn fetch(url: []const u8, headers: []const u8) i32 {
+        \\    return http.get(url, headers);
+        \\}
+        \\
+    ;
+    const sugar_body = (try sugarBodySourceForFunc(alloc, sugar, "shim.zig", "fetch")).?;
+    const binding = BindingTemplate{
+        .concept_name = "concept:http-request",
+        .library_tag = "provekit-shim-zig-http",
+        .family = "concept:family:http",
+        .ast_template = sugar_body.ast_template,
+        .template_cid = sugar_body.template_cid,
+        .param_names = sugar_body.param_names,
+        .contract_cid = "blake3-512:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    };
+
+    const response = try recognizeSourceText(
+        alloc,
+        "src/client.zig",
+        \\pub fn fetchUrl(uri: []const u8, hdrs: []const u8) i32 {
+        \\    return http.get(uri, hdrs);
+        \\}
+        \\
+    ,
+        &.{binding},
+    );
+    try std.testing.expectEqual(@as(usize, 1), response.tags.len);
+    const tag = response.tags[0];
+    try std.testing.expectEqualStrings("src/client.zig", tag.file);
+    try std.testing.expectEqualStrings("fetchUrl", tag.function_name);
+    try std.testing.expectEqualStrings("concept:http-request", tag.concept_name.?);
+    try std.testing.expectEqualStrings("provekit-shim-zig-http", tag.library_tag.?);
+    try std.testing.expectEqualStrings("concept:family:http", tag.family.?);
+    try std.testing.expectEqualStrings(sugar_body.template_cid, tag.template_cid);
+    try std.testing.expectEqualStrings("exact", tag.match_tier);
+    try std.testing.expectEqualStrings("uri", tag.param_bindings[0].source_text);
+    try std.testing.expectEqualStrings("hdrs", tag.param_bindings[1].source_text);
+}
+
+test "recognize returns empty tags for non matching source" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const sugar =
+        \\pub fn parse(input: []const u8) i32 {
+        \\    return json.parse(input);
+        \\}
+        \\
+    ;
+    const sugar_body = (try sugarBodySourceForFunc(alloc, sugar, "shim.zig", "parse")).?;
+    const binding = BindingTemplate{
+        .concept_name = "concept:json-parse",
+        .library_tag = "json",
+        .ast_template = sugar_body.ast_template,
+        .template_cid = sugar_body.template_cid,
+        .param_names = sugar_body.param_names,
+    };
+
+    const response = try recognizeSourceText(
+        alloc,
+        "client.zig",
+        \\pub fn parse(input: []const u8) i32 {
+        \\    return other.parse(input);
+        \\}
+        \\
+    ,
+        &.{binding},
+    );
+    try std.testing.expectEqual(@as(usize, 0), response.tags.len);
+}
+
+test "recognize routes multiple bindings per call site pool" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const http_body = (try sugarBodySourceForFunc(
+        alloc,
+        \\pub fn fetch(url: []const u8, headers: []const u8) i32 {
+        \\    return http.get(url, headers);
+        \\}
+        \\
+    ,
+        "http.zig",
+        "fetch",
+    )).?;
+    const sql_body = (try sugarBodySourceForFunc(
+        alloc,
+        \\pub fn query(conn: Db, sql: []const u8, args: Args) Result {
+        \\    return conn.execute(sql, args);
+        \\}
+        \\
+    ,
+        "sql.zig",
+        "query",
+    )).?;
+
+    const bindings = [_]BindingTemplate{
+        .{
+            .concept_name = "concept:http-request",
+            .library_tag = "http-lib",
+            .family = "concept:family:http",
+            .ast_template = http_body.ast_template,
+            .template_cid = http_body.template_cid,
+            .param_names = http_body.param_names,
+        },
+        .{
+            .concept_name = "concept:sql-execute",
+            .library_tag = "sql-lib",
+            .family = "concept:family:sql",
+            .ast_template = sql_body.ast_template,
+            .template_cid = sql_body.template_cid,
+            .param_names = sql_body.param_names,
+        },
+    };
+
+    const response = try recognizeSourceText(
+        alloc,
+        "calls.zig",
+        \\pub fn fetchUrl(uri: []const u8, hdrs: []const u8) i32 {
+        \\    return http.get(uri, hdrs);
+        \\}
+        \\
+        \\pub fn runQuery(db: Db, query_text: []const u8, params: Args) Result {
+        \\    return db.execute(query_text, params);
+        \\}
+        \\
+    ,
+        &bindings,
+    );
+    try std.testing.expectEqual(@as(usize, 2), response.tags.len);
+
+    var saw_http = false;
+    var saw_sql = false;
+    for (response.tags) |tag| {
+        if (std.mem.eql(u8, tag.concept_name.?, "concept:http-request")) {
+            saw_http = true;
+            try std.testing.expectEqualStrings("fetchUrl", tag.function_name);
+        }
+        if (std.mem.eql(u8, tag.concept_name.?, "concept:sql-execute")) {
+            saw_sql = true;
+            try std.testing.expectEqualStrings("runQuery", tag.function_name);
+        }
+    }
+    try std.testing.expect(saw_http);
+    try std.testing.expect(saw_sql);
 }

--- a/implementations/zig/provekit-lift-zig-source/src/main.zig
+++ b/implementations/zig/provekit-lift-zig-source/src/main.zig
@@ -63,6 +63,10 @@ fn handleLine(alloc: std.mem.Allocator, io: Io, line: []const u8, writer: *Io.Wr
         try handleLift(alloc, io, line, id, writer);
         return true;
     }
+    if (std.mem.indexOf(u8, line, "\"provekit.plugin.recognize\"") != null) {
+        try handleRecognize(alloc, io, line, id, writer);
+        return true;
+    }
     if (std.mem.indexOf(u8, line, "\"shutdown\"") != null) {
         try writer.print("{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":null}}\n", .{id});
         return false;
@@ -111,6 +115,72 @@ fn handleLift(alloc: std.mem.Allocator, io: Io, line: []const u8, id: []const u8
     const refusals_json = try std.json.Stringify.valueAlloc(alloc, refusals.items, .{ .whitespace = .minified });
     defer alloc.free(refusals_json);
     try writer.print("{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"kind\":\"ir-document\",\"ir\":{s},\"callEdges\":[],\"diagnostics\":[],\"opacityReport\":[],\"refusals\":{s}}}}}\n", .{ id, decls_json, refusals_json });
+}
+
+const RecognizeWireRequest = struct {
+    params: RecognizeWireParams,
+};
+
+const RecognizeWireParams = struct {
+    project_root: []const u8,
+    source_paths: []const []const u8,
+    binding_templates: []const RecognizeWireBinding = &.{},
+};
+
+const RecognizeWireBinding = struct {
+    concept_name: ?[]const u8 = null,
+    library_tag: ?[]const u8 = null,
+    target_library_tag: ?[]const u8 = null,
+    family: ?[]const u8 = null,
+    template_cid: []const u8 = "",
+    param_names: []const []const u8 = &.{},
+    contract_cid: ?[]const u8 = null,
+};
+
+fn handleRecognize(alloc: std.mem.Allocator, io: Io, line: []const u8, id: []const u8, writer: *Io.Writer) !void {
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    const parsed = std.json.parseFromSlice(
+        RecognizeWireRequest,
+        arena_alloc,
+        line,
+        .{ .ignore_unknown_fields = true },
+    ) catch |err| {
+        try writer.print("{{\"jsonrpc\":\"2.0\",\"id\":{s},\"error\":{{\"code\":-32602,\"message\":\"invalid recognize params: {t}\"}}}}\n", .{ id, err });
+        return;
+    };
+    defer parsed.deinit();
+
+    var bindings: std.ArrayList(lift.BindingTemplate) = .empty;
+    for (parsed.value.params.binding_templates) |binding| {
+        if (binding.template_cid.len == 0) continue;
+        try bindings.append(arena_alloc, .{
+            .concept_name = binding.concept_name,
+            .library_tag = binding.library_tag,
+            .target_library_tag = binding.target_library_tag,
+            .family = binding.family,
+            .template_cid = binding.template_cid,
+            .param_names = binding.param_names,
+            .contract_cid = binding.contract_cid,
+        });
+    }
+
+    const response = lift.recognizeSourcePaths(
+        arena_alloc,
+        io,
+        parsed.value.params.project_root,
+        parsed.value.params.source_paths,
+        bindings.items,
+    ) catch |err| {
+        try writer.print("{{\"jsonrpc\":\"2.0\",\"id\":{s},\"error\":{{\"code\":-32603,\"message\":\"recognize failed: {t}\"}}}}\n", .{ id, err });
+        return;
+    };
+
+    const tags_json = try std.json.Stringify.valueAlloc(alloc, response.tags, .{ .whitespace = .minified });
+    defer alloc.free(tags_json);
+    try writer.print("{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"tags\":{s}}}}}\n", .{ id, tags_json });
 }
 
 fn liftPath(

--- a/protocol/specs/2026-05-12-plugin-protocol.md
+++ b/protocol/specs/2026-05-12-plugin-protocol.md
@@ -319,7 +319,9 @@ a boundary citation in source and writes the kit's sugar body, `recognize`
 reads idiomatic user code and writes the boundary citations that would
 have been present had the user authored them by hand. The same
 `ast_template` artifact a kit emits at lift time (see the bind-IR
-lift result spec) is the matchable template here.
+lift result spec) is the matchable template here, but the kit owns
+template/proof resolution. The runtime MUST NOT read `.proof` files or
+construct recognizer templates from package-manager paths.
 
 Request:
 ```json
@@ -329,29 +331,16 @@ Request:
   "method": "provekit.plugin.recognize",
   "params": {
     "project_root": "/absolute/project/root",
-    "source_paths": ["src/lib.rs", "src/ingest.rs"],
-    "binding_templates": [
-      {
-        "concept_name": "concept:json-parse",
-        "library_tag": "provekit-shim-serde-json-rust",
-        "family": "concept:family:json",
-        "ast_template": { "kind": "block", "stmts": [ /* … */ ] },
-        "template_cid": "blake3-512:<hex>",
-        "param_names": ["s"],
-        "param_types": ["&str"],
-        "return_type": "Result<Value, String>",
-        "contract_cid": "blake3-512:<hex>"
-      }
-    ]
+    "source_paths": ["src/lib.rs", "src/ingest.rs"]
   }
 }
 ```
 
-`binding_templates` is the set of sugar templates the runtime has
-gathered from the loaded `.proof` envelopes for this language. The kit
-matches its native AST shape against each template's `ast_template`
-under alpha-equivalence on `param_ref` markers. The substrate does not
-construct or interpret these templates; it only forwards them.
+The kit resolves the applicable sugar templates from its own package,
+project, and proof context, then matches its native AST shape against
+each template's `ast_template` under alpha-equivalence on `param_ref`
+markers. The runtime supplies source scope and receives normalized tags;
+it does not construct, forward, or interpret `binding_templates`.
 
 Response (success):
 ```json
@@ -419,10 +408,11 @@ list.
 Implementations MAY return an empty `tags` array. Implementations MUST
 NOT return tags for spans outside the supplied `source_paths`.
 
-The substrate MUST recompute every returned tag's `template_cid` against
-the supplied `binding_templates` (and refuse mismatches as protocol
-violations). The kit's only role is structural pattern matching against
-its language's AST; cross-tag composition, family-library disambiguation,
+The substrate treats returned `template_cid` and `contract_cid` values as
+content-addressed normalized data and composes them language-blindly. The
+kit is responsible for making those CIDs correspond to the sugar templates
+and proof data it resolved. The kit's role is structural pattern matching
+against its language's AST; cross-tag composition, family-library disambiguation,
 and bridge emission all stay substrate-side.
 
 ### §4.3 Error model on the wire


### PR DESCRIPTION
## Summary

- Add recognizer parity gates for existing sugar lifters across Java, Go, Python, Rust walk, TypeScript, Zig, and Scala.
- Extend TypeScript, Zig, Swift, and Scala source lifters so sugar binding entries carry both `body_text` and language-owned `ast_template` plus stable `template_cid`/`param_names`.
- Add manifest/config-driven Scala source lifter registration and a standalone Swift source-lift recognizer test harness.
- Keep the Rust CLI language-blind in this PR; tracked the existing `cmd_recognize --binding <.proof>` proof-path leak separately in #1644.

## Verification

- `mvn -q -f implementations/java/pom.xml -pl provekit-lift-java-source -am -Dtest=RecognizeHandlerTest,JavaSugarBindingLifterTest test`
- `go test ./... -run 'Test(SugarBody|Recognize)'` in `implementations/go/provekit-lift-go`
- `make cross-language-proof-parity-python-env`
- `/tmp/provekit-cross-language-parity-python/bin/python -m pytest implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py -q -k 'sugar_body or recognize'`
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-walk --bin provekit-walk-rpc sugar_body -- --nocapture`
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-walk --bin provekit-walk-rpc recognize -- --nocapture`
- `pnpm vitest run implementations/typescript/src/lift/typescript-source/index.test.ts implementations/typescript/src/lift/typescript-source/verify.test.ts`
- `zig build test` in `implementations/zig/provekit-lift-zig-source`
- `zig build` in `implementations/zig/provekit-lift-zig-source`
- `scala-cli test implementations/scala/provekit-lift-scala-source --server=false`
- `scala-cli compile implementations/scala/provekit-lift-scala-source --server=false --scalac-option -deprecation`
- `make test-swift-source-lift`
- `zig fmt src/lift.zig src/main.zig --check` in `implementations/zig/provekit-lift-zig-source`
- `cargo fmt --manifest-path implementations/rust/Cargo.toml --package provekit-cli --check`
- `git diff --check`
- `make -n cross-language-proof-parity`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recognition capability to identify sugar bindings across multiple language implementations (Scala, Swift, TypeScript, Zig).

* **Tests**
  * Added/expanded end-to-end tests and new test targets for Swift and Scala source lifting and recognition; extended recognition tests across TypeScript and Zig.
  * Cross-language parity workflow now runs a recognize parity phase and reflects emit/materialize/recognize/prove status.

* **Chores**
  * Updated build/test orchestration and parity test dependencies.
  * Clarified plugin protocol behavior for recognition requests and template CID handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1646?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->