### PR TITLE
feat(self-check): aggregate floor runtime checks

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_self_check.rs
+++ b/implementations/rust/provekit-cli/src/cmd_self_check.rs
@@ -13,6 +13,9 @@ use serde::Serialize;
 use serde_json::Value;
 use tracing::{error, info};
 
+use crate::floor_runtime_check::{
+    floor_runtime_check, FloorCheckMode, FloorCheckStatus, FloorRuntimeCheck, FloorSignals,
+};
 use crate::panic_annotations_runtime::{
     annotation_runtime_check, AnnotationCheckMode, PanicCensusRow,
 };
@@ -298,6 +301,7 @@ fn run_inner(args: &SelfCheckArgs) -> Result<SelfCheckScoreboard, String> {
         &prove_json,
         AnnotationCheckMode::Strict,
     )?;
+    enforce_floor_runtime_checks(&scoreboard, &prove_json)?;
     info!(
         oracle_requested = scoreboard.oracle.requested,
         oracle_engaged = scoreboard.oracle.engaged,
@@ -314,6 +318,69 @@ fn run_inner(args: &SelfCheckArgs) -> Result<SelfCheckScoreboard, String> {
         "self-check: scoreboard built"
     );
     Ok(scoreboard)
+}
+
+fn floor_signals_from_scoreboard(
+    scoreboard: &SelfCheckScoreboard,
+    prove_json: &Value,
+) -> FloorSignals {
+    FloorSignals {
+        silently_dropped: scoreboard.silently_dropped as u64,
+        false_pass: scoreboard.discharge_split.false_pass as u64,
+        dropped_sites_count: scoreboard.dropped_sites.len(),
+        panic_census_unnamed_count: scoreboard
+            .panic_census
+            .iter()
+            .filter(|row| {
+                row.status != "proven" && row.category.is_none() && row.tier_to_close.is_none()
+            })
+            .count(),
+        total_callsites: prove_json
+            .get("totalCallsites")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        discharge_split_present: prove_json
+            .get("dischargeSplit")
+            .map_or(false, |value| !value.is_null()),
+    }
+}
+
+fn enforce_floor_runtime_checks(
+    scoreboard: &SelfCheckScoreboard,
+    prove_json: &Value,
+) -> Result<(), String> {
+    let checks = floor_runtime_check(
+        floor_signals_from_scoreboard(scoreboard, prove_json),
+        FloorCheckMode::Strict,
+    );
+    log_floor_runtime_checks(&checks);
+    let failures = checks
+        .iter()
+        .filter(|check| check.status == FloorCheckStatus::Fail)
+        .map(|check| format!("{}: {}", check.id, check.detail))
+        .collect::<Vec<_>>();
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "floor runtime check failed: {}",
+            failures.join("; ")
+        ))
+    }
+}
+
+fn log_floor_runtime_checks(checks: &[FloorRuntimeCheck]) {
+    for check in checks {
+        info!(
+            check_id = %check.id,
+            check_name = %check.name,
+            check_domain = %check.domain,
+            check_status = ?check.status,
+            check_severity = ?check.severity,
+            check_detail = %check.detail,
+            "self-check: floor runtime check complete"
+        );
+    }
 }
 
 fn discover_repo_root() -> Result<PathBuf, String> {
@@ -2044,6 +2111,73 @@ reason = "stale annotation"
 
         assert!(
             err.contains("panic annotation runtime check failed") && err.contains("src/missing.rs"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn runtime_floor_check_receives_post_scoreboard_projection() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let mint = mint_json_with_diagnostics(vec![]);
+        let prove = json!({
+            "totalCallsites": 1,
+            "dischargeSplit": {
+                "panicSafe": 0,
+                "reflexive": 0,
+                "vacuous": 0,
+                "undecidable": 1,
+                "falsePass": 0
+            },
+            "rows": [panic_row("src/live.rs", 1, "method:unwrap", "undecidable", None)]
+        });
+        let scoreboard = build_scoreboard_with_runtime_annotations(
+            "target",
+            td.path(),
+            &mint,
+            &prove,
+            crate::panic_annotations_runtime::AnnotationCheckMode::Strict,
+        )
+        .expect("scoreboard");
+
+        let signals = floor_signals_from_scoreboard(&scoreboard, &prove);
+
+        assert_eq!(signals.silently_dropped, 0);
+        assert_eq!(signals.false_pass, 0);
+        assert_eq!(signals.dropped_sites_count, 0);
+        assert_eq!(signals.panic_census_unnamed_count, 1);
+        assert_eq!(signals.total_callsites, 1);
+        assert!(signals.discharge_split_present);
+    }
+
+    #[test]
+    fn runtime_floor_check_fails_self_check_on_hard_floor_violation() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let mint = mint_json_with_diagnostics(vec![]);
+        let prove = json!({
+            "totalCallsites": 1,
+            "dischargeSplit": {
+                "panicSafe": 0,
+                "reflexive": 1,
+                "vacuous": 0,
+                "undecidable": 0,
+                "falsePass": 1
+            },
+            "rows": [panic_row("src/live.rs", 1, "method:unwrap", "discharged", Some("reflexive"))]
+        });
+        let scoreboard = build_scoreboard_with_runtime_annotations(
+            "target",
+            td.path(),
+            &mint,
+            &prove,
+            crate::panic_annotations_runtime::AnnotationCheckMode::Strict,
+        )
+        .expect("scoreboard");
+
+        let err = enforce_floor_runtime_checks(&scoreboard, &prove)
+            .expect_err("falsePass must fail the runtime floor");
+
+        assert!(
+            err.contains("floor runtime check failed") && err.contains("floor.false_pass.zero"),
             "unexpected error: {err}"
         );
     }

--- a/implementations/rust/provekit-cli/src/doctor.rs
+++ b/implementations/rust/provekit-cli/src/doctor.rs
@@ -39,6 +39,11 @@ use crate::doctor_oracle::{
     OracleHostObservation, OracleHostReadiness, OracleResolutionConvergence,
     RustAnalyzerOracleAdapter,
 };
+#[cfg(test)]
+use crate::floor_runtime_check::{
+    floor_runtime_check, FloorCheckMode, FloorCheckSeverity, FloorCheckStatus, FloorRuntimeCheck,
+    FloorSignals,
+};
 use crate::lift_plugin::{parse_manifest_at, resolved_working_dir_for};
 use crate::project_config::{read_project_config, PluginEntry};
 
@@ -370,6 +375,51 @@ fn report_from_checks(kit_dir: &Path, mode: DoctorMode, checks: Vec<DoctorCheck>
         release_ready: ok && mode == DoctorMode::ReleaseGate,
         checks,
         ok,
+    }
+}
+
+// Doctor-side floor aggregation is test-gated in PR6 because the production
+// caller arrives in PR7's v1 release-gate orchestration.
+#[cfg(test)]
+fn report_from_floor_signals(
+    kit_dir: &Path,
+    mode: DoctorMode,
+    signals: FloorSignals,
+) -> DoctorReport {
+    let floor_checks = floor_runtime_check(signals, floor_mode_from_doctor_mode(mode));
+    let checks = floor_checks
+        .into_iter()
+        .map(doctor_check_from_floor_runtime)
+        .collect();
+    report_from_checks(kit_dir, mode, checks)
+}
+
+#[cfg(test)]
+fn floor_mode_from_doctor_mode(mode: DoctorMode) -> FloorCheckMode {
+    match mode {
+        DoctorMode::Structural => FloorCheckMode::Structural,
+        DoctorMode::Strict => FloorCheckMode::Strict,
+        DoctorMode::ReleaseGate => FloorCheckMode::ReleaseGate,
+    }
+}
+
+#[cfg(test)]
+fn doctor_check_from_floor_runtime(check: FloorRuntimeCheck) -> DoctorCheck {
+    DoctorCheck {
+        id: check.id,
+        name: check.name,
+        status: match check.status {
+            FloorCheckStatus::Pass => CheckStatus::Pass,
+            FloorCheckStatus::Warn => CheckStatus::Warn,
+            FloorCheckStatus::Fail => CheckStatus::Fail,
+        },
+        severity: match check.severity {
+            FloorCheckSeverity::Advisory => CheckSeverity::Advisory,
+            FloorCheckSeverity::Hard => CheckSeverity::Hard,
+        },
+        domain: check.domain,
+        detail: check.detail,
+        evidence: check.evidence,
     }
 }
 
