### PR TITLE
[codex] Slice 5 width python-bind declares kit surface

### DIFF
--- a/implementations/python/.provekit/config.toml
+++ b/implementations/python/.provekit/config.toml
@@ -13,3 +13,9 @@ surface = "python"
 name = "python-source"
 kind = "lift"
 surface = "python-source"
+
+[[plugins]]
+name = "python-bind"
+kind = "lift"
+surface = "python-bind"
+layer = "library-bindings"

--- a/implementations/python/.provekit/lift/python-bind/manifest.toml
+++ b/implementations/python/.provekit/lift/python-bind/manifest.toml
@@ -1,0 +1,11 @@
+name = "python-bind"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["python3", "-m", "provekit_lift_python_source.bind_rpc", "--rpc"]
+working_dir = "provekit-lift-python-source/src"
+
+[capabilities]
+authoring_surfaces = ["python", "python-bind"]
+ir_version = "bind-ir/1.0.0"
+emits_signed_mementos = false

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_rpc.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_rpc.py
@@ -13,6 +13,8 @@ from .bind_lifter import lift_paths
 from .canonical import template_cid_of_json
 
 VERSION = "0.1.0"
+SURFACE = "python-bind"
+KIT_DECLARATION_RPC_METHOD = "provekit.plugin.kit_declaration"
 
 
 def initialize_result() -> dict[str, Any]:
@@ -25,6 +27,31 @@ def initialize_result() -> dict[str, Any]:
             "ir_version": "bind-ir/1.0.0",
             "emits_signed_mementos": False,
         },
+    }
+
+
+def kit_declaration_result() -> dict[str, Any]:
+    return {
+        "kit": {
+            "id": SURFACE,
+            "language": "python",
+            "version": VERSION,
+        },
+        "rpc": {
+            "methods": [
+                {"name": "initialize", "required": True},
+                {"name": KIT_DECLARATION_RPC_METHOD, "required": True},
+                {"name": "lift", "required": True},
+                {"name": "provekit.plugin.recognize", "required": True},
+                {"name": "shutdown", "required": False},
+            ]
+        },
+        "proofResolution": {"strategy": "pip"},
+        "effectKinds": [],
+        "effectLeaves": [],
+        "guardPredicates": [],
+        "controlCarriers": [],
+        "residueCategories": [],
     }
 
 
@@ -50,6 +77,8 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
 
     if method == "initialize":
         return {"jsonrpc": "2.0", "id": msg_id, "result": initialize_result()}
+    if method == KIT_DECLARATION_RPC_METHOD:
+        return {"jsonrpc": "2.0", "id": msg_id, "result": kit_declaration_result()}
     if method == "lift":
         return _lift(msg_id, params)
     if method == "provekit.plugin.recognize":

--- a/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import ast
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -29,6 +31,57 @@ CONCEPT_SKIP_CID = (
     "9a905548a44fce23882b17d857d275d7822bd235ab71dbf786cd991563cc1de9e"
     "610594f50ad3c89a3b7eeb43234a31b36caa8031914c85227158030669c63cb"
 )
+
+KIT_DECLARATION_RPC_METHOD = "provekit.plugin.kit_declaration"
+
+
+def _parse_top_level_toml(path: Path) -> dict[str, object]:
+    values: dict[str, object] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or line.startswith("[") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        raw_value = value.strip()
+        if raw_value == "true":
+            values[key.strip()] = True
+        elif raw_value == "false":
+            values[key.strip()] = False
+        else:
+            values[key.strip()] = ast.literal_eval(raw_value)
+    return values
+
+
+def _plugin_entries(path: Path) -> list[dict[str, object]]:
+    entries: list[dict[str, object]] = []
+    current: dict[str, object] | None = None
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line == "[[plugins]]":
+            current = {}
+            entries.append(current)
+            continue
+        if current is not None and "=" in line:
+            key, value = line.split("=", 1)
+            current[key.strip()] = ast.literal_eval(value.strip())
+    return entries
+
+
+def _build_kit_declaration_session() -> str:
+    messages = [
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        {"jsonrpc": "2.0", "id": 2, "method": KIT_DECLARATION_RPC_METHOD},
+        {"jsonrpc": "2.0", "id": 3, "method": "shutdown"},
+    ]
+    return "\n".join(json.dumps(message) for message in messages) + "\n"
+
+
+def _python_bind_manifest() -> dict[str, object]:
+    manifest = ROOT / "implementations/python/.provekit/lift/python-bind/manifest.toml"
+    assert manifest.exists(), f"missing checked-in python-bind manifest: {manifest}"
+    return _parse_top_level_toml(manifest)
 
 
 def _cid(ch: str) -> str:
@@ -801,6 +854,75 @@ def test_bind_rpc_initialize_declares_bind_ir_surface() -> None:
         "emits_signed_mementos": False,
         "ir_version": "bind-ir/1.0.0",
     }
