### PR TITLE
[codex] Slice 5 width python-source declares kit surface

### DIFF
--- a/implementations/python/.provekit/config.toml
+++ b/implementations/python/.provekit/config.toml
@@ -8,3 +8,8 @@ emit = "hypothesis"
 name = "python-lift"
 kind = "lift"
 surface = "python"
+
+[[plugins]]
+name = "python-source"
+kind = "lift"
+surface = "python-source"

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/rpc.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/rpc.py
@@ -11,6 +11,7 @@ from .lifter import lift_paths
 
 SURFACE = "python-source"
 VERSION = "0.1.0-draft"
+KIT_DECLARATION_RPC_METHOD = "provekit.plugin.kit_declaration"
 
 
 def initialize_result() -> dict[str, Any]:
@@ -24,6 +25,31 @@ def initialize_result() -> dict[str, Any]:
             "ir_version": "v1.1.0",
             "emits_signed_mementos": False,
         },
+    }
+
+
+def kit_declaration_result() -> dict[str, Any]:
+    return {
+        "kit": {
+            "id": SURFACE,
+            "language": "python",
+            "version": VERSION,
+        },
+        "rpc": {
+            "methods": [
+                {"name": "initialize", "required": True},
+                {"name": KIT_DECLARATION_RPC_METHOD, "required": True},
+                {"name": "lift", "required": True},
+                {"name": "compile", "required": False},
+                {"name": "shutdown", "required": False},
+            ]
+        },
+        "proofResolution": {"strategy": "pip"},
+        "effectKinds": [],
+        "effectLeaves": [],
+        "guardPredicates": [],
+        "controlCarriers": [],
+        "residueCategories": [],
     }
 
 
@@ -49,6 +75,8 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
 
     if method == "initialize":
         return {"jsonrpc": "2.0", "id": msg_id, "result": initialize_result()}
+    if method == KIT_DECLARATION_RPC_METHOD:
+        return {"jsonrpc": "2.0", "id": msg_id, "result": kit_declaration_result()}
     if method == "lift":
         return _lift(msg_id, params)
     if method == "compile":

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import ast
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -19,11 +21,62 @@ from provekit_lift_py_tests.canonicalizer import jcs_hash, vobj, vstr
 from provekit_lift_python_source.canonical import canonical_json_bytes, cid_of_json
 from provekit_lift_python_source.compiler import compile_body_term, compile_ir_document
 from provekit_lift_python_source.lifter import lift_source
-from provekit_lift_python_source.rpc import initialize_result
+from provekit_lift_python_source.rpc import dispatch, initialize_result
+
+KIT_DECLARATION_RPC_METHOD = "provekit.plugin.kit_declaration"
 
 
 def _canon(value: object) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _parse_top_level_toml(path: Path) -> dict[str, object]:
+    values: dict[str, object] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or line.startswith("[") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        raw_value = value.strip()
+        if raw_value == "true":
+            values[key.strip()] = True
+        elif raw_value == "false":
+            values[key.strip()] = False
+        else:
+            values[key.strip()] = ast.literal_eval(raw_value)
+    return values
+
+
+def _plugin_entries(path: Path) -> list[dict[str, object]]:
+    entries: list[dict[str, object]] = []
+    current: dict[str, object] | None = None
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line == "[[plugins]]":
+            current = {}
+            entries.append(current)
+            continue
+        if current is not None and "=" in line:
+            key, value = line.split("=", 1)
+            current[key.strip()] = ast.literal_eval(value.strip())
+    return entries
+
+
+def _build_kit_declaration_session() -> str:
+    messages = [
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        {"jsonrpc": "2.0", "id": 2, "method": KIT_DECLARATION_RPC_METHOD},
+        {"jsonrpc": "2.0", "id": 3, "method": "shutdown"},
+    ]
+    return "\n".join(json.dumps(message) for message in messages) + "\n"
+
+
+def _python_source_manifest() -> dict[str, object]:
+    return _parse_top_level_toml(
+        ROOT / "implementations/python/.provekit/lift/python-source/manifest.toml"
+    )
 
 
 def _contract(ir: list[dict[str, object]], suffix: str) -> dict[str, object]:
@@ -258,3 +311,71 @@ def test_rpc_initialize_declares_python_source_draft() -> None:
     assert result["dialect"] == "python-source"
     assert result["capabilities"]["authoring_surfaces"] == ["python-source"]
     assert result["capabilities"]["emits_signed_mementos"] is False
