### PR TITLE
[codex] Slice 5a python-hypothesis declares kit surface

### DIFF
--- a/implementations/python/provekit-emit-python-hypothesis/src/provekit_emit_python_hypothesis/rpc.py
+++ b/implementations/python/provekit-emit-python-hypothesis/src/provekit_emit_python_hypothesis/rpc.py
@@ -10,7 +10,7 @@ import traceback
 from typing import Any
 
 from .emitter import EmitPlan, emit
-from .plugin_memento import PLUGIN_MEMENTO
+from .plugin_memento import PLUGIN_MEMENTO, PLUGIN_VERSION
 
 
 def run_rpc() -> None:
@@ -28,7 +28,7 @@ def run_rpc() -> None:
         except Exception as exc:  # noqa: BLE001 - plugin errors must surface to host
             response = _error(None, -32603, f"{exc}\n{traceback.format_exc()}")
         _send(response)
-        if method == "provekit.plugin.shutdown":
+        if method in {"provekit.plugin.shutdown", "shutdown"}:
             break
 
 
@@ -38,6 +38,12 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
     params = request.get("params")
     if params is None:
         params = {}
+
+    if method == "initialize":
+        return {"jsonrpc": "2.0", "id": msg_id, "result": initialize_result()}
+
+    if method == "provekit.plugin.kit_declaration":
+        return {"jsonrpc": "2.0", "id": msg_id, "result": kit_declaration_result()}
 
     if method == "provekit.plugin.describe":
         return {"jsonrpc": "2.0", "id": msg_id, "result": PLUGIN_MEMENTO}
@@ -59,7 +65,49 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
     if method == "provekit.plugin.shutdown":
         return {"jsonrpc": "2.0", "id": msg_id, "result": None}
 
+    if method == "shutdown":
+        return {"jsonrpc": "2.0", "id": msg_id, "result": None}
+
     return _error(msg_id, -32601, f"METHOD_NOT_FOUND: {method}")
+
+
+def initialize_result() -> dict[str, Any]:
+    return {
+        "name": "python-hypothesis",
+        "version": PLUGIN_VERSION,
+        "protocol_version": "pep/1.7.0",
+        "capabilities": {
+            "target_language": "python",
+            "target_framework": "hypothesis",
+        },
+    }
+
+
+def kit_declaration_result() -> dict[str, Any]:
+    return {
+        "kit": {
+            "id": "python-hypothesis",
+            "language": "python",
+            "version": PLUGIN_VERSION,
+        },
+        "rpc": {
+            "methods": [
+                {"name": "initialize", "required": True},
+                {"name": "provekit.plugin.kit_declaration", "required": True},
+                {"name": "provekit.plugin.describe", "required": False},
+                {"name": "provekit.plugin.invoke", "required": True},
+                {"name": "provekit.plugin.check", "required": False},
+                {"name": "provekit.plugin.shutdown", "required": False},
+                {"name": "shutdown", "required": False},
+            ]
+        },
+        "proofResolution": {"strategy": "pip"},
+        "effectKinds": [],
+        "effectLeaves": [],
+        "guardPredicates": [],
+        "controlCarriers": [],
+        "residueCategories": [],
+    }
 
 
 def _check_pytest(out_dir: str) -> dict[str, Any]:

--- a/implementations/python/provekit-emit-python-hypothesis/tests/test_rpc.py
+++ b/implementations/python/provekit-emit-python-hypothesis/tests/test_rpc.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
+from pathlib import Path
 
 from provekit_emit_python_hypothesis.rpc import dispatch
 
@@ -28,6 +32,66 @@ def test_describe_returns_emit_plugin_memento_for_hypothesis() -> None:
     assert header["content"]["target_framework"] == "hypothesis"
     assert "concept:lt" in header["content"]["capabilities"]["predicates"]
     json.dumps(response)
