### PR TITLE
Require checked-in Java/Rust emit registration parity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -690,10 +690,10 @@ cross-language-proof-parity: build-java cross-language-proof-parity-python-env
 	@echo "--- emit parity ---"
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_emit_java_junit \
-		emit_java_junit_dispatches_real_emitter_and_maven_checks_output
+		emit_java_junit_uses_checked_in_java_double_registration
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_emit_java_testng \
-		emit_java_testng_dispatches_real_emitter_and_maven_checks_output
+		emit_java_testng_uses_checked_in_java_double_registration
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_emit_go_testing \
 		emit_go_testing_uses_checked_in_go_double_registration
@@ -705,7 +705,7 @@ cross-language-proof-parity: build-java cross-language-proof-parity-python-env
 		emit_python_pytest_uses_checked_in_python_double_registration
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_emit_rust_cargo_test \
-		emit_rust_cargo_test_dispatches_real_emitter_and_cargo_checks_output
+		emit_rust_cargo_test_uses_checked_in_rust_double_registration
 	@echo "--- materialize parity ---"
 	cargo test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_materialize_proof_load \

--- a/examples/java-double/.provekit/config.toml
+++ b/examples/java-double/.provekit/config.toml
@@ -1,0 +1,26 @@
+# ProvekIt project config for the Java emit fixture. Registration is per
+# project: JUnit and TestNG emit surfaces are declared here and resolved
+# through .provekit/<kind>/<surface>/manifest.toml.
+
+[[plugins]]
+name = "java-junit5"
+kind = "emit"
+surface = "java-junit5"
+emit = "junit5"
+
+[[plugins]]
+name = "java-testng"
+kind = "emit"
+surface = "java-testng"
+emit = "testng"
+
+[solvers]
+default = "z3"
+
+[solvers.dispatch]
+linear_arithmetic = "z3"
+default = "z3"
+
+[solvers.z3]
+binary = "z3"
+flags = ["-smt2", "-in"]

--- a/examples/java-double/.provekit/emit/java-junit5/manifest.toml
+++ b/examples/java-double/.provekit/emit/java-junit5/manifest.toml
@@ -1,0 +1,4 @@
+name = "java-junit5"
+command = ["java", "-jar", "../../implementations/java/provekit-emit-java-junit/target/provekit-emit-java-junit.jar", "--rpc"]
+working_dir = "."
+protocol_versions = ["pep/1.7.0"]

--- a/examples/java-double/.provekit/emit/java-testng/manifest.toml
+++ b/examples/java-double/.provekit/emit/java-testng/manifest.toml
@@ -1,0 +1,4 @@
+name = "java-testng"
+command = ["java", "-jar", "../../implementations/java/provekit-emit-java-testng/target/provekit-emit-java-testng.jar", "--rpc"]
+working_dir = "."
+protocol_versions = ["pep/1.7.0"]

--- a/examples/java-double/README.md
+++ b/examples/java-double/README.md
@@ -1,0 +1,5 @@
+# Java emit example
+
+This fixture registers Java emitters through project config only. The CLI
+selects JUnit5 or TestNG by `--target java --framework ...`; Java framework
+syntax and Maven compile checks remain kit-owned RPC behavior.

--- a/examples/java-double/pom.xml
+++ b/examples/java-double/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>example</groupId>
+  <artifactId>provekit-java-double-example</artifactId>
+  <version>0.1.0</version>
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>7.10.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.4</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/examples/java-double/src/main/java/example/DoubleLib.java
+++ b/examples/java-double/src/main/java/example/DoubleLib.java
@@ -1,0 +1,9 @@
+package example;
+
+public final class DoubleLib {
+    private DoubleLib() {}
+
+    public static int doubleValue(int x) {
+        return x * 2;
+    }
+}

--- a/examples/rust-double/.provekit/config.toml
+++ b/examples/rust-double/.provekit/config.toml
@@ -14,6 +14,12 @@ name = "rust-tests"
 surface = "rust-tests"
 emit = "ir-document"
 
+[[plugins]]
+name = "rust-cargo-test"
+kind = "emit"
+surface = "rust-cargo-test"
+emit = "cargo-test"
+
 [solvers]
 default = "z3"
 

