### PR TITLE
feat(rust): materialize source through kit RPC

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -27,7 +27,7 @@ use walkdir::WalkDir;
 
 use crate::kit_dispatch::{
     dispatch_materialize_check, dispatch_materialize_source, provides_concepts_for_realize,
-    scope_bringings_for_realize, DispatchRealizeTransport, MaterializeSourceError,
+    DispatchRealizeTransport, MaterializeSourceError,
 };
 use crate::{OutputFlags, EXIT_OK, EXIT_USER_ERROR, EXIT_VERIFY_FAIL};
 
@@ -475,7 +475,7 @@ fn is_safe_relative_path(path: &Path) -> bool {
 fn is_supported_source_file(path: &Path) -> bool {
     matches!(
         path.extension().and_then(|ext| ext.to_str()),
-        Some("ts" | "tsx" | "js" | "jsx" | "py" | "rs" | "java")
+        Some("ts" | "tsx" | "js" | "jsx" | "py" | "java")
     )
 }
 
@@ -502,97 +502,6 @@ fn should_scan_entry(path: &Path) -> bool {
     )
 }
 
-/// #1360 / #1355: Scan a Rust source for `#[provekit::boundary(... library = X ...)]`
-/// attributes and return the unique set of `library` values declared. cmd_materialize
-/// uses these to look up per-target scope_bringings from the realize manifests.
-fn collect_boundary_libraries(raw: &str) -> Vec<String> {
-    let mut libs: Vec<String> = Vec::new();
-    let mut idx = 0;
-    while let Some(start) = raw[idx..].find("#[provekit::boundary") {
-        let abs = idx + start;
-        // Find the closing `)]` (multi-line attribute supported).
-        let Some(close_rel) = raw[abs..].find(")]") else {
-            break;
-        };
-        let attr_text = &raw[abs..abs + close_rel + 2];
-        idx = abs + close_rel + 2;
-        // Extract `library = "..."` from the attribute body.
-        if let Some(lib_pos) = attr_text.find("library = \"") {
-            let after = &attr_text[lib_pos + "library = \"".len()..];
-            if let Some(end) = after.find('"') {
-                let lib = after[..end].to_string();
-                if !libs.iter().any(|existing| existing == &lib) {
-                    libs.push(lib);
-                }
-            }
-        }
-    }
-    libs
-}
-
-/// #1360 / #1355: Splice a list of `use ...;` items into a Rust source.
-/// Inserts after the last existing top-level `use` statement (or at the top
-/// of the file if none). Items that are already present in the source are
-/// skipped (deduplication against existing prelude).
-fn splice_use_items(source: &str, items: &[String]) -> String {
-    if items.is_empty() {
-        return source.to_string();
-    }
-    // Find the last `use ...;` line in the file's prelude (consecutive
-    // use statements at the top, possibly interspersed with comments /
-    // doc strings / blank lines / pub use).
-    let lines: Vec<&str> = source.lines().collect();
-    let mut last_use_idx: Option<usize> = None;
-    for (i, line) in lines.iter().enumerate() {
-        let trimmed = line.trim_start();
-        if trimmed.starts_with("use ") || trimmed.starts_with("pub use ") {
-            last_use_idx = Some(i);
-        }
-    }
-
-    // Deduplicate against existing uses (by exact line match after trim).
-    let existing_uses: std::collections::HashSet<String> = lines
-        .iter()
-        .filter_map(|l| {
-            let t = l.trim();
-            if t.starts_with("use ") || t.starts_with("pub use ") {
-                Some(t.to_string())
-            } else {
-                None
-            }
-        })
-        .collect();
-    let new_items: Vec<&String> = items
-        .iter()
-        .filter(|item| !existing_uses.contains(item.trim()))
-        .collect();
-    if new_items.is_empty() {
-        return source.to_string();
-    }
-
-    let insertion_idx = last_use_idx.map(|i| i + 1).unwrap_or(0);
-    let mut out = Vec::with_capacity(lines.len() + new_items.len());
-    for (i, line) in lines.iter().enumerate() {
-        if i == insertion_idx {
-            for item in &new_items {
-                out.push((*item).clone());
-            }
-        }
-        out.push(line.to_string());
-    }
-    if insertion_idx == lines.len() {
-        for item in &new_items {
-            out.push((*item).clone());
-        }
-    }
-    let mut joined = out.join("\n");
-    // Preserve trailing newline if the input had one.
-    if source.ends_with('\n') && !joined.ends_with('\n') {
-        joined.push('\n');
-    }
-    joined
-}
-
 fn materialize_source_text(
     project_root: &Path,
     target_lang: &str,
@@ -613,21 +522,7 @@ fn materialize_source_text(
     );
     let fragments = kit.take_fragments();
 
-    // #1360 / #1355: collect per-target scope-bringings from each
-    // @boundary site's named library and splice them into the rewritten
-    // file's prelude. Deduplicated against existing `use` items.
-    let libraries = collect_boundary_libraries(raw);
-    let mut bringings: Vec<String> = Vec::new();
-    for lib in &libraries {
-        for bringing in scope_bringings_for_realize(project_root, target_lang, lib) {
-            if !bringings.iter().any(|existing| existing == &bringing) {
-                bringings.push(bringing);
-            }
-        }
-    }
-    let final_source = splice_use_items(&rewritten, &bringings);
-
-    Ok((final_source, receipt, fragments))
+    Ok((rewritten, receipt, fragments))
 }
 
 /// Extract the source-declared package/namespace so the assemble RPC can

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -568,52 +568,6 @@ fn record_dependency_proof_diagnostic(message: String) {
         .push(message);
 }
 
