### PR TITLE
fix(go): register go-double proof surfaces

### DIFF
--- a/examples/go-double/.provekit/config.toml
+++ b/examples/go-double/.provekit/config.toml
@@ -1,11 +1,28 @@
-# ProvekIt project config for the Go end-to-end example.
-#
-# `[authoring] surface = "go"` selects the Go lift surface (the manifest at
-# .provekit/lift/go/manifest.toml). `[solvers]` names z3 for the linear-
-# arithmetic class the body-obligation `(* 3 2) == 6` falls into; the
-# `-smt2 -in` flags mirror the verifier's default z3 invocation.
-[authoring]
+# ProvekIt project config for the Go end-to-end example. Registration is
+# per project: lift and emit surfaces are all declared here and resolved
+# through .provekit/<kind>/<surface>/manifest.toml.
+
+[[plugins]]
+name = "go-lift"
+kind = "lift"
 surface = "go"
+
+[[plugins]]
+name = "go-realize"
+kind = "realize"
+surface = "go"
+
+[[plugins]]
+name = "go-testing"
+kind = "emit"
+surface = "go-testing"
+emit = "testing"
+
+[[plugins]]
+name = "go-testify"
+kind = "emit"
+surface = "go-testify"
+emit = "testify"
 
 [solvers]
 default = "z3"

--- a/examples/go-double/.provekit/emit/go-testify/manifest.toml
+++ b/examples/go-double/.provekit/emit/go-testify/manifest.toml
@@ -1,0 +1,4 @@
+name = "go-testify"
+command = ["provekit-emit-go-testify", "--rpc"]
+working_dir = "."
+protocol_versions = ["pep/1.7.0"]

--- a/examples/go-double/.provekit/emit/go-testing/manifest.toml
+++ b/examples/go-double/.provekit/emit/go-testing/manifest.toml
@@ -1,0 +1,4 @@
+name = "go-testing"
+command = ["provekit-emit-go-testing", "--rpc"]
+working_dir = "."
+protocol_versions = ["pep/1.7.0"]

--- a/examples/go-double/.provekit/realize/go/manifest.toml
+++ b/examples/go-double/.provekit/realize/go/manifest.toml
@@ -11,5 +11,6 @@
 # this manifest into a tempdir, so the in-repo example stays
 # build-location-agnostic.
 name = "go-realize"
+library_tag = "go"
 command = ["provekit-realize-go", "--rpc"]
 working_dir = "."

--- a/examples/go-double/README.md
+++ b/examples/go-double/README.md
@@ -19,7 +19,7 @@ func Double(x int) int { return x * 2 }
 ## The chain (no hand-bridging, no hand-written contracts)
 
 1. The **real Go lifter** (`provekit-lift-go-verify`, the verify-facing `go`
-   lift surface) lifts:
+   lift surface registered in `.provekit/config.toml`) lifts:
    - `double.go` -> `function-contract` with `formals: ["x"]` and
      `post = result == (* x 2)` (the verify-facing dialect normalizes Go's
      `go:mul` to the SMT-LIB core symbol `*` so z3 can reduce it),
@@ -33,16 +33,31 @@ func Double(x int) int { return x * 2 }
      `(* 3 2) == 6` -> z3 discharges -> signed witness, exit 0.
    - **negative** (break the body to `x * 3`): the obligation becomes
      `(* 3 3) == 6` -> z3 refutes -> Unsatisfied, exit 1, no witness.
