### PR TITLE
[codex] Add Scala LSP call edges

### DIFF
--- a/implementations/rust/provekit-linkerd/src/methods.rs
+++ b/implementations/rust/provekit-linkerd/src/methods.rs
@@ -10,7 +10,7 @@
 //
 // Lifting strategy for parseFile:
 //   For `rust` sources: call `provekit_lift::lift_path` in-process (fast).
-//   For `go`, `csharp`, `ruby`, `java`, `swift`, `ts`, `cpp`, `c`, `zig`, `php`:
+//   For `go`, `csharp`, `ruby`, `java`, `swift`, `ts`, `cpp`, `c`, `zig`, `php`, `scala`:
 //     spawn the kit's LSP plugin binary, send a JSON-RPC `parse` request,
 //     read the `{declarations, callEdges}` response, and map into
 //     `LinkerContract`/`LinkerCallEdge` (see `spawn_kit_lifter`).
@@ -31,6 +31,8 @@
 //     Binary built via `cc -std=c11 -o provekit-lsp-c main.c`.
 //   For `php`: spawn `provekit-lsp-php` (no args: reads stdin directly).
 //     Binary is installed from implementations/php/bin.
+//   For `scala`: spawn `provekit-lsp-scala` (no args: reads stdin directly).
+//     Wrapper lives at implementations/scala/bin/provekit-lsp-scala.
 //
 // Binary discovery order (for subprocess kits):
 //   1. Check PATH for the named binary.
@@ -255,6 +257,7 @@ enum LiftError {
 /// - `cpp`: subprocess `provekit-lsp-cpp` (no args), method `parse`.
 /// - `c`: subprocess `provekit-lsp-c --rpc`, method `parse`.
 /// - `php`: subprocess `provekit-lsp-php` (no args), method `parse`.
+/// - `scala`: subprocess `provekit-lsp-scala` (no args), method `parse`.
 async fn lift_source(
     kit_id: &str,
     file: &str,
@@ -401,8 +404,22 @@ async fn lift_source(
             spawn_kit_lifter(&binary, &[], file, source, "php-kit").await
         }
 
+        "scala" => {
+            let binary = find_binary("provekit-lsp-scala").ok_or_else(|| {
+                LiftError::LifterUnavailable(
+                    "kit 'scala' binary not found on PATH; install via: \
+                     cd implementations/scala && \
+                     chmod +x bin/provekit-lsp-scala && \
+                     ln -sf \"$PWD/bin/provekit-lsp-scala\" ~/.local/bin/provekit-lsp-scala"
+                        .to_string(),
+                )
+            })?;
+            // scala wrapper runs the Scala source daemon in --rpc mode.
+            spawn_kit_lifter(&binary, &[], file, source, "scala-kit").await
+        }
+
         other => Err(LiftError::KitNotInManifest(format!(
-            "unknown kitId '{other}'; valid kits: rust, go, cpp, csharp, python, ruby, swift, ts, zig, java, c, php"
+            "unknown kitId '{other}'; valid kits: rust, go, cpp, csharp, python, ruby, swift, ts, zig, java, c, php, scala"
         ))),
     }
 }

--- a/implementations/rust/provekit-linkerd/tests/multi_kit.rs
+++ b/implementations/rust/provekit-linkerd/tests/multi_kit.rs
@@ -36,6 +36,10 @@
 // Test 11: parseFile(kit="php", ...) dispatches to the php lifter and returns
 //          a result with a diagnostics array when provekit-lsp-php is on PATH.
 //
+// Test 12: parseFile(kit="scala", ...) is registered in linkerd dispatch.
+//          If provekit-lsp-scala is absent, it must return LifterUnavailable,
+//          not UnknownKit.
+//
 // These tests communicate with the daemon over its Unix socket.
 
 use std::io::{BufRead, BufReader, Write};
@@ -1098,6 +1102,70 @@ function add_numbers(int $a, int $b): int {
         "php kit parseFile result must have diagnostics array: {:?}",
         resp
     );