-/// #1360 / #1355: Return the per-target scope-bringings declared by
-/// the realize manifest matching `(target_lang, library_tag)`. cmd_materialize
-/// collects these across all materialized sites in a consumer file and
-/// hoists them into the file's prelude so the spliced bodies compile.
-///
-/// Returns an empty Vec when no manifest matches OR when the matched
-/// manifest declares no `scope_bringings`. This is the substrate-honest
-/// signal for "no scope-bringings needed" (NOT an error condition).
-pub fn scope_bringings_for_realize(
-    workspace_root: &Path,
-    target_lang: &str,
-    library_tag: &str,
-) -> Vec<String> {
-    let Ok(candidates) = registry_realize_candidates(workspace_root, target_lang) else {
-        return Vec::new();
-    };
-    // First try exact library_tag match.
-    for cand in &candidates {
-        if cand.tag == library_tag {
-            // RealizeCandidate.source is the manifest path relative to
-            // workspace_root (`.provekit/realize/<surface>/manifest.toml`)
-            // OR an env-var / built-in / PATH source string. Resolve relative
-            // paths against workspace_root before parsing; non-manifest
-            // sources return empty.
-            return read_scope_bringings_from_manifest_source(workspace_root, &cand.source);
-        }
-    }
-    Vec::new()
-}
-
-fn read_scope_bringings_from_manifest_source(workspace_root: &Path, source: &str) -> Vec<String> {
-    let candidate_path = PathBuf::from(source);
-    let resolved = if candidate_path.is_absolute() {
-        candidate_path
-    } else {
-        workspace_root.join(&candidate_path)
-    };
-    if !resolved.is_file() {
-        return Vec::new();
-    }
-    match parse_manifest(&resolved) {
-        Ok(parsed) => parsed.scope_bringings,
-        Err(_) => Vec::new(),
-    }
-}
-
 /// #1359 / #1355: Find all realize candidates that satisfy a
 /// constraint set `(target_lang, family?, library_tag?, library_version?)`.
 /// Candidates are filtered down progressively:
