### PR TITLE
fix(java): self-resolve recognizer sugar templates

### DIFF
--- a/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/RecognizeHandler.java
+++ b/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/RecognizeHandler.java
@@ -4,14 +4,22 @@ import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.MemberValuePair;
+import com.github.javaparser.ast.expr.NormalAnnotationExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.provekit.ir.Jcs;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
 
 public final class RecognizeHandler {
     private RecognizeHandler() {}
@@ -23,6 +31,7 @@ public final class RecognizeHandler {
         }
         Path projectRoot = Path.of(projectRootText);
         List<String> sourcePaths = stringArray(params.get("source_paths"));
+        List<SourceUnit> sources = sourceUnits(projectRoot, sourcePaths);
         Map<String, Jcs.Obj> bindingsByCid = new LinkedHashMap<>();
         if (params.get("binding_templates") instanceof Jcs.Arr bindingTemplates) {
             for (Jcs.Json value : bindingTemplates.values()) {
@@ -33,32 +42,143 @@ public final class RecognizeHandler {
                 }
             }
         }
+        Set<String> sugarTemplateFiles = new HashSet<>();
+        if (bindingsByCid.isEmpty()) {
+            for (SourceUnit sourceUnit : sources) {
+                for (MethodDeclaration method : sourceUnit.unit().findAll(MethodDeclaration.class)) {
+                    Jcs.Obj binding = bindingFromSugarMethod(method);
+                    if (binding == null) continue;
+                    String cid = binding.stringFieldOrNull("template_cid");
+                    if (cid != null && !cid.isBlank()) {
+                        bindingsByCid.put(cid, binding);
+                        sugarTemplateFiles.add(sourceUnit.relPath());
+                    }
+                }
+            }
+        }
 
         List<Jcs.Json> tags = new ArrayList<>();
-        for (String relPath : sourcePaths) {
-            Path sourcePath = projectRoot.resolve(relPath).normalize();
-            String source;
-            try {
-                source = Files.readString(sourcePath);
-            } catch (IOException e) {
-                System.err.println("recognize: skip unreadable source `" + relPath + "`: " + e.getMessage());
-                continue;
-            }
-            ParseResult<CompilationUnit> result = new JavaParser().parse(source);
-            if (!result.isSuccessful() || result.getResult().isEmpty()) {
-                System.err.println("recognize: skip unparseable source `" + relPath + "`: " + result.getProblems());
-                continue;
-            }
-            for (MethodDeclaration method : result.getResult().get().findAll(MethodDeclaration.class)) {
+        for (SourceUnit sourceUnit : sources) {
+            if (sugarTemplateFiles.contains(sourceUnit.relPath())) continue;
+            for (MethodDeclaration method : sourceUnit.unit().findAll(MethodDeclaration.class)) {
                 if (method.getBody().isEmpty()) continue;
                 JavaAstTemplates.TemplateInfo candidate = JavaAstTemplates.fromMethod(method);
                 Jcs.Obj binding = bindingsByCid.get(candidate.templateCid());
                 if (binding != null) {
-                    tags.add(tagFor(relPath, method, candidate, binding));
+                    tags.add(tagFor(sourceUnit.relPath(), method, candidate, binding));
                 }
             }
         }
         return Jcs.object("tags", Jcs.array(tags));
+    }
+
+    private record SourceUnit(String relPath, CompilationUnit unit) {}
+
+    private static List<SourceUnit> sourceUnits(Path projectRoot, List<String> sourcePaths) {
+        List<SourceUnit> out = new ArrayList<>();
+        for (String relPath : sourcePaths) {
+            for (SourcePath sourcePath : expandSourcePath(projectRoot, relPath)) {
+                String source;
+                try {
+                    source = Files.readString(sourcePath.path());
+                } catch (IOException e) {
+                    System.err.println("recognize: skip unreadable source `" + sourcePath.relPath() + "`: " + e.getMessage());
+                    continue;
+                }
+                ParseResult<CompilationUnit> result = new JavaParser().parse(source);
+                if (!result.isSuccessful() || result.getResult().isEmpty()) {
+                    System.err.println("recognize: skip unparseable source `" + sourcePath.relPath() + "`: " + result.getProblems());
+                    continue;
+                }
+                out.add(new SourceUnit(sourcePath.relPath(), result.getResult().get()));
+            }
+        }
+        return out;
+    }
+
+    private record SourcePath(String relPath, Path path) {}
+
+    private static List<SourcePath> expandSourcePath(Path projectRoot, String relPath) {
+        Path path = projectRoot.resolve(relPath).normalize();
+        if (Files.isDirectory(path)) {
+            try (Stream<Path> paths = Files.walk(path)) {
+                return paths
+                    .filter(Files::isRegularFile)
+                    .filter(p -> p.getFileName().toString().endsWith(".java"))
+                    .sorted()
+                    .map(p -> new SourcePath(relativize(projectRoot, p), p))
+                    .toList();
+            } catch (IOException e) {
+                System.err.println("recognize: skip unreadable source `" + relPath + "`: " + e.getMessage());
+                return List.of();
+            }
+        }
+        if (!Files.isRegularFile(path)) {
+            return List.of();
+        }
+        return List.of(new SourcePath(relPath, path));
+    }
+
+    private static String relativize(Path projectRoot, Path path) {
+        Path absoluteRoot = projectRoot.toAbsolutePath().normalize();
+        Path absolutePath = path.toAbsolutePath().normalize();
+        if (absolutePath.startsWith(absoluteRoot)) {
+            return absoluteRoot.relativize(absolutePath).toString().replace('\\', '/');
+        }
+        return path.toString().replace('\\', '/');
+    }
+
+    private static Jcs.Obj bindingFromSugarMethod(MethodDeclaration method) {
+        if (method.getBody().isEmpty()) return null;
+        for (AnnotationExpr annotation : method.getAnnotations()) {
+            if (!isSugarAnnotation(annotation)) continue;
+            String concept = null;
+            String library = null;
+            String family = null;
+            if (annotation instanceof NormalAnnotationExpr normal) {
+                for (MemberValuePair pair : normal.getPairs()) {
+                    String key = pair.getNameAsString();
+                    String value = stringLiteralValue(pair.getValue());
+                    if (value == null) continue;
+                    switch (key) {
+                        case "concept" -> concept = value;
+                        case "library" -> library = value;
+                        case "family" -> family = value;
+                        default -> {}
+                    }
+                }
+            }
+            if (concept == null || concept.isBlank() || library == null || library.isBlank()) {
+                continue;
+            }
+            JavaAstTemplates.TemplateInfo template = JavaAstTemplates.fromMethod(method);
+            List<Object> fields = new ArrayList<>(List.of(
+                "ast_template", template.astTemplate(),
+                "concept_name", Jcs.string(concept),
+                "library_tag", Jcs.string(library),
+                "param_names", Jcs.array(template.paramNames().stream().map(Jcs::string).toList()),
+                "target_library_tag", Jcs.string(library),
+                "template_cid", Jcs.string(template.templateCid())
+            ));
+            if (family != null && !family.isBlank()) {
+                fields.add("family");
+                fields.add(Jcs.string(family));
+            }
+            return Jcs.object(fields.toArray());
+        }
+        return null;
+    }
+
+    private static boolean isSugarAnnotation(AnnotationExpr annotation) {
+        String name = annotation.getNameAsString();
+        return name.equals("ProveKitSugar") || name.endsWith(".ProveKitSugar");
+    }
+
+    private static String stringLiteralValue(Expression expression) {
+        if (expression instanceof StringLiteralExpr literal) {
+            return literal.getValue();
+        }
+        return null;
     }
 
     private static Jcs.Obj tagFor(

--- a/implementations/java/provekit-lift-java-core/src/test/java/com/provekit/lift/RecognizeHandlerTest.java
+++ b/implementations/java/provekit-lift-java-core/src/test/java/com/provekit/lift/RecognizeHandlerTest.java
@@ -147,6 +147,72 @@ class RecognizeHandlerTest {
         assertTrue(concepts.contains("concept:sql-query"), concepts.toString());
     }
 
+    @Test
+    void recognizeSelfResolvesJavaSugarTemplatesWithoutBindingTemplates() throws Exception {
+        Path root = Files.createTempDirectory("recognize-java-self-templates");
+        String shimRel = "src/main/java/com/example/Shim.java";
+        write(root, shimRel, """
+            package com.example;
+            class Shim {
+              @ProveKitSugar(concept = "concept:http-request", library = "provekit-shim-java-okhttp")
+              Object fetch(String url, Headers headers) {
+                return client.execute(url, headers);
+              }
+            }
+            """);
+        String userRel = "src/main/java/com/example/Handlers.java";
+        write(root, userRel, """
+            package com.example;
+            class Handlers {
+              Object fetchUrl(String u, Headers h) {
+                return client.execute(u, h);
+              }
+            }
+            """);
+
+        Jcs.Obj response = RecognizeHandler.recognizeImpl(paramsWithoutBindings(root, List.of(shimRel, userRel)));
+
+        Jcs.Arr tags = response.arrayField("tags");
+        assertEquals(1, tags.values().size(), Jcs.encode(response));
+        Jcs.Obj tag = tags.objectAt(0);
+        assertEquals(userRel, tag.stringField("file"));
+        assertEquals("fetchUrl", tag.stringField("function_name"));
+        assertEquals("concept:http-request", tag.stringField("concept_name"));
+        assertEquals("provekit-shim-java-okhttp", tag.stringField("library_tag"));
+        assertEquals("exact", tag.stringField("match_tier"));
+        Jcs.Arr paramBindings = tag.arrayField("param_bindings");
+        assertEquals("u", paramBindings.objectAt(0).stringField("source_text"));
+        assertEquals("h", paramBindings.objectAt(1).stringField("source_text"));
+    }
+
+    @Test
+    void recognizeSelfResolvedJavaSugarDoesNotTagNonMatchingSource() throws Exception {
+        Path root = Files.createTempDirectory("recognize-java-self-negative");
+        String shimRel = "src/main/java/com/example/Shim.java";
+        write(root, shimRel, """
+            package com.example;
+            class Shim {
+              @ProveKitSugar(concept = "concept:http-request", library = "provekit-shim-java-okhttp")
+              Object fetch(String url, Headers headers) {
+                return client.execute(url, headers);
+              }
+            }
+            """);
+        String userRel = "src/main/java/com/example/Handlers.java";
+        write(root, userRel, """
+            package com.example;
+            class Handlers {
+              Object fetchUrl(String u, Headers h) {
+                return client.send(u, h);
+              }
+            }
+            """);
+
+        Jcs.Obj response = RecognizeHandler.recognizeImpl(paramsWithoutBindings(root, List.of(shimRel, userRel)));
+
+        assertTrue(response.arrayField("tags").isEmpty(), Jcs.encode(response));
+    }
+
     private static Jcs.Obj binding(
             String conceptName,
             String libraryTag,
@@ -178,6 +244,13 @@ class RecognizeHandlerTest {
             "project_root", Jcs.string(root.toString()),
             "source_paths", Jcs.array(sourcePaths.stream().map(Jcs::string).toList()),
             "binding_templates", Jcs.array(bindings)
+        );
+    }
+
+    private static Jcs.Obj paramsWithoutBindings(Path root, List<String> sourcePaths) {
+        return Jcs.object(
+            "project_root", Jcs.string(root.toString()),
+            "source_paths", Jcs.array(sourcePaths.stream().map(Jcs::string).toList())
         );
     }
 


### PR DESCRIPTION
## Summary
- teach the Java recognizer RPC path to build its own template pool from @ProveKitSugar methods when no binding_templates are supplied
- skip sugar template source files during the recognition pass so shim declarations do not self-tag
- add no-binding-template RPC tests for matching and non-matching Java sources

## Tests
- mvn -pl provekit-lift-java-core -am -Dtest=RecognizeHandlerTest test
- mvn -pl provekit-lift-java-source -am -Dtest=JavaSugarBindingLifterTest test
- mvn -pl provekit-lift-java-core,provekit-lift-java-source -am test
- git diff --check