### PR TITLE
Name contradiction lane in cross-language parity gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   make help: print this help
 #   make ci: Linux-profile gate (catalog + protocol + live mints + tests)
 #   make conformance: catalog + protocol + live mint CIDs + self-contract tests
-#   make cross-language-proof-parity: Java/Go/Python/Rust emit + materialize + recognize + mint + prove gate
+#   make cross-language-proof-parity: Java/Go/Python/Rust emit + materialize + recognize + mint + prove + contradiction gate
 #   make cross-language-proof-parity-extra: opt-in TypeScript/Zig/Scala/Swift parity lanes
 #   make all-mint: run all 11 Linux-profile mint commands; print CIDs
 #   make bootstrap-self-contracts: re-sign attestations from live artifacts
@@ -88,7 +88,7 @@ help:
 	@echo "  make ci             Linux-profile gate (conformance + test-all)"
 	@echo "  make conformance    catalog + protocol + 11 mint CIDs + self-contract tests"
 	@echo "  make cross-language-proof-parity"
-	@echo "                       Java/Go/Python/Rust emit + materialize + recognize + mint + prove gate"
+	@echo "                       Java/Go/Python/Rust emit + materialize + recognize + mint + prove + contradiction gate"
 	@echo "  make cross-language-proof-parity-extra"
 	@echo "                       opt-in TypeScript/Zig/Scala/Swift parity lanes"
 	@echo "  make all-mint       11 mint commands (Swift excluded: macOS-only, use mint-swift)"
@@ -684,7 +684,7 @@ check-cross-language-proof-parity-scope:
 
 .PHONY: cross-language-proof-parity
 cross-language-proof-parity: build-java cross-language-proof-parity-python-env
-	@echo "=== Cross-language proof parity: emit/materialize/recognize/mint/prove lanes for Java, Go, Python, Rust ==="
+	@echo "=== Cross-language proof parity: emit/materialize/recognize/mint/prove/contradiction lanes for Java, Go, Python, Rust ==="
 	cargo build --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-realize-rust-core --bin provekit-realize-rust
 	@echo "--- emit parity ---"

--- a/tools/check-cross-language-proof-parity-scope.sh
+++ b/tools/check-cross-language-proof-parity-scope.sh
@@ -27,7 +27,10 @@ reject() {
   fi
 }
 
+require "Cross-language proof parity: emit/materialize/recognize/mint/prove/contradiction lanes for Java, Go, Python, Rust"
+
 require "emit_java_junit_dispatches_real_emitter_and_maven_checks_output"
+require "emit_java_testng_dispatches_real_emitter_and_maven_checks_output"
 require "emit_go_testing_uses_checked_in_go_double_registration"
 require "emit_go_testify_dispatches_separate_emitter_and_compile_checks"
 require "emit_python_pytest_uses_checked_in_python_double_registration"


### PR DESCRIPTION
## Summary

- ties the core parity gate contract to the actual acceptance shape in #1486 by naming the contradiction lane in the Makefile/help text
- makes the fast dry-run guard require the full `emit/materialize/recognize/mint/prove/contradiction` gate header
- makes the guard require the Java TestNG emitter already run by the gate, so it cannot silently fall out of emit parity

## Verification

- RED: `tools/check-cross-language-proof-parity-scope.sh` failed before the Makefile wording update with missing `Cross-language proof parity: emit/materialize/recognize/mint/prove/contradiction lanes for Java, Go, Python, Rust`
- `tools/check-cross-language-proof-parity-scope.sh`
- `make check-cross-language-proof-parity-scope`
- `git diff --check -- Makefile tools/check-cross-language-proof-parity-scope.sh`

Intentionally not run: full `make cross-language-proof-parity` or broad CI-equivalent builds.
