### PR TITLE
[codex] Emit Ruby LSP call edges for diagnostics

### DIFF
--- a/implementations/ruby/bin/provekit-lsp-ruby
+++ b/implementations/ruby/bin/provekit-lsp-ruby
@@ -42,6 +42,50 @@ def err(id, code, message)
   $stdout.flush
 end
 
+def same_kit_call_edges(source, path, decls)
+  contract_names = decls
+    .select { |decl| decl.is_a?(ContractDecl) && decl.name && !decl.name.empty? }
+    .map(&:name)
+    .to_set
+  return [] if contract_names.empty?
+
+  begin
+    root = RubyVM::AbstractSyntaxTree.parse(source)
+  rescue SyntaxError, ArgumentError
+    return []
+  end
+
+  ranges = Provekit::Lift::FfiResolver.function_ranges(root)
+  seen = {}
+  edges = []
+
+  Provekit::Lift::FfiResolver.collect_nodes(root, :FCALL, :VCALL).each do |call_node|
+    callee = call_node.children.first.to_s
+    next unless contract_names.include?(callee)
+
+    line = call_node.first_lineno
+    column = call_node.first_column
+    caller = Provekit::Lift::FfiResolver.enclosing_function_name(ranges, line)
+    next unless caller && contract_names.include?(caller)
+
+    key = [caller, callee, line, column]
+    next if seen[key]
+    seen[key] = true
+
+    edges << CallEdgeDecl.new(
+      source_contract_cid: "pending-ruby:#{caller}",
+      target_contract_cid: nil,
+      target_symbol: "ruby-kit:#{callee}",
+      call_site_file: path,
+      call_site_line: line,
+      call_site_column: column,
+      evidence_term: Provekit::IR.atomic("call-site-obligation", Provekit::IR.var(name: caller)),
+    )
+  end
+
+  edges
+end
+
 ARGV.include?("--rpc") || (warn "Usage: provekit-lsp-ruby --rpc"; exit 1)
 
 STDIN.each_line do |line|
@@ -170,7 +214,8 @@ STDIN.each_line do |line|
     # Emit call-edge stream per spec #114 R1.
     # Walk source for FFI call sites (Fiddle + ffi gem patterns).
     ffi_result = Provekit::Lift::FfiResolver.resolve(source, path: path)
