### PR TITLE
[codex] fix TypeScript recognizer proof self-resolution

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1556,6 +1556,7 @@ dependencies = [
  "syn",
  "tempfile",
  "thiserror 1.0.69",
+ "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
  "walkdir",

--- a/implementations/rust/provekit-cli/tests/cmd_recognize_typescript_parity.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_recognize_typescript_parity.rs
@@ -1,0 +1,361 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use provekit_canonicalizer::{blake3_512_of, encode_jcs};
+use provekit_proof_envelope::{
+    build_proof_envelope, ed25519_pubkey_string, Ed25519Seed, ProofEnvelopeInput,
+};
+use serde_json::{json, Value as Json};
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+fn z3_available() -> bool {
+    Command::new("z3")
+        .arg("--version")
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+fn tsx_cli() -> Option<PathBuf> {
+    let path = repo_root()
+        .join("node_modules")
+        .join("tsx")
+        .join("dist")
+        .join("cli.mjs");
+    path.exists().then_some(path)
+}
+
+fn int_sort() -> Json {
+    json!({"kind": "primitive", "name": "Int"})
+}
+
+fn var(name: &str) -> Json {
+    json!({"kind": "var", "name": name})
+}
+
+fn json_to_canonical_jcs(j: &Json) -> String {
+    fn to_cv(j: &Json) -> std::sync::Arc<provekit_canonicalizer::Value> {
+        use provekit_canonicalizer::Value as CV;
+        match j {
+            Json::Null => CV::null(),
+            Json::Bool(b) => CV::boolean(*b),
+            Json::Number(n) => CV::integer(n.as_i64().unwrap_or(0)),
+            Json::String(s) => CV::string(s.clone()),
+            Json::Array(items) => CV::array(items.iter().map(to_cv).collect()),
+            Json::Object(map) => CV::object(
+                map.iter()
+                    .map(|(k, v)| (k.clone(), to_cv(v)))
+                    .collect::<Vec<_>>(),
+            ),
+        }
+    }
+    encode_jcs(&to_cv(j))
+}
+
+fn canonical_cid(j: &Json) -> String {
+    blake3_512_of(json_to_canonical_jcs(j).as_bytes())
+}
+
+fn canonical_member(env: &Json) -> (String, Vec<u8>) {
+    let canonical = json_to_canonical_jcs(env);
+    let cid = blake3_512_of(canonical.as_bytes());
+    (cid, canonical.into_bytes())
+}
+
+fn target_contract_body(source_function_name: &str, predicate: &str) -> Json {
+    json!({
+        "contractName": format!("recognize-target:{source_function_name}"),
+        "formals": ["value"],
+        "formalSorts": [int_sort()],
+        "pre": {
+            "kind": "atomic",
+            "name": predicate,
+            "args": [var("value"), var("value")]
+        }
+    })
+}
+
+fn typescript_shim_template() -> Json {
+    json!({
+        "kind": "block",
+        "stmts": [{
+            "kind": "return",
+            "expr": {
+                "kind": "method_call",
+                "receiver": {"kind": "ident", "name": "client"},
+                "method": "execute",
+                "args": [
+                    {"kind": "param_ref", "index": 1},
+                    {"kind": "param_ref", "index": 2}
+                ]
+            }
+        }]
+    })
+}
+
+fn write_typescript_shim_proof(project: &Path, predicate: &str) -> String {
+    let package_root = project
+        .join("node_modules")
+        .join("@provekit")
+        .join("shim-fetch-lib");
+    fs::create_dir_all(&package_root).expect("mkdir shim package");
+
+    let template = typescript_shim_template();
+    let template_cid = canonical_cid(&template);
+    let target_contract = json!({
+        "evidence": {
+            "kind": "contract",
+            "body": target_contract_body("fetchUrl", predicate),
+        }
+    });
+    let (target_cid, target_bytes) = canonical_member(&target_contract);
+    let binding = json!({
+        "body": {
+            "kind": "library-sugar-binding-entry",
+            "target_language": "typescript",
+            "target_library_tag": "fetch-lib",
+            "concept_name": "concept:http-request",
+            "family": "concept:family:http",
+            "source_function_name": "fetchUrl",
+            "param_names": ["url", "headers"],
+            "param_types": ["string", "Headers"],
+            "return_type": "Response",
+            "body_source": {
+                "file": "src/shim.ts",
+                "span": {"start_line": 1, "start_col": 0, "end_line": 3, "end_col": 1},
+                "source_cid": "blake3-512:".to_string() + &"1".repeat(128),
+                "body_text": "return client.execute(url, headers);",
+                "ast_template": template,
+                "template_cid": template_cid,
+                "param_names": ["url", "headers"]
+            },
+            "contract_cid": target_cid
+        }
+    });
+    let (binding_cid, binding_bytes) = canonical_member(&binding);
+
+    let mut members = BTreeMap::new();
+    members.insert(target_cid, target_bytes);
+    members.insert(binding_cid, binding_bytes);
+
+    let signer_seed: Ed25519Seed = [0x74; 32];
+    let proof = build_proof_envelope(&ProofEnvelopeInput {
+        name: "@provekit/shim-fetch-lib".to_string(),
+        version: "0.1.0".into(),
+        binary_cid: None,
+        metadata: None,
+        members,
+        signer_cid: ed25519_pubkey_string(&signer_seed),
+        signer_seed,
+        declared_at: "2026-05-31T00:00:00.000Z".into(),
+    });
+    fs::write(
+        package_root.join(format!("{}.proof", proof.cid)),
+        &proof.bytes,
+    )
+    .expect("write shim proof");
+    fs::write(
+        package_root.join("package.json"),
+        format!(
+            "{{\"name\":\"@provekit/shim-fetch-lib\",\"version\":\"0.1.0\",\"provekit\":{{\"proofHash\":\"{}\"}}}}\n",
+            proof.cid
+        ),
+    )
+    .expect("write shim package.json");
+    proof.cid
+}
+
+fn stage_typescript_project(predicate: &str, user_body: &str) -> (tempfile::TempDir, String) {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("project");
+    fs::create_dir_all(project.join("src")).expect("mkdir src");
+    fs::write(
+        project.join("src").join("user.ts"),
+        format!("export function send(uri: string, h: Headers): Response {{\n  {user_body}\n}}\n"),
+    )
+    .expect("write user.ts");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("typescript-source"))
+        .expect("mkdir typescript-source manifest dir");
+    fs::write(
+        provekit.join("config.toml"),
+        r#"[[plugins]]
+name = "typescript-source"
+surface = "typescript-source"
+layer = "library-bindings"
+"#,
+    )
+    .expect("write config.toml");
+
+    let tsx = tsx_cli().expect("tsx CLI must exist; run pnpm install at repo root");
+    let ts_source_bin = repo_root()
+        .join("implementations")
+        .join("typescript")
+        .join("src")
+        .join("lift")
+        .join("typescript-source")
+        .join("bin.ts");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("typescript-source")
+            .join("manifest.toml"),
+        format!(
+            "name = \"typescript-source\"\ncommand = [\"node\", \"{}\", \"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
+            tsx.display(),
+            ts_source_bin.display()
+        ),
+    )
+    .expect("write typescript-source manifest");
+
+    let target_proof_cid = write_typescript_shim_proof(&project, predicate);
+    (temp, target_proof_cid)
+}
+
+fn run_recognize(project: &Path, write: bool) -> Json {
+    let mut cmd = Command::new(provekit_bin());
+    cmd.arg("recognize")
+        .arg("--target")
+        .arg("typescript")
+        .arg("--project")
+        .arg(project)
+        .arg("--source")
+        .arg("src/user.ts")
+        .arg("--json");
+    if write {
+        cmd.arg("--write");
+    }
+    let output = cmd.output().expect("spawn provekit recognize");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "recognize failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    serde_json::from_str(&stdout).expect("recognize JSON receipt parses")
+}
+
+fn run_prove_json(project: &Path) -> (bool, Json, String, String) {
+    let output = Command::new(provekit_bin())
+        .arg("prove")
+        .arg(project)
+        .arg("--json")
+        .output()
+        .expect("spawn provekit prove");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let report: Json = serde_json::from_str(&stdout).unwrap_or_else(|_| {
+        panic!("prove JSON report parses\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+    (output.status.success(), report, stdout, stderr)
+}
+
+fn assert_recognize_receipt_pinned(receipt: &Json, expected_target_proof_cid: &str) {
+    let tags = receipt["tags"].as_array().expect("tags array");
+    assert_eq!(tags.len(), 1, "TypeScript recognizer receipt:\n{receipt:#}");
+    let tag = &tags[0];
+    assert_eq!(tag["function_name"], "send");
+    assert_eq!(tag["concept_name"], "concept:http-request");
+    assert_eq!(tag["library_tag"], "fetch-lib");
+    assert!(
+        tag["contract_cid"].as_str().is_some_and(|s| !s.is_empty()),
+        "tag must target the shim contract, not sibling fallback:\n{tag:#}"
+    );
+    assert_eq!(
+        tag["target_proof_cid"].as_str(),
+        Some(expected_target_proof_cid),
+        "tag must carry the TypeScript-kit resolved proof bundle CID:\n{tag:#}"
+    );
+}
+
+fn assert_no_vacuous_rows(report: &Json) {
+    let rows = report["rows"].as_array().expect("prove report has rows");
+    assert!(
+        !rows.is_empty(),
+        "prove report must contain rows\n{report:#}"
+    );
+    for row in rows {
+        let reason = row["reason"].as_str().unwrap_or_default();
+        assert!(
+            !reason.contains("vacuous")
+                && !reason.contains("no precondition")
+                && !reason.contains("back-compat"),
+            "recognized TypeScript callsite discharged vacuously\nrow:\n{row:#}\nreport:\n{report:#}"
+        );
+    }
+}
+
+#[test]
+fn typescript_recognize_write_self_resolves_package_proofs_and_proves() {
+    if !node_available() || tsx_cli().is_none() {
+        eprintln!("skipping TypeScript recognizer parity test: node/tsx unavailable");
+        return;
+    }
+    if !z3_available() {
+        eprintln!("skipping TypeScript recognizer parity test: z3 unavailable");
+        return;
+    }
+
+    let (temp, target_proof_cid) = stage_typescript_project(">=", "return client.execute(uri, h);");
+    let project = temp.path().join("project");
+
+    let receipt = run_recognize(&project, true);
+    assert_recognize_receipt_pinned(&receipt, &target_proof_cid);
+    let bridge_proof = receipt["bridge_proof"]
+        .as_str()
+        .expect("recognize --write must mint a bridge proof");
+    assert!(Path::new(bridge_proof).is_file(), "{bridge_proof}");
+
+    let (ok, report, prove_stdout, prove_stderr) = run_prove_json(&project);
+    assert!(
+        ok,
+        "prove should consume the TypeScript recognize bridge proof\nstdout:\n{prove_stdout}\nstderr:\n{prove_stderr}"
+    );
+    assert_eq!(report["totalCallsites"].as_u64(), Some(1), "{report:#}");
+    assert_eq!(report["discharged"].as_u64(), Some(1), "{report:#}");
+    assert_eq!(report["violations"].as_u64(), Some(0), "{report:#}");
+    assert_no_vacuous_rows(&report);
+}
+
+#[test]
+fn typescript_recognize_returns_no_tags_for_non_matching_source() {
+    if !node_available() || tsx_cli().is_none() {
+        eprintln!("skipping TypeScript recognizer non-match test: node/tsx unavailable");
+        return;
+    }
+
+    let (temp, _target_proof_cid) = stage_typescript_project(">=", "return other.execute(uri, h);");
+    let project = temp.path().join("project");
+
+    let receipt = run_recognize(&project, false);
+    assert_eq!(
+        receipt["tags"].as_array().map(Vec::len),
+        Some(0),
+        "non-alpha-equivalent TypeScript source must not tag:\n{receipt:#}"
+    );
+}

--- a/implementations/typescript/src/lift/typescript-source/index.test.ts
+++ b/implementations/typescript/src/lift/typescript-source/index.test.ts
@@ -1,10 +1,12 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { canonicalEncode, canonicalJsonString } from "../../claimEnvelope/canonicalize.js";
 import { computeCid } from "../../canonicalizer/hash.js";
+import { generateKeypair } from "../../producerKeys/index.js";
+import { buildProofEnvelope } from "../../proofEnvelope/index.js";
 import {
   compileTypeScriptSourceBodyIr,
   compileTypeScriptSourceIr,
@@ -26,6 +28,33 @@ function rhs(contract: Record<string, any>): any {
 
 function canonicalCid(value: unknown): string {
   return computeCid(canonicalEncode(value));
+}
+
+function installTypeScriptShimProof(
+  projectRoot: string,
+  packageName: string,
+  members: Map<string, unknown>,
+): { proofCid: string } {
+  const packageRoot = packageName.startsWith("@")
+    ? join(projectRoot, "node_modules", ...packageName.split("/"))
+    : join(projectRoot, "node_modules", packageName);
+  mkdirSync(packageRoot, { recursive: true });
+  const { privateKey, publicKey } = generateKeypair({ seed: Buffer.alloc(32, 0x42) });
+  const signerCid = computeCid(publicKey.export({ type: "spki", format: "der" }));
+  const built = buildProofEnvelope({
+    name: packageName,
+    version: "0.0.0",
+    members: members as any,
+    signerCid,
+    signerPrivateKey: privateKey,
+    declaredAt: "2026-05-31T00:00:00.000Z",
+  });
+  writeFileSync(join(packageRoot, `${built.cid}.proof`), Buffer.from(built.bytes));
+  writeFileSync(
+    join(packageRoot, "package.json"),
+    JSON.stringify({ name: packageName, version: "0.0.0", provekit: { proofHash: built.cid } }, null, 2),
+  );
+  return { proofCid: built.cid };
 }
 
 describe("typescript-source lifter", () => {
@@ -272,6 +301,62 @@ export function send(uri: string, h: Headers): Response {
       family: "concept:family:http",
       match_tier: "exact",
     });
+  });
+
+  it("recognize RPC path self-resolves TypeScript sugar templates from package proofs", () => {
+    const root = tempDir("provekit-ts-recognize-proof-");
+    try {
+      writeFileSync(
+        join(root, "user.ts"),
+        `
+export function send(uri: string, h: Headers): Response {
+  return client.execute(uri, h);
+}
+`,
+      );
+      const shim = `
+import { sugar } from "provekit";
+
+@sugar.bind({ concept: "concept:http-request", library: "fetch-lib", family: "concept:family:http" })
+function fetchUrl(url: string, headers: Headers): Response {
+  return client.execute(url, headers);
+}
+`;
+      const sugarEntry = liftTypeScriptLibraryBindingsText(shim, "src/shim.ts").libraryBindings[0]!;
+      const contractCid = "blake3-512:" + "c".repeat(128);
+      const member = {
+        body: {
+          ...sugarEntry,
+          contract_cid: contractCid,
+        },
+      };
+      const memberCid = computeCid(canonicalEncode(member));
+      const { proofCid } = installTypeScriptShimProof(
+        root,
+        "@provekit/shim-fetch-lib",
+        new Map([[memberCid, member]]),
+      );
+
+      const response = (typeScriptSource as Record<string, any>).recognizeTypeScriptSources({
+        project_root: root,
+        source_paths: ["user.ts"],
+      });
+
+      expect(response.tags).toHaveLength(1);
+      expect(response.tags[0]).toMatchObject({
+        file: "user.ts",
+        function_name: "send",
+        concept_name: "concept:http-request",
+        library_tag: "fetch-lib",
+        family: "concept:family:http",
+        template_cid: sugarEntry.body_source.template_cid,
+        contract_cid: contractCid,
+        target_proof_cid: proofCid,
+        match_tier: "exact",
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   // -----------------------------------------------------------------

--- a/implementations/typescript/src/lift/typescript-source/index.ts
+++ b/implementations/typescript/src/lift/typescript-source/index.ts
@@ -1,10 +1,11 @@
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { relative, resolve } from "node:path";
+import { existsSync, readFileSync, realpathSync, readdirSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
 import ts from "typescript";
 
 import { canonicalJsonString } from "../../claimEnvelope/canonicalize.js";
 import { computeCid } from "../../canonicalizer/hash.js";
 import type { IrFormula, IrTerm, Sort, VarTerm } from "../../ir/formulas.js";
+import { decodeProofEnvelope } from "../../proofEnvelope/index.js";
 
 export type TypeScriptSourceEffect =
   | { kind: "reads"; target: string }
@@ -95,6 +96,7 @@ export interface TypeScriptBindingTemplate {
   template_cid?: unknown;
   param_names?: unknown;
   contract_cid?: unknown;
+  target_proof_cid?: unknown;
 }
 
 export interface TypeScriptRecognizeParams {
@@ -114,6 +116,7 @@ export interface TypeScriptRecognizeTag {
   family: unknown;
   template_cid: string;
   contract_cid: unknown;
+  target_proof_cid: unknown;
   match_tier: "exact";
   param_bindings: { index: number; source_text: string }[];
 }
@@ -167,6 +170,7 @@ const SKIP_DIRS = new Set([
   "coverage",
 ]);
 const SOURCE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".mts", ".cts"]);
+const PROOF_FILE_RE = /^blake3-512:[0-9a-f]{128}\.proof$/i;
 
 export function liftTypeScriptSourceText(
   sourceText: string,
@@ -249,13 +253,13 @@ export function recognizeTypeScriptSources(params: TypeScriptRecognizeParams): T
   if (!Array.isArray(params.source_paths)) throw new Error("missing `source_paths` array");
   const root = resolve(params.project_root);
   const suppliedTemplates = params.binding_templates ?? [];
-  const selfResolvedBindings = suppliedTemplates.length > 0
-    ? []
-    : liftTypeScriptLibraryBindingsPaths(root, params.source_paths).libraryBindings;
+  const selfResolvedBindings = liftTypeScriptLibraryBindingsPaths(root, params.source_paths).libraryBindings;
   const sugarTemplateFiles = new Set(selfResolvedBindings.map((entry) => entry.body_source.file));
-  const templatePool = suppliedTemplates.length > 0
-    ? suppliedTemplates
-    : selfResolvedBindings.map(bindingTemplateFromSugarEntry);
+  const templatePool = [
+    ...suppliedTemplates,
+    ...selfResolvedBindings.map(bindingTemplateFromSugarEntry),
+    ...loadBindingTemplatesForProject(root),
+  ];
   const bindingsByCid = bindingTemplatesByCid(templatePool);
   const tags: TypeScriptRecognizeTag[] = [];
 
@@ -284,7 +288,164 @@ function bindingTemplateFromSugarEntry(entry: TypeScriptLibrarySugarBindingEntry
     template_cid: entry.body_source.template_cid,
     param_names: entry.body_source.param_names,
     contract_cid: (entry as unknown as { contract_cid?: unknown }).contract_cid ?? null,
+    target_proof_cid: (entry as unknown as { target_proof_cid?: unknown }).target_proof_cid ?? null,
   };
+}
+
+function loadBindingTemplatesForProject(projectRoot: string): TypeScriptBindingTemplate[] {
+  const templates: TypeScriptBindingTemplate[] = [];
+  for (const proofPath of resolveDependencyProofPaths(projectRoot)) {
+    templates.push(...bindingTemplatesFromProof(proofPath));
+  }
+  return templates;
+}
+
+function bindingTemplatesFromProof(proofPath: string): TypeScriptBindingTemplate[] {
+  const proofBytes = readFileSync(proofPath);
+  const proofCid = computeCid(proofBytes);
+  const catalog = decodeProofEnvelope(new Uint8Array(proofBytes));
+  const templates: TypeScriptBindingTemplate[] = [];
+
+  for (const memberBytes of catalog.members.values()) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(Buffer.from(memberBytes).toString("utf8"));
+    } catch {
+      continue;
+    }
+    const body = isRecord(parsed) && isRecord(parsed.body) ? parsed.body : parsed;
+    const template = bindingTemplateFromProofSugarEntry(body, proofCid);
+    if (template) templates.push(template);
+  }
+
+  return templates;
+}
+
+function bindingTemplateFromProofSugarEntry(raw: unknown, proofCid: string): TypeScriptBindingTemplate | null {
+  if (!isRecord(raw) || raw.kind !== "library-sugar-binding-entry") return null;
+  const targetLanguage = raw.target_language;
+  if (typeof targetLanguage === "string" && targetLanguage !== "typescript") return null;
+  if (typeof raw.concept_name !== "string" || raw.concept_name.length === 0) return null;
+  const bodySource = isRecord(raw.body_source) ? raw.body_source : null;
+  if (!bodySource || bodySource.ast_template === undefined || bodySource.ast_template === null) return null;
+
+  const templateCid = typeof bodySource.template_cid === "string" && bodySource.template_cid.length > 0
+    ? bodySource.template_cid
+    : cidOfValue(bodySource.ast_template);
+
+  return {
+    concept_name: raw.concept_name,
+    library_tag: typeof raw.target_library_tag === "string" ? raw.target_library_tag : null,
+    family: raw.family ?? null,
+    ast_template: bodySource.ast_template,
+    template_cid: templateCid,
+    param_names: stringArray(bodySource.param_names) ?? stringArray(raw.param_names) ?? [],
+    contract_cid: typeof raw.contract_cid === "string" ? raw.contract_cid : null,
+    target_proof_cid: proofCid,
+  };
+}
+
+function resolveDependencyProofPaths(projectRoot: string): string[] {
+  const root = resolve(projectRoot);
+  const proofPaths = new Set<string>();
+  const visitedNodeModules = new Set<string>();
+  const visitedPackages = new Set<string>();
+  walkNodeModules(join(root, "node_modules"), { proofPaths, visitedNodeModules, visitedPackages });
+  return [...proofPaths].sort();
+}
+
+interface DependencyProofWalkState {
+  proofPaths: Set<string>;
+  visitedNodeModules: Set<string>;
+  visitedPackages: Set<string>;
+}
+
+function walkNodeModules(nodeModulesDir: string, state: DependencyProofWalkState): void {
+  const realNodeModules = realDirectoryPath(nodeModulesDir);
+  if (realNodeModules === null || state.visitedNodeModules.has(realNodeModules)) return;
+  state.visitedNodeModules.add(realNodeModules);
+
+  let entries;
+  try {
+    entries = readdirSync(realNodeModules, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (entry.name.startsWith(".")) continue;
+    const entryPath = join(realNodeModules, entry.name);
+    if (entry.name.startsWith("@")) {
+      walkScopedPackages(entryPath, state);
+      continue;
+    }
+    collectPackage(entryPath, state);
+  }
+}
+
+function walkScopedPackages(scopeDir: string, state: DependencyProofWalkState): void {
+  const realScopeDir = realDirectoryPath(scopeDir);
+  if (realScopeDir === null) return;
+
+  let entries;
+  try {
+    entries = readdirSync(realScopeDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    collectPackage(join(realScopeDir, entry.name), state);
+  }
+}
+
+function collectPackage(packageDir: string, state: DependencyProofWalkState): void {
+  const realPackageDir = realDirectoryPath(packageDir);
+  if (realPackageDir === null || state.visitedPackages.has(realPackageDir)) return;
+  state.visitedPackages.add(realPackageDir);
+
+  collectPackageProofFiles(realPackageDir, state.proofPaths);
+  walkNodeModules(join(realPackageDir, "node_modules"), state);
+}
+
+function collectPackageProofFiles(packageDir: string, proofPaths: Set<string>): void {
+  let entries;
+  try {
+    entries = readdirSync(packageDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const entryPath = join(packageDir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === ".git") continue;
+      collectPackageProofFiles(entryPath, proofPaths);
+      continue;
+    }
+    if (entry.isFile() && PROOF_FILE_RE.test(entry.name)) {
+      proofPaths.add(entryPath);
+    }
+  }
+}
+
+function realDirectoryPath(candidate: string): string | null {
+  try {
+    const realPath = realpathSync(candidate);
+    return statSync(realPath).isDirectory() ? realPath : null;
+  } catch {
+    return null;
+  }
+}
+
+function stringArray(raw: unknown): string[] | null {
+  if (!Array.isArray(raw)) return null;
+  const out = raw.filter((item): item is string => typeof item === "string");
+  return out.length === raw.length ? out : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 export function recognizeTypeScriptSourcesText(
@@ -362,6 +523,7 @@ function recognizeFunctionLike(
     family: binding.family ?? null,
     template_cid: templateCid,
     contract_cid: binding.contract_cid ?? null,
+    target_proof_cid: binding.target_proof_cid ?? null,
     match_tier: "exact",
     param_bindings: paramNames.map((name, index) => ({ index: index + 1, source_text: name })),
   };


### PR DESCRIPTION
## Summary

- TypeScript recognizer now self-resolves `library-sugar-binding-entry` templates from package `.proof` bundles under `node_modules` inside the TS kit.
- Recognizer tags now carry `target_proof_cid` so `recognize --write` can pin bridges to the kit-resolved bundle.
- Keeps direct `binding_templates` support for focused kit tests, while the CLI path remains RPC-only and does not send templates or proof paths.
- Adds a Rust CLI parity test that stages config/manifest-only TypeScript recognize dispatch, package proof resolution, non-match behavior, bridge write, and prove consumption when node/tsx/z3 are available.

Closes #1698.

## Verification

- `PATH=/Users/tsavo/provekit/node_modules/.bin:$PATH vitest run implementations/typescript/src/lift/typescript-source/index.test.ts` -> 32 passed.
- `PATH=/Users/tsavo/provekit/node_modules/.bin:$PATH tsc --noEmit --module es2022 --moduleResolution bundler` -> exit 0.
- `git diff --check` and `git diff --cached --check` -> exit 0.
- `./bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test cmd_recognize_typescript_parity -- --nocapture` -> exit 0; remote reports both TS runtime bodies skipped because node/tsx are unavailable there.
- `./bin/bcargo fmt --manifest-path implementations/rust/provekit-cli/Cargo.toml --check` -> still reports pre-existing unrelated formatting diffs in `cmd_doctor.rs`, `cmd_mint.rs`, and `self_check_golden.rs`; no diff for the new `cmd_recognize_typescript_parity.rs` after local patching.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TypeScript recognition now automatically discovers and resolves proofs from package dependencies, enriching recognition tags with proof identifiers for downstream consumption.

* **Tests**
  * Added comprehensive test coverage for TypeScript recognition with integrated proof resolution capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->