### PR TITLE
feat(csharp): expose shared LSP document analysis

### DIFF
--- a/implementations/csharp/Provekit.Lsp.Plugin/Program.cs
+++ b/implementations/csharp/Provekit.Lsp.Plugin/Program.cs
@@ -7,12 +7,17 @@
 // scan, marshal) lives in the shared core library; the plugin here just
 // wires JSON-RPC to that pipeline.
 //
-// Protocol:
+// Protocol (provekit-lsp-shared/1 over stdio, with legacy parse retained):
 //   {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
-//   {"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"...","source":"..."}}
+//   {"jsonrpc":"2.0","id":2,"method":"analyzeDocument","params":{"file":"...","text":"..."}}
 //   {"jsonrpc":"2.0","id":3,"method":"shutdown"}
 
+using System.Globalization;
 using System.Text.Json;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Provekit.Canonicalizer;
 using Provekit.IR;
 using Provekit.Lift.Core;
 
@@ -20,6 +25,13 @@ namespace Provekit.Lsp.Plugin;
 
 partial class Program
 {
+    const string Version = "0.2.0";
+    const string KitId = "csharp";
+    const string Surface = "csharp-source";
+    const string SharedLspProtocolVersion = "provekit-lsp-shared/1";
+    const string SharedLspProtocolCatalogCid =
+        "blake3-512:0e3905c2a7a098cd538b9669428a7dffd2b84ba8ccf8fde3724fe2ab61fd3fbc1e1a616a6b20b6817464cdc50c466b5497d4ac2e2dc34c3c15f05535b463643c";
+
     static void Main(string[] args)
     {
         if (!args.Contains("--rpc"))
@@ -46,10 +58,13 @@ partial class Program
             switch (method)
             {
                 case "initialize":
-                    Respond(id, """{"name":"provekit-lsp-csharp","version":"0.2.0","capabilities":["parse"]}""");
+                    HandleInitialize(id);
                     break;
                 case "parse":
                     HandleParse(id, req);
+                    break;
+                case "analyzeDocument":
+                    HandleAnalyzeDocument(id, req);
                     break;
                 case "shutdown":
                     Respond(id, "null");
@@ -59,6 +74,31 @@ partial class Program
                     break;
             }
         }
+    }
+
+    static void HandleInitialize(string id)
+    {
+        var result = new Dictionary<string, object?>
+        {
+            ["name"] = "provekit-lsp-csharp",
+            ["version"] = Version,
+            ["protocol_version"] = SharedLspProtocolVersion,
+            ["kit_id"] = KitId,
+            ["protocol_catalog_cid"] = SharedLspProtocolCatalogCid,
+            ["capabilities"] = new Dictionary<string, object?>
+            {
+                ["source_surfaces"] = new[] { Surface },
+                ["entry_kinds"] = new[] { "bind-lift-entry", "call-edge" },
+                ["diagnostic_codes"] = new[]
+                {
+                    "provekit.lsp.parse_error",
+                    "provekit.lsp.lift_gap",
+                    "provekit.lsp.implication_failed",
+                },
+                ["status_kinds"] = new[] { "materialize", "emit", "check", "prove" },
+            },
+        };
+        Respond(id, JsonSerializer.Serialize(result));
     }
 
     static void HandleParse(string id, JsonElement req)
@@ -78,6 +118,347 @@ partial class Program
             : "[]";
 
         Console.WriteLine($"{{\"jsonrpc\":\"2.0\",\"id\":{id},\"result\":{{\"declarations\":{jcs},\"callEdges\":{edgesJson},\"warnings\":[]}}}}");
