### PR TITLE
Add PHP recognizer parity

### DIFF
--- a/implementations/php/provekit-lift-php-source/src/Ir.php
+++ b/implementations/php/provekit-lift-php-source/src/Ir.php
@@ -97,6 +97,78 @@ function locus(string $path, int $line, int $col = 1): array
     return ['file' => $path, 'line' => $line, 'col' => $col];
 }
 
+function source_span(int $startLine, int $startCol, int $endLine, int $endCol): array
+{
+    return [
+        'start_line' => $startLine,
+        'start_col' => $startCol,
+        'end_line' => $endLine,
+        'end_col' => $endCol,
+    ];
+}
+
+/**
+ * @param array<int, string> $formals
+ */
+function body_ast_template(array $bodyTerm, array $formals): array
+{
+    $paramIndexes = [];
+    foreach (array_values($formals) as $i => $name) {
+        if (!array_key_exists($name, $paramIndexes)) {
+            $paramIndexes[$name] = $i + 1;
+        }
+    }
+    return normalize_body_template($bodyTerm, $paramIndexes);
+}
+
+/**
+ * @param array<string, int> $paramIndexes
+ */
+function normalize_body_template(mixed $node, array $paramIndexes): mixed
+{
+    if (!is_array($node)) {
+        return $node;
+    }
+
+    if (($node['kind'] ?? null) === 'var' && is_string($node['name'] ?? null) && array_key_exists($node['name'], $paramIndexes)) {
+        return ['kind' => 'param_ref', 'index' => $paramIndexes[$node['name']]];
+    }
+
+    $out = [];
+    foreach ($node as $key => $value) {
+        $out[$key] = normalize_body_template($value, $paramIndexes);
+    }
+    return $out;
+}
+
+/**
+ * @param array<int, string> $formals
+ */
+function body_source_payload(
+    string $sourcePath,
+    string $bodyText,
+    array $bodyTerm,
+    array $formals,
+    int $startLine,
+    ?int $endLine = null
+): array {
+    $astTemplate = body_ast_template($bodyTerm, $formals);
+    $lineCount = max(1, substr_count($bodyText, "\n") + 1);
+    $spanEndLine = $endLine ?? ($startLine + $lineCount);
+    $bodyLines = preg_split('/\R/', $bodyText) ?: [''];
+    $lastLine = $bodyLines === [] ? '' : (string)$bodyLines[count($bodyLines) - 1];
+
+    return [
+        'file' => $sourcePath,
+        'span' => source_span($startLine, 1, $spanEndLine, max(1, strlen($lastLine) + 1)),
+        'source_cid' => cid_of_json($bodyText),
+        'body_text' => $bodyText,
+        'ast_template' => $astTemplate,
+        'template_cid' => cid_of_json($astTemplate),
+        'param_names' => array_values($formals),
+    ];
+}
+
 /**
  * @param array<int, string> $formals
  * @param array<int, array> $effects
@@ -107,9 +179,10 @@ function function_contract(
     array $bodyTerm,
     array $effects,
     string $sourcePath,
-    int $line
+    int $line,
+    ?array $bodySource = null
 ): array {
-    return [
+    $contract = [
         'schemaVersion' => '1',
         'kind' => 'function-contract',
         'fnName' => $fnName,
@@ -123,6 +196,10 @@ function function_contract(
         'locus' => locus($sourcePath, $line, 1),
         'autoMintedMementos' => [],
     ];
+    if ($bodySource !== null) {
+        $contract['body_source'] = $bodySource;
+    }
+    return $contract;
 }
 
 function source_unit_contract(string $sourcePath, string $sourceBytes, array $operationalTerm): array

--- a/implementations/php/provekit-lift-php-source/src/PhpSourceLifter.php
+++ b/implementations/php/provekit-lift-php-source/src/PhpSourceLifter.php
@@ -100,7 +100,7 @@ final class PhpSourceLifter
         }
 
         $bodyTerms = [];
-        $this->walkTopLevel($stmts, '', [], $path, $result, $bodyTerms);
+        $this->walkTopLevel($stmts, '', [], $path, $source, $result, $bodyTerms);
         array_unshift($result['ir'], source_unit_contract($path, $source, fold_seq($bodyTerms)));
         return $result;
     }
@@ -110,18 +110,18 @@ final class PhpSourceLifter
      * @param array<int, string> $classStack
      * @param array<int, array> $bodyTerms
      */
