### PR TITLE
[codex] Count bridge rows in contradiction green checks

### DIFF
--- a/implementations/rust/provekit-cli/tests/cmd_verify_go_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_go_production_bridge.rs
@@ -369,7 +369,7 @@ fn go_production_path_refuses_planted_contradictory_implication() {
         green_code, 0,
         "base Go project must prove before planting contradiction; report: {green}"
     );
-    assert_eq!(green["totalCallsites"], 1, "green report: {green}");
+    contradiction::assert_green_proves_one_bridge(&green, green_code);
 
     contradiction::plant_contradictory_implication_proof(
         &project.join(".provekit"),

--- a/implementations/rust/provekit-cli/tests/cmd_verify_java_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_java_production_bridge.rs
@@ -652,7 +652,7 @@ fn java_production_path_checked_in_fixture_refuses_planted_contradictory_implica
         green_code, 0,
         "checked-in Java project must prove before planting contradiction; report: {green}"
     );
-    assert_eq!(green["totalCallsites"], 1, "green report: {green}");
+    contradiction::assert_green_proves_one_bridge(&green, green_code);
 
     contradiction::plant_contradictory_implication_proof(
         &project.join(".provekit"),
@@ -687,7 +687,7 @@ fn java_production_path_refuses_planted_contradictory_implication() {
         green_code, 0,
         "base Java project must prove before planting contradiction; report: {green}"
     );
-    assert_eq!(green["totalCallsites"], 1, "green report: {green}");
+    contradiction::assert_green_proves_one_bridge(&green, green_code);
 
     contradiction::plant_contradictory_implication_proof(
         &project.join(".provekit"),

--- a/implementations/rust/provekit-cli/tests/cmd_verify_python_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_python_production_bridge.rs
@@ -473,7 +473,7 @@ fn python_production_path_refuses_planted_contradictory_implication() {
         green_code, 0,
         "base Python project must prove before planting contradiction; report: {green}"
     );
-    assert_eq!(green["totalCallsites"], 1, "green report: {green}");
+    contradiction::assert_green_proves_one_bridge(&green, green_code);
 
     contradiction::plant_contradictory_implication_proof(
         &project.join(".provekit"),

--- a/implementations/rust/provekit-cli/tests/cmd_verify_rust_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_rust_production_bridge.rs
@@ -458,7 +458,7 @@ fn rust_production_path_refuses_planted_contradictory_implication() {
         green_code, 0,
         "base Rust project must prove before planting contradiction; report: {green}"
     );
-    assert_eq!(green["totalCallsites"], 1, "green report: {green}");
+    contradiction::assert_green_proves_one_bridge(&green, green_code);
 
     contradiction::plant_contradictory_implication_proof(
         &project.join(".provekit"),

--- a/implementations/rust/provekit-cli/tests/cmd_verify_scala_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_scala_production_bridge.rs
@@ -8,8 +8,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use serial_test::serial;
 use serde_json::Value as Json;
+use serial_test::serial;
 
 #[path = "support/contradiction.rs"]
 mod contradiction;
@@ -270,7 +270,7 @@ fn scala_production_path_refuses_planted_contradictory_implication() {
         green_code, 0,
         "base Scala project must prove before planting contradiction; report: {green}"
     );
-    assert_eq!(green["totalCallsites"], 1, "green report: {green}");
+    contradiction::assert_green_proves_one_bridge(&green, green_code);
 
     contradiction::plant_contradictory_implication_proof(
         &project.join(".provekit"),

--- a/implementations/rust/provekit-cli/tests/cmd_verify_swift_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_swift_production_bridge.rs
@@ -370,7 +370,7 @@ fn swift_production_path_refuses_planted_contradictory_implication() {
         green_code, 0,
         "base Swift project must prove before planting contradiction; report: {green}"
     );
-    assert_eq!(green["totalCallsites"], 1, "green report: {green}");
+    contradiction::assert_green_proves_one_bridge(&green, green_code);
 
     contradiction::plant_contradictory_implication_proof(
         &project.join(".provekit"),

--- a/implementations/rust/provekit-cli/tests/cmd_verify_typescript_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_typescript_production_bridge.rs
@@ -370,7 +370,7 @@ fn typescript_production_path_refuses_planted_contradictory_implication() {
         green_code, 0,
         "base TypeScript project must prove before planting contradiction; report: {green}"
     );
-    assert_eq!(green["totalCallsites"], 1, "green report: {green}");
+    contradiction::assert_green_proves_one_bridge(&green, green_code);
 
     contradiction::plant_contradictory_implication_proof(
         &project.join(".provekit"),

--- a/implementations/rust/provekit-cli/tests/cmd_verify_zig_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_zig_production_bridge.rs
@@ -337,7 +337,7 @@ fn zig_production_path_refuses_planted_contradictory_implication() {
         green_code, 0,
         "base Zig project must prove before planting contradiction; report: {green}"
     );
-    assert_eq!(green["totalCallsites"], 1, "green report: {green}");
+    contradiction::assert_green_proves_one_bridge(&green, green_code);
 
     contradiction::plant_contradictory_implication_proof(
         &project.join(".provekit"),

--- a/implementations/rust/provekit-cli/tests/support/contradiction.rs
+++ b/implementations/rust/provekit-cli/tests/support/contradiction.rs
@@ -189,6 +189,41 @@ pub fn run_prove_json_with_code(provekit_bin: &Path, project: &Path) -> (Json, i
     (report, output.status.code().unwrap_or(-1))
 }
 
+pub fn assert_green_proves_one_bridge(report: &Json, code: i32) {
+    assert_eq!(
+        code, 0,
+        "base project must prove before planting contradiction; report: {report}"
+    );
+    assert_eq!(
+        report["violations"], 0,
+        "base project must have no violations before planting contradiction; report: {report}"
+    );
+    let rows = report["rows"].as_array().expect("rows");
+    let bridge_rows: Vec<_> = rows
+        .iter()
+        .filter(|row| {
+            row["bridge"]
+                .as_str()
+                .map(|bridge| !bridge.is_empty())
+                .unwrap_or(false)
+        })
+        .collect();
+    assert_eq!(
+        bridge_rows.len(),
+        1,
+        "base project must prove exactly one language bridge before planting contradiction; report: {report}"
+    );
+    let row = bridge_rows[0];
+    assert_eq!(
+        row["status"], "discharged",
+        "base project bridge must discharge before planting contradiction; row: {row}; report: {report}"
+    );
+    assert_ne!(
+        row["dischargeMethod"], "vacuous",
+        "base project bridge must not discharge vacuously before planting contradiction; row: {row}; report: {report}"
+    );
+}
+
 pub fn assert_prove_refuses_contradiction(report: &Json, code: i32, expected_bridge: &str) {
     assert_eq!(
         code, 1,


### PR DESCRIPTION
## Summary
- add a shared contradiction-test helper that asserts the green run proves exactly one language bridge row
- stop using `totalCallsites == 1` in contradiction green checks, since verifier reports now include self-post proof rows too
- update Java, Rust, Go, Python, TypeScript, Swift, Scala, and Zig contradiction parity tests to use the bridge-row assertion

## Validation
- `./bin/bcargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_verify_rust_production_bridge rust_production_path_refuses_planted_contradictory_implication -- --nocapture`
- synced `implementations/java` into the bcargo remote test root, then ran `./bin/bcargo test --release --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_verify_java_production_bridge java_production_path_checked_in_fixture_refuses_planted_contradictory_implication -- --nocapture`
- `rustfmt --edition 2021 --check` on the touched contradiction test files
- `git diff --check HEAD`