### PR TITLE
[codex] Python panic-freedom federation for None guards

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/compiler.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/compiler.py
@@ -94,6 +94,14 @@ def _stmt(term: Json) -> ast.stmt:
             body=_stmt_list(args[1]) or [ast.Pass()],
             orelse=[] if _name(args[2]) == "python:pass" else _stmt_list(args[2]),
         )
+    if name == "cf_ite":
+        then_branch = _unguarded(args[1])
+        else_branch = _unguarded(args[2])
+        return ast.If(
+            test=_expr(args[0]),
+            body=_stmt_list(then_branch) or [ast.Pass()],
+            orelse=[] if _name(else_branch) == "python:pass" else _stmt_list(else_branch),
+        )
     if name == "python:while":
         return ast.While(test=_expr(args[0]), body=_stmt_list(args[1]), orelse=[])
     if name == "python:for":
@@ -212,6 +220,14 @@ def _is_function_contract(value: Json) -> bool:
 
 def _name(term: Any) -> str:
     return str(term.get("name", "")) if isinstance(term, dict) else ""
+
+
+def _unguarded(term: Json) -> Json:
+    if _name(term) == "cf_guarded":
+        args = term.get("args", [])
+        if len(args) == 2:
+            return args[1]
+    return term
 
 
 def _const_string(term: Json) -> str:

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/ir.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/ir.py
@@ -50,6 +50,13 @@ def ctor(name: str, *args: Json) -> Json:
     return {"kind": "ctor", "name": name, "args": list(args)}
 
 
+def substrate_ctor(name: str, *args: Json) -> Json:
+    allowed = {"cf_ite", "cf_guarded", "is_none", "is_some"}
+    if name not in allowed:
+        raise ValueError(f"unsupported substrate operation name: {name}")
+    return {"kind": "ctor", "name": name, "args": list(args)}
+
+
 def pass_stmt() -> Json:
     return ctor("python:pass", none_const())
 

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -18,6 +18,7 @@ from .ir import (
     pass_stmt,
     source_unit_contract,
     str_const,
+    substrate_ctor,
     var,
 )
 
@@ -272,11 +273,17 @@ class _Emitter:
             self._record_write_if_nonlocal(node.targets[0])
             return ctor("python:assign", target, self.expr(node.value))
         if isinstance(node, ast.If):
+            condition = self.expr(node.test)
+            then_branch = self.statements(node.body)
+            else_branch = self.statements(node.orelse) if node.orelse else pass_stmt()
+            guarded = self.none_guarded_if(node.test, condition, then_branch, else_branch)
+            if guarded is not None:
+                return guarded
             return ctor(
                 "python:if",
-                self.expr(node.test),
-                self.statements(node.body),
-                self.statements(node.orelse) if node.orelse else pass_stmt(),
+                condition,
+                then_branch,
+                else_branch,
             )
         if isinstance(node, ast.While):
             if node.orelse:
@@ -409,6 +416,44 @@ class _Emitter:
         if isinstance(node.slice, ast.Slice):
             raise _UnsupportedSyntax(node.slice, "slice subscripts are refused")
         return self.expr(node.slice)
+
+    def none_guarded_if(
+        self,
+        test: ast.expr,
+        condition: Json,
+        then_branch: Json,
+        else_branch: Json,
+    ) -> Json | None:
+        guard = self.none_guard(test)
+        if guard is None:
+            return None
+        then_head, else_head, receiver = guard
+        return substrate_ctor(
+            "cf_ite",
+            condition,
+            substrate_ctor("cf_guarded", substrate_ctor(then_head, receiver), then_branch),
+            substrate_ctor("cf_guarded", substrate_ctor(else_head, receiver), else_branch),
+        )
+
+    def none_guard(self, test: ast.expr) -> tuple[str, str, Json] | None:
+        if not isinstance(test, ast.Compare):
+            return None
+        if len(test.ops) != 1 or len(test.comparators) != 1:
+            return None
+        raw_op = test.ops[0]
+        if not isinstance(raw_op, (ast.Is, ast.IsNot)):
+            return None
+        lhs = test.left
+        rhs = test.comparators[0]
+        if _is_none_literal(rhs) and not _is_none_literal(lhs):
+            receiver = self.expr(lhs)
+        elif _is_none_literal(lhs) and not _is_none_literal(rhs):
+            receiver = self.expr(rhs)
+        else:
+            return None
+        if isinstance(raw_op, ast.Is):
+            return "is_none", "is_some", receiver
+        return "is_some", "is_none", receiver
 
     def _record_read_if_global(self, name: str) -> None:
         if name in self.module_globals and name not in self.locals:
