### PR TITLE
fix(materialize): guard cli body authority boundary

### DIFF
--- a/.provekit/config.toml
+++ b/.provekit/config.toml
@@ -36,6 +36,45 @@
 # `provekit_ir_compiler_coq::DIALECT` constant is `"coq"`, so we match
 # the implementation rather than the spec example.
 
+# Project-level kit registry. Runtime realization is manifest/config/RPC driven:
+# these entries authorize the checked-in Java realize manifests below
+# `.provekit/realize/*/manifest.toml`; the CLI never reads body-template JSON
+# as materialization authority.
+[[plugins]]
+name = "java-realize"
+kind = "realize"
+surface = "java"
+
+[[plugins]]
+name = "java-realize-stdio"
+kind = "realize"
+surface = "java-stdio"
+
+[[plugins]]
+name = "java-realize-json"
+kind = "realize"
+surface = "java-json"
+
+[[plugins]]
+name = "java-realize-sqlite-jdbc"
+kind = "realize"
+surface = "java-sqlite-jdbc"
+
+[[plugins]]
+name = "java-realize-blake3"
+kind = "realize"
+surface = "java-blake3"
+
+[[plugins]]
+name = "java-realize-gson"
+kind = "realize"
+surface = "java-gson"
+
+[[plugins]]
+name = "java-realize-rfc8785-jcs"
+kind = "realize"
+surface = "java-rfc8785-jcs"
+
 [solvers]
 mode = "first-wins"
 portfolio = ["maude", "z3", "cvc5", "vampire", "coq", "lean"]

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -1027,9 +1027,9 @@ pub fn dispatch_realize(
         request.library_version.as_deref(),
     )?;
     // Inject the dispatched library_tag into the request so the plugin can
-    // disambiguate body-template entries when multiple libraries ship templates
-    // for the same concept. Without this, the multi-library body-template cache
-    // is load-order-dependent.
+    // disambiguate its own proof/body inventory when multiple libraries ship
+    // realizations for the same concept. The CLI does not inspect or order that
+    // inventory; it only supplies the normalized dispatch axes over RPC.
     let mut request_with_tag = request.clone();
     if request_with_tag.target_library_tag.is_empty() {
         if let Some(tag) = library_tag {

--- a/implementations/rust/provekit-cli/tests/cli_body_authority_boundary.rs
+++ b/implementations/rust/provekit-cli/tests/cli_body_authority_boundary.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn cli_src_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+fn rust_files_under(root: &Path) -> Vec<PathBuf> {
+    let mut stack = vec![root.to_path_buf()];
+    let mut files = Vec::new();
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir).unwrap_or_else(|err| {
+            panic!("read {}: {err}", dir.display());
+        }) {
+            let entry = entry.expect("read dir entry");
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    files
+}
+
+#[test]
+fn cli_runtime_source_does_not_reintroduce_body_template_json_authority() {
+    let forbidden = [
+        "project_body_templates_for_sugar_bindings",
+        "canonical-bodies",
+        "body-template JSON",
+        "body-template cache",
+    ];
+    let mut violations = Vec::new();
+    for path in rust_files_under(&cli_src_root()) {
+        let source = fs::read_to_string(&path).unwrap_or_else(|err| {
+            panic!("read {}: {err}", path.display());
+        });
+        for needle in forbidden {
+            if source.contains(needle) {
+                violations.push(format!("{} contains `{needle}`", path.display()));
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "provekit-cli must not make body-template JSON/cache files runtime authority. \
+         Kits own body/proof resolution and the CLI speaks RPC only:\n{}",
+        violations.join("\n")
+    );
+}


### PR DESCRIPTION
## Summary
- authorize the checked-in Java realize manifests from the repo-level project config so Java materialize proof-load tests dispatch through config/manifest/RPC
- add a CLI source guard against reintroducing canonical-bodies/body-template JSON cache authority in provekit-cli runtime code
- update kit dispatch wording to describe kit-owned proof/body inventory over RPC, not a CLI-ordered cache

## Verification
- cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cli_body_authority_boundary -- --nocapture
- JAVA_HOME=${JAVA_HOME:-/usr/local/opt/openjdk/libexec/openjdk.jdk/Contents/Home} cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_materialize_proof_load -- --nocapture
- cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_materialize_integration materialize_python_uses_checked_in_python_double_realize_registration -- --nocapture
- cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test go_realize_materialize go_materialize_uses_checked_in_go_double_realize_registration -- --nocapture
- cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test shim_proof_carries_rust_bodies_after_disk_deletion -- --nocapture
- rustfmt --check implementations/rust/provekit-cli/src/kit_dispatch.rs implementations/rust/provekit-cli/tests/cli_body_authority_boundary.rs
- git diff --check

Closes #1499
