### PR TITLE
fix(verifier): a contract self-post is not a call site

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_verify.rs
+++ b/implementations/rust/provekit-cli/src/cmd_verify.rs
@@ -1172,6 +1172,10 @@ mod tests {
             arg_term: None,
             containing_atomic: None,
             guard_facts: Vec::new(),
+            file: None,
+            line: None,
+            callee: None,
+            panic_site: false,
         };
         let obligation = json!({"kind":"atomic","name":"true","args":[]});
         let cid = mint_verification_witness(
@@ -1274,6 +1278,13 @@ mod tests {
             arg_term: Some(json!({"kind": "var", "name": "opt"})),
             containing_atomic: None,
             guard_facts,
+            file: None,
+            line: None,
+            callee: None,
+            // This fixture is a panic trap (`opt.unwrap()`); the guarded vs
+            // unguarded split keys off `panic_site` to demand the `panic-safe`
+            // discharge method, so it MUST be a panic site.
+            panic_site: true,
         }
     }
 

--- a/implementations/rust/provekit-verifier/src/report.rs
+++ b/implementations/rust/provekit-verifier/src/report.rs
@@ -31,10 +31,16 @@ pub fn add_callsite_with_method(
 }
 
 /// Add a contract self-post verification row. A self-post obligation
-/// (`post[result := body]`) has no real callsite, so we synthesize a
-/// minimal `CallSite` whose `property_name`/`property_cid` carry the
-/// contract CID. Counted into the same discharged/violations totals so
-/// the receipt's headline reflects self-posts alongside callsites.
+/// (`post[result := body]`, proving a contract's own body-derived post
+/// reflexively, `body == body`) is a contract-level self-consistency
+/// check, NOT a call site. It MUST NOT count toward `total_callsites`
+/// (which counts only bridge/call-site obligations), so we synthesize a
+/// minimal `CallSite` for the row but deliberately do NOT increment
+/// `total_callsites`. The row still flows into `discharged`/`violations`
+/// (a failing self-post must still fail the run) and remains visible in
+/// the discharge split's `reflexive` bucket (computed by iterating
+/// `rows`), so reflexive self-post coverage stays honest in the
+/// scoreboard without being conflated with real call sites.
 pub fn add_self_post(contract_cid: &str, verdict: ObligationVerdict, reason: &str, r: &mut Report) {
     add_self_post_with_method(contract_cid, verdict, reason, None, r);
 }
@@ -46,7 +52,8 @@ pub fn add_self_post_with_method(
     discharge_method: Option<String>,
     r: &mut Report,
 ) {
-    r.total_callsites += 1;
+    // NOTE: intentionally NO `r.total_callsites += 1` here. A self-post is
+    // a contract self-consistency obligation, not a call site (#fix/self-post-not-a-callsite).
     let cs = CallSite {
         property_name: format!("self-post:{contract_cid}"),
         property_cid: contract_cid.to_string(),
@@ -67,4 +74,56 @@ pub fn add_self_post_with_method(
 
 pub fn add_load_errors(errs: &[LoadError], r: &mut Report) {
     r.load_errors = errs.to_vec();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn self_post_does_not_count_as_a_callsite() {
+        let mut r = Report::default();
+        let cs = CallSite {
+            bridge_ir_name: "bridge.demo".into(),
+            ..CallSite::default()
+        };
+        // One real call site, then one self-post obligation.
+        add_callsite_with_method(&cs, ObligationVerdict::Discharged, "ok", None, &mut r);
+        add_self_post_with_method(
+            "blake3-512:contract",
+            ObligationVerdict::Discharged,
+            "reflexive self-post",
+            Some("reflexive".into()),
+            &mut r,
+        );
+
+        // The self-post MUST NOT inflate the call-site count: only the
+        // genuine bridge obligation counts as a call site.
+        assert_eq!(r.total_callsites, 1, "self-post must not count as a callsite");
+        // But it stays visible as a discharged row in the scoreboard.
+        assert_eq!(r.discharged, 2, "self-post still counts toward discharged");
+        assert_eq!(r.rows.len(), 2, "self-post row must remain visible");
+        assert!(
+            r.rows
+                .iter()
+                .any(|row| row.callsite.property_name == "self-post:blake3-512:contract"),
+            "self-post row must be present for the discharge split to see it"
+        );
+    }
+
+    #[test]
+    fn failing_self_post_still_drives_a_violation() {
+        let mut r = Report::default();
+        add_self_post_with_method(
+            "blake3-512:bad",
+            ObligationVerdict::Unsatisfied,
+            "internally inconsistent contract",
+            None,
+            &mut r,
+        );
+        // Excluding self-posts from the callsite count must NOT turn a
+        // failing self-post into a green run.
+        assert_eq!(r.total_callsites, 0, "self-post is not a callsite");
+        assert_eq!(r.violations, 1, "a failing self-post must still fail the run");
+    }
 }


### PR DESCRIPTION
## What

A contract self-post (`post[result := body]`, the reflexive `body == body` self-consistency check produced by `runner.rs::verify_contract_self_posts`) was being counted in `Report.total_callsites`. It is not a call site. Removed the single `r.total_callsites += 1` from `add_self_post_with_method`.

The self-post row is still appended to `Report.rows` and still flows into `discharged`/`violations` (a failing self-post still fails the run), so the reflexive discharges stay fully visible in `dischargeSplit.reflexive`. They are just no longer conflated with `totalCallsites`. `prove`'s receipt JSON now reflects only bridge/call-site obligations.

## Why

The conformance gate's two Java production-bridge tests observed `totalCallsites` of 2-3 (1 real bridge + 1-2 reflexive self-posts) where only the bridge is a call site. This inflated the count the self-check scoreboard and golden pin against. After the fix both observe `totalCallsites == 1`. The `--kit` conformance path (`cmd_verify.rs::emit_json_receipt`, the `claims` array) never included self-posts, so it is unchanged.

## Verification (real z3, no SKIP)

Run via bcargo on battleaxe with `--nocapture` to defeat the harness's silent toolchain-skip; z3 spawn pids logged.
- Java conformance `cmd_verify_java_production_bridge` 7/7 (real maven lifter + real z3).
- `provekit-cli --test self_check` passes (`silentlyDropped == 0`, `dischargeSplit.falsePass == 0`, reflexive preserved).
- No regression: `provekit-verifier` 83+ green, `provekit-ir-compiler-smt-lib` green, `provekit` bin 105/105 incl. `guarded_panic_safe_unguarded_undecidable` with real z3.
- Two new regression tests in `report.rs`: `self_post_does_not_count_as_a_callsite`, `failing_self_post_still_drives_a_violation`.

## Boy-scout

`cmd_verify.rs` had two pre-existing test-only `CallSite` initializers missing `file`/`line`/`callee`/`panic_site`, which failed to compile on this base and blocked the `guarded_panic` regression target from building. Fixed surgically (panic-trap fixture set `panic_site: true`). Confirmed via stash this was inherited red, not introduced here.

## Out of scope (pre-existing, NOT this change)

- `cmd_verify_rust_production_bridge::rust_mint_does_not_auto_bridge_body_discharge_ineligible_contract` fails on clean `origin/main` (a lift/auto-bridge issue), confirmed red on baseline with these changes stashed.
- The Java/Go production-bridge + recognize-parity gate tests early-`return` "ok" when their toolchain is absent (a silent false-green in the gate itself). Worth converting to a hard failure separately.

Co-Authored-By: Codex (gpt-5.5 xhigh) <noreply@openai.com>