### PR TITLE
add panic freedom substrate constants

### DIFF
--- a/implementations/rust/libprovekit/src/concept/mod.rs
+++ b/implementations/rust/libprovekit/src/concept/mod.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod panic_freedom;

--- a/implementations/rust/libprovekit/src/concept/panic_freedom.rs
+++ b/implementations/rust/libprovekit/src/concept/panic_freedom.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Substrate identifiers for panic-freedom concepts.
+//!
+//! These constants intentionally keep the existing Rust v1 wire tokens. The
+//! Phase 4 substrate shape audit marks the corresponding concepts as
+//! alias-read first, so introducing this module must not change proof bytes.
+
+/// Substrate panic-freedom result-ok predicate; see `SUBSTRATE-SHAPE-AUDIT.md`.
+pub const IS_OK: &str = "is_ok";
+
+/// Substrate panic-freedom result-err predicate; see `SUBSTRATE-SHAPE-AUDIT.md`.
+pub const IS_ERR: &str = "is_err";
+
+/// Substrate panic-freedom option-some predicate; see `SUBSTRATE-SHAPE-AUDIT.md`.
+pub const IS_SOME: &str = "is_some";
+
+/// Substrate panic-freedom option-none predicate; see `SUBSTRATE-SHAPE-AUDIT.md`.
+pub const IS_NONE: &str = "is_none";
+
+/// Substrate panic-freedom guarded-branch carrier; see `SUBSTRATE-SHAPE-AUDIT.md`.
+pub const CF_GUARDED: &str = "cf_guarded";
+
+/// Substrate panic-freedom control-flow choice carrier; see `SUBSTRATE-SHAPE-AUDIT.md`.
+pub const CF_ITE: &str = "cf_ite";
+
+/// Substrate panic-freedom unwrap leaf; see `SUBSTRATE-SHAPE-AUDIT.md`.
+pub const METHOD_UNWRAP: &str = "method:unwrap";
+
+/// Substrate panic-freedom expect leaf; see `SUBSTRATE-SHAPE-AUDIT.md`.
+pub const METHOD_EXPECT: &str = "method:expect";
+
+/// Substrate panic-freedom unwrap-err leaf; see `SUBSTRATE-SHAPE-AUDIT.md`.
+pub const METHOD_UNWRAP_ERR: &str = "method:unwrap_err";

--- a/implementations/rust/libprovekit/src/lib.rs
+++ b/implementations/rust/libprovekit/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod canonical;
 pub mod compose;
+pub mod concept;
 pub mod core;
 pub mod desugar;
 pub mod effect_propagation;

--- a/implementations/rust/libprovekit/tests/concept_panic_freedom.rs
+++ b/implementations/rust/libprovekit/tests/concept_panic_freedom.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use libprovekit::concept::panic_freedom;
+
+#[test]
+fn panic_freedom_constants_keep_existing_wire_tokens() {
+    assert_eq!(panic_freedom::IS_OK, "is_ok");
+    assert_eq!(panic_freedom::IS_ERR, "is_err");
+    assert_eq!(panic_freedom::IS_SOME, "is_some");
+    assert_eq!(panic_freedom::IS_NONE, "is_none");
+    assert_eq!(panic_freedom::CF_GUARDED, "cf_guarded");
+    assert_eq!(panic_freedom::CF_ITE, "cf_ite");
+    assert_eq!(panic_freedom::METHOD_UNWRAP, "method:unwrap");
+    assert_eq!(panic_freedom::METHOD_EXPECT, "method:expect");
+    assert_eq!(panic_freedom::METHOD_UNWRAP_ERR, "method:unwrap_err");
+}

