### PR TITLE
Surface body-discharge tier in verifier output

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_verify.rs
+++ b/implementations/rust/provekit-cli/src/cmd_verify.rs
@@ -250,6 +250,11 @@ struct ClaimResult {
     /// discharged). Reported separately so a reflexive discharge is never
     /// conflated with a meaningful proof.
     discharge_method: Option<String>,
+    /// Body-discharge reducer route, when the claim was reduced through a
+    /// callee body before solving. This stays separate from `discharge_method`:
+    /// a route can be visible on a violation, while a method is only a proof
+    /// classification for discharged obligations.
+    body_discharge_tier: Option<String>,
 }
 
 pub fn run(args: VerifyArgs) -> u8 {
@@ -501,6 +506,7 @@ fn verify_one_claim(
         reason: String::new(),
         witness_cid: None,
         discharge_method: None,
+        body_discharge_tier: None,
     };
 
     // Set when the panic-pre obligation was wrapped under a dominating guard
@@ -556,7 +562,10 @@ fn verify_one_claim(
     // claim. Anything outside the recognized shape falls through to the
     // existing refinement path below.
     let obligation = match body_discharge_result {
-        Ok(Some(body_discharge::BodyObligation::Reduced(reduced))) => reduced,
+        Ok(Some(body_discharge::BodyObligation::Reduced { formula, tier })) => {
+            result.body_discharge_tier = Some(tier.as_str().to_string());
+            formula
+        }
         Ok(None) => {
             // Not a body-bearing claim: resolve the target contract's pre
             // and build the refinement obligation, exactly as before.
@@ -706,9 +715,7 @@ fn verify_one_claim(
             // all_guard_facts == cs.guard_facts (unchanged). The unguarded site
             // stays undecidable; no false pass is introduced.
             let mut all_guard_facts: Vec<Json> = cs.guard_facts.clone();
-            if let Some(callee_fact) =
-                body_discharge::callee_post_guard_fact(cs, pool)
-            {
+            if let Some(callee_fact) = body_discharge::callee_post_guard_fact(cs, pool) {
                 debug!(
                     bridge = %cs.bridge_ir_name,
                     callee_fact = %callee_fact,
@@ -1054,6 +1061,7 @@ fn emit_json_receipt(
                 "reason": r.reason,
                 "witnessCid": r.witness_cid,
                 "dischargeMethod": r.discharge_method,
+                "bodyDischargeTier": r.body_discharge_tier,
             })
         })
         .collect();
@@ -1111,9 +1119,14 @@ fn emit_human_receipt(
             .as_deref()
             .map(|m| format!(", method={m}"))
             .unwrap_or_default();
+        let body_tier = r
+            .body_discharge_tier
+            .as_deref()
+            .map(|t| format!(", bodyTier={t}"))
+            .unwrap_or_default();
         println!(
-            "  [{}] {}  (class={}, solver={}{})",
-            status, r.property_name, r.obligation_class, r.discharging_solver, method
+            "  [{}] {}  (class={}, solver={}{}{})",
+            status, r.property_name, r.obligation_class, r.discharging_solver, method, body_tier
         );
         if let Some(cid) = &r.witness_cid {
             println!("        witness: {}", short_cid(cid).dimmed());
@@ -1332,10 +1345,7 @@ mod tests {
         let pool = panic_trap_pool();
         // The trap contract carries a real `pre` -> route to guard-discharge.
         assert!(
-            body_discharge::target_has_nontrivial_pre(
-                &panic_callsite(vec![]),
-                &pool
-            ),
+            body_discharge::target_has_nontrivial_pre(&panic_callsite(vec![]), &pool),
             "a contract with pre=is_some(opt) must route to guard-discharge"
         );
 
@@ -1557,11 +1567,16 @@ mod tests {
         });
 
         let mut pool = MementoPool::default();
-        pool.mementos.insert(DLIB_TOTALITY_CONTRACT_CID.into(), totality_contract);
-        pool.mementos.insert(DLIB_RESULT_UNWRAP_CID.into(), result_unwrap_contract);
-        pool.mementos.insert(DLIB_GENERIC_CONTRACT_CID.into(), generic_contract);
-        pool.bridges_by_symbol.insert("serde_json_to_string_value".into(), totality_bridge);
-        pool.bridges_by_symbol.insert("to_string_generic".into(), generic_bridge);
+        pool.mementos
+            .insert(DLIB_TOTALITY_CONTRACT_CID.into(), totality_contract);
+        pool.mementos
+            .insert(DLIB_RESULT_UNWRAP_CID.into(), result_unwrap_contract);
+        pool.mementos
+            .insert(DLIB_GENERIC_CONTRACT_CID.into(), generic_contract);
+        pool.bridges_by_symbol
+            .insert("serde_json_to_string_value".into(), totality_bridge);
+        pool.bridges_by_symbol
+            .insert("to_string_generic".into(), generic_bridge);
         pool.bundle_members
             .entry(DLIB_BUNDLE.into())
             .or_default()
@@ -1577,7 +1592,10 @@ mod tests {
     /// `callee_ctor_name`: the ctor name in the arg_term (which function
     /// produced the Result being unwrapped).
     /// `guard_facts`: any syntactic guard facts (empty for our D-lib test).
-    fn dlib_unwrap_callsite(callee_ctor_name: &str, guard_facts: Vec<Json>) -> provekit_verifier::CallSite {
+    fn dlib_unwrap_callsite(
+        callee_ctor_name: &str,
+        guard_facts: Vec<Json>,
+    ) -> provekit_verifier::CallSite {
         provekit_verifier::CallSite {
             bridge_ir_name: "result_unwrap".into(),
             bridge_target_cid: DLIB_RESULT_UNWRAP_CID.into(),
@@ -1617,8 +1635,8 @@ mod tests {
         let pool = dlib_pool();
         let no_kit = std::path::Path::new("/nonexistent-dlib-test-kit");
         let (plan, registry, _) = build_plan_and_registry(no_kit, "z3");
-        let witness_dir = std::env::temp_dir()
-            .join(format!("provekit-dlib-test-{}", std::process::id()));
+        let witness_dir =
+            std::env::temp_dir().join(format!("provekit-dlib-test-{}", std::process::id()));
         std::fs::create_dir_all(&witness_dir).ok();
 
         // POSITIVE: Value-totality ctor arg. The callee_post_guard_fact wiring

--- a/implementations/rust/provekit-cli/src/report_fmt.rs
+++ b/implementations/rust/provekit-cli/src/report_fmt.rs
@@ -42,6 +42,7 @@ fn row_to_json(row: &ReportRow) -> Json {
         "status": row.status,
         "reason": row.reason,
         "dischargeMethod": row.discharge_method,
+        "bodyDischargeTier": row.body_discharge_tier,
         "file": row.callsite.file,
         "line": row.callsite.line,
         "callee": row.callsite.callee,
@@ -136,6 +137,9 @@ pub fn print_report_pretty(r: &Report, quiet: bool) {
             if !row.reason.is_empty() {
                 println!("      reason: {}", row.reason);
             }
+            if let Some(tier) = &row.body_discharge_tier {
+                println!("      body tier: {}", tier);
+            }
         }
         if !r.load_errors.is_empty() {
             println!();
@@ -172,7 +176,7 @@ pub fn report_exit_code(r: &Report) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use provekit_verifier::Report;
+    use provekit_verifier::{CallSite, Report, ReportRow};
 
     #[test]
     fn empty_report_is_not_a_successful_proof() {
@@ -198,5 +202,23 @@ mod tests {
             reason: "bogus".into(),
         });
         assert_eq!(report_exit_code(&r), crate::EXIT_VERIFY_FAIL);
+    }
+
+    #[test]
+    fn report_json_includes_body_discharge_tier() {
+        let mut r = Report::default();
+        r.rows.push(ReportRow {
+            callsite: CallSite {
+                bridge_ir_name: "double".into(),
+                ..CallSite::default()
+            },
+            status: "discharged".into(),
+            reason: "ok".into(),
+            discharge_method: Some("reflexive".into()),
+            body_discharge_tier: Some("body-eq-same-callee".into()),
+        });
+
+        let j = report_to_json(&r);
+        assert_eq!(j["rows"][0]["bodyDischargeTier"], "body-eq-same-callee");
     }
 }

--- a/implementations/rust/provekit-cli/tests/cmd_verify_body_discharge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_body_discharge.rs
@@ -281,6 +281,10 @@ fn verify_double_body_discharges_and_mints_witness() {
         claim["status"], "discharged",
         "positive body-obligation must be discharged (not undecidable); claim: {claim}"
     );
+    assert_eq!(
+        claim["bodyDischargeTier"], "body-call-expected",
+        "standard body-discharge route must be named in the receipt; claim: {claim}"
+    );
 
     let solver = claim["dischargingSolver"].as_str().unwrap_or("");
     assert!(
@@ -684,6 +688,11 @@ fn verify_double_eq_both_calls_same_args_discharges_reflexive() {
             "eq-both-calls same-args claim[{i}] must classify as reflexive (sides \
              are identical after body reduction); claim: {claim}"
         );
+        assert_eq!(
+            claim["bodyDischargeTier"], "body-eq-same-callee",
+            "eq-both-calls same-args claim[{i}] must report the body route separately \
+             from dischargeMethod; claim: {claim}"
+        );
 
         // A signed witness is minted for a discharged claim.
         assert!(
@@ -749,6 +758,15 @@ fn verify_double_eq_both_calls_different_args_is_unsatisfied() {
         assert_eq!(
             claim["pass"], false,
             "eq-both-calls different-args claim[{i}] must not pass; claim: {claim}"
+        );
+        assert_eq!(
+            claim["bodyDischargeTier"], "body-eq-same-callee",
+            "eq-both-calls different-args claim[{i}] must still report the attempted \
+             body route on a violation; claim: {claim}"
+        );
+        assert!(
+            claim["dischargeMethod"].is_null(),
+            "unsatisfied eq-both-calls claim[{i}] must not claim a proof method; claim: {claim}"
         );
 
         // No witness for a violated claim.

--- a/implementations/rust/provekit-verifier/src/body_discharge.rs
+++ b/implementations/rust/provekit-verifier/src/body_discharge.rs
@@ -206,13 +206,36 @@ impl OpContractResolver for CatalogResolver<'_> {
     }
 }
 
-/// The kind of obligation `extract_body_obligation` produced, for the
-/// caller's receipt row.
+/// The body-discharge route that produced an obligation. This is separate from
+/// [`DischargeMethod`]: the route says WHICH reducer path produced the formula;
+/// the method says HOW a discharged formula was proven.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BodyDischargeTier {
+    /// Standard harvested assertion shape: `=(<call>, <expected>)`.
+    CallExpected,
+    /// Both sides are the same callee: `=(<call_a>, <call_b>)`.
+    EqBothCallsSameCallee,
+}
+
+impl BodyDischargeTier {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::CallExpected => "body-call-expected",
+            Self::EqBothCallsSameCallee => "body-eq-same-callee",
+        }
+    }
+}
+
+/// The kind of obligation `extract_body_obligation` produced, for the caller's
+/// receipt/report row.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BodyObligation {
     /// A body-reduced obligation formula, ready for the SMT emitter. The
     /// callee symbol has been inlined; no uninterpreted constant remains.
-    Reduced(Json),
+    Reduced {
+        formula: Json,
+        tier: BodyDischargeTier,
+    },
 }
 
 /// Try to build a body-reduced obligation for a body-bearing callsite.
@@ -325,7 +348,10 @@ pub fn extract_body_obligation(
         Ok(reduced) => {
             let reduced_json = serde_json::to_value(&reduced)
                 .map_err(|e| format!("wp obligation serialize: {e}"))?;
-            Ok(Some(BodyObligation::Reduced(reduced_json)))
+            Ok(Some(BodyObligation::Reduced {
+                formula: reduced_json,
+                tier: BodyDischargeTier::CallExpected,
+            }))
         }
         Err(WpError::Refused(r)) => {
             // The top-level callee resolved (we are past the lookup gate),
@@ -371,14 +397,12 @@ fn extract_eq_both_calls_obligation(
     let resolver = CatalogResolver::new(pool);
 
     // Reduce call_a to its body value expression.
-    let value_a: IrTerm =
-        reduce_to_value_expr(call_a_json, &cs.bridge_ir_name, &resolver)
-            .map_err(|e| format!("body-discharge: eq-both-calls: call_a: {e}"))?;
+    let value_a: IrTerm = reduce_to_value_expr(call_a_json, &cs.bridge_ir_name, &resolver)
+        .map_err(|e| format!("body-discharge: eq-both-calls: call_a: {e}"))?;
 
     // Reduce call_b to its body value expression.
-    let value_b: IrTerm =
-        reduce_to_value_expr(call_b_json, &cs.bridge_ir_name, &resolver)
-            .map_err(|e| format!("body-discharge: eq-both-calls: call_b: {e}"))?;
+    let value_b: IrTerm = reduce_to_value_expr(call_b_json, &cs.bridge_ir_name, &resolver)
+        .map_err(|e| format!("body-discharge: eq-both-calls: call_b: {e}"))?;
 
     // Build the final obligation: =(body_a, body_b).
     // When args are identical this is reflexive (body_a == body_b structurally);
@@ -390,7 +414,10 @@ fn extract_eq_both_calls_obligation(
     let obligation_json = serde_json::to_value(&obligation)
         .map_err(|e| format!("body-discharge: eq-both-calls: serialize: {e}"))?;
 
-    Ok(Some(BodyObligation::Reduced(obligation_json)))
+    Ok(Some(BodyObligation::Reduced {
+        formula: obligation_json,
+        tier: BodyDischargeTier::EqBothCallsSameCallee,
+    }))
 }
 
 /// How a DISCHARGED obligation was proven. This is the honesty axis the
@@ -709,8 +736,7 @@ fn reduce_to_value_expr(
     // Extract the LHS of `=(body_expr, sentinel)`.
     // wp(call, result==sentinel) -> `=(body_expr, sentinel)`.
     // The LHS (args[0]) IS the body value expression.
-    let shape_str = serde_json::to_string(&reduced)
-        .unwrap_or_else(|_| "<unserializable>".into());
+    let shape_str = serde_json::to_string(&reduced).unwrap_or_else(|_| "<unserializable>".into());
     match reduced {
         IrFormula::Atomic { name, mut args } if name == "=" && args.len() == 2 => {
             // args[0] = body_expr(call.args), args[1] = __eq_both_sentinel
@@ -835,7 +861,10 @@ mod routing_predicate_tests {
             "post": {"kind": "atomic", "name": "=", "args": []},
             "formals": ["opt"]
         }));
-        assert!(target_has_nontrivial_pre(&cs_targeting(cid), &pool_with(cid, env)));
+        assert!(target_has_nontrivial_pre(
+            &cs_targeting(cid),
+            &pool_with(cid, env)
+        ));
     }
 
     #[test]
@@ -874,7 +903,10 @@ mod routing_predicate_tests {
         // Target CID not in the pool -> false (keeps the no-pre path
         // byte-identical; never panics looking up a stale bridge).
         let empty = MementoPool::default();
-        assert!(!target_has_nontrivial_pre(&cs_targeting("blake3-512:absent"), &empty));
+        assert!(!target_has_nontrivial_pre(
+            &cs_targeting("blake3-512:absent"),
+            &empty
+        ));
 
         // Target memento is not a contract (e.g. a bridge) -> false.
         let cid = "blake3-512:not-a-contract";
@@ -934,8 +966,10 @@ mod callee_post_guard_fact_tests {
             }
         });
         let mut pool = MementoPool::default();
-        pool.mementos.insert(TOTAL_CONTRACT_CID.into(), contract_env);
-        pool.bridges_by_symbol.insert(BRIDGE_SYMBOL.into(), bridge_env);
+        pool.mementos
+            .insert(TOTAL_CONTRACT_CID.into(), contract_env);
+        pool.bridges_by_symbol
+            .insert(BRIDGE_SYMBOL.into(), bridge_env);
         pool
     }
 
@@ -967,8 +1001,10 @@ mod callee_post_guard_fact_tests {
             }
         });
         let mut pool = MementoPool::default();
-        pool.mementos.insert(GENERIC_CONTRACT_CID.into(), contract_env);
-        pool.bridges_by_symbol.insert(GENERIC_BRIDGE_SYMBOL.into(), bridge_env);
+        pool.mementos
+            .insert(GENERIC_CONTRACT_CID.into(), contract_env);
+        pool.bridges_by_symbol
+            .insert(GENERIC_BRIDGE_SYMBOL.into(), bridge_env);
         pool
     }
 
@@ -1169,7 +1205,8 @@ mod eq_both_calls_discharge_tests {
         });
         let mut pool = MementoPool::default();
         pool.mementos.insert(DOUBLE_CID.into(), contract_env);
-        pool.bridges_by_symbol.insert(DOUBLE_SYMBOL.into(), bridge_env);
+        pool.bridges_by_symbol
+            .insert(DOUBLE_SYMBOL.into(), bridge_env);
         pool
     }
 
@@ -1209,13 +1246,20 @@ mod eq_both_calls_discharge_tests {
         let pool = double_pool();
 
         let result = extract_body_obligation(&cs, &pool);
-        assert!(result.is_ok(), "same-args both-calls must not return Err: {result:?}");
+        assert!(
+            result.is_ok(),
+            "same-args both-calls must not return Err: {result:?}"
+        );
         let obligation_opt = result.unwrap();
         assert!(
             obligation_opt.is_some(),
             "same-args both-calls must produce an obligation (not None)"
         );
-        let BodyObligation::Reduced(obligation_json) = obligation_opt.unwrap();
+        let BodyObligation::Reduced {
+            formula: obligation_json,
+            tier,
+        } = obligation_opt.unwrap();
+        assert_eq!(tier, BodyDischargeTier::EqBothCallsSameCallee);
 
         // The obligation must be reflexive: =(body_expr(3), body_expr(3))
         assert!(
@@ -1256,7 +1300,11 @@ mod eq_both_calls_discharge_tests {
             obligation_opt.is_some(),
             "different-args both-calls must produce an obligation (not None)"
         );
-        let BodyObligation::Reduced(obligation_json) = obligation_opt.unwrap();
+        let BodyObligation::Reduced {
+            formula: obligation_json,
+            tier,
+        } = obligation_opt.unwrap();
+        assert_eq!(tier, BodyDischargeTier::EqBothCallsSameCallee);
 
         // THE DECISIVE ASSERTION: sides differ -> NOT reflexive.
         // `formula_is_reflexive` must return false for `=(6, 8)`.
@@ -1281,9 +1329,7 @@ mod eq_both_calls_discharge_tests {
         // Both sides must be the `*` ctor (body of double), not `double`.
         assert_ne!(args[0], args[1], "sides of reduced =(6,8) must differ");
         assert!(
-            !obligation_json
-                .to_string()
-                .contains(DOUBLE_SYMBOL),
+            !obligation_json.to_string().contains(DOUBLE_SYMBOL),
             "no uninterpreted `double` symbol must remain in the reduced obligation; \
              got: {obligation_json}"
         );

--- a/implementations/rust/provekit-verifier/src/report.rs
+++ b/implementations/rust/provekit-verifier/src/report.rs
@@ -6,7 +6,7 @@
 use crate::types::{CallSite, LoadError, ObligationVerdict, Report, ReportRow};
 
 pub fn add_callsite(cs: &CallSite, verdict: ObligationVerdict, reason: &str, r: &mut Report) {
-    add_callsite_with_method(cs, verdict, reason, None, r);
+    add_callsite_with_discharge(cs, verdict, reason, None, None, r);
 }
 
 pub fn add_callsite_with_method(
@@ -16,12 +16,24 @@ pub fn add_callsite_with_method(
     discharge_method: Option<String>,
     r: &mut Report,
 ) {
+    add_callsite_with_discharge(cs, verdict, reason, discharge_method, None, r);
+}
+
+pub fn add_callsite_with_discharge(
+    cs: &CallSite,
+    verdict: ObligationVerdict,
+    reason: &str,
+    discharge_method: Option<String>,
+    body_discharge_tier: Option<String>,
+    r: &mut Report,
+) {
     r.total_callsites += 1;
     r.rows.push(ReportRow {
         callsite: cs.clone(),
         status: verdict.as_str().to_string(),
         reason: reason.to_string(),
         discharge_method,
+        body_discharge_tier,
     });
     if verdict == ObligationVerdict::Discharged {
         r.discharged += 1;
@@ -64,6 +76,7 @@ pub fn add_self_post_with_method(
         status: verdict.as_str().to_string(),
         reason: reason.to_string(),
         discharge_method,
+        body_discharge_tier: None,
     });
     if verdict == ObligationVerdict::Discharged {
         r.discharged += 1;
@@ -99,7 +112,10 @@ mod tests {
 
         // The self-post MUST NOT inflate the call-site count: only the
         // genuine bridge obligation counts as a call site.
-        assert_eq!(r.total_callsites, 1, "self-post must not count as a callsite");
+        assert_eq!(
+            r.total_callsites, 1,
+            "self-post must not count as a callsite"
+        );
         // But it stays visible as a discharged row in the scoreboard.
         assert_eq!(r.discharged, 2, "self-post still counts toward discharged");
         assert_eq!(r.rows.len(), 2, "self-post row must remain visible");
@@ -124,6 +140,9 @@ mod tests {
         // Excluding self-posts from the callsite count must NOT turn a
         // failing self-post into a green run.
         assert_eq!(r.total_callsites, 0, "self-post is not a callsite");
-        assert_eq!(r.violations, 1, "a failing self-post must still fail the run");
+        assert_eq!(
+            r.violations, 1,
+            "a failing self-post must still fail the run"
+        );
     }
 }

--- a/implementations/rust/provekit-verifier/src/runner.rs
+++ b/implementations/rust/provekit-verifier/src/runner.rs
@@ -317,11 +317,18 @@ impl Runner {
 
         let report_stage_capture = StageCapture::start("report", sorted_keys(&pool.mementos));
         let mut violations = 0usize;
-        for (cs, verdict, reason, method) in per_results {
+        for (cs, verdict, reason, method, body_tier) in per_results {
             if verdict != ObligationVerdict::Discharged {
                 violations += 1;
             }
-            report_stage::add_callsite_with_method(&cs, verdict, &reason, method, &mut report);
+            report_stage::add_callsite_with_discharge(
+                &cs,
+                verdict,
+                &reason,
+                method,
+                body_tier,
+                &mut report,
+            );
         }
         report_stage::add_load_errors(&pool.load_errors, &mut report);
 
@@ -556,11 +563,18 @@ impl Runner {
 
         // Aggregate report rows.
         let mut violations = 0usize;
-        for (cs, verdict, reason, method) in per_results {
+        for (cs, verdict, reason, method, body_tier) in per_results {
             if verdict != ObligationVerdict::Discharged {
                 violations += 1;
             }
-            report_stage::add_callsite_with_method(&cs, verdict, &reason, method, &mut report);
+            report_stage::add_callsite_with_discharge(
+                &cs,
+                verdict,
+                &reason,
+                method,
+                body_tier,
+                &mut report,
+            );
         }
         report_stage::add_load_errors(&pool.load_errors, &mut report);
 
@@ -1032,7 +1046,13 @@ struct SelfPostResult {
     method: Option<body_discharge::DischargeMethod>,
 }
 
-type CallsiteResult = (CallSite, ObligationVerdict, String, Option<String>);
+type CallsiteResult = (
+    CallSite,
+    ObligationVerdict,
+    String,
+    Option<String>,
+    Option<String>,
+);
 
 /// Verify each body-derived contract's OWN postcondition. For a contract
 /// with `post = (result == <body>)` (and optionally a conjoined
@@ -1148,7 +1168,11 @@ fn work_one(
     }
     if !target_has_pre {
         match body_discharge::extract_body_obligation(cs, pool) {
-            Ok(Some(body_discharge::BodyObligation::Reduced(reduced))) => {
+            Ok(Some(body_discharge::BodyObligation::Reduced {
+                formula: reduced,
+                tier,
+            })) => {
+                let body_tier = Some(tier.as_str().to_string());
                 let smt = match smt_emitter::emit(&reduced) {
                     Ok(s) => s,
                     Err(e) => {
@@ -1158,6 +1182,7 @@ fn work_one(
                             ObligationVerdict::Undecidable,
                             format!("smt-emit: {e}"),
                             None,
+                            body_tier,
                         );
                     }
                 };
@@ -1193,7 +1218,7 @@ fn work_one(
                 if let Ok(mut g) = invs_sink.lock() {
                     g.extend(invs);
                 }
-                return (cs.clone(), verdict, reason, discharge_method);
+                return (cs.clone(), verdict, reason, discharge_method, body_tier);
             }
             Ok(None) => {}
             Err(e) => {
@@ -1202,6 +1227,7 @@ fn work_one(
                     cs.clone(),
                     ObligationVerdict::Undecidable,
                     format!("body-discharge: {e}"),
+                    None,
                     None,
                 );
             }
@@ -1216,6 +1242,7 @@ fn work_one(
                 cs.clone(),
                 ObligationVerdict::Undecidable,
                 format!("resolve-target: {e}"),
+                None,
                 None,
             );
         }
@@ -1242,6 +1269,7 @@ fn work_one(
                     cs.bridge_ir_name
                 ),
                 None,
+                None,
             );
         }
         n_vacuous.fetch_add(1, Ordering::Relaxed);
@@ -1250,6 +1278,7 @@ fn work_one(
             ObligationVerdict::Discharged,
             "vacuous: no precondition on target (publisher post-only)".into(),
             Some("vacuous".to_string()),
+            None,
         );
     }
 
@@ -1274,6 +1303,7 @@ fn work_one(
                     short(memento_cid)
                 ),
                 Some("hash-tier".to_string()),
+                None,
             );
         }
 
@@ -1312,6 +1342,7 @@ fn work_one(
                         short(&memento_cid)
                     ),
                     Some("hash-tier".to_string()),
+                    None,
                 );
             }
             crate::types::ImplicationResult::ProvenTransitive { path } => {
@@ -1326,6 +1357,7 @@ fn work_one(
                     ObligationVerdict::Discharged,
                     format!("tier0c: implication proven transitive ({path_str})"),
                     Some("hash-tier".to_string()),
+                    None,
                 );
             }
             crate::types::ImplicationResult::ProvenReflexive => {
@@ -1335,6 +1367,7 @@ fn work_one(
                     ObligationVerdict::Discharged,
                     "tier0c: implication reflexive (post == pre)".into(),
                     Some("hash-tier".to_string()),
+                    None,
                 );
             }
             crate::types::ImplicationResult::Unknown => {}
@@ -1350,6 +1383,7 @@ fn work_one(
                     short(pre_hash)
                 ),
                 Some("hash-tier".to_string()),
+                None,
             );
         }
         if let Some(cache_dir) = &cfg.cache_dir {
@@ -1363,6 +1397,7 @@ fn work_one(
                         short(&impl_cid)
                     ),
                     Some("hash-tier".to_string()),
+                    None,
                 );
             }
         }
@@ -1384,6 +1419,7 @@ fn work_one(
                     ObligationVerdict::Undecidable,
                     format!("build-implication: {e}"),
                     None,
+                    None,
                 );
             }
         };
@@ -1398,6 +1434,7 @@ fn work_one(
                     ObligationVerdict::Discharged,
                     format!("tier3a: tactic discharged ({reason})"),
                     Some("solver-substantive".to_string()),
+                    None,
                 );
             }
             formula_rewrite::TacticResult::Reduced {
@@ -1413,6 +1450,7 @@ fn work_one(
                             cs.clone(),
                             ObligationVerdict::Undecidable,
                             format!("smt-emit: {e}"),
+                            None,
                             None,
                         );
                     }
@@ -1430,6 +1468,7 @@ fn work_one(
                             ObligationVerdict::Undecidable,
                             format!("smt-emit: {e}"),
                             None,
+                            None,
                         );
                     }
                 };
@@ -1446,6 +1485,7 @@ fn work_one(
                     cs.clone(),
                     ObligationVerdict::Undecidable,
                     format!("instantiate: {e}"),
+                    None,
                     None,
                 );
             }
@@ -1527,6 +1567,7 @@ fn work_one(
                     cs.clone(),
                     ObligationVerdict::Undecidable,
                     format!("smt-emit: {e}"),
+                    None,
                     None,
                 );
             }
