### PR TITLE
[codex] Annotate self-check panic residue

### DIFF
--- a/implementations/rust/libprovekit/.provekit/residue.toml
+++ b/implementations/rust/libprovekit/.provekit/residue.toml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Target-scoped panic-site residue annotations for libprovekit self-check.
+# Cross-target propagation into consumers requires proof-bundle annotation
+# mementos and is tracked separately.
+
+[[residue]]
+file = "src/core/platform_semantics.rs"
+line = 42
+callee = "method:expect"
+category = "platform_semantics_runtime_residue"
+tier_to_close = "irreducible"
+reason = "python_kit_declaration assumes the configured Python kit serves a valid platform semantics declaration over RPC at runtime; external plugin availability is outside this static proof."

--- a/implementations/rust/provekit-cli/.provekit/residue.toml
+++ b/implementations/rust/provekit-cli/.provekit/residue.toml
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Target-scoped panic-site residue annotations for provekit-cli self-check.
+# These enrich the panicCensus without changing proof discharge.
+
+[[residue]]
+file = "src/cmd_materialize.rs"
+line = 579
+callee = "method:expect"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "self.fragments mutex drain in take_fragments can panic only if another thread panicked while holding the materialize fragment collection lock."
+
+[[residue]]
+file = "src/cmd_materialize.rs"
+line = 699
+callee = "method:expect"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "self.fragments mutex push in transform_site can panic only if another thread panicked while collecting materialize fragments."
+
+[[residue]]
+file = "src/kit_dispatch.rs"
+line = 106
+callee = "method:expect"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "registry cache lock clear in test reset can panic only if another thread panicked while holding the registry cache lock."
+
+[[residue]]
+file = "src/kit_dispatch.rs"
+line = 114
+callee = "method:expect"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "diagnostics lock drain can panic only if another thread panicked while holding the kit dispatch diagnostics lock."
+
+[[residue]]
+file = "src/kit_dispatch.rs"
+line = 123
+callee = "method:expect"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "registry cache lock read can panic only if another thread panicked while reading the registry cache."
+
+[[residue]]
+file = "src/kit_dispatch.rs"
+line = 133
+callee = "method:expect"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "registry cache lock insert can panic only if another thread panicked while building or inserting the registry cache entry."
+
+[[residue]]
+file = "src/kit_dispatch.rs"
+line = 582
+callee = "method:expect"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "diagnostics lock push in record_dependency_proof_diagnostic can panic only if another thread panicked while recording dependency proof diagnostics."
+
+[[residue]]
+file = "src/kit_dispatch.rs"
+line = 748
+callee = "method:expect"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "diagnostics lock push in record_fallback_diagnostic can panic only if another thread panicked while recording fallback diagnostics."
+
+[[tier_to_close]]
+file = "src/kit_dispatch.rs"
+line = 2416
+callee = "method:expect"
+category = "D-lib"
+tier_to_close = "provekit-cli per-type infallible serialization for RealizeRequest"
+reason = "serde_json::to_value(RealizeRequest) is expected to be total for this CLI-owned request type, but needs a manifest-backed per-type serialization totality proof."

