### PR TITLE
fix: key panic loci to receiver producers

### DIFF
--- a/examples/stage4-serde-multiline-totality-fixture/.provekit/config.toml
+++ b/examples/stage4-serde-multiline-totality-fixture/.provekit/config.toml
@@ -1,0 +1,43 @@
+# Stage 4 discrimination fixture for multi-line serde_json Value totality.
+#
+# f/f_split/f_spanning(&serde_json::Value).unwrap() -> PANIC-SAFE.
+# g/g_split/h_adjacent_cross_talk(&MyStruct).unwrap() -> UNDECIDABLE.
+#
+# The rust-bind surface provides the shim contracts (from .provekit/imports).
+# rust-fn-contracts produces body-bearing contracts for the fixture functions.
+# rust-implications bridges the to_string and .unwrap() call sites.
+[[plugins]]
+name = "rust-bind"
+surface = "rust-bind"
+layer = "library-bindings"
+
+[[plugins]]
+name = "rust-contracts"
+surface = "rust-contracts"
+emit = "ir-document"
+
+[[plugins]]
+name = "rust-fn-contracts"
+surface = "rust-fn-contracts"
+emit = "ir-document"
+
+[[plugins]]
+name = "rust-implications"
+surface = "rust-implications"
+
+[platform_profile]
+language = "rust"
+family = "concept:family:json"
+library = "stage4-serde-multiline-totality-fixture"
+version = "0.0.0"
+
+[solvers]
+mode = "first-wins"
+portfolio = ["z3"]
+
+[solvers.z3]
+binary = "z3"
+ir_compiler = "smt-lib-v2.6"
+flags = ["-smt2", "-in"]
+timeout_seconds = 30
+version = "4.x"

--- a/examples/stage4-serde-multiline-totality-fixture/.provekit/lift/rust-bind/manifest.toml
+++ b/examples/stage4-serde-multiline-totality-fixture/.provekit/lift/rust-bind/manifest.toml
@@ -1,0 +1,3 @@
+name = "rust-bind-lift"
+command = ["../../implementations/rust/target/debug/provekit-walk-rpc", "--rpc"]
+working_dir = "."

--- a/examples/stage4-serde-multiline-totality-fixture/.provekit/lift/rust-contracts/manifest.toml
+++ b/examples/stage4-serde-multiline-totality-fixture/.provekit/lift/rust-contracts/manifest.toml
@@ -1,0 +1,3 @@
+name = "rust-contracts-lift"
+command = ["../../implementations/rust/target/debug/provekit-walk-rpc", "--rpc"]
+working_dir = "."

--- a/examples/stage4-serde-multiline-totality-fixture/.provekit/lift/rust-fn-contracts/manifest.toml
+++ b/examples/stage4-serde-multiline-totality-fixture/.provekit/lift/rust-fn-contracts/manifest.toml
@@ -1,0 +1,3 @@
+name = "rust-fn-contracts-lift"
+command = ["../../implementations/rust/target/debug/provekit-walk-rpc", "--rpc"]
+working_dir = "."

--- a/examples/stage4-serde-multiline-totality-fixture/.provekit/lift/rust-implications/manifest.toml
+++ b/examples/stage4-serde-multiline-totality-fixture/.provekit/lift/rust-implications/manifest.toml
@@ -1,0 +1,5 @@
+name = "rust-implications-lift"
+method = "provekit.plugin.lift_implications"
+phase = "consumer"
+command = ["../../implementations/rust/target/debug/provekit-walk-rpc", "--rpc"]
+working_dir = "."

--- a/examples/stage4-serde-multiline-totality-fixture/Cargo.toml
+++ b/examples/stage4-serde-multiline-totality-fixture/Cargo.toml
@@ -1,0 +1,21 @@
+# Stage 4 fixture for split-line serde_json Value totality discharge.
+#
+# Discrimination test:
+#   f/f_split/f_spanning(&serde_json::Value) -> PANIC-SAFE
+#   g/g_split/h_adjacent_cross_talk(&MyStruct) -> UNDECIDABLE
+#
+# Own [workspace] for RA isolation (fast index, no monorepo stall).
+[package]
+name = "stage4-serde-multiline-totality-fixture"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[lib]
+path = "src/lib.rs"