+4. `provekit materialize` dispatches through `[[plugins]] kind = "realize"`
+   plus `.provekit/realize/go/manifest.toml`. The Go realizer owns Go sugar
+   assembly and Go module proof resolution; the CLI only sends normalized
+   requests over RPC.
+5. `provekit emit` dispatches through the same project registration. The
+   checked-in fixture declares `go-testing` and `go-testify` as separate emit
+   packages; the CLI selects them by target/framework and the Go kits own the
+   generated test syntax.
 
 ## Run it
 
 ```sh
 cd implementations/go
 go build -o /tmp/provekit-lift-go-verify ./cmd/provekit-lift-go-verify
-# point this example's .provekit/lift/go/manifest.toml command[0] at the binary
-# (or put it on PATH), then from the repo root:
+cd provekit-realize-go-core && go build -o /tmp/provekit-realize-go ./cmd/provekit-realize-go && cd ..
+go build -o /tmp/provekit-emit-go-testing ./provekit-emit-go-testing/cmd/provekit-emit-go-testing
+go build -o /tmp/provekit-emit-go-testify ./provekit-emit-go-testify/cmd/provekit-emit-go-testify
+# point the .provekit manifests at these binaries, or put them on PATH, then
+# from the repo root:
 provekit mint   --project examples/go-double --out examples/go-double --no-attest
 provekit verify --project examples/go-double --emit-witnesses /tmp/go-witnesses
+provekit materialize --project examples/go-double --target go --library go \
+  --source-dir /path/to/carriers --out-dir /tmp/go-materialized --compile-check
+provekit emit --project examples/go-double --target go --framework testing \
+  --plan /path/to/emit-plan.json --out-dir /tmp/go-emitted --compile-check
 ```
 
 The gating integration test

--- a/examples/go-identity/.provekit/config.toml
+++ b/examples/go-identity/.provekit/config.toml
@@ -12,13 +12,20 @@
 # function is not minted twice.
 [[plugins]]
 name = "go-sugar"
+kind = "lift"
 surface = "go-bind"
 layer = "library-bindings"
 
 [[plugins]]
 name = "go-contracts"
+kind = "lift"
 surface = "go-contracts"
 emit = "ir-document"
+
+[[plugins]]
+name = "go-realize"
+kind = "realize"
+surface = "go"
 
 [solvers]
 default = "z3"

--- a/examples/go-identity/.provekit/realize/go/manifest.toml
+++ b/examples/go-identity/.provekit/realize/go/manifest.toml
@@ -2,5 +2,6 @@
 # into Go sugar (provekit-realize-go-core). Closes the loop: the boundary the
 # author declared above is realized here as `func Id(x int) int { return x }`.
 name = "go-realize"
+library_tag = "go"
 command = ["provekit-realize-go", "--rpc"]
 working_dir = "."

--- a/examples/go-identity/README.md
+++ b/examples/go-identity/README.md
@@ -22,15 +22,18 @@ did not ask for a contract there.
 
 ## The authoring surface (`.provekit/config.toml`)
 
-Two `[[plugins]]`, mirroring rust's `rust-bind` / `rust-contracts`:
+Three `[[plugins]]`, mirroring rust's lift/realize split:
 
 - `go-bind` (`layer = "library-bindings"`) emits the
   `library-sugar-binding-entry` DECLARATION catalog for each annotated function.
 - `go-contracts` (`emit = "ir-document"`) emits the body-derived
   function-contracts + harvested callsites, gated on the declaration.
+- `go-realize` (`kind = "realize"`) materializes the same concept back into
+  native Go sugar through the Go kit.
 
-Both resolve to `provekit-lift-go-verify`, which emits different IR per surface
-(so a function is not minted twice).
+The lift surfaces resolve to `provekit-lift-go-verify`, which emits different
+IR per surface (so a function is not minted twice). The realize surface resolves
+to `provekit-realize-go-core`.
 
 ## The closed loop
 

--- a/examples/rusqlite-demo-consumer/.provekit/config.toml
+++ b/examples/rusqlite-demo-consumer/.provekit/config.toml
@@ -1,0 +1,5 @@
+[[plugins]]
+name = "rust-realize-rusqlite"
+kind = "realize"
+surface = "rust-rusqlite"
+

--- a/implementations/go/.provekit/lift/go/manifest.toml
+++ b/implementations/go/.provekit/lift/go/manifest.toml
@@ -1,3 +1,11 @@
 name = "go-lift"