+
+    shutdown(&sock);
+    child.wait().ok();
+    std::fs::remove_file(&sock).ok();
+}
+
+// -------------------------------------------------------------------
+// Test 12: scala kit dispatch is registered.
+// -------------------------------------------------------------------
+
+/// Test 12: parseFile with kit="scala" must route to the Scala LSP lifter.
+///
+/// This does not require provekit-lsp-scala to be installed. In environments
+/// without the binary, the correct behavior is LifterUnavailable (-33002) with
+/// an install hint. UnknownKit (-33001) means linkerd cannot route Scala at all.
+#[test]
+fn test12_scala_kit_dispatch_registered() {
+    let sock = unique_sock_path("t12");
+    let _ = std::fs::remove_file(&sock);
+
+    let mut child = spawn_daemon(&sock);
+
+    assert!(
+        wait_for_socket(&sock, Duration::from_secs(5)),
+        "daemon socket did not appear"
+    );
+
+    let scala_source = r#"
+def addOne(x: Int): Int = x + 1
+def callAddOne(x: Int): Int = addOne(x)
+"#;
+
+    let req = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "parseFile",
+        "params": {
+            "kitId": "scala",
+            "file": "/tmp/Calls.scala",
+            "source": scala_source
+        }
+    });
+
+    let resp = send_recv(&sock, &req);
+
+    if let Some(error) = resp.get("error") {
+        let code = error.get("code").and_then(|c| c.as_i64()).unwrap_or(0);
+        let message = error.get("message").and_then(|m| m.as_str()).unwrap_or("");
+        assert_eq!(
+            code, -33002,
+            "scala kit must be registered; got wrong error: {:?}",
+            resp
+        );
+        assert!(
+            message.contains("provekit-lsp-scala"),
+            "scala LifterUnavailable message should name the expected binary: {message}"
+        );
+    } else {
+        assert!(
+            resp["result"]["diagnostics"].is_array(),
+            "scala kit parseFile result must have diagnostics array: {:?}",
+            resp
+        );
+    }
 
     shutdown(&sock);
     child.wait().ok();

