### PR TITLE
fix(walk): thread panic loci through envelope mint

### DIFF
--- a/implementations/rust/libprovekit/src/compose.rs
+++ b/implementations/rust/libprovekit/src/compose.rs
@@ -363,6 +363,12 @@ pub struct FunctionContractMemento {
     pub canonical_bytes: Vec<u8>,
     pub cid: String,
     pub auto_minted_mementos: Vec<AliasingMemento>,
+    /// Per-occurrence panic-leaf source loci. METADATA ONLY: these are emitted
+    /// into contract envelope headers for verifier attribution, but they do
+    /// NOT participate in `canonical_bytes` or `cid` derivation. This shape is
+    /// the same `panicLoci` header shape emitted by walk_rpc/cmd_mint and
+    /// consumed by the verifier; keep those surfaces in lock-step.
+    pub panic_loci: Vec<Arc<Value>>,
     /// Human-supplied concept name extracted from a `// concept: <name>` (or
     /// `/// concept: <name>`) annotation immediately preceding the function.
     ///
@@ -1804,6 +1810,7 @@ mod fcm_auto_promote_tests {
             canonical_bytes: vec![],
             cid: cid.to_string(),
             auto_minted_mementos: vec![],
+            panic_loci: vec![],
             concept_hint: None,
         }
     }
@@ -2163,6 +2170,7 @@ mod domain_claim_fcm_tests {
             canonical_bytes: vec![],
             cid: "blake3-512:000000".to_string(),
             auto_minted_mementos: vec![],
+            panic_loci: vec![],
             concept_hint: None,
         }
     }

--- a/implementations/rust/libprovekit/src/core/bind.rs
+++ b/implementations/rust/libprovekit/src/core/bind.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as Json};
 use thiserror::Error;
 
-
 use super::primitives::address;
 use super::traits::{Kit, KitError};
 use super::types::{
@@ -1855,7 +1854,6 @@ fn seed_catalog() -> Catalog {
     }
 }
 
-
 fn primitive_sort(name: &str) -> Sort {
     Sort::Primitive {
         name: name.to_string(),
@@ -1909,6 +1907,7 @@ mod tests {
             canonical_bytes: vec![],
             cid: "blake3-512:test".to_string(),
             auto_minted_mementos: vec![],
+            panic_loci: vec![],
             concept_hint: None,
         }
     }
@@ -2235,6 +2234,4 @@ mod tests {
             "default fn_line should not serialize: {value}"
         );
     }
-
-
 }

--- a/implementations/rust/libprovekit/src/core/primitives.rs
+++ b/implementations/rust/libprovekit/src/core/primitives.rs
@@ -200,6 +200,7 @@ fn composed_to_contract(
         canonical_bytes: composed.canonical_bytes.clone(),
         cid: composed.cid.clone(),
         auto_minted_mementos: vec![],
+        panic_loci: vec![],
         concept_hint: None,
     }
 }

--- a/implementations/rust/libprovekit/src/core/types.rs
+++ b/implementations/rust/libprovekit/src/core/types.rs
@@ -1614,6 +1614,7 @@ impl PathContractMaterial {
             auto_minted_mementos: parse_aliasing_mementos(
                 object.and_then(|object| object.get("autoMintedMementos")),
             ),
+            panic_loci: vec![],
             concept_hint: self.concept_hint.clone(),
         }
     }
@@ -2042,6 +2043,7 @@ pub(crate) fn memento_from_parts(
         canonical_bytes,
         cid,
         auto_minted_mementos: vec![],
+        panic_loci: vec![],
         concept_hint: None,
     }
 }

--- a/implementations/rust/libprovekit/src/core/walks.rs
+++ b/implementations/rust/libprovekit/src/core/walks.rs
@@ -394,6 +394,7 @@ mod tests {
             canonical_bytes,
             cid,
             auto_minted_mementos: vec![],
+            panic_loci: vec![],
             concept_hint: None,
         }
     }
@@ -726,5 +727,4 @@ mod tests {
         assert_eq!(err.node_op_cid, missing_cid);
         assert_eq!(err.term_position, vec![1]);
     }
-
 }

--- a/implementations/rust/libprovekit/src/ffi.rs
+++ b/implementations/rust/libprovekit/src/ffi.rs
@@ -374,6 +374,7 @@ fn inner_compose(atoms_jcs: &str, effects_jcs: &str) -> Result<(String, String),
             canonical_bytes,
             cid,
             auto_minted_mementos: auto_minted,
+            panic_loci: vec![],
             concept_hint: None,
         };
         owned.push((memento, formal_idx));

--- a/implementations/rust/libprovekit/tests/compose_smoke.rs
+++ b/implementations/rust/libprovekit/tests/compose_smoke.rs
@@ -84,6 +84,7 @@ fn pure_identity_contract(fn_name: &str, formal: &str) -> FunctionContractMement
         canonical_bytes,
         cid,
         auto_minted_mementos: vec![],