--- a/implementations/rust/provekit-cli/src/cmd_self_check.rs
+++ b/implementations/rust/provekit-cli/src/cmd_self_check.rs
@@ -77,6 +77,10 @@ struct PanicCensusEntry {
     callee: String,
     status: String,
     reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    category: Option<String>,
+    #[serde(rename = "tierToClose", skip_serializing_if = "Option::is_none")]
+    tier_to_close: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -97,6 +101,17 @@ struct SelfCheckScoreboard {
 struct MintOutput {
     proof_file: PathBuf,
     json: Value,
+}
+
+#[derive(Debug, Clone)]
+struct PanicSiteAnnotation {
+    file: String,
+    line: usize,
+    callee: String,
+    status: String,
+    category: String,
+    tier_to_close: String,
+    reason: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -820,9 +835,10 @@ fn build_scoreboard(
         .get("lift")
         .ok_or("target mint JSON missing lift result")?;
     let (lift, bridges, dropped_sites, unbridged_panic_sites) = lift_scoreboards(lift_json);
+    let panic_annotations = panic_site_annotations(lift_json)?;
     let oracle = oracle_scoreboard(mint_json);
     let discharge_split = discharge_split(prove_json);
-    let panic_census = panic_census(prove_json, unbridged_panic_sites);
+    let panic_census = panic_census(prove_json, unbridged_panic_sites, panic_annotations)?;
     let silently_dropped = dropped_sites.len();
 
     Ok(SelfCheckScoreboard {
@@ -960,7 +976,73 @@ fn discharge_split(prove_json: &Value) -> DischargeSplit {
     split
 }
 
-fn panic_census(prove_json: &Value, unbridged: Vec<Site>) -> Vec<PanicCensusEntry> {
+fn panic_site_annotations(
+    lift_json: &Value,
+) -> Result<BTreeMap<(String, usize, String), PanicSiteAnnotation>, String> {
+    let mut annotations = BTreeMap::new();
+    let Some(diagnostics) = lift_json.get("diagnostics").and_then(|v| v.as_array()) else {
+        return Ok(annotations);
+    };
+    for diagnostic in diagnostics {
+        if diagnostic.get("kind").and_then(|v| v.as_str()) != Some("panic-site-annotation") {
+            continue;
+        }
+        let file = required_annotation_string(diagnostic, "file")?;
+        let line = diagnostic
+            .get("line")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| format!("panic-site annotation for {file} missing numeric line"))?
+            as usize;
+        let callee = required_annotation_string(diagnostic, "callee")?;
+        let status = required_annotation_string(diagnostic, "status")?;
+        if status != "residue" && status != "unproven" {
+            return Err(format!(
+                "panic-site annotation for {}:{} {} has invalid status `{}`",
+                file, line, callee, status
+            ));
+        }
+        let category = required_annotation_string(diagnostic, "category")?;
+        let tier_to_close = required_annotation_string(diagnostic, "tierToClose")?;
+        let reason = required_annotation_string(diagnostic, "reason")?;
+        let key = (file.clone(), line, callee.clone());
+        if annotations
+            .insert(
+                key,
+                PanicSiteAnnotation {
+                    file: file.clone(),
+                    line,
+                    callee: callee.clone(),
+                    status,
+                    category,
+                    tier_to_close,
+                    reason,
+                },
+            )
+            .is_some()
+        {
+            return Err(format!(
+                "duplicate panic-site annotation for {}:{} {}",
+                file, line, callee
+            ));
+        }
+    }
+    Ok(annotations)
+}
+
+fn required_annotation_string(diagnostic: &Value, field: &str) -> Result<String, String> {
+    diagnostic
+        .get(field)
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| format!("panic-site annotation missing {field}"))
+}
+
+fn panic_census(
+    prove_json: &Value,
+    unbridged: Vec<Site>,
+    annotations: BTreeMap<(String, usize, String), PanicSiteAnnotation>,
+) -> Result<Vec<PanicCensusEntry>, String> {
     let mut by_site: BTreeMap<(String, usize, String), PanicCensusEntry> = BTreeMap::new();
     if let Some(rows) = prove_json.get("rows").and_then(|v| v.as_array()) {
         for row in rows {
@@ -1006,6 +1088,8 @@ fn panic_census(prove_json: &Value, unbridged: Vec<Site>) -> Vec<PanicCensusEntr
                     callee,
                     status,
                     reason,
+                    category: None,
+                    tier_to_close: None,
                 },
             );
         }
@@ -1020,10 +1104,31 @@ fn panic_census(prove_json: &Value, unbridged: Vec<Site>) -> Vec<PanicCensusEntr
                 callee: site.callee,
                 status: "unproven".to_string(),
                 reason: site.reason,
+                category: None,
+                tier_to_close: None,
             });
     }
 
-    by_site.into_values().collect()
+    for (key, annotation) in annotations {
+        let Some(entry) = by_site.get_mut(&key) else {
+            return Err(format!(
+                "stale panic-site annotation for {}:{} {}",
+                annotation.file, annotation.line, annotation.callee
+            ));
+        };
+        if entry.status == "proven" {
+            return Err(format!(
+                "proven panic-site annotation for {}:{} {}",
+                annotation.file, annotation.line, annotation.callee
+            ));
+        }
+        entry.status = annotation.status;
+        entry.category = Some(annotation.category);
+        entry.tier_to_close = Some(annotation.tier_to_close);
+        entry.reason = annotation.reason;
+    }
+
+    Ok(by_site.into_values().collect())
 }
 
 fn row_reason(row: &Value) -> String {
@@ -1243,9 +1348,69 @@ mod tests {
         })
     }
 
