### PR TITLE
feat(zig): expose shared LSP document analysis

### DIFF
--- a/implementations/zig/provekit-lsp-zig/src/main.zig
+++ b/implementations/zig/provekit-lsp-zig/src/main.zig
@@ -1,22 +1,24 @@
 // provekit-lsp-zig: NDJSON LSP plugin for Zig.
 //
-// Protocol (canonical wire shape):
+// Protocol (provekit-lsp-shared/1 over stdio, with legacy parse retained):
 //   {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
-//     -> {"jsonrpc":"2.0","id":1,"result":{"name":"provekit-lsp-zig","version":"0.1.0","capabilities":["parse"]}}
-//
-//   {"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"...","source":"..."}}
-//     -> {"jsonrpc":"2.0","id":2,"result":{"declarations":[...],"callEdges":[...],"warnings":[]}}
-//
+//   {"jsonrpc":"2.0","id":2,"method":"analyzeDocument","params":{"file":"...","text":"..."}}
 //   {"jsonrpc":"2.0","id":3,"method":"shutdown"}
-//     -> {"jsonrpc":"2.0","id":3,"result":null}
 //
 // Usage: provekit-lsp-zig (reads from stdin, writes to stdout).
 // Binary name expected by consumers: provekit-lsp-zig
 
 const std = @import("std");
+const ir = @import("provekit-ir");
 const lift = @import("provekit-lift-zig-source");
 
 const Io = std.Io;
+
+const VERSION = "0.1.0";
+const KIT_ID = "zig";
+const SURFACE = "zig-source";
+const SHARED_LSP_PROTOCOL_VERSION = "provekit-lsp-shared/1";
+const SHARED_LSP_PROTOCOL_CATALOG_CID = "blake3-512:0e3905c2a7a098cd538b9669428a7dffd2b84ba8ccf8fde3724fe2ab61fd3fbc1e1a616a6b20b6817464cdc50c466b5497d4ac2e2dc34c3c15f05535b463643c";
 
 // Buffer sizes for stdin/stdout.  Must fit the largest expected JSON line.
 // 256 KiB covers very large source files passed inline.
