### PR TITLE
[codex] Add runtime failure site concept

### DIFF
--- a/docs/self-application/SUBSTRATE-SHAPE-AUDIT.md
+++ b/docs/self-application/SUBSTRATE-SHAPE-AUDIT.md
@@ -34,6 +34,7 @@ Use explicit concept identifiers for substrate panic-freedom vocabulary:
 - `concept:panic-freedom.leaf.unwrap`
 - `concept:panic-freedom.leaf.expect`
 - `concept:panic-freedom.leaf.unwrap-err`
+- `concept:panic-freedom.leaf.runtime-failure-site`
 - `concept:panic-freedom.effect-locus`
 
 The exact wire spelling can remain a string atom in ProofIR. The important
@@ -107,6 +108,7 @@ compatibility classification.
 | `method:unwrap` | `provekit-walk/src/bin/walk_rpc.rs`, `provekit-verifier/src/enumerate_callsites.rs`, panic census tests | `concept:panic-freedom.leaf.unwrap` | Rust adapter maps `Option::unwrap` and `Result::unwrap` call leaves to the concept plus a type-family precondition concept. Existing bridge `sourceSymbol` remains accepted. | Alias-read first. Bridge source symbol default change is migration-required. |
 | `method:expect` | same as above | `concept:panic-freedom.leaf.expect` | Rust adapter maps `Option::expect` and `Result::expect` to the concept plus type-family precondition concept. | Alias-read first. |
 | `method:unwrap_err` | rust-std shim and future callsite census | `concept:panic-freedom.leaf.unwrap-err` | Rust adapter maps `Result::unwrap_err` to result-err precondition. | Alias-read first. |
+| Kit-declared runtime failure leaves such as Python `raise`, Java `throw`, Go `panic`, TypeScript `throw`, nil dereference, and checked runtime-failure assertions | Non-Rust kit declarations and future effect-locus metadata | `concept:panic-freedom.leaf.runtime-failure-site` | Rust v1 leaves stay parallel for now; no Rust default emission changes. Non-Rust kits map local/subkind diagnostics to this concept while the verifier discharges only over normalized pre/post/guard facts. | Additive Path A. Subkind strings are kit-owned diagnostics, not libprovekit taxonomy or verifier semantics. |
 | `panicLoci` header field | `provekit-claim-envelope/src/lib.rs`, `provekit-lift/src/lib.rs`, `provekit-verifier/src/enumerate_callsites.rs` | `effectLoci` with `effectKind = concept:panic-freedom` | Rust adapter reads/writes current `panicLoci`; substrate readers can also accept `effectLoci`. Existing `panicLoci` remains the Rust v1 default. | Dual-read is safe. Default dual-write changes envelope bytes, so emit migration is required. |
 | `panicSite` bridge callsite field | `BridgeCallsite`, `walk_rpc.rs`, `enumerate_callsites.rs` | `effectSite = concept:panic-freedom` | Rust adapter maps current boolean to the effect-site concept. Verifier can keep bool path while accepting concept metadata. | Dual-read is safe. Default emit migration is required. |
 | `panic-site-annotation` diagnostic kind | `panic_annotations_runtime.rs`, Rust kit lift diagnostics | `effect-site-annotation` with `effectKind = concept:panic-freedom` | Rust adapter maps residue and tier annotations for Rust panic leaves. Python adapter can emit same shape for Python exception sites. | Additive reader first. Existing diagnostic kind remains accepted. |

--- a/implementations/rust/libprovekit/src/concept/panic_freedom.rs
+++ b/implementations/rust/libprovekit/src/concept/panic_freedom.rs
@@ -60,6 +60,9 @@ pub const METHOD_UNWRAP_ERR: &str = "method:unwrap_err";
 /// Substrate panic-freedom unwrap-err leaf alias; see `SUBSTRATE-SHAPE-AUDIT.md`.
 pub const METHOD_UNWRAP_ERR_CONCEPT: &str = "concept:panic-freedom.leaf.unwrap-err";
 
+/// Substrate panic-freedom runtime-failure-site leaf; see `SUBSTRATE-SHAPE-AUDIT.md`.
+pub const RUNTIME_FAILURE_SITE_CONCEPT: &str = "concept:panic-freedom.leaf.runtime-failure-site";
+
 /// Normalize result predicate aliases to the Rust v1 wire token.
 ///
 /// Phase 4 readers accept the concept aliases without changing default Rust v1

