### PR TITLE
feat(self-check): surface oracle engagement, loud-fail when --oracle is inert (Phase 0)

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -189,6 +189,14 @@ struct PerPluginDispatch {
     response: Value,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct OracleObservation {
+    requested: bool,
+    reachable: bool,
+    attempted: u64,
+    resolved: u64,
+}
+
 #[derive(Debug, Clone)]
 struct PreparedLiftStep {
     surface: String,
@@ -232,11 +240,18 @@ fn merge_ir_document_responses(per_plugin: Vec<PerPluginDispatch>) -> Result<Val
     let mut merged_implications: Vec<Value> = Vec::new();
     let mut merged_authorities: Vec<Value> = Vec::new();
     let mut merged_witnesses: Vec<Value> = Vec::new();
+    let mut oracle_observation = OracleObservation::default();
     // Content-shape dedup keys (NOT names). See `canonical_dedup_key`.
     let mut seen_content: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut seen_implications: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut seen_authorities: std::collections::HashSet<String> = std::collections::HashSet::new();
     for entry in per_plugin {
+        let plugin_oracle = oracle_observation_from_lift(&entry.response);
+        oracle_observation.requested |= plugin_oracle.requested;
+        oracle_observation.reachable |= plugin_oracle.reachable;
+        oracle_observation.attempted += plugin_oracle.attempted;
+        oracle_observation.resolved += plugin_oracle.resolved;
+
         let kind = entry
             .response
             .get("kind")
@@ -304,10 +319,24 @@ fn merge_ir_document_responses(per_plugin: Vec<PerPluginDispatch>) -> Result<Val
             merged_witnesses.extend(arr.iter().cloned());
         }
     }
+    let bridges_emitted = merged_ir
+        .iter()
+        .filter(|entry| entry.get("kind").and_then(|v| v.as_str()) == Some("bridge"))
+        .count() as u64;
+    let lift_gaps = merged_diagnostics
+        .iter()
+        .filter(|entry| entry.get("kind").and_then(|v| v.as_str()) == Some("lift-gap"))
+        .count() as u64;
     let mut merged = json!({
         "kind": "ir-document",
         "ir": merged_ir,
         "diagnostics": merged_diagnostics,
+        "bridges_emitted": bridges_emitted,
+        "lift_gaps": lift_gaps,
+        "oracle_requested": oracle_observation.requested,
+        "oracle_reachable": oracle_observation.reachable,
+        "receivers_attempted": oracle_observation.attempted,
+        "receivers_resolved": oracle_observation.resolved,
     });
     if !merged_implications.is_empty() {
         merged["implications"] = Value::Array(merged_implications);
@@ -319,6 +348,32 @@ fn merge_ir_document_responses(per_plugin: Vec<PerPluginDispatch>) -> Result<Val
         merged["witnesses"] = Value::Array(merged_witnesses);
     }
     Ok(merged)
+}
+
+fn oracle_observation_from_lift(lift: &Value) -> OracleObservation {
+    let nested = lift.get("oracle");
+    OracleObservation {
+        requested: nested
+            .and_then(|v| v.get("requested"))
+            .and_then(Value::as_bool)
+            .or_else(|| lift.get("oracle_requested").and_then(Value::as_bool))
+            .unwrap_or(false),
+        reachable: nested
+            .and_then(|v| v.get("reachable"))
+            .and_then(Value::as_bool)
+            .or_else(|| lift.get("oracle_reachable").and_then(Value::as_bool))
+            .unwrap_or(false),
+        attempted: nested
+            .and_then(|v| v.get("attempted"))
+            .and_then(Value::as_u64)
+            .or_else(|| lift.get("receivers_attempted").and_then(Value::as_u64))
+            .unwrap_or(0),
+        resolved: nested
+            .and_then(|v| v.get("resolved"))
+            .and_then(Value::as_u64)
+            .or_else(|| lift.get("receivers_resolved").and_then(Value::as_u64))
+            .unwrap_or(0),
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1343,12 +1398,19 @@ fn mint_result_claim(
 }
 
 fn dispatch_result_to_value(result: &DispatchResult) -> Value {
+    let oracle = oracle_observation_from_lift(&result.lift_result);
     json!({
         "kind": "mint-result",
         "filenameCid": result.filename_cid,
         "contractSetCid": result.contract_set_cid,
         "bytesWritten": result.bytes_written,
         "proofFile": result.proof_file.as_ref().map(|path| path.display().to_string()),
+        "oracle": {
+            "requested": oracle.requested,
+            "reachable": oracle.reachable,
+            "attempted": oracle.attempted,
+            "resolved": oracle.resolved,
+        },
         "lift": result.lift_result,
     })
 }
@@ -3134,6 +3196,37 @@ mod tests {
                 .len(),
             1,
             "merged ir-document must keep implication-lifter output: {merged}"
+        );
+    }
+
+    #[test]
+    fn dispatch_result_to_value_propagates_oracle_observation_from_lift() {
+        let result = DispatchResult {
+            filename_cid: "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+            contract_set_cid: "blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+            bytes_written: 42,
+            proof_file: None,
+            lift_result: json!({
+                "kind": "ir-document",
+                "ir": [],
+                "diagnostics": [],
+                "oracle_requested": true,
+                "oracle_reachable": true,
+                "receivers_attempted": 7,
+                "receivers_resolved": 3
+            }),
+        };
+
+        let value = dispatch_result_to_value(&result);
+
+        assert_eq!(
+            value["oracle"],
+            json!({
+                "requested": true,
+                "reachable": true,
+                "attempted": 7,
+                "resolved": 3
+            })
         );
     }
 

--- a/implementations/rust/provekit-cli/src/cmd_self_check.rs
+++ b/implementations/rust/provekit-cli/src/cmd_self_check.rs
@@ -40,6 +40,15 @@ struct BridgeScoreboard {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+struct OracleScoreboard {
+    requested: bool,
+    engaged: bool,
+    attempted: u64,
+    resolved: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct DischargeSplit {
     panic_safe: usize,
     reflexive: usize,
@@ -75,6 +84,7 @@ struct SelfCheckScoreboard {
     catalog_cid: String,
     lift: LiftScoreboard,
     bridges: BridgeScoreboard,
+    oracle: OracleScoreboard,
     silently_dropped: usize,
     dropped_sites: Vec<Site>,
     discharge_split: DischargeSplit,
@@ -120,6 +130,13 @@ pub fn run(args: SelfCheckArgs) -> u8 {
                         site.file, site.line, site.callee, site.reason
                     );
                 }
+            }
+            if scoreboard.oracle.requested && !scoreboard.oracle.engaged {
+                failed = true;
+                eprintln!(
+                    "self-check --oracle requested but the oracle resolved 0/{} receivers; the census is SYNTACTIC-ONLY (provekit-linkerd unreachable or not warm). Set PROVEKIT_LINKERD_BIN and pre-warm, or run doctor.",
+                    scoreboard.oracle.attempted
+                );
             }
             if failed {
                 crate::EXIT_VERIFY_FAIL
@@ -335,6 +352,7 @@ fn build_scoreboard(
         .get("lift")
         .ok_or("target mint JSON missing lift result")?;
     let (lift, bridges, dropped_sites, unbridged_panic_sites) = lift_scoreboards(lift_json);
+    let oracle = oracle_scoreboard(mint_json);
     let discharge_split = discharge_split(prove_json);
     let panic_census = panic_census(prove_json, unbridged_panic_sites);
     let silently_dropped = dropped_sites.len();
@@ -344,6 +362,7 @@ fn build_scoreboard(
         catalog_cid,
         lift,
         bridges,
+        oracle,
         silently_dropped,
         dropped_sites,
         discharge_split,
@@ -612,6 +631,13 @@ fn emit_scoreboard(scoreboard: &SelfCheckScoreboard, json: bool) {
             format_breakdown(&scoreboard.bridges.lift_gaps)
         );
     }
+    println!(
+        "oracle: requested={}, engaged={}, attempted={}, resolved={}",
+        scoreboard.oracle.requested,
+        scoreboard.oracle.engaged,
+        scoreboard.oracle.attempted,
+        scoreboard.oracle.resolved
+    );
     println!("silentlyDropped: {}", scoreboard.silently_dropped);
     println!(
         "dischargeSplit: panicSafe={}, reflexive={}, vacuous={}, undecidable={}, falsePass={}",
@@ -690,4 +716,91 @@ fn site_cmp(left: &Site, right: &Site) -> std::cmp::Ordering {
 
 fn usize_field(value: &Value, key: &str) -> usize {
     value.get(key).and_then(|v| v.as_u64()).unwrap_or(0) as usize
+}
+
+fn oracle_scoreboard(mint_json: &Value) -> OracleScoreboard {
+    let mint_oracle = mint_json.get("oracle");
+    let lift = mint_json.get("lift");
+    let requested = mint_oracle
+        .and_then(|v| v.get("requested"))
+        .and_then(Value::as_bool)
+        .or_else(|| {
+            lift.and_then(|v| v.get("oracle_requested"))
+                .and_then(Value::as_bool)
+        })
+        .unwrap_or(false);
+    let attempted = mint_oracle
+        .and_then(|v| v.get("attempted"))
+        .and_then(Value::as_u64)
+        .or_else(|| {
+            lift.and_then(|v| v.get("receivers_attempted"))
+                .and_then(Value::as_u64)
+        })
+        .unwrap_or(0);
+    let resolved = mint_oracle
+        .and_then(|v| v.get("resolved"))
+        .and_then(Value::as_u64)
+        .or_else(|| {
+            lift.and_then(|v| v.get("receivers_resolved"))
+                .and_then(Value::as_u64)
+        })
+        .unwrap_or(0);
+    OracleScoreboard {
+        requested,
+        engaged: requested && resolved > 0,
+        attempted,
+        resolved,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn mint_json(requested: bool, attempted: u64, resolved: u64) -> Value {
+        json!({
+            "filenameCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "oracle": {
+                "requested": requested,
+                "reachable": resolved > 0,
+                "attempted": attempted,
+                "resolved": resolved
+            },
+            "lift": {
+                "kind": "ir-document",
+                "ir": [],
+                "diagnostics": []
+            }
+        })
+    }
+
+    fn prove_json() -> Value {
+        json!({
+            "rows": []
+        })
+    }
+
+    #[test]
+    fn build_scoreboard_sets_oracle_engaged_from_requested_and_resolved() {
+        let cases = [
+            (false, 0, false),
+            (false, 1, false),
+            (true, 0, false),
+            (true, 1, true),
+        ];
+
+        for (requested, resolved, expected_engaged) in cases {
+            let scoreboard =
+                build_scoreboard("target", &mint_json(requested, 7, resolved), &prove_json())
+                    .expect("scoreboard");
+            assert_eq!(scoreboard.oracle.requested, requested);
+            assert_eq!(scoreboard.oracle.attempted, 7);
+            assert_eq!(scoreboard.oracle.resolved, resolved);
+            assert_eq!(
+                scoreboard.oracle.engaged, expected_engaged,
+                "requested={requested}, resolved={resolved}"
+            );
+        }
+    }
 }

--- a/implementations/rust/provekit-cli/tests/self_check.rs
+++ b/implementations/rust/provekit-cli/tests/self_check.rs
@@ -75,6 +75,10 @@ fn self_check_on_rust_std_shim_emits_scoreboard_shape_and_hard_invariants() {
     assert!(scoreboard["lift"]["bodyDischargeIneligible"].is_object());
     assert!(scoreboard["bridges"]["emitted"].is_u64());
     assert!(scoreboard["bridges"]["liftGaps"].is_object());
+    assert_eq!(scoreboard["oracle"]["requested"], false);
+    assert_eq!(scoreboard["oracle"]["engaged"], false);
+    assert_eq!(scoreboard["oracle"]["attempted"], 0);
+    assert_eq!(scoreboard["oracle"]["resolved"], 0);
     assert_eq!(scoreboard["silentlyDropped"], 0);
     assert_eq!(scoreboard["dischargeSplit"]["falsePass"], 0);
     assert!(scoreboard["dischargeSplit"]["panicSafe"].is_u64());

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -375,6 +375,14 @@ struct CallSite {
     col: usize,
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+struct OracleObservation {
+    requested: bool,
+    reachable: bool,
+    attempted: u64,
+    resolved: u64,
+}
+
 /// Map of `leaf ident -> crate root` for the `use` imports in one file.
 /// `use libprovekit::core::{address, cid_of_value}` yields
 /// `{address: libprovekit, cid_of_value: libprovekit}`. `crate`/`self`/`super`
@@ -1044,16 +1052,23 @@ fn is_panic_leaf(leaf: &str) -> bool {
 /// imports whose current-crate fallback is intended. The oracle refuses
 /// (leaves `None`) when disabled or unavailable, so this is a pure upgrade over
 /// Tier 2a with no behavior change when off.
-fn resolve_method_calls_via_oracle(workspace_root: &Path, callsites: &mut [(CallSite, PathBuf)]) {
+fn resolve_method_calls_via_oracle(
+    workspace_root: &Path,
+    callsites: &mut [(CallSite, PathBuf)],
+) -> OracleObservation {
     use ra_daemon_client::DaemonQuery;
 
     // Opt-in stays identical to the cold path: a mint with the oracle off must
     // never spawn or contact the daemon's RA host. When off we leave every
     // unresolved method call to the syntactic tiers (Tier 1/2a) and return.
     let oracle_on = std::env::var("PROVEKIT_RESOLVE_ORACLE").unwrap_or_default() == "rust-analyzer";
+    let mut observation = OracleObservation {
+        requested: oracle_on,
+        ..OracleObservation::default()
+    };
     if !oracle_on {
         debug!("oracle: off (PROVEKIT_RESOLVE_ORACLE != rust-analyzer); leaving method calls to Tier 1/2a");
-        return;
+        return observation;
     }
 
     // Gather the eligible positions. proc-macro2 spans are 1-based line /
@@ -1078,9 +1093,10 @@ fn resolve_method_calls_via_oracle(workspace_root: &Path, callsites: &mut [(Call
         }
     }
     let total_queries = queries.len();
+    observation.attempted = total_queries as u64;
     if queries.is_empty() {
         debug!("oracle: no unresolved method calls, skipping");
-        return;
+        return observation;
     }
     debug!(
         count = total_queries,
@@ -1090,8 +1106,11 @@ fn resolve_method_calls_via_oracle(workspace_root: &Path, callsites: &mut [(Call
     // daemon and is reused across mints, fronted by a content-addressed cache.
     // On a cold daemon this returns empty (ready:false) and we refuse to the
     // syntactic tiers; the next mint resolves warm. NEVER blocks for the index.
-    let resolved = ra_daemon_client::resolve_receiver_crates(workspace_root, &queries);
+    let batch = ra_daemon_client::resolve_receiver_crates(workspace_root, &queries);
+    observation.reachable = batch.reachable;
+    let resolved = batch.resolutions;
     let resolved_count = resolved.len();
+    observation.resolved = resolved_count as u64;
     let unavailable_count = total_queries - resolved_count;
     if resolved.is_empty() {
         debug!(
@@ -1099,7 +1118,7 @@ fn resolve_method_calls_via_oracle(workspace_root: &Path, callsites: &mut [(Call
             "oracle: daemon resolved nothing (cold/not-ready or all refused); \
              leaving method calls to Tier 1/2a"
         );
-        return;
+        return observation;
     }
     for (cs, full_path) in callsites.iter_mut() {
         if cs.is_method && cs.callee_crate.is_none() && cs.line >= 1 {
@@ -1148,6 +1167,7 @@ fn resolve_method_calls_via_oracle(workspace_root: &Path, callsites: &mut [(Call
         total_queries,
         unavailable_count
     );
+    observation
 }
 
 fn lift_implications(params: &Value) -> Result<Value, String> {
@@ -1320,7 +1340,7 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
     // `None`, which the matcher below treats exactly as before (current-crate
     // fallback / lift-gap). Tier 1/2a are untouched: only None-on-method sites
     // are sent to the oracle, so the fast path is never slowed by it.
-    resolve_method_calls_via_oracle(&workspace_root, &mut all_callsites);
+    let oracle_observation = resolve_method_calls_via_oracle(&workspace_root, &mut all_callsites);
 
     {
         for (cs, _full_path) in all_callsites {
@@ -1618,6 +1638,12 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
         "kind": "ir-document",
         "ir": entries,
         "diagnostics": diagnostics,
+        "bridges_emitted": bridge_count as u64,
+        "lift_gaps": gap_count as u64,
+        "oracle_requested": oracle_observation.requested,
+        "oracle_reachable": oracle_observation.reachable,
+        "receivers_attempted": oracle_observation.attempted,
+        "receivers_resolved": oracle_observation.resolved,
     }))
 }
 
@@ -8911,6 +8937,10 @@ pub fn caller() -> i64 {
         assert_eq!(diags[0]["kind"], "lift-gap");
         assert_eq!(diags[0]["reason"], "no-contract-for-callee");
         assert_eq!(diags[0]["callee"], "completely_unknown_function");
+        assert!(resp["oracle_requested"].is_boolean());
+        assert_eq!(resp["oracle_reachable"], false);
+        assert_eq!(resp["receivers_attempted"], 0);
+        assert_eq!(resp["receivers_resolved"], 0);
 
         let _ = fs::remove_dir_all(root);
     }

--- a/implementations/rust/provekit-walk/src/ra_daemon_client.rs
+++ b/implementations/rust/provekit-walk/src/ra_daemon_client.rs
@@ -51,6 +51,12 @@ pub struct DaemonResolution {
     pub type_stem: Option<String>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct DaemonResolutionBatch {
+    pub reachable: bool,
+    pub resolutions: HashMap<(String, u32, u32), DaemonResolution>,
+}
+
 /// Ask the resident daemon to resolve a batch of method-call positions in
 /// `workspace_root` to their receiver-defining crate AND receiver-type stem.
 ///
@@ -62,10 +68,10 @@ pub struct DaemonResolution {
 pub fn resolve_receiver_crates(
     workspace_root: &Path,
     queries: &[DaemonQuery],
-) -> HashMap<(String, u32, u32), DaemonResolution> {
-    let mut out = HashMap::new();
+) -> DaemonResolutionBatch {
+    let mut batch = DaemonResolutionBatch::default();
     if queries.is_empty() {
-        return out;
+        return batch;
     }
 
     let project_cid = project_cid_from_workspace(workspace_root);
@@ -82,7 +88,7 @@ pub fn resolve_receiver_crates(
                 "ra-daemon: could not connect/spawn provekit-linkerd; refusing all \
                  method-call resolutions to the syntactic tiers"
             );
-            return out;
+            return batch;
         }
     };
 
@@ -105,13 +111,14 @@ pub fn resolve_receiver_crates(
         Ok(r) => r,
         Err(e) => {
             warn!(error = %e, "ra-daemon: resolveReceiverCrate transport failed; refusing");
-            return out;
+            return batch;
         }
     };
+    batch.reachable = true;
 
     if let Some(err_obj) = resp.get("error") {
         warn!(error = %err_obj, "ra-daemon: daemon returned RPC error; refusing");
-        return out;
+        return batch;
     }
 
     let result = resp.get("result").cloned().unwrap_or(Json::Null);
@@ -131,7 +138,7 @@ pub fn resolve_receiver_crates(
             "ra-daemon: not ready (rust-analyzer still indexing, no cache hits); \
              refusing to the syntactic tiers. The next mint resolves warm."
         );
-        return out;
+        return batch;
     }
 
     if let Some(map) = resolved_obj {
@@ -148,7 +155,7 @@ pub fn resolve_receiver_crates(
             };
             let Some(krate) = krate else { continue };
             if let Some((file, line, col)) = parse_pos_key(key) {
-                out.insert(
+                batch.resolutions.insert(
                     (file, line, col),
                     DaemonResolution {
                         krate: krate.to_string(),
@@ -161,11 +168,11 @@ pub fn resolve_receiver_crates(
 
     info!(
         ready,
-        resolved = out.len(),
+        resolved = batch.resolutions.len(),
         queries = queries.len(),
         "ra-daemon: resolveReceiverCrate complete"
     );
-    out
+    batch
 }
 
 /// Parse a `"<file>:<line>:<col>"` position key back into its parts. The file


### PR DESCRIPTION
## Phase 0: no-silent-failure for the oracle path

`self-check --oracle` silently produced a SYNTACTIC census when the `provekit-linkerd` daemon was not warm: every oracle query refused, the lifter fell back to syntactic resolution, and the scoreboard gave a degraded K=0 census indistinguishable from an honest one. That is the exact no-silent-failure violation Phase 0 forbids (empirically: same command, oracle-engaged CID `ec72ab4d` panic-site-unproven=12 vs syntactic `be345b4d` =26).

## Change

- Lifter (`walk_rpc` + `ra_daemon_client`): counts oracle receivers `attempted` / `resolved` (generic, language-blind) and threads `oracle_requested` / `oracle_reachable` through to the lift result.
- `cmd_mint`: propagates the four values into the mint JSON self-check parses.
- `cmd_self_check`: adds an `oracle` block to the scoreboard:
  ```json
  "oracle": { "requested": false, "engaged": false, "attempted": 0, "resolved": 0 }
  ```
  `engaged = requested && resolved > 0`. When `--oracle` is requested but inert, self-check prints a loud warning and exits non-zero, WITHOUT altering the `silentlyDropped>0` / `falsePass>0` exit conditions.
- Shim self-check test asserts the deterministic no-oracle object.

## Discipline

Language-blind (counters are generic "receivers/resolved"; no rust/option/result names in the cli or scoreboard schema; oracle semantics stay in the walk kit). Observable (inert oracle is loud + counted). No golden file existed in-tree, so the shim test asserts the object directly.

## Verification

Builds clean on battleaxe (all crates). Oracle unit tests + a direct shim self-check (exit 0, `oracle.requested=false`) pass. The Cross-language conformance gate is a known long-red baseline on main (7 bug-zoo/self-application tests, being greened separately); this PR adds no new failures there.

Co-Authored-By: Codex (gpt-5.5 xhigh) <noreply@openai.com>