--- a/implementations/rust/provekit-verifier/src/body_discharge.rs
+++ b/implementations/rust/provekit-verifier/src/body_discharge.rs
@@ -1239,6 +1239,7 @@ mod callee_post_guard_fact_tests {
     //!   - a `var` arg_term (not a call) does NOT yield a fact (structural).
     use super::*;
     use crate::types::{CallSite, MementoPool};
+    use libprovekit::concept::panic_freedom;
     use serde_json::json;
 
     // CIDs for hand-built contracts in these tests.
@@ -1289,11 +1290,15 @@ mod callee_post_guard_fact_tests {
     ///   - a contract with `post = is_ok(result)` (the Value-totality contract)
     ///   - a bridge from BRIDGE_SYMBOL to that contract
     fn totality_pool() -> MementoPool {
-        singleton_totality_pool(BRIDGE_SYMBOL, TOTAL_CONTRACT_CID, "is_ok")
+        singleton_totality_pool(BRIDGE_SYMBOL, TOTAL_CONTRACT_CID, panic_freedom::IS_OK)
     }
 
     fn option_totality_pool() -> MementoPool {
-        singleton_totality_pool(OPTION_BRIDGE_SYMBOL, OPTION_TOTAL_CONTRACT_CID, "is_some")
+        singleton_totality_pool(
+            OPTION_BRIDGE_SYMBOL,
+            OPTION_TOTAL_CONTRACT_CID,
+            panic_freedom::IS_SOME,
+        )
     }
 
     /// A pool with a GENERIC (non-total) Result contract: post = is_ok || is_err.
@@ -1305,9 +1310,9 @@ mod callee_post_guard_fact_tests {
                     "post": {
                         "kind": "or",
                         "operands": [
-                            {"kind": "atomic", "name": "is_ok",
+                            {"kind": "atomic", "name": panic_freedom::IS_OK,
                              "args": [{"kind": "var", "name": "result"}]},
-                            {"kind": "atomic", "name": "is_err",
+                            {"kind": "atomic", "name": panic_freedom::IS_ERR,
                              "args": [{"kind": "var", "name": "result"}]}
                         ]
                     }
@@ -1374,7 +1379,7 @@ mod callee_post_guard_fact_tests {
         );
         assert_eq!(
             fact.get("name").and_then(|v| v.as_str()),
-            Some("is_ok"),
+            Some(panic_freedom::IS_OK),
             "the supplied fact must be is_ok"
         );
         // The arg of is_ok(.) is the whole ctor expression.
@@ -1412,7 +1417,7 @@ mod callee_post_guard_fact_tests {
         );
         assert_eq!(
             fact.get("name").and_then(|v| v.as_str()),
-            Some("is_some"),
+            Some(panic_freedom::IS_SOME),
             "the supplied fact must preserve the opaque singleton predicate name"
         );
         let fact_args = fact.get("args").and_then(|v| v.as_array()).unwrap();
@@ -1534,7 +1539,10 @@ mod callee_post_guard_fact_tests {
 
         let fact = callee_post_guard_fact(&cs, &pool)
             .expect("panic site must find producer in the caller contract bundle");
-        assert_eq!(fact.get("name").and_then(|v| v.as_str()), Some("is_ok"));
+        assert_eq!(
+            fact.get("name").and_then(|v| v.as_str()),
+            Some(panic_freedom::IS_OK)
+        );
     }
 
     #[test]
@@ -1582,7 +1590,10 @@ mod callee_post_guard_fact_tests {
 
         let fact = callee_post_guard_fact(&cs, &pool)
             .expect("split-line panic site must use producer coordinates");
-        assert_eq!(fact.get("name").and_then(|v| v.as_str()), Some("is_some"));
+        assert_eq!(
+            fact.get("name").and_then(|v| v.as_str()),
+            Some(panic_freedom::IS_SOME)
+        );
 
         let missing_producer_line = CallSite {
             producer_file: None,

--- a/implementations/rust/provekit-verifier/src/enumerate_callsites.rs
+++ b/implementations/rust/provekit-verifier/src/enumerate_callsites.rs
@@ -6,6 +6,7 @@
 //
 // Mirrors implementations/cpp/.../verifier/enumerate_callsites.cpp.
 
+use libprovekit::concept::panic_freedom;
 use serde_json::Value as Json;
 use tracing::{debug, info, warn};
 
@@ -620,7 +621,7 @@ fn walk_term(
     //     under it. A branch the kit did not wrap (unrecognized guard) carries
     //     no `cf_guarded`, so a partial inside it stays honestly undecidable.
     //   * any other ctor: descends args with the path condition unchanged.
-    if name == "cf_guarded" {
+    if name == panic_freedom::CF_GUARDED {
         if let Some(args) = t.get("args").and_then(|v| v.as_array()) {
             let guard = args.first();
             let value = args.get(1);

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -25,6 +25,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
 use base64::Engine;
+use libprovekit::concept::panic_freedom;
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 use provekit_ir_types::{EvidenceMemento, IrFormula, IrTerm, SourceKind};
 use provekit_lift_contracts::lift_file_with_docstring_evidence;
@@ -1155,8 +1156,8 @@ impl FunctionPostconditionsManifest {
 
 fn panic_stem_for_post_predicate(predicate: &str) -> Option<&'static str> {
     match predicate {
-        "is_ok" => Some("result"),
-        "is_some" => Some("option"),
+        panic_freedom::IS_OK => Some("result"),
+        panic_freedom::IS_SOME => Some("option"),
         _ => None,
     }
 }
@@ -3991,7 +3992,7 @@ fn bind_lift(params: &Value) -> Result<Value, String> {
                 // Shape: {"kind":"atomic","name":"is_ok","args":[{"kind":"var","name":"result"}]}
                 json!({
                     "kind": "atomic",
-                    "name": "is_ok",
+                    "name": panic_freedom::IS_OK,
                     "args": [{ "kind": "var", "name": "result" }],
                 })
             } else {
@@ -4318,7 +4319,7 @@ fn function_contract_lift(params: &Value) -> Result<Value, String> {
             // Matches the exact shape callee_post_guard_fact requires (body_discharge.rs).
             let post_override: Option<IrFormula> = if target.totality_result_ok {
                 Some(IrFormula::Atomic {
-                    name: "is_ok".to_string(),
+                    name: panic_freedom::IS_OK.to_string(),
                     args: vec![IrTerm::Var {
                         name: "result".to_string(),
                     }],
@@ -4483,7 +4484,7 @@ fn emit_infallible_serialize_contracts(
         entries.push(json!({
             "kind": "contract",
             "name": rule.contract,
-            "post": singleton_result_post_json("is_ok"),
+            "post": singleton_result_post_json(panic_freedom::IS_OK),
             "outBinding": "out",
             "bodyDischargeEligible": false,
             "bodyDischargeRefusalReason": "totality-axiom",

--- a/implementations/rust/provekit-walk/src/lift.rs
+++ b/implementations/rust/provekit-walk/src/lift.rs
@@ -27,6 +27,7 @@
 
 use std::collections::{BTreeMap, HashSet};
 
+use libprovekit::concept::panic_freedom;
 use proc_macro2::{Delimiter, TokenStream, TokenTree};
 use provekit_ir_types::{IrFormula, IrTerm};
 use syn::{
@@ -394,7 +395,7 @@ fn lift_tail_if_to_ite_term(if_expr: &ExprIf, ctx: &mut LiftCtx) -> Option<IrTer
         // satisfy -- a sort-mismatch error that fails the reflexive
         // discharge. As a fresh uninterpreted symbol, congruence closes
         // `cf_ite(g,a,b) == cf_ite(g,a,b)` regardless of operand sorts.
-        name: "cf_ite".to_string(),
+        name: panic_freedom::CF_ITE.to_string(),
         args: vec![cond_term, then_term, else_term],
     })
 }
@@ -425,10 +426,16 @@ fn lift_tail_if_to_ite_term(if_expr: &ExprIf, ctx: &mut LiftCtx) -> Option<IrTer
 fn branch_guard_head(cond_head: &str, else_branch: bool) -> Option<&'static str> {
     let head = cond_head.strip_prefix("method:").unwrap_or(cond_head);
     match (head, else_branch) {
-        ("is_some", false) | ("is_none", true) => Some("is_some"),
-        ("is_none", false) | ("is_some", true) => Some("is_none"),
-        ("is_ok", false) | ("is_err", true) => Some("is_ok"),
-        ("is_err", false) | ("is_ok", true) => Some("is_err"),
+        (panic_freedom::IS_SOME, false) | (panic_freedom::IS_NONE, true) => {
+            Some(panic_freedom::IS_SOME)
+        }
+        (panic_freedom::IS_NONE, false) | (panic_freedom::IS_SOME, true) => {
+            Some(panic_freedom::IS_NONE)
+        }
+        (panic_freedom::IS_OK, false) | (panic_freedom::IS_ERR, true) => Some(panic_freedom::IS_OK),
+        (panic_freedom::IS_ERR, false) | (panic_freedom::IS_OK, true) => {
+            Some(panic_freedom::IS_ERR)
+        }
         ("is_empty", false) => Some("is_empty"),
         // `!is_empty` (else of `if c.is_empty()`) establishes no partial pre.
         ("is_empty", true) => None,
@@ -468,7 +475,7 @@ fn wrap_branch_guard(cond_term: &IrTerm, else_branch: bool, value: IrTerm) -> Ir
         args: args.clone(),
     };
     IrTerm::Ctor {
-        name: "cf_guarded".to_string(),
+        name: panic_freedom::CF_GUARDED.to_string(),
         args: vec![guard, value],
     }
 }
@@ -477,7 +484,7 @@ fn len_eq_one_branch_guard(cond_term: &IrTerm, value: &IrTerm) -> Option<IrTerm>
     let receiver_key = len_eq_one_receiver_key(cond_term)?;
     let next_receiver = find_next_partial_receiver(value, &receiver_key)?;
     Some(IrTerm::Ctor {
-        name: "is_some".to_string(),
+        name: panic_freedom::IS_SOME.to_string(),
         args: vec![next_receiver],
     })
 }
@@ -502,8 +509,10 @@ fn len_eq_one_receiver_key(cond_term: &IrTerm) -> Option<String> {
 fn find_next_partial_receiver(term: &IrTerm, collection_receiver_key: &str) -> Option<IrTerm> {
     match term {
         IrTerm::Ctor { name, args }
-            if matches!(name.as_str(), "method:unwrap" | "method:expect")
-                && !args.is_empty()
+            if matches!(
+                name.as_str(),
+                panic_freedom::METHOD_UNWRAP | panic_freedom::METHOD_EXPECT
+            ) && !args.is_empty()
                 && next_into_iter_receiver_key(&args[0]).as_deref()
                     == Some(collection_receiver_key) =>
         {
@@ -555,7 +564,7 @@ fn lift_match_to_ite_term(match_expr: &syn::ExprMatch, ctx: &mut LiftCtx) -> Opt
             IrTerm::Ctor {
                 // `cf_ite` (uninterpreted), not the builtin `ite`: see the
                 // note in `lift_tail_if_to_ite_term`.
-                name: "cf_ite".to_string(),
+                name: panic_freedom::CF_ITE.to_string(),
                 args: vec![guard, value, acc.expect("non-final arm has an accumulator")],
             }
         });
@@ -809,7 +818,10 @@ fn tracked_direct_guard_fact(expr: &Expr, ctx: &mut LiftCtx) -> Option<TrackedGu
         return None;
     }
     let guard_head = method_call.method.to_string();
-    if !matches!(guard_head.as_str(), "is_some" | "is_ok" | "is_err") {
+    if !matches!(
+        guard_head.as_str(),
+        panic_freedom::IS_SOME | panic_freedom::IS_OK | panic_freedom::IS_ERR
+    ) {
         return None;
     }
     let root = expr_root_ident(&method_call.receiver)?;
@@ -1177,7 +1189,7 @@ fn receiver_as_str_is_known_json_string(receiver: &Expr, ctx: &LiftCtx) -> bool 
 fn wrap_known_option_unwrap_guard(receiver: IrTerm, value: IrTerm) -> IrTerm {
     wrap_cf_guarded(
         IrTerm::Ctor {
-            name: "is_some".to_string(),
+            name: panic_freedom::IS_SOME.to_string(),
             args: vec![receiver],
         },
         value,
@@ -1186,7 +1198,7 @@ fn wrap_known_option_unwrap_guard(receiver: IrTerm, value: IrTerm) -> IrTerm {
 
 fn wrap_cf_guarded(guard: IrTerm, value: IrTerm) -> IrTerm {
     IrTerm::Ctor {
-        name: "cf_guarded".to_string(),
+        name: panic_freedom::CF_GUARDED.to_string(),
         args: vec![guard, value],
     }
 }
@@ -1203,8 +1215,10 @@ fn assertion_guard_for_partial(
             continue;
         }
         match (method.as_str(), fact.guard_head.as_str()) {
-            ("unwrap" | "expect", "is_some" | "is_ok") => return Some(fact.guard.clone()),
-            ("unwrap_err", "is_err") => return Some(fact.guard.clone()),
+            ("unwrap" | "expect", panic_freedom::IS_SOME | panic_freedom::IS_OK) => {
+                return Some(fact.guard.clone())
+            }
+            ("unwrap_err", panic_freedom::IS_ERR) => return Some(fact.guard.clone()),
             _ => {}
         }
     }
@@ -1214,7 +1228,7 @@ fn assertion_guard_for_partial(
         })
     {
         return Some(IrTerm::Ctor {
-            name: "is_some".to_string(),
+            name: panic_freedom::IS_SOME.to_string(),
             args: vec![receiver_term.clone()],
         });
     }
@@ -1371,7 +1385,11 @@ fn lift_predicate_inner(expr: &Expr, ctx: &mut LiftCtx) -> Option<IrFormula> {
             let method_name = method.to_string();
             let is_bool_predicate = matches!(
                 method_name.as_str(),
-                "is_some" | "is_none" | "is_empty" | "is_err" | "is_ok"
+                panic_freedom::IS_SOME
+                    | panic_freedom::IS_NONE
+                    | "is_empty"
+                    | panic_freedom::IS_ERR
+                    | panic_freedom::IS_OK
             );
             if is_bool_predicate {
                 let recv_term = lift_expr_to_term_inner(receiver, ctx)?;
@@ -2031,7 +2049,7 @@ mod tests {
                     // (uninterpreted), not the SMT builtins `ite`/`=`, so
                     // they encode over uninterpreted operands without a
                     // sort mismatch and discharge reflexively.
-                    name: "cf_ite".to_string(),
+                    name: panic_freedom::CF_ITE.to_string(),
                     args: vec![
                         IrTerm::Ctor {
                             name: "cf_eq".to_string(),


### PR DESCRIPTION
## Summary
- add `libprovekit::concept::panic_freedom` constants for the current Rust v1 panic-freedom wire tokens
- prove the constants preserve existing wire values with a RED-first integration test
- replace selected Rust kit/verifier token references in `provekit-walk` and `provekit-verifier` with the constants, without changing emitted strings, schema, or behavior

## Verification
- RED first: `../../bin/bcargo test -p libprovekit panic_freedom_constants_keep_existing_wire_tokens -- --nocapture` failed on unresolved `libprovekit::concept`
- `../../bin/bcargo test -p libprovekit panic_freedom_constants_keep_existing_wire_tokens -- --nocapture`
- `../../bin/bcargo test -p provekit-walk branch_guard_head -- --nocapture`
- `../../bin/bcargo test -p provekit-verifier callee_post_guard_fact -- --nocapture`
- `../../bin/bcargo test -p provekit-verifier cf_guarded_threads_the_opaque_atom_verbatim -- --nocapture`
- `../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc -p provekit-lift --bin provekit-lift`
- `../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture`
- `git diff --check`

`../../bin/bcargo fmt --all --check` reports broad pre-existing formatting drift outside this PR; I manually aligned the changed hunks and left unrelated drift untouched. No golden files changed.