### PR TITLE
fix(rust): lift test assertions as postconditions

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1914,6 +1914,7 @@ name = "provekit-realize-rust-core"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "proc-macro2",
  "provekit-canonicalizer",
  "provekit-ir-types",
  "provekit-proof-envelope",
@@ -1924,8 +1925,10 @@ dependencies = [
  "provekit-shim-rusqlite",
  "provekit-shim-serde-json-rust",
  "provekit-shim-stdio-rust",
+ "quote",
  "serde",
  "serde_json",
+ "syn",
 ]
 
 [[package]]

--- a/implementations/rust/provekit-lift-rust-tests/src/layer2.rs
+++ b/implementations/rust/provekit-lift-rust-tests/src/layer2.rs
@@ -80,7 +80,8 @@ use provekit_ir_symbolic::{
 
 use crate::{
     callsite_contract_name_pub, is_assertion_macro_pub, lift_assertion_macro_at_callsites_pub,
-    lift_assertion_macro_pub, path_to_string_pub, translate_term_pub, BoundCall, LiftWarning,
+    lift_assertion_macro_pub, lifted_assertion_contract_decl, path_to_string_pub,
+    translate_term_pub, BoundCall, LiftWarning,
 };
 use syn::spanned::Spanned;
 
@@ -416,15 +417,8 @@ fn classify_for_loop(
             body: body_formula,
         });
 
-        out.decls.push(ContractDecl {
-            name: part.name,
-            pre: None,
-            post: None,
-            inv: Some(quantified),
-            out_binding: "out".into(),
-            evidence: None,
-            concept_hint: None,
-        });
+        out.decls
+            .push(lifted_assertion_contract_decl(part.name, quantified));
         out.lifted += 1;
         out.bounded_loop_lifted += 1;
     }
@@ -598,15 +592,8 @@ fn classify_helper_inlining(
         };
         let inlined = subst_var_in_formula(&raw_formula, &helper.param_name, &arg_term);
 
-        out.decls.push(ContractDecl {
-            name: memento_name,
-            pre: None,
-            post: None,
-            inv: Some(inlined),
-            out_binding: "out".into(),
-            evidence: None,
-            concept_hint: None,
-        });
+        out.decls
+            .push(lifted_assertion_contract_decl(memento_name, inlined));
         out.lifted += 1;
         out.helper_inlined_lifted += 1;
     }
@@ -770,15 +757,8 @@ fn classify_characterization(
     }
 
     for part in parts {
-        out.decls.push(ContractDecl {
-            name: part.name,
-            pre: None,
-            post: None,
-            inv: Some(part.formula),
-            out_binding: "out".into(),
-            evidence: None,
-            concept_hint: None,
-        });
+        out.decls
+            .push(lifted_assertion_contract_decl(part.name, part.formula));
         out.lifted += 1;
         out.characterization_lifted += 1;
     }
@@ -827,6 +807,13 @@ mod tests {
         );
     }
 
