### PR TITLE
Serde panic-freedom: fixes + doctor footgun guard + located K root cause

### DIFF
--- a/docs/self-application/serde-panic-freedom-diagnosis.md
+++ b/docs/self-application/serde-panic-freedom-diagnosis.md
@@ -309,6 +309,33 @@ is the one keyed in `bridges_by_symbol` for a panic-relevant producer. g
 "specialize consumer_pre" and "two breaks" framings: the serde break is a single
 producer-contract-selection bug in locate_producer_post.
 
+## CORRECTIONS (verified against the current binary)
+
+1. **`file`/`line` surfacing WORKS** (a stale belief earlier in this doc said it
+   was dropping). With the callsite-carry fix (e13763201) the minted bridge
+   carries `{file, start_line, panicSite}` and `prove --json` rows surface it:
+   f's unwrap is `callee=method:unwrap | file=src/lib.rs | line=25`, g's is
+   line=38. So per-site IDENTIFICATION for panic sites is in, and K-fix
+   verification is UNBLOCKED -- f (line 25 -> must become panicSafe) and g
+   (line 38 -> must stay undecidable) are cleanly distinguishable in the row
+   output despite the 138-callsite shim contamination. (Per-site {category,
+   tier-to-close} naming is still only partial: file/line yes, an explicit
+   category+tier field no.)
+
+2. **Refined lead on the producer-contract bug:** the unwrap's arg lifts as the
+   ctor `method:to_string`, but f's source is the FREE call
+   `serde_json::to_string(v)`, not a method `v.to_string()`. If the free call is
+   mis-lifted under a `method:` ctor, the disambiguation-to-totality
+   (`serde_json_to_string_value`) keys/targets a different symbol than the one
+   `locate_producer_post` looks up (`method:to_string`), so it only finds the
+   body-eq contract. NEXT: dump `bridges_by_symbol` keys + each target contract's
+   post on a fresh mint; confirm whether a totality-post bridge exists for the
+   `to_string` producer and under WHICH symbol. The fix is then either correct
+   the free-call lift (drop the bogus `method:` prefix) so the totality bridge is
+   keyed where `locate_producer_post` looks, OR have `locate_producer_post` prefer
+   a totality-post contract among the producer's bridges. Both verifiable now via
+   the line-25/line-38 discrimination.
+
 ## Reproduction
 
 Warm-oracle e2e on battleaxe: `/tmp/serde_e2e2.sh` (mints shim-std + shim-serde deps,

--- a/docs/self-application/serde-panic-freedom-diagnosis.md
+++ b/docs/self-application/serde-panic-freedom-diagnosis.md
@@ -1,0 +1,100 @@
+# Serde panic-freedom (D-lib) — full diagnosis, 2026-05-31
+
+Goal: f `serde_json::to_string(&Value).unwrap()` → PANIC-SAFE (K=1); g
+`to_string(&MyStruct).unwrap()` → UNDECIDABLE; falsePass=0. Stalled 5 agents.
+
+## Fixed today (committed on `serde-finish`, e13763201) — all verified at their layer
+
+1. **Fixture manifest** `examples/stage3-serde-totality-fixture/.provekit/lift/rust-implications/manifest.toml`
+   was missing `method = "provekit.plugin.lift_implications"` and `phase = "consumer"`.
+   So `mint` ran `bind_lift`, the implication lifter (host of the RA oracle) NEVER ran.
+   This was the actual 5-agent blocker. With it fixed, the oracle resolves both
+   unwraps to `result_unwrap` and emits 3 bridges + 1 honest lift-gap (g's to_string).
+
+2. **`mint_bridge` dropped the lifter's `callsite`** (`provekit-claim-envelope`). Added
+   `BridgeCallsite` + carry it into the bridge header (NOT into `bridge_content_cid` —
+   callsite is not bridge identity). Verifier now reads `panic_site=true`.
+
+3. **prove path missing the D-lib injection.** `callee_post_guard_fact` (the
+   is_ok-totality guard supply) lived only in `cmd_verify`; the `prove` path
+   (`runner.rs::work_one`, which the scoreboard uses) never called it. Wired in.
+
+## Phase-0 scaffolding (no-silent-failure)
+
+- Plugin subprocess stderr now **inherits by default** (was `Stdio::null()` — the
+  thing that hid all of the above for five investigations). `PROVEKIT_PLUGIN_STDERR=null` to silence.
+- Always-on `warn!` when a `method:`-seam bridge reaches the verifier without
+  callsite provenance (mint-drop smoke detector), `enumerate_callsites.rs`.
+- All new diagnostics via `tracing`, not `eprintln`.
+
+## The remaining layer (K still 0) — precisely located, NOT yet fixed
+
+f's contract post is `=(result, method:unwrap(to_string(v)))`. `enumerate_callsites`
+DOES create the unwrap callsite with `panic_site=true, arg_term=to_string(v)` (ctor) —
+verified in logs (2 ctor-arg method:unwrap callsites: f and g). The 2 var-arg
+method:unwrap obligations that reach the UNGUARDED panic path are the shim formals
+(noise), not f.
+
+f's ctor-arg callsite enters `runner.rs::work_one` and is consumed by the
+**producer-consumer / implication-composition tier** (runner.rs ~1286-1340):
+`consumer_pre = is_ok(arg)` (result_unwrap pre, instantiated), and
+`producer_post = locate_producer_post(to_string(v))`. Tier-0c calls
+`pool.can_implies(post_hash, pre_hash)`. That lookup fails (no implication memento
+in the pool), the callsite falls through this tier, and never reaches the panic-guard
+discharge (runner ~1493) where the D-lib `callee_post_guard_fact` injection lives.
+So `callee_post_guard_fact` is never invoked for f (logs: it only ever sees the shim
+ctors Some/Ok/Err, never `to_string`). Result: f stays undecidable, K=0.
+
+### Likely sound fix (next focused PR — gate on the discrimination test)
+
+For f, `producer_post` and `consumer_pre` are the SAME formula: `is_ok(to_string(v))`
+(the to_string totality post) and `is_ok(to_string(v))` (the unwrap pre specialized
+to the same receiver). So the implication `producer_post → consumer_pre` is the
+reflexive `P → P`, trivially valid.
+
+Candidate: in tier-0c (runner.rs ~1330), discharge when `post_hash == pre_hash`
+(reflexive: the producer guarantees EXACTLY what the consumer requires). This is
+sound (`P → P`), and it discriminates correctly: g's `to_string(&MyStruct)` has NO
+totality post (generic, `is_ok || is_err` or none), so `producer_post != consumer_pre`,
+no reflexive match → g stays undecidable, falsePass=0 preserved.
+
+VERIFY FIRST (one instrumented run): log `producer_post` and `consumer_pre` for the
+2 ctor-arg method:unwrap callsites. Confirm f's are byte-identical `is_ok(to_string(v))`
+and g's differ/absent BEFORE implementing. If they are NOT identical, the fix is the
+alternative: route the ctor-arg panic callsite to the panic-guard block (where the
+D-lib injection already lives) instead of letting tier-0c swallow it.
+
+### Hard gate for any attempt
+
+Re-run the e2e (`/tmp/serde_e2e2.sh` on battleaxe): REQUIRE f → panicSafe, g →
+undecidable, falsePass=0, silentlyDropped=0. If g flips or falsePass>0, REVERT — this
+is the verifier soundness core.
+
+## UPDATE — the discharge cascade is the real obstacle (deepest finding)
+
+Instrumenting `work_one` further (a `panic_site` probe at runner.rs:1288, since
+removed) showed it fires ZERO times even though `method:unwrap` panic obligations
+are emitted and "routing to guard-discharge" logs for `target_has_pre=true`. So the
+real panic callsites reach NEITHER the producer-consumer probe (1288) NOR the D-lib
+injection added in commit e13763201 (~1493). `work_one` is a multi-path cascade with
+several early returns (tier-0 hash, tier-0c implication-composition, the
+`!target_has_pre` body-discharge branch via `extract_body_obligation`, the panic
+block) and the real callsites are discharged/abandoned by one of the earlier paths.
+
+**Consequence:** commit e13763201's runner D-lib injection is in a branch the actual
+serde callsites do not traverse (harmless — refuse-floor intact, falsePass=0 — but
+inert for K). Closing K>0 requires READING THE WHOLE `work_one` (runner.rs
+~1131-1700) end to end, mapping which path the `panic_site=true, arg_term=ctor`
+callsites actually take, and applying the D-lib guard fact (or the reflexive
+`producer_post == consumer_pre` discharge) AT THAT PATH. This is a discharge-cascade
+design task in the verifier soundness core, not a localized patch — do it on a fresh
+head with the discrimination test as the hard gate, NOT exhausted.
+
+The reflexive-discharge idea (sound `P -> P` when the producer's post is byte-identical
+to the consumer's pre) is still the most promising mechanism; it just has to be wired
+into the path the callsites actually reach.
+
+## Reproduction
+
+Warm-oracle e2e on battleaxe: `/tmp/serde_e2e2.sh` (mints shim-std + shim-serde deps,
+warm-daemon mint of the fixture, prove). Debug: `RUST_LOG=warn,provekit_verifier::runner=debug,provekit_verifier::body_discharge=debug,provekit_verifier::enumerate_callsites=debug`.

--- a/docs/self-application/serde-panic-freedom-diagnosis.md
+++ b/docs/self-application/serde-panic-freedom-diagnosis.md
@@ -94,7 +94,20 @@ The reflexive-discharge idea (sound `P -> P` when the producer's post is byte-id
 to the consumer's pre) is still the most promising mechanism; it just has to be wired
 into the path the callsites actually reach.
 
-## Phase-0 gap confirmed: `doctor` does not catch this footgun
+## Phase-0 gap CLOSED: `doctor` now catches this footgun
+
+DONE (committed): `provekit doctor` now HARD-fails (exit 2) when a kit's consumer
+surface is mis-wired. walk_rpc's `initialize` capabilities self-declare
+`consumer_surfaces: { "rust-implications": { method, phase } }` (semantics in the
+kit, so doctor stays language-blind); doctor's Check 5 spawns each plugin, reads
+that, and verifies the manifest's `method`/`phase` match. Verified on
+stage3-serde-totality-fixture: broken manifest (method+phase removed) -> exit 2 with
+"add both lines"; fixed -> exit 0. This catches the exact omission that cost five
+agents a day, BEFORE a silent empty-set attestation.
+
+### Original gap (now closed; kept for context)
+
+## Phase-0 gap was: `doctor` did not catch this footgun
 
 `provekit doctor --target <kit>` exists and runs, but its checks are: TOML parse,
 plugin-command binary exists, imports count, oracle reachability. It does NOT catch

--- a/docs/self-application/serde-panic-freedom-diagnosis.md
+++ b/docs/self-application/serde-panic-freedom-diagnosis.md
@@ -166,6 +166,50 @@ golden pins just the fixture's sites. Best built WITH the cascade fix so it pins
 meaningful panicSafe>0 delta. Pinning panicSafe=0 now is legitimate scaffolding but
 low-value until the cascade lands.
 
+## COMPLETE MECHANISM (work_one routing, runner.rs ~1412) — two distinct breaks
+
+`work_one` routes on whether the panic arg has a producer:
+
+    if (producer_post, consumer_pre) both Some  -> IMPLICATION branch (~1412):
+        build_implication_obligation(producer_post -> consumer_pre), solve
+    else                                        -> GUARD branch (~1479):
+        instantiate::run(resolved, arg_term) THEN cs.guard_facts discharge
+        (this is where the D-lib callee_post_guard_fact injection from e13763201 lives)
+
+BREAK 1 -- serde / any panic site whose receiver is itself a call:
+  arg = `to_string(v)` HAS a producer (the to_string totality bridge -> post
+  `is_ok(result)`), so `producer_post = Some(is_ok(to_string(v)))` and the site
+  takes the IMPLICATION branch. BUT `consumer_pre` there is the UN-specialized
+  pre `is_ok(formal)` (instantiate only runs in the else branch). z3 sees
+  `is_ok(to_string(v)) -> is_ok(formal)` over disjoint terms -> UNSAT. The D-lib
+  injection never runs for f (f never reaches the else branch).
+
+BREAK 2 -- syntactic guard (panic-freedom-fixture `if opt.is_some(){opt.unwrap()}`):
+  arg = `opt` is a VAR (no producer) -> producer_post None -> takes the GUARD
+  branch. But `cs.guard_facts` is EMPTY: the kit's `cf_guarded(is_some(opt), ...)`
+  wrapper that enumerate_callsites threads into guard_facts (walk_term ~269) is
+  not populating it e2e. Unguarded -> is_some(formal) -> undecidable.
+
+SOUNDNESS-CORE RISK (why this is not a quick patch): the IMPLICATION branch
+(~1412) is SHARED with the non-panic eq-discharge tiers. Specializing
+`consumer_pre` to `arg_term` there perturbs obligation CIDs / hash-tier lookups
+for ALL callsites (the code already warns about this re `instantiate::run`). So
+BREAK 1's fix must specialize ONLY the panic-site implication (or route a
+producer-post panic_site through the guard branch with the D-lib is_ok fact
+instead of the implication branch) without touching the shared non-panic path.
+
+FIX SKETCH (one focused PR, gate on discrimination test f->safe / g->undecidable /
+falsePass=0 on BOTH stage3-serde AND panic-freedom fixtures):
+  1. BREAK 1: for a `panic_site` callsite that has a producer_post, either
+     (a) instantiate consumer_pre to arg_term before building the implication
+     (panic-only, so no shared-path CID drift), or (b) skip the implication
+     branch for panic sites and use the guard branch + D-lib fact.
+  2. BREAK 2: fix cf_guarded -> guard_facts threading so the syntactic-guard
+     panic site is GUARDED e2e (verify enumerate_callsites walk_term ~269
+     actually receives the cf_guarded wrapper from the lifter output).
+  Both lift e2e K together; both are sound-by-construction (specialization +
+  syntactic guard are exact), gated by the discrimination test.
+
 ## Reproduction
 
 Warm-oracle e2e on battleaxe: `/tmp/serde_e2e2.sh` (mints shim-std + shim-serde deps,

--- a/docs/self-application/serde-panic-freedom-diagnosis.md
+++ b/docs/self-application/serde-panic-freedom-diagnosis.md
@@ -245,6 +245,35 @@ on the unsound collapse and should be updated to expect undecidable (that IS the
 bug being closed). Only AFTER #1717 lands is the K cascade fix safe (BREAK 1
 re-introduces an opaque-sorted forall).
 
+## BREAK 1 fix-target REFINED (empirical: my specialization approach is wrong)
+
+Attempted BREAK 1 as "specialize consumer_pre to the arg in the implication
+branch" -- EMPIRICALLY WRONG. `build_implication_obligation` (runner.rs:1720)
+REQUIRES both post_formula AND pre_formula to be `forall` (errors "pre is not a
+forall" otherwise), renames BOTH bound vars to a shared `_h0`, and emits
+`forall _h0. (post_body[_h0] -> pre_body[_h0])`. Stripping the forall to specialize
+breaks it. And specialization is unnecessary: the builder ALREADY unifies the two
+foralls via `_h0`.
+
+So for f, the obligation SHOULD reduce to `forall _h0. (is_ok(_h0) -> is_ok(_h0))`
+= trivially valid -> discharged. It is UNSATISFIED, which means
+`post_body[_h0] != pre_body[_h0]` after renaming -- the producer post body and the
+consumer pre body are NOT both `is_ok(_h0)`. The bug is therefore in ONE of:
+  (a) `locate_producer_post` shapes the producer post body as something other than
+      `is_ok(<bound>)` (e.g. carries the concrete arg term, or a different
+      predicate/sort), OR
+  (b) the producer-post and consumer-pre forall SORTS differ, so `_h0` is declared
+      at incompatible sorts and `is_ok` is not the same uninterpreted relation, OR
+  (c) the rename (`substitute_formula_pub` with post_name/pre_name -> `_h0`) misses
+      a binder.
+
+NEXT (fresh head): instrument `build_implication_obligation` to log
+`post_body_renamed` and `pre_body_renamed` for a panic site on a CLEANLY re-minted
+stage3-serde proof (the probe must run against the SAME proof the mint produced --
+state drift across runs masked this tonight). The diff between those two bodies IS
+the fix. This is a targeted equality/shape fix in the producer-post construction,
+NOT a specialization and NOT touching the shared non-panic path.
+
 ## Reproduction
 
 Warm-oracle e2e on battleaxe: `/tmp/serde_e2e2.sh` (mints shim-std + shim-serde deps,

--- a/docs/self-application/serde-panic-freedom-diagnosis.md
+++ b/docs/self-application/serde-panic-freedom-diagnosis.md
@@ -94,6 +94,22 @@ The reflexive-discharge idea (sound `P -> P` when the producer's post is byte-id
 to the consumer's pre) is still the most promising mechanism; it just has to be wired
 into the path the callsites actually reach.
 
+## Phase-0 gap confirmed: `doctor` does not catch this footgun
+
+`provekit doctor --target <kit>` exists and runs, but its checks are: TOML parse,
+plugin-command binary exists, imports count, oracle reachability. It does NOT catch
+the exact footgun that cost five agents: a `lift` manifest that omits `method` and
+`phase`, so a consumer surface (rust-implications) silently runs the default `lift`
+producer method and the implication lifter never fires.
+
+Catching the OMISSION case soundly AND language-blind needs `doctor` to spawn each
+plugin's `provekit.plugin.describe` RPC and cross-check the manifest's effective
+`(method, phase)` against the capabilities the plugin advertises for that surface —
+e.g. "plugin advertises a consumer method for surface S but the manifest runs the
+default producer `lift`" -> WARN/FAIL. A name/heuristic check (e.g. "*-implications")
+would violate language-blindness or over-warn on legitimate producers. This is a
+scoped Phase-0 (scaffolding) task, independent of the K cascade work.
+
 ## Reproduction
 
 Warm-oracle e2e on battleaxe: `/tmp/serde_e2e2.sh` (mints shim-std + shim-serde deps,

--- a/docs/self-application/serde-panic-freedom-diagnosis.md
+++ b/docs/self-application/serde-panic-freedom-diagnosis.md
@@ -225,6 +225,26 @@ undecidable) or carry the same strip-outer-forall guard. Per the GOAL's Phase-0 
 Phase-1 -> Phase-2 order: close #1717 BEFORE turning K from 0 to N, or risk
 manufacturing the precise false-pass this whole effort exists to prevent.
 
+## #1717 implementation locator (Phase-1, do FIRST)
+
+Site: `implementations/rust/provekit-ir-compiler-smt-lib/src/lib.rs`. Its
+`supported_sorts` are only `Int/Bool/Real/String`; a `forall` quantifying an
+OPAQUE (non-primitive) sort cannot be emitted soundly and currently collapses to
+literal `true` (the latent false-pass: negated obligation `(not true)` = unsat =
+false "cannot panic"). The opacity is already tracked in `OpacityManifest`.
+
+Fix direction is REFUSE (sound-by-construction -- can ONLY remove false-passes,
+never add one, so falsePass=0 is safe): when a `forall` body quantifies an opaque
+sort, do NOT emit `true`; signal UNDECIDABLE. KEY CONSTRAINT: the refuse must
+PROPAGATE emitter->runner as `ObligationVerdict::Undecidable`, not an inline SMT
+`true` -- a local return is insufficient; the emit result type / the runner's
+interpretation of it must carry the refusal. Detector test (from the GOAL):
+`forall x:<opaque>. false` must come out UNDECIDABLE, not discharged.
+Then re-run the verifier suite: any test that flips green->undecidable was relying
+on the unsound collapse and should be updated to expect undecidable (that IS the
+bug being closed). Only AFTER #1717 lands is the K cascade fix safe (BREAK 1
+re-introduces an opaque-sorted forall).
+
 ## Reproduction
 
 Warm-oracle e2e on battleaxe: `/tmp/serde_e2e2.sh` (mints shim-std + shim-serde deps,

--- a/docs/self-application/serde-panic-freedom-diagnosis.md
+++ b/docs/self-application/serde-panic-freedom-diagnosis.md
@@ -133,6 +133,39 @@ manifest's effective `(method, phase)` against that. This is a scoped Phase-0
 (scaffolding) task, independent of the K cascade work, with NO falsePass risk (it is
 a CLI diagnostic).
 
+## SYSTEMIC FINDING: e2e panic discharge is broken for syntactic guards too
+
+The remaining cascade bug is NOT serde/D-lib specific. The canonical
+`examples/panic-freedom-fixture` (`guarded_unwrap`: `if opt.is_some() { opt.unwrap() }`,
+`unguarded_unwrap`: `opt.unwrap()`) is correctly wired (manifest has
+method=lift_implications + phase=consumer), yet its end-to-end `prove` scoreboard is:
+
+    {"panicSafe": 0, "reflexive": 28, "undecidable": 133, "falsePass": 0}
+
+`panicSafe=0` -- the SYNTACTIC-guard case does not discharge panic-safe e2e either.
+So the GOAL's "Mechanism proven on a fixture (guarded->panic-safe; deterministic test
+green)" refers to the UNIT test (a hand-built `CallSite{panic_site:true, guard_facts}`
+in cmd_verify/body_discharge), NOT the mint->prove pipeline. The whole e2e panic
+discharge path (the `work_one` cascade) drops panic callsites before the guard
+discharge for both the syntactic-guard and the D-lib paths. Fixing the cascade
+(see above) should lift BOTH at once -- the fix is not serde-specific.
+
+This is exactly the "green unit test, broken product" gap the three product surfaces
+exist to expose. Update the on-main GOAL "NOW" line: e2e K=0 is systemic, unit-test-only.
+
+## Golden snapshot: design tension (why it is not a clean now-win)
+
+A golden of the panic-freedom scoreboard is GOAL Phase-0, but the clean target is the
+per-site census (`self-check --json`), which is daemon-heavy (warm RA oracle) and not
+CI-portable. The daemon-free alternative (raw `prove` on the fixture) is brittle: the
+aggregate dischargeSplit mixes in shim-std's own callsites (undecidable=133 is mostly
+shim noise) and `prove` rows carry file=None, so the fixture's two functions can't be
+isolated for a stable pin. The robust golden therefore wants either (a) self-check
+gaining a fixture-scoped per-site mode, or (b) prove rows carrying file/line so the
+golden pins just the fixture's sites. Best built WITH the cascade fix so it pins a
+meaningful panicSafe>0 delta. Pinning panicSafe=0 now is legitimate scaffolding but
+low-value until the cascade lands.
+
 ## Reproduction
 
 Warm-oracle e2e on battleaxe: `/tmp/serde_e2e2.sh` (mints shim-std + shim-serde deps,

--- a/docs/self-application/serde-panic-freedom-diagnosis.md
+++ b/docs/self-application/serde-panic-freedom-diagnosis.md
@@ -274,6 +274,41 @@ state drift across runs masked this tonight). The diff between those two bodies 
 the fix. This is a targeted equality/shape fix in the producer-post construction,
 NOT a specialization and NOT touching the shared non-panic path.
 
+## ROOT CAUSE LOCATED (build_implication body diff, fresh-mint instrumented)
+
+Instrumented `build_implication_obligation` to log `post_body_renamed` vs
+`pre_body_renamed` on a freshly-minted stage3-serde proof. The non-reflexive diff:
+
+    post_body (producer): =(_h0, ctor "method:to_string"(value))   <- STRUCTURAL EQ
+    pre_body  (consumer): is_ok(_h0)                                <- the unwrap pre
+
+So the implication is `(_h0 = to_string(value)) -> is_ok(_h0)` -- z3 cannot prove
+it. The producer post is the to_string BODY-EQ contract (`result == to_string(value)`,
+a structural identity, useless for panic-freedom), NOT the
+`serde_json_to_string_value` TOTALITY contract (`is_ok(result)`). With the totality
+post the implication would be `is_ok(_h0) -> is_ok(_h0)` = reflexive = DISCHARGED.
+
+ROOT CAUSE: `locate_producer_post` (handshake.rs:120) does
+`bridges_by_symbol.get(inner_name)` -> follows that ONE bridge to its target
+contract and takes `.post`. `bridges_by_symbol` holds ONE bridge per symbol; for
+`method:to_string` the BODY-EQ bridge won over the disambiguated totality bridge,
+so the producer post is the eq, not `is_ok`. (Caveat: the prove was contaminated by
+138 shim callsites; confirm on a fixture-isolated run that this post is f's, and
+note the arg lifted as `method:to_string` -- verify free-call `serde_json::to_string`
+vs method `value.to_string()` lift shape.)
+
+FIX (fresh head, soundness-adjacent, gate on discrimination + verifier suite):
+`locate_producer_post` must prefer the producer contract whose post matches the
+consumer's predicate family (here `is_ok`) -- i.e. the TOTALITY contract -- over a
+structural body-eq. Options: (a) when multiple bridges/contracts exist for the
+producer symbol, select the one whose post predicate unifies with the consumer
+pre's predicate; (b) fix the bridge-collision so the disambiguated totality bridge
+is the one keyed in `bridges_by_symbol` for a panic-relevant producer. g
+(MyStruct) has NO totality contract -> no is_ok producer post -> stays undecidable
+(refuse-floor preserved, falsePass=0). This supersedes the earlier
+"specialize consumer_pre" and "two breaks" framings: the serde break is a single
+producer-contract-selection bug in locate_producer_post.
+
 ## Reproduction
 
 Warm-oracle e2e on battleaxe: `/tmp/serde_e2e2.sh` (mints shim-std + shim-serde deps,

--- a/docs/self-application/serde-panic-freedom-diagnosis.md
+++ b/docs/self-application/serde-panic-freedom-diagnosis.md
@@ -210,6 +210,21 @@ falsePass=0 on BOTH stage3-serde AND panic-freedom fixtures):
   Both lift e2e K together; both are sound-by-construction (specialization +
   syntactic guard are exact), gated by the discrimination test.
 
+## SEQUENCING: #1717 (Phase-1 soundness) must precede the K cascade fix
+
+BREAK 1's fix specializes the panic `consumer_pre` to the call arg, which puts a
+`forall <arg-sort>. <pre>` into the SMT-emitted implication. When the arg sort is
+OPAQUE (a non-primitive Rust sort), that is exactly the `forall x:<opaque>. ...`
+shape #1717 flags: the SMT emitter collapses it to literal `true`, so the negated
+obligation is `(not true)` = unsat = a FALSE "cannot panic" (latent false-pass).
+The else/guard branch already defends against this with
+`instantiate::strip_outer_forall`; the implication branch does NOT. So the K
+cascade fix MUST either close #1717 first (encode the opaque `forall` soundly or
+refuse, never collapse -- detector: `forall x:<opaque>. false` must be
+undecidable) or carry the same strip-outer-forall guard. Per the GOAL's Phase-0 ->
+Phase-1 -> Phase-2 order: close #1717 BEFORE turning K from 0 to N, or risk
+manufacturing the precise false-pass this whole effort exists to prevent.
+
 ## Reproduction
 
 Warm-oracle e2e on battleaxe: `/tmp/serde_e2e2.sh` (mints shim-std + shim-serde deps,

--- a/docs/self-application/serde-panic-freedom-diagnosis.md
+++ b/docs/self-application/serde-panic-freedom-diagnosis.md
@@ -1,5 +1,54 @@
 # Serde panic-freedom (D-lib) — full diagnosis, 2026-05-31
 
+## HANDOFF — START HERE (ready-to-dispatch, ~1-2 hrs fresh)
+
+State: branch `serde-finish`, clean tree. K (e2e panicSafe) = 0, honestly.
+Root cause LOCATED, verification UNBLOCKED. Everything below is detail; this is the
+executable plan.
+
+THE BUG (single): the panic obligation for `f`'s `serde_json::to_string(v).unwrap()`
+is built as `(producer_post) -> (consumer_pre)`. `consumer_pre = is_ok(_h0)` (correct,
+result_unwrap pre). `producer_post` = the to_string BODY-EQ contract
+`=(_h0, to_string(value))` instead of the serde_json_to_string_value TOTALITY
+`is_ok(_h0)`. So the implication is `(_h0 = to_string(value)) -> is_ok(_h0)` -> z3
+unsat. With the totality post it's `is_ok(_h0) -> is_ok(_h0)` = valid -> panic-safe.
+Cause: `locate_producer_post` (provekit-verifier/src/handshake.rs:120) follows the
+single `bridges_by_symbol[inner_name]` bridge to ONE target contract and takes its
+`post`; the body-eq won the per-symbol slot. Suspect the free call
+`serde_json::to_string` lifts under ctor `method:to_string`, keying the totality
+bridge away from the lookup.
+
+STEP 1 (diagnose, ~20 min, READ-ONLY): on battleaxe, `bash /tmp/serde_e2e2.sh`
+re-mints stage3-serde fresh, then `provekit dump <proof> --json` + a script to print
+EVERY entry of `bridges_by_symbol` (key) and its target contract's `post`. Confirm:
+is there a bridge whose target post is `is_ok(result)` (the totality) for the
+to_string producer, and under which key? (`to_string` vs `method:to_string` vs
+`serde_json_to_string_value`.)
+
+STEP 2 (fix, soundness-adjacent, ONE of):
+  (a) KIT-SIDE (preferred, safer, "semantics in the kit"): if `serde_json::to_string`
+      free call is mis-lifted as `method:to_string`, fix the lifter
+      (provekit-walk/src/bin/walk_rpc.rs visit_expr_call vs visit_expr_method_call)
+      so the free call keys where the totality bridge lives.
+  (b) VERIFIER-SIDE: make `locate_producer_post` prefer, among the producer's
+      bridges/contracts, the one whose post predicate unifies with the consumer
+      pre's predicate family (is_ok) over a structural `=`.
+
+STEP 3 (verify, NOW POSSIBLE — file/line surfaces in rows):
+  `provekit prove examples/stage3-serde-totality-fixture --with <out> --json`
+  REQUIRE: row `file=src/lib.rs line=25` (f) -> status discharged/panicSafe;
+           row `file=src/lib.rs line=38` (g, MyStruct) -> undecidable;
+           global falsePass=0, silentlyDropped=0.
+  ALSO run the panic-freedom-fixture (BREAK 2, syntactic guard) + the full
+  provekit-verifier test suite (`bcargo test -p provekit-verifier`). If g flips or
+  falsePass>0 or any suite test regresses -> REVERT.
+
+DO NOT: rush this exhausted; specialize consumer_pre (empirically wrong, breaks the
+forall build_implication needs); touch the shared non-panic discharge path.
+
+---
+
+
 Goal: f `serde_json::to_string(&Value).unwrap()` → PANIC-SAFE (K=1); g
 `to_string(&MyStruct).unwrap()` → UNDECIDABLE; falsePass=0. Stalled 5 agents.
 

--- a/docs/self-application/serde-panic-freedom-diagnosis.md
+++ b/docs/self-application/serde-panic-freedom-diagnosis.md
@@ -107,8 +107,18 @@ plugin's `provekit.plugin.describe` RPC and cross-check the manifest's effective
 `(method, phase)` against the capabilities the plugin advertises for that surface —
 e.g. "plugin advertises a consumer method for surface S but the manifest runs the
 default producer `lift`" -> WARN/FAIL. A name/heuristic check (e.g. "*-implications")
-would violate language-blindness or over-warn on legitimate producers. This is a
-scoped Phase-0 (scaffolding) task, independent of the K cascade work.
+would violate language-blindness or over-warn on legitimate producers.
+
+CONFIRMED SHAPE: `describe` (walk_rpc `initialize_result`, ~line 2109) today returns
+only `capabilities.authoring_surfaces = ["rust","rust-bind","rust-walk-contracts"]`.
+It does NOT advertise the RPC methods the plugin dispatches (`lift`,
+`provekit.plugin.lift_implications`, `provekit.plugin.recognize`, ...) nor which
+surfaces are consumers. So the work is two-part: (1) extend `describe.capabilities`
+to add e.g. `rpc_methods: [...]` and `consumer_surfaces: ["rust-implications", ...]`
+(plugin self-reports; semantics stay in the kit); (2) `doctor` cross-checks each
+manifest's effective `(method, phase)` against that. This is a scoped Phase-0
+(scaffolding) task, independent of the K cascade work, with NO falsePass risk (it is
+a CLI diagnostic).
 
 ## Reproduction
 

--- a/examples/provekit-shim-serde-json-rust/src/lib.rs
+++ b/examples/provekit-shim-serde-json-rust/src/lib.rs
@@ -97,6 +97,7 @@ pub fn json_serialize(v: &Value) -> Result<String, String> {
     version = "1",
     family = "concept:family:json",
     loss = [],
+    totality = "result_ok",
 )]
 pub fn serde_json_to_string_value(v: &Value) -> Result<String, serde_json::Error> {
     // This ALWAYS succeeds for `Value` -- see the soundness argument above.
@@ -120,6 +121,7 @@ pub fn serde_json_to_string_value(v: &Value) -> Result<String, serde_json::Error
     version = "1",
     family = "concept:family:json",
     loss = [],
+    totality = "result_ok",
 )]
 pub fn serde_json_to_string_pretty_value(v: &Value) -> Result<String, serde_json::Error> {
     serde_json::to_string_pretty(v)

--- a/examples/stage3-serde-totality-fixture/.provekit/config.toml
+++ b/examples/stage3-serde-totality-fixture/.provekit/config.toml
@@ -1,0 +1,43 @@
+# Stage 3 discrimination fixture for serde_json Value totality.
+#
+# f(&serde_json::Value).unwrap() -> PANIC-SAFE (totality axiom)
+# g(&MyStruct).unwrap()          -> UNDECIDABLE (refuse-floor)
+#
+# The rust-bind surface provides the shim contracts (from .provekit/imports).
+# rust-fn-contracts produces body-bearing contracts for f and g.
+# rust-implications bridges the to_string and .unwrap() call sites.
+[[plugins]]
+name = "rust-bind"
+surface = "rust-bind"
+layer = "library-bindings"
+
+[[plugins]]
+name = "rust-contracts"
+surface = "rust-contracts"
+emit = "ir-document"
+
+[[plugins]]
+name = "rust-fn-contracts"
+surface = "rust-fn-contracts"
+emit = "ir-document"
+
+[[plugins]]
+name = "rust-implications"
+surface = "rust-implications"
+
+[platform_profile]
+language = "rust"
+family = "concept:family:json"
+library = "stage3-serde-totality-fixture"
+version = "0.0.0"
+
+[solvers]
+mode = "first-wins"
+portfolio = ["z3"]
+
+[solvers.z3]
+binary = "z3"
+ir_compiler = "smt-lib-v2.6"
+flags = ["-smt2", "-in"]
+timeout_seconds = 30
+version = "4.x"

--- a/examples/stage3-serde-totality-fixture/.provekit/lift/rust-bind/manifest.toml
+++ b/examples/stage3-serde-totality-fixture/.provekit/lift/rust-bind/manifest.toml
@@ -1,0 +1,3 @@
+name = "rust-bind-lift"
+command = ["../../implementations/rust/target/debug/provekit-walk-rpc", "--rpc"]
+working_dir = "."

--- a/examples/stage3-serde-totality-fixture/.provekit/lift/rust-contracts/manifest.toml
+++ b/examples/stage3-serde-totality-fixture/.provekit/lift/rust-contracts/manifest.toml
@@ -1,0 +1,3 @@
+name = "rust-contracts-lift"
+command = ["../../implementations/rust/target/debug/provekit-lift", "--rpc"]
+working_dir = "."

--- a/examples/stage3-serde-totality-fixture/.provekit/lift/rust-fn-contracts/manifest.toml
+++ b/examples/stage3-serde-totality-fixture/.provekit/lift/rust-fn-contracts/manifest.toml
@@ -1,0 +1,3 @@
+name = "rust-fn-contracts-lift"
+command = ["../../implementations/rust/target/debug/provekit-walk-rpc", "--rpc"]
+working_dir = "."

--- a/examples/stage3-serde-totality-fixture/.provekit/lift/rust-implications/manifest.toml
+++ b/examples/stage3-serde-totality-fixture/.provekit/lift/rust-implications/manifest.toml
@@ -1,3 +1,5 @@
 name = "rust-implications-lift"
+method = "provekit.plugin.lift_implications"
+phase = "consumer"
 command = ["../../implementations/rust/target/debug/provekit-walk-rpc", "--rpc"]
 working_dir = "."

--- a/examples/stage3-serde-totality-fixture/.provekit/lift/rust-implications/manifest.toml
+++ b/examples/stage3-serde-totality-fixture/.provekit/lift/rust-implications/manifest.toml
@@ -1,0 +1,3 @@
+name = "rust-implications-lift"
+command = ["../../implementations/rust/target/debug/provekit-walk-rpc", "--rpc"]
+working_dir = "."

--- a/examples/stage3-serde-totality-fixture/Cargo.toml
+++ b/examples/stage3-serde-totality-fixture/Cargo.toml
@@ -1,0 +1,21 @@
+# Stage 3 fixture for the serde_json Value totality discharge.
+#
+# Discrimination test:
+#   f(&serde_json::Value) -> should discharge PANIC-SAFE (Value is total)
+#   g(&MyStruct)          -> should stay UNDECIDABLE (struct Serialize may fail)
+#
+# Own [workspace] for RA isolation (fast index, no monorepo stall).
+[package]
+name = "stage3-serde-totality-fixture"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[lib]
+path = "src/lib.rs"

--- a/examples/stage3-serde-totality-fixture/src/lib.rs
+++ b/examples/stage3-serde-totality-fixture/src/lib.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Stage 3 discrimination fixture: serde_json Value totality.
+//
+// Acceptance criteria:
+//   f: serde_json::to_string(&serde_json::Value).unwrap()
+//      -> PANIC-SAFE (Value serialization is total; is_ok(result) axiom fires)
+//
+//   g: serde_json::to_string(&MyStruct).unwrap()
+//      -> UNDECIDABLE (struct Serialize may fail; no totality contract)
+//      -> falsePass MUST be 0; g stays honestly unproven.
+//
+// The two functions share the same callee leaf (to_string) and the same
+// .unwrap() shape. The ONLY discriminant is the argument type. If both
+// discharge panic-safe, the disambiguation leaked to non-Value (false pass).
+// If neither discharges, the disambiguation never fired (totality broken).
+
+use serde::Serialize;
+use serde_json::Value;
+
+/// The totality case: `v` is `serde_json::Value`. The oracle resolves the
+/// arg type to stem "value" -> disambiguated to serde_json_to_string_value
+/// (post: is_ok(result)) -> .unwrap() discharges PANIC-SAFE.
+pub fn f(v: &Value) -> String {
+    serde_json::to_string(v).unwrap()
+}
+
+/// The non-total case: `s` is a user-defined struct. The oracle resolves the
+/// arg type to a stem that is NOT "value" -> stays to_string -> no totality
+/// contract -> .unwrap() stays UNDECIDABLE. This is the refuse-floor check.
+#[derive(Serialize)]
+pub struct MyStruct {
+    pub x: i32,
+    pub name: String,
+}
+
+pub fn g(s: &MyStruct) -> String {
+    serde_json::to_string(s).unwrap()
+}

--- a/implementations/rust/examples/parseInt_publish.rs
+++ b/implementations/rust/examples/parseInt_publish.rs
@@ -110,6 +110,7 @@ fn main() -> ExitCode {
         notes: String::new(),
         signer_seed,
         target_proof_cid: None,
+        callsite: None,
     };
     let minted_bridge = mint_bridge(&bridge_args);
     println!("  bridge   minted: parseInt -> CID {}", minted_bridge.cid);

--- a/implementations/rust/provekit-claim-envelope/src/lib.rs
+++ b/implementations/rust/provekit-claim-envelope/src/lib.rs
@@ -576,6 +576,23 @@ pub struct MintBridgeArgs {
     /// a co-member of this bridge's own bundle. There is no unpinned path;
     /// `None` is enforced as same-bundle membership, not skipped.
     pub target_proof_cid: Option<String>,
+    /// Call-site provenance for this bridge, carried verbatim from the lifter's
+    /// bridge declaration. Load-bearing: `panic_site` is how the verifier
+    /// (`enumerate_callsites` -> `cmd_verify`) routes a panic-leaf bridge into
+    /// the panic-safe discharge path. Dropping it (the pre-fix behavior) made
+    /// every minted panic site read back `panic_site=false` and stay
+    /// undecidable. `None` keeps a callsite-less bridge byte-identical to its
+    /// pre-field CID (callsite is NOT part of bridge content identity).
+    pub callsite: Option<BridgeCallsite>,
+}
+
+/// Call-site provenance carried into a bridge memento. Mirrors the lifter's
+/// `callsite` object so the verifier reads back `panicSite`/`file`/`start_line`.
+#[derive(Clone, Debug, Default)]
+pub struct BridgeCallsite {
+    pub panic_site: bool,
+    pub file: Option<String>,
+    pub line: Option<i64>,
 }
 
 /// Compute the content CID of a bridge declaration (signer-independent).
@@ -660,6 +677,22 @@ pub fn mint_bridge(args: &MintBridgeArgs) -> MintedEnvelope {
     // (self-pinned: the verifier enforces same-bundle co-membership instead).
     if let Some(ref bundle) = args.target_proof_cid {
         kind_specific.push(("targetProofCid".into(), Value::string(bundle.clone())));
+    }
+    // Carry the lifter's call-site object so the verifier can read `panicSite`
+    // (the panic-discharge routing flag) plus file/line for the scoreboard.
+    // NOT folded into `bridge_content_cid`: a bridge's identity is its
+    // (sourceSymbol -> targetContract) relationship, invariant across the
+    // distinct call sites that share a symbol.
+    if let Some(ref cs) = args.callsite {
+        let mut cs_fields: Vec<(&str, Arc<Value>)> =
+            vec![("panicSite", Value::boolean(cs.panic_site))];
+        if let Some(ref f) = cs.file {
+            cs_fields.push(("file", Value::string(f.clone())));
+        }
+        if let Some(line) = cs.line {
+            cs_fields.push(("start_line", Value::integer(line)));
+        }
+        kind_specific.push(("callsite".into(), Value::object(cs_fields)));
     }
 
     let header = build_header("bridge", &header_cid, kind_specific);

--- a/implementations/rust/provekit-claim-envelope/tests/layered_shape.rs
+++ b/implementations/rust/provekit-claim-envelope/tests/layered_shape.rs
@@ -316,6 +316,7 @@ fn bridge_memento_has_layered_shape() {
         notes: String::new(),
         signer_seed: seed(),
         target_proof_cid: None,
+        callsite: None,
     };
     let m = mint_bridge(&args);
     let env: Json = serde_json::from_slice(&m.canonical_bytes).expect("json");

--- a/implementations/rust/provekit-claim-envelope/tests/mint_bridge_implication.rs
+++ b/implementations/rust/provekit-claim-envelope/tests/mint_bridge_implication.rs
@@ -43,6 +43,7 @@ fn bridge_args() -> MintBridgeArgs {
         notes: String::new(),
         signer_seed: seed(),
         target_proof_cid: None,
+        callsite: None,
     }
 }
 

--- a/implementations/rust/provekit-cli/src/cmd_doctor.rs
+++ b/implementations/rust/provekit-cli/src/cmd_doctor.rs
@@ -289,7 +289,122 @@ pub fn run_checks(kit_dir: &Path) -> Vec<Check> {
         checks.push(oracle_check);
     }
 
+    // --- Check 5: consumer-surface method/phase wiring (HARD).
+    // The manifest method/phase omission footgun: a consumer surface
+    // (e.g. rust-implications) whose manifest omits `method`/`phase` silently
+    // runs the default `lift` PRODUCER method, so its pass never fires and the
+    // mint emits a degenerate attestation with no error. Five investigations
+    // on 2026-05-31 lost a day to exactly this. The plugin SELF-DECLARES which
+    // surfaces are consumers and what (method, phase) they require (via the
+    // `initialize` capabilities) so this stays language-blind: doctor reads the
+    // requirement from the kit's own plugin, not a hard-coded CLI table.
+    for (surface, kind_dir, manifest_path) in &manifest_entries {
+        let check_name = format!("consumer-wiring:{kind_dir}:{surface}");
+        let manifest = match parse_manifest_at(manifest_path) {
+            Ok(m) => m,
+            Err(_) => continue, // already reported by checks 1/2
+        };
+        let resolved_wd = resolved_working_dir_for(kit_dir, &manifest);
+        let consumer_reqs = match plugin_consumer_surfaces(&manifest, resolved_wd.as_deref()) {
+            Ok(c) => c,
+            Err(e) => {
+                checks.push(Check::warn(
+                    &check_name,
+                    format!("could not query plugin capabilities for {surface}: {e}"),
+                ));
+                continue;
+            }
+        };
+        let Some(req) = consumer_reqs.get(surface.as_str()) else {
+            // Not a consumer surface per the plugin: nothing to enforce.
+            continue;
+        };
+        let method_ok = manifest.method.as_deref() == Some(req.0.as_str());
+        let phase_ok = manifest.phase.as_deref() == Some(req.1.as_str());
+        if method_ok && phase_ok {
+            checks.push(Check::pass(
+                &check_name,
+                format!(
+                    "consumer surface {surface} correctly wired (method={}, phase={})",
+                    req.0, req.1
+                ),
+            ));
+        } else {
+            checks.push(Check::fail(
+                &check_name,
+                format!(
+                    "consumer surface {surface} is mis-wired: manifest {} has method={:?} phase={:?} \
+                     but the plugin requires method=\"{}\" phase=\"{}\". Without these the surface \
+                     silently runs the default `lift` producer and its pass never fires (degenerate \
+                     attestation, no error). Add both lines to the manifest.",
+                    manifest_path.display(),
+                    manifest.method,
+                    manifest.phase,
+                    req.0,
+                    req.1,
+                ),
+            ));
+        }
+    }
+
     checks
+}
+
+/// Query a plugin's `initialize` capabilities and return its declared
+/// consumer-surface requirements: `surface -> (required_method, required_phase)`.
+/// Language-blind: the requirement is the PLUGIN's self-declaration, not a CLI
+/// table. Spawns the plugin command, sends one `initialize` JSON-RPC line, reads
+/// one response line, and parses `result.capabilities.consumer_surfaces`.
+fn plugin_consumer_surfaces(
+    manifest: &crate::lift_plugin::LiftPluginManifest,
+    working_dir: Option<&Path>,
+) -> Result<std::collections::HashMap<String, (String, String)>, String> {
+    use std::io::{BufRead, BufReader, Write};
+    use std::process::{Command, Stdio};
+
+    if manifest.command.is_empty() {
+        return Err("manifest declares no command".into());
+    }
+    let mut cmd = Command::new(&manifest.command[0]);
+    cmd.args(&manifest.command[1..]);
+    if let Some(wd) = working_dir {
+        cmd.current_dir(wd);
+    }
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn().map_err(|e| format!("spawn: {e}"))?;
+    {
+        let stdin = child.stdin.as_mut().ok_or("no stdin")?;
+        let req = json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}});
+        let mut line = serde_json::to_vec(&req).map_err(|e| e.to_string())?;
+        line.push(b'\n');
+        stdin.write_all(&line).map_err(|e| format!("write: {e}"))?;
+    }
+    let stdout = child.stdout.take().ok_or("no stdout")?;
+    let mut reader = BufReader::new(stdout);
+    let mut resp_line = String::new();
+    reader
+        .read_line(&mut resp_line)
+        .map_err(|e| format!("read: {e}"))?;
+    let _ = child.kill();
+    let _ = child.wait();
+    let resp: Value =
+        serde_json::from_str(resp_line.trim()).map_err(|e| format!("parse response: {e}"))?;
+    let mut out = std::collections::HashMap::new();
+    if let Some(map) = resp
+        .pointer("/result/capabilities/consumer_surfaces")
+        .and_then(|v| v.as_object())
+    {
+        for (surface, req) in map {
+            let method = req.get("method").and_then(|v| v.as_str());
+            let phase = req.get("phase").and_then(|v| v.as_str());
+            if let (Some(m), Some(p)) = (method, phase) {
+                out.insert(surface.clone(), (m.to_string(), p.to_string()));
+            }
+        }
+    }
+    Ok(out)
 }
 
 /// Collect all (surface, kind_dir, manifest_path) triples for declared plugins.

