### PR TITLE
[codex] Federate Python verify None assertion harvest

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/leaf_assertions.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/leaf_assertions.py
@@ -21,6 +21,8 @@ call ``f(arg)`` as a ctor / negative-int literal):
     assert <lhs> == <rhs>   -> = (lhs, rhs)
     assert <lhs> != <rhs>   -> ≠ (lhs, rhs)
     assert <lhs> <  <rhs>   -> < (lhs, rhs)        (and <=, >, >=)
+    assert <lhs> is None    -> and(=(lhs, None), is_none(lhs))
+    assert <lhs> is not None -> and(≠(lhs, None), is_some(lhs))
 
 Anything else is skipped (a diagnostic, not a contract) so the harvester never
 fabricates a callsite it cannot faithfully lift.
@@ -41,6 +43,8 @@ _CMP: dict[type[ast.cmpop], str] = {
     ast.LtE: "≤",
     ast.Gt: ">",
     ast.GtE: "≥",
+    ast.Is: "=",
+    ast.IsNot: "≠",
 }
 
 
@@ -112,7 +116,7 @@ def _lift_assert(stmt: ast.Assert) -> Json:
         raise _Unsupported(f"comparison op {type(test.ops[0]).__name__} not in whitelist")
     lhs = _translate_term(test.left)
     rhs = _translate_term(test.comparators[0])
-    return {"kind": "atomic", "name": op, "args": [lhs, rhs]}
+    return _comparison_with_none_guard(op, lhs, rhs)
 
 
 def _translate_term(node: ast.expr) -> Json:
@@ -126,6 +130,8 @@ def _translate_term(node: ast.expr) -> Json:
             return {"kind": "const", "value": value, "sort": {"kind": "primitive", "name": "Int"}}
         if isinstance(value, str):
             return {"kind": "const", "value": value, "sort": {"kind": "primitive", "name": "String"}}
+        if value is None:
+            return {"kind": "ctor", "name": "None", "args": []}
         raise _Unsupported(f"unsupported constant {type(value).__name__}")
     if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
         operand = node.operand
@@ -146,3 +152,22 @@ def _translate_term(node: ast.expr) -> Json:
 
 def _and(atoms: list[Json]) -> Json:
     return {"kind": "and", "operands": atoms}
+
+
+def _comparison_with_none_guard(name: str, lhs: Json, rhs: Json) -> Json:
+    base = {"kind": "atomic", "name": name, "args": [lhs, rhs]}
+    lhs_is_none = _is_none_ctor(lhs)
+    rhs_is_none = _is_none_ctor(rhs)
+    if lhs_is_none == rhs_is_none:
+        return base
+
+    subject = rhs if lhs_is_none else lhs
+    if name == "=":
+        return _and([base, {"kind": "atomic", "name": "is_none", "args": [subject]}])
+    if name == "≠":
+        return _and([base, {"kind": "atomic", "name": "is_some", "args": [subject]}])
+    return base
+
+
+def _is_none_ctor(term: Json) -> bool:
+    return term.get("kind") == "ctor" and term.get("name") == "None" and term.get("args") == []

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/leaf_assertions.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/leaf_assertions.py
@@ -121,7 +121,7 @@ def _lift_assert(stmt: ast.Assert) -> Json:
     op = _CMP.get(type(test.ops[0]))
     if op is None:
         raise _Unsupported(f"comparison op {type(test.ops[0]).__name__} not in whitelist")
-    return _comparison_with_none_guard(op, lhs, rhs)
+    return _comparison(op, lhs, rhs)
 
 
 def _translate_term(node: ast.expr) -> Json:
@@ -159,8 +159,12 @@ def _and(atoms: list[Json]) -> Json:
     return {"kind": "and", "operands": atoms}
 
 