@@ -2858,6 +2908,87 @@ mod tests {
             config.detail.contains(".provekit/config.toml"),
             "missing-config detail should name the file: {}",
             config.detail
+        );
+    }
+
+    #[test]
+    fn floor_report_ok_is_true_when_floor_checks_pass() {
+        let td = TempDir::new().unwrap();
+        let report = report_from_floor_signals(
+            td.path(),
+            DoctorMode::Strict,
+            crate::floor_runtime_check::FloorSignals {
+                silently_dropped: 0,
+                false_pass: 0,
+                dropped_sites_count: 0,
+                panic_census_unnamed_count: 0,
+                total_callsites: 1,
+                discharge_split_present: true,
+            },
+        );
+
+        assert!(report.ok, "passing floor report should be ok: {report:#?}");
+        assert!(report
+            .checks
+            .iter()
+            .all(|check| check.status != CheckStatus::Fail));
+    }
+
+    #[test]
+    fn floor_report_ok_is_false_when_any_floor_check_fails() {
+        let td = TempDir::new().unwrap();
+        let report = report_from_floor_signals(
+            td.path(),
+            DoctorMode::Strict,
+            crate::floor_runtime_check::FloorSignals {
+                silently_dropped: 0,
+                false_pass: 1,
+                dropped_sites_count: 0,
+                panic_census_unnamed_count: 0,
+                total_callsites: 1,
+                discharge_split_present: true,
+            },
+        );
+
+        assert!(!report.ok, "failing floor report must not be ok");
+        assert_eq!(
+            check_by_id(&report, "floor.false_pass.zero").status,
+            CheckStatus::Fail
+        );
+    }
+
+    #[test]
+    fn release_gate_floor_failure_marks_report_not_release_ready() {
+        let td = TempDir::new().unwrap();
+        let passing = report_from_floor_signals(
+            td.path(),
+            DoctorMode::ReleaseGate,
+            crate::floor_runtime_check::FloorSignals {
+                silently_dropped: 0,
+                false_pass: 0,
+                dropped_sites_count: 0,
+                panic_census_unnamed_count: 0,
+                total_callsites: 1,
+                discharge_split_present: true,
+            },
+        );
+        let failing = report_from_floor_signals(
+            td.path(),
+            DoctorMode::ReleaseGate,
+            crate::floor_runtime_check::FloorSignals {
+                silently_dropped: 0,
+                false_pass: 0,
+                dropped_sites_count: 0,
+                panic_census_unnamed_count: 0,
+                total_callsites: 0,
+                discharge_split_present: true,
+            },
+        );
+
+        assert!(passing.release_ready, "passing floor must be release ready");
+        assert!(
+            !failing.release_ready,
+            "failing floor must block release readiness"
         );
     }
 

