### PR TITLE
[codex] Validate RA cache entries per dependency

### DIFF
--- a/implementations/rust/provekit-linkerd/src/methods.rs
+++ b/implementations/rust/provekit-linkerd/src/methods.rs
@@ -300,16 +300,14 @@ pub fn shutdown_response(id: &Json) -> Json {
 ///
 /// Resolution path, per query file:
 ///   1. CACHE FIRST. Read the file's on-disk bytes, compute the content-address
-///      key (blake3(content) + dep-set CID). A cache HIT is AUTHORITATIVE for
-///      the whole file: its resolved positions go straight into `resolved`, its
-///      recorded refusals stay absent, and the file sends ZERO queries to RA.
-///      This is what delivers "second mint, unchanged file, NO rust-analyzer
-///      spawn" even from a fresh daemon process (#1706 per-file granularity).
-///   2. MISS -> RA, only if the resident session is `Ready`. Each position is
-///      classified resolved / deterministic-refuse / not-ready. Resolved
-///      positions go into `resolved`.
-///   3. WRITE BACK only a file whose EVERY queried position SETTLED (resolved or
-///      deterministic-refuse) from a quiescent session. A file with any
+///      key (blake3(content) + Cargo/toolchain CID). Each cached position then
+///      validates its own dependency set. Valid resolved positions go straight
+///      into `resolved`; valid recorded refusals stay absent; invalid/missing
+///      positions alone go to RA. This is the #1706 granularity boundary.
+///   2. MISS -> RA, only if the resident session is `Ready`. Each missed
+///      position is classified resolved / deterministic-refuse / not-ready.
+///   3. WRITE BACK only the positions that SETTLED (resolved or
+///      deterministic-refuse), merging them into the existing file entry. A
 ///      not-ready position is NOT cached (a partial entry would wrongly suppress
 ///      RA later). This preserves the refuse-floor across caching.
 ///
@@ -327,7 +325,7 @@ pub async fn handle_resolve_receiver_crate(
     id: &Json,
 ) -> Json {
     use crate::ra_host::{Phase, PosResult};
-    use crate::resolve_cache::{FileResolution, PosOutcome};
+    use crate::resolve_cache::{CachedPosition, FileResolution, PosOutcome, ResolutionDeps};
     use provekit_walk::ra_oracle::ResolveQuery;
     use std::collections::BTreeMap;
 
@@ -357,10 +355,9 @@ pub async fn handle_resolve_receiver_crate(
             .push((line as u32, col as u32));
     }
 
-    // Second key component: everything the resolution depends on beyond each
-    // file's own bytes (dependency lock + the whole workspace .rs tree, so
-    // cross-file type flow cannot produce a stale hit). Computed once per request.
-    let dep_cid = crate::resolve_cache::resolution_context_cid(&workspace_root);
+    // Second key component: resolver-global inputs (Cargo.lock + toolchain).
+    // Source sensitivity is checked per position through `ResolutionDeps`.
+    let dep_cid = crate::resolve_cache::base_resolution_context_cid(&workspace_root);
 
     let mut resolved: serde_json::Map<String, Json> = serde_json::Map::new();
     // A file that misses the cache and needs RA goes here; we consult the
@@ -376,18 +373,24 @@ pub async fn handle_resolve_receiver_crate(
                 continue;
             };
             if let Some(entry) = cache_guard.get(&content, &dep_cid) {
-                // HIT: authoritative for the whole file, zero RA queries.
+                let mut missing = Vec::new();
                 for (line, col) in positions {
                     let pkey = format!("{line}:{col}");
-                    if let Some(PosOutcome::Crate { krate, type_stem }) =
-                        entry.positions.get(&pkey)
-                    {
-                        resolved.insert(
-                            format!("{file}:{line}:{col}"),
-                            resolution_value(krate, type_stem.as_deref()),
-                        );
+                    match entry.positions.get(&pkey) {
+                        Some(cached) if cached.deps.validate(&workspace_root) => {
+                            if let PosOutcome::Crate { krate, type_stem } = &cached.outcome {
+                                resolved.insert(
+                                    format!("{file}:{line}:{col}"),
+                                    resolution_value(krate, type_stem.as_deref()),
+                                );
+                            }
+                            // Refused -> stays unresolved (refuse-floor).
+                        }
+                        _ => missing.push((*line, *col)),
                     }
-                    // Refused / absent -> stays unresolved (refuse-floor).
+                }
+                if !missing.is_empty() {
+                    needs_ra.push((file.clone(), content, missing));
                 }
             } else {
                 needs_ra.push((file.clone(), content, positions.clone()));
@@ -447,22 +450,28 @@ pub async fn handle_resolve_receiver_crate(
         for ((line, col), r) in positions.iter().zip(results.iter()) {
             let pkey = format!("{line}:{col}");
             match r {
-                PosResult::Resolved { krate, type_stem } => {
+                PosResult::Resolved {
+                    krate,
+                    type_stem,
+                    definition_files,
+                } => {
                     resolved.insert(
                         format!("{file}:{line}:{col}"),
                         resolution_value(krate, type_stem.as_deref()),
                     );
+                    let deps = ResolutionDeps::from_files(&workspace_root, definition_files)
+                        .unwrap_or_else(|| ResolutionDeps::workspace(&workspace_root));
                     file_res.positions.insert(
                         pkey,
-                        PosOutcome::Crate {
-                            krate: krate.clone(),
-                            type_stem: type_stem.clone(),
-                        },
+                        CachedPosition::resolved(krate, type_stem.as_deref(), deps),
                     );
                     n_resolved += 1;
                 }
                 PosResult::Refused => {
-                    file_res.positions.insert(pkey, PosOutcome::Refused);
+                    file_res.positions.insert(
+                        pkey,
+                        CachedPosition::refused(ResolutionDeps::workspace(&workspace_root)),
+                    );
                     n_refused += 1;
                 }
                 PosResult::NotReady => {
@@ -482,7 +491,7 @@ pub async fn handle_resolve_receiver_crate(
     if !cache_writes.is_empty() {
         let mut cache_guard = cache.lock().await;
         for (content, file_res) in cache_writes {
-            cache_guard.insert(&content, &dep_cid, file_res);
+            cache_guard.merge_insert(&content, &dep_cid, file_res);
         }
         // Persist the sidecar so a fresh daemon process hits the cache and skips
         // RA entirely. Best-effort: a write failure does not break correctness

--- a/implementations/rust/provekit-linkerd/src/ra_host.rs
+++ b/implementations/rust/provekit-linkerd/src/ra_host.rs
@@ -67,6 +67,7 @@ pub enum PosResult {
     Resolved {
         krate: String,
         type_stem: Option<String>,
+        definition_files: Vec<PathBuf>,
     },
     Refused,
     NotReady,
@@ -138,11 +139,7 @@ fn vec_not_ready(n: usize) -> Vec<PosResult> {
 
 /// The session thread body: start RA (blocking), flip phase, then service
 /// batches until the command channel closes (daemon shutdown).
-fn session_loop(
-    workspace_root: PathBuf,
-    phase: Arc<Mutex<Phase>>,
-    cmd_rx: Receiver<BatchCmd>,
-) {
+fn session_loop(workspace_root: PathBuf, phase: Arc<Mutex<Phase>>, cmd_rx: Receiver<BatchCmd>) {
     info!(
         workspace = %workspace_root.display(),
         "ra-host: starting resident rust-analyzer session (indexing once, in background)"
@@ -183,6 +180,7 @@ fn session_loop(
                 Ok(Some(tr)) => PosResult::Resolved {
                     krate: tr.krate,
                     type_stem: tr.type_stem,
+                    definition_files: tr.definition_files,
                 },
                 Ok(None) => PosResult::Refused,
                 Err(()) => PosResult::NotReady,
@@ -217,8 +215,8 @@ impl RaHost {
     /// Get the session for `workspace_root`, lazily spawning it (non-blocking)
     /// on first use. The returned session may still be `Spawning`.
     pub fn session_for(&self, workspace_root: &Path) -> Arc<RaSession> {
-        let key = std::fs::canonicalize(workspace_root)
-            .unwrap_or_else(|_| workspace_root.to_path_buf());
+        let key =
+            std::fs::canonicalize(workspace_root).unwrap_or_else(|_| workspace_root.to_path_buf());
         let mut sessions = self.sessions.lock().unwrap();
         if let Some(s) = sessions.get(&key) {
             return s.clone();

--- a/implementations/rust/provekit-linkerd/src/resolve_cache.rs
+++ b/implementations/rust/provekit-linkerd/src/resolve_cache.rs
@@ -12,7 +12,9 @@
 // content-addressed cache persisted to disk skips rust-analyzer ENTIRELY when
 // that input is unchanged, even from a fresh daemon process.
 //
-// KEY (#1705): `(blake3(file_content), resolutionContextCid)`.
+// KEY (#1706): `(blake3(file_content), baseResolutionContextCid)`, where the
+// base context covers Cargo.lock + rust-toolchain only. Source sensitivity lives
+// in each cached position's dependency evidence.
 //
 // HONESTY ABOUT THE INPUT (this is the subtle part, supra omnia rectum). A
 // position's resolution is NOT a pure function of (this file's bytes + the
@@ -25,16 +27,13 @@
 // exact cross-library confusion ProvekIt exists to prevent. So a per-file key is
 // UNSOUND on its own.
 //
-// We therefore fold the WHOLE in-workspace source tree into
-// `resolutionContextCid` (blake3 of Cargo.lock, rust-toolchain[.toml], plus the
-// sorted hashes of every workspace `.rs` file). Any in-workspace edit or
-// toolchain change changes the context CID and invalidates every file's entry.
-// This is deliberately CONSERVATIVE: it over-invalidates (an edit to an
-// unrelated file also drops the cache) in exchange for soundness (a hit can
-// never reflect stale cross-file type flow). A wrong key only ever causes a MISS
-// (re-ask the warm RA), never a wrong HIT. A precise dependency-set-per-file key
-// (#1706's finest granularity) is a future refinement; the conservative tree
-// hash is the sound MVP.
+// The fallback remains the #1705 WHOLE in-workspace source tree context
+// (blake3 of Cargo.lock, rust-toolchain[.toml], plus the sorted hashes of every
+// workspace `.rs` file). #1706 moves that source sensitivity out of the global
+// key and into each cached position: when RA gives us readable definition
+// files, the position records those file CIDs; when it cannot, the position
+// records the coarse workspace context. A wrong/incomplete dependency set only
+// ever causes a MISS (re-ask the warm RA), never a wrong HIT.
 //
 // VALUE: the COMPLETE resolution map for that file from one QUIESCENT pass:
 // `{ "<line>:<col>": "<crate>" }`. A position that was resolved appears with its
@@ -46,7 +45,7 @@
 // RA on a later run). This is what keeps the refuse-floor intact across caching.
 
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use provekit_canonicalizer::blake3_512_of;
 use serde::{Deserialize, Serialize};
@@ -67,20 +66,117 @@ pub enum PosOutcome {
     Refused,
 }
 
+/// One cached position plus the dependency evidence that makes the hit valid.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CachedPosition {
+    pub outcome: PosOutcome,
+    pub deps: ResolutionDeps,
+}
+
+impl CachedPosition {
+    pub fn resolved(krate: &str, type_stem: Option<&str>, deps: ResolutionDeps) -> Self {
+        Self {
+            outcome: PosOutcome::Crate {
+                krate: krate.to_string(),
+                type_stem: type_stem.map(str::to_string),
+            },
+            deps,
+        }
+    }
+
+    pub fn refused(deps: ResolutionDeps) -> Self {
+        Self {
+            outcome: PosOutcome::Refused,
+            deps,
+        }
+    }
+}
+
+/// The dependency evidence for one cached position.
+///
+/// `files` is the precise dependency set for #1706: each path key must still
+/// read to the recorded content CID. `workspace_context_cid` is the conservative
+/// #1705 fallback: when we cannot fully name the files a resolution depends on,
+/// any workspace-source edit invalidates the position instead of serving a
+/// stale answer.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ResolutionDeps {
+    #[serde(default)]
+    pub files: BTreeMap<String, String>,
+    #[serde(default)]
+    pub workspace_context_cid: Option<String>,
+}
+
+impl ResolutionDeps {
+    pub fn workspace(workspace_root: &Path) -> Self {
+        Self {
+            files: BTreeMap::new(),
+            workspace_context_cid: Some(resolution_context_cid(workspace_root)),
+        }
+    }
+
+    pub fn from_files<'a, I, P>(workspace_root: &Path, paths: I) -> Option<Self>
+    where
+        I: IntoIterator<Item = P>,
+        P: AsRef<Path> + 'a,
+    {
+        let mut files = BTreeMap::new();
+        for path in paths {
+            let path = path.as_ref();
+            let bytes = std::fs::read(path).ok()?;
+            files.insert(
+                dependency_path_key(workspace_root, path),
+                blake3_512_of(&bytes),
+            );
+        }
+        if files.is_empty() {
+            None
+        } else {
+            Some(Self {
+                files,
+                workspace_context_cid: None,
+            })
+        }
+    }
+
+    pub fn validate(&self, workspace_root: &Path) -> bool {
+        if self.files.is_empty() && self.workspace_context_cid.is_none() {
+            return false;
+        }
+        if let Some(expected) = &self.workspace_context_cid {
+            if resolution_context_cid(workspace_root) != *expected {
+                return false;
+            }
+        }
+        for (key, expected) in &self.files {
+            let Some(path) = dependency_path_from_key(workspace_root, key) else {
+                return false;
+            };
+            let Ok(bytes) = std::fs::read(path) else {
+                return false;
+            };
+            if blake3_512_of(&bytes) != *expected {
+                return false;
+            }
+        }
+        true
+    }
+}
+
 /// The cached resolution for one file at one (content, dep-set) state.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct FileResolution {
     /// "<line>:<col>" -> outcome. Complete for the positions queried in the
     /// quiescent pass that produced it.
-    pub positions: BTreeMap<String, PosOutcome>,
+    pub positions: BTreeMap<String, CachedPosition>,
 }
 
 /// The persisted cache: content-address key -> file resolution.
 ///
-/// The key is `"<file_content_blake3>|<dep_set_cid>"`. Two different files with
-/// identical content AND dep-set legitimately share an entry: resolution depends
-/// only on content + deps, not on the path. This is the content-addressing
-/// invariant, not a bug.
+/// The key is `"<file_content_blake3>|<base_context_cid>"`. Two different files
+/// with identical content AND base context legitimately share an entry:
+/// position-level dependency validation decides which stored positions still
+/// hit under the current workspace bytes.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ResolveCache {
     entries: BTreeMap<String, FileResolution>,
@@ -100,25 +196,41 @@ impl ResolveCache {
         self.entries.is_empty()
     }
 
-    /// Compute the content-address key for a file's bytes under a dep-set CID.
+    /// Compute the content-address key for a file's bytes under a base context.
     pub fn key(file_content: &[u8], dep_set_cid: &str) -> String {
         let content_cid = blake3_512_of(file_content);
         format!("{content_cid}|{dep_set_cid}")
     }
 
-    /// Look up a file's complete resolution by content + dep-set. A hit is
-    /// AUTHORITATIVE for the whole file: every position it carries is final
-    /// (resolved or refused), and the file contributes ZERO queries to RA.
+    /// Look up a file's cached positions by content + base context. Callers must
+    /// validate each `CachedPosition`'s deps before treating that position as a
+    /// hit.
     pub fn get(&self, file_content: &[u8], dep_set_cid: &str) -> Option<&FileResolution> {
         self.entries.get(&Self::key(file_content, dep_set_cid))
     }
 
-    /// Store a file's complete resolution. Only call this with the outcome of a
-    /// QUIESCENT pass in which every queried position settled; never with a
-    /// partial/not-ready result.
+    /// Store a file's complete resolution. Tests use this for full-entry setup;
+    /// production refreshes should prefer `merge_insert`.
+    #[allow(dead_code)]
     pub fn insert(&mut self, file_content: &[u8], dep_set_cid: &str, resolution: FileResolution) {
         self.entries
             .insert(Self::key(file_content, dep_set_cid), resolution);
+    }
+
+    /// Merge a partial refresh into an existing file entry. #1706 refreshes
+    /// only invalid positions, so rewriting the whole file entry would discard
+    /// still-valid positions and force avoidable RA queries later.
+    pub fn merge_insert(
+        &mut self,
+        file_content: &[u8],
+        dep_set_cid: &str,
+        resolution: FileResolution,
+    ) {
+        let entry = self
+            .entries
+            .entry(Self::key(file_content, dep_set_cid))
+            .or_default();
+        entry.positions.extend(resolution.positions);
     }
 
     /// Serialise to bytes for the sidecar.
@@ -131,6 +243,25 @@ impl ResolveCache {
     pub fn from_bytes(bytes: &[u8]) -> Self {
         serde_json::from_slice(bytes).unwrap_or_default()
     }
+}
+
+/// The coarse cache generation key for #1706. It covers resolver-global inputs
+/// shared by every position but deliberately does NOT include workspace source
+/// bytes; source sensitivity now lives in each `CachedPosition`'s deps.
+pub fn base_resolution_context_cid(workspace_root: &Path) -> String {
+    let lock_bytes = read_nearest_ancestor_file(workspace_root, "Cargo.lock")
+        .unwrap_or_else(|| b"no-cargo-lock".to_vec());
+    let toolchain_bytes = read_nearest_ancestor_file(workspace_root, "rust-toolchain.toml")
+        .or_else(|| read_nearest_ancestor_file(workspace_root, "rust-toolchain"))
+        .unwrap_or_else(|| b"no-rust-toolchain".to_vec());
+
+    let mut acc = String::new();
+    acc.push_str("cargo-lock\0");
+    acc.push_str(&blake3_512_of(&lock_bytes));
+    acc.push('\n');
+    acc.push_str("rust-toolchain\0");
+    acc.push_str(&blake3_512_of(&toolchain_bytes));
+    blake3_512_of(acc.as_bytes())
 }
 
 /// Compute the resolution-context CID: the SECOND key component, capturing every
@@ -225,6 +356,25 @@ fn relative_path_key(root: &Path, path: &Path) -> String {
         .replace('\\', "/")
 }
 
+fn dependency_path_key(workspace_root: &Path, path: &Path) -> String {
+    let root =
+        std::fs::canonicalize(workspace_root).unwrap_or_else(|_| workspace_root.to_path_buf());
+    let normalized = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    if let Ok(rel) = normalized.strip_prefix(&root) {
+        format!("workspace:{}", rel.to_string_lossy().replace('\\', "/"))
+    } else {
+        format!("file:{}", normalized.to_string_lossy().replace('\\', "/"))
+    }
+}
+
+fn dependency_path_from_key(workspace_root: &Path, key: &str) -> Option<PathBuf> {
+    if let Some(rel) = key.strip_prefix("workspace:") {
+        Some(workspace_root.join(rel))
+    } else {
+        key.strip_prefix("file:").map(PathBuf::from)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -275,23 +425,30 @@ mod tests {
         let mut res = FileResolution::default();
         res.positions.insert(
             "3:7".into(),
-            PosOutcome::Crate {
-                krate: "std".into(),
-                type_stem: Some("option".into()),
-            },
+            CachedPosition::resolved(
+                "std",
+                Some("option"),
+                ResolutionDeps::workspace(&unique_temp_dir("unused")),
+            ),
         );
-        res.positions.insert("4:1".into(), PosOutcome::Refused);
+        res.positions.insert(
+            "4:1".into(),
+            CachedPosition::refused(ResolutionDeps::workspace(&unique_temp_dir("unused"))),
+        );
         cache.insert(b"content", "deps", res);
 
         let hit = cache.get(b"content", "deps").unwrap();
         assert_eq!(
-            hit.positions.get("3:7"),
+            hit.positions.get("3:7").map(|pos| &pos.outcome),
             Some(&PosOutcome::Crate {
                 krate: "std".into(),
                 type_stem: Some("option".into()),
             })
         );
-        assert_eq!(hit.positions.get("4:1"), Some(&PosOutcome::Refused));
+        assert_eq!(
+            hit.positions.get("4:1").map(|pos| &pos.outcome),
+            Some(&PosOutcome::Refused)
+        );
         // A different content is a miss.
         assert!(cache.get(b"changed", "deps").is_none());
     }
@@ -302,22 +459,137 @@ mod tests {
         let mut res = FileResolution::default();
         res.positions.insert(
             "1:0".into(),
-            PosOutcome::Crate {
-                krate: "serde_json".into(),
-                type_stem: None,
-            },
+            CachedPosition::resolved(
+                "serde_json",
+                None,
+                ResolutionDeps::workspace(&unique_temp_dir("unused")),
+            ),
         );
         cache.insert(b"x", "d", res);
         let bytes = cache.to_bytes();
         let restored = ResolveCache::from_bytes(&bytes);
         assert_eq!(restored.len(), 1);
         assert_eq!(
-            restored.get(b"x", "d").unwrap().positions.get("1:0"),
+            restored
+                .get(b"x", "d")
+                .unwrap()
+                .positions
+                .get("1:0")
+                .map(|pos| &pos.outcome),
             Some(&PosOutcome::Crate {
                 krate: "serde_json".into(),
                 type_stem: None,
             })
         );
+    }
+
+    #[test]
+    fn base_resolution_context_ignores_unrelated_source_edits() {
+        let root = unique_temp_dir("ra-cache-base-context");
+        write_minimal_workspace(&root);
+
+        let before = base_resolution_context_cid(&root);
+        fs::write(
+            root.join("src").join("other.rs"),
+            "pub fn other() -> u32 { 7 }\n",
+        )
+        .expect("write unrelated source");
+        let after = base_resolution_context_cid(&root);
+
+        let _ = fs::remove_dir_all(&root);
+
+        assert_eq!(
+            before, after,
+            "the cache generation key should cover Cargo/toolchain inputs, not every source file"
+        );
+    }
+
+    #[test]
+    fn precise_file_dependencies_validate_independently() {
+        let root = unique_temp_dir("ra-cache-position-deps");
+        write_minimal_workspace(&root);
+        let dep_a = root.join("src").join("dep_a.rs");
+        let dep_b = root.join("src").join("dep_b.rs");
+        fs::write(&dep_a, "pub fn a() {}\n").expect("write dep_a");
+        fs::write(&dep_b, "pub fn b() {}\n").expect("write dep_b");
+
+        let deps_a = ResolutionDeps::from_files(&root, [&dep_a]).expect("deps a");
+        let deps_b = ResolutionDeps::from_files(&root, [&dep_b]).expect("deps b");
+
+        assert!(deps_a.validate(&root), "dep_a starts valid");
+        assert!(deps_b.validate(&root), "dep_b starts valid");
+
+        fs::write(&dep_b, "pub fn b_changed() {}\n").expect("rewrite dep_b");
+
+        assert!(
+            deps_a.validate(&root),
+            "editing dep_b must not invalidate a position that only depends on dep_a"
+        );
+        assert!(
+            !deps_b.validate(&root),
+            "editing dep_b must invalidate positions that named dep_b"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn merging_partial_refresh_preserves_other_positions() {
+        let root = unique_temp_dir("ra-cache-merge");
+        write_minimal_workspace(&root);
+        let dep_a = root.join("src").join("dep_a.rs");
+        let dep_b = root.join("src").join("dep_b.rs");
+        fs::write(&dep_a, "pub fn a() {}\n").expect("write dep_a");
+        fs::write(&dep_b, "pub fn b() {}\n").expect("write dep_b");
+
+        let base = base_resolution_context_cid(&root);
+        let mut cache = ResolveCache::new();
+        let mut initial = FileResolution::default();
+        initial.positions.insert(
+            "1:1".into(),
+            CachedPosition::resolved(
+                "std",
+                Some("option"),
+                ResolutionDeps::from_files(&root, [&dep_a]).expect("dep a"),
+            ),
+        );
+        initial.positions.insert(
+            "2:1".into(),
+            CachedPosition::refused(ResolutionDeps::from_files(&root, [&dep_b]).expect("dep b")),
+        );
+        cache.insert(b"caller", &base, initial);
+
+        let mut refresh = FileResolution::default();
+        refresh.positions.insert(
+            "2:1".into(),
+            CachedPosition::resolved(
+                "std",
+                Some("result"),
+                ResolutionDeps::from_files(&root, [&dep_b]).expect("dep b refresh"),
+            ),
+        );
+        cache.merge_insert(b"caller", &base, refresh);
+
+        let hit = cache.get(b"caller", &base).expect("merged cache hit");
+        assert_eq!(hit.positions.len(), 2);
+        assert_eq!(
+            hit.positions.get("1:1").map(|pos| &pos.outcome),
+            Some(&PosOutcome::Crate {
+                krate: "std".into(),
+                type_stem: Some("option".into()),
+            }),
+            "partial refresh should not discard an unrelated cached position"
+        );
+        assert_eq!(
+            hit.positions.get("2:1").map(|pos| &pos.outcome),
+            Some(&PosOutcome::Crate {
+                krate: "std".into(),
+                type_stem: Some("result".into()),
+            }),
+            "refreshed position should be updated in place"
+        );
+
+        let _ = fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/implementations/rust/provekit-walk/src/ra_oracle.rs
+++ b/implementations/rust/provekit-walk/src/ra_oracle.rs
@@ -53,6 +53,7 @@ pub struct ResolveQuery {
 pub struct TypedResolution {
     pub krate: String,
     pub type_stem: Option<String>,
+    pub definition_files: Vec<PathBuf>,
 }
 
 /// The oracle handle: a live rust-analyzer LSP subprocess plus the bookkeeping
@@ -320,23 +321,16 @@ impl RaOracle {
                             match kind {
                                 "begin" => info!(
                                     elapsed_s = start.elapsed().as_secs(),
-                                    "RA index begin: {} {}",
-                                    token,
-                                    detail
+                                    "RA index begin: {} {}", token, detail
                                 ),
                                 "end" => info!(
                                     elapsed_s = start.elapsed().as_secs(),
-                                    "RA index done:  {} {}",
-                                    token,
-                                    pmsg
+                                    "RA index done:  {} {}", token, pmsg
                                 ),
                                 _ => match pct {
                                     Some(p) => debug!(
                                         elapsed_s = start.elapsed().as_secs(),
-                                        "RA index:       {} {}% {}",
-                                        token,
-                                        p,
-                                        pmsg
+                                        "RA index:       {} {}% {}", token, p, pmsg
                                     ),
                                     None => debug!("RA index:       {} {}", token, pmsg),
                                 },
@@ -371,7 +365,10 @@ impl RaOracle {
                             }
                         }
                         other => {
-                            trace!(method = other, "oracle: inbound message (not progress/status)");
+                            trace!(
+                                method = other,
+                                "oracle: inbound message (not progress/status)"
+                            );
                         }
                     }
                 }
@@ -536,6 +533,7 @@ impl RaOracle {
         let type_stem = hover_stem
             .clone()
             .or_else(|| type_stem_from_definition_result(&result));
+        let definition_files = definition_files_from_definition_result(&result);
         debug!(
             file = %q.abs_path.display(),
             line = q.lsp_line, col = q.lsp_col,
@@ -543,9 +541,14 @@ impl RaOracle {
             hover_stem = ?hover_stem,
             type_stem = ?type_stem,
             stem_source = if hover_stem.is_some() { "hover" } else { "definition-file-stem" },
+            definition_files = definition_files.len(),
             "oracle: resolved method call to crate + type stem"
         );
-        Ok(Some(TypedResolution { krate, type_stem }))
+        Ok(Some(TypedResolution {
+            krate,
+            type_stem,
+            definition_files,
+        }))
     }
 
     /// Ask `textDocument/hover` at the method-ident position for the RECEIVER's
@@ -709,10 +712,8 @@ impl RaOracle {
     /// back one null per requested item so RA falls back to its defaults rather
     /// than erroring.
     fn respond_if_server_request(&mut self, msg: &Value) -> bool {
-        let (Some(method), Some(id)) = (
-            msg.get("method").and_then(|m| m.as_str()),
-            msg.get("id"),
-        ) else {
+        let (Some(method), Some(id)) = (msg.get("method").and_then(|m| m.as_str()), msg.get("id"))
+        else {
             return false;
         };
         let result = if method == "workspace/configuration" {
@@ -725,7 +726,10 @@ impl RaOracle {
         } else {
             Value::Null
         };
-        trace!(method = method, "oracle: answering RA server->client request");
+        trace!(
+            method = method,
+            "oracle: answering RA server->client request"
+        );
         let reply = json!({ "jsonrpc": "2.0", "id": id.clone(), "result": result });
         let _ = self.write_message(&reply);
         true
@@ -759,7 +763,6 @@ impl RaOracle {
             }
         }
     }
-
 }
 
 /// Backoff between `ContentModified` retries: ramp from 250ms to a 3s cap so
@@ -960,6 +963,36 @@ fn type_stem_from_definition_result(result: &Value) -> Option<String> {
     }
 }
 
+/// Extract every file URI named by a settled definition result. These files are
+/// the immediate semantic evidence for #1706's per-position cache deps. When no
+/// readable file deps can be built from them, linkerd falls back to the coarse
+/// workspace context instead of serving an unverifiable hit.
+fn definition_files_from_definition_result(result: &Value) -> Vec<PathBuf> {
+    let locations: Vec<&Value> = match result {
+        Value::Array(a) => a.iter().collect(),
+        Value::Object(_) => vec![result],
+        _ => return Vec::new(),
+    };
+    let mut files = std::collections::BTreeSet::new();
+    for loc in locations {
+        let Some(uri) = loc
+            .get("uri")
+            .or_else(|| loc.get("targetUri"))
+            .and_then(|v| v.as_str())
+        else {
+            continue;
+        };
+        if let Some(path) = file_path_from_uri(uri) {
+            files.insert(path);
+        }
+    }
+    files.into_iter().collect()
+}
+
+fn file_path_from_uri(uri: &str) -> Option<PathBuf> {
+    uri.strip_prefix("file://").map(PathBuf::from)
+}
+
 /// The defining type stem from a definition-target URI: the source file stem,
 /// with the parent dir folded in for module files named `mod.rs` (so
 /// `slice/mod.rs` -> `slice`, not the useless `mod`). `None` for an unmappable
@@ -1053,8 +1086,8 @@ pub fn type_stem_from_hover_markdown(markdown: &str) -> Option<String> {
     // type. A leading keyword or a `(` (function signature) means this block is
     // not the receiver type.
     const REJECT_PREFIXES: &[&str] = &[
-        "impl ", "impl<", "fn ", "pub ", "let ", "const ", "static ", "use ",
-        "extern ", "struct ", "enum ", "trait ", "type ", "mod ", "where ",
+        "impl ", "impl<", "fn ", "pub ", "let ", "const ", "static ", "use ", "extern ", "struct ",
+        "enum ", "trait ", "type ", "mod ", "where ",
     ];
     if REJECT_PREFIXES.iter().any(|p| first_line.starts_with(p)) {
         return None;
@@ -1319,7 +1352,10 @@ mod tests {
     #[test]
     fn type_stem_from_definition_result_single_and_ambiguous() {
         let single = json!([{ "uri": "file:///opt/rust/library/core/src/option.rs", "range": {} }]);
-        assert_eq!(type_stem_from_definition_result(&single).as_deref(), Some("option"));
+        assert_eq!(
+            type_stem_from_definition_result(&single).as_deref(),
+            Some("option")
+        );
         // Two distinct stems -> refuse (no disambiguation).
         let ambiguous = json!([
             { "uri": "file:///opt/rust/library/core/src/option.rs", "range": {} },
@@ -1330,7 +1366,26 @@ mod tests {
         assert_eq!(type_stem_from_definition_result(&json!([])), None);
         // LocationLink targetUri is read.
         let link = json!([{ "targetUri": "file:///opt/rust/library/core/src/result.rs", "targetRange": {} }]);
-        assert_eq!(type_stem_from_definition_result(&link).as_deref(), Some("result"));
+        assert_eq!(
+            type_stem_from_definition_result(&link).as_deref(),
+            Some("result")
+        );
+    }
+
+    #[test]
+    fn definition_files_from_definition_result_reads_location_and_locationlink() {
+        let result = json!([
+            { "uri": "file:///opt/rust/library/core/src/option.rs", "range": {} },
+            { "targetUri": "file:///opt/rust/library/core/src/result.rs", "targetRange": {} }
+        ]);
+        let files = definition_files_from_definition_result(&result);
+        assert_eq!(files.len(), 2);
+        assert!(files
+            .iter()
+            .any(|path| path.ends_with("library/core/src/option.rs")));
+        assert!(files
+            .iter()
+            .any(|path| path.ends_with("library/core/src/result.rs")));
     }
 
     // ---- hover type-head parser (the hover panic-leaf disambiguator) ----
@@ -1431,13 +1486,17 @@ mod tests {
         // MarkupContent { kind, value }.
         let mc = json!({ "contents": { "kind": "markdown", "value": "```rust\ncore::option::Option\n```" } });
         assert_eq!(
-            hover_markdown(&mc).and_then(|m| type_stem_from_hover_markdown(&m)).as_deref(),
+            hover_markdown(&mc)
+                .and_then(|m| type_stem_from_hover_markdown(&m))
+                .as_deref(),
             Some("option")
         );
         // Bare MarkedString.
         let bare = json!({ "contents": "```rust\nString\n```" });
         assert_eq!(
-            hover_markdown(&bare).and_then(|m| type_stem_from_hover_markdown(&m)).as_deref(),
+            hover_markdown(&bare)
+                .and_then(|m| type_stem_from_hover_markdown(&m))
+                .as_deref(),
             Some("string")
         );
         // Null hover -> no markdown.


### PR DESCRIPTION
## Summary

Refs #1706.

- change the RA resolution cache from whole-workspace source invalidation in the cache key to per-position dependency validation
- record each settled position as a `CachedPosition` with either readable RA definition-file deps or the conservative #1705 workspace-context fallback
- re-query only invalid/missing positions and merge refreshed positions back into the file entry
- carry RA definition file evidence from `provekit-walk` through `provekit-linkerd` over the Rust-kit/linkerd seam; CLI remains language-agnostic

## Validation

- RED: `./bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd resolve_cache -- --nocapture` failed on missing `CachedPosition`, `ResolutionDeps`, `base_resolution_context_cid`, and `merge_insert`
- `./bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-linkerd resolve_cache -- --nocapture`
- `./bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-walk definition_files_from_definition_result -- --nocapture`
- `rustfmt --edition 2021 --check implementations/rust/provekit-linkerd/src/resolve_cache.rs implementations/rust/provekit-linkerd/src/methods.rs implementations/rust/provekit-linkerd/src/ra_host.rs implementations/rust/provekit-walk/src/ra_oracle.rs`
- `git diff --check HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance & Reliability**
  * Finer-grained dependency validation for cached resolutions to prevent stale or incorrect cache hits
  * Incremental cache updates (merge-insert) to avoid overwriting unaffected entries and reduce rework

* **New Features**
  * Resolution results now record definition file locations to improve precision of code navigation and fixes

* **Tests**
  * Added/updated tests to validate per-position deps, cache round-trip, and definition-file extraction
<!-- end of auto-generated comment: release notes by coderabbit.ai -->