### PR TITLE
[codex] Add kit declaration RPC shape

### DIFF
--- a/implementations/rust/provekit-claim-envelope/Cargo.toml
+++ b/implementations/rust/provekit-claim-envelope/Cargo.toml
@@ -9,9 +9,9 @@ description = "ProvekIt: claim/memento envelope minters (contract, bridge, impli
 [dependencies]
 provekit-canonicalizer = { path = "../provekit-canonicalizer" }
 provekit-proof-envelope = { path = "../provekit-proof-envelope" }
+serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-serde = { workspace = true }
 hex = { workspace = true }

--- a/implementations/rust/provekit-claim-envelope/src/lib.rs
+++ b/implementations/rust/provekit-claim-envelope/src/lib.rs
@@ -34,6 +34,7 @@ use std::sync::Arc;
 
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value};
 use provekit_proof_envelope::{ed25519_pubkey_string, ed25519_sign_string, Ed25519Seed};
+use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
 #[derive(Debug, thiserror::Error)]
@@ -67,6 +68,273 @@ pub struct MintedEnvelope {
 /// emitted by this kit. Older flat mementos carry `"1"`; verifiers
 /// branch on this string at load time.
 pub const LAYERED_SCHEMA_VERSION: &str = "2";
+
+/// JSON-RPC method used by kits to serve their substrate declaration.
+///
+/// The declaration is semantic content, not startup negotiation, so it is
+/// fetched on demand instead of being embedded in `initialize.capabilities`.
+pub const KIT_DECLARATION_RPC_METHOD: &str = "provekit.plugin.kit_declaration";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KitDeclaration {
+    pub kit: KitIdentity,
+    pub rpc: KitDeclarationRpc,
+    #[serde(rename = "proofResolution")]
+    pub proof_resolution: KitProofResolution,
+    #[serde(rename = "effectKinds")]
+    pub effect_kinds: Vec<String>,
+    #[serde(rename = "effectLeaves")]
+    pub effect_leaves: Vec<KitDeclarationMapping>,
+    #[serde(rename = "guardPredicates")]
+    pub guard_predicates: Vec<KitDeclarationMapping>,
+    #[serde(rename = "controlCarriers")]
+    pub control_carriers: Vec<KitDeclarationMapping>,
+    #[serde(
+        rename = "oracleHost",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub oracle_host: Option<KitOracleHost>,
+    #[serde(rename = "residueCategories")]
+    pub residue_categories: Vec<KitResidueCategory>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KitIdentity {
+    pub id: String,
+    pub language: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KitDeclarationRpc {
+    pub methods: Vec<KitDeclarationRpcMethod>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KitDeclarationRpcMethod {
+    pub name: String,
+    #[serde(default)]
+    pub required: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KitProofResolution {
+    pub strategy: String,
+    #[serde(rename = "rpcMethod", default, skip_serializing_if = "Option::is_none")]
+    pub rpc_method: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KitDeclarationMapping {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub surface: Option<String>,
+    pub local: String,
+    pub concept: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KitOracleHost {
+    #[serde(rename = "hostKind")]
+    pub host_kind: String,
+    #[serde(default)]
+    pub required: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KitResidueCategory {
+    pub name: String,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum KitDeclarationError {
+    #[error("kit declaration: {field} must not be empty")]
+    EmptyField { field: &'static str },
+    #[error(
+        "kit declaration: {category} has conflicting mapping for surface={surface:?} local={local}: {first} vs {second}"
+    )]
+    ConflictingMapping {
+        category: &'static str,
+        surface: Option<String>,
+        local: String,
+        first: String,
+        second: String,
+    },
+}
+
+impl KitDeclaration {
+    pub fn validate(&self) -> Result<(), KitDeclarationError> {
+        require_nonempty("kit.id", &self.kit.id)?;
+        require_nonempty("kit.language", &self.kit.language)?;
+        require_nonempty("kit.version", &self.kit.version)?;
+        if self.rpc.methods.is_empty() {
+            return Err(KitDeclarationError::EmptyField {
+                field: "rpc.methods",
+            });
+        }
+        for method in &self.rpc.methods {
+            require_nonempty("rpc.methods[].name", &method.name)?;
+        }
+        require_nonempty("proofResolution.strategy", &self.proof_resolution.strategy)?;
+        if let Some(method) = &self.proof_resolution.rpc_method {
+            require_nonempty("proofResolution.rpcMethod", method)?;
+        }
+        if self.effect_kinds.is_empty() {
+            return Err(KitDeclarationError::EmptyField {
+                field: "effectKinds",
+            });
+        }
+        for effect_kind in &self.effect_kinds {
+            require_nonempty("effectKinds[]", effect_kind)?;
+        }
+        validate_mappings("effectLeaves", &self.effect_leaves)?;
+        validate_mappings("guardPredicates", &self.guard_predicates)?;
+        validate_mappings("controlCarriers", &self.control_carriers)?;
+        if let Some(oracle_host) = &self.oracle_host {
+            require_nonempty("oracleHost.hostKind", &oracle_host.host_kind)?;
+        }
+        for category in &self.residue_categories {
+            require_nonempty("residueCategories[].name", &category.name)?;
+            require_nonempty("residueCategories[].status", &category.status)?;
+        }
+        Ok(())
+    }
+}
+
+fn require_nonempty(field: &'static str, value: &str) -> Result<(), KitDeclarationError> {
+    if value.trim().is_empty() {
+        Err(KitDeclarationError::EmptyField { field })
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_mappings(
+    category: &'static str,
+    mappings: &[KitDeclarationMapping],
+) -> Result<(), KitDeclarationError> {
+    let mut seen = std::collections::BTreeMap::<(Option<String>, String), String>::new();
+    for mapping in mappings {
+        if let Some(surface) = &mapping.surface {
+            require_nonempty("mapping.surface", surface)?;
+        }
+        require_nonempty("mapping.local", &mapping.local)?;
+        require_nonempty("mapping.concept", &mapping.concept)?;
+        let key = (mapping.surface.clone(), mapping.local.clone());
+        if let Some(existing) = seen.get(&key) {
+            if existing != &mapping.concept {
+                return Err(KitDeclarationError::ConflictingMapping {
+                    category,
+                    surface: key.0,
+                    local: key.1,
+                    first: existing.clone(),
+                    second: mapping.concept.clone(),
+                });
+            }
+        } else {
+            seen.insert(key, mapping.concept.clone());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod kit_declaration_schema_tests {
+    use super::{
+        KitDeclaration, KitDeclarationMapping, KitDeclarationRpc, KitDeclarationRpcMethod,
+        KitIdentity, KitProofResolution,
+    };
+
+    fn valid_declaration() -> KitDeclaration {
+        KitDeclaration {
+            kit: KitIdentity {
+                id: "provekit-walk-rpc".to_string(),
+                language: "rust".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            rpc: KitDeclarationRpc {
+                methods: vec![KitDeclarationRpcMethod {
+                    name: "provekit.plugin.kit_declaration".to_string(),
+                    required: true,
+                }],
+            },
+            proof_resolution: KitProofResolution {
+                strategy: "rpc-proof-bytes".to_string(),
+                rpc_method: Some("provekit.plugin.resolve_dependency_proofs".to_string()),
+            },
+            effect_kinds: vec!["concept:panic-freedom".to_string()],
+            effect_leaves: vec![KitDeclarationMapping {
+                surface: Some("rust-implications".to_string()),
+                local: "method:unwrap".to_string(),
+                concept: "concept:panic-freedom.leaf.unwrap".to_string(),
+            }],
+            guard_predicates: vec![],
+            control_carriers: vec![],
+            oracle_host: None,
+            residue_categories: vec![],
+        }
+    }
+
+    #[test]
+    fn kit_declaration_roundtrips_with_optional_defaults() {
+        let declaration = valid_declaration();
+
+        declaration.validate().expect("valid declaration");
+        let encoded = serde_json::to_string(&declaration).expect("encode declaration");
+        let decoded: KitDeclaration = serde_json::from_str(&encoded).expect("decode declaration");
+
+        assert_eq!(decoded, declaration);
+        assert!(decoded.oracle_host.is_none());
+    }
+
+    #[test]
+    fn kit_declaration_rejects_missing_required_fields() {
+        let missing_effect_kinds = serde_json::json!({
+            "kit": {"id": "provekit-walk-rpc", "language": "rust", "version": "0.1.0"},
+            "rpc": {"methods": [{"name": "provekit.plugin.kit_declaration", "required": true}]},
+            "proofResolution": {"strategy": "rpc-proof-bytes"}
+        });
+
+        let err = serde_json::from_value::<KitDeclaration>(missing_effect_kinds)
+            .expect_err("effectKinds is required");
+
+        assert!(
+            err.to_string().contains("effectKinds"),
+            "error should name missing field: {err}"
+        );
+    }
+
+    #[test]
+    fn kit_declaration_allows_exact_duplicate_mapping_but_rejects_conflict() {
+        let mut declaration = valid_declaration();
+        let duplicate = declaration.effect_leaves[0].clone();
+        declaration.effect_leaves.push(duplicate);
+        declaration
+            .validate()
+            .expect("exact duplicate declaration is harmless");
+
+        declaration.effect_leaves.push(KitDeclarationMapping {
+            surface: Some("rust-implications".to_string()),
+            local: "method:unwrap".to_string(),
+            concept: "concept:panic-freedom.leaf.expect".to_string(),
+        });
+
+        let err = declaration
+            .validate()
+            .expect_err("conflicting scoped mapping must fail");
+        assert!(
+            err.to_string().contains("effectLeaves"),
+            "error should identify the mapping category: {err}"
+        );
+        assert!(
+            err.to_string().contains("method:unwrap"),
+            "error should identify the local key: {err}"
+        );
+    }
+}
 
 // ---------- DERIVED hash helpers --------------------------------------------
 
@@ -325,9 +593,11 @@ pub fn body_discharge_policy_from_object_with_default(
     default_eligible: bool,
 ) -> BodyDischargePolicy {
     body_discharge_policy_from_fields_with_default(
-        entry.get("bodyDischargeEligible")
+        entry
+            .get("bodyDischargeEligible")
             .or_else(|| entry.get("body_discharge_eligible")),
-        entry.get("bodyDischargeRefusalReason")
+        entry
+            .get("bodyDischargeRefusalReason")
             .or_else(|| entry.get("body_discharge_refusal_reason")),
         entry.get("dischargePolicy"),
         default_eligible,
@@ -443,9 +713,8 @@ fn parse_body_reduction(
                         return (
                             None,
                             vec![BodyDischargePolicyWarning::Malformed {
-                                reason:
-                                    "dischargePolicy.bodyReduction.reason must be a string"
-                                        .to_string(),
+                                reason: "dischargePolicy.bodyReduction.reason must be a string"
+                                    .to_string(),
                             }],
                         )
                     }
@@ -722,10 +991,7 @@ pub fn mint_contract(args: &MintContractArgs) -> Result<MintedEnvelope, ClaimEnv
     // never read it), so it must not perturb the contract CID. Omitted when
     // empty so contracts with no panic leaf keep their existing header bytes.
     if !args.panic_loci.is_empty() {
-        kind_specific.push((
-            "panicLoci".into(),
-            Value::array(args.panic_loci.clone()),
-        ));
+        kind_specific.push(("panicLoci".into(), Value::array(args.panic_loci.clone())));
     }
 
     let header = build_header("contract", &header_cid, kind_specific);

--- a/implementations/rust/provekit-cli/src/kit_declaration.rs
+++ b/implementations/rust/provekit-cli/src/kit_declaration.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Kit declaration loader.
+//
+// This is the additive Phase 4 step-3a surface: kits own their declaration and
+// serve it over JSON-RPC. The CLI loader consumes an already-resolved manifest
+// command; it does not search language-specific package paths or enumerate kits.
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use provekit_claim_envelope::{KitDeclaration, KitDeclarationError, KIT_DECLARATION_RPC_METHOD};
+use serde_json::{json, Value};
+
+#[derive(Debug, thiserror::Error)]
+pub enum KitDeclarationLoadError {
+    #[error("kit declaration command is empty")]
+    EmptyCommand,
+    #[error("spawn kit declaration command {command:?}: {source}")]
+    Spawn {
+        command: Vec<String>,
+        source: std::io::Error,
+    },
+    #[error("kit declaration RPC I/O failed: {0}")]
+    Io(String),
+    #[error("kit declaration RPC response is invalid JSON: {0}; raw={1}")]
+    Json(serde_json::Error, String),
+    #[error("kit declaration RPC returned error for {method}: {message}")]
+    RpcError {
+        method: &'static str,
+        message: String,
+    },
+    #[error("kit declaration RPC protocol error for {method}: {message}")]
+    Protocol {
+        method: &'static str,
+        message: String,
+    },
+    #[error("kit declaration RPC response missing result for {method}: {response}")]
+    MissingResult {
+        method: &'static str,
+        response: String,
+    },
+    #[error("kit declaration result shape is invalid: {0}")]
+    Shape(serde_json::Error),
+    #[error("{0}")]
+    Invalid(#[from] KitDeclarationError),
+}
+
+pub fn load_kit_declaration_with_command(
+    command: &[String],
+    working_dir: Option<&Path>,
+) -> Result<KitDeclaration, KitDeclarationLoadError> {
+    if command.is_empty() {
+        return Err(KitDeclarationLoadError::EmptyCommand);
+    }
+
+    let mut cmd = Command::new(&command[0]);
+    cmd.args(&command[1..]);
+    if let Some(working_dir) = working_dir {
+        cmd.current_dir(working_dir);
+    }
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|source| KitDeclarationLoadError::Spawn {
+            command: command.to_vec(),
+            source,
+        })?;
+
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| KitDeclarationLoadError::Io("stdin unavailable".to_string()))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| KitDeclarationLoadError::Io("stdout unavailable".to_string()))?;
+    let mut reader = BufReader::new(stdout);
+
+    let init = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "client": {"name": "provekit-cli-kit-declaration-loader", "version": env!("CARGO_PKG_VERSION")},
+            "protocol_version": "pep/1.7.0",
+        }
+    });
+    writeln!(stdin, "{init}")
+        .map_err(|e| KitDeclarationLoadError::Io(format!("write initialize: {e}")))?;
+    let _ = read_response(&mut reader, "initialize", 1)?;
+
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": KIT_DECLARATION_RPC_METHOD,
+        "params": {}
+    });
+    writeln!(stdin, "{req}").map_err(|e| {
+        KitDeclarationLoadError::Io(format!("write {KIT_DECLARATION_RPC_METHOD}: {e}"))
+    })?;
+    let response = read_response(&mut reader, KIT_DECLARATION_RPC_METHOD, 2)?;
+
+    let shutdown = json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "shutdown",
+    });
+    let _ = writeln!(stdin, "{shutdown}");
+    drop(stdin);
+    let _ = child.wait();
+
+    let result =
+        response
+            .get("result")
+            .cloned()
+            .ok_or_else(|| KitDeclarationLoadError::MissingResult {
+                method: KIT_DECLARATION_RPC_METHOD,
+                response: response.to_string(),
+            })?;
+    let declaration: KitDeclaration =
+        serde_json::from_value(result).map_err(KitDeclarationLoadError::Shape)?;
+    declaration.validate()?;
+    Ok(declaration)
+}
+
+fn read_response<R: BufRead>(
+    reader: &mut R,
+    method: &'static str,
+    expected_id: i64,
+) -> Result<Value, KitDeclarationLoadError> {
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .map_err(|e| KitDeclarationLoadError::Io(format!("read {method}: {e}")))?;
+    if line.trim().is_empty() {
+        return Err(KitDeclarationLoadError::Io(format!(
+            "empty response for {method}"
+        )));
+    }
+    let value: Value = serde_json::from_str(line.trim())
+        .map_err(|e| KitDeclarationLoadError::Json(e, line.trim().to_string()))?;
+    let id = value.get("id").and_then(Value::as_i64).unwrap_or(-1);
+    if id != expected_id {
+        return Err(KitDeclarationLoadError::Protocol {
+            method,
+            message: format!("response id mismatch: expected {expected_id}, got {id}"),
+        });
+    }
+    if let Some(error) = value.get("error") {
+        let message = error
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown RPC error")
+            .to_string();
+        return Err(KitDeclarationLoadError::RpcError { method, message });
+    }
+    Ok(value)
+}

--- a/implementations/rust/provekit-cli/src/lib.rs
+++ b/implementations/rust/provekit-cli/src/lib.rs
@@ -38,6 +38,7 @@ pub mod doctor;
 #[allow(dead_code)]
 pub mod doctor_oracle;
 pub mod floor_runtime_check;
+pub mod kit_declaration;
 pub mod kit_dispatch;
 #[allow(dead_code)]
 pub mod lift_plugin;

--- a/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
+++ b/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
@@ -1,0 +1,160 @@
+use std::fs;
+use std::path::Path;
+
+use tempfile::TempDir;
+
+use provekit_claim_envelope::{KitDeclaration, KIT_DECLARATION_RPC_METHOD};
+
+fn make_executable(path: &Path, body: &str) {
+    fs::write(path, body).expect("write stub");
+    let mut perms = fs::metadata(path).expect("metadata").permissions();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        perms.set_mode(0o755);
+    }
+    fs::set_permissions(path, perms).expect("chmod");
+}
+
+#[test]
+fn loader_sends_kit_declaration_rpc_and_parses_result() {
+    let td = TempDir::new().expect("tempdir");
+    let marker = td.path().join("method-seen");
+    let stub = td.path().join("kit.sh");
+    make_executable(
+        &stub,
+        &format!(
+            r#"#!/bin/sh
+marker={marker}
+while IFS= read -r line; do
+  case "$line" in
+    *initialize*)
+      printf '%s\n' '{{"jsonrpc":"2.0","id":1,"result":{{"name":"stub-kit","protocol_version":"pep/1.7.0","capabilities":{{}}}}}}'
+      ;;
+    *provekit.plugin.kit_declaration*)
+      printf '%s' "$line" > "$marker"
+      printf '%s\n' '{{"jsonrpc":"2.0","id":2,"result":{{"kit":{{"id":"stub-kit","language":"rust","version":"0.1.0"}},"rpc":{{"methods":[{{"name":"provekit.plugin.kit_declaration","required":true}}]}},"proofResolution":{{"strategy":"rpc-proof-bytes","rpcMethod":"provekit.plugin.resolve_dependency_proofs"}},"effectKinds":["concept:panic-freedom"],"effectLeaves":[{{"surface":"rust-implications","local":"method:unwrap","concept":"concept:panic-freedom.leaf.unwrap"}}],"guardPredicates":[],"controlCarriers":[],"residueCategories":[]}}}}'
+      ;;
+    *shutdown*)
+      printf '%s\n' '{{"jsonrpc":"2.0","id":3,"result":null}}'
+      exit 0
+      ;;
+  esac
+done
+"#,
+            marker = marker.display()
+        ),
+    );
+
+    let declaration: KitDeclaration =
+        provekit_cli::kit_declaration::load_kit_declaration_with_command(
+            &[stub.display().to_string()],
+            Some(td.path()),
+        )
+        .expect("load declaration");
+
+    assert_eq!(declaration.kit.id, "stub-kit");
+    assert_eq!(declaration.effect_kinds, ["concept:panic-freedom"]);
+    assert!(
+        fs::read_to_string(marker)
+            .expect("marker")
+            .contains(KIT_DECLARATION_RPC_METHOD),
+        "loader must request the dedicated declaration RPC method"
+    );
+}
+
+#[test]
+fn loader_rejects_conflicting_declaration_mappings() {
+    let td = TempDir::new().expect("tempdir");
+    let stub = td.path().join("kit.sh");
+    make_executable(
+        &stub,
+        r#"#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *initialize*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"name":"stub-kit","protocol_version":"pep/1.7.0","capabilities":{}}}'
+      ;;
+    *provekit.plugin.kit_declaration*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"kit":{"id":"stub-kit","language":"rust","version":"0.1.0"},"rpc":{"methods":[{"name":"provekit.plugin.kit_declaration","required":true}]},"proofResolution":{"strategy":"rpc-proof-bytes"},"effectKinds":["concept:panic-freedom"],"effectLeaves":[{"surface":"rust-implications","local":"method:unwrap","concept":"concept:panic-freedom.leaf.unwrap"},{"surface":"rust-implications","local":"method:unwrap","concept":"concept:panic-freedom.leaf.expect"}],"guardPredicates":[],"controlCarriers":[],"residueCategories":[]}}'
+      ;;
+  esac
+done
+"#,
+    );
+
+    let err = provekit_cli::kit_declaration::load_kit_declaration_with_command(
+        &[stub.display().to_string()],
+        Some(td.path()),
+    )
+    .expect_err("conflicting declaration should fail");
+
+    assert!(
+        err.to_string().contains("effectLeaves"),
+        "error should identify declaration conflict: {err}"
+    );
+}
+
+#[test]
+fn loader_reports_missing_kit_declaration_method() {
+    let td = TempDir::new().expect("tempdir");
+    let stub = td.path().join("kit.sh");
+    make_executable(
+        &stub,
+        r#"#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *initialize*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"name":"stub-kit","protocol_version":"pep/1.7.0","capabilities":{}}}'
+      ;;
+    *provekit.plugin.kit_declaration*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"error":{"code":-32601,"message":"method not found: provekit.plugin.kit_declaration"}}'
+      ;;
+  esac
+done
+"#,
+    );
+
+    let err = provekit_cli::kit_declaration::load_kit_declaration_with_command(
+        &[stub.display().to_string()],
+        Some(td.path()),
+    )
+    .expect_err("missing declaration method should fail");
+
+    assert!(
+        err.to_string().contains(KIT_DECLARATION_RPC_METHOD),
+        "error should name missing RPC method: {err}"
+    );
+}
+
+#[test]
+fn loader_rejects_kit_declaration_response_id_mismatch() {
+    let td = TempDir::new().expect("tempdir");
+    let stub = td.path().join("kit.sh");
+    make_executable(
+        &stub,
+        r#"#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *initialize*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"name":"stub-kit","protocol_version":"pep/1.7.0","capabilities":{}}}'
+      ;;
+    *provekit.plugin.kit_declaration*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":99,"result":{"kit":{"id":"stub-kit","language":"rust","version":"0.1.0"},"rpc":{"methods":[{"name":"provekit.plugin.kit_declaration","required":true}]},"proofResolution":{"strategy":"rpc-proof-bytes"},"effectKinds":["concept:panic-freedom"],"effectLeaves":[],"guardPredicates":[],"controlCarriers":[],"residueCategories":[]}}'
+      ;;
+  esac
+done
+"#,
+    );
+
+    let err = provekit_cli::kit_declaration::load_kit_declaration_with_command(
+        &[stub.display().to_string()],
+        Some(td.path()),
+    )
+    .expect_err("response id mismatch should fail");
+
+    assert!(
+        err.to_string().contains("response id mismatch"),
+        "error should describe mismatched response id: {err}"
+    );
+}

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -29,7 +29,7 @@ use libprovekit::concept::panic_freedom;
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 use provekit_claim_envelope::{
     body_discharge_policy_from_object, body_discharge_policy_from_object_with_default,
-    BodyDischargePolicyWarning,
+    BodyDischargePolicyWarning, KIT_DECLARATION_RPC_METHOD,
 };
 use provekit_ir_types::{EvidenceMemento, IrFormula, IrTerm, SourceKind};
 use provekit_lift_contracts::lift_file_with_docstring_evidence;
