### PR TITLE
feat(go): materialize source through kit RPC

### DIFF
--- a/examples/go-double/.provekit/realize/go/manifest.toml
+++ b/examples/go-double/.provekit/realize/go/manifest.toml
@@ -12,5 +12,6 @@
 # build-location-agnostic.
 name = "go-realize"
 library_tag = "go"
+materialize_source = true
 command = ["provekit-realize-go", "--rpc"]
 working_dir = "."

--- a/examples/go-identity/.provekit/realize/go/manifest.toml
+++ b/examples/go-identity/.provekit/realize/go/manifest.toml
@@ -3,5 +3,6 @@
 # author declared above is realized here as `func Id(x int) int { return x }`.
 name = "go-realize"
 library_tag = "go"
+materialize_source = true
 command = ["provekit-realize-go", "--rpc"]
 working_dir = "."

--- a/implementations/go/provekit-lift-go/annotation.go
+++ b/implementations/go/provekit-lift-go/annotation.go
@@ -67,6 +67,13 @@ func parseFuncAnnotation(fn *ast.FuncDecl) (*Annotation, error) {
 	return nil, nil
 }
 
+// ParseFuncAnnotation exposes the Go-native ProvekIt directive parser to peer
+// Go kits. Source understanding stays in Go code; the Rust CLI consumes only
+// the kit's normalized RPC result.
+func ParseFuncAnnotation(fn *ast.FuncDecl) (*Annotation, error) {
+	return parseFuncAnnotation(fn)
+}
+
 // parseAnnotationDirective parses one `//provekit:<kind>(...)` line.
 func parseAnnotationDirective(text, fnName string) (*Annotation, error) {
 	rest := strings.TrimPrefix(text, annotationPrefix)

--- a/implementations/go/provekit-realize-go-core/go.mod
+++ b/implementations/go/provekit-realize-go-core/go.mod
@@ -4,9 +4,13 @@ go 1.22
 
 require github.com/tsavo/provekit/go/provekit-ir-symbolic v0.0.0
 
+require github.com/tsavo/provekit/go/provekit-lift-go v0.0.0
+
 require (
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	lukechampine.com/blake3 v1.4.1 // indirect
 )
 
 replace github.com/tsavo/provekit/go/provekit-ir-symbolic => ../provekit-ir-symbolic
+
+replace github.com/tsavo/provekit/go/provekit-lift-go => ../provekit-lift-go

--- a/implementations/go/provekit-realize-go-core/materialize_source.go
+++ b/implementations/go/provekit-realize-go-core/materialize_source.go
@@ -1,0 +1,429 @@
+package realizego
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/tsavo/provekit/go/provekit-ir-symbolic/canonicalizer"
+	liftgo "github.com/tsavo/provekit/go/provekit-lift-go"
+)
+
+type MaterializeSourceRequest struct {
+	ProjectRoot        string `json:"project_root"`
+	ProjectRootCamel   string `json:"projectRoot"`
+	SourceDir          string `json:"source_dir"`
+	SourceDirCamel     string `json:"sourceDir"`
+	TargetLang         string `json:"target_lang"`
+	TargetLangCamel    string `json:"targetLang"`
+	TargetLibraryTag   string `json:"target_library_tag"`
+	TargetLibraryCamel string `json:"targetLibraryTag"`
+}
+
+type MaterializeSourceResponse struct {
+	Files            []MaterializedSourceFile `json:"files"`
+	CompileClasspath []string                 `json:"compile_classpath"`
+}
+
+type MaterializedSourceFile struct {
+	Path    string                 `json:"path"`
+	Content string                 `json:"content"`
+	Receipt sourceTransformReceipt `json:"receipt"`
+}
+
+type sourceTransformReceipt struct {
+	SchemaVersion    string           `json:"schema_version"`
+	SourceLanguage   string           `json:"source_language"`
+	SourceLibrary    *string          `json:"source_library"`
+	TargetLanguage   string           `json:"target_language"`
+	TargetLibrary    string           `json:"target_library"`
+	AggregateSummary aggregateSummary `json:"aggregate_summary"`
+	SiteWitnesses    []siteWitness    `json:"site_witnesses"`
+	LossRecords      []any            `json:"loss_records"`
+	RefusalMementos  []any            `json:"refusal_mementos"`
+}
+
+type aggregateSummary struct {
+	Exact   int `json:"exact"`
+	Lossy   int `json:"lossy"`
+	Refused int `json:"refused"`
+}
+
+type siteWitness struct {
+	SourceBindingCID *string `json:"source_binding_cid"`
+	TargetBindingCID string  `json:"target_binding_cid"`
+	ContractCID      *string `json:"contract_cid,omitempty"`
+	ConceptName      string  `json:"concept_name"`
+	FunctionName     string  `json:"function_name"`
+	OutcomeKind      string  `json:"outcome_kind"`
+}
+
+type sourceEdit struct {
+	start int
+	end   int
+	text  string
+}
+
+type materializedSite struct {
+	conceptName string
+	function    string
+	source      string
+}
+
+func handleMaterializeSource(id json.RawMessage, raw json.RawMessage) any {
+	var req MaterializeSourceRequest
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &req); err != nil {
+			return errorResponse(id, -32602, fmt.Sprintf("INVALID_PARAMS: %v", err))
+		}
+	}
+	response, err := MaterializeSource(req)
+	if err != nil {
+		return errorResponse(id, -32050, "MATERIALIZE_SOURCE_FAILED: "+err.Error())
+	}
+	return successResponse(id, response)
+}
+
+func MaterializeSource(req MaterializeSourceRequest) (MaterializeSourceResponse, error) {
+	if lang := req.targetLang(); lang != "" && lang != "go" {
+		return MaterializeSourceResponse{}, fmt.Errorf("go materializer cannot handle target_lang %q", lang)
+	}
+	projectRoot := req.projectRoot()
+	if projectRoot == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return MaterializeSourceResponse{}, err
+		}
+		projectRoot = wd
+	}
+	sourceDir := req.sourceDir()
+	if sourceDir == "" {
+		sourceDir = projectRoot
+	}
+	sourceDir, err := filepath.Abs(sourceDir)
+	if err != nil {
+		return MaterializeSourceResponse{}, err
+	}
+	projectRoot, err = filepath.Abs(projectRoot)
+	if err != nil {
+		return MaterializeSourceResponse{}, err
+	}
+	targetLibrary := req.targetLibraryTag()
+
+	var files []MaterializedSourceFile
+	err = filepath.WalkDir(sourceDir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", "vendor", "node_modules", "target":
+				if path != sourceDir {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" {
+			return nil
+		}
+		file, ok, err := materializeGoFile(projectRoot, sourceDir, path, targetLibrary)
+		if err != nil {
+			return err
+		}
+		if ok {
+			files = append(files, file)
+		}
+		return nil
+	})
+	if err != nil {
+		return MaterializeSourceResponse{}, err
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return MaterializeSourceResponse{Files: files, CompileClasspath: []string{}}, nil
+}
+
+func (r MaterializeSourceRequest) projectRoot() string {
+	if r.ProjectRoot != "" {
+		return strings.TrimSpace(r.ProjectRoot)
+	}
+	return strings.TrimSpace(r.ProjectRootCamel)
+}
+
+func (r MaterializeSourceRequest) sourceDir() string {
+	if r.SourceDir != "" {
+		return strings.TrimSpace(r.SourceDir)
+	}
+	return strings.TrimSpace(r.SourceDirCamel)
+}
+
+func (r MaterializeSourceRequest) targetLang() string {
+	if r.TargetLang != "" {
+		return strings.TrimSpace(r.TargetLang)
+	}
+	return strings.TrimSpace(r.TargetLangCamel)
+}
+
+func (r MaterializeSourceRequest) targetLibraryTag() string {
+	if r.TargetLibraryTag != "" {
+		return strings.TrimSpace(r.TargetLibraryTag)
+	}
+	return strings.TrimSpace(r.TargetLibraryCamel)
+}
+
+func materializeGoFile(projectRoot, sourceDir, path, targetLibrary string) (MaterializedSourceFile, bool, error) {
+	source, err := os.ReadFile(path)
+	if err != nil {
+		return MaterializedSourceFile{}, false, err
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, source, parser.ParseComments)
+	if err != nil {
+		return MaterializedSourceFile{}, false, err
+	}
+
+	var edits []sourceEdit
+	var sites []materializedSite
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		ann, err := liftgo.ParseFuncAnnotation(fn)
+		if err != nil {
+			return MaterializedSourceFile{}, false, err
+		}
+		if ann == nil {
+			continue
+		}
+		library := ann.Library
+		if library == "" {
+			library = targetLibrary
+		}
+		if targetLibrary != "" && library != targetLibrary {
+			continue
+		}
+		if fn.Body == nil {
+			return MaterializedSourceFile{}, false, fmt.Errorf("%s: annotated function %s has no body", path, fn.Name.Name)
+		}
+		params, paramTypes, err := goFunctionParams(fn)
+		if err != nil {
+			return MaterializedSourceFile{}, false, err
+		}
+		realized, err := Realize(RealizeRequest{
+			Function:         fn.Name.Name,
+			Params:           params,
+			ParamTypes:       paramTypes,
+			ReturnType:       goReturnType(fn),
+			ConceptName:      ann.Concept,
+			TargetLibraryTag: library,
+			ProjectRoot:      projectRoot,
+		})
+		if err != nil {
+			return MaterializedSourceFile{}, false, err
+		}
+		body, err := realizedBodyLiteral(realized.Source)
+		if err != nil {
+			return MaterializedSourceFile{}, false, err
+		}
+		start := fset.Position(fn.Body.Pos()).Offset
+		end := fset.Position(fn.Body.End()).Offset
+		edits = append(edits, sourceEdit{start: start, end: end, text: body})
+		edits = append(edits, directiveRemovalEdits(fset, source, fn)...)
+		sites = append(sites, materializedSite{
+			conceptName: ann.Concept,
+			function:    fn.Name.Name,
+			source:      realized.Source,
+		})
+	}
+	if len(sites) == 0 {
+		return MaterializedSourceFile{}, false, nil
+	}
+
+	rewritten, err := applySourceEdits(source, edits)
+	if err != nil {
+		return MaterializedSourceFile{}, false, err
+	}
+	formatted, err := format.Source(rewritten)
+	if err != nil {
+		return MaterializedSourceFile{}, false, fmt.Errorf("format materialized Go %s: %w\n%s", path, err, string(rewritten))
+	}
+	rel, err := filepath.Rel(sourceDir, path)
+	if err != nil {
+		rel = filepath.Base(path)
+	}
+	return MaterializedSourceFile{
+		Path:    filepath.ToSlash(rel),
+		Content: string(formatted),
+		Receipt: receiptForSites(targetLibrary, sites),
+	}, true, nil
+}
+
+func goFunctionParams(fn *ast.FuncDecl) ([]string, []string, error) {
+	var names []string
+	var types []string
+	if fn.Type.Params == nil {
+		return names, types, nil
+	}
+	nextAnon := 0
+	for _, field := range fn.Type.Params.List {
+		typ := typeExprString(field.Type)
+		if len(field.Names) == 0 {
+			names = append(names, fmt.Sprintf("p%d", nextAnon))
+			types = append(types, typ)
+			nextAnon++
+			continue
+		}
+		for _, name := range field.Names {
+			names = append(names, name.Name)
+			types = append(types, typ)
+		}
+	}
+	return names, types, nil
+}
+
+func goReturnType(fn *ast.FuncDecl) string {
+	if fn.Type.Results == nil || len(fn.Type.Results.List) == 0 {
+		return ""
+	}
+	var parts []string
+	for _, field := range fn.Type.Results.List {
+		typ := typeExprString(field.Type)
+		if len(field.Names) == 0 {
+			parts = append(parts, typ)
+			continue
+		}
+		for _, name := range field.Names {
+			parts = append(parts, strings.TrimSpace(name.Name+" "+typ))
+		}
+	}
+	if len(parts) == 1 {
+		return parts[0]
+	}
+	return "(" + strings.Join(parts, ", ") + ")"
+}
+
+func typeExprString(expr ast.Expr) string {
+	var b bytes.Buffer
+	if err := printer.Fprint(&b, token.NewFileSet(), expr); err != nil {
+		return "int"
+	}
+	return b.String()
+}
+
+func realizedBodyLiteral(source string) (string, error) {
+	const prefix = "package materialized\n\n"
+	full := []byte(prefix + source)
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "realized.go", full, 0)
+	if err != nil {
+		return "", fmt.Errorf("parse realized Go source: %w", err)
+	}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		start := fset.Position(fn.Body.Pos()).Offset - len(prefix)
+		end := fset.Position(fn.Body.End()).Offset - len(prefix)
+		if start < 0 || end > len(source) || start >= end {
+			return "", fmt.Errorf("realized body offsets out of range")
+		}
+		return source[start:end], nil
+	}
+	return "", fmt.Errorf("realized Go source did not contain a function body")
+}
+
+func directiveRemovalEdits(fset *token.FileSet, source []byte, fn *ast.FuncDecl) []sourceEdit {
+	if fn.Doc == nil {
+		return nil
+	}
+	var edits []sourceEdit
+	for _, comment := range fn.Doc.List {
+		if !strings.HasPrefix(strings.TrimSpace(comment.Text), "//provekit:") {
+			continue
+		}
+		start := fset.Position(comment.Pos()).Offset
+		end := fset.Position(comment.End()).Offset
+		start = lineStart(source, start)
+		end = lineEnd(source, end)
+		edits = append(edits, sourceEdit{start: start, end: end, text: ""})
+	}
+	return edits
+}
+
+func lineStart(source []byte, offset int) int {
+	for offset > 0 && source[offset-1] != '\n' {
+		offset--
+	}
+	return offset
+}
+
+func lineEnd(source []byte, offset int) int {
+	for offset < len(source) && source[offset] != '\n' {
+		offset++
+	}
+	if offset < len(source) {
+		offset++
+	}
+	return offset
+}
+
+func applySourceEdits(source []byte, edits []sourceEdit) ([]byte, error) {
+	sort.Slice(edits, func(i, j int) bool {
+		if edits[i].start == edits[j].start {
+			return edits[i].end > edits[j].end
+		}
+		return edits[i].start > edits[j].start
+	})
+	out := append([]byte(nil), source...)
+	lastStart := len(out) + 1
+	for _, edit := range edits {
+		if edit.start < 0 || edit.end < edit.start || edit.end > len(out) {
+			return nil, fmt.Errorf("invalid source edit range [%d,%d)", edit.start, edit.end)
+		}
+		if edit.end > lastStart {
+			return nil, fmt.Errorf("overlapping source edits")
+		}
+		next := make([]byte, 0, len(out)-(edit.end-edit.start)+len(edit.text))
+		next = append(next, out[:edit.start]...)
+		next = append(next, edit.text...)
+		next = append(next, out[edit.end:]...)
+		out = next
+		lastStart = edit.start
+	}
+	return out, nil
+}
+
+func receiptForSites(targetLibrary string, sites []materializedSite) sourceTransformReceipt {
+	witnesses := make([]siteWitness, 0, len(sites))
+	for _, site := range sites {
+		witnesses = append(witnesses, siteWitness{
+			TargetBindingCID: canonicalizer.ComputeCID([]byte(site.source)),
+			ConceptName:      site.conceptName,
+			FunctionName:     site.function,
+			OutcomeKind:      "Exact",
+		})
+	}
+	return sourceTransformReceipt{
+		SchemaVersion:    "1",
+		SourceLanguage:   "go",
+		SourceLibrary:    nil,
+		TargetLanguage:   "go",
+		TargetLibrary:    targetLibrary,
+		AggregateSummary: aggregateSummary{Exact: len(sites)},
+		SiteWitnesses:    witnesses,
+		LossRecords:      []any{},
+		RefusalMementos:  []any{},
+	}
+}