@@ -1618,7 +1659,7 @@ fn work_one(
         None
     };
 
-    (cs.clone(), verdict, reason, discharge_method)
+    (cs.clone(), verdict, reason, discharge_method, None)
 }
 
 fn short(s: &str) -> String {

--- a/implementations/rust/provekit-verifier/src/types.rs
+++ b/implementations/rust/provekit-verifier/src/types.rs
@@ -353,10 +353,12 @@ impl MementoPool {
                     if existing != memento_cid {
                         let new_env = self.mementos.get(&memento_cid);
                         let existing_env = self.mementos.get(&existing);
-                        let new_has_pre =
-                            new_env.and_then(|e| memento_body_field(e, "preHash")).is_some();
-                        let existing_has_pre =
-                            existing_env.and_then(|e| memento_body_field(e, "preHash")).is_some();
+                        let new_has_pre = new_env
+                            .and_then(|e| memento_body_field(e, "preHash"))
+                            .is_some();
+                        let existing_has_pre = existing_env
+                            .and_then(|e| memento_body_field(e, "preHash"))
+                            .is_some();
                         if new_has_pre && !existing_has_pre {
                             // Upgrade: pre-bearing newcomer beats post-only incumbent.
                             self.cid_to_name.remove(&existing);
@@ -807,6 +809,7 @@ pub struct ReportRow {
     pub status: String,
     pub reason: String,
     pub discharge_method: Option<String>,
+    pub body_discharge_tier: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]


### PR DESCRIPTION
## Summary
- add a language-agnostic BodyDischargeTier alongside BodyObligation
- surface bodyDischargeTier in verify receipts and prove report rows without overloading dischargeMethod
- cover standard body discharge plus eq-both-calls positive/negative cases

## Verification
- ./bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_verify_body_discharge -- --nocapture
- ./bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-verifier eq_both_calls_discharge_tests -- --nocapture
- ./bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli report_json_includes_body_discharge_tier -- --nocapture
- rustfmt --edition 2021 --check implementations/rust/provekit-cli/src/cmd_verify.rs implementations/rust/provekit-cli/src/report_fmt.rs implementations/rust/provekit-cli/tests/cmd_verify_body_discharge.rs implementations/rust/provekit-verifier/src/body_discharge.rs implementations/rust/provekit-verifier/src/report.rs implementations/rust/provekit-verifier/src/runner.rs implementations/rust/provekit-verifier/src/types.rs
- git diff --check