+
+
+def test_kit_declaration_returns_emit_only_hypothesis_declaration() -> None:
+    response = dispatch(
+        {"jsonrpc": "2.0", "id": 11, "method": "provekit.plugin.kit_declaration"}
+    )
+    result = response["result"]
+
+    assert response["id"] == 11
+    assert result["kit"] == {
+        "id": "python-hypothesis",
+        "language": "python",
+        "version": "0.1.0",
+    }
+    method_names = {method["name"] for method in result["rpc"]["methods"]}
+    assert method_names == {
+        "initialize",
+        "provekit.plugin.describe",
+        "provekit.plugin.invoke",
+        "provekit.plugin.check",
+        "provekit.plugin.shutdown",
+        "provekit.plugin.kit_declaration",
+        "shutdown",
+    }
+    assert result["proofResolution"] == {"strategy": "pip"}
+    assert result["effectKinds"] == []
+    assert result["effectLeaves"] == []
+    assert result["guardPredicates"] == []
+    assert result["controlCarriers"] == []
+    assert result["residueCategories"] == []
+    json.dumps(response)
+
+
+def test_kit_declaration_stdio_round_trip() -> None:
+    src = Path(__file__).resolve().parents[1] / "src"
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = str(src) if not existing else os.pathsep.join([str(src), existing])
+    messages = [
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+        {"jsonrpc": "2.0", "id": 2, "method": "provekit.plugin.kit_declaration"},
+        {"jsonrpc": "2.0", "id": 3, "method": "shutdown"},
+    ]
+    completed = subprocess.run(
+        [sys.executable, "-m", "provekit_emit_python_hypothesis", "--rpc"],
+        input="\n".join(json.dumps(message) for message in messages) + "\n",
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=10,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    responses = [json.loads(line) for line in completed.stdout.splitlines() if line.strip()]
+    initialize = next(response for response in responses if response.get("id") == 1)
+    declaration = next(response for response in responses if response.get("id") == 2)
+    assert initialize["result"]["name"] == "python-hypothesis"
+    assert declaration["result"]["kit"]["id"] == "python-hypothesis"
+    assert declaration["result"]["effectKinds"] == []
 
 
 def test_invoke_emits_hypothesis_module() -> None:

--- a/implementations/rust/provekit-claim-envelope/src/lib.rs
+++ b/implementations/rust/provekit-claim-envelope/src/lib.rs
@@ -182,11 +182,6 @@ impl KitDeclaration {
         if let Some(method) = &self.proof_resolution.rpc_method {
             require_nonempty("proofResolution.rpcMethod", method)?;
         }
-        if self.effect_kinds.is_empty() {
-            return Err(KitDeclarationError::EmptyField {
-                field: "effectKinds",
-            });
-        }
         for effect_kind in &self.effect_kinds {
             require_nonempty("effectKinds[]", effect_kind)?;
         }
@@ -305,6 +300,19 @@ mod kit_declaration_schema_tests {
             err.to_string().contains("effectKinds"),
             "error should name missing field: {err}"
         );
+    }
+
+    #[test]
+    fn kit_declaration_allows_empty_effect_kinds_for_non_effect_kits() {
+        let mut declaration = valid_declaration();
+        declaration.effect_kinds.clear();
+        declaration.effect_leaves.clear();
+        declaration.guard_predicates.clear();
+        declaration.control_carriers.clear();
+
+        declaration
+            .validate()
+            .expect("emit-only kits may declare no effect vocabulary");
     }
 
     #[test]

--- a/implementations/rust/provekit-cli/src/doctor.rs
+++ b/implementations/rust/provekit-cli/src/doctor.rs
@@ -3028,6 +3028,55 @@ mod tests {
     }
 
     #[test]
+    fn doctor_kit_declaration_empty_effect_kinds_passes_and_skips_vocabulary() {
+        let td = TempDir::new().unwrap();
+        let kit = td.path();
+        let plugin = kit.join("emit-only-plugin");
+        let mut declaration = valid_panic_freedom_declaration("python-hypothesis");
+        declaration["kit"] =
+            json!({"id": "python-hypothesis", "language": "python", "version": "0.1.0"});
+        declaration["proofResolution"] = json!({"strategy": "pip"});
+        declaration["effectKinds"] = json!([]);
+        declaration["effectLeaves"] = json!([]);
+        declaration["guardPredicates"] = json!([]);
+        declaration["controlCarriers"] = json!([]);
+        make_kit_declaration_plugin(&plugin, declaration);
+        write_kit(
+            kit,
+            "[[plugins]]\nname = \"python-hypothesis\"\nkind = \"emit\"\nsurface = \"python-hypothesis\"\n",
+        );
+        write_manifest(
+            kit,
+            "emit",
+            "python-hypothesis",
+            "\"./emit-only-plugin\"",
+            ".",
+        );
+
+        let report = run_report_with_context(kit, DoctorContext::new(DoctorMode::Strict));
+
+        let available =
+            check_by_id_and_surface(&report, "kit.declaration.available", "python-hypothesis");
+        let methods = check_by_id_and_surface(
+            &report,
+            "kit.declaration.rpc_methods_declared",
+            "python-hypothesis",
+        );
+        let vocabulary = check_by_id_and_surface(
+            &report,
+            "kit.declaration.substrate_vocabulary.panic_freedom",
+            "python-hypothesis",
+        );
+        assert_eq!(available.status, CheckStatus::Pass);
+        assert_eq!(methods.status, CheckStatus::Pass);
+        assert_eq!(vocabulary.status, CheckStatus::Skip);
+        assert_eq!(
+            vocabulary.evidence.get("skipped").and_then(Value::as_bool),
+            Some(true)
+        );
+    }
+
+    #[test]
     fn structural_dependency_resolver_available_passes_with_binary_evidence() {
         let td = TempDir::new().unwrap();
         let kit = td.path();

--- a/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
+++ b/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
@@ -128,6 +128,43 @@ done
 }
 
 #[test]
+fn loader_accepts_empty_effect_kinds_for_emit_only_kit() {
+    let td = TempDir::new().expect("tempdir");
+    let stub = td.path().join("kit.sh");
+    make_executable(
+        &stub,
+        r#"#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *initialize*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"name":"python-hypothesis","protocol_version":"pep/1.7.0","capabilities":{}}}'
+      ;;
+    *provekit.plugin.kit_declaration*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"kit":{"id":"python-hypothesis","language":"python","version":"0.1.0"},"rpc":{"methods":[{"name":"initialize","required":true},{"name":"provekit.plugin.kit_declaration","required":true},{"name":"provekit.plugin.invoke","required":true},{"name":"provekit.plugin.check","required":false},{"name":"provekit.plugin.shutdown","required":false}]},"proofResolution":{"strategy":"pip"},"effectKinds":[],"effectLeaves":[],"guardPredicates":[],"controlCarriers":[],"residueCategories":[]}}'
+      ;;
+    *shutdown*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":null}'
+      exit 0
+      ;;
+  esac
+done
+"#,
+    );
+
+    let declaration: KitDeclaration =
+        provekit_cli::kit_declaration::load_kit_declaration_with_command(
+            &[stub.display().to_string()],
+            Some(td.path()),
+        )
+        .expect("load declaration");
+
+    assert_eq!(declaration.kit.id, "python-hypothesis");
+    assert_eq!(declaration.kit.language, "python");
+    assert!(declaration.effect_kinds.is_empty());
+    assert_eq!(declaration.proof_resolution.strategy, "pip");
+}
+
+#[test]
 fn loader_rejects_kit_declaration_response_id_mismatch() {
     let td = TempDir::new().expect("tempdir");
     let stub = td.path().join("kit.sh");


### PR DESCRIPTION
## Summary

First Python parity slice for kit declaration RPC. This adds `provekit.plugin.kit_declaration` to the configured `python-hypothesis` emitter and wires the generic lifecycle aliases the declaration loader uses: `initialize` and `shutdown`.

This also relaxes `KitDeclaration::validate` so emit-only or consumer kits can honestly declare `effectKinds: []` when they own no substrate vocabulary. Missing `effectKinds` still fails serde validation, and empty strings inside the array still fail validation.

## Why

`implementations/python/.provekit/config.toml` currently registers `python-hypothesis`, so strict doctor needs that kit to declare its surface over RPC. Padding an emitter declaration with fake effect vocabulary would violate the language-blind RPC seam. Empty content arrays are the honest declaration shape for an emitter that owns no panic-freedom substrate vocabulary.

`proofResolution: {"strategy":"pip"}` follows the Python kit self-resolution convention.

## Validation

- `pytest -q implementations/python/provekit-emit-python-hypothesis/tests/test_rpc.py -q`: 7 passed
- `pytest -q implementations/python/provekit-emit-python-hypothesis/tests`: 10 passed, 1 skipped
- `pytest -q implementations/python/provekit-emit-python-hypothesis/tests/test_rpc.py::test_invoke_emits_hypothesis_module implementations/python/provekit-emit-python-hypothesis/tests/test_rpc.py::test_invoke_reports_unsupported_gap implementations/python/provekit-emit-python-hypothesis/tests/test_rpc.py::test_invalid_params_error implementations/python/provekit-emit-python-hypothesis/tests/test_emitter.py -q`: 6 passed, 1 skipped
- `../../bin/bcargo test -p provekit-claim-envelope kit_declaration -- --nocapture`: 4 passed
- `../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture`: 5 passed
- `../../bin/bcargo test -p provekit-cli doctor_kit_declaration -- --nocapture`: 14 passed in lib and 14 passed in bin harness
- `rustfmt --edition 2021 --check implementations/rust/provekit-claim-envelope/src/lib.rs implementations/rust/provekit-cli/src/doctor.rs implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs`
- `python3 -m compileall -q implementations/python/provekit-emit-python-hypothesis/src implementations/python/provekit-emit-python-hypothesis/tests`
- `git diff --check`
- `git diff --name-only | rg '(^|/)libprovekit(/|$)' || true`: no output

One extra strict-doctor integration attempt through `bcargo run -p provekit-cli -- doctor --target ../../implementations/python --mode strict --json` failed before doctor ran because the remote `bcargo` checkout did not have `implementations/python` at that relative path. The Python stdio round trip plus synthetic strict-doctor regression cover the declaration path in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added RPC protocol support for kit initialization and declaration endpoints
  * Extended support for emit-only kits (those without effect handling capabilities)

* **Tests**
  * Added comprehensive CLI round-trip tests verifying RPC message handling and kit declaration validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->