--- a/implementations/go/provekit-realize-go-core/realizer_test.go
+++ b/implementations/go/provekit-realize-go-core/realizer_test.go
@@ -180,6 +180,73 @@ func TestPluginAssembleReturnsFormattedGoFiles(t *testing.T) {
 	}
 }
 
+func TestPluginMaterializeSourceParsesBoundaryDirective(t *testing.T) {
+	project := t.TempDir()
+	writeProofBackedGoDependency(t, project, "go", "identity", "x", "return x")
+	srcDir := filepath.Join(project, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	sourcePath := filepath.Join(srcDir, "id.go")
+	if err := os.WriteFile(sourcePath, []byte("package sample\n\n//provekit:boundary(concept=\"identity\", library=\"go\")\nfunc Id(x int) int {\n\treturn 0\n}\n"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	req := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      23,
+		"method":  "provekit.plugin.materialize_source",
+		"params": map[string]any{
+			"project_root":       project,
+			"source_dir":         srcDir,
+			"target_lang":        "go",
+			"target_library_tag": "go",
+		},
+	}
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal materialize request: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := RunRPC(bytes.NewReader(append(raw, '\n')), &stdout); err != nil {
+		t.Fatalf("RunRPC: %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &response); err != nil {
+		t.Fatalf("parse response %q: %v", stdout.String(), err)
+	}
+	if response["error"] != nil {
+		t.Fatalf("materialize_source returned error: %#v", response["error"])
+	}
+	result := response["result"].(map[string]any)
+	files := result["files"].([]any)
+	if len(files) != 1 {
+		t.Fatalf("files len = %d, want 1; response=%s", len(files), stdout.String())
+	}
+	file := files[0].(map[string]any)
+	if file["path"] != "id.go" {
+		t.Fatalf("materialized path = %#v, want id.go", file["path"])
+	}
+	content := file["content"].(string)
+	if _, err := parser.ParseFile(token.NewFileSet(), "id.go", content, parser.AllErrors); err != nil {
+		t.Fatalf("materialized Go must parse: %v\n%s", err, content)
+	}
+	for _, want := range []string{
+		"package sample",
+		"func Id(x int) int",
+		"return x",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("materialized content missing %q:\n%s", want, content)
+		}
+	}
+	if strings.Contains(content, "provekit:boundary") {
+		t.Fatalf("materialized content must not preserve boundary directive:\n%s", content)
+	}
+}
+
 func TestResolveDependencyProofsReturnsProofsFromGoModuleDependencies(t *testing.T) {
 	project := t.TempDir()
 	dep := filepath.Join(project, "dep")

--- a/implementations/go/provekit-realize-go-core/rpc.go
+++ b/implementations/go/provekit-realize-go-core/rpc.go
@@ -43,6 +43,8 @@ func RunRPC(stdin io.Reader, stdout io.Writer) error {
 			writeJSON(stdout, handleInvoke(req.ID, req.Params))
 		case "provekit.plugin.assemble":
 			writeJSON(stdout, handleAssemble(req.ID, req.Params))
+		case "provekit.plugin.materialize_source":
+			writeJSON(stdout, handleMaterializeSource(req.ID, req.Params))
 		case "provekit.plugin.resolve_dependency_proofs":
 			writeJSON(stdout, handleResolveDependencyProofs(req.ID, req.Params))
 		case "provekit.plugin.body_template_entries":

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -5,7 +5,7 @@
 
 use std::collections::BTreeMap;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use clap::Parser;
 use libprovekit::core::emit_obligation::{build_bridge_body, member_envelope_canonical};
@@ -26,8 +26,8 @@ use serde_json::Value as Json;
 use walkdir::WalkDir;
 
 use crate::kit_dispatch::{
-    dispatch_materialize_check, provides_concepts_for_realize, scope_bringings_for_realize,
-    DispatchRealizeTransport,
+    dispatch_materialize_check, dispatch_materialize_source, provides_concepts_for_realize,
+    scope_bringings_for_realize, DispatchRealizeTransport, MaterializeSourceError,
 };
 use crate::{OutputFlags, EXIT_OK, EXIT_USER_ERROR, EXIT_VERIFY_FAIL};
 
@@ -82,6 +82,10 @@ struct MaterializedFile {
     /// to the assemble RPC as `package_hint` so the kit reproduces it. None
     /// when the source declares none.
     package_hint: Option<String>,
+    /// Kit-owned source materialization can declare native compile metadata
+    /// alongside the returned files. The CLI aggregates this and passes it
+    /// back to the kit check RPC without interpreting it.
+    compile_classpath: Vec<String>,
 }
 
 pub fn run(args: MaterializeArgs) -> u8 {
@@ -118,13 +122,25 @@ pub fn run(args: MaterializeArgs) -> u8 {
             }
         };
 
-    let files = match materialize_source_dir(
+    let files = match materialize_source_dir_via_kit(
         &project_root,
         &args.source_dir,
         &target_lang,
         library_tag.as_deref(),
     ) {
-        Ok(files) => files,
+        Ok(Some(files)) => files,
+        Ok(None) => match materialize_source_dir(
+            &project_root,
+            &args.source_dir,
+            &target_lang,
+            library_tag.as_deref(),
+        ) {
+            Ok(files) => files,
+            Err(error) => {
+                eprintln!("{}: {error}", "error".red().bold());
+                return EXIT_VERIFY_FAIL;
+            }
+        },
         Err(error) => {
             eprintln!("{}: {error}", "error".red().bold());
             return EXIT_VERIFY_FAIL;
@@ -400,15 +416,66 @@ fn materialize_source_dir(
             receipt,
             fragments,
             package_hint,
+            compile_classpath: Vec::new(),
         });
     }
     Ok(files)
 }
 
+fn materialize_source_dir_via_kit(
+    project_root: &Path,
+    source_dir: &Path,
+    target_lang: &str,
+    library_tag: Option<&str>,
+) -> Result<Option<Vec<MaterializedFile>>, String> {
+    let result =
+        match dispatch_materialize_source(project_root, target_lang, library_tag, source_dir) {
+            Ok(result) => result,
+            Err(MaterializeSourceError::MethodNotSupported) => return Ok(None),
+            Err(MaterializeSourceError::Failed(error)) => return Err(error),
+        };
+
+    let mut files = Vec::with_capacity(result.files.len());
+    for file in result.files {
+        if !is_safe_relative_path(&file.path) {
+            return Err(format!(
+                "materialize source kit returned unsafe output path `{}`",
+                file.path.display()
+            ));
+        }
+        let receipt: SourceTransformReceipt = serde_json::from_value(file.receipt)
+            .map_err(|error| format!("decode materialize source receipt: {error}"))?;
+        files.push(MaterializedFile {
+            source_path: source_dir.join(&file.path),
+            relative_path: file.path,
+            content: file.content,
+            receipt,
+            fragments: Vec::new(),
+            package_hint: None,
+            compile_classpath: result.compile_classpath.clone(),
+        });
+    }
+    if !files.is_empty() {
+        eprintln!(
+            "  {} source materialized by {} kit via RPC",
+            "EMIT".green().bold(),
+            target_lang,
+        );
+    }
+    Ok(Some(files))
+}
+
+fn is_safe_relative_path(path: &Path) -> bool {
+    !path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
+}
+
 fn is_supported_source_file(path: &Path) -> bool {
     matches!(
         path.extension().and_then(|ext| ext.to_str()),
-        Some("ts" | "tsx" | "js" | "jsx" | "py" | "rs" | "java" | "go")
+        Some("ts" | "tsx" | "js" | "jsx" | "py" | "rs" | "java")
     )
 }
 
@@ -843,6 +910,9 @@ fn emit_out_dir_via_kit_assemble(
     let mut aggregated_classpath: std::collections::BTreeSet<String> =
         std::collections::BTreeSet::new();
     for file in files {
+        for cp in &file.compile_classpath {
+            aggregated_classpath.insert(cp.clone());
+        }
         // Files with no realizable fragments (refuse-only) have nothing for
         // the kit to assemble; preserve the in-place-rewritten content so the
         // refusal markers / untouched source still land in the out-dir.

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -250,6 +250,7 @@ fn manifest_plugin_memento(
         "working_dir": working_dir,
         "library_tag": parsed.library_tag.clone(),
         "capability_kind": parsed.capability_kind.clone(),
+        "materialize_source": parsed.materialize_source,
         "workspace_relative": manifest_path.starts_with(workspace_root),
     });
     let mut protocol_versions = parsed.protocol_versions.clone();
@@ -679,6 +680,7 @@ pub(crate) fn registry_realize_candidates(
             source: plugin.source.clone(),
             family: plugin.parsed.family.clone(),
             library_version: plugin.parsed.library_version.clone(),
+            materialize_source: plugin.parsed.materialize_source,
         })
         .collect::<Vec<_>>();
     candidates.sort_by(|a, b| a.tag.cmp(&b.tag).then(a.source.cmp(&b.source)));
@@ -839,6 +841,7 @@ struct ParsedManifest {
     provides_concepts: Vec<String>,
     protocol_versions: Vec<String>,
     capability_kind: Option<String>,
+    materialize_source: bool,
 }
 
 fn parse_manifest(path: &Path) -> Result<ParsedManifest, String> {
@@ -854,6 +857,7 @@ fn parse_manifest(path: &Path) -> Result<ParsedManifest, String> {
     let mut provides_concepts: Vec<String> = Vec::new();
     let mut protocol_versions: Vec<String> = Vec::new();
     let mut capability_kind: Option<String> = None;
+    let mut materialize_source = false;
     let mut section = String::new();
     for line in text.lines() {
         let line = match line.find('#') {
@@ -895,8 +899,10 @@ fn parse_manifest(path: &Path) -> Result<ParsedManifest, String> {
             ("", "library_version") => library_version = Some(val.trim_matches('"').to_string()),
             ("", "scope_bringings") => scope_bringings = parse_toml_string_array(val),
             ("", "provides_concepts") => provides_concepts = parse_toml_string_array(val),
+            ("", "materialize_source") => materialize_source = parse_toml_bool(val),
             ("", "command") => command = parse_toml_string_array(val),
             ("capabilities", "kind") => capability_kind = Some(val.trim_matches('"').to_string()),
+            ("capabilities", "materialize_source") => materialize_source = parse_toml_bool(val),
             _ => {}
         }
     }
@@ -914,7 +920,12 @@ fn parse_manifest(path: &Path) -> Result<ParsedManifest, String> {
         provides_concepts,
         protocol_versions,
         capability_kind,
+        materialize_source,
     })
+}
+
+fn parse_toml_bool(value: &str) -> bool {
+    matches!(value.trim(), "true" | "True" | "TRUE")
 }
 
 /// Parse a TOML inline string array like `["a", "b", "c"]`.
@@ -1207,6 +1218,7 @@ pub(crate) struct RealizeCandidate {
     /// to any shim manifest sharing that family.
     pub(crate) family: Option<String>,
     pub(crate) library_version: Option<String>,
+    pub(crate) materialize_source: bool,
 }
 
 /// Live (unsealed) realize candidates: the `.provekit/realize/*/manifest.toml`
@@ -1275,6 +1287,7 @@ fn project_realize_candidates(
         out.push(RealizeCandidate {
             family: parsed.family.clone(),
             library_version: parsed.library_version.clone(),
+            materialize_source: parsed.materialize_source,
             tag: parsed
                 .library_tag
                 .unwrap_or_else(|| DEFAULT_LIBRARY_TAG.to_string()),
@@ -1888,6 +1901,22 @@ pub struct AssembleResult {
     pub compile_classpath: Vec<String>,
 }
 
+/// Result of a kit-owned source materialization pass. The kit owns source
+/// discovery, parsing, and rewrite semantics; the CLI only writes returned
+/// artifacts and computes over the normalized receipt data.
+#[derive(Debug, Clone, Default)]
+pub struct MaterializeSourceResult {
+    pub files: Vec<MaterializeSourceFile>,
+    pub compile_classpath: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MaterializeSourceFile {
+    pub path: PathBuf,
+    pub content: String,
+    pub receipt: Value,
+}
+
 /// Substrate-honest error from dispatch_assemble. Carries a discriminator so
 /// the caller can distinguish "plugin doesn't implement assemble" (fall back
 /// to legacy concat) from "plugin errored" (surface to user).
@@ -1898,6 +1927,183 @@ pub enum AssembleError {
     MethodNotSupported,
     /// Something else broke. Caller should treat as a transport error.
     Failed(String),
+}
+
+#[derive(Debug)]
+pub enum MaterializeSourceError {
+    MethodNotSupported,
+    Failed(String),
+}
+
+/// Ask the selected target kit to own source discovery/parsing/rewrite for
+/// materialize. This is gated by the project registration plus the selected
+/// realize manifest's `materialize_source = true` declaration; without that
+/// manifest capability callers fall back to legacy language-agnostic carrier
+/// handling.
+pub fn dispatch_materialize_source(
+    workspace_root: &Path,
+    target_lang: &str,
+    library_tag: Option<&str>,
+    source_dir: &Path,
+) -> Result<MaterializeSourceResult, MaterializeSourceError> {
+    if configured_realize_surfaces(workspace_root, target_lang).is_empty() {
+        return Err(MaterializeSourceError::Failed(format!(
+            "no realize plugin registration for language `{target_lang}` in .provekit/config.toml"
+        )));
+    }
+    let requested = library_tag.unwrap_or(DEFAULT_LIBRARY_TAG);
+    let candidates = registry_realize_candidates(workspace_root, target_lang)
+        .map_err(MaterializeSourceError::Failed)?;
+    let Some(candidate) = candidates
+        .iter()
+        .find(|candidate| candidate.tag == requested)
+    else {
+        return Err(MaterializeSourceError::MethodNotSupported);
+    };
+    if !candidate.materialize_source {
+        return Err(MaterializeSourceError::MethodNotSupported);
+    }
+    match invoke_materialize_source(
+        target_lang,
+        requested,
+        workspace_root,
+        source_dir,
+        &candidate.command,
+    ) {
+        Err(MaterializeSourceError::MethodNotSupported) => {
+            Err(MaterializeSourceError::Failed(format!(
+                "realize manifest for {target_lang}/{requested} declares materialize_source=true \
+                 but the kit does not implement provekit.plugin.materialize_source"
+            )))
+        }
+        other => other,
+    }
+}
+
+fn invoke_materialize_source(
+    target_lang: &str,
+    library_tag: &str,
+    workspace_root: &Path,
+    source_dir: &Path,
+    cmd_spec: &ResolvedCommand,
+) -> Result<MaterializeSourceResult, MaterializeSourceError> {
+    if cmd_spec.argv.is_empty() {
+        return Err(MaterializeSourceError::Failed("empty command".to_string()));
+    }
+    let mut command = Command::new(&cmd_spec.argv[0]);
+    if cmd_spec.argv.len() > 1 {
+        command.args(&cmd_spec.argv[1..]);
+    }
+    if let Some(wd) = &cmd_spec.working_dir {
+        command.current_dir(wd);
+    }
+    command.stdin(Stdio::piped());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::null());
+
+    let mut child = command.spawn().map_err(|e| {
+        MaterializeSourceError::Failed(format!("spawn materialize source kit: {e}"))
+    })?;
+    let mut stdin = child.stdin.take().ok_or_else(|| {
+        MaterializeSourceError::Failed("materialize source kit stdin unavailable".to_string())
+    })?;
+    let stdout = child.stdout.take().ok_or_else(|| {
+        MaterializeSourceError::Failed("materialize source kit stdout unavailable".to_string())
+    })?;
+    let mut reader = BufReader::new(stdout);
+
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "provekit.plugin.materialize_source",
+        "params": {
+            "project_root": workspace_root.display().to_string(),
+            "source_dir": source_dir.display().to_string(),
+            "target_lang": target_lang,
+            "target_library_tag": library_tag,
+        },
+    });
+    writeln!(stdin, "{req}").map_err(|e| {
+        MaterializeSourceError::Failed(format!("write materialize source request: {e}"))
+    })?;
+
+    let mut line = String::new();
+    reader.read_line(&mut line).map_err(|e| {
+        MaterializeSourceError::Failed(format!("read materialize source response: {e}"))
+    })?;
+
+    let shutdown = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "provekit.plugin.shutdown",
+    });
+    let _ = writeln!(stdin, "{shutdown}");
+    drop(stdin);
+    let _ = child.wait();
+
+    let v: Value = serde_json::from_str(line.trim()).map_err(|e| {
+        MaterializeSourceError::Failed(format!(
+            "materialize source response not valid JSON: {e}; raw={}",
+            line.trim()
+        ))
+    })?;
+    if let Some(err) = v.get("error") {
+        let code = err.get("code").and_then(Value::as_i64).unwrap_or(0);
+        if code == -32601 {
+            return Err(MaterializeSourceError::MethodNotSupported);
+        }
+        return Err(MaterializeSourceError::Failed(format!(
+            "materialize source kit error: {err}"
+        )));
+    }
+    let result = v.get("result").ok_or_else(|| {
+        MaterializeSourceError::Failed("materialize source response missing result".to_string())
+    })?;
+    parse_materialize_source_result(result)
+}
+
+fn parse_materialize_source_result(
+    result: &Value,
+) -> Result<MaterializeSourceResult, MaterializeSourceError> {
+    let files_arr = result
+        .get("files")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            MaterializeSourceError::Failed(
+                "materialize source response missing result.files".to_string(),
+            )
+        })?;
+    let mut files = Vec::with_capacity(files_arr.len());
+    for file in files_arr {
+        let path = file.get("path").and_then(Value::as_str).ok_or_else(|| {
+            MaterializeSourceError::Failed("materialize source file missing path".to_string())
+        })?;
+        let content = file.get("content").and_then(Value::as_str).ok_or_else(|| {
+            MaterializeSourceError::Failed("materialize source file missing content".to_string())
+        })?;
+        let receipt = file.get("receipt").cloned().ok_or_else(|| {
+            MaterializeSourceError::Failed("materialize source file missing receipt".to_string())
+        })?;
+        files.push(MaterializeSourceFile {
+            path: PathBuf::from(path),
+            content: content.to_string(),
+            receipt,
+        });
+    }
+    let compile_classpath = result
+        .get("compile_classpath")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(Value::as_str)
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok(MaterializeSourceResult {
+        files,
+        compile_classpath,
+    })
 }
 
 /// #1375 Milestone C: route compilation-unit assembly to the target kit.
@@ -2453,6 +2659,7 @@ command = ["/bin/true"]
             source: format!("test-fixture:{tag}"),
             family: family.map(str::to_string),
             library_version: library_version.map(str::to_string),
+            materialize_source: false,
         }
     }
 

