### PR TITLE
[codex] Slice 4b provekit-lift declares kit vocabulary

### DIFF
--- a/implementations/rust/provekit-lift/Cargo.toml
+++ b/implementations/rust/provekit-lift/Cargo.toml
@@ -31,6 +31,7 @@ provekit-canonicalizer = { path = "../provekit-canonicalizer" }
 provekit-proof-envelope = { path = "../provekit-proof-envelope" }
 provekit-claim-envelope = { path = "../provekit-claim-envelope" }
 provekit-ir-symbolic = { path = "../provekit-ir-symbolic" }
+libprovekit = { path = "../libprovekit" }
 
 # Adapter crates (each owns its own shape walker).
 provekit-lift-proptest = { path = "../provekit-lift-proptest" }

--- a/implementations/rust/provekit-lift/src/lib.rs
+++ b/implementations/rust/provekit-lift/src/lib.rs
@@ -42,10 +42,11 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use libprovekit::concept::panic_freedom;
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value};
 use provekit_claim_envelope::{
     compute_contract_set_cid, contract_cid as compute_contract_cid, mint_contract, Authoring,
-    MintContractArgs,
+    MintContractArgs, KIT_DECLARATION_RPC_METHOD,
 };
 use provekit_ir_symbolic::{serialize::formula_to_value, ContractDecl, Formula};
 use provekit_proof_envelope::{
@@ -933,6 +934,14 @@ fn run_rpc_mode() -> i32 {
                 let resp = serde_json::json!({"jsonrpc":"2.0","id":id,"result":{"name":"provekit-lift","version":"1.0","protocol_version":"pep/1.7.0","capabilities":{"authoring_surfaces":["rust"],"ir_version":"v1.1.0"}}});
                 let _ = writeln!(stdout, "{resp}");
             }
+            KIT_DECLARATION_RPC_METHOD => {
+                let resp = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": kit_declaration_result(),
+                });
+                let _ = writeln!(stdout, "{resp}");
+            }
             "lift" => {
                 let params = req
                     .get("params")
@@ -1035,6 +1044,51 @@ fn run_rpc_mode() -> i32 {
         }
     }
     0
+}
+
+const RUST_CONTRACTS_SURFACE: &str = "rust-contracts";
+
+fn kit_declaration_result() -> serde_json::Value {
+    serde_json::json!({
+        "kit": {
+            "id": "provekit-lift",
+            "language": "rust",
+            "version": env!("CARGO_PKG_VERSION")
+        },
+        "rpc": {
+            "methods": [
+                {"name": "initialize", "required": true},
+                {"name": "lift", "required": true},
+                {"name": "shutdown", "required": true},
+                {"name": KIT_DECLARATION_RPC_METHOD, "required": false}
+            ]
+        },
+        "proofResolution": {
+            "strategy": "cargo"
+        },
+        "effectKinds": ["concept:panic-freedom"],
+        "effectLeaves": [],
+        "guardPredicates": kit_declaration_guard_predicates(),
+        "controlCarriers": [],
+        "residueCategories": []
+    })
+}
+
+fn kit_declaration_mapping(local: &str, concept: &str) -> serde_json::Value {
+    serde_json::json!({
+        "surface": RUST_CONTRACTS_SURFACE,
+        "local": local,
+        "concept": concept
+    })
+}
+
+fn kit_declaration_guard_predicates() -> Vec<serde_json::Value> {
+    vec![
+        kit_declaration_mapping(panic_freedom::IS_OK, panic_freedom::IS_OK_CONCEPT),
+        kit_declaration_mapping(panic_freedom::IS_ERR, panic_freedom::IS_ERR_CONCEPT),
+        kit_declaration_mapping(panic_freedom::IS_SOME, panic_freedom::IS_SOME_CONCEPT),
+        kit_declaration_mapping(panic_freedom::IS_NONE, panic_freedom::IS_NONE_CONCEPT),
+    ]
 }
 
 /// Serialize a `ContractDecl` as a `kind: "contract"` JSON memento in
@@ -1343,8 +1397,7 @@ proptest! {
         );
         assert_eq!(panic_loci[0]["callee"], "method:unwrap");
         assert_ne!(
-            panic_loci[0]["callee"],
-            "concept:panic-freedom.leaf.unwrap",
+            panic_loci[0]["callee"], "concept:panic-freedom.leaf.unwrap",
             "Rust v1 lift/mint writer must not emit the unwrap leaf concept alias"
         );
     }

