### PR TITLE
feat(php): expose shared LSP document analysis

### DIFF
--- a/implementations/php/provekit-lift/src/ForwardPropagator.php
+++ b/implementations/php/provekit-lift/src/ForwardPropagator.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../../provekit-ir-symbolic/src/Canonicalizer/Blake3.php
 
 use ProvekIt\Canonicalizer\Blake3;
 
-const PROVEKIT_LSP_PROTOCOL_CATALOG_CID = 'blake3-512:52bdb2be4b381cec2aff95db7755c84184878b45cd91882d262114a1abd2dd513f9ef3b250fb87093316fd0fcb48e4b97e109d463e57df5bda6aac0b1c719a0f';
+const PROVEKIT_LSP_PROTOCOL_CATALOG_CID = 'blake3-512:0e3905c2a7a098cd538b9669428a7dffd2b84ba8ccf8fde3724fe2ab61fd3fbc1e1a616a6b20b6817464cdc50c466b5497d4ac2e2dc34c3c15f05535b463643c';
 const PROVEKIT_LSP_IMPLICATION_FAILED_CODE = 'provekit.lsp.implication_failed';
 
 final class ForwardPost

--- a/implementations/php/provekit-lift/src/lspd.php
+++ b/implementations/php/provekit-lift/src/lspd.php
@@ -1,8 +1,8 @@
 <?php
 /** ProvekIt PHP LSP daemon: parses PHP source, extracts contracts + call edges.
  *  Mirrors the Go LSP (`provekit-lsp-go`).
- *  Protocol: provekit-lift/1 over stdio.
- *  Methods: initialize, lift, parse (legacy), shutdown.
+ *  Protocol: provekit-lsp-shared/1 over stdio.
+ *  Methods: initialize, analyzeDocument, lift, parse (legacy), shutdown.
  */
 
 declare(strict_types=1);
@@ -16,6 +16,9 @@ require_once __DIR__ . '/ForwardPropagator.php';
 
 use ProvekIt\Ir\{ContractDecl, BridgeDecl, Collector};
 use ProvekIt\Canonicalizer\{Blake3, Jcs};
+
+const PROVEKIT_LSP_KIT_ID = 'php';
+const PROVEKIT_LSP_SHARED_PROTOCOL_VERSION = 'provekit-lsp-shared/1';
 
 // ════════════════════════════════════════════
 // Annotation scanner (// @provekit-contract, // @provekit-implement)
