### PR TITLE
[codex] Emit C call edges for LSP diagnostics

### DIFF
--- a/implementations/c/provekit-lift-core/src/parser.c
+++ b/implementations/c/provekit-lift-core/src/parser.c
@@ -722,15 +722,18 @@ static int pk_c_emit_one_call_edge(
     }
     written = snprintf(NULL,
         0,
-        "{\"caller_function\":\"%s\",\"callee_name\":\"%s\","
-        "\"args\":%s,\"callsite_path\":\"%s\","
-        "\"callsite_line\":%d,\"callsite_column\":%d}",
-        caller,
-        callee,
-        args,
+        "{\"callSiteLocus\":{\"column\":%d,\"file\":\"%s\",\"line\":%d},"
+        "\"evidenceTerm\":{\"args\":%s,\"kind\":\"atomic\","
+        "\"name\":\"call-site-obligation\"},"
+        "\"kind\":\"call-edge\",\"schemaVersion\":\"1\","
+        "\"sourceContractCid\":\"pending-c:%s\","
+        "\"targetSymbol\":\"c-kit:%s\"}",
+        fact->locus.column,
         path,
         fact->locus.line,
-        fact->locus.column);
+        args,
+        caller,
+        callee);
     if (written < 0) {
         free(caller);
         free(callee);
@@ -746,15 +749,18 @@ static int pk_c_emit_one_call_edge(
     }
     (void)snprintf(json,
         (size_t)written + 1,
-        "{\"caller_function\":\"%s\",\"callee_name\":\"%s\","
-        "\"args\":%s,\"callsite_path\":\"%s\","
-        "\"callsite_line\":%d,\"callsite_column\":%d}",
-        caller,
-        callee,
-        args,
+        "{\"callSiteLocus\":{\"column\":%d,\"file\":\"%s\",\"line\":%d},"
+        "\"evidenceTerm\":{\"args\":%s,\"kind\":\"atomic\","
+        "\"name\":\"call-site-obligation\"},"
+        "\"kind\":\"call-edge\",\"schemaVersion\":\"1\","
+        "\"sourceContractCid\":\"pending-c:%s\","
+        "\"targetSymbol\":\"c-kit:%s\"}",
+        fact->locus.column,
         path,
         fact->locus.line,
-        fact->locus.column);
+        args,
+        caller,
+        callee);
     rc = pk_c_lift_result_add_call_edge(result, json);
     free(json);
     free(caller);

