### PR TITLE
[codex] accept result predicate concept aliases

### DIFF
--- a/implementations/rust/libprovekit/src/concept/panic_freedom.rs
+++ b/implementations/rust/libprovekit/src/concept/panic_freedom.rs
@@ -9,8 +9,14 @@
 /// Substrate panic-freedom result-ok predicate; see `SUBSTRATE-SHAPE-AUDIT.md`.
 pub const IS_OK: &str = "is_ok";
 
+/// Substrate panic-freedom result-ok predicate alias; see `SUBSTRATE-SHAPE-AUDIT.md`.
+pub const IS_OK_CONCEPT: &str = "concept:panic-freedom.result.ok";
+
 /// Substrate panic-freedom result-err predicate; see `SUBSTRATE-SHAPE-AUDIT.md`.
 pub const IS_ERR: &str = "is_err";
+
+/// Substrate panic-freedom result-err predicate alias; see `SUBSTRATE-SHAPE-AUDIT.md`.
+pub const IS_ERR_CONCEPT: &str = "concept:panic-freedom.result.err";
 
 /// Substrate panic-freedom option-some predicate; see `SUBSTRATE-SHAPE-AUDIT.md`.
 pub const IS_SOME: &str = "is_some";
@@ -38,3 +44,15 @@ pub const METHOD_EXPECT: &str = "method:expect";
 
 /// Substrate panic-freedom unwrap-err leaf; see `SUBSTRATE-SHAPE-AUDIT.md`.
 pub const METHOD_UNWRAP_ERR: &str = "method:unwrap_err";
+
+/// Normalize result predicate aliases to the Rust v1 wire token.
+///
+/// Phase 4 readers accept the concept aliases without changing default Rust v1
+/// proof emission. Unknown predicate names stay opaque.
+pub fn normalize_result_predicate_name(name: &str) -> &str {
+    match name {
+        IS_OK | IS_OK_CONCEPT => IS_OK,
+        IS_ERR | IS_ERR_CONCEPT => IS_ERR,
+        _ => name,
+    }
+}