--- a/examples/rust-double/.provekit/emit/rust-cargo-test/manifest.toml
+++ b/examples/rust-double/.provekit/emit/rust-cargo-test/manifest.toml
@@ -1,0 +1,4 @@
+name = "rust-cargo-test"
+command = ["../../implementations/rust/target/debug/provekit-emit-rust-cargo-test", "--rpc"]
+working_dir = "."
+protocol_versions = ["pep/1.7.0"]

--- a/examples/rust-double/src/lib.rs
+++ b/examples/rust-double/src/lib.rs
@@ -3,7 +3,7 @@ pub fn double(x: i64) -> i64 {
 }
 
 #[cfg(test)]
-mod tests {
+mod native_tests {
     use super::double;
 
     #[test]
@@ -11,3 +11,6 @@ mod tests {
         assert_eq!(double(3), 6);
     }
 }
+
+#[cfg(test)]
+include!("provekit_emitted.rs");

--- a/examples/rust-double/src/provekit_emitted.rs
+++ b/examples/rust-double/src/provekit_emitted.rs
@@ -1,0 +1,1 @@
+// Placeholder for `provekit emit --framework cargo-test` output in copied fixtures.

--- a/implementations/rust/provekit-cli/tests/cmd_emit_java_junit.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_emit_java_junit.rs
@@ -108,6 +108,72 @@ fn install_emit_registration(project: &Path, java_bin: &Path, jar: &Path) {
     .expect("write emit manifest");
 }
 
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap_or_else(|_| panic!("mkdir {}", dst.display()));
+    for entry in fs::read_dir(src).unwrap_or_else(|_| panic!("read {}", src.display())) {
+        let entry = entry.expect("read dir entry");
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type().expect("entry file type").is_dir() {
+            copy_dir_recursive(&src_path, &dst_path);
+        } else {
+            fs::copy(&src_path, &dst_path).unwrap_or_else(|_| {
+                panic!("copy {} -> {}", src_path.display(), dst_path.display())
+            });
+        }
+    }
+}
+
+fn rewrite_java_emit_manifest(manifest: &Path, java_bin: &Path, jar: &Path) {
+    let text = fs::read_to_string(manifest)
+        .unwrap_or_else(|_| panic!("read checked-in manifest {}", manifest.display()));
+    let java = java_bin
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let jar = jar
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let rewritten = text
+        .lines()
+        .map(|line| {
+            if line.trim_start().starts_with("command = ") {
+                format!("command = [\"{java}\", \"-jar\", \"{jar}\", \"--rpc\"]")
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(manifest, format!("{rewritten}\n"))
+        .unwrap_or_else(|_| panic!("write manifest {}", manifest.display()));
+}
+
+fn write_basic_emit_plan(plan: &Path) {
+    fs::write(
+        plan,
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "contract_id": "concept:eq",
+            "function": "identity",
+            "params": ["a", "b"],
+            "param_types": ["int", "int"],
+            "predicates": [{
+                "kind": "atomic",
+                "name": "concept:eq",
+                "args": [
+                    {"kind": "const", "value": 2, "sort": {"kind": "primitive", "name": "Int"}},
+                    {"kind": "const", "value": 2, "sort": {"kind": "primitive", "name": "Int"}}
+                ]
+            }]
+        }))
+        .expect("encode plan"),
+    )
+    .expect("write plan");
+}
+
 fn write_maven_test_project(out_dir: &Path) {
     fs::create_dir_all(out_dir.join("src/test/java")).expect("mkdir java test tree");
     fs::write(
@@ -224,4 +290,62 @@ fn emit_java_junit_dispatches_real_emitter_and_maven_checks_output() {
         emitted.contains("assertEquals(2, 2);"),
         "emitted:\n{emitted}"
     );
+}
+
+#[test]
+fn emit_java_junit_uses_checked_in_java_double_registration() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("java-double");
+    let example = repo_root().join("examples").join("java-double");
+    copy_dir_recursive(&example, &project);
+    let out_dir = project.join("src").join("test").join("java");
+    fs::create_dir_all(&out_dir).expect("mkdir java test tree");
+
+    let Some(java_bin) = maven_java_bin() else {
+        eprintln!("skipping: mvn is unavailable or did not report a usable Java home");
+        return;
+    };
+    let jar = build_java_junit_emitter();
+    rewrite_java_emit_manifest(
+        &project
+            .join(".provekit")
+            .join("emit")
+            .join("java-junit5")
+            .join("manifest.toml"),
+        &java_bin,
+        &jar,
+    );
+
+    let plan = project.join("plan.json");
+    write_basic_emit_plan(&plan);
+
+    let output = Command::new(provekit_bin())
+        .arg("emit")
+        .arg("--project")
+        .arg(&project)
+        .arg("--target")
+        .arg("java")
+        .arg("--framework")
+        .arg("junit5")
+        .arg("--plan")
+        .arg(&plan)
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--compile-check")
+        .arg("--json")
+        .output()
+        .expect("spawn provekit emit java");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "checked-in Java fixture registration must drive JUnit emit\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let receipt: Value = serde_json::from_str(&stdout).expect("emit stdout is JSON");
+    assert_eq!(receipt["ok"], true, "receipt: {receipt}");
+    assert_eq!(receipt["surface"], "java-junit5", "receipt: {receipt}");
+    assert_eq!(receipt["targetLanguage"], "java", "receipt: {receipt}");
+    assert_eq!(receipt["targetFramework"], "junit5", "receipt: {receipt}");
+    assert_eq!(receipt["isComplete"], true, "receipt: {receipt}");
 }

