### PR TITLE
[codex] Add effect-site annotation reader

### DIFF
--- a/implementations/rust/provekit-claim-envelope/src/lib.rs
+++ b/implementations/rust/provekit-claim-envelope/src/lib.rs
@@ -1178,14 +1178,14 @@ pub struct MintEffectSiteAnnotationArgs {
     pub signer_seed: Ed25519Seed,
 }
 
-fn effect_site_annotation_content_cid(args: &MintEffectSiteAnnotationArgs) -> String {
+fn effect_site_annotation_content_cid(args: &MintEffectSiteAnnotationArgs, line: i64) -> String {
     let mut sorted_inputs = args.input_cids.clone();
     sorted_inputs.sort();
     let input_arr: Vec<Arc<Value>> = sorted_inputs.into_iter().map(Value::string).collect();
     let content = Value::object([
         ("effectKind", Value::string(args.effect_kind.clone())),
         ("file", Value::string(args.file.clone())),
-        ("line", Value::integer(args.line as i64)),
+        ("line", Value::integer(line)),
         ("callee", Value::string(args.callee.clone())),
         ("status", Value::string(args.status.clone())),
         ("category", Value::string(args.category.clone())),
@@ -1239,8 +1239,13 @@ pub fn mint_effect_site_annotation(
             "mint_effect_site_annotation: producedBy and producedAt must not be empty".into(),
         ));
     }
+    let line = i64::try_from(args.line).map_err(|_| {
+        ClaimEnvelopeError::Other(
+            "mint_effect_site_annotation: line does not fit signed 64-bit integer".into(),
+        )
+    })?;
 
-    let header_cid = effect_site_annotation_content_cid(args);
+    let header_cid = effect_site_annotation_content_cid(args, line);
     let mut sorted_inputs = args.input_cids.clone();
     sorted_inputs.sort();
     let input_arr: Vec<Arc<Value>> = sorted_inputs.into_iter().map(Value::string).collect();
@@ -1250,7 +1255,7 @@ pub fn mint_effect_site_annotation(
         vec![
             ("effectKind".into(), Value::string(args.effect_kind.clone())),
             ("file".into(), Value::string(args.file.clone())),
-            ("line".into(), Value::integer(args.line as i64)),
+            ("line".into(), Value::integer(line)),
             ("callee".into(), Value::string(args.callee.clone())),
             ("status".into(), Value::string(args.status.clone())),
             ("category".into(), Value::string(args.category.clone())),
@@ -1282,6 +1287,23 @@ mod tests {
 
     fn dummy_seed() -> Ed25519Seed {
         [0x42; 32]
+    }
+
+    fn valid_effect_site_annotation_args() -> MintEffectSiteAnnotationArgs {
+        MintEffectSiteAnnotationArgs {
+            effect_kind: "concept:panic-freedom".into(),
+            file: "src/lib.rs".into(),
+            line: 42,
+            callee: "method:unwrap".into(),
+            status: "residue".into(),
+            category: "lock_poisoning_residue".into(),
+            tier_to_close: "irreducible".into(),
+            reason: "lock poisoning is runtime residue".into(),
+            input_cids: vec!["blake3-512:input".into()],
+            produced_by: "test".into(),
+            produced_at: "2026-06-01T00:00:00Z".into(),
+            signer_seed: dummy_seed(),
+        }
     }
 
     #[test]
@@ -1593,20 +1615,7 @@ mod tests {
 
     #[test]
     fn effect_site_annotation_mints_layered_panic_annotation_header() {
-        let args = MintEffectSiteAnnotationArgs {
-            effect_kind: "concept:panic-freedom".into(),
-            file: "src/lib.rs".into(),
-            line: 42,
-            callee: "method:unwrap".into(),
-            status: "residue".into(),
-            category: "lock_poisoning_residue".into(),
-            tier_to_close: "irreducible".into(),
-            reason: "lock poisoning is runtime residue".into(),
-            input_cids: vec!["blake3-512:input".into()],
-            produced_by: "test".into(),
-            produced_at: "2026-06-01T00:00:00Z".into(),
-            signer_seed: dummy_seed(),
-        };
+        let args = valid_effect_site_annotation_args();
 
         let minted = mint_effect_site_annotation(&args).expect("mint annotation");
         let env: serde_json::Value =
@@ -1653,6 +1662,40 @@ mod tests {
             Some("blake3-512:input")
         );
         assert!(minted.cid.starts_with("blake3-512:"));
+    }
+
+    #[test]
+    fn effect_site_annotation_input_cids_are_order_invariant() {
+        let mut first = valid_effect_site_annotation_args();
+        first.input_cids = vec!["blake3-512:a".into(), "blake3-512:b".into()];
+        let mut second = valid_effect_site_annotation_args();
+        second.input_cids = vec!["blake3-512:b".into(), "blake3-512:a".into()];
+
+        let first = mint_effect_site_annotation(&first).expect("mint first");
+        let second = mint_effect_site_annotation(&second).expect("mint second");
+        let first_env: serde_json::Value =
+            serde_json::from_slice(&first.canonical_bytes).expect("parse first");
+        let second_env: serde_json::Value =
+            serde_json::from_slice(&second.canonical_bytes).expect("parse second");
+
+        assert_eq!(first.cid, second.cid);
+        assert_eq!(
+            first_env.pointer("/header/cid"),
+            second_env.pointer("/header/cid")
+        );
+    }
+
+    #[test]
+    fn effect_site_annotation_rejects_line_values_that_do_not_fit_i64() {
+        let mut args = valid_effect_site_annotation_args();
+        args.line = usize::MAX;
+
+        let err = mint_effect_site_annotation(&args).expect_err("line overflow must fail");
+
+        assert!(
+            err.to_string().contains("line"),
+            "line conversion error should identify the field: {err}"
+        );
     }
 
     #[test]

--- a/implementations/rust/provekit-claim-envelope/src/lib.rs
+++ b/implementations/rust/provekit-claim-envelope/src/lib.rs
@@ -1159,6 +1159,123 @@ pub fn mint_witness(args: &MintWitnessArgs) -> Result<MintedEnvelope, ClaimEnvel
     ))
 }
 
+// =============================================================================
+// mint_effect_site_annotation
+// =============================================================================
+
+pub struct MintEffectSiteAnnotationArgs {
+    pub effect_kind: String,
+    pub file: String,
+    pub line: usize,
+    pub callee: String,
+    pub status: String,
+    pub category: String,
+    pub tier_to_close: String,
+    pub reason: String,
+    pub input_cids: Vec<String>,
+    pub produced_by: String,
+    pub produced_at: String,
+    pub signer_seed: Ed25519Seed,
+}
+
+fn effect_site_annotation_content_cid(args: &MintEffectSiteAnnotationArgs) -> String {
+    let mut sorted_inputs = args.input_cids.clone();
+    sorted_inputs.sort();
+    let input_arr: Vec<Arc<Value>> = sorted_inputs.into_iter().map(Value::string).collect();
+    let content = Value::object([
+        ("effectKind", Value::string(args.effect_kind.clone())),
+        ("file", Value::string(args.file.clone())),
+        ("line", Value::integer(args.line as i64)),
+        ("callee", Value::string(args.callee.clone())),
+        ("status", Value::string(args.status.clone())),
+        ("category", Value::string(args.category.clone())),
+        ("tierToClose", Value::string(args.tier_to_close.clone())),
+        ("reason", Value::string(args.reason.clone())),
+        ("inputCids", Value::array(input_arr)),
+    ]);
+    blake3_512_of(encode_jcs(&content).as_bytes())
+}
+
+pub fn mint_effect_site_annotation(
+    args: &MintEffectSiteAnnotationArgs,
+) -> Result<MintedEnvelope, ClaimEnvelopeError> {
+    if args.effect_kind.is_empty() {
+        return Err(ClaimEnvelopeError::Other(
+            "mint_effect_site_annotation: effectKind must not be empty".into(),
+        ));
+    }
+    if args.file.is_empty() {
+        return Err(ClaimEnvelopeError::Other(
+            "mint_effect_site_annotation: file must not be empty".into(),
+        ));
+    }
+    if args.callee.is_empty() {
+        return Err(ClaimEnvelopeError::Other(
+            "mint_effect_site_annotation: callee must not be empty".into(),
+        ));
+    }
+    if !matches!(args.status.as_str(), "residue" | "unproven") {
+        return Err(ClaimEnvelopeError::Other(
+            "mint_effect_site_annotation: status must be residue or unproven".into(),
+        ));
+    }
+    if args.category.is_empty() {
+        return Err(ClaimEnvelopeError::Other(
+            "mint_effect_site_annotation: category must not be empty".into(),
+        ));
+    }
+    if args.tier_to_close.is_empty() {
+        return Err(ClaimEnvelopeError::Other(
+            "mint_effect_site_annotation: tierToClose must not be empty".into(),
+        ));
+    }
+    if args.reason.is_empty() {
+        return Err(ClaimEnvelopeError::Other(
+            "mint_effect_site_annotation: reason must not be empty".into(),
+        ));
+    }
+    if args.produced_by.is_empty() || args.produced_at.is_empty() {
+        return Err(ClaimEnvelopeError::Other(
+            "mint_effect_site_annotation: producedBy and producedAt must not be empty".into(),
+        ));
+    }
+
+    let header_cid = effect_site_annotation_content_cid(args);
+    let mut sorted_inputs = args.input_cids.clone();
+    sorted_inputs.sort();
+    let input_arr: Vec<Arc<Value>> = sorted_inputs.into_iter().map(Value::string).collect();
+    let header = build_header(
+        "effect-site-annotation",
+        &header_cid,
+        vec![
+            ("effectKind".into(), Value::string(args.effect_kind.clone())),
+            ("file".into(), Value::string(args.file.clone())),
+            ("line".into(), Value::integer(args.line as i64)),
+            ("callee".into(), Value::string(args.callee.clone())),
+            ("status".into(), Value::string(args.status.clone())),
+            ("category".into(), Value::string(args.category.clone())),
+            (
+                "tierToClose".into(),
+                Value::string(args.tier_to_close.clone()),
+            ),
+            ("reason".into(), Value::string(args.reason.clone())),
+            ("inputCids".into(), Value::array(input_arr)),
+        ],
+    );
+    let metadata = Arc::new(Value::Object(vec![
+        ("producedBy".into(), Value::string(args.produced_by.clone())),
+        ("producedAt".into(), Value::string(args.produced_at.clone())),
+    ]));
+
+    Ok(assemble_layered(
+        header,
+        metadata,
+        &args.produced_at,
+        &args.signer_seed,
+        String::new(),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1472,5 +1589,101 @@ mod tests {
             Some("blake3-512:parent")
         );
         assert!(minted.cid.starts_with("blake3-512:"));
+    }
+
+    #[test]
+    fn effect_site_annotation_mints_layered_panic_annotation_header() {
+        let args = MintEffectSiteAnnotationArgs {
+            effect_kind: "concept:panic-freedom".into(),
+            file: "src/lib.rs".into(),
+            line: 42,
+            callee: "method:unwrap".into(),
+            status: "residue".into(),
+            category: "lock_poisoning_residue".into(),
+            tier_to_close: "irreducible".into(),
+            reason: "lock poisoning is runtime residue".into(),
+            input_cids: vec!["blake3-512:input".into()],
+            produced_by: "test".into(),
+            produced_at: "2026-06-01T00:00:00Z".into(),
+            signer_seed: dummy_seed(),
+        };
+
+        let minted = mint_effect_site_annotation(&args).expect("mint annotation");
+        let env: serde_json::Value =
+            serde_json::from_slice(&minted.canonical_bytes).expect("parse annotation");
+
+        assert_eq!(
+            env.pointer("/header/kind").and_then(|v| v.as_str()),
+            Some("effect-site-annotation")
+        );
+        assert_eq!(
+            env.pointer("/header/effectKind").and_then(|v| v.as_str()),
+            Some("concept:panic-freedom")
+        );
+        assert_eq!(
+            env.pointer("/header/file").and_then(|v| v.as_str()),
+            Some("src/lib.rs")
+        );
+        assert_eq!(
+            env.pointer("/header/line").and_then(|v| v.as_u64()),
+            Some(42)
+        );
+        assert_eq!(
+            env.pointer("/header/callee").and_then(|v| v.as_str()),
+            Some("method:unwrap")
+        );
+        assert_eq!(
+            env.pointer("/header/status").and_then(|v| v.as_str()),
+            Some("residue")
+        );
+        assert_eq!(
+            env.pointer("/header/category").and_then(|v| v.as_str()),
+            Some("lock_poisoning_residue")
+        );
+        assert_eq!(
+            env.pointer("/header/tierToClose").and_then(|v| v.as_str()),
+            Some("irreducible")
+        );
+        assert_eq!(
+            env.pointer("/header/reason").and_then(|v| v.as_str()),
+            Some("lock poisoning is runtime residue")
+        );
+        assert_eq!(
+            env.pointer("/header/inputCids/0").and_then(|v| v.as_str()),
+            Some("blake3-512:input")
+        );
+        assert!(minted.cid.starts_with("blake3-512:"));
+    }
+
+    #[test]
+    fn effect_site_annotation_rejects_missing_required_fields_and_invalid_status() {
+        let mut args = MintEffectSiteAnnotationArgs {
+            effect_kind: "concept:panic-freedom".into(),
+            file: "src/lib.rs".into(),
+            line: 42,
+            callee: "method:unwrap".into(),
+            status: "maybe".into(),
+            category: "lock_poisoning_residue".into(),
+            tier_to_close: "irreducible".into(),
+            reason: "lock poisoning is runtime residue".into(),
+            input_cids: Vec::new(),
+            produced_by: "test".into(),
+            produced_at: "2026-06-01T00:00:00Z".into(),
+            signer_seed: dummy_seed(),
+        };
+
+        let err = mint_effect_site_annotation(&args).expect_err("invalid status must fail");
+        assert!(
+            err.to_string().contains("status"),
+            "error should name invalid status: {err}"
+        );
+
+        args.status = "unproven".into();
+        args.effect_kind.clear();
+        let err = mint_effect_site_annotation(&args).expect_err("missing effectKind must fail");
+        assert!(
+            err.to_string().contains("effectKind"),
+            "error should name missing effectKind: {err}"
+        );
     }
 }

--- a/implementations/rust/provekit-cli/src/cmd_self_check.rs
+++ b/implementations/rust/provekit-cli/src/cmd_self_check.rs
@@ -1342,7 +1342,8 @@ fn panic_census(
     unbridged: Vec<Site>,
     annotations: BTreeMap<(String, usize, String), PanicSiteAnnotation>,
 ) -> Result<Vec<PanicCensusEntry>, String> {
-    let mut by_site: BTreeMap<(String, usize, String), PanicCensusEntry> = BTreeMap::new();
+    let mut by_site: BTreeMap<(Option<String>, String, usize, String), PanicCensusEntry> =
+        BTreeMap::new();
     if let Some(rows) = prove_json.get("rows").and_then(|v| v.as_array()) {
         for row in rows {
             if !row
@@ -1384,25 +1385,36 @@ fn panic_census(
             } else {
                 ("unproven".to_string(), row_reason(row))
             };
-            by_site.insert(
-                (file.clone(), line, callee.clone()),
-                PanicCensusEntry {
-                    file,
-                    line,
-                    callee,
-                    callsite_bundle_cid,
-                    status,
-                    reason,
-                    category: None,
-                    tier_to_close: None,
-                },
+            let key = (
+                callsite_bundle_cid.clone(),
+                file.clone(),
+                line,
+                callee.clone(),
             );
+            if by_site
+                .insert(
+                    key,
+                    PanicCensusEntry {
+                        file,
+                        line,
+                        callee,
+                        callsite_bundle_cid,
+                        status,
+                        reason,
+                        category: None,
+                        tier_to_close: None,
+                    },
+                )
+                .is_some()
+            {
+                return Err("duplicate panic census row after bundle scoping".to_string());
+            }
         }
     }
 
     for site in unbridged {
         by_site
-            .entry((site.file.clone(), site.line, site.callee.clone()))
+            .entry((None, site.file.clone(), site.line, site.callee.clone()))
             .or_insert(PanicCensusEntry {
                 file: site.file,
                 line: site.line,
@@ -1416,7 +1428,8 @@ fn panic_census(
     }
 
     for (key, annotation) in annotations {
-        let Some(entry) = by_site.get_mut(&key) else {
+        let scoped_key = (None, key.0, key.1, key.2);
+        let Some(entry) = by_site.get_mut(&scoped_key) else {
             return Err(format!(
                 "stale panic-site annotation for {}:{} {}",
                 annotation.file, annotation.line, annotation.callee
@@ -1434,7 +1447,16 @@ fn panic_census(
         entry.reason = annotation.reason;
     }
 
-    Ok(by_site.into_values().collect())
+    let mut census: Vec<_> = by_site.into_values().collect();
+    census.sort_by(|a, b| {
+        (&a.file, a.line, &a.callee, &a.callsite_bundle_cid).cmp(&(
+            &b.file,
+            b.line,
+            &b.callee,
+            &b.callsite_bundle_cid,
+        ))
+    });
+    Ok(census)
 }
 
 fn row_reason(row: &Value) -> String {
@@ -1738,6 +1760,21 @@ mod tests {
                 .expect("row object")
                 .insert("dischargeMethod".to_string(), json!(method));
         }
+        row
+    }
+
+    fn panic_row_with_bundle(
+        bundle: &str,
+        file: &str,
+        line: usize,
+        callee: &str,
+        status: &str,
+        method: Option<&str>,
+    ) -> Value {
+        let mut row = panic_row(file, line, callee, status, method);
+        row.as_object_mut()
+            .expect("row object")
+            .insert("callsiteBundleCid".to_string(), json!(bundle));
         row
     }
 
@@ -2486,6 +2523,59 @@ reason = "this row exists only in prove output"
         assert!(
             row.get("callsiteBundleCid").is_none(),
             "self-check panicCensus must not expose prove-row bundle metadata"
+        );
+    }
+
+    #[test]
+    fn panic_census_preserves_bundle_scoped_duplicate_sites_for_runtime_join() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let mint = mint_json_with_diagnostics(vec![]);
+        let prove = json!({
+            "rows": [
+                panic_row_with_bundle(
+                    "blake3-512:bundle-a",
+                    "src/lib.rs",
+                    25,
+                    "method:unwrap",
+                    "undecidable",
+                    None
+                ),
+                panic_row_with_bundle(
+                    "blake3-512:bundle-b",
+                    "src/lib.rs",
+                    25,
+                    "method:unwrap",
+                    "undecidable",
+                    None
+                )
+            ]
+        });
+
+        let scoreboard = build_scoreboard_with_runtime_annotations(
+            "target",
+            td.path(),
+            &mint,
+            &prove,
+            crate::panic_annotations_runtime::AnnotationCheckMode::Strict,
+        )
+        .expect("scoreboard");
+
+        assert_eq!(
+            scoreboard.panic_census.len(),
+            2,
+            "bundle-scoped panic sites must not collapse before runtime annotation join"
+        );
+        let bundles: std::collections::BTreeSet<_> = scoreboard
+            .panic_census
+            .iter()
+            .filter_map(|entry| entry.callsite_bundle_cid.as_deref())
+            .collect();
+        assert_eq!(
+            bundles,
+            std::collections::BTreeSet::from([
+                "blake3-512:bundle-a",
+                "blake3-512:bundle-b",
+            ])
         );
     }
 

--- a/implementations/rust/provekit-cli/src/cmd_self_check.rs
+++ b/implementations/rust/provekit-cli/src/cmd_self_check.rs
@@ -11,7 +11,8 @@ use provekit_canonicalizer::blake3_512_of;
 use provekit_claim_envelope::{
     body_discharge_policy_from_object_with_default, BodyDischargePolicyWarning,
 };
-use provekit_verifier::load_all_proofs::ProofBytes;
+use provekit_verifier::load_all_proofs::{self, ProofBytes};
+use provekit_verifier::types::{EffectSiteAnnotation, LoadError, MementoPool};
 use serde::Serialize;
 use serde_json::Value;
 use tracing::{error, info, warn};
@@ -20,7 +21,7 @@ use crate::floor_runtime_check::{
     floor_runtime_check, FloorCheckMode, FloorCheckStatus, FloorRuntimeCheck, FloorSignals,
 };
 use crate::panic_annotations_runtime::{
-    annotation_runtime_check, AnnotationCheckMode, PanicCensusRow,
+    annotation_runtime_check_with_mementos, AnnotationCheckMode, PanicCensusRow,
 };
 
 #[derive(Parser, Debug, Clone)]
@@ -116,6 +117,8 @@ struct PanicCensusEntry {
     file: String,
     line: usize,
     callee: String,
+    #[serde(skip)]
+    callsite_bundle_cid: Option<String>,
     status: String,
     reason: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -330,11 +333,13 @@ fn run_inner(args: &SelfCheckArgs) -> Result<SelfCheckScoreboard, String> {
     };
     info!("self-check: prove complete; building scoreboard");
 
-    let scoreboard = build_scoreboard_with_runtime_annotations(
+    let annotation_mementos = load_effect_site_annotation_mementos(&target_abs, &target_out)?;
+    let scoreboard = build_scoreboard_with_runtime_annotations_and_mementos(
         &target_rel,
         &target_abs,
         &target_mint.json,
         &prove_json,
+        &annotation_mementos,
         AnnotationCheckMode::Strict,
     )?;
     enforce_floor_runtime_checks(&scoreboard, &prove_json)?;
@@ -486,6 +491,58 @@ fn count_proof_files(path: &Path) -> Result<usize, String> {
         }
     }
     Ok(count)
+}
+
+fn proof_files_in(path: &Path) -> Result<Vec<PathBuf>, String> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let mut files = Vec::new();
+    for entry in fs::read_dir(path).map_err(|e| format!("read {}: {e}", path.display()))? {
+        let entry = entry.map_err(|e| format!("read {} entry: {e}", path.display()))?;
+        let path = entry.path();
+        if path.extension() == Some(OsStr::new("proof")) {
+            files.push(path);
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn load_effect_site_annotation_mementos(
+    target_abs: &Path,
+    target_out: &Path,
+) -> Result<Vec<EffectSiteAnnotation>, String> {
+    let target_proofs = proof_files_in(target_out)?;
+    let pool = load_all_proofs::run_with_files(target_abs, &target_proofs);
+    effect_site_annotations_from_pool(pool)
+}
+
+fn effect_site_annotations_from_pool(
+    pool: MementoPool,
+) -> Result<Vec<EffectSiteAnnotation>, String> {
+    let annotation_errors = pool
+        .load_errors
+        .iter()
+        .filter(|error| is_effect_site_annotation_load_error(error))
+        .map(|error| format!("{}: {}", error.proof_path, error.reason))
+        .collect::<Vec<_>>();
+    if !annotation_errors.is_empty() {
+        let errors = annotation_errors.join("; ");
+        return Err(format!("effect-site annotation proof load failed: {errors}"));
+    }
+    Ok(pool
+        .panic_effect_site_annotations
+        .values()
+        .cloned()
+        .collect())
+}
+
+fn is_effect_site_annotation_load_error(error: &LoadError) -> bool {
+    error.reason.starts_with("[effect-site-annotation]")
+        || error
+            .reason
+            .starts_with("[effect-site-annotation-duplicate]")
 }
 
 impl ImportsProofSetSnapshot {
@@ -972,11 +1029,30 @@ fn build_scoreboard(
     })
 }
 
+#[cfg(test)]
 fn build_scoreboard_with_runtime_annotations(
     target_rel: &str,
     target_path: &Path,
     mint_json: &Value,
     prove_json: &Value,
+    doctor_mode: AnnotationCheckMode,
+) -> Result<SelfCheckScoreboard, String> {
+    build_scoreboard_with_runtime_annotations_and_mementos(
+        target_rel,
+        target_path,
+        mint_json,
+        prove_json,
+        &[],
+        doctor_mode,
+    )
+}
+
+fn build_scoreboard_with_runtime_annotations_and_mementos(
+    target_rel: &str,
+    target_path: &Path,
+    mint_json: &Value,
+    prove_json: &Value,
+    memento_annotations: &[EffectSiteAnnotation],
     doctor_mode: AnnotationCheckMode,
 ) -> Result<SelfCheckScoreboard, String> {
     let catalog_cid = mint_json
@@ -996,13 +1072,18 @@ fn build_scoreboard_with_runtime_annotations(
         .iter()
         .map(panic_census_row_from_entry)
         .collect();
-    let annotation_outcome = annotation_runtime_check(target_path, &projected_rows, doctor_mode)
-        .map_err(|error| {
+    let annotation_outcome = annotation_runtime_check_with_mementos(
+        target_path,
+        &projected_rows,
+        memento_annotations,
+        doctor_mode,
+    )
+    .map_err(|error| {
             format!(
                 "panic annotation runtime check failed: {}; evidence={}",
                 error, error.check.evidence
             )
-        })?;
+    })?;
     let annotation_check = &annotation_outcome.check;
     info!(
         check_id = %annotation_check.id,
@@ -1047,6 +1128,7 @@ fn panic_census_row_from_entry(entry: &PanicCensusEntry) -> PanicCensusRow {
         file: entry.file.clone(),
         line: entry.line,
         callee: entry.callee.clone(),
+        callsite_bundle_cid: entry.callsite_bundle_cid.clone(),
         status: entry.status.clone(),
         reason: entry.reason.clone(),
         category: entry.category.clone(),
@@ -1059,6 +1141,7 @@ fn panic_census_entry_from_row(row: &PanicCensusRow) -> PanicCensusEntry {
         file: row.file.clone(),
         line: row.line,
         callee: row.callee.clone(),
+        callsite_bundle_cid: row.callsite_bundle_cid.clone(),
         status: row.status.clone(),
         reason: row.reason.clone(),
         category: row.category.clone(),
@@ -1281,6 +1364,11 @@ fn panic_census(
                 .or_else(|| row.get("bridge").and_then(|v| v.as_str()))
                 .unwrap_or("unknown")
                 .to_string();
+            let callsite_bundle_cid = row
+                .get("callsiteBundleCid")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
             let method = row.get("dischargeMethod").and_then(|v| v.as_str());
             let row_status = row.get("status").and_then(|v| v.as_str()).unwrap_or("");
             let (status, reason) = if row_status == "discharged" && method == Some("panic-safe") {
@@ -1302,6 +1390,7 @@ fn panic_census(
                     file,
                     line,
                     callee,
+                    callsite_bundle_cid,
                     status,
                     reason,
                     category: None,
@@ -1318,6 +1407,7 @@ fn panic_census(
                 file: site.file,
                 line: site.line,
                 callee: site.callee,
+                callsite_bundle_cid: None,
                 status: "unproven".to_string(),
                 reason: site.reason,
                 category: None,
@@ -1678,6 +1768,59 @@ mod tests {
             attempted,
             resolved,
         }
+    }
+
+    fn load_error(reason: &str) -> LoadError {
+        LoadError {
+            proof_path: "synthetic.proof".to_string(),
+            reason: reason.to_string(),
+        }
+    }
+
+    #[test]
+    fn effect_site_annotation_scan_tolerates_unrelated_load_errors() {
+        let mut pool = MementoPool::default();
+        pool.load_errors.push(load_error(
+            "duplicate contract name `read_response` resolves to two CIDs",
+        ));
+
+        let annotations = effect_site_annotations_from_pool(pool).expect("unrelated errors");
+
+        assert!(annotations.is_empty());
+    }
+
+    #[test]
+    fn effect_site_annotation_scan_fails_on_tagged_annotation_errors() {
+        let mut pool = MementoPool::default();
+        pool.load_errors.push(load_error(
+            "[effect-site-annotation] blake3-512:abc: missing or invalid `callee`",
+        ));
+
+        let err = effect_site_annotations_from_pool(pool)
+            .expect_err("annotation load errors must fail");
+
+        assert!(err.contains("[effect-site-annotation]"), "{err}");
+        assert!(err.contains("callee"), "{err}");
+    }
+
+    #[test]
+    fn effect_site_annotation_scan_reports_only_tagged_errors_when_mixed() {
+        let mut pool = MementoPool::default();
+        pool.load_errors.push(load_error(
+            "duplicate contract name `string_field` resolves to two CIDs",
+        ));
+        pool.load_errors.push(load_error(
+            "[effect-site-annotation-duplicate] for (bundle, src/lib.rs, 10, method:unwrap)",
+        ));
+
+        let err =
+            effect_site_annotations_from_pool(pool).expect_err("tagged mixed error must fail");
+
+        assert!(
+            err.contains("[effect-site-annotation-duplicate]"),
+            "{err}"
+        );
+        assert!(!err.contains("string_field"), "{err}");
     }
 
     #[test]
@@ -2296,6 +2439,53 @@ reason = "this row exists only in prove output"
         assert_eq!(
             scoreboard.panic_census[0].tier_to_close.as_deref(),
             Some("future totality proof")
+        );
+    }
+
+    #[test]
+    fn self_check_scoreboard_does_not_serialize_callsite_bundle_cid_in_panic_census() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let mint = mint_json_with_diagnostics(vec![]);
+        let prove = json!({
+            "rows": [{
+                "file": "src/generated_by_prove.rs",
+                "line": 44,
+                "callee": "method:unwrap",
+                "panicSite": true,
+                "status": "undecidable",
+                "reason": "synthetic panic row",
+                "callsiteBundleCid": "blake3-512:dependency-bundle"
+            }]
+        });
+        let annotations = vec![provekit_verifier::types::EffectSiteAnnotation {
+            effect_kind: "concept:panic-freedom".to_string(),
+            file: "src/generated_by_prove.rs".to_string(),
+            line: 44,
+            callee: "method:unwrap".to_string(),
+            status: "unproven".to_string(),
+            category: "D-lib".to_string(),
+            tier_to_close: "future totality proof".to_string(),
+            reason: "dependency memento annotation".to_string(),
+            memento_cid: "blake3-512:annotation".to_string(),
+            bundle_cid: "blake3-512:dependency-bundle".to_string(),
+        }];
+
+        let scoreboard = build_scoreboard_with_runtime_annotations_and_mementos(
+            "target",
+            td.path(),
+            &mint,
+            &prove,
+            &annotations,
+            crate::panic_annotations_runtime::AnnotationCheckMode::Strict,
+        )
+        .expect("scoreboard");
+        let rendered = serde_json::to_value(&scoreboard).expect("scoreboard json");
+        let row = &rendered["panicCensus"][0];
+
+        assert_eq!(row["category"], "D-lib");
+        assert!(
+            row.get("callsiteBundleCid").is_none(),
+            "self-check panicCensus must not expose prove-row bundle metadata"
         );
     }
 

--- a/implementations/rust/provekit-cli/src/panic_annotations_runtime.rs
+++ b/implementations/rust/provekit-cli/src/panic_annotations_runtime.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
+use provekit_verifier::types::EffectSiteAnnotation;
 use serde::Serialize;
 use serde_json::{json, Value};
 
@@ -78,6 +79,8 @@ pub struct PanicCensusRow {
     pub file: String,
     pub line: usize,
     pub callee: String,
+    #[serde(rename = "callsiteBundleCid", skip_serializing_if = "Option::is_none")]
+    pub callsite_bundle_cid: Option<String>,
     pub status: String,
     pub reason: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -109,6 +112,7 @@ impl std::error::Error for AnnotationCheckError {}
 
 #[derive(Debug, Clone)]
 struct RuntimeAnnotation {
+    bundle_cid: Option<String>,
     file: String,
     line: usize,
     callee: String,
@@ -121,6 +125,12 @@ struct RuntimeAnnotation {
 impl RuntimeAnnotation {
     fn key(&self) -> (String, usize, String) {
         (self.file.clone(), self.line, self.callee.clone())
+    }
+
+    fn scoped_key(&self) -> Option<(String, String, usize, String)> {
+        self.bundle_cid
+            .as_ref()
+            .map(|bundle| (bundle.clone(), self.file.clone(), self.line, self.callee.clone()))
     }
 }
 
@@ -136,8 +146,17 @@ pub fn annotation_runtime_check(
     panic_census: &[PanicCensusRow],
     mode: AnnotationCheckMode,
 ) -> Result<AnnotationRuntimeOutcome, AnnotationCheckError> {
+    annotation_runtime_check_with_mementos(target_path, panic_census, &[], mode)
+}
+
+pub fn annotation_runtime_check_with_mementos(
+    target_path: &Path,
+    panic_census: &[PanicCensusRow],
+    memento_annotations: &[EffectSiteAnnotation],
+    mode: AnnotationCheckMode,
+) -> Result<AnnotationRuntimeOutcome, AnnotationCheckError> {
     let manifest = runtime_annotation_manifest(target_path);
-    if !manifest.present {
+    if !manifest.present && memento_annotations.is_empty() {
         return Ok(AnnotationRuntimeOutcome {
             rows: panic_census.to_vec(),
             check: AnnotationRuntimeCheck::pass_with_severity(
@@ -152,6 +171,8 @@ pub fn annotation_runtime_check(
     }
 
     let mut issues = manifest.issues;
+    let memento_annotations = runtime_annotations_from_mementos(memento_annotations, &mut issues);
+    let memento_annotation_count = memento_annotations.len();
     let mut rows = panic_census.to_vec();
     let before_k = count_proven_rows(&rows);
     let row_index: BTreeMap<(String, usize, String), usize> = rows
@@ -159,35 +180,39 @@ pub fn annotation_runtime_check(
         .enumerate()
         .map(|(index, row)| ((row.file.clone(), row.line, row.callee.clone()), index))
         .collect();
+    let scoped_row_index: BTreeMap<(String, String, usize, String), usize> = rows
+        .iter()
+        .enumerate()
+        .filter_map(|(index, row)| {
+            row.callsite_bundle_cid.as_ref().map(|bundle| {
+                (
+                    (bundle.clone(), row.file.clone(), row.line, row.callee.clone()),
+                    index,
+                )
+            })
+        })
+        .collect();
+    let mut annotated_rows = BTreeMap::<usize, String>::new();
 
     for annotation in manifest.annotations {
-        let key = annotation.key();
-        let Some(index) = row_index.get(&key).copied() else {
-            issues.push(annotation_issue(
-                "stale",
-                &format!(
-                    "stale panic-site annotation for {}:{} {}",
-                    annotation.file, annotation.line, annotation.callee
-                ),
-                Some(&annotation),
-            ));
-            continue;
-        };
-        if rows[index].status == "proven" {
-            issues.push(annotation_issue(
-                "proven_site_collision",
-                &format!(
-                    "proven panic-site annotation for {}:{} {}",
-                    annotation.file, annotation.line, annotation.callee
-                ),
-                Some(&annotation),
-            ));
-            continue;
-        }
-        rows[index].status = annotation.status;
-        rows[index].category = Some(annotation.category);
-        rows[index].tier_to_close = Some(annotation.tier_to_close);
-        rows[index].reason = annotation.reason;
+        apply_runtime_annotation(
+            annotation,
+            &row_index,
+            &scoped_row_index,
+            &mut annotated_rows,
+            &mut rows,
+            &mut issues,
+        );
+    }
+    for annotation in memento_annotations {
+        apply_runtime_annotation(
+            annotation,
+            &row_index,
+            &scoped_row_index,
+            &mut annotated_rows,
+            &mut rows,
+            &mut issues,
+        );
     }
 
     let after_k = count_proven_rows(&rows);
@@ -201,8 +226,9 @@ pub fn annotation_runtime_check(
     }
 
     let evidence = json!({
-        "manifestPresent": true,
+        "manifestPresent": manifest.present,
         "rowCount": panic_census.len(),
+        "mementoAnnotationCount": memento_annotation_count,
         "annotatedRowCount": rows
             .iter()
             .filter(|row| row.category.is_some() || row.tier_to_close.is_some())
@@ -244,6 +270,105 @@ pub fn annotation_runtime_check(
             ),
         })
     }
+}
+
+fn runtime_annotations_from_mementos(
+    annotations: &[EffectSiteAnnotation],
+    issues: &mut Vec<Value>,
+) -> Vec<RuntimeAnnotation> {
+    let mut out = Vec::new();
+    let mut seen = BTreeMap::<(String, String, usize, String), String>::new();
+    for annotation in annotations {
+        let key = (
+            annotation.bundle_cid.clone(),
+            annotation.file.clone(),
+            annotation.line,
+            annotation.callee.clone(),
+        );
+        if let Some(previous) = seen.insert(key.clone(), annotation.memento_cid.clone()) {
+            issues.push(json!({
+                "kind": "effect-site-annotation-duplicate",
+                "bundleCid": key.0,
+                "file": key.1,
+                "line": key.2,
+                "callee": key.3,
+                "firstMementoCid": previous,
+                "secondMementoCid": annotation.memento_cid,
+            }));
+            continue;
+        }
+        out.push(RuntimeAnnotation {
+            bundle_cid: Some(annotation.bundle_cid.clone()),
+            file: annotation.file.clone(),
+            line: annotation.line,
+            callee: annotation.callee.clone(),
+            status: annotation.status.clone(),
+            category: annotation.category.clone(),
+            tier_to_close: annotation.tier_to_close.clone(),
+            reason: annotation.reason.clone(),
+        });
+    }
+    out
+}
+
+fn apply_runtime_annotation(
+    annotation: RuntimeAnnotation,
+    row_index: &BTreeMap<(String, usize, String), usize>,
+    scoped_row_index: &BTreeMap<(String, String, usize, String), usize>,
+    annotated_rows: &mut BTreeMap<usize, String>,
+    rows: &mut [PanicCensusRow],
+    issues: &mut Vec<Value>,
+) {
+    let index = match annotation.scoped_key() {
+        Some(scoped_key) => scoped_row_index.get(&scoped_key).copied(),
+        None => row_index.get(&annotation.key()).copied(),
+    };
+    let Some(index) = index else {
+        issues.push(annotation_issue(
+            "stale",
+            &format!(
+                "stale panic-site annotation for {}:{} {}",
+                annotation.file, annotation.line, annotation.callee
+            ),
+            Some(&annotation),
+        ));
+        return;
+    };
+    if let Some(previous) = annotated_rows.get(&index) {
+        issues.push(annotation_issue(
+            "effect-site-annotation-duplicate",
+            &format!(
+                "duplicate panic-site annotation for {}:{} {}; first source {previous}",
+                annotation.file, annotation.line, annotation.callee
+            ),
+            Some(&annotation),
+        ));
+        return;
+    }
+    if rows[index].status == "proven" {
+        issues.push(annotation_issue(
+            "proven_site_collision",
+            &format!(
+                "proven panic-site annotation for {}:{} {}",
+                annotation.file, annotation.line, annotation.callee
+            ),
+            Some(&annotation),
+        ));
+        return;
+    }
+    annotated_rows.insert(index, annotation_source(&annotation));
+    rows[index].status = annotation.status;
+    rows[index].category = Some(annotation.category);
+    rows[index].tier_to_close = Some(annotation.tier_to_close);
+    rows[index].reason = annotation.reason;
+}
+
+fn annotation_source(annotation: &RuntimeAnnotation) -> String {
+    annotation
+        .bundle_cid
+        .as_ref()
+        .map(|bundle| format!("memento:{bundle}"))
+        .unwrap_or_else(|| "manifest".to_string())
 }
 
 fn runtime_annotation_manifest(target_path: &Path) -> RuntimeAnnotationManifest {
@@ -386,6 +511,7 @@ fn runtime_annotation_from_value(
         })?;
     let reason = runtime_annotation_str(entry, "reason", table, index)?;
     Ok(RuntimeAnnotation {
+        bundle_cid: None,
         file,
         line,
         callee,
@@ -433,6 +559,9 @@ fn annotation_issue(kind: &str, detail: &str, annotation: Option<&RuntimeAnnotat
         "detail": detail,
     });
     if let (Some(obj), Some(annotation)) = (issue.as_object_mut(), annotation) {
+        if let Some(bundle) = &annotation.bundle_cid {
+            obj.insert("bundleCid".to_string(), Value::String(bundle.clone()));
+        }
         obj.insert("file".to_string(), Value::String(annotation.file.clone()));
         obj.insert("line".to_string(), json!(annotation.line));
         obj.insert(
@@ -470,10 +599,54 @@ mod tests {
             file: file.to_string(),
             line,
             callee: callee.to_string(),
+            callsite_bundle_cid: None,
             status: status.to_string(),
             reason: "synthetic runtime row".to_string(),
             category: None,
             tier_to_close: None,
+        }
+    }
+
+    fn runtime_panic_row_with_bundle(
+        bundle: &str,
+        file: &str,
+        line: usize,
+        callee: &str,
+        status: &str,
+    ) -> PanicCensusRow {
+        PanicCensusRow {
+            file: file.to_string(),
+            line,
+            callee: callee.to_string(),
+            status: status.to_string(),
+            reason: "synthetic runtime row".to_string(),
+            category: None,
+            tier_to_close: None,
+            callsite_bundle_cid: Some(bundle.to_string()),
+        }
+    }
+
+    fn effect_annotation(
+        bundle: &str,
+        file: &str,
+        line: usize,
+        callee: &str,
+        status: &str,
+        category: &str,
+        tier_to_close: &str,
+        reason: &str,
+    ) -> EffectSiteAnnotation {
+        EffectSiteAnnotation {
+            effect_kind: "concept:panic-freedom".to_string(),
+            file: file.to_string(),
+            line,
+            callee: callee.to_string(),
+            status: status.to_string(),
+            category: category.to_string(),
+            tier_to_close: tier_to_close.to_string(),
+            reason: reason.to_string(),
+            memento_cid: format!("blake3-512:memento-{line}"),
+            bundle_cid: bundle.to_string(),
         }
     }
 
@@ -835,6 +1008,266 @@ reason = "runtime residue"
             .count();
 
         assert_eq!(before, after, "annotation must not move K");
+    }
+
+    #[test]
+    fn annotation_runtime_memento_annotation_enriches_matching_bundle_row() {
+        let td = tempfile::tempdir().unwrap();
+        let rows = vec![runtime_panic_row_with_bundle(
+            "blake3-512:dep-bundle",
+            "src/lib.rs",
+            10,
+            "method:expect",
+            "unproven",
+        )];
+        let annotations = vec![effect_annotation(
+            "blake3-512:dep-bundle",
+            "src/lib.rs",
+            10,
+            "method:expect",
+            "residue",
+            "platform_semantics_runtime_residue",
+            "irreducible",
+            "dependency memento residue",
+        )];
+
+        let outcome = annotation_runtime_check_with_mementos(
+            td.path(),
+            &rows,
+            &annotations,
+            AnnotationCheckMode::Strict,
+        )
+        .expect("memento annotation");
+        let row = &outcome.rows[0];
+
+        assert_eq!(row.status, "residue");
+        assert_eq!(
+            row.category.as_deref(),
+            Some("platform_semantics_runtime_residue")
+        );
+        assert_eq!(row.reason, "dependency memento residue");
+    }
+
+    #[test]
+    fn annotation_runtime_manifest_and_memento_distinct_keys_union() {
+        let td = tempfile::tempdir().unwrap();
+        write_runtime_annotation_manifest(
+            td.path(),
+            r#"
+[[residue]]
+file = "src/local.rs"
+line = 1
+callee = "method:unwrap"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "local manifest residue"
+"#,
+        );
+        let rows = vec![
+            runtime_panic_row("src/local.rs", 1, "method:unwrap", "unproven"),
+            runtime_panic_row_with_bundle(
+                "blake3-512:dep-bundle",
+                "src/dep.rs",
+                2,
+                "method:expect",
+                "unproven",
+            ),
+        ];
+        let annotations = vec![effect_annotation(
+            "blake3-512:dep-bundle",
+            "src/dep.rs",
+            2,
+            "method:expect",
+            "unproven",
+            "D-lib",
+            "future totality proof",
+            "dependency memento tier",
+        )];
+
+        let outcome = annotation_runtime_check_with_mementos(
+            td.path(),
+            &rows,
+            &annotations,
+            AnnotationCheckMode::Strict,
+        )
+        .expect("union");
+
+        assert_eq!(outcome.rows.len(), 2);
+        assert_eq!(outcome.rows[0].category.as_deref(), Some("lock_poisoning_residue"));
+        assert_eq!(outcome.rows[1].category.as_deref(), Some("D-lib"));
+    }
+
+    #[test]
+    fn annotation_runtime_manifest_and_memento_same_key_fails_closed() {
+        let td = tempfile::tempdir().unwrap();
+        write_runtime_annotation_manifest(
+            td.path(),
+            r#"
+[[residue]]
+file = "src/lib.rs"
+line = 10
+callee = "method:expect"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "local manifest residue"
+"#,
+        );
+        let rows = vec![runtime_panic_row_with_bundle(
+            "blake3-512:target-bundle",
+            "src/lib.rs",
+            10,
+            "method:expect",
+            "unproven",
+        )];
+        let annotations = vec![effect_annotation(
+            "blake3-512:target-bundle",
+            "src/lib.rs",
+            10,
+            "method:expect",
+            "unproven",
+            "D-lib",
+            "future totality proof",
+            "duplicate memento annotation",
+        )];
+
+        let err = annotation_runtime_check_with_mementos(
+            td.path(),
+            &rows,
+            &annotations,
+            AnnotationCheckMode::Strict,
+        )
+        .expect_err("duplicate manifest/memento annotation must fail closed");
+
+        assert!(
+            err.check
+                .evidence
+                .to_string()
+                .contains("effect-site-annotation-duplicate"),
+            "duplicate evidence should carry structured tag: {:#?}",
+            err.check
+        );
+    }
+
+    #[test]
+    fn annotation_runtime_stale_memento_annotation_fails_hard() {
+        let td = tempfile::tempdir().unwrap();
+        let rows = vec![runtime_panic_row_with_bundle(
+            "blake3-512:dep-bundle",
+            "src/live.rs",
+            1,
+            "method:expect",
+            "unproven",
+        )];
+        let annotations = vec![effect_annotation(
+            "blake3-512:dep-bundle",
+            "src/stale.rs",
+            99,
+            "method:expect",
+            "residue",
+            "stale",
+            "irreducible",
+            "stale dependency memento residue",
+        )];
+
+        let err = annotation_runtime_check_with_mementos(
+            td.path(),
+            &rows,
+            &annotations,
+            AnnotationCheckMode::Strict,
+        )
+        .expect_err("strict stale memento annotation must fail");
+
+        assert!(
+            err.check.evidence.to_string().contains("stale"),
+            "stale evidence should be named: {:#?}",
+            err.check
+        );
+    }
+
+    #[test]
+    fn annotation_runtime_memento_annotation_on_proven_site_fails_closed() {
+        let td = tempfile::tempdir().unwrap();
+        let rows = vec![runtime_panic_row_with_bundle(
+            "blake3-512:dep-bundle",
+            "src/lib.rs",
+            10,
+            "method:expect",
+            "proven",
+        )];
+        let annotations = vec![effect_annotation(
+            "blake3-512:dep-bundle",
+            "src/lib.rs",
+            10,
+            "method:expect",
+            "residue",
+            "lock_poisoning_residue",
+            "irreducible",
+            "should not annotate proven rows",
+        )];
+
+        let err = annotation_runtime_check_with_mementos(
+            td.path(),
+            &rows,
+            &annotations,
+            AnnotationCheckMode::Strict,
+        )
+        .expect_err("proven-site memento annotation must fail");
+
+        assert!(
+            err.check
+                .evidence
+                .to_string()
+                .contains("proven_site_collision"),
+            "proven collision evidence should be typed: {:#?}",
+            err.check
+        );
+    }
+
+    #[test]
+    fn annotation_runtime_memento_annotations_preserve_proven_count() {
+        let td = tempfile::tempdir().unwrap();
+        let rows = vec![
+            runtime_panic_row_with_bundle(
+                "blake3-512:dep-bundle",
+                "src/lib.rs",
+                10,
+                "method:expect",
+                "proven",
+            ),
+            runtime_panic_row_with_bundle(
+                "blake3-512:dep-bundle",
+                "src/lib.rs",
+                20,
+                "method:expect",
+                "unproven",
+            ),
+        ];
+        let annotations = vec![effect_annotation(
+            "blake3-512:dep-bundle",
+            "src/lib.rs",
+            20,
+            "method:expect",
+            "residue",
+            "lock_poisoning_residue",
+            "irreducible",
+            "runtime residue",
+        )];
+        let before = rows.iter().filter(|row| row.status == "proven").count();
+
+        let outcome = annotation_runtime_check_with_mementos(
+            td.path(),
+            &rows,
+            &annotations,
+            AnnotationCheckMode::Strict,
+        )
+        .expect("valid memento annotation");
+        let after = outcome
+            .rows
+            .iter()
+            .filter(|row| row.status == "proven")
+            .count();
+
+        assert_eq!(before, after, "annotation mementos must not move K");
     }
 
     #[test]

--- a/implementations/rust/provekit-cli/src/panic_annotations_runtime.rs
+++ b/implementations/rust/provekit-cli/src/panic_annotations_runtime.rs
@@ -175,23 +175,7 @@ pub fn annotation_runtime_check_with_mementos(
     let memento_annotation_count = memento_annotations.len();
     let mut rows = panic_census.to_vec();
     let before_k = count_proven_rows(&rows);
-    let row_index: BTreeMap<(String, usize, String), usize> = rows
-        .iter()
-        .enumerate()
-        .map(|(index, row)| ((row.file.clone(), row.line, row.callee.clone()), index))
-        .collect();
-    let scoped_row_index: BTreeMap<(String, String, usize, String), usize> = rows
-        .iter()
-        .enumerate()
-        .filter_map(|(index, row)| {
-            row.callsite_bundle_cid.as_ref().map(|bundle| {
-                (
-                    (bundle.clone(), row.file.clone(), row.line, row.callee.clone()),
-                    index,
-                )
-            })
-        })
-        .collect();
+    let (row_index, scoped_row_index) = build_row_indexes(&rows, &mut issues);
     let mut annotated_rows = BTreeMap::<usize, String>::new();
 
     for annotation in manifest.annotations {
@@ -313,15 +297,43 @@ fn runtime_annotations_from_mementos(
 
 fn apply_runtime_annotation(
     annotation: RuntimeAnnotation,
-    row_index: &BTreeMap<(String, usize, String), usize>,
-    scoped_row_index: &BTreeMap<(String, String, usize, String), usize>,
+    row_index: &BTreeMap<(String, usize, String), Option<usize>>,
+    scoped_row_index: &BTreeMap<(String, String, usize, String), Option<usize>>,
     annotated_rows: &mut BTreeMap<usize, String>,
     rows: &mut [PanicCensusRow],
     issues: &mut Vec<Value>,
 ) {
     let index = match annotation.scoped_key() {
-        Some(scoped_key) => scoped_row_index.get(&scoped_key).copied(),
-        None => row_index.get(&annotation.key()).copied(),
+        Some(scoped_key) => match scoped_row_index.get(&scoped_key).copied().flatten() {
+            Some(index) => Some(index),
+            None if scoped_row_index.contains_key(&scoped_key) => {
+                issues.push(annotation_issue(
+                    "panic-census-row-duplicate",
+                    &format!(
+                        "duplicate panic census row for scoped key {}:{} {} in bundle {}",
+                        annotation.file, annotation.line, annotation.callee, scoped_key.0
+                    ),
+                    Some(&annotation),
+                ));
+                return;
+            }
+            None => None,
+        },
+        None => match row_index.get(&annotation.key()).copied().flatten() {
+            Some(index) => Some(index),
+            None if row_index.contains_key(&annotation.key()) => {
+                issues.push(annotation_issue(
+                    "panic-census-row-ambiguous",
+                    &format!(
+                        "ambiguous panic census row for unscoped annotation {}:{} {}",
+                        annotation.file, annotation.line, annotation.callee
+                    ),
+                    Some(&annotation),
+                ));
+                return;
+            }
+            None => None,
+        },
     };
     let Some(index) = index else {
         issues.push(annotation_issue(
@@ -361,6 +373,56 @@ fn apply_runtime_annotation(
     rows[index].category = Some(annotation.category);
     rows[index].tier_to_close = Some(annotation.tier_to_close);
     rows[index].reason = annotation.reason;
+}
+
+fn build_row_indexes(
+    rows: &[PanicCensusRow],
+    issues: &mut Vec<Value>,
+) -> (
+    BTreeMap<(String, usize, String), Option<usize>>,
+    BTreeMap<(String, String, usize, String), Option<usize>>,
+) {
+    let mut row_index = BTreeMap::<(String, usize, String), Option<usize>>::new();
+    let mut scoped_row_index =
+        BTreeMap::<(String, String, usize, String), Option<usize>>::new();
+
+    for (index, row) in rows.iter().enumerate() {
+        let key = (row.file.clone(), row.line, row.callee.clone());
+        match row_index.get_mut(&key) {
+            Some(slot) => *slot = None,
+            None => {
+                row_index.insert(key, Some(index));
+            }
+        }
+
+        let Some(bundle) = &row.callsite_bundle_cid else {
+            continue;
+        };
+        let scoped_key = (
+            bundle.clone(),
+            row.file.clone(),
+            row.line,
+            row.callee.clone(),
+        );
+        match scoped_row_index.get_mut(&scoped_key) {
+            Some(slot) => {
+                *slot = None;
+                issues.push(json!({
+                    "kind": "panic-census-row-duplicate",
+                    "bundleCid": scoped_key.0,
+                    "file": scoped_key.1,
+                    "line": scoped_key.2,
+                    "callee": scoped_key.3,
+                    "secondRowIndex": index,
+                }));
+            }
+            None => {
+                scoped_row_index.insert(scoped_key, Some(index));
+            }
+        }
+    }
+
+    (row_index, scoped_row_index)
 }
 
 fn annotation_source(annotation: &RuntimeAnnotation) -> String {
@@ -855,6 +917,146 @@ reason = "second"
         assert!(
             err.check.evidence.to_string().contains("duplicate"),
             "duplicate evidence should be named: {:#?}",
+            err.check
+        );
+    }
+
+    #[test]
+    fn annotation_runtime_unscoped_manifest_refuses_ambiguous_bundle_rows() {
+        let td = tempfile::tempdir().unwrap();
+        write_runtime_annotation_manifest(
+            td.path(),
+            r#"
+[[residue]]
+file = "src/lib.rs"
+line = 10
+callee = "method:expect"
+category = "lock_poisoning_residue"
+tier_to_close = "irreducible"
+reason = "ambiguous without bundle"
+"#,
+        );
+        let rows = vec![
+            runtime_panic_row_with_bundle(
+                "blake3-512:bundle-a",
+                "src/lib.rs",
+                10,
+                "method:expect",
+                "unproven",
+            ),
+            runtime_panic_row_with_bundle(
+                "blake3-512:bundle-b",
+                "src/lib.rs",
+                10,
+                "method:expect",
+                "unproven",
+            ),
+        ];
+
+        let err = annotation_runtime_check(td.path(), &rows, AnnotationCheckMode::Strict)
+            .expect_err("unscoped annotation over bundle-ambiguous rows must fail");
+
+        assert!(
+            err.check.evidence.to_string().contains("ambiguous"),
+            "ambiguous base-key evidence should be named: {:#?}",
+            err.check
+        );
+    }
+
+    #[test]
+    fn annotation_runtime_scoped_memento_disambiguates_ambiguous_bundle_rows() {
+        let td = tempfile::tempdir().unwrap();
+        let rows = vec![
+            runtime_panic_row_with_bundle(
+                "blake3-512:bundle-a",
+                "src/lib.rs",
+                10,
+                "method:expect",
+                "unproven",
+            ),
+            runtime_panic_row_with_bundle(
+                "blake3-512:bundle-b",
+                "src/lib.rs",
+                10,
+                "method:expect",
+                "unproven",
+            ),
+        ];
+        let annotations = vec![effect_annotation(
+            "blake3-512:bundle-b",
+            "src/lib.rs",
+            10,
+            "method:expect",
+            "residue",
+            "lock_poisoning_residue",
+            "irreducible",
+            "scoped dependency memento",
+        )];
+
+        let outcome = annotation_runtime_check_with_mementos(
+            td.path(),
+            &rows,
+            &annotations,
+            AnnotationCheckMode::Strict,
+        )
+        .expect("bundle-scoped memento must disambiguate ambiguous base key");
+
+        let annotated = outcome
+            .rows
+            .iter()
+            .find(|row| row.callsite_bundle_cid.as_deref() == Some("blake3-512:bundle-b"))
+            .expect("bundle-b row");
+        assert_eq!(annotated.category.as_deref(), Some("lock_poisoning_residue"));
+        assert_eq!(annotated.reason, "scoped dependency memento");
+        let untouched = outcome
+            .rows
+            .iter()
+            .find(|row| row.callsite_bundle_cid.as_deref() == Some("blake3-512:bundle-a"))
+            .expect("bundle-a row");
+        assert_eq!(untouched.category, None);
+    }
+
+    #[test]
+    fn annotation_runtime_duplicate_scoped_rows_fail_closed() {
+        let td = tempfile::tempdir().unwrap();
+        let rows = vec![
+            runtime_panic_row_with_bundle(
+                "blake3-512:bundle-a",
+                "src/lib.rs",
+                10,
+                "method:expect",
+                "unproven",
+            ),
+            runtime_panic_row_with_bundle(
+                "blake3-512:bundle-a",
+                "src/lib.rs",
+                10,
+                "method:expect",
+                "unproven",
+            ),
+        ];
+        let annotations = vec![effect_annotation(
+            "blake3-512:bundle-a",
+            "src/lib.rs",
+            10,
+            "method:expect",
+            "residue",
+            "lock_poisoning_residue",
+            "irreducible",
+            "duplicate scoped row",
+        )];
+
+        let err = annotation_runtime_check_with_mementos(
+            td.path(),
+            &rows,
+            &annotations,
+            AnnotationCheckMode::Strict,
+        )
+        .expect_err("duplicate scoped rows must fail closed");
+
+        assert!(
+            err.check.evidence.to_string().contains("duplicate"),
+            "duplicate scoped-row evidence should be named: {:#?}",
             err.check
         );
     }

--- a/implementations/rust/provekit-cli/src/report_fmt.rs
+++ b/implementations/rust/provekit-cli/src/report_fmt.rs
@@ -46,6 +46,7 @@ fn row_to_json(row: &ReportRow) -> Json {
         "file": row.callsite.file,
         "line": row.callsite.line,
         "callee": row.callsite.callee,
+        "callsiteBundleCid": row.callsite.callsite_bundle_cid,
         "panicSite": row.callsite.panic_site,
     })
 }
@@ -220,5 +221,52 @@ mod tests {
 
         let j = report_to_json(&r);
         assert_eq!(j["rows"][0]["bodyDischargeTier"], "body-eq-same-callee");
+    }
+
+    #[test]
+    fn report_json_includes_callsite_bundle_cid_when_present() {
+        let mut r = Report::default();
+        r.rows.push(ReportRow {
+            callsite: CallSite {
+                bridge_ir_name: "method:unwrap".into(),
+                callsite_bundle_cid: Some("blake3-512:caller-bundle".into()),
+                panic_site: true,
+                ..CallSite::default()
+            },
+            status: "undecidable".into(),
+            reason: "synthetic panic row".into(),
+            discharge_method: None,
+            body_discharge_tier: None,
+        });
+
+        let j = report_to_json(&r);
+
+        assert_eq!(
+            j["rows"][0]["callsiteBundleCid"],
+            "blake3-512:caller-bundle"
+        );
+    }
+
+    #[test]
+    fn report_json_nulls_callsite_bundle_cid_when_absent() {
+        let mut r = Report::default();
+        r.rows.push(ReportRow {
+            callsite: CallSite {
+                bridge_ir_name: "method:unwrap".into(),
+                panic_site: true,
+                ..CallSite::default()
+            },
+            status: "undecidable".into(),
+            reason: "synthetic panic row".into(),
+            discharge_method: None,
+            body_discharge_tier: None,
+        });
+
+        let j = report_to_json(&r);
+
+        assert!(
+            j["rows"][0]["callsiteBundleCid"].is_null(),
+            "absent callsite bundle should serialize as null to match existing Option field style"
+        );
     }
 }

--- a/implementations/rust/provekit-verifier/src/load_all_proofs.rs
+++ b/implementations/rust/provekit-verifier/src/load_all_proofs.rs
@@ -24,10 +24,14 @@ use serde_json::Value as Json;
 use tracing::{debug, info, warn};
 
 use crate::cbor_decode::decode;
-use crate::types::{LoadError, MementoPool};
+use crate::types::{memento_body, memento_kind, EffectSiteAnnotation, LoadError, MementoPool};
 
 const HASH_TAG_PREFIX: &str = "blake3-512:";
 const SIG_TAG_PREFIX: &str = "ed25519:";
+const PANIC_FREEDOM_EFFECT: &str = "concept:panic-freedom";
+const EFFECT_SITE_ANNOTATION_LOAD_ERROR_TAG: &str = "[effect-site-annotation]";
+const EFFECT_SITE_ANNOTATION_DUPLICATE_LOAD_ERROR_TAG: &str =
+    "[effect-site-annotation-duplicate]";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProofBytes {
@@ -280,6 +284,7 @@ fn load_catalog_bytes(
             .entry(derived_full.clone())
             .or_default()
             .insert(cid.clone());
+        index_effect_site_annotation(&source_label, &derived_full, cid, &env, pool);
 
         // Bridge indexing. Same dual-shape rule:
         //   v1.1: evidence.kind == "bridge", evidence.body.sourceSymbol
@@ -340,6 +345,146 @@ fn load_catalog_bytes(
         }
     }
     Ok(())
+}
+
+fn index_effect_site_annotation(
+    source_label: &str,
+    bundle_cid: &str,
+    memento_cid: &str,
+    env: &Json,
+    pool: &mut MementoPool,
+) {
+    if memento_kind(env) != Some("effect-site-annotation") {
+        return;
+    }
+    let Some(body) = memento_body(env) else {
+        pool.load_errors.push(LoadError {
+            proof_path: source_label.to_string(),
+            reason: format!(
+                "{EFFECT_SITE_ANNOTATION_LOAD_ERROR_TAG} {memento_cid}: missing header/body"
+            ),
+        });
+        return;
+    };
+
+    let Some(effect_kind) =
+        required_annotation_string(source_label, memento_cid, body, "effectKind", pool)
+    else {
+        return;
+    };
+    if effect_kind != PANIC_FREEDOM_EFFECT {
+        return;
+    }
+    let Some(file) = required_annotation_string(source_label, memento_cid, body, "file", pool)
+    else {
+        return;
+    };
+    let Some(line) = required_annotation_line(source_label, memento_cid, body, pool) else {
+        return;
+    };
+    let Some(callee) = required_annotation_string(source_label, memento_cid, body, "callee", pool)
+    else {
+        return;
+    };
+    let Some(status) = required_annotation_string(source_label, memento_cid, body, "status", pool)
+    else {
+        return;
+    };
+    if !matches!(status.as_str(), "residue" | "unproven") {
+        pool.load_errors.push(LoadError {
+            proof_path: source_label.to_string(),
+            reason: format!(
+                "{EFFECT_SITE_ANNOTATION_LOAD_ERROR_TAG} {memento_cid}: status must be residue or unproven"
+            ),
+        });
+        return;
+    }
+    let Some(category) =
+        required_annotation_string(source_label, memento_cid, body, "category", pool)
+    else {
+        return;
+    };
+    let Some(tier_to_close) =
+        required_annotation_string(source_label, memento_cid, body, "tierToClose", pool)
+    else {
+        return;
+    };
+    let Some(reason) = required_annotation_string(source_label, memento_cid, body, "reason", pool)
+    else {
+        return;
+    };
+
+    let key = (
+        bundle_cid.to_string(),
+        file.clone(),
+        line,
+        callee.clone(),
+    );
+    let annotation = EffectSiteAnnotation {
+        effect_kind,
+        file,
+        line,
+        callee,
+        status,
+        category,
+        tier_to_close,
+        reason,
+        memento_cid: memento_cid.to_string(),
+        bundle_cid: bundle_cid.to_string(),
+    };
+    if let Some(existing) = pool.panic_effect_site_annotations.get(&key) {
+        pool.load_errors.push(LoadError {
+            proof_path: source_label.to_string(),
+            reason: format!(
+                "{EFFECT_SITE_ANNOTATION_DUPLICATE_LOAD_ERROR_TAG} for ({}, {}, {}, {}): kept `{}`, dropped `{}`",
+                key.0, key.1, key.2, key.3, existing.memento_cid, memento_cid
+            ),
+        });
+        return;
+    }
+    pool.panic_effect_site_annotations.insert(key, annotation);
+}
+
+fn required_annotation_string(
+    source_label: &str,
+    memento_cid: &str,
+    body: &Json,
+    field: &str,
+    pool: &mut MementoPool,
+) -> Option<String> {
+    let value = body.get(field).and_then(|v| v.as_str()).filter(|s| !s.is_empty());
+    match value {
+        Some(value) => Some(value.to_string()),
+        None => {
+            pool.load_errors.push(LoadError {
+                proof_path: source_label.to_string(),
+                reason: format!(
+                    "{EFFECT_SITE_ANNOTATION_LOAD_ERROR_TAG} {memento_cid}: missing or invalid `{field}`"
+                ),
+            });
+            None
+        }
+    }
+}
+
+fn required_annotation_line(
+    source_label: &str,
+    memento_cid: &str,
+    body: &Json,
+    pool: &mut MementoPool,
+) -> Option<usize> {
+    match body.get("line").and_then(|v| v.as_u64()) {
+        Some(line) if usize::try_from(line).is_ok() => Some(line as usize),
+        _ => {
+            pool.load_errors.push(LoadError {
+                proof_path: source_label.to_string(),
+                reason: format!(
+                    "{EFFECT_SITE_ANNOTATION_LOAD_ERROR_TAG} {memento_cid}: missing or invalid `line`"
+                ),
+            });
+            None
+        }
+    }
 }
 
 /// Re-derive an envelope's CID. Branches on memento shape:
@@ -406,5 +551,189 @@ fn json_to_value(j: &Json) -> std::sync::Arc<Value> {
                 .collect();
             std::sync::Arc::new(Value::Object(entries))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use provekit_claim_envelope::{mint_effect_site_annotation, MintEffectSiteAnnotationArgs};
+    use provekit_proof_envelope::{build_proof_envelope, ProofEnvelopeInput};
+    use std::collections::BTreeMap;
+
+    const PANIC_EFFECT: &str = "concept:panic-freedom";
+
+    fn annotation_args(
+        effect_kind: &str,
+        file: &str,
+        line: usize,
+        callee: &str,
+        status: &str,
+        category: &str,
+        reason: &str,
+    ) -> MintEffectSiteAnnotationArgs {
+        MintEffectSiteAnnotationArgs {
+            effect_kind: effect_kind.to_string(),
+            file: file.to_string(),
+            line,
+            callee: callee.to_string(),
+            status: status.to_string(),
+            category: category.to_string(),
+            tier_to_close: "irreducible".to_string(),
+            reason: reason.to_string(),
+            input_cids: Vec::new(),
+            produced_by: "test".to_string(),
+            produced_at: "2026-06-01T00:00:00Z".to_string(),
+            signer_seed: [0x42; 32],
+        }
+    }
+
+    fn proof_bytes(members: Vec<provekit_claim_envelope::MintedEnvelope>) -> ProofBytes {
+        let mut member_map = BTreeMap::new();
+        for member in members {
+            member_map.insert(member.cid, member.canonical_bytes);
+        }
+        let proof = build_proof_envelope(&ProofEnvelopeInput {
+            name: "annotation-test".to_string(),
+            version: "1.0.0".to_string(),
+            binary_cid: None,
+            metadata: None,
+            members: member_map,
+            signer_cid: "test-signer".to_string(),
+            signer_seed: [0x24; 32],
+            declared_at: "2026-06-01T00:00:00Z".to_string(),
+        });
+        ProofBytes {
+            label: "annotation-test.proof".to_string(),
+            expected_cid: Some(proof.cid),
+            bytes: proof.bytes,
+        }
+    }
+
+    #[test]
+    fn load_all_proofs_indexes_panic_effect_site_annotation_by_bundle_and_site() {
+        let annotation = mint_effect_site_annotation(&annotation_args(
+            PANIC_EFFECT,
+            "src/lib.rs",
+            42,
+            "method:unwrap",
+            "residue",
+            "lock_poisoning_residue",
+            "lock poisoning is runtime residue",
+        ))
+        .expect("mint annotation");
+        let proof = proof_bytes(vec![annotation]);
+        let expected_bundle = proof.expected_cid.clone().expect("bundle cid");
+        let mut pool = MementoPool::default();
+
+        load_proof_bytes_into_pool(&[proof], &mut pool);
+
+        let key = (
+            expected_bundle,
+            "src/lib.rs".to_string(),
+            42,
+            "method:unwrap".to_string(),
+        );
+        let indexed = pool
+            .panic_effect_site_annotations
+            .get(&key)
+            .expect("annotation indexed by bundle/site");
+        assert_eq!(indexed.status, "residue");
+        assert_eq!(indexed.category, "lock_poisoning_residue");
+        assert_eq!(indexed.tier_to_close, "irreducible");
+        assert!(pool.load_errors.is_empty(), "{:#?}", pool.load_errors);
+    }
+
+    #[test]
+    fn load_all_proofs_ignores_non_panic_effect_site_annotation() {
+        let annotation = mint_effect_site_annotation(&annotation_args(
+            "concept:io",
+            "src/lib.rs",
+            42,
+            "read",
+            "unproven",
+            "io_residue",
+            "not a panic-freedom annotation",
+        ))
+        .expect("mint annotation");
+        let proof = proof_bytes(vec![annotation]);
+        let mut pool = MementoPool::default();
+
+        load_proof_bytes_into_pool(&[proof], &mut pool);
+
+        assert!(pool.panic_effect_site_annotations.is_empty());
+        assert!(pool.load_errors.is_empty(), "{:#?}", pool.load_errors);
+    }
+
+    #[test]
+    fn load_all_proofs_reports_malformed_panic_effect_site_annotation() {
+        let mut annotation = mint_effect_site_annotation(&annotation_args(
+            PANIC_EFFECT,
+            "src/lib.rs",
+            42,
+            "method:unwrap",
+            "residue",
+            "lock_poisoning_residue",
+            "lock poisoning is runtime residue",
+        ))
+        .expect("mint annotation");
+        let mut env: serde_json::Value =
+            serde_json::from_slice(&annotation.canonical_bytes).expect("parse annotation");
+        env.pointer_mut("/header")
+            .and_then(|v| v.as_object_mut())
+            .expect("header object")
+            .remove("callee");
+        annotation.canonical_bytes =
+            serde_json::to_vec(&env).expect("serialize malformed annotation");
+        let proof = proof_bytes(vec![annotation]);
+        let mut pool = MementoPool::default();
+
+        load_proof_bytes_into_pool(&[proof], &mut pool);
+
+        assert!(pool.panic_effect_site_annotations.is_empty());
+        assert!(
+            pool.load_errors
+                .iter()
+                .any(|err| err.reason.contains("effect-site-annotation")
+                    && err.reason.contains("callee")),
+            "missing callee should be a typed load error: {:#?}",
+            pool.load_errors
+        );
+    }
+
+    #[test]
+    fn load_all_proofs_reports_duplicate_effect_site_annotation_key() {
+        let first = mint_effect_site_annotation(&annotation_args(
+            PANIC_EFFECT,
+            "src/lib.rs",
+            42,
+            "method:unwrap",
+            "residue",
+            "lock_poisoning_residue",
+            "first annotation",
+        ))
+        .expect("mint first annotation");
+        let second = mint_effect_site_annotation(&annotation_args(
+            PANIC_EFFECT,
+            "src/lib.rs",
+            42,
+            "method:unwrap",
+            "unproven",
+            "D-lib",
+            "second annotation",
+        ))
+        .expect("mint second annotation");
+        let proof = proof_bytes(vec![first, second]);
+        let mut pool = MementoPool::default();
+
+        load_proof_bytes_into_pool(&[proof], &mut pool);
+
+        assert!(
+            pool.load_errors
+                .iter()
+                .any(|err| err.reason.contains("effect-site-annotation-duplicate")),
+            "duplicate effect-site annotation should fail loud: {:#?}",
+            pool.load_errors
+        );
     }
 }

--- a/implementations/rust/provekit-verifier/src/types.rs
+++ b/implementations/rust/provekit-verifier/src/types.rs
@@ -1001,6 +1001,37 @@ mod tests {
         assert_eq!(merged.effect_kind, "concept:panic-freedom");
         assert_eq!(merged.status, "residue");
         assert!(left.load_errors.is_empty(), "{:#?}", left.load_errors);
+
+        let original = EffectSiteAnnotation {
+            memento_cid: "blake3-512:annotation-original".to_string(),
+            ..merged.clone()
+        };
+        let duplicate = EffectSiteAnnotation {
+            memento_cid: "blake3-512:annotation-duplicate".to_string(),
+            ..merged.clone()
+        };
+        let mut left = MementoPool::default();
+        left.panic_effect_site_annotations
+            .insert(key.clone(), original);
+        let mut right = MementoPool::default();
+        right
+            .panic_effect_site_annotations
+            .insert(key.clone(), duplicate);
+
+        left.merge(right);
+
+        let kept = left
+            .panic_effect_site_annotations
+            .get(&key)
+            .expect("original annotation must remain indexed");
+        assert_eq!(kept.memento_cid, "blake3-512:annotation-original");
+        assert!(
+            left.load_errors.iter().any(|error| error
+                .reason
+                .contains("[effect-site-annotation-duplicate]")),
+            "duplicate merge must emit stable tagged load error: {:#?}",
+            left.load_errors
+        );
     }
 
     #[test]

--- a/implementations/rust/provekit-verifier/src/types.rs
+++ b/implementations/rust/provekit-verifier/src/types.rs
@@ -89,6 +89,20 @@ pub struct LoadError {
     pub reason: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectSiteAnnotation {
+    pub effect_kind: String,
+    pub file: String,
+    pub line: usize,
+    pub callee: String,
+    pub status: String,
+    pub category: String,
+    pub tier_to_close: String,
+    pub reason: String,
+    pub memento_cid: String,
+    pub bundle_cid: String,
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct MementoPool {
     /// CID -> the canonical-bytes-decoded memento envelope (as JSON).
@@ -124,6 +138,16 @@ pub struct MementoPool {
     /// two same-symbol calls on one source line, which (same bundle => same
     /// target contract => same post) is a K-completeness edge, not a false-pass.
     pub bridges_by_callsite: BTreeMap<(String, String, usize, String), Json>,
+    /// `(bundle_cid, file, line, callee)` -> panic-freedom annotation memento.
+    ///
+    /// Effect-site annotations are diagnostic proof mementos, not discharge
+    /// evidence. They annotate a specific unproven/residue effect occurrence
+    /// after `prove --json` has produced its panic census. Bundle scoping is
+    /// load-bearing: paths like `src/lib.rs` and call symbols collide across
+    /// packages, so the annotation must join only to the proof bundle that
+    /// produced the row it describes.
+    pub panic_effect_site_annotations:
+        BTreeMap<(String, String, usize, String), EffectSiteAnnotation>,
     /// sourceSymbol -> the `.proof` bundle CID the bridge memento was loaded
     /// from. Lets resolve_target enforce the self-pinned (no `targetProofCid`)
     /// case: the target contract must be a co-member of this bundle. Keyed by
@@ -563,6 +587,21 @@ impl MementoPool {
         for (k, v) in other.bridges_by_callsite {
             self.bridges_by_callsite.entry(k).or_insert(v);
         }
+        for (k, v) in other.panic_effect_site_annotations {
+            if let Some(existing) = self.panic_effect_site_annotations.get(&k) {
+                if existing.memento_cid != v.memento_cid {
+                    self.load_errors.push(LoadError {
+                        proof_path: v.memento_cid.clone(),
+                        reason: format!(
+                            "[effect-site-annotation-duplicate] for ({}, {}, {}, {}): kept `{}`, dropped `{}`",
+                            k.0, k.1, k.2, k.3, existing.memento_cid, v.memento_cid
+                        ),
+                    });
+                }
+            } else {
+                self.panic_effect_site_annotations.insert(k, v);
+            }
+        }
         for (k, v) in other.bridge_self_bundle_by_symbol {
             self.bridge_self_bundle_by_symbol.entry(k).or_insert(v);
         }
@@ -925,6 +964,43 @@ mod tests {
             "Expected direct proof, got {:?}",
             result
         );
+    }
+
+    #[test]
+    fn memento_pool_merge_preserves_effect_site_annotations() {
+        let key = (
+            "blake3-512:bundle".to_string(),
+            "src/lib.rs".to_string(),
+            42,
+            "method:unwrap".to_string(),
+        );
+        let annotation = EffectSiteAnnotation {
+            effect_kind: "concept:panic-freedom".to_string(),
+            file: "src/lib.rs".to_string(),
+            line: 42,
+            callee: "method:unwrap".to_string(),
+            status: "residue".to_string(),
+            category: "lock_poisoning_residue".to_string(),
+            tier_to_close: "irreducible".to_string(),
+            reason: "lock poisoning is runtime residue".to_string(),
+            memento_cid: "blake3-512:annotation".to_string(),
+            bundle_cid: "blake3-512:bundle".to_string(),
+        };
+        let mut left = MementoPool::default();
+        let mut right = MementoPool::default();
+        right
+            .panic_effect_site_annotations
+            .insert(key.clone(), annotation);
+
+        left.merge(right);
+
+        let merged = left
+            .panic_effect_site_annotations
+            .get(&key)
+            .expect("merge must carry annotation index");
+        assert_eq!(merged.effect_kind, "concept:panic-freedom");
+        assert_eq!(merged.status, "residue");
+        assert!(left.load_errors.is_empty(), "{:#?}", left.load_errors);
     }
 
     #[test]

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -11036,11 +11036,19 @@ reason = "serde_json::to_value(RealizeRequest) is closeable by a provekit-cli ow
             .iter()
             .filter(|diagnostic| diagnostic["kind"] == "panic-site-annotation")
             .collect();
+        let effect_annotations: Vec<&Value> = diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic["kind"] == "effect-site-annotation")
+            .collect();
 
         assert_eq!(
             annotations.len(),
             2,
             "expected manifest annotations: {diagnostics:#?}"
+        );
+        assert!(
+            effect_annotations.is_empty(),
+            "writer-stability: Rust kit must not emit effect-site-annotation diagnostics in the reader-only slice: {diagnostics:#?}"
         );
         assert_eq!(annotations[0]["status"], "residue");
         assert_eq!(annotations[0]["category"], "lock_poisoning_residue");


### PR DESCRIPTION
## Summary

This is slice 3 PR 3 for effect-site annotations: an additive reader/index/join path for `effect-site-annotation` proof mementos.

The change establishes the reader side of the third-tier shape:

- mint `effect-site-annotation` mementos with layered headers for panic-freedom residue or unproven sites
- index panic effect-site annotations by `(bundle_cid, file, line, callee)` in the verifier memento pool
- join self-check runtime annotations from both target-local manifest diagnostics and bundle-scoped mementos
- fail closed on stale annotations, duplicate same-row annotation sources, and annotations attached to proven sites
- add `callsiteBundleCid` to `prove --json` rows as an additive field
- keep self-check scoreboard `panicCensus` byte-stable by carrying bundle CID internally only

This partially addresses #1773 on the reader/index/join side. Writer migration remains a follow-up. #1783 is untouched.

## Architecture notes

- CLI and verifier remain language-blind. They consume proof data and opaque callsite coordinates.
- Kit or writer semantics do not move into the CLI.
- Manifest annotations remain target-local and unscoped: `(file, line, callee)`.
- Memento annotations are bundle-scoped: `(bundle_cid, file, line, callee)`.
- Both-present same-row joins fail closed instead of silently choosing a source.
- Non-panic effect kinds are ignored by this panic-freedom reader.
- Malformed or duplicate effect-site annotation mementos are tagged with stable `[effect-site-annotation]` / `[effect-site-annotation-duplicate]` load errors. The secondary annotation scan fails on those tags, but does not make unrelated tolerated proof-load warnings fatal.

## Validation

- `../../bin/bcargo fmt --all`
- `git diff --check`
- `../../bin/bcargo test -p provekit-claim-envelope effect_site_annotation -- --nocapture`
- `../../bin/bcargo test -p provekit-verifier effect_site_annotation -- --nocapture`
- `../../bin/bcargo test -p provekit-cli report_json_includes_callsite_bundle_cid_when_present -- --nocapture`
- `../../bin/bcargo test -p provekit-cli report_json_nulls_callsite_bundle_cid_when_absent -- --nocapture`
- `../../bin/bcargo test -p provekit-cli panic_annotations_runtime::tests -- --nocapture`
- `../../bin/bcargo test -p provekit-cli self_check_scoreboard_does_not_serialize_callsite_bundle_cid_in_panic_census -- --nocapture`
- `../../bin/bcargo test -p provekit-cli effect_site_annotation_scan -- --nocapture`
- `../../bin/bcargo test -p provekit-walk lift_implications_emits_residue_manifest_annotations -- --nocapture`
- `../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture`
- `../../bin/bcargo build -p provekit-lift --bin provekit-lift`
- `../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc`
- `make check-macos-swift-rust-scope`

JSON surface verification via `bcargo run -q` on battleaxe:

- `prove --json`: 2065 rows
- `callsiteBundleCid`: present on all 2065 rows
- `callsite_bundle_cid`: present on 0 rows
- non-null `callsiteBundleCid`: 1484 rows
- panic rows: 13, all 13 have non-null `callsiteBundleCid`
- `self-check --json`: exit 0
- self-check `panicCensus`: 30 rows
- `panicCensus` bundle CID leaks: 0 camelCase, 0 snake_case

Final scope checks:

- Path A grep for `implementations/rust/libprovekit`: zero output
- diff scope: 7 files, 1333 insertions, 36 deletions

## Advisor checkpoint

Claude was kept in the loop via tmux through the design, the golden-gate failure, the structured annotation-error tag fix, and the final JSON surface gate. Final advisor response before PR: no objection, ship it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for effect-site annotations to enable diagnostic tracking of panic-freedom proofs.
  * Enhanced self-check to load and process effect-site annotations from proof outputs.
  * Extended runtime annotation checking with bundle-scoped annotation targeting capabilities.
  * Improved proof verification with indexing and validation of effect-site annotations.

* **Improvements**
  * Updated report formatting to include callsite bundle identifiers in output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->