--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -58,7 +58,7 @@ use libprovekit::core::{
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 use provekit_claim_envelope::{
     compute_contract_set_cid, contract_cid, mint_authority, mint_bridge, mint_contract,
-    mint_implication, Authoring, MintAuthorityArgs, MintBridgeArgs, MintContractArgs,
+    mint_implication, Authoring, BridgeCallsite, MintAuthorityArgs, MintBridgeArgs, MintContractArgs,
     MintImplicationArgs,
 };
 use provekit_ir_types::Sort;
@@ -1492,6 +1492,24 @@ fn mint_bridge_from_decl(
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string());
+    // Carry the lifter's call-site provenance (panicSite/file/line) into the
+    // bridge memento. Without this the verifier reads panic_site=false on every
+    // minted panic leaf and the panic-safe discharge path is never entered.
+    let callsite = decl.get("callsite").map(|cs| BridgeCallsite {
+        panic_site: cs
+            .get("panicSite")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        file: cs
+            .get("file")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string()),
+        line: cs
+            .get("start_line")
+            .or_else(|| cs.get("line"))
+            .and_then(|v| v.as_i64()),
+    });
     let bridge = mint_bridge(&MintBridgeArgs {
         produced_by: "provekit-cli".to_string(),
         produced_at: produced_at.to_string(),
@@ -1504,6 +1522,7 @@ fn mint_bridge_from_decl(
         notes: "implication-lifted callsite bridge".to_string(),
         signer_seed,
         target_proof_cid,
+        callsite,
     });
     Ok((bridge.cid, bridge.canonical_bytes))
 }
