### PR TITLE
Slice 2 PR 6 alias-read leaf methods

### DIFF
--- a/implementations/rust/libprovekit/src/concept/panic_freedom.rs
+++ b/implementations/rust/libprovekit/src/concept/panic_freedom.rs
@@ -45,11 +45,20 @@ pub const CF_ITE_CONCEPT: &str = "concept:panic-freedom.choice";
 /// Substrate panic-freedom unwrap leaf; see `SUBSTRATE-SHAPE-AUDIT.md`.
 pub const METHOD_UNWRAP: &str = "method:unwrap";
 
+/// Substrate panic-freedom unwrap leaf alias; see `SUBSTRATE-SHAPE-AUDIT.md`.
+pub const METHOD_UNWRAP_CONCEPT: &str = "concept:panic-freedom.leaf.unwrap";
+
 /// Substrate panic-freedom expect leaf; see `SUBSTRATE-SHAPE-AUDIT.md`.
 pub const METHOD_EXPECT: &str = "method:expect";
 
+/// Substrate panic-freedom expect leaf alias; see `SUBSTRATE-SHAPE-AUDIT.md`.
+pub const METHOD_EXPECT_CONCEPT: &str = "concept:panic-freedom.leaf.expect";
+
 /// Substrate panic-freedom unwrap-err leaf; see `SUBSTRATE-SHAPE-AUDIT.md`.
 pub const METHOD_UNWRAP_ERR: &str = "method:unwrap_err";
+
+/// Substrate panic-freedom unwrap-err leaf alias; see `SUBSTRATE-SHAPE-AUDIT.md`.
+pub const METHOD_UNWRAP_ERR_CONCEPT: &str = "concept:panic-freedom.leaf.unwrap-err";
 
 /// Normalize result predicate aliases to the Rust v1 wire token.
 ///
@@ -71,6 +80,19 @@ pub fn normalize_option_predicate_name(name: &str) -> &str {
     match name {
         IS_SOME | IS_SOME_CONCEPT => IS_SOME,
         IS_NONE | IS_NONE_CONCEPT => IS_NONE,
+        _ => name,
+    }
+}
+
+/// Normalize panic leaf aliases to the Rust v1 wire token.
+///
+/// Phase 4 readers accept the concept aliases without changing default Rust v1
+/// proof emission. Unknown method names stay opaque.
+pub fn normalize_leaf_method_name(name: &str) -> &str {
+    match name {
+        METHOD_UNWRAP | METHOD_UNWRAP_CONCEPT => METHOD_UNWRAP,
+        METHOD_EXPECT | METHOD_EXPECT_CONCEPT => METHOD_EXPECT,
+        METHOD_UNWRAP_ERR | METHOD_UNWRAP_ERR_CONCEPT => METHOD_UNWRAP_ERR,
         _ => name,
     }
 }

--- a/implementations/rust/libprovekit/tests/concept_panic_freedom.rs
+++ b/implementations/rust/libprovekit/tests/concept_panic_freedom.rs
@@ -35,8 +35,20 @@ fn panic_freedom_constants_keep_existing_wire_tokens() {
         "concept:panic-freedom.choice"
     );
     assert_eq!(panic_freedom::METHOD_UNWRAP, "method:unwrap");
+    assert_eq!(
+        panic_freedom::METHOD_UNWRAP_CONCEPT,
+        "concept:panic-freedom.leaf.unwrap"
+    );
     assert_eq!(panic_freedom::METHOD_EXPECT, "method:expect");
+    assert_eq!(
+        panic_freedom::METHOD_EXPECT_CONCEPT,
+        "concept:panic-freedom.leaf.expect"
+    );
     assert_eq!(panic_freedom::METHOD_UNWRAP_ERR, "method:unwrap_err");
+    assert_eq!(
+        panic_freedom::METHOD_UNWRAP_ERR_CONCEPT,
+        "concept:panic-freedom.leaf.unwrap-err"
+    );
 }
 
 #[test]