@@ -188,6 +188,7 @@ fn handle_line(line: &str) -> Value {
         "initialize" => Ok(initialize_result()),
         "lift" => bind_lift(&params),
         "shutdown" => Ok(Value::Null),
+        KIT_DECLARATION_RPC_METHOD => Ok(kit_declaration_result()),
         // Recognizer foundation (#81, #82) per protocol §4.2.5. The lift
         // binary handles this too because it already owns the syn AST
         // machinery that recognize needs — same kit, same language.
@@ -3696,6 +3697,34 @@ fn initialize_result() -> Value {
                 }
             }
         }
+    })
+}
+
+fn kit_declaration_result() -> Value {
+    json!({
+        "kit": {
+            "id": "provekit-walk-rpc",
+            "language": "rust",
+            "version": env!("CARGO_PKG_VERSION")
+        },
+        "rpc": {
+            "methods": [
+                {"name": "initialize", "required": true},
+                {"name": "lift", "required": true},
+                {"name": "shutdown", "required": true},
+                {"name": "provekit.plugin.recognize", "required": false},
+                {"name": "provekit.plugin.lift_implications", "required": false},
+                {"name": KIT_DECLARATION_RPC_METHOD, "required": false}
+            ]
+        },
+        "proofResolution": {
+            "strategy": "cargo"
+        },
+        "effectKinds": ["concept:panic-freedom"],
+        "effectLeaves": [],
+        "guardPredicates": [],
+        "controlCarriers": [],
+        "residueCategories": []
     })
 }
 