-command = ["go", "run", "./cmd/provekit-lift-go"]
-working_dir = "provekit-lift-go-tests"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["go", "run", "./cmd/provekit-lift-go-verify", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["go"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -10,10 +10,8 @@
 //
 //   1. `dispatch_realize(target_lang, library_tag, request)`
 //      Resolves a `kind = "realize"` (sugar/body-template) plugin for
-//      `(target_lang, library_tag.unwrap_or("default"))` via convention
-//      (`.provekit/realize/<surface>/manifest.toml` or a built-in path; the
-//      Java built-in path is
-//      `implementations/java/provekit-realize-java-core/target/...`).
+//      `(target_lang, library_tag.unwrap_or("default"))` via project
+//      registration plus `.provekit/realize/<surface>/manifest.toml`.
 //      Invokes the PEP 1.7.0 `provekit.plugin.invoke` method and returns
 //      `{ source, is_stub }`.
 //
@@ -169,6 +167,7 @@ fn build_run_plugin_registry(workspace_root: &Path) -> Result<RunPluginRegistry,
 fn scan_manifest_plugins(workspace_root: &Path) -> Result<Vec<ManifestPluginRegistration>, String> {
     let mut plugins = Vec::new();
     let configured_emit_surfaces = configured_emit_surface_names(workspace_root);
+    let configured_realize_surfaces = configured_realize_surface_names(workspace_root);
     for kind in REGISTRY_MANIFEST_KINDS {
         let kind_dir = workspace_root.join(".provekit").join(kind);
         let Ok(entries) = std::fs::read_dir(&kind_dir) else {
@@ -188,6 +187,9 @@ fn scan_manifest_plugins(workspace_root: &Path) -> Result<Vec<ManifestPluginRegi
         surfaces.sort_by(|a, b| a.0.cmp(&b.0));
         for (surface, path) in surfaces {
             if *kind == "emit" && !configured_emit_surfaces.contains(&surface) {
+                continue;
+            }
+            if *kind == "realize" && !configured_realize_surfaces.contains(&surface) {
                 continue;
             }
             let manifest_path = path.join("manifest.toml");
@@ -1057,6 +1059,15 @@ fn resolve_realize_command(
             });
         }
     }
+    if configured_realize_surfaces(workspace_root, target_lang).is_empty() {
+        return Err(KitUnavailable {
+            kit_kind: "realize",
+            language: target_lang.to_string(),
+            detail: format!(
+                "no realize plugin registration for language `{target_lang}` in .provekit/config.toml"
+            ),
+        });
+    }
 
     let requested = library_tag.unwrap_or(DEFAULT_LIBRARY_TAG);
     let registry_candidates =
@@ -1217,6 +1228,10 @@ fn project_realize_candidates(
     workspace_root: &Path,
     target_lang: &str,
 ) -> Result<Vec<RealizeCandidate>, String> {
+    let configured = configured_realize_surfaces(workspace_root, target_lang);
+    if configured.is_empty() {
+        return Ok(Vec::new());
+    }
     let realize_dir = workspace_root.join(".provekit").join("realize");
     let Ok(entries) = std::fs::read_dir(&realize_dir) else {
         return Ok(Vec::new());
@@ -1236,6 +1251,9 @@ fn project_realize_candidates(
 
     let mut out = Vec::new();
     for (surface, path) in surfaces {
+        if !configured.contains(&surface) {
+            continue;
+        }
         if !realize_surface_matches_target(&surface, target_lang) {
             continue;
         }
@@ -1627,6 +1645,34 @@ fn configured_emit_surface_names(workspace_root: &Path) -> BTreeSet<String> {
             (!surface.is_empty()).then_some(surface)
         })
         .collect()
+}
+
+fn configured_realize_surface_names(workspace_root: &Path) -> BTreeSet<String> {
+    read_project_config(workspace_root)
+        .plugins
+        .into_iter()
+        .filter(|plugin| plugin.is_realize_plugin())
+        .filter_map(|plugin| {
+            let surface = plugin.surface.trim().to_string();
+            (!surface.is_empty()).then_some(surface)
+        })
+        .collect()
+}
+
+fn configured_realize_surfaces(workspace_root: &Path, target_lang: &str) -> Vec<String> {
+    let mut surfaces = read_project_config(workspace_root)
+        .plugins
+        .into_iter()
+        .filter(|plugin| plugin.is_realize_plugin())
+        .filter_map(|plugin| {
+            let surface = plugin.surface.trim().to_string();
+            (!surface.is_empty() && realize_surface_matches_target(&surface, target_lang))
+                .then_some(surface)
+        })
+        .collect::<Vec<_>>();
+    surfaces.sort();
+    surfaces.dedup();
+    surfaces
 }
 
 fn configured_emit_surfaces(

--- a/implementations/rust/provekit-cli/src/project_config.rs
+++ b/implementations/rust/provekit-cli/src/project_config.rs
@@ -15,9 +15,10 @@ use std::path::{Path, PathBuf};
 /// One entry in `.provekit/config.toml`'s `[[plugins]]` array.
 ///
 /// Each entry declares one project-enabled plugin. `kind = "lift"` routes
-/// to `.provekit/lift/<surface>/manifest.toml`; `kind = "emit"` routes
+/// to `.provekit/lift/<surface>/manifest.toml`; `kind = "realize"` routes
+/// to `.provekit/realize/<surface>/manifest.toml`; `kind = "emit"` routes
 /// to `.provekit/emit/<surface>/manifest.toml`. Omitted kind preserves
-/// legacy dual-use registrations.
+/// legacy lift/emit dual-use registrations.
 #[derive(Debug, Clone, Default)]
 pub struct PluginEntry {
     /// Human label for diagnostics. Optional; falls back to `surface`.
@@ -67,6 +68,13 @@ impl PluginEntry {
             .as_deref()
             .map(|kind| kind.eq_ignore_ascii_case("emit"))
             .unwrap_or(true)
+    }
+
+    pub fn is_realize_plugin(&self) -> bool {
+        self.kind
+            .as_deref()
+            .map(|kind| kind.eq_ignore_ascii_case("realize"))
+            .unwrap_or(false)
     }
 }
 
@@ -456,13 +464,23 @@ name = "java-testng-lifter"
 kind = "lift"
 surface = "java-testng"
 emit = "ir-document"
+
+[[plugins]]
+name = "java-realize"
+kind = "realize"
+surface = "java"
 "#,
         );
-        assert_eq!(cfg.plugins.len(), 2);
+        assert_eq!(cfg.plugins.len(), 3);
         assert!(cfg.plugins[0].is_emit_plugin());
         assert!(!cfg.plugins[0].is_lift_plugin());
+        assert!(!cfg.plugins[0].is_realize_plugin());
         assert!(cfg.plugins[1].is_lift_plugin());
         assert!(!cfg.plugins[1].is_emit_plugin());
+        assert!(!cfg.plugins[1].is_realize_plugin());
+        assert!(cfg.plugins[2].is_realize_plugin());
+        assert!(!cfg.plugins[2].is_lift_plugin());
+        assert!(!cfg.plugins[2].is_emit_plugin());
     }
 
     #[test]

--- a/implementations/rust/provekit-cli/tests/cmd_emit_go_testing.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_emit_go_testing.rs
@@ -83,6 +83,69 @@ fn install_emit_registration(project: &Path, emitter: &Path) {
     .expect("write emit manifest");
 }
 
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap_or_else(|_| panic!("mkdir {}", dst.display()));
+    for entry in fs::read_dir(src).unwrap_or_else(|_| panic!("read {}", src.display())) {
+        let entry = entry.expect("read dir entry");
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type().expect("entry file type").is_dir() {
+            copy_dir_recursive(&src_path, &dst_path);
+        } else {
+            fs::copy(&src_path, &dst_path).unwrap_or_else(|_| {
+                panic!("copy {} -> {}", src_path.display(), dst_path.display())
+            });
+        }
+    }
+}
+
+fn rewrite_manifest_command(manifest: &Path, command: &Path) {
+    let text = fs::read_to_string(manifest)
+        .unwrap_or_else(|_| panic!("read checked-in manifest {}", manifest.display()));
+    let escaped = command
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let rewritten = text
+        .lines()
+        .map(|line| {
+            if line.trim_start().starts_with("command = ") {
+                format!("command = [\"{escaped}\", \"--rpc\"]")
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(manifest, format!("{rewritten}\n"))
+        .unwrap_or_else(|_| panic!("write manifest {}", manifest.display()));
+}
+
+fn write_basic_emit_plan(plan: &Path) {
+    fs::write(
+        plan,
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "contract_id": "concept:eq",
+            "package_name": "sample",
+            "function": "Id",
+            "params": ["x"],
+            "param_types": ["int"],
+            "return_type": "int",
+            "predicates": [{
+                "kind": "atomic",
+                "name": "concept:eq",
+                "args": [
+                    {"kind": "var", "name": "x"},
+                    {"kind": "var", "name": "x"}
+                ]
+            }]
+        }))
+        .expect("encode plan"),
+    )
+    .expect("write plan");
+}
+
 #[test]
 fn emit_go_testing_dispatches_manifest_writes_artifact_and_compile_checks() {
     if !go_available() {
@@ -105,27 +168,7 @@ fn emit_go_testing_dispatches_manifest_writes_artifact_and_compile_checks() {
     install_emit_registration(&project, &emitter);
 
     let plan = project.join("plan.json");
-    fs::write(
-        &plan,
-        serde_json::to_vec_pretty(&serde_json::json!({
-            "contract_id": "concept:eq",
-            "package_name": "sample",
-            "function": "Id",
-            "params": ["x"],
-            "param_types": ["int"],
-            "return_type": "int",
-            "predicates": [{
-                "kind": "atomic",
-                "name": "concept:eq",
-                "args": [
-                    {"kind": "var", "name": "x"},
-                    {"kind": "var", "name": "x"}
-                ]
-            }]
-        }))
-        .expect("encode plan"),
-    )
-    .expect("write plan");
+    write_basic_emit_plan(&plan);
 
     let output = Command::new(provekit_bin())
         .arg("emit")
@@ -175,4 +218,69 @@ fn emit_go_testing_dispatches_manifest_writes_artifact_and_compile_checks() {
         !emitted.contains("testify"),
         "stdlib testing emitter must not reference testify:\n{emitted}"
     );
+}
+
+#[test]
+fn emit_go_testing_uses_checked_in_go_double_registration() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("go-double");
+    let out_dir = temp.path().join("out");
+    fs::create_dir_all(&project).expect("mkdir project");
+    fs::create_dir_all(&out_dir).expect("mkdir out");
+    fs::write(
+        out_dir.join("go.mod"),
+        "module example.com/provekit_emit\n\ngo 1.22\n",
+    )
+    .expect("write go.mod");
+
+    let example = repo_root().join("examples").join("go-double");
+    copy_dir_recursive(&example.join(".provekit"), &project.join(".provekit"));
+
+    let emitter = build_go_testing_emitter();
+    rewrite_manifest_command(
+        &project
+            .join(".provekit")
+            .join("emit")
+            .join("go-testing")
+            .join("manifest.toml"),
+        &emitter,
+    );
+
+    let plan = project.join("plan.json");
+    write_basic_emit_plan(&plan);
+
+    let output = Command::new(provekit_bin())
+        .arg("emit")
+        .arg("--project")
+        .arg(&project)
+        .arg("--target")
+        .arg("go")
+        .arg("--framework")
+        .arg("testing")
+        .arg("--plan")
+        .arg(&plan)
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--compile-check")
+        .arg("--json")
+        .output()
+        .expect("spawn provekit emit");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "checked-in Go fixture registration must drive emit\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let receipt: Value = serde_json::from_str(&stdout).expect("emit stdout is JSON");
+    assert_eq!(receipt["ok"], true, "receipt: {receipt}");
+    assert_eq!(receipt["surface"], "go-testing", "receipt: {receipt}");
+    assert_eq!(receipt["targetLanguage"], "go", "receipt: {receipt}");
+    assert_eq!(receipt["targetFramework"], "testing", "receipt: {receipt}");
+    assert_eq!(receipt["isComplete"], true, "receipt: {receipt}");
 }

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -31,6 +31,20 @@ fn install_node_manifest(root: &Path, surface: &str, script: &Path, library_tag:
     install_node_manifest_with_metadata(root, surface, script, library_tag, None, &[]);
 }
 
+fn append_realize_registration(root: &Path, name: &str, surface: &str) {
+    let provekit_dir = root.join(".provekit");
+    fs::create_dir_all(&provekit_dir).expect("create .provekit dir");
+    let config = provekit_dir.join("config.toml");
+    let mut text = fs::read_to_string(&config).unwrap_or_default();
+    if !text.is_empty() && !text.ends_with('\n') {
+        text.push('\n');
+    }
+    text.push_str(&format!(
+        "\n[[plugins]]\nname = \"{name}\"\nkind = \"realize\"\nsurface = \"{surface}\"\n"
+    ));
+    fs::write(config, text).expect("write realize config registration");
+}
+
 fn install_node_manifest_with_metadata(
     root: &Path,
     surface: &str,
@@ -61,6 +75,7 @@ fn install_node_manifest_with_metadata(
     );
     append_manifest_metadata(&mut manifest_text, family, provides_concepts);
     fs::write(manifest, manifest_text).expect("write manifest");
+    append_realize_registration(root, &format!("typescript-realize-{library_tag}"), surface);
 }
 
 fn append_manifest_metadata(
@@ -110,6 +125,7 @@ fn install_python_script_manifest_with_metadata(
     );
     append_manifest_metadata(&mut manifest_text, family, provides_concepts);
     fs::write(manifest, manifest_text).expect("write manifest");
+    append_realize_registration(root, &format!("python-realize-{library_tag}"), surface);
 }
 
 fn install_binary_manifest(
@@ -138,6 +154,7 @@ fn install_binary_manifest(
          working_dir = \".\"\n",
     );
     fs::write(manifest, manifest_text).expect("write manifest");
+    append_realize_registration(root, manifest_name, surface);
 }
 
 fn install_python_module_manifest(
@@ -169,6 +186,7 @@ fn install_python_module_manifest(
          working_dir = \".\"\n",
     );
     fs::write(manifest, manifest_text).expect("write manifest");
+    append_realize_registration(root, manifest_name, surface);
 }
 
 fn write_typescript_project_fixture(workspace: &Path) -> PathBuf {
@@ -787,12 +805,16 @@ for line in sys.stdin:
 
     let (before, before_code) = run_verify_json_with_code(workspace.path());
     assert_eq!(
-        before_code, 0,
-        "pre-materialize verify should be empty: {before}"
+        before_code, 1,
+        "pre-materialize verify should reject the empty proof as non-success: {before}"
     );
     assert_eq!(
         before["totalClaims"], 0,
         "without the materialize bridge the boundary call should not enumerate: {before}"
+    );
+    assert_eq!(
+        before["ok"], false,
+        "zero-claim verification must not be reported as ok: {before}"
     );
 
     let output = Command::new(env!("CARGO_BIN_EXE_provekit"))

--- a/implementations/rust/provekit-cli/tests/go_realize_materialize.rs
+++ b/implementations/rust/provekit-cli/tests/go_realize_materialize.rs
@@ -109,6 +109,60 @@ fn install_go_realize_manifest(root: &Path, bin: &Path) {
     fs::write(manifest, text).expect("write manifest");
 }
 
+fn install_go_realize_registration(root: &Path, bin: &Path) {
+    install_go_realize_manifest(root, bin);
+    fs::create_dir_all(root.join(".provekit")).expect("mkdir .provekit");
+    fs::write(
+        root.join(".provekit").join("config.toml"),
+        r#"[[plugins]]
+name = "go-realize"
+kind = "realize"
+surface = "go"
+
+"#,
+    )
+    .expect("write realize config");
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap_or_else(|_| panic!("mkdir {}", dst.display()));
+    for entry in fs::read_dir(src).unwrap_or_else(|_| panic!("read {}", src.display())) {
+        let entry = entry.expect("read dir entry");
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type().expect("entry file type").is_dir() {
+            copy_dir_recursive(&src_path, &dst_path);
+        } else {
+            fs::copy(&src_path, &dst_path).unwrap_or_else(|_| {
+                panic!("copy {} -> {}", src_path.display(), dst_path.display())
+            });
+        }
+    }
+}
+
+fn rewrite_manifest_command(manifest: &Path, command: &Path) {
+    let text = fs::read_to_string(manifest)
+        .unwrap_or_else(|_| panic!("read checked-in manifest {}", manifest.display()));
+    let escaped = command
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let rewritten = text
+        .lines()
+        .map(|line| {
+            if line.trim_start().starts_with("command = ") {
+                format!("command = [\"{escaped}\", \"--rpc\"]")
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(manifest, format!("{rewritten}\n"))
+        .unwrap_or_else(|_| panic!("write manifest {}", manifest.display()));
+}
+
 fn write_go_dependency_with_proof(project: &Path, proof_name: &str) -> PathBuf {
     let dep = project.join("dep");
     let proof = dep.join("META-INF").join("provekit").join(proof_name);
@@ -299,6 +353,127 @@ fn identity_request() -> RealizeRequest {
 }
 
 #[test]
+fn go_materialize_refuses_unconfigured_realize_manifest() {
+    if !go_available() {
+        eprintln!("go not on PATH: skipping go manifest registration test");
+        return;
+    }
+    let bin = build_go_realize();
+    let workspace = tempfile::tempdir().expect("tempdir");
+    install_go_realize_manifest(workspace.path(), &bin);
+    write_external_go_dependency_with_identity_body(workspace.path());
+    let src_dir = workspace.path().join("src");
+    fs::create_dir_all(&src_dir).expect("mkdir src");
+    write_go_identity_carrier(&src_dir);
+
+    let out_dir = workspace.path().join("materialized");
+    fs::create_dir_all(&out_dir).expect("mkdir out");
+    fs::write(
+        out_dir.join("go.mod"),
+        "module example.com/provekit_go_materialized\n\ngo 1.22\n",
+    )
+    .expect("write output go.mod");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("materialize")
+        .arg("--target")
+        .arg("go")
+        .arg("--library")
+        .arg("go")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--compile-check")
+        .output()
+        .expect("spawn provekit materialize for unconfigured Go");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "Go materialize must require a project [[plugins]] realize registration, not just a loose manifest\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("no realize plugin registration")
+            || stdout.contains("no realize plugin registration"),
+        "failure should explain the missing config registration\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn go_materialize_uses_checked_in_go_double_realize_registration() {
+    if !go_available() {
+        eprintln!("go not on PATH: skipping checked-in Go materialize registration test");
+        return;
+    }
+    let bin = build_go_realize();
+    let workspace = tempfile::tempdir().expect("tempdir");
+    copy_dir_recursive(
+        &repo_root()
+            .join("examples")
+            .join("go-double")
+            .join(".provekit"),
+        &workspace.path().join(".provekit"),
+    );
+    rewrite_manifest_command(
+        &workspace
+            .path()
+            .join(".provekit")
+            .join("realize")
+            .join("go")
+            .join("manifest.toml"),
+        &bin,
+    );
+    write_external_go_dependency_with_identity_body(workspace.path());
+    let src_dir = workspace.path().join("src");
+    fs::create_dir_all(&src_dir).expect("mkdir src");
+    write_go_identity_carrier(&src_dir);
+
+    let out_dir = workspace.path().join("materialized");
+    fs::create_dir_all(&out_dir).expect("mkdir out");
+    fs::write(
+        out_dir.join("go.mod"),
+        "module example.com/provekit_go_materialized\n\ngo 1.22\n",
+    )
+    .expect("write output go.mod");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("materialize")
+        .arg("--target")
+        .arg("go")
+        .arg("--library")
+        .arg("go")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--compile-check")
+        .output()
+        .expect("spawn provekit materialize for checked-in Go registration");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "checked-in go-double realize registration must drive materialize\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("assembled by go kit via RPC"),
+        "checked-in Go materialize route must assemble through the Go kit\nstderr:\n{stderr}"
+    );
+    let emitted = fs::read_to_string(out_dir.join("id.go")).expect("read materialized Go");
+    assert!(
+        emitted.contains("func Id(x int) int") && emitted.contains("return x"),
+        "materialized Go should contain identity body from checked-in registration:\n{emitted}"
+    );
+}
+
+#[test]
 fn go_materialize_uses_body_template_from_go_module_proof() {
     if !go_available() {
         eprintln!("go not on PATH: skipping go proof-backed materialize CLI test");
@@ -306,7 +481,7 @@ fn go_materialize_uses_body_template_from_go_module_proof() {
     }
     let bin = build_go_realize();
     let workspace = tempfile::tempdir().expect("tempdir");
-    install_go_realize_manifest(workspace.path(), &bin);
+    install_go_realize_registration(workspace.path(), &bin);
     let proof_path = write_external_go_dependency_with_proof_backed_body(workspace.path());
     assert!(
         !proof_path.starts_with(workspace.path()),
@@ -367,7 +542,7 @@ fn go_dependency_proofs_are_resolved_by_configured_go_kit() {
     }
     let bin = build_go_realize();
     let workspace = tempfile::tempdir().expect("tempdir");
-    install_go_realize_manifest(workspace.path(), &bin);
+    install_go_realize_registration(workspace.path(), &bin);
     let proof_name = "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.proof";
     let expected = write_go_dependency_with_proof(workspace.path(), proof_name);
 
@@ -402,7 +577,7 @@ fn go_materialize_cli_rewrites_carrier_and_asks_go_kit_to_compile_check() {
     }
     let bin = build_go_realize();
     let workspace = tempfile::tempdir().expect("tempdir");
-    install_go_realize_manifest(workspace.path(), &bin);
+    install_go_realize_registration(workspace.path(), &bin);
     write_external_go_dependency_with_identity_body(workspace.path());
     let src_dir = workspace.path().join("src");
     fs::create_dir_all(&src_dir).expect("mkdir src");
@@ -470,7 +645,7 @@ fn go_materialize_infers_target_from_registered_go_manifest() {
     }
     let bin = build_go_realize();
     let workspace = tempfile::tempdir().expect("tempdir");
-    install_go_realize_manifest(workspace.path(), &bin);
+    install_go_realize_registration(workspace.path(), &bin);
     write_external_go_dependency_with_identity_body(workspace.path());
     let src_dir = workspace.path().join("src");
     fs::create_dir_all(&src_dir).expect("mkdir src");
@@ -530,7 +705,7 @@ fn go_realize_shim_materializes_compilable_go_for_identity() {
     }
     let bin = build_go_realize();
     let workspace = unique_dir("ws");
-    install_go_realize_manifest(&workspace, &bin);
+    install_go_realize_registration(&workspace, &bin);
     write_external_go_dependency_with_identity_body(&workspace);
 
     let realized = dispatch_realize(&workspace, "go", None, &identity_request())


### PR DESCRIPTION
## Summary
- Register `examples/go-double` through project `[[plugins]]` for Go lift, Go realize/materialize, and separate `go-testing` / `go-testify` emit packages.
- Require realize dispatch to be config-authorized before a `.provekit/realize/<surface>/manifest.toml` can participate; loose realize manifests no longer bypass project registration.
- Add checked-in Go materialize coverage that copies the fixture config, only patches the executable path, and proves `provekit materialize --library go` routes through the Go kit over RPC.
- Update Go identity / rust-rusqlite fixtures and materialize test helpers so realize fixtures use the same config+manifest registration shape.
- Preserve the nonvacuous verify invariant in materialize bridge coverage: `totalClaims: 0` is not ok.

Addresses #1485.

## Verification
- Red: `go_materialize_refuses_unconfigured_realize_manifest` initially failed because materialize succeeded with only a loose realize manifest.
- Red: `go_materialize_uses_checked_in_go_double_realize_registration` initially failed because the checked-in Go realize manifest registered as `default` instead of `library_tag = "go"`.
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test go_realize_materialize -- --nocapture` (8 passed)
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_materialize_integration -- --nocapture` (18 passed)
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_emit_go_testing -- --nocapture` (2 passed)
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_verify_go_production_bridge -- --nocapture` (4 passed)
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli project_config::tests::parses_plugin_kind_for_dispatch_filtering -- --nocapture`
- `git diff --check`
- `rustfmt --check implementations/rust/provekit-cli/src/kit_dispatch.rs implementations/rust/provekit-cli/src/project_config.rs implementations/rust/provekit-cli/tests/go_realize_materialize.rs implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs implementations/rust/provekit-cli/tests/cmd_emit_go_testing.rs`