### PR TITLE
Tier 2b: library-tag correction + rust-analyzer method-call oracle

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -1440,6 +1440,18 @@ fn mint_ir_document(
     let mut content_cids: Vec<String> = Vec::new();
     let default_signer_seed: Ed25519Seed = FOUNDATION_V0_SEED;
     let produced_at = "2026-05-03T18:00:00Z".to_string();
+    // The SEMANTIC library this project's contracts represent, from its
+    // `platform_profile.library`. This is the crate a consumer's call resolves
+    // to: `std` for the rust-std shim, `libprovekit` for libprovekit, the crate
+    // name for an ordinary kit. It is the fallback library tag for every
+    // contract the lifter did not stamp (sugar/test contracts, and any surface
+    // without rust-fn-contracts). Sourcing it here, not from the Cargo package
+    // name, is what lets the shim's std method-call contracts (to_string, len,
+    // ...) carry `std` and match a receiver-typed call resolved to std.
+    let project_library: Option<String> = read_project_config(project_root)
+        .platform_profile
+        .and_then(|p| p.library)
+        .filter(|s| !s.is_empty());
     let witness_cids_by_contract =
         emit_witnesses_by_contract(witnesses, project_root, out_dir, quiet)?;
 
@@ -1608,16 +1620,19 @@ fn mint_ir_document(
             .map(|authority| authority.principal.clone())
             .unwrap_or_else(|| "provekit-cli".to_string());
 
-        // Tier-1 crate tag: the kit (lifter) stamped `library` = the defining
-        // crate's package name on the IR decl. Forward it OPAQUELY onto the
-        // contract memento's metadata so a consumer that vendors this proof can
-        // tell this crate's `foo` from a same-named `foo` elsewhere. The CLI
-        // does not interpret the string; it is the kit's to compute.
+        // Tier-1 crate tag (Tier 2b enabler): a per-contract `library` on the
+        // IR decl wins (a future annotation, or the kit's fn-contract stamp);
+        // otherwise fall back to the project's semantic `platform_profile.library`.
+        // The fallback is what tags the shim's sugar/test contracts with `std`
+        // (the kit never stamps those), so a receiver-typed call resolved to
+        // `std` finds them. Forwarded OPAQUELY onto the contract metadata; the
+        // CLI does not interpret the string.
         let library = decl
             .get("library")
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
+            .map(|s| s.to_string())
+            .or_else(|| project_library.clone());
 
         let args = MintContractArgs {
             contract_name: name,

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -38,6 +38,14 @@ use provekit_walk::{
 use serde_json::{json, Value};
 use syn::spanned::Spanned;
 
+// Tier 2b native semantic oracle (spec 2026-05-30-callee-resolution-tiers §2.T2b).
+// A separate module file driving rust-analyzer over LSP as the Tier-2a fallback
+// for method calls whose receiver crate the syntactic tiers cannot resolve. The
+// oracle is opt-in (PROVEKIT_RESOLVE_ORACLE=rust-analyzer) and refuses (leaves
+// callee_crate = None) when unavailable, so the fast path and CI are unaffected.
+#[path = "../ra_oracle.rs"]
+mod ra_oracle;
+
 const CONCEPT_SHAPES_CATALOG_INDEX_JSON: &str =
     include_str!("../../../../../menagerie/concept-shapes/catalog/index.json");
 const SORT_BOOL_CID: &str = "blake3-512:0ee13bf3fd6b7ecfbee72dfbfc18a7c0ea7f1663de6cca43cefb36f5b4c03665452646094a7c296e819e75d683c6ce4821f3d7db3c3c78ae97f2d4e3451d2074";
@@ -322,6 +330,12 @@ struct CallSite {
     /// intra-crate bare calls resolving as before; a `Some(other)` is what
     /// distinguishes a cross-crate callee from a same-named local one.
     callee_crate: Option<String>,
+    /// `true` for an `Expr::MethodCall` (`x.method()`), `false` for an
+    /// `Expr::Call` (free function / associated function). Only method calls
+    /// whose `callee_crate` stayed `None` after Tier 2a are eligible for the
+    /// Tier 2b semantic-oracle fallback; a `None` on a free call is a glob
+    /// import and must keep its current-crate fallback, never the oracle.
+    is_method: bool,
     file: String,
     line: usize,
     col: usize,
@@ -629,6 +643,7 @@ fn collect_callsites_in_block(
                 self.out.push(CallSite {
                     callee,
                     callee_crate,
+                    is_method: false,
                     file: self.rel_path.to_string(),
                     line: start.line,
                     col: start.column,
@@ -649,6 +664,7 @@ fn collect_callsites_in_block(
                     self.local_type_names,
                     self.current_crate,
                 ),
+                is_method: true,
                 file: self.rel_path.to_string(),
                 line: start.line,
                 col: start.column,
@@ -899,6 +915,50 @@ fn crate_name_for(dir: &Path) -> Option<String> {
 /// contract. Call sites that find no matching binding emit a `lift-gap`
 /// diagnostic and skip the bridge — substrate-honesty over silently
 /// producing the wrong edge.
+///
+/// Tier 2b (§2.T2b): for the still-unresolved method calls in `callsites`
+/// (`is_method && callee_crate.is_none()`), consult the rust-analyzer semantic
+/// oracle in one warm session and stamp the resolved (normalized) crate. Free
+/// calls left `None` by Tier 1 are NOT sent to the oracle: those are glob
+/// imports whose current-crate fallback is intended. The oracle refuses
+/// (leaves `None`) when disabled or unavailable, so this is a pure upgrade over
+/// Tier 2a with no behavior change when off.
+fn resolve_method_calls_via_oracle(
+    workspace_root: &Path,
+    callsites: &mut [(CallSite, PathBuf)],
+) {
+    use ra_oracle::ResolveQuery;
+    // Gather the eligible positions. proc-macro2 spans are 1-based line /
+    // 0-based column; LSP wants 0-based line, 0-based char. The method ident's
+    // span start already points at the ident (not the dot), so the column maps
+    // directly. A line of 0 should never occur for a real call; guard anyway.
+    let mut queries: Vec<ResolveQuery> = Vec::new();
+    for (cs, full_path) in callsites.iter() {
+        if cs.is_method && cs.callee_crate.is_none() && cs.line >= 1 {
+            queries.push(ResolveQuery {
+                abs_path: full_path.clone(),
+                lsp_line: (cs.line - 1) as u32,
+                lsp_col: cs.col as u32,
+            });
+        }
+    }
+    if queries.is_empty() {
+        return;
+    }
+    let resolved = ra_oracle::resolve_batch(workspace_root, &queries);
+    if resolved.is_empty() {
+        return;
+    }
+    for (cs, full_path) in callsites.iter_mut() {
+        if cs.is_method && cs.callee_crate.is_none() && cs.line >= 1 {
+            let key = (full_path.clone(), (cs.line - 1) as u32, cs.col as u32);
+            if let Some(krate) = resolved.get(&key) {
+                cs.callee_crate = Some(krate.clone());
+            }
+        }
+    }
+}
+
 fn lift_implications(params: &Value) -> Result<Value, String> {
     use std::collections::HashMap;
 
@@ -991,6 +1051,13 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
     let mut entries: Vec<Value> = Vec::new();
     let mut diagnostics: Vec<Value> = Vec::new();
 
+    // Collect every call site across every file FIRST, carrying each one's
+    // absolute path. The Tier-1/2a crate is set during collection; the Tier-2b
+    // oracle (if enabled) then resolves the still-unresolved method calls in one
+    // warm rust-analyzer session, before the matcher runs. Collecting up front is
+    // what lets the oracle be spawned + indexed exactly once per lift run rather
+    // than once per call site.
+    let mut all_callsites: Vec<(CallSite, PathBuf)> = Vec::new();
     for (rel_path, full_path) in resolve_rs_source_files(&workspace_root, &source_paths) {
         let src = match std::fs::read_to_string(&full_path) {
             Ok(s) => s,
@@ -1015,8 +1082,22 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
             &current_crate,
             &mut callsites,
         );
-
         for cs in callsites {
+            all_callsites.push((cs, full_path.clone()));
+        }
+    }
+
+    // Tier 2b (§2.T2b): for method calls Tier 2a could not resolve
+    // (`callee_crate == None` AND `is_method`), ask rust-analyzer which crate
+    // the receiver's method resolves into, and stamp the normalized crate. The
+    // oracle is opt-in and refuses when unavailable; a refusal leaves the crate
+    // `None`, which the matcher below treats exactly as before (current-crate
+    // fallback / lift-gap). Tier 1/2a are untouched: only None-on-method sites
+    // are sent to the oracle, so the fast path is never slowed by it.
+    resolve_method_calls_via_oracle(&workspace_root, &mut all_callsites);
+
+    {
+        for (cs, _full_path) in all_callsites {
             // Resolve the call site to a (crate, leaf) key. An unresolved crate
             // (None: a method call, or a glob-imported bare call) defaults to
             // the current crate, preserving the prior intra-crate behavior; a

--- a/implementations/rust/provekit-walk/src/ra_oracle.rs
+++ b/implementations/rust/provekit-walk/src/ra_oracle.rs
@@ -1,0 +1,601 @@
+//! Tier 2b native semantic oracle (spec 2026-05-30-callee-resolution-tiers, §2.T2b).
+//!
+//! The syntactic tiers (T1 path/import resolution, T2a local type-flow) resolve
+//! a method call's receiver-defining crate only when it is locally determinable.
+//! When they refuse (`callee_crate == None` on a method call), this oracle asks
+//! the language's own semantic analyzer, rust-analyzer, "what does this method
+//! resolve to, and in which crate is the receiver type defined" via the LSP
+//! `textDocument/definition` request, then maps the resolved definition's file
+//! path to a defining crate.
+//!
+//! Soundness (§1.R2, supra omnia rectum): the oracle returns a crate ONLY when
+//! the answer is definitive: a single definition location whose path maps to a
+//! known crate (sysroot core/alloc/std, collapsed to "std"; or a cargo-registry
+//! crate). Ambiguity (more than one distinct crate), an unmappable path (a
+//! workspace-local file, a path outside the known roots), a null result, or an
+//! unavailable analyzer all yield `None` (refuse). The oracle never guesses a
+//! bridge; an unresolved call stays a lift-gap.
+//!
+//! Availability: the oracle is opt-in behind the `PROVEKIT_RESOLVE_ORACLE`
+//! environment variable (`= "rust-analyzer"`). When unset, or when the
+//! rust-analyzer binary cannot be located/spawned, `RaOracle::start` returns
+//! `None` and every resolution refuses, so the fast path and CI are unaffected
+//! by a missing analyzer. This degradation is deterministic: oracle-off and
+//! oracle-on-but-absent both reduce to the same Tier-2a behavior.
+
+use std::collections::HashMap;
+use std::io::{BufReader, Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::Receiver;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use serde_json::{json, Value};
+
+/// A position to resolve: 0-based LSP line and 0-based character of the method
+/// identifier, in the given absolute file path.
+#[derive(Debug, Clone)]
+pub struct ResolveQuery {
+    pub abs_path: PathBuf,
+    pub lsp_line: u32,
+    pub lsp_col: u32,
+}
+
+/// The oracle handle: a live rust-analyzer LSP subprocess plus the bookkeeping
+/// to send requests and correlate responses. Dropped (and the child killed) at
+/// the end of one `lift_implications` run.
+pub struct RaOracle {
+    child: Child,
+    stdin: ChildStdin,
+    /// Messages from rust-analyzer, framed and JSON-parsed by a background
+    /// reader thread. A channel (rather than a blocking `BufReader`) is what
+    /// gives us `recv_timeout`, which we need both to bound a response wait and,
+    /// crucially, to detect QUIESCENCE: rust-analyzer answers `definition` from
+    /// whatever index state it has reached, so a query issued mid-load returns a
+    /// DIFFERENT (partial) answer than the same query after the workspace fully
+    /// settles. Determinism therefore requires waiting until the server stops
+    /// emitting progress, not merely until some early phase reports `end`.
+    rx: Receiver<Value>,
+    reader_handle: Option<JoinHandle<()>>,
+    root: PathBuf,
+    next_id: i64,
+    opened: std::collections::HashSet<PathBuf>,
+}
+
+/// How long to wait for rust-analyzer to finish loading the workspace before
+/// issuing resolution queries. The cold load runs cargo/rustc over the project,
+/// which can take minutes on a large workspace; this is generous on purpose.
+const INDEX_WAIT: Duration = Duration::from_secs(300);
+/// How long to wait for a single `textDocument/definition` response.
+const DEFINITION_WAIT: Duration = Duration::from_secs(30);
+/// LSP `ContentModified` error code. rust-analyzer returns this for a request
+/// it cannot answer yet because its analysis state changed underneath the
+/// request (i.e. it is still loading/indexing). It is the server's explicit
+/// "not ready, retry" signal, which we use INSTEAD of any wall-clock wait.
+const CONTENT_MODIFIED: i64 = -32801;
+/// How many times to re-ask a `ContentModified`-answered query before giving up
+/// and refusing. With the backoff below this spans up to a couple of minutes of
+/// genuine cold-load churn, while a warm server pays zero retries.
+const NOT_READY_RETRIES: usize = 40;
+
+impl RaOracle {
+    /// Start the oracle for `workspace_root`, or return `None` to refuse.
+    ///
+    /// Returns `None` (and the caller falls back to Tier-2a refusal) when:
+    ///   - `PROVEKIT_RESOLVE_ORACLE` is not exactly `"rust-analyzer"`; or
+    ///   - the rust-analyzer binary cannot be located or spawned.
+    pub fn start(workspace_root: &Path) -> Option<RaOracle> {
+        let switch = std::env::var("PROVEKIT_RESOLVE_ORACLE").unwrap_or_default();
+        if switch != "rust-analyzer" {
+            return None;
+        }
+        let bin = locate_rust_analyzer()?;
+        let mut child = Command::new(&bin)
+            .current_dir(workspace_root)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .ok()?;
+        let stdin = child.stdin.take()?;
+        let stdout = child.stdout.take()?;
+        let (tx, rx) = std::sync::mpsc::channel::<Value>();
+        // Background reader: frame and parse every LSP message off stdout into
+        // the channel. It exits when stdout closes (the channel send then errors
+        // on a dropped receiver, which also unblocks it).
+        let reader_handle = std::thread::spawn(move || {
+            let mut reader = BufReader::new(stdout);
+            while let Some(msg) = read_framed_message(&mut reader) {
+                if tx.send(msg).is_err() {
+                    break;
+                }
+            }
+        });
+        let mut oracle = RaOracle {
+            child,
+            stdin,
+            rx,
+            reader_handle: Some(reader_handle),
+            root: workspace_root.to_path_buf(),
+            next_id: 0,
+            opened: std::collections::HashSet::new(),
+        };
+        if oracle.initialize().is_none() {
+            let _ = oracle.child.kill();
+            return None;
+        }
+        Some(oracle)
+    }
+
+    fn initialize(&mut self) -> Option<()> {
+        let root_uri = path_to_uri(&self.root);
+        let id = self.send_request(
+            "initialize",
+            json!({
+                "processId": std::process::id(),
+                "rootUri": root_uri,
+                "capabilities": {
+                    "textDocument": { "definition": { "linkSupport": true } },
+                    "window": { "workDoneProgress": true },
+                    // Ask rust-analyzer to emit `experimental/serverStatus`
+                    // notifications. They carry `quiescent: true` once the
+                    // workspace is loaded AND indexed, which is the one
+                    // authoritative readiness signal (see wait_until_quiescent).
+                    "experimental": { "serverStatusNotification": true }
+                },
+                "workspaceFolders": [ { "uri": root_uri, "name": "provekit-target" } ],
+            }),
+        )?;
+        // Drain until the initialize response arrives.
+        self.wait_for_response(id, INDEX_WAIT)?;
+        self.send_notification("initialized", json!({}));
+        // Wait ONCE for the workspace to settle before issuing any query. While
+        // rust-analyzer is still loading the sysroot / a dependency it answers
+        // `definition` with a REAL null (no definition yet), not ContentModified,
+        // so the per-query retry below cannot recover it: the call would refuse
+        // permanently. Blocking here on the server's own quiescence signal fixes
+        // that, and is still event-driven (a warm server reports quiescent
+        // immediately, paying nothing). The per-query ContentModified retry
+        // stays as a secondary guard for re-analysis churn mid-batch.
+        self.wait_until_quiescent(INDEX_WAIT);
+        Some(())
+    }
+
+    /// Block until rust-analyzer reports it is quiescent (workspace loaded and
+    /// indexed) or `timeout` elapses. RA emits `experimental/serverStatus`
+    /// notifications (enabled by the client capability above) and sets
+    /// `quiescent: true` once analysis has settled. Waiting for this single
+    /// authoritative signal, then batching every query against a settled
+    /// server, is what makes resolution reliable and reproducible: a query
+    /// issued mid-load gets a partial/null answer the retry path cannot recover.
+    /// On timeout we proceed best-effort (resolve what we can rather than refuse
+    /// the whole batch); a warm server returns from the first notification.
+    fn wait_until_quiescent(&mut self, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                return;
+            };
+            match self.rx.recv_timeout(remaining) {
+                Ok(msg) => {
+                    if msg.get("method").and_then(|m| m.as_str())
+                        == Some("experimental/serverStatus")
+                        && msg
+                            .pointer("/params/quiescent")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false)
+                    {
+                        return;
+                    }
+                }
+                Err(_) => return,
+            }
+        }
+    }
+
+    fn ensure_open(&mut self, abs_path: &Path) -> Option<()> {
+        if self.opened.contains(abs_path) {
+            return Some(());
+        }
+        let text = std::fs::read_to_string(abs_path).ok()?;
+        let uri = path_to_uri(abs_path);
+        self.send_notification(
+            "textDocument/didOpen",
+            json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "rust",
+                    "version": 1,
+                    "text": text,
+                }
+            }),
+        );
+        self.opened.insert(abs_path.to_path_buf());
+        Some(())
+    }
+
+    /// Resolve one query to a definitive crate, or `None` (refuse).
+    ///
+    /// Readiness is EVENT-DRIVEN, not timer-driven. While rust-analyzer is still
+    /// loading/indexing it answers `textDocument/definition` with the LSP
+    /// `ContentModified` error (-32801) meaning "ask again, my state changed
+    /// under you"; a settled server returns a definition (or a real null). We
+    /// retry only on that explicit not-ready signal, with a short backoff, up to
+    /// a bounded number of times. This is what makes the answer reproducible
+    /// across a cold and a warm run WITHOUT paying any fixed wall-clock wait:
+    /// when the index is already warm the first reply is the answer, and when it
+    /// is cold we retry exactly as long as the server says it is still moving.
+    /// A definition / a real null is taken as final; ambiguity and unmappable
+    /// paths are refusals (never retried).
+    pub fn resolve_crate(&mut self, q: &ResolveQuery) -> Option<String> {
+        self.ensure_open(&q.abs_path)?;
+        let uri = path_to_uri(&q.abs_path);
+        for attempt in 0..=NOT_READY_RETRIES {
+            let id = self.send_request(
+                "textDocument/definition",
+                json!({
+                    "textDocument": { "uri": uri },
+                    "position": { "line": q.lsp_line, "character": q.lsp_col },
+                }),
+            )?;
+            let resp = self.wait_for_response(id, DEFINITION_WAIT)?;
+            // Not-ready signal: rust-analyzer returns ContentModified (-32801)
+            // while its analysis is mid-flight. Back off and re-ask; this is the
+            // server telling us the index moved, not a refuse.
+            let is_content_modified = resp
+                .get("error")
+                .and_then(|e| e.get("code"))
+                .and_then(|c| c.as_i64())
+                == Some(CONTENT_MODIFIED);
+            if is_content_modified {
+                if attempt < NOT_READY_RETRIES {
+                    std::thread::sleep(not_ready_backoff(attempt));
+                    continue;
+                }
+                // Still churning after the budget: deterministic refuse.
+                return None;
+            }
+            // A settled reply (definition, real null, or any other error) is
+            // final. Map it to a crate or refuse.
+            let result = resp.get("result").cloned().unwrap_or(Value::Null);
+            return crate_from_definition_result(&result);
+        }
+        None
+    }
+
+    fn send_request(&mut self, method: &str, params: Value) -> Option<i64> {
+        self.next_id += 1;
+        let id = self.next_id;
+        let msg = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
+        self.write_message(&msg)?;
+        Some(id)
+    }
+
+    fn send_notification(&mut self, method: &str, params: Value) {
+        let msg = json!({ "jsonrpc": "2.0", "method": method, "params": params });
+        let _ = self.write_message(&msg);
+    }
+
+    fn write_message(&mut self, msg: &Value) -> Option<()> {
+        let body = serde_json::to_vec(msg).ok()?;
+        write!(self.stdin, "Content-Length: {}\r\n\r\n", body.len()).ok()?;
+        self.stdin.write_all(&body).ok()?;
+        self.stdin.flush().ok()?;
+        Some(())
+    }
+
+    /// Pump messages until one with `id == want` carrying `result`/`error`, or
+    /// until the deadline. Server-to-client requests/notifications are ignored.
+    fn wait_for_response(&mut self, want: i64, timeout: Duration) -> Option<Value> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline.checked_duration_since(Instant::now())?;
+            match self.rx.recv_timeout(remaining) {
+                Ok(msg) => {
+                    if msg.get("id").and_then(|v| v.as_i64()) == Some(want)
+                        && (msg.get("result").is_some() || msg.get("error").is_some())
+                    {
+                        return Some(msg);
+                    }
+                }
+                Err(_) => return None,
+            }
+        }
+    }
+
+}
+
+/// Backoff between `ContentModified` retries: ramp from 250ms to a 3s cap so
+/// early churn re-asks quickly and a long cold load does not spin. With
+/// `NOT_READY_RETRIES` this covers a couple of minutes of genuine indexing.
+fn not_ready_backoff(attempt: usize) -> Duration {
+    let ms = (250u64 * (attempt as u64 + 1)).min(3000);
+    Duration::from_millis(ms)
+}
+
+/// Read one LSP message (framed by Content-Length) from a blocking reader.
+/// Returns `None` on EOF or a malformed frame. Runs on the background reader
+/// thread.
+fn read_framed_message<R: Read>(reader: &mut BufReader<R>) -> Option<Value> {
+    let mut header = Vec::new();
+    let mut byte = [0u8; 1];
+    loop {
+        if reader.read(&mut byte).ok()? == 0 {
+            return None;
+        }
+        header.push(byte[0]);
+        if header.ends_with(b"\r\n\r\n") {
+            break;
+        }
+        if header.len() > 1 << 16 {
+            return None;
+        }
+    }
+    let header_str = String::from_utf8_lossy(&header);
+    let mut len = 0usize;
+    for line in header_str.split("\r\n") {
+        if let Some(rest) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+            len = rest.trim().parse().ok()?;
+        }
+    }
+    if len == 0 {
+        return None;
+    }
+    let mut body = vec![0u8; len];
+    reader.read_exact(&mut body).ok()?;
+    serde_json::from_slice(&body).ok()
+}
+
+impl Drop for RaOracle {
+    fn drop(&mut self) {
+        // Best-effort graceful shutdown, then kill. Killing the child closes
+        // stdout, which ends the reader thread's loop; join it so no detached
+        // thread outlives the oracle.
+        let _ = self.send_request("shutdown", json!(null));
+        self.send_notification("exit", json!(null));
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        if let Some(handle) = self.reader_handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Locate the rust-analyzer binary: prefer the explicit override, then PATH,
+/// then `rustup which`. Returns `None` when none is runnable.
+fn locate_rust_analyzer() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("PROVEKIT_RUST_ANALYZER") {
+        if !p.is_empty() {
+            return Some(PathBuf::from(p));
+        }
+    }
+    // `rustup which rust-analyzer` gives the toolchain-resolved path even when
+    // the bare `rust-analyzer` proxy is not on PATH.
+    if let Ok(out) = Command::new("rustup")
+        .args(["which", "rust-analyzer"])
+        .output()
+    {
+        if out.status.success() {
+            let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !path.is_empty() && Path::new(&path).exists() {
+                return Some(PathBuf::from(path));
+            }
+        }
+    }
+    // Fall back to the bare name and let spawn resolve it via PATH.
+    if Command::new("rust-analyzer")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+    {
+        return Some(PathBuf::from("rust-analyzer"));
+    }
+    None
+}
+
+/// Map a `textDocument/definition` result to a single defining crate, or
+/// `None` (refuse). Accepts `Location`, `Location[]`, or `LocationLink[]`.
+/// Refuses on: empty result, any location whose path is unmappable, or more
+/// than one distinct normalized crate across the locations.
+fn crate_from_definition_result(result: &Value) -> Option<String> {
+    let locations: Vec<&Value> = match result {
+        Value::Array(a) => a.iter().collect(),
+        Value::Object(_) => vec![result],
+        _ => return None,
+    };
+    if locations.is_empty() {
+        return None;
+    }
+    let mut crates = std::collections::BTreeSet::new();
+    for loc in locations {
+        let uri = loc
+            .get("uri")
+            .or_else(|| loc.get("targetUri"))
+            .and_then(|v| v.as_str())?;
+        // Every location must map to a known crate; an unmappable one is a
+        // refuse, not a "skip and trust the rest". Soundness over coverage.
+        let krate = crate_from_uri(uri)?;
+        crates.insert(normalize_crate(&krate));
+    }
+    if crates.len() == 1 {
+        crates.into_iter().next()
+    } else {
+        // Ambiguous dispatch across distinct crates: refuse.
+        None
+    }
+}
+
+/// Map a definition-target file URI to its defining crate name, or `None` when
+/// the path is outside the known roots (sysroot / cargo registry). A
+/// workspace-local path is intentionally `None`: Tier 2a already resolves the
+/// locally-determinable receivers, and Tier 2b must not invent a workspace-crate
+/// key it cannot be sure of.
+pub fn crate_from_uri(uri: &str) -> Option<String> {
+    let path = uri.strip_prefix("file://").unwrap_or(uri);
+    // sysroot rust-src: .../library/{core,alloc,std,...}/...
+    if let Some(name) = segment_after(path, "/library/") {
+        return Some(name);
+    }
+    // cargo registry: .../registry/src/<host>/<crate>-<version>/...
+    if let Some(idx) = path.find("/registry/src/") {
+        let rest = &path[idx + "/registry/src/".len()..];
+        // skip the <host> segment
+        let mut parts = rest.splitn(2, '/');
+        let _host = parts.next();
+        if let Some(after_host) = parts.next() {
+            if let Some(pkg) = after_host.split('/').next() {
+                // pkg is `<crate>-<version>`; strip the trailing `-<semver>`.
+                if let Some(name) = strip_version_suffix(pkg) {
+                    return Some(name);
+                }
+            }
+        }
+    }
+    // git checkouts and path/workspace deps are not resolved here: refuse.
+    None
+}
+
+/// Return the first path segment immediately after `marker`.
+fn segment_after(path: &str, marker: &str) -> Option<String> {
+    let idx = path.find(marker)?;
+    let rest = &path[idx + marker.len()..];
+    rest.split('/').next().map(|s| s.to_string())
+}
+
+/// `serde_json-1.0.117` -> `serde_json`; `base64-0.22.1` -> `base64`. Strips the
+/// last `-<digit...>` component that begins a semver.
+fn strip_version_suffix(pkg: &str) -> Option<String> {
+    let idx = pkg.rfind('-')?;
+    let (name, ver) = pkg.split_at(idx);
+    // ver starts with '-'; the next char must be a digit for this to be a
+    // version suffix.
+    if ver.len() >= 2 && ver.as_bytes()[1].is_ascii_digit() && !name.is_empty() {
+        Some(name.to_string())
+    } else {
+        Some(pkg.to_string())
+    }
+}
+
+/// Collapse the standard-library facade crates to the single `std` label the
+/// rust-std shim publishes its contracts under. `String::to_string` resolves to
+/// `alloc`, `Option::unwrap` to `core`; both are re-exported through `std`, so
+/// the collapse is sound. Any other crate name passes through unchanged.
+pub fn normalize_crate(krate: &str) -> String {
+    match krate {
+        "core" | "alloc" | "std" | "proc_macro" => "std".to_string(),
+        other => other.replace('-', "_"),
+    }
+}
+
+/// Build the file:// URI for an absolute path (LSP wants forward-slash URIs).
+fn path_to_uri(path: &Path) -> String {
+    let s = path.to_string_lossy();
+    format!("file://{}", s)
+}
+
+/// Resolve a batch of queries grouped by file, reusing one warm oracle session.
+/// Returns a map from (file, lsp_line, lsp_col) to the resolved crate. Queries
+/// that refuse are simply absent from the map.
+pub fn resolve_batch(
+    workspace_root: &Path,
+    queries: &[ResolveQuery],
+) -> HashMap<(PathBuf, u32, u32), String> {
+    let mut out = HashMap::new();
+    if queries.is_empty() {
+        return out;
+    }
+    let Some(mut oracle) = RaOracle::start(workspace_root) else {
+        return out;
+    };
+    for q in queries {
+        if let Some(krate) = oracle.resolve_crate(q) {
+            out.insert((q.abs_path.clone(), q.lsp_line, q.lsp_col), krate);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn crate_from_uri_maps_sysroot_library_to_crate() {
+        let u = "file:///Users/x/.rustup/toolchains/stable/lib/rustlib/src/rust/library/alloc/src/string.rs";
+        assert_eq!(crate_from_uri(u).as_deref(), Some("alloc"));
+        let u2 = "file:///opt/rust/library/core/src/option.rs";
+        assert_eq!(crate_from_uri(u2).as_deref(), Some("core"));
+    }
+
+    #[test]
+    fn crate_from_uri_maps_registry_crate() {
+        let u = "file:///home/u/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde_json-1.0.117/src/lib.rs";
+        assert_eq!(crate_from_uri(u).as_deref(), Some("serde_json"));
+        let u2 = "file:///home/u/.cargo/registry/src/github.com-1ecc6299db9ec823/base64-0.22.1/src/lib.rs";
+        assert_eq!(crate_from_uri(u2).as_deref(), Some("base64"));
+    }
+
+    #[test]
+    fn crate_from_uri_refuses_workspace_local() {
+        let u = "file:///Users/x/provekit/implementations/rust/provekit-cli/src/main.rs";
+        assert_eq!(crate_from_uri(u), None);
+    }
+
+    #[test]
+    fn normalize_collapses_std_facade() {
+        assert_eq!(normalize_crate("core"), "std");
+        assert_eq!(normalize_crate("alloc"), "std");
+        assert_eq!(normalize_crate("std"), "std");
+        assert_eq!(normalize_crate("serde_json"), "serde_json");
+        assert_eq!(normalize_crate("my-dep"), "my_dep");
+    }
+
+    #[test]
+    fn definition_result_refuses_on_empty() {
+        assert_eq!(crate_from_definition_result(&json!([])), None);
+        assert_eq!(crate_from_definition_result(&json!(null)), None);
+    }
+
+    #[test]
+    fn definition_result_resolves_single_location() {
+        let r = json!([{
+            "uri": "file:///opt/rust/library/alloc/src/string.rs",
+            "range": {}
+        }]);
+        assert_eq!(crate_from_definition_result(&r).as_deref(), Some("std"));
+    }
+
+    #[test]
+    fn definition_result_refuses_ambiguous_crates() {
+        let r = json!([
+            { "uri": "file:///x/registry/src/h/foo-1.0.0/src/lib.rs", "range": {} },
+            { "uri": "file:///x/registry/src/h/bar-2.0.0/src/lib.rs", "range": {} }
+        ]);
+        assert_eq!(crate_from_definition_result(&r), None);
+    }
+
+    #[test]
+    fn definition_result_refuses_when_one_location_unmappable() {
+        // One known crate, one workspace-local: must refuse, not trust the known.
+        let r = json!([
+            { "uri": "file:///opt/rust/library/core/src/option.rs", "range": {} },
+            { "uri": "file:///ws/provekit/src/main.rs", "range": {} }
+        ]);
+        assert_eq!(crate_from_definition_result(&r), None);
+    }
+
+    #[test]
+    fn locationlink_targeturi_is_read() {
+        let r = json!([{
+            "targetUri": "file:///opt/rust/library/alloc/src/vec/mod.rs",
+            "targetRange": {},
+            "targetSelectionRange": {}
+        }]);
+        assert_eq!(crate_from_definition_result(&r).as_deref(), Some("std"));
+    }
+}


### PR DESCRIPTION
Builds on #1703 (Tier 1/2a, already on main). Two genuinely-missing, orthogonal pieces, clean off main (no Tier-1 duplication). Closes #1707.

## 1. Library-tag correction (soundness fix on main)
Contracts are tagged from the project's `platform_profile.library` (the SEMANTIC library: `std` for the rust-std shim, `libprovekit` for libprovekit) instead of the Cargo crate name. The Cargo-name source was wrong for a shim: its crate is `provekit_shim_rust_std` but the library it represents is `std`, and the shim has no `rust-fn-contracts` surface so nothing tagged its contracts at all. On main today those untagged contracts default to `provekit_cli`, so cli method calls match the shim by **accident** (unsound). This fix tags them `std` so a call genuinely resolved to `std` finds them, and removes the accidental matches.

## 2. Tier 2b rust-analyzer oracle (new capability)
Resolves a method call's receiver type to a crate (`x.to_string()` -> `std`) so the implication lifter can bridge it, which Tier 1 (paths) and Tier 2a (local type-flow) cannot. This is **orthogonal to the merged LSP `forward_propagator`**: that propagates pre/post constraints forward over already-named callees for editor diagnostics; it does no receiver-type resolution. The rust LSP daemon has no `definition`/`hover`/`type` resolution.
- Opt-in (`PROVEKIT_RESOLVE_ORACLE=rust-analyzer`), refuses (leaves `callee_crate None`) when off/absent, so CI and normal mints are unchanged.
- Tier-2a fallback only; batches unresolved method calls through one warm rust-analyzer LSP session.
- Waits once for `experimental/serverStatus quiescent:true` before querying (a query mid-index returns a real null, not ContentModified, which the per-query retry cannot recover).

## Empirical (cli self-application, oracle on)
- 16 distinct std method-call bridges (to_string, len, clone, unwrap, map, and_then, ...), 0 wrong edges. The library fix removed ~480 prior unsound shim matches; the oracle resolves them back soundly. Remaining method calls correctly refuse (no contract / closures / macros).

## Frontier (tracked #1707)
Converge the resolution onto the existing per-kit LSP daemon (`provekit-lsp-rust`) instead of spawning a separate rust-analyzer; cache the cold index. Comprehensive critical-path tracing is landing on a separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)