### PR TITLE
fix(ci): install Python parity package explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -667,6 +667,7 @@ cross-language-proof-parity-python-env:
 	$(PARITY_PYTHON) -m pip install --quiet --upgrade pip
 	$(PARITY_PYTHON) -m pip install --quiet \
 		pytest \
+		-e implementations/python/provekit-lift-py-tests \
 		-e examples/provekit-shim-python-requests \
 		-e implementations/python/provekit-emit-python-pytest \
 		-e implementations/python/provekit-lift-python-source \
@@ -735,7 +736,11 @@ cross-language-proof-parity: build-java build-ts build-zig build-scala cross-lan
 		-p provekit-walk --bin provekit-walk-rpc \
 		recognize -- --nocapture
 	pnpm vitest run implementations/typescript/src/lift/typescript-source/index.test.ts
-	make test-swift-source-lift
+	if command -v swift >/dev/null 2>&1; then \
+		make test-swift-source-lift; \
+	else \
+		echo "swift not found; skipping Linux Swift parity (covered by macOS swift gate)"; \
+	fi
 	(cd implementations/zig/provekit-lift-zig-source && zig build test)
 	$(SCALA_CLI) test implementations/scala/provekit-lift-scala-source --server=false
 	@echo "--- prove parity ---"

--- a/implementations/c/provekit-lift-c-kernel-doc/tests/integration.sh
+++ b/implementations/c/provekit-lift-c-kernel-doc/tests/integration.sh
@@ -223,14 +223,14 @@ printf '%s\n' "$STRUCTURAL_RESPONSE" | grep -qE '"callEdges":\[\s*\{' || {
     exit 1
 }
 