+def _comparison(name: str, lhs: Json, rhs: Json) -> Json:
+    return {"kind": "atomic", "name": name, "args": [lhs, rhs]}
+
+
 def _comparison_with_none_guard(name: str, lhs: Json, rhs: Json) -> Json:
-    base = {"kind": "atomic", "name": name, "args": [lhs, rhs]}
+    base = _comparison(name, lhs, rhs)
     lhs_is_none = _is_none_ctor(lhs)
     rhs_is_none = _is_none_ctor(rhs)
     if lhs_is_none == rhs_is_none:

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/leaf_assertions.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/leaf_assertions.py
@@ -43,8 +43,6 @@ _CMP: dict[type[ast.cmpop], str] = {
     ast.LtE: "≤",
     ast.Gt: ">",
     ast.GtE: "≥",
-    ast.Is: "=",
-    ast.IsNot: "≠",
 }
 
 
@@ -111,11 +109,18 @@ def _lift_assert(stmt: ast.Assert) -> Json:
         raise _Unsupported("assert is not a comparison")
     if len(test.ops) != 1 or len(test.comparators) != 1:
         raise _Unsupported("only single-comparison asserts are harvested")
+    lhs = _translate_term(test.left)
+    rhs = _translate_term(test.comparators[0])
+
+    if isinstance(test.ops[0], (ast.Is, ast.IsNot)):
+        if _is_none_ctor(lhs) == _is_none_ctor(rhs):
+            raise _Unsupported("identity comparison is only supported against None")
+        op = "=" if isinstance(test.ops[0], ast.Is) else "≠"
+        return _comparison_with_none_guard(op, lhs, rhs)
+
     op = _CMP.get(type(test.ops[0]))
     if op is None:
         raise _Unsupported(f"comparison op {type(test.ops[0]).__name__} not in whitelist")
-    lhs = _translate_term(test.left)
-    rhs = _translate_term(test.comparators[0])
     return _comparison_with_none_guard(op, lhs, rhs)
 
 

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/verify_rpc.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/verify_rpc.py
@@ -85,9 +85,20 @@ def kit_declaration_result() -> dict[str, Any]:
             ]
         },
         "proofResolution": {"strategy": "pip"},
-        "effectKinds": [],
+        "effectKinds": ["concept:panic-freedom"],
         "effectLeaves": [],
-        "guardPredicates": [],
+        "guardPredicates": [
+            {
+                "surface": SURFACE,
+                "local": "is_some",
+                "concept": "concept:panic-freedom.option.some",
+            },
+            {
+                "surface": SURFACE,
+                "local": "is_none",
+                "concept": "concept:panic-freedom.option.none",
+            },
+        ],
         "controlCarriers": [],
         "residueCategories": [],
     }

--- a/implementations/python/provekit-lift-python-source/tests/test_verify_dialect.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_verify_dialect.py
@@ -262,22 +262,18 @@ def test_leaf_harvester_plain_equality_does_not_emit_option_guard():
     assert _atoms_named(result.ir[0]["inv"], "is_some") == []
 
 
-def test_leaf_harvester_non_none_identity_does_not_emit_option_guard():
+def test_leaf_harvester_non_none_identity_skips_instead_of_lowering_to_equality():
     source = "def test_alias(left, right):\n    assert left is right\n"
     result = harvest_source(source, "test_m.py")
-    assert len(result.ir) == 1
-
-    inv = result.ir[0]["inv"]
-    assert inv == {
-        "kind": "atomic",
-        "name": "=",
-        "args": [
-            {"kind": "var", "name": "left"},
-            {"kind": "var", "name": "right"},
-        ],
-    }
-    assert _atoms_named(inv, "is_none") == []
-    assert _atoms_named(inv, "is_some") == []
+    assert result.ir == []
+    assert result.diagnostics == [
+        {
+            "kind": "leaf-assertion-skipped",
+            "message": "identity comparison is only supported against None",
+            "path": "test_m.py",
+            "line": 2,
+        }
+    ]
 
 
 def test_leaf_harvester_mixed_assertions_guard_only_none_comparison():