--- a/implementations/scala/bin/provekit-lsp-scala
+++ b/implementations/scala/bin/provekit-lsp-scala
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_path="${BASH_SOURCE[0]}"
+while [ -L "$source_path" ]; do
+  source_dir="$(cd -P "$(dirname "$source_path")" >/dev/null 2>&1 && pwd)"
+  link_target="$(readlink "$source_path")"
+  if [[ "$link_target" == /* ]]; then
+    source_path="$link_target"
+  else
+    source_path="$source_dir/$link_target"
+  fi
+done
+
+script_dir="$(cd -P "$(dirname "$source_path")" >/dev/null 2>&1 && pwd)"
+cd "$script_dir/.."
+
+exec scala-cli run provekit-lift-scala-source --server=false -- --rpc "$@"

--- a/implementations/scala/provekit-lift-scala-source/Main.scala
+++ b/implementations/scala/provekit-lift-scala-source/Main.scala
@@ -16,7 +16,11 @@ object Main:
     if args.contains("--rpc") then ScalaSourceRpc.run()
     else System.err.println("provekit-lift-scala-source expects --rpc")
 
-final case class LiftResult(ir: Seq[ujson.Value], diagnostics: Seq[ujson.Value])
+final case class LiftResult(
+    ir: Seq[ujson.Value],
+    diagnostics: Seq[ujson.Value],
+    callEdges: Seq[CallEdgeDecl] = Seq.empty,
+)
 
 final case class SourceSpan(
     startLine: Int,
@@ -52,6 +56,35 @@ final case class RecognizeParams(
 final case class ParamBinding(index: Int, sourceText: String):
   def toJson: ujson.Obj =
     ujson.Obj("index" -> index, "source_text" -> sourceText)
+
+final case class CallSiteLocus(file: String, line: Int, column: Int):
+  def toJson: ujson.Obj =
+    ujson.Obj(
+      "column" -> column,
+      "file" -> file,
+      "line" -> line,
+    )
+
+final case class CallEdgeDecl(
+    sourceContractCid: String,
+    targetContractCid: Option[String],
+    targetSymbol: String,
+    callSiteLocus: CallSiteLocus,
+):
+  def toJson: ujson.Obj =
+    ujson.Obj(
+      "callSiteLocus" -> callSiteLocus.toJson,
+      "evidenceTerm" -> ujson.Obj(
+        "args" -> ujson.Arr(),
+        "kind" -> "atomic",
+        "name" -> "call-site-obligation",
+      ),
+      "kind" -> "call-edge",
+      "schemaVersion" -> "1",
+      "sourceContractCid" -> sourceContractCid,
+      "targetContractCid" -> targetContractCid.map(ujson.Str(_)).getOrElse(ujson.Null),
+      "targetSymbol" -> targetSymbol,
+    )
 
 final case class RecognizeTag(
     file: String,
@@ -105,13 +138,17 @@ object ScalaSourceLifter:
           if emitBindings then
             ScalaTrees.definitions(parsed.tree).flatMap(defn => libraryBindingEntry(defn, sourcePath))
           else Seq.empty
-        LiftResult(ir, parsed.diagnostics)
+        val callEdges =
+          if layer == "all" then ScalaCallEdges.resolve(parsed.tree, sourcePath)
+          else Seq.empty
+        LiftResult(ir, parsed.diagnostics, callEdges)
 
   def liftPaths(workspaceRoot: String, sourcePaths: Seq[String], layer: String = "all"): LiftResult =
     val root = Path.of(if workspaceRoot.nonEmpty then workspaceRoot else ".").toAbsolutePath.normalize()
     val requested = if sourcePaths.nonEmpty then sourcePaths else Seq(".")
     val ir = mutable.ArrayBuffer.empty[ujson.Value]
     val diagnostics = mutable.ArrayBuffer.empty[ujson.Value]
+    val callEdges = mutable.ArrayBuffer.empty[CallEdgeDecl]
     for path <- expandScalaPaths(root, requested) do
       val relPath =
         try root.relativize(path).toString.replace('\\', '/')
@@ -120,13 +157,40 @@ object ScalaSourceLifter:
         val result = liftSource(Files.readString(path, StandardCharsets.UTF_8), relPath, layer)
         ir ++= result.ir
         diagnostics ++= result.diagnostics
+        callEdges ++= result.callEdges
       catch
         case e: Exception =>
           diagnostics += ujson.Obj(
             "kind" -> "io-error",
             "message" -> s"cannot read '$relPath': ${e.getMessage}",
           )
-    LiftResult(ir.toSeq, diagnostics.toSeq)
+    LiftResult(ir.toSeq, diagnostics.toSeq, callEdges.toSeq)
+
+  def parseForLsp(source: String, sourcePath: String): ujson.Obj =
+    parseSource(source, sourcePath) match
+      case Left(diagnostic) =>
+        ujson.Obj(
+          "declarations" -> ujson.Arr(),
+          "callEdges" -> ujson.Arr(),
+          "warnings" -> ujson.Arr(diagnostic),
+        )
+      case Right(parsed) =>
+        val seen = mutable.LinkedHashSet.empty[String]
+        val declarations = ScalaTrees.definitions(parsed.tree).flatMap { defn =>
+          val name = defn.name.value
+          Option.when(name.nonEmpty && seen.add(name)) {
+            ujson.Obj(
+              "kind" -> "contract",
+              "name" -> name,
+              "outBinding" -> "out",
+            )
+          }
+        }
+        ujson.Obj(
+          "declarations" -> ujson.Arr.from(declarations),
+          "callEdges" -> ujson.Arr.from(ScalaCallEdges.resolve(parsed.tree, sourcePath).map(_.toJson)),
+          "warnings" -> ujson.Arr.from(parsed.diagnostics),
+        )
 
   private def libraryBindingEntry(defn: Defn.Def, sourcePath: String): Option[ujson.Obj] =
     sugarBinding(defn).map { binding =>
@@ -294,6 +358,39 @@ object ScalaRecognizer:
       else if Files.isRegularFile(path) && path.toString.endsWith(".scala") then
         seen += path.toAbsolutePath.normalize()
     seen.toSeq
+
+object ScalaCallEdges:
+  def resolve(tree: Source, sourcePath: String): Seq[CallEdgeDecl] =
+    val definitions = ScalaTrees.definitions(tree)
+    val declaredNames = definitions.map(_.name.value).filter(_.nonEmpty).toSet
+    if declaredNames.isEmpty then return Seq.empty
+
+    val edges = mutable.ArrayBuffer.empty[CallEdgeDecl]
+    val seen = mutable.LinkedHashSet.empty[String]
+    for caller <- definitions do
+      val callerName = caller.name.value
+      if callerName.nonEmpty then
+        for call <- caller.body.collect { case apply: Term.Apply => apply } do
+          callTargetName(call).foreach { targetName =>
+            if targetName != callerName && declaredNames.contains(targetName) then
+              val line = call.fun.pos.startLine + 1
+              val column = call.fun.pos.startColumn
+              val key = s"$callerName\u0000$targetName\u0000$line\u0000$column"
+              if seen.add(key) then
+                edges += CallEdgeDecl(
+                  sourceContractCid = s"pending-scala:$callerName",
+                  targetContractCid = None,
+                  targetSymbol = s"scala-kit:$targetName",
+                  callSiteLocus = CallSiteLocus(sourcePath, line, column),
+                )
+          }
+    edges.toSeq
+
+  private def callTargetName(call: Term.Apply): Option[String] =
+    call.fun match
+      case Term.Name(name) => Some(name)
+      case Term.Select(_, Term.Name(name)) => Some(name)
+      case _ => None
 
 object ScalaTemplate:
   def functionParamNames(defn: Defn.Def): Seq[String] =
@@ -495,6 +592,7 @@ object ScalaSourceRpc:
       val result = method match
         case "initialize" | "provekit.plugin.describe" => describe()
         case "lift" => lift(params)
+        case "parse" => parse(params)
         case "provekit.plugin.recognize" => recognize(params)
         case "shutdown" | "provekit.plugin.shutdown" => ujson.Null
         case other => throw RpcFailure(-32601, s"METHOD_NOT_FOUND: $other")
@@ -533,7 +631,17 @@ object ScalaSourceRpc:
     ujson.Obj(
       "kind" -> "ir-document",
       "ir" -> ujson.Arr.from(result.ir),
+      "callEdges" -> ujson.Arr.from(result.callEdges.map(_.toJson)),
       "diagnostics" -> ujson.Arr.from(result.diagnostics),
+    )
+
+  private def parse(params: ujson.Value): ujson.Obj =
+    val language = stringAt(params, "language")
+    if language.nonEmpty && language != "scala" then
+      throw RpcFailure(-32602, s"language '$language' not supported by this plugin")
+    ScalaSourceLifter.parseForLsp(
+      rawStringAt(params, "source"),
+      stringAt(params, "path"),
     )
 
   private def recognize(params: ujson.Value): ujson.Obj =
@@ -605,3 +713,9 @@ private def firstString(value: ujson.Value, fields: String*): Option[String] =
         case ujson.Str(text) if text.trim.nonEmpty => text.trim
       }).headOption
     case _ => None
+
+private def rawStringAt(value: ujson.Value, field: String): String =
+  value match
+    case obj: ujson.Obj =>
+      obj.obj.get(field).collect { case ujson.Str(text) => text }.getOrElse("")
+    case _ => ""

--- a/implementations/scala/provekit-lift-scala-source/ScalaSourceLifterTest.scala
+++ b/implementations/scala/provekit-lift-scala-source/ScalaSourceLifterTest.scala
@@ -133,6 +133,77 @@ final class ScalaSourceLifterTest extends munit.FunSuite:
     assertEquals(tags.head("function_name").str, "FetchURL")
     assertEquals(tags.head("match_tier").str, "exact")
 
+  test("rpc lift emits same-language call edge locus"):
+    val root = Files.createTempDirectory("provekit-scala-lsp-calledges-")
+    val rel = Path.of("Calls.scala")
+    write(root.resolve(rel),
+      """package app
+        |
+        |def addOne(x: Int): Int = x + 1
+        |
+        |def callAddOne(x: Int): Int = addOne(x)
+        |""".stripMargin,
+    )
+
+    val response = ScalaSourceRpc.dispatch(
+      ujson.Obj(
+        "jsonrpc" -> "2.0",
+        "id" -> 9,
+        "method" -> "lift",
+        "params" -> ujson.Obj(
+          "workspace_root" -> root.toString,
+          "source_paths" -> ujson.Arr(rel.toString.replace('\\', '/')),
+        ),
+      ),
+    )
+
+    assert(!response.obj.contains("error"), response.render())
+    val callEdges = response("result")("callEdges").arr
+    assertEquals(callEdges.length, 1)
+    val edge = callEdges.head
+    assertEquals(edge("kind").str, "call-edge")
+    assertEquals(edge("schemaVersion").str, "1")
+    assertEquals(edge("sourceContractCid").str, "pending-scala:callAddOne")
+    assert(edge("targetContractCid").isNull)
+    assertEquals(edge("targetSymbol").str, "scala-kit:addOne")
+    assertEquals(edge("evidenceTerm")("name").str, "call-site-obligation")
+    assertEquals(edge("callSiteLocus")("file").str, rel.toString.replace('\\', '/'))
+    assertEquals(edge("callSiteLocus")("line").num.toInt, 5)
+    assert(edge("callSiteLocus")("column").num.toInt > 0)
+
+  test("rpc parse returns declarations and call edges"):
+    val source =
+      """package app
+        |
+        |def addOne(x: Int): Int = x + 1
+        |
+        |def callAddOne(x: Int): Int = addOne(x)
+        |""".stripMargin
+
+    val response = ScalaSourceRpc.dispatch(
+      ujson.Obj(
+        "jsonrpc" -> "2.0",
+        "id" -> 10,
+        "method" -> "parse",
+        "params" -> ujson.Obj(
+          "path" -> "Calls.scala",
+          "source" -> source,
+        ),
+      ),
+    )
+
+    assert(!response.obj.contains("error"), response.render())
+    val result = response("result")
+    val declarations = result("declarations").arr
+    assertEquals(declarations.map(_("name").str).toSet, Set("addOne", "callAddOne"))
+    assert(declarations.forall(_("kind").str == "contract"))
+    assert(declarations.forall(_("outBinding").str == "out"))
+
+    val edge = result("callEdges").arr.head
+    assertEquals(edge("sourceContractCid").str, "pending-scala:callAddOne")
+    assertEquals(edge("targetSymbol").str, "scala-kit:addOne")
+    assertEquals(edge("callSiteLocus")("file").str, "Calls.scala")
+
   test("recognize returns empty tags for non-matching source"):
     val binding = mustBindingTemplate(
       concept = "concept:http-request",


### PR DESCRIPTION
## Summary
- Add Scala same-language call-edge extraction with call-site loci to the Scala source daemon.
- Add LSP-shaped `parse` RPC support and a `provekit-lsp-scala` wrapper.
- Register `scala` in linkerd kit dispatch so missing binary reports LifterUnavailable instead of UnknownKit.

## Test Plan
- `scala-cli test provekit-lift-scala-source --server=false`
- `cargo test --manifest-path implementations/rust/provekit-linkerd/Cargo.toml test10_scala_kit_dispatch_registered -- --nocapture`
- `printf ... | implementations/scala/bin/provekit-lsp-scala`
- `git diff --check HEAD~1 HEAD`