@@ -93,5 +105,54 @@ fn option_predicate_concept_aliases_normalize_to_v1_wire_tokens() {
     assert_eq!(
         panic_freedom::normalize_option_predicate_name("concept:panic-freedom.option.some "),
         "concept:panic-freedom.option.some "
+    );
+}
+
+#[test]
+fn leaf_method_concept_aliases_normalize_to_v1_wire_tokens() {
+    assert_eq!(
+        panic_freedom::normalize_leaf_method_name(panic_freedom::METHOD_UNWRAP),
+        panic_freedom::METHOD_UNWRAP
+    );
+    assert_eq!(
+        panic_freedom::normalize_leaf_method_name(panic_freedom::METHOD_UNWRAP_CONCEPT),
+        panic_freedom::METHOD_UNWRAP
+    );
+    assert_eq!(
+        panic_freedom::normalize_leaf_method_name(panic_freedom::METHOD_EXPECT),
+        panic_freedom::METHOD_EXPECT
+    );
+    assert_eq!(
+        panic_freedom::normalize_leaf_method_name(panic_freedom::METHOD_EXPECT_CONCEPT),
+        panic_freedom::METHOD_EXPECT
+    );
+    assert_eq!(
+        panic_freedom::normalize_leaf_method_name(panic_freedom::METHOD_UNWRAP_ERR),
+        panic_freedom::METHOD_UNWRAP_ERR
+    );
+    assert_eq!(
+        panic_freedom::normalize_leaf_method_name(panic_freedom::METHOD_UNWRAP_ERR_CONCEPT),
+        panic_freedom::METHOD_UNWRAP_ERR
+    );
+
+    assert_eq!(
+        panic_freedom::normalize_leaf_method_name("concept:panic-freedom.leaf.UNWRAP"),
+        "concept:panic-freedom.leaf.UNWRAP"
+    );
+    assert_eq!(
+        panic_freedom::normalize_leaf_method_name("concept:panic-freedom.leaf.unwrap "),
+        "concept:panic-freedom.leaf.unwrap "
+    );
+    assert_eq!(
+        panic_freedom::normalize_leaf_method_name("method:concept:panic-freedom.leaf.unwrap"),
+        "method:concept:panic-freedom.leaf.unwrap"
+    );
+    assert_eq!(
+        panic_freedom::normalize_leaf_method_name(panic_freedom::IS_SOME_CONCEPT),
+        panic_freedom::IS_SOME_CONCEPT
+    );
+    assert_eq!(
+        panic_freedom::normalize_leaf_method_name(panic_freedom::IS_OK_CONCEPT),
+        panic_freedom::IS_OK_CONCEPT
     );
 }

--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -2758,6 +2758,7 @@ pub fn run(args: MintArgs) -> u8 {
 mod tests {
     use super::*;
     use crate::project_config::PlatformProfile;
+    use libprovekit::concept::panic_freedom;
 
     fn temp_workspace(name: &str) -> PathBuf {
         let nanos = std::time::SystemTime::now()
@@ -3245,7 +3246,7 @@ mod tests {
             "file": "src/lib.rs",
             "line": 25,
             "col": 30,
-            "callee": "method:unwrap"
+            "callee": panic_freedom::METHOD_UNWRAP
         })
     }
 
@@ -3391,6 +3392,12 @@ mod tests {
             .and_then(|value| value.as_array())
             .expect("well-formed panicLoci must be preserved");
         assert_eq!(panic_loci, &[locus]);
+        assert_eq!(panic_loci[0]["callee"], panic_freedom::METHOD_UNWRAP);
+        assert_ne!(
+            panic_loci[0]["callee"],
+            panic_freedom::METHOD_UNWRAP_CONCEPT,
+            "Rust v1 mint writer must not emit the unwrap leaf concept alias"
+        );
     }
 
     fn assert_malformed_bridge_callsite_fails_closed(callsite: Value, expected: &str) {

--- a/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.json
+++ b/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.json
@@ -24,7 +24,7 @@
   "totalCallsites": 1826,
   "dischargeSplit": {
     "panicSafe": 5,
-    "reflexive": 630,
+    "reflexive": 631,
     "vacuous": 552,
     "undecidable": 1222,
     "falsePass": 0

--- a/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.md
+++ b/implementations/rust/provekit-cli/tests/golden/self-check-provekit-shim-rust-std.md
@@ -73,6 +73,14 @@ honest reflexive discharge through the dependency import chain. The shim target
 `is_some`/`is_none` tokens. Hard invariants unchanged: `falsePass 0`,
 `silentlyDropped 0`, `droppedSites []`; `panicSafe` remains 5.
 
+Regenerated 2026-06-01: `reflexive 630 -> 631`. The leaf-method alias-read
+slice adds `normalize_leaf_method_name` to `libprovekit`; as the third Path A
+helper, it contributes one honest reflexive discharge through the dependency
+import chain. The shim target `catalogCid` stays `d1c2f286...`; writer output
+remains on the v1 `method:unwrap`/`method:expect`/`method:unwrap_err` tokens.
+Hard invariants unchanged: `falsePass 0`, `silentlyDropped 0`,
+`droppedSites []`; `panicSafe` remains 5.
+
 ## Normalization applied
 
 None. The output is byte-stable and path-independent without normalization:

--- a/implementations/rust/provekit-lift/src/lib.rs
+++ b/implementations/rust/provekit-lift/src/lib.rs
@@ -1341,6 +1341,12 @@ proptest! {
             ))
             .expect("canonical locus parses as JSON")
         );
+        assert_eq!(panic_loci[0]["callee"], "method:unwrap");
+        assert_ne!(
+            panic_loci[0]["callee"],
+            "concept:panic-freedom.leaf.unwrap",
+            "Rust v1 lift/mint writer must not emit the unwrap leaf concept alias"
+        );
     }
 
     #[test]