--- a/implementations/rust/provekit-cli/tests/cmd_emit_java_testng.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_emit_java_testng.rs
@@ -108,6 +108,72 @@ fn install_emit_registration(project: &Path, java_bin: &Path, jar: &Path) {
     .expect("write emit manifest");
 }
 
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap_or_else(|_| panic!("mkdir {}", dst.display()));
+    for entry in fs::read_dir(src).unwrap_or_else(|_| panic!("read {}", src.display())) {
+        let entry = entry.expect("read dir entry");
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type().expect("entry file type").is_dir() {
+            copy_dir_recursive(&src_path, &dst_path);
+        } else {
+            fs::copy(&src_path, &dst_path).unwrap_or_else(|_| {
+                panic!("copy {} -> {}", src_path.display(), dst_path.display())
+            });
+        }
+    }
+}
+
+fn rewrite_java_emit_manifest(manifest: &Path, java_bin: &Path, jar: &Path) {
+    let text = fs::read_to_string(manifest)
+        .unwrap_or_else(|_| panic!("read checked-in manifest {}", manifest.display()));
+    let java = java_bin
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let jar = jar
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let rewritten = text
+        .lines()
+        .map(|line| {
+            if line.trim_start().starts_with("command = ") {
+                format!("command = [\"{java}\", \"-jar\", \"{jar}\", \"--rpc\"]")
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(manifest, format!("{rewritten}\n"))
+        .unwrap_or_else(|_| panic!("write manifest {}", manifest.display()));
+}
+
+fn write_basic_emit_plan(plan: &Path) {
+    fs::write(
+        plan,
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "contract_id": "concept:eq",
+            "function": "identity",
+            "params": ["a", "b"],
+            "param_types": ["int", "int"],
+            "predicates": [{
+                "kind": "atomic",
+                "name": "eq",
+                "args": [
+                    {"kind": "const", "value": 2, "sort": {"kind": "primitive", "name": "Int"}},
+                    {"kind": "const", "value": 2, "sort": {"kind": "primitive", "name": "Int"}}
+                ]
+            }]
+        }))
+        .expect("encode plan"),
+    )
+    .expect("write plan");
+}
+
 fn write_maven_testng_project(out_dir: &Path) {
     fs::create_dir_all(out_dir.join("src/test/java")).expect("mkdir java test tree");
     fs::write(
@@ -234,4 +300,62 @@ fn emit_java_testng_dispatches_real_emitter_and_maven_checks_output() {
         !emitted.contains("org.junit"),
         "TestNG emitter must not reference JUnit:\n{emitted}"
     );
+}
+
+#[test]
+fn emit_java_testng_uses_checked_in_java_double_registration() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("java-double");
+    let example = repo_root().join("examples").join("java-double");
+    copy_dir_recursive(&example, &project);
+    let out_dir = project.join("src").join("test").join("java");
+    fs::create_dir_all(&out_dir).expect("mkdir java test tree");
+
+    let Some(java_bin) = maven_java_bin() else {
+        eprintln!("skipping: mvn is unavailable or did not report a usable Java home");
+        return;
+    };
+    let jar = build_java_testng_emitter();
+    rewrite_java_emit_manifest(
+        &project
+            .join(".provekit")
+            .join("emit")
+            .join("java-testng")
+            .join("manifest.toml"),
+        &java_bin,
+        &jar,
+    );
+
+    let plan = project.join("plan.json");
+    write_basic_emit_plan(&plan);
+
+    let output = Command::new(provekit_bin())
+        .arg("emit")
+        .arg("--project")
+        .arg(&project)
+        .arg("--target")
+        .arg("java")
+        .arg("--framework")
+        .arg("testng")
+        .arg("--plan")
+        .arg(&plan)
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--compile-check")
+        .arg("--json")
+        .output()
+        .expect("spawn provekit emit java testng");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "checked-in Java fixture registration must drive TestNG emit\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let receipt: Value = serde_json::from_str(&stdout).expect("emit stdout is JSON");
+    assert_eq!(receipt["ok"], true, "receipt: {receipt}");
+    assert_eq!(receipt["surface"], "java-testng", "receipt: {receipt}");
+    assert_eq!(receipt["targetLanguage"], "java", "receipt: {receipt}");
+    assert_eq!(receipt["targetFramework"], "testng", "receipt: {receipt}");
+    assert_eq!(receipt["isComplete"], true, "receipt: {receipt}");
 }