@@ -578,6 +623,10 @@ def _is_docstring_stmt(statement: ast.stmt) -> bool:
         and isinstance(statement.value, ast.Constant)
         and isinstance(statement.value.value, str)
     )
+
+
+def _is_none_literal(node: ast.expr) -> bool:
+    return isinstance(node, ast.Constant) and node.value is None
 
 
 def _callee_name(node: ast.expr) -> str:

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/rpc.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/rpc.py
@@ -45,10 +45,32 @@ def kit_declaration_result() -> dict[str, Any]:
             ]
         },
         "proofResolution": {"strategy": "pip"},
-        "effectKinds": [],
+        "effectKinds": ["concept:panic-freedom"],
         "effectLeaves": [],
-        "guardPredicates": [],
-        "controlCarriers": [],
+        "guardPredicates": [
+            {
+                "surface": SURFACE,
+                "local": "is_some",
+                "concept": "concept:panic-freedom.option.some",
+            },
+            {
+                "surface": SURFACE,
+                "local": "is_none",
+                "concept": "concept:panic-freedom.option.none",
+            },
+        ],
+        "controlCarriers": [
+            {
+                "surface": SURFACE,
+                "local": "cf_guarded",
+                "concept": "concept:panic-freedom.guard",
+            },
+            {
+                "surface": SURFACE,
+                "local": "cf_ite",
+                "concept": "concept:panic-freedom.choice",
+            },
+        ],
         "residueCategories": [],
     }
 

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -114,6 +114,43 @@ def _compare_pairs(node: object) -> list[tuple[str, str, str]]:
     return pairs
 
 
+def _assert_guard(term: object, expected_head: str, expected_arg: str) -> dict[str, object]:
+    assert isinstance(term, dict)
+    assert term["kind"] == "ctor"
+    assert term["name"] == "cf_guarded"
+    args = term["args"]
+    guard = args[0]
+    assert guard == {
+        "kind": "ctor",
+        "name": expected_head,
+        "args": [{"kind": "var", "name": expected_arg}],
+    }
+    return args[1]
+
+
+def _assert_none_guarded_if(
+    body: dict[str, object],
+    *,
+    op: str,
+    then_head: str,
+    else_head: str,
+) -> None:
+    assert body["kind"] == "ctor"
+    assert body["name"] == "cf_ite"
+    cond, then_branch, else_branch = body["args"]
+    assert cond == {
+        "kind": "ctor",
+        "name": "python:compare",
+        "args": [
+            {"kind": "const", "value": op, "sort": {"kind": "primitive", "name": "String"}},
+            {"kind": "var", "name": "x"},
+            {"kind": "const", "value": None, "sort": {"kind": "primitive", "name": "Unit"}},
+        ],
+    }
+    assert _assert_guard(then_branch, then_head, "x")["name"] == "python:return"
+    assert _assert_guard(else_branch, else_head, "x")["name"] == "python:return"
+
+
 def test_lift_function_emits_source_unit_and_python_ops() -> None:
     source = "GLOBAL = 3\n\ndef add_one(x):\n    y = x + GLOBAL\n    return y\n"
 
@@ -203,6 +240,73 @@ def test_compare_three_chain_mixed_ops_lifts_to_pairwise_and_composition(
     assert result.refusals == []
     assert _compare_pairs(body) == expected_pairs
     assert _ctor_names(body).count("python:and") == 2
+
+
+def test_if_is_none_lifts_to_cf_guarded_option_guards() -> None:
+    source = (
+        "def f(x):\n"
+        "    if x is None:\n"
+        "        return 0\n"
+        "    else:\n"
+        "        return 1\n"
+    )
+
+    result = lift_source(source, "none_guard.py")
+
+    body = _contract(result.ir, ".f")["post"]["args"][1]
+    assert result.refusals == []
+    _assert_none_guarded_if(
+        body,
+        op="is",
+        then_head="is_none",
+        else_head="is_some",
+    )
+    assert "python:compare" in _ctor_names(body)
+
+
+def test_if_is_not_none_lifts_to_cf_guarded_option_guards() -> None:
+    source = (
+        "def f(x):\n"
+        "    if x is not None:\n"
+        "        return 0\n"
+        "    else:\n"
+        "        return 1\n"
+    )
+
+    result = lift_source(source, "some_guard.py")
+
+    body = _contract(result.ir, ".f")["post"]["args"][1]
+    assert result.refusals == []
+    _assert_none_guarded_if(
+        body,
+        op="is not",
+        then_head="is_some",
+        else_head="is_none",
+    )
+    assert "python:compare" in _ctor_names(body)
+
+
+def test_compile_lift_roundtrip_preserves_cf_guarded_none_if_body() -> None:
+    source = (
+        "def f(x):\n"
+        "    if x is None:\n"
+        "        return 0\n"
+        "    else:\n"
+        "        return 1\n"
+    )
+    lifted = lift_source(source, "roundtrip_none.py")
+    contract = _contract(lifted.ir, ".f")
+    body = contract["post"]["args"][1]
+
+    compiled = compile_body_term(
+        body,
+        fn_name="f",
+        formals=[str(formal) for formal in contract["formals"]],
+    )
+    relifted = lift_source(compiled, "roundtrip_none.py")
+    relifted_body = _contract(relifted.ir, ".f")["post"]["args"][1]
+
+    assert canonical_json_bytes(relifted_body) == canonical_json_bytes(body)
 
 
 def test_refuses_unhandled_syntax_without_unknown_ops() -> None:
@@ -374,8 +478,30 @@ def test_kit_declaration_returns_python_source_lift_surface() -> None:
         "shutdown": False,
     }
     assert result["proofResolution"] == {"strategy": "pip"}
