### PR TITLE
[codex] Sync Python kits in bcargo

### DIFF
--- a/bin/bcargo
+++ b/bin/bcargo
@@ -186,6 +186,7 @@ sync_dir .provekit/lift
 sync_dir .provekit/realize
 
 sync_dir implementations/rust
+sync_dir implementations/python
 sync_dir examples
 sync_dir menagerie
 sync_dir tools


### PR DESCRIPTION

## Summary

- Sync `implementations/python` into the remote `bcargo` checkout.
- Close the #1809 sync-root defect without changing Rust source, Python source, libprovekit, Swift, or substrate vocabulary.
- Keep the remaining Python bridge failures explicitly tracked as #1812 and #1811.

## Root Cause

`bcargo` synced the Rust implementation plus examples and tooling, but omitted `implementations/python`. Cross-language Rust tests that invoke Python kits on battleaxe therefore failed before reaching the Python kit source.

## Evidence

- RED before patch: `../../bin/bcargo test -p provekit-cli --test cmd_verify_python_production_bridge -- --nocapture` failed with `ModuleNotFoundError: No module named provekit_lift_python_source`.
- After patch: the same command advances to `ModuleNotFoundError: No module named provekit_lift_py_tests`, proving the `implementations/python` sync layer is closed and exposing #1812.
- Remote probe with both Python source roots on `PYTHONPATH` advances to `ModuleNotFoundError: No module named blake3`, tracked by #1811.

## Validation

- `bash -n bin/bcargo`
- `git diff --check`
- `../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture`
- `../../bin/bcargo test -p provekit-cli doctor_kit_declaration -- --nocapture`
- `../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc`
- `../../bin/bcargo build -p provekit-lift --bin provekit-lift`
- `../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture`

Closes #1809


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the build system to properly synchronize Python implementations into the remote workspace during initialization, improving consistency and reliability of cross-environment builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->