### PR TITLE
fix(python): register python-double proof surfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -687,13 +687,13 @@ cross-language-proof-parity: build-java build-ts build-zig build-scala cross-lan
 		emit_java_testng_dispatches_real_emitter_and_maven_checks_output
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_emit_go_testing \
-		emit_go_testing_dispatches_manifest_writes_artifact_and_compile_checks
+		emit_go_testing_uses_checked_in_go_double_registration
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_emit_go_testify \
 		emit_go_testify_dispatches_separate_emitter_and_compile_checks
 	PYTHON=$(PARITY_PYTHON) PATH=$(PARITY_PYTHON_BIN):$(PATH) cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_emit_python_pytest \
-		emit_python_pytest_dispatches_real_emitter_and_pytest_checks_output
+		emit_python_pytest_uses_checked_in_python_double_registration
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_emit_rust_cargo_test \
 		emit_rust_cargo_test_dispatches_real_emitter_and_cargo_checks_output
@@ -709,10 +709,10 @@ cross-language-proof-parity: build-java build-ts build-zig build-scala cross-lan
 		materialize_json_client_jackson_loads_from_proof_and_compiles
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test go_realize_materialize \
-		go_materialize_cli_rewrites_carrier_and_asks_go_kit_to_compile_check
+		go_materialize_uses_checked_in_go_double_realize_registration
 	PATH=$(PARITY_PYTHON_BIN):$(PATH) cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_materialize_integration \
-		compile_check_passes_for_valid_python_materialized_output
+		materialize_python_uses_checked_in_python_double_realize_registration
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_materialize_integration \
 		materialize_out_dir_writes_materialized_copy_and_leaves_source_unchanged
@@ -747,7 +747,7 @@ cross-language-proof-parity: build-java build-ts build-zig build-scala cross-lan
 		go_production_path_double_discharges_and_mints_witness
 	PYTHON=$(PARITY_PYTHON) PATH=$(PARITY_PYTHON_BIN):$(PATH) cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_verify_python_production_bridge \
-		python_production_path_double_discharges_and_mints_witness
+		python_production_path_uses_checked_in_python_double_registration
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_verify_rust_production_bridge \
 		rust_production_path_double_discharges_and_mints_witness

--- a/examples/python-double/.provekit/config.toml
+++ b/examples/python-double/.provekit/config.toml
@@ -1,11 +1,22 @@
-# ProvekIt project config for the Python end-to-end example.
-#
-# `[authoring] surface = "python"` selects the Python verify lift surface (the
-# manifest at .provekit/lift/python/manifest.toml). `[solvers]` names z3 for
-# the linear-arithmetic class the body-obligation `(* 3 2) == 6` falls into;
-# the `-smt2 -in` flags mirror the verifier's default z3 invocation.
-[authoring]
+# ProvekIt project config for the Python end-to-end example. Registration is
+# per project: lift, realize, and emit surfaces are declared here and resolved
+# through .provekit/<kind>/<surface>/manifest.toml.
+
+[[plugins]]
+name = "python-lift"
+kind = "lift"
 surface = "python"
+
+[[plugins]]
+name = "python-realize"
+kind = "realize"
+surface = "python"
+
+[[plugins]]
+name = "python-pytest"
+kind = "emit"
+surface = "python-pytest"
+emit = "pytest"
 
 [solvers]
 default = "z3"

--- a/examples/python-double/.provekit/emit/python-pytest/manifest.toml
+++ b/examples/python-double/.provekit/emit/python-pytest/manifest.toml
@@ -1,0 +1,4 @@
+name = "python-pytest"
+command = ["provekit-emit-python-pytest", "--rpc"]
+working_dir = "."
+protocol_versions = ["pep/1.7.0"]

