### PR TITLE
feat(recognize): gate Go config-driven recognizer parity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -729,6 +729,9 @@ cross-language-proof-parity: build-java build-ts build-zig build-scala cross-lan
 		-Dtest=RecognizeHandlerTest,JavaSugarBindingLifterTest test
 	(cd implementations/go/provekit-lift-go && \
 		go test ./... -run 'Test(SugarBody|Recognize)')
+	cargo test --release --manifest-path implementations/rust/Cargo.toml \
+		-p provekit-cli --test cmd_recognize_go_parity \
+		go_recognize_write_self_resolves_project_proofs_and_proves -- --nocapture
 	$(PARITY_PYTHON) -m pytest \
 		implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py \
 		-q -k 'sugar_body or recognize'

--- a/examples/recognize-demo-go/.provekit/lift/rust-bind/manifest.toml
+++ b/examples/recognize-demo-go/.provekit/lift/rust-bind/manifest.toml
@@ -1,6 +1,0 @@
-# Compatibility alias for the current `provekit recognize` default surface.
-# The demo's real surface is go-bind; this lets the documented command run
-# without patching the CLI default in this PR.
-name = "go-bind-lift"
-command = ["go", "run", ".provekit/lift/go-bind/go-bind-rpc.go"]
-working_dir = "."

--- a/examples/recognize-demo-go/RESULT.md
+++ b/examples/recognize-demo-go/RESULT.md
@@ -74,19 +74,18 @@ ok: plugin `provekit-lift-go-verify` ready
 
 ## Recognizer pilot
 
-Current `provekit recognize` defaults to `rust-bind`. This demo includes a
-`rust-bind` manifest alias to the same Go wrapper so the requested command runs
-without changing the CLI default. The actual Go surface manifest is
-`.provekit/lift/go-bind/manifest.toml`.
+`provekit recognize` resolves the recognizer through project config and the
+surface manifest. The demo registers `go-bind` in `.provekit/config.toml` and
+the executable route lives at `.provekit/lift/go-bind/manifest.toml`; the CLI
+does not take or read shim proof paths.
 
 ```text
 $ provekit recognize \
     --project /Users/tsavo/provekit-demo-go/examples/recognize-demo-go \
     --source pkg/ingest/ingest.go \
-    --source pkg/persist/persist.go \
-    --binding /Users/tsavo/provekit-demo-go/examples/recognize-demo-go/internal-shim-stdlib-http/blake3-512:095398490c8c99e21c0db81e954681cd98094d38a2dc2b3f2bfbdb3bf2a85fc41e80534cdbad220878bea4c12cb993bfda918729a30ea7a43b45d8c830b3f075.proof
+    --source pkg/persist/persist.go
 
-dispatch: surface=`rust-bind` bindings=2 sources=2
+dispatch: surface=`go-bind` sources=2
 recognize: 2 tag(s) emitted
   [0] concept:http-get @ pkg/ingest/ingest.go:5 (fn=FetchURL, exact)
   [1] concept:sql-open @ pkg/persist/persist.go:9 (fn=OpenStore, exact)
@@ -108,10 +107,9 @@ $ provekit recognize \
     --target go \
     --project /Users/tsavo/provekit-demo-go/examples/recognize-demo-go \
     --source pkg/ingest/ingest.go \
-    --source pkg/persist/persist.go \
-    --binding /Users/tsavo/provekit-demo-go/examples/recognize-demo-go/internal-shim-stdlib-http/blake3-512:095398490c8c99e21c0db81e954681cd98094d38a2dc2b3f2bfbdb3bf2a85fc41e80534cdbad220878bea4c12cb993bfda918729a30ea7a43b45d8c830b3f075.proof
+    --source pkg/persist/persist.go
 
-dispatch: surface=`rust-bind` bindings=2 sources=2
+dispatch: surface=`go-bind` sources=2
 recognize: 2 tag(s) emitted
   [0] concept:http-get @ pkg/ingest/ingest.go:5 (fn=FetchURL, exact)
   [1] concept:sql-open @ pkg/persist/persist.go:9 (fn=OpenStore, exact)
@@ -122,9 +120,6 @@ The proof pool then discharges the two recognize callsites:
 
 ```text
 $ provekit prove /Users/tsavo/provekit-demo-go/examples/recognize-demo-go