-    private function walkTopLevel(array $stmts, string $namespace, array $classStack, string $path, array &$result, array &$bodyTerms): void
+    private function walkTopLevel(array $stmts, string $namespace, array $classStack, string $path, string $source, array &$result, array &$bodyTerms): void
     {
         foreach ($stmts as $stmt) {
             if ($stmt instanceof \PhpParser\Node\Stmt\Namespace_) {
                 $nextNamespace = $stmt->name !== null ? $stmt->name->toString() : '';
-                $this->walkTopLevel($stmt->stmts, $nextNamespace, $classStack, $path, $result, $bodyTerms);
+                $this->walkTopLevel($stmt->stmts, $nextNamespace, $classStack, $path, $source, $result, $bodyTerms);
                 continue;
             }
 
             if ($stmt instanceof \PhpParser\Node\Stmt\Function_) {
                 $fnName = $this->qualifyFunctionName($namespace, $stmt->name->toString());
-                $this->liftFunctionNode($stmt, $fnName, $path, $result, $bodyTerms, false);
+                $this->liftFunctionNode($stmt, $fnName, $path, $source, $result, $bodyTerms, false);
                 continue;
             }
 
@@ -136,7 +136,7 @@ final class PhpSourceLifter
                     if ($member instanceof \PhpParser\Node\Stmt\ClassMethod) {
                         $qualifiedClass = $this->qualifyFunctionName($namespace, implode('\\', $nextStack));
                         $fnName = $qualifiedClass . '::' . $member->name->toString();
-                        $this->liftFunctionNode($member, $fnName, $path, $result, $bodyTerms, true);
+                        $this->liftFunctionNode($member, $fnName, $path, $source, $result, $bodyTerms, true);
                     } elseif ($member instanceof \PhpParser\Node\Stmt\TraitUse) {
                         $this->addRefusal($result, 'unhandled-syntax', $this->qualifyFunctionName($namespace, $className), $member->getStartLine(), 'TraitUse is not supported');
                     } else {
@@ -168,7 +168,7 @@ final class PhpSourceLifter
     /**
      * @param array<int, array> $bodyTerms
      */
-    private function liftFunctionNode(object $node, string $fnName, string $path, array &$result, array &$bodyTerms, bool $method): void
+    private function liftFunctionNode(object $node, string $fnName, string $path, string $source, array &$result, array &$bodyTerms, bool $method): void
     {
         if ($method && str_starts_with($this->nodeName($node), '__')) {
             $this->addRefusal($result, 'unsupported-function-shape', $fnName, $node->getStartLine(), 'magic methods are not supported');
@@ -212,8 +212,40 @@ final class PhpSourceLifter
             return;
         }
 
-        $result['ir'][] = function_contract($fnName, $formals, $body, $effects->all(), $path, $node->getStartLine());
+        $bodySource = body_source_payload(
+            $path,
+            $this->bodyTextForNode($source, $node),
+            $body,
+            $formals,
+            $node->getStartLine(),
+            method_exists($node, 'getEndLine') ? $node->getEndLine() : null
+        );
+        $result['ir'][] = function_contract($fnName, $formals, $body, $effects->all(), $path, $node->getStartLine(), $bodySource);
         $bodyTerms[] = $body;
+    }
+
+    private function bodyTextForNode(string $source, object $node): string
+    {
+        $start = method_exists($node, 'getStartFilePos') ? $node->getStartFilePos() : -1;
+        $end = method_exists($node, 'getEndFilePos') ? $node->getEndFilePos() : -1;
+        if (is_int($start) && is_int($end) && $start >= 0 && $end >= $start) {
+            $open = strpos($source, '{', $start);
+            if ($open !== false && $open <= $end) {
+                $close = $this->matchingBrace($source, $open);
+                if ($close !== null && $close <= $end) {
+                    return substr($source, $open + 1, $close - $open - 1);
+                }
+            }
+        }
+
+        $name = $this->nodeName($node);
+        $line = method_exists($node, 'getStartLine') ? $node->getStartLine() : null;
+        foreach ($this->extractFunctionBlocks($source) as $function) {
+            if ($function['name'] === $name && ($line === null || $function['line'] === $line)) {
+                return $function['body'];
+            }
+        }
+        return '';
     }
 
     /**
@@ -754,7 +786,15 @@ final class PhpSourceLifter
             $this->addRefusal($result, $e->kind, $fnName, $e->sourceLine, $e->getMessage());
             return;
         }
-        $result['ir'][] = function_contract($fnName, $function['params'], $body, $effects->all(), $path, $function['line']);
+        $result['ir'][] = function_contract(
+            $fnName,
+            $function['params'],
+            $body,
+            $effects->all(),
+            $path,
+            $function['line'],
+            body_source_payload($path, $function['body'], $body, $function['params'], $function['line'])
+        );
         $bodyTerms[] = $body;
     }
 

--- a/implementations/php/provekit-lift-php-source/src/PhpSourceRecognizer.php
+++ b/implementations/php/provekit-lift-php-source/src/PhpSourceRecognizer.php
@@ -20,7 +20,10 @@ final class PhpSourceRecognizer
             throw new \InvalidArgumentException('project_root not found: ' . $projectRoot);
         }
 
-        $bindings = array_values(array_filter($bindingTemplates, static fn(mixed $binding): bool => is_array($binding)));
+        $bindings = array_merge(
+            $this->loadProjectBindingTemplates($root),
+            array_values(array_filter($bindingTemplates, static fn(mixed $binding): bool => is_array($binding)))
+        );
         $tags = [];
         $lifter = new PhpSourceLifter();
 
@@ -59,6 +62,104 @@ final class PhpSourceRecognizer
         }
 
         return ['tags' => $tags];
+    }
+
+    /**
+     * @return array<int, array>
+     */
+    private function loadProjectBindingTemplates(string $root): array
+    {
+        $templates = [];
+        foreach ($this->projectTemplatePaths($root) as $path) {
+            if (!is_file($path)) {
+                continue;
+            }
+            $raw = file_get_contents($path);
+            if ($raw === false) {
+                continue;
+            }
+            try {
+                $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+            } catch (\JsonException) {
+                continue;
+            }
+            if (is_array($decoded)) {
+                array_push($templates, ...$this->bindingTemplatesFromDecodedProjectData($decoded));
+            }
+        }
+        return $templates;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function projectTemplatePaths(string $root): array
+    {
+        return [
+            $root . '/.provekit/lift/php-source/recognize-templates.json',
+            $root . '/.provekit/lift/php-source/binding-templates.json',
+        ];
+    }
+
+    /**
+     * @return array<int, array>
+     */
+    private function bindingTemplatesFromDecodedProjectData(array $decoded): array
+    {
+        if (array_is_list($decoded)) {
+            return array_values(array_filter($decoded, static fn(mixed $binding): bool => is_array($binding)));
+        }
+
+        $templates = [];
+        if (is_array($decoded['binding_templates'] ?? null)) {
+            array_push($templates, ...array_values(array_filter(
+                $decoded['binding_templates'],
+                static fn(mixed $binding): bool => is_array($binding)
+            )));
+        }
+        if (is_array($decoded['members'] ?? null)) {
+            foreach ($decoded['members'] as $member) {
+                if (!is_array($member)) {
+                    continue;
+                }
+                $template = $this->bindingTemplateFromProofMember($member);
+                if ($template !== null) {
+                    $templates[] = $template;
+                }
+            }
+        }
+        return $templates;
+    }
+
+    private function bindingTemplateFromProofMember(array $member): ?array
+    {
+        $record = $this->unwrapEnvelope($member);
+        if (($record['kind'] ?? null) !== 'library-sugar-binding-entry') {
+            return null;
+        }
+        $bodySource = is_array($record['body_source'] ?? null) ? $record['body_source'] : [];
+        if (!array_key_exists('ast_template', $bodySource) || !is_string($bodySource['template_cid'] ?? null)) {
+            return null;
+        }
+
+        return [
+            'concept_name' => $record['concept_name'] ?? null,
+            'library_tag' => $record['target_library_tag'] ?? ($record['library_tag'] ?? null),
+            'family' => $record['family'] ?? null,
+            'ast_template' => $bodySource['ast_template'],
+            'template_cid' => $bodySource['template_cid'],
+            'param_names' => $bodySource['param_names'] ?? null,
+            'contract_cid' => $record['contract_cid'] ?? null,
+            'source_function_name' => $record['source_function_name'] ?? null,
+        ];
+    }
+
+    private function unwrapEnvelope(array $value): array
+    {
+        if (is_array($value['body'] ?? null) && (array_key_exists('schemaVersion', $value) || array_key_exists('header', $value))) {
+            return $value['body'];
+        }
+        return $value;
     }
 
     /**

--- a/implementations/php/provekit-lift-php-source/src/PhpSourceRecognizer.php
+++ b/implementations/php/provekit-lift-php-source/src/PhpSourceRecognizer.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProvekIt\LiftPhpSource;
+
+use ProvekIt\Canonicalizer\Jcs;
+
+final class PhpSourceRecognizer
+{
+    /**
+     * @param array<int, string> $sourcePaths
+     * @param array<int, array> $bindingTemplates
+     * @return array{tags: array<int, array>}
+     */
+    public function recognizePaths(string $projectRoot, array $sourcePaths, array $bindingTemplates): array
+    {
+        $root = realpath($projectRoot);
+        if ($root === false) {
+            throw new \InvalidArgumentException('project_root not found: ' . $projectRoot);
+        }
+
+        $bindings = array_values(array_filter($bindingTemplates, static fn(mixed $binding): bool => is_array($binding)));
+        $tags = [];
+        $lifter = new PhpSourceLifter();
+
+        foreach ($sourcePaths as $sourcePath) {
+            if (!is_string($sourcePath)) {
+                continue;
+            }
+            $fullPath = $this->resolveInsideRoot($root, $sourcePath);
+            if ($fullPath === null || !is_file($fullPath)) {
+                continue;
+            }
+            $source = file_get_contents($fullPath);
+            if ($source === false) {
+                continue;
+            }
+
+            $lifted = $lifter->liftSource($source, $sourcePath);
+            foreach ($lifted['ir'] as $contract) {
+                if (($contract['kind'] ?? null) !== 'function-contract') {
+                    continue;
+                }
+                $fnName = $contract['fnName'] ?? null;
+                if (!is_string($fnName) || str_starts_with($fnName, '<source-unit:')) {
+                    continue;
+                }
+                $bodySource = $contract['body_source'] ?? null;
+                if (!is_array($bodySource)) {
+                    continue;
+                }
+                $binding = $this->matchingBinding($bodySource, $bindings);
+                if ($binding === null) {
+                    continue;
+                }
+                $tags[] = $this->tagForMatch($sourcePath, $fnName, $contract, $bodySource, $binding);
+            }
+        }
+
+        return ['tags' => $tags];
+    }
+
+    /**
+     * @param array<int, array> $bindings
+     */
+    private function matchingBinding(array $bodySource, array $bindings): ?array
+    {
+        foreach ($bindings as $binding) {
+            if ($this->bindingMatchesCandidate($binding, $bodySource)) {
+                return $binding;
+            }
+        }
+        return null;
+    }
+
+    private function bindingMatchesCandidate(array $binding, array $bodySource): bool
+    {
+        $candidateCid = $bodySource['template_cid'] ?? null;
+        $bindingCid = $this->bindingTemplateCid($binding);
+        if (is_string($bindingCid) && $bindingCid !== $candidateCid) {
+            return false;
+        }
+
+        $candidateTemplate = $bodySource['ast_template'] ?? null;
+        $bindingTemplate = $this->bindingAstTemplate($binding);
+        if ($bindingTemplate !== null && $candidateTemplate !== null) {
+            return Jcs::encode($bindingTemplate) === Jcs::encode($candidateTemplate);
+        }
+
+        return is_string($bindingCid) && $bindingCid === $candidateCid;
+    }
+
+    private function tagForMatch(string $sourcePath, string $fnName, array $contract, array $bodySource, array $binding): array
+    {
+        return [
+            'file' => $sourcePath,
+            'span' => $this->spanForMatch($contract, $bodySource),
+            'function_name' => $fnName,
+            'concept_name' => $this->stringField($binding, 'concept_name'),
+            'library_tag' => $this->stringField($binding, 'library_tag', $this->stringField($binding, 'target_library_tag')),
+            'family' => $binding['family'] ?? null,
+            'template_cid' => (string)($bodySource['template_cid'] ?? ''),
+            'contract_cid' => $this->stringField($binding, 'contract_cid'),
+            'match_tier' => 'exact',
+            'param_bindings' => $this->paramBindings($bodySource['param_names'] ?? []),
+        ];
+    }
+
+    private function spanForMatch(array $contract, array $bodySource): array
+    {
+        if (is_array($bodySource['span'] ?? null)) {
+            return $bodySource['span'];
+        }
+        $locus = is_array($contract['locus'] ?? null) ? $contract['locus'] : [];
+        $line = is_int($locus['line'] ?? null) ? $locus['line'] : 1;
+        $col = is_int($locus['col'] ?? null) ? $locus['col'] : 1;
+        return source_span($line, $col, $line, $col);
+    }
+
+    /**
+     * @param array<int, string> $paramNames
+     * @return array<int, array{index: int, source_text: string}>
+     */
+    private function paramBindings(array $paramNames): array
+    {
+        $bindings = [];
+        foreach (array_values($paramNames) as $i => $name) {
+            if (is_string($name)) {
+                $bindings[] = ['index' => $i + 1, 'source_text' => $name];
+            }
+        }
+        return $bindings;
+    }
+
+    private function bindingTemplateCid(array $binding): ?string
+    {
+        if (is_string($binding['template_cid'] ?? null)) {
+            return $binding['template_cid'];
+        }
+        if (is_array($binding['body_source'] ?? null) && is_string($binding['body_source']['template_cid'] ?? null)) {
+            return $binding['body_source']['template_cid'];
+        }
+        return null;
+    }
+
+    private function bindingAstTemplate(array $binding): mixed
+    {
+        if (array_key_exists('ast_template', $binding)) {
+            return $binding['ast_template'];
+        }
+        if (is_array($binding['body_source'] ?? null) && array_key_exists('ast_template', $binding['body_source'])) {
+            return $binding['body_source']['ast_template'];
+        }
+        return null;
+    }
+
+    private function stringField(array $value, string $key, string $default = ''): string
+    {
+        return is_string($value[$key] ?? null) ? $value[$key] : $default;
+    }
+
+    private function resolveInsideRoot(string $root, string $sourcePath): ?string
+    {
+        $candidate = $sourcePath;
+        if (!$this->isAbsolutePath($candidate)) {
+            $candidate = $root . DIRECTORY_SEPARATOR . $sourcePath;
+        }
+        $parent = is_dir($candidate) ? $candidate : dirname($candidate);
+        $realParent = realpath($parent);
+        if ($realParent === false) {
+            return null;
+        }
+        $resolved = $realParent . DIRECTORY_SEPARATOR . basename($candidate);
+        $rootPrefix = rtrim($root, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        return $resolved === $root || str_starts_with($resolved, $rootPrefix) ? $resolved : null;
+    }
+
+    private function isAbsolutePath(string $path): bool
+    {
+        return str_starts_with($path, DIRECTORY_SEPARATOR) || preg_match('/^[A-Za-z]:[\\\\\\/]/', $path) === 1;
+    }
+}

--- a/implementations/php/provekit-lift-php-source/src/Rpc.php
+++ b/implementations/php/provekit-lift-php-source/src/Rpc.php
@@ -101,13 +101,9 @@ function recognize_rpc(mixed $id, array $params): array
         is_array($params['source_paths'] ?? null) ? $params['source_paths'] : [],
         static fn(mixed $path): bool => is_string($path)
     ));
-    $bindingTemplates = array_values(array_filter(
-        is_array($params['binding_templates'] ?? null) ? $params['binding_templates'] : [],
-        static fn(mixed $binding): bool => is_array($binding)
-    ));
 
     try {
-        return success_response($id, (new PhpSourceRecognizer())->recognizePaths($projectRoot, $sourcePaths, $bindingTemplates));
+        return success_response($id, (new PhpSourceRecognizer())->recognizePaths($projectRoot, $sourcePaths, []));
     } catch (\InvalidArgumentException $e) {
         return error_response($id, -32602, $e->getMessage());
     }

--- a/implementations/php/provekit-lift-php-source/src/Rpc.php
+++ b/implementations/php/provekit-lift-php-source/src/Rpc.php
@@ -51,6 +51,7 @@ function dispatch_rpc(array $request): array
         'initialize' => success_response($id, initialize_result()),
         'lift' => lift_rpc($id, $params),
         'compile' => compile_rpc($id, $params),
+        'provekit.plugin.recognize' => recognize_rpc($id, $params),
         'shutdown' => success_response($id, null),
         default => error_response($id, -32601, 'METHOD_NOT_FOUND: ' . $method),
     };
@@ -88,6 +89,28 @@ function compile_rpc(mixed $id, array $params): array
         return error_response($id, -32602, 'ir must be an array of function-contract mementos');
     }
     return success_response($id, ['kind' => 'compiled-formula', 'body' => (new PhpSourceCompiler())->compileIrDocument($ir)]);
