### PR TITLE
[codex] prove rust panic partials through guards

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -58,8 +58,8 @@ use libprovekit::core::{
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 use provekit_claim_envelope::{
     compute_contract_set_cid, contract_cid, mint_authority, mint_bridge, mint_contract,
-    mint_implication, Authoring, BridgeCallsite, MintAuthorityArgs, MintBridgeArgs, MintContractArgs,
-    MintImplicationArgs,
+    mint_implication, Authoring, BridgeCallsite, MintAuthorityArgs, MintBridgeArgs,
+    MintContractArgs, MintImplicationArgs,
 };
 use provekit_ir_types::Sort;
 use provekit_proof_envelope::{
@@ -614,7 +614,8 @@ impl MintKit {
             let dep_kept: Vec<Value> = dep_bindings
                 .into_iter()
                 .filter(|b| {
-                    let Some(name) = b.get("name").and_then(|v| v.as_str()).map(String::from) else {
+                    let Some(name) = b.get("name").and_then(|v| v.as_str()).map(String::from)
+                    else {
                         return false;
                     };
                     let lib = b
@@ -797,6 +798,14 @@ fn lift_options_from_request(
     }
 }
 
+fn has_nontrivial_pre_json(pre: &Value) -> bool {
+    if pre.is_null() {
+        return false;
+    }
+    !(pre.get("kind").and_then(|v| v.as_str()) == Some("atomic")
+        && pre.get("name").and_then(|v| v.as_str()) == Some("true"))
+}
+
 fn contract_bindings_from_producer_responses(
     producer_responses: &[PerPluginDispatch],
     project_root: &Path,
@@ -872,7 +881,7 @@ fn contract_bindings_from_dependency_proofs(project_root: &Path) -> Vec<Value> {
     let mut pool = provekit_verifier::types::MementoPool::default();
     provekit_verifier::load_all_proofs::load_files_into_pool(&proof_files, &mut pool);
 
-    use provekit_verifier::types::{memento_body_field, memento_kind};
+    use provekit_verifier::types::{memento_body, memento_body_field, memento_kind};
     // member CID -> the `.proof` bundle CID it was loaded from. This is the
     // `targetProofCid` a cross-crate bridge must pin so the verifier enforces
     // ConsequentBundlePinned (the contract member MUST come from THIS bundle,
@@ -903,7 +912,7 @@ fn contract_bindings_from_dependency_proofs(project_root: &Path) -> Vec<Value> {
     // them into one and lose the very disambiguation this exists for.
     let mut by_key: std::collections::BTreeMap<
         (Option<String>, String),
-        (String, bool, Option<String>, bool, Option<String>),
+        (String, bool, bool, Option<String>, bool, Option<String>),
     > = std::collections::BTreeMap::new();
     for (cid, env) in &pool.mementos {
         if memento_kind(env) != Some("contract") {
@@ -923,34 +932,38 @@ fn contract_bindings_from_dependency_proofs(project_root: &Path) -> Vec<Value> {
             .or_else(|| memento_body_field(env, "body_discharge_eligible"))
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
-        let body_discharge_refusal_reason =
-            memento_body_field(env, "bodyDischargeRefusalReason")
-                .or_else(|| memento_body_field(env, "body_discharge_refusal_reason"))
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
+        let body_discharge_refusal_reason = memento_body_field(env, "bodyDischargeRefusalReason")
+            .or_else(|| memento_body_field(env, "body_discharge_refusal_reason"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
         // The dependency crate this contract belongs to (the lifter stamped it
         // at mint, the CLI forwards it opaquely).
         let library = memento_body_field(env, "library")
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string());
-        let has_pre = memento_body_field(env, "preHash").is_some();
+        let has_pre = memento_body(env)
+            .and_then(|body| body.get("pre"))
+            .is_some_and(has_nontrivial_pre_json);
         let body_bearing =
             (has_pre || memento_body_field(env, "postHash").is_some()) && body_discharge_eligible;
         let bundle = member_to_bundle.get(cid.as_str()).map(|b| b.to_string());
         let key = (library, name);
-        // SELECTION PREFERENCE (most to least preferred), so a call site bridges
-        // to a DISCHARGEABLE target rather than a vacuous-passing shell:
-        //   1. PRE-bearing (carries a `preHash`): the ONLY shape that can prove
-        //      a partial cannot panic. The post-only sugar shape of the same
-        //      name vacuous-passes the obligation (a false "cannot panic"), so a
-        //      pre-bearing newcomer must always WIN over a post-only incumbent.
-        //   2. body-bearing (pre or post) over inv-only.
+        // SELECTION PREFERENCE (most to least preferred):
+        //   1. Eligible non-trivial-PRE contracts: the ONLY shape that can prove
+        //      a partial cannot panic.
+        //   2. Body-discharge-ineligible contracts: this preserves explicit
+        //      totality axioms over post-only duplicates so the lifter can route
+        //      them to the honesty boundary instead of silently picking an
+        //      eligible shell.
+        //   3. Other body-bearing (post-only) contracts over inv-only.
         // Names are not identity here -- two shapes share a name (post-only
         // sugar `option_unwrap` and pre-bearing fn-contract `option_unwrap`)
         // and we must select the dischargeable one deterministically.
-        let rank = |has_pre: bool, body_bearing: bool| -> u8 {
-            if has_pre {
+        let rank = |has_pre: bool, body_bearing: bool, eligible: bool| -> u8 {
+            if has_pre && eligible {
+                3
+            } else if !eligible {
                 2
             } else if body_bearing {
                 1
@@ -958,16 +971,11 @@ fn contract_bindings_from_dependency_proofs(project_root: &Path) -> Vec<Value> {
                 0
             }
         };
-        let new_rank = rank(has_pre, body_bearing);
+        let new_rank = rank(has_pre, body_bearing, body_discharge_eligible);
         let take = match by_key.get(&key) {
             None => true,
-            Some((incumbent_cid, incumbent_bb, _, _, _)) => {
-                let incumbent_has_pre = pool
-                    .mementos
-                    .get(incumbent_cid)
-                    .map(|e| memento_body_field(e, "preHash").is_some())
-                    .unwrap_or(false);
-                new_rank > rank(incumbent_has_pre, *incumbent_bb)
+            Some((_, incumbent_bb, incumbent_has_pre, _, incumbent_eligible, _)) => {
+                new_rank > rank(*incumbent_has_pre, *incumbent_bb, *incumbent_eligible)
             }
         };
         if take {
@@ -976,6 +984,7 @@ fn contract_bindings_from_dependency_proofs(project_root: &Path) -> Vec<Value> {
                 (
                     cid.clone(),
                     body_bearing,
+                    has_pre,
                     bundle,
                     body_discharge_eligible,
                     body_discharge_refusal_reason,
@@ -991,25 +1000,27 @@ fn contract_bindings_from_dependency_proofs(project_root: &Path) -> Vec<Value> {
                 (
                     cid,
                     body_bearing,
+                    has_pre,
                     bundle,
                     body_discharge_eligible,
                     body_discharge_refusal_reason,
                 ),
             )| {
-            json!({
-                "name": name,
-                "contract_cid": cid,
-                "body_bearing": body_bearing,
-                "bodyDischargeEligible": body_discharge_eligible,
-                "bodyDischargeRefusalReason": body_discharge_refusal_reason,
-                // The dependency bundle CID: the bridge pins this so the
-                // verifier resolves the target contract from THIS proof only.
-                "target_proof_cid": bundle,
-                // The crate this dependency contract belongs to: the lifter
-                // keys the call site by (crate, leaf) to match it.
-                "library": library,
-            })
-        },
+                json!({
+                    "name": name,
+                    "contract_cid": cid,
+                    "body_bearing": body_bearing,
+                    "has_pre": has_pre,
+                    "bodyDischargeEligible": body_discharge_eligible,
+                    "bodyDischargeRefusalReason": body_discharge_refusal_reason,
+                    // The dependency bundle CID: the bridge pins this so the
+                    // verifier resolves the target contract from THIS proof only.
+                    "target_proof_cid": bundle,
+                    // The crate this dependency contract belongs to: the lifter
+                    // keys the call site by (crate, leaf) to match it.
+                    "library": library,
+                })
+            },
         )
         .collect()
 }
@@ -1621,6 +1632,7 @@ fn mint_ir_document(
         pre_hash: Option<String>,
         post_hash: Option<String>,
         inv_hash: Option<String>,
+        has_nontrivial_pre: bool,
         body_discharge_eligible: bool,
         body_discharge_refusal_reason: Option<String>,
         library: Option<String>,
@@ -1737,10 +1749,9 @@ fn mint_ir_document(
             .and_then(|v| v.as_str())
             .unwrap_or("out")
             .to_string();
-        let pre = decl
-            .get("pre")
-            .or_else(|| decl.get("precondition"))
-            .map(json_to_cvalue);
+        let pre_decl = decl.get("pre").or_else(|| decl.get("precondition"));
+        let has_nontrivial_pre = pre_decl.is_some_and(has_nontrivial_pre_json);
+        let pre = pre_decl.map(json_to_cvalue);
         let post = decl
             .get("post")
             .or_else(|| decl.get("postcondition"))
@@ -1952,6 +1963,7 @@ fn mint_ir_document(
                 pre_hash,
                 post_hash,
                 inv_hash,
+                has_nontrivial_pre,
                 body_discharge_eligible,
                 body_discharge_refusal_reason,
                 library,
@@ -2049,17 +2061,17 @@ fn mint_ir_document(
                         // Fall back to the first shape under this name when the
                         // slot is absent everywhere (the error is raised below
                         // on the missing slot, with a clear message).
-                        .or_else(|| {
-                            cids.first().and_then(|cid| contracts_by_cid.get(cid))
-                        })
+                        .or_else(|| cids.first().and_then(|cid| contracts_by_cid.get(cid)))
                 })
             };
-            let antecedent = resolve_by_slot(antecedent_name, antecedent_slot).ok_or_else(|| {
-                format!("implication `{name}` references missing contract `{antecedent_name}`")
-            })?;
-            let consequent = resolve_by_slot(consequent_name, consequent_slot).ok_or_else(|| {
-                format!("implication `{name}` references missing contract `{consequent_name}`")
-            })?;
+            let antecedent =
+                resolve_by_slot(antecedent_name, antecedent_slot).ok_or_else(|| {
+                    format!("implication `{name}` references missing contract `{antecedent_name}`")
+                })?;
+            let consequent =
+                resolve_by_slot(consequent_name, consequent_slot).ok_or_else(|| {
+                    format!("implication `{name}` references missing contract `{consequent_name}`")
+                })?;
             let antecedent_hash = antecedent.slot_hash(antecedent_slot).ok_or_else(|| {
                 format!(
                     "implication `{name}` references missing slot `{antecedent_slot}` on contract `{antecedent_name}`"
@@ -2137,12 +2149,14 @@ fn mint_ir_document(
             // fact (carries only `inv` -> nothing for a general call site
             // to prove).
             let name = &contract.contract_name;
-            let body_bearing = (contract.pre_hash.is_some() || contract.post_hash.is_some())
-                && contract.body_discharge_eligible;
+            let has_pre = contract.has_nontrivial_pre;
+            let body_bearing =
+                (has_pre || contract.post_hash.is_some()) && contract.body_discharge_eligible;
             json!({
                 "name": name,
                 "contract_cid": contract.attestation_cid.clone(),
                 "body_bearing": body_bearing,
+                "has_pre": has_pre,
                 "bodyDischargeEligible": contract.body_discharge_eligible,
                 "bodyDischargeRefusalReason": contract.body_discharge_refusal_reason.clone(),
                 // Crate tag (Tier 1): lets the implication lifter key this
@@ -3697,9 +3711,54 @@ mod tests {
             })
             .expect("contract envelope");
         assert_eq!(
-            contract.pointer("/metadata/library").and_then(|v| v.as_str()),
+            contract
+                .pointer("/metadata/library")
+                .and_then(|v| v.as_str()),
             Some("libprovekit")
         );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn mint_ir_document_marks_only_nontrivial_pre_as_has_pre() {
+        let root = temp_workspace("mint_contract_has_pre");
+        let out_dir = root.join("out");
+        std::fs::create_dir_all(&out_dir).expect("create out dir");
+        let ir = vec![
+            json!({
+                "kind": "contract",
+                "name": "trivial_pre",
+                "outBinding": "out",
+                "pre": {"kind": "atomic", "name": "true", "args": []}
+            }),
+            json!({
+                "kind": "contract",
+                "name": "guarded_pre",
+                "outBinding": "out",
+                "pre": {"kind": "atomic", "name": "is_some", "args": []}
+            }),
+        ];
+
+        let minted = mint_ir_document(&ir, None, None, None, &root, &out_dir, true)
+            .expect("mint ir-document");
+        let by_name = |name: &str| {
+            minted
+                .contract_bindings
+                .iter()
+                .find(|binding| binding["name"] == name)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "missing binding `{name}` in {:#?}",
+                        minted.contract_bindings
+                    )
+                })
+        };
+
+        assert_eq!(by_name("trivial_pre")["has_pre"], false);
+        assert_eq!(by_name("trivial_pre")["body_bearing"], false);
+        assert_eq!(by_name("guarded_pre")["has_pre"], true);
+        assert_eq!(by_name("guarded_pre")["body_bearing"], true);
 
         let _ = std::fs::remove_dir_all(root);
     }
@@ -3725,8 +3784,7 @@ mod tests {
             // ("v1.1.0 requires blake3-512:"). Each library yields distinct
             // bytes -> distinct CID -> a separate proof file.
             let fname = format!("{}.proof", minted.filename_cid);
-            std::fs::write(imports_dir.join(fname), minted.bytes)
-                .expect("write dependency proof");
+            std::fs::write(imports_dir.join(fname), minted.bytes).expect("write dependency proof");
         }
 
         let mut bindings = contract_bindings_from_dependency_proofs(&root);
@@ -3744,7 +3802,10 @@ mod tests {
             .collect();
         assert_eq!(libraries, vec!["lib_a", "lib_b"]);
         assert_eq!(
-            bindings.iter().filter(|binding| binding["name"] == "same_leaf").count(),
+            bindings
+                .iter()
+                .filter(|binding| binding["name"] == "same_leaf")
+                .count(),
             2
         );
 
@@ -3764,8 +3825,7 @@ mod tests {
         let value_totality = bindings
             .iter()
             .find(|binding| {
-                binding.get("name").and_then(|v| v.as_str())
-                    == Some("serde_json_to_string_value")
+                binding.get("name").and_then(|v| v.as_str()) == Some("serde_json_to_string_value")
                     && binding.get("library").and_then(|v| v.as_str()) == Some("serde_json")
             })
             .unwrap_or_else(|| {
@@ -3808,8 +3868,7 @@ mod tests {
             .iter()
             .find(|binding| {
                 binding.get("name").and_then(|v| v.as_str()) == Some("json_parse")
-                    && binding.get("library").and_then(|v| v.as_str())
-                        == Some("serde_json")
+                    && binding.get("library").and_then(|v| v.as_str()) == Some("serde_json")
             })
             .unwrap_or_else(|| panic!("missing json_parse binding in {bindings:#?}"));
         assert_eq!(

--- a/implementations/rust/provekit-cli/src/cmd_self_check.rs
+++ b/implementations/rust/provekit-cli/src/cmd_self_check.rs
@@ -208,7 +208,13 @@ fn run_inner(args: &SelfCheckArgs) -> Result<SelfCheckScoreboard, String> {
             "self-check: minting dependency proof"
         );
         let out_dir = scratch.join(format!("dep-{name}"));
-        let minted = mint_project(&bin, &repo_root, &dep, &out_dir, false)?;
+        let minted = mint_project_converged(
+            &bin,
+            &repo_root,
+            &dep,
+            &out_dir,
+            dependency_mint_uses_oracle(args.oracle),
+        )?;
         copy_proof_to_imports(&minted.proof_file, &imports)?;
         let imports_proof_count = count_proof_files(&imports)?;
         info!(
@@ -504,6 +510,10 @@ fn mint_project(
         ));
     }
     Ok(MintOutput { proof_file, json })
+}
+
+fn dependency_mint_uses_oracle(self_check_oracle: bool) -> bool {
+    self_check_oracle
 }
 
 fn mint_project_converged(
@@ -1246,6 +1256,18 @@ mod tests {
             attempted,
             resolved,
         }
+    }
+
+    #[test]
+    fn dependency_mints_inherit_self_check_oracle_request() {
+        assert!(
+            dependency_mint_uses_oracle(true),
+            "self-check --oracle must mint local dependency proofs with the same oracle setting"
+        );
+        assert!(
+            !dependency_mint_uses_oracle(false),
+            "self-check without --oracle must keep dependency mints syntactic-only"
+        );
     }
 
     fn write_import(path: &Path, file_name: &str) {

--- a/implementations/rust/provekit-verifier/src/body_discharge.rs
+++ b/implementations/rust/provekit-verifier/src/body_discharge.rs
@@ -304,6 +304,10 @@ pub fn extract_body_obligation(
     cs: &CallSite,
     pool: &MementoPool,
 ) -> Result<Option<BodyObligation>, String> {
+    if cs.panic_site && cs.bridge_target_cid.is_empty() {
+        return Ok(None);
+    }
+
     let resolver = CatalogResolver::new(pool);
 
     // The callee must have a body-derived contract; otherwise this is not
@@ -1475,6 +1479,69 @@ mod callee_post_guard_fact_tests {
         let fact = callee_post_guard_fact(&cs, &pool)
             .expect("panic site must find producer in the caller contract bundle");
         assert_eq!(fact.get("name").and_then(|v| v.as_str()), Some("is_ok"));
+    }
+
+    #[test]
+    fn panic_locus_without_scoped_bridge_does_not_fall_into_global_body_discharge() {
+        // A panicLoci fallback can surface a panic site even when the kit did
+        // not emit the scoped panic-leaf bridge. In that case the verifier must
+        // let resolve_target report NoBridgeTarget. It must not grab a global
+        // same-symbol body contract and produce the misleading body-discharge
+        // refusal seen in the imported libprovekit regression.
+        let body_contract_cid = "blake3-512:global-method-expect-body";
+        let mut pool = MementoPool::default();
+        pool.mementos.insert(
+            body_contract_cid.into(),
+            json!({
+                "envelope": true,
+                "header": {
+                    "kind": "contract",
+                    "contractName": "method:expect",
+                    "formals": ["x"],
+                    "post": {
+                        "kind": "atomic",
+                        "name": "=",
+                        "args": [
+                            {"kind": "var", "name": "result"},
+                            {"kind": "var", "name": "x"}
+                        ]
+                    }
+                }
+            }),
+        );
+        pool.bridges_by_symbol.insert(
+            "method:expect".into(),
+            json!({
+                "envelope": true,
+                "header": {
+                    "kind": "bridge",
+                    "sourceSymbol": "method:expect",
+                    "targetContractCid": body_contract_cid
+                }
+            }),
+        );
+
+        let cs = CallSite {
+            panic_site: true,
+            bridge_ir_name: "method:expect".into(),
+            bridge_target_cid: String::new(),
+            callsite_bundle_cid: Some("blake3-512:caller-bundle".into()),
+            file: Some("src/core/types.rs".into()),
+            line: Some(2105),
+            arg_term: Some(json!({
+                "kind": "ctor",
+                "name": "to_value",
+                "args": [{"kind": "var", "name": "term"}]
+            })),
+            ..Default::default()
+        };
+
+        let result = extract_body_obligation(&cs, &pool)
+            .expect("missing scoped panic bridge should not become a body-discharge refusal");
+        assert!(
+            result.is_none(),
+            "missing scoped panic bridge should fall through to resolve_target/NoBridgeTarget"
+        );
     }
 }
 

--- a/implementations/rust/provekit-verifier/src/enumerate_callsites.rs
+++ b/implementations/rust/provekit-verifier/src/enumerate_callsites.rs
@@ -137,7 +137,7 @@ fn callsite_from_panic_locus(
         )),
         _ => None,
     };
-    let bridge_env = scoped_bridge.or_else(|| pool.bridges_by_symbol.get(callee));
+    let bridge_env = scoped_bridge;
     let bridge_body = bridge_env
         .and_then(memento_body)
         .cloned()
@@ -151,11 +151,10 @@ fn callsite_from_panic_locus(
         );
     }
 
-    let bridge_self_bundle_cid = if scoped_bridge.is_some() {
-        callsite_bundle_cid.map(str::to_string)
-    } else {
-        pool.bridge_self_bundle_by_symbol.get(callee).cloned()
-    };
+    let bridge_self_bundle_cid = scoped_bridge
+        .is_some()
+        .then(|| callsite_bundle_cid.map(str::to_string))
+        .flatten();
 
     Some(CallSite {
         bridge_ir_name: callee.to_string(),
@@ -208,9 +207,7 @@ fn bundle_containing_member(pool: &MementoPool, member_cid: &str) -> Option<Stri
     pool.bundle_members
         .iter()
         .find_map(|(bundle_cid, members)| {
-            members
-                .contains(member_cid)
-                .then(|| bundle_cid.to_string())
+            members.contains(member_cid).then(|| bundle_cid.to_string())
         })
 }
 
@@ -328,11 +325,36 @@ fn guarded_term_to_atomic(guard: &Json) -> Option<Json> {
 /// in one contract (same receiver, same lifted term => genuinely identical
 /// obligation, same verdict), the first locus is returned; the lines are a
 /// cosmetic tie, not a soundness question.
-fn panic_line_for<'a>(arg_term: Option<&Json>, panic_loci: &'a [Json]) -> Option<&'a Json> {
+fn panic_locus_for<'a>(
+    callee: &str,
+    arg_term: Option<&Json>,
+    panic_loci: &'a [Json],
+) -> Option<&'a Json> {
     let arg = arg_term?;
-    panic_loci
-        .iter()
-        .find(|locus| locus.get("argTerm") == Some(arg))
+    panic_loci.iter().find(|locus| {
+        locus.get("argTerm") == Some(arg)
+            && locus.get("callee").and_then(|v| v.as_str()) == Some(callee)
+    })
+}
+
+fn callsite_scoped_bridge_for_locus<'a>(
+    pool: &'a MementoPool,
+    callsite_bundle_cid: Option<&str>,
+    callee: &str,
+    locus: &Json,
+) -> Option<&'a Json> {
+    let bundle = callsite_bundle_cid?;
+    let file = locus.get("file").and_then(|v| v.as_str())?;
+    let line = locus
+        .get("line")
+        .or_else(|| locus.get("start_line"))
+        .and_then(|v| v.as_u64())? as usize;
+    pool.bridges_by_callsite.get(&(
+        bundle.to_string(),
+        file.to_string(),
+        line,
+        callee.to_string(),
+    ))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -365,7 +387,28 @@ fn walk_term(
         .and_then(|v| v.as_str())
         .unwrap_or_default()
         .to_string();
-    if let Some(benv) = pool.bridges_by_symbol.get(&name) {
+    let arg_term = t
+        .get("args")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first().cloned());
+    let scoped_panic_locus = panic_locus_for(&name, arg_term.as_ref(), panic_loci);
+    // Panic-leaf method bridges are overloadable (`method:unwrap` can target
+    // Option or Result). If the kit supplied an occurrence locus, choose the
+    // exact `(bundle,file,line,callee)` bridge before considering the global
+    // per-symbol index. This is language-blind: the verifier interprets no
+    // callee names or predicates; it only preserves the kit's opaque callsite
+    // identity. If a panic locus has no scoped bridge, do not fall back to the
+    // symbol winner; the panicLoci fallback below will surface an undecidable
+    // NoBridgeTarget instead of silently checking the wrong overload.
+    let scoped_bridge = scoped_panic_locus.and_then(|locus| {
+        callsite_scoped_bridge_for_locus(pool, callsite_bundle_cid, &name, locus)
+    });
+    let bridge_env = if scoped_panic_locus.is_some() {
+        scoped_bridge
+    } else {
+        pool.bridges_by_symbol.get(&name)
+    };
+    if let Some(benv) = bridge_env {
         // Shape-agnostic: v1.2-layered bridges carry the fields on
         // `header`; v1.1-flat on `evidence.body`.
         let bbody = memento_body(benv)
@@ -392,14 +435,6 @@ fn walk_term(
             .and_then(|v| v.get("panicSite"))
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        // The bridged ctor's first argument is the obligation's receiver
-        // (e.g. `to_string(v)` in `to_string(v).unwrap()`); it is both the
-        // CallSite's `arg_term` AND the key that pairs a panic occurrence with
-        // its source locus in THIS contract.
-        let arg_term = t
-            .get("args")
-            .and_then(|v| v.as_array())
-            .and_then(|arr| arr.first().cloned());
         // PANIC-LOCUS PRESERVATION (#1745): a panic site reads its line/col/file
         // from the contract's own `panicLoci`, keyed by `arg_term` -- NOT from
         // the per-symbol bridge `callsite` (last-writer-wins, collapses two
@@ -409,7 +444,7 @@ fn walk_term(
         // bridged call keeps reading its line from the bridge as before (those
         // are 1:1 with their bridge and are not collapsed across occurrences).
         let occ_locus = if panic_site {
-            panic_line_for(arg_term.as_ref(), panic_loci)
+            scoped_panic_locus.or_else(|| panic_locus_for(&name, arg_term.as_ref(), panic_loci))
         } else {
             None
         };
@@ -486,7 +521,11 @@ fn walk_term(
                 .unwrap_or_default()
                 .to_string(),
             bridge_target_proof_cid,
-            bridge_self_bundle_cid: pool.bridge_self_bundle_by_symbol.get(&name).cloned(),
+            bridge_self_bundle_cid: if scoped_bridge.is_some() {
+                callsite_bundle_cid.map(str::to_string)
+            } else {
+                pool.bridge_self_bundle_by_symbol.get(&name).cloned()
+            },
             property_name: property_name.to_string(),
             property_cid: property_cid.to_string(),
             callsite_bundle_cid: callsite_bundle_cid.map(str::to_string),
@@ -710,6 +749,83 @@ mod guard_propagation_tests {
         pool
     }
 
+    fn bridge(target_cid: &str, file: Option<&str>, line: Option<usize>) -> Json {
+        let callsite = match (file, line) {
+            (Some(file), Some(line)) => json!({
+                "file": file,
+                "start_line": line,
+                "panicSite": true,
+            }),
+            _ => json!(null),
+        };
+        let mut header = json!({
+            "kind": "bridge",
+            "sourceSymbol": "panic_call",
+            "targetContractCid": target_cid,
+            "sourceLayer": "rust",
+            "targetLayer": "rust-tests",
+        });
+        if !callsite.is_null() {
+            header["callsite"] = callsite;
+        }
+        json!({
+            "envelope": true,
+            "header": header
+        })
+    }
+
+    fn pool_with_scoped_panic_bridge(body_term: Json) -> MementoPool {
+        let mut pool = MementoPool::default();
+        let bundle = "blake3-512:caller-bundle".to_string();
+        let caller = "blake3-512:caller".to_string();
+        pool.bridges_by_symbol.insert(
+            "panic_call".to_string(),
+            bridge(
+                "blake3-512:wrong-symbol-target",
+                Some("src/lib.rs"),
+                Some(99),
+            ),
+        );
+        pool.bridges_by_callsite.insert(
+            (
+                bundle.clone(),
+                "src/lib.rs".to_string(),
+                10,
+                "panic_call".to_string(),
+            ),
+            bridge(
+                "blake3-512:right-callsite-target",
+                Some("src/lib.rs"),
+                Some(10),
+            ),
+        );
+        pool.bundle_members
+            .entry(bundle)
+            .or_default()
+            .insert(caller.clone());
+        let contract = json!({
+            "envelope": true,
+            "header": {
+                "kind": "contract",
+                "contractName": "caller_self_post",
+                "panicLoci": [{
+                    "argTerm": recv(),
+                    "callee": "panic_call",
+                    "file": "src/lib.rs",
+                    "line": 10,
+                    "col": 4,
+                }],
+                "post": {
+                    "kind": "atomic",
+                    "name": "=",
+                    "args": [ { "kind": "var", "name": "result" }, body_term ],
+                }
+            }
+        });
+        pool.mementos.insert(caller, contract);
+        pool
+    }
+
     fn enumerated_call(sites: &[CallSite]) -> &CallSite {
         sites
             .iter()
@@ -798,5 +914,23 @@ mod guard_propagation_tests {
             enumerated_call(&sites).guard_facts.is_empty(),
             "a non-ctor guard must add no fact"
         );
+    }
+
+    #[test]
+    fn formula_walk_prefers_callsite_scoped_bridge_and_preserves_guard_fact() {
+        let body = cf_guarded(pred("pred_a"), panic_call());
+        let sites = run(&pool_with_scoped_panic_bridge(body));
+        let cs = enumerated_call(&sites);
+        assert_eq!(
+            cs.bridge_target_cid, "blake3-512:right-callsite-target",
+            "panic formula-walk must select the exact callsite bridge, not the global symbol winner"
+        );
+        assert_eq!(
+            cs.guard_facts,
+            vec![json!({ "kind": "atomic", "name": "pred_a", "args": [recv()] })],
+            "callsite-scoped bridge selection must not drop cf_guarded path facts"
+        );
+        assert_eq!(cs.file.as_deref(), Some("src/lib.rs"));
+        assert_eq!(cs.line, Some(10));
     }
 }

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -900,11 +900,17 @@ fn type_crate_for(
             .or_else(|| {
                 if !current_crate.is_empty() && local_type_names.contains(first) {
                     Some(current_crate.to_string())
+                } else if is_std_prelude_panic_type(first) {
+                    Some("std".to_string())
                 } else {
                     None
                 }
             })
     }
+}
+
+fn is_std_prelude_panic_type(name: &str) -> bool {
+    matches!(name, "Option" | "Result")
 }
 
 fn collect_local_type_names(file: &syn::File) -> BTreeSet<String> {
@@ -1015,7 +1021,8 @@ fn collect_enum_variant_type_map_in_items(
                         }
                         syn::Fields::Unit => VariantFieldTypes::Unit,
                     };
-                    out.variants.insert((enum_name.clone(), variant_name), fields);
+                    out.variants
+                        .insert((enum_name.clone(), variant_name), fields);
                 }
             }
             syn::Item::Mod(item_mod) => {
@@ -1043,7 +1050,12 @@ fn bind_pattern_type_id(
 ) {
     match pat {
         syn::Pat::Ident(ident) => {
-            bind_value_type(&ident.ident.to_string(), scrutinee_type.clone(), local_types, value_types);
+            bind_value_type(
+                &ident.ident.to_string(),
+                scrutinee_type.clone(),
+                local_types,
+                value_types,
+            );
         }
         syn::Pat::Reference(reference) => {
             bind_pattern_type_id(
@@ -1055,7 +1067,12 @@ fn bind_pattern_type_id(
             );
         }
         syn::Pat::Struct(pat_struct) => {
-            let Some(variant_name) = pat_struct.path.segments.last().map(|seg| seg.ident.to_string()) else {
+            let Some(variant_name) = pat_struct
+                .path
+                .segments
+                .last()
+                .map(|seg| seg.ident.to_string())
+            else {
                 return;
             };
             let enum_name = pat_struct
@@ -1066,9 +1083,8 @@ fn bind_pattern_type_id(
                 .nth(1)
                 .map(|seg| seg.ident.to_string())
                 .unwrap_or_else(|| scrutinee_type.head.clone());
-            let Some(VariantFieldTypes::Named(fields)) = enum_variant_types
-                .variants
-                .get(&(enum_name, variant_name))
+            let Some(VariantFieldTypes::Named(fields)) =
+                enum_variant_types.variants.get(&(enum_name, variant_name))
             else {
                 return;
             };
@@ -1077,11 +1093,22 @@ fn bind_pattern_type_id(
                 let Some(type_id) = fields.get(&field_name).cloned() else {
                     continue;
                 };
-                bind_pattern_type_id(&field.pat, &type_id, enum_variant_types, local_types, value_types);
+                bind_pattern_type_id(
+                    &field.pat,
+                    &type_id,
+                    enum_variant_types,
+                    local_types,
+                    value_types,
+                );
             }
         }
         syn::Pat::TupleStruct(tuple_struct) => {
-            let Some(variant_name) = tuple_struct.path.segments.last().map(|seg| seg.ident.to_string()) else {
+            let Some(variant_name) = tuple_struct
+                .path
+                .segments
+                .last()
+                .map(|seg| seg.ident.to_string())
+            else {
                 return;
             };
             let enum_name = tuple_struct
@@ -1092,19 +1119,30 @@ fn bind_pattern_type_id(
                 .nth(1)
                 .map(|seg| seg.ident.to_string())
                 .unwrap_or_else(|| scrutinee_type.head.clone());
-            let Some(VariantFieldTypes::Unnamed(fields)) = enum_variant_types
-                .variants
-                .get(&(enum_name, variant_name))
+            let Some(VariantFieldTypes::Unnamed(fields)) =
+                enum_variant_types.variants.get(&(enum_name, variant_name))
             else {
                 return;
             };
             for (subpat, type_id) in tuple_struct.elems.iter().zip(fields.iter()) {
-                bind_pattern_type_id(subpat, type_id, enum_variant_types, local_types, value_types);
+                bind_pattern_type_id(
+                    subpat,
+                    type_id,
+                    enum_variant_types,
+                    local_types,
+                    value_types,
+                );
             }
         }
         syn::Pat::Or(or_pat) => {
             for case in &or_pat.cases {
-                bind_pattern_type_id(case, scrutinee_type, enum_variant_types, local_types, value_types);
+                bind_pattern_type_id(
+                    case,
+                    scrutinee_type,
+                    enum_variant_types,
+                    local_types,
+                    value_types,
+                );
             }
         }
         _ => {}
@@ -1336,23 +1374,21 @@ fn collect_callsites_in_block(
                 // manifest is per-crate Rust-kit config; the CLI/verifier never
                 // read it. Concrete type identity must be available from a
                 // conservative source position, otherwise we refuse to guess.
-                let disambiguated_target = if needs_arg_type_resolution(
-                    callee_crate.as_deref(),
-                    &callee,
-                ) {
-                    node.args.first().and_then(|a| {
-                        let name = expr_bare_ident_name(a)?;
-                        let type_id = self.value_type(&name)?;
-                        disambiguated_serde_json_totality_target(
-                            &callee,
-                            type_id,
-                            self.infallible_serialize,
-                            self.current_crate,
-                        )
-                    })
-                } else {
-                    None
-                };
+                let disambiguated_target =
+                    if needs_arg_type_resolution(callee_crate.as_deref(), &callee) {
+                        node.args.first().and_then(|a| {
+                            let name = expr_bare_ident_name(a)?;
+                            let type_id = self.value_type(&name)?;
+                            disambiguated_serde_json_totality_target(
+                                &callee,
+                                type_id,
+                                self.infallible_serialize,
+                                self.current_crate,
+                            )
+                        })
+                    } else {
+                        None
+                    };
                 self.out.push(CallSite {
                     callee,
                     contract_callee,
@@ -1412,20 +1448,37 @@ fn collect_callsites_in_block(
             let callee = node.method.to_string();
             let contract_callee = callee_with_angle_args(&callee, node.turbofish.as_ref());
             let start = node.method.span().start();
+            let syntactic_panic_target = expr_bare_ident_name(&node.receiver)
+                .and_then(|name| self.value_type(&name).cloned())
+                .and_then(|type_id| {
+                    if type_id.krate != "std" {
+                        return None;
+                    }
+                    let stem = type_id.head.to_ascii_lowercase();
+                    disambiguated_partial_leaf(&stem, &callee).map(|leaf| ("std".to_string(), leaf))
+                });
+            let callee_crate = syntactic_panic_target
+                .as_ref()
+                .map(|(krate, _)| krate.clone())
+                .or_else(|| {
+                    receiver_crate_for_expr(
+                        &node.receiver,
+                        &self.local_types,
+                        self.use_map,
+                        self.fn_return_crates,
+                        self.local_type_names,
+                        self.current_crate,
+                    )
+                });
             self.out.push(CallSite {
                 callee,
                 contract_callee,
-                callee_crate: receiver_crate_for_expr(
-                    &node.receiver,
-                    &self.local_types,
-                    self.use_map,
-                    self.fn_return_crates,
-                    self.local_type_names,
-                    self.current_crate,
-                ),
+                callee_crate,
                 is_method: true,
-                disambiguated_callee: None,
-                disambiguated_crate: None,
+                disambiguated_callee: syntactic_panic_target
+                    .as_ref()
+                    .map(|(_, leaf)| leaf.clone()),
+                disambiguated_crate: syntactic_panic_target.map(|(krate, _)| krate),
                 unsupported_reason: None,
                 file: self.rel_path.to_string(),
                 line: start.line,
@@ -1435,8 +1488,8 @@ fn collect_callsites_in_block(
         }
         fn visit_expr_match(&mut self, node: &'ast syn::ExprMatch) {
             self.visit_expr(&node.expr);
-            let scrutinee_type = expr_bare_ident_name(&node.expr)
-                .and_then(|name| self.value_type(&name).cloned());
+            let scrutinee_type =
+                expr_bare_ident_name(&node.expr).and_then(|name| self.value_type(&name).cloned());
             for arm in &node.arms {
                 let saved_local_types = self.local_types.clone();
                 let saved_value_types = self.value_types.clone();
@@ -1546,7 +1599,7 @@ fn unsupported_macro_callsite(mac: &syn::Macro, rel_path: &str) -> CallSite {
             .last()
             .map(path_segment_contract_leaf)
             .map(|leaf| format!("{leaf}!"))
-        .unwrap_or_else(|| "<macro>!".to_string()),
+            .unwrap_or_else(|| "<macro>!".to_string()),
         callee_crate: None,
         is_method: false,
         disambiguated_callee: None,
@@ -1620,14 +1673,12 @@ fn pat_type_identity(
     current_crate: &str,
 ) -> Option<TypeIdentity> {
     match pat {
-        syn::Pat::Type(pat_type) => {
-            type_identity_for(
-                strip_reference_type(&pat_type.ty),
-                use_map,
-                local_type_names,
-                current_crate,
-            )
-        }
+        syn::Pat::Type(pat_type) => type_identity_for(
+            strip_reference_type(&pat_type.ty),
+            use_map,
+            local_type_names,
+            current_crate,
+        ),
         _ => None,
     }
 }
@@ -1876,10 +1927,10 @@ fn disambiguated_serde_json_totality_target(
                 Some((
                     "serde_json".to_string(),
                     match callee {
-                    "to_string" => "serde_json_to_string_value",
-                    "to_string_pretty" => "serde_json_to_string_pretty_value",
-                    _ => return None,
-                }
+                        "to_string" => "serde_json_to_string_value",
+                        "to_string_pretty" => "serde_json_to_string_pretty_value",
+                        _ => return None,
+                    }
                     .to_string(),
                 ))
             } else {
@@ -1931,8 +1982,7 @@ fn build_param_type_map(
         // Strip outer & / &mut
         let inner_ty = strip_reference_type(ty);
         // Extract the type's (crate, head)
-        if let Some(type_id) =
-            type_identity_for(inner_ty, use_map, local_type_names, current_crate)
+        if let Some(type_id) = type_identity_for(inner_ty, use_map, local_type_names, current_crate)
         {
             map.insert(name, type_id);
         }
@@ -2208,6 +2258,39 @@ fn resolve_method_calls_via_oracle(
     observation
 }
 
+fn binding_has_pre(binding: &Value) -> bool {
+    binding
+        .get("has_pre")
+        .or_else(|| binding.get("hasPre"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or_else(|| binding.get("pre").is_some_and(has_nontrivial_pre_json))
+}
+
+fn has_nontrivial_pre_json(pre: &Value) -> bool {
+    if pre.is_null() {
+        return false;
+    }
+    !(pre.get("kind").and_then(|v| v.as_str()) == Some("atomic")
+        && pre.get("name").and_then(|v| v.as_str()) == Some("true"))
+}
+
+fn binding_is_body_bearing(binding: &Value) -> bool {
+    binding
+        .get("body_bearing")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+fn binding_rank(binding: &Value) -> u8 {
+    if binding_has_pre(binding) {
+        2
+    } else if binding_is_body_bearing(binding) {
+        1
+    } else {
+        0
+    }
+}
+
 fn lift_implications(params: &Value) -> Result<Value, String> {
     use std::collections::HashMap;
 
@@ -2303,21 +2386,15 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
                 ineligible_by_key.insert(key, binding);
                 continue;
             }
-            let is_body_bearing = binding
-                .get("body_bearing")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false);
             match contracts_by_key.get(&key) {
                 None => {
                     contracts_by_key.insert(key, binding);
                 }
                 Some(existing) => {
-                    let existing_body_bearing = existing
-                        .get("body_bearing")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false);
-                    // Upgrade to the body-bearing binding; never downgrade.
-                    if is_body_bearing && !existing_body_bearing {
+                    // Upgrade to the most dischargeable binding; never
+                    // downgrade. For panic partials, a pre-bearing contract is
+                    // the only shape that can prove the site cannot panic.
+                    if binding_rank(binding) > binding_rank(existing) {
                         contracts_by_key.insert(key, binding);
                     }
                 }
@@ -2447,23 +2524,31 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
                 );
                 dkey
             });
-            let disambig_binding = disambig_key
+            let is_panic = is_panic_leaf(&cs.callee);
+            let raw_disambig_binding = disambig_key
                 .as_ref()
                 .and_then(|dkey| contracts_by_key.get(dkey).copied());
+            let raw_disambig_binding_has_pre =
+                raw_disambig_binding.map(binding_has_pre).unwrap_or(false);
+            let disambig_binding = match (is_panic, raw_disambig_binding) {
+                (true, Some(binding)) if binding_has_pre(binding) => Some(binding),
+                (true, _) => None,
+                (false, binding) => binding,
+            };
             let disambig_ineligible = disambig_key
                 .as_ref()
                 .and_then(|dkey| ineligible_by_key.get(dkey).copied());
-            let is_panic = is_panic_leaf(&cs.callee);
             if is_panic {
                 info!(
                     callee = %cs.callee,
                     resolved_crate = %resolved_crate,
                     disambiguated_callee = ?cs.disambiguated_callee,
-                    disambig_binding_found = disambig_binding.is_some(),
+                    disambig_binding_found = raw_disambig_binding.is_some(),
+                    disambig_binding_has_pre = raw_disambig_binding_has_pre,
                     lookup_key = ?disambig_key,
                     file = %cs.file,
                     line = cs.line,
-                    "PANIC-EMIT: panic-leaf site decision -- bridges to disambiguated partial iff disambig_binding_found, else REFUSES (panic-site-unproven)"
+                    "PANIC-EMIT: panic-leaf site decision -- bridges to disambiguated pre-bearing partial iff found, else REFUSES (panic-site-unproven)"
                 );
             }
             // A value-producing select (NOT a let-else): the total-leaf branch must
@@ -4031,9 +4116,8 @@ fn collect_sugar_targets_in_items(items: &[syn::Item], targets: &mut Vec<SugarTa
         match item {
             syn::Item::Fn(item_fn) => {
                 if let Some(parsed) = extract_sugar_attr(item_fn) {
-                    let totality_result_ok =
-                        parsed.totality.as_deref() == Some("result_ok")
-                            && is_result_type_fn(item_fn);
+                    let totality_result_ok = parsed.totality.as_deref() == Some("result_ok")
+                        && is_result_type_fn(item_fn);
                     targets.push(SugarTarget {
                         concept: parsed.concept,
                         library: parsed.library,
@@ -10927,6 +11011,432 @@ edition = "2021"
             .filter_map(|entry| entry["targetContractCid"].as_str())
             .collect();
         assert_eq!(run_targets, vec![dep_run, dep_run]);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_disambiguates_prelude_option_result_panic_partials() {
+        let src = r##"
+pub fn option_case<T>(opt: Option<T>) -> T {
+    opt.unwrap()
+}
+
+pub fn result_case<T, E: std::fmt::Debug>(result: Result<T, E>, msg: &str) -> T {
+    if result.is_ok() {
+        result.expect(msg)
+    } else {
+        result.unwrap()
+    }
+}
+
+pub fn option_expect_case<T>(opt: Option<T>, msg: &str) -> T {
+    opt.expect(msg)
+}
+"##;
+        let root = temp_workspace("lift_implications_prelude_panic_partials");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "consumer-crate"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .expect("write Cargo.toml");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), src).expect("write source");
+
+        let option_unwrap_no_pre =
+            "blake3-512:111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
+        let result_unwrap_no_pre =
+            "blake3-512:222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222";
+        let result_expect_no_pre =
+            "blake3-512:333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333";
+        let option_expect_no_pre =
+            "blake3-512:444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444";
+        let option_unwrap =
+            "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let result_unwrap =
+            "blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let result_expect =
+            "blake3-512:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+        let option_expect =
+            "blake3-512:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+        let contract_bindings = json!([
+            { "name": "option_unwrap@std/src/option.rs:1:1",
+              "library": "std",
+              "contract_cid": option_unwrap_no_pre,
+              "body_bearing": true,
+              "has_pre": false },
+            { "name": "option_unwrap@std/src/option.rs:2:1",
+              "library": "std",
+              "contract_cid": option_unwrap,
+              "body_bearing": true,
+              "has_pre": true },
+            { "name": "result_unwrap@std/src/result.rs:1:1",
+              "library": "std",
+              "contract_cid": result_unwrap_no_pre,
+              "body_bearing": true,
+              "has_pre": false },
+            { "name": "result_unwrap@std/src/result.rs:2:1",
+              "library": "std",
+              "contract_cid": result_unwrap,
+              "body_bearing": true,
+              "has_pre": true },
+            { "name": "result_expect@std/src/result.rs:1:1",
+              "library": "std",
+              "contract_cid": result_expect_no_pre,
+              "body_bearing": true,
+              "has_pre": false },
+            { "name": "result_expect@std/src/result.rs:2:1",
+              "library": "std",
+              "contract_cid": result_expect,
+              "body_bearing": true,
+              "has_pre": true },
+            { "name": "option_expect@std/src/option.rs:1:1",
+              "library": "std",
+              "contract_cid": option_expect_no_pre,
+              "body_bearing": true,
+              "has_pre": false },
+            { "name": "option_expect@std/src/option.rs:2:1",
+              "library": "std",
+              "contract_cid": option_expect,
+              "body_bearing": true,
+              "has_pre": true },
+        ]);
+
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": contract_bindings,
+        }))
+        .expect("lift_implications");
+
+        let ir = resp["ir"].as_array().expect("ir array");
+        let panic_targets: Vec<&str> = ir
+            .iter()
+            .filter(|entry| {
+                entry["sourceSymbol"] == "method:unwrap" || entry["sourceSymbol"] == "method:expect"
+            })
+            .filter_map(|entry| entry["targetContractCid"].as_str())
+            .collect();
+        assert_eq!(
+            panic_targets,
+            vec![option_unwrap, result_expect, result_unwrap, option_expect],
+            "prelude Option/Result panic leaves must bridge to the std partials, not refuse or pick the current crate: {ir:?}"
+        );
+        assert!(
+            resp["diagnostics"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|diagnostic| diagnostic["reason"] != "panic-site-unproven"),
+            "prelude Option/Result panic leaves should not emit panic-site-unproven: {:#?}",
+            resp["diagnostics"]
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_refuses_prelude_panic_partial_without_pre_bearing_contract() {
+        let src = r##"
+pub fn option_case<T>(opt: Option<T>) -> T {
+    opt.unwrap()
+}
+"##;
+        let root = temp_workspace("lift_implications_panic_partial_requires_pre");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "consumer-crate"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .expect("write Cargo.toml");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), src).expect("write source");
+
+        let no_pre =
+            "blake3-512:111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
+        let contract_bindings = json!([
+            { "name": "option_unwrap@std/src/option.rs:1:1",
+              "library": "std",
+              "contract_cid": no_pre,
+              "body_bearing": true,
+              "pre": { "kind": "atomic", "name": "true", "args": [] } },
+        ]);
+
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": contract_bindings,
+        }))
+        .expect("lift_implications");
+
+        let ir = resp["ir"].as_array().expect("ir array");
+        assert!(
+            !ir.iter()
+                .any(|entry| entry["sourceSymbol"] == "method:unwrap"),
+            "panic partials must refuse rather than bridge to a no-pre duplicate: {ir:?}"
+        );
+        assert!(
+            resp["diagnostics"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|diagnostic| diagnostic["reason"] == "panic-site-unproven"),
+            "no-pre panic partial should stay as an honest panic-site-unproven gap: {:#?}",
+            resp["diagnostics"]
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_refuses_prelude_panic_partial_with_only_ineligible_totality() {
+        let src = r##"
+pub fn option_case<T>(opt: Option<T>) -> T {
+    opt.unwrap()
+}
+"##;
+        let root = temp_workspace("lift_implications_panic_partial_refuses_ineligible_totality");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "consumer-crate"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .expect("write Cargo.toml");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), src).expect("write source");
+
+        let ineligible =
+            "blake3-512:222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222";
+        let contract_bindings = json!([
+            { "name": "option_unwrap@std/src/option.rs:1:1",
+              "library": "std",
+              "contract_cid": ineligible,
+              "bodyDischargeEligible": false,
+              "bodyDischargeRefusalReason": "totality-axiom" },
+        ]);
+
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": contract_bindings,
+        }))
+        .expect("lift_implications");
+
+        let ir = resp["ir"].as_array().expect("ir array");
+        assert!(
+            !ir.iter()
+                .any(|entry| entry["sourceSymbol"] == "method:unwrap"),
+            "panic partials must not fall through to ineligible totality bindings: {ir:?}"
+        );
+        assert!(
+            resp["diagnostics"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|diagnostic| diagnostic["reason"] == "panic-site-unproven"),
+            "ineligible totality-only panic partial should stay as an honest panic-site-unproven gap: {:#?}",
+            resp["diagnostics"]
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_refuses_local_option_shadow_as_std_panic_partial() {
+        let src = r##"
+mod local {
+    pub struct Option<T>(pub T);
+
+    impl<T> Option<T> {
+        pub fn unwrap(self) -> T {
+            self.0
+        }
+    }
+}
+
+pub fn local_case<T>(opt: local::Option<T>) -> T {
+    opt.unwrap()
+}
+"##;
+        let root = temp_workspace("lift_implications_local_option_shadow");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "consumer-crate"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .expect("write Cargo.toml");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), src).expect("write source");
+
+        let contract_bindings = json!([
+            { "name": "option_unwrap@std/src/option.rs:1:1",
+              "library": "std",
+              "contract_cid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+        ]);
+
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": contract_bindings,
+        }))
+        .expect("lift_implications");
+
+        let ir = resp["ir"].as_array().expect("ir array");
+        assert!(
+            !ir.iter()
+                .any(|entry| entry["sourceSymbol"] == "method:unwrap"),
+            "local Option shadow must not bridge to std option_unwrap: {ir:?}"
+        );
+        assert!(
+            resp["diagnostics"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|diagnostic| diagnostic["reason"] == "panic-site-unproven"),
+            "local Option shadow should refuse as an unresolved panic site: {:#?}",
+            resp["diagnostics"]
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_refuses_generic_trait_receiver_as_std_panic_partial() {
+        let src = r##"
+pub trait MaybeUnwrap {
+    type Output;
+    fn unwrap(self) -> Self::Output;
+}
+
+pub fn generic_case<T: MaybeUnwrap>(value: T) -> T::Output {
+    value.unwrap()
+}
+"##;
+        let root = temp_workspace("lift_implications_generic_trait_unwrap");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "consumer-crate"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .expect("write Cargo.toml");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), src).expect("write source");
+
+        let contract_bindings = json!([
+            { "name": "option_unwrap@std/src/option.rs:1:1",
+              "library": "std",
+              "contract_cid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+        ]);
+
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": contract_bindings,
+        }))
+        .expect("lift_implications");
+
+        let ir = resp["ir"].as_array().expect("ir array");
+        assert!(
+            !ir.iter()
+                .any(|entry| entry["sourceSymbol"] == "method:unwrap"),
+            "generic trait unwrap must not bridge to std option_unwrap: {ir:?}"
+        );
+        assert!(
+            resp["diagnostics"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|diagnostic| diagnostic["reason"] == "panic-site-unproven"),
+            "generic trait unwrap should refuse as unresolved: {:#?}",
+            resp["diagnostics"]
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_refuses_option_type_alias_without_canonical_type_resolution() {
+        let src = r##"
+type MyOption<T> = std::option::Option<T>;
+
+pub fn alias_case<T>(opt: MyOption<T>) -> T {
+    opt.unwrap()
+}
+"##;
+        let root = temp_workspace("lift_implications_option_alias_refuse");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "consumer-crate"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .expect("write Cargo.toml");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), src).expect("write source");
+
+        let contract_bindings = json!([
+            { "name": "option_unwrap@std/src/option.rs:1:1",
+              "library": "std",
+              "contract_cid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+        ]);
+
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": contract_bindings,
+        }))
+        .expect("lift_implications");
+
+        let ir = resp["ir"].as_array().expect("ir array");
+        assert!(
+            !ir.iter().any(|entry| entry["sourceSymbol"] == "method:unwrap"),
+            "type aliases are refused in this syntactic prelude slice until canonical type resolution is available: {ir:?}"
+        );
+        assert!(
+            resp["diagnostics"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|diagnostic| diagnostic["reason"] == "panic-site-unproven"),
+            "type alias should refuse rather than guessing std Option: {:#?}",
+            resp["diagnostics"]
+        );
 
         let _ = fs::remove_dir_all(root);
     }

--- a/implementations/rust/provekit-walk/src/lift.rs
+++ b/implementations/rust/provekit-walk/src/lift.rs
@@ -59,6 +59,9 @@ struct LiftCtx {
     scope: Vec<Vec<(String, String)>>,
     local_value_kinds: BTreeMap<String, ValueKind>,
     return_facts: FunctionReturnFacts,
+    assertion_guard_facts: Vec<TrackedGuardFact>,
+    len_eq_one_facts: Vec<LenEqOneFact>,
+    mutable_roots: HashSet<String>,
 }
 
 impl LiftCtx {
@@ -72,6 +75,9 @@ impl LiftCtx {
             scope: Vec::new(),
             local_value_kinds: BTreeMap::new(),
             return_facts,
+            assertion_guard_facts: Vec::new(),
+            len_eq_one_facts: Vec::new(),
+            mutable_roots: HashSet::new(),
         }
     }
 
@@ -108,6 +114,12 @@ impl LiftCtx {
         }
         base.to_string()
     }
+
+    fn invalidate_root(&mut self, root: &str) {
+        self.local_value_kinds.remove(root);
+        self.assertion_guard_facts.retain(|fact| fact.root != root);
+        self.len_eq_one_facts.retain(|fact| fact.root != root);
+    }
 }
 
 #[derive(Clone, Debug, Default)]
@@ -123,6 +135,20 @@ enum ValueKind {
     Bool,
     JsonObject(BTreeMap<String, ValueKind>),
     Unknown,
+}
+
+#[derive(Clone, Debug)]
+struct TrackedGuardFact {
+    root: String,
+    receiver_key: String,
+    guard_head: String,
+    guard: IrTerm,
+}
+
+#[derive(Clone, Debug)]
+struct LenEqOneFact {
+    root: String,
+    receiver_key: String,
 }
 
 /// Collect only EXPLICIT signature facts from a Rust file. This is a
@@ -277,6 +303,8 @@ pub fn lift_function_postcondition_with_return_facts(
         .collect();
 
     seed_param_value_kinds(item_fn, &mut ctx);
+    seed_mutable_param_roots(item_fn, &mut ctx);
+    collect_assertion_guard_facts(stmts, &mut ctx);
     collect_local_value_facts(stmts, &mut ctx);
 
     // 2. Trailing-expression derivation: if the function body ends with
@@ -423,6 +451,11 @@ fn branch_guard_head(cond_head: &str, else_branch: bool) -> Option<&'static str>
 /// `cf_ite` byte-identical to before this change (CID stability / reflexive
 /// discharge unperturbed).
 fn wrap_branch_guard(cond_term: &IrTerm, else_branch: bool, value: IrTerm) -> IrTerm {
+    if !else_branch {
+        if let Some(guard) = len_eq_one_branch_guard(cond_term, &value) {
+            return wrap_cf_guarded(guard, value);
+        }
+    }
     let (head, args) = match &cond_term {
         IrTerm::Ctor { name, args } => (name.as_str(), args),
         _ => return value,
@@ -437,6 +470,49 @@ fn wrap_branch_guard(cond_term: &IrTerm, else_branch: bool, value: IrTerm) -> Ir
     IrTerm::Ctor {
         name: "cf_guarded".to_string(),
         args: vec![guard, value],
+    }
+}
+
+fn len_eq_one_branch_guard(cond_term: &IrTerm, value: &IrTerm) -> Option<IrTerm> {
+    let receiver_key = len_eq_one_receiver_key(cond_term)?;
+    let next_receiver = find_next_partial_receiver(value, &receiver_key)?;
+    Some(IrTerm::Ctor {
+        name: "is_some".to_string(),
+        args: vec![next_receiver],
+    })
+}
+
+fn len_eq_one_receiver_key(cond_term: &IrTerm) -> Option<String> {
+    let IrTerm::Ctor { name, args } = cond_term else {
+        return None;
+    };
+    if name != "cf_eq" || args.len() != 2 {
+        return None;
+    }
+    let receiver = if is_const_one(&args[1]) {
+        len_receiver_term(&args[0])?
+    } else if is_const_one(&args[0]) {
+        len_receiver_term(&args[1])?
+    } else {
+        return None;
+    };
+    term_key(&receiver)
+}
+
+fn find_next_partial_receiver(term: &IrTerm, collection_receiver_key: &str) -> Option<IrTerm> {
+    match term {
+        IrTerm::Ctor { name, args }
+            if matches!(name.as_str(), "method:unwrap" | "method:expect")
+                && !args.is_empty()
+                && next_into_iter_receiver_key(&args[0]).as_deref()
+                    == Some(collection_receiver_key) =>
+        {
+            Some(args[0].clone())
+        }
+        IrTerm::Ctor { args, .. } => args
+            .iter()
+            .find_map(|arg| find_next_partial_receiver(arg, collection_receiver_key)),
+        _ => None,
     }
 }
 
@@ -632,6 +708,20 @@ fn collect_pat_names(pat: &Pat, out: &mut HashSet<String>) {
     }
 }
 
+fn seed_mutable_param_roots(item_fn: &ItemFn, ctx: &mut LiftCtx) {
+    for input in &item_fn.sig.inputs {
+        let FnArg::Typed(arg) = input else {
+            continue;
+        };
+        let Pat::Ident(ident) = &*arg.pat else {
+            continue;
+        };
+        if ident.mutability.is_some() {
+            ctx.mutable_roots.insert(ident.ident.to_string());
+        }
+    }
+}
+
 fn seed_param_value_kinds(item_fn: &ItemFn, ctx: &mut LiftCtx) {
     for input in &item_fn.sig.inputs {
         let FnArg::Typed(arg) = input else {
@@ -648,6 +738,164 @@ fn seed_param_value_kinds(item_fn: &ItemFn, ctx: &mut LiftCtx) {
                 .insert(ident.ident.to_string(), ValueKind::String);
         }
     }
+}
+
+/// Track top-level facts established by `assert!` for later panic partials.
+///
+/// SOUNDNESS / refuse-floor: the propagation is same-function, top-level, and
+/// same-receiver only. Branch-local asserts are not scanned; mutations or
+/// shadowing invalidate a fact immediately. Mutable roots are refused because
+/// this slice does not model aliasing or mutation.
+fn collect_assertion_guard_facts(stmts: &[Stmt], ctx: &mut LiftCtx) {
+    for stmt in stmts {
+        match stmt {
+            Stmt::Local(local) => {
+                let mut names = HashSet::new();
+                collect_pat_names(&local.pat, &mut names);
+                let local_mutable = local_binding_ident(local)
+                    .map(|(_, mutable)| mutable)
+                    .unwrap_or(false);
+                for name in names {
+                    ctx.invalidate_root(&name);
+                    if local_mutable {
+                        ctx.mutable_roots.insert(name);
+                    }
+                }
+            }
+            Stmt::Macro(StmtMacro { mac, .. }) => {
+                collect_assert_macro_guard_fact(mac, ctx);
+            }
+            Stmt::Expr(Expr::Macro(ExprMacro { mac, .. }), _) => {
+                collect_assert_macro_guard_fact(mac, ctx);
+            }
+            Stmt::Expr(expr, _) => invalidate_assignment_targets(expr, ctx),
+            Stmt::Item(_) => {}
+        }
+    }
+}
+
+fn collect_assert_macro_guard_fact(mac: &Macro, ctx: &mut LiftCtx) {
+    let Some(first) = assert_macro_condition(mac) else {
+        return;
+    };
+    if let Some(fact) = tracked_direct_guard_fact(&first, ctx) {
+        ctx.assertion_guard_facts.push(fact);
+        return;
+    }
+    if let Some(fact) = tracked_len_eq_one_fact(&first, ctx) {
+        ctx.len_eq_one_facts.push(fact);
+    }
+}
+
+fn assert_macro_condition(mac: &Macro) -> Option<Expr> {
+    let seg = mac.path.segments.last()?;
+    if seg.ident != "assert" {
+        return None;
+    }
+    let parsed_cond = syn::parse2::<Expr>(mac.tokens.clone()).ok()?;
+    // assert!(c) parses to just c. assert!(c, "msg") parses as a tuple-expr;
+    // take the first elem.
+    match parsed_cond {
+        Expr::Tuple(t) => t.elems.first().cloned(),
+        other => Some(other),
+    }
+}
+
+fn tracked_direct_guard_fact(expr: &Expr, ctx: &mut LiftCtx) -> Option<TrackedGuardFact> {
+    let Expr::MethodCall(method_call) = expr else {
+        return None;
+    };
+    if !method_call.args.is_empty() {
+        return None;
+    }
+    let guard_head = method_call.method.to_string();
+    if !matches!(guard_head.as_str(), "is_some" | "is_ok" | "is_err") {
+        return None;
+    }
+    let root = expr_root_ident(&method_call.receiver)?;
+    if ctx.mutable_roots.contains(&root) {
+        return None;
+    }
+    let receiver = lift_expr_to_term_inner(&method_call.receiver, ctx)?;
+    let receiver_key = term_key(&receiver)?;
+    let guard = IrTerm::Ctor {
+        name: guard_head.clone(),
+        args: vec![receiver],
+    };
+    Some(TrackedGuardFact {
+        root,
+        receiver_key,
+        guard_head,
+        guard,
+    })
+}
+
+fn tracked_len_eq_one_fact(expr: &Expr, ctx: &mut LiftCtx) -> Option<LenEqOneFact> {
+    let Expr::Binary(binary) = expr else {
+        return None;
+    };
+    if !matches!(binary.op, BinOp::Eq(_)) {
+        return None;
+    }
+    let left = lift_expr_to_term_inner(&binary.left, ctx)?;
+    let right = lift_expr_to_term_inner(&binary.right, ctx)?;
+    let receiver = if is_const_one(&right) {
+        len_receiver_term(&left)?
+    } else if is_const_one(&left) {
+        len_receiver_term(&right)?
+    } else {
+        return None;
+    };
+    let root =
+        len_receiver_root_expr(&binary.left).or_else(|| len_receiver_root_expr(&binary.right))?;
+    if ctx.mutable_roots.contains(&root) {
+        return None;
+    }
+    Some(LenEqOneFact {
+        root,
+        receiver_key: term_key(&receiver)?,
+    })
+}
+
+fn len_receiver_term(term: &IrTerm) -> Option<IrTerm> {
+    match term {
+        IrTerm::Ctor { name, args } if name == "method:len" && args.len() == 1 => {
+            Some(args[0].clone())
+        }
+        _ => None,
+    }
+}
+
+fn len_receiver_root_expr(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::MethodCall(method_call)
+            if method_call.method == "len" && method_call.args.is_empty() =>
+        {
+            expr_root_ident(&method_call.receiver)
+        }
+        Expr::Paren(paren) => len_receiver_root_expr(&paren.expr),
+        _ => None,
+    }
+}
+
+fn is_const_one(term: &IrTerm) -> bool {
+    matches!(term, IrTerm::Const { value, .. } if value.as_i64() == Some(1))
+}
+
+fn expr_root_ident(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Path(path) => path.path.segments.last().map(|seg| seg.ident.to_string()),
+        Expr::Reference(reference) => expr_root_ident(&reference.expr),
+        Expr::Paren(paren) => expr_root_ident(&paren.expr),
+        Expr::Cast(cast) => expr_root_ident(&cast.expr),
+        Expr::Field(field) => expr_root_ident(&field.base),
+        Expr::Index(index) => expr_root_ident(&index.expr),
+        _ => None,
+    }
+}
+
+fn term_key(term: &IrTerm) -> Option<String> {
+    serde_json::to_string(term).ok()
 }
 
 /// Track local json! construction facts for this function body.
@@ -705,7 +953,7 @@ fn invalidate_assignment_targets(expr: &Expr, ctx: &mut LiftCtx) {
     match expr {
         Expr::Assign(assign) => {
             if let Some(root) = assignment_root_ident(&assign.left) {
-                ctx.local_value_kinds.remove(&root);
+                ctx.invalidate_root(&root);
             }
             invalidate_assignment_targets(&assign.right, ctx);
         }
@@ -927,15 +1175,61 @@ fn receiver_as_str_is_known_json_string(receiver: &Expr, ctx: &LiftCtx) -> bool 
 }
 
 fn wrap_known_option_unwrap_guard(receiver: IrTerm, value: IrTerm) -> IrTerm {
+    wrap_cf_guarded(
+        IrTerm::Ctor {
+            name: "is_some".to_string(),
+            args: vec![receiver],
+        },
+        value,
+    )
+}
+
+fn wrap_cf_guarded(guard: IrTerm, value: IrTerm) -> IrTerm {
     IrTerm::Ctor {
         name: "cf_guarded".to_string(),
-        args: vec![
-            IrTerm::Ctor {
-                name: "is_some".to_string(),
-                args: vec![receiver],
-            },
-            value,
-        ],
+        args: vec![guard, value],
+    }
+}
+
+fn assertion_guard_for_partial(
+    method: &syn::Ident,
+    receiver_term: &IrTerm,
+    ctx: &LiftCtx,
+) -> Option<IrTerm> {
+    let method = method.to_string();
+    let receiver_key = term_key(receiver_term)?;
+    for fact in &ctx.assertion_guard_facts {
+        if fact.receiver_key != receiver_key {
+            continue;
+        }
+        match (method.as_str(), fact.guard_head.as_str()) {
+            ("unwrap" | "expect", "is_some" | "is_ok") => return Some(fact.guard.clone()),
+            ("unwrap_err", "is_err") => return Some(fact.guard.clone()),
+            _ => {}
+        }
+    }
+    if matches!(method.as_str(), "unwrap" | "expect")
+        && ctx.len_eq_one_facts.iter().any(|fact| {
+            next_into_iter_receiver_key(receiver_term).as_ref() == Some(&fact.receiver_key)
+        })
+    {
+        return Some(IrTerm::Ctor {
+            name: "is_some".to_string(),
+            args: vec![receiver_term.clone()],
+        });
+    }
+    None
+}
+
+fn next_into_iter_receiver_key(term: &IrTerm) -> Option<String> {
+    match term {
+        IrTerm::Ctor { name, args } if name == "method:next" && args.len() == 1 => match &args[0] {
+            IrTerm::Ctor { name, args } if name == "method:into_iter" && args.len() == 1 => {
+                term_key(&args[0])
+            }
+            _ => None,
+        },
+        _ => None,
     }
 }
 
@@ -982,14 +1276,8 @@ fn lift_macro_contribution(mac: &Macro, ctx: &mut LiftCtx) -> Option<IrFormula> 
     let name = seg.ident.to_string();
     match name.as_str() {
         "assert" => {
-            let parsed_cond = syn::parse2::<Expr>(mac.tokens.clone()).ok()?;
-            // assert!(c) parses to just c. assert!(c, "msg") parses
-            // as a tuple-expr; take the first elem.
-            let first = match &parsed_cond {
-                Expr::Tuple(t) => t.elems.first()?,
-                other => other,
-            };
-            lift_predicate_inner(first, ctx)
+            let first = assert_macro_condition(mac)?;
+            lift_predicate_inner(&first, ctx)
         }
         // debug_assert! is compiled out in release builds. Lifting its
         // predicate as a real contract would misrepresent what holds in
@@ -1190,7 +1478,7 @@ fn lift_expr_to_term_inner(expr: &Expr, ctx: &mut LiftCtx) -> Option<IrTerm> {
         }
         Expr::MethodCall(m) => {
             let receiver = lift_expr_to_term_inner(&m.receiver, ctx)?;
-            let mut args = vec![receiver];
+            let mut args = vec![receiver.clone()];
             for a in &m.args {
                 let lifted = lift_expr_to_term_inner(a, ctx)?;
                 args.push(lifted);
@@ -1199,6 +1487,9 @@ fn lift_expr_to_term_inner(expr: &Expr, ctx: &mut LiftCtx) -> Option<IrTerm> {
                 name: format!("method:{}", m.method),
                 args,
             };
+            if let Some(guard) = assertion_guard_for_partial(&m.method, &receiver, ctx) {
+                return Some(wrap_cf_guarded(guard, value));
+            }
             if m.method == "unwrap"
                 && m.args.is_empty()
                 && receiver_as_str_is_known_json_string(&m.receiver, ctx)
@@ -2423,6 +2714,283 @@ mod tests {
         assert!(
             json.contains("is_none"),
             "else-branch guard is the complement is_none: {json}"
+        );
+    }
+
+    #[test]
+    fn assert_is_some_guards_later_option_unwrap() {
+        let item_fn = parse_fn(
+            r#"
+            fn f(x: Option<i64>) -> i64 {
+                assert!(x.is_some());
+                x.unwrap()
+            }
+        "#,
+        );
+        let eq = result_equation_of(&item_fn).expect("unwrap must remain in result term");
+        let json = serde_json::to_string(&eq).unwrap();
+        assert!(
+            json.contains("cf_guarded"),
+            "assert!(x.is_some()) must guard the later unwrap: {json}"
+        );
+        assert!(
+            json.contains("is_some"),
+            "guard must carry the option precondition: {json}"
+        );
+    }
+
+    #[test]
+    fn assert_is_ok_guards_later_result_unwrap() {
+        let item_fn = parse_fn(
+            r#"
+            fn f(r: Result<i64, String>) -> i64 {
+                assert!(r.is_ok());
+                r.unwrap()
+            }
+        "#,
+        );
+        let eq = result_equation_of(&item_fn).expect("unwrap must remain in result term");
+        let json = serde_json::to_string(&eq).unwrap();
+        assert!(
+            json.contains("cf_guarded"),
+            "assert!(r.is_ok()) must guard the later unwrap: {json}"
+        );
+        assert!(
+            json.contains("is_ok"),
+            "guard must carry the result precondition: {json}"
+        );
+    }
+
+    #[test]
+    fn assert_is_ok_guards_later_result_expect() {
+        let item_fn = parse_fn(
+            r#"
+            fn f(r: Result<i64, String>) -> i64 {
+                assert!(r.is_ok());
+                r.expect("present")
+            }
+        "#,
+        );
+        let eq = result_equation_of(&item_fn).expect("expect must remain in result term");
+        let json = serde_json::to_string(&eq).unwrap();
+        assert!(
+            json.contains("cf_guarded"),
+            "assert!(r.is_ok()) must guard the later expect: {json}"
+        );
+        assert!(
+            json.contains("is_ok"),
+            "guard must carry the result precondition: {json}"
+        );
+    }
+
+    #[test]
+    fn len_eq_one_guards_into_iter_next_unwrap() {
+        let item_fn = parse_fn(
+            r#"
+            fn f(values: Vec<i64>) -> i64 {
+                assert!(values.len() == 1);
+                values.into_iter().next().unwrap()
+            }
+        "#,
+        );
+        let eq = result_equation_of(&item_fn).expect("unwrap must remain in result term");
+        let json = serde_json::to_string(&eq).unwrap();
+        assert!(
+            json.contains("cf_guarded"),
+            "len == 1 must guard into_iter().next().unwrap(): {json}"
+        );
+        assert!(
+            json.contains("is_some"),
+            "guard must prove next() returns Some: {json}"
+        );
+        assert!(
+            json.contains("method:next"),
+            "guard must name the same next() receiver term: {json}"
+        );
+    }
+
+    #[test]
+    fn if_len_eq_one_guards_then_branch_into_iter_next_unwrap() {
+        let item_fn = parse_fn(
+            r#"
+            fn f(values: Vec<i64>) -> Option<i64> {
+                if values.len() == 1 {
+                    Some(values.into_iter().next().unwrap())
+                } else {
+                    None
+                }
+            }
+        "#,
+        );
+        let eq = result_equation_of(&item_fn).expect("if-tail must synthesize a result equation");
+        let json = serde_json::to_string(&eq).unwrap();
+        assert!(json.contains("cf_ite"), "must lift to a cf_ite: {json}");
+        assert!(
+            json.contains("cf_guarded"),
+            "positive len == 1 branch must guard next().unwrap(): {json}"
+        );
+        assert!(
+            json.contains("is_some"),
+            "guard must prove next() returns Some: {json}"
+        );
+        assert!(
+            json.contains("method:next"),
+            "guard must name the next() receiver term: {json}"
+        );
+    }
+
+    #[test]
+    fn if_len_eq_one_wrong_collection_does_not_guard_next_unwrap() {
+        let item_fn = parse_fn(
+            r#"
+            fn f(a: Vec<i64>, b: Vec<i64>) -> Option<i64> {
+                if a.len() == 1 {
+                    Some(b.into_iter().next().unwrap())
+                } else {
+                    None
+                }
+            }
+        "#,
+        );
+        let eq = result_equation_of(&item_fn).expect("if-tail must synthesize a result equation");
+        let json = serde_json::to_string(&eq).unwrap();
+        assert!(
+            !json.contains("cf_guarded"),
+            "len fact for a must not guard b.into_iter().next().unwrap(): {json}"
+        );
+    }
+
+    #[test]
+    fn if_compound_len_eq_one_condition_does_not_guard_next_unwrap() {
+        let item_fn = parse_fn(
+            r#"
+            fn f(values: Vec<i64>, ready: bool) -> Option<i64> {
+                if values.len() == 1 && ready {
+                    Some(values.into_iter().next().unwrap())
+                } else {
+                    None
+                }
+            }
+        "#,
+        );
+        let eq = result_equation_of(&item_fn).expect("if-tail must synthesize a result equation");
+        let json = serde_json::to_string(&eq).unwrap();
+        assert!(
+            !json.contains("cf_guarded"),
+            "compound conditions are outside the audited len==1 shape: {json}"
+        );
+    }
+
+    #[test]
+    fn if_len_not_one_does_not_guard_next_unwrap() {
+        let item_fn = parse_fn(
+            r#"
+            fn f(values: Vec<i64>) -> Option<i64> {
+                if values.len() != 0 {
+                    Some(values.into_iter().next().unwrap())
+                } else {
+                    None
+                }
+            }
+        "#,
+        );
+        let eq = result_equation_of(&item_fn).expect("if-tail must synthesize a result equation");
+        let json = serde_json::to_string(&eq).unwrap();
+        assert!(
+            !json.contains("cf_guarded"),
+            "len != 0 does not establish the exact len==1 iterator fact: {json}"
+        );
+    }
+
+    #[test]
+    fn no_assert_does_not_guard_option_unwrap() {
+        let item_fn = parse_fn(
+            r#"
+            fn f(x: Option<i64>) -> i64 {
+                x.unwrap()
+            }
+        "#,
+        );
+        let eq = result_equation_of(&item_fn).expect("unwrap must remain in result term");
+        let json = serde_json::to_string(&eq).unwrap();
+        assert!(
+            !json.contains("cf_guarded"),
+            "unguarded unwrap must remain honestly undecidable: {json}"
+        );
+    }
+
+    #[test]
+    fn unrelated_assert_does_not_guard_option_unwrap() {
+        let item_fn = parse_fn(
+            r#"
+            fn f(x: Option<i64>, ready: bool) -> i64 {
+                assert!(ready);
+                x.unwrap()
+            }
+        "#,
+        );
+        let eq = result_equation_of(&item_fn).expect("unwrap must remain in result term");
+        let json = serde_json::to_string(&eq).unwrap();
+        assert!(
+            !json.contains("cf_guarded"),
+            "unrelated assert must not guard x.unwrap(): {json}"
+        );
+    }
+
+    #[test]
+    fn different_receiver_assert_does_not_guard_option_unwrap() {
+        let item_fn = parse_fn(
+            r#"
+            fn f(x: Option<i64>, y: Option<i64>) -> i64 {
+                assert!(y.is_some());
+                x.unwrap()
+            }
+        "#,
+        );
+        let eq = result_equation_of(&item_fn).expect("unwrap must remain in result term");
+        let json = serde_json::to_string(&eq).unwrap();
+        assert!(
+            !json.contains("cf_guarded"),
+            "assert about y must not guard x.unwrap(): {json}"
+        );
+    }
+
+    #[test]
+    fn mutation_after_assert_does_not_guard_option_unwrap() {
+        let item_fn = parse_fn(
+            r#"
+            fn f(mut x: Option<i64>) -> i64 {
+                assert!(x.is_some());
+                x = None;
+                x.unwrap()
+            }
+        "#,
+        );
+        let eq = result_equation_of(&item_fn).expect("unwrap must remain in result term");
+        let json = serde_json::to_string(&eq).unwrap();
+        assert!(
+            !json.contains("cf_guarded"),
+            "mutation after assert must invalidate the guard fact: {json}"
+        );
+    }
+
+    #[test]
+    fn branch_local_assert_does_not_guard_outer_unwrap() {
+        let item_fn = parse_fn(
+            r#"
+            fn f(x: Option<i64>, cond: bool) -> i64 {
+                if cond {
+                    assert!(x.is_some());
+                }
+                x.unwrap()
+            }
+        "#,
+        );
+        let eq = result_equation_of(&item_fn).expect("unwrap must remain in result term");
+        let json = serde_json::to_string(&eq).unwrap();
+        assert!(
+            !json.contains("cf_guarded"),
+            "branch-local assert must not guard an outer unwrap: {json}"
         );
     }
 


### PR DESCRIPTION
## Summary

This PR closes the Rust self-application B slice by making guarded panic partials compose through the Rust kit and the language-blind verifier boundary.

- lift Rust assertion context into guarded partial calls for `Option`/`Result` and `len() == 1 -> into_iter().next().unwrap/expect()` shapes
- select callsite-scoped bridges for panic formula walks so same-symbol producers do not collide across callsites
- make Rust-kit implication lifting resolve prelude `Option`/`Result` panic partials to std shim contracts while refusing local shadows, generic trait receivers, aliases, no-pre duplicates, and ineligible totality fallthrough
- propagate `has_pre` as non-trivial-pre metadata through mint bindings, while preserving ineligible totality contracts over post-only duplicates for the non-panic honesty boundary
- make `self-check --oracle` mint local dependency proofs with the same oracle setting, so workspace-internal dep proofs carry the receiver-type disambiguation needed by downstream self-checks
- add a language-blind verifier guard: a panic locus without a scoped bridge target now falls through as no-bridge/undecidable instead of incorrectly consulting a global same-symbol body contract

## Root Cause

The previous path could resolve panic leaves to the wrong duplicate contract: a post/no-pre shell could win over the pre-bearing panic partial, turning a panic obligation into a vacuous or false pass. Separately, assertion facts and `len() == 1` branch facts were not consistently materialized into the lifted body terms needed to discharge std partials.

The follow-up regression was in self-check dependency minting: `provekit-cli` minted its local `libprovekit` dependency proof with the oracle off, so imported panic sites lacked scoped std `result_expect` bridges and fell through to misleading body-discharge refusals. The fix keeps packaged external proofs as proof bytes, but local self-check dependency mints inherit `--oracle`.

## Validation

- `../../bin/bcargo test -p provekit-verifier callee_post_guard_fact -- --nocapture` (7 passed)
- `../../bin/bcargo test -p provekit-cli dependency_mints_inherit_self_check_oracle_request -- --nocapture`
- `../../bin/bcargo test -p provekit-walk lift_implications_ -- --nocapture` (22 passed)
- `../../bin/bcargo test -p provekit-cli contract_bindings -- --nocapture` (3 passed)
- `../../bin/bcargo test -p provekit-cli mint_ir_document_marks_only_nontrivial_pre_as_has_pre -- --nocapture`
- `git diff --check`
- `../../bin/bcargo --sync-bins provekit,provekit-walk-rpc,provekit-linkerd,provekit-lift,provekit-realize-rust build -p provekit-cli -p provekit-walk -p provekit-linkerd -p provekit-lift -p provekit-realize-rust-core --bins`
- `provekit self-check --target implementations/rust/libprovekit --json --oracle`: `oracle=2740/2504`, `panicSafe=10`, `falsePass=0`, `silentlyDropped=0`, `droppedSites=[]`, `panicCensus=36`
- `provekit self-check --target implementations/rust/provekit-cli --json --oracle`: `oracle=3496/3410`, `panicSafe=19`, `falsePass=0`, `silentlyDropped=0`, `droppedSites=[]`, `panicCensus=53`

Cumulative K is 19 on `provekit-cli`, not the 18 predicted in the design checkpoint. The extra +1 is `src/wp.rs:295`, an imported `libprovekit` B iterator-length site (`if conj.len() == 1` then `conj.into_iter().next().unwrap()`) now propagating through the oracle-on dependency mint. All 19 sites have audited mechanisms:

- C json construction: `src/cmd_protocol.rs` 347/348/349/350/397/398/399
- D-lib imported from `libprovekit`: `src/core/lower_plugin.rs` 1477/1684, `src/core/types.rs` 2105/2137
- D-lib local to `provekit-cli`: `src/kit_dispatch.rs` 1305/2130
- B prelude/std shim: `src/lib.rs` 161/175/190/381/396
- B iterator length imported from `libprovekit`: `src/wp.rs` 295


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed panic-site resolution to correctly handle missing scoped bridge targets.
  * Improved source location preservation for panic occurrences to avoid incorrect collapsing.

* **Improvements**
  * Enhanced precondition logic handling in contract binding selection.
  * Enabled oracle settings to apply to dependency proof generation.
  * Strengthened guard-fact tracking for safer partial operations during proof derivation.
  * Improved panic-leaf method call disambiguation without relying solely on oracle resolution.

* **Tests**
  * Added and expanded test coverage for precondition handling, panic-site scenarios, and guard-fact collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->