@@ -1843,6 +1862,9 @@ fn mint_ir_document(
                 // (and it can't reference its own not-yet-computed CID). The
                 // verifier enforces same-bundle co-membership for the None case.
                 target_proof_cid: None,
+                // Function-level body-discharge bridge, not a per-call panic
+                // site: no call-site provenance to carry.
+                callsite: None,
             });
             members
                 .entry(bridge.cid.clone())

--- a/implementations/rust/provekit-cli/src/kit_dispatch.rs
+++ b/implementations/rust/provekit-cli/src/kit_dispatch.rs
@@ -1283,7 +1283,7 @@ fn invoke_realize(
     }
     command.stdin(Stdio::piped());
     command.stdout(Stdio::piped());
-    command.stderr(Stdio::null());
+    command.stderr(if std::env::var("PROVEKIT_PLUGIN_STDERR").as_deref() == Ok("null") { Stdio::null() } else { Stdio::inherit() });
 
     let mut child = command
         .spawn()
@@ -1721,7 +1721,7 @@ fn invoke_emit(
     }
     command.stdin(Stdio::piped());
     command.stdout(Stdio::piped());
-    command.stderr(Stdio::null());
+    command.stderr(if std::env::var("PROVEKIT_PLUGIN_STDERR").as_deref() == Ok("null") { Stdio::null() } else { Stdio::inherit() });
 
     let mut child = command
         .spawn()