-    edges_json = ffi_result.call_edges.empty? ? "[]" : Provekit::IR.marshal_call_edges(ffi_result.call_edges)
+    call_edges = ffi_result.call_edges + same_kit_call_edges(source, path, decls)
+    edges_json = call_edges.empty? ? "[]" : Provekit::IR.marshal_call_edges(call_edges)
 
     respond id, {
       declarations: JSON.parse(jcs),

--- a/implementations/ruby/lib/provekit/ir.rb
+++ b/implementations/ruby/lib/provekit/ir.rb
@@ -227,9 +227,11 @@ module Provekit
       end
       arr = sorted.map do |e|
         obj = {
-          callSiteColumn: e.call_site_column,
-          callSiteFile:   e.call_site_file,
-          callSiteLine:   e.call_site_line,
+          callSiteLocus:  {
+            column: e.call_site_column,
+            file:   e.call_site_file,
+            line:   e.call_site_line,
+          },
           evidenceTerm:   e.evidence_term,
           kind:           "call-edge",
           schemaVersion:  "1",

--- a/implementations/ruby/lib/provekit/lift/ffi_resolver.rb
+++ b/implementations/ruby/lib/provekit/lift/ffi_resolver.rb
@@ -316,6 +316,26 @@ module Provekit
         results
       end
 
+      def self.function_ranges(root)
+        collect_nodes(root, :DEF, :DEFN, :DEFS).map do |def_node|
+          name = def_node.children.first.to_s
+          first_line = def_node.first_lineno
+          last_line = if def_node.respond_to?(:last_lineno)
+                        def_node.last_lineno
+                      else
+                        first_line
+                      end
+          [name, first_line, last_line || first_line]
+        end
+      end
+
+      def self.enclosing_function_name(ranges, line)
+        ranges
+          .select { |_name, first_line, last_line| line >= first_line && line <= last_line }
+          .max_by { |_name, first_line, _last_line| first_line }
+          &.first
+      end
+
       # ── Public API ────────────────────────────────────────────────────────
 
       FfiResolverResult = Struct.new(:call_edges, :linker_errors, keyword_init: true)
@@ -343,6 +363,7 @@ module Provekit
         return FfiResolverResult.new(call_edges: [], linker_errors: []) if bindings.empty?
 
         call_sites = scan_call_sites(root, bindings)
+        ranges = function_ranges(root)
 
         call_edges    = []
         linker_errors = []
@@ -365,8 +386,16 @@ module Provekit
             }
           else
             target_symbol = "#{b.kit}:#{b.native_name}"
+            caller_name = enclosing_function_name(ranges, line)
+            source_contract_cid =
+              if caller_name && contract_index[caller_name]
+                contract_index[caller_name]
+              elsif caller_name
+                "pending-ruby:#{caller_name}"
+              end
+
             call_edges << IR::CallEdgeDecl.new(
-              source_contract_cid: nil,
+              source_contract_cid: source_contract_cid,
               target_contract_cid: nil,
               target_symbol: target_symbol,
               call_site_file: path,

--- a/implementations/ruby/test/test_daemon_protocol.rb
+++ b/implementations/ruby/test/test_daemon_protocol.rb
@@ -28,6 +28,18 @@ class TestDaemonProtocol < Minitest::Test
     end
   RUBY
 
+  FFI_FIXTURE_SOURCE = <<~RUBY.freeze
+    module RustBindings
+      extend FFI::Library
+      ffi_lib 'librust_callee'
+      attach_function :process, [:int], :int
+    end
+    # provekit: contract
+    def caller_fn(value)
+      RustBindings.process(value)
+    end
+  RUBY
+
   FIXTURE_PATH = "test_fixture.rb".freeze
 
   # Build the NDJSON session input for initialize -> parse -> shutdown.
@@ -139,6 +151,28 @@ class TestDaemonProtocol < Minitest::Test
     assert parse_resp, "Expected id 2 not found. Available ids: #{responses.map { |r| r['id'] }}"
     assert_instance_of Array, parse_resp["result"]["callEdges"],
                        "callEdges should be Array, not #{parse_resp["result"]["callEdges"].class}"
+  end
+
+  def test_parse_call_edges_use_canonical_call_site_locus
+    responses = run_lsp(build_session(source: FFI_FIXTURE_SOURCE, path: "ffi_fixture.rb"))
+    parse_resp = responses.find { |r| r["id"] == 2 }
+    assert parse_resp, "Expected id 2 not found. Available ids: #{responses.map { |r| r['id'] }}"
+    refute_includes parse_resp, "error",
+                    "parse returned error: #{parse_resp.inspect}"
+
+    edges = parse_resp["result"]["callEdges"]
+    assert_equal 1, edges.length, "expected one FFI call edge, got: #{edges.inspect}"
+    edge = edges.first
+    locus = edge["callSiteLocus"]
+
+    assert_instance_of Hash, locus, "call edge must include nested callSiteLocus: #{edge.inspect}"
+    assert_equal "ffi_fixture.rb", locus["file"]
+    assert_operator locus["line"], :>, 0
+    assert_operator locus["column"], :>=, 0
+    assert_equal "pending-ruby:caller_fn", edge["sourceContractCid"]
+    refute edge.key?("callSiteFile"), "legacy flat callSiteFile must not be emitted"
+    refute edge.key?("callSiteLine"), "legacy flat callSiteLine must not be emitted"
+    refute edge.key?("callSiteColumn"), "legacy flat callSiteColumn must not be emitted"
   end
 
   def test_declarations_contain_contracts

--- a/implementations/ruby/test/test_daemon_protocol.rb
+++ b/implementations/ruby/test/test_daemon_protocol.rb
@@ -175,6 +175,31 @@ class TestDaemonProtocol < Minitest::Test
     refute edge.key?("callSiteColumn"), "legacy flat callSiteColumn must not be emitted"
   end
 
+  def test_parse_emits_same_language_call_edge_locus
+    source = <<~RUBY
+      # provekit: contract
+      def add(value)
+        value
+      end
+      # provekit: contract
+      def compute(value)
+        add(value)
+      end
+    RUBY
+    responses = run_lsp(build_session(source: source, path: "fixture.rb"))
+    parse_resp = responses.find { |r| r["id"] == 2 }
+    assert parse_resp, "Expected id 2 not found. Available ids: #{responses.map { |r| r['id'] }}"
+    refute_includes parse_resp, "error",
+                    "parse returned error: #{parse_resp.inspect}"
+
+    edges = parse_resp["result"]["callEdges"]
+    assert edges.any? { |edge|
+      edge["sourceContractCid"] == "pending-ruby:compute" &&
+        edge["targetSymbol"] == "ruby-kit:add" &&
+        edge["callSiteLocus"] == { "column" => 2, "file" => "fixture.rb", "line" => 7 }
+    }, "expected compute -> ruby-kit:add call edge, got: #{edges.inspect}"
+  end
+
   def test_declarations_contain_contracts
     responses = run_lsp(build_session)
     parse_resp = responses.find { |r| r["id"] == 2 }


### PR DESCRIPTION
## Summary

- emit Ruby FFI call edges with canonical nested `callSiteLocus` instead of legacy flat `callSiteFile/callSiteLine/callSiteColumn` keys
- attribute Ruby FFI call edges to the enclosing method with a non-empty `sourceContractCid`
- emit same-kit Ruby call edges from contracted methods as `pending-ruby:<caller>` -> `ruby-kit:<callee>` with call-site loci for LSP diagnostics

## Why

The Rust daemon consumes `callSiteLocus` when projecting verifier/linker failures into editor diagnostics. Ruby owns Ruby source analysis, so the kit now emits the canonical call edges the language-agnostic daemon/linkerd path needs to put solver failures on the call site.

## Validation

- `ruby -I implementations/ruby/lib implementations/ruby/test/test_daemon_protocol.rb --name test_parse_emits_same_language_call_edge_locus` failed before implementation because no same-language call edge was emitted
- `/usr/local/opt/ruby/bin/ruby -I implementations/ruby/lib implementations/ruby/test/test_daemon_protocol.rb`
- `/usr/local/opt/ruby/bin/ruby -I implementations/ruby/lib implementations/ruby/test/test_ffi_resolver.rb`
- `cargo build --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd`
- manual `provekit-linkerd` probe with `provekit-lsp-ruby` on `compute -> add`, returning `unprovable-obligation` for `ruby-kit:add` at `/tmp/call_edge.rb`
- `git diff --check`

The shell `ruby` is macOS Ruby 2.6 and cannot parse the kit's Ruby 3 syntax for direct resolver tests, so direct resolver tests use `/usr/local/opt/ruby/bin/ruby`. The daemon binary already re-execs Homebrew Ruby when needed.