--- a/implementations/rust/libprovekit/tests/concept_panic_freedom.rs
+++ b/implementations/rust/libprovekit/tests/concept_panic_freedom.rs
@@ -5,7 +5,15 @@ use libprovekit::concept::panic_freedom;
 #[test]
 fn panic_freedom_constants_keep_existing_wire_tokens() {
     assert_eq!(panic_freedom::IS_OK, "is_ok");
+    assert_eq!(
+        panic_freedom::IS_OK_CONCEPT,
+        "concept:panic-freedom.result.ok"
+    );
     assert_eq!(panic_freedom::IS_ERR, "is_err");
+    assert_eq!(
+        panic_freedom::IS_ERR_CONCEPT,
+        "concept:panic-freedom.result.err"
+    );
     assert_eq!(panic_freedom::IS_SOME, "is_some");
     assert_eq!(panic_freedom::IS_NONE, "is_none");
     assert_eq!(panic_freedom::CF_GUARDED, "cf_guarded");
@@ -21,4 +29,32 @@ fn panic_freedom_constants_keep_existing_wire_tokens() {
     assert_eq!(panic_freedom::METHOD_UNWRAP, "method:unwrap");
     assert_eq!(panic_freedom::METHOD_EXPECT, "method:expect");
     assert_eq!(panic_freedom::METHOD_UNWRAP_ERR, "method:unwrap_err");
+}
+
+#[test]
+fn result_predicate_concept_aliases_normalize_to_v1_wire_tokens() {
+    assert_eq!(
+        panic_freedom::normalize_result_predicate_name(panic_freedom::IS_OK),
+        panic_freedom::IS_OK
+    );
+    assert_eq!(
+        panic_freedom::normalize_result_predicate_name(panic_freedom::IS_OK_CONCEPT),
+        panic_freedom::IS_OK
+    );
+    assert_eq!(
+        panic_freedom::normalize_result_predicate_name(panic_freedom::IS_ERR),
+        panic_freedom::IS_ERR
+    );
+    assert_eq!(
+        panic_freedom::normalize_result_predicate_name(panic_freedom::IS_ERR_CONCEPT),
+        panic_freedom::IS_ERR
+    );
+    assert_eq!(
+        panic_freedom::normalize_result_predicate_name("concept:panic-freedom.result.OK"),
+        "concept:panic-freedom.result.OK"
+    );
+    assert_eq!(
+        panic_freedom::normalize_result_predicate_name("concept:panic-freedom.result.ok "),
+        "concept:panic-freedom.result.ok "
+    );
 }

--- a/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.json
+++ b/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.json
@@ -24,7 +24,7 @@
   "totalCallsites": 1826,
   "dischargeSplit": {
     "panicSafe": 5,
-    "reflexive": 628,
+    "reflexive": 629,
     "vacuous": 552,
     "undecidable": 1222,
     "falsePass": 0

--- a/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.md
+++ b/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.md
@@ -57,6 +57,14 @@ Regenerated 2026-06-01: added top-level `totalCallsites 1826` for release-gate
 floor verification. This is a backward-compatible scoreboard schema expansion;
 hard invariants and proof counts are unchanged.
 
+Regenerated 2026-06-01: `reflexive 628 -> 629`. The result-predicate alias-read
+slice adds `normalize_result_predicate_name` to `libprovekit`; that helper is
+itself a body-discharge-eligible contract and contributes one honest reflexive
+discharge through the dependency import chain. The shim target `catalogCid`
+stays `d1c2f286...`; writer output remains on the v1 `is_ok`/`is_err` tokens.
+Hard invariants unchanged: `falsePass 0`, `silentlyDropped 0`,
+`droppedSites []`; `panicSafe` remains 5.
+
 ## Normalization applied
 
 None. The output is byte-stable and path-independent without normalization:

--- a/implementations/rust/provekit-verifier/src/body_discharge.rs
+++ b/implementations/rust/provekit-verifier/src/body_discharge.rs
@@ -98,6 +98,7 @@
 
 use serde_json::Value as Json;
 
+use libprovekit::concept::panic_freedom;
 use libprovekit::core::types::Term;
 use libprovekit::wp::{self, value_expr_of_term, OpContractInfo, OpContractResolver, SlotInfo, WpError};
 use provekit_ir_types::{IrFormula, IrTerm};
@@ -754,7 +755,7 @@ fn post_singleton_atomic_predicate_of_result(post: &Json) -> Option<&str> {
     if arg.get("kind").and_then(|v| v.as_str()) == Some("var")
         && arg.get("name").and_then(|v| v.as_str()) == Some("result")
     {
-        Some(predicate)
+        Some(panic_freedom::normalize_result_predicate_name(predicate))
     } else {
         None
     }
@@ -1395,6 +1396,87 @@ mod callee_post_guard_fact_tests {
             Some(BRIDGE_SYMBOL),
             "the ctor name in the fact must match the bridge symbol"
         );
+    }
+
+    #[test]
+    fn result_ok_concept_post_supplies_same_fact_as_old_is_ok() {
+        let cs = cs_with_ctor_arg(BRIDGE_SYMBOL);
+        let old_pool = singleton_totality_pool(
+            BRIDGE_SYMBOL,
+            TOTAL_CONTRACT_CID,
+            panic_freedom::IS_OK,
+        );
+        let concept_pool = singleton_totality_pool(
+            BRIDGE_SYMBOL,
+            TOTAL_CONTRACT_CID,
+            panic_freedom::IS_OK_CONCEPT,
+        );
+
+        let old_fact = callee_post_guard_fact(&cs, &old_pool)
+            .expect("old is_ok(result) singleton post must supply a fact");
+        let concept_fact = callee_post_guard_fact(&cs, &concept_pool)
+            .expect("concept result.ok(result) singleton post must supply a fact");
+
+        assert_eq!(
+            concept_fact, old_fact,
+            "concept result.ok must read as the same predicate fact as old is_ok"
+        );
+        assert_eq!(
+            concept_fact.get("name").and_then(|v| v.as_str()),
+            Some(panic_freedom::IS_OK),
+            "reader must canonicalize concept result.ok to the v1 result predicate"
+        );
+    }
+
+    #[test]
+    fn result_err_concept_post_supplies_same_fact_as_old_is_err() {
+        let cs = cs_with_ctor_arg(BRIDGE_SYMBOL);
+        let old_pool = singleton_totality_pool(
+            BRIDGE_SYMBOL,
+            TOTAL_CONTRACT_CID,
+            panic_freedom::IS_ERR,
+        );
+        let concept_pool = singleton_totality_pool(
+            BRIDGE_SYMBOL,
+            TOTAL_CONTRACT_CID,
+            panic_freedom::IS_ERR_CONCEPT,
+        );
+
+        let old_fact = callee_post_guard_fact(&cs, &old_pool)
+            .expect("old is_err(result) singleton post must supply a fact");
+        let concept_fact = callee_post_guard_fact(&cs, &concept_pool)
+            .expect("concept result.err(result) singleton post must supply a fact");
+
+        assert_eq!(
+            concept_fact, old_fact,
+            "concept result.err must read as the same predicate fact as old is_err"
+        );
+        assert_eq!(
+            concept_fact.get("name").and_then(|v| v.as_str()),
+            Some(panic_freedom::IS_ERR),
+            "reader must canonicalize concept result.err to the v1 result predicate"
+        );
+    }
+
+    #[test]
+    fn result_concept_alias_matching_is_exact() {
+        for malformed in [
+            "concept:panic-freedom.result.OK",
+            "concept:panic-freedom.result.ok ",
+            " concept:panic-freedom.result.ok",
+            "concept:panic-freedom.result.error",
+        ] {
+            let cs = cs_with_ctor_arg(BRIDGE_SYMBOL);
+            let pool = singleton_totality_pool(BRIDGE_SYMBOL, TOTAL_CONTRACT_CID, malformed);
+            let fact = callee_post_guard_fact(&cs, &pool)
+                .expect("opaque singleton predicates still supply opaque facts");
+
+            assert_eq!(
+                fact.get("name").and_then(|v| v.as_str()),
+                Some(malformed),
+                "malformed concept-like strings must not normalize to a result predicate"
+            );
+        }
     }
 
     #[test]

--- a/implementations/rust/provekit-walk/src/lift.rs
+++ b/implementations/rust/provekit-walk/src/lift.rs
@@ -424,7 +424,13 @@ fn lift_tail_if_to_ite_term(if_expr: &ExprIf, ctx: &mut LiftCtx) -> Option<IrTer
 /// condition head and emit the bare predicate name. The verifier never sees
 /// this normalization -- it only threads the resolved bare atom.
 fn branch_guard_head(cond_head: &str, else_branch: bool) -> Option<&'static str> {
-    let head = cond_head.strip_prefix("method:").unwrap_or(cond_head);
+    let method_head = cond_head.strip_prefix("method:");
+    let head = method_head.unwrap_or(cond_head);
+    let head = if method_head.is_some() {
+        head
+    } else {
+        panic_freedom::normalize_result_predicate_name(head)
+    };
     match (head, else_branch) {
         (panic_freedom::IS_SOME, false) | (panic_freedom::IS_NONE, true) => {
             Some(panic_freedom::IS_SOME)
@@ -2621,6 +2627,50 @@ mod tests {
     }
 
     #[test]
+    fn branch_guard_head_accepts_result_concept_aliases_as_read_only_inputs() {
+        assert_eq!(
+            branch_guard_head(panic_freedom::IS_OK_CONCEPT, false),
+            Some(panic_freedom::IS_OK)
+        );
+        assert_eq!(
+            branch_guard_head(panic_freedom::IS_OK_CONCEPT, true),
+            Some(panic_freedom::IS_ERR)
+        );
+        assert_eq!(
+            branch_guard_head(panic_freedom::IS_ERR_CONCEPT, false),
+            Some(panic_freedom::IS_ERR)
+        );
+        assert_eq!(
+            branch_guard_head(panic_freedom::IS_ERR_CONCEPT, true),
+            Some(panic_freedom::IS_OK)
+        );
+    }
+
+    #[test]
+    fn branch_guard_head_result_concept_aliases_are_exact() {
+        assert_eq!(
+            branch_guard_head("concept:panic-freedom.result.OK", false),
+            None
+        );
+        assert_eq!(
+            branch_guard_head("concept:panic-freedom.result.ok ", false),
+            None
+        );
+        assert_eq!(
+            branch_guard_head(" concept:panic-freedom.result.ok", false),
+            None
+        );
+        assert_eq!(
+            branch_guard_head("concept:panic-freedom.result.error", false),
+            None
+        );
+        assert_eq!(
+            branch_guard_head("method:concept:panic-freedom.result.ok", false),
+            None
+        );
+    }
+
+    #[test]
     fn branch_guard_head_refuses_unrecognized_and_negated_is_empty() {
         // `!is_empty` establishes no partial's pre -> no guard.
         assert_eq!(branch_guard_head("is_empty", true), None);
@@ -2785,6 +2835,10 @@ mod tests {
             json.contains("is_ok"),
             "guard must carry the result precondition: {json}"
         );
+        assert!(
+            !json.contains(panic_freedom::IS_OK_CONCEPT),
+            "Rust v1 writer must keep emitting the old result predicate token: {json}"
+        );
     }
 
     #[test]
@@ -2806,6 +2860,10 @@ mod tests {
         assert!(
             json.contains("is_ok"),
             "guard must carry the result precondition: {json}"
+        );
+        assert!(
+            !json.contains(panic_freedom::IS_OK_CONCEPT),
+            "Rust v1 writer must keep emitting the old result predicate token: {json}"
         );
     }
 


### PR DESCRIPTION
## Summary

Slice 2 PR 4: alias-read result predicates. Accept `concept:panic-freedom.result.ok` and `concept:panic-freedom.result.err` as read-side aliases for the existing Rust v1 `is_ok` / `is_err` result predicates. The writer remains on the old v1 tokens; this is reader compatibility only.

## What changed

- Added shared panic-freedom result concept alias constants plus `normalize_result_predicate_name`.
- Canonicalized singleton `result` post predicates in the verifier so concept aliases supply the same guard facts as `is_ok` / `is_err`.
- Taught the walk lifter branch-guard reader to accept exact result concept aliases while still refusing malformed and method-prefixed concept-like strings.
- Added writer-stability assertions that Rust v1 emission still uses `is_ok`, not the concept alias.
- Updated the shim self-check golden from `reflexive: 628` to `629` with rationale.

## Golden movement

Claude-advised classification: Path A, honest proof-shape expansion. Isolated libprovekit self-checks showed branch `fnContracts 577 -> 578`, `bodyDischargeEligible 555 -> 556`, and `reflexive 659 -> 660`; the added eligible contract is the new `normalize_result_predicate_name` helper. Catalog evidence: libprovekit `1f2623... -> ae3ca8...`; shim target `d1c2f286...` unchanged. Shim counters moved only `reflexive 628 -> 629`. `falsePass 0`, `silentlyDropped 0`, and `droppedSites []` stayed unchanged; `panicSafe` stayed 5.

This is the first Path A precedent for a libprovekit helper function: helper functions can add one honest reflexive obligation to libprovekit self-checks and propagate mechanically through dependency imports. If the panic-locus branch lands first, this PR's golden delta should rebase from `628 -> 629` to `656 -> 657`; that is the same mechanical helper-contract delta, not a separate behavior change.

## Verification

- `../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture`
- `../../bin/bcargo test -p libprovekit panic_freedom -- --nocapture`
- `../../bin/bcargo test -p libprovekit result_predicate_concept_aliases_normalize_to_v1_wire_tokens -- --nocapture`
- `../../bin/bcargo test -p provekit-verifier callee_post_guard_fact_tests::result -- --nocapture`
- `../../bin/bcargo test -p provekit-walk branch_guard_head -- --nocapture`
- `../../bin/bcargo test -p provekit-walk assert_is_ok_guards_later_result -- --nocapture`
- `git diff --check`
- diff scan: no new bare result predicate literals in changed production hunks