@@ -1795,7 +1795,7 @@ fn invoke_emit_check(
     }
     command.stdin(Stdio::piped());
     command.stdout(Stdio::piped());
-    command.stderr(Stdio::null());
+    command.stderr(if std::env::var("PROVEKIT_PLUGIN_STDERR").as_deref() == Ok("null") { Stdio::null() } else { Stdio::inherit() });
 
     let mut child = command
         .spawn()
@@ -1956,7 +1956,7 @@ fn invoke_materialize_source(
     }
     command.stdin(Stdio::piped());
     command.stdout(Stdio::piped());
-    command.stderr(Stdio::null());
+    command.stderr(if std::env::var("PROVEKIT_PLUGIN_STDERR").as_deref() == Ok("null") { Stdio::null() } else { Stdio::inherit() });
 
     let mut child = command.spawn().map_err(|e| {
         MaterializeSourceError::Failed(format!("spawn materialize source kit: {e}"))
@@ -2093,7 +2093,7 @@ pub fn dispatch_assemble(
     }
     command.stdin(Stdio::piped());
     command.stdout(Stdio::piped());
-    command.stderr(Stdio::null());
+    command.stderr(if std::env::var("PROVEKIT_PLUGIN_STDERR").as_deref() == Ok("null") { Stdio::null() } else { Stdio::inherit() });
 
     let mut child = command
         .spawn()
@@ -2220,7 +2220,7 @@ pub fn dispatch_materialize_check(
     }
     command.stdin(Stdio::piped());
     command.stdout(Stdio::piped());
-    command.stderr(Stdio::null());
+    command.stderr(if std::env::var("PROVEKIT_PLUGIN_STDERR").as_deref() == Ok("null") { Stdio::null() } else { Stdio::inherit() });
 
     let mut child = command
         .spawn()

--- a/implementations/rust/provekit-plugin-loader/src/loader.rs
+++ b/implementations/rust/provekit-plugin-loader/src/loader.rs
@@ -103,11 +103,21 @@ fn load_plugin_from_stdio_rpc(cmd_str: &str) -> Result<PluginMemento, LoadError>
         rest_args.split_whitespace().collect()
     };
 
+    // NO-SILENT-FAILURE: a plugin subprocess's stderr carries its diagnostics
+    // (lift gaps, oracle decisions, refusals). Nulling it by default is what hid
+    // a load-bearing bug from five investigations. Inherit by default so plugin
+    // diagnostics reach the operator's tracing stream; set PROVEKIT_PLUGIN_STDERR=null
+    // only to deliberately silence them.
+    let plugin_stderr = if std::env::var("PROVEKIT_PLUGIN_STDERR").as_deref() == Ok("null") {
+        Stdio::null()
+    } else {
+        Stdio::inherit()
+    };
     let mut child = Command::new(bin)
         .args(&args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(plugin_stderr)
         .spawn()
         .map_err(|e| LoadError::RpcError {
             detail: format!("failed to spawn stdio plugin `{bin}`: {e}"),

--- a/implementations/rust/provekit-verifier/src/body_discharge.rs
+++ b/implementations/rust/provekit-verifier/src/body_discharge.rs
@@ -602,33 +602,66 @@ fn formula_is_reflexive(f: &Json) -> bool {
 ///
 /// Returns `Some(is_ok(arg_term))` when all three conditions hold, else `None`.
 pub fn callee_post_guard_fact(cs: &CallSite, pool: &MementoPool) -> Option<Json> {
+    macro_rules! gdbg {
+        ($($a:tt)*) => {
+            tracing::debug!(bridge = %cs.bridge_ir_name, "callee_post_guard_fact: {}", format!($($a)*));
+        };
+    }
     // Condition 1: the arg_term must be a `ctor` (a call expression, not a var).
-    let arg = cs.arg_term.as_ref()?;
+    let Some(arg) = cs.arg_term.as_ref() else {
+        gdbg!("REJECT cond1: no arg_term");
+        return None;
+    };
     if arg.get("kind").and_then(|v| v.as_str()) != Some("ctor") {
+        gdbg!("REJECT cond1: arg_term kind != ctor (kind={:?})", arg.get("kind"));
         return None;
     }
-    let ctor_name = arg.get("name").and_then(|v| v.as_str())?;
+    let Some(ctor_name) = arg.get("name").and_then(|v| v.as_str()) else {
+        gdbg!("REJECT cond1: ctor has no name");
+        return None;
+    };
+    gdbg!("cond1 OK: arg ctor_name={ctor_name}");
 
     // Condition 2: find a bridge for this ctor name and follow it to the target contract.
-    let bridge = pool.bridges_by_symbol.get(ctor_name)?;
-    let target_cid = bridge
+    let Some(bridge) = pool.bridges_by_symbol.get(ctor_name) else {
+        gdbg!("REJECT cond2: no bridge in bridges_by_symbol for ctor_name={ctor_name} (have keys: {:?})",
+            pool.bridges_by_symbol.keys().collect::<Vec<_>>());
+        return None;
+    };
+    let Some(target_cid) = bridge
         .get("evidence")
         .and_then(|e| e.get("body"))
         .and_then(|b| b.get("targetContractCid"))
         .or_else(|| bridge.pointer("/header/targetContractCid"))
-        .and_then(|v| v.as_str())?;
+        .and_then(|v| v.as_str())
+    else {
+        gdbg!("REJECT cond2: bridge for {ctor_name} has no targetContractCid");
+        return None;
+    };
 
-    let env = pool.mementos.get(target_cid)?;
+    let Some(env) = pool.mementos.get(target_cid) else {
+        gdbg!("REJECT cond2: target contract {target_cid} not in pool.mementos");
+        return None;
+    };
     if memento_kind(env) != Some("contract") {
+        gdbg!("REJECT cond2: target {target_cid} kind != contract ({:?})", memento_kind(env));
         return None;
     }
-    let body = memento_body(env).filter(|v| v.is_object())?;
+    let Some(body) = memento_body(env).filter(|v| v.is_object()) else {
+        gdbg!("REJECT cond2: target {target_cid} has no object body");
+        return None;
+    };
 
     // Condition 3: the contract's `post` is exactly `is_ok(result)`.
-    let post = body.get("post")?;
+    let Some(post) = body.get("post") else {
+        gdbg!("REJECT cond3: target contract for {ctor_name} has no post field");
+        return None;
+    };
     if !post_is_is_ok_of_result(post) {
+        gdbg!("REJECT cond3: post is NOT exactly is_ok(result) singleton -> post={post}");
         return None;
     }
+    gdbg!("ACCEPT: supplying is_ok(arg) fact for ctor_name={ctor_name}");
 
     // Supply the fact: `is_ok(arg_term)`. The arg_term (the ctor expression)
     // is the value whose is_ok status the contract guarantees. This is

--- a/implementations/rust/provekit-verifier/src/enumerate_callsites.rs
+++ b/implementations/rust/provekit-verifier/src/enumerate_callsites.rs
@@ -7,7 +7,7 @@
 // Mirrors implementations/cpp/.../verifier/enumerate_callsites.cpp.
 
 use serde_json::Value as Json;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::types::{memento_body, memento_kind, CallSite, MementoPool};
 
@@ -224,6 +224,27 @@ fn walk_term(
             callee: callsite_callee,
             panic_site,
         };
+        debug!(
+            name = %name,
+            panic_site,
+            callsite_present = bridge_callsite.is_some(),
+            arg_term_kind = ?cs.arg_term.as_ref().and_then(|a| a.get("kind")).and_then(|k| k.as_str()),
+            "enumerate_callsites: enumerated bridge call site"
+        );
+        // NO-SILENT-FAILURE (Phase 0): a `method:`-seam bridge is the protocol's
+        // method-call ctor (language-blind seam from the lift grammar). It MUST
+        // carry call-site provenance; a missing `callsite` field means the mint
+        // dropped it, which silently reads back `panic_site=false` and sends a
+        // real panic leaf to undecidable. Surface it loudly and count it instead
+        // of letting K silently rot. (Function-level bridges have no `method:`
+        // seam, so they do not trip this.)
+        if name.starts_with("method:") && bridge_callsite.is_none() {
+            warn!(
+                bridge = %name,
+                "enumerate_callsites: method-seam bridge has NO callsite provenance -- mint dropped it; \
+                 this panic site will read panic_site=false and stay undecidable (callsite-provenance drop)"
+            );
+        }
         out.push(cs);
     }
     // Descend into the call's arguments. A nested call is no longer a

--- a/implementations/rust/provekit-verifier/src/runner.rs
+++ b/implementations/rust/provekit-verifier/src/runner.rs
@@ -26,6 +26,7 @@ use serde_json::json;
 use serde_json::Value as Json;
 use tracing::{debug, info, warn};
 
+use crate::body_discharge::callee_post_guard_fact;
 use crate::handshake::{
     formula_hash, implication_property_hash, locate_producer_post, try_tier1, try_tier2,
 };
@@ -1528,7 +1529,24 @@ fn work_one(
                  `forall`->`true` emitter collapse)"
             );
         }
-        let guarded_formula = if cs.guard_facts.is_empty() {
+        // D-lib (cross-function-postcondition-as-assumable-fact): if the panic
+        // receiver is itself a call whose bridge target carries the strengthened
+        // `is_ok(result)` totality post, inject `is_ok(arg)` as a guard fact.
+        // This is the SAME language-blind mechanism cmd_verify uses; the prove
+        // path (the scoreboard's path) was missing it, so every D-lib panic site
+        // stayed unguarded -> undecidable. callee_post_guard_fact returns None
+        // for a non-total receiver (generic Result), preserving the refuse-floor.
+        let mut all_guard_facts: Vec<Json> = cs.guard_facts.clone();
+        if let Some(callee_fact) = callee_post_guard_fact(cs, pool) {
+            debug!(
+                bridge = %cs.bridge_ir_name,
+                callee_fact = %callee_fact,
+                "work_one: D-lib callee post supplies is_ok guard fact (totality contract on \
+                 the unwrap receiver -> adding is_ok(arg) to guard context)"
+            );
+            all_guard_facts.push(callee_fact);
+        }
+        let guarded_formula = if all_guard_facts.is_empty() {
             info!(
                 bridge = %cs.bridge_ir_name,
                 target_cid = %cs.bridge_target_cid,
@@ -1539,10 +1557,10 @@ fn work_one(
             );
             specialized
         } else {
-            let antecedent = if cs.guard_facts.len() == 1 {
-                cs.guard_facts[0].clone()
+            let antecedent = if all_guard_facts.len() == 1 {
+                all_guard_facts[0].clone()
             } else {
-                json!({ "kind": "and", "operands": cs.guard_facts.clone() })
+                json!({ "kind": "and", "operands": all_guard_facts.clone() })
             };
             let guarded = json!({
                 "kind": "implies",

--- a/implementations/rust/provekit-verifier/tests/load_all_proofs.rs
+++ b/implementations/rust/provekit-verifier/tests/load_all_proofs.rs
@@ -83,6 +83,7 @@ fn publish_parseint_proof(dir: &Path) -> String {
         notes: String::new(),
         signer_seed,
         target_proof_cid: None,
+        callsite: None,
     };
     let bridge = mint_bridge(&bridge_args);
     members.insert(bridge.cid.clone(), bridge.canonical_bytes);

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -32,8 +32,8 @@ use provekit_walk::emit::{
     rust_function_term_json_for_file, shadow_proof_ir_cid, shadow_to_proof_ir,
 };
 use provekit_walk::{
-    build_function_contract_with_file, build_shadow_source, lift_function_postcondition,
-    lift_function_precondition, CalleeContract,
+    build_function_contract_with_file, build_function_contract_with_file_and_post_override,
+    build_shadow_source, lift_function_postcondition, lift_function_precondition, CalleeContract,
 };
 use quote::ToTokens;
 use serde_json::{json, Value};
@@ -2592,10 +2592,41 @@ fn function_contract_lift(params: &Value) -> Result<Value, String> {
             .replace('\\', "/");
 
         for target in collect_function_contract_targets(&file) {
-            let contract =
-                build_function_contract_with_file(&target.item_fn, None, Some(rel.as_str()));
-            let (body_discharge_eligible, refusal_reason) =
-                body_discharge_eligibility(&contract.post, &contract.formals);
+            // Phase-2 Tier D-lib: when a sugar function carries `totality =
+            // "result_ok"`, the minted post is the AXIOM `is_ok(result)`
+            // rather than the body-derived reflexive post. The axiom flows
+            // into canonical_bytes and CID via the override path so the
+            // contract is self-consistent. This is the ONLY totality
+            // mechanism; inference from types is unsound (a non-Value Result
+            // may be fallible). The gate is explicit opt-in in the attribute.
+            // Singleton totality post: is_ok(result).
+            // Shape: {"kind":"atomic","name":"is_ok","args":[{"kind":"var","name":"result"}]}
+            // Matches the exact shape callee_post_guard_fact requires (body_discharge.rs).
+            let post_override: Option<IrFormula> = if target.totality_result_ok {
+                Some(IrFormula::Atomic {
+                    name: "is_ok".to_string(),
+                    args: vec![IrTerm::Var {
+                        name: "result".to_string(),
+                    }],
+                })
+            } else {
+                None
+            };
+            let contract = build_function_contract_with_file_and_post_override(
+                &target.item_fn,
+                None,
+                Some(rel.as_str()),
+                post_override,
+            );
+            // Totality-axiom contracts are body-discharge-INELIGIBLE (no
+            // result equation, by design: the post is an axiom, not derived
+            // from the body). Mark with a distinct reason so the loud
+            // diagnostic does not fire for expected ineligibility.
+            let (body_discharge_eligible, refusal_reason) = if target.totality_result_ok {
+                (false, Some("totality-axiom".to_string()))
+            } else {
+                body_discharge_eligibility(&contract.post, &contract.formals)
+            };
             let mut entry: Value =
                 serde_json::from_slice(&contract.canonical_bytes).map_err(|e| e.to_string())?;
             entry["name"] = json!(target.fn_name.clone());
@@ -2604,12 +2635,16 @@ fn function_contract_lift(params: &Value) -> Result<Value, String> {
             entry["bodyDischargeEligible"] = json!(body_discharge_eligible);
             if let Some(reason) = refusal_reason {
                 entry["bodyDischargeRefusalReason"] = json!(reason.clone());
-                diagnostics.push(json!({
-                    "kind": "body-discharge-gap",
-                    "reason": reason,
-                    "function": target.fn_name,
-                    "file": rel,
-                }));
+                // Suppress the loud body-discharge-gap diagnostic for the
+                // totality-axiom case: ineligibility is expected and sound.
+                if !target.totality_result_ok {
+                    diagnostics.push(json!({
+                        "kind": "body-discharge-gap",
+                        "reason": reason,
+                        "function": target.fn_name,
+                        "file": rel,
+                    }));
+                }
             }
             if !current_crate.is_empty() {
                 entry["library"] = json!(current_crate.clone());
@@ -2752,6 +2787,11 @@ struct FunctionContractLiftTarget {
     fn_name: String,
     source_name: String,
     item_fn: syn::ItemFn,
+    /// True when the function carries `#[provekit::sugar(totality = "result_ok", ...)]`.
+    /// When set, the minted post is the AXIOM `is_ok(result)` (NOT body-derived).
+    /// Sound only for wrapper functions whose return type is always Ok by type invariants
+    /// (e.g. serde_json::to_string(&Value) is total). Gate: explicit opt-in only.
+    totality_result_ok: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -2801,10 +2841,12 @@ fn collect_function_contract_targets_in_items(
                     continue;
                 }
                 let fn_name = item_fn.sig.ident.to_string();
+                let totality_result_ok = sugar_declares_totality_result_ok(item_fn);
                 targets.push(FunctionContractLiftTarget {
                     source_name: fn_name.clone(),
                     fn_name,
                     item_fn: item_fn.clone(),
+                    totality_result_ok,
                 });
             }
             syn::Item::Impl(impl_block) => {
@@ -2823,10 +2865,12 @@ fn collect_function_contract_targets_in_items(
                         continue;
                     }
                     let source_name = method.sig.ident.to_string();
+                    let totality_result_ok = sugar_declares_totality_result_ok(&item_fn);
                     targets.push(FunctionContractLiftTarget {
                         fn_name: format!("{qualifier}::{source_name}"),
                         source_name,
                         item_fn,
+                        totality_result_ok,
                     });
                 }
             }
@@ -2979,6 +3023,46 @@ struct SugarAttrParsed {
     family: Option<String>,
     loss: Vec<String>,
     observed_dimension: Option<String>,
+    /// Phase-2 Tier D-lib: when `totality = "result_ok"`, the minted contract
+    /// post is the AXIOM `is_ok(result)` rather than the body-derived reflexive
+    /// post. Only valid on functions whose return type is always Ok by type
+    /// invariants (e.g. serde_json::to_string(&Value)). Must be explicitly set;
+    /// never inferred.
+    totality: Option<String>,
+}
+
+/// True iff the function carries `#[provekit::sugar(totality = "result_ok", ...)]`.
+///
+/// This is the ONLY gate for the totality post override: the attribute must be
+/// present AND the return type must be Result. Never infer from the type alone;
+/// explicit opt-in is required to prevent inadvertent totality labels on
+/// fallible functions that happen to take `&Value` arguments.
+fn sugar_declares_totality_result_ok(item_fn: &syn::ItemFn) -> bool {
+    let Some(parsed) = extract_sugar_attr(item_fn) else {
+        return false;
+    };
+    // Require explicit totality = "result_ok" in the attribute.
+    if parsed.totality.as_deref() != Some("result_ok") {
+        return false;
+    }
+    // Require a Result return type. A totality label on a non-Result return
+    // makes no sense and is rejected loudly here rather than silently mislabeling.
+    matches!(
+        &item_fn.sig.output,
+        syn::ReturnType::Type(_, ty) if is_result_type(ty)
+    )
+}
+
+/// True iff a syn Type is `Result<...>` (bare or path-qualified).
+fn is_result_type(ty: &syn::Type) -> bool {
+    let syn::Type::Path(tp) = ty else {
+        return false;
+    };
+    tp.path
+        .segments
+        .last()
+        .map(|seg| seg.ident == "Result")
+        .unwrap_or(false)
 }
 
 fn extract_sugar_attr(item_fn: &syn::ItemFn) -> Option<SugarAttrParsed> {
@@ -2998,6 +3082,7 @@ fn extract_sugar_attr(item_fn: &syn::ItemFn) -> Option<SugarAttrParsed> {
                         family: args.string("family"),
                         loss: args.string_array("loss"),
                         observed_dimension: args.string("observed_dimension"),
+                        totality: args.string("totality"),
                     });
                 }
             }

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -2134,6 +2134,7 @@ fn bind_lift(params: &Value) -> Result<Value, String> {
                 loss,
                 observed_dimension,
                 item_fn,
+                totality_result_ok,
             } = sugar_target;
             // #1396 PR-0: singleton-concept lift-gap validator.  When the
             // @sugar annotation claims a portable `concept:X`, the substrate
@@ -2269,34 +2270,42 @@ fn bind_lift(params: &Value) -> Result<Value, String> {
             // #1580: emit a SIBLING `contract` decl per
             // `#[provekit::sugar(...)]` annotation. cmd_mint mints
             // this as a regular (non-body-bearing) contract memento.
-            // The post is the trivial identity ctor — `function_name(<vars>)`
-            // — which makes the verifier's enumerate_callsites find a
-            // callsite at this ctor name. The bridge that resolves it
-            // is emitted by the recognize lane (or by other downstream
-            // consumers that want to point at this contract).
+            // The post is normally the trivial identity ctor —
+            // `function_name(<vars>)` — which makes the verifier's
+            // enumerate_callsites find a callsite at this ctor name.
             //
-            // Why NOT `function-contract` (which would auto-mint a
-            // bridge): kind=function-contract triggers body-discharge,
-            // which substrate-honestly refuses contracts that have
-            // formals but no precondition (rather than reporting a
-            // vacuous pass). Without a real body-derived precondition
-            // — which walk_rpc doesn't have without invoking a deeper
-            // lifter — staying out of body-discharge is the honest
-            // path. The contract still publishes the sugar function as
-            // a substrate-named entity; bridges resolve to it.
+            // TOTALITY EXCEPTION (Phase-2 Tier D-lib): when the sugar
+            // annotation carries `totality = "result_ok"` and the
+            // return type is Result, the post is the AXIOM `is_ok(result)`.
+            // This is the exact shape callee_post_guard_fact checks
+            // (body_discharge.rs:post_is_is_ok_of_result). With this
+            // post, bridges emitted by the recognize lane discharge the
+            // downstream `.unwrap()` as panic-safe. Sound: only functions
+            // explicitly marked totality get this post; inference from
+            // arg types is rejected (refuse-floor).
             let fn_name = item_fn.sig.ident.to_string();
-            let arg_terms: Vec<Value> = param_names
-                .iter()
-                .map(|name| json!({ "kind": "var", "name": name }))
-                .collect();
-            let post = json!({
-                "kind": "atomic",
-                "args": [{
-                    "kind": "ctor",
-                    "name": fn_name,
-                    "args": arg_terms,
-                }],
-            });
+            let post = if totality_result_ok {
+                // Singleton totality post: is_ok(result).
+                // Shape: {"kind":"atomic","name":"is_ok","args":[{"kind":"var","name":"result"}]}
+                json!({
+                    "kind": "atomic",
+                    "name": "is_ok",
+                    "args": [{ "kind": "var", "name": "result" }],
+                })
+            } else {
+                let arg_terms: Vec<Value> = param_names
+                    .iter()
+                    .map(|name| json!({ "kind": "var", "name": name }))
+                    .collect();
+                json!({
+                    "kind": "atomic",
+                    "args": [{
+                        "kind": "ctor",
+                        "name": fn_name,
+                        "args": arg_terms,
+                    }],
+                })
+            };
             entries.push(json!({
                 "kind": "contract",
                 "name": fn_name,
@@ -2807,6 +2816,10 @@ struct SugarTarget {
     loss: Vec<String>,
     observed_dimension: Option<String>,
     item_fn: syn::ItemFn,
+    /// Phase-2 Tier D-lib: when `totality = "result_ok"` in the sugar attr
+    /// AND the return type is Result, the emitted sibling `kind=contract`
+    /// carries post = `is_ok(result)` instead of the identity ctor post.
+    totality_result_ok: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -2972,6 +2985,9 @@ fn collect_sugar_targets_in_items(items: &[syn::Item], targets: &mut Vec<SugarTa
         match item {
             syn::Item::Fn(item_fn) => {
                 if let Some(parsed) = extract_sugar_attr(item_fn) {
+                    let totality_result_ok =
+                        parsed.totality.as_deref() == Some("result_ok")
+                            && is_result_type_fn(item_fn);
                     targets.push(SugarTarget {
                         concept: parsed.concept,
                         library: parsed.library,
@@ -2980,6 +2996,7 @@ fn collect_sugar_targets_in_items(items: &[syn::Item], targets: &mut Vec<SugarTa
                         loss: parsed.loss,
                         observed_dimension: parsed.observed_dimension,
                         item_fn: item_fn.clone(),
+                        totality_result_ok,
                     });
                 }
             }
@@ -3047,10 +3064,7 @@ fn sugar_declares_totality_result_ok(item_fn: &syn::ItemFn) -> bool {
     }
     // Require a Result return type. A totality label on a non-Result return
     // makes no sense and is rejected loudly here rather than silently mislabeling.
-    matches!(
-        &item_fn.sig.output,
-        syn::ReturnType::Type(_, ty) if is_result_type(ty)
-    )
+    is_result_type_fn(item_fn)
 }
 
 /// True iff a syn Type is `Result<...>` (bare or path-qualified).
@@ -3063,6 +3077,14 @@ fn is_result_type(ty: &syn::Type) -> bool {
         .last()
         .map(|seg| seg.ident == "Result")
         .unwrap_or(false)
+}
+
+/// True iff an ItemFn has a `Result<...>` return type.
+fn is_result_type_fn(item_fn: &syn::ItemFn) -> bool {
+    matches!(
+        &item_fn.sig.output,
+        syn::ReturnType::Type(_, ty) if is_result_type(ty)
+    )
 }
 
 fn extract_sugar_attr(item_fn: &syn::ItemFn) -> Option<SugarAttrParsed> {

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -384,12 +384,6 @@ struct CallSite {
     file: String,
     line: usize,
     col: usize,
-    /// Phase-2 Tier D-lib: for free calls that need arg-type disambiguation
-    /// (e.g. `serde_json::to_string(&v)` where we want to know if `v` is
-    /// `serde_json::Value`), the span-start of the first argument expression.
-    /// `None` when arg-type resolution is not needed for this call.
-    arg0_line: Option<usize>,
-    arg0_col: Option<usize>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -635,6 +629,8 @@ fn collect_callsites_in_items(
                 if in_test_context || is_rust_test_fn(item_fn) {
                     continue;
                 }
+                let param_type_map =
+                    build_param_type_map(&item_fn.sig, use_map, local_type_names, current_crate);
                 collect_callsites_in_block(
                     &item_fn.block,
                     rel_path,
@@ -642,6 +638,7 @@ fn collect_callsites_in_items(
                     fn_return_crates,
                     local_type_names,
                     current_crate,
+                    &param_type_map,
                     out,
                 );
             }
@@ -655,6 +652,12 @@ fn collect_callsites_in_items(
                         if is_rust_test_fn(&item_fn) {
                             continue;
                         }
+                        let param_type_map = build_param_type_map(
+                            &method.sig,
+                            use_map,
+                            local_type_names,
+                            current_crate,
+                        );
                         collect_callsites_in_block(
                             &method.block,
                             rel_path,
@@ -662,6 +665,7 @@ fn collect_callsites_in_items(
                             fn_return_crates,
                             local_type_names,
                             current_crate,
+                            &param_type_map,
                             out,
                         );
                     }
@@ -695,6 +699,10 @@ fn collect_callsites_in_block(
     fn_return_crates: &HashMap<String, String>,
     local_type_names: &BTreeSet<String>,
     current_crate: &str,
+    // Phase-2 Tier D-lib: param name -> (crate, type_head) for syntactic
+    // serde_json::Value arg-type disambiguation. Built from the enclosing
+    // function's declared parameter types; empty when called outside a fn.
+    param_type_map: &HashMap<String, (String, String)>,
     out: &mut Vec<CallSite>,
 ) {
     use syn::visit::Visit;
@@ -705,6 +713,7 @@ fn collect_callsites_in_block(
         local_type_names: &'a BTreeSet<String>,
         current_crate: &'a str,
         local_types: HashMap<String, String>,
+        param_type_map: &'a HashMap<String, (String, String)>,
         out: &'a mut Vec<CallSite>,
     }
     impl<'ast, 'a> Visit<'ast> for V<'a> {
@@ -713,33 +722,44 @@ fn collect_callsites_in_block(
                 call_expr_callee(&node.func, self.use_map, self.current_crate)
             {
                 let start = node.func.span().start();
-                // Phase-2 Tier D-lib: for serde_json::to_string / to_string_pretty
-                // free calls, track the first arg position for oracle type resolution.
-                // Hovering at the arg's span gives the arg type stem; if stem == "value"
-                // the call targets serde_json::Value (total serialization).
-                let (arg0_line, arg0_col) = if needs_arg_type_resolution(
+                // Phase-2 Tier D-lib: syntactic arg-type disambiguation for
+                // serde_json::to_string / to_string_pretty free calls.
+                // When the first argument is a simple ident whose declared
+                // parameter type is serde_json::Value (from the enclosing
+                // function's signature), set disambiguated_callee directly
+                // without the oracle. Sound: crate identity (serde_json) AND
+                // type head (Value) must both match the enclosing fn's
+                // explicit type annotation; inference paths leave None.
+                let disambiguated_callee = if needs_arg_type_resolution(
                     callee_crate.as_deref(),
                     &callee,
                 ) {
-                    node.args.first().map(|a| {
-                        let sp = a.span().start();
-                        (sp.line, sp.column)
-                    }).unzip()
+                    node.args.first().and_then(|a| {
+                        let name = expr_bare_ident_name(a)?;
+                        let (krate, head) = self.param_type_map.get(&name)?;
+                        if krate == "serde_json" && head == "Value" {
+                            Some(if callee == "to_string_pretty" {
+                                "serde_json_to_string_pretty_value".to_string()
+                            } else {
+                                "serde_json_to_string_value".to_string()
+                            })
+                        } else {
+                            None
+                        }
+                    })
                 } else {
-                    (None, None)
+                    None
                 };
                 self.out.push(CallSite {
                     callee,
                     contract_callee,
                     callee_crate,
                     is_method: false,
-                    disambiguated_callee: None,
+                    disambiguated_callee,
                     unsupported_reason: None,
                     file: self.rel_path.to_string(),
                     line: start.line,
                     col: start.column,
-                    arg0_line,
-                    arg0_col,
                 });
             } else if is_closure_expr(&node.func) {
                 let start = node.func.span().start();
@@ -753,8 +773,6 @@ fn collect_callsites_in_block(
                     file: self.rel_path.to_string(),
                     line: start.line,
                     col: start.column,
-                    arg0_line: None,
-                    arg0_col: None,
                 });
             } else {
                 let start = node.func.span().start();
@@ -768,8 +786,6 @@ fn collect_callsites_in_block(
                     file: self.rel_path.to_string(),
                     line: start.line,
                     col: start.column,
-                    arg0_line: None,
-                    arg0_col: None,
                 });
             }
             syn::visit::visit_expr_call(self, node);
@@ -805,8 +821,6 @@ fn collect_callsites_in_block(
                 file: self.rel_path.to_string(),
                 line: start.line,
                 col: start.column,
-                arg0_line: None,
-                arg0_col: None,
             });
             syn::visit::visit_expr_method_call(self, node);
         }
@@ -834,8 +848,6 @@ fn collect_callsites_in_block(
                 file: self.rel_path.to_string(),
                 line: start.line,
                 col: start.column,
-                arg0_line: None,
-                arg0_col: None,
             });
             syn::visit::visit_expr_index(self, node);
         }
@@ -868,6 +880,7 @@ fn collect_callsites_in_block(
         local_type_names,
         current_crate,
         local_types: HashMap::new(),
+        param_type_map,
         out,
     };
     v.visit_block(block);
@@ -897,8 +910,6 @@ fn unsupported_macro_callsite(mac: &syn::Macro, rel_path: &str) -> CallSite {
         file: rel_path.to_string(),
         line: start.line,
         col: start.column,
-        arg0_line: None,
-        arg0_col: None,
     }
 }
 
@@ -1185,7 +1196,7 @@ fn crate_name_for(dir: &Path) -> Option<String> {
 /// and fall through to the bare-leaf key (their existing total-wrapper bridges
 /// are unaffected). Anything not in this table -> `None` -> bare-leaf key
 /// (additive; the refuse-floor and the existing bridges are preserved).
-/// True iff this free call needs arg-type resolution via the oracle.
+/// True iff this free call needs arg-type resolution.
 /// The set is deliberately narrow: only the serde_json totality wrappers.
 /// A non-Value arg to `serde_json::to_string` must NOT be disambiguated
 /// (it stays `to_string` -> no-contract-for-callee -> honestly undecidable).
@@ -1194,31 +1205,75 @@ fn needs_arg_type_resolution(callee_crate: Option<&str>, callee: &str) -> bool {
         && matches!(callee, "to_string" | "to_string_pretty")
 }
 
-/// Phase-2 Tier D-lib: when a serde_json free call was resolved by the oracle
-/// to have a `serde_json::Value` first argument (stem == "value"), return the
-/// wrapper function name that carries the totality contract. Any other stem
-/// (or None) returns None, preserving the refuse-floor for non-Value args.
+/// Extract the bare identifier name from an expression, stripping leading
+/// `&`/`&mut` references. Used to look up a call argument's name in the
+/// enclosing function's parameter type map.
 ///
-/// SOUNDNESS: stem "value" is SPECIFIC to `serde_json::Value` in this context
-/// because the oracle hover at the arg position of `serde_json::to_string(&v)`
-/// yields the type path `serde_json::Value`; `type_stem_from_hover_markdown`
-/// strips to the last segment and lowercases it, giving "value". A struct named
-/// `Value` from a DIFFERENT crate cannot appear here: the callee_crate check in
-/// `needs_arg_type_resolution` already confirmed the call is `serde_json::to_string`.
-/// A user-defined `struct Value` in their own crate at a serde_json::to_string
-/// call site would fail to compile unless it implements Serialize, and if it does,
-/// the to_string may still fail (not total). The guard is callee_crate = serde_json
-/// + arg stem = value: together they uniquely identify serde_json::Value calls.
-fn disambiguated_serde_json_value_leaf(callee: &str, arg_type_stem: &str) -> Option<String> {
-    if arg_type_stem != "value" {
-        return None;
+/// Returns `Some(name)` for `v`, `&v`, `&mut v` where the ident is bare.
+/// Returns `None` for non-ident expressions (method calls, literals, etc.).
+fn expr_bare_ident_name(expr: &syn::Expr) -> Option<String> {
+    match expr {
+        syn::Expr::Path(p) if p.path.segments.len() == 1 => {
+            Some(p.path.segments[0].ident.to_string())
+        }
+        syn::Expr::Reference(r) => expr_bare_ident_name(&r.expr),
+        _ => None,
     }
-    let leaf = match callee {
-        "to_string" => "serde_json_to_string_value",
-        "to_string_pretty" => "serde_json_to_string_pretty_value",
-        _ => return None,
+}
+
+/// Build a map from parameter name to `(crate, type_head)` for the given
+/// function signature. Used for syntactic serde_json::Value arg-type
+/// disambiguation without needing the oracle.
+///
+/// For `fn f(v: &serde_json::Value)`, returns `{"v" -> ("serde_json", "Value")}`.
+/// For `fn f(v: &Value)` with `use serde_json::Value` in scope, same result.
+/// For `fn g(s: &MyStruct)`, returns `{"s" -> ("current_crate", "MyStruct")}`.
+/// Non-typed patterns (e.g. destructured) are skipped.
+fn build_param_type_map(
+    sig: &syn::Signature,
+    use_map: &HashMap<String, String>,
+    local_type_names: &BTreeSet<String>,
+    current_crate: &str,
+) -> HashMap<String, (String, String)> {
+    let mut map = HashMap::new();
+    for input in &sig.inputs {
+        let syn::FnArg::Typed(pt) = input else {
+            continue; // skip `self`
+        };
+        let syn::Pat::Ident(pi) = &*pt.pat else {
+            continue; // skip destructured patterns
+        };
+        let name = pi.ident.to_string();
+        let ty = &*pt.ty;
+        // Strip outer & / &mut
+        let inner_ty = match ty {
+            syn::Type::Reference(r) => &*r.elem,
+            other => other,
+        };
+        // Extract the type's (crate, head)
+        if let Some((krate, head)) = type_crate_and_head(inner_ty, use_map, local_type_names, current_crate) {
+            map.insert(name, (krate, head));
+        }
+    }
+    map
+}
+
+/// For a type path, return `(crate, type_head)`. Uses `type_crate_for` for the
+/// crate and extracts the last path segment for the head.
+///
+/// Returns `None` for non-path types or when the crate cannot be determined.
+fn type_crate_and_head(
+    ty: &syn::Type,
+    use_map: &HashMap<String, String>,
+    local_type_names: &BTreeSet<String>,
+    current_crate: &str,
+) -> Option<(String, String)> {
+    let syn::Type::Path(tp) = ty else {
+        return None;
     };
-    Some(leaf.to_string())
+    let head = tp.path.segments.last()?.ident.to_string();
+    let krate = type_crate_for(ty, use_map, local_type_names, current_crate)?;
+    Some((krate, head))
 }
 
 fn disambiguated_partial_leaf(type_stem: &str, leaf: &str) -> Option<String> {
@@ -1274,10 +1329,6 @@ fn resolve_method_calls_via_oracle(
     // 0-based column; LSP wants 0-based line, 0-based char. The method ident's
     // span start already points at the ident (not the dot), so the column maps
     // directly. A line of 0 should never occur for a real call; guard anyway.
-    //
-    // Also include arg0 positions for serde_json free calls that need arg-type
-    // resolution (Phase-2 Tier D-lib). These use the same DaemonQuery/hover
-    // mechanism but at the argument's span position instead of the callee ident.
     let mut queries: Vec<DaemonQuery> = Vec::new();
     for (cs, full_path) in callsites.iter() {
         if cs.is_method && cs.callee_crate.is_none() && cs.line >= 1 {
@@ -1294,30 +1345,11 @@ fn resolve_method_calls_via_oracle(
                 col: cs.col as u32,
             });
         }
-        // Phase-2 Tier D-lib: serde_json::to_string/to_string_pretty free calls
-        // that tracked an arg0 position need a separate hover query at that
-        // position to learn whether the arg is serde_json::Value.
-        if let (Some(arg_line), Some(arg_col)) = (cs.arg0_line, cs.arg0_col) {
-            if arg_line >= 1 {
-                debug!(
-                    callee = %cs.callee,
-                    file = %full_path.display(),
-                    arg_line,
-                    arg_col,
-                    "oracle query: serde_json free call arg type"
-                );
-                queries.push(DaemonQuery {
-                    file: full_path.to_string_lossy().into_owned(),
-                    line: (arg_line - 1) as u32,
-                    col: arg_col as u32,
-                });
-            }
-        }
     }
     let total_queries = queries.len();
     observation.attempted = total_queries as u64;
     if queries.is_empty() {
-        debug!("oracle: no unresolved method calls or arg-type queries, skipping");
+        debug!("oracle: no unresolved method calls, skipping");
         return observation;
     }
     debug!(
@@ -1377,44 +1409,6 @@ fn resolve_method_calls_via_oracle(
                     line = cs.line,
                     "oracle refused: no resolution for method call"
                 );
-            }
-        }
-        // Phase-2 Tier D-lib: serde_json free call arg-type resolution.
-        // The arg0 position was queried above; if the oracle resolved it,
-        // use the type stem to disambiguate to the value-totality wrapper.
-        if let (Some(arg_line), Some(arg_col)) = (cs.arg0_line, cs.arg0_col) {
-            if arg_line >= 1 {
-                let arg_key = (
-                    full_path.to_string_lossy().into_owned(),
-                    (arg_line - 1) as u32,
-                    arg_col as u32,
-                );
-                if let Some(res) = resolved.get(&arg_key) {
-                    let disambiguated = res
-                        .type_stem
-                        .as_deref()
-                        .and_then(|stem| disambiguated_serde_json_value_leaf(&cs.callee, stem));
-                    debug!(
-                        callee = %cs.callee,
-                        arg_type_stem = ?res.type_stem,
-                        disambiguated = ?disambiguated,
-                        file = %full_path.display(),
-                        arg_line,
-                        "oracle resolved serde_json free call arg type (resident daemon)"
-                    );
-                    // Only set disambiguated_callee; callee_crate was already
-                    // resolved by Tier 1 path analysis for free calls.
-                    if disambiguated.is_some() {
-                        cs.disambiguated_callee = disambiguated;
-                    }
-                } else {
-                    debug!(
-                        callee = %cs.callee,
-                        file = %full_path.display(),
-                        arg_line,
-                        "oracle refused: no resolution for serde_json arg type; call stays to_string (undecidable)"
-                    );
-                }
             }
         }
     }

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -384,6 +384,12 @@ struct CallSite {
     file: String,
     line: usize,
     col: usize,
+    /// Phase-2 Tier D-lib: for free calls that need arg-type disambiguation
+    /// (e.g. `serde_json::to_string(&v)` where we want to know if `v` is
+    /// `serde_json::Value`), the span-start of the first argument expression.
+    /// `None` when arg-type resolution is not needed for this call.
+    arg0_line: Option<usize>,
+    arg0_col: Option<usize>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -707,6 +713,21 @@ fn collect_callsites_in_block(
                 call_expr_callee(&node.func, self.use_map, self.current_crate)
             {
                 let start = node.func.span().start();
+                // Phase-2 Tier D-lib: for serde_json::to_string / to_string_pretty
+                // free calls, track the first arg position for oracle type resolution.
+                // Hovering at the arg's span gives the arg type stem; if stem == "value"
+                // the call targets serde_json::Value (total serialization).
+                let (arg0_line, arg0_col) = if needs_arg_type_resolution(
+                    callee_crate.as_deref(),
+                    &callee,
+                ) {
+                    node.args.first().map(|a| {
+                        let sp = a.span().start();
+                        (sp.line, sp.column)
+                    }).unzip()
+                } else {
+                    (None, None)
+                };
                 self.out.push(CallSite {
                     callee,
                     contract_callee,
@@ -717,6 +738,8 @@ fn collect_callsites_in_block(
                     file: self.rel_path.to_string(),
                     line: start.line,
                     col: start.column,
+                    arg0_line,
+                    arg0_col,
                 });
             } else if is_closure_expr(&node.func) {
                 let start = node.func.span().start();
@@ -730,6 +753,8 @@ fn collect_callsites_in_block(
                     file: self.rel_path.to_string(),
                     line: start.line,
                     col: start.column,
+                    arg0_line: None,
+                    arg0_col: None,
                 });
             } else {
                 let start = node.func.span().start();
@@ -743,6 +768,8 @@ fn collect_callsites_in_block(
                     file: self.rel_path.to_string(),
                     line: start.line,
                     col: start.column,
+                    arg0_line: None,
+                    arg0_col: None,
                 });
             }
             syn::visit::visit_expr_call(self, node);
@@ -778,6 +805,8 @@ fn collect_callsites_in_block(
                 file: self.rel_path.to_string(),
                 line: start.line,
                 col: start.column,
+                arg0_line: None,
+                arg0_col: None,
             });
             syn::visit::visit_expr_method_call(self, node);
         }
@@ -805,6 +834,8 @@ fn collect_callsites_in_block(
                 file: self.rel_path.to_string(),
                 line: start.line,
                 col: start.column,
+                arg0_line: None,
+                arg0_col: None,
             });
             syn::visit::visit_expr_index(self, node);
         }
@@ -866,6 +897,8 @@ fn unsupported_macro_callsite(mac: &syn::Macro, rel_path: &str) -> CallSite {
         file: rel_path.to_string(),
         line: start.line,
         col: start.column,
+        arg0_line: None,
+        arg0_col: None,
     }
 }
 
@@ -1152,6 +1185,42 @@ fn crate_name_for(dir: &Path) -> Option<String> {
 /// and fall through to the bare-leaf key (their existing total-wrapper bridges
 /// are unaffected). Anything not in this table -> `None` -> bare-leaf key
 /// (additive; the refuse-floor and the existing bridges are preserved).
+/// True iff this free call needs arg-type resolution via the oracle.
+/// The set is deliberately narrow: only the serde_json totality wrappers.
+/// A non-Value arg to `serde_json::to_string` must NOT be disambiguated
+/// (it stays `to_string` -> no-contract-for-callee -> honestly undecidable).
+fn needs_arg_type_resolution(callee_crate: Option<&str>, callee: &str) -> bool {
+    callee_crate == Some("serde_json")
+        && matches!(callee, "to_string" | "to_string_pretty")
+}
+
+/// Phase-2 Tier D-lib: when a serde_json free call was resolved by the oracle
+/// to have a `serde_json::Value` first argument (stem == "value"), return the
+/// wrapper function name that carries the totality contract. Any other stem
+/// (or None) returns None, preserving the refuse-floor for non-Value args.
+///
+/// SOUNDNESS: stem "value" is SPECIFIC to `serde_json::Value` in this context
+/// because the oracle hover at the arg position of `serde_json::to_string(&v)`
+/// yields the type path `serde_json::Value`; `type_stem_from_hover_markdown`
+/// strips to the last segment and lowercases it, giving "value". A struct named
+/// `Value` from a DIFFERENT crate cannot appear here: the callee_crate check in
+/// `needs_arg_type_resolution` already confirmed the call is `serde_json::to_string`.
+/// A user-defined `struct Value` in their own crate at a serde_json::to_string
+/// call site would fail to compile unless it implements Serialize, and if it does,
+/// the to_string may still fail (not total). The guard is callee_crate = serde_json
+/// + arg stem = value: together they uniquely identify serde_json::Value calls.
+fn disambiguated_serde_json_value_leaf(callee: &str, arg_type_stem: &str) -> Option<String> {
+    if arg_type_stem != "value" {
+        return None;
+    }
+    let leaf = match callee {
+        "to_string" => "serde_json_to_string_value",
+        "to_string_pretty" => "serde_json_to_string_pretty_value",
+        _ => return None,
+    };
+    Some(leaf.to_string())
+}
+
 fn disambiguated_partial_leaf(type_stem: &str, leaf: &str) -> Option<String> {
     let partial = match (type_stem, leaf) {
         ("option", "unwrap") => "option_unwrap",
@@ -1205,6 +1274,10 @@ fn resolve_method_calls_via_oracle(
     // 0-based column; LSP wants 0-based line, 0-based char. The method ident's
     // span start already points at the ident (not the dot), so the column maps
     // directly. A line of 0 should never occur for a real call; guard anyway.
+    //
+    // Also include arg0 positions for serde_json free calls that need arg-type
+    // resolution (Phase-2 Tier D-lib). These use the same DaemonQuery/hover
+    // mechanism but at the argument's span position instead of the callee ident.
     let mut queries: Vec<DaemonQuery> = Vec::new();
     for (cs, full_path) in callsites.iter() {
         if cs.is_method && cs.callee_crate.is_none() && cs.line >= 1 {
@@ -1221,11 +1294,30 @@ fn resolve_method_calls_via_oracle(
                 col: cs.col as u32,
             });
         }
+        // Phase-2 Tier D-lib: serde_json::to_string/to_string_pretty free calls
+        // that tracked an arg0 position need a separate hover query at that
+        // position to learn whether the arg is serde_json::Value.
+        if let (Some(arg_line), Some(arg_col)) = (cs.arg0_line, cs.arg0_col) {
+            if arg_line >= 1 {
+                debug!(
+                    callee = %cs.callee,
+                    file = %full_path.display(),
+                    arg_line,
+                    arg_col,
+                    "oracle query: serde_json free call arg type"
+                );
+                queries.push(DaemonQuery {
+                    file: full_path.to_string_lossy().into_owned(),
+                    line: (arg_line - 1) as u32,
+                    col: arg_col as u32,
+                });
+            }
+        }
     }
     let total_queries = queries.len();
     observation.attempted = total_queries as u64;
     if queries.is_empty() {
-        debug!("oracle: no unresolved method calls, skipping");
+        debug!("oracle: no unresolved method calls or arg-type queries, skipping");
         return observation;
     }
     debug!(
@@ -1285,6 +1377,44 @@ fn resolve_method_calls_via_oracle(
                     line = cs.line,
                     "oracle refused: no resolution for method call"
                 );
+            }
+        }
+        // Phase-2 Tier D-lib: serde_json free call arg-type resolution.
+        // The arg0 position was queried above; if the oracle resolved it,
+        // use the type stem to disambiguate to the value-totality wrapper.
+        if let (Some(arg_line), Some(arg_col)) = (cs.arg0_line, cs.arg0_col) {
+            if arg_line >= 1 {
+                let arg_key = (
+                    full_path.to_string_lossy().into_owned(),
+                    (arg_line - 1) as u32,
+                    arg_col as u32,
+                );
+                if let Some(res) = resolved.get(&arg_key) {
+                    let disambiguated = res
+                        .type_stem
+                        .as_deref()
+                        .and_then(|stem| disambiguated_serde_json_value_leaf(&cs.callee, stem));
+                    debug!(
+                        callee = %cs.callee,
+                        arg_type_stem = ?res.type_stem,
+                        disambiguated = ?disambiguated,
+                        file = %full_path.display(),
+                        arg_line,
+                        "oracle resolved serde_json free call arg type (resident daemon)"
+                    );
+                    // Only set disambiguated_callee; callee_crate was already
+                    // resolved by Tier 1 path analysis for free calls.
+                    if disambiguated.is_some() {
+                        cs.disambiguated_callee = disambiguated;
+                    }
+                } else {
+                    debug!(
+                        callee = %cs.callee,
+                        file = %full_path.display(),
+                        arg_line,
+                        "oracle refused: no resolution for serde_json arg type; call stays to_string (undecidable)"
+                    );
+                }
             }
         }
     }

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -1315,13 +1315,24 @@ fn resolve_method_calls_via_oracle(
     // Opt-in stays identical to the cold path: a mint with the oracle off must
     // never spawn or contact the daemon's RA host. When off we leave every
     // unresolved method call to the syntactic tiers (Tier 1/2a) and return.
-    let oracle_on = std::env::var("PROVEKIT_RESOLVE_ORACLE").unwrap_or_default() == "rust-analyzer";
+    let raw_oracle_env = std::env::var("PROVEKIT_RESOLVE_ORACLE").unwrap_or_default();
+    let oracle_on = raw_oracle_env == "rust-analyzer";
+    let total_method_calls = callsites.iter().filter(|(cs, _)| cs.is_method).count();
+    info!(
+        oracle_env = %raw_oracle_env,
+        oracle_on,
+        total_callsites = callsites.len(),
+        total_method_calls,
+        linkerd_bin = %std::env::var("PROVEKIT_LINKERD_BIN").unwrap_or_else(|_| "<unset>".into()),
+        linkerd_socket = %std::env::var("PROVEKIT_LINKERD_SOCKET").unwrap_or_else(|_| "<unset>".into()),
+        "ORACLE: resolve_method_calls_via_oracle ENTER"
+    );
     let mut observation = OracleObservation {
         requested: oracle_on,
         ..OracleObservation::default()
     };
     if !oracle_on {
-        debug!("oracle: off (PROVEKIT_RESOLVE_ORACLE != rust-analyzer); leaving method calls to Tier 1/2a");
+        info!(oracle_env = %raw_oracle_env, "ORACLE: OFF (PROVEKIT_RESOLVE_ORACLE != rust-analyzer); leaving method calls to Tier 1/2a -- NO daemon, NO disambiguation");
         return observation;
     }
 
@@ -1331,14 +1342,22 @@ fn resolve_method_calls_via_oracle(
     // directly. A line of 0 should never occur for a real call; guard anyway.
     let mut queries: Vec<DaemonQuery> = Vec::new();
     for (cs, full_path) in callsites.iter() {
-        if cs.is_method && cs.callee_crate.is_none() && cs.line >= 1 {
-            debug!(
-                callee = %cs.callee,
-                file = %full_path.display(),
-                line = cs.line,
-                col = cs.col,
-                "oracle query: unresolved method call"
-            );
+        if !cs.is_method {
+            continue;
+        }
+        let is_candidate = cs.callee_crate.is_none() && cs.line >= 1;
+        info!(
+            callee = %cs.callee,
+            callee_crate = ?cs.callee_crate,
+            disambiguated_callee = ?cs.disambiguated_callee,
+            is_panic_leaf = is_panic_leaf(&cs.callee),
+            file = %full_path.display(),
+            line = cs.line,
+            col = cs.col,
+            is_candidate,
+            "ORACLE: method-call gate -- is_candidate={is_candidate} (candidate iff callee_crate==None). callee_crate already set => oracle SKIPS this site"
+        );
+        if is_candidate {
             queries.push(DaemonQuery {
                 file: full_path.to_string_lossy().into_owned(),
                 line: (cs.line - 1) as u32,
@@ -1349,12 +1368,15 @@ fn resolve_method_calls_via_oracle(
     let total_queries = queries.len();
     observation.attempted = total_queries as u64;
     if queries.is_empty() {
-        debug!("oracle: no unresolved method calls, skipping");
+        info!(
+            total_method_calls,
+            "ORACLE: ZERO candidate queries (every method call already had callee_crate set syntactically) -- daemon will NOT be spawned, NO disambiguation will occur"
+        );
         return observation;
     }
-    debug!(
+    info!(
         count = total_queries,
-        "oracle: asking resident daemon (provekit-linkerd) to resolve method calls"
+        "ORACLE: asking resident daemon (provekit-linkerd) to resolve {total_queries} method calls -- spawning/indexing daemon now"
     );
     // The resident warm rust-analyzer indexes the workspace ONCE inside the
     // daemon and is reused across mints, fronted by a content-addressed cache.
@@ -1648,6 +1670,18 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
                 contracts_by_key.get(&dkey).copied()
             });
             let is_panic = is_panic_leaf(&cs.callee);
+            if is_panic {
+                info!(
+                    callee = %cs.callee,
+                    resolved_crate = %resolved_crate,
+                    disambiguated_callee = ?cs.disambiguated_callee,
+                    disambig_binding_found = disambig_binding.is_some(),
+                    lookup_key = ?cs.disambiguated_callee.as_ref().map(|l| (resolved_crate.clone(), l.clone())),
+                    file = %cs.file,
+                    line = cs.line,
+                    "PANIC-EMIT: panic-leaf site decision -- bridges to disambiguated partial iff disambig_binding_found, else REFUSES (panic-site-unproven)"
+                );
+            }
             // A value-producing select (NOT a let-else): the total-leaf branch must
             // be able to YIELD the ineligible binding for Fix B, which a let-else
             // `else` block (it must diverge) structurally cannot do.

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -2113,7 +2113,20 @@ fn initialize_result() -> Value {
             "capabilities": {
                 "authoring_surfaces": ["rust", "rust-bind", "rust-walk-contracts"],
             "ir_version": "bind-ir/2.0.0",
-            "emits_signed_mementos": false
+            "emits_signed_mementos": false,
+            // CONSUMER SURFACES (kit-declared, so `doctor` stays language-blind):
+            // these surfaces MUST run a specific RPC method in the `consumer`
+            // phase or they silently degrade to the default `lift` producer and
+            // their pass never runs (the manifest method/phase footgun that cost
+            // five investigations on 2026-05-31). `doctor` cross-checks each
+            // kit manifest against this so the omission is a loud check, not a
+            // silent empty-set attestation.
+            "consumer_surfaces": {
+                "rust-implications": {
+                    "method": "provekit.plugin.lift_implications",
+                    "phase": "consumer"
+                }
+            }
         }
     })
 }

--- a/implementations/rust/provekit-walk/src/contract.rs
+++ b/implementations/rust/provekit-walk/src/contract.rs
@@ -16,6 +16,7 @@
 // Memento from a `syn::ItemFn`. AST traversal stays in walk; the algebra
 // lives once, in libprovekit.
 
+use provekit_ir_types::IrFormula;
 use syn::{Expr, ExprUnsafe, FnArg, ItemFn, Pat, Stmt};
 
 // ---- Re-export the canonical algebra and supporting types ----
@@ -51,11 +52,31 @@ pub fn build_function_contract_with_file(
     body_cid: Option<String>,
     file_path: Option<&str>,
 ) -> FunctionContractMemento {
+    build_function_contract_with_file_and_post_override(item_fn, body_cid, file_path, None)
+}
+
+/// Build a FunctionContractMemento with an explicit source file path and an
+/// optional post-condition override.
+///
+/// When `post_override` is `Some(formula)`, the given formula REPLACES the
+/// body-derived post before `build_value` (and therefore before CID
+/// computation). Use this only for SOUND axiom-supplied postconditions (e.g.
+/// a totality contract where the library type guarantees the return is always
+/// Ok). The override flows into `canonical_bytes` and `cid` so every field
+/// remains consistent.
+pub fn build_function_contract_with_file_and_post_override(
+    item_fn: &ItemFn,
+    body_cid: Option<String>,
+    file_path: Option<&str>,
+    post_override: Option<IrFormula>,
+) -> FunctionContractMemento {
     let fn_name = item_fn.sig.ident.to_string();
     let (formals, formal_sorts) = extract_formals(item_fn);
     let return_sort = extract_return_sort(item_fn);
     let pre = crate::lift::lift_function_precondition(item_fn).into_formula();
-    let post = crate::lift::lift_function_postcondition(item_fn).into_formula();
+    let post = post_override.unwrap_or_else(|| {
+        crate::lift::lift_function_postcondition(item_fn).into_formula()
+    });
     let effects = detect_effects(item_fn);
     let locus = crate::locus::from_span(item_fn.sig.ident.span(), file_path);
 

--- a/implementations/rust/provekit-walk/src/lib.rs
+++ b/implementations/rust/provekit-walk/src/lib.rs
@@ -42,7 +42,10 @@ pub mod wp;
 pub use canonical::{
     cid_of_value, formula_to_canonical, jcs_bytes_of_value, serde_to_canonical, term_to_canonical,
 };
-pub use contract::{build_function_contract, build_function_contract_with_file};
+pub use contract::{
+    build_function_contract, build_function_contract_with_file,
+    build_function_contract_with_file_and_post_override,
+};
 pub use dropper::{
     detect_gaps, drop_gap, emit_drop, formula_contains_predicate, predicate_var_arg,
     verify_closure, DropFailure, DropTemplate, EmitResult, Gap, NotNullPredicate, NotRenderable,


### PR DESCRIPTION
Night session on the serde-totality / panic-freedom path. 18 commits.

## Shipped + verified
- **fix(self-app)** the three production bugs that stalled five agents:
  1. stage3-serde-totality-fixture manifest missing `method`/`phase` -> implication lifter (RA oracle host) never ran.
  2. `mint_bridge` dropped the lifter's `callsite` -> verifier read `panic_site=false` on every minted panic leaf.
  3. prove path missing the D-lib `is_ok` guard injection.
- **feat(doctor)**: `provekit doctor` now HARD-fails (exit 2) on the manifest method/phase omission footgun, language-blind (plugin self-declares `consumer_surfaces` in `initialize` capabilities). Verified: broken manifest -> exit 2 + fix hint; correct -> exit 0.
- No-silent-failure scaffolding: plugin stderr non-silent by default, callsite-provenance-drop `warn!`, tracing instead of eprintln.
- file/line now surfaces in prove rows (per-site identification).

## Diagnosis (docs/self-application/serde-panic-freedom-diagnosis.md)
K (e2e panicSafe) is still 0, **honestly**. Root cause LOCATED to a single bug: `locate_producer_post` (provekit-verifier/src/handshake.rs:120) returns the to_string BODY-EQ contract (`= result, to_string(value)`) instead of the `serde_json_to_string_value` TOTALITY (`is_ok(result)`), so the panic implication isn't reflexive. The doc carries a ready-to-dispatch HANDOFF brief (diagnose bridges_by_symbol -> kit-lift-fix or locate_producer_post-fix -> verify via line-25/line-38 discrimination + verifier suite).

Hard invariants `falsePass=0` and `silentlyDropped=0` preserved throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)