### PR TITLE
Add C# recognizer parity

### DIFF
--- a/implementations/csharp/.provekit/lift/csharp-source/manifest.toml
+++ b/implementations/csharp/.provekit/lift/csharp-source/manifest.toml
@@ -9,3 +9,4 @@ working_dir = "."
 authoring_surfaces = ["csharp-source"]
 ir_version = "v1.1.0"
 emits_signed_mementos = false
+recognize = true

--- a/implementations/csharp/Provekit.Lift.Csharp.Tests/LifterTests.cs
+++ b/implementations/csharp/Provekit.Lift.Csharp.Tests/LifterTests.cs
@@ -119,6 +119,72 @@ static int Mul(int x, int y) { return x * y; }
     }
 
     [Fact]
+    public void LiftedFunctionContractCarriesMaterializableBodySource()
+    {
+        var lifter = new CsharpLifter();
+        var result = new LiftResult();
+        var source = @"
+class Shim {
+static Response Fetch(string url, Headers headers) {
+    return client.Execute(url, headers);
+}
+}";
+
+        lifter.LiftSource(source, "shim.cs", result);
+
+        var contract = Assert.Single(result.Declarations);
+        var bodySource = Assert.IsType<JsonObject>(contract["body_source"]);
+        Assert.Equal("return client.Execute(url, headers);", bodySource["body_text"]?.GetValue<string>());
+        Assert.Equal("shim.cs", bodySource["file"]?.GetValue<string>());
+        Assert.StartsWith("blake3-512:", bodySource["source_cid"]?.GetValue<string>());
+        Assert.StartsWith("blake3-512:", bodySource["template_cid"]?.GetValue<string>());
+        Assert.Equal(new[] { "url", "headers" }, bodySource["param_names"]!.AsArray().Select(p => p!.GetValue<string>()));
+
+        var template = Assert.IsType<JsonObject>(bodySource["ast_template"]);
+        Assert.Equal("block", template["kind"]?.GetValue<string>());
+        var stmt = Assert.IsType<JsonObject>(template["stmts"]!.AsArray()[0]);
+        Assert.Equal("return", stmt["kind"]?.GetValue<string>());
+        var call = Assert.IsType<JsonObject>(stmt["expr"]);
+        Assert.Equal("method_call", call["kind"]?.GetValue<string>());
+        Assert.Equal("Execute", call["method"]?.GetValue<string>());
+        var args = call["args"]!.AsArray();
+        Assert.Equal("param_ref", args[0]!["kind"]?.GetValue<string>());
+        Assert.Equal(1, args[0]!["index"]?.GetValue<int>());
+        Assert.Equal("param_ref", args[1]!["kind"]?.GetValue<string>());
+        Assert.Equal(2, args[1]!["index"]?.GetValue<int>());
+    }
+
+    [Fact]
+    public void BodyTemplateCidIsStableUnderParameterRenaming()
+    {
+        static JsonObject BodySourceFor(string source)
+        {
+            var lifter = new CsharpLifter();
+            var result = new LiftResult();
+            lifter.LiftSource(source, "shim.cs", result);
+            return Assert.IsType<JsonObject>(Assert.Single(result.Declarations)["body_source"]);
+        }
+
+        var bodyA = BodySourceFor(@"
+class Shim {
+static Response Fetch(string url, Headers headers) {
+    return client.Execute(url, headers);
+}
+}");
+        var bodyB = BodySourceFor(@"
+class Shim {
+static Response Fetch(string uri, Headers h) {
+    return client.Execute(uri, h);
+}
+}");
+
+        Assert.Equal(bodyA["ast_template"]!.ToJsonString(), bodyB["ast_template"]!.ToJsonString());
+        Assert.Equal(bodyA["template_cid"]!.GetValue<string>(), bodyB["template_cid"]!.GetValue<string>());
+        Assert.NotEqual(bodyA["body_text"]!.GetValue<string>(), bodyB["body_text"]!.GetValue<string>());
+        Assert.NotEqual(bodyA["source_cid"]!.GetValue<string>(), bodyB["source_cid"]!.GetValue<string>());
+    }
+
+    [Fact]
     public void CompilerProducesValidCsharpExpression()
     {
         var compiler = new CsharpCompiler();

--- a/implementations/csharp/Provekit.Lift.Csharp.Tests/RecognizerTests.cs
+++ b/implementations/csharp/Provekit.Lift.Csharp.Tests/RecognizerTests.cs
@@ -1,0 +1,157 @@
+using System.Text.Json.Nodes;
+using Provekit.Lift.Csharp;
+using Xunit;
+
+public class CsharpRecognizerTests
+{
+    [Fact]
+    public void RecognizeMatchesExactAlphaEquivalentCsharpBody()
+    {
+        var binding = BindingTemplateFromShim();
+        var user = @"
+class App {
+static Response Send(string uri, Headers h) {
+    return client.Execute(uri, h);
+}
+}";
+
+        var response = CsharpRecognizer.RecognizeText(user, "src/User.cs", new[] { binding });
+
+        var tag = Assert.Single(response["tags"]!.AsArray());
+        Assert.Equal("src/User.cs", tag!["file"]?.GetValue<string>());
+        Assert.Equal("Send", tag["function_name"]?.GetValue<string>());
+        Assert.Equal("concept:http-request", tag["concept_name"]?.GetValue<string>());
+        Assert.Equal("csharp-http-shim", tag["library_tag"]?.GetValue<string>());
+        Assert.Equal("concept:family:http", tag["family"]?.GetValue<string>());
+        Assert.Equal(binding["template_cid"]!.GetValue<string>(), tag["template_cid"]?.GetValue<string>());
+        Assert.Equal(binding["contract_cid"]!.GetValue<string>(), tag["contract_cid"]?.GetValue<string>());
+        Assert.Equal("exact", tag["match_tier"]?.GetValue<string>());
+        Assert.Equal(3, tag["span"]!["start_line"]?.GetValue<int>());
+        Assert.Equal(5, tag["span"]!["end_line"]?.GetValue<int>());
+
+        var paramBindings = tag["param_bindings"]!.AsArray();
+        Assert.Equal(1, paramBindings[0]!["index"]?.GetValue<int>());
+        Assert.Equal("uri", paramBindings[0]!["source_text"]?.GetValue<string>());
+        Assert.Equal(2, paramBindings[1]!["index"]?.GetValue<int>());
+        Assert.Equal("h", paramBindings[1]!["source_text"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void RecognizeDoesNotMatchDifferentCsharpBody()
+    {
+        var binding = BindingTemplateFromShim();
+        var user = @"
+class App {
+static Response Send(string uri, Headers h) {
+    return other.Execute(uri, h);
+}
+}";
+
+        var response = CsharpRecognizer.RecognizeText(user, "src/User.cs", new[] { binding });
+
+        Assert.Empty(response["tags"]!.AsArray());
+    }
+
+    [Fact]
+    public void RpcRecognizeDispatchResolvesTemplatesFromCsharpProof()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"provekit-csharp-recognize-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            var sourcePath = Path.Combine(root, "User.cs");
+            File.WriteAllText(sourcePath, @"
+class App {
+static Response Send(string uri, Headers h) {
+    return client.Execute(uri, h);
+}
+}");
+            var request = new JsonObject
+            {
+                ["jsonrpc"] = "2.0",
+                ["id"] = 7,
+                ["method"] = "provekit.plugin.recognize",
+                ["params"] = new JsonObject
+                {
+                    ["project_root"] = root,
+                    ["source_paths"] = new JsonArray { "User.cs" },
+                },
+            };
+            File.WriteAllText(Path.Combine(root, "csharp-shim.proof"), ProofJsonFromShim());
+
+            var response = RpcServer.DispatchForTest(request);
+
+            Assert.Equal("2.0", response["jsonrpc"]?.GetValue<string>());
+            Assert.Equal(7, response["id"]?.GetValue<int>());
+            var tag = Assert.Single(response["result"]!["tags"]!.AsArray());
+            Assert.Equal("User.cs", tag!["file"]?.GetValue<string>());
+            Assert.Equal("Send", tag["function_name"]?.GetValue<string>());
+            Assert.Equal("exact", tag["match_tier"]?.GetValue<string>());
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static JsonObject BindingTemplateFromShim()
+    {
+        var entry = SugarEntryFromShim();
+        var bodySource = Assert.IsType<JsonObject>(entry["body_source"]);
+        return new JsonObject
+        {
+            ["concept_name"] = entry["concept_name"]!.DeepClone(),
+            ["library_tag"] = entry["target_library_tag"]!.DeepClone(),
+            ["family"] = entry["family"]!.DeepClone(),
+            ["ast_template"] = bodySource["ast_template"]!.DeepClone(),
+            ["template_cid"] = bodySource["template_cid"]!.GetValue<string>(),
+            ["param_names"] = bodySource["param_names"]!.DeepClone(),
+            ["contract_cid"] = entry["contract_cid"]!.DeepClone(),
+        };
+    }
+
+    private static string ProofJsonFromShim()
+    {
+        var entry = SugarEntryFromShim();
+        var proof = new JsonObject
+        {
+            ["ir"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["schemaVersion"] = "1",
+                    ["header"] = new JsonObject { ["kind"] = "library-sugar-binding-entry" },
+                    ["body"] = entry,
+                },
+            },
+        };
+        return proof.ToJsonString();
+    }
+
+    private static JsonObject SugarEntryFromShim()
+    {
+        var lifter = new CsharpLifter();
+        var result = new LiftResult();
+        lifter.LiftSource(@"
+class Shim {
+static Response Fetch(string url, Headers headers) {
+    return client.Execute(url, headers);
+}
+}", "shim.cs", result);
+
+        var contract = Assert.Single(result.Declarations);
+        var bodySource = Assert.IsType<JsonObject>(contract["body_source"]);
+        return new JsonObject
+        {
+            ["kind"] = "library-sugar-binding-entry",
+            ["concept_name"] = "concept:http-request",
+            ["target_language"] = "csharp",
+            ["target_library_tag"] = "csharp-http-shim",
+            ["family"] = "concept:family:http",
+            ["source_function_name"] = "Fetch",
+            ["param_names"] = bodySource["param_names"]!.DeepClone(),
+            ["body_source"] = bodySource.DeepClone(),
+            ["contract_cid"] = "blake3-512:" + new string('c', 128),
+        };
+    }
+}

--- a/implementations/csharp/Provekit.Lift.Csharp/ContractEmitter.cs
+++ b/implementations/csharp/Provekit.Lift.Csharp/ContractEmitter.cs
@@ -53,6 +53,7 @@ public class ContractEmitter
             ["pre"] = TrueFormula(),
             ["post"] = EqFormula(VarTerm("return_value"), postValue),
             ["bodyCid"] = null,
+            ["body_source"] = CsharpAstTemplates.BodySource(_method, _path),
             ["effects"] = JsonSerializer.SerializeToNode(SortEffects(_effects)),
             ["locus"] = new JsonObject { ["file"] = _path, ["line"] = line, ["col"] = 1 },
             ["autoMintedMementos"] = new JsonArray(),

--- a/implementations/csharp/Provekit.Lift.Csharp/CsharpAstTemplates.cs
+++ b/implementations/csharp/Provekit.Lift.Csharp/CsharpAstTemplates.cs
@@ -1,0 +1,390 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using Provekit.Canonicalizer;
+using V = Provekit.Canonicalizer.Value;
+
+namespace Provekit.Lift.Csharp;
+
+public static class CsharpAstTemplates
+{
+    public static JsonObject BodySource(MethodDeclarationSyntax method, string file)
+    {
+        var sourceText = method.SyntaxTree.GetText();
+        var bodyText = MethodBodyText(method, sourceText);
+        var paramNames = ParameterNames(method);
+        var astTemplate = MethodBodyTemplate(method, paramNames);
+
+        return new JsonObject
+        {
+            ["ast_template"] = astTemplate,
+            ["body_text"] = bodyText,
+            ["file"] = file,
+            ["param_names"] = JsonSerializer.SerializeToNode(paramNames),
+            ["source_cid"] = CidOfUtf8(bodyText),
+            ["span"] = SpanFor(method),
+            ["template_cid"] = TemplateCid(astTemplate),
+        };
+    }
+
+    public static JsonObject MethodBodyTemplate(MethodDeclarationSyntax method) =>
+        MethodBodyTemplate(method, ParameterNames(method));
+
+    public static string TemplateCid(JsonNode template) =>
+        CidOfUtf8(Jcs.Encode(ToCanonicalValue(template)));
+
+    public static string CidOfUtf8(string text) => Hash.Blake3_512Utf8(text);
+
+    private static JsonObject MethodBodyTemplate(MethodDeclarationSyntax method, IReadOnlyList<string> paramNames)
+    {
+        var statements = new JsonArray();
+        if (method.Body is not null)
+        {
+            foreach (var statement in method.Body.Statements)
+            {
+                statements.Add(StatementTemplate(statement, paramNames));
+            }
+        }
+        else if (method.ExpressionBody?.Expression is { } expression)
+        {
+            statements.Add(new JsonObject
+            {
+                ["kind"] = "expr_stmt",
+                ["expr"] = ExpressionTemplate(expression, paramNames),
+                ["trailing_semi"] = false,
+            });
+        }
+
+        return new JsonObject
+        {
+            ["kind"] = "block",
+            ["stmts"] = statements,
+        };
+    }
+
+    private static JsonObject StatementTemplate(StatementSyntax statement, IReadOnlyList<string> paramNames)
+    {
+        return statement switch
+        {
+            ReturnStatementSyntax ret => new JsonObject
+            {
+                ["kind"] = "return",
+                ["expr"] = ret.Expression is null ? null : ExpressionTemplate(ret.Expression, paramNames),
+            },
+            ExpressionStatementSyntax expr => new JsonObject
+            {
+                ["kind"] = "expr_stmt",
+                ["expr"] = ExpressionTemplate(expr.Expression, paramNames),
+                ["trailing_semi"] = true,
+            },
+            LocalDeclarationStatementSyntax local => LocalDeclarationTemplate(local, paramNames),
+            IfStatementSyntax ifStmt => new JsonObject
+            {
+                ["kind"] = "if",
+                ["cond"] = ExpressionTemplate(ifStmt.Condition, paramNames),
+                ["then"] = StatementTemplate(ifStmt.Statement, paramNames),
+                ["else"] = ifStmt.Else is null ? null : StatementTemplate(ifStmt.Else.Statement, paramNames),
+            },
+            BlockSyntax block => BlockTemplate(block, paramNames),
+            _ => RawStatement(statement),
+        };
+    }
+
+    private static JsonObject BlockTemplate(BlockSyntax block, IReadOnlyList<string> paramNames)
+    {
+        var statements = new JsonArray();
+        foreach (var statement in block.Statements)
+        {
+            statements.Add(StatementTemplate(statement, paramNames));
+        }
+
+        return new JsonObject
+        {
+            ["kind"] = "block",
+            ["stmts"] = statements,
+        };
+    }
+
+    private static JsonObject LocalDeclarationTemplate(LocalDeclarationStatementSyntax local, IReadOnlyList<string> paramNames)
+    {
+        var declarations = new JsonArray();
+        foreach (var variable in local.Declaration.Variables)
+        {
+            declarations.Add(new JsonObject
+            {
+                ["kind"] = "binding",
+                ["name"] = variable.Identifier.Text,
+                ["init"] = variable.Initializer?.Value is null
+                    ? null
+                    : ExpressionTemplate(variable.Initializer.Value, paramNames),
+            });
+        }
+
+        return new JsonObject
+        {
+            ["kind"] = "let",
+            ["declarations"] = declarations,
+        };
+    }
+
+    private static JsonObject ExpressionTemplate(ExpressionSyntax expression, IReadOnlyList<string> paramNames)
+    {
+        expression = StripParens(expression);
+        return expression switch
+        {
+            IdentifierNameSyntax id => IdentifierTemplate(id.Identifier.Text, paramNames),
+            LiteralExpressionSyntax literal => LiteralTemplate(literal),
+            BinaryExpressionSyntax binary => new JsonObject
+            {
+                ["kind"] = "binary",
+                ["op"] = binary.OperatorToken.Text,
+                ["left"] = ExpressionTemplate(binary.Left, paramNames),
+                ["right"] = ExpressionTemplate(binary.Right, paramNames),
+            },
+            InvocationExpressionSyntax invocation => InvocationTemplate(invocation, paramNames),
+            MemberAccessExpressionSyntax member => new JsonObject
+            {
+                ["kind"] = "member",
+                ["receiver"] = ExpressionTemplate(member.Expression, paramNames),
+                ["member"] = member.Name.ToString(),
+            },
+            AssignmentExpressionSyntax assign => new JsonObject
+            {
+                ["kind"] = "assign",
+                ["op"] = assign.OperatorToken.Text,
+                ["left"] = ExpressionTemplate(assign.Left, paramNames),
+                ["right"] = ExpressionTemplate(assign.Right, paramNames),
+            },
+            ObjectCreationExpressionSyntax obj => ObjectCreationTemplate(obj, paramNames),
+            ElementAccessExpressionSyntax element => ElementAccessTemplate(element, paramNames),
+            PrefixUnaryExpressionSyntax prefix => new JsonObject
+            {
+                ["kind"] = "prefix",
+                ["op"] = prefix.OperatorToken.Text,
+                ["expr"] = ExpressionTemplate(prefix.Operand, paramNames),
+            },
+            PostfixUnaryExpressionSyntax postfix => new JsonObject
+            {
+                ["kind"] = "postfix",
+                ["op"] = postfix.OperatorToken.Text,
+                ["expr"] = ExpressionTemplate(postfix.Operand, paramNames),
+            },
+            ConditionalExpressionSyntax cond => new JsonObject
+            {
+                ["kind"] = "conditional",
+                ["cond"] = ExpressionTemplate(cond.Condition, paramNames),
+                ["when_true"] = ExpressionTemplate(cond.WhenTrue, paramNames),
+                ["when_false"] = ExpressionTemplate(cond.WhenFalse, paramNames),
+            },
+            CastExpressionSyntax cast => new JsonObject
+            {
+                ["kind"] = "cast",
+                ["type"] = cast.Type.ToString(),
+                ["expr"] = ExpressionTemplate(cast.Expression, paramNames),
+            },
+            AwaitExpressionSyntax awaitExpr => new JsonObject
+            {
+                ["kind"] = "await",
+                ["expr"] = ExpressionTemplate(awaitExpr.Expression, paramNames),
+            },
+            _ => RawExpression(expression),
+        };
+    }
+
+    private static JsonObject InvocationTemplate(InvocationExpressionSyntax invocation, IReadOnlyList<string> paramNames)
+    {
+        var args = new JsonArray();
+        foreach (var argument in invocation.ArgumentList.Arguments)
+        {
+            args.Add(ExpressionTemplate(argument.Expression, paramNames));
+        }
+
+        if (invocation.Expression is MemberAccessExpressionSyntax member)
+        {
+            return new JsonObject
+            {
+                ["kind"] = "method_call",
+                ["receiver"] = ExpressionTemplate(member.Expression, paramNames),
+                ["method"] = member.Name.ToString(),
+                ["args"] = args,
+            };
+        }
+
+        return new JsonObject
+        {
+            ["kind"] = "call",
+            ["func"] = ExpressionTemplate(invocation.Expression, paramNames),
+            ["args"] = args,
+        };
+    }
+
+    private static JsonObject ObjectCreationTemplate(ObjectCreationExpressionSyntax obj, IReadOnlyList<string> paramNames)
+    {
+        var args = new JsonArray();
+        foreach (var argument in obj.ArgumentList?.Arguments ?? default(SeparatedSyntaxList<ArgumentSyntax>))
+        {
+            args.Add(ExpressionTemplate(argument.Expression, paramNames));
+        }
+
+        return new JsonObject
+        {
+            ["kind"] = "new",
+            ["type"] = obj.Type.ToString(),
+            ["args"] = args,
+        };
+    }
+
+    private static JsonObject ElementAccessTemplate(ElementAccessExpressionSyntax element, IReadOnlyList<string> paramNames)
+    {
+        var args = new JsonArray();
+        foreach (var argument in element.ArgumentList.Arguments)
+        {
+            args.Add(ExpressionTemplate(argument.Expression, paramNames));
+        }
+
+        return new JsonObject
+        {
+            ["kind"] = "index",
+            ["receiver"] = ExpressionTemplate(element.Expression, paramNames),
+            ["args"] = args,
+        };
+    }
+
+    private static JsonObject IdentifierTemplate(string name, IReadOnlyList<string> paramNames)
+    {
+        var index = IndexOf(paramNames, name);
+        if (index >= 0)
+        {
+            return new JsonObject
+            {
+                ["kind"] = "param_ref",
+                ["index"] = index + 1,
+            };
+        }
+
+        return new JsonObject
+        {
+            ["kind"] = "ident",
+            ["name"] = name,
+        };
+    }
+
+    private static int IndexOf(IReadOnlyList<string> items, string value)
+    {
+        for (var i = 0; i < items.Count; i++)
+        {
+            if (items[i] == value) return i;
+        }
+
+        return -1;
+    }
+
+    private static JsonObject LiteralTemplate(LiteralExpressionSyntax literal)
+    {
+        var value = literal.Token.Value;
+        return new JsonObject
+        {
+            ["kind"] = "literal",
+            ["ty"] = value switch
+            {
+                int or long or short or byte => "int",
+                bool => "bool",
+                string => "string",
+                null => "null",
+                _ => literal.Kind().ToString(),
+            },
+            ["value"] = value switch
+            {
+                int i => i,
+                long l => l,
+                short s => s,
+                byte b => b,
+                bool b => b,
+                string s => s,
+                null => null,
+                _ => literal.Token.Text,
+            },
+        };
+    }
+
+    private static JsonObject RawStatement(StatementSyntax statement) => new()
+    {
+        ["kind"] = "raw_stmt",
+        ["syntax_kind"] = statement.Kind().ToString(),
+        ["text"] = statement.NormalizeWhitespace().ToFullString(),
+    };
+
+    private static JsonObject RawExpression(ExpressionSyntax expression) => new()
+    {
+        ["kind"] = "raw_expr",
+        ["syntax_kind"] = expression.Kind().ToString(),
+        ["text"] = expression.NormalizeWhitespace().ToFullString(),
+    };
+
+    private static ExpressionSyntax StripParens(ExpressionSyntax expression)
+    {
+        while (expression is ParenthesizedExpressionSyntax paren)
+        {
+            expression = paren.Expression;
+        }
+
+        return expression;
+    }
+
+    private static string MethodBodyText(MethodDeclarationSyntax method, SourceText sourceText)
+    {
+        if (method.Body is not null)
+        {
+            var start = method.Body.OpenBraceToken.Span.End;
+            var end = method.Body.CloseBraceToken.Span.Start;
+            if (start <= end)
+            {
+                return sourceText.ToString(TextSpan.FromBounds(start, end)).Trim();
+            }
+        }
+
+        return method.ExpressionBody?.Expression is { } expression
+            ? sourceText.ToString(expression.Span).Trim()
+            : "";
+    }
+
+    private static IReadOnlyList<string> ParameterNames(MethodDeclarationSyntax method) =>
+        method.ParameterList.Parameters.Select(parameter => parameter.Identifier.Text).ToArray();
+
+    private static JsonObject SpanFor(SyntaxNode node)
+    {
+        var span = node.GetLocation().GetLineSpan();
+        return new JsonObject
+        {
+            ["start_line"] = span.StartLinePosition.Line + 1,
+            ["start_col"] = span.StartLinePosition.Character,
+            ["end_line"] = span.EndLinePosition.Line + 1,
+            ["end_col"] = span.EndLinePosition.Character,
+        };
+    }
+
+    private static V ToCanonicalValue(JsonNode node)
+    {
+        using var doc = JsonDocument.Parse(node.ToJsonString());
+        return ElementToValue(doc.RootElement);
+    }
+
+    private static V ElementToValue(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Null => V.Null,
+            JsonValueKind.True => V.True,
+            JsonValueKind.False => V.False,
+            JsonValueKind.String => V.String(element.GetString() ?? ""),
+            JsonValueKind.Number => V.Integer(element.GetInt64()),
+            JsonValueKind.Array => V.Array(element.EnumerateArray().Select(ElementToValue)),
+            JsonValueKind.Object => V.Object(element.EnumerateObject()
+                .Select(property => new KeyValuePair<string, V>(property.Name, ElementToValue(property.Value)))),
+            _ => V.Null,
+        };
+    }
+}

--- a/implementations/csharp/Provekit.Lift.Csharp/CsharpBindingTemplateResolver.cs
+++ b/implementations/csharp/Provekit.Lift.Csharp/CsharpBindingTemplateResolver.cs
@@ -1,0 +1,317 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Provekit.Lift.Csharp;
+
+public static class CsharpBindingTemplateResolver
+{
+    public static IReadOnlyList<JsonObject> ResolveFromProject(string projectRoot)
+    {
+        var root = Path.GetFullPath(string.IsNullOrWhiteSpace(projectRoot) ? "." : projectRoot);
+        if (!Directory.Exists(root)) return Array.Empty<JsonObject>();
+
+        var templates = new List<JsonObject>();
+        foreach (var proofPath in Directory.EnumerateFiles(root, "*.proof", SearchOption.AllDirectories)
+                     .OrderBy(path => path, StringComparer.Ordinal))
+        {
+            try
+            {
+                templates.AddRange(LoadBindingTemplatesFromProof(proofPath));
+            }
+            catch
+            {
+                // A project can contain proofs for other kits or legacy shapes.
+                // Recognition is best-effort over C# sugar entries only.
+            }
+        }
+
+        return templates;
+    }
+
+    public static IReadOnlyList<JsonObject> LoadBindingTemplatesFromProof(string path)
+    {
+        var bytes = File.ReadAllBytes(path);
+        var envelope = LooksLikeJson(bytes)
+            ? JsonNode.Parse(bytes) ?? new JsonObject()
+            : new CborJsonDecoder(bytes).Decode();
+
+        var records = CollectMemberRecords(envelope).ToList();
+        var contractByFunction = ContractCidsByFunction(records);
+        var templates = new List<JsonObject>();
+
+        foreach (var (_, raw) in records)
+        {
+            var record = UnwrapEnvelope(raw);
+            if (record?["kind"]?.GetValue<string>() != "library-sugar-binding-entry")
+                continue;
+            if (record["target_language"]?.GetValue<string>() is { } targetLanguage
+                && !string.Equals(targetLanguage, "csharp", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var bodySource = record["body_source"] as JsonObject;
+            if (bodySource?["ast_template"] is null) continue;
+
+            var functionName = record["source_function_name"]?.GetValue<string>() ?? "";
+            templates.Add(new JsonObject
+            {
+                ["concept_name"] = CloneOrNull(record["concept_name"]),
+                ["library_tag"] = CloneOrNull(record["target_library_tag"]),
+                ["family"] = CloneOrNull(record["family"]),
+                ["ast_template"] = bodySource["ast_template"]!.DeepClone(),
+                ["template_cid"] = CloneOrNull(bodySource["template_cid"]),
+                ["param_names"] = CloneOrNull(bodySource["param_names"]),
+                ["contract_cid"] = CloneOrNull(record["contract_cid"])
+                    ?? (contractByFunction.TryGetValue(functionName, out var cid) ? JsonValue.Create(cid) : null),
+                ["source_function_name"] = functionName,
+            });
+        }
+
+        return templates;
+    }
+
+    private static Dictionary<string, string> ContractCidsByFunction(IEnumerable<(string Cid, JsonNode Record)> records)
+    {
+        var contractByFunction = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (cid, raw) in records)
+        {
+            if (string.IsNullOrWhiteSpace(cid)) continue;
+            var record = UnwrapEnvelope(raw);
+            if (record is null) continue;
+
+            var isContract = record["kind"]?.GetValue<string>() == "contract"
+                || record["header"]?["kind"]?.GetValue<string>() == "contract";
+            if (!isContract) continue;
+
+            var formulaRoot = record["header"] ?? record;
+            foreach (var slot in new[] { "pre", "post", "inv" })
+            {
+                if (formulaRoot?[slot] is { } formula)
+                {
+                    CollectCtorNames(formula, name => contractByFunction.TryAdd(name, cid));
+                }
+            }
+        }
+
+        return contractByFunction;
+    }
+
+    private static IEnumerable<(string Cid, JsonNode Record)> CollectMemberRecords(JsonNode envelope)
+    {
+        if (envelope["members"] is JsonArray membersArray)
+        {
+            foreach (var item in membersArray)
+            {
+                if (item is not null) yield return ("", DecodeEmbeddedMember(item));
+            }
+        }
+        else if (envelope["members"] is JsonObject membersObject)
+        {
+            foreach (var (cid, item) in membersObject)
+            {
+                if (item is not null) yield return (cid, DecodeEmbeddedMember(item));
+            }
+        }
+
+        if (envelope["ir"] is JsonArray ir)
+        {
+            foreach (var item in ir)
+            {
+                if (item is not null) yield return ("", item);
+            }
+        }
+    }
+
+    private static JsonNode DecodeEmbeddedMember(JsonNode node)
+    {
+        if (node is JsonObject or JsonArray) return node;
+        if (node is not JsonValue value || !value.TryGetValue<string>(out var text))
+            return node;
+
+        if (TryParseJson(text, out var parsed)) return parsed;
+        if (text.Length % 2 != 0 || text.Any(c => !Uri.IsHexDigit(c))) return node;
+
+        try
+        {
+            var bytes = new byte[text.Length / 2];
+            for (var i = 0; i < bytes.Length; i++)
+            {
+                bytes[i] = Convert.ToByte(text.Substring(i * 2, 2), 16);
+            }
+
+            var utf8 = Encoding.UTF8.GetString(bytes);
+            return TryParseJson(utf8, out var fromHex) ? fromHex : node;
+        }
+        catch
+        {
+            return node;
+        }
+    }
+
+    private static JsonObject? UnwrapEnvelope(JsonNode? node)
+    {
+        if (node is not JsonObject obj) return null;
+        if (obj["body"] is JsonObject body && (obj["schemaVersion"] is not null || obj["header"] is not null))
+        {
+            return body;
+        }
+
+        return obj;
+    }
+
+    private static void CollectCtorNames(JsonNode node, Action<string> onName)
+    {
+        if (node is not JsonObject obj) return;
+        if (obj["kind"]?.GetValue<string>() == "ctor"
+            && obj["name"]?.GetValue<string>() is { } name)
+        {
+            onName(name);
+        }
+
+        foreach (var key in new[] { "args", "operands" })
+        {
+            if (obj[key] is JsonArray array)
+            {
+                foreach (var item in array)
+                {
+                    if (item is not null) CollectCtorNames(item, onName);
+                }
+            }
+        }
+
+        if (obj["body"] is { } body) CollectCtorNames(body, onName);
+    }
+
+    private static JsonNode? CloneOrNull(JsonNode? node) => node?.DeepClone();
+
+    private static bool LooksLikeJson(byte[] bytes)
+    {
+        foreach (var b in bytes)
+        {
+            if (char.IsWhiteSpace((char)b)) continue;
+            return b is (byte)'{' or (byte)'[';
+        }
+
+        return false;
+    }
+
+    private static bool TryParseJson(string text, out JsonNode parsed)
+    {
+        try
+        {
+            parsed = JsonNode.Parse(text) ?? new JsonObject();
+            return true;
+        }
+        catch
+        {
+            parsed = new JsonObject();
+            return false;
+        }
+    }
+
+    private sealed class CborJsonDecoder
+    {
+        private readonly byte[] _bytes;
+        private int _offset;
+
+        public CborJsonDecoder(byte[] bytes)
+        {
+            _bytes = bytes;
+        }
+
+        public JsonNode Decode() => DecodeValue();
+
+        private JsonNode DecodeValue()
+        {
+            var initial = ReadByte();
+            var major = initial >> 5;
+            var additional = initial & 0x1F;
+            var length = ReadLength(additional);
+
+            return major switch
+            {
+                0 => JsonValue.Create((long)length)!,
+                2 => DecodeBytes(length),
+                3 => JsonValue.Create(Encoding.UTF8.GetString(ReadBytes(length)))!,
+                4 => DecodeArray(length),
+                5 => DecodeMap(length),
+                _ => throw new InvalidDataException($"unsupported CBOR major type {major}"),
+            };
+        }
+
+        private JsonNode DecodeBytes(ulong length)
+        {
+            var bytes = ReadBytes(length);
+            var text = Encoding.UTF8.GetString(bytes);
+            if (TryParseJson(text, out var parsed)) return parsed;
+
+            return JsonValue.Create(Convert.ToHexString(bytes).ToLowerInvariant())!;
+        }
+
+        private JsonArray DecodeArray(ulong length)
+        {
+            var array = new JsonArray();
+            for (ulong i = 0; i < length; i++)
+            {
+                array.Add(DecodeValue());
+            }
+
+            return array;
+        }
+
+        private JsonObject DecodeMap(ulong length)
+        {
+            var obj = new JsonObject();
+            for (ulong i = 0; i < length; i++)
+            {
+                var key = DecodeValue();
+                var keyText = key is JsonValue value && value.TryGetValue<string>(out var text)
+                    ? text
+                    : key.ToJsonString();
+                obj[keyText] = DecodeValue();
+            }
+
+            return obj;
+        }
+
+        private ulong ReadLength(int additional)
+        {
+            return additional switch
+            {
+                < 24 => (ulong)additional,
+                24 => ReadByte(),
+                25 => ReadUInt(2),
+                26 => ReadUInt(4),
+                27 => ReadUInt(8),
+                _ => throw new InvalidDataException("indefinite CBOR lengths are not supported"),
+            };
+        }
+
+        private ulong ReadUInt(int count)
+        {
+            ulong value = 0;
+            for (var i = 0; i < count; i++)
+            {
+                value = (value << 8) | ReadByte();
+            }
+
+            return value;
+        }
+
+        private byte ReadByte()
+        {
+            if (_offset >= _bytes.Length) throw new EndOfStreamException("truncated CBOR");
+            return _bytes[_offset++];
+        }
+
+        private byte[] ReadBytes(ulong count)
+        {
+            if (count > int.MaxValue) throw new InvalidDataException("CBOR item too large");
+            var length = (int)count;
+            if (_offset + length > _bytes.Length) throw new EndOfStreamException("truncated CBOR");
+            var slice = _bytes.AsSpan(_offset, length).ToArray();
+            _offset += length;
+            return slice;
+        }
+    }
+}

--- a/implementations/csharp/Provekit.Lift.Csharp/CsharpRecognizer.cs
+++ b/implementations/csharp/Provekit.Lift.Csharp/CsharpRecognizer.cs
@@ -1,0 +1,174 @@
+using System.Text.Json.Nodes;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Provekit.Lift.Csharp;
+
+public static class CsharpRecognizer
+{
+    public static JsonObject RecognizeText(
+        string source,
+        string fileName,
+        IReadOnlyList<JsonObject> bindingTemplates)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source, path: fileName);
+        var bindingsByCid = BindingTemplatesByCid(bindingTemplates);
+        var tags = new JsonArray();
+
+        foreach (var method in tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>())
+        {
+            if (method.Body is null && method.ExpressionBody is null) continue;
+
+            var astTemplate = CsharpAstTemplates.MethodBodyTemplate(method);
+            var templateCid = CsharpAstTemplates.TemplateCid(astTemplate);
+            if (!bindingsByCid.TryGetValue(templateCid, out var binding)) continue;
+
+            tags.Add(RecognizeTag(fileName, method, templateCid, binding));
+        }
+
+        return new JsonObject { ["tags"] = tags };
+    }
+
+    public static JsonObject RecognizePaths(
+        string projectRoot,
+        IReadOnlyList<string> sourcePaths,
+        IReadOnlyList<JsonObject> bindingTemplates)
+    {
+        if (string.IsNullOrWhiteSpace(projectRoot))
+            throw new ArgumentException("missing `project_root`");
+
+        var root = Path.GetFullPath(projectRoot);
+        var tags = new JsonArray();
+
+        foreach (var requestedPath in sourcePaths)
+        {
+            var fullPath = Path.GetFullPath(Path.IsPathRooted(requestedPath)
+                ? requestedPath
+                : Path.Combine(root, requestedPath));
+            if (!IsInsideRoot(root, fullPath)) continue;
+
+            IEnumerable<string> files;
+            if (Directory.Exists(fullPath))
+            {
+                files = Directory.EnumerateFiles(fullPath, "*.cs", SearchOption.AllDirectories)
+                    .OrderBy(path => path, StringComparer.Ordinal);
+            }
+            else if (File.Exists(fullPath) && string.Equals(Path.GetExtension(fullPath), ".cs", StringComparison.OrdinalIgnoreCase))
+            {
+                files = new[] { fullPath };
+            }
+            else
+            {
+                continue;
+            }
+
+            foreach (var file in files)
+            {
+                string source;
+                try
+                {
+                    source = File.ReadAllText(file);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                var relPath = NormalizePath(Path.GetRelativePath(root, file));
+                var response = RecognizeText(source, relPath, bindingTemplates);
+                foreach (var tag in response["tags"]!.AsArray())
+                {
+                    tags.Add(tag!.DeepClone());
+                }
+            }
+        }
+
+        return new JsonObject { ["tags"] = tags };
+    }
+
+    private static Dictionary<string, JsonObject> BindingTemplatesByCid(IReadOnlyList<JsonObject> bindingTemplates)
+    {
+        var bindingsByCid = new Dictionary<string, JsonObject>(StringComparer.Ordinal);
+        foreach (var binding in bindingTemplates)
+        {
+            var cid = binding["template_cid"]?.GetValue<string>();
+            if (string.IsNullOrWhiteSpace(cid) && binding["ast_template"] is { } astTemplate)
+            {
+                cid = CsharpAstTemplates.TemplateCid(astTemplate);
+            }
+
+            if (!string.IsNullOrWhiteSpace(cid))
+            {
+                bindingsByCid[cid] = binding;
+            }
+        }
+
+        return bindingsByCid;
+    }
+
+    private static JsonObject RecognizeTag(
+        string fileName,
+        MethodDeclarationSyntax method,
+        string templateCid,
+        JsonObject binding)
+    {
+        return new JsonObject
+        {
+            ["file"] = fileName,
+            ["span"] = SpanFor(method),
+            ["function_name"] = method.Identifier.Text,
+            ["concept_name"] = CloneOrNull(binding["concept_name"]),
+            ["library_tag"] = CloneOrNull(binding["library_tag"]),
+            ["family"] = CloneOrNull(binding["family"]),
+            ["template_cid"] = templateCid,
+            ["contract_cid"] = CloneOrNull(binding["contract_cid"]),
+            ["match_tier"] = "exact",
+            ["param_bindings"] = ParamBindings(method),
+        };
+    }
+
+    private static JsonArray ParamBindings(MethodDeclarationSyntax method)
+    {
+        var bindings = new JsonArray();
+        var parameters = method.ParameterList.Parameters;
+        for (var i = 0; i < parameters.Count; i++)
+        {
+            bindings.Add(new JsonObject
+            {
+                ["index"] = i + 1,
+                ["source_text"] = parameters[i].Identifier.Text,
+            });
+        }
+
+        return bindings;
+    }
+
+    private static JsonObject SpanFor(SyntaxNode node)
+    {
+        var span = node.GetLocation().GetLineSpan();
+        return new JsonObject
+        {
+            ["start_line"] = span.StartLinePosition.Line + 1,
+            ["start_col"] = span.StartLinePosition.Character,
+            ["end_line"] = span.EndLinePosition.Line + 1,
+            ["end_col"] = span.EndLinePosition.Character,
+        };
+    }
+
+    private static JsonNode? CloneOrNull(JsonNode? node) => node?.DeepClone();
+
+    private static bool IsInsideRoot(string root, string path)
+    {
+        var normalizedRoot = root.EndsWith(Path.DirectorySeparatorChar)
+            ? root
+            : root + Path.DirectorySeparatorChar;
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return string.Equals(root, path, comparison)
+            || path.StartsWith(normalizedRoot, comparison);
+    }
+
+    private static string NormalizePath(string path) => path.Replace(Path.DirectorySeparatorChar, '/');
+}

--- a/implementations/csharp/Provekit.Lift.Csharp/Provekit.Lift.Csharp.csproj
+++ b/implementations/csharp/Provekit.Lift.Csharp/Provekit.Lift.Csharp.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Provekit.Canonicalizer\Provekit.Canonicalizer.csproj" />
     <ProjectReference Include="..\Provekit.IR\Provekit.IR.csproj" />
   </ItemGroup>
 

--- a/implementations/csharp/Provekit.Lift.Csharp/RpcServer.cs
+++ b/implementations/csharp/Provekit.Lift.Csharp/RpcServer.cs
@@ -60,10 +60,14 @@ public static class RpcServer
             "initialize" => Initialize(id),
             "lift" => LiftRpc(id, request["params"] as JsonObject, lifter),
             "compile" => CompileRpc(id, request["params"] as JsonObject, compiler),
+            "provekit.plugin.recognize" => RecognizeRpc(id, request["params"] as JsonObject),
             "shutdown" => new JsonObject { ["jsonrpc"] = "2.0", ["id"] = id?.DeepClone(), ["result"] = null },
             _ => Error(id, -32601, $"METHOD_NOT_FOUND: {method}"),
         };
     }
+
+    public static JsonObject DispatchForTest(JsonObject request) =>
+        Dispatch(request, new CsharpLifter(), new CsharpCompiler());
 
     private static JsonObject Initialize(JsonNode? id)
     {
@@ -145,6 +149,58 @@ public static class RpcServer
         {
             return Error(id, -32603, ex.Message);
         }
+    }
+
+    private static JsonObject RecognizeRpc(JsonNode? id, JsonObject? paramsObj)
+    {
+        if (paramsObj is null)
+            return Error(id, -32602, "params required");
+
+        var sourcePathsNode = paramsObj["source_paths"];
+        JsonArray? sourcePaths;
+        try { sourcePaths = sourcePathsNode?.AsArray(); } catch { sourcePaths = null; }
+        if (sourcePaths is null || sourcePaths.Count == 0)
+            return Error(id, -32602, "source_paths must be a non-empty array of strings");
+
+        var projectRoot = paramsObj["project_root"]?.GetValue<string>() ?? ".";
+        var paths = sourcePaths.Select(p => p?.GetValue<string>() ?? "")
+            .Where(p => !string.IsNullOrEmpty(p))
+            .ToList();
+        if (paths.Count == 0)
+            return Error(id, -32602, "source_paths must be a non-empty array of strings");
+
+        try
+        {
+            var directTemplates = BindingTemplatesFromParams(paramsObj);
+            var templates = directTemplates.Count > 0
+                ? directTemplates
+                : CsharpBindingTemplateResolver.ResolveFromProject(projectRoot);
+            var result = CsharpRecognizer.RecognizePaths(projectRoot, paths, templates);
+            return new JsonObject
+            {
+                ["jsonrpc"] = "2.0",
+                ["id"] = id?.DeepClone(),
+                ["result"] = result,
+            };
+        }
+        catch (Exception ex)
+        {
+            return Error(id, -32603, ex.Message);
+        }
+    }
+
+    private static IReadOnlyList<JsonObject> BindingTemplatesFromParams(JsonObject paramsObj)
+    {
+        if (paramsObj["binding_templates"] is not JsonArray directTemplates)
+            return Array.Empty<JsonObject>();
+
+        var templates = new List<JsonObject>();
+        foreach (var template in directTemplates)
+        {
+            if (template is JsonObject obj) templates.Add(obj);
+        }
+
+        return templates;
     }
 
     private static JsonObject LiftSuccessResponse(JsonNode? id, LiftResult result)

--- a/implementations/csharp/Provekit.Lift.Linq.Tests/SingleWhereTests.cs
+++ b/implementations/csharp/Provekit.Lift.Linq.Tests/SingleWhereTests.cs
@@ -9,6 +9,7 @@
 // cross-impl conformance signal.
 
 using System.IO;
+using System.Text.Json.Nodes;
 using Provekit.Lift.Linq;
 using Xunit;
 
@@ -37,6 +38,32 @@ public class SingleWhereTests
         var m = mementoes[0];
         Assert.Equal("positives", m.OutBinding);
         Assert.Equal(new[] { "xs" }, m.InputBindings);
+    }
+
+    [Fact]
+    public void LiftedWhereCarriesMaterializableBodySource()
+    {
+        var src = File.ReadAllText("fixtures/single_where.cs");
+        var lifter = new LinqLifter();
+        var mementoes = lifter.Lift(src);
+
+        var m = Assert.Single(mementoes);
+        var bodySourceProperty = typeof(MintedMemento).GetProperty("BodySource");
+        Assert.NotNull(bodySourceProperty);
+
+        var bodySource = bodySourceProperty!.GetValue(m);
+        Assert.NotNull(bodySource);
+        Assert.Equal("positives = xs.Where(x => x > 0)", bodySource!.GetType().GetProperty("BodyText")?.GetValue(bodySource));
+        Assert.StartsWith("blake3-512:", bodySource.GetType().GetProperty("SourceCid")?.GetValue(bodySource) as string);
+        Assert.StartsWith("blake3-512:", bodySource.GetType().GetProperty("TemplateCid")?.GetValue(bodySource) as string);
+
+        var template = Assert.IsType<JsonObject>(bodySource.GetType().GetProperty("AstTemplate")?.GetValue(bodySource));
+        Assert.Equal("linq_invocation", template["kind"]?.GetValue<string>());
+        Assert.Equal("Where", template["method"]?.GetValue<string>());
+        var predicate = Assert.IsType<JsonObject>(template["predicate"]);
+        Assert.Equal("binary", predicate["kind"]?.GetValue<string>());
+        Assert.Equal(">", predicate["op"]?.GetValue<string>());
+        Assert.Equal("param_ref", predicate["left"]!["kind"]?.GetValue<string>());
     }
 
     [Fact]

--- a/implementations/csharp/Provekit.Lift.Linq/LinqBodyTemplates.cs
+++ b/implementations/csharp/Provekit.Lift.Linq/LinqBodyTemplates.cs
@@ -1,0 +1,247 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+using Provekit.Canonicalizer;
+using V = Provekit.Canonicalizer.Value;
+
+namespace Provekit.Lift.Linq;
+
+public sealed record LinqSourceSpan(int StartLine, int StartCol, int EndLine, int EndCol);
+
+public sealed record LinqBodySource(
+    string File,
+    LinqSourceSpan Span,
+    string SourceCid,
+    string BodyText,
+    JsonObject AstTemplate,
+    string TemplateCid,
+    IReadOnlyList<string> ParamNames);
+
+internal static class LinqBodyTemplates
+{
+    public static LinqBodySource BodySource(IInvocationOperation operation, string outBinding)
+    {
+        var syntax = operation.Syntax;
+        var sourceText = syntax.SyntaxTree.GetText();
+        var invocationText = sourceText.ToString(syntax.Span).Trim();
+        var bodyText = string.IsNullOrWhiteSpace(outBinding)
+            ? invocationText
+            : $"{outBinding} = {invocationText}";
+        var paramNames = LambdaParamNames(syntax);
+        var astTemplate = syntax is InvocationExpressionSyntax invocation
+            ? InvocationTemplate(invocation, paramNames)
+            : new JsonObject
+            {
+                ["kind"] = "raw_linq",
+                ["syntax_kind"] = syntax.Kind().ToString(),
+                ["text"] = syntax.NormalizeWhitespace().ToFullString(),
+            };
+
+        return new LinqBodySource(
+            File: syntax.SyntaxTree.FilePath,
+            Span: SpanFor(syntax),
+            SourceCid: Hash.Blake3_512Utf8(bodyText),
+            BodyText: bodyText,
+            AstTemplate: astTemplate,
+            TemplateCid: TemplateCid(astTemplate),
+            ParamNames: paramNames);
+    }
+
+    private static JsonObject InvocationTemplate(InvocationExpressionSyntax invocation, IReadOnlyList<string> paramNames)
+    {
+        var args = new JsonArray();
+        foreach (var argument in invocation.ArgumentList.Arguments)
+        {
+            args.Add(ExpressionTemplate(argument.Expression, paramNames));
+        }
+
+        var method = invocation.Expression is MemberAccessExpressionSyntax member
+            ? member.Name.ToString()
+            : invocation.Expression.ToString();
+        var receiver = invocation.Expression is MemberAccessExpressionSyntax receiverMember
+            ? ExpressionTemplate(receiverMember.Expression, paramNames)
+            : null;
+
+        var template = new JsonObject
+        {
+            ["kind"] = "linq_invocation",
+            ["method"] = method,
+            ["receiver"] = receiver,
+            ["args"] = args,
+        };
+
+        if (FirstLambdaBody(invocation) is { } predicate)
+        {
+            template["predicate"] = ExpressionTemplate(predicate, paramNames);
+        }
+
+        return template;
+    }
+
+    private static JsonObject ExpressionTemplate(ExpressionSyntax expression, IReadOnlyList<string> paramNames)
+    {
+        expression = StripParens(expression);
+        return expression switch
+        {
+            SimpleLambdaExpressionSyntax lambda when lambda.Body is ExpressionSyntax body => ExpressionTemplate(body, paramNames),
+            ParenthesizedLambdaExpressionSyntax lambda when lambda.Body is ExpressionSyntax body => ExpressionTemplate(body, paramNames),
+            IdentifierNameSyntax id => IdentifierTemplate(id.Identifier.Text, paramNames),
+            LiteralExpressionSyntax literal => LiteralTemplate(literal),
+            BinaryExpressionSyntax binary => new JsonObject
+            {
+                ["kind"] = "binary",
+                ["op"] = binary.OperatorToken.Text,
+                ["left"] = ExpressionTemplate(binary.Left, paramNames),
+                ["right"] = ExpressionTemplate(binary.Right, paramNames),
+            },
+            InvocationExpressionSyntax invocation => InvocationTemplate(invocation, paramNames),
+            MemberAccessExpressionSyntax member => new JsonObject
+            {
+                ["kind"] = "member",
+                ["receiver"] = ExpressionTemplate(member.Expression, paramNames),
+                ["member"] = member.Name.ToString(),
+            },
+            _ => new JsonObject
+            {
+                ["kind"] = "raw_expr",
+                ["syntax_kind"] = expression.Kind().ToString(),
+                ["text"] = expression.NormalizeWhitespace().ToFullString(),
+            },
+        };
+    }
+
+    private static JsonObject IdentifierTemplate(string name, IReadOnlyList<string> paramNames)
+    {
+        var index = IndexOf(paramNames, name);
+        if (index >= 0)
+        {
+            return new JsonObject
+            {
+                ["kind"] = "param_ref",
+                ["index"] = index + 1,
+            };
+        }
+
+        return new JsonObject
+        {
+            ["kind"] = "ident",
+            ["name"] = name,
+        };
+    }
+
+    private static int IndexOf(IReadOnlyList<string> items, string value)
+    {
+        for (var i = 0; i < items.Count; i++)
+        {
+            if (items[i] == value) return i;
+        }
+
+        return -1;
+    }
+
+    private static JsonObject LiteralTemplate(LiteralExpressionSyntax literal)
+    {
+        var value = literal.Token.Value;
+        return new JsonObject
+        {
+            ["kind"] = "literal",
+            ["ty"] = value switch
+            {
+                int or long or short or byte => "int",
+                bool => "bool",
+                string => "string",
+                null => "null",
+                _ => literal.Kind().ToString(),
+            },
+            ["value"] = value switch
+            {
+                int i => i,
+                long l => l,
+                short s => s,
+                byte b => b,
+                bool b => b,
+                string s => s,
+                null => null,
+                _ => literal.Token.Text,
+            },
+        };
+    }
+
+    private static IReadOnlyList<string> LambdaParamNames(SyntaxNode syntax)
+    {
+        var names = new List<string>();
+        foreach (var lambda in syntax.DescendantNodesAndSelf().OfType<SimpleLambdaExpressionSyntax>())
+        {
+            names.Add(lambda.Parameter.Identifier.Text);
+        }
+        foreach (var lambda in syntax.DescendantNodesAndSelf().OfType<ParenthesizedLambdaExpressionSyntax>())
+        {
+            names.AddRange(lambda.ParameterList.Parameters.Select(parameter => parameter.Identifier.Text));
+        }
+        return names;
+    }
+
+    private static ExpressionSyntax? FirstLambdaBody(InvocationExpressionSyntax invocation)
+    {
+        foreach (var argument in invocation.ArgumentList.Arguments)
+        {
+            if (argument.Expression is SimpleLambdaExpressionSyntax { Body: ExpressionSyntax body })
+            {
+                return body;
+            }
+            if (argument.Expression is ParenthesizedLambdaExpressionSyntax { Body: ExpressionSyntax body2 })
+            {
+                return body2;
+            }
+        }
+        return null;
+    }
+
+    private static ExpressionSyntax StripParens(ExpressionSyntax expression)
+    {
+        while (expression is ParenthesizedExpressionSyntax paren)
+        {
+            expression = paren.Expression;
+        }
+
+        return expression;
+    }
+
+    private static LinqSourceSpan SpanFor(SyntaxNode node)
+    {
+        var span = node.GetLocation().GetLineSpan();
+        return new LinqSourceSpan(
+            span.StartLinePosition.Line + 1,
+            span.StartLinePosition.Character,
+            span.EndLinePosition.Line + 1,
+            span.EndLinePosition.Character);
+    }
+
+    private static string TemplateCid(JsonNode template) =>
+        Hash.Blake3_512Utf8(Jcs.Encode(ToCanonicalValue(template)));
+
+    private static V ToCanonicalValue(JsonNode node)
+    {
+        using var doc = JsonDocument.Parse(node.ToJsonString());
+        return ElementToValue(doc.RootElement);
+    }
+
+    private static V ElementToValue(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Null => V.Null,
+            JsonValueKind.True => V.True,
+            JsonValueKind.False => V.False,
+            JsonValueKind.String => V.String(element.GetString() ?? ""),
+            JsonValueKind.Number => V.Integer(element.GetInt64()),
+            JsonValueKind.Array => V.Array(element.EnumerateArray().Select(ElementToValue)),
+            JsonValueKind.Object => V.Object(element.EnumerateObject()
+                .Select(property => new KeyValuePair<string, V>(property.Name, ElementToValue(property.Value)))),
+            _ => V.Null,
+        };
+    }
+}

--- a/implementations/csharp/Provekit.Lift.Linq/MethodTranslators.cs
+++ b/implementations/csharp/Provekit.Lift.Linq/MethodTranslators.cs
@@ -332,7 +332,8 @@ internal static class MethodTranslators
             inputBindings.ToList(),
             contract,
             json,
-            span);
+            span,
+            LinqBodyTemplates.BodySource(op, outBinding));
     }
 }
 