--- a/implementations/rust/provekit-cli/tests/go_realize_materialize.rs
+++ b/implementations/rust/provekit-cli/tests/go_realize_materialize.rs
@@ -1,19 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // GO MATERIALIZE/REALIZE gauntlet: a contract is materialized into a Go
-// surface by the Go SHIM that supplies the native Go sugar
-// (provekit-realize-go-core). This is the emit direction's Go peer of
-// provekit-realize-python-core, exercised through the substrate's
-// language-neutral realize dispatch (kit_dispatch::dispatch_realize, PEP
-// 1.7.0 `provekit.plugin.invoke`).
-//
-// HONEST claim (and its boundary): this drives the realize DISPATCH directly
-// (the same code path `provekit materialize` uses to invoke a target kit), NOT
-// the full `provekit materialize` carrier-rewrite pipeline. The latter needs a
-// Go `@sugar`/`@boundary` authoring surface (carrier annotations in source),
-// which is DEFERRED follow-up -- see this file's sibling report. What is proven
-// here: the substrate dispatches a contract's concept to the Go shim, the shim
-// supplies REAL Go sugar, and that sugar `go build`s. Supra omnia, rectum.
+// surface by the Go SHIM that supplies native Go sugar
+// (provekit-realize-go-core). The full CLI path is config/manifest/RPC driven:
+// the Rust CLI selects the registered Go kit, the Go kit parses Go
+// `//provekit:boundary` directives and rewrites Go source, and the CLI writes
+// returned artifacts plus runs kit-owned native checks.
 //
 // The concept is `identity` -- a real cross-language concept (also in Python's
 // canonical-bodies), realized in Go as `return x`. Requires `go` on PATH.
