### PR TITLE
[codex] Slice 5b lift-py-tests declares kit surface

### DIFF
--- a/implementations/python/.provekit/config.toml
+++ b/implementations/python/.provekit/config.toml
@@ -3,3 +3,8 @@ name = "python-hypothesis"
 kind = "emit"
 surface = "python-hypothesis"
 emit = "hypothesis"
+
+[[plugins]]
+name = "python-lift"
+kind = "lift"
+surface = "python"

--- a/implementations/python/.provekit/lift/python/manifest.toml
+++ b/implementations/python/.provekit/lift/python/manifest.toml
@@ -1,3 +1,3 @@
 name = "python-lift"
-command = ["provekit-lift-python", "--rpc"]
-working_dir = "."
+command = ["python3", "-m", "provekit_lift_py_tests.lsp", "--rpc"]
+working_dir = "provekit-lift-py-tests/src"

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lsp.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lsp.py
@@ -48,6 +48,8 @@ from .cpython_ctypes_resolver import resolve_ctypes_calls
 # ---------------------------------------------------------------------------
 
 KIT_ID = "python"
+KIT_VERSION = "0.1.0"
+KIT_DECLARATION_RPC_METHOD = "provekit.plugin.kit_declaration"
 SHARED_LSP_PROTOCOL_VERSION = "provekit-lsp-shared/1"
 SHARED_LSP_PROTOCOL_CATALOG_CID = (
     "blake3-512:0e3905c2a7a098cd538b9669428a7dffd2b84ba8ccf8fde3724fe2ab61fd3fbc1e1a616a6b20b6817464cdc50c466b5497d4ac2e2dc34c3c15f05535b463643c"
@@ -82,7 +84,7 @@ def handle_initialize(msg_id: Any) -> None:
             "id": msg_id,
             "result": {
                 "name": "provekit-lsp-python",
-                "version": "0.1.0",
+                "version": KIT_VERSION,
                 "protocol_version": SHARED_LSP_PROTOCOL_VERSION,
                 "kit_id": KIT_ID,
                 "protocol_catalog_cid": SHARED_LSP_PROTOCOL_CATALOG_CID,
@@ -98,6 +100,37 @@ def handle_initialize(msg_id: Any) -> None:
             },
         }
     )
+
+
+def kit_declaration_result() -> Dict[str, Any]:
+    return {
+        "kit": {
+            "id": KIT_ID,
+            "language": "python",
+            "version": KIT_VERSION,
+        },
+        "rpc": {
+            "methods": [
+                {"name": "initialize", "required": True},
+                {"name": KIT_DECLARATION_RPC_METHOD, "required": True},
+                {"name": "analyzeDocument", "required": False},
+                {"name": "parse", "required": False},
+                {"name": "lift", "required": True},
+                {"name": "provekit.plugin.lift_implications", "required": False},
+                {"name": "shutdown", "required": False},
+            ]
+        },
+        "proofResolution": {"strategy": "pip"},
+        "effectKinds": [],
+        "effectLeaves": [],
+        "guardPredicates": [],
+        "controlCarriers": [],
+        "residueCategories": [],
+    }
+
+
+def handle_kit_declaration(msg_id: Any) -> None:
+    _send({"jsonrpc": "2.0", "id": msg_id, "result": kit_declaration_result()})
 
 
 def _implications_to_json(layer2) -> List[Dict[str, Any]]:
@@ -852,6 +885,8 @@ def main() -> None:
 
         if method == "initialize":
             handle_initialize(msg_id)
+        elif method == KIT_DECLARATION_RPC_METHOD:
+            handle_kit_declaration(msg_id)
         elif method == "analyzeDocument":
             handle_analyze_document(msg_id, params)
         elif method == "parse":

