### PR TITLE
Go recognizer resolves kit-owned sugar templates

### DIFF
--- a/implementations/go/provekit-lift-go/recognize.go
+++ b/implementations/go/provekit-lift-go/recognize.go
@@ -65,6 +65,16 @@ func RecognizeImpl(params RecognizeParams) (RecognizeResponse, error) {
 		}
 		bindingsByCID[binding.TemplateCID] = binding
 	}
+	kitBindings, err := loadBindingTemplatesForProject(params.ProjectRoot)
+	if err != nil {
+		return RecognizeResponse{}, err
+	}
+	for _, binding := range kitBindings {
+		if binding.TemplateCID == "" {
+			continue
+		}
+		bindingsByCID[binding.TemplateCID] = binding
+	}
 
 	tags := []RecognizeTag{}
 	for _, relPath := range params.SourcePaths {

--- a/implementations/go/provekit-lift-go/recognize_proofs.go
+++ b/implementations/go/provekit-lift-go/recognize_proofs.go
@@ -1,0 +1,239 @@
+package liftgo
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/proof_envelope"
+)
+
+type listedGoModule struct {
+	Dir     string          `json:"Dir"`
+	Main    bool            `json:"Main"`
+	Replace *listedGoModule `json:"Replace"`
+}
+
+var dependencyProofName = regexp.MustCompile(`^blake3-512:[0-9a-f]{128}\.proof$`)
+
+func loadBindingTemplatesForProject(projectRoot string) ([]BindingTemplate, error) {
+	paths, err := resolveDependencyProofPaths(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+	bindings := make([]BindingTemplate, 0)
+	for _, path := range paths {
+		proofBindings, err := bindingTemplatesFromProof(path)
+		if err != nil {
+			return nil, err
+		}
+		bindings = append(bindings, proofBindings...)
+	}
+	return bindings, nil
+}
+
+func bindingTemplatesFromProof(path string) ([]BindingTemplate, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read Go shim proof %s: %w", path, err)
+	}
+	catalog, err := proof_envelope.NewCBORDecoder(bytes).DecodeCatalog()
+	if err != nil {
+		return nil, fmt.Errorf("decode Go shim proof %s: %w", path, err)
+	}
+	rawMembers, ok := catalog["members"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("decode Go shim proof %s: missing members map", path)
+	}
+	bindings := make([]BindingTemplate, 0)
+	for _, rawMember := range rawMembers {
+		memberBytes, ok := rawMember.([]byte)
+		if !ok {
+			continue
+		}
+		var parsed map[string]any
+		if err := json.Unmarshal(memberBytes, &parsed); err != nil {
+			continue
+		}
+		body := parsed
+		if rawBody, ok := parsed["body"].(map[string]any); ok {
+			body = rawBody
+		}
+		binding, ok := bindingTemplateFromSugarEntry(body)
+		if ok {
+			bindings = append(bindings, binding)
+		}
+	}
+	return bindings, nil
+}
+
+func bindingTemplateFromSugarEntry(entry map[string]any) (BindingTemplate, bool) {
+	if entry["kind"] != "library-sugar-binding-entry" {
+		return BindingTemplate{}, false
+	}
+	conceptName, ok := entry["concept_name"].(string)
+	if !ok || conceptName == "" {
+		return BindingTemplate{}, false
+	}
+	libraryTag, _ := entry["target_library_tag"].(string)
+	bodySource, _ := entry["body_source"].(map[string]any)
+	template, ok := bodySource["ast_template"]
+	if !ok || template == nil {
+		return BindingTemplate{}, false
+	}
+	templateBytes, err := marshalJSONNoHTML(template)
+	if err != nil {
+		return BindingTemplate{}, false
+	}
+	templateCID, _ := bodySource["template_cid"].(string)
+	if templateCID == "" {
+		templateCID = canonicalizer.ComputeCID(templateBytes)
+	}
+	paramNames := stringSlice(bodySource["param_names"])
+	if len(paramNames) == 0 {
+		paramNames = stringSlice(entry["param_names"])
+	}
+	contractCID, _ := entry["contract_cid"].(string)
+	return BindingTemplate{
+		ConceptName: conceptName,
+		LibraryTag:  libraryTag,
+		Family:      entry["family"],
+		ASTTemplate: json.RawMessage(templateBytes),
+		TemplateCID: templateCID,
+		ParamNames:  paramNames,
+		ContractCID: contractCID,
+	}, true
+}
+
+func resolveDependencyProofPaths(projectRoot string) ([]string, error) {
+	root := strings.TrimSpace(projectRoot)
+	if root == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+		root = wd
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+	absRoot = filepath.Clean(absRoot)
+	if _, err := os.Stat(filepath.Join(absRoot, "go.mod")); err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, nil
+		}
+		return nil, err
+	}
+
+	cmd := exec.Command("go", "list", "-m", "-json", "all")
+	cmd.Dir = absRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(output))
+		if detail != "" {
+			return nil, fmt.Errorf("go list -m -json all failed: %w: %s", err, detail)
+		}
+		return nil, fmt.Errorf("go list -m -json all failed: %w", err)
+	}
+
+	proofs := map[string]struct{}{}
+	decoder := json.NewDecoder(bytes.NewReader(output))
+	for {
+		var module listedGoModule
+		if err := decoder.Decode(&module); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("decode go list module: %w", err)
+		}
+		if module.Main {
+			continue
+		}
+		dir := effectiveModuleDir(module)
+		if dir == "" {
+			continue
+		}
+		if !filepath.IsAbs(dir) {
+			dir = filepath.Join(absRoot, dir)
+		}
+		if err := collectProofPaths(filepath.Clean(dir), proofs); err != nil {
+			return nil, err
+		}
+	}
+
+	paths := make([]string, 0, len(proofs))
+	for proof := range proofs {
+		paths = append(paths, proof)
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func effectiveModuleDir(module listedGoModule) string {
+	if module.Dir != "" {
+		return module.Dir
+	}
+	if module.Replace != nil {
+		return effectiveModuleDir(*module.Replace)
+	}
+	return ""
+}
+
+func collectProofPaths(root string, proofs map[string]struct{}) error {
+	info, err := os.Stat(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return nil
+	}
+	return filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", "vendor":
+				if path != root {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		if !dependencyProofName.MatchString(entry.Name()) {
+			return nil
+		}
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+		proofs[filepath.Clean(abs)] = struct{}{}
+		return nil
+	})
+}
+
+func stringSlice(raw any) []string {
+	items, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if value, ok := item.(string); ok {
+			out = append(out, value)
+		}
+	}
+	return out
+}