+    fn mint_json_with_diagnostics(diagnostics: Vec<Value>) -> Value {
+        json!({
+            "filenameCid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "oracle": {
+                "requested": true,
+                "reachable": true,
+                "attempted": 1,
+                "resolved": 1
+            },
+            "lift": {
+                "kind": "ir-document",
+                "ir": [],
+                "diagnostics": diagnostics
+            }
+        })
+    }
+
     fn prove_json() -> Value {
         json!({
             "rows": []
+        })
+    }
+
+    fn panic_row(
+        file: &str,
+        line: usize,
+        callee: &str,
+        status: &str,
+        method: Option<&str>,
+    ) -> Value {
+        let mut row = json!({
+            "file": file,
+            "line": line,
+            "callee": callee,
+            "panicSite": true,
+            "status": status,
+            "reason": "synthetic panic row"
+        });
+        if let Some(method) = method {
+            row.as_object_mut()
+                .expect("row object")
+                .insert("dischargeMethod".to_string(), json!(method));
+        }
+        row
+    }
+
+    fn panic_site_annotation(
+        file: &str,
+        line: usize,
+        callee: &str,
+        status: &str,
+        category: &str,
+        tier_to_close: &str,
+    ) -> Value {
+        json!({
+            "kind": "panic-site-annotation",
+            "file": file,
+            "line": line,
+            "callee": callee,
+            "status": status,
+            "category": category,
+            "tierToClose": tier_to_close,
+            "reason": "synthetic annotation reason"
         })
     }
 
@@ -1465,5 +1630,196 @@ mod tests {
                 "requested={requested}, resolved={resolved}"
             );
         }