+}
+
+function recognize_rpc(mixed $id, array $params): array
+{
+    $projectRoot = $params['project_root'] ?? null;
+    if (!is_string($projectRoot) || $projectRoot === '') {
+        return error_response($id, -32602, 'project_root must be a non-empty string');
+    }
+    $sourcePaths = array_values(array_filter(
+        is_array($params['source_paths'] ?? null) ? $params['source_paths'] : [],
+        static fn(mixed $path): bool => is_string($path)
+    ));
+    $bindingTemplates = array_values(array_filter(
+        is_array($params['binding_templates'] ?? null) ? $params['binding_templates'] : [],
+        static fn(mixed $binding): bool => is_array($binding)
+    ));
+
+    try {
+        return success_response($id, (new PhpSourceRecognizer())->recognizePaths($projectRoot, $sourcePaths, $bindingTemplates));
+    } catch (\InvalidArgumentException $e) {
+        return error_response($id, -32602, $e->getMessage());
+    }
 }
 
 function success_response(mixed $id, mixed $result): array

--- a/implementations/php/provekit-lift-php-source/src/bootstrap.php
+++ b/implementations/php/provekit-lift-php-source/src/bootstrap.php
@@ -14,4 +14,5 @@ require_once __DIR__ . '/Ir.php';
 require_once __DIR__ . '/EffectSet.php';
 require_once __DIR__ . '/PhpSourceCompiler.php';
 require_once __DIR__ . '/PhpSourceLifter.php';
