### PR TITLE
[codex] Add Java LSP same-language call edges

### DIFF
--- a/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/JavaCallEdgeResolver.java
+++ b/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/JavaCallEdgeResolver.java
@@ -1,0 +1,62 @@
+package com.provekit.lift;
+
+import java.util.*;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.provekit.ir.CallEdgeDecl;
+
+/**
+ * Same-language Java call-edge resolver for the LSP parse path.
+ *
+ * JNI edges are handled by {@link JniResolver}; this resolver handles ordinary
+ * Java method calls where both caller and callee have lifted contracts in the
+ * current compilation unit.
+ */
+public final class JavaCallEdgeResolver {
+    private JavaCallEdgeResolver() {}
+
+    public static List<CallEdgeDecl> resolve(
+            CompilationUnit cu,
+            String path,
+            Map<String, String> contractIndex) {
+        if (contractIndex.isEmpty()) return List.of();
+
+        List<CallEdgeDecl> edges = new ArrayList<>();
+        Set<String> seen = new LinkedHashSet<>();
+
+        for (MethodDeclaration caller : cu.findAll(MethodDeclaration.class)) {
+            if (caller.getBody().isEmpty()) continue;
+
+            String callerSymbol = caller.getNameAsString();
+            String sourceCid = contractIndex.get(callerSymbol);
+            if (sourceCid == null || sourceCid.isBlank()) continue;
+
+            for (MethodCallExpr call : caller.getBody().get().findAll(MethodCallExpr.class)) {
+                String targetSymbol = call.getNameAsString();
+                if (targetSymbol.equals(callerSymbol)) continue;
+
+                String targetCid = contractIndex.get(targetSymbol);
+                if (targetCid == null || targetCid.isBlank()) continue;
+
+                int line = call.getBegin().map(pos -> pos.line).orElse(0);
+                int column = call.getBegin().map(pos -> pos.column).orElse(0);
+                String key = sourceCid + "\u0000" + targetCid + "\u0000" + line + "\u0000" + column;
+                if (!seen.add(key)) continue;
+
+                edges.add(new CallEdgeDecl(
+                    sourceCid,
+                    targetCid,
+                    "java-kit:" + targetSymbol,
+                    path,
+                    line,
+                    column,
+                    "{\"args\":[],\"kind\":\"atomic\",\"name\":\"call-site-obligation\"}"
+                ));
+            }
+        }
+
+        return edges;
+    }
+}

--- a/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/LiftHandler.java
+++ b/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/LiftHandler.java
@@ -45,6 +45,7 @@ public class LiftHandler {
             implications.addAll(productionWalk.implications());
             decls = mergeDeclsBySymbol(decls);
             Map<String, String> contractIndex = buildContractIndex(decls);
+            callEdges.addAll(JavaCallEdgeResolver.resolve(cu, path, contractIndex));
             callEdges.addAll(JniResolver.resolve(cu, path, contractIndex));
         }
 
@@ -142,7 +143,8 @@ public class LiftHandler {
             // the index is built from the current file's declarations.
             Map<String, String> contractIndex = buildContractIndex(decls);
 
-            // Walk for JNI call edges per spec #114 R1/R3.
+            // Walk for same-language and JNI call edges per spec #114 R1/R3.
+            callEdges.addAll(JavaCallEdgeResolver.resolve(cu, path.toString(), contractIndex));
             List<CallEdgeDecl> jniEdges = JniResolver.resolve(
                 cu, path.toString(), contractIndex);
             callEdges.addAll(jniEdges);

--- a/implementations/java/provekit-lift-java-integration-tests/src/test/java/com/provekit/lift/RpcServerParseTest.java
+++ b/implementations/java/provekit-lift-java-integration-tests/src/test/java/com/provekit/lift/RpcServerParseTest.java
@@ -163,6 +163,37 @@ public class RpcServerParseTest {
     }
 
     @Test
+    public void parseEmitsSameLanguageCallEdgeLocus() throws Exception {
+        String source = """
+            import com.provekit.contract.Requires;
+            public class MathService {
+                @Requires("x >= 0")
+                public int addOne(int x) {
+                    return x + 1;
+                }
+                @Requires("x >= 0")
+                public int callAddOne(int x) {
+                    return addOne(x);
+                }
+            }
+            """;
+        String encodedSource = jsonEncodeString(source);
+        String request = "{\"jsonrpc\":\"2.0\",\"id\":41,\"method\":\"parse\",\"params\":{\"path\":\"/tmp/MathService.java\",\"source\":" + encodedSource + "}}";
+
+        String response = invokeHandle(request);
+
+        assertFalse(response.contains("\"error\""), "Same-language call-edge parse must not error: " + response);
+        assertTrue(response.contains("\"symbol\":\"addOne\""), response);
+        assertTrue(response.contains("\"symbol\":\"callAddOne\""), response);
+        assertTrue(response.contains("\"kind\":\"call-edge\""), "Response must include a call-edge: " + response);
+        assertTrue(response.contains("\"sourceContractCid\":\"blake3-512:"), response);
+        assertTrue(response.contains("\"targetContractCid\":\"blake3-512:"), response);
+        assertTrue(response.contains("\"targetSymbol\":\"java-kit:addOne\""), response);
+        assertTrue(response.contains("\"callSiteLocus\":{\"column\":"), response);
+        assertTrue(response.contains("\"file\":\"/tmp/MathService.java\""), response);
+    }
+
+    @Test
     public void initializeReturnsParseCapability() throws Exception {
         String request = "{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"initialize\",\"params\":{}}";
         String response = invokeHandle(request);


### PR DESCRIPTION
## Summary

- Add a Java same-language call-edge resolver for ordinary method calls where caller and callee both have lifted contracts.
- Wire the resolver into both Java LSP parse and workspace lift flows alongside the existing JNI resolver.
- Add a daemon-level parse test proving `callAddOne -> addOne` emits `callSiteLocus`, source/target CIDs, and `targetSymbol: java-kit:addOne`.

## Why

The Java LSP already emitted JNI edges, but ordinary Java-to-Java call sites were invisible to the daemon. That meant verifier failures could not be lifted back to Java call-site loci for same-language contract calls.

## Verification

- Red test first: `mvn -pl provekit-lift-java-integration-tests -am -Dtest=RpcServerParseTest#parseEmitsSameLanguageCallEdgeLocus test -q` failed with `callEdges:[]`.
- `mvn -pl provekit-lift-java-integration-tests -am -Dtest=RpcServerParseTest#parseEmitsSameLanguageCallEdgeLocus test -q`
- `mvn -pl provekit-lift-java-core,provekit-lift-java-integration-tests -am -Dtest=RpcServerParseTest,JniResolverTest test -q`
- `mvn -pl provekit-lift-java-core -am package -DskipTests -q`
- `JAVA_HOME=/usr/local/Cellar/openjdk/25.0.2/libexec/openjdk.jdk/Contents/Home PATH="$PWD/implementations/java/provekit-lift-java-core/target/appassembler/bin:$PATH" cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd --test multi_kit test4_java_kit_dispatch -- --nocapture`
- `git diff --check --cached`

Note: On this host, `/usr/bin/java` cannot locate a runtime unless `JAVA_HOME` is set; Maven itself reports and uses the Homebrew OpenJDK runtime above.