### PR TITLE
fix(smt): do not declare arithmetic builtins (+ - *) as uninterpreted (conformance regression)

### DIFF
--- a/implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs
@@ -627,6 +627,26 @@ fn collect_ctor_decls_formula(formula: &Formula, out: &mut BTreeMap<String, Ctor
     }
 }
 
+/// True iff `name` is an SMT-LIB theory operator that may appear in TERM
+/// position and MUST stay interpreted -- never declared as an uninterpreted
+/// function. This is the term-position analogue of
+/// `is_builtin_atomic_predicate` (which covers boolean-position builtins).
+///
+/// The set is `+ - *`: the exact arithmetic operators the verifier's solver
+/// dispatcher (`provekit-verifier/src/solvers/dispatch.rs`) classifies as
+/// linear-arithmetic. A Java/Go/... lifter lowers `x * 2` to `ctor("*", ...)`,
+/// so without this guard the honesty-layer ctor-declaration pass emitted
+/// `(declare-fun * (Int Int) Int)`, shadowing the theory and turning a proven
+/// `(= (* 3 2) 6)` obligation `sat` (false counterexample).
+///
+/// Integer `/` and `%` are DELIBERATELY excluded: SMT-LIB Int division/modulo
+/// semantics (Euclidean) differ from source truncation, so leaving them
+/// uninterpreted is the sound choice (the cardinal-sin guard). They keep
+/// getting declared uninterpreted, exactly as before.
+fn is_builtin_term_operator(name: &str) -> bool {
+    matches!(name, "+" | "-" | "*")
+}
+
 fn collect_ctor_decls_term(
     term: &Term,
     expected_ret: Option<&str>,
@@ -638,10 +658,17 @@ fn collect_ctor_decls_term(
                 .iter()
                 .map(|arg| known_term_sort(arg).unwrap_or_else(|| "Int".to_string()))
                 .collect();
-            out.entry(name.clone()).or_insert_with(|| CtorSignature {
-                args: arg_sorts.clone(),
-                ret: expected_ret.unwrap_or("Int").to_string(),
-            });
+            // Arithmetic theory operators stay interpreted: declaring them as
+            // uninterpreted functions would shadow the SMT theory and let the
+            // solver pick a counterexample interpretation. Still recurse into
+            // the arguments so any genuine non-builtin ctor nested underneath
+            // (e.g. `Ok`, `method:foo`) is declared.
+            if !is_builtin_term_operator(name) {
+                out.entry(name.clone()).or_insert_with(|| CtorSignature {
+                    args: arg_sorts.clone(),
+                    ret: expected_ret.unwrap_or("Int").to_string(),
+                });
+            }
             for (arg, arg_sort) in args.iter().zip(arg_sorts.iter()) {
                 collect_ctor_decls_term(arg, Some(arg_sort), out);
             }

--- a/implementations/rust/provekit-ir-compiler-smt-lib/tests/arith_builtin_not_uninterpreted.rs
+++ b/implementations/rust/provekit-ir-compiler-smt-lib/tests/arith_builtin_not_uninterpreted.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression guard for the honesty-layer SMT-encoding bug.
+//
+// The reflexive-discharge honesty layer (#1716) added a pass that declares
+// every `Term::Ctor` head it meets in TERM position as an UNINTERPRETED
+// function (`Ok`, `Err`, `method:foo`, ...). The maven Java lifter lowers a
+// binary arithmetic expression like `x * 2` to `ctor("*", [x, 2])`, so the
+// pass wrongly emitted `(declare-fun * (Int Int) Int)`. Declaring an SMT-LIB
+// theory builtin as an uninterpreted function shadows the theory: z3 then
+// treats `*` as a free symbol, so the linear-arithmetic obligation
+// `twice(3) == 6` (`(= (* 3 2) 6)`) becomes satisfiable (a counterexample is
+// found) and the previously-discharged obligation regresses to `unsatisfied`.
+//
+// The interpreted term-operator set is exactly `+ - *` -- the same set the
+// verifier's solver dispatcher (provekit-verifier/src/solvers/dispatch.rs)
+// classifies as linear-arithmetic. Integer `/` and `%` deliberately stay
+// uninterpreted (SMT Int division/modulo semantics differ from source
+// truncation; see `fix(go): leave integer division/modulo uninterpreted`).
+
+use serde_json::json;
+
+use provekit_ir_compiler_smt_lib::emit;
+
+/// `(= (* 3 2) 6)` -- the exact shape of the regressed Java `twice` obligation.
+fn twice_obligation() -> serde_json::Value {
+    json!({
+        "kind": "atomic", "name": "=",
+        "args": [
+            {"kind": "ctor", "name": "*", "args": [
+                {"kind": "const", "value": 3, "sort": {"kind": "primitive", "name": "Int"}},
+                {"kind": "const", "value": 2, "sort": {"kind": "primitive", "name": "Int"}}
+            ]},
+            {"kind": "const", "value": 6, "sort": {"kind": "primitive", "name": "Int"}}
+        ]
+    })
+}
+
+#[test]
+fn multiply_stays_interpreted_not_declared_uninterpreted() {
+    let s = emit(&twice_obligation()).expect("emit");
+    // The bug: `*` was declared as an uninterpreted function, shadowing the
+    // SMT theory operator. It must NOT appear in a declare-fun.
+    assert!(
+        !s.contains("(declare-fun *"),
+        "`*` is an SMT theory builtin and must stay interpreted; \
+         it was wrongly declared uninterpreted:\n{s}"
+    );
+    // It must still be emitted as a builtin application.
+    assert!(
+        s.contains("(* 3 2)"),
+        "multiply must render as the builtin `(* 3 2)`:\n{s}"
+    );
+}
+
+/// Discrimination: a genuine non-builtin ctor (`Ok`) IS declared uninterpreted,
+/// so the fix narrows the declaration set rather than disabling the pass.
+#[test]
+fn genuine_ctor_is_still_declared_uninterpreted() {
+    let f = json!({
+        "kind": "atomic", "name": "=",
+        "args": [
+            {"kind": "ctor", "name": "Ok", "args": [
+                {"kind": "const", "value": 6, "sort": {"kind": "primitive", "name": "Int"}}
+            ]},
+            {"kind": "ctor", "name": "Ok", "args": [
+                {"kind": "const", "value": 6, "sort": {"kind": "primitive", "name": "Int"}}
+            ]}
+        ]
+    });
+    let s = emit(&f).expect("emit");
+    assert!(
+        s.contains("(declare-fun Ok"),
+        "a genuine non-builtin ctor must still be declared uninterpreted:\n{s}"
+    );
+}
+
+/// Addition and subtraction share the arithmetic builtin set with multiply.
+#[test]
+fn add_and_sub_stay_interpreted() {
+    for op in ["+", "-"] {
+        let f = json!({
+            "kind": "atomic", "name": "=",
+            "args": [
+                {"kind": "ctor", "name": op, "args": [
+                    {"kind": "var", "name": "a"},
+                    {"kind": "const", "value": 1, "sort": {"kind": "primitive", "name": "Int"}}
+                ]},
+                {"kind": "var", "name": "b"}
+            ]
+        });
+        let s = emit(&f).expect("emit");
+        assert!(
+            !s.contains(&format!("(declare-fun {op}")),
+            "`{op}` is an SMT theory builtin and must stay interpreted:\n{s}"
+        );
+    }
+}
+
+/// Structural guard: integer division and modulo deliberately stay
+/// uninterpreted (cardinal-sin guard -- SMT Int `/`/`%` semantics differ from
+/// source truncation), so over-interpreting must NOT widen to them.
+#[test]
+fn division_and_modulo_stay_uninterpreted() {
+    for op in ["/", "%"] {
+        let f = json!({
+            "kind": "atomic", "name": "=",
+            "args": [
+                {"kind": "ctor", "name": op, "args": [
+                    {"kind": "var", "name": "a"},
+                    {"kind": "const", "value": 2, "sort": {"kind": "primitive", "name": "Int"}}
+                ]},
+                {"kind": "var", "name": "b"}
+            ]
+        });
+        let s = emit(&f).expect("emit");
+        assert!(
+            s.contains(&format!("(declare-fun {op}")),
+            "`{op}` must stay uninterpreted (Int div/mod cardinal-sin guard):\n{s}"
+        );
+    }
+}


### PR DESCRIPTION
The honesty layer's collect_ctor_decls_term declared every Term::Ctor head uninterpreted, including the SMT-LIB theory builtins `+ - *`, shadowing arithmetic so z3 returned sat on `(* 3 2)==6` and the linear-arithmetic conformance obligation failed (CI run 26702768593, java_production_path_uses_checked_in_java_double_registration). Fix: is_builtin_term_operator skips declaring `+ - *` (matching the verifier's linear-arithmetic set), still recurses into args so Ok/method:* ctors are declared; `/ %` stay uninterpreted (Int div/mod != source truncation). Verified with real z3: failing test now passes, smt-lib + verifier + guarded_panic_safe_unguarded_undecidable all green. NOTE: a SECOND, independent gate failure remains (self-post reflexive rows inflate totalCallsites in the receipt) and is being fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)