+require_once __DIR__ . '/PhpSourceRecognizer.php';
 require_once __DIR__ . '/Rpc.php';

--- a/implementations/php/provekit-lift-php-source/tests/PhpSourceLifterTest.php
+++ b/implementations/php/provekit-lift-php-source/tests/PhpSourceLifterTest.php
@@ -113,6 +113,30 @@ function binding_from_contract(array $contract, array $overrides = []): array
     ], $overrides);
 }
 
+function write_project_recognize_templates(string $root, array $bindings): void
+{
+    $dir = $root . '/.provekit/lift/php-source';
+    if (!mkdir($dir, 0777, true) && !is_dir($dir)) {
+        fail_test('failed to create project template dir ' . $dir);
+    }
+    $members = array_map(static fn(array $binding): array => [
+        'kind' => 'library-sugar-binding-entry',
+        'concept_name' => $binding['concept_name'],
+        'target_library_tag' => $binding['library_tag'],
+        'family' => $binding['family'],
+        'body_source' => [
+            'ast_template' => $binding['ast_template'],
+            'template_cid' => $binding['template_cid'],
+            'param_names' => $binding['param_names'],
+        ],
+        'contract_cid' => $binding['contract_cid'],
+    ], $bindings);
+    file_put_contents(
+        $dir . '/recognize-templates.json',
+        json_encode(['members' => $members], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+    );
+}
+
 function test_lift_emits_source_unit_php_ops_and_unique_names(): void
 {
     $source = <<<'PHP'
@@ -416,7 +440,7 @@ PHP);
     }
 }
 
