### PR TITLE
[codex] Declare Python verify kit surface

### DIFF
--- a/implementations/python/.provekit/config.toml
+++ b/implementations/python/.provekit/config.toml
@@ -19,3 +19,9 @@ name = "python-bind"
 kind = "lift"
 surface = "python-bind"
 layer = "library-bindings"
+
+[[plugins]]
+name = "python-verify"
+kind = "lift"
+surface = "python-verify"
+emit = "ir-document"

--- a/implementations/python/.provekit/lift/python-verify/manifest.toml
+++ b/implementations/python/.provekit/lift/python-verify/manifest.toml
@@ -1,0 +1,11 @@
+name = "python-verify"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["python3", "-m", "provekit_lift_python_source.verify_rpc", "--rpc"]
+working_dir = "provekit-lift-python-source/src"
+
+[capabilities]
+authoring_surfaces = ["python-verify"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/verify_rpc.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/verify_rpc.py
@@ -44,7 +44,8 @@ from .leaf_assertions import harvest_source
 from .lifter import lift_source
 from .verify_dialect import VerifyDialectRefusal, collect_int_signatures, to_verify_dialect
 
-SURFACE = "python"
+KIT_DECLARATION_RPC_METHOD = "provekit.plugin.kit_declaration"
+SURFACE = "python-verify"
 VERSION = "0.1.0"
 
 _IGNORED_DIRS = {".git", ".venv", "venv", "__pycache__", ".mypy_cache", ".pytest_cache", ".provekit"}
@@ -65,6 +66,30 @@ def initialize_result() -> dict[str, Any]:
             "ir_version": "v1.1.0",
             "emits_signed_mementos": False,
         },
+    }
+
+
+def kit_declaration_result() -> dict[str, Any]:
+    return {
+        "kit": {
+            "id": SURFACE,
+            "language": "python",
+            "version": VERSION,
+        },
+        "rpc": {
+            "methods": [
+                {"name": "initialize", "required": True},
+                {"name": KIT_DECLARATION_RPC_METHOD, "required": True},
+                {"name": "lift", "required": True},
+                {"name": "shutdown", "required": False},
+            ]
+        },
+        "proofResolution": {"strategy": "pip"},
+        "effectKinds": [],
+        "effectLeaves": [],
+        "guardPredicates": [],
+        "controlCarriers": [],
+        "residueCategories": [],
     }
 
 
@@ -216,6 +241,8 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
 
     if method == "initialize":
         return {"jsonrpc": "2.0", "id": msg_id, "result": initialize_result()}
+    if method == KIT_DECLARATION_RPC_METHOD:
+        return {"jsonrpc": "2.0", "id": msg_id, "result": kit_declaration_result()}
     if method == "lift":
         root = str(params.get("workspace_root", "."))
         mode = _mode_from_options(params.get("options"))
@@ -265,3 +292,7 @@ def main(argv: list[str] | None = None) -> None:
         run_rpc()
     else:
         parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/implementations/python/provekit-lift-python-source/tests/test_verify_dialect.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_verify_dialect.py
@@ -11,7 +11,18 @@ Covers the three transform halves and the cardinal-sin division guard:
 
 from __future__ import annotations
 
+import ast
+import json
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
+
+ROOT = Path(__file__).resolve().parents[4]
+PKG_SRC = ROOT / "implementations/python/provekit-lift-python-source/src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
 
 from provekit_lift_python_source.leaf_assertions import harvest_source
 from provekit_lift_python_source.lifter import lift_source
@@ -20,7 +31,58 @@ from provekit_lift_python_source.verify_dialect import (
     collect_int_signatures,
     to_verify_dialect,
 )
-from provekit_lift_python_source.verify_rpc import lift_workspace
+from provekit_lift_python_source.verify_rpc import dispatch, initialize_result, lift_workspace
+
+KIT_DECLARATION_RPC_METHOD = "provekit.plugin.kit_declaration"
+
+
+def _parse_top_level_toml(path: Path) -> dict[str, object]:
+    values: dict[str, object] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or line.startswith("[") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        raw_value = value.strip()
+        if raw_value == "true":
+            values[key.strip()] = True
+        elif raw_value == "false":
+            values[key.strip()] = False
+        else:
+            values[key.strip()] = ast.literal_eval(raw_value)
+    return values
+
+
+def _plugin_entries(path: Path) -> list[dict[str, object]]:
+    entries: list[dict[str, object]] = []
+    current: dict[str, object] | None = None
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line == "[[plugins]]":
+            current = {}
+            entries.append(current)
+            continue
+        if current is not None and "=" in line:
+            key, value = line.split("=", 1)
+            current[key.strip()] = ast.literal_eval(value.strip())
+    return entries
+
+
+def _build_kit_declaration_session() -> str:
+    messages = [
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        {"jsonrpc": "2.0", "id": 2, "method": KIT_DECLARATION_RPC_METHOD},
+        {"jsonrpc": "2.0", "id": 3, "method": "shutdown"},
+    ]
+    return "\n".join(json.dumps(message) for message in messages) + "\n"
+
+
+def _python_verify_manifest() -> dict[str, object]:
+    return _parse_top_level_toml(
+        ROOT / "implementations/python/.provekit/lift/python-verify/manifest.toml"
+    )
 
 
 def _fn_contract(source: str, source_path: str = "m.py"):
