### PR TITLE
feat(oracle): cli-K foundation -- hover resolution validated + RA toolchain auto-pin (silent-failure fix)

### DIFF
--- a/docs/self-application/GOAL-provekit-proves-provekit.md
+++ b/docs/self-application/GOAL-provekit-proves-provekit.md
@@ -46,9 +46,21 @@ honest scoreboard with ZERO silent drops and ZERO false "cannot panic".
   below).
 - Known debt: #1717 (SMT emitter collapses an opaque-sorted `forall` to literal
   `true` on the negated path = latent false-pass; the panic path routes around
-  it). name-in-CID preimage (contradicts names-are-sugar). monorepo
-  rust-analyzer daemon stall (separate infra bug; fixture isolation is the
-  workaround).
+  it). name-in-CID preimage (contradicts names-are-sugar).
+- RESOLVED (2026-05-31): the "monorepo rust-analyzer never quiesces" stall was
+  NOT a distinct infra bug needing a warm-index daemon. It was a SILENT failure:
+  rust-analyzer shells out `cargo metadata`, and when the ambient cargo is a
+  different vintage than the RA binary that call fails on a flag mismatch (e.g.
+  `--lockfile-path`); RA then resolves NOTHING yet reports `quiescent=true,
+  health=warning` -- a K=0 census that looks honest but is a broken oracle.
+  `ra_oracle` now pins RA's `CARGO`/`RUSTUP_TOOLCHAIN` to the toolchain the RA
+  binary lives in. With the pin, RA indexes the FULL provekit-cli workspace and
+  quiesces `health=ok` in ~52s, resolving real cli method receivers via hover
+  (`serde_json::to_string_pretty(&report).unwrap()` -> `core::result::Result` ->
+  stem `result`). Validated by `provekit-walk`'s `hover_probe` bin against
+  `examples/oracle-hover-fixture` AND against provekit-cli itself. The cli-K
+  FOUNDATION (resolution + leaf disambiguation) is unblocked; the remaining lever
+  to raise K is the Phase 2 reasoning tiers, not infra.
 
 ## The metric (the one number we watch)
 

--- a/docs/self-application/GOAL-provekit-proves-provekit.md
+++ b/docs/self-application/GOAL-provekit-proves-provekit.md
@@ -40,10 +40,24 @@ honest scoreboard with ZERO silent drops and ZERO false "cannot panic".
   `cmd_verify::tests::guarded_panic_safe_unguarded_undecidable`). The verifier is
   LANGUAGE-BLIND; the rule is generic: "target carries a non-trivial pre ->
   discharge it under the call-site guard facts."
-- On provekit-cli itself: **K = 0 of 37** production unwrap/expect sites, and
-  that is HONEST: 0 are syntactically guarded; they rest on library totality,
-  value construction, and dataflow facts the engine cannot yet see (census
-  below).
+- On provekit-cli itself (2026-05-31, full oracle-engaged `self-check` run, warm
+  `provekit-linkerd` daemon): **K (panicSafe) = 0**, **silentlyDropped = 0**,
+  **falsePass = 0** (both hard invariants HELD). K=0 is HONEST: provekit-cli has
+  ZERO syntactically-guarded panic sites, so the oracle disambiguates each leaf
+  but cannot manufacture a guard. The oracle MATERIALLY improved the census vs
+  the syntactic-only run (catalog `be345b4d` -> `ec72ab4d`):
+  panic-site-unproven 26 -> 12, bridges emitted 1276 -> 2108, no-contract-for-callee
+  4043 -> 3225, undecidable 1948 -> 2160. The 12 residue are all `.expect()`,
+  9 of them `kit_dispatch.rs` Mutex `lock().expect()` (renders `LockResult`, a
+  `Result` alias) = genuine POISONING RESIDUE ("lock is total" would be unsound).
+- PRODUCT-PATH WIRING (operational, not yet a one-command surface): the mint
+  lifter resolves via a RESIDENT `provekit-linkerd` daemon, not a cold per-mint
+  RA. A cold mint finishes before the daemon's ~52s index, so queries refuse and
+  the census is syntactic-only. The oracle-engaged census requires the daemon
+  PRE-WARMED (`PROVEKIT_LINKERD_BIN` set, one warm-up mint, then `self-check`
+  within the 5-min idle window). Folding this warm-up into `self-check`/`doctor`
+  (so `--oracle` guarantees a warm daemon or loudly says it could not) is the
+  remaining Phase-0 wiring.
 - Known debt: #1717 (SMT emitter collapses an opaque-sorted `forall` to literal
   `true` on the negated path = latent false-pass; the panic path routes around
   it). name-in-CID preimage (contradicts names-are-sugar).

