### PR TITLE
Fix Java realization fragment metadata

### DIFF
--- a/.provekit/realize/java-blake3/manifest.toml
+++ b/.provekit/realize/java-blake3/manifest.toml
@@ -5,5 +5,8 @@ library_tag = "bouncycastle"
 family = "concept:family:hash"
 library_version = "1.78"
 provides_concepts = ["concept:blake3-512-of"]
+dependencies = [
+  "org.bouncycastle:bcprov-jdk18on:1.81.1",
+]
 command = ["java", "-jar", "implementations/java/provekit-realize-java-core/target/provekit-realize-java.jar", "--rpc"]
 working_dir = "."

--- a/.provekit/realize/java-gson/manifest.toml
+++ b/.provekit/realize/java-gson/manifest.toml
@@ -9,5 +9,8 @@ library_tag = "gson"
 family = "concept:family:json"
 library_version = "2.11"
 provides_concepts = ["concept:json-parse", "concept:json-serialize"]
+dependencies = [
+  "com.google.code.gson:gson:2.11.0",
+]
 command = ["java", "-jar", "implementations/java/provekit-realize-java-core/target/provekit-realize-java.jar", "--rpc"]
 working_dir = "."

--- a/.provekit/realize/java-json/manifest.toml
+++ b/.provekit/realize/java-json/manifest.toml
@@ -7,5 +7,10 @@ library_tag = "jackson"
 family = "concept:family:json"
 library_version = "2.17"
 provides_concepts = ["concept:json-parse", "concept:json-serialize"]
+dependencies = [
+  "com.fasterxml.jackson.core:jackson-databind:2.17.2",
+  "com.fasterxml.jackson.core:jackson-core:2.17.2",
+  "com.fasterxml.jackson.core:jackson-annotations:2.17.2",
+]
 command = ["java", "-jar", "implementations/java/provekit-realize-java-core/target/provekit-realize-java.jar", "--rpc"]
 working_dir = "."

--- a/.provekit/realize/java-rfc8785-jcs/manifest.toml
+++ b/.provekit/realize/java-rfc8785-jcs/manifest.toml
@@ -6,5 +6,10 @@ library_tag = "provekit-rfc8785-jcs-java"
 family = "concept:family:json-canonicalization"
 library_version = "0.1"
 provides_concepts = ["concept:rfc8785-jcs-encode", "concept:rfc8785-jcs-encode-value", "concept:rfc8785-jcs-encode-string"]
+dependencies = [
+  "com.fasterxml.jackson.core:jackson-databind:2.17.2",
+  "com.fasterxml.jackson.core:jackson-core:2.17.2",
+  "com.fasterxml.jackson.core:jackson-annotations:2.17.2",
+]
 command = ["java", "-jar", "implementations/java/provekit-realize-java-core/target/provekit-realize-java.jar", "--rpc"]
 working_dir = "."

--- a/.provekit/realize/java-sqlite-jdbc/manifest.toml
+++ b/.provekit/realize/java-sqlite-jdbc/manifest.toml
@@ -8,6 +8,9 @@ name = "java-realize-sqlite-jdbc"
 library_tag = "sqlite-jdbc"
 family = "concept:family:sql"
 library_version = "3.45.3.0"
+dependencies = [
+  "org.xerial:sqlite-jdbc:3.45.3.0",
+]
 # #1364 / #1355: per-kit concept coverage. Concept names aligned with
 # provekit-shim-rusqlite for cross-library cluster membership (per the
 # sqlite-jdbc shim's pom.xml description). #1468: the connection-/statement-level

--- a/bin/bcargo
+++ b/bin/bcargo
@@ -108,11 +108,13 @@ sync_file Cargo.toml
 sync_file Cargo.lock
 sync_file rust-toolchain
 sync_file rust-toolchain.toml
-# Repo-root workspace config: the solver-portfolio registry + repo-root mint
-# read `.provekit/config.toml`. Sync the file only -- the sibling `.provekit/`
-# subdirs (cache/, runs/, fuzz-runs/, harvest/, baselines/) are large outputs
-# we deliberately do not ship.
+# Repo-root workspace config and hand-authored plugin manifests. Generated
+# `.provekit/` outputs (runs/, witnesses/, cache/, baselines/, etc.) stay out
+# of the remote copy, but lift/realize manifests are source inputs for CLI
+# dispatch and must travel with bcargo.
 sync_file .provekit/config.toml
+sync_dir .provekit/lift
+sync_dir .provekit/realize
 
 sync_dir implementations/rust
 sync_dir examples

