### PR TITLE
feat(rust): expose shared LSP document analysis

### DIFF
--- a/implementations/rust/provekit-lsp-rust/src/main.rs
+++ b/implementations/rust/provekit-lsp-rust/src/main.rs
@@ -10,7 +10,8 @@
 //
 //   {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
 //   {"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"...","source":"..."}}
-//   {"jsonrpc":"2.0","id":3,"method":"shutdown"}
+//   {"jsonrpc":"2.0","id":3,"method":"analyzeDocument","params":{"file":"...","text":"..."}}
+//   {"jsonrpc":"2.0","id":4,"method":"shutdown"}
 //
 // The `parse` handler parses the source with `syn`, runs all registered
 // lift adapters (proptest, contracts, kani, prusti, rust-tests, etc.),
@@ -56,6 +57,10 @@ use provekit_lift::{
     adapter_prusti, adapter_quickcheck, adapter_rust_tests, adapter_verus,
 };
 use provekit_lsp_rust::forward_propagator::ForwardPropagator;
+
+const KIT_ID: &str = "rust";
+const SHARED_LSP_PROTOCOL_VERSION: &str = "provekit-lsp-shared/1";
+const SHARED_LSP_PROTOCOL_CATALOG_CID: &str = "blake3-512:0e3905c2a7a098cd538b9669428a7dffd2b84ba8ccf8fde3724fe2ab61fd3fbc1e1a616a6b20b6817464cdc50c466b5497d4ac2e2dc34c3c15f05535b463643c";
 
 fn main() {
     // Parse CLI.
@@ -115,9 +120,26 @@ fn main() {
                     "result": {
                         "name": "provekit-lsp-rust",
                         "version": "0.1.0",
-                        "capabilities": ["parse"]
+                        "protocol_version": SHARED_LSP_PROTOCOL_VERSION,
+                        "kit_id": KIT_ID,
+                        "protocol_catalog_cid": SHARED_LSP_PROTOCOL_CATALOG_CID,
+                        "capabilities": {
+                            "source_surfaces": ["rust-source"],
+                            "entry_kinds": ["bind-lift-entry"],
+                            "diagnostic_codes": [
+                                "provekit.lsp.parse_error",
+                                "provekit.lsp.implication_failed"
+                            ],
+                            "status_kinds": ["materialize", "emit", "check", "prove"]
+                        }
                     }
                 });
+                let _ = writeln!(stdout, "{resp}");
+                let _ = stdout.flush();
+            }
+            "analyzeDocument" => {
+                let params = req.get("params").cloned().unwrap_or_default();
+                let resp = handle_analyze_document(id.clone(), params);
                 let _ = writeln!(stdout, "{resp}");
                 let _ = stdout.flush();
             }
