### PR TITLE
test(swift): cover recognizer RPC parity

### DIFF
--- a/implementations/swift/Sources/ProvekitLiftSwiftSource/SwiftSourceRPC.swift
+++ b/implementations/swift/Sources/ProvekitLiftSwiftSource/SwiftSourceRPC.swift
@@ -21,6 +21,16 @@ public enum SwiftSourceRPC {
         ]
     }
 
+    public static func handle(_ request: [String: Any]) -> [String: Any] {
+        do {
+            return try dispatch(request)
+        } catch let error as SwiftSourceRPCExit {
+            return error.response
+        } catch {
+            return errorResponse(id: request["id"], code: -32603, message: String(describing: error))
+        }
+    }
+
     public static func run() {
         while let line = readLine(strippingNewline: true) {
             let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/implementations/swift/Sources/SwiftSourceLiftTests/main.swift
+++ b/implementations/swift/Sources/SwiftSourceLiftTests/main.swift
@@ -19,6 +19,8 @@ struct SwiftSourceLiftTests {
             ("recognize returns no tags for non-match", testRecognizeReturnsNoTagsForNonMatch),
             ("recognize routes multiple bindings", testRecognizeRoutesMultipleBindings),
             ("recognize paths self-resolves sugar templates", testRecognizePathsSelfResolvesSugarTemplates),
+            ("recognize RPC self-resolves sugar templates", testRecognizeRPCSelfResolvesSugarTemplates),
+            ("recognize RPC returns no tags for non-match", testRecognizeRPCReturnsNoTagsForNonMatch),
         ]
 
         var failures: [String] = []
@@ -209,6 +211,84 @@ private func testRecognizePathsSelfResolvesSugarTemplates() throws {
     try expect(tag["function_name"] as? String == "getStatus", "wrong function: \(tag)")
     try expect(tag["concept_name"] as? String == "concept:http-request", "wrong concept: \(tag)")
     try expect(tag["library_tag"] as? String == "urlsession", "wrong library: \(tag)")
+}
+
+private func testRecognizeRPCSelfResolvesSugarTemplates() throws {
+    let root = try temporarySwiftRecognitionProject(
+        clientSource: """
+        func getStatus(_ endpoint: String) -> Int {
+            return send(endpoint)
+        }
+        """
+    )
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let response = SwiftSourceRPC.handle([
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "provekit.plugin.recognize",
+        "params": [
+            "project_root": root.path,
+            "source_paths": ["Shim.swift", "Client.swift"],
+        ],
+    ])
+    let tags = try rpcTags(response)
+
+    try expect(tags.count == 1, "expected one RPC tag, got \(tags.count)")
+    let tag = try require(tags.first, "missing RPC tag")
+    try expect(tag["file"] as? String == "Client.swift", "wrong RPC file: \(tag)")
+    try expect(tag["function_name"] as? String == "getStatus", "wrong RPC function: \(tag)")
+    try expect(tag["concept_name"] as? String == "concept:http-request", "wrong RPC concept: \(tag)")
+    try expect(tag["library_tag"] as? String == "urlsession", "wrong RPC library: \(tag)")
+}
+
+private func testRecognizeRPCReturnsNoTagsForNonMatch() throws {
+    let root = try temporarySwiftRecognitionProject(
+        clientSource: """
+        func getStatus(_ endpoint: String) -> Int {
+            return 200
+        }
+        """
+    )
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let response = SwiftSourceRPC.handle([
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "provekit.plugin.recognize",
+        "params": [
+            "project_root": root.path,
+            "source_paths": ["Shim.swift", "Client.swift"],
+        ],
+    ])
+    let tags = try rpcTags(response)
+
+    try expect(tags.isEmpty, "expected no RPC tags, got \(tags.count)")
+}
+
+private func temporarySwiftRecognitionProject(clientSource: String) throws -> URL {
+    let root = try FileManager.default.url(
+        for: .itemReplacementDirectory,
+        in: .userDomainMask,
+        appropriateFor: URL(fileURLWithPath: NSTemporaryDirectory()),
+        create: true
+    )
+    try """
+    @ProveKitSugar(concept: "concept:http-request", library: "urlsession", family: "concept:family:http")
+    func fetch(_ url: String) -> Int {
+        return send(url)
+    }
+    """.write(to: root.appendingPathComponent("Shim.swift"), atomically: true, encoding: .utf8)
+    try clientSource.write(to: root.appendingPathComponent("Client.swift"), atomically: true, encoding: .utf8)
+    return root
+}
+
+private func rpcTags(_ response: [String: Any]) throws -> [[String: Any]] {
+    if let error = response["error"] {
+        throw TestFailure(message: "unexpected RPC error: \(error)")
+    }
+    let result = try require(response["result"] as? [String: Any], "missing RPC result")
+    return try require(result["tags"] as? [[String: Any]], "missing RPC tags")
 }
 
 private func sugarBodySource(_ source: String) throws -> [String: Any] {


### PR DESCRIPTION
## Summary
- add Swift recognizer RPC tests that self-resolve kit-owned sugar templates with only project_root/source_paths
- cover non-matching Swift source over the RPC recognize method
- expose a small SwiftSourceRPC.handle entry point that reuses the existing dispatch path for tests

## Tests
- swift run test-swift-source-lift
- make test-swift-source-lift
- git diff --check

## Known gap
- swift test currently fails on this host because Tests/ProvekitLiftSwiftSourceTests imports XCTest and the installed CommandLineTools environment reports no such module XCTest.
