### PR TITLE
Add Ruby recognizer parity

### DIFF
--- a/implementations/ruby/lib/provekit/lift/ruby_source.rb
+++ b/implementations/ruby/lib/provekit/lift/ruby_source.rb
@@ -10,6 +10,8 @@ require "set"
 
 require_relative "../blake3"
 require_relative "../ir"
+require_relative "../ruby_ast_template"
+require_relative "../ruby_recognizer"
 
 module Provekit
   module Lift
@@ -555,6 +557,7 @@ module Provekit
               "authoring_surfaces" => [SURFACE],
               "ir_version" => IR_VERSION,
               "emits_signed_mementos" => false,
+              "recognize" => true,
             },
           }
         end
@@ -593,6 +596,12 @@ module Provekit
             rpc_lift(id, params)
           when "compile"
             rpc_compile(id, params)
+          when "provekit.plugin.recognize"
+            {
+              "jsonrpc" => "2.0",
+              "id" => id,
+              "result" => Provekit::RubyRecognizer.recognize(params),
+            }
           when "shutdown"
             { "jsonrpc" => "2.0", "id" => id, "result" => nil }
           else
@@ -617,6 +626,10 @@ module Provekit
           collector = DefinitionCollector.new
           collector.collect(sexp)
           result.refusals.concat(collector.refusals)
+          body_sources_by_line =
+            Provekit::RubyAstTemplate.extract_methods(source, source_path).each_with_object({}) do |info, out|
+              out[info[:line]] = info[:body_source]
+            end
 
           body_terms = []
           contracts = []
@@ -624,6 +637,7 @@ module Provekit
             contract = lift_function(info, source_path, result)
             next if contract.nil?
 
+            contract["body_source"] = body_sources_by_line[info.line] if body_sources_by_line[info.line]
             body_terms << contract["post"]["args"][1]
             contracts << contract
           end

--- a/implementations/ruby/lib/provekit/pep_server.rb
+++ b/implementations/ruby/lib/provekit/pep_server.rb
@@ -1,6 +1,7 @@
 require "json"
 require "provekit/ruby_lifter"
 require "provekit/ruby_realizer"
+require "provekit/ruby_recognizer"
 require "provekit/sugar_dict"
 require "provekit/version"
 
@@ -12,7 +13,7 @@ module Provekit
       "protocol_version" => "provekit-plugin/1.7.0",
       "kit_cid" => "blake3-512:df3bd324caec5f9e818bb2f0a8d44ac923a9136f923a946f525023001637832a21a21ac32145c5c27de71c3f429e9ae6cf2d5f1a163d654df717d620169b9322",
       "language" => "ruby",