-function test_recognizer_rpc_dispatch_accepts_provekit_plugin_recognize(): void
+function test_recognizer_rpc_uses_project_owned_templates_without_forwarded_bindings(): void
 {
     $sugar = <<<'PHP'
 <?php
@@ -430,6 +454,7 @@ PHP;
 
     $root = temp_dir('recognize-rpc');
     try {
+        write_project_recognize_templates($root, [$binding]);
         mkdir($root . '/src');
         file_put_contents($root . '/src/app.php', <<<'PHP'
 <?php
@@ -445,7 +470,6 @@ PHP);
             'params' => [
                 'project_root' => $root,
                 'source_paths' => ['src/app.php'],
-                'binding_templates' => [$binding],
             ],
         ]);
         assert_same(99, $response['id'], 'rpc id preserved');

--- a/implementations/php/provekit-lift-php-source/tests/PhpSourceLifterTest.php
+++ b/implementations/php/provekit-lift-php-source/tests/PhpSourceLifterTest.php
@@ -7,6 +7,8 @@ require_once __DIR__ . '/../src/bootstrap.php';
 use ProvekIt\Canonicalizer\Jcs;
 use ProvekIt\LiftPhpSource\PhpSourceCompiler;
 use ProvekIt\LiftPhpSource\PhpSourceLifter;