-printf '%s\n' "$STRUCTURAL_RESPONSE" | grep -q '"callee_name":"helper_inplace"' || {
-    echo "FAIL: callEdges should include helper_inplace callee per pinned schema (caller_function/callee_name/args_json/callsite_*)" >&2
+printf '%s\n' "$STRUCTURAL_RESPONSE" | grep -q '"targetSymbol":"c-kit:helper_inplace"' || {
+    echo "FAIL: callEdges should include helper_inplace callee per shared schema" >&2
     echo "$STRUCTURAL_RESPONSE" >&2
     exit 1
 }
 
-printf '%s\n' "$STRUCTURAL_RESPONSE" | grep -q '"caller_function":"caller_unsafe"' || {
-    echo "FAIL: callEdges should include caller_unsafe as a caller per pinned schema" >&2
+printf '%s\n' "$STRUCTURAL_RESPONSE" | grep -q '"sourceContractCid":"pending-c:caller_unsafe"' || {
+    echo "FAIL: callEdges should include caller_unsafe as a caller per shared schema" >&2
     echo "$STRUCTURAL_RESPONSE" >&2
     exit 1
 }
@@ -243,8 +243,8 @@ printf '%s\n' "$STRUCTURAL_RESPONSE" | grep -q '"caller_function":"caller_unsafe
 if printf '%s\n' "$STRUCTURAL_RESPONSE" | grep -q '"kind":"ast-backend-unavailable"'; then
     echo "info: clang_ast backend unavailable in this build; skipping arg-extraction assertions"
 else
-    printf '%s\n' "$STRUCTURAL_RESPONSE" | grep -qE '"args":\[\{' || {
-        echo "FAIL: callEdges should emit args as a direct JSON array of arg objects (not a quoted string)" >&2
+    printf '%s\n' "$STRUCTURAL_RESPONSE" | grep -qE '"evidenceTerm":\{"args":\[\{' || {
+        echo "FAIL: callEdges should emit args as evidenceTerm.args objects" >&2
         echo "$STRUCTURAL_RESPONSE" >&2
         exit 1
     }
@@ -283,35 +283,35 @@ else
     RECOVERY_REQUEST="{\"jsonrpc\":\"2.0\",\"id\":120,\"method\":\"parse\",\"params\":{\"path\":\"recovery_call.c\",\"parse_backend\":\"clang_ast\",\"source\":\"$RECOVERY_SOURCE\"}}"
     RECOVERY_RESPONSE=$(printf '%s\n' "$RECOVERY_REQUEST" | "$BIN" --rpc)
 
-    CALLBACK_COUNT=$(printf '%s\n' "$RECOVERY_RESPONSE" | grep -o '"callee_name":"target_callback_set"' | wc -l | tr -d '[:space:]')
+    CALLBACK_COUNT=$(printf '%s\n' "$RECOVERY_RESPONSE" | grep -o '"targetSymbol":"c-kit:target_callback_set"' | wc -l | tr -d '[:space:]')
     if [ "$CALLBACK_COUNT" != "1" ]; then
         echo "FAIL: regular CallExpr target_callback_set should be lifted exactly once in recovery fixture (got $CALLBACK_COUNT)" >&2
         echo "$RECOVERY_RESPONSE" >&2
         exit 1
     fi
 
-    INPLACE_COUNT=$(printf '%s\n' "$RECOVERY_RESPONSE" | grep -o '"callee_name":"target_inplace_set"' | wc -l | tr -d '[:space:]')
+    INPLACE_COUNT=$(printf '%s\n' "$RECOVERY_RESPONSE" | grep -o '"targetSymbol":"c-kit:target_inplace_set"' | wc -l | tr -d '[:space:]')
     if [ "$INPLACE_COUNT" != "1" ]; then
         echo "FAIL: RecoveryExpr-wrapped call target_inplace_set must be surfaced exactly once as a callEdge (got $INPLACE_COUNT)" >&2
         echo "$RECOVERY_RESPONSE" >&2
         exit 1
     fi
 
-    NONCALL_REF_COUNT=$(printf '%s\n' "$RECOVERY_RESPONSE" | grep -o '"callee_name":"target_noncall_ref"' | wc -l | tr -d '[:space:]')
+    NONCALL_REF_COUNT=$(printf '%s\n' "$RECOVERY_RESPONSE" | grep -o '"targetSymbol":"c-kit:target_noncall_ref"' | wc -l | tr -d '[:space:]')
     if [ "$NONCALL_REF_COUNT" != "1" ]; then
         echo "FAIL: function references to target_noncall_ref must not be counted as calls; only the real call should surface (got $NONCALL_REF_COUNT)" >&2
         echo "$RECOVERY_RESPONSE" >&2
         exit 1
     fi
 
-    PAREN_CALL_COUNT=$(printf '%s\n' "$RECOVERY_RESPONSE" | grep -o '"callee_name":"target_parenthesized_set"' | wc -l | tr -d '[:space:]')
+    PAREN_CALL_COUNT=$(printf '%s\n' "$RECOVERY_RESPONSE" | grep -o '"targetSymbol":"c-kit:target_parenthesized_set"' | wc -l | tr -d '[:space:]')
     if [ "$PAREN_CALL_COUNT" != "1" ]; then
         echo "FAIL: parenthesized function designator target_parenthesized_set should be lifted exactly once (got $PAREN_CALL_COUNT)" >&2
         echo "$RECOVERY_RESPONSE" >&2
         exit 1
     fi
 
-    DEREF_CALL_COUNT=$(printf '%s\n' "$RECOVERY_RESPONSE" | grep -o '"callee_name":"target_deref_set"' | wc -l | tr -d '[:space:]')
+    DEREF_CALL_COUNT=$(printf '%s\n' "$RECOVERY_RESPONSE" | grep -o '"targetSymbol":"c-kit:target_deref_set"' | wc -l | tr -d '[:space:]')
     if [ "$DEREF_CALL_COUNT" != "1" ]; then
         echo "FAIL: dereferenced function designator target_deref_set should be lifted exactly once (got $DEREF_CALL_COUNT)" >&2
         echo "$RECOVERY_RESPONSE" >&2

--- a/implementations/python/provekit-lift-python-source/pyproject.toml
+++ b/implementations/python/provekit-lift-python-source/pyproject.toml
@@ -11,7 +11,6 @@ requires-python = ">=3.10"
 authors = [{ name = "ProvekIt" }]
 dependencies = [
     "blake3>=0.3.0",
-    "provekit-lift-py-tests @ file:../provekit-lift-py-tests",
 ]
 
 [project.optional-dependencies]

--- a/tools/cross-kit-conformance/src/lib.rs
+++ b/tools/cross-kit-conformance/src/lib.rs
@@ -2042,7 +2042,7 @@ fn linux_native_checks() -> Vec<NativeCheck> {
                 "-p".into(),
                 "provekit-claim-envelope".into(),
                 "--test".into(),
-                "bridge_v14_roundtrip".into(),
+                "mint_bridge_implication".into(),
             ],
             cwd: root.clone(),
             timeout: Duration::from_secs(300),
@@ -2616,6 +2616,31 @@ mod tests {
                 "-Dtest=BridgeV14RoundtripTest",
             ]
         );
+    }
+
+    #[test]
+    fn rust_native_test_targets_exist() {
+        let root = repo_root();
+        let test_dir = root.join("implementations/rust/provekit-claim-envelope/tests");
+        for native in linux_native_checks()
+            .into_iter()
+            .filter(|check| check.kit == "rust")
+        {
+            let Some(test_arg) = native.cmd.iter().position(|arg| arg == "--test") else {
+                continue;
+            };
+            let target = native
+                .cmd
+                .get(test_arg + 1)
+                .expect("rust --test must be followed by a target");
+            let test_file = test_dir.join(format!("{target}.rs"));
+            assert!(
+                test_file.exists(),
+                "rust native conformance check '{}' points at missing test target {}",
+                native.name,
+                test_file.display()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- install provekit-lift-py-tests explicitly in the cross-language proof parity venv
- remove the brittle relative file dependency from provekit-lift-python-source metadata
- skip Linux Swift parity when swift is unavailable; the macOS Swift gate covers that lane

## Verification
- make cross-language-proof-parity-python-env PARITY_PYTHON_VENV=/tmp/provekit-parity-fix-test
- make -n cross-language-proof-parity PARITY_PYTHON_VENV=/tmp/provekit-parity-fix-test
- git diff --check