### PR TITLE
[codex] add v1 release gate

### DIFF
--- a/implementations/rust/provekit-cli/src/cmd_release_gate.rs
+++ b/implementations/rust/provekit-cli/src/cmd_release_gate.rs
@@ -1,0 +1,582 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use clap::Parser;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::doctor::{report_from_floor_signals, CheckSeverity, DoctorMode, DoctorReport};
+use crate::floor_runtime_check::FloorSignals;
+use crate::{EXIT_OK, EXIT_USER_ERROR, EXIT_VERIFY_FAIL};
+
+#[derive(Parser, Debug, Clone)]
+pub struct ReleaseGateArgs {
+    /// Emit structured JSON release evidence.
+    #[arg(long)]
+    pub json: bool,
+    /// Optional TOML target list. Defaults to provekit-cli and libprovekit.
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GateInvocation {
+    pub target_name: String,
+    pub target_path: String,
+    pub command: String,
+    pub args: Vec<OsString>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GateOutput {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+pub trait GateExecutor {
+    fn run(&mut self, invocation: &GateInvocation) -> Result<GateOutput, String>;
+}
+
+#[derive(Debug, Clone)]
+pub struct ReleaseGateReceipt {
+    pub release_ready: bool,
+    pub targets: Vec<TargetReceipt>,
+    pub failures: Vec<ReleaseGateFailure>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReleaseGateFailure {
+    pub target: String,
+    pub command: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct TargetReceipt {
+    pub name: String,
+    pub path: String,
+    pub doctor: GateCommandReceipt,
+    pub self_check: GateCommandReceipt,
+    pub evidence: TargetEvidence,
+    pub floor_report: DoctorReport,
+    pub release_ready: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct GateCommandReceipt {
+    pub command: String,
+    pub ok: bool,
+    pub exit_code: i32,
+    pub stdout_json: Value,
+    pub stderr: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct TargetEvidence {
+    pub k_panic_safe: u64,
+    pub floor: FloorSignals,
+    pub residue: ResidueEvidence,
+    pub doctor_checks: Vec<DoctorCheckEvidence>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResidueEvidence {
+    pub residue: usize,
+    pub tier_to_close: usize,
+    pub raw_unproven: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DoctorCheckEvidence {
+    pub name: String,
+    pub status: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ReleaseGateConfig {
+    #[serde(default)]
+    target: Vec<ReleaseGateConfigTarget>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ReleaseGateConfigTarget {
+    name: String,
+    path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ReleaseGateTarget {
+    name: String,
+    path: String,
+}
+
+pub fn run(args: ReleaseGateArgs) -> u8 {
+    let repo_root = match discover_repo_root() {
+        Ok(root) => root,
+        Err(error) => {
+            eprintln!("release-gate failed: {error}");
+            return EXIT_USER_ERROR;
+        }
+    };
+    let bin = match std::env::current_exe() {
+        Ok(bin) => bin,
+        Err(error) => {
+            eprintln!("release-gate failed: resolve current executable: {error}");
+            return EXIT_USER_ERROR;
+        }
+    };
+    let mut executor = SystemGateExecutor { bin, repo_root };
+    match run_release_gate_with_executor(args.clone(), &mut executor) {
+        Ok(receipt) => {
+            if args.json {
+                println!("{}", receipt_json(&receipt));
+            } else {
+                print_human(&receipt);
+            }
+            release_gate_exit_code(&receipt)
+        }
+        Err(error) => {
+            eprintln!("release-gate failed: {error}");
+            EXIT_USER_ERROR
+        }
+    }
+}
+
+pub fn release_gate_plan(args: &ReleaseGateArgs) -> Result<Vec<GateInvocation>, String> {
+    let mut plan = Vec::new();
+    for target in release_gate_targets(args)? {
+        plan.push(doctor_invocation(&target));
+        plan.push(self_check_invocation(&target));
+    }
+    Ok(plan)
+}
+
+pub fn run_release_gate_with_executor(
+    args: ReleaseGateArgs,
+    executor: &mut dyn GateExecutor,
+) -> Result<ReleaseGateReceipt, String> {
+    let plan = release_gate_plan(&args)?;
+    let mut target_receipts = Vec::new();
+    let mut failures = Vec::new();
+
+    for pair in plan.chunks(2) {
+        let [doctor_invocation, self_check_invocation] = pair else {
+            return Err("release-gate plan must contain doctor/self-check pairs".to_string());
+        };
+        let target_name = doctor_invocation.target_name.clone();
+        let target_path = doctor_invocation.target_path.clone();
+
+        let doctor_output = executor.run(doctor_invocation)?;
+        let doctor = command_receipt(doctor_invocation, doctor_output, doctor_gate_ok);
+        if !doctor.ok {
+            failures.push(ReleaseGateFailure {
+                target: target_name.clone(),
+                command: doctor.command.clone(),
+                reason: failed_gate_reason(&doctor),
+            });
+        }
+
+        let self_check_output = executor.run(self_check_invocation)?;
+        let self_check =
+            command_receipt(self_check_invocation, self_check_output, self_check_gate_ok);
+        if !self_check.ok {
+            failures.push(ReleaseGateFailure {
+                target: target_name.clone(),
+                command: self_check.command.clone(),
+                reason: failed_gate_reason(&self_check),
+            });
+        }
+
+        let floor = floor_signals_from_self_check_json(&self_check.stdout_json);
+        let floor_report = report_from_floor_signals(
+            Path::new(&target_path),
+            DoctorMode::ReleaseGate,
+            floor,
+        );
+        if !floor_report.ok {
+            failures.push(ReleaseGateFailure {
+                target: target_name.clone(),
+                command: "floor".to_string(),
+                reason: "release-gate floor aggregation failed".to_string(),
+            });
+        }
+
+        let evidence = TargetEvidence {
+            k_panic_safe: k_panic_safe(&self_check.stdout_json),
+            floor,
+            residue: residue_evidence(&self_check.stdout_json),
+            doctor_checks: doctor_check_evidence(&doctor.stdout_json),
+        };
+        let release_ready = doctor.ok && self_check.ok && floor_report.release_ready;
+        target_receipts.push(TargetReceipt {
+            name: target_name,
+            path: target_path,
+            doctor,
+            self_check,
+            evidence,
+            floor_report,
+            release_ready,
+        });
+    }
+
+    let release_ready =
+        failures.is_empty() && target_receipts.iter().all(|target| target.release_ready);
+    Ok(ReleaseGateReceipt {
+        release_ready,
+        targets: target_receipts,
+        failures,
+    })
+}
+
+pub fn release_gate_exit_code(receipt: &ReleaseGateReceipt) -> u8 {
+    if receipt.release_ready {
+        EXIT_OK
+    } else {
+        EXIT_VERIFY_FAIL
+    }
+}
+
+fn release_gate_targets(args: &ReleaseGateArgs) -> Result<Vec<ReleaseGateTarget>, String> {
+    if let Some(config) = &args.config {
+        let text = std::fs::read_to_string(config)
+            .map_err(|e| format!("read release-gate config {}: {e}", config.display()))?;
+        let parsed: ReleaseGateConfig = toml::from_str(&text)
+            .map_err(|e| format!("parse release-gate config {}: {e}", config.display()))?;
+        if parsed.target.is_empty() {
+            return Err(format!(
+                "release-gate config {} has no [[target]] entries",
+                config.display()
+            ));
+        }
+        return Ok(parsed
+            .target
+            .into_iter()
+            .map(|target| ReleaseGateTarget {
+                name: target.name,
+                path: target.path,
+            })
+            .collect());
+    }
+    Ok(vec![
+        ReleaseGateTarget {
+            name: "provekit-cli".to_string(),
+            path: "implementations/rust/provekit-cli".to_string(),
+        },
+        ReleaseGateTarget {
+            name: "libprovekit".to_string(),
+            path: "implementations/rust/libprovekit".to_string(),
+        },
+    ])
+}
+
+fn doctor_invocation(target: &ReleaseGateTarget) -> GateInvocation {
+    GateInvocation {
+        target_name: target.name.clone(),
+        target_path: target.path.clone(),
+        command: "doctor".to_string(),
+        args: vec![
+            "doctor".into(),
+            "--target".into(),
+            target.path.clone().into(),
+            "--mode".into(),
+            "releaseGate".into(),
+            "--oracle".into(),
+            "--json".into(),
+        ],
+    }
+}
+
+fn self_check_invocation(target: &ReleaseGateTarget) -> GateInvocation {
+    GateInvocation {
+        target_name: target.name.clone(),
+        target_path: target.path.clone(),
+        command: "self-check".to_string(),
+        args: vec![
+            "self-check".into(),
+            "--target".into(),
+            target.path.clone().into(),
+            "--oracle".into(),
+            "--json".into(),
+        ],
+    }
+}
+
+fn command_receipt(
+    invocation: &GateInvocation,
+    output: GateOutput,
+    gate_ok: fn(i32, &Value) -> bool,
+) -> GateCommandReceipt {
+    let stdout_json = serde_json::from_str(&output.stdout).unwrap_or(Value::Null);
+    let ok = gate_ok(output.exit_code, &stdout_json);
+    GateCommandReceipt {
+        command: invocation.command.clone(),
+        ok,
+        exit_code: output.exit_code,
+        stdout_json,
+        stderr: output.stderr,
+    }
+}
+
+fn doctor_gate_ok(exit_code: i32, stdout_json: &Value) -> bool {
+    exit_code == 0
+        && stdout_json
+            .get("ok")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        && stdout_json
+            .get("releaseReady")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+}
+
+fn self_check_gate_ok(exit_code: i32, stdout_json: &Value) -> bool {
+    exit_code == 0 && stdout_json.is_object()
+}
+
+fn failed_gate_reason(command: &GateCommandReceipt) -> String {
+    if !command.stderr.trim().is_empty() {
+        return command.stderr.trim().to_string();
+    }
+    format!("{} exited {}", command.command, command.exit_code)
+}
+
+fn floor_signals_from_self_check_json(json: &Value) -> FloorSignals {
+    let split = json.get("dischargeSplit").unwrap_or(&Value::Null);
+    FloorSignals {
+        silently_dropped: json
+            .get("silentlyDropped")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        false_pass: split.get("falsePass").and_then(Value::as_u64).unwrap_or(0),
+        dropped_sites_count: json
+            .get("droppedSites")
+            .and_then(Value::as_array)
+            .map_or(0, Vec::len),
+        panic_census_unnamed_count: json
+            .get("panicCensus")
+            .and_then(Value::as_array)
+            .map_or(0, |rows| {
+                rows.iter()
+                    .filter(|row| {
+                        row.get("status").and_then(Value::as_str) != Some("proven")
+                            && row.get("category").is_none()
+                            && row.get("tierToClose").is_none()
+                    })
+                    .count()
+            }),
+        total_callsites: json
+            .get("totalCallsites")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        discharge_split_present: json
+            .get("dischargeSplit")
+            .is_some_and(|value| !value.is_null()),
+    }
+}
+
+fn k_panic_safe(json: &Value) -> u64 {
+    json.get("dischargeSplit")
+        .and_then(|split| split.get("panicSafe"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0)
+}
+
+fn residue_evidence(json: &Value) -> ResidueEvidence {
+    let mut evidence = ResidueEvidence {
+        residue: 0,
+        tier_to_close: 0,
+        raw_unproven: 0,
+    };
+    let Some(rows) = json.get("panicCensus").and_then(Value::as_array) else {
+        return evidence;
+    };
+    for row in rows {
+        let status = row.get("status").and_then(Value::as_str).unwrap_or("");
+        let category = row.get("category").and_then(Value::as_str);
+        let tier_to_close = row.get("tierToClose").and_then(Value::as_str);
+        if status == "residue" || category.is_some_and(|value| value.ends_with("_residue")) {
+            evidence.residue += 1;
+        } else if status != "proven" && tier_to_close.is_some() {
+            evidence.tier_to_close += 1;
+        } else if status != "proven" && category.is_none() && tier_to_close.is_none() {
+            evidence.raw_unproven += 1;
+        }
+    }
+    evidence
+}
+
+fn doctor_check_evidence(json: &Value) -> Vec<DoctorCheckEvidence> {
+    json.get("checks")
+        .and_then(Value::as_array)
+        .map(|checks| {
+            checks
+                .iter()
+                .map(|check| DoctorCheckEvidence {
+                    name: check
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string(),
+                    status: check
+                        .get("status")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string(),
+                    detail: check
+                        .get("detail")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string(),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+struct SystemGateExecutor {
+    bin: PathBuf,
+    repo_root: PathBuf,
+}
+
+impl GateExecutor for SystemGateExecutor {
+    fn run(&mut self, invocation: &GateInvocation) -> Result<GateOutput, String> {
+        let output = Command::new(&self.bin)
+            .current_dir(&self.repo_root)
+            .args(&invocation.args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .map_err(|e| format!("run {:?}: {e}", invocation.args))?;
+        Ok(GateOutput {
+            exit_code: output.status.code().unwrap_or(EXIT_VERIFY_FAIL as i32),
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        })
+    }
+}
+
+fn discover_repo_root() -> Result<PathBuf, String> {
+    let mut dir = std::env::current_dir().map_err(|e| format!("read current directory: {e}"))?;
+    loop {
+        if dir
+            .join("implementations/rust/provekit-cli/Cargo.toml")
+            .is_file()
+            && dir.join("implementations/rust/libprovekit/Cargo.toml").is_file()
+        {
+            return Ok(dir);
+        }
+        if !dir.pop() {
+            return Err("could not discover provekit repository root".to_string());
+        }
+    }
+}
+
+fn print_human(receipt: &ReleaseGateReceipt) {
+    println!("ProvekIt release-gate");
+    for target in &receipt.targets {
+        let status = if target.release_ready { "ready" } else { "blocked" };
+        println!(
+            "target: {} ({}) K={} residue={} tierToClose={} rawUnproven={}",
+            target.name,
+            status,
+            target.evidence.k_panic_safe,
+            target.evidence.residue.residue,
+            target.evidence.residue.tier_to_close,
+            target.evidence.residue.raw_unproven
+        );
+    }
+    println!("releaseReady: {}", receipt.release_ready);
+}
+
+fn receipt_json(receipt: &ReleaseGateReceipt) -> Value {
+    json!({
+        "releaseReady": receipt.release_ready,
+        "targets": receipt.targets.iter().map(target_json).collect::<Vec<_>>(),
+        "failures": receipt.failures.iter().map(|failure| {
+            json!({
+                "target": failure.target,
+                "command": failure.command,
+                "reason": failure.reason,
+            })
+        }).collect::<Vec<_>>(),
+    })
+}
+
+fn target_json(target: &TargetReceipt) -> Value {
+    json!({
+        "name": target.name,
+        "path": target.path,
+        "releaseReady": target.release_ready,
+        "doctor": command_json(&target.doctor),
+        "selfCheck": command_json(&target.self_check),
+        "evidence": {
+            "kPanicSafe": target.evidence.k_panic_safe,
+            "floor": floor_json(target.evidence.floor),
+            "residue": {
+                "residue": target.evidence.residue.residue,
+                "tierToClose": target.evidence.residue.tier_to_close,
+                "rawUnproven": target.evidence.residue.raw_unproven,
+            },
+            "doctorChecks": target.evidence.doctor_checks.iter().map(|check| {
+                json!({
+                    "name": check.name,
+                    "status": check.status,
+                    "detail": check.detail,
+                })
+            }).collect::<Vec<_>>(),
+        },
+        "floorReport": doctor_report_json(&target.floor_report),
+    })
+}
+
+fn command_json(command: &GateCommandReceipt) -> Value {
+    json!({
+        "command": command.command,
+        "ok": command.ok,
+        "exitCode": command.exit_code,
+        "stdoutJson": command.stdout_json,
+        "stderr": command.stderr,
+    })
+}
+
+fn floor_json(floor: FloorSignals) -> Value {
+    json!({
+        "silentlyDropped": floor.silently_dropped,
+        "falsePass": floor.false_pass,
+        "droppedSites": floor.dropped_sites_count,
+        "panicCensusUnnamed": floor.panic_census_unnamed_count,
+        "totalCallsites": floor.total_callsites,
+        "dischargeSplitPresent": floor.discharge_split_present,
+    })
+}
+
+fn doctor_report_json(report: &DoctorReport) -> Value {
+    json!({
+        "mode": report.mode.as_str(),
+        "ok": report.ok,
+        "releaseReady": report.release_ready,
+        "checks": report.checks.iter().map(|check| {
+            json!({
+                "id": check.id,
+                "name": check.name,
+                "status": check.status.as_str(),
+                "severity": severity_as_str(&check.severity),
+                "domain": check.domain,
+                "detail": check.detail,
+                "evidence": check.evidence,
+            })
+        }).collect::<Vec<_>>(),
+    })
+}
+
+fn severity_as_str(severity: &CheckSeverity) -> &'static str {
+    match severity {
+        CheckSeverity::Advisory => "advisory",
+        CheckSeverity::Hard => "hard",
+    }
+}

--- a/implementations/rust/provekit-cli/src/cmd_self_check.rs
+++ b/implementations/rust/provekit-cli/src/cmd_self_check.rs
@@ -101,6 +101,8 @@ struct SelfCheckScoreboard {
     oracle: OracleScoreboard,
     silently_dropped: usize,
     dropped_sites: Vec<Site>,
+    #[serde(rename = "totalCallsites")]
+    total_callsites: u64,
     discharge_split: DischargeSplit,
     panic_census: Vec<PanicCensusEntry>,
 }
@@ -309,6 +311,7 @@ fn run_inner(args: &SelfCheckArgs) -> Result<SelfCheckScoreboard, String> {
         oracle_resolved = scoreboard.oracle.resolved,
         silently_dropped = scoreboard.silently_dropped,
         dropped_sites = scoreboard.dropped_sites.len(),
+        total_callsites = scoreboard.total_callsites,
         panic_census = scoreboard.panic_census.len(),
         panic_safe = scoreboard.discharge_split.panic_safe,
         false_pass = scoreboard.discharge_split.false_pass,
@@ -335,10 +338,7 @@ fn floor_signals_from_scoreboard(
                 row.status != "proven" && row.category.is_none() && row.tier_to_close.is_none()
             })
             .count(),
-        total_callsites: prove_json
-            .get("totalCallsites")
-            .and_then(Value::as_u64)
-            .unwrap_or(0),
+        total_callsites: scoreboard.total_callsites,
         discharge_split_present: prove_json
             .get("dischargeSplit")
             .map_or(false, |value| !value.is_null()),
@@ -922,6 +922,7 @@ fn build_scoreboard(
     let discharge_split = discharge_split(prove_json);
     let panic_census = panic_census(prove_json, unbridged_panic_sites, panic_annotations)?;
     let silently_dropped = dropped_sites.len();
+    let total_callsites = total_callsites(prove_json);
 
     Ok(SelfCheckScoreboard {
         target: target_rel.to_string(),
@@ -931,6 +932,7 @@ fn build_scoreboard(
         oracle,
         silently_dropped,
         dropped_sites,
+        total_callsites,
         discharge_split,
         panic_census,
     })
@@ -983,6 +985,7 @@ fn build_scoreboard_with_runtime_annotations(
         .map(panic_census_entry_from_row)
         .collect();
     let silently_dropped = dropped_sites.len();
+    let total_callsites = total_callsites(prove_json);
 
     Ok(SelfCheckScoreboard {
         target: target_rel.to_string(),
@@ -992,9 +995,17 @@ fn build_scoreboard_with_runtime_annotations(
         oracle,
         silently_dropped,
         dropped_sites,
+        total_callsites,
         discharge_split,
         panic_census,
     })
+}
+
+fn total_callsites(prove_json: &Value) -> u64 {
+    prove_json
+        .get("totalCallsites")
+        .and_then(Value::as_u64)
+        .unwrap_or(0)
 }
 
 fn panic_census_row_from_entry(entry: &PanicCensusEntry) -> PanicCensusRow {
@@ -1381,6 +1392,7 @@ fn emit_scoreboard(scoreboard: &SelfCheckScoreboard, json: bool) {
         scoreboard.oracle.resolved
     );
     println!("silentlyDropped: {}", scoreboard.silently_dropped);
+    println!("totalCallsites: {}", scoreboard.total_callsites);
     println!(
         "dischargeSplit: panicSafe={}, reflexive={}, vacuous={}, undecidable={}, falsePass={}",
         scoreboard.discharge_split.panic_safe,
@@ -1799,6 +1811,20 @@ mod tests {
                 "requested={requested}, resolved={resolved}"
             );
         }
+    }
+
+    #[test]
+    fn build_scoreboard_emits_total_callsites_for_release_gate_floor() {
+        let prove = json!({
+            "totalCallsites": 1,
+            "rows": []
+        });
+        let scoreboard =
+            build_scoreboard("target", &mint_json(true, 7, 7), &prove).expect("scoreboard");
+        let rendered = serde_json::to_value(&scoreboard).expect("scoreboard json");
+
+        assert_eq!(scoreboard.total_callsites, 1);
+        assert_eq!(rendered["totalCallsites"], 1);
     }
 
     #[test]

--- a/implementations/rust/provekit-cli/src/doctor.rs
+++ b/implementations/rust/provekit-cli/src/doctor.rs
@@ -39,7 +39,6 @@ use crate::doctor_oracle::{
     OracleHostObservation, OracleHostReadiness, OracleResolutionConvergence,
     RustAnalyzerOracleAdapter,
 };
-#[cfg(test)]
 use crate::floor_runtime_check::{
     floor_runtime_check, FloorCheckMode, FloorCheckSeverity, FloorCheckStatus, FloorRuntimeCheck,
     FloorSignals,
@@ -378,10 +377,7 @@ fn report_from_checks(kit_dir: &Path, mode: DoctorMode, checks: Vec<DoctorCheck>
     }
 }
 
-// Doctor-side floor aggregation is test-gated in PR6 because the production
-// caller arrives in PR7's v1 release-gate orchestration.
-#[cfg(test)]
-fn report_from_floor_signals(
+pub fn report_from_floor_signals(
     kit_dir: &Path,
     mode: DoctorMode,
     signals: FloorSignals,
@@ -394,7 +390,6 @@ fn report_from_floor_signals(
     report_from_checks(kit_dir, mode, checks)
 }
 
-#[cfg(test)]
 fn floor_mode_from_doctor_mode(mode: DoctorMode) -> FloorCheckMode {
     match mode {
         DoctorMode::Structural => FloorCheckMode::Structural,
@@ -403,7 +398,6 @@ fn floor_mode_from_doctor_mode(mode: DoctorMode) -> FloorCheckMode {
     }
 }
 
-#[cfg(test)]
 fn doctor_check_from_floor_runtime(check: FloorRuntimeCheck) -> DoctorCheck {
     DoctorCheck {
         id: check.id,

--- a/implementations/rust/provekit-cli/src/lib.rs
+++ b/implementations/rust/provekit-cli/src/lib.rs
@@ -32,8 +32,15 @@ pub struct OutputFlags {
 }
 
 pub mod cmd_self_check;
+pub mod cmd_release_gate;
+#[allow(dead_code)]
+pub mod doctor;
+#[allow(dead_code)]
+pub mod doctor_oracle;
 pub mod floor_runtime_check;
 pub mod kit_dispatch;
+#[allow(dead_code)]
+pub mod lift_plugin;
 pub mod panic_annotations_runtime;
 pub mod project_config;
 pub mod sort_morphism_catalog;

--- a/implementations/rust/provekit-cli/src/main.rs
+++ b/implementations/rust/provekit-cli/src/main.rs
@@ -34,6 +34,7 @@ mod cmd_plugin;
 mod cmd_protocol;
 mod cmd_prove;
 mod cmd_recognize;
+mod cmd_release_gate;
 mod cmd_self_check;
 mod cmd_verify;
 mod cmd_verify_protocol;
@@ -153,6 +154,8 @@ enum Cmd {
     /// empty-set attestation. Exit 0 on pass (warnings allowed), exit 2 on any
     /// hard failure (invalid TOML or missing/non-executable binary).
     Doctor(cmd_doctor::DoctorArgs),
+    /// Run the v1 release health gate and emit a release evidence receipt.
+    ReleaseGate(cmd_release_gate::ReleaseGateArgs),
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -322,6 +325,7 @@ fn main() -> ExitCode {
         Cmd::Bind(a) => cmd_bind::run(a),
         Cmd::Materialize(a) => cmd_materialize::run(a),
         Cmd::Doctor(a) => cmd_doctor::run(a),
+        Cmd::ReleaseGate(a) => cmd_release_gate::run(a),
     };
     ExitCode::from(code)
 }

--- a/implementations/rust/provekit-cli/tests/cmd_release_gate.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_release_gate.rs
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::VecDeque;
+use std::path::PathBuf;
+
+use clap::Parser;
+use provekit_cli::cmd_release_gate::{
+    release_gate_exit_code, release_gate_plan, run_release_gate_with_executor, GateExecutor,
+    GateInvocation, GateOutput, ReleaseGateArgs,
+};
+use provekit_cli::doctor::{report_from_floor_signals, DoctorMode};
+use provekit_cli::floor_runtime_check::FloorSignals;
+use serde_json::{json, Value};
+
+fn invocation_args(invocation: &GateInvocation) -> Vec<String> {
+    invocation
+        .args
+        .iter()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect()
+}
+
+#[test]
+fn default_plan_runs_doctor_and_self_check_for_cli_and_lib() {
+    let args = ReleaseGateArgs::try_parse_from(["release-gate"]).unwrap();
+    let plan = release_gate_plan(&args).expect("default release-gate plan");
+
+    let actual: Vec<(String, String, Vec<String>)> = plan
+        .iter()
+        .map(|invocation| {
+            (
+                invocation.target_name.clone(),
+                invocation.command.clone(),
+                invocation_args(invocation),
+            )
+        })
+        .collect();
+
+    assert_eq!(
+        actual,
+        vec![
+            (
+                "provekit-cli".to_string(),
+                "doctor".to_string(),
+                vec![
+                    "doctor",
+                    "--target",
+                    "implementations/rust/provekit-cli",
+                    "--mode",
+                    "releaseGate",
+                    "--oracle",
+                    "--json",
+                ]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            ),
+            (
+                "provekit-cli".to_string(),
+                "self-check".to_string(),
+                vec![
+                    "self-check",
+                    "--target",
+                    "implementations/rust/provekit-cli",
+                    "--oracle",
+                    "--json",
+                ]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            ),
+            (
+                "libprovekit".to_string(),
+                "doctor".to_string(),
+                vec![
+                    "doctor",
+                    "--target",
+                    "implementations/rust/libprovekit",
+                    "--mode",
+                    "releaseGate",
+                    "--oracle",
+                    "--json",
+                ]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            ),
+            (
+                "libprovekit".to_string(),
+                "self-check".to_string(),
+                vec![
+                    "self-check",
+                    "--target",
+                    "implementations/rust/libprovekit",
+                    "--oracle",
+                    "--json",
+                ]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            ),
+        ]
+    );
+}
+
+#[test]
+fn config_file_replaces_default_targets() {
+    let td = tempfile::tempdir().unwrap();
+    let config = td.path().join("release-gate.toml");
+    std::fs::write(
+        &config,
+        r#"
+[[target]]
+name = "custom"
+path = "examples/custom"
+"#,
+    )
+    .unwrap();
+
+    let config_arg = config.to_string_lossy().to_string();
+    let args =
+        ReleaseGateArgs::try_parse_from(["release-gate", "--config", config_arg.as_str()])
+            .unwrap();
+    let plan = release_gate_plan(&args).expect("custom release-gate plan");
+
+    assert_eq!(plan.len(), 2);
+    assert!(plan
+        .iter()
+        .all(|invocation| invocation.target_name == "custom"));
+    assert_eq!(
+        invocation_args(&plan[0]),
+        vec![
+            "doctor",
+            "--target",
+            "examples/custom",
+            "--mode",
+            "releaseGate",
+            "--oracle",
+            "--json",
+        ]
+    );
+    assert_eq!(
+        invocation_args(&plan[1]),
+        vec![
+            "self-check",
+            "--target",
+            "examples/custom",
+            "--oracle",
+            "--json",
+        ]
+    );
+}
+
+#[test]
+fn all_four_green_gates_mark_release_ready() {
+    let args = ReleaseGateArgs::try_parse_from(["release-gate"]).unwrap();
+    let mut executor = FakeExecutor::new(vec![
+        ok_doctor("provekit-cli"),
+        ok_self_check("implementations/rust/provekit-cli", 21, 53, 0),
+        ok_doctor("libprovekit"),
+        ok_self_check("implementations/rust/libprovekit", 12, 35, 0),
+    ]);
+
+    let receipt = run_release_gate_with_executor(args, &mut executor).expect("release receipt");
+
+    assert!(receipt.release_ready, "{receipt:#?}");
+    assert_eq!(release_gate_exit_code(&receipt), provekit_cli::EXIT_OK);
+    assert_eq!(receipt.targets.len(), 2);
+    assert_eq!(executor.invocations.len(), 4);
+}
+
+#[test]
+fn any_failed_gate_marks_release_not_ready_and_names_failure() {
+    let args = ReleaseGateArgs::try_parse_from(["release-gate"]).unwrap();
+    let mut executor = FakeExecutor::new(vec![
+        ok_doctor("provekit-cli"),
+        failed_self_check("implementations/rust/provekit-cli"),
+        ok_doctor("libprovekit"),
+        ok_self_check("implementations/rust/libprovekit", 12, 35, 0),
+    ]);
+
+    let receipt = run_release_gate_with_executor(args, &mut executor).expect("release receipt");
+
+    assert!(!receipt.release_ready, "{receipt:#?}");
+    assert_eq!(release_gate_exit_code(&receipt), provekit_cli::EXIT_VERIFY_FAIL);
+    assert_eq!(receipt.failures.len(), 1);
+    assert_eq!(receipt.failures[0].target, "provekit-cli");
+    assert_eq!(receipt.failures[0].command, "self-check");
+}
+
+#[test]
+fn receipt_extracts_k_floor_residue_and_doctor_evidence() {
+    let args = ReleaseGateArgs::try_parse_from(["release-gate"]).unwrap();
+    let mut executor = FakeExecutor::new(vec![
+        ok_doctor("provekit-cli"),
+        ok_self_check("implementations/rust/provekit-cli", 21, 53, 9),
+        ok_doctor("libprovekit"),
+        ok_self_check("implementations/rust/libprovekit", 12, 35, 1),
+    ]);
+
+    let receipt = run_release_gate_with_executor(args, &mut executor).expect("release receipt");
+    let cli = receipt
+        .targets
+        .iter()
+        .find(|target| target.name == "provekit-cli")
+        .expect("provekit-cli target");
+
+    assert_eq!(cli.evidence.k_panic_safe, 21);
+    assert_eq!(cli.evidence.floor.silently_dropped, 0);
+    assert_eq!(cli.evidence.floor.false_pass, 0);
+    assert_eq!(cli.evidence.floor.dropped_sites_count, 0);
+    assert_eq!(cli.evidence.floor.total_callsites, 53);
+    assert!(cli.evidence.floor.discharge_split_present);
+    assert_eq!(cli.evidence.residue.residue, 9);
+    assert_eq!(cli.evidence.residue.tier_to_close, 1);
+    assert_eq!(cli.evidence.residue.raw_unproven, 0);
+    assert!(cli
+        .evidence
+        .doctor_checks
+        .iter()
+        .any(|check| check.name == "dependency-pool-stable" && check.status == "pass"));
+}
+
+#[test]
+fn total_callsites_zero_in_self_check_json_fails_floor_aggregation() {
+    let args = ReleaseGateArgs::try_parse_from(["release-gate"]).unwrap();
+    let mut executor = FakeExecutor::new(vec![
+        ok_doctor("provekit-cli"),
+        ok_self_check("implementations/rust/provekit-cli", 21, 0, 0),
+        ok_doctor("libprovekit"),
+        ok_self_check("implementations/rust/libprovekit", 12, 35, 0),
+    ]);
+
+    let receipt = run_release_gate_with_executor(args, &mut executor).expect("release receipt");
+    let cli = receipt
+        .targets
+        .iter()
+        .find(|target| target.name == "provekit-cli")
+        .expect("provekit-cli target");
+
+    assert!(!receipt.release_ready, "{receipt:#?}");
+    assert!(cli
+        .floor_report
+        .checks
+        .iter()
+        .any(|check| check.id == "floor.total_callsites.nonzero"
+            && check.status.as_str() == "fail"));
+}
+
+#[test]
+fn doctor_floor_aggregation_is_production_surface_for_release_gate() {
+    let report = report_from_floor_signals(
+        PathBuf::from("implementations/rust/provekit-cli").as_path(),
+        DoctorMode::ReleaseGate,
+        FloorSignals {
+            silently_dropped: 0,
+            false_pass: 0,
+            dropped_sites_count: 0,
+            panic_census_unnamed_count: 0,
+            total_callsites: 1,
+            discharge_split_present: true,
+        },
+    );
+
+    assert!(report.ok);
+    assert!(report.release_ready);
+}
+
+#[derive(Debug)]
+struct FakeExecutor {
+    invocations: Vec<GateInvocation>,
+    outputs: VecDeque<GateOutput>,
+}
+
+impl FakeExecutor {
+    fn new(outputs: Vec<GateOutput>) -> Self {
+        Self {
+            invocations: Vec::new(),
+            outputs: outputs.into(),
+        }
+    }
+}
+
+impl GateExecutor for FakeExecutor {
+    fn run(&mut self, invocation: &GateInvocation) -> Result<GateOutput, String> {
+        self.invocations.push(invocation.clone());
+        self.outputs
+            .pop_front()
+            .ok_or_else(|| format!("no fake output for {invocation:?}"))
+    }
+}
+
+fn ok_doctor(target: &str) -> GateOutput {
+    GateOutput {
+        exit_code: 0,
+        stdout: json!({
+            "mode": "releaseGate",
+            "ok": true,
+            "releaseReady": true,
+            "checks": [
+                {"name": "config-toml-parse", "status": "pass", "detail": target},
+                {"name": "dependency-pool-stable", "status": "pass", "detail": "stable"}
+            ]
+        })
+        .to_string(),
+        stderr: String::new(),
+    }
+}
+
+fn ok_self_check(target: &str, panic_safe: u64, total_callsites: u64, residue: usize) -> GateOutput {
+    GateOutput {
+        exit_code: 0,
+        stdout: self_check_json(target, panic_safe, total_callsites, residue).to_string(),
+        stderr: String::new(),
+    }
+}
+
+fn failed_self_check(target: &str) -> GateOutput {
+    GateOutput {
+        exit_code: 1,
+        stdout: self_check_json(target, 0, 1, 0).to_string(),
+        stderr: "self-check invariant violation".to_string(),
+    }
+}
+
+fn self_check_json(target: &str, panic_safe: u64, total_callsites: u64, residue: usize) -> Value {
+    let mut panic_census = vec![
+        json!({
+            "file": "src/lib.rs",
+            "line": 1,
+            "callee": "method:unwrap",
+            "status": "proven",
+            "reason": "panic-safe"
+        }),
+        json!({
+            "file": "src/lib.rs",
+            "line": 2,
+            "callee": "method:unwrap",
+            "status": "unproven",
+            "category": "D-lib",
+            "tierToClose": "D-lib",
+            "reason": "closeable"
+        }),
+    ];
+    for idx in 0..residue {
+        panic_census.push(json!({
+            "file": "src/lib.rs",
+            "line": 100 + idx,
+            "callee": "method:expect",
+            "status": "residue",
+            "category": "lock_poisoning_residue",
+            "tierToClose": "irreducible",
+            "reason": "honest residue"
+        }));
+    }
+    json!({
+        "target": target,
+        "catalogCid": "blake3-512:test",
+        "lift": {
+            "fnContracts": 1,
+            "bodyDischargeEligible": 1,
+            "bodyDischargeIneligible": {}
+        },
+        "bridges": {
+            "emitted": 1,
+            "liftGaps": {}
+        },
+        "oracle": {
+            "requested": true,
+            "engaged": true,
+            "attempted": 1,
+            "resolved": 1
+        },
+        "silentlyDropped": 0,
+        "droppedSites": [],
+        "totalCallsites": total_callsites,
+        "dischargeSplit": {
+            "panicSafe": panic_safe,
+            "reflexive": 0,
+            "vacuous": 0,
+            "undecidable": 0,
+            "falsePass": 0
+        },
+        "panicCensus": panic_census
+    })
+}

--- a/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.json
+++ b/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.json
@@ -21,6 +21,7 @@
   },
   "silentlyDropped": 0,
   "droppedSites": [],
+  "totalCallsites": 1826,
   "dischargeSplit": {
     "panicSafe": 5,
     "reflexive": 628,

--- a/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.md
+++ b/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.md
@@ -10,6 +10,7 @@ rust-analyzer daemon, no wall-clock, no absolute paths.
 
 - `silentlyDropped: 0` -- hard invariant, must stay zero
 - `falsePass: 0` -- hard invariant, must stay zero
+- `totalCallsites: 1826` -- release-gate floor evidence, must stay nonzero
 - `panicSafe: 5` -- five rust-std shim panic sites discharge through real proof obligations
 - `panicCensus`: 30 sites, 5 `proven` and 25 `unproven`; unproven rows keep the verifier's refuse-floor reason
 - `catalogCid` is a content hash of the lifted contracts; it is path-independent (verified 2026-05-31 across two checkout paths)
@@ -51,6 +52,10 @@ runtime hook. The no-oracle scoreboard now records real bridge/prove effects:
 `panicCensus 5 -> 30` (`5 proven`, `25 unproven`), and the legacy
 `panic-site-unproven` liftGap key disappears from the production scoreboard.
 Hard invariants unchanged: `falsePass 0`, `silentlyDropped 0`, `droppedSites []`.
+
+Regenerated 2026-06-01: added top-level `totalCallsites 1826` for release-gate
+floor verification. This is a backward-compatible scoreboard schema expansion;
+hard invariants and proof counts are unchanged.
 
 ## Normalization applied
 

--- a/implementations/rust/provekit-cli/tests/self_check.rs
+++ b/implementations/rust/provekit-cli/tests/self_check.rs
@@ -80,6 +80,10 @@ fn self_check_on_rust_std_shim_emits_scoreboard_shape_and_hard_invariants() {
     assert_eq!(scoreboard["oracle"]["attempted"], 0);
     assert_eq!(scoreboard["oracle"]["resolved"], 0);
     assert_eq!(scoreboard["silentlyDropped"], 0);
+    assert!(
+        scoreboard["totalCallsites"].as_u64().unwrap_or(0) > 0,
+        "totalCallsites is release-gate floor evidence"
+    );
     assert_eq!(scoreboard["dischargeSplit"]["falsePass"], 0);
     assert!(scoreboard["dischargeSplit"]["panicSafe"].is_u64());
     assert!(scoreboard["dischargeSplit"]["reflexive"].is_u64());


### PR DESCRIPTION
## Summary

Adds the v1 `provekit release-gate` command as the executable release evidence receipt for the Rust self-application arc.

The command orchestrates the shipped CLI surfaces for both `provekit-cli` and `libprovekit`:

- `provekit doctor --target <target> --mode releaseGate --oracle --json`
- `provekit self-check --target <target> --oracle --json`

It aggregates the four results into a release receipt, fails closed when any gate fails, includes K/floor/residue/doctor evidence, and calls the doctor floor aggregation path in production.

## Details

- Adds `cmd_release_gate` with a subprocess executor for production and a stub executor seam for fast tests.
- Supports default Rust v1 targets plus `--config` with `[[target]]` entries.
- Promotes `doctor::report_from_floor_signals` out of `cfg(test)` so PR6 floor aggregation has its production caller.
- Adds top-level `totalCallsites` to `self-check --json`, making floor verification self-contained from the command surface.
- Refreshes the rust-std shim self-check golden with the additive `totalCallsites: 1826` field and a one-line why.
- Filed #1786 for the stale `--release-gate` spelling in docs; this PR intentionally uses the shipped `--mode releaseGate` surface.

## Validation

- RED first: `../../bin/bcargo test -p provekit-cli --test cmd_release_gate -- --nocapture` failed on missing `cmd_release_gate` / production `doctor` surface.
- `../../bin/bcargo test -p provekit-cli --test cmd_release_gate -- --nocapture` -> 7 passed.
- `../../bin/bcargo test -p provekit-cli total_callsites -- --nocapture` -> 3 lib + 3 bin tests passed.
- `../../bin/bcargo test -p provekit-cli floor_report -- --nocapture` -> 2 lib + 2 bin tests passed.
- `../../bin/bcargo test -p provekit-cli --test self_check -- --nocapture` -> 1 passed.
- `../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` -> 1 passed.
- `../../bin/bcargo test -p provekit-cli doctor -- --nocapture` -> 48 lib + 54 bin tests passed.
- `git diff --check` clean.

Note: an attempted parallel `self_check_golden` run hit a `bcargo` rsync race in generated `.provekit/imports`; rerunning serially passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `release-gate` command to provekit-cli for validating release readiness across multiple targets, with support for TOML configuration files and JSON output formatting.

* **Improvements**
  * Self-check scoreboard now includes total callsites tracking for enhanced metrics collection.
  * Improved floor signal reporting in doctor output for better diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->