-      "supported_verbs" => ["lift_source", "realize_concept"],
+      "supported_verbs" => ["lift_source", "realize_concept", "recognize_source"],
       "supported_sugar_cids" => SugarDict.default_cids,
       "capabilities" => {
         "authoring_surfaces" => ["ruby-source", "ruby-sorbet", "ruby-comments"],
@@ -46,6 +47,8 @@ module Provekit
         write_result(id, MANIFEST)
       when "provekit.plugin.invoke"
         write_result(id, invoke(request["params"] || {}))
+      when "provekit.plugin.recognize"
+        write_result(id, Provekit::RubyRecognizer.recognize(request["params"] || {}))
       when "provekit.plugin.shutdown"
         write_result(id, nil)
         exit 0
@@ -75,6 +78,8 @@ module Provekit
         @lifter.lift_source(payload["source"].to_s, payload["path"] || "source.rb")
       when "realize_concept"
         @realizer.realize(payload["proofir"] || payload["ir"] || {}, payload["plan"] || {})
+      when "recognize_source", "recognize"
+        Provekit::RubyRecognizer.recognize(payload)
       else
         raise ArgumentError, "unsupported verb: #{verb}"
       end

--- a/implementations/ruby/lib/provekit/ruby_ast_template.rb
+++ b/implementations/ruby/lib/provekit/ruby_ast_template.rb
@@ -1,0 +1,245 @@
+require "ripper"
+
+require "provekit/blake3"
+require "provekit/ir"
+
+module Provekit
+  module RubyAstTemplate
+    module_function
+
+    def extract_methods(source, file = "source.rb")
+      sexp = Ripper.sexp(source)
+      return [] unless sexp
+
+      lines = source.lines
+      collect_defs(sexp).map do |node|
+        method_name = def_name(node)
+        params = def_params(node)
+        start_line = def_line(node)
+        next unless method_name && start_line
+
+        start_index = start_line - 1
+        end_index = find_matching_end(lines, start_index)
+        body_text = dedent(lines[(start_index + 1)...end_index].join)
+        span_text = lines[start_index..end_index].join
+        body_source = body_source_for_body(
+          body_text,
+          params,
+          file: file,
+          span: {
+            "start_line" => start_line,
+            "start_col" => leading_spaces(lines[start_index]),
+            "end_line" => end_index + 1,
+            "end_col" => lines[end_index].to_s.length,
+          },
+          source_text: span_text,
+        )
+
+        {
+          name: method_name,
+          params: params,
+          line: start_line,
+          body: body_text,
+          body_source: body_source,
+        }
+      end.compact.sort_by { |info| info[:line] }
+    end
+
+    def body_source_for_body(body_text, params = [], file: "source.rb", span: nil, source_text: nil)
+      text = dedent(body_text.to_s)
+      template = ast_template_for_body(text, params)
+      {
+        "file" => file,
+        "span" => span || default_span(text),
+        "source_cid" => cid_for(source_text || text),
+        "body_text" => text,
+        "ast_template" => template,
+        "template_cid" => cid_for(template),
+        "param_names" => params.map(&:to_s),
+      }
+    end
+
+    def ast_template_for_body(body_text, params = [])
+      text = body_text.to_s
+      wrapper = +"def __provekit_template__(#{params.map(&:to_s).join(", ")})\n"
+      wrapper << indent_body(text)
+      wrapper << "\n" unless wrapper.end_with?("\n")
+      wrapper << "end\n"
+
+      sexp = Ripper.sexp(wrapper)
+      statements = sexp ? body_statements_from_wrapper(sexp) : nil
+      if statements.nil?
+        return {
+          "kind" => "ruby:block",
+          "stmts" => [{ "kind" => "unparsed", "source" => text.strip }],
+        }
+      end
+
+      {
+        "kind" => "ruby:block",
+        "stmts" => Array(statements).map { |stmt| canonicalize(stmt, params) },
+      }
+    end
+
+    def cid_for(value)
+      bytes = value.is_a?(String) ? value : Provekit::IR::Jcs.encode(value)
+      Provekit::Blake3.hex(bytes)
+    end
+
+    def dedent(text)
+      lines = text.to_s.lines
+      lines.shift while lines.first&.strip == ""
+      lines.pop while lines.last&.strip == ""
+      width = lines.reject { |line| line.strip == "" }.map { |line| leading_spaces(line) }.min || 0
+      lines.map { |line| line.sub(/\A[ \t]{0,#{width}}/, "") }.join.chomp
+    end
+
+    def indent_body(text)
+      return "" if text.to_s.empty?
+
+      text.lines.map { |line| line.strip.empty? ? line : "  #{line}" }.join
+    end
+
+    def default_span(text)
+      line_count = [text.lines.length, 1].max
+      {
+        "start_line" => 1,
+        "start_col" => 0,
+        "end_line" => line_count,
+        "end_col" => text.lines.last.to_s.length,
+      }
+    end
+
+    def leading_spaces(line)
+      line.to_s[/\A[ \t]*/].to_s.length
+    end
+
+    def collect_defs(node, out = [])
+      return out unless node.is_a?(Array)
+
+      kind = node_kind(node)
+      out << node if kind == :def || kind == :defs
+      node.each { |child| collect_defs(child, out) if child.is_a?(Array) }
+      out
+    end
+
+    def def_name(node)
+      case node_kind(node)
+      when :def
+        token_text(node[1])
+      when :defs
+        receiver = receiver_name(node[1])
+        name = token_text(node[3])
+        receiver && receiver != "" ? "#{receiver}.#{name}" : name
+      end
+    end
+
+    def receiver_name(node)
+      case node_kind(node)
+      when :var_ref, :vcall
+        token_text(node[1])
+      when :@kw, :@ident, :@const
+        token_text(node)
+      else
+        nil
+      end
+    end
+
+    def def_params(node)
+      params_node = node_kind(node) == :defs ? node[4] : node[2]
+      params_node = params_node[1] if node_kind(params_node) == :paren
+      return [] unless node_kind(params_node) == :params
+
+      required = Array(params_node[1])
+      required.map { |item| token_text(item) }.compact
+    end
+
+    def def_line(node)
+      name_node = node_kind(node) == :defs ? node[3] : node[1]
+      token_line(name_node)
+    end
+
+    def find_matching_end(lines, start_index)
+      depth = 0
+      i = start_index
+      while i < lines.length
+        line = lines[i].to_s
+        depth += line.scan(/^\s*(def|class|module|begin|if|unless|case|while|until|for)\b/).length
+        depth += 1 if line =~ /\bdo\s*(\|.*\|)?\s*$/
+        if line.strip == "end"
+          depth -= 1
+          return i if depth <= 0
+        end
+        i += 1
+      end
+      [lines.length - 1, start_index].max
+    end
+
+    def body_statements_from_wrapper(sexp)
+      def_node = Array(sexp[1]).find { |node| node_kind(node) == :def }
+      return nil unless def_node
+
+      body = def_node[3]
+      return [] if body.nil?
+      return nil unless node_kind(body) == :bodystmt
+
+      body[1] || []
+    end
+
+    def canonicalize(node, params)
+      case node
+      when Array
+        return canonicalize_token(node, params) if token_node?(node)
+
+        kind = node_kind(node)
+        unless kind.is_a?(Symbol)
+          return {
+            "kind" => "list",
+            "children" => node.map { |child| canonicalize(child, params) },
+          }
+        end
+
+        {
+          "kind" => kind.to_s,
+          "children" => Array(node[1..]).map { |child| canonicalize(child, params) },
+        }
+      when Symbol
+        { "kind" => "symbol", "name" => node.to_s }
+      when String, Integer, Float, TrueClass, FalseClass, NilClass
+        node
+      else
+        node.to_s
+      end
+    end
+
+    def canonicalize_token(node, params)
+      text = node[1].to_s
+      index = params.map(&:to_s).index(text)
+      return { "kind" => "param_ref", "index" => index + 1 } if index
+
+      type = node[0].to_s.delete_prefix("@")
+      case node[0]
+      when :@int, :@float, :@rational, :@imaginary, :@tstring_content
+        { "kind" => "literal", "type" => type, "value" => text }
+      else
+        { "kind" => "token", "type" => type, "text" => text }
+      end
+    end
+
+    def token_node?(node)
+      node.length >= 3 && node[0].is_a?(Symbol) && node[0].to_s.start_with?("@")
+    end
+
+    def node_kind(node)
+      node.is_a?(Array) ? node[0] : nil
+    end
+
+    def token_text(node)
+      token_node?(node) ? node[1].to_s : nil
+    end
+
+    def token_line(node)
+      token_node?(node) && node[2].is_a?(Array) ? node[2][0].to_i : nil
+    end
+  end
+end

--- a/implementations/ruby/lib/provekit/ruby_lifter.rb
+++ b/implementations/ruby/lib/provekit/ruby_lifter.rb
@@ -2,6 +2,7 @@ require "json"
 require "ripper"
 require "provekit/ir"
 require "provekit/blake3"
+require "provekit/ruby_ast_template"
 
 module Provekit
   class RubyLifter
@@ -12,7 +13,7 @@ module Provekit
       sexp = Ripper.sexp(source)
       comments = comment_roles(source)
       sigs = sorbet_sigs(source)
-      methods = method_regions(source)
+      methods = Provekit::RubyAstTemplate.extract_methods(source, path)
       declarations = []
 
       methods.each do |method_info|
@@ -43,7 +44,8 @@ module Provekit
             "effects" => effects,
             "values" => bindings,
             "ordering" => ordering
-          })
+          }),
+          "body_source" => method_info[:body_source]
         }
         contract.delete("pre") unless contract["pre"]
         contract.delete("post") unless contract["post"]
