### PR TITLE
Require checked-in Rust materialize registration parity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -750,7 +750,7 @@ cross-language-proof-parity: build-java cross-language-proof-parity-python-env
 		materialize_out_dir_writes_materialized_copy_and_leaves_source_unchanged
 	$(CARGO) test --release --manifest-path implementations/rust/Cargo.toml \
 		-p provekit-cli --test cmd_materialize_integration \
-		materialize_rust_reqwest_example_uses_rust_library_shim
+		materialize_rust_reqwest_uses_checked_in_rust_double_realize_registration
 	@echo "--- recognizer parity ---"
 	$(MVN) -q -f implementations/java/pom.xml \
 		-pl provekit-lift-java-source -am \

--- a/examples/rust-double/.provekit/config.toml
+++ b/examples/rust-double/.provekit/config.toml
@@ -20,6 +20,11 @@ kind = "emit"
 surface = "rust-cargo-test"
 emit = "cargo-test"
 
+[[plugins]]
+name = "rust-realize-reqwest"
+kind = "realize"
+surface = "rust-reqwest"
+
 [solvers]
 default = "z3"
 

--- a/examples/rust-double/.provekit/realize/rust-reqwest/manifest.toml
+++ b/examples/rust-double/.provekit/realize/rust-reqwest/manifest.toml
@@ -1,0 +1,6 @@
+name = "rust-realize-reqwest"
+library_tag = "reqwest"
+materialize_source = true
+command = ["../../implementations/rust/target/debug/provekit-realize-rust", "--rpc"]
+working_dir = "."
+protocol_versions = ["pep/1.7.0"]

--- a/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
@@ -312,6 +312,29 @@ fn rewrite_python_realize_manifest(manifest: &Path) {
         .unwrap_or_else(|_| panic!("write manifest {}", manifest.display()));
 }
 
+fn rewrite_binary_manifest_command(manifest: &Path, binary: &Path) {
+    let text = fs::read_to_string(manifest)
+        .unwrap_or_else(|_| panic!("read checked-in manifest {}", manifest.display()));
+    let binary = binary
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let rewritten = text
+        .lines()
+        .map(|line| {
+            if line.trim_start().starts_with("command = ") {
+                format!("command = [\"{binary}\", \"--rpc\"]")
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(manifest, format!("{rewritten}\n"))
+        .unwrap_or_else(|_| panic!("write manifest {}", manifest.display()));
+}
+
 fn concept_carrier_lines(indent: &str) -> String {
     format!(
         "{indent}// provekit-concept: {}\n{indent}// provekit-concept-payload-cid: {}\n",
@@ -1345,6 +1368,73 @@ fn materialize_rust_reqwest_example_uses_rust_library_shim() {
     assert!(
         stdout.contains("reqwest::get(url)"),
         "Rust reqwest example should route through the Rust reqwest shim:\n{stdout}"
+    );
+    assert!(!stdout.contains("provekit::boundary"));
+}
+
+#[test]
+fn materialize_rust_reqwest_uses_checked_in_rust_double_realize_registration() {
+    let repo = repo_root();
+    let binary = repo
+        .join("implementations")
+        .join("rust")
+        .join("target")
+        .join("debug")
+        .join("provekit-realize-rust");
+    if !binary.exists() {
+        eprintln!("skipping checked-in Rust materialize registration test: provekit-realize-rust binary is unavailable; build with `cargo build -p provekit-realize-rust-core`");
+        return;
+    }
+
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let project = workspace.path().join("rust-double");
+    copy_dir_recursive(
+        &repo.join("examples").join("rust-double").join(".provekit"),
+        &project.join(".provekit"),
+    );
+    rewrite_binary_manifest_command(
+        &project
+            .join(".provekit")
+            .join("realize")
+            .join("rust-reqwest")
+            .join("manifest.toml"),
+        &binary,
+    );
+    fs::write(
+        project.join("Cargo.toml"),
+        "[package]\nname = \"checked-in-rust-materialize\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+    )
+    .expect("write Cargo.toml");
+    let src_dir = project.join("src");
+    fs::create_dir_all(&src_dir).expect("mkdir src");
+    write_rust_http_request_source(&src_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_provekit"))
+        .env("PROVEKIT_REPO_ROOT", repo)
+        .arg("materialize")
+        .arg("--library")
+        .arg("rust-reqwest")
+        .arg("--source-dir")
+        .arg(&src_dir)
+        .arg("--project")
+        .arg(&project)
+        .output()
+        .expect("spawn provekit materialize for checked-in Rust reqwest");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "checked-in rust-double realize registration must drive materialize\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("source materialized by rust kit via RPC"),
+        "Rust source materialize must route through the checked-in Rust kit\nstderr:\n{stderr}"
+    );
+    assert!(stdout.contains("// file: lib.rs"));
+    assert!(
+        stdout.contains("reqwest::get(url)"),
+        "Rust reqwest materialize should route through the reqwest shim:\n{stdout}"
     );
     assert!(!stdout.contains("provekit::boundary"));
 }

--- a/tools/check-cross-language-proof-parity-scope.sh
+++ b/tools/check-cross-language-proof-parity-scope.sh
@@ -43,7 +43,7 @@ require "go_dependency_proofs_are_resolved_by_configured_go_kit"
 require "materialize_python_uses_checked_in_python_double_realize_registration"
 require "materialize_python_requests_example_uses_python_library_shim"
 require "test_resolve_dependency_proofs_returns_distribution_proof_bytes"
-require "materialize_rust_reqwest_example_uses_rust_library_shim"
+require "materialize_rust_reqwest_uses_checked_in_rust_double_realize_registration"
 
 require "RecognizeHandlerTest,JavaSugarBindingLifterTest"
 require "Test(SugarBody|Recognize)"


### PR DESCRIPTION
## Summary
- Adds checked-in Rust reqwest realize registration to examples/rust-double.
- Adds a Rust materialize integration test that copies the checked-in project config, rewrites only the manifest command to the local Rust kit, and verifies materialize goes through kit RPC.
- Updates cross-language-proof-parity to require that checked-in Rust materialize registration test.

## Test Plan
- tools/check-cross-language-proof-parity-scope.sh (RED before Makefile update, green after)
- cargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_materialize_integration materialize_rust_reqwest_uses_checked_in_rust_double_realize_registration -- --nocapture
- make check-cross-language-proof-parity-scope
- rustfmt --check implementations/rust/provekit-cli/tests/cmd_materialize_integration.rs
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Rust/reqwest materialization via checked-in double-realize registration with RPC integration.
  * Configured new plugin for Rust/reqwest surface realization.

* **Tests**
  * Added integration test to validate Rust/reqwest materialization with registered realize kit.

* **Chores**
  * Updated cross-language proof parity verification scope for Rust/reqwest materialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TSavo/provekit/pull/1715?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->