-dependency proof resolver ["go", "run", ".provekit/lift/go-bind/go-bind-rpc.go"] does not implement provekit.plugin.resolve_dependency_proofs
-warning: bridge FetchURL has no targetProofCid; ConsequentBundlePinned not enforced (back-compat path)
-warning: bridge OpenStore has no targetProofCid; ConsequentBundlePinned not enforced (back-compat path)
 ProvekIt verifier report
   total callsites : 2
   discharged      : 2
@@ -137,6 +132,6 @@ ProvekIt verifier report
       reason: vacuous: no precondition on target (publisher post-only)
 ```
 
-The dependency-proof resolver warning is expected for this demo-local Go
-wrapper; the shim proof is supplied explicitly to `recognize`, and
-`recognize --write` emits the bridge/contract proof consumed by `prove`.
+The Go recognizer kit finds the demo-local shim proof from its own project
+semantics and returns tags over RPC. `recognize --write` emits the
+bridge/contract proof consumed by `prove`.

--- a/implementations/go/provekit-lift-go/recognize_proofs.go
+++ b/implementations/go/provekit-lift-go/recognize_proofs.go
@@ -146,6 +146,9 @@ func resolveDependencyProofPaths(projectRoot string) ([]string, error) {
 	}
 
 	proofs := map[string]struct{}{}
+	if err := collectProjectProofPaths(absRoot, proofs); err != nil {
+		return nil, err
+	}
 	decoder := json.NewDecoder(bytes.NewReader(output))
 	for {
 		var module listedGoModule
@@ -176,6 +179,64 @@ func resolveDependencyProofPaths(projectRoot string) ([]string, error) {
 	}
 	sort.Strings(paths)
 	return paths, nil
+}
+
+func collectProjectProofPaths(root string, proofs map[string]struct{}) error {
+	info, err := os.Stat(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return nil
+	}
+	return filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if shouldSkipProjectProofDir(root, path, entry.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !dependencyProofName.MatchString(entry.Name()) {
+			return nil
+		}
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+		proofs[filepath.Clean(abs)] = struct{}{}
+		return nil
+	})
+}
+
+func shouldSkipProjectProofDir(root, path, name string) bool {
+	if path == root {
+		return false
+	}
+	switch name {
+	case ".git", "node_modules", "target", "vendor":
+		return true
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	rel = filepath.ToSlash(filepath.Clean(rel))
+	switch rel {
+	case ".provekit/materialize",
+		".provekit/proof-runs",
+		".provekit/recognize",
+		".provekit/self-contracts-attestations",
+		".provekit/witnesses":
+		return true
+	default:
+		return false
+	}
 }
 
 func effectiveModuleDir(module listedGoModule) string {

--- a/implementations/rust/provekit-cli/src/cmd_recognize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_recognize.rs
@@ -30,6 +30,7 @@ use provekit_proof_envelope::{
 };
 use serde_json::{json, Value};
 
+use crate::project_config::{read_project_config, read_user_config, PluginEntry, ProjectConfig};
 use crate::{OutputFlags, EXIT_OK, EXIT_USER_ERROR, EXIT_VERIFY_FAIL};
 
 // Distinct signer seed for recognize-emitted bridges. Different from
@@ -50,8 +51,7 @@ pub struct RecognizeArgs {
     /// Repeatable. e.g. `--source src/lib.rs --source src/ingest.rs`.
     #[arg(long = "source")]
     pub source_paths: Vec<String>,
-    /// Lift surface name (default `rust-bind`). Resolves to
-    /// `<project>/.provekit/lift/<surface>/manifest.toml`.
+    /// Lift surface name. If omitted, resolves from project/user config.
     #[arg(long)]
     pub surface: Option<String>,
     /// Mint bridge mementos from recognize tags into the project's
@@ -84,10 +84,13 @@ pub fn run(args: RecognizeArgs) -> u8 {
         }
     };
 
-    let surface = args
-        .surface
-        .clone()
-        .unwrap_or_else(|| "rust-bind".to_string());
+    let surface = match resolve_recognize_surface(args.surface.as_deref(), &project_root) {
+        Ok(surface) => surface,
+        Err(e) => {
+            eprintln!("{}: {e}", "error".red().bold());
+            return EXIT_USER_ERROR;
+        }
+    };
     let manifest = match find_plugin_manifest(&project_root, &surface) {
         Ok(m) => m,
         Err(e) => {
@@ -220,6 +223,81 @@ pub fn run(args: RecognizeArgs) -> u8 {
     }
 
     EXIT_OK
+}
+
+fn resolve_recognize_surface(
+    explicit: Option<&str>,
+    project_root: &Path,
+) -> Result<String, String> {
+    if let Some(surface) = explicit
+        .map(str::trim)
+        .filter(|surface| !surface.is_empty())
+    {
+        return Ok(surface.to_string());
+    }
+
+    let project_cfg = read_project_config(project_root);
+    let user_cfg = read_user_config();
+
+    if let Some(surface) = project_cfg
+        .surface_recognize
+        .clone()
+        .or_else(|| user_cfg.surface_recognize.clone())
+    {
+        return Ok(surface);
+    }
+
+    if let Some(surface) = configured_recognize_surface("project", &project_cfg)? {
+        return Ok(surface);
+    }
+    if let Some(surface) = configured_recognize_surface("user", &user_cfg)? {
+        return Ok(surface);
+    }
+
+    if let Some(surface) = project_cfg
+        .surface_default
+        .clone()
+        .or_else(|| user_cfg.surface_default.clone())
+    {
+        return Ok(surface);
+    }
+
+    Err("no recognize surface configured. Set [authoring.recognize] surface, declare exactly one recognizer [[plugins]] entry with layer = \"library-bindings\", or pass --surface.".to_string())
+}
+
+fn configured_recognize_surface(
+    source: &str,
+    cfg: &ProjectConfig,
+) -> Result<Option<String>, String> {
+    let surfaces = cfg
+        .plugins
+        .iter()
+        .filter(|plugin| plugin_is_recognizer(plugin))
+        .map(|plugin| plugin.surface.trim().to_string())
+        .filter(|surface| !surface.is_empty())
+        .collect::<Vec<_>>();
+    match surfaces.as_slice() {
+        [] => Ok(None),
+        [surface] => Ok(Some(surface.clone())),
+        _ => Err(format!(
+            "multiple {source} recognizer surfaces configured: {}. Pass --surface or set [authoring.recognize] surface.",
+            surfaces.join(", ")
+        )),
+    }
+}
+
+fn plugin_is_recognizer(plugin: &PluginEntry) -> bool {
+    if plugin
+        .kind
+        .as_deref()
+        .is_some_and(|kind| kind.eq_ignore_ascii_case("recognize"))
+    {
+        return true;
+    }
+    plugin.is_lift_plugin()
+        && plugin.layer.as_deref().is_some_and(|layer| {
+            layer.eq_ignore_ascii_case("library-bindings") || layer.eq_ignore_ascii_case("all")
+        })
 }
 
 // recognize_bridge_body was removed (#1579). The single-target form is

--- a/implementations/rust/provekit-cli/src/project_config.rs
+++ b/implementations/rust/provekit-cli/src/project_config.rs
@@ -4,8 +4,9 @@
 // materialization routing.
 //
 // ProvekIt does not auto-detect the authoring surface. Projects and
-// users can set a default `[authoring] surface = ...`, and lift can
-// override it with `[authoring.lift] surface = ...`.
+// users can set a default `[authoring] surface = ...`, and commands can
+// override it with sections such as `[authoring.lift] surface = ...` or
+// `[authoring.recognize] surface = ...`.
 //
 // Same shape as `.npmrc` / `.cargo/config.toml`: declarative files
 // at known paths. The user is in charge.
@@ -128,6 +129,7 @@ pub struct ProjectConfig {
 
     pub surface_default: Option<String>,
     pub surface_lift: Option<String>,
+    pub surface_recognize: Option<String>,
 
     /// Solver configuration. v1 captures the shape; the verifier
     /// itself still runs Z3 only. Future work routes through this.
@@ -154,6 +156,7 @@ impl ProjectConfig {
     pub fn surface_for(&self, cmd: &str) -> Option<String> {
         let per_cmd = match cmd {
             "lift" => self.surface_lift.clone(),
+            "recognize" => self.surface_recognize.clone(),
             _ => None,
         };
         per_cmd.or_else(|| self.surface_default.clone())
@@ -267,6 +270,7 @@ fn parse_config(text: &str) -> ProjectConfig {
         match (section.as_deref(), key) {
             (Some("authoring"), "surface") => cfg.surface_default = Some(val),
             (Some("authoring.lift"), "surface") => cfg.surface_lift = Some(val),
+            (Some("authoring.recognize"), "surface") => cfg.surface_recognize = Some(val),
             (Some("solvers"), "default") => cfg.solver_default = Some(val),
             (Some("solvers"), "chain") => {
                 cfg.solver_chain = parse_string_array(&val);
@@ -496,6 +500,15 @@ family = "concept:family:hash"
     fn lift_surface_overrides_default() {
         let cfg =
             parse_config("[authoring]\nsurface = \"ts-zod\"\n[authoring.lift]\nsurface = \"rust\"");
+        assert_eq!(cfg.surface_for("lift").as_deref(), Some("rust"));
+    }
+
+    #[test]
+    fn recognize_surface_overrides_default() {
+        let cfg = parse_config(
+            "[authoring]\nsurface = \"rust\"\n[authoring.recognize]\nsurface = \"go-bind\"",
+        );
+        assert_eq!(cfg.surface_for("recognize").as_deref(), Some("go-bind"));
         assert_eq!(cfg.surface_for("lift").as_deref(), Some("rust"));
     }
 

--- a/implementations/rust/provekit-cli/tests/cmd_recognize_go_parity.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_recognize_go_parity.rs
@@ -1,0 +1,139 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap_or_else(|_| panic!("mkdir {}", dst.display()));
+    for entry in fs::read_dir(src).unwrap_or_else(|_| panic!("read {}", src.display())) {
+        let entry = entry.expect("read dir entry");
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type().expect("entry file type").is_dir() {
+            copy_dir_recursive(&src_path, &dst_path);
+        } else {
+            fs::copy(&src_path, &dst_path).unwrap_or_else(|_| {
+                panic!("copy {} -> {}", src_path.display(), dst_path.display())
+            });
+        }
+    }
+}
+
+fn write_direct_go_recognizer_manifest(project: &Path) {
+    let manifest = project.join(".provekit/lift/go-bind/manifest.toml");
+    fs::create_dir_all(manifest.parent().unwrap()).expect("mkdir go-bind manifest dir");
+    let working_dir = repo_root()
+        .join("implementations")
+        .join("go")
+        .join("provekit-lift-go");
+    fs::write(
+        manifest,
+        format!(
+            "name = \"go-bind-lift\"\ncommand = [\"go\", \"run\", \"./cmd/provekit-lift-go\", \"--rpc\"]\nworking_dir = \"{}\"\n",
+            working_dir.display()
+        ),
+    )
+    .expect("write go-bind manifest");
+}
+
+fn copy_go_recognizer_demo() -> tempfile::TempDir {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("project");
+    copy_dir_recursive(
+        &repo_root().join("examples").join("recognize-demo-go"),
+        &project,
+    );
+    let _ = fs::remove_dir_all(project.join(".provekit/recognize"));
+    write_direct_go_recognizer_manifest(&project);
+    temp
+}
+
+#[test]
+fn go_recognize_write_self_resolves_project_proofs_and_proves() {
+    if !go_available() {
+        eprintln!("skipping Go recognizer parity test: go toolchain unavailable");
+        return;
+    }
+
+    let temp = copy_go_recognizer_demo();
+    let project = temp.path().join("project");
+
+    let recognize = Command::new(provekit_bin())
+        .arg("recognize")
+        .arg("--target")
+        .arg("go")
+        .arg("--project")
+        .arg(&project)
+        .arg("--source")
+        .arg("pkg/ingest/ingest.go")
+        .arg("--source")
+        .arg("pkg/persist/persist.go")
+        .arg("--write")
+        .arg("--json")
+        .output()
+        .expect("spawn provekit recognize");
+
+    let stdout = String::from_utf8_lossy(&recognize.stdout);
+    let stderr = String::from_utf8_lossy(&recognize.stderr);
+    assert!(
+        recognize.status.success(),
+        "recognize failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let receipt: serde_json::Value =
+        serde_json::from_str(&stdout).expect("recognize JSON receipt parses");
+    let tags = receipt["tags"]
+        .as_array()
+        .expect("recognize receipt has tags array");
+    assert_eq!(
+        tags.len(),
+        2,
+        "Go recognizer must resolve from project config, self-resolve the demo-local shim proof, and tag both user callsites without CLI proof paths\nreceipt:\n{receipt:#}"
+    );
+    let bridge_proof = receipt["bridge_proof"]
+        .as_str()
+        .expect("recognize --write must mint a bridge proof");
+    assert!(
+        Path::new(bridge_proof).is_file(),
+        "recognize bridge proof path should exist: {bridge_proof}"
+    );
+
+    let prove = Command::new(provekit_bin())
+        .arg("prove")
+        .arg(&project)
+        .arg("--json")
+        .output()
+        .expect("spawn provekit prove");
+    let prove_stdout = String::from_utf8_lossy(&prove.stdout);
+    let prove_stderr = String::from_utf8_lossy(&prove.stderr);
+    assert!(
+        prove.status.success(),
+        "prove should consume the recognize bridge proof\nstdout:\n{prove_stdout}\nstderr:\n{prove_stderr}"
+    );
+    let report: serde_json::Value =
+        serde_json::from_str(&prove_stdout).expect("prove JSON report parses");
+    assert_eq!(report["totalCallsites"].as_u64(), Some(2), "{report:#}");
+    assert_eq!(report["discharged"].as_u64(), Some(2), "{report:#}");
+    assert_eq!(report["violations"].as_u64(), Some(0), "{report:#}");
+}

--- a/implementations/rust/provekit-cli/tests/cmd_recognize_no_proof_paths.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_recognize_no_proof_paths.rs
@@ -13,6 +13,15 @@ fn write_fake_recognizer_project(project: &Path) -> PathBuf {
 
     let manifest_dir = project.join(".provekit/lift/no-proof-reader");
     fs::create_dir_all(&manifest_dir).expect("create manifest dir");
+    fs::write(
+        project.join(".provekit/config.toml"),
+        r#"[[plugins]]
+name = "no-proof-reader"
+surface = "no-proof-reader"
+layer = "library-bindings"
+"#,
+    )
+    .expect("write project config");
 
     let plugin = project.join("fake_recognizer.py");
     fs::write(
@@ -49,6 +58,33 @@ print(json.dumps({
     .expect("write manifest");
 
     captured_request
+}
+
+#[test]
+fn recognize_without_surface_uses_configured_recognizer_plugin() {
+    let project = tempfile::tempdir().expect("tempdir");
+    let captured_request = write_fake_recognizer_project(project.path());
+
+    let output = Command::new(provekit_bin())
+        .arg("recognize")
+        .arg("--project")
+        .arg(project.path())
+        .arg("--source")
+        .arg("src/lib.rs")
+        .arg("--json")
+        .output()
+        .expect("spawn provekit recognize");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "recognize should dispatch through the configured recognizer plugin, not a built-in surface\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        captured_request.is_file(),
+        "configured recognizer plugin should have received the RPC request"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- removes the built-in `rust-bind` fallback from `provekit recognize`; omitted `--surface` now resolves from project/user config or a single recognizer `[[plugins]]` entry
- makes the Go recognizer kit self-resolve project-local sugar proof envelopes before dependency module proofs
- adds a CLI integration gate for Go: config-driven `recognize --write` over RPC, then `prove --json` consumes the minted recognize bridge
- removes the Go demo `rust-bind` compatibility alias and updates the result notes to the config/manifest/RPC route

This advances #1639 for the Go recognizer CLI route. It does not close #1639 because the remaining per-kit and nonvacuous gaps are now tracked separately: #1697, #1698, #1699, #1700, #1701.

## Verification

- RED before fix: `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_recognize_no_proof_paths recognize_without_surface_uses_configured_recognizer_plugin -- --nocapture` failed on hardcoded `rust-bind`
- `cargo test --locked --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_recognize_no_proof_paths -- --nocapture`
- `cargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_recognize_go_parity go_recognize_write_self_resolves_project_proofs_and_proves -- --nocapture`
- `go test -count=1 ./... -run 'Test(SugarBody|Recognize)'` from `implementations/go/provekit-lift-go`
- `rustfmt --edition 2021 --check implementations/rust/provekit-cli/src/cmd_recognize.rs implementations/rust/provekit-cli/src/project_config.rs implementations/rust/provekit-cli/tests/cmd_recognize_no_proof_paths.rs implementations/rust/provekit-cli/tests/cmd_recognize_go_parity.rs`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Go recognizer now auto-discovers project-local proofs without requiring explicit binding configuration
  * Recognize command surface selection now configuration-driven, supporting project-specific overrides

* **Tests**
  * Added integration tests verifying Go recognizer self-resolution and parity behavior
  * Added tests for configured recognizer plugin selection via project configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->