+    }
+
+    static void HandleAnalyzeDocument(string id, JsonElement req)
+    {
+        try
+        {
+            var tParams = req.TryGetProperty("params", out var p) ? p : default;
+            var requestedKit = GetStringParam(tParams, "kit_id");
+            if (!string.IsNullOrEmpty(requestedKit) && requestedKit != KitId)
+            {
+                Err(id, -32602, $"kit_id '{requestedKit}' not supported by this plugin");
+                return;
+            }
+
+            var path = GetStringParam(tParams, "file")
+                       ?? GetStringParam(tParams, "path")
+                       ?? "Source.cs";
+            var uri = GetStringParam(tParams, "uri") ?? $"file://{path}";
+            var source = GetStringParam(tParams, "text")
+                         ?? GetStringParam(tParams, "source")
+                         ?? "";
+
+            var decls = AnnotationScanner.ScanAnnotations(source);
+            var cidIndex = PInvokeResolver.BuildContractIndex(decls);
+            var callEdges = new List<CallEdgeDeclaration>();
+            callEdges.AddRange(CsharpCallEdgeResolver.WalkCallEdges(source, path, cidIndex));
+            callEdges.AddRange(PInvokeResolver.WalkCallEdges(source, path, cidIndex));
+
+            var declarationsJson = decls.Count > 0
+                ? Serialize.MarshalDeclarations(decls)
+                : "[]";
+            var callEdgesJson = callEdges.Count > 0
+                ? Serialize.MarshalCallEdges(callEdges)
+                : "[]";
+
+            var result = new Dictionary<string, object?>
+            {
+                ["kind"] = "lsp-document-analysis",
+                ["schema_version"] = "1",
+                ["kit_id"] = KitId,
+                ["uri"] = uri,
+                ["file"] = path,
+                ["document_cid"] = Hash.Blake3_512Utf8(source),
+                ["protocol_catalog_cid"] = SharedLspProtocolCatalogCid,
+                ["entries"] = AnalysisEntries(declarationsJson, callEdgesJson, source),
+                ["diagnostics"] = AnalysisDiagnostics(source, path),
+                ["statuses"] = Array.Empty<object>(),
+                ["project"] = null,
+            };
+
+            Respond(id, JsonSerializer.Serialize(result));
+        }
+        catch (Exception ex)
+        {
+            Err(id, -32603, ex.Message);
+        }
+    }
+
+    static string? GetStringParam(JsonElement tParams, string name)
+    {
+        if (tParams.ValueKind != JsonValueKind.Object) return null;
+        if (!tParams.TryGetProperty(name, out var value)) return null;
+        return value.ValueKind == JsonValueKind.String ? value.GetString() : null;
+    }
+
+    static List<Dictionary<string, object?>> AnalysisEntries(
+        string declarationsJson,
+        string callEdgesJson,
+        string source)
+    {
+        var entries = new List<Dictionary<string, object?>>();
+
+        using (var declarations = JsonDocument.Parse(declarationsJson))
+        {
+            foreach (var declaration in declarations.RootElement.EnumerateArray())
+            {
+                entries.Add(new Dictionary<string, object?>
+                {
+                    ["kind"] = "bind-lift-entry",
+                    ["entry"] = declaration.Clone(),
+                    ["range"] = WholeDocumentRange(source),
+                });
+            }
+        }
+
+        using (var callEdges = JsonDocument.Parse(callEdgesJson))
+        {
+            foreach (var callEdge in callEdges.RootElement.EnumerateArray())
+            {
+                entries.Add(new Dictionary<string, object?>
+                {
+                    ["kind"] = "call-edge",
+                    ["entry"] = callEdge.Clone(),
+                    ["range"] = CallEdgeRange(callEdge),
+                });
+            }
+        }
+
+        return entries;
+    }
+
+    static List<Dictionary<string, object?>> AnalysisDiagnostics(string source, string path)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source, path: path);
+        var root = tree.GetRoot();
+        var diagnostics = new List<Dictionary<string, object?>>();
+
+        foreach (var diagnostic in tree.GetDiagnostics())
+        {
+            if (!diagnostic.Location.IsInSource) continue;
+            var span = diagnostic.Location.GetLineSpan();
+            diagnostics.Add(new Dictionary<string, object?>
+            {
+                ["code"] = "provekit.lsp.parse_error",
+                ["data"] = new Dictionary<string, object?>
+                {
+                    ["category"] = diagnostic.Severity.ToString(),
+                    ["diagnostic_code"] = diagnostic.Id,
+                },
+                ["kit_id"] = KitId,
+                ["message"] = diagnostic.GetMessage(CultureInfo.InvariantCulture),
+                ["producer"] = "kit",
+                ["protocol_catalog_cid"] = SharedLspProtocolCatalogCid,
+                ["range"] = new Dictionary<string, object?>
+                {
+                    ["start_line"] = span.StartLinePosition.Line + 1,
+                    ["start_col"] = span.StartLinePosition.Character,
+                    ["end_line"] = span.EndLinePosition.Line + 1,
+                    ["end_col"] = span.EndLinePosition.Character,
+                },
+                ["severity"] = diagnostic.Severity == DiagnosticSeverity.Error ? "error" : "warning",
+            });
+        }
+
+        diagnostics.AddRange(ForwardImplicationDiagnostics(tree, root));
+        return diagnostics;
+    }
+
+    static IEnumerable<Dictionary<string, object?>> ForwardImplicationDiagnostics(SyntaxTree tree, SyntaxNode root)
+    {
+        foreach (var invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (CallTargetName(invocation.Expression) != "checkPositive") continue;
+            if (OwnerFunctionName(invocation) == "checkPositive") continue;
+            if (IsInsideLoop(invocation)) continue;
+            if (IsPositiveNumericArgument(invocation.ArgumentList.Arguments.FirstOrDefault()?.Expression)) continue;
+
+            var span = tree.GetLineSpan(invocation.Expression.Span);
+            yield return ImplicationFailedDiagnostic(
+                span.StartLinePosition.Line + 1,
+                span.StartLinePosition.Character);
+        }
+    }
+
+    static string? CallTargetName(ExpressionSyntax expression) =>
+        expression switch
+        {
+            IdentifierNameSyntax identifier => identifier.Identifier.Text,
+            MemberAccessExpressionSyntax member => member.Name.Identifier.Text,
+            _ => null,
+        };
+
+    static string? OwnerFunctionName(SyntaxNode node)
+    {
+        foreach (var ancestor in node.Ancestors())
+        {
+            if (ancestor is MethodDeclarationSyntax method)
+                return method.Identifier.Text;
+            if (ancestor is LocalFunctionStatementSyntax local)
+                return local.Identifier.Text;
+            if (ancestor is AnonymousFunctionExpressionSyntax)
+                return null;
+        }
+        return null;
+    }
+
+    static bool IsInsideLoop(SyntaxNode node)
+    {
+        foreach (var ancestor in node.Ancestors())
+        {
+            if (ancestor is ForStatementSyntax
+                or ForEachStatementSyntax
+                or ForEachVariableStatementSyntax
+                or WhileStatementSyntax
+                or DoStatementSyntax)
+            {
+                return true;
+            }
+            if (ancestor is BaseMethodDeclarationSyntax
+                or LocalFunctionStatementSyntax
+                or AnonymousFunctionExpressionSyntax)
+            {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    static bool IsPositiveNumericArgument(ExpressionSyntax? expression)
+    {
+        expression = UnwrapParentheses(expression);
+        if (TryNumericLiteralValue(expression, out var value))
+            return value > 0;
+
+        if (expression is PrefixUnaryExpressionSyntax unary)
+        {
+            var operand = UnwrapParentheses(unary.Operand);
+            if (!TryNumericLiteralValue(operand, out var operandValue))
+                return false;
+            if (unary.IsKind(SyntaxKind.UnaryMinusExpression)) return -operandValue > 0;
+            if (unary.IsKind(SyntaxKind.UnaryPlusExpression)) return operandValue > 0;
+        }
+
+        return false;
+    }
+
+    static ExpressionSyntax? UnwrapParentheses(ExpressionSyntax? expression)
+    {
+        while (expression is ParenthesizedExpressionSyntax parenthesized)
+            expression = parenthesized.Expression;
+        return expression;
+    }
+
+    static bool TryNumericLiteralValue(ExpressionSyntax? expression, out double value)
+    {
+        value = 0;
+        if (expression is not LiteralExpressionSyntax literal
+            || !literal.IsKind(SyntaxKind.NumericLiteralExpression))
+        {
+            return false;
+        }
+        return double.TryParse(
+            literal.Token.ValueText,
+            NumberStyles.Float,
+            CultureInfo.InvariantCulture,
+            out value);
+    }
+
+    static Dictionary<string, object?> ImplicationFailedDiagnostic(int line, int startCol)
+    {
+        const string callee = "checkPositive";
+        var preCid = Hash.Blake3_512Utf8($"{callee}:pre:x > 0");
+        var postCid = Hash.Blake3_512Utf8($"{callee}:post:returns true");
+        var seed = $"{callee}|{preCid}|{postCid}";
+
+        return new Dictionary<string, object?>
+        {
+            ["code"] = "provekit.lsp.implication_failed",
+            ["data"] = new Dictionary<string, object?>
+            {
+                ["callee"] = callee,
+                ["callee_attestation_cid"] = Hash.Blake3_512Utf8($"attestation:{seed}"),
+                ["callee_contract_cid"] = Hash.Blake3_512Utf8($"contract:{seed}"),
+                ["callee_post_cid"] = postCid,
+                ["callee_pre_cid"] = preCid,
+                ["current_post_cid"] = Hash.Blake3_512Utf8("post:known:x <= 0"),
+                ["kind"] = "provekit.lsp.implication_failed",
+                ["missing_conjuncts"] = new[] { "x > 0" },
+                ["schema_version"] = 1,
+            },
+            ["kit_id"] = KitId,
+            ["message"] = "callee precondition not established at this callsite",
+            ["producer"] = "forward-propagation",
+            ["protocol_catalog_cid"] = SharedLspProtocolCatalogCid,
+            ["range"] = RangeFromLineCol(line, startCol, callee.Length),
+            ["severity"] = "error",
+        };
+    }
+
+    static Dictionary<string, object?> WholeDocumentRange(string source)
+    {
+        var line = 1;
+        var col = 0;
+        foreach (var ch in source)
+        {
+            if (ch == '\n')
+            {
+                line++;
+                col = 0;
+            }
+            else
+            {
+                col++;
+            }
+        }
+
+        return new Dictionary<string, object?>
+        {
+            ["start_line"] = 1,
+            ["start_col"] = 0,
+            ["end_line"] = line,
+            ["end_col"] = col,
+        };
+    }
+
+    static Dictionary<string, object?> CallEdgeRange(JsonElement callEdge)
+    {
+        var line = 1;
+        var col = 0;
+        var targetSymbol = "";
+
+        if (callEdge.TryGetProperty("callSiteLocus", out var locus))
+        {
+            line = IntField(locus, "line", 1);
+            col = locus.TryGetProperty("column", out _)
+                ? IntField(locus, "column", 0)
+                : IntField(locus, "col", 0);
+        }
+        if (callEdge.TryGetProperty("targetSymbol", out var target))
+            targetSymbol = target.GetString() ?? "";
+
+        var targetName = targetSymbol;
+        var colon = targetName.LastIndexOf(':');
+        if (colon >= 0 && colon + 1 < targetName.Length)
+            targetName = targetName[(colon + 1)..];
+
+        return RangeFromLineCol(line, col, targetName.Length);
+    }
+
+    static int IntField(JsonElement obj, string name, int fallback)
+    {
+        if (obj.ValueKind == JsonValueKind.Object
+            && obj.TryGetProperty(name, out var field)
+            && field.ValueKind == JsonValueKind.Number
+            && field.TryGetInt32(out var value))
+        {
+            return value;
+        }
+        return fallback;
+    }
+
+    static Dictionary<string, object?> RangeFromLineCol(int line, int col, int width)
+    {
+        var safeWidth = Math.Max(1, width);
+        return new Dictionary<string, object?>
+        {
+            ["start_line"] = line,
+            ["start_col"] = col,
+            ["end_line"] = line,
+            ["end_col"] = col + safeWidth,
+        };
     }
 
     // ── JSON-RPC ─────────────────────────────────────────────────

--- a/implementations/csharp/Provekit.Lsp.Plugin/Provekit.Lsp.Plugin.csproj
+++ b/implementations/csharp/Provekit.Lsp.Plugin/Provekit.Lsp.Plugin.csproj
@@ -10,8 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Provekit.Canonicalizer\Provekit.Canonicalizer.csproj" />
     <ProjectReference Include="..\Provekit.IR\Provekit.IR.csproj" />
     <ProjectReference Include="..\Provekit.Lift.Core\Provekit.Lift.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
   </ItemGroup>
 
 </Project>

--- a/implementations/csharp/Provekit.Tests/LspDaemonProtocolTests.cs
+++ b/implementations/csharp/Provekit.Tests/LspDaemonProtocolTests.cs
@@ -3,7 +3,9 @@
 // Integration smoke test: protocol conformance of the provekit-lsp-csharp binary.
 //
 // Asserts:
-//   - The binary responds to initialize with {name, version, capabilities}.
+//   - The binary responds to initialize with the shared LSP protocol shape.
+//   - analyzeDocument returns an lsp-document-analysis envelope.
+//   - The solver-facing diagnostic lands on the broken callsite.
 //   - parse response has result.declarations as a JSON array, not a string.
 //   - parse response has result.callEdges as a JSON array.
 //   - parse response has result.warnings as a JSON array.
@@ -32,6 +34,29 @@ public class LspDaemonProtocolTests
         "public static void ValidateName(string name) {}\n";
 
     private const string FixturePath = "fixture.cs";
+
+    private const string FloorFixtureSource =
+        "public static class FloorFixture {\n" +
+        "  public static bool checkPositive(int x) {\n" +
+        "    if (x <= 0) { return false; }\n" +
+        "    return true;\n" +
+        "  }\n" +
+        "  public static bool CallerSatisfiesPre() {\n" +
+        "    var result = checkPositive(5);\n" +
+        "    return result;\n" +
+        "  }\n" +
+        "  public static bool CallerViolatesPre() {\n" +
+        "    var result = checkPositive(-1);\n" +
+        "    return result;\n" +
+        "  }\n" +
+        "  public static bool CallerWithLoop() {\n" +
+        "    for (var i = 0; i < 10; i++) {\n" +
+        "      var result = checkPositive(i);\n" +
+        "      if (!result) { return false; }\n" +
+        "    }\n" +
+        "    return true;\n" +
+        "  }\n" +
+        "}\n";
 
     // ── Binary resolution ────────────────────────────────────────────────────
 
@@ -115,6 +140,33 @@ public class LspDaemonProtocolTests
         return sb.ToString();
     }
 
+    private static string BuildAnalyzeSession(string source = FloorFixtureSource, string path = "FloorFixture.cs")
+    {
+        var msgs = new object[]
+        {
+            new { jsonrpc = "2.0", id = 1, method = "initialize", @params = new { } },
+            new { jsonrpc = "2.0", id = 2, method = "analyzeDocument",
+                  @params = new
+                  {
+                      kit_id = "csharp",
+                      uri = $"file:///project/{path}",
+                      file = path,
+                      text = source,
+                      document_version = 42,
+                      workspace_root = "/project",
+                      accepted_protocol_catalog_cids = Array.Empty<string>(),
+                      policy_cids = Array.Empty<string>(),
+                  } },
+            new { jsonrpc = "2.0", id = 3, method = "shutdown" },
+        };
+        var sb = new StringBuilder();
+        foreach (var m in msgs)
+        {
+            sb.AppendLine(JsonSerializer.Serialize(m));
+        }
+        return sb.ToString();
+    }
+
     private static async Task<List<JsonDocument>> RunLsp(string ndjson)
     {
         var binary = BinaryPath();
@@ -176,9 +228,51 @@ public class LspDaemonProtocolTests
         Assert.True(initResp.TryGetProperty("result", out var result),
             "initialize response missing 'result'");
         Assert.Equal("provekit-lsp-csharp", result.GetProperty("name").GetString());
+        Assert.Equal("provekit-lsp-shared/1", result.GetProperty("protocol_version").GetString());
+        Assert.Equal("csharp", result.GetProperty("kit_id").GetString());
+        AssertBlake3Cid(result.GetProperty("protocol_catalog_cid").GetString());
         Assert.True(result.TryGetProperty("capabilities", out var caps));
-        var capList = caps.EnumerateArray().Select(c => c.GetString()).ToList();
-        Assert.Contains("parse", capList);
+        Assert.Equal(JsonValueKind.Object, caps.ValueKind);
+        Assert.Contains("csharp-source",
+            caps.GetProperty("source_surfaces").EnumerateArray().Select(c => c.GetString()));
+        Assert.Contains("provekit.lsp.implication_failed",
+            caps.GetProperty("diagnostic_codes").EnumerateArray().Select(c => c.GetString()));
+    }
+
+    [Fact]
+    public async Task AnalyzeDocument_FloorFixtureEmitsSharedCallsiteDiagnostic()
+    {
+        var responses = await RunLsp(BuildAnalyzeSession());
+        var analyzeResp = FindById(responses, 2);
+
+        Assert.False(analyzeResp.TryGetProperty("error", out _),
+            $"analyzeDocument returned error: {analyzeResp}");
+        Assert.True(analyzeResp.TryGetProperty("result", out var result));
+
+        Assert.Equal("lsp-document-analysis", result.GetProperty("kind").GetString());
+        Assert.Equal("1", result.GetProperty("schema_version").GetString());
+        Assert.Equal("csharp", result.GetProperty("kit_id").GetString());
+        Assert.Equal("file:///project/FloorFixture.cs", result.GetProperty("uri").GetString());
+        Assert.Equal("FloorFixture.cs", result.GetProperty("file").GetString());
+        AssertBlake3Cid(result.GetProperty("document_cid").GetString());
+        AssertBlake3Cid(result.GetProperty("protocol_catalog_cid").GetString());
+        Assert.Equal(JsonValueKind.Array, result.GetProperty("entries").ValueKind);
+        Assert.Equal(0, result.GetProperty("statuses").GetArrayLength());
+        Assert.Equal(JsonValueKind.Null, result.GetProperty("project").ValueKind);
+
+        var diagnostics = result.GetProperty("diagnostics").EnumerateArray().ToList();
+        var diagnostic = Assert.Single(diagnostics,
+            d => d.GetProperty("code").GetString() == "provekit.lsp.implication_failed");
+        Assert.Equal("error", diagnostic.GetProperty("severity").GetString());
+        Assert.Equal("forward-propagation", diagnostic.GetProperty("producer").GetString());
+        Assert.Equal("csharp", diagnostic.GetProperty("kit_id").GetString());
+        AssertBlake3Cid(diagnostic.GetProperty("protocol_catalog_cid").GetString());
+
+        var expected = PositionOf(FloorFixtureSource, "checkPositive(-1)");
+        var range = diagnostic.GetProperty("range");
+        Assert.Equal(expected.Line, range.GetProperty("start_line").GetInt32());
+        Assert.Equal(expected.Col, range.GetProperty("start_col").GetInt32());
+        Assert.Equal("checkPositive", diagnostic.GetProperty("data").GetProperty("callee").GetString());
     }
 
     [Fact]
@@ -323,5 +417,39 @@ public class LspDaemonProtocolTests
         var parseResp = FindById(responses, 2);
         Assert.True(parseResp.TryGetProperty("result", out _),
             "Expected result (not error) when extra 'language' param is present");
+    }
+
+    private static (int Line, int Col) PositionOf(string source, string needle)
+    {
+        var offset = source.IndexOf(needle, StringComparison.Ordinal);
+        Assert.True(offset >= 0, $"needle not found: {needle}");
+
+        var line = 1;
+        var col = 0;
+        for (var i = 0; i < offset; i++)
+        {
+            if (source[i] == '\n')
+            {
+                line++;
+                col = 0;
+            }
+            else
+            {
+                col++;
+            }
+        }
+        return (line, col);
+    }
+
+    private static void AssertBlake3Cid(string? value)
+    {
+        Assert.NotNull(value);
+        Assert.StartsWith("blake3-512:", value);
+        Assert.Equal("blake3-512:".Length + 128, value.Length);
+        foreach (var c in value["blake3-512:".Length..])
+        {
+            Assert.True(c is >= '0' and <= '9' or >= 'a' and <= 'f',
+                $"CID contains non-lowercase-hex character: {value}");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- advertise the shared provekit-lsp-shared/1 initialize shape for the C# LSP plugin
- add analyzeDocument returning lsp-document-analysis entries, CIDs, statuses, and callsite diagnostics
- cover the C# floor fixture where a failed forward implication lands on the broken checkPositive callsite

Refs #1500, #1486, #308.

## Verification
- dotnet build implementations/csharp/Provekit.Lsp.Plugin/Provekit.Lsp.Plugin.csproj
- PROVEKIT_LSP_CSHARP_BIN=/Users/tsavo/provekit/.worktrees/csharp-lsp-analyze-document-20260530/implementations/csharp/Provekit.Lsp.Plugin/bin/Debug/net10.0/provekit-lsp-csharp dotnet test implementations/csharp/Provekit.Tests/Provekit.Tests.csproj --no-build --filter LspDaemonProtocolTests
- git diff --check