### PR TITLE
chore(libprovekit): enable implication baseline

### DIFF
--- a/implementations/rust/libprovekit/.provekit/config.toml
+++ b/implementations/rust/libprovekit/.provekit/config.toml
@@ -10,9 +10,10 @@
 # up the crate graph: every dependency publishes its contracts, the consumer
 # bridges into them.
 #
-# Producer surfaces only (no rust-implications): this crate's job here is to
-# PUBLISH contracts the cli bridges into. (libprovekit's own internal
-# discharge would add rust-implications, the same way the cli does.)
+# Producer surfaces publish contracts the cli bridges into. The
+# rust-implications consumer surface also lets libprovekit self-check enumerate
+# its own internal callsite obligations, giving the D-lib per-type work a
+# production baseline instead of an empty census.
 
 [[plugins]]
 name = "rust-bind"
@@ -27,6 +28,11 @@ emit = "ir-document"
 [[plugins]]
 name = "rust-fn-contracts"
 surface = "rust-fn-contracts"
+emit = "ir-document"
+
+[[plugins]]
+name = "rust-implications"
+surface = "rust-implications"
 emit = "ir-document"
 
 [platform_profile]

--- a/implementations/rust/libprovekit/.provekit/lift/rust-implications/manifest.toml
+++ b/implementations/rust/libprovekit/.provekit/lift/rust-implications/manifest.toml
@@ -1,0 +1,5 @@
+name = "rust-implications-lift"
+method = "provekit.plugin.lift_implications"
+phase = "consumer"
+command = ["../target/debug/provekit-walk-rpc", "--rpc"]
+working_dir = "."


### PR DESCRIPTION
## Summary
- enables the `rust-implications` consumer surface for `implementations/rust/libprovekit`
- adds the project-local manifest that dispatches to `provekit-walk-rpc` over RPC
- establishes the warm-oracle self-check baseline for libprovekit so the next D-lib per-type slice has a real production comparison point

## Warm oracle baseline
Command run on battleaxe from the bcargo-synced checkout:
```sh
provekit self-check --target implementations/rust/libprovekit --oracle --json
```

- oracle: requested=true, engaged=true, attempted=3012, resolved=2706
- lift: fnContracts=577, bodyDischargeEligible=555, bodyDischargeIneligible={missing-result-equation=22}
- bridges: emitted=2344, liftGaps={no-contract-for-callee=2860, panic-site-unproven=3, unsupported-macro-callsite=423}
- dischargeSplit: falsePass=0, panicSafe=0, reflexive=665, undecidable=1518, vacuous=154
- floor: droppedSites=[], silentlyDropped=0
- panicCensus count=15

Cold scoreboard is documented only for comparison; the warm scoreboard above is the baseline PR-C measures K delta against.

## Cold comparison
- oracle absent/off
- bridges: emitted=2261, liftGaps={no-contract-for-callee=2919, panic-site-unproven=27, unsupported-macro-callsite=423}
- dischargeSplit: falsePass=0, panicSafe=0, reflexive=657, undecidable=1284, vacuous=355
- panicCensus count=27, all receiver type did not resolve

The earlier cold run was an invocation mistake: `cmd_self_check` intentionally strips oracle env unless `--oracle` is passed. The warm run confirms oracle propagation is working.

## Warm panic census categorization
| Site | Category | Note |
| --- | --- | --- |
| `src/compose.rs:1157 expect` | oracle-residue | `OccurrenceKind::from_str(...).expect(...)`; RA did not map the receiver to a known panic partial. |
| `src/compose.rs:1410 expect` | oracle-residue | `serde_json::to_value(f).expect(...)`; receiver did not disambiguate to a known partial in this run. |
| `src/core/bind.rs:548 method:expect` | D-fn | `ConceptOpCatalog.cid(CONCEPT_BIND_RESULT).expect(...)`; needs a function-level/catalog primitive postcondition. |
| `src/core/lower_plugin.rs:1477 method:expect` | D-lib | `serde_json::to_value(realized).expect(...)`; serde totality for `RealizedSource`. |
| `src/core/lower_plugin.rs:1684 method:expect` | D-lib | `serde_json::to_string(sort).expect(...)`; serde totality for `Sort`. |
| `src/core/platform_semantics.rs:41 method:expect` | residue | Filesystem/config loading invariant for the python kit declaration. |
| `src/core/types.rs:2105 method:expect` | D-lib | `serde_json::to_value(dialect).expect(...)`; serde totality for `Dialect`. |
| `src/core/types.rs:2137 method:expect` | D-lib | `serde_json::to_value(term).expect(...)`; serde totality for `Term`. |
| `src/lib.rs:161 method:unwrap` | B | Rust-std shim `option_unwrap`: `assert!(opt.is_some()); opt.unwrap()`. Needs intra-function fact flow from the native assert. |
| `src/lib.rs:175 method:unwrap` | B | Rust-std shim `result_unwrap`: `assert!(result.is_ok()); result.unwrap()`. Needs intra-function fact flow. |
| `src/lib.rs:190 method:expect` | B | Rust-std shim `result_expect`: `assert!(result.is_ok()); result.expect(msg)`. Needs intra-function fact flow. |
| `src/lib.rs:396 method:expect` | B | Rust-std shim `option_expect`: `assert!(opt.is_some()); opt.expect(msg)`. Needs intra-function fact flow. |
| `src/wp.rs:295 method:unwrap` | B | Guarded `conj.len() == 1` branch followed by `conj.into_iter().next().unwrap()`. |
| `src/wp/tests.rs:74 expect` | oracle-residue | Test helper `Cid::parse(...).expect(...)` also emitted an unresolved receiver row. |
| `src/wp/tests.rs:74 method:expect` | D-fn | Same test helper, mapped row; needs `Cid::parse` literal success/postcondition. |

Confirmed D-lib sites for PR-C: 4. Candidate K delta can rise if later categorization moves more rows into D-lib, but this baseline names the current floor.

## Validation
- `git diff --check`
- `../../bin/bcargo --sync-bins provekit,provekit-walk-rpc,provekit-linkerd build -p provekit-cli --bin provekit -p provekit-walk --bin provekit-walk-rpc -p provekit-linkerd --bin provekit-linkerd`
- `../../bin/bcargo --sync-bin provekit-lift build -p provekit-lift --bin provekit-lift`
- battleaxe warm `provekit self-check --target implementations/rust/libprovekit --oracle --json`