-    assert result["effectKinds"] == []
+    assert result["effectKinds"] == ["concept:panic-freedom"]
     assert result["effectLeaves"] == []
-    assert result["guardPredicates"] == []
-    assert result["controlCarriers"] == []
+    assert result["guardPredicates"] == [
+        {
+            "surface": "python-source",
+            "local": "is_some",
+            "concept": "concept:panic-freedom.option.some",
+        },
+        {
+            "surface": "python-source",
+            "local": "is_none",
+            "concept": "concept:panic-freedom.option.none",
+        },
+    ]
+    assert result["controlCarriers"] == [
+        {
+            "surface": "python-source",
+            "local": "cf_guarded",
+            "concept": "concept:panic-freedom.guard",
+        },
+        {
+            "surface": "python-source",
+            "local": "cf_ite",
+            "concept": "concept:panic-freedom.choice",
+        },
+    ]
     assert result["residueCategories"] == []


### PR DESCRIPTION
## Summary

First Python depth slice for panic-freedom federation.

`python-source` now emits substrate-aligned branch carriers for Python None checks:

- `if x is None` lifts to `cf_ite(..., cf_guarded(is_none(x), then), cf_guarded(is_some(x), else))`
- `if x is not None` flips the branch guards: `is_some` on the then branch, `is_none` on the else branch
- The emitted guard heads are bare substrate vocabulary, not `python:*` names
- The Python compiler unwraps `cf_guarded` branch values when compiling back to normal Python `if` source, preserving compile-lift roundtrip behavior

The `python-source` kit declaration now claims substantive panic-freedom vocabulary for `is_some`, `is_none`, `cf_guarded`, and `cf_ite`. This implements the C2 emission-alias path from #1822 for `python-source` without adding verifier or `libprovekit` language knowledge.

## Validation

- `PYTHONPATH=implementations/python/provekit-lift-python-source/src:implementations/python/provekit-lift-py-tests/src python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q -k 'cf_guarded or kit_declaration_returns_python_source_lift_surface'` - 4 passed
- `PYTHONPATH=implementations/python/provekit-lift-python-source/src:implementations/python/provekit-lift-py-tests/src python3 -m pytest implementations/python/provekit-lift-python-source/tests -q` - 105 passed
- `python3 -m compileall -q implementations/python/provekit-lift-python-source/src/provekit_lift_python_source implementations/python/provekit-lift-python-source/tests/test_lifter.py`
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture` - 6 passed
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo test -p provekit-cli doctor_kit_declaration_non_rust_vocabulary -- --nocapture` - 4 passed in lib, 4 passed in bin
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc`
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo build -p provekit-lift --bin provekit-lift`
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` - 1 passed, 114.70s
- `../../bin/bcargo test -p provekit-cli --test cmd_verify_python_production_bridge -- --nocapture` - 5 passed
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo test -p provekit-verifier cf_guarded -- --nocapture` - 2 passed
- `git diff --check`

Notes:

- An earlier `cmd_verify_python_production_bridge` run with `BCARGO_PYTHON_ENV=0` failed because the remote Python environment lacked `blake3`. The rerun above used default Python env provisioning and passed.
- No production edits were made under `libprovekit`, `provekit-verifier`, `provekit-cli/src/doctor.rs`, or `provekit-cli/src/cmd_verify.rs`.
