### PR TITLE
[codex] Sync Go kits in bcargo

### DIFF
--- a/bin/bcargo
+++ b/bin/bcargo
@@ -193,6 +193,7 @@ sync_dir .provekit/realize
 
 sync_dir implementations/rust
 sync_dir implementations/python
+sync_dir implementations/go
 sync_dir examples
 sync_dir menagerie
 sync_dir tools


### PR DESCRIPTION
Closes #1818.

## Summary
- Mirror the Python bcargo sync fix for Go by syncing `implementations/go` to the battleaxe remote workspace.
- Keep the change bounded to `bin/bcargo`: no CLI/verifier logic, no Go kit logic, no substrate semantic changes.
- Preserve the cross-language invariant: Go semantics stay in the Go kit; bcargo only makes the configured kit source available to Rust integration tests that invoke Go binaries.

## Reproduction
On a fresh worktree from `origin/main` at `66f1cb627`, this failed before verifier semantics:

```sh
BCARGO_PYTHON_ENV=0 ../../bin/bcargo test -p provekit-cli --test cmd_verify_go_division_unsound -- --nocapture
```

Both tests failed at `cmd_verify_go_division_unsound.rs:89` with:

```text
spawn go build: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

The remote tree had `implementations/rust` and `implementations/python`, but no `implementations/go`.

## Validation
- `bash -n bin/bcargo`: pass.
- `git diff --check`: pass.
- `git diff --name-only | rg '(^|/)libprovekit(/|$)' || true`: zero output.
- Remote check: `implementations/go` is present after bcargo sync, including `cmd/provekit-lift-go-verify`.
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo test -p provekit-cli --test cmd_verify_go_division_unsound -- --nocapture`: pass 2/2. Both cases report `status=undecidable`, `exit=3`, `witnesses=0`.
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo test -p provekit-cli --test cmd_verify_go_production_bridge -- --nocapture`: pass 4/4, covering positive witness, broken body unsatisfied, and contradictory implication refusal.

## Cascade Note
Unlike the Python cascade, the Go path closes in this single sync layer: Go binaries are built from the synced module and the existing verifier integration tests then reach semantics. No Go env provisioning, wrapper source-root fix, or Go semantic follow-up was exposed by this PR.