--- a/implementations/rust/provekit-lift/tests/kit_declaration_rpc.rs
+++ b/implementations/rust/provekit-lift/tests/kit_declaration_rpc.rs
@@ -1,0 +1,149 @@
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+
+use provekit_claim_envelope::{KitDeclaration, KitDeclarationMapping, KIT_DECLARATION_RPC_METHOD};
+use serde_json::{json, Value};
+
+const RUST_CONTRACTS_SURFACE: &str = "rust-contracts";
+
+#[test]
+fn lift_rpc_serves_rust_contracts_kit_declaration() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_provekit-lift"))
+        .arg("--rpc")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn provekit-lift --rpc");
+    let mut stdin = child.stdin.take().expect("stdin");
+    let stdout = child.stdout.take().expect("stdout");
+    let mut reader = BufReader::new(stdout);
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}})
+    )
+    .expect("write initialize");
+    let init_response = read_response(&mut reader);
+    assert!(
+        init_response.get("error").is_none(),
+        "initialize failed: {init_response}"
+    );
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": KIT_DECLARATION_RPC_METHOD,
+            "params": {}
+        })
+    )
+    .expect("write kit declaration request");
+    let declaration_response = read_response(&mut reader);
+    assert!(
+        declaration_response.get("error").is_none(),
+        "kit declaration RPC failed: {declaration_response}"
+    );
+
+    let declaration: KitDeclaration = serde_json::from_value(
+        declaration_response
+            .get("result")
+            .cloned()
+            .expect("kit declaration result"),
+    )
+    .expect("kit declaration schema");
+    declaration.validate().expect("valid declaration");
+
+    assert_eq!(declaration.kit.id, "provekit-lift");
+    assert_eq!(declaration.kit.language, "rust");
+    assert_method_declared(&declaration, "initialize");
+    assert_method_declared(&declaration, "lift");
+    assert_method_declared(&declaration, "shutdown");
+    assert_method_declared(&declaration, KIT_DECLARATION_RPC_METHOD);
+    assert_eq!(declaration.proof_resolution.strategy, "cargo");
+    assert_eq!(declaration.effect_kinds, ["concept:panic-freedom"]);
+    assert!(
+        declaration.effect_leaves.is_empty(),
+        "provekit-lift/contracts must not claim panic leaves owned by walk_rpc: {:?}",
+        declaration.effect_leaves
+    );
+    assert_kit_declaration_mappings(
+        "guardPredicates",
+        &declaration.guard_predicates,
+        &[
+            ("is_ok", "concept:panic-freedom.result.ok"),
+            ("is_err", "concept:panic-freedom.result.err"),
+            ("is_some", "concept:panic-freedom.option.some"),
+            ("is_none", "concept:panic-freedom.option.none"),
+        ],
+    );
+    assert!(
+        declaration.control_carriers.is_empty(),
+        "provekit-lift/contracts must not claim control carriers owned by walk_rpc: {:?}",
+        declaration.control_carriers
+    );
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({"jsonrpc":"2.0","id":3,"method":"shutdown","params":{}})
+    )
+    .expect("write shutdown");
+    let shutdown_response = read_response(&mut reader);
+    assert!(
+        shutdown_response.get("error").is_none(),
+        "shutdown failed: {shutdown_response}"
+    );
+    drop(stdin);
+    let status = child.wait().expect("wait for provekit-lift");
+    assert!(status.success(), "provekit-lift exited with {status}");
+}
+
+fn read_response(reader: &mut BufReader<std::process::ChildStdout>) -> Value {
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read response");
+    assert!(!line.is_empty(), "child closed stdout before response");
+    serde_json::from_str(&line).expect("JSON-RPC response")
+}
+
+fn assert_method_declared(declaration: &KitDeclaration, method: &str) {
+    assert!(
+        declaration
+            .rpc
+            .methods
+            .iter()
+            .any(|declared| declared.name == method),
+        "declaration must advertise {method}: {:?}",
+        declaration.rpc.methods
+    );
+}
+
+fn assert_kit_declaration_mappings(
+    label: &str,
+    mappings: &[KitDeclarationMapping],
+    expected: &[(&str, &str)],
+) {
+    for mapping in mappings {
+        assert_eq!(
+            mapping.surface.as_deref(),
+            Some(RUST_CONTRACTS_SURFACE),
+            "{label} mapping must be scoped to rust-contracts: {mapping:?}"
+        );
+    }
+    for (local, concept) in expected {
+        assert!(
+            mappings.iter().any(|mapping| mapping.local == *local
+                && mapping.concept == *concept
+                && mapping.surface.as_deref() == Some(RUST_CONTRACTS_SURFACE)),
+            "{label} must include {local} -> {concept}: {mappings:?}"
+        );
+    }
+    assert_eq!(
+        mappings.len(),
+        expected.len(),
+        "{label} should not claim extra mappings: {mappings:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- add provekit-lift --rpc support for provekit.plugin.kit_declaration
- declare the rust-contracts panic-freedom guard predicate subset via RPC, without claiming walk_rpc panic leaves or control carriers
- add a real stdio integration test for initialize -> kit_declaration -> shutdown

Stacked on #1803 because doctor must accept valid vocabulary subsets per kit surface.

## Verification
- RED: ../../bin/bcargo test -p provekit-lift --test kit_declaration_rpc -- --nocapture failed on unknown method before implementation
- ../../bin/bcargo test -p provekit-cli doctor_kit_declaration_panic_freedom_vocabulary -- --nocapture
- ../../bin/bcargo test -p provekit-lift -- --nocapture
- git diff --check
- rustfmt --edition 2021 --check implementations/rust/provekit-lift/src/lib.rs implementations/rust/provekit-lift/tests/kit_declaration_rpc.rs
- libprovekit path guard: git diff --name-only | rg '^implementations/rust/libprovekit' || true