@@ -188,6 +190,11 @@ module Provekit
       copy = Marshal.load(Marshal.dump(contract))
       copy.delete("contract_cid")
       copy.dig("evidence")&.delete("path")
+      if (body_source = copy["body_source"])
+        body_source.delete("file")
+        body_source.delete("span")
+        body_source.delete("source_cid")
+      end
       copy
     end
   end

--- a/implementations/ruby/lib/provekit/ruby_recognizer.rb
+++ b/implementations/ruby/lib/provekit/ruby_recognizer.rb
@@ -1,6 +1,7 @@
 require "pathname"
 
 require "provekit/ruby_ast_template"
+require "provekit/sugar_dict"
 
 module Provekit
   module RubyRecognizer
@@ -39,7 +40,9 @@ module Provekit
     end
 
     def recognize_text(source, file = "source.rb", binding_templates = [])
-      bindings = binding_templates_by_cid(binding_templates)
+      templates = Array(binding_templates)
+      templates = default_binding_templates if templates.empty?
+      bindings = binding_templates_by_cid(templates)
       tags = []
 
       RubyAstTemplate.extract_methods(source, file).each do |method_info|
@@ -65,6 +68,24 @@ module Provekit
       end
 
       { "tags" => tags }
+    end
+
+    def default_binding_templates
+      Provekit::SugarDict.patterns.each_with_object([]) do |pattern, out|
+        body = pattern[:body_source]
+        next unless body && body["ast_template"] && body["template_cid"]
+
+        out << {
+          "concept_name" => pattern[:proofir],
+          "library_tag" => pattern[:cid],
+          "family" => "provekit:sugar:ruby",
+          "ast_template" => body["ast_template"],
+          "template_cid" => body["template_cid"],
+          "param_names" => body["param_names"],
+          "contract_cid" => nil,
+          "source_function_name" => pattern[:role],
+        }
+      end
     end
 
     def binding_templates_by_cid(binding_templates)

