### PR TITLE
Fix Go recognizer nonvacuous target obligations

### DIFF
--- a/implementations/go/provekit-lift-go/recognize.go
+++ b/implementations/go/provekit-lift-go/recognize.go
@@ -19,13 +19,14 @@ type RecognizeParams struct {
 }
 
 type BindingTemplate struct {
-	ConceptName string          `json:"concept_name"`
-	LibraryTag  string          `json:"library_tag"`
-	Family      any             `json:"family"`
-	ASTTemplate json.RawMessage `json:"ast_template"`
-	TemplateCID string          `json:"template_cid"`
-	ParamNames  []string        `json:"param_names"`
-	ContractCID string          `json:"contract_cid"`
+	ConceptName    string          `json:"concept_name"`
+	LibraryTag     string          `json:"library_tag"`
+	Family         any             `json:"family"`
+	ASTTemplate    json.RawMessage `json:"ast_template"`
+	TemplateCID    string          `json:"template_cid"`
+	ParamNames     []string        `json:"param_names"`
+	ContractCID    string          `json:"contract_cid"`
+	TargetProofCID string          `json:"target_proof_cid"`
 }
 
 type RecognizeResponse struct {
@@ -33,16 +34,17 @@ type RecognizeResponse struct {
 }
 
 type RecognizeTag struct {
-	File          string         `json:"file"`
-	Span          SourceSpan     `json:"span"`
-	FunctionName  string         `json:"function_name"`
-	ConceptName   string         `json:"concept_name"`
-	LibraryTag    string         `json:"library_tag"`
-	Family        any            `json:"family"`
-	TemplateCID   string         `json:"template_cid"`
-	ContractCID   string         `json:"contract_cid"`
-	MatchTier     string         `json:"match_tier"`
-	ParamBindings []ParamBinding `json:"param_bindings"`
+	File           string         `json:"file"`
+	Span           SourceSpan     `json:"span"`
+	FunctionName   string         `json:"function_name"`
+	ConceptName    string         `json:"concept_name"`
+	LibraryTag     string         `json:"library_tag"`
+	Family         any            `json:"family"`
+	TemplateCID    string         `json:"template_cid"`
+	ContractCID    string         `json:"contract_cid"`
+	TargetProofCID string         `json:"target_proof_cid"`
+	MatchTier      string         `json:"match_tier"`
+	ParamBindings  []ParamBinding `json:"param_bindings"`
 }
 
 type ParamBinding struct {
@@ -138,15 +140,16 @@ func recognizeFunc(fset *token.FileSet, relPath string, fn *ast.FuncDecl, bindin
 		})
 	}
 	return RecognizeTag{
-		File:          relPath,
-		Span:          funcSpan(fset, fn),
-		FunctionName:  fn.Name.Name,
-		ConceptName:   binding.ConceptName,
-		LibraryTag:    binding.LibraryTag,
-		Family:        binding.Family,
-		TemplateCID:   templateCID,
-		ContractCID:   binding.ContractCID,
-		MatchTier:     "exact",
-		ParamBindings: paramBindings,
+		File:           relPath,
+		Span:           funcSpan(fset, fn),
+		FunctionName:   fn.Name.Name,
+		ConceptName:    binding.ConceptName,
+		LibraryTag:     binding.LibraryTag,
+		Family:         binding.Family,
+		TemplateCID:    templateCID,
+		ContractCID:    binding.ContractCID,
+		TargetProofCID: binding.TargetProofCID,
+		MatchTier:      "exact",
+		ParamBindings:  paramBindings,
 	}, true, nil
 }

--- a/implementations/go/provekit-lift-go/recognize_proofs.go
+++ b/implementations/go/provekit-lift-go/recognize_proofs.go
@@ -45,6 +45,7 @@ func bindingTemplatesFromProof(path string) ([]BindingTemplate, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read Go shim proof %s: %w", path, err)
 	}
