### PR TITLE
feat(self-check): join panic annotations at runtime

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_self_check.rs
+++ b/implementations/rust/provekit-cli/src/cmd_self_check.rs
@@ -13,6 +13,10 @@ use serde::Serialize;
 use serde_json::Value;
 use tracing::{error, info};
 
+use crate::panic_annotations_runtime::{
+    annotation_runtime_check, AnnotationCheckMode, PanicCensusRow,
+};
+
 #[derive(Parser, Debug, Clone)]
 pub struct SelfCheckArgs {
     /// Target crate directory. Defaults to implementations/rust/provekit-cli.
@@ -287,7 +291,13 @@ fn run_inner(args: &SelfCheckArgs) -> Result<SelfCheckScoreboard, String> {
     };
     info!("self-check: prove complete; building scoreboard");
 
-    let scoreboard = build_scoreboard(&target_rel, &target_mint.json, &prove_json)?;
+    let scoreboard = build_scoreboard_with_runtime_annotations(
+        &target_rel,
+        &target_abs,
+        &target_mint.json,
+        &prove_json,
+        AnnotationCheckMode::Strict,
+    )?;
     info!(
         oracle_requested = scoreboard.oracle.requested,
         oracle_engaged = scoreboard.oracle.engaged,
@@ -820,6 +830,11 @@ where
     Ok(count)
 }
 
+#[cfg(test)]
+// DEPRECATED (#1783): legacy lift-diagnostic panic-site annotation join.
+// Production self-check uses panic_annotations_runtime with target-local
+// .provekit/residue.toml after prove produces panicCensus. Retain this
+// test-only route until the old tests are migrated or deleted.
 fn build_scoreboard(
     target_rel: &str,
     mint_json: &Value,
@@ -852,6 +867,91 @@ fn build_scoreboard(
         discharge_split,
         panic_census,
     })
+}
+
+fn build_scoreboard_with_runtime_annotations(
+    target_rel: &str,
+    target_path: &Path,
+    mint_json: &Value,
+    prove_json: &Value,
+    doctor_mode: AnnotationCheckMode,
+) -> Result<SelfCheckScoreboard, String> {
+    let catalog_cid = mint_json
+        .get("filenameCid")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or("target mint JSON missing filenameCid")?
+        .to_string();
+    let lift_json = mint_json
+        .get("lift")
+        .ok_or("target mint JSON missing lift result")?;
+    let (lift, bridges, dropped_sites, unbridged_panic_sites) = lift_scoreboards(lift_json);
+    let oracle = oracle_scoreboard(mint_json);
+    let discharge_split = discharge_split(prove_json);
+    let raw_panic_census = panic_census(prove_json, unbridged_panic_sites, BTreeMap::new())?;
+    let projected_rows: Vec<PanicCensusRow> = raw_panic_census
+        .iter()
+        .map(panic_census_row_from_entry)
+        .collect();
+    let annotation_outcome = annotation_runtime_check(target_path, &projected_rows, doctor_mode)
+        .map_err(|error| {
+            format!(
+                "panic annotation runtime check failed: {}; evidence={}",
+                error, error.check.evidence
+            )
+        })?;
+    let annotation_check = &annotation_outcome.check;
+    info!(
+        check_id = %annotation_check.id,
+        check_name = %annotation_check.name,
+        check_domain = %annotation_check.domain,
+        check_status = ?annotation_check.status,
+        check_severity = ?annotation_check.severity,
+        check_detail = %annotation_check.detail,
+        "self-check: panic annotation runtime check complete"
+    );
+    let panic_census = annotation_outcome
+        .rows
+        .iter()
+        .map(panic_census_entry_from_row)
+        .collect();
+    let silently_dropped = dropped_sites.len();
+
+    Ok(SelfCheckScoreboard {
+        target: target_rel.to_string(),
+        catalog_cid,
+        lift,
+        bridges,
+        oracle,
+        silently_dropped,
+        dropped_sites,
+        discharge_split,
+        panic_census,
+    })
+}
+
+fn panic_census_row_from_entry(entry: &PanicCensusEntry) -> PanicCensusRow {
+    PanicCensusRow {
+        file: entry.file.clone(),
+        line: entry.line,
+        callee: entry.callee.clone(),
+        status: entry.status.clone(),
+        reason: entry.reason.clone(),
+        category: entry.category.clone(),
+        tier_to_close: entry.tier_to_close.clone(),
+    }
+}
+
+fn panic_census_entry_from_row(row: &PanicCensusRow) -> PanicCensusEntry {
+    PanicCensusEntry {
+        file: row.file.clone(),
+        line: row.line,
+        callee: row.callee.clone(),
+        status: row.status.clone(),
+        reason: row.reason.clone(),
+        category: row.category.clone(),
+        tier_to_close: row.tier_to_close.clone(),
+    }
 }
 
 fn lift_scoreboards(lift_json: &Value) -> (LiftScoreboard, BridgeScoreboard, Vec<Site>, Vec<Site>) {
@@ -976,6 +1076,7 @@ fn discharge_split(prove_json: &Value) -> DischargeSplit {
     split
 }
 
+#[cfg(test)]
 fn panic_site_annotations(
     lift_json: &Value,
 ) -> Result<BTreeMap<(String, usize, String), PanicSiteAnnotation>, String> {
@@ -1029,6 +1130,7 @@ fn panic_site_annotations(
     Ok(annotations)
 }
 
+#[cfg(test)]
 fn required_annotation_string(diagnostic: &Value, field: &str) -> Result<String, String> {
     diagnostic
         .get(field)
@@ -1821,5 +1923,128 @@ mod tests {
 
         assert_eq!(scoreboard.discharge_split.panic_safe, 21);
         assert_eq!(scoreboard.discharge_split.false_pass, 0);
+    }
+
+    fn write_self_check_residue_manifest(target: &Path, body: &str) {
+        let provekit = target.join(".provekit");
+        fs::create_dir_all(&provekit).expect("create .provekit");
+        fs::write(provekit.join("residue.toml"), body).expect("write residue manifest");
+    }
+
+    #[test]
+    fn build_scoreboard_applies_runtime_doctor_annotations_from_target_manifest() {
+        let td = tempfile::tempdir().expect("tempdir");
+        write_self_check_residue_manifest(
+            td.path(),
+            r#"
+[[residue]]
+file = "src/kit_dispatch.rs"
+line = 106
+callee = "expect"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "runtime doctor annotation"
+"#,
+        );
+        let mint = mint_json_with_diagnostics(vec![]);
+        let prove = json!({
+            "rows": [panic_row("src/kit_dispatch.rs", 106, "expect", "undecidable", None)]
+        });
+
+        let scoreboard = build_scoreboard_with_runtime_annotations(
+            "target",
+            td.path(),
+            &mint,
+            &prove,
+            crate::panic_annotations_runtime::AnnotationCheckMode::Strict,
+        )
+        .expect("scoreboard");
+        let rendered = serde_json::to_value(&scoreboard).expect("scoreboard json");
+        let row = &rendered["panicCensus"][0];
+
+        assert_eq!(row["status"], "residue");
+        assert_eq!(row["category"], "lock_poisoning_residue");
+        assert_eq!(row["tierToClose"], "irreducible");
+        assert_eq!(row["reason"], "runtime doctor annotation");
+    }
+
+    #[test]
+    fn runtime_doctor_annotation_receives_post_prove_panic_census_projection() {
+        let td = tempfile::tempdir().expect("tempdir");
+        write_self_check_residue_manifest(
+            td.path(),
+            r#"
+[[tier_to_close]]
+file = "src/generated_by_prove.rs"
+line = 44
+callee = "method:unwrap"
+category = "D-lib"
+tier_to_close = "future totality proof"
+reason = "this row exists only in prove output"
+"#,
+        );
+        let mint = mint_json_with_diagnostics(vec![]);
+        let prove = json!({
+            "rows": [panic_row(
+                "src/generated_by_prove.rs",
+                44,
+                "method:unwrap",
+                "undecidable",
+                None
+            )]
+        });
+
+        let scoreboard = build_scoreboard_with_runtime_annotations(
+            "target",
+            td.path(),
+            &mint,
+            &prove,
+            crate::panic_annotations_runtime::AnnotationCheckMode::Strict,
+        )
+        .expect("scoreboard");
+
+        assert_eq!(
+            scoreboard.panic_census[0].category.as_deref(),
+            Some("D-lib")
+        );
+        assert_eq!(
+            scoreboard.panic_census[0].tier_to_close.as_deref(),
+            Some("future totality proof")
+        );
+    }
+
+    #[test]
+    fn runtime_doctor_annotation_drift_fails_self_check_scoreboard_build() {
+        let td = tempfile::tempdir().expect("tempdir");
+        write_self_check_residue_manifest(
+            td.path(),
+            r#"
+[[residue]]
+file = "src/missing.rs"
+line = 99
+callee = "method:unwrap"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "stale annotation"
+"#,
+        );
+        let mint = mint_json_with_diagnostics(vec![]);
+        let prove = json!({
+            "rows": [panic_row("src/live.rs", 1, "method:unwrap", "undecidable", None)]
+        });
+
+        let err = build_scoreboard_with_runtime_annotations(
+            "target",
+            td.path(),
+            &mint,
+            &prove,
+            crate::panic_annotations_runtime::AnnotationCheckMode::Strict,
+        )
+        .expect_err("strict runtime annotation drift must fail");
+
+        assert!(
+            err.contains("panic annotation runtime check failed") && err.contains("src/missing.rs"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/implementations/rust/provekit-cli/src/lib.rs
+++ b/implementations/rust/provekit-cli/src/lib.rs
@@ -33,5 +33,6 @@ pub struct OutputFlags {
 
 pub mod cmd_self_check;
 pub mod kit_dispatch;
+pub mod panic_annotations_runtime;
 pub mod project_config;
 pub mod sort_morphism_catalog;

--- a/implementations/rust/provekit-cli/src/main.rs
+++ b/implementations/rust/provekit-cli/src/main.rs
@@ -42,6 +42,7 @@ mod doctor;
 mod doctor_oracle;
 mod kit_dispatch;
 mod lift_plugin;
+pub mod panic_annotations_runtime;
 mod project_config;
 mod protocol;
 mod report_fmt;

--- a/implementations/rust/provekit-cli/src/panic_annotations_runtime.rs
+++ b/implementations/rust/provekit-cli/src/panic_annotations_runtime.rs
@@ -1,0 +1,855 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use serde::Serialize;
+use serde_json::{json, Value};
+
+pub const PANIC_ANNOTATIONS_RUNTIME_NAME: &str = "panic-annotations-runtime";
+pub const PANIC_ANNOTATIONS_RUNTIME_ID: &str = "panic_annotations.census.joinable";
+pub const PANIC_ANNOTATIONS_RUNTIME_DOMAIN: &str = "panic_annotations";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnnotationCheckMode {
+    // These modes intentionally parallel DoctorMode without importing it.
+    // This module is a substrate census join used by doctor, self-check, and
+    // future product surfaces; callers translate policy modes at the boundary.
+    Structural,
+    Strict,
+    ReleaseGate,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AnnotationCheckStatus {
+    Pass,
+    Warn,
+    Fail,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AnnotationCheckSeverity {
+    Advisory,
+    Hard,
+}
+
+#[derive(Debug, Clone)]
+pub struct AnnotationRuntimeCheck {
+    pub id: String,
+    pub name: String,
+    pub status: AnnotationCheckStatus,
+    pub severity: AnnotationCheckSeverity,
+    pub domain: String,
+    pub detail: String,
+    pub evidence: Value,
+}
+
+impl AnnotationRuntimeCheck {
+    fn pass_with_severity(
+        severity: AnnotationCheckSeverity,
+        detail: impl Into<String>,
+        evidence: Value,
+    ) -> Self {
+        Self::with_status_and_severity(AnnotationCheckStatus::Pass, severity, detail, evidence)
+    }
+
+    fn with_status_and_severity(
+        status: AnnotationCheckStatus,
+        severity: AnnotationCheckSeverity,
+        detail: impl Into<String>,
+        evidence: Value,
+    ) -> Self {
+        Self {
+            id: PANIC_ANNOTATIONS_RUNTIME_ID.to_string(),
+            name: PANIC_ANNOTATIONS_RUNTIME_NAME.to_string(),
+            status,
+            severity,
+            domain: PANIC_ANNOTATIONS_RUNTIME_DOMAIN.to_string(),
+            detail: detail.into(),
+            evidence,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PanicCensusRow {
+    pub file: String,
+    pub line: usize,
+    pub callee: String,
+    pub status: String,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    #[serde(rename = "tierToClose", skip_serializing_if = "Option::is_none")]
+    pub tier_to_close: Option<String>,
+}
+
+pub type AnnotatedPanicCensusRow = PanicCensusRow;
+
+#[derive(Debug, Clone)]
+pub struct AnnotationRuntimeOutcome {
+    pub rows: Vec<AnnotatedPanicCensusRow>,
+    pub check: AnnotationRuntimeCheck,
+}
+
+#[derive(Debug, Clone)]
+pub struct AnnotationCheckError {
+    pub check: AnnotationRuntimeCheck,
+}
+
+impl std::fmt::Display for AnnotationCheckError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.check.detail)
+    }
+}
+
+impl std::error::Error for AnnotationCheckError {}
+
+#[derive(Debug, Clone)]
+struct RuntimeAnnotation {
+    file: String,
+    line: usize,
+    callee: String,
+    status: String,
+    category: String,
+    tier_to_close: String,
+    reason: String,
+}
+
+impl RuntimeAnnotation {
+    fn key(&self) -> (String, usize, String) {
+        (self.file.clone(), self.line, self.callee.clone())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RuntimeAnnotationManifest {
+    present: bool,
+    annotations: Vec<RuntimeAnnotation>,
+    issues: Vec<Value>,
+}
+
+pub fn annotation_runtime_check(
+    target_path: &Path,
+    panic_census: &[PanicCensusRow],
+    mode: AnnotationCheckMode,
+) -> Result<AnnotationRuntimeOutcome, AnnotationCheckError> {
+    let manifest = runtime_annotation_manifest(target_path);
+    if !manifest.present {
+        return Ok(AnnotationRuntimeOutcome {
+            rows: panic_census.to_vec(),
+            check: AnnotationRuntimeCheck::pass_with_severity(
+                AnnotationCheckSeverity::Advisory,
+                "no panic annotation manifest present",
+                json!({
+                    "manifestPresent": false,
+                    "rowCount": panic_census.len(),
+                }),
+            ),
+        });
+    }
+
+    let mut issues = manifest.issues;
+    let mut rows = panic_census.to_vec();
+    let before_k = count_proven_rows(&rows);
+    let row_index: BTreeMap<(String, usize, String), usize> = rows
+        .iter()
+        .enumerate()
+        .map(|(index, row)| ((row.file.clone(), row.line, row.callee.clone()), index))
+        .collect();
+
+    for annotation in manifest.annotations {
+        let key = annotation.key();
+        let Some(index) = row_index.get(&key).copied() else {
+            issues.push(annotation_issue(
+                "stale",
+                &format!(
+                    "stale panic-site annotation for {}:{} {}",
+                    annotation.file, annotation.line, annotation.callee
+                ),
+                Some(&annotation),
+            ));
+            continue;
+        };
+        if rows[index].status == "proven" {
+            issues.push(annotation_issue(
+                "proven_site_collision",
+                &format!(
+                    "proven panic-site annotation for {}:{} {}",
+                    annotation.file, annotation.line, annotation.callee
+                ),
+                Some(&annotation),
+            ));
+            continue;
+        }
+        rows[index].status = annotation.status;
+        rows[index].category = Some(annotation.category);
+        rows[index].tier_to_close = Some(annotation.tier_to_close);
+        rows[index].reason = annotation.reason;
+    }
+
+    let after_k = count_proven_rows(&rows);
+    if before_k != after_k {
+        issues.push(json!({
+            "kind": "k_instability",
+            "detail": format!("panic annotation runtime changed proven count from {before_k} to {after_k}"),
+            "before": before_k,
+            "after": after_k,
+        }));
+    }
+
+    let evidence = json!({
+        "manifestPresent": true,
+        "rowCount": panic_census.len(),
+        "annotatedRowCount": rows
+            .iter()
+            .filter(|row| row.category.is_some() || row.tier_to_close.is_some())
+            .count(),
+        "errors": issues,
+    });
+
+    if evidence
+        .get("errors")
+        .and_then(Value::as_array)
+        .map_or(false, |errors| !errors.is_empty())
+    {
+        let (status, severity) = annotation_drift_policy(mode);
+        let check = AnnotationRuntimeCheck::with_status_and_severity(
+            status,
+            severity,
+            format!(
+                "panic annotation runtime check found {} drift issue(s)",
+                evidence
+                    .get("errors")
+                    .and_then(Value::as_array)
+                    .map(Vec::len)
+                    .unwrap_or(0)
+            ),
+            evidence,
+        );
+        if mode == AnnotationCheckMode::Structural {
+            Ok(AnnotationRuntimeOutcome { rows, check })
+        } else {
+            Err(AnnotationCheckError { check })
+        }
+    } else {
+        Ok(AnnotationRuntimeOutcome {
+            rows,
+            check: AnnotationRuntimeCheck::pass_with_severity(
+                AnnotationCheckSeverity::Advisory,
+                "panic annotation manifest joins current panic census",
+                evidence,
+            ),
+        })
+    }
+}
+
+fn runtime_annotation_manifest(target_path: &Path) -> RuntimeAnnotationManifest {
+    let path = target_path.join(".provekit").join("residue.toml");
+    if !path.is_file() {
+        return RuntimeAnnotationManifest {
+            present: false,
+            annotations: Vec::new(),
+            issues: Vec::new(),
+        };
+    }
+
+    let text = match fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(error) => {
+            return RuntimeAnnotationManifest {
+                present: true,
+                annotations: Vec::new(),
+                issues: vec![json!({
+                    "kind": "malformed",
+                    "path": path.display().to_string(),
+                    "detail": format!("read panic annotation manifest: {error}"),
+                })],
+            };
+        }
+    };
+    let value = match text.parse::<toml::Value>() {
+        Ok(value) => value,
+        Err(error) => {
+            return RuntimeAnnotationManifest {
+                present: true,
+                annotations: Vec::new(),
+                issues: vec![json!({
+                    "kind": "malformed",
+                    "path": path.display().to_string(),
+                    "detail": format!("parse panic annotation manifest: {error}"),
+                })],
+            };
+        }
+    };
+
+    let mut annotations = Vec::new();
+    let mut issues = Vec::new();
+    let mut seen = BTreeMap::<(String, usize, String), String>::new();
+    collect_runtime_annotations(
+        &value,
+        "residue",
+        "residue",
+        &mut seen,
+        &mut annotations,
+        &mut issues,
+    );
+    collect_runtime_annotations(
+        &value,
+        "tier_to_close",
+        "unproven",
+        &mut seen,
+        &mut annotations,
+        &mut issues,
+    );
+
+    RuntimeAnnotationManifest {
+        present: true,
+        annotations,
+        issues,
+    }
+}
+
+fn collect_runtime_annotations(
+    value: &toml::Value,
+    table: &str,
+    status: &str,
+    seen: &mut BTreeMap<(String, usize, String), String>,
+    annotations: &mut Vec<RuntimeAnnotation>,
+    issues: &mut Vec<Value>,
+) {
+    let Some(entries) = value.get(table) else {
+        return;
+    };
+    let Some(entries) = entries.as_array() else {
+        issues.push(json!({
+            "kind": "malformed",
+            "table": table,
+            "detail": format!("{table} must be an array of tables"),
+        }));
+        return;
+    };
+    for (index, entry) in entries.iter().enumerate() {
+        match runtime_annotation_from_value(entry, table, index, status) {
+            Ok(annotation) => {
+                let key = annotation.key();
+                if let Some(previous) = seen.insert(key.clone(), table.to_string()) {
+                    issues.push(json!({
+                        "kind": "duplicate",
+                        "file": key.0,
+                        "line": key.1,
+                        "callee": key.2,
+                        "firstTable": previous,
+                        "secondTable": table,
+                    }));
+                } else {
+                    annotations.push(annotation);
+                }
+            }
+            Err(issue) => issues.push(issue),
+        }
+    }
+}
+
+fn runtime_annotation_from_value(
+    entry: &toml::Value,
+    table: &str,
+    index: usize,
+    status: &str,
+) -> Result<RuntimeAnnotation, Value> {
+    let file = runtime_annotation_str(entry, "file", table, index)?;
+    let line = entry
+        .get("line")
+        .and_then(toml::Value::as_integer)
+        .filter(|line| *line >= 0)
+        .map(|line| line as usize)
+        .ok_or_else(|| {
+            annotation_malformed_issue(table, index, "line", "line must be a nonnegative integer")
+        })?;
+    let callee = runtime_annotation_str(entry, "callee", table, index)?;
+    let category = runtime_annotation_str(entry, "category", table, index)?;
+    let tier_to_close = entry
+        .get("tier_to_close")
+        .or_else(|| entry.get("tierToClose"))
+        .and_then(toml::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            annotation_malformed_issue(
+                table,
+                index,
+                "tier_to_close",
+                "tier_to_close must be a nonempty string",
+            )
+        })?;
+    let reason = runtime_annotation_str(entry, "reason", table, index)?;
+    Ok(RuntimeAnnotation {
+        file,
+        line,
+        callee,
+        status: status.to_string(),
+        category,
+        tier_to_close,
+        reason,
+    })
+}
+
+fn runtime_annotation_str(
+    entry: &toml::Value,
+    field: &str,
+    table: &str,
+    index: usize,
+) -> Result<String, Value> {
+    entry
+        .get(field)
+        .and_then(toml::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            annotation_malformed_issue(
+                table,
+                index,
+                field,
+                &format!("{field} must be a nonempty string"),
+            )
+        })
+}
+
+fn annotation_malformed_issue(table: &str, index: usize, field: &str, detail: &str) -> Value {
+    json!({
+        "kind": "malformed",
+        "table": table,
+        "index": index,
+        "field": field,
+        "detail": detail,
+    })
+}
+
+fn annotation_issue(kind: &str, detail: &str, annotation: Option<&RuntimeAnnotation>) -> Value {
+    let mut issue = json!({
+        "kind": kind,
+        "detail": detail,
+    });
+    if let (Some(obj), Some(annotation)) = (issue.as_object_mut(), annotation) {
+        obj.insert("file".to_string(), Value::String(annotation.file.clone()));
+        obj.insert("line".to_string(), json!(annotation.line));
+        obj.insert(
+            "callee".to_string(),
+            Value::String(annotation.callee.clone()),
+        );
+    }
+    issue
+}
+
+fn count_proven_rows(rows: &[PanicCensusRow]) -> usize {
+    rows.iter().filter(|row| row.status == "proven").count()
+}
+
+fn annotation_drift_policy(
+    mode: AnnotationCheckMode,
+) -> (AnnotationCheckStatus, AnnotationCheckSeverity) {
+    match mode {
+        AnnotationCheckMode::Structural => (
+            AnnotationCheckStatus::Warn,
+            AnnotationCheckSeverity::Advisory,
+        ),
+        AnnotationCheckMode::Strict | AnnotationCheckMode::ReleaseGate => {
+            (AnnotationCheckStatus::Fail, AnnotationCheckSeverity::Hard)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn runtime_panic_row(file: &str, line: usize, callee: &str, status: &str) -> PanicCensusRow {
+        PanicCensusRow {
+            file: file.to_string(),
+            line,
+            callee: callee.to_string(),
+            status: status.to_string(),
+            reason: "synthetic runtime row".to_string(),
+            category: None,
+            tier_to_close: None,
+        }
+    }
+
+    fn write_runtime_annotation_manifest(target: &Path, body: &str) {
+        let provekit = target.join(".provekit");
+        fs::create_dir_all(&provekit).expect("create .provekit");
+        fs::write(provekit.join("residue.toml"), body).expect("write residue manifest");
+    }
+
+    #[test]
+    fn annotation_runtime_no_manifest_passes_with_unchanged_census() {
+        let td = tempfile::tempdir().unwrap();
+        let rows = vec![runtime_panic_row(
+            "src/lib.rs",
+            10,
+            "method:expect",
+            "unproven",
+        )];
+
+        let outcome = annotation_runtime_check(td.path(), &rows, AnnotationCheckMode::Strict)
+            .expect("no manifest");
+
+        assert_eq!(outcome.check.status, AnnotationCheckStatus::Pass);
+        assert_eq!(
+            outcome
+                .check
+                .evidence
+                .get("manifestPresent")
+                .and_then(Value::as_bool),
+            Some(false)
+        );
+        assert_eq!(outcome.rows, rows);
+    }
+
+    #[test]
+    fn annotation_runtime_valid_residue_enriches_unproven_row() {
+        let td = tempfile::tempdir().unwrap();
+        write_runtime_annotation_manifest(
+            td.path(),
+            r#"
+[[residue]]
+file = "src/lib.rs"
+line = 10
+callee = "method:expect"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "lock poisoning is runtime residue"
+"#,
+        );
+        let rows = vec![runtime_panic_row(
+            "src/lib.rs",
+            10,
+            "method:expect",
+            "unproven",
+        )];
+
+        let outcome = annotation_runtime_check(td.path(), &rows, AnnotationCheckMode::Strict)
+            .expect("valid residue");
+        let row = &outcome.rows[0];
+
+        assert_eq!(outcome.check.status, AnnotationCheckStatus::Pass);
+        assert_eq!(row.status, "residue");
+        assert_eq!(row.category.as_deref(), Some("lock_poisoning_residue"));
+        assert_eq!(row.tier_to_close.as_deref(), Some("irreducible"));
+        assert_eq!(row.reason, "lock poisoning is runtime residue");
+    }
+
+    #[test]
+    fn annotation_runtime_valid_tier_to_close_preserves_unproven_status() {
+        let td = tempfile::tempdir().unwrap();
+        write_runtime_annotation_manifest(
+            td.path(),
+            r#"
+[[tier_to_close]]
+file = "src/lib.rs"
+line = 10
+callee = "method:expect"
+category = "D-lib"
+tier_to_close = "per-type totality proof"
+reason = "close with a manifest-backed function postcondition"
+"#,
+        );
+        let rows = vec![runtime_panic_row(
+            "src/lib.rs",
+            10,
+            "method:expect",
+            "unproven",
+        )];
+
+        let outcome = annotation_runtime_check(td.path(), &rows, AnnotationCheckMode::Strict)
+            .expect("valid tier");
+        let row = &outcome.rows[0];
+
+        assert_eq!(row.status, "unproven");
+        assert_eq!(row.category.as_deref(), Some("D-lib"));
+        assert_eq!(
+            row.tier_to_close.as_deref(),
+            Some("per-type totality proof")
+        );
+    }
+
+    #[test]
+    fn annotation_runtime_stale_annotation_warns_in_structural() {
+        let td = tempfile::tempdir().unwrap();
+        write_runtime_annotation_manifest(
+            td.path(),
+            r#"
+[[residue]]
+file = "src/lib.rs"
+line = 99
+callee = "method:expect"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "stale row"
+"#,
+        );
+        let rows = vec![runtime_panic_row(
+            "src/lib.rs",
+            10,
+            "method:expect",
+            "unproven",
+        )];
+
+        let outcome = annotation_runtime_check(td.path(), &rows, AnnotationCheckMode::Structural)
+            .expect("warn only");
+
+        assert_eq!(outcome.check.status, AnnotationCheckStatus::Warn);
+        assert_eq!(outcome.check.severity, AnnotationCheckSeverity::Advisory);
+        assert!(
+            outcome.check.evidence.to_string().contains("stale"),
+            "stale warning should be named: {:#?}",
+            outcome.check
+        );
+        assert_eq!(outcome.rows, rows);
+    }
+
+    #[test]
+    fn annotation_runtime_stale_annotation_fails_hard_in_strict() {
+        let td = tempfile::tempdir().unwrap();
+        write_runtime_annotation_manifest(
+            td.path(),
+            r#"
+[[residue]]
+file = "src/lib.rs"
+line = 99
+callee = "method:expect"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "stale row"
+"#,
+        );
+        let rows = vec![runtime_panic_row(
+            "src/lib.rs",
+            10,
+            "method:expect",
+            "unproven",
+        )];
+
+        let err = annotation_runtime_check(td.path(), &rows, AnnotationCheckMode::Strict)
+            .expect_err("strict stale annotations must fail");
+
+        assert_eq!(err.check.status, AnnotationCheckStatus::Fail);
+        assert_eq!(err.check.severity, AnnotationCheckSeverity::Hard);
+        assert!(
+            err.check.evidence.to_string().contains("src/lib.rs")
+                && err.check.evidence.to_string().contains("99"),
+            "strict stale evidence should name the entry: {:#?}",
+            err.check
+        );
+    }
+
+    #[test]
+    fn annotation_runtime_duplicate_keys_fail_hard_in_release_gate() {
+        let td = tempfile::tempdir().unwrap();
+        write_runtime_annotation_manifest(
+            td.path(),
+            r#"
+[[residue]]
+file = "src/lib.rs"
+line = 10
+callee = "method:expect"
+category = "first"
+tier_to_close = "irreducible"
+reason = "first"
+
+[[tier_to_close]]
+file = "src/lib.rs"
+line = 10
+callee = "method:expect"
+category = "second"
+tier_to_close = "later"
+reason = "second"
+"#,
+        );
+        let rows = vec![runtime_panic_row(
+            "src/lib.rs",
+            10,
+            "method:expect",
+            "unproven",
+        )];
+
+        let err = annotation_runtime_check(td.path(), &rows, AnnotationCheckMode::ReleaseGate)
+            .expect_err("releaseGate duplicate annotations must fail");
+
+        assert_eq!(err.check.status, AnnotationCheckStatus::Fail);
+        assert!(
+            err.check.evidence.to_string().contains("duplicate"),
+            "duplicate evidence should be named: {:#?}",
+            err.check
+        );
+    }
+
+    #[test]
+    fn annotation_runtime_proven_site_collision_fails_hard() {
+        let td = tempfile::tempdir().unwrap();
+        write_runtime_annotation_manifest(
+            td.path(),
+            r#"
+[[residue]]
+file = "src/lib.rs"
+line = 10
+callee = "method:expect"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "should not annotate proven rows"
+"#,
+        );
+        let rows = vec![runtime_panic_row(
+            "src/lib.rs",
+            10,
+            "method:expect",
+            "proven",
+        )];
+
+        let err = annotation_runtime_check(td.path(), &rows, AnnotationCheckMode::Strict)
+            .expect_err("proven-site annotation must fail");
+
+        assert_eq!(err.check.status, AnnotationCheckStatus::Fail);
+        assert!(
+            err.check
+                .evidence
+                .to_string()
+                .contains("proven_site_collision"),
+            "proven collision evidence should be typed: {:#?}",
+            err.check
+        );
+    }
+
+    #[test]
+    fn annotation_runtime_malformed_manifest_warns_in_structural_and_fails_in_strict() {
+        let td = tempfile::tempdir().unwrap();
+        write_runtime_annotation_manifest(
+            td.path(),
+            r#"
+[[residue]]
+file = "src/lib.rs"
+line = 10
+callee = "method:expect"
+category = "lock_poisoning_residue"
+reason = "missing tier_to_close"
+"#,
+        );
+        let rows = vec![runtime_panic_row(
+            "src/lib.rs",
+            10,
+            "method:expect",
+            "unproven",
+        )];
+
+        let structural =
+            annotation_runtime_check(td.path(), &rows, AnnotationCheckMode::Structural)
+                .expect("warn");
+        assert_eq!(structural.check.status, AnnotationCheckStatus::Warn);
+        assert!(
+            structural.check.evidence.to_string().contains("malformed"),
+            "structural malformed evidence should be typed: {:#?}",
+            structural.check
+        );
+
+        let strict = annotation_runtime_check(td.path(), &rows, AnnotationCheckMode::Strict)
+            .expect_err("strict malformed manifest must fail");
+        assert_eq!(strict.check.status, AnnotationCheckStatus::Fail);
+    }
+
+    #[test]
+    fn annotation_runtime_reports_all_drift_errors_together() {
+        let td = tempfile::tempdir().unwrap();
+        write_runtime_annotation_manifest(
+            td.path(),
+            r#"
+[[residue]]
+file = "src/lib.rs"
+line = 10
+callee = "method:expect"
+category = "dup-one"
+tier_to_close = "irreducible"
+reason = "duplicate one"
+
+[[tier_to_close]]
+file = "src/lib.rs"
+line = 10
+callee = "method:expect"
+category = "dup-two"
+tier_to_close = "later"
+reason = "duplicate two"
+
+[[residue]]
+file = "src/lib.rs"
+line = 99
+callee = "method:expect"
+category = "stale"
+tier_to_close = "irreducible"
+reason = "stale"
+"#,
+        );
+        let rows = vec![runtime_panic_row(
+            "src/lib.rs",
+            10,
+            "method:expect",
+            "proven",
+        )];
+
+        let err = annotation_runtime_check(td.path(), &rows, AnnotationCheckMode::Strict)
+            .expect_err("multiple drift errors must fail");
+        let evidence = err.check.evidence.to_string();
+
+        assert!(evidence.contains("duplicate"), "{evidence}");
+        assert!(evidence.contains("stale"), "{evidence}");
+        assert!(evidence.contains("proven_site_collision"), "{evidence}");
+    }
+
+    #[test]
+    fn annotation_runtime_preserves_proven_count() {
+        let td = tempfile::tempdir().unwrap();
+        write_runtime_annotation_manifest(
+            td.path(),
+            r#"
+[[residue]]
+file = "src/lib.rs"
+line = 20
+callee = "method:expect"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "runtime residue"
+"#,
+        );
+        let rows = vec![
+            runtime_panic_row("src/lib.rs", 10, "method:expect", "proven"),
+            runtime_panic_row("src/lib.rs", 20, "method:expect", "unproven"),
+        ];
+
+        let before = rows.iter().filter(|row| row.status == "proven").count();
+        let outcome =
+            annotation_runtime_check(td.path(), &rows, AnnotationCheckMode::Strict).expect("valid");
+        let after = outcome
+            .rows
+            .iter()
+            .filter(|row| row.status == "proven")
+            .count();
+
+        assert_eq!(before, after, "annotation must not move K");
+    }
+
+    #[test]
+    fn annotation_runtime_check_is_not_coupled_to_self_check_scoreboard() {
+        let source = include_str!("panic_annotations_runtime.rs");
+        let start = source
+            .find("pub fn annotation_runtime_check")
+            .expect("annotation runtime function");
+        let body = &source[start
+            ..source[start..]
+                .find("fn runtime_annotation_manifest")
+                .unwrap()
+                + start];
+
+        assert!(!body.contains("SelfCheckScoreboard"));
+        assert!(!body.contains("cmd_self_check"));
+    }
+}

--- a/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.json
+++ b/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.json
@@ -1,16 +1,15 @@
 {
   "target": "examples/provekit-shim-rust-std",
-  "catalogCid": "blake3-512:b17a0f02846bf0a1a5226db5e3bee0c5e31c0608981df83f82a6b111c24b336f5a43833449691b69dd32ebadd007e9b93d31401951d767470fd928d8cc68cfa6",
+  "catalogCid": "blake3-512:d1c2f28626001b6b2436d35620b50624d2aae3b88dda5a7eea5bb1baa872cfd3100c4f6534625639e7a1e7a201eddc7aebcfc521c81a0d014dd8213ab12cf8bc",
   "lift": {
     "fnContracts": 28,
     "bodyDischargeEligible": 28,
     "bodyDischargeIneligible": {}
   },
   "bridges": {
-    "emitted": 0,
+    "emitted": 9,
     "liftGaps": {
-      "no-contract-for-callee": 23,
-      "panic-site-unproven": 5,
+      "no-contract-for-callee": 19,
       "unsupported-macro-callsite": 5
     }
   },
@@ -23,47 +22,222 @@
   "silentlyDropped": 0,
   "droppedSites": [],
   "dischargeSplit": {
-    "panicSafe": 0,
-    "reflexive": 656,
-    "vacuous": 0,
-    "undecidable": 1380,
+    "panicSafe": 5,
+    "reflexive": 628,
+    "vacuous": 552,
+    "undecidable": 1222,
     "falsePass": 0
   },
   "panicCensus": [
     {
+      "file": "src/compose.rs",
+      "line": 1157,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/compose.rs",
+      "line": 1410,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/core/bind.rs",
+      "line": 550,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/core/emit_obligation.rs",
+      "line": 62,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/core/lower_plugin.rs",
+      "line": 155,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/core/lower_plugin.rs",
+      "line": 1477,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/core/lower_plugin.rs",
+      "line": 1684,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/core/platform_semantics.rs",
+      "line": 42,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/core/source_transform.rs",
+      "line": 645,
+      "callee": "method:unwrap",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:unwrap has no targetContractCid"
+    },
+    {
+      "file": "src/core/source_transform.rs",
+      "line": 1055,
+      "callee": "method:unwrap",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:unwrap has no targetContractCid"
+    },
+    {
+      "file": "src/core/source_transform_kit.rs",
+      "line": 296,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/core/source_transform_kit.rs",
+      "line": 307,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/core/source_transform_kit.rs",
+      "line": 308,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/core/types.rs",
+      "line": 1193,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/core/types.rs",
+      "line": 1198,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/core/types.rs",
+      "line": 1946,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/core/types.rs",
+      "line": 2070,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/core/types.rs",
+      "line": 2093,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/core/types.rs",
+      "line": 2105,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/core/types.rs",
+      "line": 2137,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/core/types.rs",
+      "line": 2180,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/desugar.rs",
+      "line": 489,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
       "file": "src/lib.rs",
       "line": 161,
-      "callee": "unwrap",
-      "status": "unproven",
-      "reason": "receiver type did not resolve to a known panic partial; a bare unwrap/expect would vacuous-pass, so the site is reported as unproven (cannot show it does not panic)"
+      "callee": "method:unwrap",
+      "status": "proven",
+      "reason": "solver 'z3' returned unsat (obligation holds)"
     },
     {
       "file": "src/lib.rs",
       "line": 175,
-      "callee": "unwrap",
-      "status": "unproven",
-      "reason": "receiver type did not resolve to a known panic partial; a bare unwrap/expect would vacuous-pass, so the site is reported as unproven (cannot show it does not panic)"
+      "callee": "method:unwrap",
+      "status": "proven",
+      "reason": "solver 'z3' returned unsat (obligation holds)"
     },
     {
       "file": "src/lib.rs",
       "line": 190,
-      "callee": "expect",
-      "status": "unproven",
-      "reason": "receiver type did not resolve to a known panic partial; a bare unwrap/expect would vacuous-pass, so the site is reported as unproven (cannot show it does not panic)"
+      "callee": "method:expect",
+      "status": "proven",
+      "reason": "solver 'z3' returned unsat (obligation holds)"
     },
     {
       "file": "src/lib.rs",
       "line": 381,
-      "callee": "unwrap_err",
-      "status": "unproven",
-      "reason": "receiver type did not resolve to a known panic partial; a bare unwrap/expect would vacuous-pass, so the site is reported as unproven (cannot show it does not panic)"
+      "callee": "method:unwrap_err",
+      "status": "proven",
+      "reason": "solver 'z3' returned unsat (obligation holds)"
     },
     {
       "file": "src/lib.rs",
       "line": 396,
-      "callee": "expect",
+      "callee": "method:expect",
+      "status": "proven",
+      "reason": "solver 'z3' returned unsat (obligation holds)"
+    },
+    {
+      "file": "src/wp.rs",
+      "line": 295,
+      "callee": "method:unwrap",
       "status": "unproven",
-      "reason": "receiver type did not resolve to a known panic partial; a bare unwrap/expect would vacuous-pass, so the site is reported as unproven (cannot show it does not panic)"
+      "reason": "resolve-target: NoBridgeTarget: callsite method:unwrap has no targetContractCid"
+    },
+    {
+      "file": "src/wp/tests.rs",
+      "line": 74,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
+    },
+    {
+      "file": "src/wp/tests.rs",
+      "line": 578,
+      "callee": "method:expect",
+      "status": "unproven",
+      "reason": "resolve-target: NoBridgeTarget: callsite method:expect has no targetContractCid"
     }
   ]
 }

--- a/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.md
+++ b/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.md
@@ -6,12 +6,12 @@ The deterministic scoreboard from `provekit self-check --target examples/proveki
 run WITHOUT `--oracle`. `oracle.requested=false` makes the output fully deterministic: no
 rust-analyzer daemon, no wall-clock, no absolute paths.
 
-## Honest numbers (2026-05-31)
+## Honest numbers (current 2026-06-01)
 
 - `silentlyDropped: 0` -- hard invariant, must stay zero
 - `falsePass: 0` -- hard invariant, must stay zero
-- `panicSafe: 0` -- honest: the shim has 5 syntactic panic sites, none guarded, none dischargeable without the oracle
-- `panicCensus`: 5 sites, all `src/lib.rs`, all `unproven`; the reason line is the verifier's refuse-floor message
+- `panicSafe: 5` -- five rust-std shim panic sites discharge through real proof obligations
+- `panicCensus`: 30 sites, 5 `proven` and 25 `unproven`; unproven rows keep the verifier's refuse-floor reason
 - `catalogCid` is a content hash of the lifted contracts; it is path-independent (verified 2026-05-31 across two checkout paths)
 
 ## Regenerated 2026-06-01 (panic-locus branch)
@@ -43,6 +43,14 @@ self-check (`panicCensus 4 -> 5`, new `expect` at `src/lib.rs:190`), and one
 surfaced `assert!` macro gap (`unsupported-macro-callsite 4 -> 5`). Hard
 invariants unchanged: `falsePass 0`, `panicSafe 0`, `silentlyDropped 0`,
 `droppedSites []`.
+
+Regenerated 2026-06-01: `catalogCid` `b17a0f02...` -> `d1c2f286...`.
+PR5 moves self-check residue/tier classification to the post-prove panic census
+runtime hook. The no-oracle scoreboard now records real bridge/prove effects:
+`bridges.emitted 0 -> 9`, `panicSafe 0 -> 5`, `vacuous 0 -> 552`,
+`panicCensus 5 -> 30` (`5 proven`, `25 unproven`), and the legacy
+`panic-site-unproven` liftGap key disappears from the production scoreboard.
+Hard invariants unchanged: `falsePass 0`, `silentlyDropped 0`, `droppedSites []`.
 
 ## Normalization applied
 


### PR DESCRIPTION
## Summary
- Add standalone `panic_annotations_runtime` substrate module for post-prove panic census annotation join and drift detection.
- Wire `self-check` to run the runtime annotation check after prove projects `panicCensus` and before scoreboard emission.
- Keep the legacy lift-diagnostic panic-site annotation join `cfg(test)`-only with a deprecation comment; cleanup is tracked in #1783.
- Refresh the shim self-check golden from the current runtime scoreboard.

## Architecture
- `AnnotationCheckMode` intentionally mirrors structural/strict/releaseGate instead of importing `DoctorMode`; doctor and self-check translate at the boundary so the runtime module remains independent.
- The CLI still computes over normalized panic census data. It does not read `.proof` and does not learn kit or language semantics.
- Target-local `.provekit/residue.toml` is an annotation manifest, not a proof path.

## Golden
- The shim conformance gate now reports `panicCensus` 30 rows: 5 proven, 25 unproven. This is the shim target golden, not a production cli/lib K claim.
- Hard floors remain intact: `falsePass=0`, `silentlyDropped=0`, `droppedSites=[]`.

## Validation
- `git diff --check`
- `../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc`
- `../../bin/bcargo build -p provekit-lift --bin provekit-lift`
- `../../bin/bcargo test -p provekit-cli annotation_runtime -- --nocapture`
- `../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture`
- `../../bin/bcargo test -p provekit-cli doctor -- --nocapture`