### PR TITLE
[codex] Add C# LSP same-language call edges

### DIFF
--- a/implementations/csharp/Provekit.Lift.Core/CsharpCallEdgeResolver.cs
+++ b/implementations/csharp/Provekit.Lift.Core/CsharpCallEdgeResolver.cs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Provekit.Lift.Core.CsharpCallEdgeResolver: Roslyn-driven same-language
+// call-edge emitter for the C# LSP parse path.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Provekit.IR;
+
+namespace Provekit.Lift.Core;
+
+public static class CsharpCallEdgeResolver
+{
+    /// <summary>
+    /// Walk <paramref name="source"/> for C# method calls where both caller
+    /// and callee have lifted contracts in <paramref name="contractCids"/>.
+    /// </summary>
+    public static IReadOnlyList<CallEdgeDeclaration> WalkCallEdges(
+        string source,
+        string path,
+        IReadOnlyDictionary<string, string> contractCids)
+    {
+        if (contractCids.Count == 0)
+            return Array.Empty<CallEdgeDeclaration>();
+
+        var tree = CSharpSyntaxTree.ParseText(source, path: path);
+        var root = tree.GetRoot();
+        var edges = new List<CallEdgeDeclaration>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var method in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
+        {
+            var callerName = method.Identifier.Text;
+            if (!contractCids.TryGetValue(callerName, out var sourceCid))
+                continue;
+
+            var bodyNode = (SyntaxNode?)method.Body ?? method.ExpressionBody;
+            if (bodyNode is null)
+                continue;
+
+            foreach (var invocation in bodyNode.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            {
+                var calleeName = ExtractCalleeName(invocation.Expression);
+                if (calleeName is null || calleeName == callerName)
+                    continue;
+
+                if (!contractCids.TryGetValue(calleeName, out var targetCid))
+                    continue;
+
+                var lineSpan = invocation.GetLocation().GetLineSpan();
+                var line = lineSpan.StartLinePosition.Line + 1;
+                var column = lineSpan.StartLinePosition.Character + 1;
+                var key = $"{sourceCid}\0{targetCid}\0{line}\0{column}";
+                if (!seen.Add(key))
+                    continue;
+
+                edges.Add(new CallEdgeDeclaration(
+                    SourceContractCid: sourceCid,
+                    TargetContractCid: targetCid,
+                    TargetSymbol: $"csharp-kit:{calleeName}",
+                    CallSiteLocus: new Locus(path, line, column),
+                    EvidenceTerm: $"call-site-obligation({callerName})"));
+            }
+        }
+
+        return edges;
+    }
+
+    private static string? ExtractCalleeName(ExpressionSyntax expression)
+    {
+        return expression switch
+        {
+            IdentifierNameSyntax id => id.Identifier.Text,
+            GenericNameSyntax generic => generic.Identifier.Text,
+            MemberAccessExpressionSyntax member => ExtractMemberName(member.Name),
+            _ => null,
+        };
+    }
+
+    private static string ExtractMemberName(SimpleNameSyntax name)
+    {
+        return name switch
+        {
+            IdentifierNameSyntax id => id.Identifier.Text,
+            GenericNameSyntax generic => generic.Identifier.Text,
+            _ => name.Identifier.Text,
+        };
+    }
+}

--- a/implementations/csharp/Provekit.Lift.Core/SourceLifter.cs
+++ b/implementations/csharp/Provekit.Lift.Core/SourceLifter.cs
@@ -23,14 +23,16 @@ public static class SourceLifter
     /// Compile <paramref name="source"/> to an in-memory assembly, lift
     /// every public class via DataAnnotations, append annotation-scan
     /// declarations, and return both the combined ContractDecl list and
-    /// the P/Invoke call-edge stream per spec #114 R1.
+    /// the same-language/P/Invoke call-edge streams per spec #114 R1.
     /// </summary>
     public static (List<ContractDecl> Declarations, IReadOnlyList<CallEdgeDeclaration> CallEdges)
         LiftSourceWithCallEdges(string source, string path = "Source.cs")
     {
         var decls = LiftSource(source, path);
         var cidIndex = PInvokeResolver.BuildContractIndex(decls);
-        var edges = PInvokeResolver.WalkCallEdges(source, path, cidIndex);
+        var edges = new List<CallEdgeDeclaration>();
+        edges.AddRange(CsharpCallEdgeResolver.WalkCallEdges(source, path, cidIndex));
+        edges.AddRange(PInvokeResolver.WalkCallEdges(source, path, cidIndex));
         return (decls, edges);
     }
 

--- a/implementations/csharp/Provekit.Tests/LspDaemonProtocolTests.cs
+++ b/implementations/csharp/Provekit.Tests/LspDaemonProtocolTests.cs
@@ -204,6 +204,38 @@ public class LspDaemonProtocolTests
     }
 
     [Fact]