+    fn postcondition_formula(decl: &ContractDecl) -> &Rc<Formula> {
+        assert!(decl.pre.is_none(), "Layer 2 tests do not synthesize pre");
+        assert!(decl.post.is_some(), "Layer 2 assertions must become post");
+        assert!(decl.inv.is_none(), "Layer 2 assertions must not use inv");
+        decl.post.as_ref().expect("post")
+    }
+
     #[test]
     fn pattern1_bounded_loop_lifts_to_forall_implies() {
         let src = r#"
@@ -843,8 +830,8 @@ mod tests {
         assert_eq!(out.bounded_loop_lifted, 1);
         assert!(out.claimed_tests.contains("squares_are_nonneg"));
         assert_callsite_name(&out.decls[0].name, "square");
-        let inv = out.decls[0].inv.as_ref().unwrap();
-        match &**inv {
+        let post = postcondition_formula(&out.decls[0]);
+        match &**post {
             Formula::Quantifier { kind, name, .. } => {
                 assert_eq!(kind, "forall");
                 assert_eq!(name, "x", "loop var name preserved for stable CID");
@@ -922,10 +909,10 @@ mod tests {
         let out = lift_file_layer2(&f, "t.rs");
         assert_eq!(out.lifted, 2, "warnings: {:?}", out.warnings);
         assert_eq!(out.helper_inlined_lifted, 2);
-        let names: Vec<_> = out.decls.iter().map(|d| d.name.as_str()).collect();
-        assert_eq!(names.len(), 2);
-        for name in names {
-            assert_callsite_name(name, "assert_palindrome");
+        assert_eq!(out.decls.len(), 2);
+        for decl in &out.decls {
+            assert_callsite_name(&decl.name, "assert_palindrome");
+            postcondition_formula(decl);
         }
     }
 
@@ -943,10 +930,10 @@ mod tests {
         let out = lift_file_layer2(&f, "t.rs");
         assert_eq!(out.lifted, 3, "warnings: {:?}", out.warnings);
         assert_eq!(out.characterization_lifted, 3);
-        let names: Vec<_> = out.decls.iter().map(|d| d.name.as_str()).collect();
-        assert_eq!(names.len(), 3);
-        for name in names {
-            assert_callsite_name(name, "f");
+        assert_eq!(out.decls.len(), 3);
+        for decl in &out.decls {
+            assert_callsite_name(&decl.name, "f");
+            postcondition_formula(decl);
         }
     }
 

--- a/implementations/rust/provekit-lift-rust-tests/src/lib.rs
+++ b/implementations/rust/provekit-lift-rust-tests/src/lib.rs
@@ -67,9 +67,10 @@
 //
 // Each lifted ContractDecl has:
 //   - name           = "<callee>@<file>:<line>:<col>"
-//   - inv            = the lifted atomic Formula (closed; no foralls)
-//   - pre/post       = None
-//   - out_binding    = "out" (unused; provided for ContractDecl shape parity)
+//   - post           = the lifted Formula (closed for point tests, quantified
+//                      for bounded-loop/property-style tests)
+//   - pre/inv        = None
+//   - out_binding    = "out"
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
@@ -185,6 +186,18 @@ pub struct AdapterOutput {
     pub seen: usize,
     /// Assertion macros successfully lifted to a ContractDecl.
     pub lifted: usize,
+}
+
+pub(crate) fn lifted_assertion_contract_decl(name: String, formula: Rc<Formula>) -> ContractDecl {
+    ContractDecl {
+        name,
+        pre: None,
+        post: Some(formula),
+        inv: None,
+        out_binding: "out".into(),
+        evidence: None,
+        concept_hint: None,
+    }
 }
 
 /// Walk a parsed `syn::File` for `#[test]` / `#[tokio::test]` functions
@@ -395,15 +408,8 @@ fn visit_test_fn(f: &syn::ItemFn, source_path: &str, out: &mut AdapterOutput) {
         match lift_assertion_macro_at_callsites(mac, source_path, &bindings) {
             Ok(parts) => {
                 for part in parts {
-                    out.decls.push(ContractDecl {
-                        name: part.name,
-                        pre: None,
-                        post: None,
-                        inv: Some(part.formula),
-                        out_binding: "out".into(),
-                        evidence: None,
-                        concept_hint: None,
-                    });
+                    out.decls
+                        .push(lifted_assertion_contract_decl(part.name, part.formula));
                     out.lifted += 1;
                 }
             }
@@ -453,15 +459,10 @@ fn visit_test_fn_with_evidence(
             Ok(parts) => {
                 for part in parts {
                     // Emit ContractDecl (same as the basic path).
-                    out.decls.push(ContractDecl {
-                        name: part.name.clone(),
-                        pre: None,
-                        post: None,
-                        inv: Some(part.formula.clone()),
-                        out_binding: "out".into(),
-                        evidence: None,
-                        concept_hint: None,
-                    });
+                    out.decls.push(lifted_assertion_contract_decl(
+                        part.name.clone(),
+                        part.formula.clone(),
+                    ));
                     out.lifted += 1;
 
                     // Also mint an EvidenceMemento.
@@ -1491,6 +1492,26 @@ mod tests {
         );
     }
 
+    fn assert_promoted_to_postcondition(decl: &ContractDecl) {
+        assert!(
+            decl.pre.is_none(),
+            "unit-test assertions should not synthesize a precondition"
+        );
+        assert!(
+            decl.post.is_some(),
+            "unit-test assertions must become postconditions"
+        );
+        assert!(
+            decl.inv.is_none(),
+            "unit-test assertions must not hide in inv and discharge vacuously"
+        );
+    }
+
+    fn postcondition_formula(decl: &ContractDecl) -> &Rc<Formula> {
+        assert_promoted_to_postcondition(decl);
+        decl.post.as_ref().expect("post")
+    }
+
     #[test]
     fn lifts_simple_assert_eq() {
         let src = r#"
@@ -1503,7 +1524,22 @@ mod tests {
         let out = lift_file(&f, "t.rs");
         assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
         assert_callsite_name(&out.decls[0].name, "parse_int");
-        assert!(out.decls[0].inv.is_some());
+        assert_promoted_to_postcondition(&out.decls[0]);
+    }
+
+    #[test]
+    fn lifts_simple_assert_eq_as_postcondition_not_invariant() {
+        let src = r#"
+            #[test]
+            fn parse_int_42() {
+                assert_eq!(parse_int("42"), 42);
+            }
+        "#;
+        let f = parse(src);
+        let out = lift_file(&f, "t.rs");
+        assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
+        assert_callsite_name(&out.decls[0].name, "parse_int");
+        assert_promoted_to_postcondition(&out.decls[0]);
     }
 
     #[test]
@@ -1552,8 +1588,8 @@ mod tests {
         let out = lift_file(&f, "t.rs");
         assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
         assert_callsite_name(&out.decls[0].name, "is_some");
-        let inv = out.decls[0].inv.as_ref().expect("inv");
-        match &**inv {
+        let post = postcondition_formula(&out.decls[0]);
+        match &**post {
             Formula::Atomic { name, args } if name == "=" && args.len() == 2 => match &*args[1] {
                 Term::Ctor { name, args } => {
                     assert_eq!(name, "True");
@@ -1577,8 +1613,8 @@ mod tests {
         let out = lift_file(&f, "t.rs");
         assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
         assert_callsite_name(&out.decls[0].name, "is_none");
-        let inv = out.decls[0].inv.as_ref().expect("inv");
-        match &**inv {
+        let post = postcondition_formula(&out.decls[0]);
+        match &**post {
             Formula::Atomic { name, args } if name == "=" && args.len() == 2 => match &*args[1] {
                 Term::Ctor { name, args } => {
                     assert_eq!(name, "False");
@@ -1603,8 +1639,8 @@ mod tests {
         let out = lift_file(&f, "t.rs");
         assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
         assert_callsite_name(&out.decls[0].name, "foo");
-        let inv = out.decls[0].inv.as_ref().expect("inv");
-        let lhs = match &**inv {
+        let post = postcondition_formula(&out.decls[0]);
+        let lhs = match &**post {
             Formula::Atomic { name, args } if name == "=" && args.len() == 2 => args[0].clone(),
             other => panic!("expected atomic =, got {other:?}"),
         };
@@ -1666,8 +1702,8 @@ mod tests {
         assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
         assert_callsite_name(&out.decls[0].name, "len");
         // Inspect the IR: the LHS should be Ctor("len", [str_const("foo")]).
-        let inv = out.decls[0].inv.as_ref().expect("inv");
-        let lhs = match &**inv {
+        let post = postcondition_formula(&out.decls[0]);
+        let lhs = match &**post {
             Formula::Atomic { name, args } if name == "=" && args.len() == 2 => args[0].clone(),
             other => panic!("expected atomic =, got {other:?}"),
         };
@@ -1702,8 +1738,8 @@ mod tests {
         let out = lift_file(&f, "t.rs");
         assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
         // Walk the structure.
-        let inv = out.decls[0].inv.as_ref().expect("inv");
-        let lhs = match &**inv {
+        let post = postcondition_formula(&out.decls[0]);
+        let lhs = match &**post {
             Formula::Atomic { name, args } if name == "=" && args.len() == 2 => args[0].clone(),
             other => panic!("expected atomic =, got {other:?}"),
         };


### PR DESCRIPTION
Closes #1593.

## Summary
- promote rust-tests lifted assertions into `post` instead of `inv`
- route Layer 0, evidence, bounded-loop, helper-inline, and characterization declarations through one contract-shape helper
- keep `pre` and `inv` empty so test evidence participates as substantive postconditions instead of vacuous invariants

## Verification
- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-lift-rust-tests lifts_simple_assert_eq_as_postcondition_not_invariant -- --nocapture`
- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-lift-rust-tests -- --nocapture`
- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_verify_rust_production_bridge rust_production_path_double_discharges_and_mints_witness -- --nocapture`
- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_verify_rust_production_bridge rust_production_path_refuses_planted_contradictory_implication -- --nocapture`
- `git diff --check`