--- a/implementations/java/provekit-realize-java-core/pom.xml
+++ b/implementations/java/provekit-realize-java-core/pom.xml
@@ -44,6 +44,10 @@
             <version>0.1.0</version>
         </dependency>
         <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-symbol-solver-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.10.0</version>

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/RpcServer.java
@@ -320,9 +320,10 @@ public final class RpcServer {
         String packageHint = JsonUtil.decodeJsonStringField(paramsObj, "package_hint");
         String fragmentsJson = JsonUtil.extractArrayField(paramsObj, "fragments");
 
-        // Parse fragments + collect imports/sources/helpers.
+        // Parse fragments + collect imports/sources/helpers/dependencies.
         java.util.TreeSet<String> mergedImports = new java.util.TreeSet<>();
         java.util.LinkedHashSet<String> mergedHelpers = new java.util.LinkedHashSet<>();
+        java.util.LinkedHashSet<String> mergedDependencies = new java.util.LinkedHashSet<>();
         java.util.List<String> bodies = new java.util.ArrayList<>();
         try {
             com.provekit.ir.Jcs.Json doc = com.provekit.ir.Jcs.parse(fragmentsJson);
@@ -346,6 +347,15 @@ public final class RpcServer {
                         for (com.provekit.ir.Jcs.Json v : ha.values()) {
                             if (v instanceof com.provekit.ir.Jcs.Str s) {
                                 mergedHelpers.add(s.value());
+                            }
+                        }
+                    }
+                    // #1380: collect package coordinates from each fragment.
+                    com.provekit.ir.Jcs.Json dependenciesArr = o.get("dependencies");
+                    if (dependenciesArr instanceof com.provekit.ir.Jcs.Arr da) {
+                        for (com.provekit.ir.Jcs.Json v : da.values()) {
+                            if (v instanceof com.provekit.ir.Jcs.Str s) {
+                                mergedDependencies.add(s.value());
                             }
                         }
                     }
@@ -390,17 +400,16 @@ public final class RpcServer {
         }
         out.append("}\n");
 
-        // #1388: emit the kit's runtime classpath so the substrate's
+        // #1388/#1380: emit the kit's runtime classpath so the substrate's
         // --compile-check can invoke javac with the JARs the materialized
         // code references (jackson, bouncycastle, etc.).
         //
         // Sources:
         //   1. The plugin's java.class.path (the realize-java jar with its
         //      shaded dependencies).
-        //   2. Known maven-cached dependency JARs (jackson, bouncycastle)
-        //      that the materialized code references but the realize plugin
-        //      doesn't load itself. Stop-gap until proper Maven-coord
-        //      resolution lands on the substrate side.
+        //   2. Fragment-declared Maven coordinates from the Java kit's
+        //      manifests. The substrate forwards them but does not interpret
+        //      Java package semantics.
         java.util.LinkedHashSet<String> classpath = new java.util.LinkedHashSet<>();
         String javaCp = System.getProperty("java.class.path", "");
         if (!javaCp.isEmpty()) {
@@ -416,13 +425,9 @@ public final class RpcServer {
         String userHome = System.getProperty("user.home", "");
         if (!userHome.isEmpty()) {
             java.nio.file.Path m2 = java.nio.file.Paths.get(userHome, ".m2", "repository");
-            scanMavenJars(m2, "com/fasterxml/jackson/core/jackson-databind", classpath);
-            scanMavenJars(m2, "com/fasterxml/jackson/core/jackson-core", classpath);
-            scanMavenJars(m2, "com/fasterxml/jackson/core/jackson-annotations", classpath);
-            scanMavenJars(m2, "org/bouncycastle/bcprov-jdk18on", classpath);
-            scanMavenJars(m2, "org/bouncycastle/bcprov-jdk15on", classpath);
-            scanMavenJars(m2, "com/google/code/gson/gson", classpath);
-            scanMavenJars(m2, "org/xerial/sqlite-jdbc", classpath);
+            for (String coordinate : mergedDependencies) {
+                scanMavenCoordinateJar(m2, coordinate, classpath);
+            }
         }
         StringBuilder cpJson = new StringBuilder("[");
         boolean first = true;
@@ -439,6 +444,7 @@ public final class RpcServer {
             + "\"path\":" + JsonUtil.quoted(filePath)
             + ",\"content\":" + JsonUtil.quoted(out.toString())
             + "}],\"compile_classpath\":" + cpJson
+            + ",\"dependencies\":" + jsonStringArray(new java.util.ArrayList<>(mergedDependencies))
             + "}";
     }
 
@@ -504,37 +510,23 @@ public final class RpcServer {
         }
     }
 
-    /**
-     * #1388: scan ~/.m2/repository/<group>/<artifact>/ for the most-recent
-     * version's JAR and add it to the classpath set. Picks the
-     * lexicographically-latest version directory. Silent on absence — the
-     * kit-owned compile check will surface missing JARs as package-not-found
-     * errors.
-     */
-    private static void scanMavenJars(
+    private static void scanMavenCoordinateJar(
             java.nio.file.Path m2Root,
-            String artifactDir,
+            String coordinate,
             java.util.Collection<String> classpath) {
         if (m2Root == null || !java.nio.file.Files.isDirectory(m2Root)) return;
-        java.nio.file.Path artifactPath = m2Root.resolve(artifactDir);
-        if (!java.nio.file.Files.isDirectory(artifactPath)) return;
-        try (java.util.stream.Stream<java.nio.file.Path> versions =
-                java.nio.file.Files.list(artifactPath)) {
-            java.util.List<java.nio.file.Path> dirs = versions
-                .filter(java.nio.file.Files::isDirectory)
-                .sorted(java.util.Comparator.reverseOrder())
-                .toList();
-            for (java.nio.file.Path versionDir : dirs) {
-                String artifactBase = artifactDir.substring(artifactDir.lastIndexOf('/') + 1);
-                String jarName = artifactBase + "-" + versionDir.getFileName().toString() + ".jar";
-                java.nio.file.Path jar = versionDir.resolve(jarName);
-                if (java.nio.file.Files.isRegularFile(jar)) {
-                    classpath.add(jar.toAbsolutePath().toString());
-                    return;  // first (latest) match wins
-                }
-            }
-        } catch (Exception ignored) {
-            // Best-effort: missing dep manifests as javac error downstream.
+        if (coordinate == null || coordinate.isBlank()) return;
+        String[] parts = coordinate.split(":");
+        if (parts.length < 3) return;
+        String groupPath = parts[0].replace('.', '/');
+        String artifact = parts[1];
+        String version = parts[2];
+        java.nio.file.Path jar = m2Root.resolve(groupPath)
+                .resolve(artifact)
+                .resolve(version)
+                .resolve(artifact + "-" + version + ".jar");
+        if (java.nio.file.Files.isRegularFile(jar)) {
+            classpath.add(jar.toAbsolutePath().toString());
         }
     }
 
@@ -707,12 +699,12 @@ public final class RpcServer {
         String wrapperRecord = r.observationWrapperEmissionRecord() == null
                 ? ""
                 : ",\"observation_wrapper_emission_record\":" + r.observationWrapperEmissionRecord();
-        // #1374: extract FQN imports from the emitted source. Substrate-side
-        // assembly (Milestone C) deduplicates these and emits the idiomatic
-        // import block for the target language. The body itself can keep
-        // FQN-inline references (compiles either way); the imports field
-        // lets downstream tooling know what the fragment USES.
-        String importsJson = importsFromSource(r.source());
+        // #1380: prefer kit-owned structured import metadata. Keep the
+        // source scan as a legacy fallback for old body-template entries that
+        // still inline FQNs in the body.
+        java.util.TreeSet<String> imports = new java.util.TreeSet<>(r.imports());
+        imports.addAll(importsFromSourceValues(r.source()));
+        String importsJson = jsonStringArray(new java.util.ArrayList<>(imports));
         // #1390: emit helpers as a structured field. The assembler hoists
         // them into the compilation unit before methods.
         StringBuilder helpersJson = new StringBuilder("[");
@@ -723,6 +715,7 @@ public final class RpcServer {
             firstHelper = false;
         }
         helpersJson.append(']');
+        String dependenciesJson = jsonStringArray(r.dependencies());
         return "{\"kind\":\"realization-fragment\""
                 + ",\"source\":" + JsonUtil.quoted(r.source())
                 + ",\"emitted_artifact_cid\":"
@@ -732,6 +725,7 @@ public final class RpcServer {
                 + ",\"used_sugars\":" + r.usedSugarsJson()
                 + ",\"imports\":" + importsJson
                 + ",\"helpers\":" + helpersJson
+                + ",\"dependencies\":" + dependenciesJson
                 + wrapperRecord
                 + "}";
     }
@@ -745,30 +739,22 @@ public final class RpcServer {
      * suffixes (the matcher captures up to the FIRST PascalCase identifier;
      * `JsonNode.NumberType` matches just `JsonNode`).
      *
-     * Returns a JSON array of unique FQN strings sorted lexicographically.
+     * Returns unique FQN strings sorted lexicographically.
      */
-    private static String importsFromSource(String source) {
-        if (source == null || source.isEmpty()) return "[]";
+    private static java.util.List<String> importsFromSourceValues(String source) {
+        java.util.TreeSet<String> imports = new java.util.TreeSet<>();
+        if (source == null || source.isEmpty()) return java.util.List.of();
         java.util.regex.Pattern p = java.util.regex.Pattern.compile(
             "\\b([a-z][a-z0-9_]*(?:\\.[a-z][a-z0-9_]*)+\\.[A-Z][A-Za-z0-9_]*)"
         );
         java.util.regex.Matcher m = p.matcher(source);
-        java.util.TreeSet<String> imports = new java.util.TreeSet<>();
         while (m.find()) {
             String fqn = m.group(1);
             // Skip java.lang.* — implicit in every compilation unit.
             if (fqn.startsWith("java.lang.")) continue;
             imports.add(fqn);
         }
-        StringBuilder sb = new StringBuilder("[");
-        boolean first = true;
-        for (String fqn : imports) {
-            if (!first) sb.append(',');
-            sb.append(JsonUtil.quoted(fqn));
-            first = false;
-        }
-        sb.append(']');
-        return sb.toString();
+        return new java.util.ArrayList<>(imports);
     }
 
     /**

--- a/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
+++ b/implementations/java/provekit-realize-java-core/src/main/java/com/provekit/realize/SugarRealizer.java
@@ -62,13 +62,27 @@ final class SugarRealizer {
             String observedLossRecord,
             String usedSugarsJson,
             String observationWrapperEmissionRecord,
+            /// #1380: structured imports required by this fragment. These
+            /// come from kit-owned body metadata, not body-text comments.
+            List<String> imports,
             /// #1390: static field helpers needed by the body. Empty for
             /// stubs and bodies that don't reference class-level statics.
-            List<String> helpers) {
+            List<String> helpers,
+            /// #1380: build dependencies required by this fragment. The Java
+            /// kit reads these from project realize manifests and returns
+            /// them over RPC; the CLI only transports the normalized data.
+            List<String> dependencies) {
         Realization(String source, boolean isStub, String observedLossRecord,
                    String usedSugarsJson, String observationWrapperEmissionRecord) {
             this(source, isStub, observedLossRecord, usedSugarsJson,
-                 observationWrapperEmissionRecord, List.of());
+                 observationWrapperEmissionRecord, List.of(), List.of(), List.of());
+        }
+
+        Realization(String source, boolean isStub, String observedLossRecord,
+                   String usedSugarsJson, String observationWrapperEmissionRecord,
+                   List<String> helpers) {
+            this(source, isStub, observedLossRecord, usedSugarsJson,
+                 observationWrapperEmissionRecord, List.of(), helpers, List.of());
         }
     }
 
@@ -449,14 +463,18 @@ final class SugarRealizer {
                 + "}\n"
                 + witnessClass;
         // #1390: collect helpers from the matched body-template entry.
+        List<String> fragmentImports = bodyTemplate.map(RenderedBody::imports).orElse(List.of());
         List<String> helpers = bodyTemplate.map(RenderedBody::helpers).orElse(List.of());
+        List<String> dependencies = bodyTemplate.map(RenderedBody::dependencies).orElse(List.of());
         return new Realization(
                 source,
                 isStub,
                 observedLossRecordJson(sugarEmissions, bodyLossRecord),
                 usedSugarsJson(sugarEmissions),
                 observationWrapperEmissionRecord,
-                helpers);
+                fragmentImports,
+                helpers,
+                dependencies);
     }
 
     private static String parameterAnnotations(List<SugarEmission> emissions, String paramName) {
@@ -4096,12 +4114,20 @@ final class SugarRealizer {
             /// for the same concept. Empty string means "library-agnostic"
             /// (legacy catch-all).
             String targetLibraryTag,
+            /// #1380: imports lifted as structured fragment metadata. Older
+            /// shim proofs carried these in marker comments; the Java kit
+            /// strips those comments and returns the data over RPC instead.
+            List<String> fileImports,
             /// #1390: static field helpers lifted from the shim's source file.
             /// Bodies reference these as short-named symbols (e.g.
             /// `MAPPER.readTree(s)`); the assembler hoists them into the
             /// compilation unit before methods. Empty when the shim has no
             /// class-level static fields.
-            List<String> fileHelpers) {}
+            List<String> fileHelpers,
+            /// #1380: package coordinates declared by the chosen realize
+            /// manifest for this library. Assembly uses them to build the
+            /// kit-owned compile classpath.
+            List<String> dependencyCoordinates) {}
 
     private record TemplateCitation(
             String placeholder,
@@ -4109,9 +4135,14 @@ final class SugarRealizer {
             String mode,
             List<String> params) {}
 
-    private record RenderedBody(String body, Jcs.Json lossRecord, List<String> helpers) {
+    private record RenderedBody(
+            String body,
+            Jcs.Json lossRecord,
+            List<String> imports,
+            List<String> helpers,
+            List<String> dependencies) {
         RenderedBody(String body, Jcs.Json lossRecord) {
-            this(body, lossRecord, List.of());
+            this(body, lossRecord, List.of(), List.of(), List.of());
         }
     }
 
@@ -4220,6 +4251,9 @@ final class SugarRealizer {
         }
         String rendered = renderedMaybe.get();
         Jcs.Json lossRecord = entry.lossRecord();
+        List<String> imports = new ArrayList<>(entry.fileImports());
+        List<String> helpers = new ArrayList<>(entry.fileHelpers());
+        List<String> dependencies = new ArrayList<>(entry.dependencyCoordinates());
         for (TemplateCitation citation : entry.citations()) {
             List<String> citationParams = new ArrayList<>();
             for (String rawParam : citation.params()) {
@@ -4243,15 +4277,22 @@ final class SugarRealizer {
             }
             rendered = rendered.replace("${" + citation.placeholder() + "}", citationBody.get().body());
             lossRecord = combineLossRecords(lossRecord, citationBody.get().lossRecord());
+            imports.addAll(citationBody.get().imports());
+            helpers.addAll(citationBody.get().helpers());
+            dependencies.addAll(citationBody.get().dependencies());
         }
         if (rendered.contains("${")) {
             // Unbound placeholder: refuse-match per spec §2.1.
             return Optional.empty();
         }
-        // #1390: attach the matched entry's static field helpers to the
-        // rendered body so emitStubInner / RpcServer can carry them through
-        // to the assembler. Empty when the shim has no class-level statics.
-        return Optional.of(new RenderedBody(rendered, lossRecord, entry.fileHelpers()));
+        // #1380/#1390: attach structured fragment context so emitStubInner /
+        // RpcServer can carry it through to the assembler.
+        return Optional.of(new RenderedBody(
+                rendered,
+                lossRecord,
+                dedupePreserveOrder(imports),
+                dedupePreserveOrder(helpers),
+                dedupePreserveOrder(dependencies)));
     }
 
     private static Optional<String> substituteTemplateBindings(String template, List<String> params) {
@@ -4347,12 +4388,6 @@ final class SugarRealizer {
             guard.append("\"max_params\":").append(entry.maxParams());
         }
         guard.append("}");
-        StringBuilder helpers = new StringBuilder("[");
-        for (int i = 0; i < entry.fileHelpers().size(); i++) {
-            if (i > 0) helpers.append(",");
-            helpers.append(JsonUtil.quoted(entry.fileHelpers().get(i)));
-        }
-        helpers.append("]");
         return "{"
                 + "\"concept_name\":" + JsonUtil.quoted(entry.conceptName()) + ","
                 + "\"emission_template\":{\"kind\":" + JsonUtil.quoted(entry.templateKind())
@@ -4360,7 +4395,9 @@ final class SugarRealizer {
                 + "\"loss_record_contribution\":{\"form\":\"literal\",\"value\":" + Jcs.encode(entry.lossRecord()) + "},"
                 + "\"signature_guard\":" + guard + ","
                 + "\"target_library_tag\":" + JsonUtil.quoted(entry.targetLibraryTag()) + ","
-                + "\"file_helpers\":" + helpers
+                + "\"imports\":" + stringArrayJson(entry.fileImports()) + ","
+                + "\"file_helpers\":" + stringArrayJson(entry.fileHelpers()) + ","
+                + "\"dependencies\":" + stringArrayJson(entry.dependencyCoordinates())
                 + "}";
     }
 
@@ -4421,6 +4458,7 @@ final class SugarRealizer {
         if (!(bodySourceJson instanceof Jcs.Obj bodySource)) return null;
         String bodyText = bodySource.stringFieldOrNull("body_text");
         if (bodyText == null || bodyText.isBlank()) return null;
+        FragmentMetadata fragmentMetadata = extractFragmentMetadata(bodyText);
         List<String> fileHelpers = new ArrayList<>();
         Jcs.Json helpersJson = decl.get("file_helpers");
         if (helpersJson instanceof Jcs.Arr helpersArr) {
@@ -4433,13 +4471,146 @@ final class SugarRealizer {
                 conceptName,
                 null,
                 "verbatim",
-                substituteShimParamsWithPlaceholders(bodyText, paramNames),
+                substituteShimParamsWithPlaceholders(fragmentMetadata.body(), paramNames),
                 List.of(),
                 lossRecordFromBindingEntry(decl),
                 arity,
                 arity,
                 libraryTag,
-                List.copyOf(fileHelpers));
+                fragmentMetadata.imports(),
+                List.copyOf(fileHelpers),
+                mergeStringLists(fragmentMetadata.dependencies(), manifestDependenciesForLibraryTag(libraryTag)));
+    }
+
+    private record FragmentMetadata(String body, List<String> imports, List<String> dependencies) {}
+
+    private static FragmentMetadata extractFragmentMetadata(String bodyText) {
+        List<String> imports = new ArrayList<>();
+        List<String> dependencies = new ArrayList<>();
+        StringBuilder body = new StringBuilder();
+        boolean firstBodyLine = true;
+        for (String line : bodyText.split("\\R", -1)) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("// __fragment_imports__:")) {
+                imports.addAll(parseFragmentMetadataList(
+                        trimmed.substring("// __fragment_imports__:".length())));
+                continue;
+            }
+            if (trimmed.startsWith("// __fragment_dependencies__:")) {
+                dependencies.addAll(parseFragmentMetadataList(
+                        trimmed.substring("// __fragment_dependencies__:".length())));
+                continue;
+            }
+            if (!firstBodyLine) body.append('\n');
+            body.append(line);
+            firstBodyLine = false;
+        }
+        return new FragmentMetadata(
+                body.toString(),
+                dedupePreserveOrder(imports),
+                dedupePreserveOrder(dependencies));
+    }
+
+    private static List<String> parseFragmentMetadataList(String text) {
+        if (text == null || text.isBlank()) return List.of();
+        List<String> out = new ArrayList<>();
+        for (String part : text.split(",")) {
+            String value = part.trim();
+            if (!value.isEmpty()) out.add(value);
+        }
+        return out;
+    }
+
+    private static final Map<String, List<String>> MANIFEST_DEPENDENCIES_CACHE = new HashMap<>();
+
+    private static List<String> manifestDependenciesForLibraryTag(String libraryTag) {
+        if (libraryTag == null || libraryTag.isBlank()) return List.of();
+        synchronized (MANIFEST_DEPENDENCIES_CACHE) {
+            List<String> cached = MANIFEST_DEPENDENCIES_CACHE.get(libraryTag);
+            if (cached != null) return cached;
+            List<String> loaded = loadManifestDependenciesForLibraryTag(libraryTag);
+            MANIFEST_DEPENDENCIES_CACHE.put(libraryTag, loaded);
+            return loaded;
+        }
+    }
+
+    private static List<String> loadManifestDependenciesForLibraryTag(String libraryTag) {
+        java.nio.file.Path root = workspaceRoot();
+        if (root == null) return List.of();
+        java.nio.file.Path realizeDir = root.resolve(".provekit").resolve("realize");
+        if (!java.nio.file.Files.isDirectory(realizeDir)) return List.of();
+        List<String> out = new ArrayList<>();
+        try (java.util.stream.Stream<java.nio.file.Path> paths = java.nio.file.Files.list(realizeDir)) {
+            for (java.nio.file.Path dir : (Iterable<java.nio.file.Path>) paths::iterator) {
+                java.nio.file.Path manifest = dir.resolve("manifest.toml");
+                if (!java.nio.file.Files.isRegularFile(manifest)) continue;
+                String raw = java.nio.file.Files.readString(manifest, StandardCharsets.UTF_8);
+                if (!libraryTag.equals(tomlStringValue(raw, "library_tag"))) continue;
+                out.addAll(tomlStringArrayValue(raw, "dependencies"));
+            }
+        } catch (IOException ignored) {
+            return List.of();
+        }
+        return dedupePreserveOrder(out);
+    }
+
+    private static java.nio.file.Path workspaceRoot() {
+        java.nio.file.Path cwd = java.nio.file.Paths.get(System.getProperty("user.dir", "."));
+        for (java.nio.file.Path p = cwd; p != null; p = p.getParent()) {
+            if (java.nio.file.Files.isDirectory(p.resolve(".provekit").resolve("realize"))) {
+                return p;
+            }
+        }
+        return null;
+    }
+
+    private static String tomlStringValue(String raw, String key) {
+        Matcher matcher = Pattern.compile("(?m)^\\s*" + Pattern.quote(key) + "\\s*=\\s*\"([^\"]*)\"")
+                .matcher(raw);
+        return matcher.find() ? matcher.group(1) : null;
+    }
+
+    private static List<String> tomlStringArrayValue(String raw, String key) {
+        Matcher matcher = Pattern.compile("(?ms)^\\s*" + Pattern.quote(key) + "\\s*=\\s*\\[(.*?)\\]")
+                .matcher(raw);
+        if (!matcher.find()) return List.of();
+        String body = matcher.group(1);
+        List<String> out = new ArrayList<>();
+        Matcher values = Pattern.compile("\"([^\"]*)\"").matcher(body);
+        while (values.find()) {
+            String value = values.group(1).trim();
+            if (!value.isEmpty()) out.add(value);
+        }
+        return out;
+    }
+
+    private static List<String> mergeStringLists(List<String> first, List<String> second) {
+        List<String> out = new ArrayList<>();
+        if (first != null) out.addAll(first);
+        if (second != null) out.addAll(second);
+        return dedupePreserveOrder(out);
+    }
+
+    private static List<String> dedupePreserveOrder(List<String> values) {
+        if (values == null || values.isEmpty()) return List.of();
+        List<String> out = new ArrayList<>();
+        for (String value : values) {
+            if (value == null || value.isBlank()) continue;
+            if (!out.contains(value)) out.add(value);
+        }
+        return List.copyOf(out);
+    }
+
+    private static String stringArrayJson(List<String> values) {
+        StringBuilder out = new StringBuilder("[");
+        if (values != null) {
+            for (int i = 0; i < values.size(); i++) {
+                if (i > 0) out.append(',');
+                out.append(JsonUtil.quoted(values.get(i)));
+            }
+        }
+        out.append("]");
+        return out.toString();
     }
 
     private static List<String> stringArray(Jcs.Json value) {
@@ -4748,6 +4919,7 @@ final class SugarRealizer {
                 }
                 String entryLibraryTag = itemObj.stringFieldOrNull("target_library_tag");
                 if (entryLibraryTag == null) entryLibraryTag = "";
+                List<String> fileImports = stringArray(itemObj.get("imports"));
                 // #1390: static field helpers lifted from the shim's source.
                 List<String> fileHelpers = new ArrayList<>();
                 Jcs.Json helpersJson = itemObj.get("file_helpers");
@@ -4756,6 +4928,9 @@ final class SugarRealizer {
                         if (v instanceof Jcs.Str s) fileHelpers.add(s.value());
                     }
                 }
+                List<String> dependencyCoordinates = mergeStringLists(
+                        stringArray(itemObj.get("dependencies")),
+                        manifestDependenciesForLibraryTag(entryLibraryTag));
                 out.add(new BodyTemplateEntry(
                         conceptName,
                         mode,
@@ -4766,7 +4941,9 @@ final class SugarRealizer {
                         minParams,
                         maxParams,
                         entryLibraryTag,
-                        fileHelpers));
+                        fileImports,
+                        fileHelpers,
+                        dependencyCoordinates));
             }
             return out;
         } catch (RuntimeException e) {

--- a/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/RealizationFragmentContractTest.java
+++ b/implementations/java/provekit-realize-java-core/src/test/java/com/provekit/realize/RealizationFragmentContractTest.java
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.provekit.realize;
+
+import com.provekit.ir.Jcs;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RealizationFragmentContractTest {
+    @Test
+    public void jacksonFragmentExposesImportsAndDependenciesStructurally() throws Exception {
+        String response = invokeHandle("""
+            {"jsonrpc":"2.0","id":11,"method":"provekit.plugin.invoke","params":{
+              "function":"json_parse",
+              "source_function_name":"json_parse",
+              "params":["s"],
+              "param_types":["java.lang.String"],
+              "return_type":"JsonNode",
+              "concept_name":"concept:json-parse",
+              "target_library_tag":"jackson"
+            }}
+            """);
+
+        Jcs.Obj doc = assertInstanceOf(Jcs.Obj.class, Jcs.parse(response));
+        assertNull(doc.get("error"), "invoke must return a result, not error: " + response);
+        Jcs.Obj result = doc.objectField("result");
+
+        assertEquals("realization-fragment", result.stringField("kind"));
+        assertFalse(
+            result.stringField("source").contains("__fragment_imports__"),
+            "fragment metadata must be structured, not smuggled in body comments"
+        );
+
+        Jcs.Arr imports = result.arrayField("imports");
+        assertContains(imports, "com.fasterxml.jackson.databind.JsonNode");
+        assertContains(imports, "com.fasterxml.jackson.databind.ObjectMapper");
+        assertContains(imports, "com.fasterxml.jackson.core.JsonProcessingException");
+
+        Jcs.Arr helpers = result.arrayField("helpers");
+        assertContains(helpers, "static final ObjectMapper MAPPER = new ObjectMapper();");
+
+        Jcs.Arr dependencies = result.arrayField("dependencies");
+        assertContains(dependencies, "com.fasterxml.jackson.core:jackson-databind:2.17.2");
+        assertContains(dependencies, "com.fasterxml.jackson.core:jackson-core:2.17.2");
+        assertContains(dependencies, "com.fasterxml.jackson.core:jackson-annotations:2.17.2");
+
+        String assembleResponse = invokeHandle("{\"jsonrpc\":\"2.0\",\"id\":12,"
+            + "\"method\":\"provekit.plugin.assemble\",\"params\":{"
+            + "\"target_lang\":\"java\","
+            + "\"file_basename\":\"json_client\","
+            + "\"fragments\":[" + Jcs.encode(result) + "]}}");
+        Jcs.Obj assembleDoc = assertInstanceOf(Jcs.Obj.class, Jcs.parse(assembleResponse));
+        assertNull(assembleDoc.get("error"), "assemble must return a result, not error: " + assembleResponse);
+        Jcs.Obj assembleResult = assembleDoc.objectField("result");
+        Jcs.Arr files = assembleResult.arrayField("files");
+        Jcs.Obj file = assertInstanceOf(Jcs.Obj.class, files.values().get(0));
+        String content = file.stringField("content");
+        assertFalse(content.contains("__fragment_imports__"));
+        assertTrue(content.indexOf("import com.fasterxml.jackson.databind.ObjectMapper;") < content.indexOf("public final class JsonClient"));
+        assertTrue(content.indexOf("static final ObjectMapper MAPPER = new ObjectMapper();") < content.indexOf("public static JsonNode json_parse"));
+        assertContains(assembleResult.arrayField("dependencies"), "com.fasterxml.jackson.core:jackson-databind:2.17.2");
+    }
+
+    private static void assertContains(Jcs.Arr array, String expected) {
+        for (Jcs.Json value : array.values()) {
+            if (value instanceof Jcs.Str s && s.value().equals(expected)) {
+                return;
+            }
+        }
+        fail("expected array to contain `" + expected + "` but got " + Jcs.encode(array));
+    }
+
+    private static String invokeHandle(String jsonLine) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        PrintWriter writer = new PrintWriter(new OutputStreamWriter(bytes, StandardCharsets.UTF_8), true);
+        RpcServer server = new RpcServer();
+
+        Field outField = RpcServer.class.getDeclaredField("out");
+        outField.setAccessible(true);
+        outField.set(server, writer);
+
+        Method handle = RpcServer.class.getDeclaredMethod("handle", String.class);
+        handle.setAccessible(true);
+        handle.invoke(server, jsonLine);
+
+        writer.flush();
+        return bytes.toString(StandardCharsets.UTF_8).trim();
+    }
+}

--- a/implementations/rust/provekit-cli/src/cmd_materialize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_materialize.rs
@@ -557,9 +557,9 @@ pub struct MaterializeKit<'root> {
     project_root: &'root Path,
     /// Per-site realization fragments, collected during `transform_site`, so
     /// the `--out-dir` path can hand them to the LANGUAGE KIT's assemble RPC
-    /// (which owns imports/helper-hoisting/package/class-wrapping — the
-    /// substrate holds no language syntax). Each entry mirrors the cross-
-    /// language fragment shape `{concept_name, source, imports, helpers}`.
+    /// (which owns imports/helper-hoisting/package/class-wrapping/dependency
+    /// resolution; the substrate holds no language syntax). Each entry mirrors
+    /// the cross-language fragment shape and is transported opaquely.
     /// `Mutex` (not `RefCell`) because `SiteTransformKit: Send + Sync`.
     fragments: std::sync::Mutex<Vec<Json>>,
 }
@@ -691,8 +691,9 @@ impl SiteTransformKit for MaterializeKit<'_> {
         let binding_cid = realized.emitted_artifact_cid.clone().unwrap_or_default();
         // Collect the per-site fragment for the kit's assemble RPC. The kit's
         // assembler peels the wrapper class, dedupes imports, hoists helpers,
-        // and emits the package + compilation unit. The substrate does not
-        // assemble; it just forwards what the realize plugin produced.
+        // resolves package dependencies, and emits the package + compilation
+        // unit. The substrate does not assemble or interpret language/package
+        // semantics; it forwards what the realize plugin produced.
         self.fragments
             .lock()
             .expect("fragments mutex")
@@ -701,6 +702,9 @@ impl SiteTransformKit for MaterializeKit<'_> {
                 "source": realized.source.clone(),
                 "imports": realized.imports.clone(),
                 "helpers": realized.helpers.clone(),
+                "dependencies": realized.dependencies.clone(),
+                "diagnostics": realized.diagnostics.clone(),
+                "compile_unit_requirements": realized.compile_unit_requirements.clone(),
             }));
         if has_loss(&realized.observed_loss_record) {
             Ok(SiteOutcome::LoudlyLossy {


### PR DESCRIPTION
## Summary
- expose Java realization imports, helpers, and dependencies as structured fragment RPC metadata instead of marker comments in body text
- read Java dependency coordinates from project realize manifests and resolve exact Maven artifacts during Java kit assembly
- forward realization fragment context opaquely through materialize assemble RPC and sync lift/realize manifests in bcargo

Closes #1380.

## Test Plan
- mvn -q -f implementations/java/pom.xml -pl provekit-realize-java-core -Dtest=RealizationFragmentContractTest test
- mvn -f implementations/java/pom.xml -pl provekit-realize-java-core -Dtest=BodyTemplateWiringTest,JavaNullBoundaryRealizerTest,RpcServerDependencyProofsTest,RealizationFragmentContractTest test
- mvn -q -f implementations/java/pom.xml -pl provekit-realize-java-core test
- mvn -q -f implementations/java/pom.xml -pl provekit-realize-java-core -am package -DskipTests
- ./bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_materialize_proof_load materialize_json_client_jackson_loads_from_proof_and_compiles -- --nocapture (Rust compiled remotely; test self-skipped because Java shaded jar is not present on the remote scratch copy)
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Plugin manifests now declare explicit Maven dependencies for proper artifact resolution
  * Code generation pipeline now tracks and includes dependency metadata in realization outputs

* **Tests**
  * Added test coverage validating dependency metadata in generated code fragments

* **Chores**
  * Updated build and synchronization configurations for enhanced metadata handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->