--- a/implementations/python/provekit-lift-python-source/tests/test_verify_dialect.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_verify_dialect.py
@@ -262,6 +262,38 @@ def test_leaf_harvester_plain_equality_does_not_emit_option_guard():
     assert _atoms_named(result.ir[0]["inv"], "is_some") == []
 
 
+def test_leaf_harvester_eq_none_does_not_emit_option_guard():
+    source = "def test_missing():\n    assert maybe_none() == None\n"
+    result = harvest_source(source, "test_m.py")
+    assert result.diagnostics == []
+    assert len(result.ir) == 1
+
+    inv = result.ir[0]["inv"]
+    assert inv == {
+        "kind": "atomic",
+        "name": "=",
+        "args": [_call_term("maybe_none"), _none_term()],
+    }
+    assert _atoms_named(inv, "is_none") == []
+    assert _atoms_named(inv, "is_some") == []
+
+
+def test_leaf_harvester_ne_none_does_not_emit_option_guard():
+    source = "def test_present():\n    assert maybe_value() != None\n"
+    result = harvest_source(source, "test_m.py")
+    assert result.diagnostics == []
+    assert len(result.ir) == 1
+
+    inv = result.ir[0]["inv"]
+    assert inv == {
+        "kind": "atomic",
+        "name": "≠",
+        "args": [_call_term("maybe_value"), _none_term()],
+    }
+    assert _atoms_named(inv, "is_none") == []
+    assert _atoms_named(inv, "is_some") == []
+
+
 def test_leaf_harvester_non_none_identity_skips_instead_of_lowering_to_equality():
     source = "def test_alias(left, right):\n    assert left is right\n"
     result = harvest_source(source, "test_m.py")

--- a/implementations/python/provekit-lift-python-source/tests/test_verify_dialect.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_verify_dialect.py
@@ -95,6 +95,27 @@ def _fn_contract(source: str, source_path: str = "m.py"):
     raise AssertionError("no function-contract lifted")
 
 
+def _flatten_and(formula: dict[str, object]) -> list[dict[str, object]]:
+    if formula.get("kind") != "and":
+        return [formula]
+    atoms: list[dict[str, object]] = []
+    for operand in formula["operands"]:
+        atoms.extend(_flatten_and(operand))
+    return atoms
+
+
+def _call_term(name: str, *args: dict[str, object]) -> dict[str, object]:
+    return {"kind": "ctor", "name": name, "args": list(args)}
+
+
+def _none_term() -> dict[str, object]:
+    return {"kind": "ctor", "name": "None", "args": []}
+
+
+def _atoms_named(formula: dict[str, object], name: str) -> list[dict[str, object]]:
+    return [atom for atom in _flatten_and(formula) if atom.get("name") == name]
+
+
 def test_double_lowers_to_dischargeable_core_form():
     source = "def double(x: int) -> int:\n    return x * 2\n"
     contract = _fn_contract(source)
@@ -173,6 +194,105 @@ def test_leaf_harvester_lifts_call_eq():
         "args": [{"kind": "const", "value": 3, "sort": {"kind": "primitive", "name": "Int"}}],
     }
     assert inv["args"][1]["value"] == 6