@@ -8377,6 +8406,32 @@ pub fn wrap_positive(amount: usize) -> Option<usize> {
         );
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn kit_declaration_result_is_minimal_valid_declaration() {
+        let declaration: provekit_claim_envelope::KitDeclaration =
+            serde_json::from_value(kit_declaration_result()).expect("kit declaration shape");
+
+        declaration.validate().expect("valid kit declaration");
+        assert_eq!(declaration.kit.id, "provekit-walk-rpc");
+        assert_eq!(declaration.kit.language, "rust");
+        assert_eq!(
+            declaration.effect_kinds,
+            vec!["concept:panic-freedom".to_string()]
+        );
+        assert!(
+            declaration.effect_leaves.is_empty(),
+            "3a stub must not claim full rust effect-leaf coverage"
+        );
+        assert!(
+            declaration.guard_predicates.is_empty(),
+            "3a stub must not claim full rust guard-predicate coverage"
+        );
+        assert!(
+            declaration.control_carriers.is_empty(),
+            "3a stub must not claim full rust control-carrier coverage"
+        );
     }
 
     #[test]

--- a/implementations/rust/provekit-walk/tests/kit_declaration_rpc.rs
+++ b/implementations/rust/provekit-walk/tests/kit_declaration_rpc.rs
@@ -1,0 +1,93 @@
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+
+use provekit_claim_envelope::{KitDeclaration, KIT_DECLARATION_RPC_METHOD};
+use serde_json::{json, Value};
+
+#[test]
+fn walk_rpc_serves_kit_declaration_over_stdio() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_provekit-walk-rpc"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn provekit-walk-rpc");
+    let mut stdin = child.stdin.take().expect("stdin");
+    let stdout = child.stdout.take().expect("stdout");
+    let mut reader = BufReader::new(stdout);
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}})
+    )
+    .expect("write initialize");
+    let init_response = read_response(&mut reader);
+    assert!(
+        init_response.get("error").is_none(),
+        "initialize failed: {init_response}"
+    );
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": KIT_DECLARATION_RPC_METHOD,
+            "params": {}
+        })
+    )
+    .expect("write kit declaration request");
+    let declaration_response = read_response(&mut reader);
+    assert!(
+        declaration_response.get("error").is_none(),
+        "kit declaration RPC failed: {declaration_response}"
+    );
+
+    let declaration: KitDeclaration = serde_json::from_value(
+        declaration_response
+            .get("result")
+            .cloned()
+            .expect("kit declaration result"),
+    )
+    .expect("kit declaration schema");
+    declaration.validate().expect("valid declaration");
+
+    assert_eq!(declaration.kit.id, "provekit-walk-rpc");
+    assert_eq!(declaration.kit.language, "rust");
+    assert!(
+        declaration
+            .rpc
+            .methods
+            .iter()
+            .any(|method| method.name == KIT_DECLARATION_RPC_METHOD),
+        "declaration must advertise its declaration RPC method"
+    );
+    assert_eq!(declaration.effect_kinds, ["concept:panic-freedom"]);
+    assert!(declaration.effect_leaves.is_empty());
+    assert!(declaration.guard_predicates.is_empty());
+    assert!(declaration.control_carriers.is_empty());
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({"jsonrpc":"2.0","id":3,"method":"shutdown","params":{}})
+    )
+    .expect("write shutdown");
+    let shutdown_response = read_response(&mut reader);
+    assert!(
+        shutdown_response.get("error").is_none(),
+        "shutdown failed: {shutdown_response}"
+    );
+    drop(stdin);
+    let status = child.wait().expect("wait for provekit-walk-rpc");
+    assert!(status.success(), "provekit-walk-rpc exited with {status}");
+}
+
+fn read_response(reader: &mut impl BufRead) -> Value {
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read response");
+    assert!(!line.trim().is_empty(), "empty JSON-RPC response");
+    serde_json::from_str(line.trim()).expect("JSON-RPC response JSON")
+}