@@ -144,3 +206,105 @@ def test_bare_surface_emits_all_functions(tmp_path):
     ir, _diag = lift_workspace(str(tmp_path), "bare")
     fn_names = [i["fnName"].rsplit(".", 1)[-1] for i in ir if i.get("kind") == "function-contract"]
     assert fn_names == ["double"]
+
+
+def test_verify_rpc_initialize_declares_python_verify_surface():
+    result = initialize_result()
+
+    assert result["name"] == "provekit-lift-python-verify"
+    assert result["version"] == "0.1.0"
+    assert result["protocol_version"] == "provekit-lift/1"
+    assert result["dialect"] == "python-verify"
+    assert result["capabilities"] == {
+        "authoring_surfaces": ["python-verify"],
+        "ir_version": "v1.1.0",
+        "emits_signed_mementos": False,
+    }
+
+
+def test_checked_in_project_registers_python_verify_contract_surface():
+    entries = _plugin_entries(ROOT / "implementations/python/.provekit/config.toml")
+
+    assert {
+        "name": "python-verify",
+        "kind": "lift",
+        "surface": "python-verify",
+        "emit": "ir-document",
+    } in entries
+
+
+def test_checked_in_python_verify_manifest_invokes_module_form_and_declares_kit():
+    manifest = _python_verify_manifest()
+
+    assert manifest["command"] == [
+        "python3",
+        "-m",
+        "provekit_lift_python_source.verify_rpc",
+        "--rpc",
+    ]
+    assert manifest["working_dir"] == "provekit-lift-python-source/src"
+
+    completed = subprocess.run(
+        manifest["command"],
+        cwd=ROOT / "implementations/python" / str(manifest["working_dir"]),
+        input=_build_kit_declaration_session(),
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    responses = [
+        json.loads(line) for line in completed.stdout.splitlines() if line.strip()
+    ]
+    declaration = next(response for response in responses if response.get("id") == 2)
+    assert "error" not in declaration, declaration
+    assert declaration["result"]["kit"]["id"] == "python-verify"
+
+
+def test_verify_rpc_kit_declaration_returns_python_verify_surface():
+    response = dispatch({"jsonrpc": "2.0", "id": 2, "method": KIT_DECLARATION_RPC_METHOD})
+
+    assert "error" not in response, response
+    result = response["result"]
+    assert result["kit"] == {
+        "id": "python-verify",
+        "language": "python",
+        "version": "0.1.0",
+    }
+    required_by_name = {
+        method["name"]: method["required"] for method in result["rpc"]["methods"]
+    }
+    assert required_by_name == {
+        "initialize": True,
+        KIT_DECLARATION_RPC_METHOD: True,
+        "lift": True,
+        "shutdown": False,
+    }
+    assert result["proofResolution"] == {"strategy": "pip"}
+    assert result["effectKinds"] == []
+    assert result["effectLeaves"] == []
+    assert result["guardPredicates"] == []
+    assert result["controlCarriers"] == []
+    assert result["residueCategories"] == []
+
+
+def test_verify_rpc_module_command_produces_output():
+    completed = subprocess.run(
+        [
+            "python3",
+            "-m",
+            "provekit_lift_python_source.verify_rpc",
+            "--rpc",
+        ],
+        cwd=ROOT / "implementations/python/provekit-lift-python-source/src",
+        input='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}\n',
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip(), "verify_rpc module command silently produced no RPC output"


### PR DESCRIPTION
## Summary

- Registers the verify-facing Python lift surface as `python-verify` with `emit = "ir-document"` so project config drives the contract-mode verify lifter.
- Adds `.provekit/lift/python-verify/manifest.toml` using the module command `python3 -m provekit_lift_python_source.verify_rpc --rpc`.
- Teaches `verify_rpc` to answer `provekit.plugin.kit_declaration` and adds the missing module `__main__` guard so the manifest command produces JSON-RPC output.

## Verification

- `pytest -q implementations/python/provekit-lift-python-source/tests/test_verify_dialect.py -q -k 'verify_rpc_initialize_declares_python_verify_surface or checked_in_project_registers_python_verify_contract_surface or checked_in_python_verify_manifest_invokes_module_form_and_declares_kit or verify_rpc_kit_declaration_returns_python_verify_surface or verify_rpc_module_command_produces_output'`\n- `python3 -m compileall -q implementations/python/provekit-lift-python-source/src implementations/python/provekit-lift-python-source/tests`\n- `pytest -q implementations/python/provekit-lift-python-source/tests -q`\n- `../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture`\n- `../../bin/bcargo test -p provekit-cli doctor_kit_declaration -- --nocapture`\n- `git diff --check`\n- `git diff --cached --check`\n\n## Pre-existing blocked gate\n\n- `../../bin/bcargo test -p provekit-cli --test cmd_verify_python_production_bridge -- --nocapture` fails on this branch and on detached `origin/main` commit `631927987` before product behavior with `ModuleNotFoundError: No module named 'provekit_lift_python_source'`.\n- Root cause is `bin/bcargo` not syncing `implementations/python` to the remote checkout. Tracked separately in #1809.\n\n## Scope guard\n\n- No Rust production changes.\n- No `libprovekit` changes.\n- No Swift changes.\n- No vocabulary concept mappings added; effect arrays stay empty.