--- a/implementations/rust/provekit-cli/tests/cmd_emit_rust_cargo_test.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_emit_rust_cargo_test.rs
@@ -93,6 +93,70 @@ fn install_emit_registration(project: &Path, emitter: &Path) {
     .expect("write emit manifest");
 }
 
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap_or_else(|_| panic!("mkdir {}", dst.display()));
+    for entry in fs::read_dir(src).unwrap_or_else(|_| panic!("read {}", src.display())) {
+        let entry = entry.expect("read dir entry");
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type().expect("entry file type").is_dir() {
+            copy_dir_recursive(&src_path, &dst_path);
+        } else {
+            fs::copy(&src_path, &dst_path).unwrap_or_else(|_| {
+                panic!("copy {} -> {}", src_path.display(), dst_path.display())
+            });
+        }
+    }
+}
+
+fn rewrite_manifest_command(manifest: &Path, command: &Path) {
+    let text = fs::read_to_string(manifest)
+        .unwrap_or_else(|_| panic!("read checked-in manifest {}", manifest.display()));
+    let escaped = command
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let rewritten = text
+        .lines()
+        .map(|line| {
+            if line.trim_start().starts_with("command = ") {
+                format!("command = [\"{escaped}\", \"--rpc\"]")
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(manifest, format!("{rewritten}\n"))
+        .unwrap_or_else(|_| panic!("write manifest {}", manifest.display()));
+}
+
+fn write_double_emit_plan(plan: &Path) {
+    fs::write(
+        plan,
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "contract_id": "concept:eq",
+            "function": "double",
+            "params": ["x"],
+            "param_types": ["i64"],
+            "return_type": "i64",
+            "predicates": [{
+                "kind": "atomic",
+                "name": "=",
+                "args": [
+                    {"kind": "ctor", "name": "double", "args": [
+                        {"kind": "const", "value": 3, "sort": {"kind": "primitive", "name": "i64"}}
+                    ]},
+                    {"kind": "const", "value": 6, "sort": {"kind": "primitive", "name": "i64"}}
+                ]
+            }]
+        }))
+        .expect("encode plan"),
+    )
+    .expect("write plan");
+}
+
 fn write_cargo_test_project(project: &Path) -> PathBuf {
     fs::create_dir_all(project.join("src")).expect("mkdir src");
     fs::write(
@@ -186,4 +250,62 @@ fn emit_rust_cargo_test_dispatches_real_emitter_and_cargo_checks_output() {
         emitted.contains("assert_eq!(add(2, 3), 5);"),
         "emitted:\n{emitted}"
     );
+}
+
+#[test]
+fn emit_rust_cargo_test_uses_checked_in_rust_double_registration() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("rust-double");
+    copy_dir_recursive(&repo_root().join("examples").join("rust-double"), &project);
+    let manifest = project
+        .join(".provekit")
+        .join("emit")
+        .join("rust-cargo-test")
+        .join("manifest.toml");
+    assert!(
+        manifest.exists(),
+        "checked-in rust-double fixture must register the rust-cargo-test emitter at {}",
+        manifest.display()
+    );
+
+    let emitter = build_rust_cargo_test_emitter();
+    rewrite_manifest_command(&manifest, &emitter);
+    let out_dir = project.join("src");
+
+    let plan = project.join("plan.json");
+    write_double_emit_plan(&plan);
+
+    let output = Command::new(provekit_bin())
+        .arg("emit")
+        .arg("--project")
+        .arg(&project)
+        .arg("--target")
+        .arg("rust")
+        .arg("--framework")
+        .arg("cargo-test")
+        .arg("--plan")
+        .arg(&plan)
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--compile-check")
+        .arg("--json")
+        .output()
+        .expect("spawn provekit emit rust");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "checked-in Rust fixture registration must drive cargo-test emit\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let receipt: Value = serde_json::from_str(&stdout).expect("emit stdout is JSON");
+    assert_eq!(receipt["ok"], true, "receipt: {receipt}");
+    assert_eq!(receipt["surface"], "rust-cargo-test", "receipt: {receipt}");
+    assert_eq!(receipt["targetLanguage"], "rust", "receipt: {receipt}");
+    assert_eq!(
+        receipt["targetFramework"], "cargo-test",
+        "receipt: {receipt}"
+    );
+    assert_eq!(receipt["compileCheck"]["ok"], true, "receipt: {receipt}");
+    assert_eq!(receipt["isComplete"], true, "receipt: {receipt}");
 }

