### PR TITLE
[codex] Add Swift LSP call-edge diagnostics plumbing

### DIFF
--- a/implementations/swift/Sources/LSPTests/main.swift
+++ b/implementations/swift/Sources/LSPTests/main.swift
@@ -75,10 +75,13 @@ test("lifter extracts call edge from fixture (2 funcs, 1 call)") {
     let result = SwiftLifter.lift(source: source, path: "fixture.swift")
     let declOk = result.declarations.count == 2
     let edgeOk = result.callEdges.count >= 1
-    let symbolOk = result.callEdges.contains { $0.targetSymbol == "add" }
+    let symbolOk = result.callEdges.contains {
+        $0.sourceContractCid == "pending-swift:compute" &&
+        $0.targetSymbol == "swift-kit:add"
+    }
     return assert(declOk, "Expected 2 decls, got \(result.declarations.count)") &&
            assert(edgeOk, "Expected >=1 call edge, got \(result.callEdges.count)") &&
-           assert(symbolOk, "Expected call edge to 'add'")
+           assert(symbolOk, "Expected call edge from compute to swift-kit:add")
 }
 
 test("declaration wire shape has correct fields") {
@@ -259,11 +262,16 @@ if let binaryPath = findLSPBinary() {
         let decls = result["declarations"] as? [[String: Any]]
         let edges = result["callEdges"] as? [[String: Any]]
         let warnings = result["warnings"]
+        let edgeOk = edges?.contains {
+            $0["sourceContractCid"] as? String == "pending-swift:compute" &&
+            $0["targetSymbol"] as? String == "swift-kit:add"
+        } ?? false
 
         return assert(decls != nil, "declarations not an array of objects") &&
                assert((decls?.count ?? 0) == 2, "Expected 2 decls, got \(decls?.count ?? -1)") &&
                assert(edges != nil, "callEdges not an array of objects") &&
                assert((edges?.count ?? 0) >= 1, "Expected >=1 call edge, got \(edges?.count ?? -1)") &&
+               assert(edgeOk, "Expected call edge from compute to swift-kit:add") &&
                assert(warnings != nil, "warnings field missing")
     }
 

--- a/implementations/swift/Sources/SwiftLifter/SwiftLifter.swift
+++ b/implementations/swift/Sources/SwiftLifter/SwiftLifter.swift
@@ -54,7 +54,7 @@ public struct LiftedDeclaration: Sendable {
 
 /// A call-edge object in parse-protocol wire shape.
 public struct LiftedCallEdge: Sendable {
-    public let sourceContractCid: String  // placeholder: empty when CID unknown
+    public let sourceContractCid: String  // concrete CID, or pending-swift:<caller> before hashing
     public let targetSymbol: String
     public let callSiteLocus: CallSiteLocus
 
@@ -137,11 +137,10 @@ public enum SwiftLifter {
         )
         callVisitor.walk(sourceFile)
 
-        // Deduplicate call edges by (targetSymbol, line, column): mirrors v0
-        // behavior so the wire shape is byte-identical for the same input.
+        // Deduplicate call edges by source, target, and call-site position.
         var seen = Set<String>()
         let uniqueEdges = callVisitor.callEdges.filter { edge in
-            let key = "\(edge.targetSymbol):\(edge.callSiteLocus.line):\(edge.callSiteLocus.column)"
+            let key = "\(edge.sourceContractCid):\(edge.targetSymbol):\(edge.callSiteLocus.line):\(edge.callSiteLocus.column)"
             return seen.insert(key).inserted
         }
 
@@ -184,6 +183,7 @@ private final class CallEdgeVisitor: SyntaxVisitor {
     private let declaredNames: Set<String>
     private let path: String
     private let locationConverter: SourceLocationConverter
+    private var declarationStack: [String] = []
 
     init(
         viewMode: SyntaxTreeViewMode,
@@ -195,6 +195,29 @@ private final class CallEdgeVisitor: SyntaxVisitor {
         self.path = path
         self.locationConverter = locationConverter
         super.init(viewMode: viewMode)
+    }
+
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        let name = node.name.text
+        if !name.isEmpty {
+            declarationStack.append(name)
+        }
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: FunctionDeclSyntax) {
+        if !node.name.text.isEmpty {
+            _ = declarationStack.popLast()
+        }
+    }
+
+    override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+        declarationStack.append("init")
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: InitializerDeclSyntax) {
+        _ = declarationStack.popLast()
     }
 
     override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
@@ -215,6 +238,9 @@ private final class CallEdgeVisitor: SyntaxVisitor {
         guard let name = calleeName, declaredNames.contains(name) else {
             return .visitChildren
         }
+        guard let callerName = declarationStack.last else {
+            return .visitChildren
+        }
 
         // SourceLocationConverter gives us 1-based line and 1-based column;
         // the regex-v0 lifter emitted 1-based line and 0-based UTF-16 column
@@ -227,8 +253,8 @@ private final class CallEdgeVisitor: SyntaxVisitor {
         let column = max(0, location.column - 1)
 
         callEdges.append(LiftedCallEdge(
-            sourceContractCid: "",
-            targetSymbol: name,
+            sourceContractCid: "pending-swift:\(callerName)",
+            targetSymbol: "swift-kit:\(name)",
             callSiteLocus: CallSiteLocus(file: path, line: line, column: column)
         ))
         return .visitChildren


### PR DESCRIPTION
## Summary
- Track the enclosing Swift declaration while scanning same-kit function calls.
- Emit linkerd-consumable Swift call edges as `pending-swift:<caller>` to `swift-kit:<callee>` with the existing call-site locus.
- Tighten Swift lifter and daemon subprocess tests around the emitted call-edge shape.

## Verification
- `swift run test-swift-lsp` first failed on the new call-edge source/target expectation before implementation.
- `swift build --product provekit-lsp-swift`
- `swift run test-swift-lsp`
- `PATH="$PWD/implementations/swift/.build/debug:$PATH" cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd --test multi_kit test7_swift_kit_dispatch -- --nocapture`
- Manual linkerd probe for `compute -> add` returned an `unprovable-obligation` diagnostic with `targetSymbol: swift-kit:add`, `sourceContractCid: pending-swift:compute`, and `file: /tmp/call-edge.swift`.
- `git diff --check`