### PR TITLE
[codex] Federate Python test None guards

### DIFF
--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/decorators.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/decorators.py
@@ -28,6 +28,7 @@ from .ir import (
     Bool,
     Sort,
     atomic,
+    comparison_with_none_guard,
     eq,
     ne,
     gt,
@@ -225,7 +226,7 @@ def _translate_expr(node: ast.expr, available_names: List[str]) -> Formula:
             raise ValueError(f"unsupported comparison: {type(op).__name__}")
         l = _translate_term(node.left, available_names)
         r = _translate_term(node.comparators[0], available_names)
-        return atomic(sym, [l, r])
+        return comparison_with_none_guard(sym, l, r)
 
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
         l = _translate_term(node.left, available_names)

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/ir.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/ir.py
@@ -188,6 +188,24 @@ def ne(a: Term, b: Term) -> Formula:
     return atomic("≠", [a, b])
 
 
+def comparison_with_none_guard(name: str, left: Term, right: Term) -> Formula:
+    base = atomic(name, [left, right])
+    left_is_none = _is_none_ctor(left)
+    right_is_none = _is_none_ctor(right)
+    if left_is_none == right_is_none:
+        return base
+    subject = right if left_is_none else left
+    if name == "=":
+        return and_([base, atomic("is_none", [subject])])
+    if name == "≠":
+        return and_([base, atomic("is_some", [subject])])
+    return base
+
+
+def _is_none_ctor(term: Term) -> bool:
+    return isinstance(term, _Ctor) and term.name == "None" and not term.args
+
+
 def connective(kind: str, operands: List[Formula]) -> Formula:
     return _Connective(kind, tuple(operands))
 

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/layer2.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/layer2.py
@@ -77,6 +77,7 @@ from .ir import (
     and_,
     atomic,
     bool_const,
+    comparison_with_none_guard,
     connective,
     ctor,
     eq,
@@ -498,7 +499,7 @@ def _translate_bool_expr(node: ast.expr) -> Formula:
             raise ValueError(f"unsupported comparison op: {op_kind.__name__}")
         l = _translate_term(node.left)
         r = _translate_term(node.comparators[0])
-        return atomic(sym, [l, r])
+        return comparison_with_none_guard(sym, l, r)
     if isinstance(node, ast.NamedExpr):
         # Walrus inside an assert: skip.
         raise ValueError("walrus operator in assert is not liftable")
@@ -520,12 +521,14 @@ def _lift_assertion_stmt(stmt: ast.stmt) -> Formula:
             l = _translate_term(call.args[0])
             r = _translate_term(call.args[1])
             sym = _UNITTEST_BINARY_PREDICATES[name]
-            return atomic(sym, [l, r])
+            return comparison_with_none_guard(sym, l, r)
         if name in _UNITTEST_NONE_PREDICATES:
             if len(call.args) < 1:
                 raise ValueError(f"{name} expects 1 positional arg")
             t = _translate_term(call.args[0])
-            return atomic(_UNITTEST_NONE_PREDICATES[name], [t, ctor("None", [])])
+            return comparison_with_none_guard(
+                _UNITTEST_NONE_PREDICATES[name], t, ctor("None", [])
+            )
         if name == "assertTrue":
             if len(call.args) < 1:
                 raise ValueError("assertTrue expects 1 positional arg")
@@ -1406,12 +1409,14 @@ def _lift_assertion_stmt_scoped(
                 raise ValueError(f"{name} expects at least 2 positional args")
             l = _translate_term_scoped(call.args[0], scope, call_vars)
             r = _translate_term_scoped(call.args[1], scope, call_vars)
-            return atomic(_UNITTEST_BINARY_PREDICATES[name], [l, r])
+            return comparison_with_none_guard(_UNITTEST_BINARY_PREDICATES[name], l, r)
         if name in _UNITTEST_NONE_PREDICATES:
             if len(call.args) < 1:
                 raise ValueError(f"{name} expects 1 positional arg")
             t = _translate_term_scoped(call.args[0], scope, call_vars)
-            return atomic(_UNITTEST_NONE_PREDICATES[name], [t, ctor("None", [])])
+            return comparison_with_none_guard(
+                _UNITTEST_NONE_PREDICATES[name], t, ctor("None", [])
+            )
         if name == "assertTrue":
             if len(call.args) < 1:
                 raise ValueError("assertTrue expects 1 positional arg")
@@ -1434,12 +1439,10 @@ def _translate_bool_expr_scoped(
         sym = _COMPARE_OP_MAP.get(type(node.ops[0]))
         if sym is None:
             raise ValueError(f"unsupported comparison op: {type(node.ops[0]).__name__}")
-        return atomic(
+        return comparison_with_none_guard(
             sym,
-            [
-                _translate_term_scoped(node.left, scope, call_vars),
-                _translate_term_scoped(node.comparators[0], scope, call_vars),
-            ],
+            _translate_term_scoped(node.left, scope, call_vars),
+            _translate_term_scoped(node.comparators[0], scope, call_vars),
         )
     if isinstance(node, ast.BoolOp):
         operands = [

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lift/pydantic.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lift/pydantic.py
@@ -41,6 +41,7 @@ from ..ir import (
     String,
     Bool,
     atomic,
+    comparison_with_none_guard,
     eq,
     ne,
     gt,
@@ -241,7 +242,9 @@ def lift_pydantic_model_witnesses(
         annotation = annotations.get(field_name, getattr(field_info, "annotation", None))
         formulas: List[Formula] = []
         if _field_required(field_info) and not _is_optional_annotation(annotation):
-            formulas.append(ne(make_var(field_name), ctor("None", [])))
+            formulas.append(
+                comparison_with_none_guard("≠", make_var(field_name), ctor("None", []))
+            )
         type_name = _annotation_name(annotation)
         if type_name and type_name != "Any":
             formulas.append(atomic("is_type", [make_var(field_name), str_const(type_name)]))

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lsp.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lsp.py
@@ -121,9 +121,20 @@ def kit_declaration_result() -> Dict[str, Any]:
             ]
         },
         "proofResolution": {"strategy": "pip"},
-        "effectKinds": [],
+        "effectKinds": ["concept:panic-freedom"],
         "effectLeaves": [],
-        "guardPredicates": [],
+        "guardPredicates": [
+            {
+                "surface": KIT_ID,
+                "local": "is_some",
+                "concept": "concept:panic-freedom.option.some",
+            },
+            {
+                "surface": KIT_ID,
+                "local": "is_none",
+                "concept": "concept:panic-freedom.option.none",
+            },
+        ],
         "controlCarriers": [],
         "residueCategories": [],
     }

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/walk.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/walk.py
@@ -22,6 +22,7 @@ from .ir import (
     and_,
     atomic,
     bool_const,
+    comparison_with_none_guard,
     connective,
     ctor,
     eq,
@@ -412,7 +413,9 @@ def _lift_predicate(node: ast.expr) -> Formula:
         sym = _COMPARE_OP_MAP.get(type(node.ops[0]))
         if sym is None:
             raise ValueError(f"unsupported comparison op: {type(node.ops[0]).__name__}")
-        return atomic(sym, [_term_from_expr(node.left), _term_from_expr(node.comparators[0])])
+        return comparison_with_none_guard(
+            sym, _term_from_expr(node.left), _term_from_expr(node.comparators[0])
+        )
     if isinstance(node, ast.BoolOp):
         operands = [_lift_predicate(value) for value in node.values]
         if isinstance(node.op, ast.And):

--- a/implementations/python/provekit-lift-py-tests/tests/test_daemon_protocol.py
+++ b/implementations/python/provekit-lift-py-tests/tests/test_daemon_protocol.py
@@ -124,6 +124,32 @@ def _build_kit_declaration_session() -> str:
     return "\n".join(json.dumps(m) for m in msgs) + "\n"
 
 
+def _flatten_and_json(formula: dict) -> List[dict]:
+    if formula.get("kind") == "and":
+        out: List[dict] = []
+        for operand in formula.get("operands", []):
+            out.extend(_flatten_and_json(operand))
+        return out
+    return [formula]
+
+
+def _assert_json_none_guard_formula(
+    formula: dict, *, comparison_name: str, guard_name: str
+) -> None:
+    atoms = [atom for atom in _flatten_and_json(formula) if atom.get("kind") == "atomic"]
+    assert any(
+        atom.get("name") == comparison_name
+        and len(atom.get("args", [])) == 2
+        and atom["args"][1].get("kind") == "ctor"
+        and atom["args"][1].get("name") == "None"
+        for atom in atoms
+    )
+    guards = [atom for atom in atoms if atom.get("name") == guard_name]
+    assert len(guards) == 1
+    assert ":" not in guards[0]["name"]
+    assert len(guards[0].get("args", [])) == 1
+
+
 def _repo_root() -> str:
     return os.path.normpath(os.path.join(os.path.dirname(__file__), "../../../.."))
 
@@ -204,7 +230,7 @@ class TestDaemonProtocol:
         assert declaration["result"]["kit"]["id"] == "python"
 
     def test_kit_declaration_returns_python_lift_surface(self):
-        """Binary serves an honest empty-vocabulary kit declaration."""
+        """Binary serves an honest Python test-lift declaration."""
         responses = _run_lsp(_build_kit_declaration_session())
         declaration_resp = next(r for r in responses if r.get("id") == 2)
         assert "error" not in declaration_resp, declaration_resp
@@ -225,9 +251,20 @@ class TestDaemonProtocol:
             "shutdown",
         }
         assert result["proofResolution"] == {"strategy": "pip"}
-        assert result["effectKinds"] == []
+        assert result["effectKinds"] == ["concept:panic-freedom"]
         assert result["effectLeaves"] == []
-        assert result["guardPredicates"] == []
+        assert result["guardPredicates"] == [
+            {
+                "surface": "python",
+                "local": "is_some",
+                "concept": "concept:panic-freedom.option.some",
+            },
+            {
+                "surface": "python",
+                "local": "is_none",
+                "concept": "concept:panic-freedom.option.none",
+            },
+        ]
         assert result["controlCarriers"] == []
         assert result["residueCategories"] == []
         json.dumps(declaration_resp)
@@ -397,15 +434,28 @@ class ParserTest(unittest.TestCase):
         assert decl["name"] == "test_native_assertions"
         inv = decl["inv"]
         assert inv["kind"] == "and"
-        assert [op["name"] for op in inv["operands"]] == ["=", "≠", ">", "=", "≠"]
+        flat_atoms = [
+            op for op in _flatten_and_json(inv) if op.get("kind") == "atomic"
+        ]
+        assert [op["name"] for op in flat_atoms] == [
+            "=",
+            "≠",
+            ">",
+            "=",
+            "is_none",
+            "≠",
+            "is_some",
+        ]
         none_atoms = [
-            op for op in inv["operands"]
+            op for op in flat_atoms
             if op["name"] in {"=", "≠"}
             and len(op["args"]) == 2
             and op["args"][1].get("kind") == "ctor"
             and op["args"][1].get("name") == "None"
         ]
         assert len(none_atoms) == 2
+        _assert_json_none_guard_formula(inv, comparison_name="=", guard_name="is_none")
+        _assert_json_none_guard_formula(inv, comparison_name="≠", guard_name="is_some")
 
     def test_parse_unsupported_unittest_assertion_reports_lift_gap_warning(self):
         """Unsupported unittest forms report a gap and do not mint a contract."""

--- a/implementations/python/provekit-lift-py-tests/tests/test_decorators.py
+++ b/implementations/python/provekit-lift-py-tests/tests/test_decorators.py
@@ -10,6 +10,9 @@ from provekit_lift_py_tests.decorators import (
     collect_module,
 )
 from provekit_lift_py_tests.ir import (
+    _Atomic,
+    _Connective,
+    _Ctor,
     atomic,
     eq,
     gt,
@@ -19,6 +22,30 @@ from provekit_lift_py_tests.ir import (
     str_const,
     bool_const,
 )
+
+
+def _flatten_and(formula):
+    if isinstance(formula, _Connective) and formula.kind == "and":
+        out = []
+        for operand in formula.operands:
+            out.extend(_flatten_and(operand))
+        return out
+    return [formula]
+
+
+def _assert_none_guard_formula(formula, *, comparison_name: str, guard_name: str):
+    atoms = [atom for atom in _flatten_and(formula) if isinstance(atom, _Atomic)]
+    assert any(
+        atom.name == comparison_name
+        and len(atom.args) == 2
+        and isinstance(atom.args[1], _Ctor)
+        and atom.args[1].name == "None"
+        for atom in atoms
+    )
+    guards = [atom for atom in atoms if atom.name == guard_name]
+    assert len(guards) == 1
+    assert ":" not in guards[0].name
+    assert len(guards[0].args) == 1
 
 
 class TestContractDecorator:
@@ -43,6 +70,19 @@ class TestContractDecorator:
         assert decl.pre is not None
         assert decl.post is not None
         assert decl.out_binding == "out"
+
+    def test_none_string_expr_emits_substrate_guard_fact(self):
+        @contract(pre="x is not None")
+        def identity(x: object) -> object:
+            return x
+
+        decl = identity._provekit_contract
+        assert decl.pre is not None
+        _assert_none_guard_formula(
+            decl.pre,
+            comparison_name="≠",
+            guard_name="is_some",
+        )
 
     def test_runtime_precondition_passes(self):
         @contract(pre=lambda x: x >= 0)

--- a/implementations/python/provekit-lift-py-tests/tests/test_layer2.py
+++ b/implementations/python/provekit-lift-py-tests/tests/test_layer2.py
@@ -20,6 +20,30 @@ def _lift(src: str):
     return lift_file_layer2(textwrap.dedent(src), "t.py")
 
 
+def _flatten_and(formula):
+    if isinstance(formula, _Connective) and formula.kind == "and":
+        out = []
+        for operand in formula.operands:
+            out.extend(_flatten_and(operand))
+        return out
+    return [formula]
+
+
+def _assert_none_guard_formula(formula, *, comparison_name: str, guard_name: str):
+    atoms = [atom for atom in _flatten_and(formula) if isinstance(atom, _Atomic)]
+    assert any(
+        atom.name == comparison_name
+        and len(atom.args) == 2
+        and isinstance(atom.args[1], _Ctor)
+        and atom.args[1].name == "None"
+        for atom in atoms
+    )
+    guards = [atom for atom in atoms if atom.name == guard_name]
+    assert len(guards) == 1
+    assert ":" not in guards[0].name
+    assert len(guards[0].args) == 1
+
+
 # --- Pattern 1: bounded loops --------------------------------------------
 
 
@@ -203,15 +227,30 @@ def test_pattern3_plain_unittest_testcase_assertions_lift_to_contract_atoms():
     inv = out.decls[0].inv
     assert isinstance(inv, _Connective)
     assert inv.kind == "and"
-    atoms = list(inv.operands)
-    assert len(atoms) == 5
-    assert [atom.name for atom in atoms] == ["=", "≠", ">", "=", "≠"]
+    atoms = [atom for atom in _flatten_and(inv) if isinstance(atom, _Atomic)]
+    assert [atom.name for atom in atoms] == ["=", "≠", ">", "=", "is_none", "≠", "is_some"]
     none_atoms = [
         atom
         for atom in atoms
         if atom.name in {"=", "≠"} and isinstance(atom.args[1], _Ctor)
     ]
     assert [atom.args[1].name for atom in none_atoms] == ["None", "None"]
+    _assert_none_guard_formula(inv, comparison_name="=", guard_name="is_none")
+    _assert_none_guard_formula(inv, comparison_name="≠", guard_name="is_some")
+
+
+def test_pattern3_pytest_none_comparisons_emit_substrate_guard_facts():
+    out = _lift("""
+        def test_none_assertions():
+            assert maybe_none() is None
+            assert maybe_value() is not None
+    """)
+    assert out.characterization_lifted == 1, f"warnings: {out.warnings}"
+    inv = out.decls[0].inv
+    assert isinstance(inv, _Connective)
+    assert inv.kind == "and"
+    _assert_none_guard_formula(inv, comparison_name="=", guard_name="is_none")
+    _assert_none_guard_formula(inv, comparison_name="≠", guard_name="is_some")
 
 
 def test_unittest_unsupported_assertion_warns_without_fake_contract():

--- a/implementations/python/provekit-lift-py-tests/tests/test_lift_pydantic.py
+++ b/implementations/python/provekit-lift-py-tests/tests/test_lift_pydantic.py
@@ -97,5 +97,6 @@ class TestPydanticLift:
         assert any(w["extension_fields"]["loss_record"] for w in witnesses)
         predicate_text = " ".join(w["predicate_text"] for w in witnesses)
         assert "name != None" in predicate_text
+        assert "is_some(name)" in predicate_text
         assert "type(name) == str" in predicate_text
         assert "strlen(name) >= 1" in predicate_text

--- a/implementations/python/provekit-lift-py-tests/tests/test_walk.py
+++ b/implementations/python/provekit-lift-py-tests/tests/test_walk.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import textwrap
 
-from provekit_lift_py_tests.ir import _Atomic, _Connective, _ConstInt, _Var
+from provekit_lift_py_tests.ir import _Atomic, _Connective, _ConstInt, _Ctor, _Var
 from provekit_lift_py_tests.lsp import _lift_source
 from provekit_lift_py_tests.walk import lift_production_walk
 
@@ -17,6 +17,30 @@ def _edge(out, suffix: str):
     matches = [d for d in out.decls if d.name.endswith(suffix)]
     assert len(matches) == 1, f"expected one {suffix} edge, got {[d.name for d in out.decls]}"
     return matches[0]
+
+
+def _flatten_and(formula):
+    if isinstance(formula, _Connective) and formula.kind == "and":
+        out = []
+        for operand in formula.operands:
+            out.extend(_flatten_and(operand))
+        return out
+    return [formula]
+
+
+def _assert_none_guard_formula(formula, *, comparison_name: str, guard_name: str):
+    atoms = [atom for atom in _flatten_and(formula) if isinstance(atom, _Atomic)]
+    assert any(
+        atom.name == comparison_name
+        and len(atom.args) == 2
+        and isinstance(atom.args[1], _Ctor)
+        and atom.args[1].name == "None"
+        for atom in atoms
+    )
+    guards = [atom for atom in atoms if atom.name == guard_name]
+    assert len(guards) == 1
+    assert ":" not in guards[0].name
+    assert len(guards[0].args) == 1
 
 
 def test_walk_substitutes_assignment_back_to_function_entry():
@@ -60,6 +84,26 @@ def test_walk_substitutes_assignment_back_to_function_entry():
 
     entry_edge = _edge(out, "::entry")
     assert entry_edge.pre == pre
+
+
+def test_walk_none_precondition_emits_substrate_guard_fact():
+    out = _lift(
+        """
+        def f(x):
+            assert x is not None
+            return x
+
+        def caller(value):
+            return f(value)
+        """
+    )
+
+    entry_edge = _edge(out, "::entry")
+    _assert_none_guard_formula(
+        entry_edge.pre,
+        comparison_name="≠",
+        guard_name="is_some",
+    )
 
 
 def test_walk_if_guard_becomes_callsite_premise():


### PR DESCRIPTION
## Summary

Federates Python test-lift `None` evidence into substrate panic-freedom vocabulary.

This applies the Python depth pattern from `python-source` to `provekit-lift-py-tests`, but in the kit's native formula-emission shape:

- preserves existing `= None` / `≠ None` facts
- adds bare substrate guard facts `is_none(subject)` / `is_some(subject)` alongside them
- keeps `controlCarriers` empty because this kit does not emit `cf_guarded` / `cf_ite` body-term carriers
- updates the kit declaration to claim `concept:panic-freedom` and the two guard predicates only

Covered formula emission paths:

- layer2 pytest and unittest assertions
- layer2 value-scope assertions
- decorator string contracts
- production walk preconditions
- pydantic required-field witnesses

## Invariants

- CLI/verifier remain language-blind.
- No Rust lib/CLI/verifier/doctor/cmd_verify production files changed.
- The Python kit owns the Python semantics and speaks the same RPC declaration surface.
- The declaration is honest: it claims guard predicates it emits, and does not claim control carriers it does not emit.

## Verification

RED targets failed first for missing guard facts / empty declaration, then passed after implementation.

- `python3 -m pytest implementations/python/provekit-lift-py-tests/tests/test_layer2.py -q -k 'substrate_guard or native_assertions'`
- `python3 -m pytest implementations/python/provekit-lift-py-tests/tests/test_daemon_protocol.py -q -k 'kit_declaration_returns_python_lift_surface or parse_plain_unittest'`
- `python3 -m pytest implementations/python/provekit-lift-py-tests/tests/test_walk.py -q -k 'none_precondition'`
- `python3 -m pytest implementations/python/provekit-lift-py-tests/tests/test_decorators.py implementations/python/provekit-lift-py-tests/tests/test_lift_pydantic.py -q -k 'none_string_expr or bridge_emits_source'`
- `python3 -m pytest implementations/python/provekit-lift-py-tests/tests -q` -> 170 passed, 3 skipped
- `python3 -m compileall -q implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests implementations/python/provekit-lift-py-tests/tests`
- `git diff --check origin/main...HEAD`
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo test -p provekit-cli doctor_kit_declaration_non_rust_vocabulary -- --nocapture` -> 4+4 passed
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture` -> 6 passed
- `../../bin/bcargo test -p provekit-cli --test cmd_verify_python_production_bridge -- --nocapture` -> 5 passed
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc`
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo build -p provekit-lift --bin provekit-lift`
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` -> 1 passed, 116.90s
