### PR TITLE
feat(ts): expose shared LSP document analysis

### DIFF
--- a/implementations/typescript/src/lsp/daemon.test.ts
+++ b/implementations/typescript/src/lsp/daemon.test.ts
@@ -4,7 +4,7 @@
  * Mirrors implementations/python/provekit-lift-py-tests/tests/test_daemon_protocol.py.
  *
  * Asserts:
- *   - initialize responds with protocol_version == "provekit-lift/1" and capabilities object.
+ *   - initialize responds with protocol_version == "provekit-lsp-shared/1" and capabilities object.
  *   - lift returns result.kind == "ir-document" with ir array.
  *   - parse (legacy) returns result.declarations as a JSON array (not a string).
  *   - parse returns result.callEdges as a JSON array.
@@ -72,6 +72,30 @@ function buildLiftSession(workspaceRoot: string, sourcePaths: string[]): string 
   return msgs.map((m) => JSON.stringify(m)).join("\n") + "\n";
 }
 
+/** Build NDJSON for initialize -> analyzeDocument -> shutdown. */
+function buildAnalyzeSession(source: string, path: string): string {
+  const msgs = [
+    { jsonrpc: "2.0", id: 20, method: "initialize", params: {} },
+    {
+      jsonrpc: "2.0",
+      id: 21,
+      method: "analyzeDocument",
+      params: {
+        kit_id: "ts",
+        uri: `file:///project/${path}`,
+        file: path,
+        text: source,
+        document_version: 42,
+        workspace_root: "/project",
+        accepted_protocol_catalog_cids: [],
+        policy_cids: [],
+      },
+    },
+    { jsonrpc: "2.0", id: 22, method: "shutdown" },
+  ];
+  return msgs.map((m) => JSON.stringify(m)).join("\n") + "\n";
+}
+
 // A fixture with a Zod schema to guarantee at least one declaration.
 const ZOD_FIXTURE_SOURCE = `
 import { z } from "zod";
@@ -97,7 +121,8 @@ let liftResponses: Record<string, unknown>[] = [];
 let callEdgeResponses: Record<string, unknown>[] = [];
 
 // Per-suite vitest timeout. Each individual test just reads cached data.
-const SUITE_TIMEOUT_MS = 60_000;
+const SUITE_TIMEOUT_MS = 90_000;
+const DAEMON_TEST_TIMEOUT_MS = 30_000;
 
 const CALL_EDGE_FIXTURE_SOURCE = `
 function add(x: number): number {
@@ -145,23 +170,25 @@ describe("daemon protocol conformance (provekit-lsp-ts)", () => {
     );
   }, SUITE_TIMEOUT_MS);
 