+        panic_loci: vec![],
         concept_hint: None,
     }
 }

--- a/implementations/rust/libprovekit/tests/core_interface.rs
+++ b/implementations/rust/libprovekit/tests/core_interface.rs
@@ -110,6 +110,7 @@ fn pure_identity_contract(fn_name: &str, formal: &str) -> FunctionContractMement
         canonical_bytes,
         cid,
         auto_minted_mementos: vec![],
+        panic_loci: vec![],
         concept_hint: None,
     }
 }

--- a/implementations/rust/libprovekit/tests/lower_claim_bind_result.rs
+++ b/implementations/rust/libprovekit/tests/lower_claim_bind_result.rs
@@ -70,6 +70,7 @@ fn minimal_contract(fn_name: &str) -> FunctionContractMemento {
         canonical_bytes: jcs_bytes_of_value(&value),
         cid: cid_of_value(&value),
         auto_minted_mementos: vec![],
+        panic_loci: vec![],
         concept_hint: None,
     }
 }

--- a/implementations/rust/libprovekit/tests/prove_kit.rs
+++ b/implementations/rust/libprovekit/tests/prove_kit.rs
@@ -78,6 +78,7 @@ fn pure_identity_contract(fn_name: &str, formal: &str) -> FunctionContractMement
         canonical_bytes,
         cid,
         auto_minted_mementos: vec![],
+        panic_loci: vec![],
         concept_hint: None,
     }
 }

--- a/implementations/rust/provekit-cli/src/cmd_compose.rs
+++ b/implementations/rust/provekit-cli/src/cmd_compose.rs
@@ -474,6 +474,7 @@ impl WireFunctionContractMemento {
             canonical_bytes,
             cid,
             auto_minted_mementos: auto,
+            panic_loci: vec![],
             concept_hint: None,
         }
     }

--- a/implementations/rust/provekit-verifier/src/domain_claim_verifier.rs
+++ b/implementations/rust/provekit-verifier/src/domain_claim_verifier.rs
@@ -1037,6 +1037,7 @@ mod tests {
             canonical_bytes: vec![],
             cid: "blake3-512:000000".to_string(),
             auto_minted_mementos: vec![],
+            panic_loci: vec![],
             concept_hint: None,
         };
 

--- a/implementations/rust/provekit-walk/src/contract.rs
+++ b/implementations/rust/provekit-walk/src/contract.rs
@@ -17,7 +17,7 @@
 // lives once, in libprovekit.
 
 use provekit_ir_types::IrFormula;
-use syn::{Expr, ExprUnsafe, FnArg, ItemFn, Pat, Stmt};
+use syn::{spanned::Spanned, Expr, ExprUnsafe, FnArg, ItemFn, Pat, Stmt};
 
 // ---- Re-export the canonical algebra and supporting types ----
 
@@ -74,11 +74,11 @@ pub fn build_function_contract_with_file_and_post_override(
     let (formals, formal_sorts) = extract_formals(item_fn);
     let return_sort = extract_return_sort(item_fn);
     let pre = crate::lift::lift_function_precondition(item_fn).into_formula();
-    let post = post_override.unwrap_or_else(|| {
-        crate::lift::lift_function_postcondition(item_fn).into_formula()
-    });
+    let post = post_override
+        .unwrap_or_else(|| crate::lift::lift_function_postcondition(item_fn).into_formula());
     let effects = detect_effects(item_fn);
     let locus = crate::locus::from_span(item_fn.sig.ident.span(), file_path);
+    let panic_loci = collect_panic_loci(item_fn, file_path);
 
     let value = build_value(
         &fn_name,
@@ -110,8 +110,57 @@ pub fn build_function_contract_with_file_and_post_override(
         canonical_bytes,
         cid,
         auto_minted_mementos: vec![],
+        panic_loci,
         concept_hint: None,
     }
+}
+
+fn is_panic_leaf(leaf: &str) -> bool {
+    matches!(leaf, "unwrap" | "expect" | "unwrap_err")
+}
+
+fn collect_panic_loci(
+    item_fn: &ItemFn,
+    file_path: Option<&str>,
+) -> Vec<std::sync::Arc<provekit_canonicalizer::Value>> {
+    use syn::visit::Visit;
+
+    struct PanicLocusVisitor {
+        file: String,
+        out: Vec<std::sync::Arc<provekit_canonicalizer::Value>>,
+    }
+
+    impl<'ast> Visit<'ast> for PanicLocusVisitor {
+        fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+            let leaf = node.method.to_string();
+            if is_panic_leaf(&leaf) {
+                if let Some(recv) = crate::lift::lift_expr_to_term(&node.receiver) {
+                    if let Ok(arg_term) = serde_json::to_value(&recv) {
+                        let producer_start = node.receiver.span().start();
+                        let panic_start = node.method.span().start();
+                        self.out
+                            .push(crate::canonical::serde_to_canonical(serde_json::json!({
+                                "argTerm": arg_term,
+                                "file": self.file,
+                                "line": producer_start.line,
+                                "col": producer_start.column,
+                                "panicLine": panic_start.line,
+                                "panicCol": panic_start.column,
+                                "callee": format!("method:{}", leaf),
+                            })));
+                    }
+                }
+            }
+            syn::visit::visit_expr_method_call(self, node);
+        }
+    }
+
+    let mut visitor = PanicLocusVisitor {
+        file: file_path.unwrap_or("unknown").to_string(),
+        out: Vec::new(),
+    };
+    visitor.visit_item_fn(item_fn);
+    visitor.out
 }
 
 // ---- Effect detection ----