+    }
+
+    #[test]
+    fn panic_census_applies_residue_annotation_to_unproven_site() {
+        let mint = mint_json_with_diagnostics(vec![panic_site_annotation(
+            "src/kit_dispatch.rs",
+            106,
+            "expect",
+            "residue",
+            "lock_poisoning_residue",
+            "irreducible",
+        )]);
+        let prove = json!({
+            "rows": [panic_row("src/kit_dispatch.rs", 106, "expect", "undecidable", None)]
+        });
+
+        let scoreboard = build_scoreboard("target", &mint, &prove).expect("scoreboard");
+        let rendered = serde_json::to_value(&scoreboard).expect("scoreboard json");
+        let row = &rendered["panicCensus"][0];
+
+        assert_eq!(row["status"], "residue");
+        assert_eq!(row["category"], "lock_poisoning_residue");
+        assert_eq!(row["tierToClose"], "irreducible");
+        assert_eq!(row["reason"], "synthetic annotation reason");
+    }
+
+    #[test]
+    fn panic_census_applies_tier_to_close_annotation_without_proving_site() {
+        let mint = mint_json_with_diagnostics(vec![panic_site_annotation(
+            "src/kit_dispatch.rs",
+            2416,
+            "expect",
+            "unproven",
+            "D-lib",
+            "provekit-cli per-type infallible serialization for RealizeRequest",
+        )]);
+        let prove = json!({
+            "rows": [panic_row("src/kit_dispatch.rs", 2416, "expect", "undecidable", None)]
+        });
+
+        let scoreboard = build_scoreboard("target", &mint, &prove).expect("scoreboard");
+        let rendered = serde_json::to_value(&scoreboard).expect("scoreboard json");
+        let row = &rendered["panicCensus"][0];
+
+        assert_eq!(row["status"], "unproven");
+        assert_eq!(row["category"], "D-lib");
+        assert_eq!(
+            row["tierToClose"],
+            "provekit-cli per-type infallible serialization for RealizeRequest"
+        );
+    }
+
+    #[test]
+    fn panic_census_rejects_duplicate_annotation_keys() {
+        let mint = mint_json_with_diagnostics(vec![
+            panic_site_annotation(
+                "src/kit_dispatch.rs",
+                106,
+                "expect",
+                "residue",
+                "lock_poisoning_residue",
+                "irreducible",
+            ),
+            panic_site_annotation(
+                "src/kit_dispatch.rs",
+                106,
+                "expect",
+                "unproven",
+                "D-lib",
+                "future tier",
+            ),
+        ]);
+        let prove = json!({
+            "rows": [panic_row("src/kit_dispatch.rs", 106, "expect", "undecidable", None)]
+        });
+
+        let err = build_scoreboard("target", &mint, &prove)
+            .expect_err("duplicate annotations must fail closed");
+        assert!(
+            err.contains("duplicate panic-site annotation"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn panic_census_rejects_stale_annotation_without_matching_site() {
+        let mint = mint_json_with_diagnostics(vec![panic_site_annotation(
+            "src/kit_dispatch.rs",
+            9999,
+            "expect",
+            "residue",
+            "lock_poisoning_residue",
+            "irreducible",
+        )]);
+        let prove = json!({
+            "rows": [panic_row("src/kit_dispatch.rs", 106, "expect", "undecidable", None)]
+        });
+
+        let err = build_scoreboard("target", &mint, &prove)
+            .expect_err("stale annotations must fail closed");
+        assert!(
+            err.contains("stale panic-site annotation"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn panic_census_rejects_annotation_on_proven_site() {
+        let mint = mint_json_with_diagnostics(vec![panic_site_annotation(
+            "src/kit_dispatch.rs",
+            106,
+            "expect",
+            "residue",
+            "lock_poisoning_residue",
+            "irreducible",
+        )]);
+        let prove = json!({
+            "rows": [panic_row(
+                "src/kit_dispatch.rs",
+                106,
+                "expect",
+                "discharged",
+                Some("panic-safe")
+            )]
+        });
+
+        let err = build_scoreboard("target", &mint, &prove)
+            .expect_err("annotations on proven sites must fail closed");
+        assert!(
+            err.contains("proven panic-site annotation"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn panic_census_rejects_annotation_missing_tier_to_close() {
+        let mut annotation = panic_site_annotation(
+            "src/kit_dispatch.rs",
+            106,
+            "expect",
+            "residue",
+            "lock_poisoning_residue",
+            "irreducible",
+        );
+        annotation
+            .as_object_mut()
+            .expect("annotation object")
+            .remove("tierToClose");
+        let mint = mint_json_with_diagnostics(vec![annotation]);
+        let prove = json!({
+            "rows": [panic_row("src/kit_dispatch.rs", 106, "expect", "undecidable", None)]
+        });
+
+        let err = build_scoreboard("target", &mint, &prove)
+            .expect_err("missing tierToClose must fail closed");
+        assert!(err.contains("tierToClose"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn panic_census_annotation_preserves_panic_safe_count() {
+        let mut rows = Vec::new();
+        for line in 1..=21 {
+            rows.push(panic_row(
+                "src/proven.rs",
+                line,
+                "unwrap",
+                "discharged",
+                Some("panic-safe"),
+            ));
+        }
+        rows.push(panic_row(
+            "src/kit_dispatch.rs",
+            106,
+            "expect",
+            "undecidable",
+            None,
+        ));
+        let mint = mint_json_with_diagnostics(vec![panic_site_annotation(
+            "src/kit_dispatch.rs",
+            106,
+            "expect",
+            "residue",
+            "lock_poisoning_residue",
+            "irreducible",
+        )]);
+        let prove = json!({ "rows": rows });
+
+        let scoreboard = build_scoreboard("target", &mint, &prove).expect("scoreboard");
+
+        assert_eq!(scoreboard.discharge_split.panic_safe, 21);
+        assert_eq!(scoreboard.discharge_split.false_pass, 0);
     }
 }

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -795,6 +795,142 @@ struct FunctionPostconditionRule {
     reason: String,
 }
 
+#[derive(Debug, Clone, Default)]
+struct ResidueManifest {
+    annotations: Vec<PanicSiteAnnotationDiagnostic>,
+}
+
+#[derive(Debug, Clone)]
+struct PanicSiteAnnotationDiagnostic {
+    file: String,
+    line: usize,
+    callee: String,
+    status: &'static str,
+    category: String,
+    tier_to_close: String,
+    reason: String,
+}
+
+impl ResidueManifest {
+    fn load(workspace_root: &Path) -> Result<Self, String> {
+        let path = workspace_root.join(".provekit").join("residue.toml");
+        if !path.is_file() {
+            return Ok(Self::default());
+        }
+        let raw =
+            std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+        let value: toml::Value =
+            toml::from_str(&raw).map_err(|e| format!("parse {}: {e}", path.display()))?;
+        let table = value
+            .as_table()
+            .ok_or_else(|| format!("{} must be a TOML table", path.display()))?;
+
+        let mut annotations = Vec::new();
+        let mut seen = BTreeSet::new();
+        Self::read_section(
+            &path,
+            table,
+            "residue",
+            "residue",
+            &mut annotations,
+            &mut seen,
+        )?;
+        Self::read_section(
+            &path,
+            table,
+            "tier_to_close",
+            "unproven",
+            &mut annotations,
+            &mut seen,
+        )?;
+
+        Ok(Self { annotations })
+    }
+
+    fn read_section(
+        path: &Path,
+        table: &toml::map::Map<String, toml::Value>,
+        section: &str,
+        status: &'static str,
+        annotations: &mut Vec<PanicSiteAnnotationDiagnostic>,
+        seen: &mut BTreeSet<(String, usize, String)>,
+    ) -> Result<(), String> {
+        let Some(entries_value) = table.get(section) else {
+            return Ok(());
+        };
+        let entries = entries_value.as_array().ok_or_else(|| {
+            format!(
+                "{} field `{section}` must be an array of tables (`[[{section}]]`)",
+                path.display()
+            )
+        })?;
+
+        for (idx, entry) in entries.iter().enumerate() {
+            let context = format!("{section}[{idx}]");
+            let table = entry.as_table().ok_or_else(|| {
+                format!(
+                    "{} `{context}` must be a table, got {}",
+                    path.display(),
+                    toml_value_type(entry)
+                )
+            })?;
+            let file = required_toml_string_for(path, &context, table, "file")?;
+            let line = required_toml_u64_for(path, &context, table, "line")? as usize;
+            let callee = required_toml_string_for(path, &context, table, "callee")?;
+            let category = required_toml_string_for(path, &context, table, "category")?;
+            let tier_to_close = required_toml_string_for(path, &context, table, "tier_to_close")?;
+            let reason = required_toml_string_for(path, &context, table, "reason")?;
+            let key = (file.clone(), line, callee.clone());
+            if !seen.insert(key) {
+                return Err(format!(
+                    "duplicate panic-site annotation for {}:{} {} in {}",
+                    file,
+                    line,
+                    callee,
+                    path.display()
+                ));
+            }
+            annotations.push(PanicSiteAnnotationDiagnostic {
+                file,
+                line,
+                callee,
+                status,
+                category,
+                tier_to_close,
+                reason,
+            });
+        }
+
+        Ok(())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.annotations.is_empty()
+    }
+
+    fn into_diagnostics(self) -> Vec<Value> {
+        self.annotations
+            .into_iter()
+            .map(PanicSiteAnnotationDiagnostic::into_diagnostic)
+            .collect()
+    }
+}
+
+impl PanicSiteAnnotationDiagnostic {
+    fn into_diagnostic(self) -> Value {
+        json!({
+            "kind": "panic-site-annotation",
+            "file": self.file,
+            "line": self.line,
+            "callee": self.callee,
+            "status": self.status,
+            "category": self.category,
+            "tierToClose": self.tier_to_close,
+            "reason": self.reason,
+        })
+    }
+}
+
 impl FunctionPostconditionsManifest {
     fn load(workspace_root: &Path) -> Result<Self, String> {
         let path = workspace_root
@@ -832,20 +968,23 @@ impl FunctionPostconditionsManifest {
                     toml_value_type(entry)
                 )
             })?;
-            let call_kind = match required_toml_string_for(&path, &context, table, "call_kind")?
-                .as_str()
-            {
-                "associated" => FunctionPostconditionCallKind::Associated,
-                "method" => FunctionPostconditionCallKind::Method,
-                other => {
-                    return Err(format!(
+            let call_kind =
+                match required_toml_string_for(&path, &context, table, "call_kind")?.as_str() {
+                    "associated" => FunctionPostconditionCallKind::Associated,
+                    "method" => FunctionPostconditionCallKind::Method,
+                    other => {
+                        return Err(format!(
                         "{} `{context}.call_kind` must be `associated` or `method`, got `{other}`",
                         path.display()
                     ))
-                }
-            };
-            let callee_crate =
-                normalize_crate_root(&required_toml_string_for(&path, &context, table, "callee_crate")?);
+                    }
+                };
+            let callee_crate = normalize_crate_root(&required_toml_string_for(
+                &path,
+                &context,
+                table,
+                "callee_crate",
+            )?);
             let callee = required_toml_string_for(&path, &context, table, "callee")?;
             let contract = required_toml_string_for(&path, &context, table, "contract")?;
             let post_predicate =
@@ -860,8 +999,7 @@ impl FunctionPostconditionsManifest {
 
             let (type_path, receiver_path, arg0) = match call_kind {
                 FunctionPostconditionCallKind::Associated => {
-                    let type_path =
-                        required_toml_string_for(&path, &context, table, "type_path")?;
+                    let type_path = required_toml_string_for(&path, &context, table, "type_path")?;
                     let format_literal =
                         required_toml_string_for(&path, &context, table, "arg0_format_literal")?;
                     let repeat_literal =
@@ -1768,17 +1906,21 @@ fn collect_callsites_in_block(
                     let stem = type_id.head.to_ascii_lowercase();
                     disambiguated_partial_leaf(&stem, &callee).map(|leaf| ("std".to_string(), leaf))
                 });
-            let manifest_panic_target = syntactic_panic_target.as_ref().is_none().then(|| {
-                if is_panic_leaf(&callee) {
-                    self.function_postconditions.panic_partial_for_receiver(
-                        &node.receiver,
-                        self.current_crate,
-                        &callee,
-                    )
-                } else {
-                    None
-                }
-            }).flatten();
+            let manifest_panic_target = syntactic_panic_target
+                .as_ref()
+                .is_none()
+                .then(|| {
+                    if is_panic_leaf(&callee) {
+                        self.function_postconditions.panic_partial_for_receiver(
+                            &node.receiver,
+                            self.current_crate,
+                            &callee,
+                        )
+                    } else {
+                        None
+                    }
+                })
+                .flatten();
             let callee_crate = syntactic_panic_target
                 .as_ref()
                 .map(|(krate, _)| krate.clone())
@@ -1808,11 +1950,7 @@ fn collect_callsites_in_block(
                 disambiguated_callee: syntactic_panic_target
                     .as_ref()
                     .map(|(_, leaf)| leaf.clone())
-                    .or_else(|| {
-                        manifest_panic_target
-                            .as_ref()
-                            .map(|(_, leaf)| leaf.clone())
-                    })
+                    .or_else(|| manifest_panic_target.as_ref().map(|(_, leaf)| leaf.clone()))
                     .or_else(|| {
                         function_postcondition_target
                             .as_ref()
@@ -2578,7 +2716,11 @@ fn receiver_producer_callsite(receiver: &syn::Expr) -> Option<(String, usize, us
     match receiver {
         syn::Expr::MethodCall(method) => {
             let start = method.method.span().start();
-            Some((format!("method:{}", method.method), start.line, start.column))
+            Some((
+                format!("method:{}", method.method),
+                start.line,
+                start.column,
+            ))
         }
         syn::Expr::Call(call) => {
             let (_, callee) = associated_call_path_and_leaf(&call.func)?;
@@ -2836,6 +2978,13 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
             "lift_implications: loaded function postconditions manifest"
         );
     }
+    let residue_manifest = ResidueManifest::load(&workspace_root)?;
+    if !residue_manifest.is_empty() {
+        info!(
+            entries = residue_manifest.annotations.len(),
+            "lift_implications: loaded panic-site residue manifest"
+        );
+    }
 
     // Index contracts by (crate, leaf), not bare leaf. The leaf is the substring
     // before the first '@' in the contract `name` (`<callee>@<file>:<line>:<col>`
@@ -2893,6 +3042,7 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
 
     let mut entries: Vec<Value> = Vec::new();
     let mut diagnostics: Vec<Value> = Vec::new();
+    diagnostics.extend(residue_manifest.into_diagnostics());
 
     // Collect every call site across every file FIRST, carrying each one's
     // absolute path. The Tier-1/2a crate is set during collection; the Tier-2b
@@ -4237,11 +4387,7 @@ fn function_contract_lift(params: &Value) -> Result<Value, String> {
     }
 
     emit_infallible_serialize_contracts(&infallible_serialize, &current_crate, &mut entries)?;
-    emit_function_postcondition_contracts(
-        &function_postconditions,
-        &current_crate,
-        &mut entries,
-    )?;
+    emit_function_postcondition_contracts(&function_postconditions, &current_crate, &mut entries)?;
 
     // Producer-side visibility. This surface emits the contracts that the
     // implication matcher later bridges into; a collapse here (e.g. a soundness
@@ -10102,6 +10248,12 @@ pub fn bitwise_not() -> i64 {
             .expect("write function postconditions manifest");
     }
 
+    fn write_residue_manifest(root: &Path, body: &str) {
+        let provekit_dir = root.join(".provekit");
+        fs::create_dir_all(&provekit_dir).expect("create .provekit dir");
+        fs::write(provekit_dir.join("residue.toml"), body).expect("write residue manifest");
+    }
+
     fn write_sugar_binding_proof(
         proof_dir: &Path,
         mut sugar_entry: Value,
@@ -10801,6 +10953,162 @@ pub fn caller(input: &str) -> i64 {
     }
 
     #[test]
+    fn lift_implications_emits_residue_manifest_annotations() {
+        let root = temp_workspace("lift_implications_residue_annotations");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "consumer-crate"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .expect("write Cargo.toml");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), "pub fn f() {}\n").expect("write source");
+        write_residue_manifest(
+            &root,
+            r#"
+[[residue]]
+file = "src/kit_dispatch.rs"
+line = 106
+callee = "expect"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "Mutex::lock returns Err only when another thread panicked while holding the lock; assuming lock totality would be unsound."
+
+[[tier_to_close]]
+file = "src/kit_dispatch.rs"
+line = 2416
+callee = "expect"
+category = "D-lib"
+tier_to_close = "provekit-cli per-type infallible serialization for RealizeRequest"
+reason = "serde_json::to_value(RealizeRequest) is closeable by a provekit-cli owned per-type manifest."
+"#,
+        );
+
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": [],
+        }))
+        .expect("lift_implications");
+        let diagnostics = resp["diagnostics"].as_array().expect("diagnostics");
+        let annotations: Vec<&Value> = diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic["kind"] == "panic-site-annotation")
+            .collect();
+
+        assert_eq!(
+            annotations.len(),
+            2,
+            "expected manifest annotations: {diagnostics:#?}"
+        );
+        assert_eq!(annotations[0]["status"], "residue");
+        assert_eq!(annotations[0]["category"], "lock_poisoning_residue");
+        assert_eq!(annotations[0]["tierToClose"], "irreducible");
+        assert_eq!(annotations[1]["status"], "unproven");
+        assert_eq!(annotations[1]["category"], "D-lib");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_rejects_duplicate_residue_manifest_sites() {
+        let root = temp_workspace("lift_implications_residue_duplicate");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "consumer-crate"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .expect("write Cargo.toml");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), "pub fn f() {}\n").expect("write source");
+        write_residue_manifest(
+            &root,
+            r#"
+[[residue]]
+file = "src/kit_dispatch.rs"
+line = 106
+callee = "expect"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "first"
+
+[[tier_to_close]]
+file = "src/kit_dispatch.rs"
+line = 106
+callee = "expect"
+category = "D-lib"
+tier_to_close = "future tier"
+reason = "second"
+"#,
+        );
+
+        let err = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": [],
+        }))
+        .expect_err("duplicate residue manifest sites must fail closed");
+        assert!(
+            err.contains("duplicate panic-site annotation"),
+            "unexpected error: {err}"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_rejects_residue_manifest_missing_tier_to_close() {
+        let root = temp_workspace("lift_implications_residue_missing_tier");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "consumer-crate"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .expect("write Cargo.toml");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), "pub fn f() {}\n").expect("write source");
+        write_residue_manifest(
+            &root,
+            r#"
+[[residue]]
+file = "src/kit_dispatch.rs"
+line = 106
+callee = "expect"
+category = "lock_poisoning_residue"
+reason = "missing tier"
+"#,
+        );
+
+        let err = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": [],
+        }))
+        .expect_err("missing tier_to_close must fail closed");
+        assert!(err.contains("tier_to_close"), "unexpected error: {err}");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn lift_implications_skips_cfg_test_callsites() {
         let src = r##"
 pub fn production() -> i64 {
@@ -11373,8 +11681,7 @@ reason = "grammar_op_shape(CONCEPT_BIND_RESULT) has a fixed primitive arm and js
         let catalog_hits: Vec<&Value> = ir
             .iter()
             .filter(|entry| {
-                entry["sourceSymbol"] == "method:cid"
-                    && entry["targetContractCid"] == catalog_cid
+                entry["sourceSymbol"] == "method:cid" && entry["targetContractCid"] == catalog_cid
             })
             .collect();
         assert_eq!(


### PR DESCRIPTION
## What changed

- Adds a Rust-kit `.provekit/residue.toml` surface for target-scoped panic-site annotations.
- Emits `panic-site-annotation` lift diagnostics from the Rust kit for `[[residue]]` and `[[tier_to_close]]` entries.
- Teaches `self-check` to apply those diagnostics to the panic census, fail closed on stale/duplicate/proven-site annotations, and expose `category` plus `tierToClose` in JSON.
- Seeds current self-application annotations:
  - `provekit-cli`: 8 Mutex poisoning residues and 1 `RealizeRequest` D-lib tier-to-close row.
  - `libprovekit`: 1 platform semantics runtime residue row.

## Why

The panic census needs to name honest residue instead of leaving every unproven panic site as an undifferentiated gap. These annotations do not prove new sites. They enrich the existing census with a category, a closing tier, and a reason while preserving the verifier floor.

This is intentionally target-scoped. Cross-target propagation of annotations through dependency `.proof` bundles is future substrate work tracked in #1773.

## Notes

#1774 tracks a separate K reproducibility issue: clean dependency-proof state can report a different `panicSafe` count from a warmed/cached state. This PR does not solve that. The residue annotations are applied per row regardless of cache state, and the no-silent-failure floor remains the gate.

## Validation

- `git diff --check`
- `../../bin/bcargo test -p provekit-cli panic_census_ -- --nocapture`
  - 7 targeted CLI annotation/fail-closed tests passed in both `src/lib.rs` and `src/main.rs` test targets.
- `../../bin/bcargo test -p provekit-walk residue_manifest -- --nocapture`
  - 3 Rust-kit residue manifest tests passed.
- `provekit self-check --target provekit-cli --oracle --json` on battleaxe with pinned RA/linkerd env:
  - `dischargeSplit={panicSafe:21,falsePass:0,reflexive:1065,vacuous:349,undecidable:2244}`
  - `oracle={attempted:3516,resolved:3430}`
  - `silentlyDropped=0`, `droppedSites=[]`
  - panic census statuses: `proven=21`, `residue=8`, `unproven=24`
  - 8 `lock_poisoning_residue` rows applied and `src/kit_dispatch.rs:2416` carries the D-lib `tierToClose`.
- `provekit self-check --target libprovekit --oracle --json` on battleaxe with pinned RA/linkerd env:
  - `dischargeSplit={panicSafe:12,falsePass:0,reflexive:663,vacuous:194,undecidable:1486}`
  - `oracle={attempted:2740,resolved:2504}`
  - `silentlyDropped=0`, `droppedSites=[]`
  - panic census statuses: `proven=12`, `residue=1`, `unproven=22`
  - `src/core/platform_semantics.rs:42` carries `platform_semantics_runtime_residue`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for panic-site annotations to explicitly categorize and document acceptable panic conditions across verification targets.

* **Configuration**
  * Introduced `.provekit/residue.toml` configuration files enabling explicit declaration of panic-site metadata with categorization and proof-status information.

* **Improvements**
  * Enhanced self-check scoreboard to validate and apply panic-site annotations with strict deduplication and error handling for misconfigurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->