--- a/examples/oracle-hover-fixture/Cargo.toml
+++ b/examples/oracle-hover-fixture/Cargo.toml
@@ -1,0 +1,27 @@
+# Standalone fixture for the rust-analyzer hover type-resolution probe.
+#
+# The panic-freedom-fixture uses `Option<i64>` DIRECTLY, so its `.unwrap()`
+# def-jumps cleanly to std's `option.rs` and the OLD definition-file-stem
+# heuristic already resolves it -- a green test there proves nothing about
+# hover. This fixture instead mirrors the real provekit-cli census shape:
+# `serde_json::to_string(&value).unwrap()`, where the `.unwrap()` receiver is a
+# workspace-local expression of std `Result` type. That is the case the hover
+# refinement was built for. Standalone (one crate) so rust-analyzer indexes it
+# in seconds instead of stalling on the monorepo.
+[package]
+name = "oracle-hover-fixture"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+# Empty [workspace] table: declares this fixture its OWN workspace root so cargo
+# and rust-analyzer do NOT search upward into the provekit monorepo workspace
+# (which is exactly the load that makes RA stall and never quiesce). This is the
+# isolation that lets RA index the fixture in seconds.
+[workspace]
+
+[dependencies]
+serde_json = "1"
+
+[lib]
+path = "src/lib.rs"

--- a/examples/oracle-hover-fixture/src/lib.rs
+++ b/examples/oracle-hover-fixture/src/lib.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Hover type-resolution fixture. The single production function does the exact
+// shape the provekit-cli panic census is dominated by:
+//
+//     serde_json::to_string(value).unwrap()
+//
+// The `.unwrap()` RECEIVER is `serde_json::to_string(value)` -- a workspace-local
+// call expression whose type is std `Result<String, serde_json::Error>`. The old
+// definition-file-stem heuristic derives the receiver-type stem from the file the
+// method DEFINITION lands in; for a method called on a workspace-local receiver
+// expression that path can yield nothing or the wrong file. The hover refinement
+// asks rust-analyzer for the receiver's OWN type at the `unwrap` ident position,
+// which renders `core::result::Result<...>` directly.
+//
+// The probe (`provekit-walk`'s `hover_probe` bin) drives `resolve_typed_classified`
+// at the `unwrap` ident below and asserts `stem_source == "hover"` (the
+// discrimination: that hover FIRED, not merely that the final stem happens to be
+// "result"), printing the raw hover markdown so the live rust-analyzer output is
+// seen rather than assumed.
+
+use serde_json::Value;
+
+/// Serialize `value` and unwrap. The `.unwrap()` is the panic leaf under test.
+pub fn render(value: &Value) -> String {
+    serde_json::to_string(value).unwrap()
+}

