### PR TITLE
[codex] Close D-fn self-application postconditions

### DIFF
--- a/docs/self-application/GOAL-provekit-proves-provekit.md
+++ b/docs/self-application/GOAL-provekit-proves-provekit.md
@@ -156,13 +156,30 @@ architectural thesis at v2.
   post-#1767 is 5 B prelude/std-shim sites plus imported `libprovekit`
   `wp.rs:295` (`len()==1 -> next().unwrap()`). **Cumulative production K so
   far: 19 sites discharged via sound reasoning on real production code.**
+- **D-fn cross-function postconditions (#1771, verified
+  2026-06-01).** Rust kit reads audited
+  `.provekit/contracts/function_postconditions.toml` entries for
+  `Cid::parse(format!("blake3-512:{}", "0".repeat(128)))` and
+  `ConceptOpCatalog.cid(CONCEPT_BIND_RESULT)`, emits singleton postcondition
+  contracts, and routes manifest-backed panic receivers through fixed std
+  partials (`is_ok` -> Result, `is_some` -> Option). The verifier remains
+  language-blind: it consumes opaque producer coordinates and generic
+  singleton `P(result)` facts, with no Rust predicate vocabulary hardcoded.
+  Result on libprovekit self-check: `panicSafe=12`, `falsePass=0`,
+  `silentlyDropped=0`, `droppedSites=[]`, `panicCensus=35`,
+  `oracle={requested:true, engaged:true, attempted:2740, resolved:2504}`.
+  Result on provekit-cli self-check: `panicSafe=21`, `falsePass=0`,
+  `silentlyDropped=0`, `droppedSites=[]`, `panicCensus=53`,
+  `oracle={requested:true, engaged:true, attempted:3496, resolved:3410}`.
+  **Cumulative production K so far: 21 sites discharged via sound reasoning
+  on real production code.**
 
-## Current census (provekit-cli, post-#1769)
+## Current census (provekit-cli, #1771 D-fn branch)
 
-Latest measured gate: `panicCensus=53`, `panicSafe=19`, `falsePass=0`,
+Latest measured gate: `panicCensus=53`, `panicSafe=21`, `falsePass=0`,
 `silentlyDropped=0`, `droppedSites=[]`. The original 7-site C bucket is closed
-by #1767, and the B guarded-panic bucket is closed by #1769. The remaining
-closable row class is D-fn; residue still needs first-class naming.
+by #1767, the B guarded-panic bucket is closed by #1769, and the two D-fn rows
+are closed by #1771. Residue still needs first-class naming.
 
 | Category | Count | Closing mechanism |
 |---|---|---|
@@ -170,13 +187,13 @@ closable row class is D-fn; residue still needs first-class naming.
 | D-lib | 3 known remaining | serde_json totality not yet closed by #1762/#1765: remaining derived-Serialize / pretty-print cases. The `&Value` kit_dispatch sites are closed by #1765. |
 | C | 0 | Closed by #1767: 7 `cmd_protocol.rs` `payload["k"].as_str().unwrap()` sites discharged via Rust-kit `json!` construction tracking and `cf_guarded(...)` postcondition terms. |
 | B | 0 | Closed by #1769: intra-fn `assert!(x.is_some()/is_ok()/is_err())` propagation plus `len==1 -> next()` guard. |
-| D-fn | 2 | Cross-function postconditions: catalog primitive `.cid()`, `Cid::parse` on literal. |
+| D-fn | 0 | Closed by #1771: catalog primitive `.cid()` and `Cid::parse` on literal discharge through manifest-backed function postconditions. |
 | oracle-residue | 0 | None in panicCensus; the 86 unresolved receivers are non-panic obligations. |
 | unknown | 0 | Every site has a named category. Honest. |
 
-The honest read: C and B are closed, D-lib is mostly closed, and D-fn is the
-next closable bucket. v1 is "K covering the provable buckets, residue named,
-hard floor never violated." K = N is not required and not honest.
+The honest read: C, B, and D-fn are closed, D-lib is mostly closed, and residue
+must be named. v1 is "K covering the provable buckets, residue named, hard
+floor never violated." K = N is not required and not honest.
 
 ## Current census (libprovekit, 15 unproven sites, warm-oracle baseline)
 
@@ -211,6 +228,12 @@ Post-#1769 current libprovekit score: `panicCensus=36`, `panicSafe=10`,
 `falsePass=0`, `silentlyDropped=0`, `droppedSites=[]`; the B guarded-panic
 slice contributes 6 current K rows here: 5 prelude/std-shim rows plus
 `wp.rs:295` (`len()==1 -> next().unwrap()`), on top of the 4 D-lib sites.
+
+Current #1771 branch libprovekit score: `panicCensus=35`, `panicSafe=12`,
+`falsePass=0`, `silentlyDropped=0`, `droppedSites=[]`; the +2 rows are
+`src/core/bind.rs:550` (`ConceptOpCatalog.cid(CONCEPT_BIND_RESULT).expect(...)`)
+and `src/wp/tests.rs:74`
+(`Cid::parse(format!("blake3-512:{}", "0".repeat(128))).expect(...)`).
 
 ## The metric (the one number we watch)
 
@@ -263,8 +286,9 @@ Each tier ships as one PR, golden-pinned, with visible scoreboard delta.
   `len()==1 -> next().unwrap()` site. Also hardens self-check dependency mints
   to inherit `--oracle` and adds the verifier no-scoped-bridge guard. +6 K
   delta on provekit-cli; cumulative production K=19.
-- **D-fn cross-function postconditions**: closes the 2 remaining sites
-  (`Cid::parse` on literal, catalog primitive `.cid()`).
+- **D-fn cross-function postconditions (#1771):** closes the 2
+  remaining D-fn sites (`Cid::parse` on literal, catalog primitive `.cid()`).
+  +2 K delta on provekit-cli; cumulative production K=21.
 ### Phase 3 - RESIDUE NAMED + V1 RELEASE
 - The 10 residue sites get an explicit `residue` category in the panicCensus
   output (not "unproven"; honest residue with reason).
@@ -367,6 +391,9 @@ the first.
     `len()==1 -> next()`, self-check dependency mints inherit `--oracle`, and
     verifier no-scoped-bridge guard. +6 K delta on provekit-cli. Cumulative
     production K: 19.
+  - #1771 (D-fn slice) manifest-backed cross-function postconditions for
+    `Cid::parse` on literal and catalog primitive `.cid()`. +2 K delta on
+    provekit-cli. Cumulative production K: 21.
 - **Open follow-ups**:
   - #1757 self-check golden drift reached main without gate update.
   - #1763 self-check should fail closed when requested oracle host cannot

--- a/docs/self-application/PLAN-panic-loci-completion.md
+++ b/docs/self-application/PLAN-panic-loci-completion.md
@@ -35,6 +35,12 @@ the marked checkpoints.
   `silentlyDropped=0`, `falsePass=0`, `panicSafe=0`, `panicCensus=32`, with
   every unproven site named by category. Next K movement comes from the Phase-2
   D-lib per-type slice, not more panic-locus plumbing.
+- **D-fn branch #1771 verified 2026-06-01.** The manifest-backed cross-function
+  postcondition slice reached the expected gates: libprovekit
+  `panicSafe=12`, provekit-cli `panicSafe=21`, both with `silentlyDropped=0`,
+  `falsePass=0`, and `droppedSites=[]`. See
+  `docs/self-application/GOAL-provekit-proves-provekit.md` for the current
+  scoreboard and census.
 
 ## Recommended order
 

--- a/implementations/rust/libprovekit/.provekit/contracts/function_postconditions.toml
+++ b/implementations/rust/libprovekit/.provekit/contracts/function_postconditions.toml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Rust-kit manifest for audited function postconditions that are specific to
+# libprovekit's own code. The Rust kit reads this as side metadata during
+# lifting; the CLI/verifier receive only the emitted contract/bridge IR over RPC.
+
+[[functions]]
+call_kind = "associated"
+callee_crate = "libprovekit"
+type_path = "Cid"
+callee = "parse"
+arg0_format_literal = "blake3-512:{}"
+arg0_repeat_literal = "0"
+arg0_repeat_count = 128
+contract = "cid_parse__zero_digest"
+post_predicate = "is_ok"
+reason = "format!(\"blake3-512:{}\", \"0\".repeat(128)) is exactly a blake3-512 prefix plus 128 ASCII hex zeroes"
+
+[[functions]]
+call_kind = "method"
+callee_crate = "libprovekit"
+receiver_path = "ConceptOpCatalog"
+callee = "cid"
+arg0_path = "CONCEPT_BIND_RESULT"
+contract = "concept_op_catalog_cid__concept_bind_result"
+post_predicate = "is_some"
+reason = "grammar_op_shape(CONCEPT_BIND_RESULT) has a fixed primitive arm and json_cid returns a valid CID"

--- a/implementations/rust/provekit-cli/src/cmd_verify.rs
+++ b/implementations/rust/provekit-cli/src/cmd_verify.rs
@@ -1218,6 +1218,9 @@ mod tests {
             property_name: "demo_property".into(),
             property_cid: "blake3-512:prop".into(),
             arg_term: None,
+            producer_file: None,
+            producer_line: None,
+            producer_symbol: None,
             containing_atomic: None,
             guard_facts: Vec::new(),
             file: None,
@@ -1325,6 +1328,9 @@ mod tests {
             property_name: "panic_site".into(),
             property_cid: "blake3-512:panic-prop".into(),
             arg_term: Some(json!({"kind": "var", "name": "opt"})),
+            producer_file: None,
+            producer_line: None,
+            producer_symbol: None,
             containing_atomic: None,
             guard_facts,
             file: None,
@@ -1471,7 +1477,10 @@ mod tests {
 
     // CID constants for the D-lib test pool.
     const DLIB_TOTALITY_CONTRACT_CID: &str = "blake3-512:dlib-totality-contract";
+    const DLIB_OPTION_TOTALITY_CONTRACT_CID: &str = "blake3-512:dlib-option-totality-contract";
     const DLIB_RESULT_UNWRAP_CID: &str = "blake3-512:dlib-result-unwrap";
+    const DLIB_OPTION_EXPECT_CID: &str = "blake3-512:dlib-option-expect";
+    const DLIB_OPTION_EXPECT_MISMATCH_CID: &str = "blake3-512:dlib-option-expect-mismatch";
     const DLIB_GENERIC_CONTRACT_CID: &str = "blake3-512:dlib-generic-result";
     const DLIB_BUNDLE: &str = "blake3-512:dlib-bundle";
 
@@ -1491,6 +1500,21 @@ mod tests {
                     "post": {
                         "kind": "atomic",
                         "name": "is_ok",
+                        "args": [{"kind": "var", "name": "result"}]
+                    }
+                }
+            }
+        });
+
+        // Option-totality contract: post = is_some(result), no pre.
+        // This is the D-fn catalog primitive shape (`.cid(...)` known Some).
+        let option_totality_contract = json!({
+            "evidence": {
+                "kind": "contract",
+                "body": {
+                    "post": {
+                        "kind": "atomic",
+                        "name": "is_some",
                         "args": [{"kind": "var", "name": "result"}]
                     }
                 }
@@ -1526,6 +1550,57 @@ mod tests {
             }
         });
 
+        // Option::expect partial: pre = is_some(result).
+        let option_expect_contract = json!({
+            "evidence": {
+                "kind": "contract",
+                "body": {
+                    "pre": {
+                        "kind": "atomic",
+                        "name": "is_some",
+                        "args": [{"kind": "var", "name": "result"}]
+                    },
+                    "post": {
+                        "kind": "atomic",
+                        "name": "=",
+                        "args": [
+                            {"kind": "var", "name": "out"},
+                            {"kind": "ctor", "name": "option_expect",
+                             "args": [{"kind": "var", "name": "result"}]}
+                        ]
+                    },
+                    "formals": ["result"],
+                    "formalSorts": [{"kind": "primitive", "name": "Option"}]
+                }
+            }
+        });
+
+        // Same partial shape, but the pre mentions a different receiver.
+        // A supplied is_some(actual_receiver) fact must not discharge it.
+        let option_expect_mismatch_contract = json!({
+            "evidence": {
+                "kind": "contract",
+                "body": {
+                    "pre": {
+                        "kind": "atomic",
+                        "name": "is_some",
+                        "args": [{"kind": "var", "name": "other"}]
+                    },
+                    "post": {
+                        "kind": "atomic",
+                        "name": "=",
+                        "args": [
+                            {"kind": "var", "name": "out"},
+                            {"kind": "ctor", "name": "option_expect",
+                             "args": [{"kind": "var", "name": "result"}]}
+                        ]
+                    },
+                    "formals": ["result"],
+                    "formalSorts": [{"kind": "primitive", "name": "Option"}]
+                }
+            }
+        });
+
         // (c) generic Result contract: post = is_ok(result) || is_err(result).
         // This is NOT a totality contract -- it says the result is some kind
         // of Result, not specifically Ok. No pre, no formals.
@@ -1557,6 +1632,17 @@ mod tests {
             }
         });
 
