### PR TITLE
feat(go): expose shared LSP document analysis

### DIFF
--- a/implementations/go/cmd/provekit-lsp-go/main.go
+++ b/implementations/go/cmd/provekit-lsp-go/main.go
@@ -4,7 +4,8 @@
 //
 //	{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
 //	{"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"...","source":"..."}}
-//	{"jsonrpc":"2.0","id":3,"method":"shutdown"}
+//	{"jsonrpc":"2.0","id":3,"method":"analyzeDocument","params":{"file":"...","text":"..."}}
+//	{"jsonrpc":"2.0","id":4,"method":"shutdown"}
 //
 // For parse, scans the source for //provekit: annotations and
 // go-playground/validator struct tags, lifts to canonical IR,
@@ -29,6 +30,12 @@ import (
 	validator "github.com/tsavo/provekit/go/provekit-lift-go-validator"
 )
 
+const (
+	goKitID                     = "go"
+	sharedLSPProtocolVersion    = "provekit-lsp-shared/1"
+	sharedLSPProtocolCatalogCID = "blake3-512:0e3905c2a7a098cd538b9669428a7dffd2b84ba8ccf8fde3724fe2ab61fd3fbc1e1a616a6b20b6817464cdc50c466b5497d4ac2e2dc34c3c15f05535b463643c"
+)
+
 type rpcRequest struct {
 	JSONRPC string          `json:"jsonrpc"`
 	ID      interface{}     `json:"id"`
@@ -38,6 +45,15 @@ type rpcRequest struct {
 
 type parseParams struct {
 	Path   string `json:"path"`
+	Source string `json:"source"`
+}
+
+type analyzeDocumentParams struct {
+	KitID  string `json:"kit_id"`
+	URI    string `json:"uri"`
+	File   string `json:"file"`
+	Path   string `json:"path"`
+	Text   string `json:"text"`
 	Source string `json:"source"`
 }
 
@@ -54,9 +70,19 @@ type rpcError struct {
 }
 
 type initializeResult struct {
-	Name         string   `json:"name"`
-	Version      string   `json:"version"`
-	Capabilities []string `json:"capabilities"`
+	Name               string          `json:"name"`
+	Version            string          `json:"version"`
+	ProtocolVersion    string          `json:"protocol_version"`
+	KitID              string          `json:"kit_id"`
+	ProtocolCatalogCID string          `json:"protocol_catalog_cid"`
+	Capabilities       lspCapabilities `json:"capabilities"`
+}
+
+type lspCapabilities struct {
+	SourceSurfaces  []string `json:"source_surfaces"`
+	EntryKinds      []string `json:"entry_kinds"`
+	DiagnosticCodes []string `json:"diagnostic_codes"`
+	StatusKinds     []string `json:"status_kinds"`
 }
 
 type parseResult struct {
@@ -65,6 +91,44 @@ type parseResult struct {
 	Diagnostics  []LSPDiagnostic   `json:"diagnostics"`
 	ContractCids map[string]string `json:"contractCids,omitempty"`
 	Warnings     []interface{}     `json:"warnings"`
+}
+
+type sourceRange struct {
+	StartLine int `json:"start_line"`
+	StartCol  int `json:"start_col"`
+	EndLine   int `json:"end_line"`
+	EndCol    int `json:"end_col"`
+}
+
+type lspDocumentEntry struct {
+	Kind  string      `json:"kind"`
+	Entry interface{} `json:"entry"`
+	Range sourceRange `json:"range"`
+}
+
+type sharedDiagnostic struct {
+	Code               string      `json:"code"`
+	Message            string      `json:"message"`
+	Severity           string      `json:"severity"`
+	Range              sourceRange `json:"range"`
+	Producer           string      `json:"producer"`
+	KitID              string      `json:"kit_id"`
+	ProtocolCatalogCID string      `json:"protocol_catalog_cid"`
+	Data               interface{} `json:"data,omitempty"`
+}
+
+type lspDocumentAnalysisResult struct {
+	Kind               string             `json:"kind"`
+	SchemaVersion      string             `json:"schema_version"`
+	KitID              string             `json:"kit_id"`
+	URI                string             `json:"uri"`
+	File               string             `json:"file"`
+	DocumentCID        string             `json:"document_cid"`
+	ProtocolCatalogCID string             `json:"protocol_catalog_cid"`
+	Entries            []lspDocumentEntry `json:"entries"`
+	Diagnostics        []sharedDiagnostic `json:"diagnostics"`
+	Statuses           []interface{}      `json:"statuses"`
+	Project            interface{}        `json:"project"`
 }
 
 func main() {
@@ -89,6 +153,8 @@ func handleRequest(line string) bool {
 		handleInit(req.ID)
 	case "parse":
 		handleParse(req.ID, req.Params)
+	case "analyzeDocument":
+		handleAnalyzeDocument(req.ID, req.Params)
 	case "shutdown":
 		handleShutdown(req.ID)
 		return false
@@ -100,9 +166,17 @@ func handleRequest(line string) bool {
 
 func handleInit(id interface{}) {
 	send(id, initializeResult{
-		Name:         "provekit-lsp-go",
-		Version:      "0.1.0",
-		Capabilities: []string{"parse"},
+		Name:               "provekit-lsp-go",
+		Version:            "0.1.0",
+		ProtocolVersion:    sharedLSPProtocolVersion,
+		KitID:              goKitID,
+		ProtocolCatalogCID: sharedLSPProtocolCatalogCID,
+		Capabilities: lspCapabilities{
+			SourceSurfaces:  []string{"go-source"},
+			EntryKinds:      []string{"bind-lift-entry", "call-edge"},
+			DiagnosticCodes: []string{"provekit.lsp.parse_error", "provekit.lsp.implication_failed"},
+			StatusKinds:     []string{"materialize", "emit", "check", "prove"},
+		},
 	})
 }
 
@@ -113,23 +187,67 @@ func handleParse(id interface{}, paramsRaw json.RawMessage) {
 		return
 	}
 
+	result, err := buildParseResult(params.Path, params.Source)
+	if err != nil {
+		sendError(id, -32603, err.Error())
+		return
+	}
+	send(id, result)
+}
+
+func handleAnalyzeDocument(id interface{}, paramsRaw json.RawMessage) {
+	var params analyzeDocumentParams
+	if err := json.Unmarshal(paramsRaw, &params); err != nil {
+		sendError(id, -32602, "invalid params")
+		return
+	}
+
+	path := firstNonEmpty(params.File, params.Path, "source.go")
+	source := firstNonEmpty(params.Text, params.Source)
+	uri := params.URI
+	if uri == "" {
+		uri = "file://" + path
+	}
+
+	if _, err := parser.ParseFile(token.NewFileSet(), path, source, parser.ParseComments); err != nil {
+		send(id, makeAnalysisResult(uri, path, source, nil, []sharedDiagnostic{
+			parseErrorDiagnostic(err.Error()),
+		}))
+		return
+	}
+
+	parseResult, err := buildParseResult(path, source)
+	if err != nil {
+		sendError(id, -32603, err.Error())
+		return
+	}
+
+	send(id, makeAnalysisResult(
+		uri,
+		path,
+		source,
+		analysisEntriesFromParseResult(parseResult, wholeDocumentRange(source)),
+		sharedDiagnosticsFromLSP(parseResult.Diagnostics),
+	))
+}
+
+func buildParseResult(path, source string) (parseResult, error) {
 	var decls []ir.Declaration
 	warnings := []interface{}{}
 
 	// Walk source for validator structs
-	validatorDecls := walkSource(params.Source, params.Path)
+	validatorDecls := walkSource(source, path)
 	decls = append(decls, validatorDecls...)
 
 	// Scan for //provekit: annotations
-	annotationDecls := scanAnnotations(params.Source, params.Path)
+	annotationDecls := scanAnnotations(source, path)
 	decls = append(decls, annotationDecls...)
 
 	// Marshal declarations
 	contractCids := buildContractCids(decls)
 	jcs, err := json.Marshal(decls)
 	if err != nil {
-		sendError(id, -32603, fmt.Sprintf("marshal: %v", err))
-		return
+		return parseResult{}, fmt.Errorf("marshal: %v", err)
 	}
 	if len(jcs) == 0 || string(jcs) == "null" {
 		jcs = []byte("[]")
@@ -138,29 +256,171 @@ func handleParse(id interface{}, paramsRaw json.RawMessage) {
 	// Emit call-edge stream per spec #114 R1.
 	// Walk function bodies to find call sites; emit one CallEdgeDeclaration
 	// per call site where the calling function has a known contract.
-	callEdges := walkCallEdges(params.Source, params.Path, decls)
+	callEdges := walkCallEdges(source, path, decls)
 	edgesJSON, err := json.Marshal(callEdges)
 	if err != nil {
-		sendError(id, -32603, fmt.Sprintf("marshal call edges: %v", err))
-		return
+		return parseResult{}, fmt.Errorf("marshal call edges: %v", err)
 	}
 	if len(edgesJSON) == 0 || string(edgesJSON) == "null" {
 		edgesJSON = []byte("[]")
 	}
 
-	diagnostics := FloorV1SeedForwardPropagator().EmitDiagnostics(LowerFloorSource(params.Source))
+	diagnostics := FloorV1SeedForwardPropagator().EmitDiagnostics(LowerFloorSource(source))
 
-	send(id, parseResult{
+	return parseResult{
 		Declarations: jcs,
 		CallEdges:    edgesJSON,
 		Diagnostics:  diagnostics,
 		ContractCids: contractCids,
 		Warnings:     warnings,
-	})
+	}, nil
 }
 
 func handleShutdown(id interface{}) {
 	send(id, nil)
+}
+
+func makeAnalysisResult(
+	uri string,
+	path string,
+	source string,
+	entries []lspDocumentEntry,
+	diagnostics []sharedDiagnostic,
+) lspDocumentAnalysisResult {
+	if entries == nil {
+		entries = []lspDocumentEntry{}
+	}
+	if diagnostics == nil {
+		diagnostics = []sharedDiagnostic{}
+	}
+	return lspDocumentAnalysisResult{
+		Kind:               "lsp-document-analysis",
+		SchemaVersion:      "1",
+		KitID:              goKitID,
+		URI:                uri,
+		File:               path,
+		DocumentCID:        canonicalizer.ComputeCID([]byte(source)),
+		ProtocolCatalogCID: sharedLSPProtocolCatalogCID,
+		Entries:            entries,
+		Diagnostics:        diagnostics,
+		Statuses:           []interface{}{},
+		Project:            nil,
+	}
+}
+
+func analysisEntriesFromParseResult(result parseResult, rng sourceRange) []lspDocumentEntry {
+	entries := []lspDocumentEntry{}
+	appendRawEntries(&entries, "bind-lift-entry", result.Declarations, rng)
+	appendRawEntries(&entries, "call-edge", result.CallEdges, rng)
+	return entries
+}
+
+func appendRawEntries(entries *[]lspDocumentEntry, kind string, raw json.RawMessage, rng sourceRange) {
+	if len(raw) == 0 {
+		return
+	}
+	var values []interface{}
+	if err := json.Unmarshal(raw, &values); err != nil {
+		return
+	}
+	for _, value := range values {
+		*entries = append(*entries, lspDocumentEntry{
+			Kind:  kind,
+			Entry: value,
+			Range: rng,
+		})
+	}
+}
+
+func sharedDiagnosticsFromLSP(diagnostics []LSPDiagnostic) []sharedDiagnostic {
+	shared := make([]sharedDiagnostic, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		shared = append(shared, sharedDiagnosticFromLSP(diagnostic))
+	}
+	return shared
+}
+
+func sharedDiagnosticFromLSP(diagnostic LSPDiagnostic) sharedDiagnostic {
+	code := diagnostic.Data.Kind
+	if code == "" {
+		code = diagnostic.Code
+	}
+	if code == "" {
+		code = "provekit.lsp.lift_gap"
+	}
+	return sharedDiagnostic{
+		Code:               code,
+		Message:            diagnostic.Message,
+		Severity:           sharedSeverity(diagnostic.Severity),
+		Range:              sourceRangeFromLSPRange(diagnostic.Range),
+		Producer:           "forward-propagation",
+		KitID:              goKitID,
+		ProtocolCatalogCID: sharedLSPProtocolCatalogCID,
+		Data:               diagnostic.Data,
+	}
+}
+
+func parseErrorDiagnostic(message string) sharedDiagnostic {
+	return sharedDiagnostic{
+		Code:               "provekit.lsp.parse_error",
+		Message:            message,
+		Severity:           "error",
+		Range:              sourceRange{StartLine: 1, StartCol: 0, EndLine: 1, EndCol: 0},
+		Producer:           "kit",
+		KitID:              goKitID,
+		ProtocolCatalogCID: sharedLSPProtocolCatalogCID,
+	}
+}
+
+func sharedSeverity(severity int) string {
+	switch severity {
+	case 1:
+		return "error"
+	case 2:
+		return "warning"
+	case 3:
+		return "information"
+	case 4:
+		return "hint"
+	default:
+		return "information"
+	}
+}
+
+func sourceRangeFromLSPRange(rng LSPRange) sourceRange {
+	return sourceRange{
+		StartLine: rng.Start.Line + 1,
+		StartCol:  rng.Start.Character,
+		EndLine:   rng.End.Line + 1,
+		EndCol:    rng.End.Character,
+	}
+}
+
+func wholeDocumentRange(source string) sourceRange {
+	line := 1
+	col := 0
+	for _, r := range source {
+		if r == '\n' {
+			line++
+			col = 0
+			continue
+		}
+		if r > 0xFFFF {
+			col += 2
+		} else {
+			col++
+		}
+	}
+	return sourceRange{StartLine: 1, StartCol: 0, EndLine: line, EndCol: col}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 // sendResponse is the response writer. Defaults to writing JSON to stdout.

--- a/implementations/go/cmd/provekit-lsp-go/main_test.go
+++ b/implementations/go/cmd/provekit-lsp-go/main_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -39,6 +42,22 @@ func TestHandleInit(t *testing.T) {
 	}
 	if m["version"] != "0.1.0" {
 		t.Errorf("version: got %v", m["version"])
+	}
+	if m["protocol_version"] != "provekit-lsp-shared/1" {
+		t.Errorf("protocol_version: got %v", m["protocol_version"])
+	}
+	if m["kit_id"] != "go" {
+		t.Errorf("kit_id: got %v", m["kit_id"])
+	}
+	caps, ok := m["capabilities"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("capabilities not an object: %T", m["capabilities"])
+	}
+	if !arrayContainsString(caps["source_surfaces"], "go-source") {
+		t.Fatalf("source_surfaces must contain go-source: %#v", caps["source_surfaces"])
+	}
+	if !arrayContainsString(caps["diagnostic_codes"], "provekit.lsp.implication_failed") {
+		t.Fatalf("diagnostic_codes must contain implication failure: %#v", caps["diagnostic_codes"])
 	}
 }
 
@@ -214,10 +233,126 @@ func TestHandleUnknownMethod(t *testing.T) {
 	}
 }
 
+func TestHandleAnalyzeDocumentFloorFixtureSharedDiagnostic(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), "../../../.."))
+	fixture := filepath.Join(root, "tests/lsp/floor-fixture/go.go")
+	source, err := os.ReadFile(fixture)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	done := capture()
+	params := map[string]interface{}{
+		"kit_id":                         "go",
+		"uri":                            "file:///project/tests/lsp/floor-fixture/go.go",
+		"file":                           "tests/lsp/floor-fixture/go.go",
+		"text":                           string(source),
+		"document_version":               42,
+		"workspace_root":                 "/project",
+		"accepted_protocol_catalog_cids": []interface{}{},
+		"policy_cids":                    []interface{}{},
+	}
+	handleRequest(mustMarshal(rpcRequest{
+		JSONRPC: "2.0",
+		ID:      8.0,
+		Method:  "analyzeDocument",
+		Params:  json.RawMessage(mustMarshal(params)),
+	}))
+	resp := done()
+	if resp.Error != nil {
+		t.Fatalf("analyzeDocument error: %s", resp.Error.Message)
+	}
+
+	m := resultMap(resp)
+	if m["kind"] != "lsp-document-analysis" {
+		t.Fatalf("kind = %v, want lsp-document-analysis", m["kind"])
+	}
+	if m["schema_version"] != "1" {
+		t.Fatalf("schema_version = %v, want 1", m["schema_version"])
+	}
+	if m["kit_id"] != "go" {
+		t.Fatalf("kit_id = %v, want go", m["kit_id"])
+	}
+	if m["uri"] != "file:///project/tests/lsp/floor-fixture/go.go" {
+		t.Fatalf("uri = %v", m["uri"])
+	}
+	if m["file"] != "tests/lsp/floor-fixture/go.go" {
+		t.Fatalf("file = %v", m["file"])
+	}
+	documentCID, ok := m["document_cid"].(string)
+	if !ok || len(documentCID) != len("blake3-512:")+128 || documentCID[:len("blake3-512:")] != "blake3-512:" {
+		t.Fatalf("document_cid = %v, want BLAKE3-512 CID", m["document_cid"])
+	}
+	if _, ok := m["entries"].([]interface{}); !ok {
+		t.Fatalf("entries not an array: %T", m["entries"])
+	}
+	if _, ok := m["statuses"].([]interface{}); !ok {
+		t.Fatalf("statuses not an array: %T", m["statuses"])
+	}
+	if m["project"] != nil {
+		t.Fatalf("project = %v, want nil", m["project"])
+	}
+
+	diagnostics, ok := m["diagnostics"].([]interface{})
+	if !ok {
+		t.Fatalf("diagnostics not an array: %T", m["diagnostics"])
+	}
+	if len(diagnostics) != 1 {
+		t.Fatalf("expected one diagnostic, got %#v", diagnostics)
+	}
+	diagnostic, ok := diagnostics[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("diagnostic not an object: %T", diagnostics[0])
+	}
+	if diagnostic["code"] != "provekit.lsp.implication_failed" {
+		t.Fatalf("code = %v, want provekit.lsp.implication_failed", diagnostic["code"])
+	}
+	if diagnostic["severity"] != "error" {
+		t.Fatalf("severity = %v, want error", diagnostic["severity"])
+	}
+	if diagnostic["producer"] != "forward-propagation" {
+		t.Fatalf("producer = %v, want forward-propagation", diagnostic["producer"])
+	}
+	if diagnostic["kit_id"] != "go" {
+		t.Fatalf("kit_id = %v, want go", diagnostic["kit_id"])
+	}
+	rng, ok := diagnostic["range"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("range not an object: %T", diagnostic["range"])
+	}
+	if rng["start_line"] != float64(19) || rng["start_col"] != float64(11) {
+		t.Fatalf("range start = %v:%v, want 19:11", rng["start_line"], rng["start_col"])
+	}
+	data, ok := diagnostic["data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("data not an object: %T", diagnostic["data"])
+	}
+	if data["callee"] != "checkPositive" {
+		t.Fatalf("callee = %v, want checkPositive", data["callee"])
+	}
+}
+
 func mustMarshal(v interface{}) string {
 	b, err := json.Marshal(v)
 	if err != nil {
 		panic(err)
 	}
 	return string(b)
+}
+
+func arrayContainsString(value interface{}, expected string) bool {
+	items, ok := value.([]interface{})
+	if !ok {
+		return false
+	}
+	for _, item := range items {
+		if item == expected {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Summary
- advertise `provekit-lsp-shared/1` from the Go kit LSP helper
- add `analyzeDocument` returning `lsp-document-analysis` with document CID, entries, diagnostics, statuses, and project fields
- wrap existing Go declarations, call edges, and forward-propagation diagnostics in the shared editor-facing shape while keeping legacy `parse` available

Refs #1502, #1486, #308.

Verification
- `go test -run 'TestHandleInit|TestHandleAnalyzeDocumentFloorFixtureSharedDiagnostic' -v ./cmd/provekit-lsp-go`\n- `go test -v ./cmd/provekit-lsp-go`\n- `git diff --check`