### PR TITLE
fix(verify): reject zero-claim receipts

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_verify.rs
+++ b/implementations/rust/provekit-cli/src/cmd_verify.rs
@@ -319,10 +319,8 @@ pub fn run(args: VerifyArgs) -> u8 {
     let callsites = enumerate_callsites::run(&pool);
 
     if callsites.is_empty() {
-        // No contract claims to discharge. This is not a verification
-        // failure: it is the verb correctly reporting an empty catalog.
-        // (The lifter has not yet written claims, or the kit declares
-        // none.) Surface it loudly so the operator knows to lift first.
+        // No contract claims were discharged. Reporting this as success is a
+        // vacuous green: the run proved nothing.
         let kit_label = args
             .kit
             .clone()
@@ -337,14 +335,14 @@ pub fn run(args: VerifyArgs) -> u8 {
                 "totalClaims": 0,
                 "discharged": 0,
                 "failed": 0,
-                "ok": true,
-                "note": "no contract claims found in catalog; nothing to verify (lift the kit first)",
+                "ok": false,
+                "note": "no contract claims found in catalog; zero-claim verification is not a successful proof",
             });
             println!("{}", serde_json::to_string_pretty(&out).unwrap());
         } else if !quiet {
             println!(
-                "{}: no contract claims found for `{}`; nothing to verify",
-                "verify".yellow().bold(),
+                "{}: no contract claims found for `{}`; zero-claim verification is not a successful proof",
+                "verify".red().bold(),
                 kit_label
             );
             println!(
@@ -352,7 +350,7 @@ pub fn run(args: VerifyArgs) -> u8 {
                 args.kit.as_deref().unwrap_or("<kit>")
             );
         }
-        return EXIT_OK;
+        return EXIT_VERIFY_FAIL;
     }
 
     // Build the solver-dispatch plan + registry. Honor the kit's own

--- a/implementations/rust/provekit-cli/tests/cmd_verify_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_integration.rs
@@ -225,15 +225,16 @@ fn run_verify_json(project: &Path, witness_dir: &Path) -> Json {
 }
 
 #[test]
-fn verify_empty_catalog_is_clean_and_emits_receipt() {
-    // A project with no .proof claims: verify must emit a receipt with
-    // zero claims and exit clean (nothing to verify, not a failure).
+fn verify_empty_catalog_is_not_a_successful_proof() {
+    // A project with no .proof claims: verify must emit a receipt, but it
+    // must not report a successful proof when it checked zero claims.
     let dir = unique_dir("empty");
     let witnesses = dir.join("w");
-    let receipt = run_verify_json(&dir, &witnesses);
+    let (receipt, code) = run_verify_json_with_code(&dir, &witnesses);
     assert_eq!(receipt["kind"], "verification-receipt");
     assert_eq!(receipt["totalClaims"], 0);
-    assert_eq!(receipt["ok"], true);
+    assert_eq!(receipt["ok"], false);
+    assert_ne!(code, 0, "zero-claim verify must exit nonzero: {receipt}");
     let _ = fs::remove_dir_all(&dir);
 }
 


### PR DESCRIPTION
## Summary
- make `provekit verify` treat zero discovered claims as a failed proof, not a successful receipt
- preserve the diagnostic receipt shape while setting `ok: false` and returning `EXIT_VERIFY_FAIL`
- update the empty-catalog integration test to assert nonzero exit

## Verification
- `git diff --check`
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_verify_integration verify_empty_catalog_is_not_a_successful_proof -- --nocapture`

## Notes
- Stopped the broad cross-language gate after it had already passed emit/materialize/recognizer lanes and Java/Go/Python/Rust prove parity; this PR is scoped to the zero-claim verify invariant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The verify command now correctly reports verification runs with zero claims as unsuccessful, with appropriate error messaging and non-zero exit codes, instead of treating them as successful operations.

* **Tests**
  * Integration tests updated to verify that zero-claim verification is treated as a failure rather than a success.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->