+
+
+def test_leaf_harvester_lifts_is_none_with_substrate_guard():
+    source = "def test_missing():\n    assert maybe_none() is None\n"
+    result = harvest_source(source, "test_m.py")
+    assert result.diagnostics == []
+    assert len(result.ir) == 1
+
+    inv = result.ir[0]["inv"]
+    call = _call_term("maybe_none")
+    assert {
+        "kind": "atomic",
+        "name": "=",
+        "args": [call, _none_term()],
+    } in _flatten_and(inv)
+    assert {
+        "kind": "atomic",
+        "name": "is_none",
+        "args": [call],
+    } in _flatten_and(inv)
+
+
+def test_leaf_harvester_lifts_is_not_none_with_substrate_guard():
+    source = "def test_present():\n    assert maybe_value() is not None\n"
+    result = harvest_source(source, "test_m.py")
+    assert result.diagnostics == []
+    assert len(result.ir) == 1
+
+    inv = result.ir[0]["inv"]
+    call = _call_term("maybe_value")
+    assert {
+        "kind": "atomic",
+        "name": "≠",
+        "args": [call, _none_term()],
+    } in _flatten_and(inv)
+    assert {
+        "kind": "atomic",
+        "name": "is_some",
+        "args": [call],
+    } in _flatten_and(inv)
+
+
+def test_leaf_harvester_emits_bare_substrate_guard_heads():
+    source = (
+        "def test_option_guards():\n"
+        "    assert maybe_none() is None\n"
+        "    assert maybe_value() is not None\n"
+    )
+    result = harvest_source(source, "test_m.py")
+    guard_names = [
+        atom["name"]
+        for atom in _flatten_and(result.ir[0]["inv"])
+        if atom.get("name") in {"is_none", "is_some"}
+    ]
+
+    assert guard_names == ["is_none", "is_some"]
+    assert all(":" not in name for name in guard_names)
+
+
+def test_leaf_harvester_plain_equality_does_not_emit_option_guard():
+    source = "def test_count():\n    assert count() == 0\n"
+    result = harvest_source(source, "test_m.py")
+    assert len(result.ir) == 1
+
+    assert _atoms_named(result.ir[0]["inv"], "is_none") == []
+    assert _atoms_named(result.ir[0]["inv"], "is_some") == []
+
+
+def test_leaf_harvester_non_none_identity_does_not_emit_option_guard():
+    source = "def test_alias(left, right):\n    assert left is right\n"
+    result = harvest_source(source, "test_m.py")
+    assert len(result.ir) == 1
+
+    inv = result.ir[0]["inv"]
+    assert inv == {
+        "kind": "atomic",
+        "name": "=",
+        "args": [
+            {"kind": "var", "name": "left"},
+            {"kind": "var", "name": "right"},
+        ],
+    }
+    assert _atoms_named(inv, "is_none") == []
+    assert _atoms_named(inv, "is_some") == []
+
+
+def test_leaf_harvester_mixed_assertions_guard_only_none_comparison():
+    source = (
+        "def test_mixed():\n"
+        "    assert maybe_none() is None\n"
+        "    assert count() == 0\n"
+    )
+    result = harvest_source(source, "test_m.py")
+    assert len(result.ir) == 1
+
+    inv = result.ir[0]["inv"]
+    assert len(_atoms_named(inv, "is_none")) == 1
+    assert _atoms_named(inv, "is_some") == []
+    assert len(_atoms_named(inv, "=")) == 2
 
 
 def test_leaf_harvester_negative_int_literal():
@@ -283,9 +403,20 @@ def test_verify_rpc_kit_declaration_returns_python_verify_surface():
         "shutdown": False,
     }
     assert result["proofResolution"] == {"strategy": "pip"}
-    assert result["effectKinds"] == []
+    assert result["effectKinds"] == ["concept:panic-freedom"]
     assert result["effectLeaves"] == []
-    assert result["guardPredicates"] == []
+    assert result["guardPredicates"] == [
+        {
+            "surface": "python-verify",
+            "local": "is_some",
+            "concept": "concept:panic-freedom.option.some",
+        },
+        {
+            "surface": "python-verify",
+            "local": "is_none",
+            "concept": "concept:panic-freedom.option.none",
+        },
+    ]
     assert result["controlCarriers"] == []
     assert result["residueCategories"] == []
 


### PR DESCRIPTION
## Summary

This is the third Python C2 depth slice. `python-verify` now harvests `assert x is None` and `assert x is not None` instead of skipping them, and it emits substrate-aligned guard facts from day one.