@@ -1087,23 +1136,29 @@ mod tests {
             }
         }
 
-        let int_sort = || provekit_ir_types::Sort::Primitive { name: "Int".to_string() };
+        let int_sort = || provekit_ir_types::Sort::Primitive {
+            name: "Int".to_string(),
+        };
         // Contract for "method_double" with formals [self, x]:
         //   post = (result == *(x, 2))
         // This mirrors what extract_formals produces for `fn method_double(&self, x: i64) -> i64 { x * 2 }`.
-        let mut info = OpContractInfo::new(vec![
-            SlotInfo::value("self"),
-            SlotInfo::value("x"),
-        ]);
+        let mut info = OpContractInfo::new(vec![SlotInfo::value("self"), SlotInfo::value("x")]);
         info.post = Some(IrFormula::Atomic {
             name: "=".to_string(),
             args: vec![
-                IrTerm::Var { name: "result".to_string() },
+                IrTerm::Var {
+                    name: "result".to_string(),
+                },
                 IrTerm::Ctor {
                     name: "*".to_string(),
                     args: vec![
-                        IrTerm::Var { name: "x".to_string() },
-                        IrTerm::Const { value: serde_json::json!(2), sort: int_sort() },
+                        IrTerm::Var {
+                            name: "x".to_string(),
+                        },
+                        IrTerm::Const {
+                            value: serde_json::json!(2),
+                            sort: int_sort(),
+                        },
                     ],
                 },
             ],
@@ -1117,8 +1172,13 @@ mod tests {
             op_cid: Cid::parse(format!("blake3-512:{}", "0".repeat(128))).unwrap(),
             name: "method_double".to_string(),
             args: vec![
-                Term::Var { name: "self_val".to_string() },
-                Term::Const { value: serde_json::json!(3), sort: int_sort() },
+                Term::Var {
+                    name: "self_val".to_string(),
+                },
+                Term::Const {
+                    value: serde_json::json!(3),
+                    sort: int_sort(),
+                },
             ],
         };
 
@@ -1126,8 +1186,13 @@ mod tests {
         let q = IrFormula::Atomic {
             name: "=".to_string(),
             args: vec![
-                IrTerm::Var { name: "result".to_string() },
-                IrTerm::Const { value: serde_json::json!(6), sort: int_sort() },
+                IrTerm::Var {
+                    name: "result".to_string(),
+                },
+                IrTerm::Const {
+                    value: serde_json::json!(6),
+                    sort: int_sort(),
+                },
             ],
         };
 
@@ -1187,22 +1252,28 @@ mod tests {
             }
         }
 
-        let int_sort = || provekit_ir_types::Sort::Primitive { name: "Int".to_string() };
+        let int_sort = || provekit_ir_types::Sort::Primitive {
+            name: "Int".to_string(),
+        };
         // WRONG post: `result == *(x, 3)` (body actually does `x * 2`).
-        let mut info = OpContractInfo::new(vec![
-            SlotInfo::value("self"),
-            SlotInfo::value("x"),
-        ]);
+        let mut info = OpContractInfo::new(vec![SlotInfo::value("self"), SlotInfo::value("x")]);
         info.post = Some(IrFormula::Atomic {
             name: "=".to_string(),
             args: vec![
-                IrTerm::Var { name: "result".to_string() },
+                IrTerm::Var {
+                    name: "result".to_string(),
+                },
                 IrTerm::Ctor {
                     name: "*".to_string(),
                     args: vec![
-                        IrTerm::Var { name: "x".to_string() },
+                        IrTerm::Var {
+                            name: "x".to_string(),
+                        },
                         // WRONG: 3 instead of 2
-                        IrTerm::Const { value: serde_json::json!(3), sort: int_sort() },
+                        IrTerm::Const {
+                            value: serde_json::json!(3),
+                            sort: int_sort(),
+                        },
                     ],
                 },
             ],
@@ -1215,8 +1286,13 @@ mod tests {
             op_cid: Cid::parse(format!("blake3-512:{}", "0".repeat(128))).unwrap(),
             name: "method_wrong".to_string(),
             args: vec![
-                Term::Var { name: "self_val".to_string() },
-                Term::Const { value: serde_json::json!(3), sort: int_sort() },
+                Term::Var {
+                    name: "self_val".to_string(),
+                },
+                Term::Const {
+                    value: serde_json::json!(3),
+                    sort: int_sort(),
+                },
             ],
         };
 
@@ -1224,13 +1300,22 @@ mod tests {
         let q = IrFormula::Atomic {
             name: "=".to_string(),
             args: vec![
-                IrTerm::Var { name: "result".to_string() },
-                IrTerm::Const { value: serde_json::json!(6), sort: int_sort() },
+                IrTerm::Var {
+                    name: "result".to_string(),
+                },
+                IrTerm::Const {
+                    value: serde_json::json!(6),
+                    sort: int_sort(),
+                },
             ],
         };
 
         let result = libprovekit::wp::wp(&call, &q, &resolver);
-        assert!(result.is_ok(), "wp must not error even for a wrong post: {:?}", result);
+        assert!(
+            result.is_ok(),
+            "wp must not error even for a wrong post: {:?}",
+            result
+        );
 
         let reduced = result.unwrap();
         // The reduced formula should be `=(*(3,3), 6)` -- sides differ structurally.
@@ -1249,10 +1334,7 @@ mod tests {
                 );
             }
             _ => {
-                panic!(
-                    "expected an = atomic from wp reduction, got: {}",
-                    s
-                );
+                panic!("expected an = atomic from wp reduction, got: {}", s);
             }
         }
     }

--- a/implementations/rust/provekit-walk/src/envelope.rs
+++ b/implementations/rust/provekit-walk/src/envelope.rs
@@ -15,8 +15,9 @@
 // into the proof.ir bundle pipeline and the resolve/index
 // substrate-verifier path with no further translation.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
+use provekit_canonicalizer::{encode_jcs, Value};
 use provekit_claim_envelope::{
     contract_cid as kit_contract_cid, mint_contract, Authoring, ClaimEnvelopeError,
     MintContractArgs, MintedEnvelope,
@@ -39,7 +40,7 @@ pub fn wrap_function_contract(
     produced_at: &str,
     signer_seed: &Ed25519Seed,
 ) -> Result<MintedEnvelope, ClaimEnvelopeError> {
-    let args = mint_args(contract, produced_at, signer_seed);
+    let args = mint_args(contract, produced_at, signer_seed)?;
     mint_contract(&args)
 }
 
@@ -48,13 +49,13 @@ pub fn wrap_function_contract(
 /// mint-counter assertion)" — paper 07 §6's "compose for free,
 /// compress to nothing" empirically.
 ///
-/// Lookups are by `contract_cid` (signer-independent). The cache
-/// returns the previously-minted MintedEnvelope unchanged on hit;
-/// callers receive the same `cid` and `canonical_bytes` they would
-/// have re-minted, but without paying the Ed25519 signing cost.
+/// Lookups are by signer-independent `contract_cid` plus a deterministic
+/// fingerprint of header-only panic provenance. `panic_loci` does not move the
+/// contract CID, but it must affect the cache key so a source-locus edit cannot
+/// return a stale `panicLoci` header.
 #[derive(Debug, Default)]
 pub struct EnvelopeCache {
-    /// contract_cid → cached MintedEnvelope
+    /// contract_cid + panic_loci fingerprint → cached MintedEnvelope
     by_contract: HashMap<String, MintedEnvelope>,
     /// Number of times mint_contract was actually invoked.
     pub mints: u64,
@@ -77,25 +78,49 @@ impl EnvelopeCache {
 }
 
 /// Wrap a FunctionContractMemento with a content-addressed cache: if the
-/// signer-independent `contract_cid` has already been minted into this
-/// cache, return the cached envelope (incrementing `cache.hits`);
-/// otherwise mint, insert, and return (incrementing `cache.mints`).
+/// signer-independent `contract_cid` and header provenance fingerprint have
+/// already been minted into this cache, return the cached envelope
+/// (incrementing `cache.hits`); otherwise mint, insert, and return
+/// (incrementing `cache.mints`).
 pub fn wrap_function_contract_cached(
     contract: &FunctionContractMemento,
     produced_at: &str,
     signer_seed: &Ed25519Seed,
     cache: &mut EnvelopeCache,
 ) -> Result<MintedEnvelope, ClaimEnvelopeError> {
-    let args = mint_args(contract, produced_at, signer_seed);
+    let args = mint_args(contract, produced_at, signer_seed)?;
     let cid = kit_contract_cid(&args);
-    if let Some(env) = cache.by_contract.get(&cid) {
+    let cache_key = envelope_cache_key(&cid, &args.panic_loci);
+    if let Some(env) = cache.by_contract.get(&cache_key) {
         cache.hits += 1;
         return Ok(env.clone());
     }
     let env = mint_contract(&args)?;
     cache.mints += 1;
-    cache.by_contract.insert(cid, env.clone());
+    cache.by_contract.insert(cache_key, env.clone());
     Ok(env)
+}
+
+fn envelope_cache_key(
+    contract_cid: &str,
+    panic_loci: &[Arc<provekit_canonicalizer::Value>],
+) -> String {
+    let loci_cid = panic_loci_fingerprint(panic_loci);
+    format!("{contract_cid}:{loci_cid}")
+}
+
+fn panic_loci_fingerprint(panic_loci: &[Arc<Value>]) -> String {
+    let canonical_loci = normalized_panic_loci(panic_loci);
+    crate::canonical::cid_of_value(Value::array(canonical_loci).as_ref())
+}
+
+fn normalized_panic_loci(panic_loci: &[Arc<Value>]) -> Vec<Arc<Value>> {
+    let mut keyed: Vec<(String, Arc<Value>)> = panic_loci
+        .iter()
+        .map(|locus| (encode_jcs(locus.as_ref()), locus.clone()))
+        .collect();
+    keyed.sort_by(|a, b| a.0.cmp(&b.0));
+    keyed.into_iter().map(|(_, locus)| locus).collect()
 }
 
 /// Build the `MintContractArgs` from a contract memento. Exposed so
@@ -106,10 +131,12 @@ pub fn mint_args(
     contract: &FunctionContractMemento,
     produced_at: &str,
     signer_seed: &Ed25519Seed,
-) -> MintContractArgs {
+) -> Result<MintContractArgs, ClaimEnvelopeError> {
+    validate_panic_loci(&contract.panic_loci)?;
     let pre = formula_to_canonical(&contract.pre);
     let post = formula_to_canonical(&contract.post);
     let out_binding = contract.result_var_name();
+    let panic_loci = normalized_panic_loci(&contract.panic_loci);
 
     let input_cids: Vec<String> = contract
         .body_cid
@@ -132,7 +159,7 @@ pub fn mint_args(
         })
         .collect();
 
-    MintContractArgs {
+    Ok(MintContractArgs {
         contract_name: contract.fn_name.clone(),
         pre: Some(pre),
         post: Some(post),
@@ -151,11 +178,34 @@ pub fn mint_args(
         emit_empty_formals: contract.formals.is_empty(),
         formal_sorts,
         library: None,
-        // PANIC-LOCUS PRESERVATION (#1745): this single-contract envelope path
-        // (used by walk's own minter, not the project-wide ir-document mint the
-        // panic-freedom fixture drives) does not yet thread per-occurrence panic
-        // loci. Emit none here; the field omits cleanly when empty.
-        panic_loci: Vec::new(),
+        // PANIC-LOCUS PRESERVATION (#1745/#1749): header metadata only.
+        // `provekit_claim_envelope::contract_cid` deliberately ignores this
+        // field, so per-occurrence source provenance cannot perturb contract
+        // identity or invalidate existing proofs.
+        panic_loci,
+    })
+}
+
+fn validate_panic_loci(panic_loci: &[Arc<Value>]) -> Result<(), ClaimEnvelopeError> {
+    for (idx, locus) in panic_loci.iter().enumerate() {
+        if !matches!(locus.as_ref(), Value::Object(_)) {
+            return Err(ClaimEnvelopeError::Other(format!(
+                "panic_loci[{idx}] must be an object, got {}",
+                value_type_name(locus.as_ref())
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn value_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Integer(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
     }
 }
 
@@ -164,6 +214,7 @@ mod tests {
     use super::*;
     use crate::contract::build_function_contract;
     use provekit_claim_envelope::contract_cid as kit_contract_cid;
+    use serde_json::Value as JsonValue;
 
     fn fixture_contract(src: &str) -> FunctionContractMemento {
         let file: syn::File = syn::parse_str(src).unwrap();
@@ -176,6 +227,62 @@ mod tests {
             })
             .unwrap();
         build_function_contract(&item_fn, None)
+    }
+
+    fn sample_panic_locus() -> Arc<Value> {
+        sample_panic_locus_at(2, 3)
+    }
+
+    fn sample_panic_locus_at(line: i64, panic_line: i64) -> Arc<Value> {
+        Value::object([
+            (
+                "argTerm",
+                Value::object([
+                    ("kind", Value::string("call")),
+                    ("callee", Value::string("serde_json::to_string")),
+                    (
+                        "args",
+                        Value::array(vec![Value::object([
+                            ("kind", Value::string("var")),
+                            ("name", Value::string("v")),
+                        ])]),
+                    ),
+                ]),
+            ),
+            ("file", Value::string("src/lib.rs")),
+            ("line", Value::integer(line)),
+            ("col", Value::integer(4)),
+            ("panicLine", Value::integer(panic_line)),
+            ("panicCol", Value::integer(9)),
+            ("callee", Value::string("method:unwrap")),
+        ])
+    }
+
+    fn header_json(env: &MintedEnvelope) -> JsonValue {
+        serde_json::from_slice::<JsonValue>(&env.canonical_bytes)
+            .expect("canonical envelope JSON")
+            .get("header")
+            .expect("layered envelope header")
+            .clone()
+    }
+
+    fn assert_panic_locus_lines(src: &str, expected_line: u64, expected_panic_line: u64) {
+        let c = fixture_contract(src);
+        let env = wrap_function_contract(&c, "2026-05-04T00:00:00Z", &DEV_SIGNER_SEED).unwrap();
+        let header = header_json(&env);
+        let panic_loci = header
+            .get("panicLoci")
+            .and_then(JsonValue::as_array)
+            .expect("panicLoci must be present for panic-bearing contracts");
+        assert_eq!(
+            panic_loci.len(),
+            1,
+            "expected one panic locus: {panic_loci:?}"
+        );
+        assert_eq!(panic_loci[0]["file"], "unknown");
+        assert_eq!(panic_loci[0]["line"], expected_line);
+        assert_eq!(panic_loci[0]["panicLine"], expected_panic_line);
+        assert_eq!(panic_loci[0]["callee"], "method:unwrap");
     }
 
     #[test]
@@ -248,10 +355,178 @@ mod tests {
         // minted envelope, so callers can compute it cheaply without
         // signing.
         let c = fixture_contract("fn neg(x: i64) -> i64 { -x }");
-        let args = mint_args(&c, "2026-05-04T00:00:00Z", &DEV_SIGNER_SEED);
+        let args = mint_args(&c, "2026-05-04T00:00:00Z", &DEV_SIGNER_SEED).unwrap();
         let cid_via_args = kit_contract_cid(&args);
         let env = wrap_function_contract(&c, "2026-05-04T00:00:00Z", &DEV_SIGNER_SEED).unwrap();
         assert_eq!(cid_via_args, env.contract_cid);
+    }
+
+    #[test]
+    fn panic_loci_round_trip_in_contract_header() {
+        let mut c = fixture_contract("fn split(v: serde_json::Value) -> String { v.to_string() }");
+        c.panic_loci = vec![sample_panic_locus()];
+
+        let env = wrap_function_contract(&c, "2026-05-04T00:00:00Z", &DEV_SIGNER_SEED).unwrap();
+        let header = header_json(&env);
+
+        let panic_loci = header
+            .get("panicLoci")
+            .and_then(JsonValue::as_array)
+            .expect("panicLoci must be present for panic-bearing contracts");
+        assert_eq!(panic_loci.len(), 1);
+        assert_eq!(panic_loci[0]["file"], "src/lib.rs");
+        assert_eq!(panic_loci[0]["line"], 2);
+        assert_eq!(panic_loci[0]["panicLine"], 3);
+        assert_eq!(panic_loci[0]["callee"], "method:unwrap");
+    }
+
+    #[test]
+    fn one_line_unwrap_panic_locus_round_trips_through_envelope() {
+        let src = r#"fn one_line(v: serde_json::Value) -> String {
+    serde_json::to_string(&v).unwrap()
+}
+"#;
+        assert_panic_locus_lines(src, 2, 2);
+    }
+
+    #[test]
+    fn split_line_unwrap_panic_locus_round_trips_through_envelope() {
+        let src = r#"fn split_line(v: serde_json::Value) -> String {
+    serde_json::to_string(&v)
+        .unwrap()
+}
+"#;
+        assert_panic_locus_lines(src, 2, 3);
+    }
+
+    #[test]
+    fn spanning_receiver_panic_locus_round_trips_through_envelope() {
+        let src = r#"fn spanning(v: serde_json::Value) -> String {
+    serde_json::to_string(
+        &v,
+    )
+    .unwrap()
+}
+"#;
+        assert_panic_locus_lines(src, 2, 5);
+    }
+
+    #[test]
+    fn empty_panic_loci_omits_header_field() {
+        let mut c = fixture_contract("fn no_panic(x: i64) -> i64 { x }");
+        c.panic_loci = Vec::new();
+
+        let env = wrap_function_contract(&c, "2026-05-04T00:00:00Z", &DEV_SIGNER_SEED).unwrap();
+        let header = header_json(&env);
+
+        assert!(
+            header.get("panicLoci").is_none(),
+            "empty panic_loci must omit panicLoci, got {header:#}"
+        );
+    }
+
+    #[test]
+    fn malformed_panic_loci_string_entry_fails_closed() {
+        let mut c = fixture_contract("fn bad(x: i64) -> i64 { x }");
+        c.panic_loci = vec![Value::string("not-a-locus-object")];
+
+        let err = wrap_function_contract(&c, "2026-05-04T00:00:00Z", &DEV_SIGNER_SEED)
+            .expect_err("malformed panic_loci must fail closed");
+
+        assert!(
+            err.to_string()
+                .contains("panic_loci[0] must be an object, got string"),
+            "error should name panic_loci path and type, got: {err}"
+        );
+    }
+
+    #[test]
+    fn malformed_panic_loci_number_entry_fails_closed() {
+        let mut c = fixture_contract("fn bad(x: i64) -> i64 { x }");
+        c.panic_loci = vec![Value::integer(42)];
+
+        let err = wrap_function_contract(&c, "2026-05-04T00:00:00Z", &DEV_SIGNER_SEED)
+            .expect_err("malformed panic_loci must fail closed");
+
+        assert!(
+            err.to_string()
+                .contains("panic_loci[0] must be an object, got number"),
+            "error should name panic_loci path and type, got: {err}"
+        );
+    }
+
+    #[test]
+    fn malformed_panic_loci_array_entry_fails_closed() {
+        let mut c = fixture_contract("fn bad(x: i64) -> i64 { x }");
+        c.panic_loci = vec![Value::array(vec![])];
+
+        let err = wrap_function_contract(&c, "2026-05-04T00:00:00Z", &DEV_SIGNER_SEED)
+            .expect_err("malformed panic_loci must fail closed");
+
+        assert!(
+            err.to_string()
+                .contains("panic_loci[0] must be an object, got array"),
+            "error should name panic_loci path and type, got: {err}"
+        );
+    }
+
+    #[test]
+    fn malformed_panic_loci_null_entry_fails_closed() {
+        let mut c = fixture_contract("fn bad(x: i64) -> i64 { x }");
+        c.panic_loci = vec![Value::null()];
+
+        let err = wrap_function_contract(&c, "2026-05-04T00:00:00Z", &DEV_SIGNER_SEED)
+            .expect_err("malformed panic_loci must fail closed");
+
+        assert!(
+            err.to_string()
+                .contains("panic_loci[0] must be an object, got null"),
+            "error should name panic_loci path and type, got: {err}"
+        );
+    }
+
+    #[test]
+    fn panic_loci_are_header_metadata_not_contract_identity() {
+        let base = fixture_contract("fn stable(x: i64) -> i64 { x }");
+        let absent_or_default =
+            mint_args(&base, "2026-05-04T00:00:00Z", &DEV_SIGNER_SEED).expect("base mint args");
+
+        let mut empty = base.clone();
+        empty.panic_loci = Vec::new();
+        let empty_args = mint_args(&empty, "2026-05-04T00:00:00Z", &DEV_SIGNER_SEED)
+            .expect("empty panic_loci mint args");
+
+        let mut nonempty = base.clone();
+        nonempty.panic_loci = vec![sample_panic_locus()];
+        let nonempty_args = mint_args(&nonempty, "2026-05-04T00:00:00Z", &DEV_SIGNER_SEED)
+            .expect("nonempty panic_loci mint args");
+
+        let cid = kit_contract_cid(&absent_or_default);
+        assert_eq!(kit_contract_cid(&empty_args), cid);
+        assert_eq!(kit_contract_cid(&nonempty_args), cid);
+    }
+
+    #[test]
+    fn panic_loci_header_bytes_are_deterministic() {
+        let mut c = fixture_contract("fn stable(v: serde_json::Value) -> String { v.to_string() }");
+        c.panic_loci = vec![sample_panic_locus()];
+
+        let a = wrap_function_contract(&c, "2026-05-04T00:00:00Z", &DEV_SIGNER_SEED).unwrap();
+        let b = wrap_function_contract(&c, "2026-05-04T00:00:00Z", &DEV_SIGNER_SEED).unwrap();
+
+        assert_eq!(a.contract_cid, b.contract_cid);
+        assert_eq!(a.canonical_bytes, b.canonical_bytes);
+    }
+
+    #[test]
+    fn panic_loci_fingerprint_is_order_independent() {
+        let first = sample_panic_locus_at(2, 2);
+        let second = sample_panic_locus_at(5, 5);
+
+        let a = panic_loci_fingerprint(&[first.clone(), second.clone()]);
+        let b = panic_loci_fingerprint(&[second, first]);
+
+        assert_eq!(a, b);
     }
 
     // ---- AC #6: mint-counter cache assertion ----
@@ -306,6 +581,78 @@ mod tests {
             .unwrap();
         assert_eq!(cache.mints, 2, "no re-mint");
         assert_eq!(cache.hits, 2);
+    }
+
+    #[test]
+    fn cached_wrap_keys_by_panic_loci_header_metadata() {
+        let mut first =
+            fixture_contract("fn same(v: serde_json::Value) -> String { v.to_string() }");
+        first.panic_loci = vec![sample_panic_locus_at(2, 2)];
+        let mut second = first.clone();
+        second.panic_loci = vec![sample_panic_locus_at(5, 5)];
+        let mut cache = EnvelopeCache::new();
+
+        let env1 = wrap_function_contract_cached(
+            &first,
+            "2026-05-05T00:00:00Z",
+            &DEV_SIGNER_SEED,
+            &mut cache,
+        )
+        .unwrap();
+        let env2 = wrap_function_contract_cached(
+            &second,
+            "2026-05-05T00:00:00Z",
+            &DEV_SIGNER_SEED,
+            &mut cache,
+        )
+        .unwrap();
+
+        assert_eq!(env1.contract_cid, env2.contract_cid);
+        assert_ne!(
+            header_json(&env1)["panicLoci"],
+            header_json(&env2)["panicLoci"],
+            "cache must not return stale header panicLoci for same contract cid"
+        );
+        assert_eq!(cache.mints, 2);
+        assert_eq!(cache.hits, 0);
+
+        let env2_again = wrap_function_contract_cached(
+            &second,
+            "2026-05-05T00:00:00Z",
+            &DEV_SIGNER_SEED,
+            &mut cache,
+        )
+        .unwrap();
+        assert_eq!(env2.canonical_bytes, env2_again.canonical_bytes);
+        assert_eq!(cache.mints, 2);
+        assert_eq!(cache.hits, 1);
+    }
+
+    #[test]
+    fn cached_wrap_empty_panic_loci_hits_default_key() {
+        let default = fixture_contract("fn same(x: i64) -> i64 { x }");
+        let mut explicit_empty = default.clone();
+        explicit_empty.panic_loci = Vec::new();
+        let mut cache = EnvelopeCache::new();
+
+        let env1 = wrap_function_contract_cached(
+            &default,
+            "2026-05-05T00:00:00Z",
+            &DEV_SIGNER_SEED,
+            &mut cache,
+        )
+        .unwrap();
+        let env2 = wrap_function_contract_cached(
+            &explicit_empty,
+            "2026-05-05T00:00:00Z",
+            &DEV_SIGNER_SEED,
+            &mut cache,
+        )
+        .unwrap();
+
+        assert_eq!(env1.canonical_bytes, env2.canonical_bytes);
+        assert_eq!(cache.mints, 1);
+        assert_eq!(cache.hits, 1);
     }
 
     #[test]

--- a/implementations/rust/provekit-walk/src/llbc_calls.rs
+++ b/implementations/rust/provekit-walk/src/llbc_calls.rs
@@ -345,6 +345,7 @@ mod tests {
             canonical_bytes: vec![],
             cid: String::new(),
             auto_minted_mementos: vec![],
+            panic_loci: vec![],
             concept_hint: None,
         };
         let composed = compose_callsite_pre(&callee, &[var("x")]);

--- a/implementations/rust/provekit-walk/src/marriage.rs
+++ b/implementations/rust/provekit-walk/src/marriage.rs
@@ -873,6 +873,7 @@ mod tests {
             canonical_bytes: vec![],
             cid: String::new(),
             auto_minted_mementos: vec![],
+            panic_loci: vec![],
             concept_hint: None,
         };
 
@@ -1089,6 +1090,7 @@ mod tests {
             auto_minted_mementos: vec![],
             formal_regions: vec![],
             return_region: None,
+            panic_loci: vec![],
             concept_hint: None,
         };
 


### PR DESCRIPTION
## Summary

- threads `FunctionContractMemento::panic_loci` through the provekit-walk single-contract envelope mint path
- emits `panicLoci` as header-only metadata without changing `canonical_bytes` or `contract_cid`
- keys `EnvelopeCache` by `contract_cid` plus an order-independent panic-loci fingerprint so source provenance edits cannot return stale headers
- fails closed on malformed panic-loci entries with typed field-path errors

This is preventive #1749 hardening for the alternate walk envelope mint surface. The active production panic-bearing path already goes through walk_rpc -> cmd_mint; this closes the no-silent-degradation gap so a future kit/path cannot drop panic provenance.

## Soundness notes

- `panic_loci` is metadata only; the CID test asserts equality across absent/default, explicit empty, and non-empty panic loci.
- Empty/default panic loci share the same cache key and hit the cache.
- Non-empty panic loci are normalized by JCS before fingerprinting, making the cache fingerprint order-independent.
- Validation happens before cache lookup through `mint_args(...) ?`, so malformed panic loci never poison the cache.
- Verifier logic is unchanged; the verifier fixture update only adds the new metadata field to a test literal.

## Validation

- `../../bin/bcargo test -p provekit-walk envelope::tests:: -- --nocapture`
  - 22 passed, 0 failed
- `../../bin/bcargo test -p libprovekit -p provekit-verifier -p provekit-walk -p provekit-cli panic_loci -- --nocapture`
  - green; includes cmd_mint malformed top-level panicLoci tests and walk_rpc receiver-line tests
- `git diff --check`
