### PR TITLE
[codex] Sync Python verify wrapper source roots

### DIFF
--- a/implementations/rust/provekit-cli/tests/cmd_verify_python_division_unsound.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_python_division_unsound.rs
@@ -48,12 +48,31 @@ fn repo_root() -> PathBuf {
         .to_path_buf()
 }
 
-fn python_lift_src() -> PathBuf {
+fn python_source_lift_src() -> PathBuf {
     repo_root()
         .join("implementations")
         .join("python")
         .join("provekit-lift-python-source")
         .join("src")
+}
+
+fn python_test_lift_src() -> PathBuf {
+    repo_root()
+        .join("implementations")
+        .join("python")
+        .join("provekit-lift-py-tests")
+        .join("src")
+}
+
+fn python_lift_pythonpath() -> String {
+    std::env::join_paths([python_source_lift_src(), python_test_lift_src()])
+        .expect("join Python lift source roots")
+        .into_string()
+        .expect("Python lift source roots must be UTF-8")
+}
+
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn z3_available() -> bool {
@@ -88,16 +107,18 @@ fn build_python_lift_verify() -> PathBuf {
     // Unique per call: parallel tests in this binary share one process id, so a
     // pid-keyed path collides (ETXTBSY when one execs while another writes).
     static SEQ: AtomicU64 = AtomicU64::new(0);
-    let src = python_lift_src();
+    let pythonpath = python_lift_pythonpath();
+    let quoted_pythonpath = shell_single_quote(&pythonpath);
     let script = std::env::temp_dir().join(format!(
         "provekit-lift-python-verify-div-{}-{}.sh",
         std::process::id(),
         SEQ.fetch_add(1, Ordering::Relaxed)
     ));
     let body = format!(
-        "#!/bin/sh\nexec python3 -c \"import sys; sys.path.insert(0, '{}'); \
-         from provekit_lift_python_source.verify_rpc import run_rpc; run_rpc()\"\n",
-        src.display()
+        "#!/bin/sh\nPYTHON=${{PYTHON:-python3}}\n\
+         PYTHONPATH={quoted_pythonpath}${{PYTHONPATH:+:$PYTHONPATH}}\n\
+         export PYTHONPATH\n\
+         exec \"$PYTHON\" -c \"from provekit_lift_python_source.verify_rpc import run_rpc; run_rpc()\"\n"
     );
     // sync_all + drop writer fd before chmod/spawn so exec never sees an open writer.
     {

--- a/implementations/rust/provekit-cli/tests/cmd_verify_python_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_python_production_bridge.rs
@@ -58,14 +58,32 @@ fn repo_root() -> PathBuf {
         .to_path_buf()
 }
 
-/// The verify-facing Python lifter's source tree, prepended to `sys.path` so
-/// the binary resolves to THIS checkout's module (not a stale installed one).
-fn python_lift_src() -> PathBuf {
+/// The verify-facing Python lifter source tree.
+fn python_source_lift_src() -> PathBuf {
     repo_root()
         .join("implementations")
         .join("python")
         .join("provekit-lift-python-source")
         .join("src")
+}
+
+fn python_test_lift_src() -> PathBuf {
+    repo_root()
+        .join("implementations")
+        .join("python")
+        .join("provekit-lift-py-tests")
+        .join("src")
+}
+
+fn python_lift_pythonpath() -> String {
+    std::env::join_paths([python_source_lift_src(), python_test_lift_src()])
+        .expect("join Python lift source roots")
+        .into_string()
+        .expect("Python lift source roots must be UTF-8")
+}
+
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn z3_available() -> bool {
@@ -95,9 +113,9 @@ fn unique_dir(suffix: &str) -> PathBuf {
 }
 
 /// Write a small wrapper shell script that runs the verify-facing Python lift
-/// surface with THIS checkout's `src` on `sys.path`, and return its path. The
-/// Go test compiles a Go binary; Python is interpreted, so the analog is a
-/// stable wrapper invoking `python3 -c "...; run_rpc()"`.
+/// surface with THIS checkout's source roots on `PYTHONPATH`, and return its
+/// path. The Go test compiles a Go binary; Python is interpreted, so the analog
+/// is a stable wrapper invoking `python3 -c "...; run_rpc()"`.
 fn build_python_lift_verify() -> PathBuf {
     use std::io::Write as _;
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -106,16 +124,18 @@ fn build_python_lift_verify() -> PathBuf {
     // One test exec'ing the wrapper while another truncates it for write =>
     // ETXTBSY (os error 26). An atomic counter gives each call its own path.
     static SEQ: AtomicU64 = AtomicU64::new(0);
-    let src = python_lift_src();
+    let pythonpath = python_lift_pythonpath();
+    let quoted_pythonpath = shell_single_quote(&pythonpath);
     let script = std::env::temp_dir().join(format!(
         "provekit-lift-python-verify-{}-{}.sh",
         std::process::id(),
         SEQ.fetch_add(1, Ordering::Relaxed)
     ));
     let body = format!(
-        "#!/bin/sh\nexec python3 -c \"import sys; sys.path.insert(0, '{}'); \
-         from provekit_lift_python_source.verify_rpc import run_rpc; run_rpc()\"\n",
-        src.display()
+        "#!/bin/sh\nPYTHON=${{PYTHON:-python3}}\n\
+         PYTHONPATH={quoted_pythonpath}${{PYTHONPATH:+:$PYTHONPATH}}\n\
+         export PYTHONPATH\n\
+         exec \"$PYTHON\" -c \"from provekit_lift_python_source.verify_rpc import run_rpc; run_rpc()\"\n"
     );
     // sync_all + drop the writer fd BEFORE chmod/spawn so `exec` never sees an
     // open writer (the second half of the ETXTBSY guard; see cli_surface.rs).


### PR DESCRIPTION

## Summary

- Add both checked-out Python lift source roots to the Rust verify integration wrappers `PYTHONPATH`.
- Make those wrappers honor `PYTHON=${PYTHON:-python3}`, matching the existing Python emitter wrapper convention.
- Keep the change scoped to test wrappers only: no CLI, verifier, libprovekit, Swift, or substrate vocabulary changes.

## Why

#1813 closed the `bcargo` sync-root layer by syncing `implementations/python`. The next failure was #1812: the verify-facing Python lifter imports shared code from `provekit_lift_py_tests`, but the Rust verify test wrappers only exposed `provekit-lift-python-source/src`.

This PR closes that source-root layer. The remaining `ModuleNotFoundError: blake3` is the known remote Python environment layer tracked by #1811. The packaging hygiene issue where `provekit-lift-python-source` imports `provekit-lift-py-tests` without declaring that relationship is tracked separately in #1814.

## Evidence

- RED before patch: `../../bin/bcargo test -p provekit-cli --test cmd_verify_python_production_bridge -- --nocapture` failed with `ModuleNotFoundError: No module named provekit_lift_py_tests`.
- Post-patch: the same command advances to `ModuleNotFoundError: No module named blake3`, proving the #1812 source-root layer is closed and #1811 remains.
- `../../bin/bcargo test -p provekit-cli --test cmd_verify_python_division_unsound -- --nocapture` also compiles and advances to the same #1811 `blake3` layer.

## Validation

- `rustfmt implementations/rust/provekit-cli/tests/cmd_verify_python_production_bridge.rs implementations/rust/provekit-cli/tests/cmd_verify_python_division_unsound.rs`
- `git diff --check`
- Path A scope check: no libprovekit, verifier, walk, or Swift changes.
- `../../bin/bcargo test -p provekit-cli --test cmd_emit_python_pytest emit_python_pytest_uses_checked_in_python_double_registration -- --nocapture`
- `../../bin/bcargo test -p provekit-cli --test cmd_emit_python_unittest emit_python_unittest_dispatches_real_emitter_and_unittest_checks_output -- --nocapture`
- `../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture`
- `../../bin/bcargo test -p provekit-cli doctor_kit_declaration -- --nocapture`

Closes #1812
