### PR TITLE
Slice 3 PR 2 dual-read body-discharge policy

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -2034,6 +2034,7 @@ dependencies = [
  "thiserror 1.0.69",
  "toml 0.8.23",
  "tracing",
+ "tracing-subscriber",
  "walkdir",
 ]
 

--- a/implementations/rust/provekit-claim-envelope/Cargo.toml
+++ b/implementations/rust/provekit-claim-envelope/Cargo.toml
@@ -9,9 +9,9 @@ description = "ProvekIt: claim/memento envelope minters (contract, bridge, impli
 [dependencies]
 provekit-canonicalizer = { path = "../provekit-canonicalizer" }
 provekit-proof-envelope = { path = "../provekit-proof-envelope" }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
 serde = { workspace = true }
-serde_json = { workspace = true }
 hex = { workspace = true }

--- a/implementations/rust/provekit-claim-envelope/src/lib.rs
+++ b/implementations/rust/provekit-claim-envelope/src/lib.rs
@@ -34,6 +34,7 @@ use std::sync::Arc;
 
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value};
 use provekit_proof_envelope::{ed25519_pubkey_string, ed25519_sign_string, Ed25519Seed};
+use serde_json::Value as JsonValue;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ClaimEnvelopeError {
@@ -293,6 +294,175 @@ pub struct MintContractArgs {
     /// `verdict`): the locus is developer-facing provenance, not part of what is
     /// proven, so it must not move the contract identity. Empty omits the key.
     pub panic_loci: Vec<Arc<Value>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BodyDischargePolicy {
+    pub body_discharge_eligible: bool,
+    pub body_discharge_refusal_reason: Option<String>,
+    pub warnings: Vec<BodyDischargePolicyWarning>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BodyDischargePolicyWarning {
+    Disagreement {
+        legacy_eligible: bool,
+        legacy_reason: Option<String>,
+        policy_eligible: bool,
+        policy_reason: Option<String>,
+    },
+    Malformed {
+        reason: String,
+    },
+}
+
+pub fn body_discharge_policy_from_object(entry: &JsonValue) -> BodyDischargePolicy {
+    body_discharge_policy_from_object_with_default(entry, true)
+}
+
+pub fn body_discharge_policy_from_object_with_default(
+    entry: &JsonValue,
+    default_eligible: bool,
+) -> BodyDischargePolicy {
+    body_discharge_policy_from_fields_with_default(
+        entry.get("bodyDischargeEligible")
+            .or_else(|| entry.get("body_discharge_eligible")),
+        entry.get("bodyDischargeRefusalReason")
+            .or_else(|| entry.get("body_discharge_refusal_reason")),
+        entry.get("dischargePolicy"),
+        default_eligible,
+    )
+}
+
+pub fn body_discharge_policy_from_fields(
+    legacy_eligible: Option<&JsonValue>,
+    legacy_reason: Option<&JsonValue>,
+    discharge_policy: Option<&JsonValue>,
+) -> BodyDischargePolicy {
+    body_discharge_policy_from_fields_with_default(
+        legacy_eligible,
+        legacy_reason,
+        discharge_policy,
+        true,
+    )
+}
+
+pub fn body_discharge_policy_from_fields_with_default(
+    legacy_eligible: Option<&JsonValue>,
+    legacy_reason: Option<&JsonValue>,
+    discharge_policy: Option<&JsonValue>,
+    default_eligible: bool,
+) -> BodyDischargePolicy {
+    let legacy_eligible = legacy_eligible.and_then(JsonValue::as_bool);
+    let legacy_reason = legacy_reason
+        .and_then(JsonValue::as_str)
+        .map(str::to_string);
+    let legacy_present = legacy_eligible.is_some() || legacy_reason.is_some();
+    let legacy_policy = (
+        legacy_eligible.unwrap_or(default_eligible),
+        legacy_reason.clone(),
+    );
+
+    let (policy, mut warnings) = parse_body_reduction(discharge_policy);
+    match policy {
+        Some((policy_eligible, policy_reason)) if legacy_present => {
+            if legacy_policy != (policy_eligible, policy_reason.clone()) {
+                warnings.push(BodyDischargePolicyWarning::Disagreement {
+                    legacy_eligible: legacy_policy.0,
+                    legacy_reason: legacy_policy.1.clone(),
+                    policy_eligible,
+                    policy_reason,
+                });
+            }
+            BodyDischargePolicy {
+                body_discharge_eligible: legacy_policy.0,
+                body_discharge_refusal_reason: legacy_policy.1,
+                warnings,
+            }
+        }
+        Some((policy_eligible, policy_reason)) => BodyDischargePolicy {
+            body_discharge_eligible: policy_eligible,
+            body_discharge_refusal_reason: policy_reason,
+            warnings,
+        },
+        None => BodyDischargePolicy {
+            body_discharge_eligible: legacy_policy.0,
+            body_discharge_refusal_reason: legacy_policy.1,
+            warnings,
+        },
+    }
+}
+
+fn parse_body_reduction(
+    discharge_policy: Option<&JsonValue>,
+) -> (
+    Option<(bool, Option<String>)>,
+    Vec<BodyDischargePolicyWarning>,
+) {
+    let Some(discharge_policy) = discharge_policy else {
+        return (None, Vec::new());
+    };
+    let Some(policy_object) = discharge_policy.as_object() else {
+        return (
+            None,
+            vec![BodyDischargePolicyWarning::Malformed {
+                reason: "dischargePolicy must be an object".to_string(),
+            }],
+        );
+    };
+    let Some(body_reduction) = policy_object.get("bodyReduction") else {
+        return (None, Vec::new());
+    };
+    let Some(body_reduction_object) = body_reduction.as_object() else {
+        return (
+            None,
+            vec![BodyDischargePolicyWarning::Malformed {
+                reason: "dischargePolicy.bodyReduction must be an object".to_string(),
+            }],
+        );
+    };
+    let Some(status) = body_reduction_object
+        .get("status")
+        .and_then(JsonValue::as_str)
+    else {
+        return (
+            None,
+            vec![BodyDischargePolicyWarning::Malformed {
+                reason: "dischargePolicy.bodyReduction.status must be a string".to_string(),
+            }],
+        );
+    };
+
+    match status {
+        "allowed" => (Some((true, None)), Vec::new()),
+        "refused" => {
+            let reason = match body_reduction_object.get("reason") {
+                Some(reason) => match reason.as_str() {
+                    Some(reason) => Some(reason.to_string()),
+                    None => {
+                        return (
+                            None,
+                            vec![BodyDischargePolicyWarning::Malformed {
+                                reason:
+                                    "dischargePolicy.bodyReduction.reason must be a string"
+                                        .to_string(),
+                            }],
+                        )
+                    }
+                },
+                None => None,
+            };
+            (Some((false, reason)), Vec::new())
+        }
+        other => (
+            None,
+            vec![BodyDischargePolicyWarning::Malformed {
+                reason: format!(
+                    "dischargePolicy.bodyReduction.status must be allowed or refused, got {other}"
+                ),
+            }],
+        ),
+    }
 }
 
 // =============================================================================
@@ -995,6 +1165,148 @@ mod tests {
 
     fn dummy_seed() -> Ed25519Seed {
         [0x42; 32]
+    }
+
+    #[test]
+    fn body_discharge_policy_accepts_new_allowed() {
+        let entry = serde_json::json!({
+            "dischargePolicy": {
+                "bodyReduction": {
+                    "status": "allowed"
+                }
+            }
+        });
+
+        let policy = body_discharge_policy_from_object(&entry);
+
+        assert!(policy.body_discharge_eligible);
+        assert_eq!(policy.body_discharge_refusal_reason, None);
+        assert!(policy.warnings.is_empty());
+    }
+
+    #[test]
+    fn body_discharge_policy_accepts_new_refused_with_reason() {
+        let entry = serde_json::json!({
+            "dischargePolicy": {
+                "bodyReduction": {
+                    "status": "refused",
+                    "reason": "totality-axiom"
+                }
+            }
+        });
+
+        let policy = body_discharge_policy_from_object(&entry);
+
+        assert!(!policy.body_discharge_eligible);
+        assert_eq!(
+            policy.body_discharge_refusal_reason.as_deref(),
+            Some("totality-axiom")
+        );
+        assert!(policy.warnings.is_empty());
+    }
+
+    #[test]
+    fn body_discharge_policy_keeps_snake_case_legacy_fields() {
+        let entry = serde_json::json!({
+            "body_discharge_eligible": false,
+            "body_discharge_refusal_reason": "legacy-snake"
+        });
+
+        let policy = body_discharge_policy_from_object(&entry);
+
+        assert!(!policy.body_discharge_eligible);
+        assert_eq!(
+            policy.body_discharge_refusal_reason.as_deref(),
+            Some("legacy-snake")
+        );
+        assert!(policy.warnings.is_empty());
+    }
+
+    #[test]
+    fn body_discharge_policy_accepts_matching_legacy_and_policy_fields() {
+        let entry = serde_json::json!({
+            "bodyDischargeEligible": false,
+            "bodyDischargeRefusalReason": "totality-axiom",
+            "dischargePolicy": {
+                "bodyReduction": {
+                    "status": "refused",
+                    "reason": "totality-axiom"
+                }
+            }
+        });
+
+        let policy = body_discharge_policy_from_object(&entry);
+
+        assert!(!policy.body_discharge_eligible);
+        assert_eq!(
+            policy.body_discharge_refusal_reason.as_deref(),
+            Some("totality-axiom")
+        );
+        assert!(policy.warnings.is_empty());
+    }
+
+    #[test]
+    fn body_discharge_policy_legacy_wins_on_disagreement() {
+        let entry = serde_json::json!({
+            "bodyDischargeEligible": false,
+            "bodyDischargeRefusalReason": "legacy-refusal",
+            "dischargePolicy": {
+                "bodyReduction": {
+                    "status": "allowed"
+                }
+            }
+        });
+
+        let policy = body_discharge_policy_from_object(&entry);
+
+        assert!(!policy.body_discharge_eligible);
+        assert_eq!(
+            policy.body_discharge_refusal_reason.as_deref(),
+            Some("legacy-refusal")
+        );
+        assert!(matches!(
+            policy.warnings.as_slice(),
+            [BodyDischargePolicyWarning::Disagreement { .. }]
+        ));
+    }
+
+    #[test]
+    fn body_discharge_policy_malformed_warns_and_falls_back_to_legacy() {
+        let entry = serde_json::json!({
+            "bodyDischargeEligible": true,
+            "dischargePolicy": {
+                "bodyReduction": {
+                    "status": "maybe"
+                }
+            }
+        });
+
+        let policy = body_discharge_policy_from_object(&entry);
+
+        assert!(policy.body_discharge_eligible);
+        assert_eq!(policy.body_discharge_refusal_reason, None);
+        assert!(matches!(
+            policy.warnings.as_slice(),
+            [BodyDischargePolicyWarning::Malformed { .. }]
+        ));
+    }
+
+    #[test]
+    fn body_discharge_policy_ignores_foreign_policy_keys() {
+        let entry = serde_json::json!({
+            "dischargePolicy": {
+                "headerReduction": {
+                    "status": "refused",
+                    "reason": "not-this-policy"
+                }
+            }
+        });
+
+        let policy = body_discharge_policy_from_object_with_default(&entry, false);
+
+        assert!(!policy.body_discharge_eligible);
+        assert_eq!(policy.body_discharge_refusal_reason, None);
+        assert!(policy.warnings.is_empty());
     }
 
     #[test]

--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -48,7 +48,7 @@ use base64::Engine;
 use clap::Parser;
 use owo_colors::OwoColorize;
 use serde_json::{json, Value};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use libprovekit::core::{
     address, Boundary, Cid, Dialect, Domain, DomainClaim, DomainKind, FunctionContractDomain,
@@ -57,9 +57,9 @@ use libprovekit::core::{
 };
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 use provekit_claim_envelope::{
-    compute_contract_set_cid, contract_cid, mint_authority, mint_bridge, mint_contract,
-    mint_implication, Authoring, BridgeCallsite, MintAuthorityArgs, MintBridgeArgs,
-    MintContractArgs, MintImplicationArgs,
+    body_discharge_policy_from_fields, compute_contract_set_cid, contract_cid, mint_authority,
+    mint_bridge, mint_contract, mint_implication, Authoring, BodyDischargePolicyWarning,
+    BridgeCallsite, MintAuthorityArgs, MintBridgeArgs, MintContractArgs, MintImplicationArgs,
 };
 use provekit_ir_types::Sort;
 use provekit_proof_envelope::{
@@ -77,6 +77,37 @@ use crate::{EXIT_OK, EXIT_USER_ERROR, EXIT_VERIFY_FAIL};
 // ---------------------------------------------------------------------------
 // Foundation signing constants
 // ---------------------------------------------------------------------------
+
+fn log_body_discharge_policy_warnings(
+    context: &str,
+    contract: &str,
+    warnings: &[BodyDischargePolicyWarning],
+) {
+    for warning in warnings {
+        match warning {
+            BodyDischargePolicyWarning::Disagreement {
+                legacy_eligible,
+                legacy_reason,
+                policy_eligible,
+                policy_reason,
+            } => warn!(
+                context = %context,
+                contract = %contract,
+                legacy_eligible = *legacy_eligible,
+                legacy_reason = ?legacy_reason,
+                policy_eligible = *policy_eligible,
+                policy_reason = ?policy_reason,
+                "body-discharge-disagreement: dischargePolicy/bodyDischarge* disagree; using legacy bodyDischarge*"
+            ),
+            BodyDischargePolicyWarning::Malformed { reason } => warn!(
+                context = %context,
+                contract = %contract,
+                reason = %reason,
+                "body-discharge-malformed: ignoring malformed dischargePolicy"
+            ),
+        }
+    }
+}
 
 /// The v0 foundation seed. PUBLICLY KNOWN. Same seed used by foundation-keygen.
 const FOUNDATION_V0_SEED: Ed25519Seed = [0x42u8; 32];
@@ -928,14 +959,20 @@ fn contract_bindings_from_dependency_proofs(project_root: &Path) -> Vec<Value> {
             Some(n) => n.to_string(),
             None => continue,
         };
-        let body_discharge_eligible = memento_body_field(env, "bodyDischargeEligible")
-            .or_else(|| memento_body_field(env, "body_discharge_eligible"))
-            .and_then(|v| v.as_bool())
-            .unwrap_or(true);
-        let body_discharge_refusal_reason = memento_body_field(env, "bodyDischargeRefusalReason")
-            .or_else(|| memento_body_field(env, "body_discharge_refusal_reason"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+        let body_policy = body_discharge_policy_from_fields(
+            memento_body_field(env, "bodyDischargeEligible")
+                .or_else(|| memento_body_field(env, "body_discharge_eligible")),
+            memento_body_field(env, "bodyDischargeRefusalReason")
+                .or_else(|| memento_body_field(env, "body_discharge_refusal_reason")),
+            memento_body_field(env, "dischargePolicy"),
+        );
+        log_body_discharge_policy_warnings(
+            "mint-dependency-contract-binding",
+            &name,
+            &body_policy.warnings,
+        );
+        let body_discharge_eligible = body_policy.body_discharge_eligible;
+        let body_discharge_refusal_reason = body_policy.body_discharge_refusal_reason;
         // The dependency crate this contract belongs to (the lifter stamped it
         // at mint, the CLI forwards it opaquely).
         let library = memento_body_field(env, "library")
@@ -1803,16 +1840,20 @@ fn mint_ir_document(
             }
             None => Vec::new(),
         };
-        let body_discharge_eligible = decl
-            .get("bodyDischargeEligible")
-            .or_else(|| decl.get("body_discharge_eligible"))
-            .and_then(|v| v.as_bool())
-            .unwrap_or(true);
-        let body_discharge_refusal_reason = decl
-            .get("bodyDischargeRefusalReason")
-            .or_else(|| decl.get("body_discharge_refusal_reason"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+        let body_policy = body_discharge_policy_from_fields(
+            decl.get("bodyDischargeEligible")
+                .or_else(|| decl.get("body_discharge_eligible")),
+            decl.get("bodyDischargeRefusalReason")
+                .or_else(|| decl.get("body_discharge_refusal_reason")),
+            decl.get("dischargePolicy"),
+        );
+        log_body_discharge_policy_warnings(
+            "mint-ir-contract-decl",
+            &name,
+            &body_policy.warnings,
+        );
+        let body_discharge_eligible = body_policy.body_discharge_eligible;
+        let body_discharge_refusal_reason = body_policy.body_discharge_refusal_reason;
         // A bridge is written only when this contract is a body-bearing
         // function target: it carries a `post` AND an explicit `formals`
         // field. Presence is the marker, not non-emptiness: zero-arg
@@ -3815,6 +3856,128 @@ mod tests {
                 .count(),
             2
         );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn dependency_contract_bindings_accept_discharge_policy_body_reduction_refused() {
+        let root = temp_workspace("dependency_contract_discharge_policy_refused");
+        let imports_dir = root.join(".provekit").join("imports");
+        std::fs::create_dir_all(&imports_dir).expect("create imports dir");
+        let signer_seed: Ed25519Seed = [0x42; 32];
+        let produced_at = "2026-06-01T00:00:00.000Z".to_string();
+        let contract = mint_contract(&MintContractArgs {
+            contract_name: "new_policy_dep".to_string(),
+            pre: None,
+            post: Some(json_to_cvalue(&json!({
+                "kind": "atomic",
+                "name": "=",
+                "args": [
+                    {"kind": "var", "name": "result"},
+                    {"kind": "var", "name": "x"}
+                ]
+            }))),
+            inv: None,
+            out_binding: "result".to_string(),
+            produced_by: "test".to_string(),
+            produced_at: produced_at.clone(),
+            input_cids: Vec::new(),
+            authoring: Authoring::KitAuthor {
+                author: "test".to_string(),
+                note: None,
+            },
+            signer_seed,
+            formals: vec!["x".to_string()],
+            emit_empty_formals: false,
+            formal_sorts: Vec::new(),
+            library: Some("dep_lib".to_string()),
+            body_discharge_eligible: true,
+            body_discharge_refusal_reason: None,
+            panic_loci: Vec::new(),
+        })
+        .expect("mint contract");
+        let mut env: Value =
+            serde_json::from_slice(&contract.canonical_bytes).expect("parse memento");
+        env.pointer_mut("/metadata")
+            .and_then(|v| v.as_object_mut())
+            .expect("metadata object")
+            .insert(
+                "dischargePolicy".to_string(),
+                json!({
+                    "bodyReduction": {
+                        "status": "refused",
+                        "reason": "totality-axiom"
+                    }
+                }),
+            );
+
+        let mut members = BTreeMap::new();
+        members.insert(
+            contract.cid,
+            serde_json::to_vec(&env).expect("serialize mutated memento"),
+        );
+        let proof = build_proof_envelope(&ProofEnvelopeInput {
+            name: "dependency-policy-fixture".to_string(),
+            version: "1.0.0".to_string(),
+            binary_cid: None,
+            metadata: None,
+            members,
+            signer_cid: ed25519_pubkey_string(&signer_seed),
+            signer_seed,
+            declared_at: produced_at,
+        });
+        std::fs::write(imports_dir.join(format!("{}.proof", proof.cid)), proof.bytes)
+            .expect("write dependency proof");
+
+        let bindings = contract_bindings_from_dependency_proofs(&root);
+        let binding = bindings
+            .iter()
+            .find(|binding| binding["name"] == "new_policy_dep")
+            .unwrap_or_else(|| panic!("missing new_policy_dep binding: {bindings:#?}"));
+
+        assert_eq!(binding["bodyDischargeEligible"], false);
+        assert_eq!(binding["bodyDischargeRefusalReason"], "totality-axiom");
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn mint_ir_document_accepts_discharge_policy_body_reduction_refused() {
+        let root = temp_workspace("mint_ir_document_discharge_policy_refused");
+        let out_dir = root.join("out");
+        std::fs::create_dir_all(&out_dir).expect("create out dir");
+        let ir = vec![json!({
+            "kind": "function-contract",
+            "name": "totality_axiom",
+            "outBinding": "result",
+            "formals": ["x"],
+            "post": {
+                "kind": "atomic",
+                "name": "=",
+                "args": [
+                    {"kind": "var", "name": "result"},
+                    {"kind": "var", "name": "x"}
+                ]
+            },
+            "dischargePolicy": {
+                "bodyReduction": {
+                    "status": "refused",
+                    "reason": "totality-axiom"
+                }
+            }
+        })];
+
+        let minted =
+            mint_ir_document(&ir, None, None, None, &root, &out_dir, true).expect("mint");
+        let binding = minted
+            .contract_bindings
+            .iter()
+            .find(|binding| binding["name"] == "totality_axiom")
+            .unwrap_or_else(|| panic!("missing totality_axiom binding: {:#?}", minted.contract_bindings));
+
+        assert_eq!(binding["bodyDischargeEligible"], false);
+        assert_eq!(binding["bodyDischargeRefusalReason"], "totality-axiom");
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/implementations/rust/provekit-cli/src/cmd_self_check.rs
+++ b/implementations/rust/provekit-cli/src/cmd_self_check.rs
@@ -8,10 +8,13 @@ use std::process::{Command, Output, Stdio};
 
 use clap::Parser;
 use provekit_canonicalizer::blake3_512_of;
+use provekit_claim_envelope::{
+    body_discharge_policy_from_object_with_default, BodyDischargePolicyWarning,
+};
 use provekit_verifier::load_all_proofs::ProofBytes;
 use serde::Serialize;
 use serde_json::Value;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::floor_runtime_check::{
     floor_runtime_check, FloorCheckMode, FloorCheckStatus, FloorRuntimeCheck, FloorSignals,
@@ -74,6 +77,37 @@ struct Site {
     line: usize,
     callee: String,
     reason: String,
+}
+
+fn log_body_discharge_policy_warnings(
+    context: &str,
+    contract: &str,
+    warnings: &[BodyDischargePolicyWarning],
+) {
+    for warning in warnings {
+        match warning {
+            BodyDischargePolicyWarning::Disagreement {
+                legacy_eligible,
+                legacy_reason,
+                policy_eligible,
+                policy_reason,
+            } => warn!(
+                context = %context,
+                contract = %contract,
+                legacy_eligible = *legacy_eligible,
+                legacy_reason = ?legacy_reason,
+                policy_eligible = *policy_eligible,
+                policy_reason = ?policy_reason,
+                "body-discharge-disagreement: dischargePolicy/bodyDischarge* disagree; using legacy bodyDischarge*"
+            ),
+            BodyDischargePolicyWarning::Malformed { reason } => warn!(
+                context = %context,
+                contract = %contract,
+                reason = %reason,
+                "body-discharge-malformed: ignoring malformed dischargePolicy"
+            ),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1043,20 +1077,22 @@ fn lift_scoreboards(lift_json: &Value) -> (LiftScoreboard, BridgeScoreboard, Vec
             match entry.get("kind").and_then(|v| v.as_str()) {
                 Some("function-contract") => {
                     fn_contracts += 1;
-                    if entry
-                        .get("bodyDischargeEligible")
-                        .or_else(|| entry.get("body_discharge_eligible"))
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false)
-                    {
+                    let body_policy = body_discharge_policy_from_object_with_default(entry, false);
+                    let contract = entry
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("<unnamed>");
+                    log_body_discharge_policy_warnings(
+                        "self-check-lift-scoreboard",
+                        contract,
+                        &body_policy.warnings,
+                    );
+                    if body_policy.body_discharge_eligible {
                         body_discharge_eligible += 1;
                     } else {
-                        let reason = entry
-                            .get("bodyDischargeRefusalReason")
-                            .or_else(|| entry.get("body_discharge_refusal_reason"))
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("unspecified")
-                            .to_string();
+                        let reason = body_policy
+                            .body_discharge_refusal_reason
+                            .unwrap_or_else(|| "unspecified".to_string());
                         *body_discharge_ineligible.entry(reason).or_insert(0) += 1;
                     }
                 }
@@ -1511,6 +1547,46 @@ fn oracle_scoreboard(mint_json: &Value) -> OracleScoreboard {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::fmt::MakeWriter;
+
+    #[derive(Clone, Default)]
+    struct SharedLog(Arc<Mutex<Vec<u8>>>);
+
+    struct SharedLogWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedLogWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().expect("log lock").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for SharedLog {
+        type Writer = SharedLogWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            SharedLogWriter(self.0.clone())
+        }
+    }
+
+    fn capture_warn_log(f: impl FnOnce()) -> String {
+        let log = SharedLog::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::WARN)
+            .with_writer(log.clone())
+            .with_ansi(false)
+            .without_time()
+            .finish();
+        tracing::subscriber::with_default(subscriber, f);
+        let bytes = log.0.lock().expect("log lock").clone();
+        String::from_utf8(bytes).expect("log is utf8")
+    }
 
     fn mint_json(requested: bool, attempted: u64, resolved: u64) -> Value {
         json!({
@@ -1602,6 +1678,123 @@ mod tests {
             attempted,
             resolved,
         }
+    }
+
+    #[test]
+    fn lift_scoreboard_accepts_discharge_policy_body_reduction_allowed() {
+        let lift_json = json!({
+            "ir": [{
+                "kind": "function-contract",
+                "name": "total",
+                "dischargePolicy": {
+                    "bodyReduction": {
+                        "status": "allowed"
+                    }
+                }
+            }]
+        });
+
+        let (lift, _, _, _) = lift_scoreboards(&lift_json);
+
+        assert_eq!(lift.fn_contracts, 1);
+        assert_eq!(lift.body_discharge_eligible, 1);
+        assert!(lift.body_discharge_ineligible.is_empty());
+    }
+
+    #[test]
+    fn lift_scoreboard_accepts_discharge_policy_body_reduction_refused() {
+        let lift_json = json!({
+            "ir": [{
+                "kind": "function-contract",
+                "name": "axiom",
+                "dischargePolicy": {
+                    "bodyReduction": {
+                        "status": "refused",
+                        "reason": "totality-axiom"
+                    }
+                }
+            }]
+        });
+
+        let (lift, _, _, _) = lift_scoreboards(&lift_json);
+
+        assert_eq!(lift.fn_contracts, 1);
+        assert_eq!(lift.body_discharge_eligible, 0);
+        assert_eq!(lift.body_discharge_ineligible.get("totality-axiom"), Some(&1));
+    }
+
+    #[test]
+    fn lift_scoreboard_keeps_legacy_body_discharge_fields_on_disagreement() {
+        let lift_json = json!({
+            "ir": [{
+                "kind": "function-contract",
+                "name": "legacy_wins",
+                "bodyDischargeEligible": false,
+                "bodyDischargeRefusalReason": "legacy-refusal",
+                "dischargePolicy": {
+                    "bodyReduction": {
+                        "status": "allowed"
+                    }
+                }
+            }]
+        });
+
+        let (lift, _, _, _) = lift_scoreboards(&lift_json);
+
+        assert_eq!(lift.body_discharge_eligible, 0);
+        assert_eq!(lift.body_discharge_ineligible.get("legacy-refusal"), Some(&1));
+    }
+
+    #[test]
+    fn lift_scoreboard_warns_once_for_body_discharge_policy_disagreement() {
+        let lift_json = json!({
+            "ir": [{
+                "kind": "function-contract",
+                "name": "legacy_wins",
+                "bodyDischargeEligible": false,
+                "bodyDischargeRefusalReason": "legacy-refusal",
+                "dischargePolicy": {
+                    "bodyReduction": {
+                        "status": "allowed"
+                    }
+                }
+            }]
+        });
+
+        let logs = capture_warn_log(|| {
+            let _ = lift_scoreboards(&lift_json);
+        });
+
+        assert_eq!(
+            logs.matches("body-discharge-disagreement").count(),
+            1,
+            "one policy disagreement must warn once; logs:\n{logs}"
+        );
+    }
+
+    #[test]
+    fn lift_scoreboard_warns_for_malformed_body_discharge_policy() {
+        let lift_json = json!({
+            "ir": [{
+                "kind": "function-contract",
+                "name": "malformed_policy",
+                "bodyDischargeEligible": true,
+                "dischargePolicy": {
+                    "bodyReduction": {
+                        "status": 42
+                    }
+                }
+            }]
+        });
+
+        let logs = capture_warn_log(|| {
+            let _ = lift_scoreboards(&lift_json);
+        });
+
+        assert!(
+            logs.contains("body-discharge-malformed"),
+            "malformed policy must warn with tag; logs:\n{logs}"
+        );
     }
 
     #[test]

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -27,6 +27,10 @@ use std::sync::{Arc, OnceLock};
 use base64::Engine;
 use libprovekit::concept::panic_freedom;
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
+use provekit_claim_envelope::{
+    body_discharge_policy_from_object, body_discharge_policy_from_object_with_default,
+    BodyDischargePolicyWarning,
+};
 use provekit_ir_types::{EvidenceMemento, IrFormula, IrTerm, SourceKind};
 use provekit_lift_contracts::lift_file_with_docstring_evidence;
 use provekit_walk::emit::{
@@ -67,6 +71,37 @@ const SORT_STRING_CID: &str = "blake3-512:be8721d24849feb74c4721520bdba02d352a94
 const BODY_TEXT_CANONICALIZATION: &str = "trim-outer-whitespace-v1";
 
 static CONCEPT_OP_CIDS: OnceLock<BTreeMap<String, String>> = OnceLock::new();
+
+fn log_body_discharge_policy_warnings(
+    context: &str,
+    contract: &str,
+    warnings: &[BodyDischargePolicyWarning],
+) {
+    for warning in warnings {
+        match warning {
+            BodyDischargePolicyWarning::Disagreement {
+                legacy_eligible,
+                legacy_reason,
+                policy_eligible,
+                policy_reason,
+            } => warn!(
+                context = %context,
+                contract = %contract,
+                legacy_eligible = *legacy_eligible,
+                legacy_reason = ?legacy_reason,
+                policy_eligible = *policy_eligible,
+                policy_reason = ?policy_reason,
+                "body-discharge-disagreement: dischargePolicy/bodyDischarge* disagree; using legacy bodyDischarge*"
+            ),
+            BodyDischargePolicyWarning::Malformed { reason } => warn!(
+                context = %context,
+                contract = %contract,
+                reason = %reason,
+                "body-discharge-malformed: ignoring malformed dischargePolicy"
+            ),
+        }
+    }
+}
 
 fn main() -> io::Result<()> {
     // Logs go to stderr only; stdout is the JSON-RPC channel and must stay
@@ -3009,11 +3044,13 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
             if leaf.is_empty() {
                 continue;
             }
-            let body_discharge_eligible = binding
-                .get("bodyDischargeEligible")
-                .or_else(|| binding.get("body_discharge_eligible"))
-                .and_then(|v| v.as_bool())
-                .unwrap_or(true);
+            let body_policy = body_discharge_policy_from_object(binding);
+            log_body_discharge_policy_warnings(
+                "walk-lift-implication-contract-binding",
+                name,
+                &body_policy.warnings,
+            );
+            let body_discharge_eligible = body_policy.body_discharge_eligible;
             let library = binding
                 .get("library")
                 .and_then(|v| v.as_str())
@@ -3261,11 +3298,9 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
                             diagnostics.push(json!({
                                 "kind": "lift-note",
                                 "reason": "body-discharge-ineligible-bridged",
-                                "detail": ineligible
-                                    .get("bodyDischargeRefusalReason")
-                                    .or_else(|| ineligible.get("body_discharge_refusal_reason"))
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("callee contract is not body-discharge eligible; bridged anyway"),
+                                "detail": body_discharge_policy_from_object(ineligible)
+                                    .body_discharge_refusal_reason
+                                    .unwrap_or_else(|| "callee contract is not body-discharge eligible; bridged anyway".to_string()),
                                 "callee": cs.callee,
                                 "calleeCrate": key.0,
                                 "file": cs.file,
@@ -4400,17 +4435,16 @@ fn function_contract_lift(params: &Value) -> Result<Value, String> {
     let total_fnc = entries.len();
     let eligible = entries
         .iter()
-        .filter(|e| {
-            e.get("bodyDischargeEligible")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false)
-        })
+        .filter(|e| body_discharge_policy_from_object_with_default(e, false).body_discharge_eligible)
         .count();
-    let mut refusal_by_reason: std::collections::BTreeMap<&str, usize> =
+    let mut refusal_by_reason: std::collections::BTreeMap<String, usize> =
         std::collections::BTreeMap::new();
     for e in &entries {
-        if let Some(r) = e.get("bodyDischargeRefusalReason").and_then(|v| v.as_str()) {
-            *refusal_by_reason.entry(r).or_insert(0) += 1;
+        let body_policy = body_discharge_policy_from_object_with_default(e, false);
+        if !body_policy.body_discharge_eligible {
+            if let Some(reason) = body_policy.body_discharge_refusal_reason {
+                *refusal_by_reason.entry(reason).or_insert(0) += 1;
+            }
         }
     }
     let refusal_breakdown = refusal_by_reason
@@ -12941,6 +12975,52 @@ pub fn caller(x: i64) -> i64 {
         assert!(
             diags.is_empty(),
             "matched generic call should not gap: {diags:?}"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_treats_discharge_policy_refused_binding_as_ineligible() {
+        let src = r##"
+pub fn blocked(x: i64) -> i64 {
+    x
+}
+
+pub fn caller(x: i64) -> i64 {
+    blocked(x)
+}
+"##;
+        let root = temp_workspace("lift_implications_discharge_policy_refused");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(src_dir.join("lib.rs"), src).expect("write source");
+        let target_cid = "blake3-512:111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
+
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": ["."],
+            "contract_bindings": [{
+                "name": "blocked",
+                "contract_cid": target_cid,
+                "dischargePolicy": {
+                    "bodyReduction": {
+                        "status": "refused",
+                        "reason": "totality-axiom"
+                    }
+                }
+            }]
+        }))
+        .expect("lift implications");
+
+        let diagnostics = resp["diagnostics"].as_array().expect("diagnostics array");
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag["kind"] == "lift-note"
+                    && diag["reason"] == "body-discharge-ineligible-bridged"
+                    && diag["detail"] == "totality-axiom"
+            }),
+            "new dischargePolicy refused binding must be surfaced as ineligible: {diagnostics:?}"
         );
 
         let _ = fs::remove_dir_all(root);


### PR DESCRIPTION
## Summary

This is Slice 3 PR 2 for substrate shape promotion. It adds reader-only dual-read support for legacy `bodyDischargeEligible` / `bodyDischargeRefusalReason` and the new object-wrapped `dischargePolicy.bodyReduction` shape.

The new shape is:

```json
{
  "dischargePolicy": {
    "bodyReduction": {
      "status": "allowed"
    }
  }
}
```

or, when refused:

```json
{
  "dischargePolicy": {
    "bodyReduction": {
      "status": "refused",
      "reason": "totality-axiom"
    }
  }
}
```

Object-wrapped `bodyReduction` is intentional. It leaves room for future sibling reduction policies such as `headerReduction` or `axiomReduction` without turning `reason` into a floating sibling field.

## Behavior

- Centralizes body-discharge policy parsing in `provekit-claim-envelope`.
- Wires dual-read into `cmd_mint` dependency proof reloads and IR declarations.
- Wires dual-read into `cmd_self_check` lift scoreboard counting.
- Wires dual-read into `provekit-walk-rpc` implication binding and summary reads.
- Emits structured warn tags:
  - `body-discharge-disagreement` when old and new fields disagree.
  - `body-discharge-malformed` when the new shape is invalid.
- Keeps old Rust v1 fields authoritative on disagreement.
- Preserves snake_case legacy compatibility.
- Keeps production writers unchanged. Emission still uses only legacy `bodyDischargeEligible` and `bodyDischargeRefusalReason`; writer migration remains a migration-required tier.

## Path A And Floor

The shared helper lives in `provekit-claim-envelope`. Before insertion, I verified it is not in the `libprovekit` lift chain:

- `git grep -l "provekit-claim-envelope" implementations/rust/libprovekit/`: zero hits.
- `git grep -l "provekit_claim_envelope" implementations/rust/libprovekit/`: zero hits.

Golden stayed stable:

- `silentlyDropped`: 0
- `droppedSites`: []
- `panicSafe`: 5
- `reflexive`: 631
- `falsePass`: 0

## Tests

- `../../bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-claim-envelope body_discharge_policy -- --nocapture`
- `../../bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli lift_scoreboard_accepts_discharge_policy -- --nocapture`
- `../../bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli lift_scoreboard_keeps_legacy_body_discharge_fields_on_disagreement -- --nocapture`
- `../../bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli lift_scoreboard_warns -- --nocapture`
- `../../bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli mint_ir_document_accepts_discharge_policy_body_reduction_refused -- --nocapture`
- `../../bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli dependency_contract_bindings_accept_discharge_policy_body_reduction_refused -- --nocapture`
- `../../bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli dependency_contract_bindings_keep_default_body_discharge_metadata -- --nocapture`
- `../../bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli dependency_contract_bindings_include_serde_json_value_totality -- --nocapture`
- `../../bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-walk lift_implications_treats_discharge_policy_refused_binding_as_ineligible -- --nocapture`
- `../../bin/bcargo fmt --manifest-path implementations/rust/Cargo.toml --all`
- `git diff --check`
- `../../bin/bcargo build --manifest-path implementations/rust/Cargo.toml -p provekit-lift --bin provekit-lift`
- `../../bin/bcargo build --manifest-path implementations/rust/Cargo.toml -p provekit-walk --bin provekit-walk-rpc`
- `../../bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test self_check_golden -- --nocapture`
- `make check-macos-swift-rust-scope`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced standardized body discharge policy parsing with comprehensive validation and warning emission for malformed or conflicting policies across CLI tools.

* **Chores**
  * Refactored policy handling to use centralized parsing logic, improving consistency and maintainability.

* **Tests**
  * Extended test coverage for policy parsing, warning detection, and discharge eligibility tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->