### PR TITLE
[codex] Provision Python kit env in bcargo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,24 @@ SCALA_CLI ?= scala-cli
 PARITY_PYTHON_VENV ?= /tmp/provekit-cross-language-parity-python
 PARITY_PYTHON_BIN := $(PARITY_PYTHON_VENV)/bin
 PARITY_PYTHON := $(PARITY_PYTHON_BIN)/python
+BCARGO_PYTHON_VENV ?= /tmp/provekit-bcargo-python-kit-env
+BCARGO_PYTHON_BIN := $(BCARGO_PYTHON_VENV)/bin
+BCARGO_PYTHON := $(BCARGO_PYTHON_BIN)/python
+BCARGO_PYTHON_ENV_STAMP := $(BCARGO_PYTHON_VENV)/.provekit-python-kits.stamp
+PYTHON_KIT_EDITABLES = \
+	-e examples/provekit-shim-python-sqlite3 \
+	-e examples/provekit-shim-python-aiosqlite \
+	-e examples/provekit-shim-python-requests \
+	-e implementations/python/libprovekit-py \
+	-e implementations/python/provekit-lift-py-tests \
+	-e implementations/python/provekit-lift-python-source \
+	-e implementations/python/provekit-emit-python-pytest \
+	-e implementations/python/provekit-emit-python-unittest \
+	-e implementations/python/provekit-emit-python-hypothesis \
+	-e implementations/python/provekit-realize-python-core \
+	-e implementations/python/provekit-realize-python-sqlite3 \
+	-e implementations/python/provekit-realize-python-aiosqlite \
+	-e implementations/python/provekit-realize-python-requests
 BCARGO ?= $(CURDIR)/bin/bcargo
 CARGO_LOCAL ?= cargo
 ifeq ($(CI),)
@@ -690,6 +708,16 @@ cross-language-proof-parity-python-env:
 		-e implementations/python/provekit-lift-python-source \
 		-e implementations/python/provekit-realize-python-core \
 		-e implementations/python/provekit-realize-python-requests
+
+.PHONY: bcargo-python-kit-env
+bcargo-python-kit-env: $(BCARGO_PYTHON_ENV_STAMP)
+
+$(BCARGO_PYTHON_ENV_STAMP): Makefile $(wildcard implementations/python/*/pyproject.toml examples/provekit-shim-python-*/pyproject.toml)
+	$(PYTHON) -m venv $(BCARGO_PYTHON_VENV)
+	$(BCARGO_PYTHON) -m pip install --quiet --upgrade pip
+	$(BCARGO_PYTHON) -m pip install --quiet --no-cache-dir pytest $(PYTHON_KIT_EDITABLES)
+	mkdir -p $(dir $(BCARGO_PYTHON_ENV_STAMP))
+	touch $(BCARGO_PYTHON_ENV_STAMP)
 
 .PHONY: check-cross-language-proof-parity-scope
 check-cross-language-proof-parity-scope:

--- a/bin/bcargo
+++ b/bin/bcargo
@@ -15,6 +15,7 @@ Options:
 Environment:
   BCARGO_REMOTE_HOST   SSH host alias to use (default: battleaxe)
   BCARGO_REMOTE_ROOT   Remote scratch root (default: /home/tsavo/remote/provekit-bcargo)
+  BCARGO_PYTHON_ENV    Set to 0 to skip remote Python kit env provisioning
 EOF
 }
 
@@ -87,6 +88,10 @@ _bcargo_root_tag="$(printf '%s' "$repo_root" | shasum 2>/dev/null | cut -c1-12)"
 _bcargo_root_tag="${_bcargo_root_tag:-default}"
 remote_root="${BCARGO_REMOTE_ROOT:-/home/tsavo/remote/provekit-bcargo-${_bcargo_root_tag}}"
 remote_repo="$remote_root/provekit"
+remote_python_venv="$remote_root/python-kit-env"
+remote_python_bin="$remote_python_venv/bin"
+remote_python="$remote_python_bin/python"
+provision_python_env="${BCARGO_PYTHON_ENV:-1}"
 ssh_bin="${BCARGO_SSH:-ssh}"
 rsync_bin="${BCARGO_RSYNC:-rsync}"
 
@@ -175,6 +180,7 @@ sync_file() {
 
 sync_file Cargo.toml
 sync_file Cargo.lock
+sync_file Makefile
 sync_file rust-toolchain
 sync_file rust-toolchain.toml
 # Repo-root workspace config and hand-authored plugin manifests. Generated
@@ -252,7 +258,11 @@ for arg in "$@"; do
   remote_args+=("$(quote_sh "$arg")")
 done
 
-inner="cd $(quote_sh "$remote_cwd") && exec cargo"
+if [[ "$provision_python_env" == "0" ]]; then
+  inner="cd $(quote_sh "$remote_cwd") && exec cargo"
+else
+  inner="cd $(quote_sh "$remote_repo") && BCARGO_PYTHON_VENV=$(quote_sh "$remote_python_venv") make --quiet bcargo-python-kit-env && cd $(quote_sh "$remote_cwd") && PYTHON=$(quote_sh "$remote_python") PATH=$(quote_sh "$remote_python_bin"):\$PATH exec cargo"
+fi
 for arg in "${remote_args[@]}"; do
   inner+=" $arg"
 done


### PR DESCRIPTION
Closes #1811.

## What changed

- Added `bcargo-python-kit-env`, a Makefile target that creates a per-bcargo Python virtualenv and installs the Python kit/editable packages needed by the Python lift/verify path.
- Updated `bin/bcargo` to sync `Makefile`, provision that remote venv before cargo runs, and execute cargo with `PYTHON`/`PATH` pointed at the venv.
- Added `BCARGO_PYTHON_ENV=0` as an explicit opt-out for Rust-only contexts.

## Cascade state

- Layer 1 (#1813): `bcargo` syncs `implementations/python`.
- Layer 2 (#1815): Python verify wrappers include both Python source roots.
- Layer 3 (#1811, this PR): battleaxe/bcargo gets the Python kit dependency environment, including `blake3`.
- Layer 4 (#1816): `cmd_verify_python_division_unsound` now runs to completion and exposes a separate semantic expectation mismatch. This PR does not claim that test passes; it tracks the newly exposed layer separately.

#1814 remains the separate pyproject dependency hygiene issue.

## Scope

This is infrastructure only: `Makefile` and `bin/bcargo`. No verifier/proof logic changed, and no Path A/self-check golden files changed. The stamp file prevents reinstalling the Python env on every repeated `bcargo` invocation.

## Validation

- `bash -n bin/bcargo`
- `make -n bcargo-python-kit-env`
- `git diff --check`
- `../../bin/bcargo test -p provekit-cli --test cmd_verify_python_production_bridge -- --nocapture` -> 5/5 pass on battleaxe
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture` -> 6/6 pass on battleaxe