--- a/implementations/rust/provekit-verifier/src/enumerate_callsites.rs
+++ b/implementations/rust/provekit-verifier/src/enumerate_callsites.rs
@@ -117,6 +117,7 @@ fn callsite_from_panic_locus(
         .get("callee")
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())?;
+    let callee = panic_freedom::normalize_leaf_method_name(callee);
     let file = locus
         .get("file")
         .and_then(|v| v.as_str())
@@ -350,9 +351,14 @@ fn panic_locus_for<'a>(
     panic_loci: &'a [Json],
 ) -> Option<&'a Json> {
     let arg = arg_term?;
+    let callee = panic_freedom::normalize_leaf_method_name(callee);
     panic_loci.iter().find(|locus| {
         locus.get("argTerm") == Some(arg)
-            && locus.get("callee").and_then(|v| v.as_str()) == Some(callee)
+            && locus
+                .get("callee")
+                .and_then(|v| v.as_str())
+                .map(panic_freedom::normalize_leaf_method_name)
+                == Some(callee)
     })
 }
 
@@ -363,6 +369,7 @@ fn callsite_scoped_bridge_for_locus<'a>(
     locus: &Json,
 ) -> Option<&'a Json> {
     let bundle = callsite_bundle_cid?;
+    let callee = panic_freedom::normalize_leaf_method_name(callee);
     let file = locus.get("file").and_then(|v| v.as_str())?;
     let line = locus
         .get("line")