--- a/implementations/rust/provekit-walk/src/bin/hover_probe.rs
+++ b/implementations/rust/provekit-walk/src/bin/hover_probe.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Go/no-go probe for the rust-analyzer hover type-resolution refinement.
+//!
+//! The hover refinement's parser is unit-tested against SYNTHETIC markdown
+//! (`core::result::Result` as the first fenced block). What no test confirms is
+//! what LIVE rust-analyzer actually renders at a method-ident position on the
+//! real census shape -- it might emit the module path, an `impl<T> Result<T,E>`
+//! header, or the `pub fn unwrap(...)` signature first (which the parser
+//! correctly REFUSES). If it refuses, hover is inert and silently falls back to
+//! the def-file-stem -- a false foundation for the Tier work stacked on it.
+//!
+//! This probe points a cold-spawned `RaOracle` at a standalone fixture whose
+//! `.unwrap()` receiver is a workspace-local std-`Result` expression
+//! (`serde_json::to_string(value).unwrap()`), then:
+//!   1. prints the RAW hover markdown (the assumed-but-unseen input),
+//!   2. runs it through the public parser,
+//!   3. drives `resolve_typed_classified`,
+//!   4. prints a PASS/FAIL discrimination verdict: PASS iff the stem came from
+//!      HOVER (`stem_source == "hover"`), not merely that the final stem is right.
+//!
+//! Usage:  hover_probe <crate-root> [<src-rel-path>]
+//!   defaults: crate-root="examples/oracle-hover-fixture", src="src/lib.rs"
+//! Requires PROVEKIT_RESOLVE_ORACLE=rust-analyzer (set here if unset).
+//! Exit: 0 = PASS (hover fired), 3 = NO-GO (hover inert / refused),
+//!       2 = could not run (oracle/RA unavailable).
+
+use provekit_walk::ra_oracle::{type_stem_from_hover_markdown, RaOracle, ResolveQuery};
+use std::path::PathBuf;
+
+/// Locate the method-ident position of the first `.<method>(` in `src` and
+/// return (lsp_line, lsp_col), both 0-based (LSP). proc-macro2 columns are
+/// already 0-based and the production pipeline uses `span.line - 1` for the LSP
+/// line; this mirrors that. ASCII fixture, so byte offset == UTF-16 offset.
+fn locate_method(src: &str, method: &str) -> Option<(u32, u32)> {
+    let needle = format!(".{method}");
+    for (i, line) in src.lines().enumerate() {
+        // Skip comment lines: the fixture's doc block contains the call shape as
+        // PROSE (`serde_json::to_string(value).unwrap()`), and pointing RA at a
+        // comment position resolves to nothing (a false NO-GO). Only real code.
+        if line.trim_start().starts_with("//") {
+            continue;
+        }
+        if let Some(dot) = line.find(&needle) {
+            let col = dot + 1; // char index of the ident start, just past the '.'
+            return Some((i as u32, col as u32));
+        }
+    }
+    None
+}
+
+fn main() {
+    // Init a stderr tracing subscriber so the ra_oracle readiness/quiescence and
+    // per-request round-trip logs actually surface under RUST_LOG (e.g.
+    // RUST_LOG=info,provekit_walk::ra_oracle=debug). Without this the probe is
+    // blind to WHY a resolution refused (not-ready vs. genuine null).
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing_subscriber::filter::LevelFilter::WARN.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    if std::env::var("PROVEKIT_RESOLVE_ORACLE").ok().as_deref() != Some("rust-analyzer") {
+        std::env::set_var("PROVEKIT_RESOLVE_ORACLE", "rust-analyzer");
+    }
+
+    let args: Vec<String> = std::env::args().collect();
+    let crate_root_arg = args
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| "examples/oracle-hover-fixture".to_string());
+    let src_rel = args
+        .get(2)
+        .cloned()
+        .unwrap_or_else(|| "src/lib.rs".to_string());
+
+    let crate_root = PathBuf::from(&crate_root_arg)
+        .canonicalize()
+        .unwrap_or_else(|e| panic!("crate root {crate_root_arg:?}: {e}"));
+    let abs_path = crate_root
+        .join(&src_rel)
+        .canonicalize()
+        .unwrap_or_else(|e| panic!("source {src_rel:?} under crate root: {e}"));
+
+    let source = std::fs::read_to_string(&abs_path).expect("read fixture source");
+    let (lsp_line, lsp_col) =
+        locate_method(&source, "unwrap").expect("fixture has a `.unwrap()` site");
+
+    println!("== hover_probe ==");
+    println!("crate root : {}", crate_root.display());
+    println!("source     : {}", abs_path.display());
+    println!(
+        "position   : line {lsp_line}, col {lsp_col} (0-based LSP) at `unwrap`"
+    );
+
+    let mut oracle = match RaOracle::start(&crate_root) {
+        Some(o) => o,
+        None => {
+            eprintln!(
+                "PROBE COULD NOT RUN: RaOracle did not start \
+                 (rust-analyzer missing/disabled). Set PROVEKIT_RUST_ANALYZER \
+                 or put rust-analyzer on PATH."
+            );
+            std::process::exit(2);
+        }
+    };
+
+    let q = ResolveQuery {
+        abs_path: abs_path.clone(),
+        lsp_line,
+        lsp_col,
+    };
+
+    // 1+2: raw hover markdown + what the parser makes of it.
+    println!("\n===== RAW HOVER MARKDOWN (live rust-analyzer at `unwrap`) =====");
+    let hover_md = oracle.hover_markdown_raw(&q);
+    let hover_stem = match &hover_md {
+        Some(md) => {
+            println!("{md}");
+            println!("----- (end raw markdown) -----");
+            let stem = type_stem_from_hover_markdown(md);
+            match &stem {
+                Some(s) => println!("parser     -> hover stem = {s:?}"),
+                None => println!(
+                    "parser     -> REFUSED (None): first ```rust``` block is not a \
+                     bare type path (signature/binding/module/empty)"
+                ),
+            }
+            stem
+        }
+        None => {
+            println!("(no hover result: RA returned null / not-ready / transport failure)");
+            None
+        }
+    };
+
+    // 3: the production resolution path.
+    println!("\n===== resolve_typed_classified (production path) =====");
+    let resolved = oracle.resolve_typed_classified(&q);
+    match &resolved {
+        Ok(Some(res)) => {
+            println!("krate      = {}", res.krate);
+            println!("type_stem  = {:?}", res.type_stem);
+        }
+        Ok(None) => println!("deterministic refuse (Ok(None)): no crate resolved"),
+        Err(()) => println!("not-ready (Err(())): ContentModified budget exhausted"),
+    }
+
+    // 4: the discrimination verdict.
+    println!("\n===== VERDICT =====");
+    let final_stem = match &resolved {
+        Ok(Some(res)) => res.type_stem.clone(),
+        _ => None,
+    };
+    let stem_source = if hover_stem.is_some() {
+        "hover"
+    } else {
+        "definition-file-stem (or unresolved)"
+    };
+    println!("stem_source = {stem_source}");
+    println!("final stem  = {final_stem:?}");
+
+    let pass = hover_stem.is_some() && final_stem.is_some() && hover_stem == final_stem;
+    if pass {
+        println!(
+            "RESULT: PASS -- hover FIRED and supplied the receiver-type stem \
+             on a workspace-local std-typed receiver. cli-K foundation is real."
+        );
+        std::process::exit(0);
+    } else if hover_stem.is_none() && final_stem.is_some() {
+        println!(
+            "RESULT: NO-GO -- hover REFUSED; the stem ({final_stem:?}) came from the \
+             def-file-stem fallback, not hover. Hover is INERT on this shape. The \
+             raw markdown above shows why; the parser or the queried position needs \
+             to change before any Tier work is stacked on hover."
+        );
+        std::process::exit(3);
+    } else {
+        println!(
+            "RESULT: NO-GO -- no stem resolved at all (hover and fallback both \
+             empty). The receiver did not resolve; investigate the raw markdown \
+             and the def path above."
+        );
+        std::process::exit(3);
+    }
+}