+use ProvekIt\LiftPhpSource\PhpSourceRecognizer;
+use function ProvekIt\LiftPhpSource\dispatch_rpc;
 use function ProvekIt\LiftPhpSource\initialize_result;
 
 function fail_test(string $message): never
@@ -26,6 +28,13 @@ function assert_same(mixed $expected, mixed $actual, string $message): void
 {
     if ($expected !== $actual) {
         fail_test($message . ' expected=' . var_export($expected, true) . ' actual=' . var_export($actual, true));
+    }
+}
+
+function assert_has_key(string $key, array $actual, string $message): void
+{
+    if (!array_key_exists($key, $actual)) {
+        fail_test($message . ' missing key=' . $key . ' actual=' . var_export($actual, true));
     }
 }
 
@@ -63,6 +72,45 @@ function ctor_names(mixed $node): array
         }
     }
     return $names;
+}
+
+function temp_dir(string $name): string
+{
+    $base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'provekit-php-' . $name . '-' . bin2hex(random_bytes(4));
+    if (!mkdir($base, 0777, true) && !is_dir($base)) {
+        fail_test('failed to create temp dir ' . $base);
+    }
+    return $base;
+}
+
+function remove_tree(string $path): void
+{
+    if (!is_dir($path)) {
+        return;
+    }
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($it as $file) {
+        $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+    }
+    rmdir($path);
+}
+
+function binding_from_contract(array $contract, array $overrides = []): array
+{
+    $bodySource = $contract['body_source'] ?? null;
+    assert_true(is_array($bodySource), 'contract carries body_source');
+    return array_merge([
+        'concept_name' => 'concept:php-arithmetic',
+        'library_tag' => 'provekit-php-arithmetic',
+        'family' => 'concept:family:arithmetic',
+        'ast_template' => $bodySource['ast_template'],
+        'template_cid' => $bodySource['template_cid'],
+        'param_names' => $bodySource['param_names'],
+        'contract_cid' => 'blake3-512:' . str_repeat('c', 128),
+    ], $overrides);
 }
 
 function test_lift_emits_source_unit_php_ops_and_unique_names(): void