@@ -406,11 +413,12 @@ fn walk_term(
         .and_then(|v| v.as_str())
         .unwrap_or_default()
         .to_string();
+    let bridge_name = panic_freedom::normalize_leaf_method_name(&name).to_string();
     let arg_term = t
         .get("args")
         .and_then(|v| v.as_array())
         .and_then(|arr| arr.first().cloned());
-    let scoped_panic_locus = panic_locus_for(&name, arg_term.as_ref(), panic_loci);
+    let scoped_panic_locus = panic_locus_for(&bridge_name, arg_term.as_ref(), panic_loci);
     // Panic-leaf method bridges are overloadable (`method:unwrap` can target
     // Option or Result). If the kit supplied an occurrence locus, choose the
     // exact `(bundle,file,line,callee)` bridge before considering the global
@@ -420,12 +428,12 @@ fn walk_term(
     // symbol winner; the panicLoci fallback below will surface an undecidable
     // NoBridgeTarget instead of silently checking the wrong overload.
     let scoped_bridge = scoped_panic_locus.and_then(|locus| {
-        callsite_scoped_bridge_for_locus(pool, callsite_bundle_cid, &name, locus)
+        callsite_scoped_bridge_for_locus(pool, callsite_bundle_cid, &bridge_name, locus)
     });
     let bridge_env = if scoped_panic_locus.is_some() {
         scoped_bridge
     } else {
-        pool.bridges_by_symbol.get(&name)
+        pool.bridges_by_symbol.get(&bridge_name)
     };
     if let Some(benv) = bridge_env {
         // Shape-agnostic: v1.2-layered bridges carry the fields on
@@ -449,7 +457,8 @@ fn walk_term(
             .get("sourceSymbol")
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
+            .map(panic_freedom::normalize_leaf_method_name)
+            .map(str::to_string);
         let panic_site = bridge_callsite
             .and_then(|v| v.get("panicSite"))
             .and_then(|v| v.as_bool())
@@ -463,7 +472,8 @@ fn walk_term(
         // bridged call keeps reading its line from the bridge as before (those
         // are 1:1 with their bridge and are not collapsed across occurrences).
         let occ_locus = if panic_site {
-            scoped_panic_locus.or_else(|| panic_locus_for(&name, arg_term.as_ref(), panic_loci))
+            scoped_panic_locus
+                .or_else(|| panic_locus_for(&bridge_name, arg_term.as_ref(), panic_loci))
         } else {
             None
         };
@@ -486,13 +496,13 @@ fn walk_term(
             // stays honestly undecidable downstream.
             if panic_loci.is_empty() {
                 debug!(
-                    name = %name,
+                    name = %bridge_name,
                     "enumerate_callsites: panic site with no contract panicLoci -- \
                      carrying no line (occurrence locus unavailable; honestly undecidable)"
                 );
             } else {
                 warn!(
-                    name = %name,
+                    name = %bridge_name,
                     "enumerate_callsites: panic site arg_term matched no contract locus -- \
                      carrying no line rather than the collapsed per-symbol bridge line \
                      (panic-locus miss; site stays undecidable)"
@@ -515,7 +525,7 @@ fn walk_term(
         };
         if panic_site {
             debug!(
-                name = %name,
+                name = %bridge_name,
                 line = ?callsite_line,
                 file = ?callsite_file,
                 matched_locus = occ_locus.is_some(),
@@ -523,7 +533,7 @@ fn walk_term(
             );
         }
         let cs = CallSite {
-            bridge_ir_name: name.clone(),
+            bridge_ir_name: bridge_name.clone(),
             bridge_target_cid: bbody
                 .get("targetContractCid")
                 .and_then(|v| v.as_str())
@@ -543,7 +553,7 @@ fn walk_term(
             bridge_self_bundle_cid: if scoped_bridge.is_some() {
                 callsite_bundle_cid.map(str::to_string)
             } else {
-                pool.bridge_self_bundle_by_symbol.get(&name).cloned()
+                pool.bridge_self_bundle_by_symbol.get(&bridge_name).cloned()
             },
             property_name: property_name.to_string(),
             property_cid: property_cid.to_string(),
@@ -580,7 +590,7 @@ fn walk_term(
             panic_site,
         };
         debug!(
-            name = %name,
+            name = %bridge_name,
             panic_site,
             callsite_present = bridge_callsite.is_some(),
             arg_term_kind = ?cs.arg_term.as_ref().and_then(|a| a.get("kind")).and_then(|k| k.as_str()),
@@ -593,9 +603,9 @@ fn walk_term(
         // real panic leaf to undecidable. Surface it loudly and count it instead
         // of letting K silently rot. (Function-level bridges have no `method:`
         // seam, so they do not trip this.)
-        if name.starts_with("method:") && bridge_callsite.is_none() {
+        if bridge_name.starts_with("method:") && bridge_callsite.is_none() {
             warn!(
-                bridge = %name,
+                bridge = %bridge_name,
                 "enumerate_callsites: method-seam bridge has NO callsite provenance -- mint dropped it; \
                  this panic site will read panic_site=false and stay undecidable (callsite-provenance drop)"
             );
@@ -699,6 +709,8 @@ fn walk_term(
         // is not directly participating in.
         let inner_atomic = if pool.bridges_by_symbol.contains_key(&name) {
             None
+        } else if pool.bridges_by_symbol.contains_key(&bridge_name) {
+            None
         } else {
             containing_atomic
         };
@@ -750,6 +762,10 @@ mod guard_propagation_tests {
     // so it enumerates as a CallSite. The name is OPAQUE to the verifier.
     fn panic_call() -> Json {
         json!({ "kind": "ctor", "name": "panic_call", "args": [recv()] })
+    }
+
+    fn leaf_call(name: &str) -> Json {
+        json!({ "kind": "ctor", "name": name, "args": [recv()] })
     }
 
     // An OPAQUE guard predicate atom term -- whatever the kit resolved for this
@@ -838,6 +854,15 @@ mod guard_propagation_tests {
     }
 
     fn bridge(target_cid: &str, file: Option<&str>, line: Option<usize>) -> Json {
+        bridge_for_symbol("panic_call", target_cid, file, line)
+    }
+
+    fn bridge_for_symbol(
+        source_symbol: &str,
+        target_cid: &str,
+        file: Option<&str>,
+        line: Option<usize>,
+    ) -> Json {
         let callsite = match (file, line) {
             (Some(file), Some(line)) => json!({
                 "file": file,
@@ -848,7 +873,7 @@ mod guard_propagation_tests {
         };
         let mut header = json!({
             "kind": "bridge",
-            "sourceSymbol": "panic_call",
+            "sourceSymbol": source_symbol,
             "targetContractCid": target_cid,
             "sourceLayer": "rust",
             "targetLayer": "rust-tests",
@@ -914,11 +939,80 @@ mod guard_propagation_tests {
         pool
     }
 
+    fn pool_with_leaf_scoped_panic_bridge(body_term: Json, method: &str) -> MementoPool {
+        pool_with_leaf_scoped_panic_bridge_and_locus(body_term, method, method)
+    }
+
+    fn pool_with_leaf_scoped_panic_bridge_and_locus(
+        body_term: Json,
+        bridge_method: &str,
+        locus_callee: &str,
+    ) -> MementoPool {
+        let mut pool = MementoPool::default();
+        let bundle = "blake3-512:caller-bundle".to_string();
+        let caller = "blake3-512:caller".to_string();
+        pool.bridges_by_symbol.insert(
+            bridge_method.to_string(),
+            bridge_for_symbol(
+                bridge_method,
+                "blake3-512:wrong-symbol-target",
+                Some("src/lib.rs"),
+                Some(99),
+            ),
+        );
+        pool.bridges_by_callsite.insert(
+            (
+                bundle.clone(),
+                "src/lib.rs".to_string(),
+                10,
+                bridge_method.to_string(),
+            ),
+            bridge_for_symbol(
+                bridge_method,
+                "blake3-512:right-callsite-target",
+                Some("src/lib.rs"),
+                Some(10),
+            ),
+        );
+        pool.bundle_members
+            .entry(bundle)
+            .or_default()
+            .insert(caller.clone());
+        let contract = json!({
+            "envelope": true,
+            "header": {
+                "kind": "contract",
+                "contractName": "caller_self_post",
+                "panicLoci": [{
+                    "argTerm": recv(),
+                    "callee": locus_callee,
+                    "file": "src/lib.rs",
+                    "line": 10,
+                    "col": 4,
+                }],
+                "post": {
+                    "kind": "atomic",
+                    "name": "=",
+                    "args": [ { "kind": "var", "name": "result" }, body_term ],
+                }
+            }
+        });
+        pool.mementos.insert(caller, contract);
+        pool
+    }
+
     fn enumerated_call(sites: &[CallSite]) -> &CallSite {
         sites
             .iter()
             .find(|cs| cs.bridge_ir_name == "panic_call")
             .expect("the panic call must enumerate")
+    }
+
+    fn leaf_callsite<'a>(sites: &'a [CallSite], method: &str) -> &'a CallSite {
+        sites
+            .iter()
+            .find(|cs| cs.bridge_ir_name == method)
+            .unwrap_or_else(|| panic!("the leaf call must enumerate as {method}: {sites:?}"))
     }
 
     #[test]
@@ -1134,5 +1228,169 @@ mod guard_propagation_tests {
         );
         assert_eq!(cs.file.as_deref(), Some("src/lib.rs"));
         assert_eq!(cs.line, Some(10));
+    }
+
+    #[test]
+    fn leaf_method_concept_aliases_enumerate_with_canonical_callsites() {
+        for (method, concept) in [
+            (
+                panic_freedom::METHOD_UNWRAP,
+                panic_freedom::METHOD_UNWRAP_CONCEPT,
+            ),
+            (
+                panic_freedom::METHOD_EXPECT,
+                panic_freedom::METHOD_EXPECT_CONCEPT,
+            ),
+            (
+                panic_freedom::METHOD_UNWRAP_ERR,
+                panic_freedom::METHOD_UNWRAP_ERR_CONCEPT,
+            ),
+        ] {
+            let body = cf_guarded(pred("pred_a"), leaf_call(concept));
+            let sites = run(&pool_with_leaf_scoped_panic_bridge(body, method));
+            let cs = leaf_callsite(&sites, method);
+            assert_eq!(
+                cs.bridge_ir_name, method,
+                "concept leaf input must enumerate with the canonical old method token"
+            );
+            assert_eq!(
+                cs.callee.as_deref(),
+                Some(method),
+                "callsite callee output must stay canonical for {concept}"
+            );
+            assert_eq!(
+                cs.bridge_target_cid, "blake3-512:right-callsite-target",
+                "concept leaf input must select the old-key callsite-scoped bridge"
+            );
+            assert_eq!(
+                cs.guard_facts,
+                vec![json!({ "kind": "atomic", "name": "pred_a", "args": [recv()] })],
+                "formula-walk alias enumeration must preserve dominating guard facts; \
+                 panicLoci-only fallback would lose them for {concept}"
+            );
+            assert_eq!(cs.file.as_deref(), Some("src/lib.rs"));
+            assert_eq!(cs.line, Some(10));
+        }
+    }
+
+    #[test]
+    fn panic_locus_for_leaf_concept_input_matches_old_locus_key() {
+        let arg = recv();
+        for (method, concept) in [
+            (
+                panic_freedom::METHOD_UNWRAP,
+                panic_freedom::METHOD_UNWRAP_CONCEPT,
+            ),
+            (
+                panic_freedom::METHOD_EXPECT,
+                panic_freedom::METHOD_EXPECT_CONCEPT,
+            ),
+            (
+                panic_freedom::METHOD_UNWRAP_ERR,
+                panic_freedom::METHOD_UNWRAP_ERR_CONCEPT,
+            ),
+        ] {
+            let loci = vec![json!({
+                "argTerm": arg,
+                "callee": method,
+                "file": "src/lib.rs",
+                "line": 10,
+            })];
+            let locus = panic_locus_for(concept, Some(&arg), &loci)
+                .unwrap_or_else(|| panic!("concept leaf {concept} must match old locus {method}"));
+            assert_eq!(locus["callee"], method);
+        }
+    }
+
+    #[test]
+    fn callsite_scoped_bridge_for_locus_leaf_concept_input_uses_old_key() {
+        let locus = json!({
+            "argTerm": recv(),
+            "callee": panic_freedom::METHOD_UNWRAP,
+            "file": "src/lib.rs",
+            "line": 10,
+        });
+        let pool = pool_with_leaf_scoped_panic_bridge(
+            leaf_call(panic_freedom::METHOD_UNWRAP_CONCEPT),
+            panic_freedom::METHOD_UNWRAP,
+        );
+        let bridge = callsite_scoped_bridge_for_locus(
+            &pool,
+            Some("blake3-512:caller-bundle"),
+            panic_freedom::METHOD_UNWRAP_CONCEPT,
+            &locus,
+        )
+        .expect("concept leaf input must locate the old-key scoped bridge");
+        let body = memento_body(bridge).expect("bridge body");
+        assert_eq!(
+            body["targetContractCid"],
+            "blake3-512:right-callsite-target"
+        );
+    }
+
+    #[test]
+    fn panic_loci_concept_leaf_rows_surface_canonical_method_callsites() {
+        for (method, concept) in [
+            (
+                panic_freedom::METHOD_UNWRAP,
+                panic_freedom::METHOD_UNWRAP_CONCEPT,
+            ),
+            (
+                panic_freedom::METHOD_EXPECT,
+                panic_freedom::METHOD_EXPECT_CONCEPT,
+            ),
+            (
+                panic_freedom::METHOD_UNWRAP_ERR,
+                panic_freedom::METHOD_UNWRAP_ERR_CONCEPT,
+            ),
+        ] {
+            let pool = pool_with_leaf_scoped_panic_bridge_and_locus(
+                json!({ "kind": "lit", "value": 0 }),
+                method,
+                concept,
+            );
+            let locus = json!({
+                "argTerm": recv(),
+                "callee": concept,
+                "file": "src/lib.rs",
+                "line": 10,
+            });
+            let cs = callsite_from_panic_locus(
+                &locus,
+                "caller_self_post",
+                "blake3-512:caller",
+                &pool,
+                Some("blake3-512:caller-bundle"),
+            )
+            .unwrap_or_else(|| panic!("concept panicLoci row must surface {method}"));
+            assert_eq!(cs.bridge_ir_name, method);
+            assert_eq!(cs.callee.as_deref(), Some(method));
+            assert_eq!(
+                cs.bridge_target_cid, "blake3-512:right-callsite-target",
+                "concept panicLoci row must use the old-key scoped bridge"
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_leaf_concept_tokens_do_not_match_method_bridges() {
+        for bad_name in [
+            " concept:panic-freedom.leaf.unwrap",
+            "concept:panic-freedom.leaf.unwrap ",
+            "concept:panic-freedom.leaf.Unwrap",
+            "concept:panic-freedom.leaf.unwrap_err",
+            panic_freedom::IS_SOME_CONCEPT,
+            panic_freedom::IS_OK_CONCEPT,
+        ] {
+            let body = cf_guarded(pred("pred_a"), leaf_call(bad_name));
+            let sites =
+                run(&pool_with_leaf_scoped_panic_bridge(body, panic_freedom::METHOD_UNWRAP));
+            let cs = leaf_callsite(&sites, panic_freedom::METHOD_UNWRAP);
+            assert!(
+                cs.guard_facts.is_empty(),
+                "malformed or cross-family token {bad_name} must not enumerate through the formula; \
+                 only the panicLoci fallback should remain"
+            );
+        }
     }
 }

--- a/implementations/rust/provekit-walk/src/envelope.rs
+++ b/implementations/rust/provekit-walk/src/envelope.rs
@@ -215,6 +215,7 @@ fn value_type_name(value: &Value) -> &'static str {
 mod tests {
     use super::*;
     use crate::contract::build_function_contract;
+    use libprovekit::concept::panic_freedom;
     use provekit_claim_envelope::contract_cid as kit_contract_cid;
     use serde_json::Value as JsonValue;
 
@@ -284,7 +285,12 @@ mod tests {
         assert_eq!(panic_loci[0]["file"], "unknown");
         assert_eq!(panic_loci[0]["line"], expected_line);
         assert_eq!(panic_loci[0]["panicLine"], expected_panic_line);
-        assert_eq!(panic_loci[0]["callee"], "method:unwrap");
+        assert_eq!(panic_loci[0]["callee"], panic_freedom::METHOD_UNWRAP);
+        assert_ne!(
+            panic_loci[0]["callee"],
+            panic_freedom::METHOD_UNWRAP_CONCEPT,
+            "Rust v1 envelope writer must not emit the unwrap leaf concept alias"
+        );
     }
 
     #[test]
@@ -379,7 +385,12 @@ mod tests {
         assert_eq!(panic_loci[0]["file"], "src/lib.rs");
         assert_eq!(panic_loci[0]["line"], 2);
         assert_eq!(panic_loci[0]["panicLine"], 3);
-        assert_eq!(panic_loci[0]["callee"], "method:unwrap");
+        assert_eq!(panic_loci[0]["callee"], panic_freedom::METHOD_UNWRAP);
+        assert_ne!(
+            panic_loci[0]["callee"],
+            panic_freedom::METHOD_UNWRAP_CONCEPT,
+            "Rust v1 envelope writer must not emit the unwrap leaf concept alias"
+        );
     }
 
     #[test]

--- a/implementations/rust/provekit-walk/src/lift.rs
+++ b/implementations/rust/provekit-walk/src/lift.rs
@@ -2857,6 +2857,14 @@ mod tests {
             "then-branch guard is is_some: {json}"
         );
         assert!(
+            json.contains(panic_freedom::METHOD_UNWRAP),
+            "Rust v1 emission must keep the old unwrap leaf token: {json}"
+        );
+        assert!(
+            !json.contains(panic_freedom::METHOD_UNWRAP_CONCEPT),
+            "Rust v1 emission must not write the leaf concept alias: {json}"
+        );
+        assert!(
             !json.contains(panic_freedom::IS_SOME_CONCEPT),
             "Rust v1 emission must keep the old option predicate: {json}"
         );
@@ -2913,6 +2921,14 @@ mod tests {
             "guard must carry the result precondition: {json}"
         );
         assert!(
+            json.contains(panic_freedom::METHOD_UNWRAP),
+            "Rust v1 writer must keep emitting the old unwrap leaf token: {json}"
+        );
+        assert!(
+            !json.contains(panic_freedom::METHOD_UNWRAP_CONCEPT),
+            "Rust v1 writer must not emit the unwrap leaf concept alias: {json}"
+        );
+        assert!(
             !json.contains(panic_freedom::IS_OK_CONCEPT),
             "Rust v1 writer must keep emitting the old result predicate token: {json}"
         );
@@ -2937,6 +2953,14 @@ mod tests {
         assert!(
             json.contains("is_ok"),
             "guard must carry the result precondition: {json}"
+        );
+        assert!(
+            json.contains(panic_freedom::METHOD_EXPECT),
+            "Rust v1 writer must keep emitting the old expect leaf token: {json}"
+        );
+        assert!(
+            !json.contains(panic_freedom::METHOD_EXPECT_CONCEPT),
+            "Rust v1 writer must not emit the expect leaf concept alias: {json}"
         );
         assert!(
             !json.contains(panic_freedom::IS_OK_CONCEPT),


### PR DESCRIPTION
## Summary
- Adds leaf method concept aliases for unwrap, expect, and unwrap_err in the panic-freedom concept registry.
- Canonicalizes leaf aliases at the enumerate_callsites reader boundary before bridge lookup, panic locus matching, scoped bridge keys, and CallSite output.
- Keeps Rust v1 writers on method:* tokens and adds writer stability pins for walk, envelope, lift, and mint paths.

## Validation
- RED confirmed missing leaf constants and normalize_leaf_method_name in libprovekit and provekit-verifier.
- ../../bin/bcargo test -p libprovekit leaf_method_concept_aliases_normalize_to_v1_wire_tokens -- --nocapture
- ../../bin/bcargo test -p libprovekit panic_freedom_constants_keep_existing_wire_tokens -- --nocapture
- ../../bin/bcargo test -p provekit-verifier guard_propagation_tests -- --nocapture
- ../../bin/bcargo test -p provekit-walk if_is_some_lifts_then_to_cf_guarded_is_some_else_to_is_none -- --nocapture
- ../../bin/bcargo test -p provekit-walk assert_is_ok_guards_later_result -- --nocapture
- ../../bin/bcargo test -p provekit-walk panic_loci_round_trip_in_contract_header -- --nocapture
- ../../bin/bcargo test -p provekit-walk one_line_unwrap_panic_locus_round_trips_through_envelope -- --nocapture
- ../../bin/bcargo test -p provekit-lift mint_proof_preserves_panic_loci_in_contract_header -- --nocapture
- ../../bin/bcargo test -p provekit-cli mint_ir_document_well_formed_panic_loci_threads_through_header -- --nocapture
- ../../bin/bcargo fmt --all
- git diff --check
- rg normalize_leaf_method_name implementations/rust/provekit-walk/src implementations/rust/provekit-lift/src implementations/rust/provekit-cli/src returned zero hits.

## Golden
- self_check_golden first failed exactly as predicted: reflexive 630 -> 631 only.
- bcargo does not forward UPDATE_GOLDEN, so the one JSON line was updated directly from the observed normalized mismatch, then the gate was rerun.
- ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture passed in 113.20s.
- Hard floors unchanged: falsePass 0, silentlyDropped 0, droppedSites [], panicSafe 5. Shim target catalogCid remains d1c2f286...