@@ -255,14 +258,54 @@ while (($line = fgets($stdin)) !== false) {
                 'result' => [
                     'name'             => 'provekit-lsp-php',
                     'version'          => '1.0.0',
-                    'protocol_version' => 'provekit-lift/1',
+                    'protocol_version' => PROVEKIT_LSP_SHARED_PROTOCOL_VERSION,
+                    'kit_id'           => PROVEKIT_LSP_KIT_ID,
+                    'protocol_catalog_cid' => PROVEKIT_LSP_PROTOCOL_CATALOG_CID,
                     'capabilities'     => [
-                        'authoring_surfaces'    => ['php-source'],
-                        'ir_version'            => 'v1.1.0',
-                        'emits_signed_mementos' => false,
+                        'source_surfaces' => ['php-source'],
+                        'entry_kinds' => ['bind-lift-entry', 'call-edge'],
+                        'diagnostic_codes' => [
+                            'provekit.lsp.parse_error',
+                            'provekit.lsp.lift_gap',
+                            'provekit.lsp.implication_failed',
+                        ],
+                        'status_kinds' => ['materialize', 'emit', 'check', 'prove'],
                     ],
                 ],
-            ])),
+            ], JSON_UNESCAPED_SLASHES)),
+
+            'analyzeDocument' => (function () use ($id, $params) {
+                $kitId = $params['kit_id'] ?? PROVEKIT_LSP_KIT_ID;
+                if ($kitId !== PROVEKIT_LSP_KIT_ID) {
+                    send(json_encode([
+                        'jsonrpc' => '2.0', 'id' => $id,
+                        'error' => ['code' => -32602, 'message' => "provekit-lsp-php only handles kit_id 'php', got '{$kitId}'"],
+                    ], JSON_UNESCAPED_SLASHES));
+                    return;
+                }
+
+                $path = $params['file'] ?? $params['path'] ?? 'source.php';
+                $uri = $params['uri'] ?? ('file://' . $path);
+                $source = $params['text'] ?? $params['source'] ?? '';
+                $analysis = analyzeDocumentSource($source, $path);
+
+                send(json_encode([
+                    'jsonrpc' => '2.0', 'id' => $id,
+                    'result' => [
+                        'kind' => 'lsp-document-analysis',
+                        'schema_version' => '1',
+                        'kit_id' => PROVEKIT_LSP_KIT_ID,
+                        'uri' => $uri,
+                        'file' => $path,
+                        'document_cid' => Blake3::cid($source),
+                        'protocol_catalog_cid' => PROVEKIT_LSP_PROTOCOL_CATALOG_CID,
+                        'entries' => $analysis['entries'],
+                        'diagnostics' => $analysis['diagnostics'],
+                        'statuses' => [],
+                        'project' => null,
+                    ],
+                ], JSON_UNESCAPED_SLASHES));
+            })(),
 
             'lift' => (function () use ($id, $params) {
                 $workspaceRoot = $params['workspace_root'] ?? '.';
@@ -363,6 +406,120 @@ while (($line = fgets($stdin)) !== false) {
 fclose($stdin);
 
 function send(string $json): void { echo $json . "\n"; flush(); }
+
+/**
+ * @return array{entries: array<int, array<string, mixed>>, diagnostics: array<int, array<string, mixed>>}
+ */
+function analyzeDocumentSource(string $source, string $path): array
+{
+    $scanned = AnnotationScanner::scan($source, $path);
+    $callEdges = array_merge(
+        $scanned['callEdges'],
+        AnnotationScanner::walkCallEdges($source, $path, $scanned['declarations']),
+    );
+    $diagnostics = array_map(
+        fn(array $diagnostic): array => sharedForwardDiagnostic($diagnostic),
+        forwardDiagnosticsForSource($source),
+    );
+
+    return [
+        'entries' => analysisEntries($scanned['declarations'], $callEdges, $source),
+        'diagnostics' => $diagnostics,
+    ];
+}
+
+/**
+ * @param array<int, array<string, mixed>> $declarations
+ * @param array<int, array<string, mixed>> $callEdges
+ * @return array<int, array<string, mixed>>
+ */
+function analysisEntries(array $declarations, array $callEdges, string $source): array
+{
+    $range = wholeDocumentRange($source);
+    $entries = [];
+    foreach ($declarations as $declaration) {
+        $entries[] = [
+            'kind' => 'bind-lift-entry',
+            'entry' => $declaration,
+            'range' => $range,
+        ];
+    }
+    foreach ($callEdges as $edge) {
+        $entries[] = [
+            'kind' => 'call-edge',
+            'entry' => $edge,
+            'range' => callEdgeRange($edge),
+        ];
+    }
+    return $entries;
+}
+
+/**
+ * @return array{start_line: int, start_col: int, end_line: int, end_col: int}
+ */
+function wholeDocumentRange(string $source): array
+{
+    $line = 1;
+    $column = 0;
+    $length = strlen($source);
+    for ($i = 0; $i < $length; $i++) {
+        if ($source[$i] === "\n") {
+            $line++;
+            $column = 0;
+        } else {
+            $column++;
+        }
+    }
+    return ['start_line' => 1, 'start_col' => 0, 'end_line' => $line, 'end_col' => $column];
+}
+
+/**
+ * @param array<string, mixed> $edge
+ * @return array{start_line: int, start_col: int, end_line: int, end_col: int}
+ */
+function callEdgeRange(array $edge): array
+{
+    $locus = is_array($edge['callSiteLocus'] ?? null) ? $edge['callSiteLocus'] : [];
+    $target = preg_replace('/^php-kit:/', '', (string)($edge['targetSymbol'] ?? ''));
+    $width = max(1, strlen(is_string($target) ? $target : ''));
+    $line = (int)($locus['line'] ?? 1);
+    $column = (int)($locus['column'] ?? $locus['col'] ?? 0);
+    return ['start_line' => $line, 'start_col' => $column, 'end_line' => $line, 'end_col' => $column + $width];
+}
+
+/**
+ * @param array<string, mixed> $diagnostic
+ * @return array<string, mixed>
+ */
+function sharedForwardDiagnostic(array $diagnostic): array
+{
+    return [
+        'code' => (string)($diagnostic['code'] ?? PROVEKIT_LSP_IMPLICATION_FAILED_CODE),
+        'data' => $diagnostic['data'] ?? [],
+        'kit_id' => PROVEKIT_LSP_KIT_ID,
+        'message' => (string)($diagnostic['message'] ?? 'callee precondition not established at this callsite'),
+        'producer' => 'forward-propagation',
+        'protocol_catalog_cid' => PROVEKIT_LSP_PROTOCOL_CATALOG_CID,
+        'range' => sharedRangeFromLsp($diagnostic['range'] ?? []),
+        'severity' => 'error',
+    ];
+}
+
+/**
+ * @param mixed $range
+ * @return array{start_line: int, start_col: int, end_line: int, end_col: int}
+ */
+function sharedRangeFromLsp(mixed $range): array
+{
+    $start = is_array($range) && is_array($range['start'] ?? null) ? $range['start'] : [];
+    $end = is_array($range) && is_array($range['end'] ?? null) ? $range['end'] : [];
+    return [
+        'start_line' => ((int)($start['line'] ?? 0)) + 1,
+        'start_col' => (int)($start['character'] ?? 0),
+        'end_line' => ((int)($end['line'] ?? $start['line'] ?? 0)) + 1,
+        'end_col' => (int)($end['character'] ?? (($start['character'] ?? 0) + 1)),
+    ];
+}
 
 /**
  * @return array<int, array<string, mixed>>

--- a/implementations/php/provekit-lift/tests/integration_lsp.sh
+++ b/implementations/php/provekit-lift/tests/integration_lsp.sh
@@ -3,7 +3,8 @@
 #
 # Integration test for provekit-lsp-php (lspd.php).
 #
-# Tests provekit-lift/1 protocol: initialize, lift, parse (legacy), shutdown.
+# Tests provekit-lsp-shared/1 protocol: initialize, analyzeDocument, lift,
+# parse (legacy), shutdown.
 
 set -e
 
@@ -72,9 +73,10 @@ LIFT2=$(printf '%s\n' "$LIFT_RESPONSES" | sed -n '2p')
 LIFT3=$(printf '%s\n' "$LIFT_RESPONSES" | sed -n '3p')
 
 check "T1 initialize: name"              "$LIFT1" '"name":"provekit-lsp-php"'
-check "T2 initialize: protocol_version"  "$LIFT1" '"protocol_version":"provekit-lift'
-check "T3 initialize: authoring_surfaces" "$LIFT1" '"authoring_surfaces":["php-source"]'
-check "T4 initialize: emits_signed_mementos false" "$LIFT1" '"emits_signed_mementos":false'
+check "T2 initialize: protocol_version"  "$LIFT1" '"protocol_version":"provekit-lsp-shared/1"'
+check "T3 initialize: kit_id" "$LIFT1" '"kit_id":"php"'
+check "T4 initialize: source_surfaces" "$LIFT1" '"source_surfaces":["php-source"]'
+check "T4b initialize: diagnostic code" "$LIFT1" '"provekit.lsp.implication_failed"'
 check "T5 lift: kind ir-document"        "$LIFT2" '"kind":"ir-document"'
 check "T6 lift: ir key present"          "$LIFT2" '"ir":'
 check "T7 lift: contract add_numbers"    "$LIFT2" '"name":"add_numbers"'
@@ -106,6 +108,58 @@ check "T15 parse: call edge target"    "$PARSE2" '"targetSymbol":"php-kit:add_nu
 check "T16 parse: call edge locus file" "$PARSE2" '"file":"fixture.php"'
 check "T17 parse: call edge locus line" "$PARSE2" '"line":8'
 check "T18 parse: call edge locus column" "$PARSE2" '"column":11'
+
+# ---------------------------------------------------------------------------
+# Round 3: shared analyzeDocument method
+# ---------------------------------------------------------------------------
+printf "\n-- analyzeDocument --\n"
+
+cat > "$TMPDIR_PATH/floor.php" << 'EOF'
+<?php
+// @provekit-contract
+function checkPositive(int $x): bool {
+    if ($x <= 0) { return false; }
+    return true;
+}
+// @provekit-contract
+function callerSatisfiesPre(): bool {
+    $result = checkPositive(5);
+    return $result;
+}
+// @provekit-contract
+function callerViolatesPre(): bool {
+    $result = checkPositive(-1);
+    return $result;
+}
+function callerWithLoop(): bool {
+    for ($i = 0; $i < 10; $i++) {
+        $result = checkPositive($i);
+        if (!$result) { return false; }
+    }
+    return true;
+}
+EOF
+
+FLOOR_SOURCE=$(cat "$TMPDIR_PATH/floor.php" | sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/' | tr -d '\n' | sed 's/\\n$//')
+ANALYZE_REQUESTS=$(printf '%s\n%s\n%s\n' \
+    '{"jsonrpc":"2.0","id":20,"method":"initialize","params":{}}' \
+    "{\"jsonrpc\":\"2.0\",\"id\":21,\"method\":\"analyzeDocument\",\"params\":{\"kit_id\":\"php\",\"uri\":\"file:///project/floor.php\",\"file\":\"floor.php\",\"text\":\"$FLOOR_SOURCE\",\"document_version\":42,\"workspace_root\":\"/project\",\"accepted_protocol_catalog_cids\":[],\"policy_cids\":[]}}" \
+    '{"jsonrpc":"2.0","id":22,"method":"shutdown"}')
+
+ANALYZE_RESPONSES=$(printf '%s\n' "$ANALYZE_REQUESTS" | "$PHP_BIN" "$LSPD")
+ANALYZE2=$(printf '%s\n' "$ANALYZE_RESPONSES" | sed -n '2p')
+
+check "T19 analyze: kind" "$ANALYZE2" '"kind":"lsp-document-analysis"'
+check "T20 analyze: schema" "$ANALYZE2" '"schema_version":"1"'
+check "T21 analyze: kit" "$ANALYZE2" '"kit_id":"php"'
+check "T22 analyze: document cid" "$ANALYZE2" '"document_cid":"blake3-512:'
+check "T23 analyze: statuses empty" "$ANALYZE2" '"statuses":[]'
+check "T24 analyze: project null" "$ANALYZE2" '"project":null'
+check "T25 analyze: diagnostic code" "$ANALYZE2" '"code":"provekit.lsp.implication_failed"'
+check "T26 analyze: diagnostic producer" "$ANALYZE2" '"producer":"forward-propagation"'
+check "T27 analyze: range line" "$ANALYZE2" '"start_line":14'
+check "T28 analyze: range column" "$ANALYZE2" '"start_col":14'
+check "T29 analyze: callee" "$ANALYZE2" '"callee":"\\checkPositive"'
 
 # Cleanup
 rm -rf "$TMPDIR_PATH"


### PR DESCRIPTION
## Summary
- advertise provekit-lsp-shared/1 from the PHP LSP helper
- add analyzeDocument returning lsp-document-analysis with entries, diagnostics, statuses, project, and document CID
- normalize PHP forward diagnostics into the shared provekit.lsp diagnostic shape and shared source range fields

Refs #1500, #1486, #308

## Verification
- php -l provekit-lift/src/lspd.php
- php -l provekit-lift/src/ForwardPropagator.php
- sh provekit-lift/tests/integration_lsp.sh
- php provekit-lift/tests/ForwardPropagatorTest.php
- git diff --check