### PR TITLE
Normalize LSP implication diagnostic code across kits

### DIFF
--- a/docs/lsp/callsite-resolution-v1.md
+++ b/docs/lsp/callsite-resolution-v1.md
@@ -112,7 +112,7 @@ The selected entry's `signer` and `signer_role` are copied into the diagnostic p
 | Swift | Type member | `String.count`, `Array.append` |
 | Zig | Module path | `std.mem.copy` |
 
-If a host language parser cannot resolve a dynamic call to one of these forms, the forward propagator uses `top` for that path and suppresses `implication-failed`.
+If a host language parser cannot resolve a dynamic call to one of these forms, the forward propagator uses `top` for that path and suppresses `provekit.lsp.implication_failed`.
 
 ## Performance
 

--- a/docs/lsp/forward-propagation-floor-v1.md
+++ b/docs/lsp/forward-propagation-floor-v1.md
@@ -42,7 +42,7 @@ The diagnostic payload MUST carry the v1.6.2 identifiers that let a user or tool
 - `current_post_cid`
 - `signer` and `signer_role`
 
-The plugin MUST suppress `implication-failed` when the accumulated post is `top`.
+The plugin MUST suppress `provekit.lsp.implication_failed` when the accumulated post is `top`.
 
 ## Callsite Resolution
 