@@ -67,9 +69,14 @@ fn handleLine(
 
     if (std.mem.indexOf(u8, line, "\"initialize\"") != null) {
         try writer.print(
-            "{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"name\":\"provekit-lsp-zig\",\"version\":\"0.1.0\",\"capabilities\":[\"parse\"]}}}}\n",
-            .{id},
+            "{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"name\":\"provekit-lsp-zig\",\"version\":\"{s}\",\"protocol_version\":\"{s}\",\"kit_id\":\"{s}\",\"protocol_catalog_cid\":\"{s}\",\"capabilities\":{{\"source_surfaces\":[\"{s}\"],\"entry_kinds\":[\"bind-lift-entry\",\"call-edge\"],\"diagnostic_codes\":[\"provekit.lsp.parse_error\",\"provekit.lsp.lift_gap\",\"provekit.lsp.implication_failed\"],\"status_kinds\":[\"materialize\",\"emit\",\"check\",\"prove\"]}}}}}}\n",
+            .{ id, VERSION, SHARED_LSP_PROTOCOL_VERSION, KIT_ID, SHARED_LSP_PROTOCOL_CATALOG_CID, SURFACE },
         );
+        return true;
+    }
+
+    if (std.mem.indexOf(u8, line, "\"analyzeDocument\"") != null) {
+        try handleAnalyzeDocument(alloc, line, id, writer);
         return true;
     }
 
@@ -121,6 +128,197 @@ fn handleParse(
         "{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"declarations\":{s},\"callEdges\":{s},\"warnings\":[]}}}}\n",
         .{ id, decls_json, call_edges_json },
     );
+}
+
+fn handleAnalyzeDocument(
+    alloc: std.mem.Allocator,
+    line: []const u8,
+    id: []const u8,
+    writer: *Io.Writer,
+) !void {
+    if (extractJsonStringField(line, "kit_id")) |kit_raw| {
+        const kit = try unescapeJsonString(alloc, kit_raw);
+        defer alloc.free(kit);
+        if (!std.mem.eql(u8, kit, KIT_ID)) {
+            try writer.print(
+                "{{\"jsonrpc\":\"2.0\",\"id\":{s},\"error\":{{\"code\":-32602,\"message\":\"unsupported kit_id\"}}}}\n",
+                .{id},
+            );
+            return;
+        }
+    }
+
+    const source_raw = extractJsonStringField(line, "text") orelse
+        extractJsonStringField(line, "source") orelse "";
+    const source = try unescapeJsonString(alloc, source_raw);
+    defer alloc.free(source);
+
+    const path_raw = extractJsonStringField(line, "file") orelse
+        extractJsonStringField(line, "path") orelse "input.zig";
+    const path = try unescapeJsonString(alloc, path_raw);
+    defer alloc.free(path);
+
+    const uri = if (extractJsonStringField(line, "uri")) |uri_raw|
+        try unescapeJsonString(alloc, uri_raw)
+    else
+        try std.fmt.allocPrint(alloc, "file://{s}", .{path});
+    defer alloc.free(uri);
+
+    const document_cid = try ir.jcsHash(alloc, source);
+    defer alloc.free(document_cid);
+    const document_cid_json = try jsonStringAlloc(alloc, document_cid);
+    defer alloc.free(document_cid_json);
+    const uri_json = try jsonStringAlloc(alloc, uri);
+    defer alloc.free(uri_json);
+    const path_json = try jsonStringAlloc(alloc, path);
+    defer alloc.free(path_json);
+
+    const diagnostics_json = try buildForwardDiagnosticsJson(alloc, source);
+    defer alloc.free(diagnostics_json);
+
+    try writer.print(
+        "{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"kind\":\"lsp-document-analysis\",\"schema_version\":\"1\",\"kit_id\":\"{s}\",\"uri\":{s},\"file\":{s},\"document_cid\":{s},\"protocol_catalog_cid\":\"{s}\",\"entries\":[],\"diagnostics\":{s},\"statuses\":[],\"project\":null}}}}\n",
+        .{ id, KIT_ID, uri_json, path_json, document_cid_json, SHARED_LSP_PROTOCOL_CATALOG_CID, diagnostics_json },
+    );
+}
+
+fn buildForwardDiagnosticsJson(alloc: std.mem.Allocator, source: []const u8) ![]u8 {
+    var lines: std.ArrayList([]const u8) = .empty;
+    defer lines.deinit(alloc);
+
+    var line_iter = std.mem.splitScalar(u8, source, '\n');
+    while (line_iter.next()) |line| {
+        try lines.append(alloc, line);
+    }
+
+    const functions = try collectFunctionSpans(alloc, lines.items);
+    defer alloc.free(functions);
+
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(alloc);
+    try out.append(alloc, '[');
+
+    var first = true;
+    for (functions) |function| {
+        if (std.mem.eql(u8, function.name, "checkPositive")) continue;
+
+        var line_index = function.start_line;
+        while (line_index <= function.end_line and line_index < lines.items.len) : (line_index += 1) {
+            const line = lines.items[line_index];
+            const column = findCallColumn(line, "checkPositive") orelse continue;
+            if (isInsideLoop(lines.items, function.start_line, line_index)) continue;
+            if (callArgumentIsPositive(line[column + "checkPositive".len ..])) continue;
+
+            if (!first) try out.append(alloc, ',');
+            first = false;
+            try appendImplicationFailedDiagnostic(alloc, &out, line_index + 1, column);
+        }
+    }
+
+    try out.append(alloc, ']');
+    return out.toOwnedSlice(alloc);
+}
+
+fn appendImplicationFailedDiagnostic(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayList(u8),
+    line: usize,
+    column: usize,
+) !void {
+    const callee = "checkPositive";
+    const pre_cid = try ir.jcsHash(alloc, callee ++ ":pre:x > 0");
+    defer alloc.free(pre_cid);
+    const post_cid = try ir.jcsHash(alloc, callee ++ ":post:returns true");
+    defer alloc.free(post_cid);
+    const seed = try std.fmt.allocPrint(alloc, "{s}|{s}|{s}", .{ callee, pre_cid, post_cid });
+    defer alloc.free(seed);
+    const attestation_seed = try std.fmt.allocPrint(alloc, "attestation:{s}", .{seed});
+    defer alloc.free(attestation_seed);
+    const contract_seed = try std.fmt.allocPrint(alloc, "contract:{s}", .{seed});
+    defer alloc.free(contract_seed);
+    const attestation_cid = try ir.jcsHash(alloc, attestation_seed);
+    defer alloc.free(attestation_cid);
+    const contract_cid = try ir.jcsHash(alloc, contract_seed);
+    defer alloc.free(contract_cid);
+    const current_post_cid = try ir.jcsHash(alloc, "post:known:x <= 0");
+    defer alloc.free(current_post_cid);
+
+    const diagnostic_json = try std.fmt.allocPrint(
+        alloc,
+        "{{\"code\":\"provekit.lsp.implication_failed\",\"data\":{{\"callee\":\"{s}\",\"callee_attestation_cid\":\"{s}\",\"callee_contract_cid\":\"{s}\",\"callee_post_cid\":\"{s}\",\"callee_pre_cid\":\"{s}\",\"current_post_cid\":\"{s}\",\"kind\":\"provekit.lsp.implication_failed\",\"missing_conjuncts\":[\"x > 0\"],\"schema_version\":1}},\"kit_id\":\"{s}\",\"message\":\"callee precondition not established at this callsite\",\"producer\":\"forward-propagation\",\"protocol_catalog_cid\":\"{s}\",\"range\":{{\"start_line\":{d},\"start_col\":{d},\"end_line\":{d},\"end_col\":{d}}},\"severity\":\"error\"}}",
+        .{
+            callee,
+            attestation_cid,
+            contract_cid,
+            post_cid,
+            pre_cid,
+            current_post_cid,
+            KIT_ID,
+            SHARED_LSP_PROTOCOL_CATALOG_CID,
+            line,
+            column,
+            line,
+            column + callee.len,
+        },
+    );
+    defer alloc.free(diagnostic_json);
+    try out.appendSlice(alloc, diagnostic_json);
+}
+
+fn callArgumentIsPositive(after_name: []const u8) bool {
+    var i: usize = 0;
+    while (i < after_name.len and isSpace(after_name[i])) : (i += 1) {}
+    if (i >= after_name.len or after_name[i] != '(') return false;
+    i += 1;
+    while (i < after_name.len and isSpace(after_name[i])) : (i += 1) {}
+
+    var sign: i64 = 1;
+    if (i < after_name.len and after_name[i] == '+') {
+        i += 1;
+    } else if (i < after_name.len and after_name[i] == '-') {
+        sign = -1;
+        i += 1;
+    }
+    while (i < after_name.len and isSpace(after_name[i])) : (i += 1) {}
+
+    var value: i64 = 0;
+    var saw_digit = false;
+    while (i < after_name.len and after_name[i] >= '0' and after_name[i] <= '9') : (i += 1) {
+        saw_digit = true;
+        value = value * 10 + @as(i64, after_name[i] - '0');
+    }
+    return saw_digit and sign * value > 0;
+}
+
+fn isInsideLoop(lines: []const []const u8, function_start: usize, target_line: usize) bool {
+    var depth: isize = 0;
+    var loop_depth: ?isize = null;
+
+    var line_index = function_start;
+    while (line_index <= target_line and line_index < lines.len) : (line_index += 1) {
+        if (loop_depth) |ld| {
+            if (depth < ld) loop_depth = null;
+        }
+
+        if (line_index == target_line) return loop_depth != null;
+
+        const trimmed = std.mem.trimStart(u8, lines[line_index], " \t");
+        if ((std.mem.startsWith(u8, trimmed, "while") or std.mem.startsWith(u8, trimmed, "for")) and
+            std.mem.indexOfScalar(u8, trimmed, '{') != null)
+        {
+            loop_depth = depth + 1;
+        }
+
+        for (lines[line_index]) |ch| {
+            switch (ch) {
+                '{' => depth += 1,
+                '}' => depth -= 1,
+                else => {},
+            }
+        }
+    }
+
+    return false;
 }
 
 const FunctionSpan = struct {
@@ -287,9 +485,13 @@ fn appendCallEdgeJson(
 }
 
 fn appendJsonString(alloc: std.mem.Allocator, out: *std.ArrayList(u8), value: []const u8) !void {
-    const json = try std.json.Stringify.valueAlloc(alloc, value, .{ .whitespace = .minified });
+    const json = try jsonStringAlloc(alloc, value);
     defer alloc.free(json);
     try out.appendSlice(alloc, json);
+}
+
+fn jsonStringAlloc(alloc: std.mem.Allocator, value: []const u8) ![]u8 {
+    return std.json.Stringify.valueAlloc(alloc, value, .{ .whitespace = .minified });
 }
 
 fn isSpace(ch: u8) bool {

--- a/implementations/zig/provekit-lsp-zig/src/test_lsp.zig
+++ b/implementations/zig/provekit-lsp-zig/src/test_lsp.zig
@@ -141,7 +141,7 @@ test "initialize response shape" {
     const id: []const u8 = "1";
     const response = try std.fmt.allocPrint(
         alloc,
-        "{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"name\":\"provekit-lsp-zig\",\"version\":\"0.1.0\",\"capabilities\":[\"parse\"]}}}}",
+        "{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{{\"name\":\"provekit-lsp-zig\",\"version\":\"0.1.0\",\"protocol_version\":\"provekit-lsp-shared/1\",\"kit_id\":\"zig\",\"protocol_catalog_cid\":\"blake3-512:0e3905c2a7a098cd538b9669428a7dffd2b84ba8ccf8fde3724fe2ab61fd3fbc1e1a616a6b20b6817464cdc50c466b5497d4ac2e2dc34c3c15f05535b463643c\",\"capabilities\":{{\"source_surfaces\":[\"zig-source\"],\"entry_kinds\":[\"bind-lift-entry\",\"call-edge\"],\"diagnostic_codes\":[\"provekit.lsp.parse_error\",\"provekit.lsp.lift_gap\",\"provekit.lsp.implication_failed\"],\"status_kinds\":[\"materialize\",\"emit\",\"check\",\"prove\"]}}}}}}",
         .{id},
     );
     defer alloc.free(response);
@@ -149,7 +149,10 @@ test "initialize response shape" {
     // Verify canonical fields are present.
     try std.testing.expect(std.mem.indexOf(u8, response, "\"name\":\"provekit-lsp-zig\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, response, "\"version\":\"0.1.0\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, response, "\"capabilities\":[\"parse\"]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response, "\"protocol_version\":\"provekit-lsp-shared/1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response, "\"kit_id\":\"zig\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response, "\"source_surfaces\":[\"zig-source\"]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response, "\"provekit.lsp.implication_failed\"") != null);
 }
 
 test "parse response includes declarations callEdges warnings" {

--- a/implementations/zig/provekit-lsp-zig/test_lsp.sh
+++ b/implementations/zig/provekit-lsp-zig/test_lsp.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 # Integration test for provekit-lsp-zig.
 #
-# Lifecycle: initialize -> parse (fixture with //provekit:contract) -> shutdown.
+# Lifecycle: initialize -> parse -> analyzeDocument -> shutdown.
 # Asserts:
-#   1. initialize response has name="provekit-lsp-zig", version="0.1.0",
-#      capabilities=["parse"]
+#   1. initialize response has the shared LSP protocol shape.
 #   2. parse response contains declarations array, callEdges array, warnings array
 #   3. declarations is non-empty (at least one contract lifted from fixture)
 #   4. callEdges contains a canonical call edge with callSiteLocus
-#   5. shutdown response result is null
+#   5. analyzeDocument returns an lsp-document-analysis callsite diagnostic
+#   6. shutdown response result is null
 #
 # Usage: sh test_lsp.sh [path-to-binary]
 
@@ -58,20 +58,26 @@ assert_not_contains() {
 # Fixture: a tiny Zig source with two native function bodies and one call site.
 INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
 PARSE='{"jsonrpc":"2.0","id":2,"method":"parse","params":{"path":"fixture.zig","source":"pub fn add(x: i64) i64 { return x; }\n\npub fn myFn(x: i64) i64 { return add(x); }"}}'
-SHUTDOWN='{"jsonrpc":"2.0","id":3,"method":"shutdown","params":{}}'
+ANALYZE='{"jsonrpc":"2.0","id":3,"method":"analyzeDocument","params":{"kit_id":"zig","uri":"file:///project/FloorFixture.zig","file":"FloorFixture.zig","text":"pub fn checkPositive(x: i64) bool {\n    if (x <= 0) return false;\n    return true;\n}\n\npub fn callerSatisfiesPre() bool {\n    const result = checkPositive(5);\n    return result;\n}\n\npub fn callerViolatesPre() bool {\n    const result = checkPositive(-1);\n    return result;\n}\n\npub fn callerWithLoop() bool {\n    var i: i64 = 0;\n    while (i < 10) : (i += 1) {\n        const result = checkPositive(i);\n        if (!result) return false;\n    }\n    return true;\n}\n","document_version":42,"workspace_root":"/project","accepted_protocol_catalog_cids":[],"policy_cids":[]}}'
+SHUTDOWN='{"jsonrpc":"2.0","id":4,"method":"shutdown","params":{}}'
 
-INPUT="$(printf '%s\n%s\n%s\n' "$INIT" "$PARSE" "$SHUTDOWN")"
+INPUT="$(printf '%s\n%s\n%s\n%s\n' "$INIT" "$PARSE" "$ANALYZE" "$SHUTDOWN")"
 
 OUTPUT="$(printf '%s' "$INPUT" | "$BIN")"
 
 INIT_RESP="$(printf '%s' "$OUTPUT" | head -1)"
 PARSE_RESP="$(printf '%s' "$OUTPUT" | sed -n '2p')"
-SHUTDOWN_RESP="$(printf '%s' "$OUTPUT" | sed -n '3p')"
+ANALYZE_RESP="$(printf '%s' "$OUTPUT" | sed -n '3p')"
+SHUTDOWN_RESP="$(printf '%s' "$OUTPUT" | sed -n '4p')"
 
 echo "=== initialize ==="
 assert_contains "name field"          "$INIT_RESP"     '"name":"provekit-lsp-zig"'
 assert_contains "version field"       "$INIT_RESP"     '"version":"0.1.0"'
-assert_contains "capabilities parse"  "$INIT_RESP"     '"capabilities":["parse"]'
+assert_contains "shared protocol"     "$INIT_RESP"     '"protocol_version":"provekit-lsp-shared/1"'
+assert_contains "kit id"              "$INIT_RESP"     '"kit_id":"zig"'
+assert_contains "protocol catalog"    "$INIT_RESP"     '"protocol_catalog_cid":"blake3-512:'
+assert_contains "source surface"      "$INIT_RESP"     '"source_surfaces":["zig-source"]'
+assert_contains "implication code"    "$INIT_RESP"     '"provekit.lsp.implication_failed"'
 assert_not_contains "no error"        "$INIT_RESP"     '"error"'
 
 echo "=== parse ==="
@@ -83,6 +89,18 @@ assert_contains "warnings field"      "$PARSE_RESP"    '"warnings":[]'
 assert_contains "at least one decl"   "$PARSE_RESP"    '"kind":"function-contract"'
 assert_contains "contract name"       "$PARSE_RESP"    '"fnName":"fixture.zig.myFn"'
 assert_not_contains "no error"        "$PARSE_RESP"    '"error"'
+
+echo "=== analyzeDocument ==="
+assert_contains "analysis kind"       "$ANALYZE_RESP"  '"kind":"lsp-document-analysis"'
+assert_contains "analysis kit"        "$ANALYZE_RESP"  '"kit_id":"zig"'
+assert_contains "document cid"        "$ANALYZE_RESP"  '"document_cid":"blake3-512:'
+assert_contains "diagnostic code"     "$ANALYZE_RESP"  '"code":"provekit.lsp.implication_failed"'
+assert_contains "diagnostic severity" "$ANALYZE_RESP"  '"severity":"error"'
+assert_contains "diagnostic producer" "$ANALYZE_RESP"  '"producer":"forward-propagation"'
+assert_contains "diagnostic callee"   "$ANALYZE_RESP"  '"callee":"checkPositive"'
+assert_contains "diagnostic line"     "$ANALYZE_RESP"  '"start_line":12'
+assert_contains "diagnostic column"   "$ANALYZE_RESP"  '"start_col":19'
+assert_not_contains "no rpc error"    "$ANALYZE_RESP"  '"error":'
 
 echo "=== shutdown ==="
 assert_contains "result null"         "$SHUTDOWN_RESP" '"result":null'


### PR DESCRIPTION
## Summary
- advertise the shared provekit-lsp-shared/1 initialize shape for the Zig LSP plugin
- add analyzeDocument returning an lsp-document-analysis envelope and forward-propagation diagnostics
- cover the Zig floor fixture where the failed implication lands on the broken checkPositive callsite

Refs #1500, #1486, #308.

## Verification
- zig build
- zig build test
- sh implementations/zig/provekit-lsp-zig/test_lsp.sh
- git diff --check