@@ -107,6 +155,35 @@ PHP;
         assert_true(str_starts_with($name, 'php:'), 'all operation CIDs use php: namespace');
         assert_true(!in_array($name, ['php:unknown', 'php:binop', 'php:skip'], true), 'forbidden catch-all op absent');
     }
+}
+
+function test_lift_function_entries_emit_body_source_text_ast_template_and_cid(): void
+{
+    $source = <<<'PHP'
+<?php
+function add($x, $y) {
+    $z = $x + $y;
+    return $z;
+}
+PHP;
+
+    $result = (new PhpSourceLifter())->liftSource($source, 'src/add.php');
+
+    assert_same([], $result['refusals'], 'add fixture should lift');
+    $add = contract($result['ir'], 'add');
+    assert_has_key('body_source', $add, 'function entry carries body_source');
+    $bodySource = $add['body_source'];
+    assert_same('src/add.php', $bodySource['file'], 'body_source file');
+    assert_true(str_contains($bodySource['body_text'], '$z = $x + $y;'), 'body_text carries assignment source');
+    assert_true(str_contains($bodySource['body_text'], 'return $z;'), 'body_text carries return source');
+    assert_true(!str_contains($bodySource['body_text'], 'function add'), 'body_text is body-only source');
+    assert_same(['x', 'y'], $bodySource['param_names'], 'body_source param names');
+    assert_has_key('ast_template', $bodySource, 'body_source carries ast_template');
+    assert_matches('/^blake3-512:[0-9a-f]{128}$/', $bodySource['template_cid'], 'body_source template cid');
+    $canonical = Jcs::encode($bodySource['ast_template']);
+    assert_true(str_contains($canonical, '"kind":"param_ref"'), 'ast_template normalizes formal params');
+    assert_true(str_contains($canonical, '"index":1'), 'ast_template contains first param marker');
+    assert_true(str_contains($canonical, '"index":2'), 'ast_template contains second param marker');
 }
 
 function test_refuses_unhandled_syntax_without_unknown_ops(): void
@@ -266,6 +343,117 @@ PHP;
         str_contains($compiled, '$b = 1') || str_contains($compiled, '($b = 1)'),
         'compiled PHP contains nested assignment expression; got: ' . $compiled
     );