--- a/implementations/csharp/Provekit.LSP/ForwardPropagator.cs
+++ b/implementations/csharp/Provekit.LSP/ForwardPropagator.cs
@@ -49,7 +49,7 @@ public class ForwardPropagator
         {
             if (!calleePre.Constraints.Contains(c))
             {
-                return new DiagnosticResult("implication-failed",
+                return new DiagnosticResult("provekit.lsp.implication_failed",
                     $"post does not imply callee pre: {string.Join(" && ", calleePre.Constraints)}");
             }
         }

--- a/implementations/go/cmd/provekit-lsp-go/forward_propagator.go
+++ b/implementations/go/cmd/provekit-lsp-go/forward_propagator.go
@@ -240,7 +240,7 @@ func (p ForwardPropagator) CheckCallsite(calleeID string, currentPost Post, lspR
 		Range:    lspRange,
 		Severity: 1,
 		Source:   "provekit",
-		Code:     "implication-failed",
+		Code:     "provekit.lsp.implication_failed",
 		Message:  "callee precondition not established at this callsite",
 		Data: DiagnosticData{
 			SchemaVersion:          1,

--- a/implementations/go/cmd/provekit-lsp-go/forward_propagator_test.go
+++ b/implementations/go/cmd/provekit-lsp-go/forward_propagator_test.go
@@ -68,8 +68,8 @@ func TestCallsiteViolatesPreDiagnosticEmitted(t *testing.T) {
 		t.Fatalf("expected one diagnostic, got %#v", diagnostics)
 	}
 	diagnostic := diagnostics[0]
-	if diagnostic.Code != "implication-failed" {
-		t.Fatalf("code = %q, want implication-failed", diagnostic.Code)
+	if diagnostic.Code != "provekit.lsp.implication_failed" {
+		t.Fatalf("code = %q, want provekit.lsp.implication_failed", diagnostic.Code)
 	}
 	if diagnostic.Source != "provekit" {
 		t.Fatalf("source = %q, want provekit", diagnostic.Source)
@@ -126,7 +126,7 @@ func TestTopFallbackSuppressesFalsePositive(t *testing.T) {
 	diagnostics := propagator.EmitDiagnostics(body)
 
 	if len(diagnostics) != 0 {
-		t.Fatalf("top fallback must suppress implication-failed diagnostics: %#v", diagnostics)
+		t.Fatalf("top fallback must suppress provekit.lsp.implication_failed diagnostics: %#v", diagnostics)
 	}
 }
 
@@ -261,8 +261,8 @@ func TestParseFloorFixtureEmitsForwardPropagationDiagnostic(t *testing.T) {
 	if !ok {
 		t.Fatalf("diagnostic not an object: %T", diagnostics[0])
 	}
-	if diagnostic["code"] != "implication-failed" {
-		t.Fatalf("code = %v, want implication-failed", diagnostic["code"])
+	if diagnostic["code"] != "provekit.lsp.implication_failed" {
+		t.Fatalf("code = %v, want provekit.lsp.implication_failed", diagnostic["code"])
 	}
 	data, ok := diagnostic["data"].(map[string]interface{})
 	if !ok {

--- a/implementations/java/provekit-lsp-java/src/main/java/com/provekit/lsp/ForwardPropagator.java
+++ b/implementations/java/provekit-lsp-java/src/main/java/com/provekit/lsp/ForwardPropagator.java
@@ -102,7 +102,7 @@ public class ForwardPropagator {
         if (calleePre == null) return null;
         for (String c : currentPost.constraints) {
             if (!calleePre.constraints.contains(c)) {
-                return new DiagnosticResult("implication-failed",
+                return new DiagnosticResult("provekit.lsp.implication_failed",
                     "post does not imply callee pre: " + String.join(" && ", calleePre.constraints));
             }
         }

--- a/implementations/php/provekit-lift/src/ForwardPropagator.php
+++ b/implementations/php/provekit-lift/src/ForwardPropagator.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../../provekit-ir-symbolic/src/Canonicalizer/Blake3.php
 use ProvekIt\Canonicalizer\Blake3;
 
 const PROVEKIT_LSP_PROTOCOL_CATALOG_CID = 'blake3-512:52bdb2be4b381cec2aff95db7755c84184878b45cd91882d262114a1abd2dd513f9ef3b250fb87093316fd0fcb48e4b97e109d463e57df5bda6aac0b1c719a0f';
+const PROVEKIT_LSP_IMPLICATION_FAILED_CODE = 'provekit.lsp.implication_failed';
 
 final class ForwardPost
 {
@@ -224,11 +225,11 @@ final class LspDiagnostic
             'range' => $this->range->toArray(),
             'severity' => 1,
             'source' => 'provekit',
-            'code' => 'implication-failed',
+            'code' => PROVEKIT_LSP_IMPLICATION_FAILED_CODE,
             'message' => 'callee precondition not established at this callsite',
             'data' => [
                 'schema_version' => 1,
-                'kind' => 'provekit.lsp.implication_failed',
+                'kind' => PROVEKIT_LSP_IMPLICATION_FAILED_CODE,
                 'callee' => $this->entry->calleeId,
                 'callee_contract_cid' => $this->entry->contractCid,
                 'callee_attestation_cid' => $this->entry->attestationCid,
@@ -264,7 +265,7 @@ final class ForwardPropagator
     {
         return new self([
             BaselineEntry::new(
-                'checkPositive',
+                '\\checkPositive',
                 ForwardPost::known(['x > 0']),
                 ForwardPost::known(['returns true']),
             ),
@@ -380,15 +381,15 @@ final class ForwardPropagator
 
             $calls = self::checkPositiveCalls($scanLine);
             if (!$isFunctionDefinition) {
-                foreach ($calls as [$start, $arg]) {
+                foreach ($calls as [$rangeStart, $nameStart, $arg]) {
                     if ($topBlockDepth !== null || $topSingleStatementPending) {
                         $stmts[] = ForwardStmt::unsupported();
                     } else {
                         $stmts[] = ForwardStmt::assign(self::postForCheckPositiveArg($arg));
                     }
                     $stmts[] = ForwardStmt::call(
-                        'checkPositive',
-                        LspRange::singleLine($lineIdx, $start, $start + strlen('checkPositive')),
+                        '\\checkPositive',
+                        LspRange::singleLine($lineIdx, $rangeStart, $nameStart + strlen('checkPositive')),
                     );
                 }
             }
@@ -451,7 +452,7 @@ final class ForwardPropagator
         return false;
     }
 
-    /** @return array<int, array{0: int, 1: string}> */
+    /** @return array<int, array{0: int, 1: int, 2: string}> */
     private static function checkPositiveCalls(string $line): array
     {
         $calls = [];
@@ -498,7 +499,8 @@ final class ForwardPropagator
             if ($end >= $lineLen || $depth !== 0) {
                 break;
             }
-            $calls[] = [$start, trim(substr($line, $argsStart, $end - $argsStart))];
+            $rangeStart = ($start > 0 && $line[$start - 1] === '\\') ? $start - 1 : $start;
+            $calls[] = [$rangeStart, $start, trim(substr($line, $argsStart, $end - $argsStart))];
             $searchFrom = $end + 1;
         }
         return $calls;
@@ -520,6 +522,9 @@ final class ForwardPropagator
             }
             if ($line[$idx] === ':') {
                 return $idx > 0 && $line[$idx - 1] === ':';
+            }
+            if ($line[$idx] === '\\') {
+                return $idx > 0 && self::isIdentifierByte($line[$idx - 1]);
             }
             return false;
         }

--- a/implementations/php/provekit-lift/src/lspd.php
+++ b/implementations/php/provekit-lift/src/lspd.php
@@ -295,6 +295,9 @@ while (($line = fgets($stdin)) !== false) {
                     foreach ($scanned['declarations'] as $decl) {
                         $ir[] = $decl;
                     }
+                    foreach (forwardDiagnosticsForSource($source) as $diagnostic) {
+                        $diagnostics[] = $diagnostic;
+                    }
                 }
 
                 send(json_encode([
@@ -327,12 +330,7 @@ while (($line = fgets($stdin)) !== false) {
 
                 // Merge manual call edges with auto-detected ones
                 $allCallEdges = array_merge($scanned['callEdges'], $callEdges);
-                $diagnostics = array_map(
-                    fn(LspDiagnostic $diagnostic): array => $diagnostic->toArray(),
-                    ForwardPropagator::floorV1SeedIndex()->emitDiagnostics(
-                        ForwardPropagator::lowerFloorSource($source)
-                    ),
-                );
+                $diagnostics = forwardDiagnosticsForSource($source);
 
                 send(json_encode([
                     'jsonrpc' => '2.0', 'id' => $id,
@@ -365,3 +363,16 @@ while (($line = fgets($stdin)) !== false) {
 fclose($stdin);
 
 function send(string $json): void { echo $json . "\n"; flush(); }
+
+/**
+ * @return array<int, array<string, mixed>>
+ */
+function forwardDiagnosticsForSource(string $source): array
+{
+    return array_map(
+        fn(LspDiagnostic $diagnostic): array => $diagnostic->toArray(),
+        ForwardPropagator::floorV1SeedIndex()->emitDiagnostics(
+            ForwardPropagator::lowerFloorSource($source)
+        ),
+    );
+}

--- a/implementations/php/provekit-lift/tests/ForwardPropagatorTest.php
+++ b/implementations/php/provekit-lift/tests/ForwardPropagatorTest.php
@@ -26,7 +26,7 @@ function assert_same(mixed $expected, mixed $actual, string $message): void
 function check_positive_entry(): BaselineEntry
 {
     return BaselineEntry::new(
-        'checkPositive',
+        '\\checkPositive',
         ForwardPost::known(['x > 0']),
         ForwardPost::known(['returns true']),
     );
@@ -43,7 +43,7 @@ function consume_return_entry(): BaselineEntry
 
 function call_check_positive(): ForwardStmt
 {
-    return ForwardStmt::call('checkPositive', LspRange::singleLine(4, 12, 25));
+    return ForwardStmt::call('\\checkPositive', LspRange::singleLine(4, 12, 25));
 }
 
 function call_consume_return(): ForwardStmt
@@ -72,10 +72,10 @@ function testCallsiteViolatesPreDiagnosticEmitted(): void
 
     assert_same(1, count($diagnostics), 'violating callsite should emit one diagnostic');
     $diagnostic = $diagnostics[0]->toArray();
-    assert_same('implication-failed', $diagnostic['code'], 'diagnostic code');
+    assert_same('provekit.lsp.implication_failed', $diagnostic['code'], 'diagnostic code');
     assert_same('provekit', $diagnostic['source'], 'diagnostic source');
     assert_same(1, $diagnostic['severity'], 'diagnostic severity');
-    assert_same('checkPositive', $diagnostic['data']['callee'], 'diagnostic callee');
+    assert_same('\\checkPositive', $diagnostic['data']['callee'], 'diagnostic callee');
     assert_same(['x > 0'], $diagnostic['data']['missing_conjuncts'], 'missing conjuncts');
     assert_true(str_starts_with($diagnostic['data']['current_post_cid'], 'blake3-512:'), 'current_post_cid prefix');
     assert_true(str_starts_with($diagnostic['data']['baseline_index_cid'], 'blake3-512:'), 'baseline_index_cid prefix');
@@ -104,7 +104,7 @@ function testTopFallbackSuppressesFalsePositive(): void
         call_check_positive(),
     ]);
 
-    assert_same(0, count($diagnostics), 'top fallback should suppress implication-failed diagnostics');
+    assert_same(0, count($diagnostics), 'top fallback should suppress provekit.lsp.implication_failed diagnostics');
 }
 
 function testFailedPreconditionDoesNotPropagateCalleePostcondition(): void
@@ -117,7 +117,7 @@ function testFailedPreconditionDoesNotPropagateCalleePostcondition(): void
     ]);
 
     assert_same(2, count($diagnostics), 'failed precondition should not add the callee postcondition');
-    assert_same('checkPositive', $diagnostics[0]->toArray()['data']['callee'], 'first diagnostic callee');
+    assert_same('\\checkPositive', $diagnostics[0]->toArray()['data']['callee'], 'first diagnostic callee');
     assert_same('consumeReturn', $diagnostics[1]->toArray()['data']['callee'], 'second diagnostic callee');
 }
 
@@ -243,6 +243,38 @@ PHP;
     assert_same(1, count($diagnostics), 'whitespace before the call paren should still lower checkPositive callsites');
 }
 
+function testLeadingBackslashGlobalCallUsesPhpCanonicalCallee(): void
+{
+    $source = <<<'PHP'
+<?php
+function demo(): void {
+    \checkPositive(-1);
+}
+PHP;
+
+    $diagnostics = ForwardPropagator::floorV1SeedIndex()
+        ->emitDiagnostics(ForwardPropagator::lowerFloorSource($source));
+
+    assert_same(1, count($diagnostics), 'leading-backslash global call should lower to one callsite');
+    assert_same('\\checkPositive', $diagnostics[0]->toArray()['data']['callee'], 'canonical PHP callee');
+    assert_same(4, $diagnostics[0]->toArray()['range']['start']['character'], 'range should start at leading backslash');
+}
+
+function testNamespacedFunctionCallDoesNotResolveAsGlobalSeed(): void
+{
+    $source = <<<'PHP'
+<?php
+function demo(): void {
+    Foo\checkPositive(-1);
+}
+PHP;
+
+    $diagnostics = ForwardPropagator::floorV1SeedIndex()
+        ->emitDiagnostics(ForwardPropagator::lowerFloorSource($source));
+
+    assert_same(0, count($diagnostics), 'namespaced calls should not resolve as global checkPositive');
+}
+
 function testCommonPhpControlBlocksUseTopFallback(): void
 {
     $source = <<<'PHP'
@@ -307,9 +339,48 @@ function testParseFloorFixtureEmitsForwardPropagationDiagnostic(): void
     $diagnostics = $response['result']['diagnostics'] ?? null;
     assert_true(is_array($diagnostics), 'diagnostics field should be an array');
     assert_same(1, count($diagnostics), 'parse fixture should emit one diagnostic');
-    assert_same('implication-failed', $diagnostics[0]['code'], 'parse diagnostic code');
+    assert_same('provekit.lsp.implication_failed', $diagnostics[0]['code'], 'parse diagnostic code');
     assert_same('provekit.lsp.implication_failed', $diagnostics[0]['data']['kind'], 'parse diagnostic kind');
-    assert_same('checkPositive', $diagnostics[0]['data']['callee'], 'parse diagnostic callee');
+    assert_same('\\checkPositive', $diagnostics[0]['data']['callee'], 'parse diagnostic callee');
+}
+
+function testLiftFloorFixtureEmitsForwardPropagationDiagnostic(): void
+{
+    $root = realpath(__DIR__ . '/../../../..');
+    assert_true($root !== false, 'repo root must resolve');
+
+    $cmd = ['php', __DIR__ . '/../src/lspd.php'];
+    $proc = proc_open(
+        $cmd,
+        [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+        $pipes,
+        $root,
+    );
+    assert_true(is_resource($proc), 'lspd process should start');
+
+    $request = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'lift',
+        'params' => ['workspace_root' => $root, 'source_paths' => ['tests/lsp/floor-fixture/php.php']],
+    ], JSON_THROW_ON_ERROR);
+    fwrite($pipes[0], $request . "\n");
+    fclose($pipes[0]);
+
+    $line = fgets($pipes[1]);
+    fclose($pipes[1]);
+    $stderr = stream_get_contents($pipes[2]);
+    fclose($pipes[2]);
+    $code = proc_close($proc);
+    assert_same(0, $code, 'lspd process exit code: ' . $stderr);
+    assert_true(is_string($line), 'lspd should emit one response line');
+
+    $response = json_decode(trim($line), true, flags: JSON_THROW_ON_ERROR);
+    $diagnostics = $response['result']['diagnostics'] ?? null;
+    assert_true(is_array($diagnostics), 'lift diagnostics field should be an array');
+    assert_same(1, count($diagnostics), 'lift fixture should emit one forward diagnostic');
+    assert_same('provekit.lsp.implication_failed', $diagnostics[0]['code'], 'lift diagnostic code');
+    assert_same('\\checkPositive', $diagnostics[0]['data']['callee'], 'lift diagnostic callee');
 }
 
 testCallsiteSatisfiesPreNoDiagnostic();
@@ -324,7 +395,10 @@ testCommentsAndStringsDoNotCreateCallsites();
 testCheckPositiveScannerUsesIdentifierBoundaries();
 testCheckPositiveScannerIgnoresQualifiedMemberCalls();
 testCheckPositiveScannerAllowsWhitespaceBeforeParen();
+testLeadingBackslashGlobalCallUsesPhpCanonicalCallee();
+testNamespacedFunctionCallDoesNotResolveAsGlobalSeed();
 testCommonPhpControlBlocksUseTopFallback();
 testParseFloorFixtureEmitsForwardPropagationDiagnostic();
+testLiftFloorFixtureEmitsForwardPropagationDiagnostic();
 
 echo "ForwardPropagatorTest passed\n";

--- a/implementations/python/provekit_lsp/forward_propagator.py
+++ b/implementations/python/provekit_lsp/forward_propagator.py
@@ -44,7 +44,7 @@ class ForwardPropagator:
         for c in current_post.constraints:
             if c not in callee_pre.constraints:
                 return DiagnosticResult(
-                    code="implication-failed",
+                    code="provekit.lsp.implication_failed",
                     message=f"post does not imply callee pre: {' && '.join(callee_pre.constraints)}",
                 )
         return None

--- a/implementations/ruby/lib/provekit/lsp/forward_propagator.rb
+++ b/implementations/ruby/lib/provekit/lsp/forward_propagator.rb
@@ -16,7 +16,7 @@ class ForwardPropagator
 
     current_post[:constraints].each do |c|
       unless callee_pre[:constraints].include?(c)
-        return { code: "implication-failed", message: "post does not imply callee pre: #{callee_pre[:constraints].join(' && ')}" }
+        return { code: "provekit.lsp.implication_failed", message: "post does not imply callee pre: #{callee_pre[:constraints].join(' && ')}" }
       end
     end
     nil

--- a/implementations/rust/provekit-lsp-rust/src/forward_propagator.rs
+++ b/implementations/rust/provekit-lsp-rust/src/forward_propagator.rs
@@ -392,7 +392,7 @@ impl ForwardPropagator {
             range,
             severity: 1,
             source: "provekit".into(),
-            code: "implication-failed".into(),
+            code: "provekit.lsp.implication_failed".into(),
             message: "callee precondition not established at this callsite".into(),
             data: DiagnosticData {
                 schema_version: 1,

--- a/implementations/rust/provekit-lsp-rust/tests/forward_propagator.rs
+++ b/implementations/rust/provekit-lsp-rust/tests/forward_propagator.rs
@@ -83,7 +83,7 @@ fn callsite_violates_pre_diagnostic_emitted() {
 
     assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
     let diagnostic = &diagnostics[0];
-    assert_eq!(diagnostic.code, "implication-failed");
+    assert_eq!(diagnostic.code, "provekit.lsp.implication_failed");
     assert_eq!(diagnostic.source, "provekit");
     assert_eq!(diagnostic.severity, 1);
     assert_eq!(diagnostic.range, LspRange::single_line(4, 12, 18));
@@ -96,7 +96,7 @@ fn callsite_violates_pre_diagnostic_emitted() {
         .starts_with("blake3-512:"));
 
     let as_json = diagnostic.to_lsp_json();
-    assert_eq!(as_json["code"], "implication-failed");
+    assert_eq!(as_json["code"], "provekit.lsp.implication_failed");
     assert_eq!(as_json["source"], "provekit");
     assert_eq!(as_json["data"]["kind"], "provekit.lsp.implication_failed");
 }
@@ -119,7 +119,7 @@ fn branch_merge_partial_satisfaction_diagnostic_on_join_path() {
     let diagnostics = propagator.emit_diagnostics(&body);
 
     assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
-    assert_eq!(diagnostics[0].code, "implication-failed");
+    assert_eq!(diagnostics[0].code, "provekit.lsp.implication_failed");
     assert_eq!(
         diagnostics[0].data.missing_conjuncts,
         vec!["receiver is Some"]
@@ -160,8 +160,8 @@ fn failed_precondition_does_not_propagate_callee_postcondition() {
     assert_eq!(
         actual,
         BTreeSet::from([
-            ("checkPositive", "implication-failed"),
-            ("consumeReturn", "implication-failed"),
+            ("checkPositive", "provekit.lsp.implication_failed"),
+            ("consumeReturn", "provekit.lsp.implication_failed"),
         ])
     );
 }
@@ -191,7 +191,7 @@ async fn async_violates() {
     assert_eq!(diagnostics.len(), 3, "{diagnostics:#?}");
     assert!(diagnostics
         .iter()
-        .all(|diagnostic| diagnostic.code == "implication-failed"));
+        .all(|diagnostic| diagnostic.code == "provekit.lsp.implication_failed"));
     assert!(diagnostics
         .iter()
         .all(|diagnostic| diagnostic.data.callee == "checkPositive"));
@@ -212,7 +212,7 @@ pub unsafe extern "C" fn extern_violates() {
         .emit_diagnostics(&ForwardPropagator::lower_floor_source(source));
 
     assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
-    assert_eq!(diagnostics[0].code, "implication-failed");
+    assert_eq!(diagnostics[0].code, "provekit.lsp.implication_failed");
     assert_eq!(diagnostics[0].data.callee, "checkPositive");
 }
 
@@ -243,7 +243,7 @@ fn violates<'a>(value: &'a str) {
         .emit_diagnostics(&ForwardPropagator::lower_floor_source(source));
 
     assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
-    assert_eq!(diagnostics[0].code, "implication-failed");
+    assert_eq!(diagnostics[0].code, "provekit.lsp.implication_failed");
     assert_eq!(diagnostics[0].data.callee, "checkPositive");
 }
 

--- a/implementations/rust/provekit-lsp-rust/tests/round_trip.rs
+++ b/implementations/rust/provekit-lsp-rust/tests/round_trip.rs
@@ -228,7 +228,10 @@ fn parse_floor_fixture_emits_forward_propagation_diagnostic() {
     let diagnostic = &diagnostics[0];
     assert_eq!(diagnostic["severity"].as_i64(), Some(1));
     assert_eq!(diagnostic["source"].as_str(), Some("provekit"));
-    assert_eq!(diagnostic["code"].as_str(), Some("implication-failed"));
+    assert_eq!(
+        diagnostic["code"].as_str(),
+        Some("provekit.lsp.implication_failed")
+    );
     assert_eq!(
         diagnostic["data"]["kind"].as_str(),
         Some("provekit.lsp.implication_failed")

--- a/implementations/swift/Sources/Provekit/ForwardPropagator.swift
+++ b/implementations/swift/Sources/Provekit/ForwardPropagator.swift
@@ -43,7 +43,7 @@ public class ForwardPropagator {
         for constraint in currentPost.constraints {
             if !calleePre.constraints.contains(constraint) {
                 return DiagnosticResult(
-                    code: "implication-failed",
+                    code: "provekit.lsp.implication_failed",
                     message: "post does not imply callee pre: \(calleePre.constraints.joined(separator: " && "))"
                 )
             }

--- a/implementations/typescript/src/lsp/daemon.test.ts
+++ b/implementations/typescript/src/lsp/daemon.test.ts
@@ -305,7 +305,7 @@ function caller(cond: boolean) {
     expect(parseResp).toBeDefined();
   });
 
-  it("callsite violates pre: diagnostic with code implication-failed", () => {
+  it("callsite violates pre: diagnostic with code provekit.lsp.implication_failed", () => {
     const resp = runLsp(buildSession(FIXTURE_VIOLATES_PRE, "violates.ts"));
     const parseResp = resp.find((r) => r.id === 2);
     expect(parseResp).toBeDefined();

--- a/implementations/typescript/src/lsp/forward_propagator.ts
+++ b/implementations/typescript/src/lsp/forward_propagator.ts
@@ -113,7 +113,7 @@ export class ForwardPropagator {
     );
     if (!implies) {
       return {
-        code: "implication-failed",
+        code: "provekit.lsp.implication_failed",
         message: `post does not imply callee pre: ${callee.pre.constraints.join(" && ")}`,
       };
     }

--- a/implementations/zig/provekit-lsp-zig/src/forward_propagator.zig
+++ b/implementations/zig/provekit-lsp-zig/src/forward_propagator.zig
@@ -44,7 +44,7 @@ pub const ForwardPropagator = struct {
             }
             if (!found) {
                 return .{
-                    .code = "implication-failed",
+                    .code = "provekit.lsp.implication_failed",
                     .message = "post does not imply callee pre",
                 };
             }


### PR DESCRIPTION
## Summary

- normalize forward-propagation diagnostics to the shared `provekit.lsp.implication_failed` LSP code across Rust, Go, PHP, Python, Java, Ruby, Swift, C#, TypeScript, and Zig
- update floor docs to name the canonical diagnostic code when describing `top` suppression
- wire PHP `lift` responses to include forward-propagation diagnostics, matching the existing `parse` path
- switch PHP floor fixture callsite IDs to canonical leading-backslash global identifiers and suppress namespaced false matches

## Verification

- `CARGO_BUILD_JOBS=2 cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-lsp-rust --test forward_propagator`
- `CARGO_BUILD_JOBS=2 cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-lsp-rust --test round_trip parse_floor_fixture_emits_forward_propagation_diagnostic -- --exact`
- `CARGO_BUILD_JOBS=2 cargo check --manifest-path implementations/rust/Cargo.toml -p provekit-lsp-rust`
- `go test -v -timeout=45s ./cmd/provekit-lsp-go` from `implementations/go`
- `php -l implementations/php/provekit-lift/src/ForwardPropagator.php`
- `php -l implementations/php/provekit-lift/src/lspd.php`
- `php -l implementations/php/provekit-lift/tests/ForwardPropagatorTest.php`
- `php implementations/php/provekit-lift/tests/ForwardPropagatorTest.php`
- `sh implementations/php/provekit-lift/tests/integration_lsp.sh`
- `python3 -m py_compile implementations/python/provekit_lsp/forward_propagator.py`
- `ruby -c implementations/ruby/lib/provekit/lsp/forward_propagator.rb`
- `swiftc -typecheck implementations/swift/Sources/ProveKit/ForwardPropagator.swift`
- temp `dotnet build` including `implementations/csharp/Provekit.LSP/ForwardPropagator.cs`
- `git diff --check`
- `rg -n 'implication-failed' . -S`

## Not run

- TypeScript vitest: `pnpm exec vitest` failed because `vitest` is not installed in this fresh worktree.
- Zig standalone test: `zig test implementations/zig/provekit-lsp-zig/src/forward_propagator.zig` hits the pre-existing unused-parameter error on `addToCatalog(..., pre, ...)`.
- Full `make conformance`: deliberately skipped after the previous run consumed too much wall time.
