### PR TITLE
[codex] accept option predicate concept aliases

### DIFF
--- a/implementations/rust/libprovekit/src/concept/panic_freedom.rs
+++ b/implementations/rust/libprovekit/src/concept/panic_freedom.rs
@@ -21,8 +21,14 @@ pub const IS_ERR_CONCEPT: &str = "concept:panic-freedom.result.err";
 /// Substrate panic-freedom option-some predicate; see `SUBSTRATE-SHAPE-AUDIT.md`.
 pub const IS_SOME: &str = "is_some";
 
+/// Substrate panic-freedom option-some predicate alias; see `SUBSTRATE-SHAPE-AUDIT.md`.
+pub const IS_SOME_CONCEPT: &str = "concept:panic-freedom.option.some";
+
 /// Substrate panic-freedom option-none predicate; see `SUBSTRATE-SHAPE-AUDIT.md`.
 pub const IS_NONE: &str = "is_none";
+
+/// Substrate panic-freedom option-none predicate alias; see `SUBSTRATE-SHAPE-AUDIT.md`.
+pub const IS_NONE_CONCEPT: &str = "concept:panic-freedom.option.none";
 
 /// Substrate panic-freedom guarded-branch carrier; see `SUBSTRATE-SHAPE-AUDIT.md`.
 pub const CF_GUARDED: &str = "cf_guarded";
@@ -53,6 +59,18 @@ pub fn normalize_result_predicate_name(name: &str) -> &str {
     match name {
         IS_OK | IS_OK_CONCEPT => IS_OK,
         IS_ERR | IS_ERR_CONCEPT => IS_ERR,
+        _ => name,
+    }
+}
+
+/// Normalize option predicate aliases to the Rust v1 wire token.
+///
+/// Phase 4 readers accept the concept aliases without changing default Rust v1
+/// proof emission. Unknown predicate names stay opaque.
+pub fn normalize_option_predicate_name(name: &str) -> &str {
+    match name {
+        IS_SOME | IS_SOME_CONCEPT => IS_SOME,
+        IS_NONE | IS_NONE_CONCEPT => IS_NONE,
         _ => name,
     }
 }

--- a/implementations/rust/libprovekit/tests/concept_panic_freedom.rs
+++ b/implementations/rust/libprovekit/tests/concept_panic_freedom.rs
@@ -15,7 +15,15 @@ fn panic_freedom_constants_keep_existing_wire_tokens() {
         "concept:panic-freedom.result.err"
     );
     assert_eq!(panic_freedom::IS_SOME, "is_some");
+    assert_eq!(
+        panic_freedom::IS_SOME_CONCEPT,
+        "concept:panic-freedom.option.some"
+    );
     assert_eq!(panic_freedom::IS_NONE, "is_none");