--- a/implementations/python/provekit-lift-py-tests/tests/test_daemon_protocol.py
+++ b/implementations/python/provekit-lift-py-tests/tests/test_daemon_protocol.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 import shutil
@@ -113,6 +114,40 @@ def _build_analyze_session(source: str, path: str, uri: str = "file:///project/t
     return "\n".join(json.dumps(m) for m in msgs) + "\n"
 
 
+def _build_kit_declaration_session() -> str:
+    """Build NDJSON input for initialize -> kit_declaration -> shutdown."""
+    msgs = [
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        {"jsonrpc": "2.0", "id": 2, "method": "provekit.plugin.kit_declaration"},
+        {"jsonrpc": "2.0", "id": 3, "method": "shutdown"},
+    ]
+    return "\n".join(json.dumps(m) for m in msgs) + "\n"
+
+
+def _repo_root() -> str:
+    return os.path.normpath(os.path.join(os.path.dirname(__file__), "../../../.."))
+
+
+def _python_lift_manifest() -> dict[str, object]:
+    manifest = os.path.join(
+        _repo_root(), "implementations/python/.provekit/lift/python/manifest.toml"
+    )
+    values: dict[str, object] = {}
+    with open(manifest, "r", encoding="utf-8") as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            key = key.strip()
+            value = value.strip()
+            if value.startswith("["):
+                values[key] = ast.literal_eval(value)
+            elif value.startswith('"'):
+                values[key] = ast.literal_eval(value)
+    return values
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -130,6 +165,72 @@ class TestDaemonProtocol:
         assert result["kit_id"] == "python"
         assert "python-source" in result["capabilities"]["source_surfaces"]
         assert "provekit.lsp.implication_failed" in result["capabilities"]["diagnostic_codes"]
+
+    def test_checked_in_project_registers_python_lift_surface(self):
+        """The checked-in Python kit config registers the lift-py-tests surface."""
+        config = os.path.join(_repo_root(), "implementations/python/.provekit/config.toml")
+        with open(config, "r", encoding="utf-8") as f:
+            text = f.read()
+        assert 'name = "python-lift"' in text
+        assert 'kind = "lift"' in text
+        assert 'surface = "python"' in text
+
+    def test_checked_in_python_lift_manifest_invokes_module_form(self):
+        """The checked-in lift manifest works from a clean source working_dir."""
+        manifest = _python_lift_manifest()
+        assert manifest["command"] == [
+            "python3",
+            "-m",
+            "provekit_lift_py_tests.lsp",
+            "--rpc",
+        ]
+        assert manifest["working_dir"] == "provekit-lift-py-tests/src"
+
+        completed = subprocess.run(
+            manifest["command"],
+            cwd=os.path.join(_repo_root(), "implementations/python", manifest["working_dir"]),
+            input=_build_kit_declaration_session(),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+
+        assert completed.returncode == 0, completed.stderr
+        responses = [
+            json.loads(line) for line in completed.stdout.splitlines() if line.strip()
+        ]
+        declaration = next(response for response in responses if response.get("id") == 2)
+        assert declaration["result"]["kit"]["id"] == "python"
+
+    def test_kit_declaration_returns_python_lift_surface(self):
+        """Binary serves an honest empty-vocabulary kit declaration."""
+        responses = _run_lsp(_build_kit_declaration_session())
+        declaration_resp = next(r for r in responses if r.get("id") == 2)
+        assert "error" not in declaration_resp, declaration_resp
+        result = declaration_resp["result"]
+        assert result["kit"] == {
+            "id": "python",
+            "language": "python",
+            "version": "0.1.0",
+        }
+        method_names = {method["name"] for method in result["rpc"]["methods"]}
+        assert method_names == {
+            "initialize",
+            "provekit.plugin.kit_declaration",
+            "analyzeDocument",
+            "parse",
+            "lift",
+            "provekit.plugin.lift_implications",
+            "shutdown",
+        }
+        assert result["proofResolution"] == {"strategy": "pip"}
+        assert result["effectKinds"] == []
+        assert result["effectLeaves"] == []
+        assert result["guardPredicates"] == []
+        assert result["controlCarriers"] == []
+        assert result["residueCategories"] == []
+        json.dumps(declaration_resp)
 
     def test_parse_declarations_is_array(self):
         """parse response: result.declarations is a JSON array, not a string."""
@@ -236,9 +337,7 @@ def compute(x: int) -> int:
 
     def test_analyze_document_floor_fixture_emits_shared_callsite_diagnostic(self):
         """analyzeDocument returns shared envelope plus call-site diagnostic."""
-        repo_root = os.path.normpath(
-            os.path.join(os.path.dirname(__file__), "../../../..")
-        )
+        repo_root = _repo_root()
         fixture = os.path.join(repo_root, "tests/lsp/floor-fixture/python.py")
         with open(fixture, "r", encoding="utf-8") as f:
             source = f.read()

--- a/implementations/rust/provekit-cli/src/doctor.rs
+++ b/implementations/rust/provekit-cli/src/doctor.rs
@@ -3077,6 +3077,53 @@ mod tests {
     }
 
     #[test]
+    fn doctor_kit_declaration_python_lift_empty_effect_kinds_passes_and_skips_vocabulary() {
+        let td = TempDir::new().unwrap();
+        let kit = td.path();
+        let plugin = kit.join("python-lift-plugin");
+        let mut declaration = valid_panic_freedom_declaration("python");
+        declaration["kit"] = json!({"id": "python", "language": "python", "version": "0.1.0"});
+        declaration["rpc"]["methods"] = json!([
+            {"name": "initialize", "required": true},
+            {"name": provekit_claim_envelope::KIT_DECLARATION_RPC_METHOD, "required": true},
+            {"name": "analyzeDocument", "required": false},
+            {"name": "parse", "required": false},
+            {"name": "lift", "required": true},
+            {"name": "provekit.plugin.lift_implications", "required": false},
+            {"name": "shutdown", "required": false}
+        ]);
+        declaration["proofResolution"] = json!({"strategy": "pip"});
+        declaration["effectKinds"] = json!([]);
+        declaration["effectLeaves"] = json!([]);
+        declaration["guardPredicates"] = json!([]);
+        declaration["controlCarriers"] = json!([]);
+        make_kit_declaration_plugin(&plugin, declaration);
+        write_kit(
+            kit,
+            "[[plugins]]\nname = \"python-lift\"\nkind = \"lift\"\nsurface = \"python\"\n",
+        );
+        write_manifest(kit, "lift", "python", "\"./python-lift-plugin\"", ".");
+
+        let report = run_report_with_context(kit, DoctorContext::new(DoctorMode::Strict));
+
+        let available = check_by_id_and_surface(&report, "kit.declaration.available", "python");
+        let methods =
+            check_by_id_and_surface(&report, "kit.declaration.rpc_methods_declared", "python");
+        let vocabulary = check_by_id_and_surface(
+            &report,
+            "kit.declaration.substrate_vocabulary.panic_freedom",
+            "python",
+        );
+        assert_eq!(available.status, CheckStatus::Pass);
+        assert_eq!(methods.status, CheckStatus::Pass);
+        assert_eq!(vocabulary.status, CheckStatus::Skip);
+        assert_eq!(
+            vocabulary.evidence.get("skipped").and_then(Value::as_bool),
+            Some(true)
+        );
+    }
+
+    #[test]
     fn structural_dependency_resolver_available_passes_with_binary_evidence() {
         let td = TempDir::new().unwrap();
         let kit = td.path();

--- a/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
+++ b/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
@@ -165,6 +165,48 @@ done
 }
 
 #[test]
+fn loader_accepts_empty_effect_kinds_for_python_lift_kit() {
+    let td = TempDir::new().expect("tempdir");
+    let stub = td.path().join("kit.sh");
+    make_executable(
+        &stub,
+        r#"#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *initialize*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"name":"provekit-lsp-python","version":"0.1.0","protocol_version":"provekit-lsp-shared/1","kit_id":"python","capabilities":{}}}'
+      ;;
+    *provekit.plugin.kit_declaration*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"kit":{"id":"python","language":"python","version":"0.1.0"},"rpc":{"methods":[{"name":"initialize","required":true},{"name":"provekit.plugin.kit_declaration","required":true},{"name":"analyzeDocument","required":false},{"name":"parse","required":false},{"name":"lift","required":true},{"name":"provekit.plugin.lift_implications","required":false},{"name":"shutdown","required":false}]},"proofResolution":{"strategy":"pip"},"effectKinds":[],"effectLeaves":[],"guardPredicates":[],"controlCarriers":[],"residueCategories":[]}}'
+      ;;
+    *shutdown*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":null}'
+      exit 0
+      ;;
+  esac
+done
+"#,
+    );
+
+    let declaration: KitDeclaration =
+        provekit_cli::kit_declaration::load_kit_declaration_with_command(
+            &[stub.display().to_string()],
+            Some(td.path()),
+        )
+        .expect("load declaration");
+
+    assert_eq!(declaration.kit.id, "python");
+    assert_eq!(declaration.kit.language, "python");
+    assert!(declaration.effect_kinds.is_empty());
+    assert_eq!(declaration.proof_resolution.strategy, "pip");
+    assert!(declaration
+        .rpc
+        .methods
+        .iter()
+        .any(|method| method.name == "provekit.plugin.lift_implications"));
+}
+
+#[test]
 fn loader_rejects_kit_declaration_response_id_mismatch() {
     let td = TempDir::new().expect("tempdir");
     let stub = td.path().join("kit.sh");


### PR DESCRIPTION
## Summary

Second Python parity slice for kit declaration RPC. This mirrors the #1805 pattern for the checked-in Python lift surface:

- `provekit_lift_py_tests.lsp` now serves `provekit.plugin.kit_declaration`.
- `implementations/python/.provekit/config.toml` now registers the `python-lift` lift surface.
- `implementations/python/.provekit/lift/python/manifest.toml` now uses self-contained module invocation instead of relying on an installed `provekit-lift-python` script on `PATH`.

The declaration is honest for this width slice: `kit.id = "python"`, `language = "python"`, `proofResolution.strategy = "pip"`, and all effect vocabulary arrays are empty. Substantive Python panic vocabulary is intentionally deferred to the later design slice.

## Why

Without the config entry, doctor never asks this kit for a declaration. Without the manifest fix, the newly registered surface can depend on a globally installed script in clean checkouts. This PR treats RPC declaration, config registration, and manifest invocation as one unit of checked-in registration.

`kit.id = "python"` matches the existing `initialize` identity in `lsp.py`. That is intentionally narrower scope than migrating identity to `python-lift`. Future cross-kit validation may want finer Python kit ids, but that should be a separate naming slice.

## Validation

RED observed first:

- `test_checked_in_project_registers_python_lift_surface` failed because config lacked `python-lift`.
- `test_kit_declaration_returns_python_lift_surface` failed because `provekit.plugin.kit_declaration` returned `-32601`.
- `test_checked_in_python_lift_manifest_invokes_module_form` failed because the manifest used `provekit-lift-python --rpc`.

GREEN checks:

- `pytest -q implementations/python/provekit-lift-py-tests/tests/test_daemon_protocol.py::TestDaemonProtocol::test_checked_in_project_registers_python_lift_surface implementations/python/provekit-lift-py-tests/tests/test_daemon_protocol.py::TestDaemonProtocol::test_kit_declaration_returns_python_lift_surface -q`: 2 passed
- `pytest -q implementations/python/provekit-lift-py-tests/tests/test_daemon_protocol.py::TestDaemonProtocol::test_checked_in_python_lift_manifest_invokes_module_form -q`: 1 passed
- `pytest -q implementations/python/provekit-lift-py-tests/tests -q`: passed with 3 skips
- `python3 -m compileall -q implementations/python/provekit-lift-py-tests/src implementations/python/provekit-lift-py-tests/tests`
- `../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture`: 6 passed
- `../../bin/bcargo test -p provekit-cli doctor_kit_declaration -- --nocapture`: 15 passed in lib and 15 passed in bin harness
- `rustfmt --edition 2021 --check implementations/rust/provekit-cli/src/doctor.rs implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs`
- `git diff --check`
- `git diff --name-only | rg '(^|/)libprovekit(/|$)' || true`: no output
- `git diff --name-only | rg 'swift|xctest|\.swift' || true`: no output

Manual module-form verification before patching manifest:

- From `implementations/python/provekit-lift-py-tests/src`, `python3 -m provekit_lift_py_tests.lsp --rpc` answered `initialize` and `shutdown` without `PYTHONPATH`.

One broader doctor attempt through `bcargo run -p provekit-cli -- doctor --target ../../implementations/python --mode strict --json` failed before doctor could inspect the target because the remote `bcargo` checkout still lacks `implementations/python`. That is the same remote sync limitation documented in #1805; the real Python stdio manifest test plus synthetic strict doctor regression cover this PR's path.