+	proofCID := canonicalizer.ComputeCID(bytes)
 	catalog, err := proof_envelope.NewCBORDecoder(bytes).DecodeCatalog()
 	if err != nil {
 		return nil, fmt.Errorf("decode Go shim proof %s: %w", path, err)
@@ -67,7 +68,7 @@ func bindingTemplatesFromProof(path string) ([]BindingTemplate, error) {
 		if rawBody, ok := parsed["body"].(map[string]any); ok {
 			body = rawBody
 		}
-		binding, ok := bindingTemplateFromSugarEntry(body)
+		binding, ok := bindingTemplateFromSugarEntry(body, proofCID)
 		if ok {
 			bindings = append(bindings, binding)
 		}
@@ -75,7 +76,7 @@ func bindingTemplatesFromProof(path string) ([]BindingTemplate, error) {
 	return bindings, nil
 }
 
-func bindingTemplateFromSugarEntry(entry map[string]any) (BindingTemplate, bool) {
+func bindingTemplateFromSugarEntry(entry map[string]any, proofCID string) (BindingTemplate, bool) {
 	if entry["kind"] != "library-sugar-binding-entry" {
 		return BindingTemplate{}, false
 	}
@@ -103,13 +104,14 @@ func bindingTemplateFromSugarEntry(entry map[string]any) (BindingTemplate, bool)
 	}
 	contractCID, _ := entry["contract_cid"].(string)
 	return BindingTemplate{
-		ConceptName: conceptName,
-		LibraryTag:  libraryTag,
-		Family:      entry["family"],
-		ASTTemplate: json.RawMessage(templateBytes),
-		TemplateCID: templateCID,
-		ParamNames:  paramNames,
-		ContractCID: contractCID,
+		ConceptName:    conceptName,
+		LibraryTag:     libraryTag,
+		Family:         entry["family"],
+		ASTTemplate:    json.RawMessage(templateBytes),
+		TemplateCID:    templateCID,
+		ParamNames:     paramNames,
+		ContractCID:    contractCID,
+		TargetProofCID: proofCID,
 	}, true
 }
 

--- a/implementations/go/provekit-lift-go/recognize_test.go
+++ b/implementations/go/provekit-lift-go/recognize_test.go
@@ -256,6 +256,9 @@ func FetchURL(u string, h Header) Response {
 			if tag["template_cid"] != binding.TemplateCID || tag["contract_cid"] != binding.ContractCID {
 				t.Fatalf("tag cids = %#v", tag)
 			}
+			if tag["target_proof_cid"] == "" {
+				t.Fatalf("tag must carry target_proof_cid for bridge pinning: %#v", tag)
+			}
 			if tag["match_tier"] != "exact" {
 				t.Fatalf("match_tier = %#v", tag["match_tier"])
 			}

--- a/implementations/rust/provekit-cli/src/cmd_recognize.rs
+++ b/implementations/rust/provekit-cli/src/cmd_recognize.rs
@@ -356,9 +356,9 @@ fn recognize_implication_body(tag: &Value) -> Option<Value> {
 ///     to a contract memento and composes pre/post.
 ///
 /// Bridge target resolution order:
-///   1. The tag's contract_cid if it cites a contract that exists in
-///      a kit-resolved proof source. This is the production linkage when shims
-///      mint contracts covering their sugar functions.
+///   1. The tag's contract_cid + target_proof_cid if it cites a contract that
+///      exists in a kit-resolved proof source. This is the production linkage
+///      when shims mint contracts covering their sugar functions.
 ///   2. Fallback to the recognize-emitted SIBLING contract (the one
 ///      this same call just minted). Self-resolution keeps the loop
 ///      closed even when the shim mints no contract for that function —
@@ -394,24 +394,36 @@ fn emit_bridge_envelope(
     // Second pass: mint the bridge memento for each tag with
     // targetContractCid resolved against the production binding's
     // contract_cid first (shim-minted contracts), falling back to the
-    // sibling recognize-emitted contract from pass 1.
+    // sibling recognize-emitted contract from pass 1. When a kit supplies a
+    // target_proof_cid, carry it into the bridge as targetProofCid; the kit
+    // owns proof/package resolution, the CLI only copies normalized RPC data
+    // into the language-neutral bridge.
     for tag in tags {
         let function_name = match tag.get("function_name").and_then(|v| v.as_str()) {
             Some(s) if !s.is_empty() => s,
             _ => continue,
         };
         // Resolve target: shim/library contract_cid when the kit supplied one;
-        // otherwise the sibling contract minted by this recognize run.
-        let target_cid = tag
+        // otherwise the sibling contract minted by this recognize run. The
+        // targetProofCid pin is valid only for the kit-supplied contract;
+        // sibling fallback is self-pinned by same-bundle co-membership.
+        let tag_contract_cid = tag
             .get("contract_cid")
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
-            .map(|s| s.to_string())
-            .or_else(|| sibling_contract_by_function.get(function_name).cloned());
+            .map(|s| s.to_string());
+        let target_proof_cid = tag_contract_cid.as_ref().and_then(|_| {
+            tag.get("target_proof_cid")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+        });
+        let target_cid =
+            tag_contract_cid.or_else(|| sibling_contract_by_function.get(function_name).cloned());
         let Some(target_cid) = target_cid else {
             continue;
         };
-        let body = recognize_bridge_body_with_target(tag, target_language, &target_cid);
+        let body =
+            recognize_bridge_body_with_target(tag, target_language, &target_cid, target_proof_cid);
         let (cid, bytes) = member_envelope_canonical("bridge", &body)?;
         members.entry(cid).or_insert(bytes);
     }
@@ -444,6 +456,7 @@ fn recognize_bridge_body_with_target(
     tag: &Value,
     target_language: &str,
     target_cid: &str,
+    target_proof_cid: Option<&str>,
 ) -> Value {
     let function_name = tag
         .get("function_name")
@@ -453,13 +466,22 @@ fn recognize_bridge_body_with_target(
         .get("library_tag")
         .and_then(|v| v.as_str())
         .unwrap_or(target_language);
-    build_bridge_body(
+    let mut body = build_bridge_body(
         "recognize",
         function_name,
         target_language,
         library_tag,
         target_cid,
-    )
+    );
+    if let Some(target_proof_cid) = target_proof_cid {
+        if let Value::Object(map) = &mut body {
+            map.insert(
+                "targetProofCid".to_string(),
+                Value::String(target_proof_cid.to_string()),
+            );
+        }
+    }
+    body
 }
 
 // flat_member_canonical + canonical_value_of_json were moved to

--- a/implementations/rust/provekit-cli/tests/cmd_recognize_go_parity.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_recognize_go_parity.rs
@@ -1,6 +1,14 @@
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+
+use provekit_canonicalizer::{blake3_512_of, encode_jcs};
+use provekit_proof_envelope::{
+    build_proof_envelope, cbor_decode, ed25519_pubkey_string, CborValue, Ed25519Seed,
+    ProofEnvelopeInput,
+};
+use serde_json::{json, Value as Json};
 
 fn provekit_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
@@ -70,22 +78,156 @@ fn copy_go_recognizer_demo() -> tempfile::TempDir {
     temp
 }
 
-#[test]
-fn go_recognize_write_self_resolves_project_proofs_and_proves() {
-    if !go_available() {
-        eprintln!("skipping Go recognizer parity test: go toolchain unavailable");
-        return;
+fn int_sort() -> Json {
+    json!({"kind": "primitive", "name": "Int"})
+}
+
+fn var(name: &str) -> Json {
+    json!({"kind": "var", "name": name})
+}
+
+fn json_to_canonical_jcs(j: &Json) -> String {
+    fn to_cv(j: &Json) -> std::sync::Arc<provekit_canonicalizer::Value> {
+        use provekit_canonicalizer::Value as CV;
+        match j {
+            Json::Null => CV::null(),
+            Json::Bool(b) => CV::boolean(*b),
+            Json::Number(n) => CV::integer(n.as_i64().unwrap_or(0)),
+            Json::String(s) => CV::string(s.clone()),
+            Json::Array(items) => CV::array(items.iter().map(to_cv).collect()),
+            Json::Object(map) => CV::object(
+                map.iter()
+                    .map(|(k, v)| (k.clone(), to_cv(v)))
+                    .collect::<Vec<_>>(),
+            ),
+        }
+    }
+    encode_jcs(&to_cv(j))
+}
+
+fn canonical_member(env: &Json) -> (String, Vec<u8>) {
+    let canonical = json_to_canonical_jcs(env);
+    let cid = blake3_512_of(canonical.as_bytes());
+    (cid, canonical.into_bytes())
+}
+
+fn target_contract_body(source_function_name: &str, predicate: &str) -> Json {
+    json!({
+        "contractName": format!("recognize-target:{source_function_name}"),
+        "formals": ["value"],
+        "formalSorts": [int_sort()],
+        "pre": {
+            "kind": "atomic",
+            "name": predicate,
+            "args": [var("value"), var("value")]
+        }
+    })
+}
+
+fn proof_members(bytes: &[u8]) -> BTreeMap<String, Vec<u8>> {
+    let catalog = cbor_decode(bytes).expect("decode fixture proof cbor");
+    let members = catalog
+        .as_map()
+        .and_then(|m| m.get("members"))
+        .and_then(CborValue::as_map)
+        .expect("fixture proof has members map");
+    members
+        .iter()
+        .map(|(cid, value)| {
+            (
+                cid.clone(),
+                value
+                    .as_bstr()
+                    .unwrap_or_else(|| panic!("member {cid} is bstr"))
+                    .to_vec(),
+            )
+        })
+        .collect()
+}
+
+fn write_go_shim_proof_with_target_contracts(project: &Path, predicate: &str) -> String {
+    let shim_dir = project.join("internal-shim-stdlib-http");
+    let proof_paths = fs::read_dir(&shim_dir)
+        .unwrap_or_else(|_| panic!("read {}", shim_dir.display()))
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|s| s.to_str()) == Some("proof"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        proof_paths.len(),
+        1,
+        "fixture should start with exactly one local shim proof: {proof_paths:?}"
+    );
+
+    let original = fs::read(&proof_paths[0]).expect("read original shim proof");
+    let mut members = BTreeMap::new();
+    let mut rewritten_bindings = 0usize;
+    for (cid, member_bytes) in proof_members(&original) {
+        let mut member: Json = serde_json::from_slice(&member_bytes)
+            .unwrap_or_else(|_| panic!("member {cid} is JSON"));
+        let is_sugar_binding = member.pointer("/body/kind").and_then(Json::as_str)
+            == Some("library-sugar-binding-entry");
+        if !is_sugar_binding {
+            members.insert(cid, member_bytes);
+            continue;
+        }
+
+        let source_function_name = member
+            .pointer("/body/source_function_name")
+            .and_then(Json::as_str)
+            .unwrap_or("recognized");
+        let target_contract = json!({
+            "evidence": {
+                "kind": "contract",
+                "body": target_contract_body(source_function_name, predicate),
+            }
+        });
+        let (target_cid, target_bytes) = canonical_member(&target_contract);
+        member["body"]["contract_cid"] = json!(target_cid.clone());
+        let (binding_cid, binding_bytes) = canonical_member(&member);
+        members.insert(target_cid, target_bytes);
+        members.insert(binding_cid, binding_bytes);
+        rewritten_bindings += 1;
+    }
+    assert_eq!(
+        rewritten_bindings, 2,
+        "fixture should contain two sugar bindings to pin"
+    );
+
+    for path in proof_paths {
+        fs::remove_file(&path).unwrap_or_else(|_| panic!("remove {}", path.display()));
     }
 
+    let signer_seed: Ed25519Seed = [0x67; 32];
+    let proof = build_proof_envelope(&ProofEnvelopeInput {
+        name: "@test/go-recognize-nonvacuous-shim".to_string(),
+        version: "0.1.0".into(),
+        binary_cid: None,
+        metadata: None,
+        members,
+        signer_cid: ed25519_pubkey_string(&signer_seed),
+        signer_seed,
+        declared_at: "2026-05-30T00:00:00.000Z".into(),
+    });
+    let path = shim_dir.join(format!("{}.proof", proof.cid));
+    fs::write(&path, &proof.bytes).unwrap_or_else(|_| panic!("write {}", path.display()));
+    proof.cid
+}
+
+fn copy_go_recognizer_demo_with_target_contracts(predicate: &str) -> (tempfile::TempDir, String) {
     let temp = copy_go_recognizer_demo();
     let project = temp.path().join("project");
+    let target_proof_cid = write_go_shim_proof_with_target_contracts(&project, predicate);
+    (temp, target_proof_cid)
+}
 
+fn run_recognize_write(project: &Path) -> Json {
     let recognize = Command::new(provekit_bin())
         .arg("recognize")
         .arg("--target")
         .arg("go")
         .arg("--project")
-        .arg(&project)
+        .arg(project)
         .arg("--source")
         .arg("pkg/ingest/ingest.go")
         .arg("--source")
@@ -101,8 +243,10 @@ fn go_recognize_write_self_resolves_project_proofs_and_proves() {
         recognize.status.success(),
         "recognize failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
-    let receipt: serde_json::Value =
-        serde_json::from_str(&stdout).expect("recognize JSON receipt parses");
+    serde_json::from_str(&stdout).expect("recognize JSON receipt parses")
+}
+
+fn assert_recognize_receipt_pinned(receipt: &Json, expected_target_proof_cid: &str) {
     let tags = receipt["tags"]
         .as_array()
         .expect("recognize receipt has tags array");
@@ -111,6 +255,17 @@ fn go_recognize_write_self_resolves_project_proofs_and_proves() {
         2,
         "Go recognizer must resolve from project config, self-resolve the demo-local shim proof, and tag both user callsites without CLI proof paths\nreceipt:\n{receipt:#}"
     );
+    for tag in tags {
+        assert!(
+            tag["contract_cid"].as_str().is_some_and(|s| !s.is_empty()),
+            "recognizer tag must target a shim contract cid, not sibling fallback\n{tag:#}"
+        );
+        assert_eq!(
+            tag["target_proof_cid"].as_str(),
+            Some(expected_target_proof_cid),
+            "recognizer tag must carry the kit-resolved proof bundle cid\n{tag:#}"
+        );
+    }
     let bridge_proof = receipt["bridge_proof"]
         .as_str()
         .expect("recognize --write must mint a bridge proof");
@@ -118,22 +273,87 @@ fn go_recognize_write_self_resolves_project_proofs_and_proves() {
         Path::new(bridge_proof).is_file(),
         "recognize bridge proof path should exist: {bridge_proof}"
     );
+}
 
+fn run_prove_json(project: &Path) -> (bool, Json, String, String) {
     let prove = Command::new(provekit_bin())
         .arg("prove")
-        .arg(&project)
+        .arg(project)
         .arg("--json")
         .output()
         .expect("spawn provekit prove");
-    let prove_stdout = String::from_utf8_lossy(&prove.stdout);
-    let prove_stderr = String::from_utf8_lossy(&prove.stderr);
+    let stdout = String::from_utf8_lossy(&prove.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&prove.stderr).to_string();
+    let report: Json = serde_json::from_str(&stdout).unwrap_or_else(|_| {
+        panic!("prove JSON report parses\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+    (prove.status.success(), report, stdout, stderr)
+}
+
+fn assert_no_vacuous_rows(report: &Json) {
+    let rows = report["rows"].as_array().expect("prove report has rows");
     assert!(
-        prove.status.success(),
+        !rows.is_empty(),
+        "prove report must contain rows\n{report:#}"
+    );
+    for row in rows {
+        let reason = row["reason"].as_str().unwrap_or_default();
+        assert!(
+            !reason.contains("vacuous")
+                && !reason.contains("no precondition")
+                && !reason.contains("back-compat"),
+            "recognized callsite discharged vacuously\nrow:\n{row:#}\nreport:\n{report:#}"
+        );
+    }
+}
+
+#[test]
+fn go_recognize_write_self_resolves_project_proofs_and_proves() {
+    if !go_available() {
+        eprintln!("skipping Go recognizer parity test: go toolchain unavailable");
+        return;
+    }
+
+    let (temp, target_proof_cid) = copy_go_recognizer_demo_with_target_contracts(">=");
+    let project = temp.path().join("project");
+
+    let receipt = run_recognize_write(&project);
+    assert_recognize_receipt_pinned(&receipt, &target_proof_cid);
+
+    let (ok, report, prove_stdout, prove_stderr) = run_prove_json(&project);
+    assert!(
+        ok,
         "prove should consume the recognize bridge proof\nstdout:\n{prove_stdout}\nstderr:\n{prove_stderr}"
     );
-    let report: serde_json::Value =
-        serde_json::from_str(&prove_stdout).expect("prove JSON report parses");
     assert_eq!(report["totalCallsites"].as_u64(), Some(2), "{report:#}");
     assert_eq!(report["discharged"].as_u64(), Some(2), "{report:#}");
     assert_eq!(report["violations"].as_u64(), Some(0), "{report:#}");
+    assert_no_vacuous_rows(&report);
+}
+
+#[test]
+fn go_recognize_write_rejects_unmet_target_obligation() {
+    if !go_available() {
+        eprintln!("skipping Go recognizer contradiction test: go toolchain unavailable");
+        return;
+    }
+
+    let (temp, target_proof_cid) = copy_go_recognizer_demo_with_target_contracts(">");
+    let project = temp.path().join("project");
+
+    let receipt = run_recognize_write(&project);
+    assert_recognize_receipt_pinned(&receipt, &target_proof_cid);
+
+    let (ok, report, _stdout, _stderr) = run_prove_json(&project);
+    assert!(
+        !ok,
+        "unmet recognized target precondition must fail\n{report:#}"
+    );
+    assert_eq!(report["totalCallsites"].as_u64(), Some(2), "{report:#}");
+    assert_eq!(report["discharged"].as_u64(), Some(0), "{report:#}");
+    assert!(
+        report["violations"].as_u64().unwrap_or_default() > 0,
+        "unmet recognized target precondition must report violations\n{report:#}"
+    );
+    assert_no_vacuous_rows(&report);
 }


### PR DESCRIPTION
Closes #1701 for the Go recognizer lane.

What changed:
- Go recognizer now carries the containing `target_proof_cid` for proof-backed sugar bindings over RPC.
- `provekit recognize --write` copies `contract_cid + target_proof_cid` into bridge mementos when the kit supplies a real target contract.
- Sibling fallback remains self-pinned; `targetProofCid` is not applied to fallback bridges.
- Go recognizer parity now builds a proof-backed fixture with real target preconditions, asserts non-vacuous discharge, and includes an impossible `x > x` negative case that must fail.

Verification:
- `go test .` in `implementations/go/provekit-lift-go`
- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_recognize_go_parity -- --nocapture`
- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_recognize_no_proof_paths -- --nocapture`
- `cargo check --manifest-path implementations/rust/Cargo.toml -p provekit-cli`
- `git diff --check`