@@ -22,14 +14,12 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::Arc;
 
-use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CanonicalValue};
+use provekit_canonicalizer::blake3_512_of;
 use provekit_cli::kit_dispatch::{dependency_proofs_via_rpc, dispatch_realize, RealizeRequest};
 use provekit_proof_envelope::{
     build_proof_envelope, ed25519_pubkey_string, Ed25519Seed, ProofEnvelopeInput,
 };
-use serde_json::Value as Json;
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -100,7 +90,7 @@ fn install_go_realize_manifest(root: &Path, bin: &Path) {
         .join("manifest.toml");
     fs::create_dir_all(manifest.parent().unwrap()).expect("mkdir manifest dir");
     let text = format!(
-        "name = \"go-realize\"\nlibrary_tag = \"go\"\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
+        "name = \"go-realize\"\nlibrary_tag = \"go\"\nmaterialize_source = true\ncommand = [\"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
         bin.display()
             .to_string()
             .replace('\\', "\\\\")
@@ -181,68 +171,24 @@ fn write_go_dependency_with_proof(project: &Path, proof_name: &str) -> PathBuf {
     proof
 }
 
-fn identity_payload_json(function: &str) -> String {
-    format!(
-        "{{\"artifact_kind\":\"provekit-concept-citation-comment-sugar\",\"concept_name\":\"identity\",\"function\":\"{function}\",\"params\":[\"x\"],\"param_types\":[\"int\"],\"return_type\":\"int\"}}"
-    )
+fn write_go_boundary_source(src_dir: &Path) -> PathBuf {
+    write_go_boundary_source_for(src_dir, "id.go", "Id", "identity")
 }
 
-fn proof_backed_payload_json(function: &str) -> String {
-    format!(
-        "{{\"artifact_kind\":\"provekit-concept-citation-comment-sugar\",\"concept_name\":\"concept:go-proof-backed\",\"function\":\"{function}\",\"params\":[\"x\"],\"param_types\":[\"int\"],\"return_type\":\"int\"}}"
-    )
-}
-
-fn payload_cid(payload: &str) -> String {
-    let json: Json = serde_json::from_str(payload).expect("payload json parses");
-    let canonical = canonical_value_from_json(&json);
-    blake3_512_of(encode_jcs(canonical.as_ref()).as_bytes())
-}
-
-fn canonical_value_from_json(value: &Json) -> Arc<CanonicalValue> {
-    match value {
-        Json::Null => CanonicalValue::null(),
-        Json::Bool(value) => CanonicalValue::boolean(*value),
-        Json::Number(value) => {
-            CanonicalValue::integer(value.as_i64().expect("test JSON uses integers only"))
-        }
-        Json::String(value) => CanonicalValue::string(value),
-        Json::Array(values) => {
-            CanonicalValue::array(values.iter().map(canonical_value_from_json).collect())
-        }
-        Json::Object(entries) => CanonicalValue::object(
-            entries
-                .iter()
-                .map(|(key, value)| (key.clone(), canonical_value_from_json(value))),
-        ),
-    }
-}
-
-fn write_go_identity_carrier(src_dir: &Path) -> PathBuf {
-    let payload = identity_payload_json("Id");
-    let source = src_dir.join("id.go");
+fn write_go_boundary_source_for(
+    src_dir: &Path,
+    file_name: &str,
+    function: &str,
+    concept: &str,
+) -> PathBuf {
+    let source = src_dir.join(file_name);
     fs::write(
         &source,
         format!(
-            "package sample\n\n// provekit-concept: {payload}\n// provekit-concept-payload-cid: {}\n",
-            payload_cid(&payload)
+            "package sample\n\n//provekit:boundary(concept=\"{concept}\", library=\"go\")\nfunc {function}(x int) int {{\n\treturn 0\n}}\n"
         ),
     )
-    .expect("write go carrier source");
-    source
-}
-
-fn write_go_proof_backed_carrier(src_dir: &Path) -> PathBuf {
-    let payload = proof_backed_payload_json("AddFortyOne");
-    let source = src_dir.join("add_forty_one.go");
-    fs::write(
-        &source,
-        format!(
-            "package sample\n\n// provekit-concept: {payload}\n// provekit-concept-payload-cid: {}\n",
-            payload_cid(&payload)
-        ),
-    )
-    .expect("write go proof-backed carrier source");
+    .expect("write go boundary source");
     source
 }
 
@@ -364,7 +310,7 @@ fn go_materialize_refuses_unconfigured_realize_manifest() {
     write_external_go_dependency_with_identity_body(workspace.path());
     let src_dir = workspace.path().join("src");
     fs::create_dir_all(&src_dir).expect("mkdir src");
-    write_go_identity_carrier(&src_dir);
+    write_go_boundary_source(&src_dir);
 
     let out_dir = workspace.path().join("materialized");
     fs::create_dir_all(&out_dir).expect("mkdir out");
@@ -430,7 +376,7 @@ fn go_materialize_uses_checked_in_go_double_realize_registration() {
     write_external_go_dependency_with_identity_body(workspace.path());
     let src_dir = workspace.path().join("src");
     fs::create_dir_all(&src_dir).expect("mkdir src");
-    write_go_identity_carrier(&src_dir);
+    write_go_boundary_source(&src_dir);
 
     let out_dir = workspace.path().join("materialized");
     fs::create_dir_all(&out_dir).expect("mkdir out");
@@ -463,8 +409,8 @@ fn go_materialize_uses_checked_in_go_double_realize_registration() {
         "checked-in go-double realize registration must drive materialize\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
     assert!(
-        stderr.contains("assembled by go kit via RPC"),
-        "checked-in Go materialize route must assemble through the Go kit\nstderr:\n{stderr}"
+        stderr.contains("source materialized by go kit via RPC"),
+        "checked-in Go materialize route must parse/rewrite through the Go kit\nstderr:\n{stderr}"
     );
     let emitted = fs::read_to_string(out_dir.join("id.go")).expect("read materialized Go");
     assert!(
@@ -490,7 +436,12 @@ fn go_materialize_uses_body_template_from_go_module_proof() {
 
     let src_dir = workspace.path().join("src");
     fs::create_dir_all(&src_dir).expect("mkdir src");
-    write_go_proof_backed_carrier(&src_dir);
+    write_go_boundary_source_for(
+        &src_dir,
+        "add_forty_one.go",
+        "AddFortyOne",
+        "concept:go-proof-backed",
+    );
 
     let out_dir = workspace.path().join("materialized");
     fs::create_dir_all(&out_dir).expect("mkdir out");
@@ -566,11 +517,11 @@ fn go_dependency_proofs_are_resolved_by_configured_go_kit() {
     );
 }
 
-/// Full CLI path: `provekit materialize` reads Go carrier comments, dispatches
-/// the concept to the Go realize kit over RPC, writes materialized Go under
-/// --out-dir, and asks the same Go kit to run its native check.
+/// Full CLI path: `provekit materialize` asks the configured Go kit to parse
+/// Go boundary directives, writes materialized Go under --out-dir, and asks
+/// the same Go kit to run its native check.
 #[test]
-fn go_materialize_cli_rewrites_carrier_and_asks_go_kit_to_compile_check() {
+fn go_materialize_cli_rewrites_boundary_and_asks_go_kit_to_compile_check() {
     if !go_available() {
         eprintln!("go not on PATH: skipping go materialize CLI test");
         return;
@@ -581,7 +532,7 @@ fn go_materialize_cli_rewrites_carrier_and_asks_go_kit_to_compile_check() {
     write_external_go_dependency_with_identity_body(workspace.path());
     let src_dir = workspace.path().join("src");
     fs::create_dir_all(&src_dir).expect("mkdir src");
-    write_go_identity_carrier(&src_dir);
+    write_go_boundary_source(&src_dir);
 
     let out_dir = workspace.path().join("materialized");
     fs::create_dir_all(&out_dir).expect("mkdir out");
@@ -618,8 +569,8 @@ fn go_materialize_cli_rewrites_carrier_and_asks_go_kit_to_compile_check() {
         "Go materialize must ask the Go kit to run its native check\nstderr:\n{stderr}"
     );
     assert!(
-        stderr.contains("assembled by go kit via RPC"),
-        "Go materialize must use the configured Go kit for assembly, not legacy concat fallback\nstderr:\n{stderr}"
+        stderr.contains("source materialized by go kit via RPC"),
+        "Go materialize must use the configured Go kit for source discovery/transformation\nstderr:\n{stderr}"
     );
 
     let emitted = fs::read_to_string(out_dir.join("id.go")).expect("read materialized Go");
@@ -632,8 +583,93 @@ fn go_materialize_cli_rewrites_carrier_and_asks_go_kit_to_compile_check() {
         "materialized Go should contain identity body:\n{emitted}"
     );
     assert!(
-        !emitted.contains("provekit-concept:"),
-        "materialized Go must remove the carrier comments:\n{emitted}"
+        !emitted.contains("provekit:boundary"),
+        "materialized Go must remove the boundary directive:\n{emitted}"
+    );
+}
+
+#[test]
+fn rust_cli_materialize_scanner_does_not_claim_go_files() {
+    let source = fs::read_to_string(
+        repo_root()
+            .join("implementations")
+            .join("rust")
+            .join("provekit-cli")
+            .join("src")
+            .join("cmd_materialize.rs"),
+    )
+    .expect("read cmd_materialize.rs");
+    assert!(
+        !source.contains(r#"| "go""#) && !source.contains(r#""go" |"#),
+        "Go source discovery/transformation must be kit-owned over RPC, not listed in the CLI's legacy source scanner"
+    );
+}
+
+#[test]
+fn go_materialize_cli_uses_go_kit_to_parse_boundary_directives() {
+    if !go_available() {
+        eprintln!("go not on PATH: skipping go boundary materialize CLI test");
+        return;
+    }
+    let bin = build_go_realize();
+    let workspace = tempfile::tempdir().expect("tempdir");
+    install_go_realize_registration(workspace.path(), &bin);
+    write_external_go_dependency_with_identity_body(workspace.path());
+    let src_dir = workspace.path().join("src");
+    fs::create_dir_all(&src_dir).expect("mkdir src");
+    write_go_boundary_source(&src_dir);
+
+    let out_dir = workspace.path().join("materialized");
+    fs::create_dir_all(&out_dir).expect("mkdir out");
+    fs::write(
+        out_dir.join("go.mod"),
+        "module example.com/provekit_go_materialized\n\ngo 1.22\n",
+    )
+    .expect("write output go.mod");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .arg("materialize")
+        .arg("--target")
+        .arg("go")
+        .arg("--library")
+        .arg("go")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(workspace.path())
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--compile-check")
+        .output()
+        .expect("spawn provekit materialize for Go boundary directive");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "Go boundary materialize should be parsed and rewritten by the Go kit over RPC\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("source materialized by go kit via RPC"),
+        "Go source discovery/transformation must be kit-owned, not CLI carrier scanning\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("compile-check: go test ./... passed"),
+        "Go materialize must ask the Go kit to run its native check\nstderr:\n{stderr}"
+    );
+
+    let emitted = fs::read_to_string(out_dir.join("id.go")).expect("read materialized Go");
+    assert!(
+        emitted.contains("func Id(x int) int"),
+        "materialized Go should contain realized function signature:\n{emitted}"
+    );
+    assert!(
+        emitted.contains("return x"),
+        "materialized Go body must come from the Go module .proof resolved inside the Go kit:\n{emitted}"
+    );
+    assert!(
+        !emitted.contains("provekit:boundary"),
+        "materialized Go must not preserve the source boundary directive:\n{emitted}"
     );
 }
 
@@ -649,7 +685,7 @@ fn go_materialize_infers_target_from_registered_go_manifest() {
     write_external_go_dependency_with_identity_body(workspace.path());
     let src_dir = workspace.path().join("src");
     fs::create_dir_all(&src_dir).expect("mkdir src");
-    write_go_identity_carrier(&src_dir);
+    write_go_boundary_source(&src_dir);
 
     let out_dir = workspace.path().join("materialized");
     fs::create_dir_all(&out_dir).expect("mkdir out");
@@ -680,8 +716,8 @@ fn go_materialize_infers_target_from_registered_go_manifest() {
         "Go materialize should infer target from the registered Go manifest, without --target\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
     assert!(
-        stderr.contains("assembled by go kit via RPC"),
-        "inferred Go materialize must still assemble through the Go kit\nstderr:\n{stderr}"
+        stderr.contains("source materialized by go kit via RPC"),
+        "inferred Go materialize must still source-transform through the Go kit\nstderr:\n{stderr}"
     );
     assert!(
         stderr.contains("compile-check: go test ./... passed"),


### PR DESCRIPTION
## Summary
- add manifest-gated `materialize_source` dispatch so the CLI asks configured realize kits to own source discovery/rewrite over RPC
- implement Go `provekit.plugin.materialize_source` in the Go realize kit using Go parser/AST annotations and Go-module `.proof` resolution
- switch Go materialize fixtures to real `//provekit:boundary` source and assert the Rust CLI legacy scanner no longer claims `.go` files

Closes #1480.

## Verification
- go test ./... (implementations/go/provekit-realize-go-core)
- go test ./... (implementations/go/provekit-lift-go)
- cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test go_realize_materialize -- --nocapture
- rustfmt --check implementations/rust/provekit-cli/src/cmd_materialize.rs implementations/rust/provekit-cli/src/kit_dispatch.rs implementations/rust/provekit-cli/tests/go_realize_materialize.rs
- git diff --check

## Known unrelated failure on main
- `cmd_materialize_integration materialize_dry_run_replaces_concept_citation_with_realized_library_source` fails on clean `origin/main` because the TypeScript better-sqlite3 realizer returns a stub for `concept:sql-query-all`. The broader `cmd_materialize_integration materialize_` lane still shows those pre-existing TS failures; this PR did not introduce them.