### PR TITLE
[codex] Add python-source runtime failure declaration

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/rpc.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/rpc.py
@@ -46,7 +46,13 @@ def kit_declaration_result() -> dict[str, Any]:
         },
         "proofResolution": {"strategy": "pip"},
         "effectKinds": ["concept:panic-freedom"],
-        "effectLeaves": [],
+        "effectLeaves": [
+            {
+                "surface": SURFACE,
+                "local": "python:raise",
+                "concept": "concept:panic-freedom.leaf.runtime-failure-site",
+            }
+        ],
         "guardPredicates": [
             {
                 "surface": SURFACE,

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -24,6 +24,11 @@ from provekit_lift_python_source.lifter import lift_source
 from provekit_lift_python_source.rpc import dispatch, initialize_result
 
 KIT_DECLARATION_RPC_METHOD = "provekit.plugin.kit_declaration"
+RUNTIME_FAILURE_EFFECT_LEAF = {
+    "surface": "python-source",
+    "local": "python:raise",
+    "concept": "concept:panic-freedom.leaf.runtime-failure-site",
+}
 
 
 def _canon(value: object) -> str:
@@ -455,6 +460,7 @@ def test_checked_in_python_source_manifest_invokes_module_form_and_declares_kit(
     declaration = next(response for response in responses if response.get("id") == 2)
     assert "error" not in declaration, declaration
     assert declaration["result"]["kit"]["id"] == "python-source"
+    assert declaration["result"]["effectLeaves"] == [RUNTIME_FAILURE_EFFECT_LEAF]
 
 
 def test_kit_declaration_returns_python_source_lift_surface() -> None:
@@ -479,7 +485,8 @@ def test_kit_declaration_returns_python_source_lift_surface() -> None:
     }
     assert result["proofResolution"] == {"strategy": "pip"}
     assert result["effectKinds"] == ["concept:panic-freedom"]
-    assert result["effectLeaves"] == []
+    assert result["effectLeaves"] == [RUNTIME_FAILURE_EFFECT_LEAF]
+    assert "subkind" not in result["effectLeaves"][0]
     assert result["guardPredicates"] == [
         {
             "surface": "python-source",


### PR DESCRIPTION
## Summary

Slice 2 of #1828. This is declaration-only: `python-source` now declares one panic-freedom effect leaf mapping `python:raise` to `concept:panic-freedom.leaf.runtime-failure-site`.

This replaces #1833, which GitHub auto-closed when the stacked #1831 base branch was deleted after #1831 merged. The branch has been rebased onto `main`; the replacement PR contains only the Python declaration slice.

## Scope Discipline

No emission behavior changes. The Python source lifter still emits `ctor("python:raise", exc)` plus `effect={kind:"panics"}` exactly as before.

No `libprovekit` changes and no Path A surface in this slice. No subkind is added to the declaration; subkind remains per-emission diagnostic metadata for a later slice. Other Python kits are untouched.

## Evidence

TDD:

- RED: `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q` failed with 2 expected failures because `effectLeaves` was still `[]`.
- GREEN: same command passed, `24 passed`.

Doctor and federation:

- Direct checked-in manifest/RPC response asserted `python-source` returns `effectLeaves=[{"surface":"python-source","local":"python:raise","concept":"concept:panic-freedom.leaf.runtime-failure-site"}]` with no `subkind`.
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo run -p provekit-cli -- doctor --target ../../implementations/python --mode strict --json` exited 0.
- Saved doctor JSON assertion passed: `ok=true`, `kit-declaration-panic-freedom-vocabulary:lift:python-source` is `pass`, and `kit-declaration-cross-kit-consistency` is `pass`.
- `../../bin/bcargo test -p provekit-cli doctor_kit_declaration_non_rust_vocabulary_accepts_runtime_failure_site_leaf -- --nocapture` passed in lib and bin harnesses.
- `../../bin/bcargo test -p provekit-cli doctor_kit_declaration_non_rust_vocabulary_rejects_unknown_concept -- --nocapture` passed in lib and bin harnesses.

Golden and build gates:

- `../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc` passed.
- `../../bin/bcargo build -p provekit-lift --bin provekit-lift` passed.
- `../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` passed: `self_check_golden_provekit_shim_rust_std ... ok`, 126.76s.
- `git diff --check` passed.

## Follow-up

The doctor CLI legacy JSON strips evidence/id/severity/domain from `DoctorReport`, so the CLI cannot expose the mapping evidence object directly. Filed #1832 for that separate output-surface gap. It does not block this declaration slice because the evidence chain above proves the declaration content and doctor acceptance through current surfaces.

Fixes part of #1828.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incomplete capability declarations for Python runtime failures. The system now properly reports runtime failure locations in Python code, improving accuracy of static analysis for exception handling and fault tolerance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->