--- a/examples/python-double/.provekit/lift/python/manifest.toml
+++ b/examples/python-double/.provekit/lift/python/manifest.toml
@@ -1,0 +1,11 @@
+name = "python-lift"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["provekit-lift-python-verify", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["python"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false

--- a/examples/python-double/.provekit/realize/python/manifest.toml
+++ b/examples/python-double/.provekit/realize/python/manifest.toml
@@ -1,0 +1,5 @@
+name = "python-realize"
+library_tag = "python"
+protocol_version = "pep/1.7.0"
+command = ["provekit-realize-python", "--rpc"]
+working_dir = "."

--- a/examples/python-double/README.md
+++ b/examples/python-double/README.md
@@ -1,0 +1,8 @@
+# Python end-to-end example
+
+`double.py` and `test_double.py` are the Python production bridge fixture. The
+project registers lift, realize, and pytest emit surfaces in `.provekit/config.toml`;
+the CLI dispatches to those kits over RPC and keeps the shared mint/prove work.
+
+For hermetic tests, the integration suite copies this fixture and rewrites only
+manifest command paths to point at the checkout-local Python modules.

--- a/implementations/rust/provekit-cli/tests/cmd_emit_python_pytest.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_emit_python_pytest.rs
@@ -72,23 +72,56 @@ fn install_emit_registration(project: &Path) {
     .expect("write emit manifest");
 }
 
-#[test]
-fn emit_python_pytest_dispatches_real_emitter_and_pytest_checks_output() {
-    if !python_available() {
-        eprintln!("skipping: python3 cannot import blake3 and pytest");
-        return;
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap_or_else(|_| panic!("mkdir {}", dst.display()));
+    for entry in fs::read_dir(src).unwrap_or_else(|_| panic!("read {}", src.display())) {
+        let entry = entry.expect("read dir entry");
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type().expect("entry file type").is_dir() {
+            copy_dir_recursive(&src_path, &dst_path);
+        } else {
+            fs::copy(&src_path, &dst_path).unwrap_or_else(|_| {
+                panic!("copy {} -> {}", src_path.display(), dst_path.display())
+            });
+        }
     }
+}
 
-    let temp = tempfile::tempdir().expect("tempdir");
-    let project = temp.path().join("project");
-    let out_dir = temp.path().join("out");
-    fs::create_dir_all(&project).expect("mkdir project");
-    fs::create_dir_all(&out_dir).expect("mkdir out");
-    install_emit_registration(&project);
+fn rewrite_python_emit_manifest(manifest: &Path) {
+    let python_src = repo_root()
+        .join("implementations")
+        .join("python")
+        .join("provekit-emit-python-pytest")
+        .join("src");
+    let pythonpath = python_src
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let python = python_bin().replace('\\', "\\\\").replace('"', "\\\"");
+    let text = fs::read_to_string(manifest)
+        .unwrap_or_else(|_| panic!("read checked-in manifest {}", manifest.display()));
+    let rewritten = text
+        .lines()
+        .map(|line| {
+            if line.trim_start().starts_with("command = ") {
+                format!(
+                    "command = [\"env\", \"PYTHONPATH={pythonpath}\", \"{python}\", \"-m\", \"provekit_emit_python_pytest\", \"--rpc\"]"
+                )
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(manifest, format!("{rewritten}\n"))
+        .unwrap_or_else(|_| panic!("write manifest {}", manifest.display()));
+}
 
-    let plan = project.join("plan.json");
+fn write_basic_emit_plan(plan: &Path) {
     fs::write(
-        &plan,
+        plan,
         serde_json::to_vec_pretty(&serde_json::json!({
             "contract_id": "concept:eq",
             "function": "identity",
@@ -106,6 +139,24 @@ fn emit_python_pytest_dispatches_real_emitter_and_pytest_checks_output() {
         .expect("encode plan"),
     )
     .expect("write plan");
+}
+
+#[test]
+fn emit_python_pytest_dispatches_real_emitter_and_pytest_checks_output() {
+    if !python_available() {
+        eprintln!("skipping: python3 cannot import blake3 and pytest");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("project");
+    let out_dir = temp.path().join("out");
+    fs::create_dir_all(&project).expect("mkdir project");
+    fs::create_dir_all(&out_dir).expect("mkdir out");
+    install_emit_registration(&project);
+
+    let plan = project.join("plan.json");
+    write_basic_emit_plan(&plan);
 
     let output = Command::new(provekit_bin())
         .arg("emit")
@@ -144,4 +195,64 @@ fn emit_python_pytest_dispatches_real_emitter_and_pytest_checks_output() {
         "emitted:\n{emitted}"
     );
     assert!(emitted.contains("assert 2 == 2"), "emitted:\n{emitted}");
+}
+
+#[test]
+fn emit_python_pytest_uses_checked_in_python_double_registration() {
+    if !python_available() {
+        eprintln!("skipping: python3 cannot import blake3 and pytest");
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("python-double");
+    let out_dir = temp.path().join("out");
+    fs::create_dir_all(&project).expect("mkdir project");
+    fs::create_dir_all(&out_dir).expect("mkdir out");
+    copy_dir_recursive(
+        &repo_root()
+            .join("examples")
+            .join("python-double")
+            .join(".provekit"),
+        &project.join(".provekit"),
+    );
+    rewrite_python_emit_manifest(
+        &project
+            .join(".provekit")
+            .join("emit")
+            .join("python-pytest")
+            .join("manifest.toml"),
+    );
+
+    let plan = project.join("plan.json");
+    write_basic_emit_plan(&plan);
+
+    let output = Command::new(provekit_bin())
+        .arg("emit")
+        .arg("--project")
+        .arg(&project)
+        .arg("--target")
+        .arg("python")
+        .arg("--framework")
+        .arg("pytest")
+        .arg("--plan")
+        .arg(&plan)
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--compile-check")
+        .arg("--json")
+        .output()
+        .expect("spawn provekit emit python");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "checked-in Python fixture registration must drive pytest emit\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let receipt: Value = serde_json::from_str(&stdout).expect("emit stdout is JSON");
+    assert_eq!(receipt["ok"], true, "receipt: {receipt}");
+    assert_eq!(receipt["surface"], "python-pytest", "receipt: {receipt}");
+    assert_eq!(receipt["targetLanguage"], "python", "receipt: {receipt}");
+    assert_eq!(receipt["targetFramework"], "pytest", "receipt: {receipt}");
 }

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -265,6 +265,52 @@ fn write_rust_reqwest_project_fixture(workspace: &Path) -> Option<PathBuf> {
     Some(src_dir)
 }
 
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap_or_else(|_| panic!("mkdir {}", dst.display()));
+    for entry in fs::read_dir(src).unwrap_or_else(|_| panic!("read {}", src.display())) {
+        let entry = entry.expect("read dir entry");
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type().expect("entry file type").is_dir() {
+            copy_dir_recursive(&src_path, &dst_path);
+        } else {
+            fs::copy(&src_path, &dst_path).unwrap_or_else(|_| {
+                panic!("copy {} -> {}", src_path.display(), dst_path.display())
+            });
+        }
+    }
+}
+
+fn rewrite_python_realize_manifest(manifest: &Path) {
+    let core_src = repo_root()
+        .join("implementations")
+        .join("python")
+        .join("provekit-realize-python-core")
+        .join("src");
+    let pythonpath = core_src
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let text = fs::read_to_string(manifest)
+        .unwrap_or_else(|_| panic!("read checked-in manifest {}", manifest.display()));
+    let rewritten = text
+        .lines()
+        .map(|line| {
+            if line.trim_start().starts_with("command = ") {
+                format!(
+                    "command = [\"env\", \"PYTHONPATH={pythonpath}\", \"python3\", \"-m\", \"provekit_realize_python_core\", \"--rpc\"]"
+                )
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(manifest, format!("{rewritten}\n"))
+        .unwrap_or_else(|_| panic!("write manifest {}", manifest.display()));
+}
+
 fn concept_carrier_lines(indent: &str) -> String {
     format!(
         "{indent}// provekit-concept: {}\n{indent}// provekit-concept-payload-cid: {}\n",
@@ -551,6 +597,20 @@ fn write_python_http_request_source(src_dir: &Path) -> PathBuf {
         ),
     )
     .expect("write python HTTP source");
+    source_path
+}
+
+fn write_python_identity_source(src_dir: &Path) -> PathBuf {
+    let source_path = src_dir.join("identity.py");
+    let payload = "{\"artifact_kind\":\"provekit-concept-citation-comment-sugar\",\"concept_name\":\"identity\",\"function\":\"identity_value\",\"params\":[\"x\"],\"param_types\":[\"int\"],\"return_type\":\"int\"}";
+    fs::write(
+        &source_path,
+        format!(
+            "{}def placeholder():\n    pass\n",
+            carrier_lines("#", "", payload)
+        ),
+    )
+    .expect("write python identity source");
     source_path
 }
 
@@ -1197,6 +1257,70 @@ fn materialize_python_requests_example_uses_python_library_shim() {
         "Python requests example should route through the requests shim:\n{stdout}"
     );
     assert!(!stdout.contains("provekit-concept:"));
+}
+
+#[test]
+fn materialize_python_uses_checked_in_python_double_realize_registration() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let project = workspace.path().join("python-double");
+    fs::create_dir_all(&project).expect("mkdir project");
+    copy_dir_recursive(
+        &repo_root()
+            .join("examples")
+            .join("python-double")
+            .join(".provekit"),
+        &project.join(".provekit"),
+    );
+    rewrite_python_realize_manifest(
+        &project
+            .join(".provekit")
+            .join("realize")
+            .join("python")
+            .join("manifest.toml"),
+    );
+    fs::write(
+        project.join("pyproject.toml"),
+        "[project]\nname = \"checked-in-python-materialize\"\nversion = \"0.0.0\"\n",
+    )
+    .expect("write pyproject");
+    let src_dir = project.join("src");
+    fs::create_dir_all(&src_dir).expect("mkdir src");
+    write_python_identity_source(&src_dir);
+
+    let out_dir = workspace.path().join("materialized");
+    fs::create_dir_all(&out_dir).expect("mkdir out");
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("materialize")
+        .arg("--target")
+        .arg("python")
+        .arg("--library")
+        .arg("python")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(&project)
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--compile-check")
+        .output()
+        .expect("spawn provekit materialize for checked-in Python fixture");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "checked-in Python fixture registration must drive materialize\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("assembled by python kit via RPC"),
+        "Python materialize route must assemble through the Python kit\nstderr:\n{stderr}"
+    );
+    let emitted =
+        fs::read_to_string(out_dir.join("identity.py")).expect("read materialized Python");
+    assert!(
+        emitted.contains("def identity_value(x):") && emitted.contains("return x"),
+        "materialized Python should contain identity body from checked-in registration:\n{emitted}"
+    );
 }
 
 #[test]

--- a/implementations/rust/provekit-cli/tests/cmd_verify_python_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_python_production_bridge.rs
@@ -176,6 +176,45 @@ fn stage_python_project(suffix: &str, lift_script: &Path, body_factor: i64) -> P
     project
 }
 
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap_or_else(|_| panic!("mkdir {}", dst.display()));
+    for entry in fs::read_dir(src).unwrap_or_else(|_| panic!("read {}", src.display())) {
+        let entry = entry.expect("read dir entry");
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type().expect("entry file type").is_dir() {
+            copy_dir_recursive(&src_path, &dst_path);
+        } else {
+            fs::copy(&src_path, &dst_path).unwrap_or_else(|_| {
+                panic!("copy {} -> {}", src_path.display(), dst_path.display())
+            });
+        }
+    }
+}
+
+fn rewrite_manifest_command(manifest: &Path, command: &Path) {
+    let text = fs::read_to_string(manifest)
+        .unwrap_or_else(|_| panic!("read checked-in manifest {}", manifest.display()));
+    let escaped = command
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let rewritten = text
+        .lines()
+        .map(|line| {
+            if line.trim_start().starts_with("command = ") {
+                format!("command = [\"{escaped}\", \"--rpc\"]")
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(manifest, format!("{rewritten}\n"))
+        .unwrap_or_else(|_| panic!("write manifest {}", manifest.display()));
+}
+
 fn run_mint(project: &Path) {
     let out = Command::new(provekit_bin())
         .arg("mint")
@@ -209,6 +248,49 @@ fn run_verify_json_with_code(project: &Path, witness_dir: &Path) -> (Json, i32) 
     let receipt = serde_json::from_str(&stdout)
         .unwrap_or_else(|e| panic!("verify JSON parse failed: {e}\nstdout: {stdout}"));
     (receipt, out.status.code().unwrap_or(-1))
+}
+
+#[test]
+fn python_production_path_uses_checked_in_python_double_registration() {
+    if !python_available() {
+        eprintln!("python3 not on PATH: skipping checked-in python production-bridge test");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("z3 not on PATH: skipping checked-in python production-bridge test");
+        return;
+    }
+    let lift_script = build_python_lift_verify();
+    let project = unique_dir("checked-in-registration");
+    let example = repo_root().join("examples").join("python-double");
+    fs::copy(example.join("double.py"), project.join("double.py")).expect("copy double.py");
+    fs::copy(
+        example.join("test_double.py"),
+        project.join("test_double.py"),
+    )
+    .expect("copy test_double.py");
+    copy_dir_recursive(&example.join(".provekit"), &project.join(".provekit"));
+    rewrite_manifest_command(
+        &project
+            .join(".provekit")
+            .join("lift")
+            .join("python")
+            .join("manifest.toml"),
+        &lift_script,
+    );
+
+    run_mint(&project);
+
+    let witnesses = project.join("witnesses-out");
+    let (receipt, code) = run_verify_json_with_code(&project, &witnesses);
+    assert_eq!(receipt["totalClaims"], 1, "receipt: {receipt}");
+    assert_eq!(receipt["ok"], true, "receipt: {receipt}");
+    assert_eq!(
+        code, 0,
+        "checked-in Python route must prove; receipt: {receipt}"
+    );
+
+    let _ = fs::remove_dir_all(&project);
 }
 
 /// THE bridge-writer assertion (language-neutral, runs without z3): the TOOL


### PR DESCRIPTION
## Summary
- Stack on #1672 and register `examples/python-double` through project `[[plugins]]` for lift, Python realize/materialize, and `python-pytest` emit.
- Add checked-in Python manifests for lift, realize, and pytest emit; tests copy the fixture and only patch executable/module paths.
- Add CLI coverage for checked-in Python mint/verify, emit, and materialize routes.
- Move the cross-language parity gate to the checked-in Go/Python registration lanes for emit/materialize/prove.

Addresses #1492.

## Verification
- Red: `python_production_path_uses_checked_in_python_double_registration` failed before `.provekit/lift/python/manifest.toml` existed.
- Red: `emit_python_pytest_uses_checked_in_python_double_registration` failed before `.provekit/emit/python-pytest/manifest.toml` existed.
- Red: `materialize_python_uses_checked_in_python_double_realize_registration` failed before `.provekit/realize/python/manifest.toml` existed.
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_emit_python_pytest -- --nocapture` (2 passed)
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_verify_python_production_bridge -- --nocapture` (5 passed)
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_materialize_integration -- --nocapture` (19 passed)
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_emit_go_testing emit_go_testing_uses_checked_in_go_double_registration -- --nocapture`
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test go_realize_materialize go_materialize_uses_checked_in_go_double_realize_registration -- --nocapture`
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_verify_go_production_bridge go_production_path_double_discharges_and_mints_witness -- --nocapture`
- `git diff --check`
- `rustfmt --check implementations/rust/provekit-cli/tests/cmd_verify_python_production_bridge.rs implementations/rust/provekit-cli/tests/cmd_emit_python_pytest.rs implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs`