### PR TITLE
feat(scala): add prove parity lanes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -757,6 +757,9 @@ cross-language-proof-parity: build-java build-ts build-zig build-scala cross-lan
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_verify_zig_production_bridge \
 		zig_production_path_double_discharges_and_mints_witness
+	cargo test --release --manifest-path implementations/rust/Cargo.toml \
+		-p provekit-cli --test cmd_verify_scala_production_bridge \
+		scala_production_path_double_discharges_and_mints_witness
 	@echo "--- contradiction parity ---"
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_verify_java_production_bridge \
@@ -776,6 +779,9 @@ cross-language-proof-parity: build-java build-ts build-zig build-scala cross-lan
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_verify_zig_production_bridge \
 		zig_production_path_refuses_planted_contradictory_implication
+	cargo test --release --manifest-path implementations/rust/Cargo.toml \
+		-p provekit-cli --test cmd_verify_scala_production_bridge \
+		scala_production_path_refuses_planted_contradictory_implication
 	@echo "==== cross-language-proof-parity: PASS ===="
 
 .PHONY: bootstrap-self-contracts

--- a/implementations/rust/provekit-cli/tests/cmd_verify_scala_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_scala_production_bridge.rs
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Scala production-bridge gauntlet. The Rust CLI is only the generic
+// config/manifest/RPC client here: Scala parsing, ScalaTest assertion
+// harvesting, and Scala-term-to-ProofIR normalization live in the Scala kit.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serial_test::serial;
+use serde_json::Value as Json;
+
+#[path = "support/contradiction.rs"]
+mod contradiction;
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn z3_available() -> bool {
+    Command::new("z3")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn scala_cli_available() -> bool {
+    Command::new("scala-cli")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-scala-prod-bridge-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir project");
+    p
+}
+
+fn toml_path(path: &Path) -> String {
+    path.display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
+fn stage_scala_project(suffix: &str, body_factor: i64) -> PathBuf {
+    let root = repo_root();
+    let project = unique_dir(suffix);
+    fs::create_dir_all(project.join("src")).expect("mkdir src");
+    fs::write(
+        project.join("src").join("App.scala"),
+        format!(
+            r#"package app
+
+def double(x: Int): Int = x * {body_factor}
+"#
+        ),
+    )
+    .expect("write App.scala");
+    fs::write(
+        project.join("DoubleSpec.scala"),
+        r#"package app
+
+import org.scalatest.funsuite.AnyFunSuite
+
+final class DoubleSpec extends AnyFunSuite {
+  test("double three is six") {
+    assert(double(3) == 6)
+  }
+}
+"#,
+    )
+    .expect("write DoubleSpec.scala");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("scala-source"))
+        .expect("mkdir scala-source manifest dir");
+    fs::create_dir_all(provekit.join("lift").join("scala-scalatest"))
+        .expect("mkdir scala-scalatest manifest dir");
+    fs::write(
+        provekit.join("config.toml"),
+        "[[plugins]]\n\
+         name = \"scala-source\"\n\
+         surface = \"scala-source\"\n\
+         layer = \"verify\"\n\
+         \n\
+         [[plugins]]\n\
+         name = \"scala-scalatest-tests\"\n\
+         surface = \"scala-scalatest\"\n\
+         layer = \"tests\"\n\
+         \n\
+         [solvers]\n\
+         default = \"z3\"\n\
+         \n\
+         [solvers.dispatch]\n\
+         linear_arithmetic = \"z3\"\n\
+         default = \"z3\"\n\
+         \n\
+         [solvers.z3]\n\
+         binary = \"z3\"\n\
+         flags = [\"-smt2\", \"-in\"]\n",
+    )
+    .expect("write config.toml");
+
+    let source_dir = root
+        .join("implementations")
+        .join("scala")
+        .join("provekit-lift-scala-source");
+    let command = format!(
+        "[\"scala-cli\", \"run\", \"{}\", \"--server=false\", \"--\", \"--rpc\"]",
+        toml_path(&source_dir)
+    );
+    for name in ["scala-source", "scala-scalatest"] {
+        fs::write(
+            provekit.join("lift").join(name).join("manifest.toml"),
+            format!("name = \"{name}\"\ncommand = {command}\nworking_dir = \".\"\n"),
+        )
+        .unwrap_or_else(|_| panic!("write {name} manifest.toml"));
+    }
+
+    project
+}
+
+fn run_mint(project: &Path) {
+    let out = Command::new(provekit_bin())
+        .arg("mint")
+        .arg("--project")
+        .arg(project)
+        .arg("--out")
+        .arg(project)
+        .arg("--no-attest")
+        .arg("--quiet")
+        .output()
+        .expect("spawn provekit mint");
+    assert!(
+        out.status.success(),
+        "provekit mint must succeed\n  stdout: {}\n  stderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn run_verify_json_with_code(project: &Path, witness_dir: &Path) -> (Json, i32) {
+    let out = Command::new(provekit_bin())
+        .arg("verify")
+        .arg("--project")
+        .arg(project)
+        .arg("--emit-witnesses")
+        .arg(witness_dir)
+        .arg("--json")
+        .output()
+        .expect("spawn provekit verify");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let receipt = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("verify JSON parse failed: {e}\nstdout: {stdout}"));
+    (receipt, out.status.code().unwrap_or(-1))
+}
+
+#[test]
+#[serial(scala_cli)]
+fn scala_production_path_double_discharges_and_mints_witness() {
+    if !scala_cli_available() {
+        eprintln!("scala-cli not on PATH: skipping Scala production-bridge positive test");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping Scala production-bridge positive test");
+        return;
+    }
+    let project = stage_scala_project("pos", 2);
+    run_mint(&project);
+
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+
+    assert_eq!(
+        receipt["kind"], "verification-receipt",
+        "receipt: {receipt}"
+    );
+    assert_eq!(
+        receipt["totalClaims"], 1,
+        "exactly one body-bearing Scala callsite must enumerate; receipt: {receipt}"
+    );
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+    assert_eq!(
+        claim["pass"], true,
+        "double(3)==6 must discharge through Scala body (* x 2); claim: {claim}"
+    );
+    assert_eq!(claim["status"], "discharged", "claim: {claim}");
+    let solver = claim["dischargingSolver"].as_str().unwrap_or("");
+    assert!(
+        solver.starts_with("z3@"),
+        "discharging solver must be z3; got `{solver}`"
+    );
+    let witness_cid = claim["witnessCid"].as_str().expect("witness minted");
+    assert!(witness_cid.starts_with("blake3-512:"));
+    eprintln!("SCALA_PRODUCTION_POSITIVE_WITNESS_CID={witness_cid}");
+    assert_eq!(receipt["ok"], true, "receipt: {receipt}");
+    assert_eq!(code, 0, "positive run exits clean; got {code}");
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+#[serial(scala_cli)]
+fn scala_production_path_broken_body_fails_unsatisfied_no_witness() {
+    if !scala_cli_available() {
+        eprintln!("scala-cli not on PATH: skipping Scala production-bridge negative test");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping Scala production-bridge negative test");
+        return;
+    }
+    let project = stage_scala_project("neg", 3);
+    run_mint(&project);
+
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+
+    assert_eq!(receipt["totalClaims"], 1, "receipt: {receipt}");
+    let claim = &receipt["claims"].as_array().expect("claims")[0];
+    assert_eq!(
+        claim["status"], "unsatisfied",
+        "broken Scala body x*3 must be UNSATISFIED; claim: {claim}"
+    );
+    assert_eq!(claim["pass"], false, "claim: {claim}");
+    assert!(claim["witnessCid"].is_null(), "claim: {claim}");
+    assert_eq!(receipt["ok"], false, "receipt: {receipt}");
+    assert_eq!(code, 1, "broken-body claim must exit 1; got {code}");
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+#[serial(scala_cli)]
+fn scala_production_path_refuses_planted_contradictory_implication() {
+    if !scala_cli_available() {
+        eprintln!("scala-cli not on PATH: skipping Scala contradictory-implication test");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping Scala contradictory-implication test");
+        return;
+    }
+    let project = stage_scala_project("contradiction", 2);
+    run_mint(&project);
+
+    let (green, green_code) = contradiction::run_prove_json_with_code(&provekit_bin(), &project);
+    assert_eq!(
+        green_code, 0,
+        "base Scala project must prove before planting contradiction; report: {green}"
+    );
+    assert_eq!(green["totalCallsites"], 1, "green report: {green}");
+
+    contradiction::plant_contradictory_implication_proof(
+        &project.join(".provekit"),
+        "scala",
+        "scala-tests",
+        "scala_parity",
+    );
+    let (red, red_code) = contradiction::run_prove_json_with_code(&provekit_bin(), &project);
+    contradiction::assert_prove_refuses_contradiction(
+        &red,
+        red_code,
+        "scala_parity_requires_positive",
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}

--- a/implementations/scala/provekit-lift-scala-source/Main.scala
+++ b/implementations/scala/provekit-lift-scala-source/Main.scala
@@ -134,10 +134,17 @@ object ScalaSourceLifter:
       case Left(diagnostic) => LiftResult(Seq.empty, Seq(diagnostic))
       case Right(parsed) =>
         val emitBindings = layer == "library-bindings" || layer == "all"
-        val ir =
+        val emitVerify = layer == "verify" || layer == "all"
+        val emitTests = layer == "tests" || layer == "all"
+        val ir = Seq(
           if emitBindings then
             ScalaTrees.definitions(parsed.tree).flatMap(defn => libraryBindingEntry(defn, sourcePath))
-          else Seq.empty
+          else Seq.empty,
+          if emitVerify then
+            ScalaTrees.definitions(parsed.tree).flatMap(defn => functionContractEntry(defn, sourcePath))
+          else Seq.empty,
+          if emitTests then testContractEntries(parsed.tree, sourcePath) else Seq.empty,
+        ).flatten
         val callEdges =
           if layer == "all" then ScalaCallEdges.resolve(parsed.tree, sourcePath)
           else Seq.empty
@@ -235,6 +242,52 @@ object ScalaSourceLifter:
       binding.libraryVersion.foreach(value => entry("library_version") = value)
       binding.observedDimension.foreach(value => entry("observed_dimension") = value)
       entry
+    }
+
+  private def functionContractEntry(defn: Defn.Def, sourcePath: String): Option[ujson.Obj] =
+    if sugarBinding(defn).isDefined then None
+    else
+      ScalaFormula.term(defn.body, ScalaTemplate.functionParamNames(defn)).map { bodyTerm =>
+        val formals = ScalaTemplate.functionParamNames(defn)
+        val formalSorts = defn.paramss.flatten.map(param =>
+          ScalaFormula.sort(param.decltpe.map(_.syntax).getOrElse(""))
+        )
+        ujson.Obj(
+          "schemaVersion" -> "1",
+          "kind" -> "function-contract",
+          "fnName" -> defn.name.value,
+          "bridgeSourceSymbol" -> defn.name.value,
+          "formals" -> ujson.Arr.from(formals),
+          "formalSorts" -> ujson.Arr.from(formalSorts),
+          "returnSort" -> ScalaFormula.sort(defn.decltpe.map(_.syntax).getOrElse("")),
+          "pre" -> ScalaFormula.True,
+          "post" -> ujson.Obj(
+            "kind" -> "atomic",
+            "name" -> "=",
+            "args" -> ujson.Arr(ujson.Obj("kind" -> "var", "name" -> "result"), bodyTerm),
+          ),
+          "bodyCid" -> ScalaTemplate.cidOfUtf8(ScalaTemplate.bodyText(defn)),
+          "locus" -> ujson.Obj(
+            "file" -> sourcePath,
+            "line" -> ScalaTrees.span(defn).startLine,
+            "col" -> ScalaTrees.span(defn).startCol,
+          ),
+        )
+      }
+
+  private def testContractEntries(tree: Tree, sourcePath: String): Seq[ujson.Obj] =
+    ScalaTrees.testBlocks(tree).flatMap { case (testName, body) =>
+      ScalaTrees.assertions(body).zipWithIndex.flatMap { case (assertion, index) =>
+        ScalaFormula.assertionFormula(assertion).map { inv =>
+          ujson.Obj(
+            "schemaVersion" -> "1",
+            "kind" -> "contract",
+            "name" -> s"$testName::$index",
+            "outBinding" -> "out",
+            "inv" -> inv,
+          )
+        }
+      }
     }
 
   private def sugarBinding(defn: Defn.Def): Option[SugarBinding] =
@@ -548,9 +601,120 @@ object ScalaTemplate:
       case Term.Name(root) => Some((parts += root).reverse.toSeq)
       case _ => None
 
+object ScalaFormula:
+  val True: ujson.Obj = ujson.Obj("kind" -> "atomic", "name" -> "true", "args" -> ujson.Arr())
+
+  def sort(typeName: String): ujson.Obj =
+    val name = typeName.trim match
+      case "Int" | "Long" | "Short" | "Byte" => "Int"
+      case "Double" | "Float" | "BigDecimal" => "Real"
+      case "Boolean" => "Bool"
+      case "" | "Unit" | "Any" | "Nothing" => "Int"
+      case other => other
+    ujson.Obj("kind" -> "primitive", "name" -> name)
+
+  def assertionFormula(term: Term): Option[ujson.Obj] =
+    term match
+      case Term.Apply(Term.Name("assert"), args) =>
+        args.headOption.flatMap(predicate)
+      case Term.Apply(Term.Select(_, Term.Name("assert")), args) =>
+        args.headOption.flatMap(predicate)
+      case _ => None
+
+  def predicate(term: Term): Option[ujson.Obj] =
+    term match
+      case Term.ApplyInfix(left, Term.Name(op), _, args) if args.length == 1 =>
+        for
+          lhs <- termValue(left, Seq.empty)
+          rhs <- termValue(args.head, Seq.empty)
+          name <- predicateName(op)
+        yield ujson.Obj("kind" -> "atomic", "name" -> name, "args" -> ujson.Arr(lhs, rhs))
+      case Term.Apply(Term.Select(left, Term.Name(op)), args) if args.length == 1 =>
+        for
+          lhs <- termValue(left, Seq.empty)
+          rhs <- termValue(args.head, Seq.empty)
+          name <- predicateName(op)
+        yield ujson.Obj("kind" -> "atomic", "name" -> name, "args" -> ujson.Arr(lhs, rhs))
+      case _ => None
+
+  def term(term: Term, params: Seq[String]): Option[ujson.Value] =
+    termValue(term, params)
+
+  private def termValue(term: Term, params: Seq[String]): Option[ujson.Value] =
+    term match
+      case Term.Block(stats) =>
+        stats.reverse.collectFirst { case t: Term => t }.flatMap(termValue(_, params))
+      case Term.Return(expr) => termValue(expr, params)
+      case Term.ApplyInfix(left, Term.Name(op), _, args) if args.length == 1 =>
+        for
+          lhs <- termValue(left, params)
+          rhs <- termValue(args.head, params)
+          name <- ctorName(op)
+        yield ujson.Obj("kind" -> "ctor", "name" -> name, "args" -> ujson.Arr(lhs, rhs))
+      case Term.Apply(Term.Select(left, Term.Name(op)), args) if args.length == 1 && ctorName(op).isDefined =>
+        for
+          lhs <- termValue(left, params)
+          rhs <- termValue(args.head, params)
+          name <- ctorName(op)
+        yield ujson.Obj("kind" -> "ctor", "name" -> name, "args" -> ujson.Arr(lhs, rhs))
+      case Term.Apply(Term.Name(name), args) =>
+        val rendered = args.map(termValue(_, params))
+        if rendered.exists(_.isEmpty) then None
+        else Some(ujson.Obj("kind" -> "ctor", "name" -> name, "args" -> ujson.Arr.from(rendered.flatten)))
+      case Term.Name(name) => Some(ujson.Obj("kind" -> "var", "name" -> name))
+      case Lit.Int(value) => Some(intConst(value.toLong))
+      case Lit.Long(value) => Some(intConst(value))
+      case Lit.Float(value) => Some(realConst(value.toString.toDouble))
+      case Lit.Double(value) => Some(realConst(value.toString.toDouble))
+      case Lit.Boolean(value) =>
+        Some(ujson.Obj("kind" -> "const", "value" -> value, "sort" -> sort("Boolean")))
+      case Lit.String(value) =>
+        Some(ujson.Obj("kind" -> "const", "value" -> value, "sort" -> sort("String")))
+      case _ => None
+
+  private def predicateName(op: String): Option[String] =
+    op match
+      case "==" => Some("=")
+      case "!=" => Some("!=")
+      case "<" | "<=" | ">" | ">=" => Some(op)
+      case _ => None
+
+  private def ctorName(op: String): Option[String] =
+    op match
+      case "+" | "-" | "*" | "/" | "%" => Some(if op == "%" then "mod" else op)
+      case _ => None
+
+  private def intConst(value: Long): ujson.Obj =
+    ujson.Obj("kind" -> "const", "value" -> ujson.Num(value.toDouble), "sort" -> sort("Int"))
+
+  private def realConst(value: Double): ujson.Obj =
+    ujson.Obj("kind" -> "const", "value" -> ujson.Num(value), "sort" -> sort("Real"))
+
 object ScalaTrees:
   def definitions(tree: Tree): Seq[Defn.Def] =
     tree.collect { case defn: Defn.Def => defn }
+
+  def testBlocks(tree: Tree): Seq[(String, Term)] =
+    tree.collect {
+      case Term.Apply(Term.Apply(Term.Name("test"), firstArgs), secondArgs)
+          if firstArgs.length == 1 && secondArgs.length == 1 =>
+        (firstArgs.head, secondArgs.head)
+      case Term.Apply(Term.Apply(Term.Select(_, Term.Name("test")), firstArgs), secondArgs)
+          if firstArgs.length == 1 && secondArgs.length == 1 =>
+        (firstArgs.head, secondArgs.head)
+      case Term.Apply(Term.Name("test"), args) if args.length >= 2 =>
+        (args.head, args(1))
+      case Term.Apply(Term.Select(_, Term.Name("test")), args) if args.length >= 2 =>
+        (args.head, args(1))
+    }.collect {
+      case (Lit.String(name), body: Term) => (name, body)
+    }
+
+  def assertions(tree: Tree): Seq[Term] =
+    tree.collect {
+      case term @ Term.Apply(Term.Name("assert"), _) => term
+      case term @ Term.Apply(Term.Select(_, Term.Name("assert")), _) => term
+    }
 
   def span(tree: Tree): SourceSpan =
     SourceSpan(

--- a/implementations/scala/provekit-lift-scala-source/ScalaSourceLifterTest.scala
+++ b/implementations/scala/provekit-lift-scala-source/ScalaSourceLifterTest.scala
@@ -278,6 +278,116 @@ final class ScalaSourceLifterTest extends munit.FunSuite:
     assertEquals(routed("concept:sql-execute"), "RunQuery")
     assert(response.tags.forall(_.matchTier == "exact"))
 
+  test("verify layer lifts Scala function bodies to body-bearing function contracts"):
+    val result = ScalaSourceLifter.liftSource(
+      """package app
+        |
+        |def double(x: Int): Int = x * 2
+        |""".stripMargin,
+      "Double.scala",
+      layer = "verify",
+    )
+
+    assertEquals(result.diagnostics, Seq.empty)
+    assertEquals(result.ir.length, 1)
+    val contract = result.ir.head.obj
+    assertEquals(contract("kind").str, "function-contract")
+    assertEquals(contract("fnName").str, "double")
+    assertEquals(contract("bridgeSourceSymbol").str, "double")
+    assertEquals(jsonStrings(contract("formals")), Seq("x"))
+    assertEquals(contract("formalSorts")(0)("name").str, "Int")
+    val post = contract("post").obj
+    assertEquals(post("name").str, "=")
+    assertEquals(post("args")(0)("name").str, "result")
+    val body = post("args")(1).obj
+    assertEquals(body("kind").str, "ctor")
+    assertEquals(body("name").str, "*")
+    assertEquals(body("args")(0)("name").str, "x")
+    assertEquals(body("args")(1)("value").num.toInt, 2)
+
+  test("tests layer lifts ScalaTest assert callsites to source contracts"):
+    val result = ScalaSourceLifter.liftSource(
+      """package app
+        |
+        |import org.scalatest.funsuite.AnyFunSuite
+        |
+        |final class DoubleSpec extends AnyFunSuite {
+        |  test("double three is six") {
+        |    assert(double(3) == 6)
+        |  }
+        |}
+        |""".stripMargin,
+      "DoubleSpec.scala",
+      layer = "tests",
+    )
+
+    assertEquals(result.diagnostics, Seq.empty)
+    assertEquals(result.ir.length, 1)
+    val contract = result.ir.head.obj
+    assertEquals(contract("kind").str, "contract")
+    assertEquals(contract("name").str, "double three is six::0")
+    val inv = contract("inv").obj
+    assertEquals(inv("kind").str, "atomic")
+    assertEquals(inv("name").str, "=")
+    val call = inv("args")(0).obj
+    assertEquals(call("kind").str, "ctor")
+    assertEquals(call("name").str, "double")
+    assertEquals(call("args")(0)("value").num.toInt, 3)
+    assertEquals(inv("args")(1)("value").num.toInt, 6)
+
+  test("rpc lift dispatch honors Scala parity layers through options"):
+    val root = Files.createTempDirectory("provekit-scala-rpc-layers-")
+    val sourceRel = Path.of("Double.scala")
+    val testRel = Path.of("DoubleSpec.scala")
+    write(root.resolve(sourceRel),
+      """package app
+        |
+        |def double(x: Int): Int = x * 2
+        |""".stripMargin,
+    )
+    write(root.resolve(testRel),
+      """package app
+        |
+        |import org.scalatest.funsuite.AnyFunSuite
+        |
+        |final class DoubleSpec extends AnyFunSuite {
+        |  test("double three is six") {
+        |    assert(double(3) == 6)
+        |  }
+        |}
+        |""".stripMargin,
+    )
+
+    val sourceResponse = ScalaSourceRpc.dispatch(
+      ujson.Obj(
+        "jsonrpc" -> "2.0",
+        "id" -> 11,
+        "method" -> "lift",
+        "params" -> ujson.Obj(
+          "workspace_root" -> root.toString,
+          "source_paths" -> ujson.Arr(sourceRel.toString),
+          "options" -> ujson.Obj("layer" -> "verify"),
+        ),
+      ),
+    )
+    val testResponse = ScalaSourceRpc.dispatch(
+      ujson.Obj(
+        "jsonrpc" -> "2.0",
+        "id" -> 12,
+        "method" -> "lift",
+        "params" -> ujson.Obj(
+          "workspace_root" -> root.toString,
+          "source_paths" -> ujson.Arr(testRel.toString),
+          "options" -> ujson.Obj("layer" -> "tests"),
+        ),
+      ),
+    )
+
+    assert(!sourceResponse.obj.contains("error"))
+    assert(!testResponse.obj.contains("error"))
+    assertEquals(sourceResponse("result")("ir").arr.head("kind").str, "function-contract")
+    assertEquals(testResponse("result")("ir").arr.head("kind").str, "contract")
+
   private def mustSugarBodySource(source: String, functionName: String): ujson.Obj =
     val result = ScalaSourceLifter.liftSource(source, "shim.scala", layer = "library-bindings")
     assertEquals(result.diagnostics, Seq.empty)


### PR DESCRIPTION
## Summary
- add Scala source `verify` layer that emits body-bearing `function-contract` IR for simple Scala functions
- add ScalaTest `tests` layer that lifts native `test { assert(...) }` callsite contracts
- add Scala Rust CLI production-bridge gauntlet for positive witness, broken-body violation, and planted contradiction refusal
- wire Scala into `cross-language-proof-parity` prove and contradiction lanes

## Verification
- `scala-cli test implementations/scala/provekit-lift-scala-source --server=false`
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_verify_scala_production_bridge scala_production_path_double_discharges_and_mints_witness -- --nocapture`
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_verify_scala_production_bridge scala_production_path_broken_body_fails_unsatisfied_no_witness -- --nocapture`
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_verify_scala_production_bridge scala_production_path_refuses_planted_contradictory_implication -- --nocapture`
- post-rebase: `scala-cli test implementations/scala/provekit-lift-scala-source --server=false`
- post-rebase: `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_verify_scala_production_bridge -- --nocapture`

## Notes
- `cargo fmt --all --check` from `implementations/rust` is blocked by pre-existing formatting drift in unrelated files on the parent branch; this PR does not touch those files.