@@ -250,6 +272,223 @@ fn project_cid_from_socket(socket_path: &PathBuf) -> String {
     let mut h = DefaultHasher::new();
     socket_path.hash(&mut h);
     format!("{:016x}", h.finish())
+}
+
+fn handle_analyze_document(
+    id: serde_json::Value,
+    params: serde_json::Value,
+) -> serde_json::Value {
+    let file = params
+        .get("file")
+        .or_else(|| params.get("path"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("source.rs");
+    let uri = params
+        .get("uri")
+        .and_then(|v| v.as_str())
+        .map(str::to_owned)
+        .unwrap_or_else(|| format!("file://{file}"));
+    let source = params
+        .get("text")
+        .or_else(|| params.get("source"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let parse_resp = handle_parse(serde_json::Value::Null, source, file);
+    let result = match parse_resp.get("result") {
+        Some(result) => result,
+        None => {
+            let message = parse_resp
+                .get("error")
+                .and_then(|err| err.get("message"))
+                .and_then(|message| message.as_str())
+                .unwrap_or("rust source parse failed");
+            return analyze_document_response(
+                id,
+                &uri,
+                file,
+                source,
+                Vec::new(),
+                vec![parse_error_diagnostic(message)],
+                Vec::new(),
+            );
+        }
+    };
+
+    let entries = result
+        .get("declarations")
+        .and_then(|v| v.as_array())
+        .into_iter()
+        .flatten()
+        .cloned()
+        .map(|entry| {
+            serde_json::json!({
+                "kind": "bind-lift-entry",
+                "entry": entry,
+                "range": whole_document_range(source)
+            })
+        })
+        .collect();
+
+    let diagnostics = result
+        .get("diagnostics")
+        .and_then(|v| v.as_array())
+        .into_iter()
+        .flatten()
+        .map(shared_diagnostic_from_lsp_diagnostic)
+        .collect();
+
+    analyze_document_response(id, &uri, file, source, entries, diagnostics, Vec::new())
+}
+
+fn analyze_document_response(
+    id: serde_json::Value,
+    uri: &str,
+    file: &str,
+    source: &str,
+    entries: Vec<serde_json::Value>,
+    diagnostics: Vec<serde_json::Value>,
+    statuses: Vec<serde_json::Value>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": {
+            "kind": "lsp-document-analysis",
+            "schema_version": "1",
+            "kit_id": KIT_ID,
+            "uri": uri,
+            "file": file,
+            "document_cid": blake3_512_cid(source.as_bytes()),
+            "protocol_catalog_cid": SHARED_LSP_PROTOCOL_CATALOG_CID,
+            "entries": entries,
+            "diagnostics": diagnostics,
+            "statuses": statuses,
+            "project": null
+        }
+    })
+}
+
+fn parse_error_diagnostic(message: &str) -> serde_json::Value {
+    serde_json::json!({
+        "code": "provekit.lsp.parse_error",
+        "message": message,
+        "severity": "error",
+        "range": first_byte_range(),
+        "producer": "kit",
+        "kit_id": KIT_ID,
+        "protocol_catalog_cid": SHARED_LSP_PROTOCOL_CATALOG_CID
+    })
+}
+
+fn shared_diagnostic_from_lsp_diagnostic(diagnostic: &serde_json::Value) -> serde_json::Value {
+    let code = diagnostic
+        .get("data")
+        .and_then(|data| data.get("kind"))
+        .and_then(|kind| kind.as_str())
+        .or_else(|| diagnostic.get("code").and_then(|code| code.as_str()))
+        .unwrap_or("provekit.lsp.lift_gap");
+    let message = diagnostic
+        .get("message")
+        .and_then(|message| message.as_str())
+        .unwrap_or("ProvekIt diagnostic");
+    let severity = diagnostic
+        .get("severity")
+        .and_then(|severity| severity.as_u64())
+        .map(shared_severity)
+        .unwrap_or("information");
+    let range = diagnostic
+        .get("range")
+        .map(lsp_range_to_source_range)
+        .unwrap_or_else(first_byte_range);
+
+    let mut shared = serde_json::json!({
+        "code": code,
+        "message": message,
+        "severity": severity,
+        "range": range,
+        "producer": "forward-propagation",
+        "kit_id": KIT_ID,
+        "protocol_catalog_cid": SHARED_LSP_PROTOCOL_CATALOG_CID
+    });
+    if let Some(data) = diagnostic.get("data") {
+        shared["data"] = data.clone();
+    }
+    shared
+}
+
+fn shared_severity(severity: u64) -> &'static str {
+    match severity {
+        1 => "error",
+        2 => "warning",
+        3 => "information",
+        4 => "hint",
+        _ => "information",
+    }
+}
+
+fn lsp_range_to_source_range(range: &serde_json::Value) -> serde_json::Value {
+    let start = range.get("start").unwrap_or(&serde_json::Value::Null);
+    let end = range.get("end").unwrap_or(&serde_json::Value::Null);
+    let start_line = start.get("line").and_then(|v| v.as_u64()).unwrap_or(0) + 1;
+    let start_col = start
+        .get("character")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let end_line = end.get("line").and_then(|v| v.as_u64()).unwrap_or(0) + 1;
+    let end_col = end
+        .get("character")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(start_col);
+    serde_json::json!({
+        "start_line": start_line,
+        "start_col": start_col,
+        "end_line": end_line,
+        "end_col": end_col
+    })
+}
+
+fn whole_document_range(source: &str) -> serde_json::Value {
+    let mut line = 1u64;
+    let mut col = 0u64;
+    for ch in source.chars() {
+        if ch == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    serde_json::json!({
+        "start_line": 1,
+        "start_col": 0,
+        "end_line": line,
+        "end_col": col
+    })
+}
+
+fn first_byte_range() -> serde_json::Value {
+    serde_json::json!({
+        "start_line": 1,
+        "start_col": 0,
+        "end_line": 1,
+        "end_col": 0
+    })
+}
+
+fn blake3_512_cid(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(bytes);
+    let mut output = [0u8; 64];
+    hasher.finalize_xof().fill(&mut output);
+
+    let mut cid = String::from("blake3-512:");
+    for byte in output {
+        write!(&mut cid, "{byte:02x}").expect("write to string");
+    }
+    cid
 }
 
 /// Default mode: parse Rust `source` with syn, run the lift adapters, and

--- a/implementations/rust/provekit-lsp-rust/tests/round_trip.rs
+++ b/implementations/rust/provekit-lsp-rust/tests/round_trip.rs
@@ -99,12 +99,34 @@ fn initialize_returns_capabilities() {
         result.get("version").and_then(|v| v.as_str()).is_some(),
         "missing version: {result}"
     );
+    assert_eq!(
+        result["protocol_version"].as_str(),
+        Some("provekit-lsp-shared/1"),
+        "rust helper must advertise the shared LSP protocol: {result}"
+    );
+    assert_eq!(
+        result["kit_id"].as_str(),
+        Some("rust"),
+        "rust helper must identify its owning kit: {result}"
+    );
     let caps = result["capabilities"]
-        .as_array()
-        .unwrap_or_else(|| panic!("missing capabilities array: {result}"));
+        .as_object()
+        .unwrap_or_else(|| panic!("missing capabilities object: {result}"));
     assert!(
-        caps.iter().any(|c| c.as_str() == Some("parse")),
-        "capabilities must include 'parse': {caps:?}"
+        caps.get("source_surfaces")
+            .and_then(|v| v.as_array())
+            .into_iter()
+            .flatten()
+            .any(|c| c.as_str() == Some("rust-source")),
+        "capabilities must include rust-source: {caps:?}"
+    );
+    assert!(
+        caps.get("diagnostic_codes")
+            .and_then(|v| v.as_array())
+            .into_iter()
+            .flatten()
+            .any(|c| c.as_str() == Some("provekit.lsp.implication_failed")),
+        "capabilities must include the stable implication diagnostic code: {caps:?}"
     );
 
     // Tidy shutdown.
@@ -243,6 +265,101 @@ fn parse_floor_fixture_emits_forward_propagation_diagnostic() {
             .and_then(|items| items.first())
             .and_then(|item| item.as_str()),
         Some("x > 0")
+    );
+
+    let _ = plugin.exchange(&json!({"jsonrpc":"2.0","id":99,"method":"shutdown"}));
+    let _ = plugin.wait_for_exit(Duration::from_secs(10));
+}
+
+#[test]
+fn analyze_document_floor_fixture_emits_shared_callsite_diagnostic() {
+    let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../..")
+        .join("tests/lsp/floor-fixture/rust.rs");
+    let source = std::fs::read_to_string(&fixture_path)
+        .unwrap_or_else(|err| panic!("read fixture {fixture_path:?}: {err}"));
+
+    let mut plugin = Plugin::spawn();
+
+    let _ = plugin.exchange(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "client": {"name": "provekit-lsp", "version": "0.0.0"},
+            "protocol_version": "provekit-lsp-shared/1"
+        }
+    }));
+
+    let resp = plugin.exchange(&json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "analyzeDocument",
+        "params": {
+            "kit_id": "rust",
+            "uri": "file:///project/tests/lsp/floor-fixture/rust.rs",
+            "file": "tests/lsp/floor-fixture/rust.rs",
+            "text": source,
+            "document_version": 42,
+            "workspace_root": "/project",
+            "accepted_protocol_catalog_cids": [],
+            "policy_cids": []
+        }
+    }));
+
+    let result = resp
+        .get("result")
+        .unwrap_or_else(|| panic!("analyzeDocument returned error: {resp}"));
+
+    assert_eq!(result["kind"].as_str(), Some("lsp-document-analysis"));
+    assert_eq!(result["schema_version"].as_str(), Some("1"));
+    assert_eq!(result["kit_id"].as_str(), Some("rust"));
+    assert_eq!(
+        result["uri"].as_str(),
+        Some("file:///project/tests/lsp/floor-fixture/rust.rs")
+    );
+    assert_eq!(
+        result["file"].as_str(),
+        Some("tests/lsp/floor-fixture/rust.rs")
+    );
+    let document_cid = result["document_cid"]
+        .as_str()
+        .unwrap_or_else(|| panic!("missing document CID: {result}"));
+    assert!(
+        document_cid.starts_with("blake3-512:") && document_cid.len() == "blake3-512:".len() + 128,
+        "document CID must be a BLAKE3-512 CID: {document_cid}"
+    );
+    assert!(
+        result["entries"].as_array().is_some(),
+        "entries must be an array: {result}"
+    );
+    assert!(
+        result["statuses"].as_array().is_some(),
+        "statuses must be an array: {result}"
+    );
+    assert!(result["project"].is_null(), "project state must be null: {result}");
+
+    let diagnostics = result["diagnostics"]
+        .as_array()
+        .unwrap_or_else(|| panic!("diagnostics must be an array: {result}"));
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "only the negative callsite should emit a diagnostic: {diagnostics:#?}"
+    );
+    let diagnostic = &diagnostics[0];
+    assert_eq!(
+        diagnostic["code"].as_str(),
+        Some("provekit.lsp.implication_failed")
+    );
+    assert_eq!(diagnostic["severity"].as_str(), Some("error"));
+    assert_eq!(diagnostic["producer"].as_str(), Some("forward-propagation"));
+    assert_eq!(diagnostic["kit_id"].as_str(), Some("rust"));
+    assert_eq!(diagnostic["range"]["start_line"].as_u64(), Some(20));
+    assert_eq!(diagnostic["range"]["start_col"].as_u64(), Some(17));
+    assert_eq!(
+        diagnostic["data"]["callee"].as_str(),
+        Some("checkPositive")
     );
 
     let _ = plugin.exchange(&json!({"jsonrpc":"2.0","id":99,"method":"shutdown"}));


### PR DESCRIPTION
Summary
- advertise `provekit-lsp-shared/1` from the Rust kit LSP helper
- add `analyzeDocument` returning `lsp-document-analysis` with document CID, entries, diagnostics, statuses, and project fields
- lift existing Rust forward-propagation diagnostics into shared diagnostic code/range shape at the call site while keeping legacy `parse` available

Refs #1503, #1486, #308.

Verification
- `CARGO_BUILD_JOBS=2 cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-lsp-rust --test round_trip analyze_document_floor_fixture_emits_shared_callsite_diagnostic -- --exact`
- `CARGO_BUILD_JOBS=2 cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-lsp-rust --test round_trip`
- `CARGO_BUILD_JOBS=2 cargo check --manifest-path implementations/rust/Cargo.toml -p provekit-lsp-rust`
- `git diff --check`