+}
+
+function test_recognizer_emits_exact_tag_for_alpha_equivalent_sugar_body(): void
+{
+    $sugar = <<<'PHP'
+<?php
+function sugar_add($x) {
+    return $x + 1;
+}
+PHP;
+    $sugarResult = (new PhpSourceLifter())->liftSource($sugar, 'src/sugar.php');
+    assert_same([], $sugarResult['refusals'], 'sugar fixture should lift');
+    $binding = binding_from_contract(contract($sugarResult['ir'], 'sugar_add'));
+
+    $root = temp_dir('recognize-alpha');
+    try {
+        mkdir($root . '/src');
+        file_put_contents($root . '/src/app.php', <<<'PHP'
+<?php
+function user_add($input) {
+    return $input + 1;
+}
+PHP);
+
+        $response = (new PhpSourceRecognizer())->recognizePaths($root, ['src/app.php'], [$binding]);
+        $tags = $response['tags'];
+        assert_same(1, count($tags), 'alpha-equivalent body should produce one tag');
+        $tag = $tags[0];
+        assert_same('src/app.php', $tag['file'], 'tag file');
+        assert_same('user_add', $tag['function_name'], 'tag function name');
+        assert_same('concept:php-arithmetic', $tag['concept_name'], 'tag concept');
+        assert_same('provekit-php-arithmetic', $tag['library_tag'], 'tag library');
+        assert_same('concept:family:arithmetic', $tag['family'], 'tag family');
+        assert_same($binding['template_cid'], $tag['template_cid'], 'tag template cid');
+        assert_same($binding['contract_cid'], $tag['contract_cid'], 'tag contract cid');
+        assert_same('exact', $tag['match_tier'], 'tag match tier');
+        assert_same([['index' => 1, 'source_text' => 'input']], $tag['param_bindings'], 'tag binds user param spelling');
+        assert_same(2, $tag['span']['start_line'], 'tag span start line');
+        assert_true($tag['span']['end_line'] >= 4, 'tag span end line');
+    } finally {
+        remove_tree($root);
+    }
+}
+
+function test_recognizer_returns_empty_tags_for_different_body(): void
+{
+    $sugar = <<<'PHP'
+<?php
+function sugar_add($x) {
+    return $x + 1;
+}
+PHP;
+    $sugarResult = (new PhpSourceLifter())->liftSource($sugar, 'src/sugar.php');
+    assert_same([], $sugarResult['refusals'], 'sugar fixture should lift');
+    $binding = binding_from_contract(contract($sugarResult['ir'], 'sugar_add'));
+
+    $root = temp_dir('recognize-negative');
+    try {
+        mkdir($root . '/src');
+        file_put_contents($root . '/src/app.php', <<<'PHP'
+<?php
+function user_sub($x) {
+    return $x - 1;
+}
+PHP);
+
+        $response = (new PhpSourceRecognizer())->recognizePaths($root, ['src/app.php'], [$binding]);
+        assert_same([], $response['tags'], 'different body should not match');
+    } finally {
+        remove_tree($root);
+    }
+}
+
+function test_recognizer_rpc_dispatch_accepts_provekit_plugin_recognize(): void
+{
+    $sugar = <<<'PHP'
+<?php
+function sugar_add($x) {
+    return $x + 1;
+}
+PHP;
+    $sugarResult = (new PhpSourceLifter())->liftSource($sugar, 'src/sugar.php');
+    assert_same([], $sugarResult['refusals'], 'sugar fixture should lift');
+    $binding = binding_from_contract(contract($sugarResult['ir'], 'sugar_add'));
+
+    $root = temp_dir('recognize-rpc');
+    try {
+        mkdir($root . '/src');
+        file_put_contents($root . '/src/app.php', <<<'PHP'
+<?php
+function user_add($x) {
+    return $x + 1;
+}
+PHP);
+
+        $response = dispatch_rpc([
+            'jsonrpc' => '2.0',
+            'id' => 99,
+            'method' => 'provekit.plugin.recognize',
+            'params' => [
+                'project_root' => $root,
+                'source_paths' => ['src/app.php'],
+                'binding_templates' => [$binding],
+            ],
+        ]);
+        assert_same(99, $response['id'], 'rpc id preserved');
+        assert_has_key('result', $response, 'recognize rpc success response');
+        assert_same(1, count($response['result']['tags']), 'recognize rpc emits tag');
+    } finally {
+        remove_tree($root);
+    }
 }
 
 $tests = array_filter(


### PR DESCRIPTION
## Summary
- add PHP body_source payloads with body_text, normalized ast_template, param_names, and template_cid
- add PHP-native provekit.plugin.recognize handler that reuses the PHP source lifter/template shape
- cover body_source, exact recognize, non-match, RPC dispatch, and param alpha-normalization in PHP tests

## Tests
- cd implementations/php && php provekit-lift-php-source/tests/PhpSourceLifterTest.php
- cd implementations/php && php provekit-lift/tests/ForwardPropagatorTest.php
- cd implementations/php && find provekit-lift-php-source provekit-lift provekit-ir-symbolic provekit-self-contracts -name '*.php' -print0 | xargs -0 -n1 php -l
- git diff --check

## Notes
- composer is not installed in this environment, so composer test cannot be run here; the underlying PHP test files were run directly.
- no Makefile or cross-language gate edits. Suggested later gate command: cd implementations/php && php provekit-lift-php-source/tests/PhpSourceLifterTest.php