### PR TITLE
[codex] Declare Rust panic-freedom kit vocabulary

### DIFF
--- a/implementations/rust/provekit-claim-envelope/src/lib.rs
+++ b/implementations/rust/provekit-claim-envelope/src/lib.rs
@@ -267,7 +267,7 @@ mod kit_declaration_schema_tests {
             },
             effect_kinds: vec!["concept:panic-freedom".to_string()],
             effect_leaves: vec![KitDeclarationMapping {
-                surface: Some("rust-implications".to_string()),
+                surface: Some("rust-fn-contracts".to_string()),
                 local: "method:unwrap".to_string(),
                 concept: "concept:panic-freedom.leaf.unwrap".to_string(),
             }],
@@ -317,7 +317,7 @@ mod kit_declaration_schema_tests {
             .expect("exact duplicate declaration is harmless");
 
         declaration.effect_leaves.push(KitDeclarationMapping {
-            surface: Some("rust-implications".to_string()),
+            surface: Some("rust-fn-contracts".to_string()),
             local: "method:unwrap".to_string(),
             concept: "concept:panic-freedom.leaf.expect".to_string(),
         });

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -3721,11 +3721,54 @@ fn kit_declaration_result() -> Value {
             "strategy": "cargo"
         },
         "effectKinds": ["concept:panic-freedom"],
-        "effectLeaves": [],
-        "guardPredicates": [],
-        "controlCarriers": [],
+        "effectLeaves": kit_declaration_panic_effect_leaves(),
+        "guardPredicates": kit_declaration_panic_guard_predicates(),
+        "controlCarriers": kit_declaration_panic_control_carriers(),
         "residueCategories": []
     })