--- a/implementations/ruby/lib/provekit/ruby_recognizer.rb
+++ b/implementations/ruby/lib/provekit/ruby_recognizer.rb
@@ -1,0 +1,102 @@
+require "pathname"
+
+require "provekit/ruby_ast_template"
+
+module Provekit
+  module RubyRecognizer
+    module_function
+
+    def recognize(params)
+      if params["source"]
+        return recognize_text(
+          params["source"].to_s,
+          params["path"] || "source.rb",
+          Array(params["binding_templates"]),
+        )
+      end
+
+      project_root = params["project_root"].to_s
+      raise ArgumentError, "missing `project_root`" if project_root.empty?
+
+      source_paths = Array(params["source_paths"])
+      raise ArgumentError, "missing `source_paths` array" if source_paths.empty?
+
+      root = Pathname.new(project_root).realpath
+      templates = Array(params["binding_templates"])
+      tags = []
+
+      source_paths.each do |requested|
+        full = resolve_inside_root(root, requested)
+        next unless full && full.exist?
+
+        ruby_files(full).sort_by(&:to_s).each do |file|
+          rel = file.relative_path_from(root).to_s
+          tags.concat(recognize_text(File.read(file, encoding: "UTF-8"), rel, templates)["tags"])
+        end
+      end
+
+      { "tags" => tags }
+    end
+
+    def recognize_text(source, file = "source.rb", binding_templates = [])
+      bindings = binding_templates_by_cid(binding_templates)
+      tags = []
+
+      RubyAstTemplate.extract_methods(source, file).each do |method_info|
+        body = method_info[:body_source]
+        template_cid = body["template_cid"]
+        binding = bindings[template_cid]
+        next unless binding
+
+        tags << {
+          "file" => file,
+          "span" => body["span"],
+          "function_name" => method_info[:name],
+          "concept_name" => binding["concept_name"],
+          "library_tag" => binding["library_tag"],
+          "family" => binding["family"],
+          "template_cid" => template_cid,
+          "contract_cid" => binding.key?("contract_cid") ? binding["contract_cid"] : nil,
+          "match_tier" => "exact",
+          "param_bindings" => method_info[:params].each_with_index.map do |name, index|
+            { "index" => index + 1, "source_text" => name }
+          end,
+        }
+      end
+
+      { "tags" => tags }
+    end
+
+    def binding_templates_by_cid(binding_templates)
+      Array(binding_templates).each_with_object({}) do |binding, out|
+        next unless binding.is_a?(Hash)
+
+        cid = binding["template_cid"]
+        cid = RubyAstTemplate.cid_for(binding["ast_template"]) if (cid.nil? || cid == "") && binding["ast_template"]
+        next unless cid.is_a?(String) && !cid.empty?
+
+        out[cid] = binding
+      end
+    end
+
+    def resolve_inside_root(root, requested)
+      path = Pathname.new(requested.to_s)
+      full = path.absolute? ? path : root + path
+      resolved = full.realpath
+      relative_to?(resolved, root) ? resolved : nil
+    rescue SystemCallError
+      nil
+    end
+
+    def ruby_files(path)
+      return [path] if path.file? && path.extname == ".rb"
+      return [] unless path.directory?
+
+      path.find.select { |entry| entry.file? && entry.extname == ".rb" }
+    end
+
+    def relative_to?(path, root)
+      path.ascend.any? { |ancestor| ancestor == root }
+    end
+  end
+end