--- a/implementations/rust/libprovekit/tests/concept_panic_freedom.rs
+++ b/implementations/rust/libprovekit/tests/concept_panic_freedom.rs
@@ -49,6 +49,10 @@ fn panic_freedom_constants_keep_existing_wire_tokens() {
         panic_freedom::METHOD_UNWRAP_ERR_CONCEPT,
         "concept:panic-freedom.leaf.unwrap-err"
     );
+    assert_eq!(
+        panic_freedom::RUNTIME_FAILURE_SITE_CONCEPT,
+        "concept:panic-freedom.leaf.runtime-failure-site"
+    );
 }
 
 #[test]
@@ -133,6 +137,10 @@ fn leaf_method_concept_aliases_normalize_to_v1_wire_tokens() {
     assert_eq!(
         panic_freedom::normalize_leaf_method_name(panic_freedom::METHOD_UNWRAP_ERR_CONCEPT),
         panic_freedom::METHOD_UNWRAP_ERR
+    );
+    assert_eq!(
+        panic_freedom::normalize_leaf_method_name(panic_freedom::RUNTIME_FAILURE_SITE_CONCEPT),
+        panic_freedom::RUNTIME_FAILURE_SITE_CONCEPT
     );
 
     assert_eq!(

--- a/implementations/rust/provekit-cli/src/doctor.rs
+++ b/implementations/rust/provekit-cli/src/doctor.rs
@@ -1466,6 +1466,10 @@ fn kit_declaration_panic_freedom_vocabulary_check(
             panic_freedom::METHOD_UNWRAP_ERR,
             panic_freedom::METHOD_UNWRAP_ERR_CONCEPT,
         ),
+        (
+            panic_freedom::RUNTIME_FAILURE_SITE_CONCEPT,
+            panic_freedom::RUNTIME_FAILURE_SITE_CONCEPT,
+        ),
     ];
     let guard_predicate_vocabulary = [
         (panic_freedom::IS_OK, panic_freedom::IS_OK_CONCEPT),
@@ -3481,6 +3485,54 @@ mod tests {
     }
 
     #[test]
+    fn doctor_kit_declaration_non_rust_vocabulary_accepts_runtime_failure_site_leaf() {
+        let td = TempDir::new().unwrap();
+        let kit = td.path();
+        let plugin = kit.join("python-runtime-failure-plugin");
+        let mut declaration = valid_panic_freedom_declaration("python");
+        declaration["kit"] =
+            json!({"id": "python-source", "language": "python", "version": "0.1.0"});
+        declaration["proofResolution"] = json!({"strategy": "pip"});
+        declaration["effectLeaves"] = json!([
+            {
+                "surface": "python",
+                "local": "python:raise",
+                "concept": "concept:panic-freedom.leaf.runtime-failure-site"
+            }
+        ]);
+        declaration["guardPredicates"] = json!([]);
+        declaration["controlCarriers"] = json!([]);
+        make_kit_declaration_plugin(&plugin, declaration);
+        write_kit(
+            kit,
+            "[[plugins]]\nname = \"python\"\nkind = \"lift\"\nsurface = \"python\"\n",
+        );
+        write_manifest(
+            kit,
+            "lift",
+            "python",
+            "\"./python-runtime-failure-plugin\"",
+            ".",
+        );
+
+        let report = run_report_with_context(kit, DoctorContext::new(DoctorMode::Strict));
+
+        let vocabulary = check_by_id_and_surface(
+            &report,
+            "kit.declaration.substrate_vocabulary.panic_freedom",
+            "python",
+        );
+        assert_eq!(vocabulary.status, CheckStatus::Pass, "{vocabulary:#?}");
+        assert_eq!(
+            vocabulary
+                .evidence
+                .get("validationMode")
+                .and_then(Value::as_str),
+            Some("concept-side-only")
+        );
+    }
+
+    #[test]
     fn doctor_kit_declaration_rejects_empty_mapping_concept_before_vocabulary_check() {
         let td = TempDir::new().unwrap();
         let kit = td.path();
@@ -3950,6 +4002,57 @@ mod tests {
             .expect("shared kit ids");
         assert!(kit_ids.contains(&Value::String("python-source".to_string())));
         assert!(kit_ids.contains(&Value::String("python-tests".to_string())));
+    }
+
+    #[test]
+    fn doctor_cross_kit_consistency_ignores_runtime_failure_subkind() {
+        let td = TempDir::new().unwrap();
+        let kit = td.path();
+        let mut source_declaration = declaration_with_mapping(
+            "python-source",
+            "python",
+            "python-source",
+            PANIC_FREEDOM_EFFECT_KIND,
+            "effectLeaves",
+            "python:raise",
+            "concept:panic-freedom.leaf.runtime-failure-site",
+        );
+        source_declaration["effectLeaves"][0]["subkind"] = json!("explicit-raise");
+        let mut tests_declaration = declaration_with_mapping(
+            "python-tests",
+            "python",
+            "python-tests",
+            PANIC_FREEDOM_EFFECT_KIND,
+            "effectLeaves",
+            "python:raise",
+            "concept:panic-freedom.leaf.runtime-failure-site",
+        );
+        tests_declaration["effectLeaves"][0]["subkind"] = json!("assert-raises");
+        write_declaration_plugins(
+            kit,
+            &[
+                ("python-source-plugin", "python-source", source_declaration),
+                ("python-tests-plugin", "python-tests", tests_declaration),
+            ],
+        );
+
+        let report = run_report_with_context(kit, DoctorContext::new(DoctorMode::Strict));
+
+        let consistency = check_by_id(&report, "kit.declaration.cross_kit_consistency");
+        assert_eq!(consistency.status, CheckStatus::Pass, "{consistency:#?}");
+        let consistent = consistency
+            .evidence
+            .get("consistentLocals")
+            .and_then(Value::as_array)
+            .expect("consistent locals");
+        let shared = consistent
+            .iter()
+            .find(|entry| entry.get("local").and_then(Value::as_str) == Some("python:raise"))
+            .expect("shared python:raise evidence");
+        assert_eq!(
+            shared.get("concept").and_then(Value::as_str),
+            Some("concept:panic-freedom.leaf.runtime-failure-site")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds the substrate panic-freedom concept `concept:panic-freedom.leaf.runtime-failure-site` for non-Rust kit-declared runtime failure leaves.

This is slice 1 for #1828: substrate vocabulary only. It adds the libprovekit concept constant, teaches `provekit doctor` to accept the concept through existing concept-side-only kit declaration validation, and records the concept in `SUBSTRATE-SHAPE-AUDIT.md`.

## Scope Discipline

Path A invocation acknowledged: first libprovekit edit since Slice 2's per-family normalizer helpers (#1793, #1794, #1795). Substrate vocabulary expansion adds one concept constant, one doctor recognition entry, and one audit doc row. Per the #1828 documented decision, Option B with refinements, Rust v1 leaves remain parallel and runtime-failure-site is the non-Rust kit federation concept.

This PR does not change kit emission, kit declarations, verifier discharge logic, or Rust v1 unwrap/expect/unwrap_err behavior. `normalize_leaf_method_name` intentionally does not map runtime-failure-site to any Rust method token.

Subkind/local strings remain kit-owned diagnostics. The new doctor test pins that cross-kit consistency still passes when two Python kits declare the same local and concept with different `subkind` diagnostics.

## Validation

- `../../bin/bcargo test -p libprovekit --test concept_panic_freedom -- --nocapture` - 4 passed
- `../../bin/bcargo test -p provekit-cli doctor_kit_declaration_non_rust_vocabulary_accepts_runtime_failure_site_leaf -- --nocapture` - matching lib and bin harness tests passed
- `../../bin/bcargo test -p provekit-cli doctor_cross_kit_consistency_ignores_runtime_failure_subkind -- --nocapture` - matching lib and bin harness tests passed
- `../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc` - passed
- `../../bin/bcargo build -p provekit-lift --bin provekit-lift` - passed
- `../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` - passed after final cleanup, `self_check_golden_provekit_shim_rust_std ... ok`, 110.80s
- `git diff --check` - clean

`self_check_golden` stayed stable, including the reflexive 631 floor and the pinned floor invariants: `panicSafe=5`, `falsePass=0`, `silentlyDropped=0`, `droppedSites=[]`.

`../../bin/bcargo fmt --check` exits 1 on broad pre-existing formatter drift outside this slice. I applied the relevant rustfmt suggestions for touched lines and left unrelated files alone.

Fixes #1828.