--- a/tools/check-cross-language-proof-parity-scope.sh
+++ b/tools/check-cross-language-proof-parity-scope.sh
@@ -29,12 +29,12 @@ reject() {
 
 require "Cross-language proof parity: emit/materialize/recognize/mint/prove/contradiction lanes for Java, Go, Python, Rust"
 
-require "emit_java_junit_dispatches_real_emitter_and_maven_checks_output"
-require "emit_java_testng_dispatches_real_emitter_and_maven_checks_output"
+require "emit_java_junit_uses_checked_in_java_double_registration"
+require "emit_java_testng_uses_checked_in_java_double_registration"
 require "emit_go_testing_uses_checked_in_go_double_registration"
 require "emit_go_testify_dispatches_separate_emitter_and_compile_checks"
 require "emit_python_pytest_uses_checked_in_python_double_registration"
-require "emit_rust_cargo_test_dispatches_real_emitter_and_cargo_checks_output"
+require "emit_rust_cargo_test_uses_checked_in_rust_double_registration"
 
 require "materialize_json_client_jackson_loads_from_proof_and_compiles"
 require "go_materialize_uses_checked_in_go_double_realize_registration"


### PR DESCRIPTION
## Summary
- Adds checked-in `examples/java-double` emit registration for JUnit5 and TestNG through `.provekit/config.toml` and per-surface manifests.
- Adds checked-in Rust cargo-test emit registration to `examples/rust-double` and points the parity gate at checked-in Java/Rust registration tests.
- Keeps emit dispatch config/manifest/RPC-driven; tests rewrite only manifest command paths to locally built kit binaries.

## Test Plan
- `tools/check-cross-language-proof-parity-scope.sh`
- `make check-cross-language-proof-parity-scope`
- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_emit_rust_cargo_test emit_rust_cargo_test_uses_checked_in_rust_double_registration -- --nocapture`
- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_emit_java_junit emit_java_junit_uses_checked_in_java_double_registration -- --nocapture`
- `cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_emit_java_testng emit_java_testng_uses_checked_in_java_double_registration -- --nocapture`
- `cargo test --manifest-path examples/rust-double/Cargo.toml --quiet`
- `rustfmt --check implementations/rust/provekit-cli/tests/cmd_emit_java_junit.rs implementations/rust/provekit-cli/tests/cmd_emit_java_testng.rs implementations/rust/provekit-cli/tests/cmd_emit_rust_cargo_test.rs`
- `git diff --check`