+
+
+def test_checked_in_project_registers_python_bind_recognizer_surface() -> None:
+    entries = _plugin_entries(ROOT / "implementations/python/.provekit/config.toml")
+
+    assert {
+        "name": "python-bind",
+        "kind": "lift",
+        "surface": "python-bind",
+        "layer": "library-bindings",
+    } in entries
+
+
+def test_checked_in_python_bind_manifest_invokes_module_form_and_declares_kit() -> None:
+    manifest = _python_bind_manifest()
+
+    assert manifest["command"] == [
+        "python3",
+        "-m",
+        "provekit_lift_python_source.bind_rpc",
+        "--rpc",
+    ]
+    assert manifest["working_dir"] == "provekit-lift-python-source/src"
+
+    completed = subprocess.run(
+        manifest["command"],
+        cwd=ROOT / "implementations/python" / str(manifest["working_dir"]),
+        input=_build_kit_declaration_session(),
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    responses = [
+        json.loads(line) for line in completed.stdout.splitlines() if line.strip()
+    ]
+    declaration = next(response for response in responses if response.get("id") == 2)
+    assert "error" not in declaration, declaration
+    assert declaration["result"]["kit"]["id"] == "python-bind"
+
+
+def test_bind_rpc_kit_declaration_returns_python_bind_surface() -> None:
+    response = dispatch({"jsonrpc": "2.0", "id": 2, "method": KIT_DECLARATION_RPC_METHOD})
+
+    assert "error" not in response, response
+    result = response["result"]
+    assert result["kit"] == {
+        "id": "python-bind",
+        "language": "python",
+        "version": "0.1.0",
+    }
+    required_by_name = {
+        method["name"]: method["required"] for method in result["rpc"]["methods"]
+    }
+    assert required_by_name == {
+        "initialize": True,
+        KIT_DECLARATION_RPC_METHOD: True,
+        "lift": True,
+        "provekit.plugin.recognize": True,
+        "shutdown": False,
+    }
+    assert result["proofResolution"] == {"strategy": "pip"}
+    assert result["effectKinds"] == []
+    assert result["effectLeaves"] == []
+    assert result["guardPredicates"] == []
+    assert result["controlCarriers"] == []
+    assert result["residueCategories"] == []
 
 
 def test_bind_rpc_lift_returns_ir_document(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fourth Python kit-declaration width slice. This adds the `python-bind` surface for the bind RPC entrypoint and registers it as the Python library-bindings recognizer surface.

This PR changes config, manifest, and RPC as one registration unit:

- registers `python-bind` in `implementations/python/.provekit/config.toml`
- adds a new checked-in `.provekit/lift/python-bind/manifest.toml`
- adds `provekit.plugin.kit_declaration` to `provekit_lift_python_source.bind_rpc`
- adds tests that exercise both direct dispatch and the checked-in manifest module command

The manifest uses module form: `python3 -m provekit_lift_python_source.bind_rpc --rpc` from `provekit-lift-python-source/src`.

## Routing Notes

`layer = "library-bindings"` is consumed by existing CLI routing. `project_config` already parses `PluginEntry.layer`, `cmd_recognize` already selects recognizer surfaces from lift plugins whose layer is `library-bindings` or `all`, and `lift_plugin` already passes layer through. No Rust production code changes are introduced here.

The manifest `[capabilities]` block follows the richer Python manifest convention from `python-source` and `python-self-contracts`. `kit.id = "python-bind"` matches the surface identity because this daemon has no `initialize.kit_id` field.

## Declaration Shape

The declaration is intentionally empty-vocabulary for now:

- `kit.language = "python"`
- `kit.version = "0.1.0"`
- `proofResolution = { strategy = "pip" }`
- `effectKinds = []`
- empty `effectLeaves`, `guardPredicates`, `controlCarriers`, and `residueCategories`
- RPC methods: `initialize`, `provekit.plugin.kit_declaration`, `lift`, `provekit.plugin.recognize`, `shutdown`

This does not introduce Python vocabulary concepts, does not touch validator logic, and does not bundle `verify_rpc`, `python-self-contracts`, or `python-implications`.

## RED

Before implementation, the targeted Python tests failed for the intended reasons:

- config had no `python-bind` recognizer plugin entry
- the checked-in `python-bind` manifest was missing
- direct `bind_rpc.dispatch` returned `METHOD_NOT_FOUND: provekit.plugin.kit_declaration`

## GREEN

Validated locally:

- `pytest -q implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py::test_checked_in_project_registers_python_bind_recognizer_surface implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py::test_checked_in_python_bind_manifest_invokes_module_form_and_declares_kit implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py::test_bind_rpc_kit_declaration_returns_python_bind_surface -q`
- `pytest -q implementations/python/provekit-lift-python-source/tests -q`
- `python3 -m compileall -q implementations/python/provekit-lift-python-source/src implementations/python/provekit-lift-python-source/tests`
- from `implementations/rust`: `../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture`
- from `implementations/rust`: `../../bin/bcargo test -p provekit-cli doctor_kit_declaration -- --nocapture`
- staged `git diff --check`
- staged `git diff --cached --name-only | rg '(^|/)libprovekit(/|$)' || true` produced no output
- staged `git diff --cached --name-only | rg 'swift|xctest|\.swift' || true` produced no output

Existing Rust loader and doctor tests cover the empty-`effectKinds` path generically, so this PR does not add a redundant synthetic Rust stub test. The new behavior is the live Python bind RPC/config/manifest registration.