--- a/implementations/ruby/lib/provekit/sugar_dict.rb
+++ b/implementations/ruby/lib/provekit/sugar_dict.rb
@@ -2,6 +2,7 @@ require "provekit/sugars/sorbet_sigs"
 require "provekit/sugars/dry_validation"
 require "provekit/sugars/contracts_ruby"
 require "provekit/sugars/comment_roles"
+require "provekit/ruby_ast_template"
 
 module Provekit
   module SugarDict
@@ -15,10 +16,32 @@ module Provekit
     end
 
     def self.patterns
-      Sugars::SorbetSigs.patterns +
+      with_body_sources(
+        Sugars::SorbetSigs.patterns +
         Sugars::DryValidation.patterns +
         Sugars::ContractsRuby.patterns +
         Sugars::CommentRoles.patterns
+      )
+    end
+
+    def self.with_body_sources(patterns)
+      patterns.map do |pattern|
+        ruby = pattern[:ruby]
+        next pattern unless ruby.respond_to?(:call)
+
+        params = ruby.parameters.each_with_index.map do |param, index|
+          name = param[1]
+          name ? name.to_s : "arg#{index + 1}"
+        end
+        body_text = ruby.call(*params)
+        pattern.merge(
+          body_source: Provekit::RubyAstTemplate.body_source_for_body(
+            body_text,
+            params,
+            file: "<sugar-dict>",
+          )
+        )
+      end
     end
   end
 end

--- a/implementations/ruby/manifest.json
+++ b/implementations/ruby/manifest.json
@@ -5,7 +5,7 @@
   "kit_cid": "blake3-512:df3bd324caec5f9e818bb2f0a8d44ac923a9136f923a946f525023001637832a21a21ac32145c5c27de71c3f429e9ae6cf2d5f1a163d654df717d620169b9322",
   "language": "ruby",
   "command": ["bundle", "exec", "bin/provekit-ruby-plugin", "--rpc"],