+    assert_eq!(
+        panic_freedom::IS_NONE_CONCEPT,
+        "concept:panic-freedom.option.none"
+    );
     assert_eq!(panic_freedom::CF_GUARDED, "cf_guarded");
     assert_eq!(
         panic_freedom::CF_GUARDED_CONCEPT,
@@ -56,5 +64,34 @@ fn result_predicate_concept_aliases_normalize_to_v1_wire_tokens() {
     assert_eq!(
         panic_freedom::normalize_result_predicate_name("concept:panic-freedom.result.ok "),
         "concept:panic-freedom.result.ok "
+    );
+}
+
+#[test]
+fn option_predicate_concept_aliases_normalize_to_v1_wire_tokens() {
+    assert_eq!(
+        panic_freedom::normalize_option_predicate_name(panic_freedom::IS_SOME),
+        panic_freedom::IS_SOME
+    );
+    assert_eq!(
+        panic_freedom::normalize_option_predicate_name(panic_freedom::IS_SOME_CONCEPT),
+        panic_freedom::IS_SOME
+    );
+    assert_eq!(
+        panic_freedom::normalize_option_predicate_name(panic_freedom::IS_NONE),
+        panic_freedom::IS_NONE
+    );
+    assert_eq!(
+        panic_freedom::normalize_option_predicate_name(panic_freedom::IS_NONE_CONCEPT),
+        panic_freedom::IS_NONE
+    );
+
+    assert_eq!(
+        panic_freedom::normalize_option_predicate_name("concept:panic-freedom.option.SOME"),
+        "concept:panic-freedom.option.SOME"
+    );
+    assert_eq!(
+        panic_freedom::normalize_option_predicate_name("concept:panic-freedom.option.some "),
+        "concept:panic-freedom.option.some "
     );
 }

--- a/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.json
+++ b/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.json
@@ -24,7 +24,7 @@
   "totalCallsites": 1826,
   "dischargeSplit": {
     "panicSafe": 5,
-    "reflexive": 629,
+    "reflexive": 630,
     "vacuous": 552,
     "undecidable": 1222,
     "falsePass": 0

--- a/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.md
+++ b/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.md
@@ -65,6 +65,14 @@ stays `d1c2f286...`; writer output remains on the v1 `is_ok`/`is_err` tokens.
 Hard invariants unchanged: `falsePass 0`, `silentlyDropped 0`,
 `droppedSites []`; `panicSafe` remains 5.
 
+Regenerated 2026-06-01: `reflexive 629 -> 630`. The option-predicate
+alias-read slice adds `normalize_option_predicate_name` to `libprovekit`; like
+the result helper, it is itself body-discharge-eligible and contributes one
+honest reflexive discharge through the dependency import chain. The shim target
+`catalogCid` stays `d1c2f286...`; writer output remains on the v1
+`is_some`/`is_none` tokens. Hard invariants unchanged: `falsePass 0`,
+`silentlyDropped 0`, `droppedSites []`; `panicSafe` remains 5.
+
 ## Normalization applied
 
 None. The output is byte-stable and path-independent without normalization:

--- a/implementations/rust/provekit-verifier/src/body_discharge.rs
+++ b/implementations/rust/provekit-verifier/src/body_discharge.rs
@@ -755,7 +755,8 @@ fn post_singleton_atomic_predicate_of_result(post: &Json) -> Option<&str> {
     if arg.get("kind").and_then(|v| v.as_str()) == Some("var")
         && arg.get("name").and_then(|v| v.as_str()) == Some("result")
     {
-        Some(panic_freedom::normalize_result_predicate_name(predicate))
+        let predicate = panic_freedom::normalize_result_predicate_name(predicate);
+        Some(panic_freedom::normalize_option_predicate_name(predicate))
     } else {
         None
     }
@@ -1475,6 +1476,141 @@ mod callee_post_guard_fact_tests {
                 fact.get("name").and_then(|v| v.as_str()),
                 Some(malformed),
                 "malformed concept-like strings must not normalize to a result predicate"
+            );
+        }
+    }
+
+    #[test]
+    fn option_some_concept_post_supplies_same_fact_as_old_is_some() {
+        let cs = cs_with_ctor_arg(OPTION_BRIDGE_SYMBOL);
+        let old_pool = singleton_totality_pool(
+            OPTION_BRIDGE_SYMBOL,
+            OPTION_TOTAL_CONTRACT_CID,
+            panic_freedom::IS_SOME,
+        );
+        let concept_pool = singleton_totality_pool(
+            OPTION_BRIDGE_SYMBOL,
+            OPTION_TOTAL_CONTRACT_CID,
+            panic_freedom::IS_SOME_CONCEPT,
+        );
+
+        let old_fact = callee_post_guard_fact(&cs, &old_pool)
+            .expect("old is_some(result) singleton post must supply a fact");
+        let concept_fact = callee_post_guard_fact(&cs, &concept_pool)
+            .expect("concept option.some(result) singleton post must supply a fact");
+
+        assert_eq!(
+            concept_fact, old_fact,
+            "concept option.some must read as the same predicate fact as old is_some"
+        );
+        assert_eq!(
+            concept_fact.get("name").and_then(|v| v.as_str()),
+            Some(panic_freedom::IS_SOME),
+            "reader must canonicalize concept option.some to the v1 option predicate"
+        );
+    }
+
+    #[test]
+    fn option_none_concept_post_supplies_same_fact_as_old_is_none() {
+        let cs = cs_with_ctor_arg(OPTION_BRIDGE_SYMBOL);
+        let old_pool = singleton_totality_pool(
+            OPTION_BRIDGE_SYMBOL,
+            OPTION_TOTAL_CONTRACT_CID,
+            panic_freedom::IS_NONE,
+        );
+        let concept_pool = singleton_totality_pool(
+            OPTION_BRIDGE_SYMBOL,
+            OPTION_TOTAL_CONTRACT_CID,
+            panic_freedom::IS_NONE_CONCEPT,
+        );
+
+        let old_fact = callee_post_guard_fact(&cs, &old_pool)
+            .expect("old is_none(result) singleton post must supply a fact");
+        let concept_fact = callee_post_guard_fact(&cs, &concept_pool)
+            .expect("concept option.none(result) singleton post must supply a fact");
+
+        assert_eq!(
+            concept_fact, old_fact,
+            "concept option.none must read as the same predicate fact as old is_none"
+        );
+        assert_eq!(
+            concept_fact.get("name").and_then(|v| v.as_str()),
+            Some(panic_freedom::IS_NONE),
+            "reader must canonicalize concept option.none to the v1 option predicate"
+        );
+    }
+
+    #[test]
+    fn option_concept_alias_matching_is_exact() {
+        for malformed in [
+            "concept:panic-freedom.option.SOME",
+            "concept:panic-freedom.option.some ",
+            " concept:panic-freedom.option.some",
+            "concept:panic-freedom.option.null",
+        ] {
+            let cs = cs_with_ctor_arg(OPTION_BRIDGE_SYMBOL);
+            let pool =
+                singleton_totality_pool(OPTION_BRIDGE_SYMBOL, OPTION_TOTAL_CONTRACT_CID, malformed);
+            let fact = callee_post_guard_fact(&cs, &pool)
+                .expect("opaque singleton predicates still supply opaque facts");
+
+            assert_eq!(
+                fact.get("name").and_then(|v| v.as_str()),
+                Some(malformed),
+                "malformed option concept-like strings must not normalize to an option predicate"
+            );
+        }
+    }
+
+    #[test]
+    fn option_concepts_do_not_normalize_to_result_predicates() {
+        for (predicate, expected) in [
+            (panic_freedom::IS_SOME_CONCEPT, panic_freedom::IS_SOME),
+            (panic_freedom::IS_NONE_CONCEPT, panic_freedom::IS_NONE),
+        ] {
+            let cs = cs_with_ctor_arg(BRIDGE_SYMBOL);
+            let pool = singleton_totality_pool(BRIDGE_SYMBOL, TOTAL_CONTRACT_CID, predicate);
+            let fact = callee_post_guard_fact(&cs, &pool)
+                .expect("a singleton atomic P(result) post still supplies an opaque P(arg) fact");
+
+            assert_eq!(
+                fact.get("name").and_then(|v| v.as_str()),
+                Some(expected),
+                "option concept {predicate} must canonicalize only to its option predicate"
+            );
+            assert!(
+                !matches!(
+                    fact.get("name").and_then(|v| v.as_str()),
+                    Some(panic_freedom::IS_OK | panic_freedom::IS_ERR)
+                ),
+                "option concept {predicate} must never become a result predicate"
+            );
+        }
+    }
+
+    #[test]
+    fn result_concepts_do_not_normalize_to_option_predicates() {
+        for (predicate, expected) in [
+            (panic_freedom::IS_OK_CONCEPT, panic_freedom::IS_OK),
+            (panic_freedom::IS_ERR_CONCEPT, panic_freedom::IS_ERR),
+        ] {
+            let cs = cs_with_ctor_arg(OPTION_BRIDGE_SYMBOL);
+            let pool =
+                singleton_totality_pool(OPTION_BRIDGE_SYMBOL, OPTION_TOTAL_CONTRACT_CID, predicate);
+            let fact = callee_post_guard_fact(&cs, &pool)
+                .expect("a singleton atomic P(result) post still supplies an opaque P(arg) fact");
+
+            assert_eq!(
+                fact.get("name").and_then(|v| v.as_str()),
+                Some(expected),
+                "result concept {predicate} must canonicalize only to its result predicate"
+            );
+            assert!(
+                !matches!(
+                    fact.get("name").and_then(|v| v.as_str()),
+                    Some(panic_freedom::IS_SOME | panic_freedom::IS_NONE)
+                ),
+                "result concept {predicate} must never become an option predicate"
             );
         }
     }

--- a/implementations/rust/provekit-walk/src/dropper/predicates/not_null.rs
+++ b/implementations/rust/provekit-walk/src/dropper/predicates/not_null.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use libprovekit::concept::panic_freedom;
 use provekit_ir_types::{IrFormula, IrTerm};
 
 use crate::dropper::predicate::{
@@ -102,12 +103,15 @@ impl PredicateDescriptor for NotNullPredicate {
 fn is_guard_for(formula: &IrFormula, var_name: &str) -> bool {
     match formula {
         IrFormula::Atomic { name, args } => {
-            matches!(name.as_str(), "is_some") && has_var(args, var_name)
+            panic_freedom::normalize_option_predicate_name(name.as_str()) == panic_freedom::IS_SOME
+                && has_var(args, var_name)
         }
         IrFormula::Not { operands } => {
             if operands.len() == 1 {
                 if let IrFormula::Atomic { name, args } = &operands[0] {
-                    return matches!(name.as_str(), "is_none") && has_var(args, var_name);
+                    return panic_freedom::normalize_option_predicate_name(name.as_str())
+                        == panic_freedom::IS_NONE
+                        && has_var(args, var_name);
                 }
             }
             false
@@ -132,7 +136,9 @@ fn formula_contains_guard_for(formula: &IrFormula, var_name: &str) -> bool {
         IrFormula::Not { operands } => {
             if operands.len() == 1 {
                 if let IrFormula::Atomic { name, args } = &operands[0] {
-                    let is_guard = matches!(name.as_str(), "is_none");
+                    let is_guard =
+                        panic_freedom::normalize_option_predicate_name(name.as_str())
+                            == panic_freedom::IS_NONE;
                     let has_var = args.iter().any(|t| match t {
                         IrTerm::Var { name } => name == var_name,
                         _ => false,
@@ -170,6 +176,29 @@ mod tests {
     use super::*;
     use provekit_ir_types::{IrFormula, IrTerm};
 
+    fn var(name: &str) -> IrTerm {
+        IrTerm::Var { name: name.into() }
+    }
+
+    fn atom(name: &str, var_name: &str) -> IrFormula {
+        IrFormula::Atomic {
+            name: name.into(),
+            args: vec![var(var_name)],
+        }
+    }
+
+    fn not_atom(name: &str, var_name: &str) -> IrFormula {
+        IrFormula::Not {
+            operands: vec![atom(name, var_name)],
+        }
+    }
+
+    fn implies_not_null(premise: IrFormula, var_name: &str) -> IrFormula {
+        IrFormula::Implies {
+            operands: vec![premise, atom("not_null", var_name)],
+        }
+    }
+
     #[test]
     fn not_null_predicate_verified_templates_returns_defensive_only() {
         let templates = NotNullPredicate.verified_templates();
@@ -195,6 +224,22 @@ mod tests {
         assert!(
             rendered.contains("not_null"),
             "panic msg must name invariant"
+        );
+    }
+
+    #[test]
+    fn not_null_kit_render_still_emits_rust_is_none() {
+        let rendered = NotNullPredicate
+            .render(DropTemplate::Defensive, "x")
+            .expect("Defensive must render OK");
+
+        assert!(
+            rendered.contains("x.is_none()"),
+            "Rust kit render must keep Rust Option syntax: {rendered}"
+        );
+        assert!(
+            !rendered.contains(panic_freedom::IS_NONE_CONCEPT),
+            "Rust kit render must not emit substrate concept names: {rendered}"
         );
     }
 
@@ -259,6 +304,101 @@ mod tests {
             ],
         };
         assert!(NotNullPredicate.is_premise_guarded(&wp, "x"));
+    }
+
+    #[test]
+    fn is_premise_guarded_true_for_option_some_concept_premise() {
+        let premise = atom(panic_freedom::IS_SOME_CONCEPT, "x");
+        let wp = implies_not_null(premise.clone(), "x");
+
+        assert!(is_guard_for(&premise, "x"));
+        assert!(
+            NotNullPredicate.is_premise_guarded(&wp, "x"),
+            "concept option.some(x) must discharge the same not_null premise as is_some(x)"
+        );
+    }
+
+    #[test]
+    fn not_is_none_discharges_guard() {
+        let not_is_none = not_atom(panic_freedom::IS_NONE, "x");
+
+        assert!(is_guard_for(&not_is_none, "x"));
+        assert!(NotNullPredicate.guard_discharged(&not_is_none, "x"));
+        assert!(NotNullPredicate.is_premise_guarded(
+            &implies_not_null(not_is_none, "x"),
+            "x"
+        ));
+    }
+
+    #[test]
+    fn not_option_none_concept_discharges_guard() {
+        let not_option_none = not_atom(panic_freedom::IS_NONE_CONCEPT, "x");
+
+        assert!(is_guard_for(&not_option_none, "x"));
+        assert!(NotNullPredicate.guard_discharged(&not_option_none, "x"));
+        assert!(
+            NotNullPredicate.is_premise_guarded(&implies_not_null(not_option_none, "x"), "x"),
+            "Not(concept option.none(x)) must discharge the same not_null premise as Not(is_none(x))"
+        );
+    }
+
+    #[test]
+    fn result_predicates_do_not_discharge_not_null_guard() {
+        for name in [
+            panic_freedom::IS_OK,
+            panic_freedom::IS_ERR,
+            panic_freedom::IS_OK_CONCEPT,
+            panic_freedom::IS_ERR_CONCEPT,
+        ] {
+            let premise = atom(name, "x");
+            assert!(
+                !is_guard_for(&premise, "x"),
+                "result predicate {name} must not discharge not_null"
+            );
+            assert!(
+                !NotNullPredicate.is_premise_guarded(&implies_not_null(premise, "x"), "x"),
+                "result predicate {name} must not guard a not_null implication"
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_option_concepts_do_not_discharge_not_null_guard() {
+        for name in [
+            "concept:panic-freedom.option.SOME",
+            "concept:panic-freedom.option.some ",
+            " concept:panic-freedom.option.some",
+            "method:concept:panic-freedom.option.some",
+            "concept:panic-freedom.option.null",
+        ] {
+            let premise = atom(name, "x");
+            assert!(
+                !is_guard_for(&premise, "x"),
+                "malformed option concept {name} must not discharge not_null"
+            );
+            assert!(
+                !NotNullPredicate.is_premise_guarded(&implies_not_null(premise, "x"), "x"),
+                "malformed option concept {name} must not guard a not_null implication"
+            );
+        }
+
+        for name in [
+            "concept:panic-freedom.option.NONE",
+            "concept:panic-freedom.option.none ",
+            " concept:panic-freedom.option.none",
+            "method:concept:panic-freedom.option.none",
+            "concept:panic-freedom.option.null",
+        ] {
+            let premise = not_atom(name, "x");
+            assert!(
+                !is_guard_for(&premise, "x"),
+                "malformed negated option concept {name} must not discharge not_null"
+            );
+            assert!(
+                !NotNullPredicate.guard_discharged(&premise, "x"),
+                "malformed negated option concept {name} must not count as a discharged guard"
+            );
+        }
     }
 
     #[test]

--- a/implementations/rust/provekit-walk/src/lift.rs
+++ b/implementations/rust/provekit-walk/src/lift.rs
@@ -429,7 +429,8 @@ fn branch_guard_head(cond_head: &str, else_branch: bool) -> Option<&'static str>
     let head = if method_head.is_some() {
         head
     } else {
-        panic_freedom::normalize_result_predicate_name(head)
+        let head = panic_freedom::normalize_result_predicate_name(head);
+        panic_freedom::normalize_option_predicate_name(head)
     };
     match (head, else_branch) {
         (panic_freedom::IS_SOME, false) | (panic_freedom::IS_NONE, true) => {
@@ -2647,6 +2648,50 @@ mod tests {
     }
 
     #[test]
+    fn branch_guard_head_accepts_option_concept_aliases_as_read_only_inputs() {
+        assert_eq!(
+            branch_guard_head(panic_freedom::IS_SOME_CONCEPT, false),
+            Some(panic_freedom::IS_SOME)
+        );
+        assert_eq!(
+            branch_guard_head(panic_freedom::IS_SOME_CONCEPT, true),
+            Some(panic_freedom::IS_NONE)
+        );
+        assert_eq!(
+            branch_guard_head(panic_freedom::IS_NONE_CONCEPT, false),
+            Some(panic_freedom::IS_NONE)
+        );
+        assert_eq!(
+            branch_guard_head(panic_freedom::IS_NONE_CONCEPT, true),
+            Some(panic_freedom::IS_SOME)
+        );
+    }
+
+    #[test]
+    fn branch_guard_head_option_concept_complements_match_old_names() {
+        assert_eq!(
+            branch_guard_head(panic_freedom::IS_SOME_CONCEPT, true),
+            branch_guard_head(panic_freedom::IS_SOME, true),
+            "negated concept option.some must compute the same complement as negated is_some"
+        );
+        assert_eq!(
+            branch_guard_head(panic_freedom::IS_NONE_CONCEPT, true),
+            branch_guard_head(panic_freedom::IS_NONE, true),
+            "negated concept option.none must compute the same complement as negated is_none"
+        );
+        assert_eq!(
+            branch_guard_head(panic_freedom::IS_SOME_CONCEPT, false),
+            branch_guard_head(panic_freedom::IS_SOME, false),
+            "positive concept option.some must compute the same guard as is_some"
+        );
+        assert_eq!(
+            branch_guard_head(panic_freedom::IS_NONE_CONCEPT, false),
+            branch_guard_head(panic_freedom::IS_NONE, false),
+            "positive concept option.none must compute the same guard as is_none"
+        );
+    }
+
+    #[test]
     fn branch_guard_head_result_concept_aliases_are_exact() {
         assert_eq!(
             branch_guard_head("concept:panic-freedom.result.OK", false),
@@ -2666,6 +2711,30 @@ mod tests {
         );
         assert_eq!(
             branch_guard_head("method:concept:panic-freedom.result.ok", false),
+            None
+        );
+    }
+
+    #[test]
+    fn branch_guard_head_option_concept_aliases_are_exact() {
+        assert_eq!(
+            branch_guard_head("concept:panic-freedom.option.SOME", false),
+            None
+        );
+        assert_eq!(
+            branch_guard_head("concept:panic-freedom.option.some ", false),
+            None
+        );
+        assert_eq!(
+            branch_guard_head(" concept:panic-freedom.option.some", false),
+            None
+        );
+        assert_eq!(
+            branch_guard_head("concept:panic-freedom.option.null", false),
+            None
+        );
+        assert_eq!(
+            branch_guard_head("method:concept:panic-freedom.option.some", false),
             None
         );
     }
@@ -2788,8 +2857,16 @@ mod tests {
             "then-branch guard is is_some: {json}"
         );
         assert!(
+            !json.contains(panic_freedom::IS_SOME_CONCEPT),
+            "Rust v1 emission must keep the old option predicate: {json}"
+        );
+        assert!(
             json.contains("is_none"),
             "else-branch guard is the complement is_none: {json}"
+        );
+        assert!(
+            !json.contains(panic_freedom::IS_NONE_CONCEPT),
+            "Rust v1 emission must keep the old option complement: {json}"
         );
     }
 


### PR DESCRIPTION
## Summary

Stacked on #1793. This continues Slice 2 formula-atom alias-read coverage for option predicates:

- adds `concept:panic-freedom.option.some` / `.none` constants and a separate `normalize_option_predicate_name` helper in `libprovekit`
- teaches the language-blind singleton `P(result)` reader to canonicalize option aliases without changing writer output
- teaches the Rust-kit branch guard and not-null guard readers to accept option concept aliases
- keeps Rust v1 emission on `is_some` / `is_none`

This is the second consecutive Path A instance after #1793: a per-family normalizer is itself body-discharge-eligible, so the shim self-check gains exactly one reflexive discharge through the dependency import chain.

## Floors

`self-check-provekit-shim-rust-std` moved only on the expected Path A axis:

- `reflexive: 629 -> 630`
- `falsePass: 0` unchanged
- `silentlyDropped: 0` unchanged
- `droppedSites: []` unchanged
- `panicSafe: 5` unchanged
- `catalogCid: d1c2f286...` unchanged for the shim target

## Validation

All commands used `bcargo`:

- `../../bin/bcargo test -p libprovekit option_predicate_concept_aliases_normalize_to_v1_wire_tokens -- --nocapture`
- `../../bin/bcargo test -p libprovekit panic_freedom_constants_keep_existing_wire_tokens -- --nocapture`
- `../../bin/bcargo test -p provekit-verifier callee_post_guard_fact_tests:: -- --nocapture` - 17 passed
- `../../bin/bcargo test -p provekit-walk branch_guard_head -- --nocapture` - 7 passed
- `../../bin/bcargo test -p provekit-walk if_is_some_lifts_then_to_cf_guarded_is_some_else_to_is_none -- --nocapture`
- `../../bin/bcargo test -p provekit-walk not_null -- --nocapture` - 17 passed
- `../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` - passed after the expected golden update
- `git diff --check`
- changed-hunk scan for new bare `"is_some"` / `"is_none"` production literals outside constants
