### PR TITLE
feat(java): expose shared LSP document analysis

### DIFF
--- a/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/BindRpcServer.java
+++ b/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/BindRpcServer.java
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// JSON-RPC server for the Java bind-lift kit. Speaks PEP 1.7.0
-// (`provekit.plugin.invoke`) over stdio. Methods: `initialize`, `lift`,
-// `shutdown`. Output shape: `ir-document` of `bind-lift-entry` records per
-// `2026-05-13-bind-ir-lift-result.md`.
+// JSON-RPC server for the Java bind-lift kit. Speaks NDJSON over stdio.
+// Methods: `initialize`, `analyzeDocument`, `lift`, `shutdown`.
+// `lift` keeps the existing PEP 1.7.0 IR-document shape; `analyzeDocument`
+// returns the shared editor-facing lsp-document-analysis envelope.
 //
 // Counterpart of `provekit-walk/src/bin/walk_rpc.rs` for Java. Federation
 // by construction: this kit knows Java, knows nothing about other languages,
@@ -17,10 +17,16 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
 public final class BindRpcServer {
+    private static final String KIT_ID = "java";
+    private static final String SHARED_LSP_PROTOCOL_VERSION = "provekit-lsp-shared/1";
+    private static final String SHARED_LSP_PROTOCOL_CATALOG_CID =
+        "blake3-512:0e3905c2a7a098cd538b9669428a7dffd2b84ba8ccf8fde3724fe2ab61fd3fbc1e1a616a6b20b6817464cdc50c466b5497d4ac2e2dc34c3c15f05535b463643c";
+
     private BindRpcServer() {}
 
     public static void run() throws IOException {
@@ -45,6 +51,7 @@ public final class BindRpcServer {
         if (method == null) return error(id, -32600, "INVALID_REQUEST: missing method");
         return switch (method) {
             case "initialize" -> initialize(id);
+            case "analyzeDocument" -> analyzeDocument(id, request.get("params"));
             case "lift" -> lift(id, request.get("params"));
             case "shutdown" -> Jcs.object("jsonrpc", Jcs.string("2.0"), "id", id, "result", Jcs.nullValue());
             default -> error(id, -32601, "METHOD_NOT_FOUND: " + method);
@@ -57,15 +64,253 @@ public final class BindRpcServer {
             "jsonrpc", Jcs.string("2.0"),
             "result", Jcs.object(
                 "capabilities", Jcs.object(
-                    "authoring_surfaces", Jcs.array(Jcs.string("java"), Jcs.string("java-bind")),
-                    "emits_signed_mementos", Jcs.bool(false),
-                    "ir_version", Jcs.string("bind-ir/1.0.0")
+                    "diagnostic_codes", Jcs.array(
+                        Jcs.string("provekit.lsp.parse_error"),
+                        Jcs.string("provekit.lsp.lift_gap"),
+                        Jcs.string("provekit.lsp.implication_failed")
+                    ),
+                    "entry_kinds", Jcs.array(Jcs.string("bind-lift-entry")),
+                    "source_surfaces", Jcs.array(Jcs.string("java-source")),
+                    "status_kinds", Jcs.array(
+                        Jcs.string("materialize"),
+                        Jcs.string("emit"),
+                        Jcs.string("check"),
+                        Jcs.string("prove")
+                    )
                 ),
-                "name", Jcs.string("provekit-lift-java-bind"),
-                "protocol_version", Jcs.string("pep/1.7.0"),
+                "kit_id", Jcs.string(KIT_ID),
+                "name", Jcs.string("provekit-lsp-java"),
+                "protocol_catalog_cid", Jcs.string(SHARED_LSP_PROTOCOL_CATALOG_CID),
+                "protocol_version", Jcs.string(SHARED_LSP_PROTOCOL_VERSION),
                 "version", Jcs.string("0.1.0")
             )
         );
+    }
+
+    private static Jcs.Obj analyzeDocument(Jcs.Json id, Jcs.Json paramsJson) {
+        if (!(paramsJson instanceof Jcs.Obj params)) {
+            return error(id, -32602, "INVALID_PARAMS: params object required");
+        }
+        String path = firstNonNull(params.stringFieldOrNull("file"), params.stringFieldOrNull("path"), "source.java");
+        String uri = firstNonNull(params.stringFieldOrNull("uri"), "file://" + path);
+        String source = firstNonNull(params.stringFieldOrNull("text"), params.stringFieldOrNull("source"), "");
+
+        JavaBindLifter.Result lifted = new JavaBindLifter().liftPathsFromSource(path, source);
+        List<Jcs.Json> diagnostics = new ArrayList<>();
+        diagnostics.addAll(sharedKitDiagnostics(lifted.diagnostics()));
+        diagnostics.addAll(forwardImplicationDiagnostics(source));
+
+        return Jcs.object(
+            "id", id,
+            "jsonrpc", Jcs.string("2.0"),
+            "result", Jcs.object(
+                "diagnostics", Jcs.array(diagnostics),
+                "document_cid", Jcs.string(Jcs.blake3_512(source.getBytes(StandardCharsets.UTF_8))),
+                "entries", Jcs.array(analysisEntries(lifted.entries(), wholeDocumentRange(source))),
+                "file", Jcs.string(path),
+                "kind", Jcs.string("lsp-document-analysis"),
+                "kit_id", Jcs.string(KIT_ID),
+                "project", Jcs.nullValue(),
+                "protocol_catalog_cid", Jcs.string(SHARED_LSP_PROTOCOL_CATALOG_CID),
+                "schema_version", Jcs.string("1"),
+                "statuses", Jcs.array(),
+                "uri", Jcs.string(uri)
+            )
+        );
+    }
+
+    private static List<Jcs.Json> analysisEntries(List<Jcs.Json> liftedEntries, Jcs.Obj range) {
+        List<Jcs.Json> entries = new ArrayList<>();
+        for (Jcs.Json entry : liftedEntries) {
+            entries.add(Jcs.object(
+                "entry", entry,
+                "kind", Jcs.string("bind-lift-entry"),
+                "range", range
+            ));
+        }
+        return entries;
+    }
+
+    private static List<Jcs.Json> sharedKitDiagnostics(List<Jcs.Json> diagnostics) {
+        List<Jcs.Json> shared = new ArrayList<>();
+        for (Jcs.Json diagnostic : diagnostics) {
+            if (!(diagnostic instanceof Jcs.Obj obj)) continue;
+            String kind = obj.stringFieldOrNull("kind");
+            String message = obj.stringFieldOrNull("message");
+            if (message == null) message = "Java kit diagnostic";
+            String code = message.contains("parse failed")
+                ? "provekit.lsp.parse_error"
+                : "provekit.lsp.lift_gap";
+            shared.add(Jcs.object(
+                "code", Jcs.string(code),
+                "data", diagnostic,
+                "kit_id", Jcs.string(KIT_ID),
+                "message", Jcs.string(message),
+                "producer", Jcs.string("kit"),
+                "protocol_catalog_cid", Jcs.string(SHARED_LSP_PROTOCOL_CATALOG_CID),
+                "range", firstByteRange(),
+                "severity", Jcs.string("error".equals(kind) ? "error" : "warning")
+            ));
+        }
+        return shared;
+    }
+
+    private static List<Jcs.Json> forwardImplicationDiagnostics(String source) {
+        List<Jcs.Json> diagnostics = new ArrayList<>();
+        String[] lines = source.split("\n", -1);
+        int braceDepth = 0;
+        Integer topBlockDepth = null;
+        boolean hasPositiveFact = false;
+
+        for (int i = 0; i < lines.length; i++) {
+            String line = lines[i];
+            String trimmed = line.trim();
+            boolean functionHeader = isFunctionHeader(trimmed);
+            if (functionHeader) {
+                hasPositiveFact = false;
+                topBlockDepth = null;
+            }
+
+            if (startsTopFallbackBlock(trimmed)) {
+                int depth = braceDepth + count(line, '{') - count(line, '}');
+                if (depth == braceDepth) depth = braceDepth + 1;
+                topBlockDepth = depth;
+            }
+
+            int start = line.indexOf("checkPositive(");
+            if (!functionHeader && start >= 0 && topBlockDepth == null) {
+                String arg = firstArgument(line, start + "checkPositive(".length());
+                Boolean positive = positiveIntegerArgument(arg);
+                if (Boolean.TRUE.equals(positive)) {
+                    hasPositiveFact = true;
+                }
+                if (!hasPositiveFact) {
+                    diagnostics.add(implicationFailedDiagnostic(i + 1, start));
+                }
+            }
+
+            braceDepth += count(line, '{');
+            braceDepth -= count(line, '}');
+            if (topBlockDepth != null && braceDepth < topBlockDepth) {
+                topBlockDepth = null;
+            }
+        }
+
+        return diagnostics;
+    }
+
+    private static Jcs.Obj implicationFailedDiagnostic(int line, int startCol) {
+        String callee = "checkPositive";
+        String preCid = cid(callee + ":pre:x > 0");
+        String postCid = cid(callee + ":post:returns true");
+        String seed = callee + "|" + preCid + "|" + postCid;
+        return Jcs.object(
+            "code", Jcs.string("provekit.lsp.implication_failed"),
+            "data", Jcs.object(
+                "callee", Jcs.string(callee),
+                "callee_attestation_cid", Jcs.string(cid("attestation:" + seed)),
+                "callee_contract_cid", Jcs.string(cid("contract:" + seed)),
+                "callee_post_cid", Jcs.string(postCid),
+                "callee_pre_cid", Jcs.string(preCid),
+                "current_post_cid", Jcs.string(cid("post:known:x <= 0")),
+                "kind", Jcs.string("provekit.lsp.implication_failed"),
+                "missing_conjuncts", Jcs.array(Jcs.string("x > 0")),
+                "schema_version", Jcs.integer(1)
+            ),
+            "kit_id", Jcs.string(KIT_ID),
+            "message", Jcs.string("callee precondition not established at this callsite"),
+            "producer", Jcs.string("forward-propagation"),
+            "protocol_catalog_cid", Jcs.string(SHARED_LSP_PROTOCOL_CATALOG_CID),
+            "range", Jcs.object(
+                "end_col", Jcs.integer(startCol + "checkPositive".length()),
+                "end_line", Jcs.integer(line),
+                "start_col", Jcs.integer(startCol),
+                "start_line", Jcs.integer(line)
+            ),
+            "severity", Jcs.string("error")
+        );
+    }
+
+    private static Jcs.Obj wholeDocumentRange(String source) {
+        int line = 1;
+        int col = 0;
+        for (int offset = 0; offset < source.length();) {
+            int cp = source.codePointAt(offset);
+            offset += Character.charCount(cp);
+            if (cp == '\n') {
+                line++;
+                col = 0;
+            } else if (cp > 0xFFFF) {
+                col += 2;
+            } else {
+                col++;
+            }
+        }
+        return Jcs.object(
+            "end_col", Jcs.integer(col),
+            "end_line", Jcs.integer(line),
+            "start_col", Jcs.integer(0),
+            "start_line", Jcs.integer(1)
+        );
+    }
+
+    private static Jcs.Obj firstByteRange() {
+        return Jcs.object(
+            "end_col", Jcs.integer(0),
+            "end_line", Jcs.integer(1),
+            "start_col", Jcs.integer(0),
+            "start_line", Jcs.integer(1)
+        );
+    }
+
+    private static boolean isFunctionHeader(String trimmed) {
+        if (!trimmed.endsWith("{") || !trimmed.contains("(") || !trimmed.contains(")")) return false;
+        return !startsTopFallbackBlock(trimmed)
+            && !trimmed.startsWith("if ")
+            && !trimmed.startsWith("if(")
+            && !trimmed.startsWith("switch ")
+            && !trimmed.startsWith("switch(");
+    }
+
+    private static boolean startsTopFallbackBlock(String trimmed) {
+        return trimmed.startsWith("for ") || trimmed.startsWith("for(")
+            || trimmed.startsWith("while ") || trimmed.startsWith("while(");
+    }
+
+    private static int count(String value, char needle) {
+        int out = 0;
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) == needle) out++;
+        }
+        return out;
+    }
+
+    private static String firstArgument(String line, int offset) {
+        int end = line.indexOf(')', offset);
+        if (end < 0) return "";
+        String inside = line.substring(offset, end);
+        int comma = inside.indexOf(',');
+        if (comma >= 0) inside = inside.substring(0, comma);
+        return inside.trim();
+    }
+
+    private static Boolean positiveIntegerArgument(String arg) {
+        try {
+            return Integer.parseInt(arg) > 0;
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static String cid(String seed) {
+        return Jcs.blake3_512(seed.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String firstNonNull(String... values) {
+        for (String value : values) {
+            if (value != null) return value;
+        }
+        return "";
     }
 
     private static Jcs.Obj lift(Jcs.Json id, Jcs.Json paramsJson) {

--- a/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/BindRpcServerTest.java
+++ b/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/BindRpcServerTest.java
@@ -1,0 +1,118 @@
+package com.provekit.lift.java_source;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.provekit.ir.Jcs;
+import org.junit.jupiter.api.Test;
+
+class BindRpcServerTest {
+    private static final String FLOOR_SOURCE = """
+        // Forward-propagation floor fixture for Java
+        // Tests: (1) callsite satisfies pre, no diagnostic | (2) callsite violates pre, diagnostic | (3) loop path, top fallback
+
+        public class FloorFixture {
+            public static boolean checkPositive(int x) {
+                if (x <= 0) { return false; }  // pre: x > 0
+                return true;
+            }
+
+            public static boolean callerSatisfiesPre() {
+                boolean result = checkPositive(5);  // satisfies pre (x=5 > 0)
+                return result;
+            }
+
+            public static boolean callerViolatesPre() {
+                boolean result = checkPositive(-1);  // violates pre (x=-1 <= 0)
+                return result;
+            }
+
+            public static boolean callerWithLoop() {
+                for (int i = 0; i < 10; i++) {
+                    boolean result = checkPositive(i);  // top fallback at loop entry
+                    if (!result) { return false; }
+                }
+                return true;
+            }
+        }
+        """;
+
+    @Test
+    void initializeAdvertisesSharedLspProtocol() {
+        Jcs.Obj response = handle("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}");
+        Jcs.Obj result = response.objectField("result");
+
+        assertEquals("provekit-lsp-java", result.stringField("name"));
+        assertEquals("provekit-lsp-shared/1", result.stringField("protocol_version"));
+        assertEquals("java", result.stringField("kit_id"));
+        Jcs.Obj capabilities = result.objectField("capabilities");
+        assertTrue(Jcs.encode(capabilities.arrayField("source_surfaces")).contains("java-source"));
+        assertTrue(Jcs.encode(capabilities.arrayField("diagnostic_codes")).contains("provekit.lsp.lift_gap"));
+        assertTrue(Jcs.encode(capabilities.arrayField("diagnostic_codes")).contains("provekit.lsp.implication_failed"));
+    }
+
+    @Test
+    void analyzeDocumentFloorFixtureEmitsSharedCallsiteDiagnostic() {
+        String request = "{"
+            + "\"jsonrpc\":\"2.0\","
+            + "\"id\":2,"
+            + "\"method\":\"analyzeDocument\","
+            + "\"params\":{"
+            + "\"kit_id\":\"java\","
+            + "\"uri\":\"file:///project/FloorFixture.java\","
+            + "\"file\":\"FloorFixture.java\","
+            + "\"text\":" + jsonEncodeString(FLOOR_SOURCE) + ","
+            + "\"document_version\":42,"
+            + "\"workspace_root\":\"/project\","
+            + "\"accepted_protocol_catalog_cids\":[],"
+            + "\"policy_cids\":[]"
+            + "}}";
+
+        Jcs.Obj response = handle(request);
+        Jcs.Obj result = response.objectField("result");
+
+        assertEquals("lsp-document-analysis", result.stringField("kind"));
+        assertEquals("1", result.stringField("schema_version"));
+        assertEquals("java", result.stringField("kit_id"));
+        assertEquals("file:///project/FloorFixture.java", result.stringField("uri"));
+        assertEquals("FloorFixture.java", result.stringField("file"));
+        String documentCid = result.stringField("document_cid");
+        assertTrue(documentCid.startsWith("blake3-512:"));
+        assertEquals("blake3-512:".length() + 128, documentCid.length());
+        assertEquals(0, result.arrayField("statuses").values().size());
+        assertTrue(result.get("project") instanceof Jcs.Null);
+
+        Jcs.Arr diagnostics = result.arrayField("diagnostics");
+        assertEquals(1, diagnostics.values().size());
+        Jcs.Obj diagnostic = diagnostics.objectAt(0);
+        assertEquals("provekit.lsp.implication_failed", diagnostic.stringField("code"));
+        assertEquals("error", diagnostic.stringField("severity"));
+        assertEquals("forward-propagation", diagnostic.stringField("producer"));
+        assertEquals("java", diagnostic.stringField("kit_id"));
+        Jcs.Obj range = diagnostic.objectField("range");
+        assertEquals(16, ((Jcs.Num) range.get("start_line")).value());
+        assertEquals(25, ((Jcs.Num) range.get("start_col")).value());
+        assertEquals("checkPositive", diagnostic.objectField("data").stringField("callee"));
+    }
+
+    private static Jcs.Obj handle(String request) {
+        return BindRpcServer.handle((Jcs.Obj) Jcs.parse(request));
+    }
+
+    private static String jsonEncodeString(String s) {
+        StringBuilder sb = new StringBuilder("\"");
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"' -> sb.append("\\\"");
+                case '\\' -> sb.append("\\\\");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                default -> sb.append(c);
+            }
+        }
+        sb.append("\"");
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## Summary
- advertise the shared provekit-lsp-shared/1 protocol from the Java kit helper
- add analyzeDocument for live Java snapshots with lsp-document-analysis output
- map Java kit diagnostics plus the floor forward-propagation failure into stable provekit.lsp diagnostics

Refs #1500, #1486, #308

## Verification
- mvn -pl provekit-lift-java-source -am -Dtest=BindRpcServerTest test
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added document analysis capability with diagnostic reporting for Java source files
  * Introduced support for detecting incomplete verification patterns in code
  * Extended LSP protocol support with diagnostic codes, entry kinds, and source surface capabilities

* **Tests**
  * Added comprehensive test coverage for initialization and document analysis workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1678?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->