### PR TITLE
[codex] Emit C++ call edges for LSP diagnostics

### DIFF
--- a/implementations/cpp/provekit-lsp-cpp/main.cpp
+++ b/implementations/cpp/provekit-lsp-cpp/main.cpp
@@ -36,11 +36,49 @@ struct Annotation {
     int line;
 };
 
+struct FunctionSpan {
+    std::string name;
+    int start_line;
+    int end_line;
+    bool has_contract;
+};
+
 static std::string trim(const std::string& s) {
     size_t start = s.find_first_not_of(" \t");
     if (start == std::string::npos) return "";
     size_t end = s.find_last_not_of(" \t");
     return s.substr(start, end - start + 1);
+}
+
+static std::string json_escape(const std::string& s) {
+    std::string out;
+    for (char c : s) {
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n";  break;
+            case '\r': out += "\\r";  break;
+            case '\t': out += "\\t";  break;
+            default:
+                if (static_cast<unsigned char>(c) < 0x20) {
+                    char buf[7];
+                    std::snprintf(buf, sizeof(buf), "\\u%04x", static_cast<unsigned char>(c));
+                    out += buf;
+                } else {
+                    out += c;
+                }
+                break;
+        }
+    }
+    return out;
+}
+
+static std::vector<std::string> split_lines(const std::string& text) {
+    std::vector<std::string> lines;
+    std::istringstream iss(text);
+    std::string line;
+    while (std::getline(iss, line)) lines.push_back(line);
+    return lines;
 }
 
 static std::string find_ahead_fn(const std::vector<std::string>& lines, int start_line) {
@@ -54,6 +92,59 @@ static std::string find_ahead_fn(const std::vector<std::string>& lines, int star
         }
     }
     return "unknown";
+}
+
+static int brace_delta(const std::string& line) {
+    int delta = 0;
+    for (char c : line) {
+        if (c == '{') {
+            delta++;
+        } else if (c == '}') {
+            delta--;
+        }
+    }
+    return delta;
+}
+
+static bool has_contract_annotation_before(const std::vector<std::string>& lines, int fn_line) {
+    int min_line = fn_line - 10;
+    if (min_line < 0) min_line = 0;
+    for (int i = fn_line - 1; i >= min_line; i--) {
+        if (trim(lines[(size_t)i]).find("//provekit:contract") == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static std::vector<FunctionSpan> scan_function_spans(const std::string& text) {
+    std::vector<FunctionSpan> spans;
+    std::vector<std::string> lines = split_lines(text);
+    std::regex fn_re(R"(^\s*(?:(?:auto|void|int|bool|float|double|std::string|size_t)\s+)?([a-zA-Z_][a-zA-Z0-9_]*)\s*\()");
+
+    for (size_t i = 0; i < lines.size(); i++) {
+        std::smatch m;
+        if (!std::regex_search(lines[i], m, fn_re)) continue;
+
+        int depth = 0;
+        bool saw_open = false;
+        int end_line = static_cast<int>(i);
+        for (size_t j = i; j < lines.size(); j++) {
+            int delta = brace_delta(lines[j]);
+            if (lines[j].find('{') != std::string::npos) saw_open = true;
+            depth += delta;
+            end_line = static_cast<int>(j);
+            if (saw_open && depth <= 0) break;
+        }
+
+        spans.push_back({
+            m[1].str(),
+            static_cast<int>(i) + 1,
+            end_line + 1,
+            has_contract_annotation_before(lines, static_cast<int>(i)),
+        });
+    }
+    return spans;
 }
 
 static std::vector<Annotation> scan_source(const std::string& text) {
@@ -75,6 +166,57 @@ static std::vector<Annotation> scan_source(const std::string& text) {
         }
     }
     return anns;
+}
+
+static void append_array_items(std::string& items, const std::string& array_json) {
+    if (array_json.size() < 2) return;
+    if (array_json.front() != '[' || array_json.back() != ']') return;
+    std::string inner = array_json.substr(1, array_json.size() - 2);
+    if (inner.empty()) return;
+    if (!items.empty()) items += ",";
+    items += inner;
+}
+
+static std::string build_call_edges_json(const std::string& source, const std::string& path) {
+    std::vector<std::string> lines = split_lines(source);
+    std::vector<FunctionSpan> spans = scan_function_spans(source);
+    std::string items;
+
+    for (const auto& caller : spans) {
+        if (!caller.has_contract) continue;
+
+        int start = caller.start_line - 1;
+        int end = caller.end_line - 1;
+        if (start < 0) start = 0;
+        if (end >= static_cast<int>(lines.size())) end = static_cast<int>(lines.size()) - 1;
+
+        for (int line_no = start; line_no <= end; line_no++) {
+            for (const auto& callee : spans) {
+                if (callee.name == caller.name) continue;
+
+                std::regex call_re("\\b" + callee.name + R"(\s*\()");
+                std::smatch m;
+                if (!std::regex_search(lines[(size_t)line_no], m, call_re)) continue;
+
+                if (!items.empty()) items += ",";
+                items += "{\"callSiteLocus\":{\"column\":";
+                items += std::to_string(m.position(0));
+                items += ",\"file\":\"";
+                items += json_escape(path);
+                items += "\",\"line\":";
+                items += std::to_string(line_no + 1);
+                items += "},\"evidenceTerm\":{\"args\":[],\"kind\":\"atomic\",";
+                items += "\"name\":\"call-site-obligation\"},\"kind\":\"call-edge\",";
+                items += "\"schemaVersion\":\"1\",\"sourceContractCid\":\"pending-cpp:";
+                items += json_escape(caller.name);
+                items += "\",\"targetSymbol\":\"cpp-kit:";
+                items += json_escape(callee.name);
+                items += "\"}";
+            }
+        }
+    }
+
+    return "[" + items + "]";
 }
 
 // ---------------------------------------------------------------------------
@@ -278,6 +420,7 @@ int main() {
             // Lift each file; aggregate declarations.
             reset_collector();
             begin_collecting();
+            std::string call_edges_items;
 
             for (const auto& sp : source_paths) {
                 std::string full_path = sp;
@@ -294,12 +437,13 @@ int main() {
                         contract(ann.function_name, nullptr, post);
                     }
                 }
+                append_array_items(call_edges_items, build_call_edges_json(source, full_path));
             }
 
             auto decls = finish();
             std::string ir_json = marshal_declarations(decls);
             send_result(id,
-                "{\"callEdges\":[],"
+                "{\"callEdges\":[" + call_edges_items + "],"
                 "\"diagnostics\":[],"
                 "\"ir\":" + ir_json + ","
                 "\"kind\":\"ir-document\","
@@ -312,12 +456,14 @@ int main() {
             // the escaped version we receive from the caller.
             std::string source_escaped = extract_string(line, "source");
             std::string source = unescape_json(source_escaped);
+            std::string path = extract_string(line, "path");
+            if (path.empty()) path = "source.cpp";
 
             std::string decls_json = lift_to_declarations_json(source);
+            std::string call_edges_json = build_call_edges_json(source, path);
 
-            // callEdges: always empty (no call-graph analysis in cpp LSP).
             // warnings: always empty.
-            std::string result = "{\"callEdges\":[],\"declarations\":" + decls_json + ",\"warnings\":[]}";
+            std::string result = "{\"callEdges\":" + call_edges_json + ",\"declarations\":" + decls_json + ",\"warnings\":[]}";
             send_result(id, result);
 
         } else if (method == "shutdown") {

--- a/implementations/cpp/provekit-lsp-cpp/test_lsp.sh
+++ b/implementations/cpp/provekit-lsp-cpp/test_lsp.sh
@@ -53,7 +53,10 @@ assert_not_contains() {
 TMPDIR_PATH="$(mktemp -d)"
 cat > "$TMPDIR_PATH/fixture.cpp" << 'EOF'
 //provekit:contract
-int compute_sum(int a, int b) { return a + b; }
+int add(int a, int b) { return a + b; }
+
+//provekit:contract
+int compute_sum(int a, int b) { return add(a, b); }
 EOF
 
 echo "=== initialize ==="
@@ -75,19 +78,23 @@ LIFT_RESP=$(printf '%s\n' "$LIFT_OUTPUT" | sed -n '2p')
 assert_contains "kind ir-document"        "$LIFT_RESP" '"kind":"ir-document"'
 assert_contains "ir key"                  "$LIFT_RESP" '"ir":'
 assert_contains "contract compute_sum"    "$LIFT_RESP" '"name":"compute_sum"'
-assert_contains "callEdges empty"         "$LIFT_RESP" '"callEdges":[]'
+assert_contains "callEdges target"        "$LIFT_RESP" '"targetSymbol":"cpp-kit:add"'
+assert_contains "callEdges source"        "$LIFT_RESP" '"sourceContractCid":"pending-cpp:compute_sum"'
+assert_contains "callEdges locus"         "$LIFT_RESP" '"callSiteLocus":{'
 assert_contains "diagnostics key"         "$LIFT_RESP" '"diagnostics":[]'
 assert_not_contains "no error"            "$LIFT_RESP" '"error"'
 
 echo "=== parse (legacy) ==="
 PARSE_INPUT=$(printf '%s\n%s\n%s\n' \
     '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
-    '{"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"fixture.cpp","source":"//provekit:contract\nint compute_sum(int a, int b) { return a + b; }"}}' \
+    '{"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"fixture.cpp","source":"//provekit:contract\nint add(int a, int b) { return a + b; }\n\n//provekit:contract\nint compute_sum(int a, int b) { return add(a, b); }"}}' \
     '{"jsonrpc":"2.0","id":3,"method":"shutdown"}')
 PARSE_OUTPUT=$(printf '%s\n' "$PARSE_INPUT" | "$BIN")
 PARSE_RESP=$(printf '%s\n' "$PARSE_OUTPUT" | sed -n '2p')
 assert_contains "declarations field"      "$PARSE_RESP" '"declarations":'
-assert_contains "callEdges empty"         "$PARSE_RESP" '"callEdges":[]'
+assert_contains "callEdges target"        "$PARSE_RESP" '"targetSymbol":"cpp-kit:add"'
+assert_contains "callEdges source"        "$PARSE_RESP" '"sourceContractCid":"pending-cpp:compute_sum"'
+assert_contains "callEdges locus"         "$PARSE_RESP" '"callSiteLocus":{'
 assert_contains "at least one decl"       "$PARSE_RESP" '"kind":"contract"'
 assert_contains "contract name"           "$PARSE_RESP" '"name":"compute_sum"'
 assert_not_contains "no error"            "$PARSE_RESP" '"error"'


### PR DESCRIPTION
## Summary

- add C++ LSP call-site scanning between contracted functions
- emit canonical call-edge JSON with nested `callSiteLocus`, `sourceContractCid`, and `targetSymbol`
- update the C++ LSP integration fixture to require non-empty call edges in both `lift` and `parse`

## Why

The C++ LSP previously returned `callEdges: []`, so linkerd had no C++ call-site data to project verifier failures into IDE diagnostics. This keeps C++ parsing in the C++ kit and feeds the existing language-agnostic daemon shape.

## Validation

- `tools/build-cpp-lsp.sh && sh implementations/cpp/provekit-lsp-cpp/test_lsp.sh` failed before implementation because both `lift` and `parse` returned `callEdges: []`
- `tools/build-cpp-lsp.sh && sh implementations/cpp/provekit-lsp-cpp/test_lsp.sh`
- `PATH="$PWD/implementations/cpp/target:$PATH" cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd --test multi_kit test6_cpp_kit_dispatch -- --nocapture`
- `git diff --check`