--- a/implementations/c/provekit-lsp-c/main.c
+++ b/implementations/c/provekit-lsp-c/main.c
@@ -326,15 +326,11 @@ static void handle_parse(const char *id, const char *json_line) {
         }
     }
     if (facts->extraction_result) {
-        for (size_t i = 0; i < facts->extraction_result->diagnostics.len; i++) {
-            if (pk_c_lift_result_add_diagnostic(
-                result_obj,
-                facts->extraction_result->diagnostics.items[i]) != 0) {
-                pk_c_source_facts_free(facts);
-                pk_c_lift_result_free(result_obj);
-                send_error(id, -32603, "parse: out of memory");
-                return;
-            }
+        if (pk_c_lift_result_extend(result_obj, facts->extraction_result) != 0) {
+            pk_c_source_facts_free(facts);
+            pk_c_lift_result_free(result_obj);
+            send_error(id, -32603, "parse: out of memory");
+            return;
         }
     }
     pk_c_source_facts_free(facts);
@@ -444,17 +440,13 @@ static char *read_file(const char *path) {
  * opacityReport/refusals pass through as-is. */
 static char *build_ir_document(const pk_c_lift_result *r) {
     /* ir-document shape:
-     * {"kind":"ir-document","ir":[...],"callEdges":[],"diagnostics":[...],"opacityReport":[...],"refusals":[...]}
+     * {"kind":"ir-document","ir":[...],"callEdges":[...],"diagnostics":[...],"opacityReport":[...],"refusals":[...]}
      */
     const char *prefix = "{\"kind\":\"ir-document\",\"ir\":";
     const char *call_edges_key  = ",\"callEdges\":";
     const char *diagnostics_key = ",\"diagnostics\":";
     const char *opacity_key     = ",\"opacityReport\":";
     const char *refusals_key    = ",\"refusals\":";
-
-    /* We borrow the declarations array for "ir". callEdges always empty
-     * (C LSP cannot compute contract CIDs). */
-    const pk_c_json_array empty = {NULL, 0, 0};
 
     size_t len = 0;
     /* Manually sum lengths — mirror pk_c_lift_result_to_json logic */
@@ -466,7 +458,13 @@ static char *build_ir_document(const pk_c_lift_result *r) {
         len += strlen(r->declarations.items[i]);
     }
     len += 1; /* ']' */
-    len += strlen(call_edges_key) + 2; /* "[]" */
+    len += strlen(call_edges_key);
+    len += 1;
+    for (size_t i = 0; i < r->call_edges.len; i++) {
+        if (i > 0) len += 1;
+        len += strlen(r->call_edges.items[i]);
+    }
+    len += 1;
     len += strlen(diagnostics_key);
     len += 1;
     for (size_t i = 0; i < r->diagnostics.len; i++) {
@@ -489,7 +487,6 @@ static char *build_ir_document(const pk_c_lift_result *r) {
     }
     len += 1; /* '}' */
     len += 1; /* NUL */
-    (void)empty;
 
     char *json = (char *)malloc(len);
     if (!json) return NULL;
@@ -506,9 +503,16 @@ static char *build_ir_document(const pk_c_lift_result *r) {
     }
     *dst++ = ']';
 
-    /* callEdges always empty */
+    /* callEdges */
     dst += sprintf(dst, "%s", call_edges_key);
-    *dst++ = '['; *dst++ = ']';
+    *dst++ = '[';
+    for (size_t i = 0; i < r->call_edges.len; i++) {
+        if (i > 0) *dst++ = ',';
+        size_t slen = strlen(r->call_edges.items[i]);
+        memcpy(dst, r->call_edges.items[i], slen);
+        dst += slen;
+    }
+    *dst++ = ']';
 
     /* diagnostics */
     dst += sprintf(dst, "%s", diagnostics_key);
@@ -571,8 +575,10 @@ static int lift_single_path(const char *path, pk_c_lift_result *merged) {
         }
     }
     if (facts->extraction_result) {
-        for (size_t i = 0; i < facts->extraction_result->diagnostics.len; i++) {
-            pk_c_lift_result_add_diagnostic(r, facts->extraction_result->diagnostics.items[i]);
+        if (pk_c_lift_result_extend(r, facts->extraction_result) != 0) {
+            pk_c_lift_result_free(r);
+            pk_c_source_facts_free(facts);
+            return -1;
         }
     }
     pk_c_source_facts_free(facts);

--- a/implementations/c/provekit-lsp-c/tests/integration.sh
+++ b/implementations/c/provekit-lsp-c/tests/integration.sh
@@ -85,14 +85,10 @@ check "T7 parse: contract compute declared" "$LINE2" '"name":"compute"'
 # T8: parse response contains callEdges array
 check "T8 parse: callEdges key present" "$LINE2" '"callEdges":'
 
-# T9: callEdges is emitted as an empty array.
-#
-# The C LSP cannot compute contract CIDs (no JCS encoder + BLAKE3 here), so
-# the canonical IR shape (sourceContractCid, targetContractCid, targetSymbol,
-# callSiteLocus, evidenceTerm) cannot be produced. Until that's wired up,
-# emit []; the legacy {callee, caller, line} shape was silently dropped by
-# the daemon. (Review feedback: PR #165 / Copilot.)
-check "T9 parse: callEdges is empty array" "$LINE2" '"callEdges":[]'
+# T9: parse response contains a canonical call edge for compute -> add.
+check "T9 parse: callEdges includes targetSymbol" "$LINE2" '"targetSymbol":"c-kit:add"'
+check "T9b parse: callEdges includes sourceContractCid" "$LINE2" '"sourceContractCid":"pending-c:compute"'
+check "T9c parse: callEdges includes callSiteLocus" "$LINE2" '"callSiteLocus":{'
 
 # T10: parse response contains diagnostics array
 check "T10 parse: diagnostics key present" "$LINE2" '"diagnostics":'
@@ -137,8 +133,10 @@ check "T17 lift: ir contains add" "$LIFT2" '"name":"add"'
 # T18: lift response ir array contains contract 'compute'
 check "T18 lift: ir contains compute" "$LIFT2" '"name":"compute"'
 
-# T19: lift response callEdges is empty array
-check "T19 lift: callEdges empty" "$LIFT2" '"callEdges":[]'
+# T19: lift response includes the canonical call edge too
+check "T19 lift: callEdges includes targetSymbol" "$LIFT2" '"targetSymbol":"c-kit:add"'
+check "T19b lift: callEdges includes sourceContractCid" "$LIFT2" '"sourceContractCid":"pending-c:compute"'
+check "T19c lift: callEdges includes callSiteLocus" "$LIFT2" '"callSiteLocus":{'
 
 # T20: lift response contains diagnostics array
 check "T20 lift: diagnostics key present" "$LIFT2" '"diagnostics":'


### PR DESCRIPTION
## Summary

- emit C call-site facts as canonical call-edge JSON with nested `callSiteLocus`
- propagate C lift-core call edges through both `parse` and `lift` LSP responses
- update the C LSP integration test to require non-empty call edges for the `compute -> add` fixture

## Why

The C parser already collected call-site facts, but the C LSP deliberately returned `callEdges: []`, so the language-agnostic daemon had nothing to lift into IDE diagnostics. This keeps the C-specific call-site extraction in the C kit and gives linkerd the canonical shape it already consumes.

## Validation

- `make -C implementations/c/provekit-lsp-c test` failed before the implementation because `parse` and `lift` returned `callEdges: []`
- `make -C implementations/c/provekit-lsp-c test`
- `make -C implementations/c/provekit-lift-core test`
- `PATH="$PWD/implementations/c/provekit-lsp-c:$PATH" cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd --test multi_kit test8_c_kit_dispatch -- --nocapture`
- `git diff --check`

One initial linkerd run failed before exercising C because the daemon socket did not appear in the fresh target dir. I confirmed `implementations/rust/target/debug/provekit-linkerd` started manually with a socket, then reran the same single test successfully.