+}
+
+const RUST_FN_CONTRACTS_SURFACE: &str = "rust-fn-contracts";
+
+fn kit_declaration_mapping(local: &str, concept: &str) -> Value {
+    json!({
+        "surface": RUST_FN_CONTRACTS_SURFACE,
+        "local": local,
+        "concept": concept
+    })
+}
+
+fn kit_declaration_panic_effect_leaves() -> Vec<Value> {
+    vec![
+        kit_declaration_mapping(
+            panic_freedom::METHOD_UNWRAP,
+            panic_freedom::METHOD_UNWRAP_CONCEPT,
+        ),
+        kit_declaration_mapping(
+            panic_freedom::METHOD_EXPECT,
+            panic_freedom::METHOD_EXPECT_CONCEPT,
+        ),
+        kit_declaration_mapping(
+            panic_freedom::METHOD_UNWRAP_ERR,
+            panic_freedom::METHOD_UNWRAP_ERR_CONCEPT,
+        ),
+    ]
+}
+
+fn kit_declaration_panic_guard_predicates() -> Vec<Value> {
+    vec![
+        kit_declaration_mapping(panic_freedom::IS_OK, panic_freedom::IS_OK_CONCEPT),
+        kit_declaration_mapping(panic_freedom::IS_ERR, panic_freedom::IS_ERR_CONCEPT),
+        kit_declaration_mapping(panic_freedom::IS_SOME, panic_freedom::IS_SOME_CONCEPT),
+        kit_declaration_mapping(panic_freedom::IS_NONE, panic_freedom::IS_NONE_CONCEPT),
+    ]
+}
+
+fn kit_declaration_panic_control_carriers() -> Vec<Value> {
+    vec![
+        kit_declaration_mapping(panic_freedom::CF_GUARDED, panic_freedom::CF_GUARDED_CONCEPT),
+        kit_declaration_mapping(panic_freedom::CF_ITE, panic_freedom::CF_ITE_CONCEPT),
+    ]
 }
 
 fn bind_lift(params: &Value) -> Result<Value, String> {
@@ -8132,14 +8175,65 @@ fn cvalue_to_json(v: &CValue) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use libprovekit::concept::panic_freedom;
     use libprovekit::core::{bind_result_payload, bind_term_document, BindOptions, Term};
     use provekit_ir_types::Sort;
     use provekit_proof_envelope::{
         build_proof_envelope, ed25519_pubkey_string, Ed25519Seed, ProofEnvelopeInput,
     };
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    const RUST_FN_CONTRACTS_SURFACE: &str = "rust-fn-contracts";
+
+    fn assert_kit_declaration_mappings(
+        category: &str,
+        mappings: &[provekit_claim_envelope::KitDeclarationMapping],
+        expected: &[(&str, &str)],
+    ) {
+        assert_eq!(
+            mappings.len(),
+            expected.len(),
+            "{category} should declare exactly the expected mappings: {mappings:#?}"
+        );
+
+        let mut locals = BTreeSet::new();
+        for mapping in mappings {
+            assert_eq!(
+                mapping.surface.as_deref(),
+                Some(RUST_FN_CONTRACTS_SURFACE),
+                "{category} mapping should be owned by rust-fn-contracts: {mapping:#?}"
+            );
+            assert!(
+                locals.insert(mapping.local.clone()),
+                "{category} must not duplicate local mapping {}",
+                mapping.local
+            );
+        }
+
+        for (local, concept) in expected {
+            assert!(
+                mappings.iter().any(|mapping| {
+                    mapping.surface.as_deref() == Some(RUST_FN_CONTRACTS_SURFACE)
+                        && mapping.local == *local
+                        && mapping.concept == *concept
+                }),
+                "{category} missing mapping {local} -> {concept}: {mappings:#?}"
+            );
+        }
+    }
+
+    fn assert_mapping_absent(
+        category: &str,
+        mappings: &[provekit_claim_envelope::KitDeclarationMapping],
+        local: &str,
+    ) {
+        assert!(
+            !mappings.iter().any(|mapping| mapping.local == local),
+            "{category} must not contain {local}: {mappings:#?}"
+        );
+    }
 
     fn panic_loci_for_first_fn(src: &str) -> Vec<Value> {
         let file = syn::parse_file(src).expect("source parses");
@@ -8409,7 +8503,7 @@ pub fn wrap_positive(amount: usize) -> Option<usize> {
     }
 
     #[test]
-    fn kit_declaration_result_is_minimal_valid_declaration() {
+    fn kit_declaration_result_declares_rust_panic_freedom_vocabulary() {
         let declaration: provekit_claim_envelope::KitDeclaration =
             serde_json::from_value(kit_declaration_result()).expect("kit declaration shape");
 
@@ -8420,17 +8514,64 @@ pub fn wrap_positive(amount: usize) -> Option<usize> {
             declaration.effect_kinds,
             vec!["concept:panic-freedom".to_string()]
         );
-        assert!(
-            declaration.effect_leaves.is_empty(),
-            "3a stub must not claim full rust effect-leaf coverage"
+
+        assert_kit_declaration_mappings(
+            "effectLeaves",
+            &declaration.effect_leaves,
+            &[
+                (
+                    panic_freedom::METHOD_UNWRAP,
+                    panic_freedom::METHOD_UNWRAP_CONCEPT,
+                ),
+                (
+                    panic_freedom::METHOD_EXPECT,
+                    panic_freedom::METHOD_EXPECT_CONCEPT,
+                ),
+                (
+                    panic_freedom::METHOD_UNWRAP_ERR,
+                    panic_freedom::METHOD_UNWRAP_ERR_CONCEPT,
+                ),
+            ],
         );
-        assert!(
-            declaration.guard_predicates.is_empty(),
-            "3a stub must not claim full rust guard-predicate coverage"
+        assert_kit_declaration_mappings(
+            "guardPredicates",
+            &declaration.guard_predicates,
+            &[
+                (panic_freedom::IS_OK, panic_freedom::IS_OK_CONCEPT),
+                (panic_freedom::IS_ERR, panic_freedom::IS_ERR_CONCEPT),
+                (panic_freedom::IS_SOME, panic_freedom::IS_SOME_CONCEPT),
+                (panic_freedom::IS_NONE, panic_freedom::IS_NONE_CONCEPT),
+            ],
         );
+        assert_kit_declaration_mappings(
+            "controlCarriers",
+            &declaration.control_carriers,
+            &[
+                (panic_freedom::CF_GUARDED, panic_freedom::CF_GUARDED_CONCEPT),
+                (panic_freedom::CF_ITE, panic_freedom::CF_ITE_CONCEPT),
+            ],
+        );
+
+        assert_mapping_absent(
+            "guardPredicates",
+            &declaration.guard_predicates,
+            panic_freedom::METHOD_UNWRAP,
+        );
+        assert_mapping_absent(
+            "controlCarriers",
+            &declaration.control_carriers,
+            panic_freedom::METHOD_UNWRAP,
+        );
+    }
+
+    #[test]
+    fn kit_declaration_result_is_not_the_empty_3a_stub() {
+        let declaration: provekit_claim_envelope::KitDeclaration =
+            serde_json::from_value(kit_declaration_result()).expect("kit declaration shape");
+
         assert!(
-            declaration.control_carriers.is_empty(),
-            "3a stub must not claim full rust control-carrier coverage"
+            !declaration.effect_leaves.is_empty(),
+            "3b declaration must replace the empty 3a effect-leaf stub"
         );
     }
 

--- a/implementations/rust/provekit-walk/tests/kit_declaration_rpc.rs
+++ b/implementations/rust/provekit-walk/tests/kit_declaration_rpc.rs
@@ -1,8 +1,11 @@
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Command, Stdio};
 
+use libprovekit::concept::panic_freedom;
 use provekit_claim_envelope::{KitDeclaration, KIT_DECLARATION_RPC_METHOD};
 use serde_json::{json, Value};
+
+const RUST_FN_CONTRACTS_SURFACE: &str = "rust-fn-contracts";
 
 #[test]
 fn walk_rpc_serves_kit_declaration_over_stdio() {
@@ -65,9 +68,52 @@ fn walk_rpc_serves_kit_declaration_over_stdio() {
         "declaration must advertise its declaration RPC method"
     );
     assert_eq!(declaration.effect_kinds, ["concept:panic-freedom"]);
-    assert!(declaration.effect_leaves.is_empty());
-    assert!(declaration.guard_predicates.is_empty());
-    assert!(declaration.control_carriers.is_empty());
+    assert_kit_declaration_mappings(
+        "effectLeaves",
+        &declaration.effect_leaves,
+        &[
+            (
+                panic_freedom::METHOD_UNWRAP,
+                panic_freedom::METHOD_UNWRAP_CONCEPT,
+            ),
+            (
+                panic_freedom::METHOD_EXPECT,
+                panic_freedom::METHOD_EXPECT_CONCEPT,
+            ),
+            (
+                panic_freedom::METHOD_UNWRAP_ERR,
+                panic_freedom::METHOD_UNWRAP_ERR_CONCEPT,
+            ),
+        ],
+    );
+    assert_kit_declaration_mappings(
+        "guardPredicates",
+        &declaration.guard_predicates,
+        &[
+            (panic_freedom::IS_OK, panic_freedom::IS_OK_CONCEPT),
+            (panic_freedom::IS_ERR, panic_freedom::IS_ERR_CONCEPT),
+            (panic_freedom::IS_SOME, panic_freedom::IS_SOME_CONCEPT),
+            (panic_freedom::IS_NONE, panic_freedom::IS_NONE_CONCEPT),
+        ],
+    );
+    assert_kit_declaration_mappings(
+        "controlCarriers",
+        &declaration.control_carriers,
+        &[
+            (panic_freedom::CF_GUARDED, panic_freedom::CF_GUARDED_CONCEPT),
+            (panic_freedom::CF_ITE, panic_freedom::CF_ITE_CONCEPT),
+        ],
+    );
+    assert_mapping_absent(
+        "guardPredicates",
+        &declaration.guard_predicates,
+        panic_freedom::METHOD_UNWRAP,
+    );
+    assert_mapping_absent(
+        "controlCarriers",
+        &declaration.control_carriers,
+        panic_freedom::METHOD_UNWRAP,
+    );
 
     writeln!(
         stdin,
@@ -90,4 +136,46 @@ fn read_response(reader: &mut impl BufRead) -> Value {
     reader.read_line(&mut line).expect("read response");
     assert!(!line.trim().is_empty(), "empty JSON-RPC response");
     serde_json::from_str(line.trim()).expect("JSON-RPC response JSON")
+}
+
+fn assert_kit_declaration_mappings(
+    category: &str,
+    mappings: &[provekit_claim_envelope::KitDeclarationMapping],
+    expected: &[(&str, &str)],
+) {
+    assert_eq!(
+        mappings.len(),
+        expected.len(),
+        "{category} should declare exactly the expected mappings: {mappings:#?}"
+    );
+
+    for mapping in mappings {
+        assert_eq!(
+            mapping.surface.as_deref(),
+            Some(RUST_FN_CONTRACTS_SURFACE),
+            "{category} mapping should be owned by rust-fn-contracts: {mapping:#?}"
+        );
+    }
+
+    for (local, concept) in expected {
+        assert!(
+            mappings.iter().any(|mapping| {
+                mapping.surface.as_deref() == Some(RUST_FN_CONTRACTS_SURFACE)
+                    && mapping.local == *local
+                    && mapping.concept == *concept
+            }),
+            "{category} missing mapping {local} -> {concept}: {mappings:#?}"
+        );
+    }
+}
+
+fn assert_mapping_absent(
+    category: &str,
+    mappings: &[provekit_claim_envelope::KitDeclarationMapping],
+    local: &str,
+) {
+    assert!(
+        !mappings.iter().any(|mapping| mapping.local == local),
+        "{category} must not contain {local}: {mappings:#?}"
+    );
 }


### PR DESCRIPTION
## Summary

Declares the Rust kit's panic-freedom vocabulary through the existing `provekit.plugin.kit_declaration` RPC response.

This populates the 3a stub with:
- `effectLeaves`: `method:unwrap`, `method:expect`, `method:unwrap_err`
- `guardPredicates`: `is_ok`, `is_err`, `is_some`, `is_none`
- `controlCarriers`: `cf_guarded`, `cf_ite`

All mappings use `surface = "rust-fn-contracts"` and the local/concept strings come from `libprovekit::concept::panic_freedom` constants.

## Attribution

`rust-fn-contracts` is the canonical surface for this vocabulary because `function_contract_lift` emits the function contract mementos, attaches `panicLoci`, and emits the contract pre/post bodies where the guard predicates and control carriers appear. `rust-implications` consumes those contract bindings to emit callsite/bridge obligations; it does not own the substrate vocabulary introduction.

The claim-envelope fixture surface is also corrected from `rust-implications` to `rust-fn-contracts` so the schema example does not teach the wrong ownership.

`residueCategories` remains empty in this slice; this PR only fills the panic-freedom leaves, guards, and carriers needed for the next doctor validation step.

## Validation

- RED: `../../bin/bcargo test -p provekit-walk kit_declaration -- --nocapture` failed before implementation on empty `effectLeaves`.
- GREEN: `../../bin/bcargo test -p provekit-walk kit_declaration -- --nocapture`
- GREEN: `../../bin/bcargo test -p provekit-claim-envelope kit_declaration -- --nocapture`
- GREEN: `../../bin/bcargo build -p provekit-lift --bin provekit-lift`
- GREEN: `../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture`
- GREEN: `git diff --check`
- GREEN: `make check-macos-swift-rust-scope`
- GREEN: `git diff --name-only | rg '^implementations/rust/libprovekit' || true` produced no output.

Note: `../../bin/bcargo fmt --all -- --check` was attempted and is blocked by existing unrelated repo-wide rustfmt drift across libprovekit/CLI/verifier/examples. I did not apply repo-wide formatting churn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rust kit now fully advertises panic-freedom vocabulary capabilities with method-level effect coverage

* **Tests**
  * Expanded validation tests to verify panic-freedom mapping contents and correct vocabulary ownership
  * Added stricter assertions ensuring all expected vocabulary mappings are properly declared

<!-- end of auto-generated comment: release notes by coderabbit.ai -->