This differs from #1823 and #1824: those slices added substrate aliases beside existing emission. This slice is capability-additive because the verify-facing leaf harvester previously rejected `ast.Is` / `ast.IsNot` and `None` constants entirely.

Refs #1822.

## What Changed

- Add `ast.Is` / `ast.IsNot` support in `leaf_assertions.py`, mapping to `=` / `≠`.
- Translate literal `None` as `ctor("None", [])` for verify-facing leaf assertions.
- Add a centralized `_comparison_with_none_guard` helper that emits bare `is_none(x)` / `is_some(x)` only when exactly one comparison side is `None`.
- Declare `python-verify` panic-freedom guard predicates in `kit_declaration` while keeping `effectLeaves` and `controlCarriers` empty.
- Add RED to GREEN coverage for `is None`, `is not None`, bare guard heads, non-None identity, and ordinary equality non-broadening.

## Invariants

- CLI and verifier stay language-blind. No Rust verifier, doctor, or cmd_verify production files changed.
- Formula kit only declares guard predicates. It does not claim `cf_guarded` / `cf_ite` carriers.
- Substrate guard heads are bare: `is_none` and `is_some`, not Python-prefixed.
- Ordinary comparisons and non-None identity comparisons do not receive option guards.

## Verification

- RED targeted run first: 6 failed, 1 passed, 14 deselected for the expected missing `Is` / `IsNot` / declaration behavior.
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_verify_dialect.py -q` - 21 passed.
- `python3 -m compileall -q implementations/python/provekit-lift-python-source/src/provekit_lift_python_source implementations/python/provekit-lift-python-source/tests/test_verify_dialect.py` - passed.
- `git diff --check` - passed.
- Path A grep for Rust/CLI/verifier/doctor/cmd_verify production changes - zero.
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo test -p provekit-cli doctor_kit_declaration_non_rust_vocabulary -- --nocapture` - 4+4 passed.
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture` - 6 passed.
- `../../bin/bcargo test -p provekit-cli --test cmd_verify_python_production_bridge -- --nocapture` - 5 passed.
- `../../bin/bcargo test -p provekit-cli --test cmd_verify_python_division_unsound -- --nocapture` - 2 passed, both `status=undecidable exit=3 witnesses=0`.
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc` - passed.
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo build -p provekit-lift --bin provekit-lift` - passed.
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` - 1 passed, golden unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Python `is None` and `is not None` assertions in contract validation
  * Enhanced capability declarations to advertise panic-freedom support with corresponding constraint checking

* **Tests**
  * Added comprehensive test coverage for None assertion handling and verification capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review Follow-up

- Addressed identity-vs-equality semantics: `ast.Is` and `ast.IsNot` are now gated on exactly one literal `None` operand before lowering.
- Non-None identity comparisons such as `assert left is right` preserve the pre-PR skip behavior and do not lower to value equality.
- Added `test_leaf_harvester_non_none_identity_skips_instead_of_lowering_to_equality` to pin that behavior.

## CI Note

The `Cross-language conformance gate` failure is inherited from main, not caused by this Python change. The exact failed test, `provekit_cli_self_application_proves_green_then_refuses_planted_contradiction`, also fails on fresh `origin/main` at `30fe7e1d3` with the same shape: `prove` exits nonzero, `totalCallsites=374`, `violations=276`, `falsePass=0`, and duplicate Rust contract-name load errors. Tracked separately in a GitHub issue.


## Additional Review Follow-up

- `== None` and `!= None` now remain plain equality/inequality assertions and do not emit `is_none` / `is_some` guards.
- Option guard emission is restricted to identity checks only: `is None` and `is not None`.
- Added `test_leaf_harvester_eq_none_does_not_emit_option_guard` and `test_leaf_harvester_ne_none_does_not_emit_option_guard` to pin this distinction.