+        // Bridge: concept_op_catalog_cid_known -> option-totality contract.
+        let option_totality_bridge = json!({
+            "evidence": {
+                "kind": "bridge",
+                "body": {
+                    "sourceSymbol": "concept_op_catalog_cid_known",
+                    "targetContractCid": DLIB_OPTION_TOTALITY_CONTRACT_CID
+                }
+            }
+        });
+
         // (d2) Bridge: to_string_generic -> generic contract.
         let generic_bridge = json!({
             "evidence": {
@@ -1571,12 +1657,26 @@ mod tests {
         let mut pool = MementoPool::default();
         pool.mementos
             .insert(DLIB_TOTALITY_CONTRACT_CID.into(), totality_contract);
+        pool.mementos.insert(
+            DLIB_OPTION_TOTALITY_CONTRACT_CID.into(),
+            option_totality_contract,
+        );
         pool.mementos
             .insert(DLIB_RESULT_UNWRAP_CID.into(), result_unwrap_contract);
+        pool.mementos
+            .insert(DLIB_OPTION_EXPECT_CID.into(), option_expect_contract);
+        pool.mementos.insert(
+            DLIB_OPTION_EXPECT_MISMATCH_CID.into(),
+            option_expect_mismatch_contract,
+        );
         pool.mementos
             .insert(DLIB_GENERIC_CONTRACT_CID.into(), generic_contract);
         pool.bridges_by_symbol
             .insert("serde_json_to_string_value".into(), totality_bridge);
+        pool.bridges_by_symbol.insert(
+            "concept_op_catalog_cid_known".into(),
+            option_totality_bridge,
+        );
         pool.bridges_by_symbol
             .insert("to_string_generic".into(), generic_bridge);
         pool.bundle_members
@@ -1584,7 +1684,10 @@ mod tests {
             .or_default()
             .extend([
                 DLIB_TOTALITY_CONTRACT_CID.to_string(),
+                DLIB_OPTION_TOTALITY_CONTRACT_CID.to_string(),
                 DLIB_RESULT_UNWRAP_CID.to_string(),
+                DLIB_OPTION_EXPECT_CID.to_string(),
+                DLIB_OPTION_EXPECT_MISMATCH_CID.to_string(),
                 DLIB_GENERIC_CONTRACT_CID.to_string(),
             ]);
         pool
@@ -1616,6 +1719,30 @@ mod tests {
             })),
             containing_atomic: None,
             guard_facts,
+            ..Default::default()
+        }
+    }
+
+    fn dlib_option_expect_callsite(
+        callee_ctor_name: &str,
+        target_cid: &str,
+    ) -> provekit_verifier::CallSite {
+        provekit_verifier::CallSite {
+            bridge_ir_name: "option_expect".into(),
+            bridge_target_cid: target_cid.into(),
+            bridge_source_layer: "rust".into(),
+            bridge_target_layer: "concept".into(),
+            bridge_target_proof_cid: None,
+            bridge_self_bundle_cid: Some(DLIB_BUNDLE.into()),
+            property_name: "dlib_option_panic_site".into(),
+            property_cid: "blake3-512:dlib-option-prop".into(),
+            arg_term: Some(json!({
+                "kind": "ctor",
+                "name": callee_ctor_name,
+                "args": [{"kind": "var", "name": "v"}]
+            })),
+            containing_atomic: None,
+            guard_facts: vec![],
             ..Default::default()
         }
     }
@@ -1693,6 +1820,103 @@ mod tests {
             Some("panic-safe"),
             "D-lib control must never be tagged panic-safe; reason: {}",
             control.reason
+        );
+
+        let _ = std::fs::remove_dir_all(&witness_dir);
+    }
+
+    #[test]
+    fn dlib_singleton_is_some_post_discharges_option_expect_panic_safe() {
+        // D-fn / language-blind callee-post fact supply:
+        // post = is_some(result) should supply is_some(receiver), exactly like
+        // post = is_ok(result) supplies is_ok(receiver). The verifier must not
+        // hardcode Rust's Result predicate vocabulary.
+        let pool = dlib_pool();
+        let no_kit = std::path::Path::new("/nonexistent-dlib-option-test-kit");
+        let (plan, registry, _) = build_plan_and_registry(no_kit, "z3");
+        let witness_dir =
+            std::env::temp_dir().join(format!("provekit-dlib-option-test-{}", std::process::id()));
+        std::fs::create_dir_all(&witness_dir).ok();
+
+        let positive = verify_one_claim(
+            &dlib_option_expect_callsite("concept_op_catalog_cid_known", DLIB_OPTION_EXPECT_CID),
+            &pool,
+            &plan,
+            &registry,
+            &witness_dir,
+            &VERIFY_SIGNER_SEED_DEV,
+            false,
+        );
+        assert_eq!(
+            positive.verdict,
+            ObligationVerdict::Discharged,
+            "D-fn singleton is_some post must discharge option_expect pre as PANIC-SAFE; reason: {}",
+            positive.reason
+        );
+        assert_eq!(
+            positive.discharge_method.as_deref(),
+            Some("panic-safe"),
+            "D-fn singleton post discharge must be tagged panic-safe; reason: {}",
+            positive.reason
+        );
+
+        let _ = std::fs::remove_dir_all(&witness_dir);
+    }
+
+    #[test]
+    fn dlib_wrong_predicate_and_wrong_receiver_stay_undecidable() {
+        let pool = dlib_pool();
+        let no_kit = std::path::Path::new("/nonexistent-dlib-option-negative-test-kit");
+        let (plan, registry, _) = build_plan_and_registry(no_kit, "z3");
+        let witness_dir =
+            std::env::temp_dir().join(format!("provekit-dlib-option-neg-test-{}", std::process::id()));
+        std::fs::create_dir_all(&witness_dir).ok();
+
+        let wrong_predicate = verify_one_claim(
+            &dlib_option_expect_callsite("serde_json_to_string_value", DLIB_OPTION_EXPECT_CID),
+            &pool,
+            &plan,
+            &registry,
+            &witness_dir,
+            &VERIFY_SIGNER_SEED_DEV,
+            false,
+        );
+        assert_ne!(
+            wrong_predicate.verdict,
+            ObligationVerdict::Discharged,
+            "post=is_ok(result) must not discharge pre=is_some(receiver); reason: {}",
+            wrong_predicate.reason
+        );
+        assert_ne!(
+            wrong_predicate.discharge_method.as_deref(),
+            Some("panic-safe"),
+            "wrong-predicate control must never be tagged panic-safe; reason: {}",
+            wrong_predicate.reason
+        );
+
+        let wrong_receiver = verify_one_claim(
+            &dlib_option_expect_callsite(
+                "concept_op_catalog_cid_known",
+                DLIB_OPTION_EXPECT_MISMATCH_CID,
+            ),
+            &pool,
+            &plan,
+            &registry,
+            &witness_dir,
+            &VERIFY_SIGNER_SEED_DEV,
+            false,
+        );
+        assert_ne!(
+            wrong_receiver.verdict,
+            ObligationVerdict::Discharged,
+            "post=is_some(actual_receiver) must not discharge pre=is_some(other_receiver); reason: {}",
+            wrong_receiver.reason
+        );
+        assert_ne!(
+            wrong_receiver.discharge_method.as_deref(),
+            Some("panic-safe"),
+            "wrong-receiver control must never be tagged panic-safe; reason: {}",
+            wrong_receiver.reason
         );
 
         let _ = std::fs::remove_dir_all(&witness_dir);

--- a/implementations/rust/provekit-verifier/src/body_discharge.rs
+++ b/implementations/rust/provekit-verifier/src/body_discharge.rs
@@ -577,11 +577,11 @@ fn formula_is_reflexive(f: &Json) -> bool {
 ///
 /// When a callsite's `arg_term` is a `ctor` (i.e. the argument to the
 /// partial is the RETURN VALUE of another function call), look up that
-/// callee's contract in the pool and check whether its `post` is the
-/// `is_ok(result)` postcondition. If so, return `is_ok(arg_term)` as an
-/// established fact -- the callee's totality contract supplies the fact
-/// that its result is always `Ok`, so the receiving `unwrap()` cannot
-/// panic.
+/// callee's contract in the pool and check whether its `post` is a singleton
+/// atomic postcondition over `result`. If so, return the same atomic predicate
+/// over `arg_term` as an established fact -- the callee's totality contract
+/// supplies the fact that its result satisfies that predicate, so a matching
+/// receiving partial can discharge its precondition.
 ///
 /// This is the CROSS-FUNCTION-POSTCONDITION-AS-ASSUMABLE-FACT mechanism
 /// (Phase 2 Tier D-lib). It is LANGUAGE-BLIND: it reads the post field as
@@ -590,21 +590,19 @@ fn formula_is_reflexive(f: &Json) -> bool {
 ///
 ///   1. `cs.arg_term` is a `ctor` (the arg is a call expression, not a bare var)
 ///   2. The ctor name has a bridge in the pool
-///   3. The bridge's target contract has `post = is_ok(result)`
-///      (the strengthened singleton totality post, NOT the generic
-///      `is_ok || is_err` disjunction)
+///   3. The bridge's target contract has `post = P(result)` for a singleton
+///      atomic predicate `P`
 ///
 /// SOUNDNESS: the postcondition is read from a contract in the pool whose
 /// soundness is the contract author's responsibility. This function only
-/// checks structural shape. A false `is_ok` post is a false contract, not
+/// checks structural shape. A false singleton post is a false contract, not
 /// a verifier bug.
 ///
-/// DISCRIMINATION: when the bridge target's post is NOT exactly
-/// `is_ok(result)` (e.g. it is the generic `is_ok(result) || is_err(result)`
-/// or any other predicate), this returns `None`. Only the STRENGTHENED
-/// singleton triggers the fact supply.
+/// DISCRIMINATION: when the bridge target's post is NOT a singleton atomic over
+/// `result` (e.g. a disjunction or conjunction), this returns `None`. Only the
+/// strengthened singleton triggers the fact supply.
 ///
-/// Returns `Some(is_ok(arg_term))` when all three conditions hold, else `None`.
+/// Returns `Some(P(arg_term))` when all three conditions hold, else `None`.
 pub fn callee_post_guard_fact(cs: &CallSite, pool: &MementoPool) -> Option<Json> {
     macro_rules! gdbg {
         ($($a:tt)*) => {
@@ -644,13 +642,22 @@ pub fn callee_post_guard_fact(cs: &CallSite, pool: &MementoPool) -> Option<Json>
     // from elsewhere must never discharge a panic obligation it does not govern.
     // Non-panic sites keep the per-symbol lookup byte-for-byte.
     let bridge: &Json = if cs.panic_site {
-        match (cs.callsite_bundle_cid.as_deref(), cs.file.as_deref(), cs.line) {
+        let producer_file = cs.producer_file.as_deref().or(cs.file.as_deref());
+        let producer_line = cs.producer_line.or(cs.line);
+        let producer_symbol = cs.producer_symbol.as_deref().unwrap_or(ctor_name);
+        if producer_symbol != ctor_name {
+            gdbg!(
+                "REJECT cond2: producerSymbol={producer_symbol} does not match arg ctor {ctor_name}"
+            );
+            return None;
+        }
+        match (cs.callsite_bundle_cid.as_deref(), producer_file, producer_line) {
             (Some(bundle), Some(file), Some(line)) => {
                 let key = (
                     bundle.to_string(),
                     file.to_string(),
                     line,
-                    ctor_name.to_string(),
+                    producer_symbol.to_string(),
                 );
                 match pool.bridges_by_callsite.get(&key) {
                     Some(b) => {
@@ -704,52 +711,53 @@ pub fn callee_post_guard_fact(cs: &CallSite, pool: &MementoPool) -> Option<Json>
         return None;
     };
 
-    // Condition 3: the contract's `post` is exactly `is_ok(result)`.
+    // Condition 3: the contract's `post` is exactly one atomic `P(result)`.
     let Some(post) = body.get("post") else {
         gdbg!("REJECT cond3: target contract for {ctor_name} has no post field");
         return None;
     };
-    if !post_is_is_ok_of_result(post) {
-        gdbg!("REJECT cond3: post is NOT exactly is_ok(result) singleton -> post={post}");
+    let Some(predicate_name) = post_singleton_atomic_predicate_of_result(post) else {
+        gdbg!("REJECT cond3: post is NOT a singleton atomic P(result) -> post={post}");
         return None;
-    }
-    gdbg!("ACCEPT: supplying is_ok(arg) fact for ctor_name={ctor_name}");
+    };
+    gdbg!("ACCEPT: supplying {predicate_name}(arg) fact for ctor_name={ctor_name}");
 
-    // Supply the fact: `is_ok(arg_term)`. The arg_term (the ctor expression)
-    // is the value whose is_ok status the contract guarantees. This is
-    // structurally identical to what a syntactic `if result.is_ok()` guard
+    // Supply the fact: `P(arg_term)`. The arg_term (the ctor expression)
+    // is the value whose predicate status the contract guarantees. This is
+    // structurally identical to what a syntactic predicate guard
     // supplies; the discharge engine cannot tell them apart (language-blind).
     Some(serde_json::json!({
         "kind": "atomic",
-        "name": "is_ok",
+        "name": predicate_name,
         "args": [arg.clone()]
     }))
 }
 
-/// True iff `post` is the singleton totality postcondition `is_ok(result)`.
+/// Return the predicate name iff `post` is a singleton atomic `P(result)`.
 ///
-/// Shape: `{"kind": "atomic", "name": "is_ok", "args": [{"kind": "var", "name": "result"}]}`.
+/// Shape: `{"kind": "atomic", "name": "<predicate>", "args": [{"kind": "var", "name": "result"}]}`.
 ///
-/// Recognizes ONLY the strengthened singleton, not the generic
-/// `is_ok(result) || is_err(result)`. This is the soundness boundary for
-/// D-lib: only a contract that explicitly strengthens to ALWAYS-OK carries
+/// Recognizes ONLY a strengthened singleton, not a generic disjunction or
+/// conjunction. This is the soundness boundary for D-fn/D-lib: only a contract
+/// that explicitly strengthens to a single predicate over the result carries
 /// this post.
-fn post_is_is_ok_of_result(post: &Json) -> bool {
+fn post_singleton_atomic_predicate_of_result(post: &Json) -> Option<&str> {
     if post.get("kind").and_then(|v| v.as_str()) != Some("atomic") {
-        return false;
+        return None;
     }
-    if post.get("name").and_then(|v| v.as_str()) != Some("is_ok") {
-        return false;
-    }
-    let args = match post.get("args").and_then(|v| v.as_array()) {
-        Some(a) => a,
-        None => return false,
-    };
+    let predicate = post.get("name").and_then(|v| v.as_str())?;
+    let args = post.get("args").and_then(|v| v.as_array())?;
     if args.len() != 1 {
-        return false;
+        return None;
     }
-    args[0].get("kind").and_then(|v| v.as_str()) == Some("var")
-        && args[0].get("name").and_then(|v| v.as_str()) == Some("result")
+    let arg = &args[0];
+    if arg.get("kind").and_then(|v| v.as_str()) == Some("var")
+        && arg.get("name").and_then(|v| v.as_str()) == Some("result")
+    {
+        Some(predicate)
+    } else {
+        None
+    }
 }
 
 /// Recognize the `=(<call>, <expected>)` harvested-assertion shape on a
@@ -1235,21 +1243,27 @@ mod callee_post_guard_fact_tests {
 
     // CIDs for hand-built contracts in these tests.
     const TOTAL_CONTRACT_CID: &str = "blake3-512:serde-value-totality";
+    const OPTION_TOTAL_CONTRACT_CID: &str = "blake3-512:option-totality-contract";
     const GENERIC_CONTRACT_CID: &str = "blake3-512:generic-result-contract";
     const BRIDGE_SYMBOL: &str = "serde_json_to_string_value";
+    const OPTION_BRIDGE_SYMBOL: &str = "concept_op_catalog_cid_known";
     const GENERIC_BRIDGE_SYMBOL: &str = "to_string_generic";
 
     /// A memento pool with:
-    ///   - a contract with `post = is_ok(result)` (the Value-totality contract)
-    ///   - a bridge from BRIDGE_SYMBOL to that contract
-    fn totality_pool() -> MementoPool {
+    ///   - a contract with `post = <predicate>(result)`
+    ///   - a bridge from `bridge_symbol` to that contract
+    fn singleton_totality_pool(
+        bridge_symbol: &str,
+        contract_cid: &str,
+        predicate: &str,
+    ) -> MementoPool {
         let contract_env = json!({
             "evidence": {
                 "kind": "contract",
                 "body": {
                     "post": {
                         "kind": "atomic",
-                        "name": "is_ok",
+                        "name": predicate,
                         "args": [{"kind": "var", "name": "result"}]
                     }
                 }
@@ -1259,17 +1273,27 @@ mod callee_post_guard_fact_tests {
             "evidence": {
                 "kind": "bridge",
                 "body": {
-                    "sourceSymbol": BRIDGE_SYMBOL,
-                    "targetContractCid": TOTAL_CONTRACT_CID
+                    "sourceSymbol": bridge_symbol,
+                    "targetContractCid": contract_cid
                 }
             }
         });
         let mut pool = MementoPool::default();
-        pool.mementos
-            .insert(TOTAL_CONTRACT_CID.into(), contract_env);
+        pool.mementos.insert(contract_cid.into(), contract_env);
         pool.bridges_by_symbol
-            .insert(BRIDGE_SYMBOL.into(), bridge_env);
+            .insert(bridge_symbol.into(), bridge_env);
         pool
+    }
+
+    /// A memento pool with:
+    ///   - a contract with `post = is_ok(result)` (the Value-totality contract)
+    ///   - a bridge from BRIDGE_SYMBOL to that contract
+    fn totality_pool() -> MementoPool {
+        singleton_totality_pool(BRIDGE_SYMBOL, TOTAL_CONTRACT_CID, "is_ok")
+    }
+
+    fn option_totality_pool() -> MementoPool {
+        singleton_totality_pool(OPTION_BRIDGE_SYMBOL, OPTION_TOTAL_CONTRACT_CID, "is_some")
     }
 
     /// A pool with a GENERIC (non-total) Result contract: post = is_ok || is_err.
@@ -1365,6 +1389,38 @@ mod callee_post_guard_fact_tests {
             fact_args[0].get("name").and_then(|v| v.as_str()),
             Some(BRIDGE_SYMBOL),
             "the ctor name in the fact must match the bridge symbol"
+        );
+    }
+
+    #[test]
+    fn positive_ctor_with_is_some_post_supplies_fact() {
+        // LANGUAGE-BLINDNESS: the verifier should not know that `is_ok` is
+        // special. Any singleton atomic post `P(result)` supplies `P(arg)`;
+        // the solver decides whether that fact discharges the target pre.
+        let cs = cs_with_ctor_arg(OPTION_BRIDGE_SYMBOL);
+        let pool = option_totality_pool();
+        let fact = callee_post_guard_fact(&cs, &pool);
+        assert!(
+            fact.is_some(),
+            "a ctor arg whose contract has singleton post=is_some(result) must yield a guard fact"
+        );
+        let fact = fact.unwrap();
+        assert_eq!(
+            fact.get("kind").and_then(|v| v.as_str()),
+            Some("atomic"),
+            "the supplied fact must be an atomic"
+        );
+        assert_eq!(
+            fact.get("name").and_then(|v| v.as_str()),
+            Some("is_some"),
+            "the supplied fact must preserve the opaque singleton predicate name"
+        );
+        let fact_args = fact.get("args").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(fact_args.len(), 1);
+        assert_eq!(
+            fact_args[0].get("name").and_then(|v| v.as_str()),
+            Some(OPTION_BRIDGE_SYMBOL),
+            "the fact's argument must be the receiver ctor expression"
         );
     }
 
@@ -1479,6 +1535,74 @@ mod callee_post_guard_fact_tests {
         let fact = callee_post_guard_fact(&cs, &pool)
             .expect("panic site must find producer in the caller contract bundle");
         assert_eq!(fact.get("name").and_then(|v| v.as_str()), Some("is_ok"));
+    }
+
+    #[test]
+    fn panic_site_uses_opaque_producer_coordinates_for_split_line_chain() {
+        // Multi-line chains have distinct coordinates: the panic leaf is at
+        // `.expect()`/`.unwrap()`, while the receiver producer bridge is keyed
+        // at the receiver call. The verifier must consume those coordinates as
+        // opaque data from the kit, with no Rust-specific semantics.
+        let callsite_bundle = "blake3-512:libprovekit-proof";
+        let mut pool = option_totality_pool();
+        let producer_bridge = json!({
+            "evidence": {
+                "kind": "bridge",
+                "body": {
+                    "sourceSymbol": OPTION_BRIDGE_SYMBOL,
+                    "targetContractCid": OPTION_TOTAL_CONTRACT_CID
+                }
+            }
+        });
+        pool.bridges_by_callsite.insert(
+            (
+                callsite_bundle.to_string(),
+                "src/core/bind.rs".to_string(),
+                549,
+                OPTION_BRIDGE_SYMBOL.to_string(),
+            ),
+            producer_bridge,
+        );
+
+        let cs = CallSite {
+            panic_site: true,
+            callsite_bundle_cid: Some(callsite_bundle.into()),
+            file: Some("src/core/bind.rs".into()),
+            line: Some(550),
+            producer_file: Some("src/core/bind.rs".into()),
+            producer_line: Some(549),
+            producer_symbol: Some(OPTION_BRIDGE_SYMBOL.into()),
+            arg_term: Some(json!({
+                "kind": "ctor",
+                "name": OPTION_BRIDGE_SYMBOL,
+                "args": [{"kind": "var", "name": "concept"}]
+            })),
+            ..Default::default()
+        };
+
+        let fact = callee_post_guard_fact(&cs, &pool)
+            .expect("split-line panic site must use producer coordinates");
+        assert_eq!(fact.get("name").and_then(|v| v.as_str()), Some("is_some"));
+
+        let missing_producer_line = CallSite {
+            producer_file: None,
+            producer_line: None,
+            producer_symbol: None,
+            ..cs.clone()
+        };
+        assert!(
+            callee_post_guard_fact(&missing_producer_line, &pool).is_none(),
+            "without producerLine, the panic leaf line must not find the receiver producer bridge"
+        );
+
+        let wrong_producer_symbol = CallSite {
+            producer_symbol: Some("method:other".into()),
+            ..cs
+        };
+        assert!(
+            callee_post_guard_fact(&wrong_producer_symbol, &pool).is_none(),
+            "producerSymbol must match the receiver ctor and must not fall back by line alone"
+        );
     }
 
     #[test]

--- a/implementations/rust/provekit-verifier/src/enumerate_callsites.rs
+++ b/implementations/rust/provekit-verifier/src/enumerate_callsites.rs
@@ -127,6 +127,21 @@ fn callsite_from_panic_locus(
         .and_then(|v| v.as_u64())
         .map(|n| n as usize);
     let arg_term = locus.get("argTerm").cloned();
+    let producer_file = locus
+        .get("producerFile")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| file.clone());
+    let producer_line = locus
+        .get("producerLine")
+        .and_then(|v| v.as_u64())
+        .map(|n| n as usize);
+    let producer_symbol = locus
+        .get("producerSymbol")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
 
     let scoped_bridge = match (callsite_bundle_cid, file.as_deref(), line) {
         (Some(bundle), Some(file), Some(line)) => pool.bridges_by_callsite.get(&(
@@ -183,6 +198,9 @@ fn callsite_from_panic_locus(
         property_cid: property_cid.to_string(),
         callsite_bundle_cid: callsite_bundle_cid.map(str::to_string),
         arg_term,
+        producer_file,
+        producer_line,
+        producer_symbol,
         containing_atomic: None,
         guard_facts: Vec::new(),
         file,
@@ -530,6 +548,27 @@ fn walk_term(
             property_cid: property_cid.to_string(),
             callsite_bundle_cid: callsite_bundle_cid.map(str::to_string),
             arg_term: arg_term.clone(),
+            producer_file: occ_locus
+                .and_then(|locus| {
+                    locus
+                        .get("producerFile")
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                })
+                .map(str::to_string)
+                .or_else(|| callsite_file.clone()),
+            producer_line: occ_locus
+                .and_then(|locus| locus.get("producerLine"))
+                .and_then(|v| v.as_u64())
+                .map(|n| n as usize),
+            producer_symbol: occ_locus
+                .and_then(|locus| {
+                    locus
+                        .get("producerSymbol")
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                })
+                .map(str::to_string),
             containing_atomic: containing_atomic.cloned(),
             // Snapshot the dominating guard context for this call site. The
             // runner discharges a panic partial's `pre` under these facts.

--- a/implementations/rust/provekit-verifier/src/types.rs
+++ b/implementations/rust/provekit-verifier/src/types.rs
@@ -752,6 +752,14 @@ pub struct CallSite {
     /// loaded together.
     pub callsite_bundle_cid: Option<String>,
     pub arg_term: Option<Json>,
+    /// Optional kit-provided producer provenance for panic-site receiver calls.
+    /// For `producer().expect(..)`, the panic leaf and the producer call can
+    /// start on different source lines. The verifier treats these as opaque
+    /// coordinates into `bridges_by_callsite`; the language kit owns how they
+    /// were derived.
+    pub producer_file: Option<String>,
+    pub producer_line: Option<usize>,
+    pub producer_symbol: Option<String>,
     /// The atomic predicate the matched call ctor sits directly inside, if
     /// the call was found as an argument of an atomic (e.g. the `=` in a
     /// harvested `assert_eq!(double(3), 6)` -> `=(double(3), 6)`). Captured

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -761,6 +761,268 @@ impl InfallibleSerializeManifest {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+struct FunctionPostconditionsManifest {
+    rules: Vec<FunctionPostconditionRule>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FunctionPostconditionCallKind {
+    Associated,
+    Method,
+}
+
+#[derive(Debug, Clone)]
+enum FunctionPostconditionArg0 {
+    FormatRepeat {
+        format_literal: String,
+        repeat_literal: String,
+        repeat_count: u64,
+    },
+    Path(String),
+}
+
+#[derive(Debug, Clone)]
+struct FunctionPostconditionRule {
+    call_kind: FunctionPostconditionCallKind,
+    callee_crate: String,
+    type_path: Option<String>,
+    receiver_path: Option<String>,
+    callee: String,
+    arg0: FunctionPostconditionArg0,
+    contract: String,
+    post_predicate: String,
+    reason: String,
+}
+
+impl FunctionPostconditionsManifest {
+    fn load(workspace_root: &Path) -> Result<Self, String> {
+        let path = workspace_root
+            .join(".provekit")
+            .join("contracts")
+            .join("function_postconditions.toml");
+        if !path.is_file() {
+            return Ok(Self::default());
+        }
+        let raw =
+            std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+        let value: toml::Value =
+            toml::from_str(&raw).map_err(|e| format!("parse {}: {e}", path.display()))?;
+        let table = value
+            .as_table()
+            .ok_or_else(|| format!("{} must be a TOML table", path.display()))?;
+        let Some(functions_value) = table.get("functions") else {
+            return Ok(Self::default());
+        };
+        let entries = functions_value.as_array().ok_or_else(|| {
+            format!(
+                "{} field `functions` must be an array of tables (`[[functions]]`)",
+                path.display()
+            )
+        })?;
+
+        let mut manifest = Self::default();
+        let mut seen_contracts = BTreeSet::new();
+        for (idx, entry) in entries.iter().enumerate() {
+            let context = format!("functions[{idx}]");
+            let table = entry.as_table().ok_or_else(|| {
+                format!(
+                    "{} `{context}` must be a table, got {}",
+                    path.display(),
+                    toml_value_type(entry)
+                )
+            })?;
+            let call_kind = match required_toml_string_for(&path, &context, table, "call_kind")?
+                .as_str()
+            {
+                "associated" => FunctionPostconditionCallKind::Associated,
+                "method" => FunctionPostconditionCallKind::Method,
+                other => {
+                    return Err(format!(
+                        "{} `{context}.call_kind` must be `associated` or `method`, got `{other}`",
+                        path.display()
+                    ))
+                }
+            };
+            let callee_crate =
+                normalize_crate_root(&required_toml_string_for(&path, &context, table, "callee_crate")?);
+            let callee = required_toml_string_for(&path, &context, table, "callee")?;
+            let contract = required_toml_string_for(&path, &context, table, "contract")?;
+            let post_predicate =
+                required_toml_string_for(&path, &context, table, "post_predicate")?;
+            let reason = required_toml_string_for(&path, &context, table, "reason")?;
+            if !seen_contracts.insert(contract.clone()) {
+                return Err(format!(
+                    "{} duplicate function postcondition contract `{contract}`",
+                    path.display()
+                ));
+            }
+
+            let (type_path, receiver_path, arg0) = match call_kind {
+                FunctionPostconditionCallKind::Associated => {
+                    let type_path =
+                        required_toml_string_for(&path, &context, table, "type_path")?;
+                    let format_literal =
+                        required_toml_string_for(&path, &context, table, "arg0_format_literal")?;
+                    let repeat_literal =
+                        required_toml_string_for(&path, &context, table, "arg0_repeat_literal")?;
+                    let repeat_count =
+                        required_toml_u64_for(&path, &context, table, "arg0_repeat_count")?;
+                    (
+                        Some(type_path),
+                        None,
+                        FunctionPostconditionArg0::FormatRepeat {
+                            format_literal,
+                            repeat_literal,
+                            repeat_count,
+                        },
+                    )
+                }
+                FunctionPostconditionCallKind::Method => {
+                    let receiver_path =
+                        required_toml_string_for(&path, &context, table, "receiver_path")?;
+                    let arg0_path = required_toml_string_for(&path, &context, table, "arg0_path")?;
+                    (
+                        None,
+                        Some(receiver_path),
+                        FunctionPostconditionArg0::Path(arg0_path),
+                    )
+                }
+            };
+
+            manifest.rules.push(FunctionPostconditionRule {
+                call_kind,
+                callee_crate,
+                type_path,
+                receiver_path,
+                callee,
+                arg0,
+                contract,
+                post_predicate,
+                reason,
+            });
+        }
+        Ok(manifest)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    fn rule_for_associated_call(
+        &self,
+        func: &syn::Expr,
+        args: &syn::punctuated::Punctuated<syn::Expr, syn::Token![,]>,
+        current_crate: &str,
+    ) -> Option<&FunctionPostconditionRule> {
+        let (type_path, callee) = associated_call_path_and_leaf(func)?;
+        self.rules.iter().find_map(|rule| {
+            if rule.call_kind != FunctionPostconditionCallKind::Associated {
+                return None;
+            }
+            if rule.callee_crate != current_crate || rule.callee != callee {
+                return None;
+            }
+            if rule.type_path.as_deref() != Some(type_path.as_str()) {
+                return None;
+            }
+            let FunctionPostconditionArg0::FormatRepeat {
+                format_literal,
+                repeat_literal,
+                repeat_count,
+            } = &rule.arg0
+            else {
+                return None;
+            };
+            let arg0 = only_call_arg(args)?;
+            if !expr_matches_format_repeat(arg0, format_literal, repeat_literal, *repeat_count) {
+                return None;
+            }
+            Some(rule)
+        })
+    }
+
+    fn target_for_associated_call(
+        &self,
+        func: &syn::Expr,
+        args: &syn::punctuated::Punctuated<syn::Expr, syn::Token![,]>,
+        current_crate: &str,
+    ) -> Option<(String, String)> {
+        self.rule_for_associated_call(func, args, current_crate)
+            .map(|rule| (current_crate.to_string(), rule.contract.clone()))
+    }
+
+    fn rule_for_method_call(
+        &self,
+        node: &syn::ExprMethodCall,
+        current_crate: &str,
+    ) -> Option<&FunctionPostconditionRule> {
+        let callee = node.method.to_string();
+        self.rules.iter().find_map(|rule| {
+            if rule.call_kind != FunctionPostconditionCallKind::Method {
+                return None;
+            }
+            if rule.callee_crate != current_crate || rule.callee != callee {
+                return None;
+            }
+            if expr_path_text(&node.receiver) != rule.receiver_path {
+                return None;
+            }
+            let FunctionPostconditionArg0::Path(expected_arg) = &rule.arg0 else {
+                return None;
+            };
+            let arg0 = only_call_arg(&node.args)?;
+            if expr_path_text(arg0).as_deref() != Some(expected_arg.as_str()) {
+                return None;
+            }
+            Some(rule)
+        })
+    }
+
+    fn target_for_method_call(
+        &self,
+        node: &syn::ExprMethodCall,
+        current_crate: &str,
+    ) -> Option<(String, String)> {
+        self.rule_for_method_call(node, current_crate)
+            .map(|rule| (current_crate.to_string(), rule.contract.clone()))
+    }
+
+    fn panic_partial_for_receiver(
+        &self,
+        receiver: &syn::Expr,
+        current_crate: &str,
+        panic_leaf: &str,
+    ) -> Option<(String, String)> {
+        let rule = match receiver {
+            syn::Expr::Call(call) => {
+                self.rule_for_associated_call(&call.func, &call.args, current_crate)
+            }
+            syn::Expr::MethodCall(method) => self.rule_for_method_call(method, current_crate),
+            syn::Expr::Paren(paren) => {
+                return self.panic_partial_for_receiver(&paren.expr, current_crate, panic_leaf);
+            }
+            syn::Expr::Group(group) => {
+                return self.panic_partial_for_receiver(&group.expr, current_crate, panic_leaf);
+            }
+            syn::Expr::Reference(reference) => {
+                return self.panic_partial_for_receiver(&reference.expr, current_crate, panic_leaf);
+            }
+            _ => None,
+        }?;
+        let stem = panic_stem_for_post_predicate(&rule.post_predicate)?;
+        disambiguated_partial_leaf(stem, panic_leaf).map(|leaf| ("std".to_string(), leaf))
+    }
+}
+
+fn panic_stem_for_post_predicate(predicate: &str) -> Option<&'static str> {
+    match predicate {
+        "is_ok" => Some("result"),
+        "is_some" => Some("option"),
+        _ => None,
+    }
+}
+
 fn toml_value_type(value: &toml::Value) -> &'static str {
     match value {
         toml::Value::String(_) => "string",
@@ -779,9 +1041,18 @@ fn required_toml_string(
     table: &toml::map::Map<String, toml::Value>,
     field: &str,
 ) -> Result<String, String> {
+    required_toml_string_for(path, &format!("serde_json[{idx}]"), table, field)
+}
+
+fn required_toml_string_for(
+    path: &Path,
+    context: &str,
+    table: &toml::map::Map<String, toml::Value>,
+    field: &str,
+) -> Result<String, String> {
     let value = table.get(field).ok_or_else(|| {
         format!(
-            "{} `serde_json[{idx}]` missing required string field `{field}`",
+            "{} `{context}` missing required string field `{field}`",
             path.display()
         )
     })?;
@@ -792,11 +1063,38 @@ fn required_toml_string(
         .map(str::to_string)
         .ok_or_else(|| {
             format!(
-                "{} `serde_json[{idx}].{field}` must be a non-empty string, got {}",
+                "{} `{context}.{field}` must be a non-empty string, got {}",
                 path.display(),
                 toml_value_type(value)
             )
         })
+}
+
+fn required_toml_u64_for(
+    path: &Path,
+    context: &str,
+    table: &toml::map::Map<String, toml::Value>,
+    field: &str,
+) -> Result<u64, String> {
+    let value = table.get(field).ok_or_else(|| {
+        format!(
+            "{} `{context}` missing required integer field `{field}`",
+            path.display()
+        )
+    })?;
+    let raw = value.as_integer().ok_or_else(|| {
+        format!(
+            "{} `{context}.{field}` must be a non-negative integer, got {}",
+            path.display(),
+            toml_value_type(value)
+        )
+    })?;
+    u64::try_from(raw).map_err(|_| {
+        format!(
+            "{} `{context}.{field}` must be a non-negative integer, got {raw}",
+            path.display()
+        )
+    })
 }
 
 /// Map of `leaf ident -> crate root` for the `use` imports in one file.
@@ -1250,6 +1548,7 @@ fn collect_callsites_in_items(
     current_crate: &str,
     enum_variant_types: &EnumVariantTypeMap,
     infallible_serialize: &InfallibleSerializeManifest,
+    function_postconditions: &FunctionPostconditionsManifest,
     out: &mut Vec<CallSite>,
 ) {
     for item in items {
@@ -1269,6 +1568,7 @@ fn collect_callsites_in_items(
                     current_crate,
                     enum_variant_types,
                     infallible_serialize,
+                    function_postconditions,
                     &param_type_map,
                     out,
                 );
@@ -1298,6 +1598,7 @@ fn collect_callsites_in_items(
                             current_crate,
                             enum_variant_types,
                             infallible_serialize,
+                            function_postconditions,
                             &param_type_map,
                             out,
                         );
@@ -1318,6 +1619,7 @@ fn collect_callsites_in_items(
                         current_crate,
                         enum_variant_types,
                         infallible_serialize,
+                        function_postconditions,
                         out,
                     );
                 }
@@ -1336,6 +1638,7 @@ fn collect_callsites_in_block(
     current_crate: &str,
     enum_variant_types: &EnumVariantTypeMap,
     infallible_serialize: &InfallibleSerializeManifest,
+    function_postconditions: &FunctionPostconditionsManifest,
     // Phase-2 Tier D-lib: param name -> concrete type identity for syntactic
     // serde_json arg-type disambiguation. Built from the enclosing function's
     // declared parameter types; empty when called outside a fn.
@@ -1353,6 +1656,7 @@ fn collect_callsites_in_block(
         value_types: HashMap<String, TypeIdentity>,
         enum_variant_types: &'a EnumVariantTypeMap,
         infallible_serialize: &'a InfallibleSerializeManifest,
+        function_postconditions: &'a FunctionPostconditionsManifest,
         param_type_map: &'a HashMap<String, TypeIdentity>,
         out: &'a mut Vec<CallSite>,
     }
@@ -1389,6 +1693,13 @@ fn collect_callsites_in_block(
                     } else {
                         None
                     };
+                let disambiguated_target = disambiguated_target.or_else(|| {
+                    self.function_postconditions.target_for_associated_call(
+                        &node.func,
+                        &node.args,
+                        self.current_crate,
+                    )
+                });
                 self.out.push(CallSite {
                     callee,
                     contract_callee,
@@ -1457,6 +1768,17 @@ fn collect_callsites_in_block(
                     let stem = type_id.head.to_ascii_lowercase();
                     disambiguated_partial_leaf(&stem, &callee).map(|leaf| ("std".to_string(), leaf))
                 });
+            let manifest_panic_target = syntactic_panic_target.as_ref().is_none().then(|| {
+                if is_panic_leaf(&callee) {
+                    self.function_postconditions.panic_partial_for_receiver(
+                        &node.receiver,
+                        self.current_crate,
+                        &callee,
+                    )
+                } else {
+                    None
+                }
+            }).flatten();
             let callee_crate = syntactic_panic_target
                 .as_ref()
                 .map(|(krate, _)| krate.clone())
@@ -1470,6 +1792,14 @@ fn collect_callsites_in_block(
                         self.current_crate,
                     )
                 });
+            let function_postcondition_target = syntactic_panic_target
+                .as_ref()
+                .is_none()
+                .then(|| {
+                    self.function_postconditions
+                        .target_for_method_call(node, self.current_crate)
+                })
+                .flatten();
             self.out.push(CallSite {
                 callee,
                 contract_callee,
@@ -1477,8 +1807,21 @@ fn collect_callsites_in_block(
                 is_method: true,
                 disambiguated_callee: syntactic_panic_target
                     .as_ref()
-                    .map(|(_, leaf)| leaf.clone()),
-                disambiguated_crate: syntactic_panic_target.map(|(krate, _)| krate),
+                    .map(|(_, leaf)| leaf.clone())
+                    .or_else(|| {
+                        manifest_panic_target
+                            .as_ref()
+                            .map(|(_, leaf)| leaf.clone())
+                    })
+                    .or_else(|| {
+                        function_postcondition_target
+                            .as_ref()
+                            .map(|(_, leaf)| leaf.clone())
+                    }),
+                disambiguated_crate: syntactic_panic_target
+                    .map(|(krate, _)| krate)
+                    .or_else(|| manifest_panic_target.map(|(krate, _)| krate))
+                    .or_else(|| function_postcondition_target.map(|(krate, _)| krate)),
                 unsupported_reason: None,
                 file: self.rel_path.to_string(),
                 line: start.line,
@@ -1577,6 +1920,7 @@ fn collect_callsites_in_block(
         value_types: param_type_map.clone(),
         enum_variant_types,
         infallible_serialize,
+        function_postconditions,
         param_type_map,
         out,
     };
@@ -1812,6 +2156,114 @@ fn call_expr_callee(
         syn::Expr::Paren(p) => call_expr_callee(&p.expr, use_map, current_crate),
         _ => None,
     }
+}
+
+fn associated_call_path_and_leaf(expr: &syn::Expr) -> Option<(String, String)> {
+    let syn::Expr::Path(path) = expr else {
+        return None;
+    };
+    if path.path.segments.len() < 2 {
+        return None;
+    }
+    let callee = path.path.segments.last()?.ident.to_string();
+    let type_path = path
+        .path
+        .segments
+        .iter()
+        .take(path.path.segments.len() - 1)
+        .map(|seg| seg.ident.to_string())
+        .collect::<Vec<_>>()
+        .join("::");
+    Some((type_path, callee))
+}
+
+fn only_call_arg<T, P>(args: &syn::punctuated::Punctuated<T, P>) -> Option<&T> {
+    if args.len() == 1 {
+        args.first()
+    } else {
+        None
+    }
+}
+
+fn expr_path_text(expr: &syn::Expr) -> Option<String> {
+    match expr {
+        syn::Expr::Path(path) => Some(
+            path.path
+                .segments
+                .iter()
+                .map(|seg| seg.ident.to_string())
+                .collect::<Vec<_>>()
+                .join("::"),
+        ),
+        syn::Expr::Reference(reference) => expr_path_text(&reference.expr),
+        syn::Expr::Paren(paren) => expr_path_text(&paren.expr),
+        syn::Expr::Group(group) => expr_path_text(&group.expr),
+        _ => None,
+    }
+}
+
+fn expr_matches_format_repeat(
+    expr: &syn::Expr,
+    format_literal: &str,
+    repeat_literal: &str,
+    repeat_count: u64,
+) -> bool {
+    use syn::parse::Parser;
+
+    let syn::Expr::Macro(expr_macro) = expr else {
+        return false;
+    };
+    if expr_macro
+        .mac
+        .path
+        .segments
+        .last()
+        .map(|seg| seg.ident != "format")
+        .unwrap_or(true)
+    {
+        return false;
+    }
+    let parser = syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated;
+    let Ok(args) = parser.parse2(expr_macro.mac.tokens.clone()) else {
+        return false;
+    };
+    if args.len() != 2 {
+        return false;
+    }
+    let Some(syn::Expr::Lit(format_arg)) = args.first() else {
+        return false;
+    };
+    let syn::Lit::Str(format_str) = &format_arg.lit else {
+        return false;
+    };
+    if format_str.value() != format_literal {
+        return false;
+    }
+    let Some(syn::Expr::MethodCall(repeat_call)) = args.iter().nth(1) else {
+        return false;
+    };
+    if repeat_call.method != "repeat" || repeat_call.args.len() != 1 {
+        return false;
+    }
+    let syn::Expr::Lit(receiver) = repeat_call.receiver.as_ref() else {
+        return false;
+    };
+    let syn::Lit::Str(receiver_str) = &receiver.lit else {
+        return false;
+    };
+    if receiver_str.value() != repeat_literal {
+        return false;
+    }
+    let Some(syn::Expr::Lit(count_arg)) = repeat_call.args.first() else {
+        return false;
+    };
+    let syn::Lit::Int(count_int) = &count_arg.lit else {
+        return false;
+    };
+    count_int
+        .base10_parse::<u64>()
+        .map(|count| count == repeat_count)
+        .unwrap_or(false)
 }
 
 /// Crate roots in source use `_`-free hyphenless identifiers; a Cargo package
@@ -2061,11 +2513,13 @@ fn is_panic_leaf(leaf: &str) -> bool {
 /// then carries no line and stays honestly undecidable (fail-safe, never the
 /// collapsed line).
 ///
-/// The `line`/`col` fields deliberately name the receiver producer call's start
-/// span, not the panic leaf's method-token span. `bridges_by_callsite` is keyed
-/// by the producer bridge line, so a split-line `to_string(v)\n.unwrap()` must
-/// use the receiver start line to find the co-located totality fact. The leaf
-/// position is preserved separately as `panicLine`/`panicCol` for diagnostics.
+/// The `line`/`col` fields name the panic leaf's method-token span, so the
+/// verifier can resolve the panic partial bridge at the exact panic site. The
+/// receiver producer's bridge coordinates ride separately as
+/// `producerLine`/`producerCol`/`producerSymbol`; a split-line
+/// `ConceptOpCatalog\n  .cid(..)\n  .expect(..)` needs all three coordinates
+/// because the receiver expression, producer call, and panic leaf can start on
+/// three different source lines. The verifier treats these as opaque provenance.
 fn collect_panic_loci(item_fn: &syn::ItemFn, rel_path: &str) -> Vec<Value> {
     use syn::visit::Visit;
 
@@ -2083,17 +2537,27 @@ fn collect_panic_loci(item_fn: &syn::ItemFn, rel_path: &str) -> Vec<Value> {
                 // production lifter so the term matches the contract `post`.
                 if let Some(recv) = provekit_walk::lift::lift_expr_to_term(&node.receiver) {
                     if let Ok(arg_term) = serde_json::to_value(&recv) {
-                        let producer_start = node.receiver.span().start();
+                        let receiver_start = node.receiver.span().start();
                         let panic_start = node.method.span().start();
-                        self.out.push(json!({
+                        let mut locus = json!({
                             "argTerm": arg_term,
                             "file": self.rel_path,
-                            "line": producer_start.line,
-                            "col": producer_start.column,
+                            "line": panic_start.line,
+                            "col": panic_start.column,
+                            "receiverLine": receiver_start.line,
+                            "receiverCol": receiver_start.column,
                             "panicLine": panic_start.line,
                             "panicCol": panic_start.column,
                             "callee": format!("method:{}", leaf),
-                        }));
+                        });
+                        if let Some((producer_symbol, producer_line, producer_col)) =
+                            receiver_producer_callsite(&node.receiver)
+                        {
+                            locus["producerSymbol"] = json!(producer_symbol);
+                            locus["producerLine"] = json!(producer_line);
+                            locus["producerCol"] = json!(producer_col);
+                        }
+                        self.out.push(locus);
                     }
                 }
             }
@@ -2108,6 +2572,24 @@ fn collect_panic_loci(item_fn: &syn::ItemFn, rel_path: &str) -> Vec<Value> {
     };
     v.visit_item_fn(item_fn);
     v.out
+}
+
+fn receiver_producer_callsite(receiver: &syn::Expr) -> Option<(String, usize, usize)> {
+    match receiver {
+        syn::Expr::MethodCall(method) => {
+            let start = method.method.span().start();
+            Some((format!("method:{}", method.method), start.line, start.column))
+        }
+        syn::Expr::Call(call) => {
+            let (_, callee) = associated_call_path_and_leaf(&call.func)?;
+            let start = call.func.span().start();
+            Some((callee, start.line, start.column))
+        }
+        syn::Expr::Paren(paren) => receiver_producer_callsite(&paren.expr),
+        syn::Expr::Group(group) => receiver_producer_callsite(&group.expr),
+        syn::Expr::Reference(reference) => receiver_producer_callsite(&reference.expr),
+        _ => None,
+    }
 }
 
 /// Tier 2b (§2.T2b): for the still-unresolved method calls in `callsites`
@@ -2347,6 +2829,13 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
             "lift_implications: loaded infallible serde_json manifest"
         );
     }
+    let function_postconditions = FunctionPostconditionsManifest::load(&workspace_root)?;
+    if !function_postconditions.is_empty() {
+        info!(
+            entries = function_postconditions.rules.len(),
+            "lift_implications: loaded function postconditions manifest"
+        );
+    }
 
     // Index contracts by (crate, leaf), not bare leaf. The leaf is the substring
     // before the first '@' in the contract `name` (`<callee>@<file>:<line>:<col>`
@@ -2439,6 +2928,7 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
             &current_crate,
             &enum_variant_types,
             &infallible_serialize,
+            &function_postconditions,
             &mut callsites,
         );
         let file_callsite_count = callsites.len();
@@ -3340,12 +3830,11 @@ fn bind_lift(params: &Value) -> Result<Value, String> {
             // TOTALITY EXCEPTION (Phase-2 Tier D-lib): when the sugar
             // annotation carries `totality = "result_ok"` and the
             // return type is Result, the post is the AXIOM `is_ok(result)`.
-            // This is the exact shape callee_post_guard_fact checks
-            // (body_discharge.rs:post_is_is_ok_of_result). With this
-            // post, bridges emitted by the recognize lane discharge the
-            // downstream `.unwrap()` as panic-safe. Sound: only functions
-            // explicitly marked totality get this post; inference from
-            // arg types is rejected (refuse-floor).
+            // This is one exact singleton shape callee_post_guard_fact accepts.
+            // With this post, bridges emitted by the recognize lane discharge
+            // the downstream `.unwrap()` as panic-safe. Sound: only functions
+            // explicitly marked totality get this post; inference from arg
+            // types is rejected (refuse-floor).
             let fn_name = item_fn.sig.ident.to_string();
             let post = if totality_result_ok {
                 // Singleton totality post: is_ok(result).
@@ -3617,6 +4106,7 @@ fn function_contract_lift(params: &Value) -> Result<Value, String> {
     // per-scan-root names, noted as a limitation.
     let current_crate = crate_name_for(&root).unwrap_or_default();
     let infallible_serialize = InfallibleSerializeManifest::load(&root)?;
+    let function_postconditions = FunctionPostconditionsManifest::load(&root)?;
     let mut entries: Vec<Value> = Vec::new();
     let mut diagnostics: Vec<Value> = Vec::new();
     let mut visited: std::collections::BTreeSet<PathBuf> = Default::default();
@@ -3747,6 +4237,11 @@ fn function_contract_lift(params: &Value) -> Result<Value, String> {
     }
 
     emit_infallible_serialize_contracts(&infallible_serialize, &current_crate, &mut entries)?;
+    emit_function_postcondition_contracts(
+        &function_postconditions,
+        &current_crate,
+        &mut entries,
+    )?;
 
     // Producer-side visibility. This surface emits the contracts that the
     // implication matcher later bridges into; a collapse here (e.g. a soundness
@@ -3842,7 +4337,7 @@ fn emit_infallible_serialize_contracts(
         entries.push(json!({
             "kind": "contract",
             "name": rule.contract,
-            "post": is_ok_result_post_json(),
+            "post": singleton_result_post_json("is_ok"),
             "outBinding": "out",
             "bodyDischargeEligible": false,
             "bodyDischargeRefusalReason": "totality-axiom",
@@ -3852,10 +4347,48 @@ fn emit_infallible_serialize_contracts(
     Ok(())
 }
 
-fn is_ok_result_post_json() -> Value {
+fn emit_function_postcondition_contracts(
+    manifest: &FunctionPostconditionsManifest,
+    current_crate: &str,
+    entries: &mut Vec<Value>,
+) -> Result<(), String> {
+    if manifest.is_empty() {
+        return Ok(());
+    }
+    if current_crate.is_empty() {
+        return Err(
+            "function_postconditions.toml requires a Cargo package name for contract emission"
+                .to_string(),
+        );
+    }
+    for rule in &manifest.rules {
+        debug!(
+            call_kind = ?rule.call_kind,
+            callee_crate = %rule.callee_crate,
+            callee = %rule.callee,
+            contract_library = %current_crate,
+            contract = %rule.contract,
+            post_predicate = %rule.post_predicate,
+            reason = %rule.reason,
+            "function_contract_lift: emitting project-local function postcondition contract"
+        );
+        entries.push(json!({
+            "kind": "contract",
+            "name": rule.contract,
+            "post": singleton_result_post_json(&rule.post_predicate),
+            "outBinding": "out",
+            "bodyDischargeEligible": false,
+            "bodyDischargeRefusalReason": "totality-axiom",
+            "library": current_crate,
+        }));
+    }
+    Ok(())
+}
+
+fn singleton_result_post_json(predicate: &str) -> Value {
     json!({
         "kind": "atomic",
-        "name": "is_ok",
+        "name": predicate,
         "args": [{ "kind": "var", "name": "result" }],
     })
 }
@@ -7411,20 +7944,29 @@ mod tests {
         collect_panic_loci(item_fn, "src/lib.rs")
     }
 
-    fn assert_single_panic_locus_lines(src: &str, expected_line: u64, expected_panic_line: u64) {
+    fn assert_single_panic_locus_lines(
+        src: &str,
+        expected_producer_line: u64,
+        expected_panic_line: u64,
+    ) {
         let loci = panic_loci_for_first_fn(src);
         assert_eq!(loci.len(), 1, "expected one panic locus: {loci:?}");
         assert_eq!(loci[0]["file"], "src/lib.rs");
         assert_eq!(loci[0]["callee"], "method:unwrap");
         assert_eq!(
             loci[0]["line"].as_u64(),
-            Some(expected_line),
-            "panic locus line must be the receiver producer call's start line, not the unwrap leaf line: {loci:?}"
+            Some(expected_panic_line),
+            "panic locus line must be the panic leaf line; producer provenance rides producerLine: {loci:?}"
         );
         assert_eq!(
             loci[0]["panicLine"].as_u64(),
             Some(expected_panic_line),
             "panicLine must preserve the unwrap leaf line for diagnostics: {loci:?}"
+        );
+        assert_eq!(
+            loci[0]["producerLine"].as_u64(),
+            Some(expected_producer_line),
+            "producerLine must key the receiver producer bridge independently from the panic leaf: {loci:?}"
         );
     }
 
@@ -7457,6 +7999,25 @@ mod tests {
 }
 "#;
         assert_single_panic_locus_lines(src, 2, 5);
+    }
+
+    #[test]
+    fn collect_panic_loci_splits_receiver_start_from_method_producer_line() {
+        let src = r#"pub struct ConceptOpCatalog;
+const CONCEPT_BIND_RESULT: &str = "concept:bind-result";
+
+pub fn split_method_chain() -> Cid {
+    ConceptOpCatalog
+        .cid(CONCEPT_BIND_RESULT)
+        .unwrap()
+}
+"#;
+        let loci = panic_loci_for_first_fn(src);
+        assert_eq!(loci.len(), 1, "expected one panic locus: {loci:?}");
+        assert_eq!(loci[0]["line"].as_u64(), Some(7), "{loci:?}");
+        assert_eq!(loci[0]["panicLine"].as_u64(), Some(7), "{loci:?}");
+        assert_eq!(loci[0]["producerLine"].as_u64(), Some(6), "{loci:?}");
+        assert_eq!(loci[0]["producerSymbol"], "method:cid", "{loci:?}");
     }
 
     #[test]
@@ -9534,6 +10095,13 @@ pub fn bitwise_not() -> i64 {
             .expect("write infallible serialize manifest");
     }
 
+    fn write_function_postconditions_manifest(root: &Path, body: &str) {
+        let contracts_dir = root.join(".provekit").join("contracts");
+        fs::create_dir_all(&contracts_dir).expect("create contracts dir");
+        fs::write(contracts_dir.join("function_postconditions.toml"), body)
+            .expect("write function postconditions manifest");
+    }
+
     fn write_sugar_binding_proof(
         proof_dir: &Path,
         mut sugar_entry: Value,
@@ -10460,6 +11028,102 @@ pub fn identity(value: i64) -> i64 {
     }
 
     #[test]
+    fn function_contract_lift_emits_function_postconditions_from_manifest() {
+        let root = temp_workspace("function_contract_dfn_postconditions");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "consumer-crate"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .expect("write Cargo.toml");
+        fs::write(
+            src_dir.join("lib.rs"),
+            r#"
+pub fn identity(value: i64) -> i64 {
+    value
+}
+"#,
+        )
+        .expect("write source");
+        write_function_postconditions_manifest(
+            &root,
+            r#"
+[[functions]]
+call_kind = "associated"
+callee_crate = "consumer_crate"
+type_path = "Cid"
+callee = "parse"
+arg0_format_literal = "blake3-512:{}"
+arg0_repeat_literal = "0"
+arg0_repeat_count = 128
+contract = "cid_parse__zero_digest"
+post_predicate = "is_ok"
+reason = "format!(\"blake3-512:{}\", \"0\".repeat(128)) is a valid blake3-512 CID"
+
+[[functions]]
+call_kind = "method"
+callee_crate = "consumer_crate"
+receiver_path = "ConceptOpCatalog"
+callee = "cid"
+arg0_path = "CONCEPT_BIND_RESULT"
+contract = "concept_op_catalog_cid__concept_bind_result"
+post_predicate = "is_some"
+reason = "grammar_op_shape(CONCEPT_BIND_RESULT) has a fixed primitive arm and json_cid returns a valid CID"
+"#,
+        );
+
+        let resp = function_contract_lift(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": ["."]
+        }))
+        .expect("function contract lift");
+
+        let entries = resp["ir"].as_array().expect("ir array");
+        let by_name = |name: &str| -> &Value {
+            entries
+                .iter()
+                .find(|entry| entry["name"] == name)
+                .unwrap_or_else(|| panic!("missing synthetic D-fn contract `{name}`: {entries:?}"))
+        };
+
+        let parse = by_name("cid_parse__zero_digest");
+        assert_eq!(parse["kind"], "contract");
+        assert_eq!(parse["library"], "consumer_crate");
+        assert_eq!(parse["bodyDischargeEligible"], false);
+        assert_eq!(parse["bodyDischargeRefusalReason"], "totality-axiom");
+        assert_eq!(
+            parse["post"],
+            json!({
+                "kind": "atomic",
+                "name": "is_ok",
+                "args": [{ "kind": "var", "name": "result" }]
+            })
+        );
+
+        let cid = by_name("concept_op_catalog_cid__concept_bind_result");
+        assert_eq!(cid["kind"], "contract");
+        assert_eq!(cid["library"], "consumer_crate");
+        assert_eq!(cid["bodyDischargeEligible"], false);
+        assert_eq!(cid["bodyDischargeRefusalReason"], "totality-axiom");
+        assert_eq!(
+            cid["post"],
+            json!({
+                "kind": "atomic",
+                "name": "is_some",
+                "args": [{ "kind": "var", "name": "result" }]
+            })
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn lift_implications_disambiguates_blessed_concrete_param_from_manifest_alias() {
         let src = r##"
 use serde_json as sj;
@@ -10521,6 +11185,214 @@ reason = "derive Serialize over serde_json-infallible fields"
         assert_eq!(bridge["targetContractCid"], expected_cid);
         assert_eq!(bridge["callsite"]["start_line"], 7);
         assert_eq!(bridge["callsite"]["panicSite"], false);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_disambiguates_function_postcondition_shapes_from_manifest() {
+        let src = r##"
+pub struct Cid;
+pub struct ConceptOpCatalog;
+
+const CONCEPT_BIND_RESULT: &str = "concept:bind-result";
+const CONCEPT_SEQ: &str = "concept:seq";
+
+impl Cid {
+    pub fn parse(_value: String) -> Result<Cid, ()> {
+        panic!()
+    }
+}
+
+impl ConceptOpCatalog {
+    pub fn cid(&self, _name: &str) -> Option<Cid> {
+        panic!()
+    }
+}
+
+pub fn parse_zero_digest() -> Cid {
+    Cid::parse(format!("blake3-512:{}", "0".repeat(128))).expect("sentinel cid is valid")
+}
+
+pub fn parse_other_digest() -> Cid {
+    Cid::parse(format!("blake3-512:{}", "1".repeat(128))).expect("not audited")
+}
+
+pub fn parse_wrong_count() -> Cid {
+    Cid::parse(format!("blake3-512:{}", "0".repeat(64))).expect("not audited")
+}
+
+pub fn parse_wrong_prefix() -> Cid {
+    Cid::parse(format!("blake3-256:{}", "0".repeat(128))).expect("not audited")
+}
+
+pub fn parse_unknown_predicate() -> Cid {
+    Cid::parse(format!("blake3-512:{}", "2".repeat(128))).expect("audited producer, unknown panic predicate")
+}
+
+pub fn parse_variable(value: String) -> Cid {
+    Cid::parse(value).expect("not audited")
+}
+
+pub fn catalog_bind_result() -> Cid {
+    ConceptOpCatalog.cid(CONCEPT_BIND_RESULT).expect("concept:bind-result is primitive")
+}
+
+pub fn catalog_other_name() -> Cid {
+    ConceptOpCatalog.cid(CONCEPT_SEQ).expect("not audited")
+}
+"##;
+        let root = temp_workspace("lift_implications_dfn_postconditions");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "consumer-crate"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .expect("write Cargo.toml");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), src).expect("write source");
+        write_function_postconditions_manifest(
+            &root,
+            r#"
+[[functions]]
+call_kind = "associated"
+callee_crate = "consumer_crate"
+type_path = "Cid"
+callee = "parse"
+arg0_format_literal = "blake3-512:{}"
+arg0_repeat_literal = "0"
+arg0_repeat_count = 128
+contract = "cid_parse__zero_digest"
+post_predicate = "is_ok"
+reason = "format!(\"blake3-512:{}\", \"0\".repeat(128)) is a valid blake3-512 CID"
+
+[[functions]]
+call_kind = "associated"
+callee_crate = "consumer_crate"
+type_path = "Cid"
+callee = "parse"
+arg0_format_literal = "blake3-512:{}"
+arg0_repeat_literal = "2"
+arg0_repeat_count = 128
+contract = "cid_parse__unknown_predicate"
+post_predicate = "is_canonical"
+reason = "recognized producer with an unknown singleton predicate must not imply a std panic partial"
+
+[[functions]]
+call_kind = "method"
+callee_crate = "consumer_crate"
+receiver_path = "ConceptOpCatalog"
+callee = "cid"
+arg0_path = "CONCEPT_BIND_RESULT"
+contract = "concept_op_catalog_cid__concept_bind_result"
+post_predicate = "is_some"
+reason = "grammar_op_shape(CONCEPT_BIND_RESULT) has a fixed primitive arm and json_cid returns a valid CID"
+"#,
+        );
+
+        let parse_cid = "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let catalog_cid = "blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let unknown_predicate_cid = "blake3-512:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+        let result_expect_cid = "blake3-512:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+        let option_expect_cid = "blake3-512:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": [
+                {
+                    "name": "cid_parse__zero_digest",
+                    "library": "consumer_crate",
+                    "contract_cid": parse_cid,
+                    "bodyDischargeEligible": false,
+                    "bodyDischargeRefusalReason": "totality-axiom"
+                },
+                {
+                    "name": "cid_parse__unknown_predicate",
+                    "library": "consumer_crate",
+                    "contract_cid": unknown_predicate_cid,
+                    "bodyDischargeEligible": false,
+                    "bodyDischargeRefusalReason": "totality-axiom"
+                },
+                {
+                    "name": "concept_op_catalog_cid__concept_bind_result",
+                    "library": "consumer_crate",
+                    "contract_cid": catalog_cid,
+                    "bodyDischargeEligible": false,
+                    "bodyDischargeRefusalReason": "totality-axiom"
+                },
+                {
+                    "name": "result_expect@std/src/result.rs:2:1",
+                    "library": "std",
+                    "contract_cid": result_expect_cid,
+                    "body_bearing": true,
+                    "has_pre": true
+                },
+                {
+                    "name": "option_expect@std/src/option.rs:2:1",
+                    "library": "std",
+                    "contract_cid": option_expect_cid,
+                    "body_bearing": true,
+                    "has_pre": true
+                }
+            ],
+        }))
+        .expect("lift_implications");
+
+        let ir = resp["ir"].as_array().expect("ir array");
+        let parse_hits: Vec<&Value> = ir
+            .iter()
+            .filter(|entry| {
+                entry["sourceSymbol"] == "parse" && entry["targetContractCid"] == parse_cid
+            })
+            .collect();
+        assert_eq!(
+            parse_hits.len(),
+            1,
+            "only the exact audited Cid::parse(format!(\"blake3-512:{{}}\", \"0\".repeat(128))) shape may bridge to the parse totality contract; wrong literal/count/prefix and variables must refuse: {ir:?}"
+        );
+
+        let unknown_predicate_hits: Vec<&Value> = ir
+            .iter()
+            .filter(|entry| {
+                entry["sourceSymbol"] == "parse"
+                    && entry["targetContractCid"] == unknown_predicate_cid
+            })
+            .collect();
+        assert_eq!(
+            unknown_predicate_hits.len(),
+            1,
+            "the unknown-predicate manifest entry should still emit its producer bridge, proving the later panic refusal is predicate-gated rather than recognizer failure: {ir:?}"
+        );
+
+        let catalog_hits: Vec<&Value> = ir
+            .iter()
+            .filter(|entry| {
+                entry["sourceSymbol"] == "method:cid"
+                    && entry["targetContractCid"] == catalog_cid
+            })
+            .collect();
+        assert_eq!(
+            catalog_hits.len(),
+            1,
+            "only ConceptOpCatalog.cid(CONCEPT_BIND_RESULT) may bridge to the catalog totality contract: {ir:?}"
+        );
+
+        let panic_targets: Vec<&str> = ir
+            .iter()
+            .filter(|entry| entry["sourceSymbol"] == "method:expect")
+            .filter_map(|entry| entry["targetContractCid"].as_str())
+            .collect();
+        assert_eq!(
+            panic_targets,
+            vec![result_expect_cid, option_expect_cid],
+            "manifest-audited receiver calls must route their panic leaf to the matching std partial; unaudited receiver shapes must still refuse: {ir:?}"
+        );
 
         let _ = fs::remove_dir_all(root);
     }


### PR DESCRIPTION
## What changed

- Adds a Rust-kit `function_postconditions.toml` manifest surface for audited project-local function postconditions.
- Emits singleton postcondition contracts for libprovekit's audited `Cid::parse(...)` and `ConceptOpCatalog.cid(...)` calls.
- Routes manifest-backed panic receivers to fixed std partials (`is_ok` -> Result, `is_some` -> Option) in the Rust kit only.
- Splits panic leaf coordinates from receiver producer coordinates so the verifier can consume opaque `producerLine` / `producerSymbol` data without knowing Rust semantics.
- Generalizes verifier callee-post fact supply from hard-coded `is_ok(result)` to singleton `P(result)` facts.
- Updates the self-application goal docs with the verified D-fn scoreboards.

## Why

D-fn was the remaining Phase 2 bucket: cross-function postconditions for catalog primitive `.cid()` and literal `Cid::parse(...)`. Before this, those producer facts existed conceptually but did not compose into the panic partial proof path. This closes that bucket while preserving the cross-platform invariant: kits own language semantics; CLI/verifier consume normalized proof data over RPC.

## Validation

- `../../bin/bcargo fmt`
- `../../bin/bcargo test -p provekit-walk collect_panic_loci_ -- --nocapture` -> 4 passed
- `../../bin/bcargo test -p provekit-walk lift_implications_ -- --nocapture` -> 23 passed
- `../../bin/bcargo test -p provekit-verifier callee_post_guard_fact -- --nocapture` -> 9 passed
- `../../bin/bcargo test -p provekit-cli dlib_ -- --nocapture` -> D-lib/D-fn focused CLI tests passed
- `provekit self-check --target implementations/rust/libprovekit --json --oracle` on battleaxe: `panicSafe=12`, `falsePass=0`, `silentlyDropped=0`, `droppedSites=[]`, oracle `2504/2740`
- `provekit self-check --target implementations/rust/provekit-cli --json --oracle` on battleaxe: `panicSafe=21`, `falsePass=0`, `silentlyDropped=0`, `droppedSites=[]`, oracle `3410/3496`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added function postconditions manifest support for enhanced contract handling and function-specific verification rules.
  * Extended JSON-RPC server configuration to support function postconditions during contract lifting.

* **Improvements**
  * Enhanced panic-site tracking with additional producer provenance metadata for more accurate call-site identification.
  * Improved cross-function postcondition inference to support generic singleton predicates beyond the standard `is_ok` pattern.

* **Documentation**
  * Updated self-application goals and completion plan with Phase 2 milestone verification checkpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->