### PR TITLE
Remove vestigial serde shim dep from CLI

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -2055,6 +2055,7 @@ dependencies = [
  "serde_json",
  "syn",
  "thiserror 1.0.69",
+ "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
 ]

--- a/implementations/rust/provekit-cli/Cargo.toml
+++ b/implementations/rust/provekit-cli/Cargo.toml
@@ -45,7 +45,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-provekit-shim-serde-json-rust = { path = "../../../examples/provekit-shim-serde-json-rust" }
 serde_yaml = "0.9"
 walkdir = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
## Summary

- Remove the vestigial `provekit-shim-serde-json-rust` normal dependency from `provekit-cli`.
- Keep the CLI language-blind at the Cargo graph level; Rust shim crates remain outside the CLI build tree.
- Refresh `Cargo.lock`; the only generated lock delta is adding the already-declared `toml 0.8.23` edge to `provekit-walk`.

## Root Cause

`provekit-cli` had a direct path dependency on the serde JSON Rust shim even though no CLI Rust code imports `provekit_shim_serde_json_rust`. The macOS Swift/Rust scope gate correctly caught this as a Rust shim example crate leaking into the CLI dependency tree.

## Verification

- RED: `make check-macos-swift-rust-scope` fails on unmodified `origin/main` with `FAIL: provekit-cli must not pull Rust shim example crates into macOS Swift mint builds`.
- GREEN: `make check-macos-swift-rust-scope` passes after the dependency removal.
- `git diff --check`
- `../../bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli dependency_contract_bindings -- --nocapture`
- `../../bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli rust_recognize_write_self_resolves_imported_sugar_proof -- --nocapture`
- `../../bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test self_check_golden -- --nocapture`

## Baseline Note

`configured_rust_shims_emit_nonvacuous_implication_claims` is baseline-red on unmodified `origin/main`, failing on `examples/provekit-shim-blake3-rust` with `totalCallsites: 0`; the same failure reproduces after this change and is not introduced here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused dependency from the Rust CLI tool, reducing build dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->