### PR TITLE
fix(smt-lib): encode opaque-sorted quantifiers soundly (close #1717)

### DIFF
--- a/implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs
+++ b/implementations/rust/provekit-ir-compiler-smt-lib/src/generated.rs
@@ -131,6 +131,63 @@ pub fn emit_sort(sort: &Sort) -> String {
     emit_sort_with_reason(sort).0
 }
 
+/// Derive a deterministic, language-blind SMT-LIB sort name for an opaque
+/// sort. Uses the blake3 CID of the serialized sort as the disambiguator so
+/// two distinct opaque sorts always get distinct names, and the same sort
+/// always gets the same name within a compilation unit.
+///
+/// Output format: `S_<first-32-hex-chars-of-CID>`. Prefix ensures the name
+/// starts with a letter (SMT-LIB simple symbol rule). The 32-char CID prefix
+/// gives 128 bits of collision resistance -- more than sufficient for any
+/// realistic formula. The symbol is safe for SMT-LIB simple-symbol syntax
+/// (only [A-Za-z0-9_]).
+fn opaque_sort_smt_name(sort: &Sort) -> String {
+    let serialized = serde_json::to_value(sort).unwrap_or(serde_json::Value::Null);
+    let cid = position_cid_of(&serialized);
+    // Sanitize: keep only alphanumeric and underscore, then prefix with S_.
+    let safe: String = cid
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .take(32)
+        .collect();
+    format!("S_{}", safe)
+}
+
+/// Walk a formula collecting the SMT sort names for all opaque-sorted
+/// quantifiers (Forall/Exists/Choice) so that `(declare-sort <S> 0)` can be
+/// emitted into the preamble before the body. Each distinct opaque sort name
+/// is stored as a key (value is unused).
+fn collect_opaque_quantifier_sorts_formula(
+    formula: &Formula,
+    out: &mut BTreeMap<String, ()>,
+) {
+    match formula {
+        Formula::Atomic { .. } => {}
+        Formula::And { operands }
+        | Formula::Or { operands }
+        | Formula::Not { operands }
+        | Formula::Implies { operands } => {
+            for o in operands {
+                collect_opaque_quantifier_sorts_formula(o, out);
+            }
+        }
+        Formula::Forall { sort, body, .. }
+        | Formula::Exists { sort, body, .. }
+        | Formula::Choice { sort, body, .. } => {
+            let (_, reason) = emit_sort_with_reason(sort);
+            if reason.is_some() {
+                out.insert(opaque_sort_smt_name(sort), ());
+            }
+            collect_opaque_quantifier_sorts_formula(body, out);
+        }
+        Formula::Substitute { .. } | Formula::Apply { .. } => {}
+        Formula::DivergenceBetween { source, target } => {
+            collect_opaque_quantifier_sorts_formula(source, out);
+            collect_opaque_quantifier_sorts_formula(target, out);
+        }
+    }
+}
+
 pub fn emit_formula(formula: &Formula) -> String {
     match formula {
         Formula::Atomic { name, args } => {
@@ -164,19 +221,25 @@ pub fn emit_formula(formula: &Formula) -> String {
         Formula::Forall { name, sort, body } => {
             let (sort_str, reason) = emit_sort_with_reason(sort);
             let body_str = emit_formula(body);
-            if let Some(_r) = reason {
-                // Quantifier over opaque sort: assert SMT-LIB truth as placeholder.
-                return "true".to_string();
-            }
-            format!("(forall (({} {})) {})", name, sort_str, body_str)
+            // Opaque sort: use the CID-derived uninterpreted sort name declared
+            // in the preamble. Collapsing to `true` is unsound: `forall x:S.
+            // false` would then appear as `true` and pass falsely.
+            let effective_sort = if reason.is_some() {
+                opaque_sort_smt_name(sort)
+            } else {
+                sort_str
+            };
+            format!("(forall (({} {})) {})", name, effective_sort, body_str)
         }
         Formula::Exists { name, sort, body } => {
             let (sort_str, reason) = emit_sort_with_reason(sort);
             let body_str = emit_formula(body);
-            if let Some(_r) = reason {
-                return "true".to_string();
-            }
-            format!("(exists (({} {})) {})", name, sort_str, body_str)
+            let effective_sort = if reason.is_some() {
+                opaque_sort_smt_name(sort)
+            } else {
+                sort_str
+            };
+            format!("(exists (({} {})) {})", name, effective_sort, body_str)
         }
         Formula::Choice {
             var_name,
@@ -185,16 +248,18 @@ pub fn emit_formula(formula: &Formula) -> String {
         } => {
             let (sort_str, reason) = emit_sort_with_reason(sort);
             let body_str = emit_formula(body);
-            if let Some(_r) = reason {
-                return "true".to_string();
-            }
+            let effective_sort = if reason.is_some() {
+                opaque_sort_smt_name(sort)
+            } else {
+                sort_str
+            };
             let var_y = format!("{}_y", var_name);
             let body_y = body_str.replace(var_name, &var_y);
             let unique = format!(
                 "(and {} (forall (({} {})) (=> {} (= {} {}))))",
-                body_str, var_y, sort_str, body_y, var_y, var_name
+                body_str, var_y, effective_sort, body_y, var_y, var_name
             );
-            format!("(exists (({} {})) {})", var_name, sort_str, unique)
+            format!("(exists (({} {})) {})", var_name, effective_sort, unique)
         }
         // wp-rule schema nodes (spec 2026-05-13-wp-as-formula.md §2.3):
         // `substitute` / `apply` appear only inside an unreduced `wp_rule`
@@ -339,35 +404,38 @@ fn emit_formula_with_opacities(formula: &Formula, opacities: &mut Vec<OpacityEnt
         }
         Formula::Forall { name, sort, body } => {
             let (_, reason) = emit_sort_with_reason(sort);
-            if let Some(reason_code) = reason {
+            let effective_sort = if let Some(reason_code) = reason {
+                // Record opacity provenance. Still emit a sound quantifier
+                // using the CID-derived uninterpreted sort name declared in
+                // the preamble. Collapsing to `true` is unsound.
                 let serialized = serde_json::to_value(sort).unwrap_or(serde_json::Value::Null);
                 let cid = position_cid_of(&serialized);
                 opacities.push(OpacityEntry {
                     position_cid: cid,
                     reason_code,
                 });
-                "true".to_string()
+                opaque_sort_smt_name(sort)
             } else {
-                let sort_str = emit_sort(sort);
-                let body_str = emit_formula_with_opacities(body, opacities);
-                format!("(forall (({} {})) {})", name, sort_str, body_str)
-            }
+                emit_sort(sort)
+            };
+            let body_str = emit_formula_with_opacities(body, opacities);
+            format!("(forall (({} {})) {})", name, effective_sort, body_str)
         }
         Formula::Exists { name, sort, body } => {
             let (_, reason) = emit_sort_with_reason(sort);
-            if let Some(reason_code) = reason {
+            let effective_sort = if let Some(reason_code) = reason {
                 let serialized = serde_json::to_value(sort).unwrap_or(serde_json::Value::Null);
                 let cid = position_cid_of(&serialized);
                 opacities.push(OpacityEntry {
                     position_cid: cid,
                     reason_code,
                 });
-                "true".to_string()
+                opaque_sort_smt_name(sort)
             } else {
-                let sort_str = emit_sort(sort);
-                let body_str = emit_formula_with_opacities(body, opacities);
-                format!("(exists (({} {})) {})", name, sort_str, body_str)
-            }
+                emit_sort(sort)
+            };
+            let body_str = emit_formula_with_opacities(body, opacities);
+            format!("(exists (({} {})) {})", name, effective_sort, body_str)
         }
         Formula::Choice {
             var_name,
@@ -375,25 +443,25 @@ fn emit_formula_with_opacities(formula: &Formula, opacities: &mut Vec<OpacityEnt
             body,
         } => {
             let (_, reason) = emit_sort_with_reason(sort);
-            if let Some(reason_code) = reason {
+            let effective_sort = if let Some(reason_code) = reason {
                 let serialized = serde_json::to_value(sort).unwrap_or(serde_json::Value::Null);
                 let cid = position_cid_of(&serialized);
                 opacities.push(OpacityEntry {
                     position_cid: cid,
                     reason_code,
                 });
-                "true".to_string()
+                opaque_sort_smt_name(sort)
             } else {
-                let sort_str = emit_sort(sort);
-                let body_str = emit_formula_with_opacities(body, opacities);
-                let var_y = format!("{}_y", var_name);
-                let body_y = body_str.replace(var_name, &var_y);
-                let unique = format!(
-                    "(and {} (forall (({} {})) (=> {} (= {} {}))))",
-                    body_str, var_y, sort_str, body_y, var_y, var_name
-                );
-                format!("(exists (({} {})) {})", var_name, sort_str, unique)
-            }
+                emit_sort(sort)
+            };
+            let body_str = emit_formula_with_opacities(body, opacities);
+            let var_y = format!("{}_y", var_name);
+            let body_y = body_str.replace(var_name, &var_y);
+            let unique = format!(
+                "(and {} (forall (({} {})) (=> {} (= {} {}))))",
+                body_str, var_y, effective_sort, body_y, var_y, var_name
+            );
+            format!("(exists (({} {})) {})", var_name, effective_sort, unique)
         }
         // wp-rule schema nodes (spec 2026-05-13-wp-as-formula.md §2.3):
         // see the note in `emit_formula`.
@@ -804,6 +872,19 @@ pub fn compile_formula(formula: &Formula) -> CompiledFormula {
         preamble.push_str("(declare-fun static_region () Region)\n");
         preamble.push_str("(assert (forall ((r Region)) (Outlives static_region r)))\n");
     }
+    // Declare every opaque-sorted quantifier sort as an uninterpreted sort.
+    // These are sorts the SMT-LIB backend cannot encode natively (non-builtin
+    // primitive sorts, function sorts, dependent sorts, ...). Rather than
+    // collapsing the quantifier to `true` (which is unsound: `forall x:S.
+    // false` would falsely pass), we model each opaque sort as a fresh
+    // uninterpreted sort via `(declare-sort <S> 0)`. Z3 then reasons over it
+    // under an open-world assumption, which is sound: it can only produce
+    // false-negatives (undecidable), never false-positives (false-pass).
+    let mut opaque_sort_decls: BTreeMap<String, ()> = BTreeMap::new();
+    collect_opaque_quantifier_sorts_formula(formula, &mut opaque_sort_decls);
+    for sort_name in opaque_sort_decls.keys() {
+        preamble.push_str(&format!("(declare-sort {} 0)\n", sort_name));
+    }
     for (name, sort) in free_vars.iter() {
         preamble.push_str(&format!("(declare-const {} {})\n", smt_quote(name), sort));
     }
@@ -901,6 +982,13 @@ pub fn compile_asserted_formula(formula: &Formula) -> CompiledFormula {
         preamble.push_str("(assert (forall ((r1 Region) (r2 Region) (r3 Region)) (=> (and (Outlives r1 r2) (Outlives r2 r3)) (Outlives r1 r3))))\n");
         preamble.push_str("(declare-fun static_region () Region)\n");
         preamble.push_str("(assert (forall ((r Region)) (Outlives static_region r)))\n");
+    }
+    // Declare opaque-sorted quantifier sorts as uninterpreted sorts (see the
+    // matching block in `compile_formula` for full rationale).
+    let mut opaque_sort_decls: BTreeMap<String, ()> = BTreeMap::new();
+    collect_opaque_quantifier_sorts_formula(formula, &mut opaque_sort_decls);
+    for sort_name in opaque_sort_decls.keys() {
+        preamble.push_str(&format!("(declare-sort {} 0)\n", sort_name));
     }
     for (name, sort) in free_vars.iter() {
         preamble.push_str(&format!("(declare-const {} {})\n", smt_quote(name), sort));

--- a/implementations/rust/provekit-ir-compiler-smt-lib/src/lib.rs
+++ b/implementations/rust/provekit-ir-compiler-smt-lib/src/lib.rs
@@ -364,7 +364,9 @@ mod tests {
 
     #[test]
     fn functionsort_quantifier_emits_opacity_entry() {
-        // forall (f: Function) . true: FunctionSort in quantifier
+        // forall (f: Function) . true: FunctionSort in quantifier.
+        // After fix: the quantifier is emitted soundly over a CID-derived
+        // uninterpreted sort instead of collapsing to `true`.
         let ir = serde_json::json!({
             "kind": "forall",
             "name": "f",
@@ -377,13 +379,29 @@ mod tests {
             result.opacity_manifest.opacities[0].reason_code,
             "predicate_quantification"
         );
-        assert!(result.body.contains("(assert (not true))"));
-        assert!(!result.body.contains("(true)"));
+        // Sound encoding: the body now contains a real quantifier, not `true`.
+        assert!(
+            result.body.contains("(assert (not (forall ((f S_"),
+            "must emit sound quantifier, got: {}",
+            result.body
+        );
+        assert!(
+            !result.body.contains("(assert (not true))"),
+            "must not collapse quantifier to true: {}",
+            result.body
+        );
+        // The opaque sort is declared in the preamble, not emitted raw.
+        assert!(
+            result.preamble.contains("(declare-sort S_"),
+            "opaque sort must be declared in preamble: {}",
+            result.preamble
+        );
     }
 
     #[test]
     fn dependent_sort_quantifier_emits_opacity_entry() {
-        // exists (n: Dependent) . true: DependentSort in quantifier
+        // exists (n: Dependent) . true: DependentSort in quantifier.
+        // After fix: emitted soundly over a CID-derived uninterpreted sort.
         let ir = serde_json::json!({
             "kind": "exists",
             "name": "n",
@@ -396,8 +414,17 @@ mod tests {
             result.opacity_manifest.opacities[0].reason_code,
             "dependent_type"
         );
-        assert!(result.body.contains("(assert (not true))"));
-        assert!(!result.body.contains("(true)"));
+        // Sound encoding: real quantifier, not collapsed to `true`.
+        assert!(
+            result.body.contains("(assert (not (exists ((n S_"),
+            "must emit sound existential quantifier, got: {}",
+            result.body
+        );
+        assert!(
+            !result.body.contains("(assert (not true))"),
+            "must not collapse quantifier to true: {}",
+            result.body
+        );
     }
 
     #[test]
@@ -422,6 +449,7 @@ mod tests {
         // Rust source sorts such as `Ref<Connection>` are valid IR
         // primitive-sort labels for identity, but not SMT-LIB builtin sorts.
         // The SMT backend must not emit them raw.
+        // After fix: emitted soundly over a CID-derived uninterpreted sort.
         let ir = serde_json::json!({
             "kind": "forall",
             "name": "conn",
@@ -439,8 +467,23 @@ mod tests {
             "opaque Rust source sort must not be emitted as raw SMT-LIB: {}",
             result.body
         );
-        assert!(result.body.contains("(assert (not true))"));
-        assert!(!result.body.contains("(true)"));
+        // Sound encoding: real quantifier over CID-derived sort, not `true`.
+        assert!(
+            result.body.contains("(assert (not (forall ((conn S_"),
+            "must emit sound quantifier, got: {}",
+            result.body
+        );
+        assert!(
+            !result.body.contains("(assert (not true))"),
+            "must not collapse quantifier to true: {}",
+            result.body
+        );
+        // The opaque sort is declared in the preamble via (declare-sort S_... 0).
+        assert!(
+            result.preamble.contains("(declare-sort S_"),
+            "opaque sort must be declared in preamble: {}",
+            result.preamble
+        );
     }
 
     #[test]
@@ -483,6 +526,90 @@ mod tests {
         assert!(
             cids[0] <= cids[1],
             "opacities must be sorted by positionCid"
+        );
+    }
+
+    // ACCEPTANCE DETECTOR (issue #1717 soundness fix):
+    //
+    // Positive:       forall x:opaque. true  -> DISCHARGED (negation is unsat)
+    // Discrimination: forall x:opaque. false -> NOT DISCHARGED (negation is sat)
+    //
+    // Before the fix both collapsed to `true`, making the negation
+    // `(assert (not true))` which z3 returns `unsat` for -- a false pass.
+    // After the fix the negated `false` case emits:
+    //   `(assert (not (forall ((x S_...)) false)))` == `(assert (exists ((x S_...)) true))`
+    // Over a nonempty uninterpreted sort, z3 returns `sat` -> not discharged.
+    // The `true` body case emits:
+    //   `(assert (not (forall ((x S_...)) true)))` == `(assert (exists ((x S_...)) false))`
+    // which z3 returns `unsat` -> discharged. Both are correct.
+    //
+    // This test HARD-FAILS if z3 is not present (no skip): a skipped solver
+    // test is a false green (per product invariant falsePass=0).
+
+    #[test]
+    fn opaque_sort_forall_true_is_discharged_under_z3() {
+        // POSITIVE case: `forall x:opaque. true` must be discharged (negation unsat).
+        let z3 = which_z3().expect(
+            "z3 must be available for opaque-sort soundness check; \
+             install z3 and re-run (a missing z3 is a false green)"
+        );
+        let ir = serde_json::json!({
+            "kind": "forall",
+            "name": "x",
+            "sort": { "kind": "primitive", "name": "OpaqueT" },
+            "body": { "kind": "atomic", "name": "true", "args": [] }
+        });
+        let result = compile_to_parts(&ir).expect("compile succeeds");
+        // Sanity: check the sound quantifier is present in the body.
+        assert!(
+            result.body.contains("(forall ((x S_"),
+            "must emit real quantifier over opaque sort, got: {}",
+            result.body
+        );
+        let script = format!("{}{}", result.preamble, result.body);
+        let out = run_z3(&z3, &script);
+        assert_eq!(
+            out.trim(),
+            "unsat",
+            "forall x:opaque. true must be discharged (negation unsat); z3 said: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn opaque_sort_forall_false_is_not_discharged_under_z3() {
+        // DISCRIMINATION case: `forall x:opaque. false` must NOT be discharged
+        // (negation sat). Before fix this falsely returned `unsat` (false pass).
+        let z3 = which_z3().expect(
+            "z3 must be available for opaque-sort soundness check; \
+             install z3 and re-run (a missing z3 is a false green)"
+        );
+        let ir = serde_json::json!({
+            "kind": "forall",
+            "name": "x",
+            "sort": { "kind": "primitive", "name": "OpaqueT" },
+            "body": { "kind": "atomic", "name": "false", "args": [] }
+        });
+        let result = compile_to_parts(&ir).expect("compile succeeds");
+        // Sanity: the body must contain the real quantifier, not collapsed true.
+        assert!(
+            result.body.contains("(forall ((x S_"),
+            "must emit real quantifier over opaque sort, got: {}",
+            result.body
+        );
+        assert!(
+            !result.body.contains("(assert (not true))"),
+            "quantifier must not have been collapsed to true: {}",
+            result.body
+        );
+        let script = format!("{}{}", result.preamble, result.body);
+        let out = run_z3(&z3, &script);
+        assert_eq!(
+            out.trim(),
+            "sat",
+            "forall x:opaque. false must NOT be discharged (negation must be sat); \
+             z3 said: {} -- this is the false-pass soundness hole from issue #1717",
+            out
         );
     }
 }


### PR DESCRIPTION
## Soundness hole #1717 (Phase 1)

`emit_formula` / `emit_formula_with_opacities` in `provekit-ir-compiler-smt-lib/src/generated.rs` returned the literal `"true"` for any `Forall`/`Exists`/`Choice` over a non-builtin sort (opaque primitive, function/dependent/float/region sort). On the negated validity path this compiled every opaque-sorted quantifier to `(assert (not true))`, which z3 trivially returns `unsat` for -- "discharged" -- regardless of the body. So `forall x:<opaque>. false` FALSELY PASSED. That is a latent false-pass; the product's hard invariant is falsePass=0.

## Fix: sound-encode, never collapse

Replaced the collapse with `(declare-sort S_<CID-prefix> 0)` in the preamble plus a real `(forall ((x S_...)) <body>)`. The sort name is derived from the blake3 CID of the serialized sort: deterministic, collision-resistant, language-blind, no raw source names in SMT output (CID-not-name). z3 reasons under the open-world assumption, which is sound: it can only under-prove, never false-pass. Opacity provenance is preserved in the manifest; both `compile_formula` and `compile_asserted_formula` emit the declare-sort blocks.

## Detector (real z3, hard-fails if z3 absent)

- `opaque_sort_forall_true_is_discharged_under_z3`: `forall x:OpaqueT. true` -> discharged. PASS.
- `opaque_sort_forall_false_is_not_discharged_under_z3`: `forall x:OpaqueT. false` -> NOT discharged (false-pass gone). PASS.

Three existing snapshot tests that asserted the buggy `(assert (not true))` output were updated to the sound encoding. All tests pass across `provekit-ir-compiler-smt-lib` (30) and `provekit-verifier` (8 + suites), real z3.

Note: the Cross-language conformance gate is a known long-red baseline on main (7 bug-zoo/self-application tests, being greened separately); this PR introduces no new failures there.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>