### PR TITLE
fix(rust-std): add result expect partial

### DIFF
--- a/examples/provekit-shim-rust-std/src/lib.rs
+++ b/examples/provekit-shim-rust-std/src/lib.rs
@@ -175,6 +175,21 @@ pub fn result_unwrap<T, E: std::fmt::Debug>(result: Result<T, E>) -> T {
     result.unwrap()
 }
 
+// PARTIAL: Result::expect. Runtime precondition: result.is_ok() (same as
+// result_unwrap); separate concept for a distinctly named contract. Published
+// contract is post-only; the assert! is not lifted as a pre (see header note).
+#[provekit::sugar(
+    concept = "library:rust-result-expect",
+    library = "std",
+    version = "rust-1",
+    family = "concept:family:rust-std",
+    loss = [],
+)]
+pub fn result_expect<T, E: std::fmt::Debug>(result: Result<T, E>, msg: &str) -> T {
+    assert!(result.is_ok());
+    result.expect(msg)
+}
+
 // ---------------------------------------------------------------------------
 // Measured-frequency extensions
 // ---------------------------------------------------------------------------
@@ -520,6 +535,18 @@ mod tests {
     fn result_unwrap_partial_satisfied_precondition() {
         assert_eq!(result_unwrap(Result::Ok::<i32, &str>(5)), 5);
         assert_eq!(result_unwrap(Result::Ok::<&str, &str>("y")), "y");
+    }
+
+    #[test]
+    fn result_expect_partial_satisfied_precondition() {
+        assert_eq!(
+            result_expect(Result::Ok::<i32, &str>(5), "must be ok"),
+            5
+        );
+        assert_eq!(
+            result_expect(Result::Ok::<&str, &str>("y"), "must be ok"),
+            "y"
+        );
     }
 
     // --- measured-frequency extensions ---

--- a/examples/stage3-serde-totality-fixture/.provekit/config.toml
+++ b/examples/stage3-serde-totality-fixture/.provekit/config.toml
@@ -1,7 +1,8 @@
 # Stage 3 discrimination fixture for serde_json Value totality.
 #
-# f(&serde_json::Value).unwrap() -> PANIC-SAFE (totality axiom)
-# g(&MyStruct).unwrap()          -> UNDECIDABLE (refuse-floor)
+# f(&serde_json::Value).unwrap()        -> PANIC-SAFE (totality axiom)
+# f_expect(&serde_json::Value).expect() -> PANIC-SAFE (same totality axiom)
+# g(&MyStruct).unwrap()                 -> UNDECIDABLE (refuse-floor)
 #
 # The rust-bind surface provides the shim contracts (from .provekit/imports).
 # rust-fn-contracts produces body-bearing contracts for f and g.

--- a/examples/stage3-serde-totality-fixture/Cargo.toml
+++ b/examples/stage3-serde-totality-fixture/Cargo.toml
@@ -1,8 +1,8 @@
 # Stage 3 fixture for the serde_json Value totality discharge.
 #
 # Discrimination test:
-#   f(&serde_json::Value) -> should discharge PANIC-SAFE (Value is total)
-#   g(&MyStruct)          -> should stay UNDECIDABLE (struct Serialize may fail)
+#   f/f_expect(&serde_json::Value) -> should discharge PANIC-SAFE (Value is total)
+#   g(&MyStruct)                   -> should stay UNDECIDABLE (struct Serialize may fail)
 #
 # Own [workspace] for RA isolation (fast index, no monorepo stall).
 [package]

--- a/examples/stage3-serde-totality-fixture/src/lib.rs
+++ b/examples/stage3-serde-totality-fixture/src/lib.rs
@@ -5,6 +5,8 @@
 // Acceptance criteria:
 //   f: serde_json::to_string(&serde_json::Value).unwrap()
 //      -> PANIC-SAFE (Value serialization is total; is_ok(result) axiom fires)
+//   f_expect: serde_json::to_string(&serde_json::Value).expect(...)
+//      -> PANIC-SAFE through the same totality producer and Result precondition
 //
 //   g: serde_json::to_string(&MyStruct).unwrap()
 //      -> UNDECIDABLE (struct Serialize may fail; no totality contract)
@@ -23,6 +25,13 @@ use serde_json::Value;
 /// (post: is_ok(result)) -> .unwrap() discharges PANIC-SAFE.
 pub fn f(v: &Value) -> String {
     serde_json::to_string(v).unwrap()
+}
+
+/// Same totality producer as `f`, but through `Result::expect`. This proves the
+/// rust-std `result_expect` partial composes with the existing D-lib totality
+/// path rather than only existing in the shim catalog.
+pub fn f_expect(v: &Value) -> String {
+    serde_json::to_string(v).expect("infallible for Value")
 }
 
 /// The non-total case: `s` is a user-defined struct. The oracle resolves the

--- a/implementations/rust/provekit-cli/tests/cmd_mint_rust_project_implications.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_rust_project_implications.rs
@@ -469,6 +469,7 @@ fn rust_stdlib_checked_config_lifts_constructor_algebra_from_unit_tests() {
         ("is_none@src/lib.rs:", "False"),
         ("unwrap@src/lib.rs:", "Some"),
         ("unwrap@src/lib.rs:", "Ok"),
+        ("result_expect@src/lib.rs:", "Result::Ok"),
         ("unwrap_err@src/lib.rs:", "Err"),
         ("unwrap_or@src/lib.rs:", "Option::None"),
         ("unwrap_or@src/lib.rs:", "Err"),

--- a/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.json
+++ b/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.json
@@ -1,17 +1,17 @@
 {
   "target": "examples/provekit-shim-rust-std",
-  "catalogCid": "blake3-512:5943fb5bef2e46344df022782f50abe574ada18ff8db945c9906c926ee2ab0c85631acb82dd584d109f6571b96a772ed7df588d3368d09e1e331b9471f244f9c",
+  "catalogCid": "blake3-512:b17a0f02846bf0a1a5226db5e3bee0c5e31c0608981df83f82a6b111c24b336f5a43833449691b69dd32ebadd007e9b93d31401951d767470fd928d8cc68cfa6",
   "lift": {
-    "fnContracts": 27,
-    "bodyDischargeEligible": 27,
+    "fnContracts": 28,
+    "bodyDischargeEligible": 28,
     "bodyDischargeIneligible": {}
   },
   "bridges": {
     "emitted": 0,
     "liftGaps": {
       "no-contract-for-callee": 23,
-      "panic-site-unproven": 4,
-      "unsupported-macro-callsite": 4
+      "panic-site-unproven": 5,
+      "unsupported-macro-callsite": 5
     }
   },
   "oracle": {
@@ -26,7 +26,7 @@
     "panicSafe": 0,
     "reflexive": 656,
     "vacuous": 0,
-    "undecidable": 1276,
+    "undecidable": 1380,
     "falsePass": 0
   },
   "panicCensus": [
@@ -46,14 +46,21 @@
     },
     {
       "file": "src/lib.rs",
-      "line": 366,
-      "callee": "unwrap_err",
+      "line": 190,
+      "callee": "expect",
       "status": "unproven",
       "reason": "receiver type did not resolve to a known panic partial; a bare unwrap/expect would vacuous-pass, so the site is reported as unproven (cannot show it does not panic)"
     },
     {
       "file": "src/lib.rs",
       "line": 381,
+      "callee": "unwrap_err",
+      "status": "unproven",
+      "reason": "receiver type did not resolve to a known panic partial; a bare unwrap/expect would vacuous-pass, so the site is reported as unproven (cannot show it does not panic)"
+    },
+    {
+      "file": "src/lib.rs",
+      "line": 396,
       "callee": "expect",
       "status": "unproven",
       "reason": "receiver type did not resolve to a known panic partial; a bare unwrap/expect would vacuous-pass, so the site is reported as unproven (cannot show it does not panic)"

--- a/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.md
+++ b/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.md
@@ -10,8 +10,8 @@ rust-analyzer daemon, no wall-clock, no absolute paths.
 
 - `silentlyDropped: 0` -- hard invariant, must stay zero
 - `falsePass: 0` -- hard invariant, must stay zero
-- `panicSafe: 0` -- honest: the shim has 4 syntactic panic sites, none guarded, none dischargeable without the oracle
-- `panicCensus`: 4 sites, all `src/lib.rs`, all `unproven`; the reason line is the verifier's refuse-floor message
+- `panicSafe: 0` -- honest: the shim has 5 syntactic panic sites, none guarded, none dischargeable without the oracle
+- `panicCensus`: 5 sites, all `src/lib.rs`, all `unproven`; the reason line is the verifier's refuse-floor message
 - `catalogCid` is a content hash of the lifted contracts; it is path-independent (verified 2026-05-31 across two checkout paths)
 
 ## Regenerated 2026-06-01 (panic-locus branch)
@@ -34,6 +34,15 @@ Refreshed 2026-06-01: `catalogCid` `0f9278...` -> `5943fb5b...`
 after pre-existing main drift; baseline `7daf1918a` (before this PR's
 lift-direct changes) produces `5943fb5b...`, with member set and decoded
 member JSON unchanged from this branch. Hard invariants unchanged.
+
+Regenerated 2026-06-01: `catalogCid` `5943fb5b...` -> `b17a0f02...`.
+`Result::expect` was added as a distinct rust-std partial, mirroring
+`Result::unwrap` with precondition `result.is_ok()`. This intentionally adds one
+function contract (`27 -> 28`), one unproven panic site in the no-oracle shim
+self-check (`panicCensus 4 -> 5`, new `expect` at `src/lib.rs:190`), and one
+surfaced `assert!` macro gap (`unsupported-macro-callsite 4 -> 5`). Hard
+invariants unchanged: `falsePass 0`, `panicSafe 0`, `silentlyDropped 0`,
+`droppedSites []`.
 
 ## Normalization applied
 

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -1430,6 +1430,7 @@ fn crate_name_for(dir: &Path) -> Option<String> {
 ///   (`option`, `unwrap`)     -> `option_unwrap`     (pre: `opt.is_some()`)
 ///   (`result`, `unwrap`)     -> `result_unwrap`     (pre: `result.is_ok()`)
 ///   (`option`, `expect`)     -> `option_expect`     (pre: `opt.is_some()`)
+///   (`result`, `expect`)     -> `result_expect`     (pre: `result.is_ok()`)
 ///   (`result`, `unwrap_err`) -> `result_unwrap_err` (pre: `result.is_err()`)
 ///
 /// The returned leaf is the shim partial's CONTRACT NAME, which is exactly the
@@ -1526,6 +1527,7 @@ fn disambiguated_partial_leaf(type_stem: &str, leaf: &str) -> Option<String> {
         ("option", "unwrap") => "option_unwrap",
         ("result", "unwrap") => "result_unwrap",
         ("option", "expect") => "option_expect",
+        ("result", "expect") => "result_expect",
         ("result", "unwrap_err") => "result_unwrap_err",
         _ => return None,
     };
@@ -6846,6 +6848,10 @@ mod tests {
         assert_eq!(
             disambiguated_partial_leaf("option", "expect").as_deref(),
             Some("option_expect")
+        );
+        assert_eq!(
+            disambiguated_partial_leaf("result", "expect").as_deref(),
+            Some("result_expect")
         );
         assert_eq!(
             disambiguated_partial_leaf("result", "unwrap_err").as_deref(),


### PR DESCRIPTION
## Summary
- add an additive `Result::expect` rust-std shim partial mirroring `Result::unwrap` with the `result.is_ok()` precondition
- map Rust `Result::expect` panic leaves to `result_expect` in walk disambiguation
- extend the stage3 serde totality fixture with `f_expect` so the existing D-lib totality producer is exercised through `.expect()`

## Evidence
- `../../bin/bcargo test -p provekit-walk disambiguated_partial_leaf_maps_panic_set -- --nocapture`
- `../../bin/bcargo test --manifest-path ../../examples/provekit-shim-rust-std/Cargo.toml result_expect_partial_satisfied_precondition -- --nocapture`
- `../../bin/bcargo test -p provekit-cli rust_stdlib_checked_config_lifts_constructor_algebra_from_unit_tests -- --nocapture`
- `../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture`
- convergent warm-oracle stage3 e2e: cold passes 1-2 refused panic leaves; pass 3 onward stable proof `68a3c0f...` emitted `method:expect@src/lib.rs:34 -> result_expect`
- converged prove split: `panicSafe=2`, `falsePass=0`, `undecidable=138`, `vacuous=7`, `reflexive=29`
- `f_expect` line 34 discharged with `dischargeMethod=panic-safe`; existing `f` line 27 stayed panic-safe; `g` line 47 stayed unsatisfied
- `callee_post_guard_fact` ACCEPT logged for `method:expect` line 34; no verifier diff (`git diff -- implementations/rust/provekit-verifier | wc -l = 0`)

## Golden movement
`self-check-provekit-shim-rust-std` moves intentionally because the shim catalog now contains one new partial:
- `catalogCid 5943fb5b... -> b17a0f02...`
- `fnContracts 27 -> 28`
- `panicCensus 4 -> 5` with the new unguarded `expect` site in the shim self-check
- hard floors unchanged: `falsePass=0`, `panicSafe=0`, `silentlyDropped=0`, `droppedSites=[]`

## Note
The stage3 fixture result requires the convergent oracle harness. A cold two-pass run can still show `panic-site-unproven=3`; the stable warm pass is the meaningful gate.