### PR TITLE
[codex] Fix lift-py-tests identity None gating

### DIFF
--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/ir.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/ir.py
@@ -188,8 +188,12 @@ def ne(a: Term, b: Term) -> Formula:
     return atomic("≠", [a, b])
 
 
-def comparison_with_none_guard(name: str, left: Term, right: Term) -> Formula:
+def comparison_with_none_guard(
+    name: str, left: Term, right: Term, *, emit_none_guard: bool = True
+) -> Formula:
     base = atomic(name, [left, right])
+    if not emit_none_guard:
+        return base
     left_is_none = _is_none_ctor(left)
     right_is_none = _is_none_ctor(right)
     if left_is_none == right_is_none:

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/layer2.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/layer2.py
@@ -74,6 +74,7 @@ from .ir import (
     Formula,
     Int,
     Term,
+    _Ctor,
     and_,
     atomic,
     bool_const,
@@ -482,9 +483,33 @@ _COMPARE_OP_MAP = {
     ast.LtE: "≤",
     ast.Gt: ">",
     ast.GtE: "≥",
+}
+
+_IDENTITY_OP_MAP = {
     ast.Is: "=",
     ast.IsNot: "≠",
 }
+
+
+def _is_none_term(term: Term) -> bool:
+    return isinstance(term, _Ctor) and term.name == "None" and not term.args
+
+
+def _comparison_from_ast_op(op: ast.cmpop, left: Term, right: Term) -> Formula:
+    identity_sym = _IDENTITY_OP_MAP.get(type(op))
+    if identity_sym is not None:
+        if _is_none_term(left) == _is_none_term(right):
+            raise ValueError("identity comparison is only supported against None")
+        return comparison_with_none_guard(
+            identity_sym,
+            left,
+            right,
+            emit_none_guard=True,
+        )
+    sym = _COMPARE_OP_MAP.get(type(op))
+    if sym is None:
+        raise ValueError(f"unsupported comparison op: {type(op).__name__}")
+    return comparison_with_none_guard(sym, left, right, emit_none_guard=False)
 
 
 def _translate_bool_expr(node: ast.expr) -> Formula:
@@ -492,14 +517,9 @@ def _translate_bool_expr(node: ast.expr) -> Formula:
     if isinstance(node, ast.Compare):
         if len(node.ops) != 1 or len(node.comparators) != 1:
             raise ValueError("only single comparisons are liftable (no chained `a < b < c`)")
-        op = node.ops[0]
-        op_kind = type(op)
-        sym = _COMPARE_OP_MAP.get(op_kind)
-        if sym is None:
-            raise ValueError(f"unsupported comparison op: {op_kind.__name__}")
         l = _translate_term(node.left)
         r = _translate_term(node.comparators[0])
-        return comparison_with_none_guard(sym, l, r)
+        return _comparison_from_ast_op(node.ops[0], l, r)
     if isinstance(node, ast.NamedExpr):
         # Walrus inside an assert: skip.
         raise ValueError("walrus operator in assert is not liftable")
@@ -521,13 +541,16 @@ def _lift_assertion_stmt(stmt: ast.stmt) -> Formula:
             l = _translate_term(call.args[0])
             r = _translate_term(call.args[1])
             sym = _UNITTEST_BINARY_PREDICATES[name]
-            return comparison_with_none_guard(sym, l, r)
+            return comparison_with_none_guard(sym, l, r, emit_none_guard=False)
         if name in _UNITTEST_NONE_PREDICATES:
             if len(call.args) < 1:
                 raise ValueError(f"{name} expects 1 positional arg")
             t = _translate_term(call.args[0])
             return comparison_with_none_guard(
-                _UNITTEST_NONE_PREDICATES[name], t, ctor("None", [])
+                _UNITTEST_NONE_PREDICATES[name],
+                t,
+                ctor("None", []),
+                emit_none_guard=True,
             )
         if name == "assertTrue":
             if len(call.args) < 1:
@@ -1409,13 +1432,21 @@ def _lift_assertion_stmt_scoped(
                 raise ValueError(f"{name} expects at least 2 positional args")
             l = _translate_term_scoped(call.args[0], scope, call_vars)
             r = _translate_term_scoped(call.args[1], scope, call_vars)
-            return comparison_with_none_guard(_UNITTEST_BINARY_PREDICATES[name], l, r)
+            return comparison_with_none_guard(
+                _UNITTEST_BINARY_PREDICATES[name],
+                l,
+                r,
+                emit_none_guard=False,
+            )
         if name in _UNITTEST_NONE_PREDICATES:
             if len(call.args) < 1:
                 raise ValueError(f"{name} expects 1 positional arg")
             t = _translate_term_scoped(call.args[0], scope, call_vars)
             return comparison_with_none_guard(
-                _UNITTEST_NONE_PREDICATES[name], t, ctor("None", [])
+                _UNITTEST_NONE_PREDICATES[name],
+                t,
+                ctor("None", []),
+                emit_none_guard=True,
             )
         if name == "assertTrue":
             if len(call.args) < 1:
@@ -1436,11 +1467,8 @@ def _translate_bool_expr_scoped(
     if isinstance(node, ast.Compare):
         if len(node.ops) != 1 or len(node.comparators) != 1:
             raise ValueError("only single comparisons are liftable")
-        sym = _COMPARE_OP_MAP.get(type(node.ops[0]))
-        if sym is None:
-            raise ValueError(f"unsupported comparison op: {type(node.ops[0]).__name__}")
-        return comparison_with_none_guard(
-            sym,
+        return _comparison_from_ast_op(
+            node.ops[0],
             _translate_term_scoped(node.left, scope, call_vars),
             _translate_term_scoped(node.comparators[0], scope, call_vars),
         )

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/layer2.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/layer2.py
@@ -361,6 +361,9 @@ _UNITTEST_BINARY_PREDICATES = {
     "assertGreaterEqual": "≥",
     "assertLess": "<",
     "assertLessEqual": "≤",
+}
+
+_UNITTEST_IDENTITY_PREDICATES = {
     "assertIs": "=",
     "assertIsNot": "≠",
 }
@@ -386,6 +389,8 @@ def _is_assertion_stmt(stmt: ast.stmt) -> bool:
         if isinstance(call, ast.Call):
             name = _attr_method_name(call.func)
             if name is not None and name in _UNITTEST_BINARY_PREDICATES:
+                return True
+            if name is not None and name in _UNITTEST_IDENTITY_PREDICATES:
                 return True
             if name is not None and name in _UNITTEST_NONE_PREDICATES:
                 return True
@@ -418,6 +423,7 @@ def _unsupported_unittest_assertions(stmts: Sequence[ast.stmt]) -> List[str]:
             continue
         if (
             name in _UNITTEST_BINARY_PREDICATES
+            or name in _UNITTEST_IDENTITY_PREDICATES
             or name in _UNITTEST_NONE_PREDICATES
             or name in _UNITTEST_TRUTH_PREDICATES
         ):
@@ -495,17 +501,21 @@ def _is_none_term(term: Term) -> bool:
     return isinstance(term, _Ctor) and term.name == "None" and not term.args
 
 
+def _comparison_from_identity_symbol(sym: str, left: Term, right: Term) -> Formula:
+    if _is_none_term(left) == _is_none_term(right):
+        raise ValueError("identity comparison is only supported against None")
+    return comparison_with_none_guard(
+        sym,
+        left,
+        right,
+        emit_none_guard=True,
+    )
+
+
 def _comparison_from_ast_op(op: ast.cmpop, left: Term, right: Term) -> Formula:
     identity_sym = _IDENTITY_OP_MAP.get(type(op))
     if identity_sym is not None:
-        if _is_none_term(left) == _is_none_term(right):
-            raise ValueError("identity comparison is only supported against None")
-        return comparison_with_none_guard(
-            identity_sym,
-            left,
-            right,
-            emit_none_guard=True,
-        )
+        return _comparison_from_identity_symbol(identity_sym, left, right)
     sym = _COMPARE_OP_MAP.get(type(op))
     if sym is None:
         raise ValueError(f"unsupported comparison op: {type(op).__name__}")
@@ -535,6 +545,16 @@ def _lift_assertion_stmt(stmt: ast.stmt) -> Formula:
     if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
         call = stmt.value
         name = _attr_method_name(call.func)
+        if name in _UNITTEST_IDENTITY_PREDICATES:
+            if len(call.args) < 2:
+                raise ValueError(f"{name} expects at least 2 positional args")
+            l = _translate_term(call.args[0])
+            r = _translate_term(call.args[1])
+            return _comparison_from_identity_symbol(
+                _UNITTEST_IDENTITY_PREDICATES[name],
+                l,
+                r,
+            )
         if name in _UNITTEST_BINARY_PREDICATES:
             if len(call.args) < 2:
                 raise ValueError(f"{name} expects at least 2 positional args")
@@ -1350,6 +1370,8 @@ def _assertion_value_exprs(stmt: ast.stmt) -> List[ast.expr]:
         name = _attr_method_name(stmt.value.func)
         if name in _UNITTEST_BINARY_PREDICATES:
             exprs.extend(stmt.value.args[:2])
+        elif name in _UNITTEST_IDENTITY_PREDICATES:
+            exprs.extend(stmt.value.args[:2])
         elif name in _UNITTEST_NONE_PREDICATES and stmt.value.args:
             exprs.append(stmt.value.args[0])
         elif name in _UNITTEST_TRUTH_PREDICATES and stmt.value.args:
@@ -1427,6 +1449,16 @@ def _lift_assertion_stmt_scoped(
     if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
         call = stmt.value
         name = _attr_method_name(call.func)
+        if name in _UNITTEST_IDENTITY_PREDICATES:
+            if len(call.args) < 2:
+                raise ValueError(f"{name} expects at least 2 positional args")
+            l = _translate_term_scoped(call.args[0], scope, call_vars)
+            r = _translate_term_scoped(call.args[1], scope, call_vars)
+            return _comparison_from_identity_symbol(
+                _UNITTEST_IDENTITY_PREDICATES[name],
+                l,
+                r,
+            )
         if name in _UNITTEST_BINARY_PREDICATES:
             if len(call.args) < 2:
                 raise ValueError(f"{name} expects at least 2 positional args")

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/walk.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/walk.py
@@ -19,6 +19,7 @@ from .ir import (
     ContractDecl,
     Formula,
     Term,
+    _Ctor,
     and_,
     atomic,
     bool_const,
@@ -81,6 +82,9 @@ _COMPARE_OP_MAP = {
     ast.LtE: "≤",
     ast.Gt: ">",
     ast.GtE: "≥",
+}
+
+_IDENTITY_OP_MAP = {
     ast.Is: "=",
     ast.IsNot: "≠",
 }
@@ -94,6 +98,27 @@ _BINOP_TERM_NAMES = {
     ast.Mod: "%",
     ast.Pow: "**",
 }
+
+
+def _is_none_term(term: Term) -> bool:
+    return isinstance(term, _Ctor) and term.name == "None" and not term.args
+
+
+def _comparison_from_ast_op(op: ast.cmpop, left: Term, right: Term) -> Formula:
+    identity_sym = _IDENTITY_OP_MAP.get(type(op))
+    if identity_sym is not None:
+        if _is_none_term(left) == _is_none_term(right):
+            raise ValueError("identity comparison is only supported against None")
+        return comparison_with_none_guard(
+            identity_sym,
+            left,
+            right,
+            emit_none_guard=True,
+        )
+    sym = _COMPARE_OP_MAP.get(type(op))
+    if sym is None:
+        raise ValueError(f"unsupported comparison op: {type(op).__name__}")
+    return comparison_with_none_guard(sym, left, right, emit_none_guard=False)
 
 
 def lift_production_walk(source: str, source_path: str) -> ProductionWalkOutput:
@@ -410,11 +435,10 @@ def _lift_predicate(node: ast.expr) -> Formula:
     if isinstance(node, ast.Compare):
         if len(node.ops) != 1 or len(node.comparators) != 1:
             raise ValueError("only single comparisons are liftable")
-        sym = _COMPARE_OP_MAP.get(type(node.ops[0]))
-        if sym is None:
-            raise ValueError(f"unsupported comparison op: {type(node.ops[0]).__name__}")
-        return comparison_with_none_guard(
-            sym, _term_from_expr(node.left), _term_from_expr(node.comparators[0])
+        return _comparison_from_ast_op(
+            node.ops[0],
+            _term_from_expr(node.left),
+            _term_from_expr(node.comparators[0]),
         )
     if isinstance(node, ast.BoolOp):
         operands = [_lift_predicate(value) for value in node.values]

--- a/implementations/python/provekit-lift-py-tests/tests/test_layer2.py
+++ b/implementations/python/provekit-lift-py-tests/tests/test_layer2.py
@@ -300,6 +300,36 @@ def test_pattern3_unittest_equal_none_does_not_emit_substrate_guard_facts():
     assert _guard_names(inv) == []
 
 
+def test_pattern3_unittest_non_none_identity_is_not_lifted_as_value_equality():
+    out = _lift("""
+        import unittest
+
+        class TestSomething(unittest.TestCase):
+            def test_identity_is_not_equality(self):
+                self.assertIs(left(), right())
+                self.assertIsNot(other_left(), other_right())
+    """)
+    assert out.characterization_lifted == 0
+    assert "test_identity_is_not_equality" not in out.claimed_tests
+
+
+def test_pattern3_unittest_identity_none_assertions_emit_substrate_guard_facts():
+    out = _lift("""
+        import unittest
+
+        class TestSomething(unittest.TestCase):
+            def test_none_identity(self):
+                self.assertIs(maybe_none(), None)
+                self.assertIsNot(maybe_value(), None)
+    """)
+    assert out.characterization_lifted == 1, f"warnings: {out.warnings}"
+    inv = out.decls[0].inv
+    assert isinstance(inv, _Connective)
+    assert inv.kind == "and"
+    _assert_none_guard_formula(inv, comparison_name="=", guard_name="is_none")
+    _assert_none_guard_formula(inv, comparison_name="≠", guard_name="is_some")
+
+
 def test_unittest_unsupported_assertion_warns_without_fake_contract():
     out = _lift("""
         import unittest
@@ -492,6 +522,21 @@ def test_pattern5_non_none_identity_assertion_is_not_lifted_as_value_equality():
     assert all(not name.endswith("::assertion") for name in {d.name for d in out.decls})
 
 
+def test_pattern5_unittest_non_none_identity_assertion_is_not_lifted_as_value_equality():
+    out = _lift("""
+        import unittest
+
+        class TestParser(unittest.TestCase):
+            def test_parse_identity(self):
+                actual = parse_int("42")
+                expected = parse_int("042")
+                self.assertIs(actual, expected)
+    """)
+    assert out.value_scope_lifted == 0
+    assert not out.implications
+    assert all(not name.endswith("::assertion") for name in {d.name for d in out.decls})
+
+
 def test_pattern5_eq_none_assertion_does_not_emit_substrate_guard_fact():
     out = _lift("""
         def test_parse_eq_none():
@@ -501,6 +546,34 @@ def test_pattern5_eq_none_assertion_does_not_emit_substrate_guard_fact():
     assert out.value_scope_lifted == 1, f"warnings: {out.warnings}"
     assertion = next(d for d in out.decls if d.name.endswith("::assertion"))
     assert _guard_names(assertion.inv) == []
+
+
+def test_pattern5_unittest_identity_none_assertion_emits_substrate_guard_fact():
+    out = _lift("""
+        import unittest
+
+        class TestParser(unittest.TestCase):
+            def test_parse_none_identity(self):
+                actual = parse_optional("42")
+                self.assertIs(actual, None)
+    """)
+    assert out.value_scope_lifted == 1, f"warnings: {out.warnings}"
+    assertion = next(d for d in out.decls if d.name.endswith("::assertion"))
+    _assert_none_guard_formula(assertion.inv, comparison_name="=", guard_name="is_none")
+
+
+def test_pattern5_unittest_identity_not_none_assertion_emits_substrate_guard_fact():
+    out = _lift("""
+        import unittest
+
+        class TestParser(unittest.TestCase):
+            def test_parse_not_none_identity(self):
+                actual = parse_optional("42")
+                self.assertIsNot(actual, None)
+    """)
+    assert out.value_scope_lifted == 1, f"warnings: {out.warnings}"
+    assertion = next(d for d in out.decls if d.name.endswith("::assertion"))
+    _assert_none_guard_formula(assertion.inv, comparison_name="≠", guard_name="is_some")
 
 
 # --- No pattern fires ----------------------------------------------------

--- a/implementations/python/provekit-lift-py-tests/tests/test_layer2.py
+++ b/implementations/python/provekit-lift-py-tests/tests/test_layer2.py
@@ -44,6 +44,14 @@ def _assert_none_guard_formula(formula, *, comparison_name: str, guard_name: str
     assert len(guards[0].args) == 1
 
 
+def _guard_names(formula):
+    return [
+        atom.name
+        for atom in _flatten_and(formula)
+        if isinstance(atom, _Atomic) and atom.name in {"is_none", "is_some"}
+    ]
+
+
 # --- Pattern 1: bounded loops --------------------------------------------
 
 
@@ -253,6 +261,45 @@ def test_pattern3_pytest_none_comparisons_emit_substrate_guard_facts():
     _assert_none_guard_formula(inv, comparison_name="≠", guard_name="is_some")
 
 
+def test_pattern3_pytest_non_none_identity_is_not_lifted_as_value_equality():
+    out = _lift("""
+        def test_identity_is_not_equality():
+            assert left() is right()
+            assert f(1) == 1
+    """)
+    assert out.characterization_lifted == 0
+    assert "test_identity_is_not_equality" not in out.claimed_tests
+
+
+def test_pattern3_pytest_eq_none_does_not_emit_substrate_guard_facts():
+    out = _lift("""
+        def test_eq_none_is_value_equality():
+            assert maybe_none() == None
+            assert maybe_value() != None
+    """)
+    assert out.characterization_lifted == 1, f"warnings: {out.warnings}"
+    inv = out.decls[0].inv
+    assert isinstance(inv, _Connective)
+    assert inv.kind == "and"
+    assert _guard_names(inv) == []
+
+
+def test_pattern3_unittest_equal_none_does_not_emit_substrate_guard_facts():
+    out = _lift("""
+        import unittest
+
+        class TestSomething(unittest.TestCase):
+            def test_none_equality(self):
+                self.assertEqual(maybe_none(), None)
+                self.assertNotEqual(maybe_value(), None)
+    """)
+    assert out.characterization_lifted == 1, f"warnings: {out.warnings}"
+    inv = out.decls[0].inv
+    assert isinstance(inv, _Connective)
+    assert inv.kind == "and"
+    assert _guard_names(inv) == []
+
+
 def test_unittest_unsupported_assertion_warns_without_fake_contract():
     out = _lift("""
         import unittest
@@ -431,6 +478,29 @@ def test_pattern5_mints_every_callsite_implication_in_one_assertion():
     assert len(out.implications) == 2
     assert all(imp.antecedent.endswith("::facts") for imp in out.implications)
     assert all(imp.consequent.endswith("::assertion") for imp in out.implications)
+
+
+def test_pattern5_non_none_identity_assertion_is_not_lifted_as_value_equality():
+    out = _lift("""
+        def test_parse_identity():
+            actual = parse_int("42")
+            expected = parse_int("042")
+            assert actual is expected
+    """)
+    assert out.value_scope_lifted == 0
+    assert not out.implications
+    assert all(not name.endswith("::assertion") for name in {d.name for d in out.decls})
+
+
+def test_pattern5_eq_none_assertion_does_not_emit_substrate_guard_fact():
+    out = _lift("""
+        def test_parse_eq_none():
+            actual = parse_optional("42")
+            assert actual == None
+    """)
+    assert out.value_scope_lifted == 1, f"warnings: {out.warnings}"
+    assertion = next(d for d in out.decls if d.name.endswith("::assertion"))
+    assert _guard_names(assertion.inv) == []
 
 
 # --- No pattern fires ----------------------------------------------------

--- a/implementations/python/provekit-lift-py-tests/tests/test_walk.py
+++ b/implementations/python/provekit-lift-py-tests/tests/test_walk.py
@@ -106,6 +106,40 @@ def test_walk_none_precondition_emits_substrate_guard_fact():
     )
 
 
+def test_walk_non_none_identity_precondition_is_not_lifted_as_value_equality():
+    out = _lift(
+        """
+        def f(x, y):
+            assert x is y
+            return x
+
+        def caller(left, right):
+            return f(left, right)
+        """
+    )
+
+    assert out.decls == []
+    assert out.implications == []
+
+
+def test_walk_eq_none_precondition_does_not_emit_substrate_guard_fact():
+    out = _lift(
+        """
+        def f(x):
+            assert x == None
+            return x
+
+        def caller(value):
+            return f(value)
+        """
+    )
+
+    entry_edge = _edge(out, "::entry")
+    atoms = [atom for atom in _flatten_and(entry_edge.pre) if isinstance(atom, _Atomic)]
+    assert [atom.name for atom in atoms] == ["="]
+    assert all(atom.name not in {"is_none", "is_some"} for atom in atoms)
+
+
 def test_walk_if_guard_becomes_callsite_premise():
     out = _lift(
         """


### PR DESCRIPTION
Closes #1829.

## What changed

- Gates `ast.Is` / `ast.IsNot` handling in `provekit-lift-py-tests` so identity comparisons only lower when exactly one operand is literal `None`.
- Keeps `is None` / `is not None` substrate guards, while `== None` / `!= None` stay plain value equality/inequality with no `is_none` / `is_some` guard.
- Applies the policy to layer2 characterization, unittest assertion handling, value-scope assertions, and production walk preconditions.

## Why

`lift-py-tests` still treated Python identity as value equality. That meant `assert x is y` could mint `=(x, y)`, which is not faithful Python semantics. This mirrors the #1825 `python-verify` fix for the same identity-vs-equality issue.

## Validation

- RED observed first: 7 new tests failed against current behavior.
- GREEN: targeted 7 tests passed.
- `python3 -m pytest implementations/python/provekit-lift-py-tests/tests -q` -> 177 passed, 3 skipped.
- `python3 -m compileall -q implementations/python/provekit-lift-py-tests/src implementations/python/provekit-lift-py-tests/tests`
- `git diff --check`
- Scope grep: only `provekit-lift-py-tests` files changed; no libprovekit/verifier/doctor/substrate edits.
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo run -p provekit-cli -- doctor --target ../../implementations/python --mode strict --json` -> ok true, cross-kit consistency pass.
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture` -> 6 passed.
- `../../bin/bcargo test -p provekit-cli --test cmd_verify_python_production_bridge -- --nocapture` -> 5 passed.
- `../../bin/bcargo test -p provekit-cli --test cmd_verify_python_division_unsound -- --nocapture` -> 2 passed.
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc`
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo build -p provekit-lift --bin provekit-lift`
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` -> 1 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional parameter to control guard generation in comparison lifting.

* **Bug Fixes**
  * Improved identity comparison (is/is not) handling to prevent false value-equality assumptions; refined None equality comparisons to avoid unnecessary guard emission.

* **Tests**
  * Extended coverage for identity comparisons and None equality behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->