--- a/examples/stage4-serde-multiline-totality-fixture/src/lib.rs
+++ b/examples/stage4-serde-multiline-totality-fixture/src/lib.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Stage 4 discrimination fixture: multi-line serde_json Value totality.
+//
+// Acceptance criteria:
+//   f/f_split/f_spanning: serde_json::to_string(&serde_json::Value).unwrap()
+//      -> PANIC-SAFE (Value serialization is total; is_ok(result) axiom fires)
+//
+//   g/g_split/h_adjacent_cross_talk: serde_json::to_string(&MyStruct).unwrap()
+//      -> UNDECIDABLE (struct Serialize may fail; no totality contract)
+//      -> falsePass MUST be 0; non-Value sites stay honestly unproven.
+//
+// The split-line cases prove panic-locus lookup uses the receiver producer
+// line, not the `.unwrap()` line. The adjacent case proves lookup does not grab
+// a nearby totality producer for a distinct non-total receiver.
+
+use serde::Serialize;
+use serde_json::Value;
+
+/// Baseline totality case: producer and panic leaf are on the same line.
+pub fn f(v: &Value) -> String {
+    serde_json::to_string(v).unwrap()
+}
+
+/// The receiver producer call and `.unwrap()` are on different source lines.
+pub fn f_split(v: &Value) -> String {
+    serde_json::to_string(v)
+        .unwrap()
+}
+
+/// The receiver producer call itself spans multiple lines.
+pub fn f_spanning(v: &Value) -> String {
+    serde_json::to_string(
+        v,
+    )
+    .unwrap()
+}
+
+#[derive(Serialize)]
+pub struct MyStruct {
+    pub x: i32,
+    pub name: String,
+}
+
+/// Baseline non-total case: must stay undecidable.
+pub fn g(s: &MyStruct) -> String {
+    serde_json::to_string(s).unwrap()
+}
+
+/// Split-line non-total case. Fixing producer-line lookup must not broaden into
+/// "all split-line to_string unwraps are safe."
+pub fn g_split(s: &MyStruct) -> String {
+    serde_json::to_string(s)
+        .unwrap()
+}
+
+/// Adjacent cross-talk probe: a known-total producer is immediately above a
+/// split-line non-total producer. The first unwrap must discharge, and the
+/// second must stay undecidable.
+pub fn h_adjacent_cross_talk(v: &Value, s: &MyStruct) -> (String, String) {
+    (
+        serde_json::to_string(v).unwrap(),
+        serde_json::to_string(s)
+            .unwrap(),
+    )
+}

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -1519,7 +1519,7 @@ fn is_panic_leaf(leaf: &str) -> bool {
 /// PANIC-LOCUS PRESERVATION (#1745): collect the source loci of every panic-leaf
 /// method call (`x.unwrap()` / `.expect()` / `.unwrap_err()`) in a function body,
 /// keyed by the LIFTED argument term so the verifier can attribute a per-symbol
-/// `method:unwrap` obligation back to ITS OWN call site.
+/// `method:unwrap` obligation back to ITS OWN receiver producer call site.
 ///
 /// The problem this closes: a panic-leaf call lifts to the abstract ctor
 /// `method:unwrap` with NO source span (the IR term is span-free by design). Two
@@ -1537,6 +1537,12 @@ fn is_panic_leaf(leaf: &str) -> bool {
 /// receiver that does not lift (returns None) records no locus: the occurrence
 /// then carries no line and stays honestly undecidable (fail-safe, never the
 /// collapsed line).
+///
+/// The `line`/`col` fields deliberately name the receiver producer call's start
+/// span, not the panic leaf's method-token span. `bridges_by_callsite` is keyed
+/// by the producer bridge line, so a split-line `to_string(v)\n.unwrap()` must
+/// use the receiver start line to find the co-located totality fact. The leaf
+/// position is preserved separately as `panicLine`/`panicCol` for diagnostics.
 fn collect_panic_loci(item_fn: &syn::ItemFn, rel_path: &str) -> Vec<Value> {
     use syn::visit::Visit;
 
@@ -1554,12 +1560,15 @@ fn collect_panic_loci(item_fn: &syn::ItemFn, rel_path: &str) -> Vec<Value> {
                 // production lifter so the term matches the contract `post`.
                 if let Some(recv) = provekit_walk::lift::lift_expr_to_term(&node.receiver) {
                     if let Ok(arg_term) = serde_json::to_value(&recv) {
-                        let start = node.method.span().start();
+                        let producer_start = node.receiver.span().start();
+                        let panic_start = node.method.span().start();
                         self.out.push(json!({
                             "argTerm": arg_term,
                             "file": self.rel_path,
-                            "line": start.line,
-                            "col": start.column,
+                            "line": producer_start.line,
+                            "col": producer_start.column,
+                            "panicLine": panic_start.line,
+                            "panicCol": panic_start.column,
                             "callee": format!("method:{}", leaf),
                         }));
                     }
@@ -6733,6 +6742,67 @@ mod tests {
     use std::collections::BTreeMap;
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn panic_loci_for_first_fn(src: &str) -> Vec<Value> {
+        let file = syn::parse_file(src).expect("source parses");
+        let item_fn = file
+            .items
+            .iter()
+            .find_map(|item| match item {
+                syn::Item::Fn(item_fn) => Some(item_fn),
+                _ => None,
+            })
+            .expect("fixture has a function");
+        collect_panic_loci(item_fn, "src/lib.rs")
+    }
+
+    fn assert_single_panic_locus_lines(src: &str, expected_line: u64, expected_panic_line: u64) {
+        let loci = panic_loci_for_first_fn(src);
+        assert_eq!(loci.len(), 1, "expected one panic locus: {loci:?}");
+        assert_eq!(loci[0]["file"], "src/lib.rs");
+        assert_eq!(loci[0]["callee"], "method:unwrap");
+        assert_eq!(
+            loci[0]["line"].as_u64(),
+            Some(expected_line),
+            "panic locus line must be the receiver producer call's start line, not the unwrap leaf line: {loci:?}"
+        );
+        assert_eq!(
+            loci[0]["panicLine"].as_u64(),
+            Some(expected_panic_line),
+            "panicLine must preserve the unwrap leaf line for diagnostics: {loci:?}"
+        );
+    }
+
+    #[test]
+    fn collect_panic_loci_uses_receiver_line_for_single_line_unwrap() {
+        let src = r#"pub fn one_line(v: &serde_json::Value) -> String {
+    serde_json::to_string(v).unwrap()
+}
+"#;
+        assert_single_panic_locus_lines(src, 2, 2);
+    }
+
+    #[test]
+    fn collect_panic_loci_uses_receiver_line_for_two_line_unwrap() {
+        let src = r#"pub fn two_line(v: &serde_json::Value) -> String {
+    serde_json::to_string(v)
+        .unwrap()
+}
+"#;
+        assert_single_panic_locus_lines(src, 2, 3);
+    }
+
+    #[test]
+    fn collect_panic_loci_uses_receiver_start_line_for_spanning_unwrap() {
+        let src = r#"pub fn spanning(v: &serde_json::Value) -> String {
+    serde_json::to_string(
+        v,
+    )
+    .unwrap()
+}
+"#;
+        assert_single_panic_locus_lines(src, 2, 5);
+    }
 
     #[test]
     fn disambiguated_partial_leaf_maps_panic_set() {


### PR DESCRIPTION
## Summary

Closes #1748.

This fixes the multi-line panic-locus completeness miss by recording panic loci at the receiver producer call start, while preserving the panic leaf position separately for diagnostics.

`serde_json::to_string(v)\n    .unwrap()` now keys the `method:unwrap` obligation to the same source line as the `to_string(Value)` producer bridge, so the callsite-scoped guard fact can discharge the panic precondition. The verifier remains unchanged and language-blind.

## Fixture

Adds `examples/stage4-serde-multiline-totality-fixture` to pin the verdict-level behavior:

- one-line `Value` totality unwrap discharges panic-safe
- split-line `Value` totality unwrap discharges panic-safe
- spanning `Value` totality unwrap discharges panic-safe
- non-Value `MyStruct` cases stay unsatisfied
- adjacent cross-talk probe discharges the `Value` site and leaves the neighboring non-Value site unsatisfied

## Follow-up

Filed #1751 for the warm-oracle convergence floor. The stage4 e2e exposed that cold oracle proofs can under-discharge until `receivers_resolved == receivers_attempted`; that is a harness/product K measurement issue, not a blocker for this emitter-side fix.

## Validation

- `../../bin/bcargo test -p provekit-walk collect_panic_loci_uses_receiver -- --nocapture`
- `../../bin/bcargo check --manifest-path ../../examples/stage4-serde-multiline-totality-fixture/Cargo.toml`
- stage3 warm-oracle e2e remains byte-stable:
  - `dischargeSplit {panicSafe:1, reflexive:28, solverSubstantive:0, vacuous:6, hashTier:0, undecidable:132, falsePass:0}`
  - `f@25` panic-safe, `g@38` unsatisfied
- stage4 warmed e2e:
  - `dischargeSplit {panicSafe:4, reflexive:32, solverSubstantive:0, vacuous:11, hashTier:0, undecidable:134, falsePass:0}`
  - `method:unwrap` lines `22/27/33/62` discharged panic-safe
  - `method:unwrap` lines `47/53/63` unsatisfied
- `git diff -- implementations/rust/provekit-verifier | wc -l` -> `0`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Panic location tracking now records both the receiver-producer call site and the actual panic method location for more precise error diagnostics.

* **Tests**
  * Added a new test fixture for multiline serialization patterns, including test cases for single-line, split-line, and spanning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->