@@ -823,13 +777,6 @@ struct ParsedManifest {
     /// #1359 / #1355: optional `library_version` pin. Parallel to `family`.
     #[allow(dead_code)]
     library_version: Option<String>,
-    /// #1360 / #1355: per-target scope-bringings the consumer crate needs
-    /// in its prelude when bodies from this realize plugin are spliced.
-    /// E.g. `use std::io::{self, BufRead, Write};` for the rust-stdio
-    /// shim. cmd_materialize collects these across all materialized sites
-    /// and hoists them into the consumer file's `use` section.
-    /// Empty vec when manifest omits the key (back-compat).
-    scope_bringings: Vec<String>,
     /// #1364 / #1355: optional declaration of which concept_names this
     /// realize plugin CAN handle. cmd_materialize can defensively refuse-
     /// loudly when a consumer's @boundary asks for a concept not in the
@@ -853,7 +800,6 @@ fn parse_manifest(path: &Path) -> Result<ParsedManifest, String> {
     let mut library_tag: Option<String> = None;
     let mut family: Option<String> = None;
     let mut library_version: Option<String> = None;
-    let mut scope_bringings: Vec<String> = Vec::new();
     let mut provides_concepts: Vec<String> = Vec::new();
     let mut protocol_versions: Vec<String> = Vec::new();
     let mut capability_kind: Option<String> = None;
@@ -897,7 +843,6 @@ fn parse_manifest(path: &Path) -> Result<ParsedManifest, String> {
             // Parsed but not yet wired into dispatch resolution (that's chunk 2).
             ("", "family") => family = Some(val.trim_matches('"').to_string()),
             ("", "library_version") => library_version = Some(val.trim_matches('"').to_string()),
-            ("", "scope_bringings") => scope_bringings = parse_toml_string_array(val),
             ("", "provides_concepts") => provides_concepts = parse_toml_string_array(val),
             ("", "materialize_source") => materialize_source = parse_toml_bool(val),
             ("", "command") => command = parse_toml_string_array(val),
@@ -916,7 +861,6 @@ fn parse_manifest(path: &Path) -> Result<ParsedManifest, String> {
         library_tag,
         family,
         library_version,
-        scope_bringings,
         provides_concepts,
         protocol_versions,
         capability_kind,
@@ -930,9 +874,7 @@ fn parse_toml_bool(value: &str) -> bool {
 
 /// Parse a TOML inline string array like `["a", "b", "c"]`.
 ///
-/// Quote-aware: commas inside `"..."` are NOT separators (needed for
-/// #1360's `scope_bringings = ["use std::io::{self, BufRead, Write};"]`
-/// where the value contains commas inside the quoted use-statement).
+/// Quote-aware: commas inside `"..."` are NOT separators.
 fn parse_toml_string_array(value: &str) -> Vec<String> {
     let inner = value.trim().trim_matches(|c| c == '[' || c == ']');
     let mut out: Vec<String> = Vec::new();
@@ -2491,13 +2433,6 @@ mod tests {
     // -----------------------------------------------------------------
 
     // -----------------------------------------------------------------
-    // #1360 / #1355: scope_bringings on realize manifest (case-1
-    // effect propagation — use/import items the materialized body needs
-    // in the consumer crate's prelude). Parsed here; cmd_materialize
-    // reads them at splice time and hoists into the target file.
-    // -----------------------------------------------------------------
-
-    // -----------------------------------------------------------------
     // #1364 / #1355: provides_concepts declaration on realize manifests
     // (per-kit concept coverage — chunk 1 plumbs the parse; chunk 2
     // wires defensive checks in cmd_materialize; chunk 3+ populates per
@@ -2546,52 +2481,6 @@ command = ["/bin/true"]
         .expect("write");
         let parsed = parse_manifest(&manifest_path).expect("parse");
         assert!(parsed.provides_concepts.is_empty());
-        let _ = fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn parse_manifest_accepts_scope_bringings_array() {
-        let dir = std::env::temp_dir().join("provekit-test-1360-scope");
-        let _ = fs::remove_dir_all(&dir);
-        fs::create_dir_all(&dir).expect("temp dir");
-        let manifest_path = dir.join("manifest.toml");
-        fs::write(
-            &manifest_path,
-            r#"
-name = "rust-realize-shim-stdio"
-library_tag = "provekit-shim-stdio-rust"
-family = "concept:family:stdio-stream"
-scope_bringings = ["use std::io::{self, BufRead, Write};"]
-command = ["/bin/true"]
-"#,
-        )
-        .expect("write");
-        let parsed = parse_manifest(&manifest_path).expect("parse");
-        assert_eq!(parsed.scope_bringings.len(), 1);
-        assert_eq!(
-            parsed.scope_bringings[0],
-            "use std::io::{self, BufRead, Write};"
-        );
-        let _ = fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn parse_manifest_without_scope_bringings_yields_empty_vec() {
-        let dir = std::env::temp_dir().join("provekit-test-1360-no-scope");
-        let _ = fs::remove_dir_all(&dir);
-        fs::create_dir_all(&dir).expect("temp dir");
-        let manifest_path = dir.join("manifest.toml");
-        fs::write(
-            &manifest_path,
-            r#"
-name = "rust-realize-default"
-library_tag = "default"
-command = ["/bin/true"]
-"#,
-        )
-        .expect("write");
-        let parsed = parse_manifest(&manifest_path).expect("parse");
-        assert!(parsed.scope_bringings.is_empty());
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -150,6 +150,7 @@ fn install_binary_manifest(
     let manifest_text = format!(
         "name = \"{manifest_name}\"\n\
          library_tag = \"{library_tag}\"\n\
+         materialize_source = true\n\
          command = [\"{binary}\", \"--rpc\"]\n\
          working_dir = \".\"\n",
     );
@@ -717,13 +718,17 @@ for line in sys.stdin:
 
 fn write_rust_http_request_source(src_dir: &Path) -> PathBuf {
     let source_path = src_dir.join("lib.rs");
-    let payload = http_payload_json("fetch_status", "&str", "i64");
     fs::write(
         &source_path,
-        format!(
-            "// rust materialize example\n{}// end\n",
-            carrier_lines("//", "", &payload)
-        ),
+        r#"
+#[provekit::boundary(
+    concept = "concept:http-request",
+    library = "reqwest",
+)]
+pub async fn fetch_status(url: &str) -> i64 {
+    0
+}
+"#,
     )
     .expect("write rust HTTP source");
     source_path
@@ -1350,12 +1355,16 @@ fn materialize_rust_reqwest_example_uses_rust_library_shim() {
         output.status.success(),
         "Rust reqwest materialize example should succeed\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
+    assert!(
+        stderr.contains("source materialized by rust kit via RPC"),
+        "Rust source materialize must route through the registered Rust kit\nstderr:\n{stderr}"
+    );
     assert!(stdout.contains("// file: lib.rs"));
     assert!(
         stdout.contains("reqwest::get(url)"),
         "Rust reqwest example should route through the Rust reqwest shim:\n{stdout}"
     );
-    assert!(!stdout.contains("provekit-concept:"));
+    assert!(!stdout.contains("provekit::boundary"));
 }
 
 #[test]

--- a/implementations/rust/provekit-realize-rust-core/Cargo.toml
+++ b/implementations/rust/provekit-realize-rust-core/Cargo.toml
@@ -26,5 +26,8 @@ provekit-shim-reqwest-rust = { path = "../../../examples/provekit-shim-reqwest-r
 provekit-shim-rusqlite = { path = "../../../examples/provekit-shim-rusqlite" }
 provekit-shim-serde-json-rust = { path = "../../../examples/provekit-shim-serde-json-rust" }
 provekit-shim-stdio-rust = { path = "../../../examples/provekit-shim-stdio-rust" }
+proc-macro2 = { workspace = true, features = ["span-locations"] }
+quote = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+syn = { workspace = true }

--- a/implementations/rust/provekit-realize-rust-core/src/lib.rs
+++ b/implementations/rust/provekit-realize-rust-core/src/lib.rs
@@ -7,6 +7,7 @@ use std::sync::OnceLock;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 use provekit_ir_types::realization_tags::tag_sugar_carrier;
+use quote::ToTokens;
 use serde_json::{json, Value};
 
 pub mod platform_semantics;
@@ -2451,6 +2452,25 @@ pub fn dispatch(request: &Value) -> Value {
                 }
             })
         }
+        "provekit.plugin.materialize_source" => {
+            let params = request
+                .get("params")
+                .and_then(Value::as_object)
+                .cloned()
+                .unwrap_or_default();
+            match materialize_source(&params) {
+                Ok(result) => serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": result,
+                }),
+                Err(materialize_error) => error(
+                    id,
+                    -32050,
+                    &format!("MATERIALIZE_SOURCE_FAILED: {materialize_error}"),
+                ),
+            }
+        }
         "provekit.plugin.invoke" => {
             let Some(params) = request.get("params").and_then(Value::as_object) else {
                 return error(id, -32602, "INVALID_PARAMS: params must be an object");
@@ -2654,6 +2674,590 @@ pub fn dispatch(request: &Value) -> Value {
         }),
         _ => error(id, -32601, &format!("METHOD_NOT_FOUND: {method}")),
     }
+}
+
+fn materialize_source(params: &serde_json::Map<String, Value>) -> Result<Value, String> {
+    let target_lang = string_param(params, "target_lang", "targetLang").unwrap_or_default();
+    if !target_lang.is_empty() && target_lang != "rust" {
+        return Err(format!(
+            "rust materializer cannot handle target_lang `{target_lang}`"
+        ));
+    }
+
+    let project_root = string_param(params, "project_root", "projectRoot")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    let source_dir = string_param(params, "source_dir", "sourceDir")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| project_root.clone());
+    let target_library = string_param(params, "target_library_tag", "targetLibraryTag")
+        .or_else(|| string_param(params, "library_tag", "libraryTag"))
+        .unwrap_or_default();
+
+    let source_dir = absolute_path(&source_dir)?;
+    let project_root = absolute_path(&project_root)?;
+
+    let mut paths = Vec::new();
+    collect_rust_source_files(&source_dir, &mut paths)?;
+    paths.sort();
+
+    let mut files = Vec::new();
+    for path in paths {
+        if let Some(file) =
+            materialize_rust_file(&project_root, &source_dir, &path, &target_library)?
+        {
+            files.push(file);
+        }
+    }
+
+    Ok(json!({
+        "files": files,
+        "compile_classpath": [],
+    }))
+}
+
+fn string_param(
+    params: &serde_json::Map<String, Value>,
+    snake: &str,
+    camel: &str,
+) -> Option<String> {
+    params
+        .get(snake)
+        .or_else(|| params.get(camel))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn absolute_path(path: &Path) -> Result<PathBuf, String> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    std::env::current_dir()
+        .map(|cwd| cwd.join(path))
+        .map_err(|error| format!("resolve current dir: {error}"))
+}
+
+fn collect_rust_source_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
+    let entries =
+        std::fs::read_dir(dir).map_err(|error| format!("read {}: {error}", dir.display()))?;
+    for entry in entries {
+        let entry = entry.map_err(|error| format!("read {} entry: {error}", dir.display()))?;
+        let path = entry.path();
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("");
+        if path.is_dir() {
+            if matches!(file_name, ".git" | "node_modules" | "target" | "vendor") {
+                continue;
+            }
+            collect_rust_source_files(&path, out)?;
+            continue;
+        }
+        if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn materialize_rust_file(
+    _project_root: &Path,
+    source_dir: &Path,
+    path: &Path,
+    target_library: &str,
+) -> Result<Option<Value>, String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|error| format!("read {}: {error}", path.display()))?;
+    let file =
+        syn::parse_file(&raw).map_err(|error| format!("parse {}: {error}", path.display()))?;
+
+    let mut targets = Vec::new();
+    collect_materialize_boundaries(&raw, &file.items, &mut targets);
+    if targets.is_empty() {
+        return Ok(None);
+    }
+
+    let mut edits = Vec::new();
+    let mut sites = Vec::new();
+    for target in targets {
+        let library = if target.library.is_empty() {
+            target_library.to_string()
+        } else {
+            target.library.clone()
+        };
+        if !target_library.is_empty() && library != target_library {
+            continue;
+        }
+
+        let _target_library_guard = TargetLibraryTagGuard::set(&library);
+        let realized = emit_stub(
+            &target.function_name,
+            &target.params,
+            &target.param_types,
+            &target.return_type,
+            &target.concept_name,
+        );
+
+        if realized.is_stub {
+            sites.push(MaterializedRustSite::refused(
+                target.concept_name,
+                target.function_name,
+                format!("realize plugin for rust library `{library}` returned a stub"),
+            ));
+            continue;
+        }
+
+        let realized_block = realized_block_source(&realized.source)?;
+        edits.push(SourceEdit {
+            start: target.body_start,
+            end: target.body_end,
+            text: realized_block,
+        });
+        edits.extend(target.attr_edits);
+
+        let binding_cid = realized.emitted_artifact_cid.clone();
+        let loss_dims = loss_dimensions(&realized.observed_loss_record);
+        sites.push(MaterializedRustSite {
+            concept_name: target.concept_name,
+            function_name: target.function_name,
+            target_binding_cid: binding_cid,
+            outcome_kind: if loss_dims.is_empty() {
+                "Exact".to_string()
+            } else {
+                "LoudlyLossy".to_string()
+            },
+            loss_dims,
+            refusal_reason: None,
+        });
+    }
+
+    if sites.is_empty() {
+        return Ok(None);
+    }
+
+    let rewritten = apply_source_edits(raw.as_bytes(), edits)?;
+    let relative_path = path
+        .strip_prefix(source_dir)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    Ok(Some(json!({
+        "path": relative_path,
+        "content": String::from_utf8(rewritten)
+            .map_err(|error| format!("materialized Rust was not UTF-8: {error}"))?,
+        "receipt": receipt_for_rust_sites(target_library, &sites),
+    })))
+}
+
+#[derive(Debug, Clone)]
+struct MaterializeBoundaryTarget {
+    concept_name: String,
+    library: String,
+    function_name: String,
+    params: Vec<String>,
+    param_types: Vec<String>,
+    return_type: String,
+    body_start: usize,
+    body_end: usize,
+    attr_edits: Vec<SourceEdit>,
+}
+
+#[derive(Debug, Clone)]
+struct MaterializedRustSite {
+    concept_name: String,
+    function_name: String,
+    target_binding_cid: String,
+    outcome_kind: String,
+    loss_dims: Vec<String>,
+    refusal_reason: Option<String>,
+}
+
+impl MaterializedRustSite {
+    fn refused(concept_name: String, function_name: String, reason: String) -> Self {
+        Self {
+            concept_name,
+            function_name,
+            target_binding_cid: String::new(),
+            outcome_kind: "Refused".to_string(),
+            loss_dims: Vec::new(),
+            refusal_reason: Some(reason),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SourceEdit {
+    start: usize,
+    end: usize,
+    text: String,
+}
+
+fn collect_materialize_boundaries(
+    source: &str,
+    items: &[syn::Item],
+    targets: &mut Vec<MaterializeBoundaryTarget>,
+) {
+    for item in items {
+        match item {
+            syn::Item::Fn(item_fn) => {
+                if let Some(target) = materialize_boundary_target(source, item_fn) {
+                    targets.push(target);
+                }
+            }
+            syn::Item::Mod(module) => {
+                if let Some((_, nested)) = &module.content {
+                    collect_materialize_boundaries(source, nested, targets);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn materialize_boundary_target(
+    source: &str,
+    item_fn: &syn::ItemFn,
+) -> Option<MaterializeBoundaryTarget> {
+    let mut parsed = None;
+    let mut attr_edits = Vec::new();
+    for attr in &item_fn.attrs {
+        if !is_provekit_attr(attr, "boundary") {
+            continue;
+        }
+        if parsed.is_none() {
+            parsed = parse_boundary_attr(attr);
+        }
+        if let Some(edit) = attr_removal_edit(source, attr) {
+            attr_edits.push(edit);
+        }
+    }
+
+    let parsed = parsed?;
+    let body_start =
+        line_column_to_byte_offset(source, item_fn.block.brace_token.span.open().start())?;
+    let body_end =
+        line_column_to_byte_offset(source, item_fn.block.brace_token.span.close().end())?;
+    let (params, param_types) = function_params(&item_fn.sig);
+    Some(MaterializeBoundaryTarget {
+        concept_name: parsed.concept,
+        library: parsed.library,
+        function_name: item_fn.sig.ident.to_string(),
+        params,
+        param_types,
+        return_type: function_return_type(&item_fn.sig),
+        body_start,
+        body_end,
+        attr_edits,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct ParsedBoundaryAttr {
+    concept: String,
+    library: String,
+}
+
+fn is_provekit_attr(attr: &syn::Attribute, name: &str) -> bool {
+    let segments = attr.path().segments.iter().collect::<Vec<_>>();
+    segments.len() == 2 && segments[0].ident == "provekit" && segments[1].ident == name
+}
+
+fn parse_boundary_attr(attr: &syn::Attribute) -> Option<ParsedBoundaryAttr> {
+    let meta_list = attr.meta.require_list().ok()?;
+    let args = parse_attr_named_args(&meta_list.tokens);
+    let concept = args.string("concept").unwrap_or_default();
+    if concept.is_empty() {
+        return None;
+    }
+    Some(ParsedBoundaryAttr {
+        concept,
+        library: args.string("library").unwrap_or_default(),
+    })
+}
+
+#[derive(Debug, Default)]
+struct ParsedAttrArgs {
+    strings: BTreeMap<String, String>,
+}
+
+impl ParsedAttrArgs {
+    fn string(&self, key: &str) -> Option<String> {
+        self.strings.get(key).cloned()
+    }
+}
+
+fn parse_attr_named_args(tokens: &proc_macro2::TokenStream) -> ParsedAttrArgs {
+    let mut out = ParsedAttrArgs::default();
+    let tokens = tokens.clone().into_iter().collect::<Vec<_>>();
+    let mut i = 0;
+    while i < tokens.len() {
+        let key = match &tokens[i] {
+            proc_macro2::TokenTree::Ident(ident) => ident.to_string(),
+            _ => {
+                i += 1;
+                continue;
+            }
+        };
+        let is_eq = matches!(tokens.get(i + 1), Some(proc_macro2::TokenTree::Punct(p)) if p.as_char() == '=');
+        if !is_eq {
+            i += 1;
+            continue;
+        }
+        if let Some(proc_macro2::TokenTree::Literal(lit)) = tokens.get(i + 2) {
+            if let Some(unquoted) = unquote_string_literal(&lit.to_string()) {
+                out.strings.insert(key, unquoted);
+            }
+            i += 3;
+        } else {
+            i += 1;
+        }
+        if matches!(tokens.get(i), Some(proc_macro2::TokenTree::Punct(p)) if p.as_char() == ',') {
+            i += 1;
+        }
+    }
+    out
+}
+
+fn unquote_string_literal(raw: &str) -> Option<String> {
+    if raw.starts_with('"') && raw.ends_with('"') && raw.len() >= 2 {
+        Some(raw[1..raw.len() - 1].to_string())
+    } else {
+        None
+    }
+}
+
+fn function_params(sig: &syn::Signature) -> (Vec<String>, Vec<String>) {
+    let mut params = Vec::new();
+    let mut param_types = Vec::new();
+    let mut synthetic = 0usize;
+    for input in &sig.inputs {
+        match input {
+            syn::FnArg::Typed(pat_ty) => {
+                let name = match &*pat_ty.pat {
+                    syn::Pat::Ident(ident) => ident.ident.to_string(),
+                    _ => {
+                        let name = format!("p{synthetic}");
+                        synthetic += 1;
+                        name
+                    }
+                };
+                params.push(name);
+                param_types.push(rust_type_surface(&pat_ty.ty));
+            }
+            syn::FnArg::Receiver(_) => {
+                params.push("self".to_string());
+                param_types.push("Self".to_string());
+            }
+        }
+    }
+    (params, param_types)
+}
+
+fn function_return_type(sig: &syn::Signature) -> String {
+    match &sig.output {
+        syn::ReturnType::Default => String::new(),
+        syn::ReturnType::Type(_, ty) => rust_type_surface(ty),
+    }
+}
+
+fn rust_type_surface(ty: &syn::Type) -> String {
+    ty.to_token_stream().to_string().replace(' ', "")
+}
+
+fn attr_removal_edit(source: &str, attr: &syn::Attribute) -> Option<SourceEdit> {
+    let open = line_column_to_byte_offset(source, attr.bracket_token.span.open().start())?;
+    let close = line_column_to_byte_offset(source, attr.bracket_token.span.close().end())?;
+    let bytes = source.as_bytes();
+    let start = line_start_offset(bytes, open);
+    let line_end = line_end_offset(bytes, close);
+    let suffix = source.get(close..line_end).unwrap_or("");
+    let end = if suffix.trim().is_empty() {
+        line_end
+    } else {
+        close
+    };
+    Some(SourceEdit {
+        start,
+        end,
+        text: String::new(),
+    })
+}
+
+fn line_column_to_byte_offset(src: &str, loc: proc_macro2::LineColumn) -> Option<usize> {
+    if loc.line == 0 {
+        return None;
+    }
+
+    let mut line_starts = vec![0usize];
+    for (idx, byte) in src.bytes().enumerate() {
+        if byte == b'\n' {
+            line_starts.push(idx + 1);
+        }
+    }
+
+    let line_start = *line_starts.get(loc.line - 1)?;
+    let line_end = line_starts
+        .get(loc.line)
+        .copied()
+        .map(|next_start| next_start.saturating_sub(1))
+        .unwrap_or(src.len());
+    let line = src.get(line_start..line_end)?;
+
+    if loc.column == 0 {
+        return Some(line_start);
+    }
+
+    match line.char_indices().nth(loc.column) {
+        Some((offset, _)) => Some(line_start + offset),
+        None if line.chars().count() == loc.column => Some(line_end),
+        None => None,
+    }
+}
+
+fn line_start_offset(bytes: &[u8], mut offset: usize) -> usize {
+    while offset > 0 && bytes[offset - 1] != b'\n' {
+        offset -= 1;
+    }
+    offset
+}
+
+fn line_end_offset(bytes: &[u8], mut offset: usize) -> usize {
+    while offset < bytes.len() && bytes[offset] != b'\n' {
+        offset += 1;
+    }
+    if offset < bytes.len() {
+        offset += 1;
+    }
+    offset
+}
+
+fn realized_block_source(source: &str) -> Result<String, String> {
+    let file =
+        syn::parse_file(source).map_err(|error| format!("parse realized Rust source: {error}"))?;
+    for item in file.items {
+        if let syn::Item::Fn(item_fn) = item {
+            let start =
+                line_column_to_byte_offset(source, item_fn.block.brace_token.span.open().start())
+                    .ok_or("realized Rust block start out of range")?;
+            let end =
+                line_column_to_byte_offset(source, item_fn.block.brace_token.span.close().end())
+                    .ok_or("realized Rust block end out of range")?;
+            return source
+                .get(start..end)
+                .map(str::to_string)
+                .ok_or_else(|| "realized Rust block slice out of range".to_string());
+        }
+    }
+    Err("realized Rust source did not contain a function body".to_string())
+}
+
+fn apply_source_edits(source: &[u8], mut edits: Vec<SourceEdit>) -> Result<Vec<u8>, String> {
+    edits.sort_by(|a, b| {
+        if a.start == b.start {
+            b.end.cmp(&a.end)
+        } else {
+            b.start.cmp(&a.start)
+        }
+    });
+
+    let mut out = source.to_vec();
+    let mut last_start = out.len() + 1;
+    for edit in edits {
+        if edit.start > edit.end || edit.end > out.len() {
+            return Err(format!(
+                "invalid source edit range [{}, {})",
+                edit.start, edit.end
+            ));
+        }
+        if edit.end > last_start {
+            return Err("overlapping Rust source edits".to_string());
+        }
+        let mut next = Vec::with_capacity(out.len() - (edit.end - edit.start) + edit.text.len());
+        next.extend_from_slice(&out[..edit.start]);
+        next.extend_from_slice(edit.text.as_bytes());
+        next.extend_from_slice(&out[edit.end..]);
+        out = next;
+        last_start = edit.start;
+    }
+    Ok(out)
+}
+
+fn loss_dimensions(record: &Value) -> Vec<String> {
+    match record {
+        Value::Null => Vec::new(),
+        Value::Object(map) if map.is_empty() => Vec::new(),
+        Value::Object(map) => map.keys().cloned().collect(),
+        other => vec![other.to_string()],
+    }
+}
+
+fn receipt_for_rust_sites(target_library: &str, sites: &[MaterializedRustSite]) -> Value {
+    let exact = sites
+        .iter()
+        .filter(|site| site.outcome_kind == "Exact")
+        .count();
+    let lossy = sites
+        .iter()
+        .filter(|site| site.outcome_kind == "LoudlyLossy")
+        .count();
+    let refused = sites
+        .iter()
+        .filter(|site| site.outcome_kind == "Refused")
+        .count();
+    let site_witnesses = sites
+        .iter()
+        .map(|site| {
+            json!({
+                "source_binding_cid": null,
+                "target_binding_cid": site.target_binding_cid,
+                "concept_name": site.concept_name,
+                "function_name": site.function_name,
+                "outcome_kind": site.outcome_kind,
+            })
+        })
+        .collect::<Vec<_>>();
+    let loss_records = sites
+        .iter()
+        .filter(|site| !site.loss_dims.is_empty())
+        .map(|site| {
+            json!({
+                "concept_name": site.concept_name,
+                "dimensions": site.loss_dims,
+            })
+        })
+        .collect::<Vec<_>>();
+    let refusal_mementos = sites
+        .iter()
+        .filter_map(|site| {
+            site.refusal_reason.as_ref().map(|reason| {
+                json!({
+                    "concept_name": site.concept_name,
+                    "reason": reason,
+                    "would_close_with_concept": site.concept_name,
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+
+    json!({
+        "schema_version": "1",
+        "source_language": "rust",
+        "source_library": null,
+        "target_language": "rust",
+        "target_library": target_library,
+        "aggregate_summary": {
+            "exact": exact,
+            "lossy": lossy,
+            "refused": refused,
+        },
+        "site_witnesses": site_witnesses,
+        "loss_records": loss_records,
+        "refusal_mementos": refusal_mementos,
+    })
 }
 
 fn check_materialized(params: &serde_json::Map<String, Value>) -> Value {


### PR DESCRIPTION
## Summary
- implement `provekit.plugin.materialize_source` in the Rust realize kit for `#[provekit::boundary]` source rewriting
- remove Rust-specific materialize parsing/import-splicing fallback from the CLI
- update the Rust reqwest materialize integration test to require manifest/config-driven kit RPC

Closes #1494

## Test Plan
- `/Users/tsavo/provekit/bin/bcargo build --manifest-path implementations/rust/Cargo.toml -p provekit-realize-rust-core --bin provekit-realize-rust`
- `/Users/tsavo/provekit/bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_materialize_integration materialize_rust_reqwest_example_uses_rust_library_shim -- --nocapture`
- `rustfmt --check implementations/rust/provekit-realize-rust-core/src/lib.rs implementations/rust/provekit-cli/src/cmd_materialize.rs implementations/rust/provekit-cli/src/kit_dispatch.rs implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs`
- `git diff --check`
- CLI leak guards for removed Rust materialize fallback/scope-bringing symbols