### PR DESCRIPTION
## Summary

Adds the Phase 4 step-3a kit declaration shape:

- Defines the shared `KitDeclaration` schema and `provekit.plugin.kit_declaration` RPC method in `provekit-claim-envelope`.
- Adds a CLI loader that consumes an already-resolved manifest/config command over JSON-RPC without workspace/PATH kit discovery.
- Adds a minimal `provekit-walk-rpc` declaration response with kit identity, actual RPC methods, proof resolution metadata, `concept:panic-freedom`, and empty effect/guard/control arrays for 3a.

## Scope boundary

This is intentionally 3a only:

- No doctor enforcement in this PR.
- No full Rust effect-leaf / guard-predicate / control-carrier declaration coverage in this PR.
- No `libprovekit` changes.
- Full Rust declaration emission is the 3b follow-up; generic doctor validation is the next step after that.

## Validation

- `../../bin/bcargo test -p provekit-claim-envelope kit_declaration -- --nocapture`
- `../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture`
- `../../bin/bcargo test -p provekit-walk kit_declaration -- --nocapture`
- `../../bin/bcargo build -p provekit-lift --bin provekit-lift`
- `../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture`
- `make check-macos-swift-rust-scope`
- `git diff --check`
- `git diff --name-only | rg '^implementations/rust/libprovekit' || true`

Note: global `../../bin/bcargo fmt --check` reports pre-existing unrelated formatting drift outside this slice, so this PR avoids global formatting churn.