--- a/implementations/rust/provekit-cli/src/floor_runtime_check.rs
+++ b/implementations/rust/provekit-cli/src/floor_runtime_check.rs
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use serde_json::{json, Value};
+
+pub const FLOOR_RUNTIME_DOMAIN: &str = "floor";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FloorCheckMode {
+    // These modes intentionally parallel DoctorMode without importing it.
+    // Floor aggregation is a substrate runtime check; doctor and self-check
+    // translate policy modes at the boundary.
+    Structural,
+    Strict,
+    ReleaseGate,
+}
+
+impl FloorCheckMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            FloorCheckMode::Structural => "structural",
+            FloorCheckMode::Strict => "strict",
+            FloorCheckMode::ReleaseGate => "releaseGate",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FloorCheckStatus {
+    Pass,
+    Warn,
+    Fail,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FloorCheckSeverity {
+    Advisory,
+    Hard,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FloorSignals {
+    pub silently_dropped: u64,
+    pub false_pass: u64,
+    pub dropped_sites_count: usize,
+    pub panic_census_unnamed_count: usize,
+    pub total_callsites: u64,
+    pub discharge_split_present: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct FloorRuntimeCheck {
+    pub id: String,
+    pub name: String,
+    pub status: FloorCheckStatus,
+    pub severity: FloorCheckSeverity,
+    pub domain: String,
+    pub detail: String,
+    pub evidence: Value,
+}
+
+impl FloorRuntimeCheck {
+    fn new(
+        id: impl Into<String>,
+        name: impl Into<String>,
+        status: FloorCheckStatus,
+        severity: FloorCheckSeverity,
+        detail: impl Into<String>,
+        evidence: Value,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            name: name.into(),
+            status,
+            severity,
+            domain: FLOOR_RUNTIME_DOMAIN.to_string(),
+            detail: detail.into(),
+            evidence,
+        }
+    }
+}
+
+pub fn floor_runtime_check(signals: FloorSignals, mode: FloorCheckMode) -> Vec<FloorRuntimeCheck> {
+    vec![
+        silently_dropped_check(signals, mode),
+        false_pass_check(signals, mode),
+        dropped_sites_check(signals, mode),
+        panic_census_named_check(signals, mode),
+        total_callsites_check(signals, mode),
+        discharge_split_check(signals, mode),
+    ]
+}
+
+fn silently_dropped_check(signals: FloorSignals, mode: FloorCheckMode) -> FloorRuntimeCheck {
+    hard_zero_check(
+        "floor.silently_dropped.zero",
+        "floor-silently-dropped-zero",
+        signals.silently_dropped,
+        "silentlyDropped",
+        mode,
+    )
+}
+
+fn false_pass_check(signals: FloorSignals, mode: FloorCheckMode) -> FloorRuntimeCheck {
+    hard_zero_check(
+        "floor.false_pass.zero",
+        "floor-false-pass-zero",
+        signals.false_pass,
+        "falsePass",
+        mode,
+    )
+}
+
+fn dropped_sites_check(signals: FloorSignals, mode: FloorCheckMode) -> FloorRuntimeCheck {
+    let count = signals.dropped_sites_count as u64;
+    hard_zero_check(
+        "floor.dropped_sites.empty",
+        "floor-dropped-sites-empty",
+        count,
+        "droppedSites",
+        mode,
+    )
+}
+
+fn panic_census_named_check(signals: FloorSignals, mode: FloorCheckMode) -> FloorRuntimeCheck {
+    let count = signals.panic_census_unnamed_count;
+    // Naming coverage is advisory until the exhaustive coverage slice lands.
+    // The hard v1 floor is no silent drops and no false passes; unnamed
+    // unproven rows stay loud without blocking today's honest self-check.
+    let (status, detail) = if count == 0 {
+        (
+            FloorCheckStatus::Pass,
+            "panicCensus has no unnamed unproven rows".to_string(),
+        )
+    } else {
+        (
+            FloorCheckStatus::Warn,
+            format!("panicCensus has {count} unnamed unproven row(s)"),
+        )
+    };
+    FloorRuntimeCheck::new(
+        "floor.panic_census.named",
+        "floor-panic-census-named",
+        status,
+        FloorCheckSeverity::Advisory,
+        detail,
+        json!({
+            "mode": mode.as_str(),
+            "unnamedCount": count,
+        }),
+    )
+}
+
+fn total_callsites_check(signals: FloorSignals, mode: FloorCheckMode) -> FloorRuntimeCheck {
+    let total = signals.total_callsites;
+    let (status, detail) = if total > 0 {
+        (
+            FloorCheckStatus::Pass,
+            format!("totalCallsites is nonzero ({total})"),
+        )
+    } else {
+        (
+            FloorCheckStatus::Fail,
+            "totalCallsites is zero; refusing a vacuous proof".to_string(),
+        )
+    };
+    FloorRuntimeCheck::new(
+        "floor.total_callsites.nonzero",
+        "floor-total-callsites-nonzero",
+        status,
+        FloorCheckSeverity::Hard,
+        detail,
+        json!({
+            "mode": mode.as_str(),
+            "totalCallsites": total,
+        }),
+    )
+}
+
+fn discharge_split_check(signals: FloorSignals, mode: FloorCheckMode) -> FloorRuntimeCheck {
+    let (status, detail) = if signals.discharge_split_present {
+        (
+            FloorCheckStatus::Pass,
+            "dischargeSplit is present".to_string(),
+        )
+    } else {
+        (
+            FloorCheckStatus::Fail,
+            "dischargeSplit is missing".to_string(),
+        )
+    };
+    FloorRuntimeCheck::new(
+        "floor.discharge_split.present",
+        "floor-discharge-split-present",
+        status,
+        FloorCheckSeverity::Hard,
+        detail,
+        json!({
+            "mode": mode.as_str(),
+            "present": signals.discharge_split_present,
+        }),
+    )
+}
+
+fn hard_zero_check(
+    id: &'static str,
+    name: &'static str,
+    value: u64,
+    field: &'static str,
+    mode: FloorCheckMode,
+) -> FloorRuntimeCheck {
+    let (status, detail) = if value == 0 {
+        (FloorCheckStatus::Pass, format!("{field} is zero"))
+    } else {
+        (
+            FloorCheckStatus::Fail,
+            format!("{field} is {value}; hard floor requires zero"),
+        )
+    };
+    FloorRuntimeCheck::new(
+        id,
+        name,
+        status,
+        FloorCheckSeverity::Hard,
+        detail,
+        json!({
+            "mode": mode.as_str(),
+            "field": field,
+            "value": value,
+        }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn passing_signals() -> FloorSignals {
+        FloorSignals {
+            silently_dropped: 0,
+            false_pass: 0,
+            dropped_sites_count: 0,
+            panic_census_unnamed_count: 0,
+            total_callsites: 42,
+            discharge_split_present: true,
+        }
+    }
+
+    fn check_by_id<'a>(checks: &'a [FloorRuntimeCheck], id: &str) -> &'a FloorRuntimeCheck {
+        checks
+            .iter()
+            .find(|check| check.id == id)
+            .unwrap_or_else(|| panic!("{id} check in {checks:#?}"))
+    }
+
+    #[test]
+    fn silently_dropped_zero_passes() {
+        let checks = floor_runtime_check(passing_signals(), FloorCheckMode::Strict);
+        let check = check_by_id(&checks, "floor.silently_dropped.zero");
+
+        assert_eq!(check.status, FloorCheckStatus::Pass);
+        assert_eq!(check.severity, FloorCheckSeverity::Hard);
+    }
+
+    #[test]
+    fn false_pass_zero_passes() {
+        let checks = floor_runtime_check(passing_signals(), FloorCheckMode::Strict);
+        let check = check_by_id(&checks, "floor.false_pass.zero");
+
+        assert_eq!(check.status, FloorCheckStatus::Pass);
+        assert_eq!(check.severity, FloorCheckSeverity::Hard);
+    }
+
+    #[test]
+    fn dropped_sites_empty_passes() {
+        let checks = floor_runtime_check(passing_signals(), FloorCheckMode::Strict);
+        let check = check_by_id(&checks, "floor.dropped_sites.empty");
+
+        assert_eq!(check.status, FloorCheckStatus::Pass);
+        assert_eq!(check.severity, FloorCheckSeverity::Hard);
+    }
+
+    #[test]
+    fn panic_census_named_passes_when_no_unnamed_unproven_rows() {
+        let checks = floor_runtime_check(passing_signals(), FloorCheckMode::Strict);
+        let check = check_by_id(&checks, "floor.panic_census.named");
+
+        assert_eq!(check.status, FloorCheckStatus::Pass);
+        assert_eq!(check.severity, FloorCheckSeverity::Advisory);
+    }
+
+    #[test]
+    fn total_callsites_nonzero_passes() {
+        let checks = floor_runtime_check(passing_signals(), FloorCheckMode::Strict);
+        let check = check_by_id(&checks, "floor.total_callsites.nonzero");
+
+        assert_eq!(check.status, FloorCheckStatus::Pass);
+        assert_eq!(check.severity, FloorCheckSeverity::Hard);
+    }
+
+    #[test]
+    fn discharge_split_present_passes() {
+        let checks = floor_runtime_check(passing_signals(), FloorCheckMode::Strict);
+        let check = check_by_id(&checks, "floor.discharge_split.present");
+
+        assert_eq!(check.status, FloorCheckStatus::Pass);
+        assert_eq!(check.severity, FloorCheckSeverity::Hard);
+    }
+
+    #[test]
+    fn silently_dropped_positive_fails_hard() {
+        let mut signals = passing_signals();
+        signals.silently_dropped = 1;
+
+        let checks = floor_runtime_check(signals, FloorCheckMode::Strict);
+        let check = check_by_id(&checks, "floor.silently_dropped.zero");
+
+        assert_eq!(check.status, FloorCheckStatus::Fail);
+        assert_eq!(check.severity, FloorCheckSeverity::Hard);
+    }
+
+    #[test]
+    fn false_pass_positive_fails_hard() {
+        let mut signals = passing_signals();
+        signals.false_pass = 1;
+
+        let checks = floor_runtime_check(signals, FloorCheckMode::Strict);
+        let check = check_by_id(&checks, "floor.false_pass.zero");
+
+        assert_eq!(check.status, FloorCheckStatus::Fail);
+        assert_eq!(check.severity, FloorCheckSeverity::Hard);
+    }
+
+    #[test]
+    fn dropped_sites_nonempty_fails_hard() {
+        let mut signals = passing_signals();
+        signals.dropped_sites_count = 1;
+
+        let checks = floor_runtime_check(signals, FloorCheckMode::Strict);
+        let check = check_by_id(&checks, "floor.dropped_sites.empty");
+
+        assert_eq!(check.status, FloorCheckStatus::Fail);
+        assert_eq!(check.severity, FloorCheckSeverity::Hard);
+    }
+
+    #[test]
+    fn unnamed_panic_census_rows_warn_advisory_until_coverage_slice() {
+        let mut signals = passing_signals();
+        signals.panic_census_unnamed_count = 1;
+
+        let checks = floor_runtime_check(signals, FloorCheckMode::Strict);
+        let check = check_by_id(&checks, "floor.panic_census.named");
+
+        assert_eq!(check.status, FloorCheckStatus::Warn);
+        assert_eq!(check.severity, FloorCheckSeverity::Advisory);
+    }
+
+    #[test]
+    fn total_callsites_zero_fails_hard() {
+        let mut signals = passing_signals();
+        signals.total_callsites = 0;
+
+        let checks = floor_runtime_check(signals, FloorCheckMode::Strict);
+        let check = check_by_id(&checks, "floor.total_callsites.nonzero");
+
+        assert_eq!(check.status, FloorCheckStatus::Fail);
+        assert_eq!(check.severity, FloorCheckSeverity::Hard);
+    }
+
+    #[test]
+    fn discharge_split_missing_fails_hard() {
+        let mut signals = passing_signals();
+        signals.discharge_split_present = false;
+
+        let checks = floor_runtime_check(signals, FloorCheckMode::Strict);
+        let check = check_by_id(&checks, "floor.discharge_split.present");
+
+        assert_eq!(check.status, FloorCheckStatus::Fail);
+        assert_eq!(check.severity, FloorCheckSeverity::Hard);
+    }
+
+    #[test]
+    fn structural_false_pass_violation_still_fails_hard() {
+        let mut signals = passing_signals();
+        signals.false_pass = 1;
+
+        let checks = floor_runtime_check(signals, FloorCheckMode::Structural);
+        let check = check_by_id(&checks, "floor.false_pass.zero");
+
+        assert_eq!(check.status, FloorCheckStatus::Fail);
+        assert_eq!(check.severity, FloorCheckSeverity::Hard);
+    }
+
+    #[test]
+    fn strict_false_pass_violation_fails_hard() {
+        let mut signals = passing_signals();
+        signals.false_pass = 1;
+
+        let checks = floor_runtime_check(signals, FloorCheckMode::Strict);
+        let check = check_by_id(&checks, "floor.false_pass.zero");
+
+        assert_eq!(check.status, FloorCheckStatus::Fail);
+        assert_eq!(check.severity, FloorCheckSeverity::Hard);
+    }
+
+    #[test]
+    fn release_gate_false_pass_violation_fails_hard() {
+        let mut signals = passing_signals();
+        signals.false_pass = 1;
+
+        let checks = floor_runtime_check(signals, FloorCheckMode::ReleaseGate);
+        let check = check_by_id(&checks, "floor.false_pass.zero");
+
+        assert_eq!(check.status, FloorCheckStatus::Fail);
+        assert_eq!(check.severity, FloorCheckSeverity::Hard);
+    }
+
+    #[test]
+    fn floor_runtime_check_accepts_projection_without_self_check_scoreboard() {
+        let checks = floor_runtime_check(
+            FloorSignals {
+                silently_dropped: 0,
+                false_pass: 0,
+                dropped_sites_count: 0,
+                panic_census_unnamed_count: 0,
+                total_callsites: 1,
+                discharge_split_present: true,
+            },
+            FloorCheckMode::ReleaseGate,
+        );
+
+        assert_eq!(checks.len(), 6);
+        assert!(checks
+            .iter()
+            .all(|check| check.status == FloorCheckStatus::Pass));
+    }
+}

--- a/implementations/rust/provekit-cli/src/lib.rs
+++ b/implementations/rust/provekit-cli/src/lib.rs
@@ -32,6 +32,7 @@ pub struct OutputFlags {
 }
 
 pub mod cmd_self_check;
+pub mod floor_runtime_check;
 pub mod kit_dispatch;
 pub mod panic_annotations_runtime;
 pub mod project_config;

--- a/implementations/rust/provekit-cli/src/main.rs
+++ b/implementations/rust/provekit-cli/src/main.rs
@@ -40,6 +40,7 @@ mod cmd_verify_protocol;
 mod cmd_version;
 mod doctor;
 mod doctor_oracle;
+pub mod floor_runtime_check;
 mod kit_dispatch;
 mod lift_plugin;
 pub mod panic_annotations_runtime;


### PR DESCRIPTION
## Summary
- Add a standalone `floor_runtime_check` substrate module with `FloorSignals` and six floor checks: silently dropped, false pass, dropped sites, panic census naming, total callsites, and discharge split presence.
- Wire `self-check` to project floor signals after scoreboard construction and before scoreboard emission, log each floor check, and fail closed on hard floor violations.
- Keep doctor-side floor aggregation test-gated until PR7 release-gate orchestration provides the production caller.
- Keep `panic_census.named` advisory until the exhaustive naming coverage slice lands.

## Architecture
- The floor module consumes normalized data only; it does not import `cmd_self_check`, doctor, kit, or language-specific code.
- Hard floor checks remain hard across structural/strict/releaseGate modes. Mode is preserved as evidence, not used to weaken floor invariants.
- `panic_census.named` is loud but advisory for this slice so current honest unnamed unproven rows do not block self-check.

## Validation
- RED verified first: missing `FloorSignals` / `floor_runtime_check` / doctor report mapping / self-check hook failed to compile.
- `git diff --check`
- `../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc`
- `../../bin/bcargo build -p provekit-lift --bin provekit-lift`
- `../../bin/bcargo test -p provekit-cli floor_runtime -- --nocapture`
- `../../bin/bcargo test -p provekit-cli runtime_floor -- --nocapture`
- `../../bin/bcargo test -p provekit-cli floor_report -- --nocapture`
- `../../bin/bcargo test -p provekit-cli release_gate_floor -- --nocapture`
- `../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture`
- `../../bin/bcargo test -p provekit-cli doctor -- --nocapture`

Note: a broad `floor` test filter also ran the new floor tests successfully, but then matched an unrelated Python division integration test and failed because this environment lacked `provekit_lift_python_source`. That broad filter is not a PR6 gate.