-  "supported_verbs": ["lift_source", "realize_concept"],
+  "supported_verbs": ["lift_source", "realize_concept", "recognize_source"],
   "supported_sugar_cids": [
     "provekit:sugar:ruby:sorbet-sigs:v1",
     "provekit:sugar:ruby:dry-validation:v1",

--- a/implementations/ruby/spec/lifter_spec.rb
+++ b/implementations/ruby/spec/lifter_spec.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 require "provekit/ruby_lifter"
+require "provekit/sugar_dict"
 
 describe Provekit::RubyLifter do
   it "lifts methods, Sorbet sigs, comments, bindings, panics, and IO effects" do
@@ -26,5 +27,53 @@ describe Provekit::RubyLifter do
     expect(decl.dig("evidence", "values").first["name"]).to eq("y")
     expect(decl.dig("evidence", "effects").map { |effect| effect["kind"] }).to include("Panics")
     expect(decl.dig("evidence", "effects").map { |effect| effect["kind"] }).to include("Io")
+  end
+
+  it "emits materializable method body source and AST template" do
+    source = <<~RUBY
+      def fetch_url(url, headers)
+        client.execute(url, headers)
+      end
+    RUBY
+
+    doc = Provekit::RubyLifter.new.lift_source(source, "shim.rb")
+    body = doc["declarations"].first["body_source"]
+
+    expect(body["file"]).to eq("shim.rb")
+    expect(body["body_text"]).to eq("client.execute(url, headers)")
+    expect(body["param_names"]).to eq(["url", "headers"])
+    expect(body["ast_template"]["kind"]).to eq("ruby:block")
+    expect(body["ast_template"].to_s).to include("param_ref")
+    expect(body["template_cid"].start_with?("blake3-512:")).to eq(true)
+  end
+
+  it "keeps method AST template CIDs stable under parameter renaming" do
+    source_a = <<~RUBY
+      def fetch_url(url, headers)
+        client.execute(url, headers)
+      end
+    RUBY
+    source_b = <<~RUBY
+      def fetch_url(uri, h)
+        client.execute(uri, h)
+      end
+    RUBY
+
+    body_a = Provekit::RubyLifter.new.lift_source(source_a, "a.rb")["declarations"].first["body_source"]
+    body_b = Provekit::RubyLifter.new.lift_source(source_b, "b.rb")["declarations"].first["body_source"]
+
+    expect(body_a["ast_template"]).to eq(body_b["ast_template"])
+    expect(body_a["template_cid"]).to eq(body_b["template_cid"])
+  end
+
+  it "attaches body_source templates to materializable sugar dictionary patterns" do
+    Provekit::SugarDict.patterns.each do |pattern|
+      next unless pattern[:ruby]
+
+      body = pattern[:body_source]
+      expect(body["body_text"].empty?).to eq(false)
+      expect(body["ast_template"]["kind"]).to eq("ruby:block")
+      expect(body["template_cid"].start_with?("blake3-512:")).to eq(true)
+    end
   end
 end

--- a/implementations/ruby/spec/recognizer_spec.rb
+++ b/implementations/ruby/spec/recognizer_spec.rb
@@ -6,6 +6,7 @@ require "fileutils"
 require "provekit/lift/ruby_source"
 require "provekit/ruby_lifter"
 require "provekit/ruby_recognizer"
+require "provekit/sugars/sorbet_sigs"
 
 describe Provekit::RubyRecognizer do
   def binding_from(source, concept = "concept:http-request")
@@ -66,18 +67,12 @@ describe Provekit::RubyRecognizer do
     expect(response["tags"]).to eq([])
   end
 
-  it "supports provekit.plugin.recognize on the Ruby source RPC surface" do
-    shim = <<~RUBY
-      def fetch_url(url, headers)
-        client.execute(url, headers)
-      end
-    RUBY
-
+  it "resolves Ruby-owned sugar templates on the RPC recognize path" do
     Dir.mktmpdir("provekit-ruby-recognize") do |root|
       FileUtils.mkdir_p(File.join(root, "src"))
       File.write(File.join(root, "src", "user.rb"), <<~RUBY)
-        def send_request(uri, h)
-          client.execute(uri, h)
+        def require_name(name)
+          T.must(name)
         end
       RUBY
 
@@ -87,13 +82,16 @@ describe Provekit::RubyRecognizer do
         "method" => "provekit.plugin.recognize",
         "params" => {
           "project_root" => root,
-          "source_paths" => ["src/user.rb"],
-          "binding_templates" => [binding_from(shim)]
+          "source_paths" => ["src/user.rb"]
         }
       )
 
       expect(response["result"]["tags"].length).to eq(1)
-      expect(response["result"]["tags"].first["function_name"]).to eq("send_request")
+      tag = response["result"]["tags"].first
+      expect(tag["function_name"]).to eq("require_name")
+      expect(tag["concept_name"]).to eq("forall x. eq(x, nil) => false")
+      expect(tag["library_tag"]).to eq(Provekit::Sugars::SorbetSigs::CID)
+      expect(tag["template_cid"].start_with?("blake3-512:")).to eq(true)
     end
   end
 end

--- a/implementations/ruby/spec/recognizer_spec.rb
+++ b/implementations/ruby/spec/recognizer_spec.rb
@@ -1,0 +1,99 @@
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
+require "tmpdir"
+require "fileutils"
+
+require "provekit/lift/ruby_source"
+require "provekit/ruby_lifter"
+require "provekit/ruby_recognizer"
+
+describe Provekit::RubyRecognizer do
+  def binding_from(source, concept = "concept:http-request")
+    entry = Provekit::RubyLifter.new.lift_source(source, "shim.rb")["declarations"].first
+    {
+      "concept_name" => concept,
+      "library_tag" => "ruby-http-client",
+      "family" => "concept:family:http",
+      "ast_template" => entry["body_source"]["ast_template"],
+      "template_cid" => entry["body_source"]["template_cid"],
+      "param_names" => entry["body_source"]["param_names"],
+      "contract_cid" => "blake3-512:" + ("c" * 128)
+    }
+  end
+
+  it "recognizes an exact alpha-equivalent Ruby sugar body" do
+    shim = <<~RUBY
+      def fetch_url(url, headers)
+        client.execute(url, headers)
+      end
+    RUBY
+    user = <<~RUBY
+      def send_request(uri, h)
+        client.execute(uri, h)
+      end
+    RUBY
+
+    response = Provekit::RubyRecognizer.recognize_text(user, "src/user.rb", [binding_from(shim)])
+    tag = response["tags"].first
+
+    expect(response["tags"].length).to eq(1)
+    expect(tag["file"]).to eq("src/user.rb")
+    expect(tag["function_name"]).to eq("send_request")
+    expect(tag["concept_name"]).to eq("concept:http-request")
+    expect(tag["library_tag"]).to eq("ruby-http-client")
+    expect(tag["family"]).to eq("concept:family:http")
+    expect(tag["match_tier"]).to eq("exact")
+    expect(tag["param_bindings"]).to eq([
+      { "index" => 1, "source_text" => "uri" },
+      { "index" => 2, "source_text" => "h" }
+    ])
+  end
+
+  it "does not recognize a different Ruby body" do
+    shim = <<~RUBY
+      def fetch_url(url, headers)
+        client.execute(url, headers)
+      end
+    RUBY
+    user = <<~RUBY
+      def send_request(uri, h)
+        client.send(uri, h)
+      end
+    RUBY
+
+    response = Provekit::RubyRecognizer.recognize_text(user, "src/user.rb", [binding_from(shim)])
+
+    expect(response["tags"]).to eq([])
+  end
+
+  it "supports provekit.plugin.recognize on the Ruby source RPC surface" do
+    shim = <<~RUBY
+      def fetch_url(url, headers)
+        client.execute(url, headers)
+      end
+    RUBY
+
+    Dir.mktmpdir("provekit-ruby-recognize") do |root|
+      FileUtils.mkdir_p(File.join(root, "src"))
+      File.write(File.join(root, "src", "user.rb"), <<~RUBY)
+        def send_request(uri, h)
+          client.execute(uri, h)
+        end
+      RUBY
+
+      response = Provekit::Lift::RubySource.dispatch(
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "provekit.plugin.recognize",
+        "params" => {
+          "project_root" => root,
+          "source_paths" => ["src/user.rb"],
+          "binding_templates" => [binding_from(shim)]
+        }
+      )
+
+      expect(response["result"]["tags"].length).to eq(1)
+      expect(response["result"]["tags"].first["function_name"]).to eq("send_request")
+    end
+  end
+end

--- a/implementations/ruby/test/test_ruby_source_lift.rb
+++ b/implementations/ruby/test/test_ruby_source_lift.rb
@@ -56,6 +56,9 @@ class TestRubySourceLift < Minitest::Test
 
     add_one = contract(result.ir, "M::C#add_one")
     assert_equal ["x"], add_one["formals"]
+    assert_equal "y = x + K\nreturn y", add_one["body_source"]["body_text"]
+    assert_equal "ruby:block", add_one["body_source"]["ast_template"]["kind"]
+    assert_match(/\Ablake3-512:[0-9a-f]{128}\z/, add_one["body_source"]["template_cid"])
     assert_equal [{ "kind" => "reads", "target" => "K" }], add_one["effects"]
     assert_equal ["ruby:seq", "ruby:assign", "ruby:add", "ruby:const", "ruby:return"], ctor_names(add_one["post"]["args"][1])
 


### PR DESCRIPTION
## Summary
- add Ruby-native Ripper AST body templates and stable template CIDs for Ruby lifter/sugar dictionary surfaces
- add Ruby recognizer RPC support for exact alpha-equivalent body matches with source locations and param bindings
- align with #1652: CLI-facing recognize now works with only project_root + source_paths by resolving Ruby-owned SugarDict templates inside the kit
- register recognize support through Ruby-local manifest/server surfaces

## Tests
- /usr/local/opt/ruby/bin/ruby vendor/rspec-lite/bin/rspec spec/recognizer_spec.rb
- /usr/local/opt/ruby/bin/rake test
- direct plugin RPC smoke: provekit.plugin.recognize with project_root + source_paths and no binding_templates
- git diff --check

## Notes
- System /usr/bin/ruby is 2.6.10 and cannot parse this kit's Ruby 3 syntax; tests were run with Homebrew Ruby 4.0.3.
- No Rust CLI, Makefile, or non-Ruby files were changed.