+
+
+def test_checked_in_project_registers_python_source_lift_surface() -> None:
+    entries = _plugin_entries(ROOT / "implementations/python/.provekit/config.toml")
+
+    assert {
+        "name": "python-source",
+        "kind": "lift",
+        "surface": "python-source",
+    } in entries
+
+
+def test_checked_in_python_source_manifest_invokes_module_form_and_declares_kit() -> None:
+    manifest = _python_source_manifest()
+
+    assert manifest["command"] == [
+        "python3",
+        "-m",
+        "provekit_lift_python_source",
+        "--rpc",
+    ]
+    assert manifest["working_dir"] == "provekit-lift-python-source/src"
+
+    completed = subprocess.run(
+        manifest["command"],
+        cwd=ROOT / "implementations/python" / str(manifest["working_dir"]),
+        input=_build_kit_declaration_session(),
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    responses = [
+        json.loads(line) for line in completed.stdout.splitlines() if line.strip()
+    ]
+    declaration = next(response for response in responses if response.get("id") == 2)
+    assert "error" not in declaration, declaration
+    assert declaration["result"]["kit"]["id"] == "python-source"
+
+
+def test_kit_declaration_returns_python_source_lift_surface() -> None:
+    response = dispatch({"jsonrpc": "2.0", "id": 2, "method": KIT_DECLARATION_RPC_METHOD})
+
+    assert "error" not in response, response
+    result = response["result"]
+    assert result["kit"] == {
+        "id": "python-source",
+        "language": "python",
+        "version": "0.1.0-draft",
+    }
+    required_by_name = {
+        method["name"]: method["required"] for method in result["rpc"]["methods"]
+    }
+    assert required_by_name == {
+        "initialize": True,
+        KIT_DECLARATION_RPC_METHOD: True,
+        "lift": True,
+        "compile": False,
+        "shutdown": False,
+    }
+    assert result["proofResolution"] == {"strategy": "pip"}
+    assert result["effectKinds"] == []
+    assert result["effectLeaves"] == []
+    assert result["guardPredicates"] == []
+    assert result["controlCarriers"] == []
+    assert result["residueCategories"] == []


### PR DESCRIPTION
## Summary

Third Python kit-declaration width slice. This mirrors the empty-vocabulary pattern from #1805 and #1806 for the `python-source` lift surface.

This PR changes the checked-in Python project registration and the source lifter RPC daemon as one registration unit:

- registers `python-source` in `implementations/python/.provekit/config.toml`
- adds `provekit.plugin.kit_declaration` to `provekit_lift_python_source.rpc`
- adds tests that exercise both direct dispatch and the checked-in manifest module command

The `python-source` manifest was already module-form, so this slice does not change it. `kit.id = "python-source"` matches the manifest name, surface, and dialect identity; the package name remains `provekit-lift-python-source`.

## Declaration Shape

The new declaration is intentionally empty-vocabulary for now:

- `kit.language = "python"`
- `kit.version = "0.1.0-draft"`
- `proofResolution = { strategy = "pip" }`
- `effectKinds = []`
- empty `effectLeaves`, `guardPredicates`, `controlCarriers`, and `residueCategories`
- RPC methods: `initialize`, `provekit.plugin.kit_declaration`, `lift`, `compile`, `shutdown`

This does not introduce Python vocabulary concepts, does not touch validator logic, and does not bundle `bind_rpc` or `verify_rpc`.

## RED

Before implementation, the targeted Python tests failed for the intended reasons:

- config had no `python-source` plugin entry
- direct `dispatch` returned `METHOD_NOT_FOUND: provekit.plugin.kit_declaration`
- the checked-in manifest command also returned `METHOD_NOT_FOUND` for the declaration RPC

## GREEN

Validated locally:

- `pytest -q implementations/python/provekit-lift-python-source/tests/test_lifter.py::test_checked_in_project_registers_python_source_lift_surface implementations/python/provekit-lift-python-source/tests/test_lifter.py::test_checked_in_python_source_manifest_invokes_module_form_and_declares_kit implementations/python/provekit-lift-python-source/tests/test_lifter.py::test_kit_declaration_returns_python_source_lift_surface -q`
- `pytest -q implementations/python/provekit-lift-python-source/tests -q`
- `python3 -m compileall -q implementations/python/provekit-lift-python-source/src implementations/python/provekit-lift-python-source/tests`
- from `implementations/rust`: `../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture`
- from `implementations/rust`: `../../bin/bcargo test -p provekit-cli doctor_kit_declaration -- --nocapture`
- `git diff --check`
- `git diff --name-only | rg '(^|/)libprovekit(/|$)' || true` produced no output
- `git diff --name-only | rg 'swift|xctest|\.swift' || true` produced no output

Existing Rust loader and doctor tests already cover the empty-`effectKinds` path generically, so this PR does not add a redundant synthetic Rust stub test. The new behavior is the live Python RPC/config registration.
