### PR TITLE
Add C++ source recognizer parity

### DIFF
--- a/implementations/cpp/provekit-lift-cpp-source/include/cpp_source_lifter.hpp
+++ b/implementations/cpp/provekit-lift-cpp-source/include/cpp_source_lifter.hpp
@@ -25,6 +25,48 @@ struct LiftResult {
     std::vector<canonicalizer::ValuePtr> opacity_report;
 };
 
+struct SourceSpan {
+    int start_line = 0;
+    int start_col = 0;
+    int end_line = 0;
+    int end_col = 0;
+};
+
+struct BindingTemplate {
+    std::string concept_name;
+    std::string library_tag;
+    canonicalizer::ValuePtr family;
+    canonicalizer::ValuePtr ast_template;
+    std::string template_cid;
+    std::vector<std::string> param_names;
+    std::string contract_cid;
+    std::string source_function_name;
+};
+
+struct ParamBinding {
+    int index = 0;
+    std::string source_text;
+};
+
+struct RecognizeTag {
+    std::string file;
+    SourceSpan span;
+    std::string function_name;
+    std::string concept_name;
+    std::string library_tag;
+    canonicalizer::ValuePtr family;
+    std::string template_cid;
+    std::string contract_cid;
+    std::string match_tier;
+    std::vector<ParamBinding> param_bindings;
+};
+
+struct RecognizeResult {
+    std::vector<RecognizeTag> tags;
+    std::vector<Refusal> refusals;
+    std::vector<canonicalizer::ValuePtr> diagnostics;
+};
+
 struct CompileBodyOptions {
     std::string function_name = "f";
     std::vector<std::string> formals;
@@ -34,6 +76,8 @@ struct CompileBodyOptions {
 canonicalizer::ValuePtr initialize_result();
 LiftResult lift_source(const std::string& path, const std::string& source);
 LiftResult lift_paths(const std::string& workspace_root, const std::vector<std::string>& source_paths);
+RecognizeResult recognize_source(const std::string& path, const std::string& source, const std::vector<BindingTemplate>& bindings);
+RecognizeResult recognize_paths(const std::string& project_root, const std::vector<std::string>& source_paths);
 std::string compile_ir_document(const std::vector<canonicalizer::ValuePtr>& ir);
 std::string compile_body_term(const canonicalizer::ValuePtr& term, const CompileBodyOptions& options = {});
 canonicalizer::ValuePtr post_rhs(const canonicalizer::ValuePtr& contract);
@@ -41,6 +85,7 @@ const canonicalizer::ValuePtr* find_contract(const LiftResult& result, const std
 std::string canonical_bytes(const canonicalizer::ValuePtr& value);
 std::string cid_of_value(const canonicalizer::ValuePtr& value);
 std::string lift_result_json(const LiftResult& result);
+std::string recognize_result_json(const RecognizeResult& result);
 int run_rpc();
 
 }  // namespace provekit::cpp_source

--- a/implementations/cpp/provekit-lift-cpp-source/src/cpp_source_lifter.cpp
+++ b/implementations/cpp/provekit-lift-cpp-source/src/cpp_source_lifter.cpp
@@ -8,11 +8,15 @@
 #include <algorithm>
 #include <cctype>
 #include <cerrno>
+#include <cstdint>
 #include <cstdlib>
+#include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <functional>
 #include <iostream>
 #include <map>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <stdexcept>
@@ -78,6 +82,15 @@ ValuePtr locus_value(const std::string& file, int line, int col) {
     return obj({{"col", intv(col)}, {"file", strv(file)}, {"line", intv(line)}});
 }
 
+ValuePtr span_value(const SourceSpan& span) {
+    return obj({
+        {"end_col", intv(span.end_col)},
+        {"end_line", intv(span.end_line)},
+        {"start_col", intv(span.start_col)},
+        {"start_line", intv(span.start_line)},
+    });
+}
+
 ValuePtr empty_array() { return arr({}); }
 
 ValuePtr get_field(const ValuePtr& value, const std::string& key) {
@@ -126,6 +139,36 @@ SourceLoc cursor_loc(CXCursor cursor) {
     unsigned column = 0;
     clang_getExpansionLocation(location, nullptr, &line, &column, nullptr);
     return {static_cast<int>(line), static_cast<int>(column)};
+}
+
+SourceSpan cursor_span(CXCursor cursor) {
+    CXSourceRange range = clang_getCursorExtent(cursor);
+    CXSourceLocation start = clang_getRangeStart(range);
+    CXSourceLocation end = clang_getRangeEnd(range);
+    unsigned start_line = 0;
+    unsigned start_column = 0;
+    unsigned end_line = 0;
+    unsigned end_column = 0;
+    clang_getExpansionLocation(start, nullptr, &start_line, &start_column, nullptr);
+    clang_getExpansionLocation(end, nullptr, &end_line, &end_column, nullptr);
+    return {
+        static_cast<int>(start_line),
+        start_column > 0 ? static_cast<int>(start_column - 1) : 0,
+        static_cast<int>(end_line),
+        static_cast<int>(end_column),
+    };
+}
+
+std::optional<std::pair<unsigned, unsigned>> cursor_offsets(CXCursor cursor) {
+    CXSourceRange range = clang_getCursorExtent(cursor);
+    CXSourceLocation start = clang_getRangeStart(range);
+    CXSourceLocation end = clang_getRangeEnd(range);
+    unsigned start_offset = 0;
+    unsigned end_offset = 0;
+    clang_getExpansionLocation(start, nullptr, nullptr, nullptr, &start_offset);
+    clang_getExpansionLocation(end, nullptr, nullptr, nullptr, &end_offset);
+    if (end_offset < start_offset) return std::nullopt;
+    return std::make_pair(start_offset, end_offset);
 }
 
 bool from_main_file(CXCursor cursor) {
@@ -184,6 +227,14 @@ std::string normalize_source_text(std::string text) {
         }
     }
     return out;
+}
+
+std::string trim_ws(const std::string& text) {
+    size_t start = 0;
+    while (start < text.size() && std::isspace(static_cast<unsigned char>(text[start]))) ++start;
+    size_t end = text.size();
+    while (end > start && std::isspace(static_cast<unsigned char>(text[end - 1]))) --end;
+    return text.substr(start, end - start);
 }
 
 std::string qualified_name(CXCursor cursor) {
@@ -936,12 +987,93 @@ void collect_known(CXCursor root, CollectContext& ctx) {
         &ctx);
 }
 
-ValuePtr function_contract(CXCursor fn, LiftContext& ctx, ValuePtr body_term, ValuePtr post_term, const std::vector<std::string>& formals, const std::vector<ValuePtr>& formal_sorts, ValuePtr return_sort) {
+ValuePtr template_with_param_refs(const ValuePtr& value, const std::map<std::string, int>& param_index) {
+    if (!value) return nullv();
+    switch (value->kind()) {
+        case ValueKind::Null:
+            return nullv();
+        case ValueKind::Bool:
+            return boolv(value->as_bool());
+        case ValueKind::Integer:
+            return intv(value->as_int());
+        case ValueKind::String:
+            return strv(value->as_string());
+        case ValueKind::Array: {
+            std::vector<ValuePtr> items;
+            for (const auto& item : value->as_array()) items.push_back(template_with_param_refs(item, param_index));
+            return arr(items);
+        }
+        case ValueKind::Object: {
+            std::string kind = get_string(get_field(value, "kind"));
+            if (kind == "var") {
+                std::string name = get_string(get_field(value, "name"));
+                auto it = param_index.find(name);
+                if (it != param_index.end()) {
+                    return obj({{"index", intv(it->second)}, {"kind", strv("param_ref")}});
+                }
+            }
+            std::vector<std::pair<std::string, ValuePtr>> fields;
+            for (const auto& [key, child] : value->as_object()) {
+                fields.push_back({key, template_with_param_refs(child, param_index)});
+            }
+            return obj(fields);
+        }
+    }
+    return nullv();
+}
+
+ValuePtr ast_template_for_body(const ValuePtr& body_term, const std::vector<std::string>& formals) {
+    std::map<std::string, int> param_index;
+    for (size_t i = 0; i < formals.size(); ++i) {
+        param_index.emplace(formals[i], static_cast<int>(i + 1));
+    }
+    return template_with_param_refs(body_term, param_index);
+}
+
+std::string body_text_from_compound(CXCursor body, const std::string& source) {
+    auto offsets = cursor_offsets(body);
+    if (!offsets) return trim_ws(cursor_source(body));
+    size_t start = offsets->first;
+    size_t end = offsets->second;
+    if (start > source.size()) return "";
+    if (end > source.size()) end = source.size();
+    if (end < start) return "";
+    std::string extent = source.substr(start, end - start);
+    size_t open = extent.find('{');
+    size_t close = extent.rfind('}');
+    if (open != std::string::npos && close != std::string::npos && close > open) {
+        return trim_ws(extent.substr(open + 1, close - open - 1));
+    }
+    return trim_ws(extent);
+}
+
+ValuePtr body_source_value(CXCursor body,
+                           const std::string& path,
+                           const std::string& source,
+                           const ValuePtr& body_term,
+                           const std::vector<std::string>& formals) {
+    ValuePtr ast_template = ast_template_for_body(body_term, formals);
+    std::string body_text = body_text_from_compound(body, source);
+    std::vector<ValuePtr> param_names;
+    for (const auto& formal : formals) param_names.push_back(strv(formal));
+    return obj({
+        {"ast_template", ast_template},
+        {"body_text", strv(body_text)},
+        {"file", strv(path)},
+        {"param_names", arr(param_names)},
+        {"source_cid", strv(canonicalizer::compute_cid(body_text))},
+        {"span", span_value(cursor_span(body))},
+        {"template_cid", strv(cid_of_value(ast_template))},
+    });
+}
+
+ValuePtr function_contract(CXCursor fn, LiftContext& ctx, ValuePtr body_term, ValuePtr post_term, ValuePtr body_source, const std::vector<std::string>& formals, const std::vector<ValuePtr>& formal_sorts, ValuePtr return_sort) {
     SourceLoc loc = cursor_loc(fn);
     std::string body_cid = cid_of_value(body_term);
     return obj({
         {"autoMintedMementos", empty_array()},
         {"bodyCid", strv(body_cid)},
+        {"body_source", std::move(body_source)},
         {"effects", arr(ctx.effects.values())},
         {"fnName", strv(ctx.function_name)},
         {"formalSorts", arr(formal_sorts)},
@@ -1002,7 +1134,7 @@ bool unsupported_function_shape(CXCursor fn, std::string& reason) {
     return false;
 }
 
-void lift_function(CXCursor fn, const CollectContext& collected, const std::string& path, std::vector<ValuePtr>& declarations, std::vector<ValuePtr>& body_terms, std::vector<Refusal>& refusals) {
+void lift_function(CXCursor fn, const CollectContext& collected, const std::string& path, const std::string& source, std::vector<ValuePtr>& declarations, std::vector<ValuePtr>& body_terms, std::vector<Refusal>& refusals) {
     std::string fn_name = stable_function_name(fn);
     std::string shape_reason;
     if (unsupported_function_shape(fn, shape_reason)) {
@@ -1054,7 +1186,8 @@ void lift_function(CXCursor fn, const CollectContext& collected, const std::stri
             return;
         }
         ValuePtr post = lifted.has_return ? lifted.return_term : unit_const();
-        declarations.push_back(function_contract(fn, ctx, lifted.term, post, formals, formal_sorts, prim_sort(sort_name_for_type(ret))));
+        ValuePtr body_source = body_source_value(body, path, source, lifted.term, formals);
+        declarations.push_back(function_contract(fn, ctx, lifted.term, post, body_source, formals, formal_sorts, prim_sort(sort_name_for_type(ret))));
         body_terms.push_back(lifted.term);
     } catch (const Unsupported& u) {
         refusals.push_back({u.kind, fn_name, u.line, u.what()});
@@ -1066,6 +1199,7 @@ void lift_function(CXCursor fn, const CollectContext& collected, const std::stri
 struct LiftVisitContext {
     const CollectContext* collected = nullptr;
     std::string path;
+    std::string source;
     std::vector<ValuePtr>* declarations = nullptr;
     std::vector<ValuePtr>* body_terms = nullptr;
     std::vector<Refusal>* refusals = nullptr;
@@ -1087,7 +1221,7 @@ void lift_translation_unit(CXCursor root, LiftVisitContext& ctx) {
                 return CXChildVisit_Continue;
             }
             if (is_function_cursor(kind) && clang_isCursorDefinition(cursor)) {
-                lift_function(cursor, *ctx->collected, ctx->path, *ctx->declarations, *ctx->body_terms, *ctx->refusals);
+                lift_function(cursor, *ctx->collected, ctx->path, ctx->source, *ctx->declarations, *ctx->body_terms, *ctx->refusals);
                 return CXChildVisit_Continue;
             }
             return CXChildVisit_Recurse;
@@ -1334,6 +1468,7 @@ LiftResult lift_source(const std::string& path, const std::string& source) {
     LiftVisitContext ctx;
     ctx.collected = &collected;
     ctx.path = path;
+    ctx.source = source;
     ctx.declarations = &function_decls;
     ctx.body_terms = &body_terms;
     ctx.refusals = &result.refusals;
@@ -1611,7 +1746,356 @@ std::vector<std::string> source_paths_from_params(const ValuePtr& params) {
     return paths;
 }
 
+std::vector<std::string> string_array_field(const ValuePtr& value, const std::string& key) {
+    std::vector<std::string> out;
+    auto node = get_field(value, key);
+    if (!node || node->kind() != ValueKind::Array) return out;
+    for (const auto& item : node->as_array()) out.push_back(get_string(item));
+    return out;
+}
+
+SourceSpan span_from_value(const ValuePtr& value) {
+    if (!value || value->kind() != ValueKind::Object) return {};
+    return {
+        static_cast<int>(get_field(value, "start_line") && get_field(value, "start_line")->kind() == ValueKind::Integer ? get_field(value, "start_line")->as_int() : 0),
+        static_cast<int>(get_field(value, "start_col") && get_field(value, "start_col")->kind() == ValueKind::Integer ? get_field(value, "start_col")->as_int() : 0),
+        static_cast<int>(get_field(value, "end_line") && get_field(value, "end_line")->kind() == ValueKind::Integer ? get_field(value, "end_line")->as_int() : 0),
+        static_cast<int>(get_field(value, "end_col") && get_field(value, "end_col")->kind() == ValueKind::Integer ? get_field(value, "end_col")->as_int() : 0),
+    };
+}
+
+ValuePtr unwrap_envelope_value(const ValuePtr& value) {
+    if (!value || value->kind() != ValueKind::Object) return value;
+    ValuePtr body = get_field(value, "body");
+    if (body && (get_field(value, "schemaVersion") || get_field(value, "header") || get_field(value, "envelope"))) {
+        return body;
+    }
+    return value;
+}
+
+void collect_templates_from_record(const ValuePtr& raw, std::vector<BindingTemplate>& out) {
+    ValuePtr record = unwrap_envelope_value(raw);
+    if (!record || record->kind() != ValueKind::Object) return;
+    if (get_string(get_field(record, "kind")) != "library-sugar-binding-entry") return;
+    std::string target_language = get_string(get_field(record, "target_language"));
+    if (!target_language.empty() && target_language != "cpp" && target_language != "cpp-source") return;
+
+    ValuePtr body_source = get_field(record, "body_source");
+    if (!body_source || body_source->kind() != ValueKind::Object) return;
+    ValuePtr ast_template = get_field(body_source, "ast_template");
+    if (!ast_template) ast_template = get_field(body_source, "tree");
+    if (!ast_template) return;
+
+    BindingTemplate binding;
+    binding.concept_name = get_string(get_field(record, "concept_name"));
+    binding.library_tag = get_string(get_field(record, "target_library_tag"), get_string(get_field(record, "library_tag")));
+    binding.family = get_field(record, "family") ? get_field(record, "family") : nullv();
+    binding.ast_template = ast_template;
+    binding.template_cid = get_string(get_field(body_source, "template_cid"));
+    if (binding.template_cid.empty()) binding.template_cid = cid_of_value(ast_template);
+    binding.param_names = string_array_field(body_source, "param_names");
+    if (binding.param_names.empty()) binding.param_names = string_array_field(record, "param_names");
+    binding.contract_cid = get_string(get_field(record, "contract_cid"));
+    binding.source_function_name = get_string(get_field(record, "source_function_name"));
+    if (!binding.template_cid.empty()) out.push_back(std::move(binding));
+}
+
+void collect_templates_from_value(const ValuePtr& root, std::vector<BindingTemplate>& out) {
+    if (!root) return;
+    collect_templates_from_record(root, out);
+    ValuePtr members = get_field(root, "members");
+    if (members && members->kind() == ValueKind::Array) {
+        for (const auto& item : members->as_array()) collect_templates_from_record(item, out);
+    } else if (members && members->kind() == ValueKind::Object) {
+        for (const auto& [_, item] : members->as_object()) collect_templates_from_record(item, out);
+    }
+    ValuePtr ir = get_field(root, "ir");
+    if (ir && ir->kind() == ValueKind::Array) {
+        for (const auto& item : ir->as_array()) collect_templates_from_record(item, out);
+    }
+}
+
+struct CborNode {
+    enum class Kind { Uint, Tstr, Bstr, Array, Map } kind = Kind::Uint;
+    uint64_t uint_value = 0;
+    std::string text;
+    std::vector<uint8_t> bytes;
+    std::vector<CborNode> array;
+    std::map<std::string, CborNode> map;
+};
+
+class CborReader {
+   public:
+    explicit CborReader(const std::string& bytes)
+        : data_(reinterpret_cast<const uint8_t*>(bytes.data())), size_(bytes.size()) {}
+
+    CborNode read() { return read_value(); }
+
+   private:
+    void read_head(uint8_t& major, uint64_t& arg) {
+        if (pos_ >= size_) throw std::runtime_error("CBOR decode: unexpected EOF");
+        uint8_t first = data_[pos_++];
+        major = first >> 5;
+        uint8_t info = first & 0x1f;
+        if (info < 24) {
+            arg = info;
+        } else if (info == 24) {
+            if (pos_ + 1 > size_) throw std::runtime_error("CBOR decode: truncated u8");
+            arg = data_[pos_++];
+        } else if (info == 25) {
+            if (pos_ + 2 > size_) throw std::runtime_error("CBOR decode: truncated u16");
+            arg = (uint64_t(data_[pos_]) << 8) | uint64_t(data_[pos_ + 1]);
+            pos_ += 2;
+        } else if (info == 26) {
+            if (pos_ + 4 > size_) throw std::runtime_error("CBOR decode: truncated u32");
+            arg = (uint64_t(data_[pos_]) << 24) | (uint64_t(data_[pos_ + 1]) << 16) |
+                  (uint64_t(data_[pos_ + 2]) << 8) | uint64_t(data_[pos_ + 3]);
+            pos_ += 4;
+        } else if (info == 27) {
+            if (pos_ + 8 > size_) throw std::runtime_error("CBOR decode: truncated u64");
+            arg = 0;
+            for (int i = 0; i < 8; ++i) arg = (arg << 8) | uint64_t(data_[pos_ + i]);
+            pos_ += 8;
+        } else {
+            throw std::runtime_error("CBOR decode: indefinite-length item not supported");
+        }
+    }
+
+    CborNode read_value() {
+        uint8_t major = 0;
+        uint64_t arg = 0;
+        read_head(major, arg);
+        CborNode node;
+        if (major == 0) {
+            node.kind = CborNode::Kind::Uint;
+            node.uint_value = arg;
+            return node;
+        }
+        if (major == 2 || major == 3) {
+            if (pos_ + arg > size_) throw std::runtime_error("CBOR decode: byte/text string exceeds remaining");
+            if (major == 2) {
+                node.kind = CborNode::Kind::Bstr;
+                node.bytes.assign(data_ + pos_, data_ + pos_ + arg);
+            } else {
+                node.kind = CborNode::Kind::Tstr;
+                node.text.assign(reinterpret_cast<const char*>(data_ + pos_), static_cast<size_t>(arg));
+            }
+            pos_ += static_cast<size_t>(arg);
+            return node;
+        }
+        if (major == 4) {
+            node.kind = CborNode::Kind::Array;
+            for (uint64_t i = 0; i < arg; ++i) node.array.push_back(read_value());
+            return node;
+        }
+        if (major == 5) {
+            node.kind = CborNode::Kind::Map;
+            for (uint64_t i = 0; i < arg; ++i) {
+                CborNode key = read_value();
+                if (key.kind != CborNode::Kind::Tstr) throw std::runtime_error("CBOR decode: map key is not text");
+                node.map.emplace(key.text, read_value());
+            }
+            return node;
+        }
+        throw std::runtime_error("CBOR decode: unsupported major type " + std::to_string(major));
+    }
+
+    const uint8_t* data_;
+    size_t size_ = 0;
+    size_t pos_ = 0;
+};
+
+void collect_templates_from_member_bytes(const std::vector<uint8_t>& bytes, std::vector<BindingTemplate>& out) {
+    std::string text(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+    collect_templates_from_value(JsonParser(text).parse(), out);
+}
+
+void collect_templates_from_cbor_catalog(const std::string& bytes, std::vector<BindingTemplate>& out) {
+    CborNode root = CborReader(bytes).read();
+    if (root.kind != CborNode::Kind::Map) return;
+    auto it = root.map.find("members");
+    if (it == root.map.end()) return;
+    const CborNode& members = it->second;
+    if (members.kind == CborNode::Kind::Map) {
+        for (const auto& [_, member] : members.map) {
+            if (member.kind == CborNode::Kind::Bstr) collect_templates_from_member_bytes(member.bytes, out);
+        }
+    } else if (members.kind == CborNode::Kind::Array) {
+        for (const auto& member : members.array) {
+            if (member.kind == CborNode::Kind::Bstr) collect_templates_from_member_bytes(member.bytes, out);
+        }
+    }
+}
+
+std::string read_binary_file(const std::filesystem::path& path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) throw std::runtime_error("cannot open " + path.string());
+    std::ostringstream buf;
+    buf << in.rdbuf();
+    return buf.str();
+}
+
+void append_proofs_in_dir(const std::filesystem::path& dir, bool recursive, std::vector<std::filesystem::path>& out) {
+    std::error_code ec;
+    if (!std::filesystem::exists(dir, ec) || !std::filesystem::is_directory(dir, ec)) return;
+    if (recursive) {
+        for (const auto& entry : std::filesystem::recursive_directory_iterator(dir, ec)) {
+            if (ec) break;
+            if (entry.is_regular_file(ec) && entry.path().extension() == ".proof") out.push_back(entry.path());
+        }
+    } else {
+        for (const auto& entry : std::filesystem::directory_iterator(dir, ec)) {
+            if (ec) break;
+            if (entry.is_regular_file(ec) && entry.path().extension() == ".proof") out.push_back(entry.path());
+        }
+    }
+}
+
+std::vector<std::filesystem::path> enumerate_recognizer_proofs(const std::string& project_root) {
+    std::vector<std::filesystem::path> out;
+    std::filesystem::path root(project_root.empty() ? "." : project_root);
+    append_proofs_in_dir(root, false, out);
+    append_proofs_in_dir(root / ".provekit", true, out);
+    std::error_code ec;
+    if (std::filesystem::exists(root, ec) && std::filesystem::is_directory(root, ec)) {
+        for (const auto& entry : std::filesystem::directory_iterator(root, ec)) {
+            if (ec) break;
+            if (entry.is_directory(ec) && entry.path().filename() != ".git" && entry.path().filename() != ".provekit") {
+                append_proofs_in_dir(entry.path(), false, out);
+            }
+        }
+    }
+    return out;
+}
+
+std::vector<BindingTemplate> load_binding_templates_from_project(const std::string& project_root, std::vector<ValuePtr>& diagnostics) {
+    std::vector<BindingTemplate> bindings;
+    for (const auto& proof_path : enumerate_recognizer_proofs(project_root)) {
+        try {
+            std::string bytes = read_binary_file(proof_path);
+            size_t first = bytes.find_first_not_of(" \t\r\n");
+            if (first != std::string::npos && (bytes[first] == '{' || bytes[first] == '[')) {
+                collect_templates_from_value(JsonParser(bytes).parse(), bindings);
+            } else {
+                collect_templates_from_cbor_catalog(bytes, bindings);
+            }
+        } catch (const std::exception& ex) {
+            diagnostics.push_back(obj({
+                {"message", strv("recognize proof load skipped " + proof_path.string() + ": " + ex.what())},
+                {"severity", strv("warning")},
+            }));
+        }
+    }
+    return bindings;
+}
+
+ValuePtr family_or_null(const ValuePtr& family) { return family ? family : nullv(); }
+
+ValuePtr recognize_tag_value(const RecognizeTag& tag) {
+    std::vector<ValuePtr> param_bindings;
+    for (const auto& binding : tag.param_bindings) {
+        param_bindings.push_back(obj({{"index", intv(binding.index)}, {"source_text", strv(binding.source_text)}}));
+    }
+    return obj({
+        {"concept_name", strv(tag.concept_name)},
+        {"contract_cid", tag.contract_cid.empty() ? nullv() : strv(tag.contract_cid)},
+        {"family", family_or_null(tag.family)},
+        {"file", strv(tag.file)},
+        {"function_name", strv(tag.function_name)},
+        {"library_tag", strv(tag.library_tag)},
+        {"match_tier", strv(tag.match_tier)},
+        {"param_bindings", arr(param_bindings)},
+        {"span", span_value(tag.span)},
+        {"template_cid", strv(tag.template_cid)},
+    });
+}
+
+ValuePtr recognize_result_value(const RecognizeResult& result) {
+    std::vector<ValuePtr> tags;
+    for (const auto& tag : result.tags) tags.push_back(recognize_tag_value(tag));
+    std::vector<ValuePtr> refusals;
+    for (const auto& r : result.refusals) {
+        std::vector<std::pair<std::string, ValuePtr>> fields{{"kind", strv(r.kind)}, {"reason", strv(r.reason)}};
+        if (!r.function.empty()) fields.push_back({"function", strv(r.function)});
+        if (r.line > 0) fields.push_back({"line", intv(r.line)});
+        refusals.push_back(obj(fields));
+    }
+    return obj({{"diagnostics", arr(result.diagnostics)}, {"refusals", arr(refusals)}, {"tags", arr(tags)}});
+}
+
 }  // namespace
+
+std::string recognize_result_json(const RecognizeResult& result) {
+    return canonical_bytes(recognize_result_value(result));
+}
+
+RecognizeResult recognize_source(const std::string& path, const std::string& source, const std::vector<BindingTemplate>& bindings) {
+    RecognizeResult result;
+    std::map<std::string, BindingTemplate> bindings_by_cid;
+    for (const auto& binding : bindings) {
+        if (!binding.template_cid.empty()) bindings_by_cid[binding.template_cid] = binding;
+    }
+
+    LiftResult lifted = lift_source(path, source);
+    result.diagnostics.insert(result.diagnostics.end(), lifted.diagnostics.begin(), lifted.diagnostics.end());
+    result.refusals.insert(result.refusals.end(), lifted.refusals.begin(), lifted.refusals.end());
+
+    for (const auto& decl : lifted.declarations) {
+        if (get_string(get_field(decl, "kind")) != "function-contract") continue;
+        std::string function_name = get_string(get_field(decl, "fnName"));
+        if (function_name.find("<source-unit:") != std::string::npos) continue;
+        ValuePtr body_source = get_field(decl, "body_source");
+        if (!body_source) continue;
+        std::string template_cid = get_string(get_field(body_source, "template_cid"));
+        auto binding_it = bindings_by_cid.find(template_cid);
+        if (binding_it == bindings_by_cid.end()) continue;
+        const BindingTemplate& binding = binding_it->second;
+
+        std::vector<ParamBinding> param_bindings;
+        std::vector<std::string> param_names = string_array_field(body_source, "param_names");
+        for (size_t i = 0; i < param_names.size(); ++i) {
+            param_bindings.push_back({static_cast<int>(i + 1), param_names[i]});
+        }
+
+        result.tags.push_back({
+            path,
+            span_from_value(get_field(body_source, "span")),
+            function_name,
+            binding.concept_name,
+            binding.library_tag,
+            family_or_null(binding.family),
+            template_cid,
+            binding.contract_cid,
+            "exact",
+            param_bindings,
+        });
+    }
+    return result;
+}
+
+RecognizeResult recognize_paths(const std::string& project_root, const std::vector<std::string>& source_paths) {
+    RecognizeResult aggregate;
+    std::vector<ValuePtr> diagnostics;
+    std::vector<BindingTemplate> bindings = load_binding_templates_from_project(project_root, diagnostics);
+    aggregate.diagnostics.insert(aggregate.diagnostics.end(), diagnostics.begin(), diagnostics.end());
+
+    for (const auto& rel : source_paths) {
+        std::filesystem::path path(rel);
+        if (!path.is_absolute()) path = std::filesystem::path(project_root.empty() ? "." : project_root) / rel;
+        std::ifstream in(path, std::ios::binary);
+        if (!in) {
+            aggregate.diagnostics.push_back(obj({{"message", strv("recognize source path not found: " + path.string())}, {"severity", strv("warning")}}));
+            continue;
+        }
+        std::ostringstream buf;
+        buf << in.rdbuf();
+        RecognizeResult one = recognize_source(rel, buf.str(), bindings);
+        aggregate.tags.insert(aggregate.tags.end(), one.tags.begin(), one.tags.end());
+        aggregate.refusals.insert(aggregate.refusals.end(), one.refusals.begin(), one.refusals.end());
+        aggregate.diagnostics.insert(aggregate.diagnostics.end(), one.diagnostics.begin(), one.diagnostics.end());
+    }
+    return aggregate;
+}
 
 int run_rpc() {
     std::string line;
@@ -1647,6 +2131,17 @@ int run_rpc() {
                 }
                 std::string body = compile_ir_document(ir->as_array());
                 std::cout << response(id, obj({{"body", strv(body)}, {"kind", strv("compiled-formula")}})) << "\n";
+            } else if (method == "provekit.plugin.recognize" || method == "recognize") {
+                ValuePtr params = get_field(req, "params");
+                std::vector<std::string> paths = source_paths_from_params(params);
+                if (paths.empty()) {
+                    std::cout << error_response(id, -32602, "source_paths must be a non-empty array of strings") << "\n";
+                    continue;
+                }
+                std::string root = get_string(get_field(params, "project_root"));
+                if (root.empty()) root = get_string(get_field(params, "workspace_root"), ".");
+                RecognizeResult recognized = recognize_paths(root, paths);
+                std::cout << response(id, recognize_result_value(recognized)) << "\n";
             } else if (method == "shutdown") {
                 std::cout << response(id, nullptr) << "\n";
                 return 0;

--- a/implementations/cpp/provekit-lift-cpp-source/tests/test_cpp_source_lifter.cpp
+++ b/implementations/cpp/provekit-lift-cpp-source/tests/test_cpp_source_lifter.cpp
@@ -3,6 +3,8 @@
 #include "provekit/canonicalizer/jcs.hpp"
 
 #include <cstdlib>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -10,12 +12,16 @@
 namespace {
 
 using provekit::cpp_source::CompileBodyOptions;
+using provekit::cpp_source::BindingTemplate;
 using provekit::cpp_source::LiftResult;
 using provekit::cpp_source::canonical_bytes;
+using provekit::cpp_source::cid_of_value;
 using provekit::cpp_source::compile_body_term;
 using provekit::cpp_source::find_contract;
 using provekit::cpp_source::lift_source;
 using provekit::cpp_source::post_rhs;
+using provekit::cpp_source::recognize_paths;
+using provekit::cpp_source::recognize_source;
 
 void require(bool ok, const std::string& message) {
     if (!ok) {
@@ -40,6 +46,12 @@ provekit::canonicalizer::ValuePtr field(const provekit::canonicalizer::ValuePtr&
     return nullptr;
 }
 
+std::string string_field(const provekit::canonicalizer::ValuePtr& value, const std::string& key) {
+    auto child = field(value, key);
+    if (!child || child->kind() != provekit::canonicalizer::ValueKind::String) return "";
+    return child->as_string();
+}
+
 provekit::canonicalizer::ValuePtr source_unit_body(const LiftResult& result) {
     for (const auto& item : result.declarations) {
         if (!contains(item, "\"cpp:source-unit\"")) continue;
@@ -51,6 +63,53 @@ provekit::canonicalizer::ValuePtr source_unit_body(const LiftResult& result) {
         return args->as_array()[1];
     }
     return nullptr;
+}
+
+BindingTemplate binding_from_contract(const provekit::canonicalizer::ValuePtr& contract,
+                                      std::string concept,
+                                      std::string library_tag,
+                                      std::string contract_cid) {
+    auto body_source = field(contract, "body_source");
+    require(body_source != nullptr, "contract should carry body_source for recognizer binding");
+    auto ast_template = field(body_source, "ast_template");
+    if (!ast_template) ast_template = field(body_source, "tree");
+    require(ast_template != nullptr, "body_source should carry ast_template or tree");
+    BindingTemplate binding;
+    binding.concept_name = std::move(concept);
+    binding.library_tag = std::move(library_tag);
+    binding.family = provekit::canonicalizer::Value::string("concept:family:cpp-test");
+    binding.ast_template = ast_template;
+    binding.template_cid = string_field(body_source, "template_cid");
+    binding.param_names = {"x", "y"};
+    binding.contract_cid = std::move(contract_cid);
+    binding.source_function_name = string_field(contract, "fnName");
+    return binding;
+}
+
+std::string json_string(const std::string& s) {
+    std::string out = "\"";
+    for (char ch : s) {
+        switch (ch) {
+            case '\\': out += "\\\\"; break;
+            case '"': out += "\\\""; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default: out.push_back(ch); break;
+        }
+    }
+    out.push_back('"');
+    return out;
+}
+
+std::filesystem::path temp_dir(const std::string& label) {
+    for (int i = 0; i < 100; ++i) {
+        auto path = std::filesystem::temp_directory_path() /
+                    (label + "-" + std::to_string(std::rand()) + "-" + std::to_string(i));
+        if (std::filesystem::create_directory(path)) return path;
+    }
+    require(false, "should create temp dir");
+    return {};
 }
 
 void test_lift_simple_add_emits_contract_and_source_unit() {
@@ -71,6 +130,116 @@ void test_lift_simple_add_emits_contract_and_source_unit() {
     require(contains(*contract, "\"bodyCid\":\"blake3-512:"), "contract should carry a body CID");
     require(!contains(*contract, "cpp:unknown"), "IR must not contain cpp:unknown");
     require(!contains(*contract, "cpp:binop"), "IR must not contain cpp:binop");
+}
+
+void test_lifted_contract_carries_body_source_text_and_ast_template() {
+    const std::string source = "int f(int x, int y) { return x + y; }\n";
+    LiftResult result = lift_source("add.cpp", source);
+
+    require(result.refusals.empty(), "body-source fixture should not refuse");
+    const auto contract = find_contract(result, "f");
+    require(contract != nullptr, "function contract for f should be present");
+    auto body_source = field(*contract, "body_source");
+    require(body_source != nullptr, "function contract should carry body_source");
+
+    const std::string body_text = string_field(body_source, "body_text");
+    require(body_text.find("return") != std::string::npos, "body_source.body_text should contain function body text");
+    require(body_text.find("x + y") != std::string::npos, "body_source.body_text should preserve source expression");
+
+    auto ast_template = field(body_source, "ast_template");
+    if (!ast_template) ast_template = field(body_source, "tree");
+    require(ast_template != nullptr, "body_source should carry ast_template or equivalent tree");
+    require(contains(ast_template, "\"param_ref\""), "ast_template should normalize formal parameter references");
+    require(string_field(body_source, "template_cid") == cid_of_value(ast_template),
+            "body_source.template_cid should be the CID of ast_template");
+}
+
+void test_recognize_emits_exact_tag_for_alpha_equivalent_cpp_body() {
+    LiftResult sugar = lift_source("shim.cpp", "int sugar(int x, int y) { return x + y; }\n");
+    require(sugar.refusals.empty(), "sugar fixture should not refuse");
+    const auto sugar_contract = find_contract(sugar, "sugar");
+    require(sugar_contract != nullptr, "sugar contract missing");
+
+    BindingTemplate binding = binding_from_contract(*sugar_contract,
+                                                    "concept:cpp-add",
+                                                    "provekit-shim-cpp-test",
+                                                    "blake3-512:contract");
+    auto recognized = recognize_source("user.cpp",
+                                       "int user(int left, int right) { return left + right; }\n",
+                                       {binding});
+
+    require(recognized.tags.size() == 1, "alpha-equivalent body should emit one exact tag");
+    const auto& tag = recognized.tags[0];
+    require(tag.file == "user.cpp", "recognize tag should carry source file");
+    require(tag.function_name.find("user") != std::string::npos, "recognize tag should carry function name");
+    require(tag.concept_name == "concept:cpp-add", "recognize tag should carry concept");
+    require(tag.library_tag == "provekit-shim-cpp-test", "recognize tag should carry library tag");
+    require(tag.template_cid == binding.template_cid, "recognize tag should carry matched template CID");
+    require(tag.contract_cid == "blake3-512:contract", "recognize tag should carry contract CID");
+    require(tag.match_tier == "exact", "recognize tag should be exact");
+    require(tag.param_bindings.size() == 2, "recognize tag should carry parameter bindings");
+    require(tag.param_bindings[0].source_text == "left", "first parameter binding should use user source name");
+    require(tag.param_bindings[1].source_text == "right", "second parameter binding should use user source name");
+    require(tag.span.start_line == 1 && tag.span.end_line == 1, "recognize tag should carry useful source span");
+}
+
+void test_recognize_does_not_match_different_cpp_body() {
+    LiftResult sugar = lift_source("shim.cpp", "int sugar(int x, int y) { return x + y; }\n");
+    require(sugar.refusals.empty(), "sugar fixture should not refuse");
+    const auto sugar_contract = find_contract(sugar, "sugar");
+    require(sugar_contract != nullptr, "sugar contract missing");
+
+    BindingTemplate binding = binding_from_contract(*sugar_contract,
+                                                    "concept:cpp-add",
+                                                    "provekit-shim-cpp-test",
+                                                    "blake3-512:contract");
+    auto recognized = recognize_source("user.cpp",
+                                       "int user(int left, int right) { return left - right; }\n",
+                                       {binding});
+
+    require(recognized.tags.empty(), "different body should not emit an exact recognize tag");
+}
+
+void test_recognize_paths_resolves_templates_from_cpp_owned_proof_context() {
+    LiftResult sugar = lift_source("shim.cpp", "int sugar(int x, int y) { return x + y; }\n");
+    require(sugar.refusals.empty(), "sugar fixture should not refuse");
+    const auto sugar_contract = find_contract(sugar, "sugar");
+    require(sugar_contract != nullptr, "sugar contract missing");
+    BindingTemplate binding = binding_from_contract(*sugar_contract,
+                                                    "concept:cpp-add",
+                                                    "provekit-shim-cpp-test",
+                                                    "blake3-512:contract");
+
+    auto root = temp_dir("provekit-cpp-recognize");
+    std::filesystem::create_directories(root / "src");
+    {
+        std::ofstream out(root / "src" / "user.cpp");
+        out << "int user(int left, int right) { return left + right; }\n";
+    }
+    {
+        std::ofstream proof(root / "cpp-binding.proof");
+        proof << "{\"members\":[{\"kind\":\"library-sugar-binding-entry\","
+              << "\"target_language\":\"cpp\","
+              << "\"concept_name\":\"concept:cpp-add\","
+              << "\"target_library_tag\":\"provekit-shim-cpp-test\","
+              << "\"family\":\"concept:family:cpp-test\","
+              << "\"source_function_name\":\"sugar\","
+              << "\"contract_cid\":\"blake3-512:contract\","
+              << "\"body_source\":{"
+              << "\"body_text\":" << json_string(string_field(field(*sugar_contract, "body_source"), "body_text")) << ","
+              << "\"ast_template\":" << encoded(binding.ast_template) << ","
+              << "\"template_cid\":" << json_string(binding.template_cid) << ","
+              << "\"param_names\":[\"x\",\"y\"]"
+              << "}}]}";
+    }
+
+    auto recognized = recognize_paths(root.string(), {"src/user.cpp"});
+    std::filesystem::remove_all(root);
+
+    require(recognized.tags.size() == 1,
+            "CLI-facing recognize path should resolve templates inside the C++ kit without binding_templates");
+    require(recognized.tags[0].template_cid == binding.template_cid,
+            "kit-owned proof resolution should feed recognizer template CID");
 }
 
 void test_refuses_unsupported_lambda_without_unknown_ops() {
@@ -190,6 +359,10 @@ void test_initialize_reports_cpp_source_draft() {
 
 int main() {
     test_lift_simple_add_emits_contract_and_source_unit();
+    test_lifted_contract_carries_body_source_text_and_ast_template();
+    test_recognize_emits_exact_tag_for_alpha_equivalent_cpp_body();
+    test_recognize_does_not_match_different_cpp_body();
+    test_recognize_paths_resolves_templates_from_cpp_owned_proof_context();
     test_refuses_unsupported_lambda_without_unknown_ops();
     test_effects_use_canonical_shapes_and_sort_order();
     test_round_trip_body_term_is_byte_identical();


### PR DESCRIPTION
## Summary
- add C++ body_source metadata with body_text, normalized ast_template, source/template CIDs, and spans
- implement C++ source recognizer matching lifted AST templates with alpha-equivalent formal parameters
- make the C++ recognize RPC resolve templates from kit-owned project proof context instead of caller-supplied binding_templates

## Tests
- PK_CPP_ENABLE_CLANG_AST=1 tools/test-cpp-source-lift.sh
- PK_CPP_ENABLE_CLANG_AST=1 tools/build-cpp-source-lift.sh
- RPC smoke: provekit.plugin.recognize without binding_templates returns a normal JSON-RPC result

## Notes
- Did not edit Rust CLI, Makefile, or cross-language gates.
- Follow-on gate command to add later: PK_CPP_ENABLE_CLANG_AST=1 tools/test-cpp-source-lift.sh