### PR TITLE
fix(example): stage4_driver missing callsite field (compile error on main)

### DIFF
--- a/examples/stage4-handshake-demo/stage4_driver.rs
+++ b/examples/stage4-handshake-demo/stage4_driver.rs
@@ -201,6 +201,7 @@ fn run() -> Result<(), String> {
         notes: String::new(),
         signer_seed: parse_kit_seed,
         target_proof_cid: None,
+        callsite: None,
     });
     parse_kit_members.insert(
         parse_kit_bridge.cid.clone(),


### PR DESCRIPTION
MintBridgeArgs.callsite (added in e13763201) was missing from the stage4_driver verifier example; #1742 admin-merge past CI left a latent E0063 on main (cargo test -p provekit-verifier fails building examples). One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated example code with minor internal configuration adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->