--- a/implementations/go/provekit-lift-go/recognize_test.go
+++ b/implementations/go/provekit-lift-go/recognize_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/proof_envelope"
 )
 
 func TestSugarBodyEmitsAstTemplateAlongsideBodyText(t *testing.T) {
@@ -75,6 +77,12 @@ func Fetch(addr string, hdrs Header) Response {
 `)
 	bodyA := mustSugarBodySource(t, "a.go", srcA, "Fetch")
 	bodyB := mustSugarBodySource(t, "b.go", srcB, "Fetch")
+	if bodyA.BodyText != "return http.Get(url, headers)" {
+		t.Fatalf("body_text A = %q, want verbatim original parameter spelling", bodyA.BodyText)
+	}
+	if bodyB.BodyText != "return http.Get(addr, hdrs)" {
+		t.Fatalf("body_text B = %q, want verbatim renamed parameter spelling", bodyB.BodyText)
+	}
 	if !bytes.Equal(compactJSON(t, bodyA.ASTTemplate), compactJSON(t, bodyB.ASTTemplate)) {
 		t.Fatalf("alpha-equivalent templates diverged:\nA: %s\nB: %s", compactJSON(t, bodyA.ASTTemplate), compactJSON(t, bodyB.ASTTemplate))
 	}
@@ -180,6 +188,81 @@ func FetchURL(u string, h Header) Response {
 	}
 }
 
+func TestRecognizeRPCUsesGoKitOwnedTemplatesWithoutBindingTemplates(t *testing.T) {
+	binding := mustBindingTemplate(t, "concept:http-request", "provekit-shim-go-stdlib-http", "concept:family:http", `package shim
+
+func Fetch(url string, headers Header) Response {
+	return http.Get(url, headers)
+}
+`, "Fetch")
+
+	for _, tt := range []struct {
+		name     string
+		source   string
+		wantTags int
+	}{
+		{
+			name: "matching body",
+			source: `package handlers
+
+func FetchURL(u string, h Header) Response {
+	return http.Get(u, h)
+}
+`,
+			wantTags: 1,
+		},
+		{
+			name: "non-matching body",
+			source: `package handlers
+
+func FetchURL(u string, h Header) Response {
+	return completelyDifferent(u, h)
+}
+`,
+			wantTags: 0,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeRecognizeProofBackedGoDependency(t, root, binding)
+			rel := filepath.Join("pkg", "handlers", "fetch.go")
+			writeFile(t, filepath.Join(root, rel), tt.source)
+
+			stdin := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"provekit.plugin.recognize","params":{"project_root":` + strconvQuote(root) + `,"source_paths":[` + strconvQuote(rel) + `]}}` + "\n")
+			var stdout bytes.Buffer
+			if err := RunRPC(stdin, &stdout); err != nil {
+				t.Fatalf("RunRPC: %v", err)
+			}
+
+			var response map[string]any
+			if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &response); err != nil {
+				t.Fatalf("response JSON parses: %v\nstdout: %s", err, stdout.String())
+			}
+			if response["error"] != nil {
+				t.Fatalf("recognize RPC returned error: %v", response["error"])
+			}
+			result := response["result"].(map[string]any)
+			tags := result["tags"].([]any)
+			if len(tags) != tt.wantTags {
+				t.Fatalf("tags = %#v, want %d", tags, tt.wantTags)
+			}
+			if tt.wantTags == 0 {
+				return
+			}
+			tag := tags[0].(map[string]any)
+			if tag["concept_name"] != binding.ConceptName || tag["library_tag"] != binding.LibraryTag {
+				t.Fatalf("tag axes = %#v", tag)
+			}
+			if tag["template_cid"] != binding.TemplateCID || tag["contract_cid"] != binding.ContractCID {
+				t.Fatalf("tag cids = %#v", tag)
+			}
+			if tag["match_tier"] != "exact" {
+				t.Fatalf("match_tier = %#v", tag["match_tier"])
+			}
+		})
+	}
+}
+
 func TestRecognizeRoutesMultipleBindingsPerCallSitePool(t *testing.T) {
 	httpBinding := mustBindingTemplate(t, "concept:http-request", "http-lib", "concept:family:http", `package shim
 
@@ -230,6 +313,64 @@ func RunQuery(db DB, query string, params Args) Result {
 	if seen["concept:sql-execute"] != "RunQuery" {
 		t.Fatalf("sql binding routed to %#v", seen["concept:sql-execute"])
 	}
+}
+
+func writeRecognizeProofBackedGoDependency(t *testing.T, project string, binding BindingTemplate) string {
+	t.Helper()
+	member := map[string]any{
+		"body": map[string]any{
+			"kind":                 "library-sugar-binding-entry",
+			"concept_name":         binding.ConceptName,
+			"source_function_name": "Fetch",
+			"target_language":      "go",
+			"target_library_tag":   binding.LibraryTag,
+			"family":               binding.Family,
+			"param_names":          binding.ParamNames,
+			"param_types":          []string{"string", "Header"},
+			"return_type":          "Response",
+			"body_source": map[string]any{
+				"body_text":    "return http.Get(url, headers)",
+				"ast_template": binding.ASTTemplate,
+				"template_cid": binding.TemplateCID,
+				"param_names":  binding.ParamNames,
+			},
+			"contract_cid": binding.ContractCID,
+		},
+	}
+	memberBytes, err := marshalJSONNoHTML(member)
+	if err != nil {
+		t.Fatalf("marshal member: %v", err)
+	}
+	var seed [32]byte
+	for i := range seed {
+		seed[i] = 0x42
+	}
+	out, err := proof_envelope.NewBuilder().Build(&proof_envelope.Input{
+		Name:       "@test/go-recognize-proof-backed",
+		Version:    "0.0.0",
+		Members:    map[string][]byte{"blake3-512:" + strings.Repeat("b", 128): memberBytes},
+		SignerCID:  "blake3-512:" + strings.Repeat("c", 128),
+		SignerSeed: seed,
+		DeclaredAt: "2026-05-29T00:00:00.000Z",
+	})
+	if err != nil {
+		t.Fatalf("build proof envelope: %v", err)
+	}
+	dep := filepath.Join(project, "dep")
+	proofPath := filepath.Join(dep, "META-INF", "provekit", out.FilenameCID+".proof")
+	if err := os.MkdirAll(filepath.Dir(proofPath), 0o755); err != nil {
+		t.Fatalf("mkdir dependency proof dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dep, "go.mod"), []byte("module example.com/proofdep\n\ngo 1.22\n"), 0o644); err != nil {
+		t.Fatalf("write dep go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project, "go.mod"), []byte("module example.com/app\n\ngo 1.22\n\nrequire example.com/proofdep v0.0.0\nreplace example.com/proofdep => ./dep\n"), 0o644); err != nil {
+		t.Fatalf("write project go.mod: %v", err)
+	}
+	if err := os.WriteFile(proofPath, out.Bytes, 0o644); err != nil {
+		t.Fatalf("write proof: %v", err)
+	}
+	return proofPath
 }
 
 func mustSugarBodySource(t *testing.T, path string, src []byte, fn string) SugarBodySource {


### PR DESCRIPTION
## Summary
- load Go dependency .proof catalogs from the Go module graph inside provekit-lift-go recognizer
- extract library-sugar-binding-entry ast templates into the recognizer template index without requiring RPC binding_templates
- add RPC coverage for matching and non-matching Go bodies, plus explicit body_text verbatim alpha-rename assertions

## Tests
- go test . -count=1 (implementations/go/provekit-lift-go)
- go test . -count=1 (implementations/go/cmd/provekit-lift-go-verify)
- git diff --check