+    public async Task Parse_EmitsSameLanguageCallEdgeLocus()
+    {
+        const string source =
+            "public class C {\n" +
+            "  //provekit:contract\n" +
+            "  public static int AddOne(int x) { return x + 1; }\n" +
+            "  //provekit:contract\n" +
+            "  public static int CallAddOne(int x) { return AddOne(x); }\n" +
+            "}\n";
+
+        var responses = await RunLsp(BuildSession(source, "call-edge.cs"));
+        var parseResp = FindById(responses, 2);
+
+        Assert.False(parseResp.TryGetProperty("error", out _),
+            $"parse returned error: {parseResp}");
+        Assert.True(parseResp.TryGetProperty("result", out var result));
+
+        var callEdges = result.GetProperty("callEdges").EnumerateArray().ToList();
+        var edge = Assert.Single(callEdges,
+            e => e.GetProperty("targetSymbol").GetString() == "csharp-kit:AddOne");
+
+        Assert.Equal("call-edge", edge.GetProperty("kind").GetString());
+        Assert.StartsWith("blake3-512:", edge.GetProperty("sourceContractCid").GetString());
+        Assert.StartsWith("blake3-512:", edge.GetProperty("targetContractCid").GetString());
+
+        var locus = edge.GetProperty("callSiteLocus");
+        Assert.Equal("call-edge.cs", locus.GetProperty("file").GetString());
+        Assert.Equal(5, locus.GetProperty("line").GetInt32());
+        Assert.True(locus.GetProperty("column").GetInt32() > 0);
+    }
+
+    [Fact]
     public async Task Parse_WarningsIsArray()
     {
         var responses = await RunLsp(BuildSession());


### PR DESCRIPTION
## Summary

- Add a Roslyn same-language call-edge resolver for C# method calls where caller and callee both have lifted contracts.
- Compose same-language edges with the existing P/Invoke resolver in `SourceLifter.LiftSourceWithCallEdges`.
- Add an LSP daemon test proving `CallAddOne -> AddOne` emits `callSiteLocus`, source/target CIDs, and `targetSymbol: csharp-kit:AddOne`.

## Why

The C# LSP daemon already emitted P/Invoke call edges, but ordinary C# method calls were invisible in the parse response. That prevented linkerd from turning same-language C# contract-call failures into call-site diagnostics.

## Verification

- Red test first: `dotnet build Provekit.Lsp.Plugin/Provekit.Lsp.Plugin.csproj -c Release --nologo && dotnet test Provekit.Tests/Provekit.Tests.csproj --filter FullyQualifiedName~LspDaemonProtocolTests.Parse_EmitsSameLanguageCallEdgeLocus --nologo` failed with `callEdges: []`.
- `dotnet build Provekit.Lsp.Plugin/Provekit.Lsp.Plugin.csproj -c Release --nologo`
- `PROVEKIT_LSP_CSHARP_BIN="$PWD/Provekit.Lsp.Plugin/bin/Release/net10.0/provekit-lsp-csharp" dotnet test Provekit.Tests/Provekit.Tests.csproj --filter FullyQualifiedName~LspDaemonProtocolTests.Parse_EmitsSameLanguageCallEdgeLocus --nologo`
- `PROVEKIT_LSP_CSHARP_BIN="$PWD/Provekit.Lsp.Plugin/bin/Release/net10.0/provekit-lsp-csharp" dotnet test Provekit.Tests/Provekit.Tests.csproj --filter FullyQualifiedName~LspDaemonProtocolTests --nologo`
- `dotnet test Provekit.Lift.PInvoke.Tests/Provekit.Lift.PInvoke.Tests.csproj --nologo`
- `git diff --check --cached`
- Manual linkerd `parseFile` dispatch with a temporary `provekit-lsp-csharp` shim returned an `unprovable-obligation` diagnostic for `targetSymbol: csharp-kit:AddOne` on `/tmp/call-edge.cs`.