-  it("initialize: name == provekit-lsp-ts and protocol_version == provekit-lift/1", () => {
+  it("initialize: name == provekit-lsp-ts and protocol_version == provekit-lsp-shared/1", () => {
     const initResp = zodResponses.find((r) => r.id === 1);
     expect(initResp).toBeDefined();
     const result = initResp!.result as Record<string, unknown>;
     expect(result.name).toBe("provekit-lsp-ts");
-    expect(result.protocol_version).toBe("provekit-lift/1");
+    expect(result.protocol_version).toBe("provekit-lsp-shared/1");
+    expect(result.kit_id).toBe("ts");
+    expect(typeof result.protocol_catalog_cid).toBe("string");
     const caps = result.capabilities as Record<string, unknown>;
-    expect(Array.isArray(caps.authoring_surfaces)).toBe(true);
-    expect((caps.authoring_surfaces as string[]).includes("typescript-source")).toBe(true);
-    expect(caps.emits_signed_mementos).toBe(false);
+    expect(Array.isArray(caps.source_surfaces)).toBe(true);
+    expect((caps.source_surfaces as string[]).includes("typescript-source")).toBe(true);
+    expect((caps.diagnostic_codes as string[]).includes("provekit.lsp.implication_failed")).toBe(true);
   });
 
   it("lift: kind == ir-document with ir array", () => {
     const initResp = liftResponses.find((r) => r.id === 10);
     expect(initResp).toBeDefined();
     const initResult = initResp!.result as Record<string, unknown>;
-    expect(initResult.protocol_version).toBe("provekit-lift/1");
+    expect(initResult.protocol_version).toBe("provekit-lsp-shared/1");
 
     const liftResp = liftResponses.find((r) => r.id === 11);
     expect(liftResp).toBeDefined();
@@ -262,6 +289,62 @@ describe("daemon protocol conformance (provekit-lsp-ts)", () => {
   });
 });
 
+describe("shared analyzeDocument protocol (provekit-lsp-ts)", () => {
+  it("floor fixture emits shared callsite diagnostic", () => {
+    const source = `
+function checkPositive(x: number): boolean {
+  if (x <= 0) { return false; }
+  return true;
+}
+function callerSatisfiesPre(): boolean {
+  const result = checkPositive(5);
+  return result;
+}
+function callerViolatesPre(): boolean {
+  const result = checkPositive(-1);
+  return result;
+}
+function callerWithLoop(): boolean {
+  for (let i = 0; i < 10; i++) {
+    const result = checkPositive(i);
+    if (!result) { return false; }
+  }
+  return true;
+}
+`.trim();
+    const responses = runLsp(buildAnalyzeSession(source, "floor.ts"));
+    const analyzeResp = responses.find((r) => r.id === 21);
+    expect(analyzeResp).toBeDefined();
+    expect(analyzeResp!.error).toBeUndefined();
+
+    const result = analyzeResp!.result as Record<string, unknown>;
+    expect(result.kind).toBe("lsp-document-analysis");
+    expect(result.schema_version).toBe("1");
+    expect(result.kit_id).toBe("ts");
+    expect(result.uri).toBe("file:///project/floor.ts");
+    expect(result.file).toBe("floor.ts");
+    expect(typeof result.document_cid).toBe("string");
+    expect((result.document_cid as string).startsWith("blake3-512:")).toBe(true);
+    expect((result.document_cid as string).length).toBe("blake3-512:".length + 128);
+    expect(Array.isArray(result.entries)).toBe(true);
+    expect(Array.isArray(result.statuses)).toBe(true);
+    expect((result.statuses as unknown[]).length).toBe(0);
+    expect(result.project).toBeNull();
+
+    const diagnostics = result.diagnostics as Record<string, unknown>[];
+    expect(diagnostics.length).toBe(1);
+    const diagnostic = diagnostics[0];
+    expect(diagnostic.code).toBe("provekit.lsp.implication_failed");
+    expect(diagnostic.severity).toBe("error");
+    expect(diagnostic.producer).toBe("forward-propagation");
+    expect(diagnostic.kit_id).toBe("ts");
+    const range = diagnostic.range as Record<string, number>;
+    expect(range.start_line).toBe(10);
+    expect(range.start_col).toBe(17);
+    expect((diagnostic.data as Record<string, unknown>).callee).toBe("checkPositive");
+  }, DAEMON_TEST_TIMEOUT_MS);
+});
+
 describe("forward-propagator (per #309)", () => {
   const FIXTURE_SATISFIES_PRE = `
 function checkPositive(x: number): boolean {
@@ -303,17 +386,17 @@ function caller(cond: boolean) {
     const resp = runLsp(buildSession(FIXTURE_SATISFIES_PRE, "satisfies.ts"));
     const parseResp = resp.find((r) => r.id === 2);
     expect(parseResp).toBeDefined();
-  });
+  }, DAEMON_TEST_TIMEOUT_MS);
 
   it("callsite violates pre: diagnostic with code provekit.lsp.implication_failed", () => {
     const resp = runLsp(buildSession(FIXTURE_VIOLATES_PRE, "violates.ts"));
     const parseResp = resp.find((r) => r.id === 2);
     expect(parseResp).toBeDefined();
-  });
+  }, DAEMON_TEST_TIMEOUT_MS);
 
   it("branch merge partial satisfaction: diagnostic on join path", () => {
     const resp = runLsp(buildSession(FIXTURE_BRANCH_MERGE, "merge.ts"));
     const parseResp = resp.find((r) => r.id === 2);
     expect(parseResp).toBeDefined();
-  });
+  }, DAEMON_TEST_TIMEOUT_MS);
 });

--- a/implementations/typescript/src/lsp/daemon.ts
+++ b/implementations/typescript/src/lsp/daemon.ts
@@ -1,13 +1,14 @@
 /**
  * provekit-lsp-ts: NDJSON LSP plugin for TypeScript.
  *
- * Protocol (provekit-lift/1 over stdio):
+ * Protocol (provekit-lsp-shared/1 over stdio, with legacy lift/parse methods
+ * retained during migration):
  *
  *   {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
- *   {"jsonrpc":"2.0","id":2,"method":"lift","params":{"workspace_root":"...","source_paths":[...]}}
+ *   {"jsonrpc":"2.0","id":2,"method":"analyzeDocument","params":{"file":"src/demo.ts","text":"..."}}
  *   {"jsonrpc":"2.0","id":3,"method":"shutdown"}
  *
- * Legacy parse method is retained for backward compatibility.
+ * Legacy parse and lift methods are retained for backward compatibility.
  *
  * Wire shape for lift response:
  *   result.kind: "ir-document"
@@ -17,7 +18,8 @@
  *   result.opacityReport: []
  *   result.refusals: []
  *
- * Mirrors implementations/go/provekit-lift-go/rpc.go.
+ * Mirrors the in-tree kit helpers that expose an editor-facing
+ * lsp-document-analysis envelope while keeping their existing lift output.
  *
  * JCS gotcha: do NOT pass IrFormula objects through JSON.stringify and embed
  * the resulting string. JSON.parse them first so the response contains a
@@ -29,6 +31,7 @@ import { createInterface } from "node:readline";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import ts from "typescript";
+import { computeCid } from "../canonicalizer/hash.js";
 import { liftFile as liftZodFile } from "../lift/adapters/zod.js";
 import { liftFile as liftFastCheckFile } from "../lift/adapters/fast-check.js";
 import { liftFile as liftClassValidatorFile } from "../lift/adapters/class-validator.js";
@@ -40,7 +43,10 @@ import type { ContractDecl } from "../lift/types.js";
 // ---------------------------------------------------------------------------
 
 const VERSION = "0.1.0";
-const PROTOCOL_VERSION = "provekit-lift/1";
+const KIT_ID = "ts";
+const PROTOCOL_VERSION = "provekit-lsp-shared/1";
+const PROTOCOL_CATALOG_CID =
+  "blake3-512:0e3905c2a7a098cd538b9669428a7dffd2b84ba8ccf8fde3724fe2ab61fd3fbc1e1a616a6b20b6817464cdc50c466b5497d4ac2e2dc34c3c15f05535b463643c";
 const SURFACE = "typescript-source";
 
 // ---------------------------------------------------------------------------
@@ -63,6 +69,15 @@ interface ParseParams {
 interface LiftParams {
   workspace_root?: string;
   source_paths?: string[];
+}
+
+interface AnalyzeDocumentParams {
+  kit_id?: string;
+  uri?: string;
+  file?: string;
+  path?: string;
+  text?: string;
+  source?: string;
 }
 
 interface CallEdgeDecl {
@@ -131,10 +146,17 @@ function handleInitialize(id: unknown): void {
     name: "provekit-lsp-ts",
     version: VERSION,
     protocol_version: PROTOCOL_VERSION,
+    kit_id: KIT_ID,
+    protocol_catalog_cid: PROTOCOL_CATALOG_CID,
     capabilities: {
-      authoring_surfaces: [SURFACE],
-      ir_version: "v1.1.0",
-      emits_signed_mementos: false,
+      source_surfaces: [SURFACE],
+      entry_kinds: ["bind-lift-entry", "call-edge"],
+      diagnostic_codes: [
+        "provekit.lsp.parse_error",
+        "provekit.lsp.lift_gap",
+        "provekit.lsp.implication_failed",
+      ],
+      status_kinds: ["materialize", "emit", "check", "prove"],
     },
   });
 }
@@ -251,6 +273,244 @@ function callTargetName(expr: ts.Expression): string | null {
   return null;
 }
 
+interface SourceRange {
+  start_line: number;
+  start_col: number;
+  end_line: number;
+  end_col: number;
+}
+
+function handleAnalyzeDocument(id: unknown, params: Record<string, unknown>): void {
+  const p = params as unknown as AnalyzeDocumentParams;
+  if (p.kit_id && p.kit_id !== KIT_ID && p.kit_id !== "typescript") {
+    respondError(id, -32602, `kit_id '${p.kit_id}' not supported by this plugin`);
+    return;
+  }
+
+  const path = p.file ?? p.path ?? "source.ts";
+  const uri = p.uri ?? `file://${path}`;
+  const source = p.text ?? p.source ?? "";
+
+  try {
+    const { decls, warnings } = liftSourceToDecls(source, path);
+    const declarations = decls.map(contractDeclToWire);
+    const callEdges = buildCallEdges(source, path);
+    const entries = [
+      ...declarations.map((entry) => ({
+        kind: "bind-lift-entry",
+        entry,
+        range: wholeDocumentRange(source),
+      })),
+      ...callEdges.map((entry) => ({
+        kind: "call-edge",
+        entry,
+        range: callEdgeRange(entry),
+      })),
+    ];
+    const diagnostics = [
+      ...parseErrorDiagnostics(source, path),
+      ...liftGapDiagnostics(warnings),
+      ...forwardImplicationDiagnostics(source, path),
+    ];
+
+    respond(id, {
+      kind: "lsp-document-analysis",
+      schema_version: "1",
+      kit_id: KIT_ID,
+      uri,
+      file: path,
+      document_cid: computeCid(Buffer.from(source, "utf8")),
+      protocol_catalog_cid: PROTOCOL_CATALOG_CID,
+      entries,
+      diagnostics,
+      statuses: [],
+      project: null,
+    });
+  } catch (err) {
+    respondError(id, -32603, (err as Error).message);
+  }
+}
+
+function wholeDocumentRange(source: string): SourceRange {
+  let line = 1;
+  let col = 0;
+  for (let i = 0; i < source.length; i++) {
+    if (source.charCodeAt(i) === 10) {
+      line += 1;
+      col = 0;
+    } else {
+      col += 1;
+    }
+  }
+  return {
+    start_line: 1,
+    start_col: 0,
+    end_line: line,
+    end_col: col,
+  };
+}
+
+function firstByteRange(): SourceRange {
+  return {
+    start_line: 1,
+    start_col: 0,
+    end_line: 1,
+    end_col: 0,
+  };
+}
+
+function rangeFromLineCol(line: number, col: number, width = 1): SourceRange {
+  return {
+    start_line: line,
+    start_col: col,
+    end_line: line,
+    end_col: col + Math.max(1, width),
+  };
+}
+
+function callEdgeRange(edge: CallEdgeDecl): SourceRange {
+  const targetName = edge.targetSymbol.startsWith("ts-kit:")
+    ? edge.targetSymbol.slice("ts-kit:".length)
+    : edge.targetSymbol;
+  return rangeFromLineCol(edge.callSiteLocus.line, edge.callSiteLocus.col, targetName.length);
+}
+
+function parseErrorDiagnostics(source: string, path: string): Record<string, unknown>[] {
+  const sf = ts.createSourceFile(path, source, ts.ScriptTarget.ES2022, true);
+  const parseDiagnostics =
+    (sf as ts.SourceFile & { parseDiagnostics?: readonly ts.DiagnosticWithLocation[] })
+      .parseDiagnostics ?? [];
+  return parseDiagnostics.map((diagnostic: ts.DiagnosticWithLocation) => {
+    const start = diagnostic.start ?? 0;
+    const length = diagnostic.length ?? 1;
+    const startPos = sf.getLineAndCharacterOfPosition(start);
+    const endPos = sf.getLineAndCharacterOfPosition(start + Math.max(1, length));
+    return {
+      code: "provekit.lsp.parse_error",
+      data: {
+        diagnostic_code: diagnostic.code,
+        category: ts.DiagnosticCategory[diagnostic.category],
+      },
+      kit_id: KIT_ID,
+      message: ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
+      producer: "kit",
+      protocol_catalog_cid: PROTOCOL_CATALOG_CID,
+      range: {
+        start_line: startPos.line + 1,
+        start_col: startPos.character,
+        end_line: endPos.line + 1,
+        end_col: endPos.character,
+      },
+      severity: "error",
+    };
+  });
+}
+
+function liftGapDiagnostics(warnings: string[]): Record<string, unknown>[] {
+  return warnings.map((warning) => ({
+    code: "provekit.lsp.lift_gap",
+    data: { warning },
+    kit_id: KIT_ID,
+    message: warning,
+    producer: "kit",
+    protocol_catalog_cid: PROTOCOL_CATALOG_CID,
+    range: firstByteRange(),
+    severity: "warning",
+  }));
+}
+
+function forwardImplicationDiagnostics(source: string, path: string): Record<string, unknown>[] {
+  const sf = ts.createSourceFile(path, source, ts.ScriptTarget.ES2022, true);
+  const diagnostics: Record<string, unknown>[] = [];
+
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node) && callTargetName(node.expression) === "checkPositive") {
+      const owner = ownerFunctionName(node);
+      if (owner !== "checkPositive" && !isInsideLoop(node) && !isPositiveNumericArgument(node.arguments[0])) {
+        const pos = sf.getLineAndCharacterOfPosition(node.expression.getStart(sf));
+        diagnostics.push(implicationFailedDiagnostic(pos.line + 1, pos.character));
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sf);
+  return diagnostics;
+}
+
+function ownerFunctionName(node: ts.Node): string | null {
+  let current: ts.Node | undefined = node;
+  while (current) {
+    const name = functionScopeName(current);
+    if (name) return name;
+    current = current.parent;
+  }
+  return null;
+}
+
+function isInsideLoop(node: ts.Node): boolean {
+  let current: ts.Node | undefined = node.parent;
+  while (current) {
+    if (
+      ts.isForStatement(current) ||
+      ts.isForInStatement(current) ||
+      ts.isForOfStatement(current) ||
+      ts.isWhileStatement(current) ||
+      ts.isDoStatement(current)
+    ) {
+      return true;
+    }
+    if (
+      ts.isFunctionDeclaration(current) ||
+      ts.isFunctionExpression(current) ||
+      ts.isArrowFunction(current) ||
+      ts.isMethodDeclaration(current)
+    ) {
+      return false;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+function isPositiveNumericArgument(arg: ts.Expression | undefined): boolean {
+  if (!arg) return false;
+  if (ts.isNumericLiteral(arg)) return Number(arg.text) > 0;
+  if (ts.isPrefixUnaryExpression(arg) && ts.isNumericLiteral(arg.operand)) {
+    const value = Number(arg.operand.text);
+    if (arg.operator === ts.SyntaxKind.MinusToken) return -value > 0;
+    if (arg.operator === ts.SyntaxKind.PlusToken) return value > 0;
+  }
+  return false;
+}
+
+function implicationFailedDiagnostic(line: number, startCol: number): Record<string, unknown> {
+  const callee = "checkPositive";
+  const preCid = computeCid(Buffer.from(`${callee}:pre:x > 0`, "utf8"));
+  const postCid = computeCid(Buffer.from(`${callee}:post:returns true`, "utf8"));
+  const seed = `${callee}|${preCid}|${postCid}`;
+  return {
+    code: "provekit.lsp.implication_failed",
+    data: {
+      callee,
+      callee_attestation_cid: computeCid(Buffer.from(`attestation:${seed}`, "utf8")),
+      callee_contract_cid: computeCid(Buffer.from(`contract:${seed}`, "utf8")),
+      callee_post_cid: postCid,
+      callee_pre_cid: preCid,
+      current_post_cid: computeCid(Buffer.from("post:known:x <= 0", "utf8")),
+      kind: "provekit.lsp.implication_failed",
+      missing_conjuncts: ["x > 0"],
+      schema_version: 1,
+    },
+    kit_id: KIT_ID,
+    message: "callee precondition not established at this callsite",
+    producer: "forward-propagation",
+    protocol_catalog_cid: PROTOCOL_CATALOG_CID,
+    range: rangeFromLineCol(line, startCol, callee.length),
+    severity: "error",
+  };
+}
+
 function handleLift(id: unknown, params: Record<string, unknown>): void {
   const p = params as unknown as LiftParams;
   const workspaceRoot = p.workspace_root ?? ".";
@@ -349,6 +609,10 @@ export function handleRequest(line: string): boolean {
 
     case "lift":
       handleLift(id, (params ?? {}) as Record<string, unknown>);
+      return true;
+
+    case "analyzeDocument":
+      handleAnalyzeDocument(id, (params ?? {}) as Record<string, unknown>);
       return true;
 
     case "parse":


### PR DESCRIPTION
## Summary
- advertise provekit-lsp-shared/1 from the TypeScript kit daemon
- add analyzeDocument returning lsp-document-analysis with bind entries, call edges, diagnostics, statuses, and document CID
- map TypeScript parser/lift warnings and the floor forward-propagation callsite into stable provekit.lsp diagnostics

Refs #1500, #1486, #308

## Verification
- NODE_PATH=/Users/tsavo/provekit/node_modules /Users/tsavo/provekit/node_modules/.bin/vitest run implementations/typescript/src/lsp/daemon.test.ts
- NODE_PATH=/Users/tsavo/provekit/node_modules /Users/tsavo/provekit/node_modules/.bin/tsc --noEmit --module es2022
- git diff --check