--- a/implementations/csharp/Provekit.Lift.Linq/MintedMemento.cs
+++ b/implementations/csharp/Provekit.Lift.Linq/MintedMemento.cs
@@ -22,4 +22,5 @@ public sealed record MintedMemento(
     IReadOnlyList<string> InputBindings,
     ContractDecl Contract,
     string IrJson,
-    string SourceSpan);
+    string SourceSpan,
+    LinqBodySource BodySource);

--- a/implementations/csharp/Provekit.Lift.Linq/Provekit.Lift.Linq.csproj
+++ b/implementations/csharp/Provekit.Lift.Linq/Provekit.Lift.Linq.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Provekit.Canonicalizer\Provekit.Canonicalizer.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- add C# body_source.body_text + ast_template/template_cid emission for C# source contracts
- add LINQ body source/template capture for lifted mementos
- implement provekit.plugin.recognize in the C# kit with kit-owned .proof/template resolution for the RPC path, while retaining direct normalized-template unit coverage
- advertise recognize in the C# source manifest

## Tests
- git diff --check
- dotnet test implementations/csharp/Provekit.Lift.Csharp.Tests/Provekit.Lift.Csharp.Tests.csproj
- dotnet test implementations/csharp/Provekit.Lift.Linq.Tests/Provekit.Lift.Linq.Tests.csproj
- dotnet test implementations/csharp/Provekit.sln

## Follow-up gate command
Add this later to the cross-language gate rather than in this C#-scoped PR:
`dotnet test implementations/csharp/Provekit.Lift.Csharp.Tests/Provekit.Lift.Csharp.Tests.csproj && dotnet test implementations/csharp/Provekit.Lift.Linq.Tests/Provekit.Lift.Linq.Tests.csproj`