--- a/implementations/rust/provekit-walk/src/ra_oracle.rs
+++ b/implementations/rust/provekit-walk/src/ra_oracle.rs
@@ -199,7 +199,12 @@ impl RaOracle {
                 "processId": std::process::id(),
                 "rootUri": root_uri,
                 "capabilities": {
-                    "textDocument": { "definition": { "linkSupport": true } },
+                    "textDocument": {
+                        "definition": { "linkSupport": true },
+                        // Ask for markdown hover so the receiver type renders as a
+                        // fenced ```rust``` block we can parse the type head from.
+                        "hover": { "contentFormat": ["markdown", "plaintext"] }
+                    },
                     "window": { "workDoneProgress": true },
                     // Ask rust-analyzer to emit `experimental/serverStatus`
                     // notifications. They carry `quiescent: true` once the
@@ -498,15 +503,87 @@ impl RaOracle {
         // The type stem is BEST-EFFORT on top of a definite crate: an ambiguous
         // or unmappable stem leaves `type_stem = None` (the caller keeps the
         // crate but cannot reach a disambiguated partial), never a wrong stem.
-        let type_stem = type_stem_from_definition_result(&result);
+        //
+        // PREFER hover for the panic-leaf type stem. `textDocument/hover` at the
+        // method-ident position renders the RECEIVER's own type as text: its first
+        // ```rust``` block is the receiver-type path (e.g. `core::result::Result`,
+        // `core::option::Option`). That gives the receiver TYPE HEAD directly, with
+        // no def-jump-to-a-file heuristic, so it disambiguates the panic partial
+        // even when the definition lands at a workspace-local position (where the
+        // def-file-stem path yields nothing). The definition file-stem
+        // (`type_stem_from_definition_result`) stays as the FALLBACK for the cases
+        // hover refuses, so this is strictly additive: a hover that is empty,
+        // ambiguous, or a signature/binding block (not a bare type path) refuses,
+        // and the caller drops to the def-stem, then to None. An unresolved stem
+        // stays unresolved; we never guess. (The crate still comes from
+        // `definition`; hover only refines the type stem.)
+        let hover_stem = self.hover_type_stem(q);
+        let type_stem = hover_stem
+            .clone()
+            .or_else(|| type_stem_from_definition_result(&result));
         debug!(
             file = %q.abs_path.display(),
             line = q.lsp_line, col = q.lsp_col,
             resolved_crate = %krate,
+            hover_stem = ?hover_stem,
             type_stem = ?type_stem,
+            stem_source = if hover_stem.is_some() { "hover" } else { "definition-file-stem" },
             "oracle: resolved method call to crate + type stem"
         );
         Ok(Some(TypedResolution { krate, type_stem }))
+    }
+
+    /// Ask `textDocument/hover` at the method-ident position for the RECEIVER's
+    /// type stem (`result`/`option`/`slice`/`str`/...), or `None` (refuse).
+    ///
+    /// rust-analyzer's hover at a method-call ident renders the receiver type as
+    /// the FIRST fenced ```rust``` block of the markdown (a bare type path such as
+    /// `core::result::Result` or `core::option::Option`); the method signature and
+    /// docs follow in later blocks. `type_stem_from_hover_markdown` extracts the
+    /// head of that first block (last `::` segment, generics stripped, lowercased).
+    ///
+    /// Soundness: this is BEST-EFFORT and never blocks the crate resolution. Hover
+    /// is a refinement layered on top of the already-settled definition result, so
+    /// a not-ready (ContentModified) hover, a transport failure, an empty/ambiguous
+    /// markdown, or a block that is a signature/binding rather than a bare type
+    /// path all yield `None` (refuse) and the caller falls back to the definition
+    /// file-stem. We never guess a stem from an ambiguous hover.
+    fn hover_type_stem(&mut self, q: &ResolveQuery) -> Option<String> {
+        if self.ensure_open(&q.abs_path).is_none() {
+            return None;
+        }
+        let uri = path_to_uri(&q.abs_path);
+        // Hover refines an already-resolved crate, so it does NOT carry the
+        // ContentModified retry budget the crate path does: if RA answers "not
+        // ready" we simply refuse the stem (the def-stem fallback or `None`
+        // remains). A single ContentModified retry catches a transient churn
+        // without spinning.
+        for attempt in 0..=1 {
+            let id = self.send_request(
+                "textDocument/hover",
+                json!({
+                    "textDocument": { "uri": uri },
+                    "position": { "line": q.lsp_line, "character": q.lsp_col },
+                }),
+            )?;
+            let resp = self.wait_for_response(id, DEFINITION_WAIT)?;
+            let is_content_modified = resp
+                .get("error")
+                .and_then(|e| e.get("code"))
+                .and_then(|c| c.as_i64())
+                == Some(CONTENT_MODIFIED);
+            if is_content_modified {
+                if attempt < 1 {
+                    std::thread::sleep(not_ready_backoff(attempt));
+                    continue;
+                }
+                return None;
+            }
+            let result = resp.get("result")?;
+            let markdown = hover_markdown(result)?;
+            return type_stem_from_hover_markdown(&markdown);
+        }
+        None
     }
 
     /// Send the `textDocument/definition` request for `q`, honouring the
@@ -829,6 +906,150 @@ pub fn type_stem_from_uri(uri: &str) -> Option<String> {
     Some(stem.to_string())
 }
 
+/// Extract the markdown text from a `textDocument/hover` result value. rust-
+/// analyzer returns `{ "contents": { "kind": "markdown"|"plaintext", "value":
+/// <str> } }`; older shapes (`MarkedString` as a bare string, or an array) are
+/// tolerated. `None` when there is no string value (null hover / unexpected
+/// shape).
+fn hover_markdown(result: &Value) -> Option<String> {
+    let contents = result.get("contents")?;
+    match contents {
+        // MarkupContent { kind, value }.
+        Value::Object(o) => o.get("value").and_then(|v| v.as_str()).map(str::to_string),
+        // MarkedString as a bare string.
+        Value::String(s) => Some(s.clone()),
+        // MarkedString[]: concatenate any string/`value` members in order.
+        Value::Array(a) => {
+            let mut parts: Vec<String> = Vec::new();
+            for item in a {
+                match item {
+                    Value::String(s) => parts.push(s.clone()),
+                    Value::Object(o) => {
+                        if let Some(v) = o.get("value").and_then(|v| v.as_str()) {
+                            parts.push(v.to_string());
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            if parts.is_empty() {
+                None
+            } else {
+                Some(parts.join("\n"))
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Parse the RECEIVER TYPE STEM from a `textDocument/hover` markdown body, or
+/// `None` (refuse). This is the hover path of the panic-leaf type discriminator:
+/// hover at a method-call ident renders the receiver type as the FIRST fenced
+/// ```rust``` block (a bare type path, e.g. `core::result::Result`); the method
+/// signature and docs follow in later blocks.
+///
+/// Extraction: take the first ```rust``` fenced block; its first non-empty line
+/// is the receiver type. Strip a leading `&`/`&mut `/`*` (a borrowed receiver is
+/// the value's identity for partial selection), drop everything from the first
+/// `<` (the generic args), take the last `::`-separated path segment, and
+/// lowercase it to the stem (`Result` -> `result`, `Option` -> `option`,
+/// `Vec` -> `vec`, `str` -> `str`).
+///
+/// REFUSE (`None`) when:
+///   - there is no ```rust``` block, or it is empty;
+///   - the first line is a SIGNATURE or BINDING, not a bare type path: it begins
+///     with a Rust keyword (`impl`/`fn`/`pub`/`let`/`const`/`static`/`use`/
+///     `extern`/`struct`/`enum`/`trait`/`type`/`mod`/`where`) or contains a `(`
+///     (a function signature). A hover that only renders the method signature
+///     (not the receiver type) would otherwise yield a wrong head. (At the
+///     method-ident position RA renders the receiver type first, so this is the
+///     defensive floor, not the common path.)
+///   - the resulting head is empty.
+/// The head is NOT itself constrained to a known panic type here: the
+/// `(type_stem, leaf)` mapping downstream is the gate that refuses an
+/// out-of-set head. This keeps the parser a pure, total text function.
+pub fn type_stem_from_hover_markdown(markdown: &str) -> Option<String> {
+    // Find the first fenced ```rust ... ``` block.
+    let block = first_rust_fenced_block(markdown)?;
+    let first_line = block.lines().map(str::trim).find(|l| !l.is_empty())?;
+
+    // Reject signature / binding blocks: only a bare type path is a receiver
+    // type. A leading keyword or a `(` (function signature) means this block is
+    // not the receiver type.
+    const REJECT_PREFIXES: &[&str] = &[
+        "impl ", "impl<", "fn ", "pub ", "let ", "const ", "static ", "use ",
+        "extern ", "struct ", "enum ", "trait ", "type ", "mod ", "where ",
+    ];
+    if REJECT_PREFIXES.iter().any(|p| first_line.starts_with(p)) {
+        return None;
+    }
+    if first_line.contains('(') {
+        return None;
+    }
+
+    // Strip a borrow prefix (`&`, `&mut `, `*`): the partial selection is on the
+    // pointee type's stem.
+    let mut ty = first_line.trim();
+    loop {
+        let trimmed = ty
+            .strip_prefix("&mut ")
+            .or_else(|| ty.strip_prefix('&'))
+            .or_else(|| ty.strip_prefix('*'))
+            .map(str::trim_start);
+        match trimmed {
+            Some(t) => ty = t,
+            None => break,
+        }
+    }
+
+    // Drop generic args (everything from the first `<`).
+    let ty = match ty.find('<') {
+        Some(i) => &ty[..i],
+        None => ty,
+    };
+    let ty = ty.trim();
+    if ty.is_empty() {
+        return None;
+    }
+
+    // Take the last `::`-separated path segment and lowercase it.
+    let head = ty.rsplit("::").next()?.trim();
+    if head.is_empty() || head.contains(char::is_whitespace) {
+        return None;
+    }
+    Some(head.to_ascii_lowercase())
+}
+
+/// Return the body of the first fenced ```rust``` (or bare ```` ``` ````) block
+/// in `markdown`, or `None`. We accept an explicit `rust` language tag and also
+/// a bare fence (some hovers omit the tag); a fence tagged with another language
+/// (e.g. ```json``` in docs) is skipped in favour of the first `rust`/untagged
+/// one. The first such block at a method-ident hover is the receiver type.
+fn first_rust_fenced_block(markdown: &str) -> Option<String> {
+    let mut lines = markdown.lines().peekable();
+    while let Some(line) = lines.next() {
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix("```") {
+            let tag = rest.trim();
+            let is_rust_or_bare = tag.is_empty() || tag.eq_ignore_ascii_case("rust");
+            // Collect the block body up to the closing fence regardless, so we
+            // can skip non-rust blocks correctly.
+            let mut body: Vec<&str> = Vec::new();
+            for inner in lines.by_ref() {
+                if inner.trim_start().starts_with("```") {
+                    break;
+                }
+                body.push(inner);
+            }
+            if is_rust_or_bare {
+                return Some(body.join("\n"));
+            }
+            // Otherwise keep scanning for the next fence.
+        }
+    }
+    None
+}
+
 /// Map a definition-target file URI to its defining crate name, or `None` when
 /// the path is outside the known roots (sysroot / cargo registry). A
 /// workspace-local path is intentionally `None`: Tier 2a already resolves the
@@ -1034,6 +1255,118 @@ mod tests {
         // LocationLink targetUri is read.
         let link = json!([{ "targetUri": "file:///opt/rust/library/core/src/result.rs", "targetRange": {} }]);
         assert_eq!(type_stem_from_definition_result(&link).as_deref(), Some("result"));
+    }
+
+    // ---- hover type-head parser (the hover panic-leaf disambiguator) ----
+
+    /// Build a method-ident hover markdown the way rust-analyzer renders it: the
+    /// receiver type as the FIRST ```rust``` block, then the method signature.
+    fn hover_md(receiver_type_block: &str, signature_block: &str) -> String {
+        format!(
+            "\n```rust\n{receiver_type_block}\n```\n\n```rust\n{signature_block}\n```\n\n---\n\ndocs..."
+        )
+    }
+
+    #[test]
+    fn hover_type_head_parses_result_option_vec_str() {
+        // The receiver-type block RA emits at a method-ident hover (captured from
+        // a real session): a bare fully-qualified type path.
+        assert_eq!(
+            type_stem_from_hover_markdown(&hover_md(
+                "core::result::Result",
+                "impl<T, E> Result<T, E>\npub fn unwrap(self) -> T"
+            ))
+            .as_deref(),
+            Some("result")
+        );
+        assert_eq!(
+            type_stem_from_hover_markdown(&hover_md(
+                "core::option::Option",
+                "impl<T> Option<T>\npub const fn unwrap(self) -> T"
+            ))
+            .as_deref(),
+            Some("option")
+        );
+        // `Vec<T>` head -> `vec` (generics stripped). A non-std-path bare type is
+        // still parsed to its head; the downstream (type, leaf) map is the gate.
+        assert_eq!(
+            type_stem_from_hover_markdown("```rust\nVec<u32>\n```").as_deref(),
+            Some("vec")
+        );
+        // `core::str` (no generic args) -> `str`.
+        assert_eq!(
+            type_stem_from_hover_markdown("```rust\ncore::str\n```").as_deref(),
+            Some("str")
+        );
+        // A borrowed receiver `&str` -> the pointee stem `str`.
+        assert_eq!(
+            type_stem_from_hover_markdown("```rust\n&str\n```").as_deref(),
+            Some("str")
+        );
+        assert_eq!(
+            type_stem_from_hover_markdown("```rust\n&mut Vec<u8>\n```").as_deref(),
+            Some("vec")
+        );
+    }
+
+    #[test]
+    fn hover_type_head_refuses_signature_binding_and_empty() {
+        // A SIGNATURE-only block (no leading receiver-type block): refuse, never
+        // mis-read a fn signature as the receiver type.
+        assert_eq!(
+            type_stem_from_hover_markdown(
+                "```rust\npub fn unwrap(self) -> T\nwhere\n    E: fmt::Debug,\n```"
+            ),
+            None
+        );
+        // An `impl` header is a signature block, not a bare type: refuse.
+        assert_eq!(
+            type_stem_from_hover_markdown("```rust\nimpl<T, E> Result<T, E>\n```"),
+            None
+        );
+        // A `let` binding render (hover at the receiver expression, not the
+        // method): refuse — not a bare type path.
+        assert_eq!(
+            type_stem_from_hover_markdown("```rust\nlet opt: Option<u32>\n```"),
+            None
+        );
+        // No ```rust``` block at all (e.g. an `extern crate serde_json` doc hover
+        // that opens with prose): refuse.
+        assert_eq!(
+            type_stem_from_hover_markdown("# Serde JSON\n\nsome prose, no code fence"),
+            None
+        );
+        // Empty markdown -> refuse.
+        assert_eq!(type_stem_from_hover_markdown(""), None);
+        // An empty ```rust``` block -> refuse.
+        assert_eq!(type_stem_from_hover_markdown("```rust\n\n```"), None);
+    }
+
+    #[test]
+    fn hover_type_head_skips_non_rust_fence_then_reads_rust() {
+        // A leading ```json``` fence (serde docs) must be SKIPPED; the first
+        // ```rust``` block is the receiver type.
+        let md = "```json\n{ \"k\": 1 }\n```\n\n```rust\ncore::result::Result\n```";
+        assert_eq!(type_stem_from_hover_markdown(md).as_deref(), Some("result"));
+    }
+
+    #[test]
+    fn hover_markdown_extracts_value_from_shapes() {
+        // MarkupContent { kind, value }.
+        let mc = json!({ "contents": { "kind": "markdown", "value": "```rust\ncore::option::Option\n```" } });
+        assert_eq!(
+            hover_markdown(&mc).and_then(|m| type_stem_from_hover_markdown(&m)).as_deref(),
+            Some("option")
+        );
+        // Bare MarkedString.
+        let bare = json!({ "contents": "```rust\nString\n```" });
+        assert_eq!(
+            hover_markdown(&bare).and_then(|m| type_stem_from_hover_markdown(&m)).as_deref(),
+            Some("string")
+        );
+        // Null hover -> no markdown.
+        assert_eq!(hover_markdown(&json!({ "contents": Value::Null })), None);
+        assert_eq!(hover_markdown(&json!({})), None);
     }
 
     #[test]

--- a/implementations/rust/provekit-walk/src/ra_oracle.rs
+++ b/implementations/rust/provekit-walk/src/ra_oracle.rs
@@ -586,6 +586,26 @@ impl RaOracle {
         None
     }
 
+    /// Diagnostic: return the RAW `textDocument/hover` markdown at `q`, before any
+    /// stem parsing. Used by the `hover_probe` bin to SEE what live rust-analyzer
+    /// renders at a method-ident position (the input `type_stem_from_hover_markdown`
+    /// is assumed to receive), rather than trusting synthetic unit-test markdown.
+    /// Not on the resolution hot path; `hover_type_stem` is the production caller.
+    pub fn hover_markdown_raw(&mut self, q: &ResolveQuery) -> Option<String> {
+        self.ensure_open(&q.abs_path)?;
+        let uri = path_to_uri(&q.abs_path);
+        let id = self.send_request(
+            "textDocument/hover",
+            json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": q.lsp_line, "character": q.lsp_col },
+            }),
+        )?;
+        let resp = self.wait_for_response(id, DEFINITION_WAIT)?;
+        let result = resp.get("result")?;
+        hover_markdown(result)
+    }
+
     /// Send the `textDocument/definition` request for `q`, honouring the
     /// ContentModified not-ready retry/backoff, and return the raw `result`
     /// value:

--- a/implementations/rust/provekit-walk/src/ra_oracle.rs
+++ b/implementations/rust/provekit-walk/src/ra_oracle.rs
@@ -132,13 +132,28 @@ impl RaOracle {
             binary = %bin.display(),
             "oracle: spawning rust-analyzer LSP subprocess"
         );
-        let mut child = Command::new(&bin)
-            .current_dir(workspace_root)
+        // rust-analyzer shells out `cargo metadata` to load the dependency graph.
+        // If the ambient `cargo` it resolves to is OLDER than the rust-analyzer
+        // binary, that call fails on a flag RA's vintage emits (e.g.
+        // `--lockfile-path`), RA silently resolves NOTHING, yet still reports
+        // `quiescent=true, health=warning`. That is a silent zero-resolution: a
+        // K=0 census that looks honest but is a broken oracle. When RA was located
+        // under a rustup toolchain, pin `CARGO`/`RUSTUP_TOOLCHAIN` to that SAME
+        // toolchain so RA's `cargo metadata` matches its own vintage. Only set
+        // what the caller has not set, so an explicit override always wins.
+        let toolchain_env = rustup_toolchain_env_for(&bin);
+        let mut cmd = Command::new(&bin);
+        cmd.current_dir(workspace_root)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .spawn()
-            .ok()?;
+            .stderr(Stdio::null());
+        for (k, v) in &toolchain_env {
+            if std::env::var_os(k).is_none() {
+                info!(key = %k, value = %v, "oracle: pinning RA toolchain env (matches the RA binary)");
+                cmd.env(k, v);
+            }
+        }
+        let mut child = cmd.spawn().ok()?;
         let stdin = child.stdin.take()?;
         let stdout = child.stdout.take()?;
         let (tx, rx) = std::sync::mpsc::channel::<Value>();
@@ -836,6 +851,47 @@ fn locate_rust_analyzer() -> Option<PathBuf> {
         return Some(PathBuf::from("rust-analyzer"));
     }
     None
+}
+
+/// Derive the `CARGO` / `RUSTUP_TOOLCHAIN` env that pins rust-analyzer's
+/// `cargo metadata` shell-out to the SAME rustup toolchain the RA binary lives
+/// in. Returns an empty vec when `bin` is not under a rustup toolchain layout
+/// (a bare `rust-analyzer` on PATH, or a non-rustup install) -- in that case we
+/// leave the ambient env alone and rely on health-signal surfacing if it breaks.
+///
+/// A rustup RA binary is at `<...>/toolchains/<tc>/bin/rust-analyzer`; the
+/// matching cargo is the sibling `<...>/toolchains/<tc>/bin/cargo`.
+fn rustup_toolchain_env_for(bin: &Path) -> Vec<(String, String)> {
+    // bin/ dir, then the toolchain dir, then its parent (must be `toolchains`).
+    let bin_dir = match bin.parent() {
+        Some(d) => d,
+        None => return Vec::new(),
+    };
+    let tc_dir = match bin_dir.parent() {
+        Some(d) => d,
+        None => return Vec::new(),
+    };
+    let is_rustup_layout = tc_dir
+        .parent()
+        .and_then(|p| p.file_name())
+        .map(|n| n == "toolchains")
+        .unwrap_or(false);
+    if !is_rustup_layout {
+        return Vec::new();
+    }
+    let tc_name = match tc_dir.file_name().and_then(|n| n.to_str()) {
+        Some(n) => n.to_string(),
+        None => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    let cargo = bin_dir.join("cargo");
+    if cargo.is_file() {
+        if let Some(c) = cargo.to_str() {
+            out.push(("CARGO".to_string(), c.to_string()));
+        }
+    }
+    out.push(("RUSTUP_TOOLCHAIN".to_string(), tc_name));
+    out
 }
 
 /// Map a `textDocument/definition` result to a single defining crate, or


### PR DESCRIPTION
## What this lands

The cli-K resolution foundation, validated end-to-end, plus the silent-failure fix that was blocking it.

1. **hover receiver-type resolution** (`698d4763f`) -- hover refines the receiver-type stem when the definition lands at a workspace-local position.
2. **`hover_probe` validation** (`90c49f29c`) -- `examples/oracle-hover-fixture` (own `[workspace]` so RA does not stall on the monorepo) + a `hover_probe` bin that cold-spawns RaOracle, prints the RAW hover markdown, and emits a PASS/NO-GO discrimination verdict (`stem_source==hover`). Validated against the fixture AND provekit-cli itself.
3. **RA toolchain auto-pin** (`08fcfc761`) -- THE silent-failure fix. rust-analyzer shells out `cargo metadata`; a cargo-vintage mismatch (e.g. `--lockfile-path`) makes it fail, RA resolves NOTHING yet reports `quiescent=true, health=warning` -- a K=0 census that looks honest but is a broken oracle. `ra_oracle` now pins `CARGO`/`RUSTUP_TOOLCHAIN` to the toolchain the RA binary lives in. Verified with NO manual env.
4. GOAL doc updates recording the findings.

## Why it matters

The "monorepo rust-analyzer never quiesces" stall -- listed as known infra debt, the reason cli-K work was on a fixture -- was NOT a distinct bug. It was this silent toolchain mismatch. With the pin, the full provekit-cli workspace indexes + quiesces health=ok in ~52s and resolves real cli receivers via hover.

## Measured impact (oracle-engaged `self-check` on provekit-cli, warm provekit-linkerd daemon)

| metric | syntactic-only | oracle-engaged |
|---|---|---|
| bridges emitted | 1276 | 2108 |
| no-contract-for-callee | 4043 | 3225 |
| panic-site-unproven | 26 | 12 |
| undecidable | 1948 | 2160 |
| silentlyDropped | 0 | 0 |
| falsePass | 0 | 0 |
| panicSafe (K) | 0 | 0 |

K=0 is HONEST: provekit-cli has zero syntactically-guarded panic sites. The 12 residue are all `.expect()`, mostly `kit_dispatch` Mutex `lock().expect()` (poisoning residue). Raising K is Phase 2 (totality contracts), not infra.

## Discipline

Language-blind (all RA/hover logic stays in the `provekit-walk` kit). The toolchain mismatch this fixes WAS a silent failure; the probe makes resolution observable. CID-not-name preserved.

Co-Authored-By: Codex (gpt-5.5 xhigh) <noreply@openai.com>