### PR TITLE
[codex] python-source emits runtime-failure panicLoci for ast.Raise

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/ir.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/ir.py
@@ -86,8 +86,9 @@ def function_contract(
     effects: list[Json],
     source_path: str,
     line: int,
+    panic_loci: list[Json] | None = None,
 ) -> Json:
-    return {
+    contract = {
         "schemaVersion": "1",
         "kind": "function-contract",
         "fnName": fn_name,
@@ -101,6 +102,9 @@ def function_contract(
         "locus": locus(source_path, line, 1),
         "autoMintedMementos": [],
     }
+    if panic_loci:
+        contract["panicLoci"] = list(panic_loci)
+    return contract
 
 
 def source_unit_contract(

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -22,6 +22,10 @@ from .ir import (
     var,
 )
 
+PANIC_FREEDOM_EFFECT_KIND = "concept:panic-freedom"
+RUNTIME_FAILURE_SITE_CONCEPT = "concept:panic-freedom.leaf.runtime-failure-site"
+
+
 @dataclass
 class LiftResult:
     ir: list[Json] = field(default_factory=list)
@@ -248,11 +252,15 @@ class _Emitter:
         locals_: set[str],
         module_globals: set[str],
         effects: _EffectSet,
+        source_path: str,
+        panic_loci: list[Json],
     ) -> None:
         self.fn_name = fn_name
         self.locals = set(locals_)
         self.module_globals = module_globals
         self.effects = effects
+        self.source_path = source_path
+        self.panic_loci = panic_loci
 
     def statements(self, statements: list[ast.stmt]) -> Json:
         emitted: list[Json] = []
@@ -315,8 +323,24 @@ class _Emitter:
         if isinstance(node, ast.Raise):
             self.effects.add_panics()
             value = none_const() if node.exc is None else self.expr(node.exc)
+            self.panic_loci.append(self.runtime_failure_locus(node, value))
             return ctor("python:raise", value)
         raise _UnsupportedSyntax(node, f"unhandled statement kind: {type(node).__name__}")
+
+    def runtime_failure_locus(self, node: ast.Raise, arg_term: Json) -> Json:
+        locus = {
+            "effectKind": PANIC_FREEDOM_EFFECT_KIND,
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "explicit-raise",
+            "argTerm": arg_term,
+            "file": self.source_path,
+            "line": int(getattr(node, "lineno", 0) or 0),
+            "col": int(getattr(node, "col_offset", 0) or 0) + 1,
+        }
+        exception_class = _exception_class(node.exc)
+        if exception_class:
+            locus["exceptionClass"] = exception_class
+        return locus
 
     def target(self, node: ast.expr) -> Json:
         if isinstance(node, ast.Name):
@@ -502,11 +526,14 @@ def _lift_function(
         formals = [arg.arg for arg in node.args.args]
         locals_ = _function_locals(node, formals)
         effects = _EffectSet()
+        panic_loci: list[Json] = []
         emitter = _Emitter(
             fn_name=info.fn_name,
             locals_=locals_,
             module_globals=module_globals,
             effects=effects,
+            source_path=source_path,
+            panic_loci=panic_loci,
         )
         body = emitter.statements(node.body)
         return function_contract(
@@ -516,6 +543,7 @@ def _lift_function(
             effects=effects.sorted(),
             source_path=source_path,
             line=node.lineno,
+            panic_loci=panic_loci,
         )
     except _UnsupportedSyntax as exc:
         result.refusals.append(
@@ -636,6 +664,19 @@ def _callee_name(node: ast.expr) -> str:
         base = _callee_name(node.value)
         return f"{base}.{node.attr}" if base else node.attr
     raise _UnsupportedSyntax(node, f"unsupported callee kind: {type(node).__name__}")
+
+
+def _exception_class(node: ast.expr | None) -> str | None:
+    if node is None:
+        return None
+    try:
+        if isinstance(node, ast.Call):
+            return _callee_name(node.func)
+        if isinstance(node, (ast.Name, ast.Attribute)):
+            return _callee_name(node)
+    except _UnsupportedSyntax:
+        return None
+    return None
 
 
 def _target_text(node: ast.AST) -> str:

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -335,7 +335,7 @@ class _Emitter:
             "argTerm": arg_term,
             "file": self.source_path,
             "line": int(getattr(node, "lineno", 0) or 0),
-            "col": int(getattr(node, "col_offset", 0) or 0) + 1,
+            "col": int(getattr(node, "col_offset", 0) or 0),
         }
         exception_class = _exception_class(node.exc)
         if exception_class:

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -322,7 +322,7 @@ def test_raise_emits_runtime_failure_locus_without_changing_effect_set() -> None
             "argTerm": {"kind": "var", "name": "ValueError"},
             "file": "raises.py",
             "line": 2,
-            "col": 5,
+            "col": 4,
         }
     ]
 
@@ -342,7 +342,7 @@ def test_multiple_raise_sites_keep_distinct_runtime_failure_loci() -> None:
     assert contract["effects"] == [{"kind": "panics"}]
     loci = _runtime_failure_loci(contract)
     assert [locus["exceptionClass"] for locus in loci] == ["ValueError", "RuntimeError"]
-    assert [(locus["line"], locus["col"]) for locus in loci] == [(3, 9), (4, 5)]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(3, 8), (4, 4)]
     assert all(locus["effectKind"] == PANIC_FREEDOM_EFFECT_KIND for locus in loci)
     assert all(locus["callee"] == RUNTIME_FAILURE_SITE_CONCEPT for locus in loci)
     assert all(locus["subkind"] == "explicit-raise" for locus in loci)
@@ -367,7 +367,7 @@ def test_bare_raise_emits_runtime_failure_locus_with_unit_arg() -> None:
             },
             "file": "bare_raise.py",
             "line": 2,
-            "col": 5,
+            "col": 4,
         }
     ]
 

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -29,6 +29,8 @@ RUNTIME_FAILURE_EFFECT_LEAF = {
     "local": "python:raise",
     "concept": "concept:panic-freedom.leaf.runtime-failure-site",
 }
+PANIC_FREEDOM_EFFECT_KIND = "concept:panic-freedom"
+RUNTIME_FAILURE_SITE_CONCEPT = "concept:panic-freedom.leaf.runtime-failure-site"
 
 
 def _canon(value: object) -> str:
@@ -89,6 +91,12 @@ def _contract(ir: list[dict[str, object]], suffix: str) -> dict[str, object]:
         if str(item.get("fnName", "")).endswith(suffix):
             return item
     raise AssertionError(f"missing contract ending in {suffix!r}: {ir!r}")
+
+
+def _runtime_failure_loci(contract: dict[str, object]) -> list[dict[str, object]]:
+    loci = contract.get("panicLoci")
+    assert isinstance(loci, list), contract
+    return [locus for locus in loci if isinstance(locus, dict)]
 
 
 def _ctor_names(node: object) -> list[str]:
@@ -289,6 +297,79 @@ def test_if_is_not_none_lifts_to_cf_guarded_option_guards() -> None:
         else_head="is_none",
     )
     assert "python:compare" in _ctor_names(body)
+
+
+def test_raise_emits_runtime_failure_locus_without_changing_effect_set() -> None:
+    source = "def f():\n    raise ValueError\n"
+
+    result = lift_source(source, "raises.py")
+
+    contract = _contract(result.ir, ".f")
+    body = contract["post"]["args"][1]
+    assert result.refusals == []
+    assert body == {
+        "kind": "ctor",
+        "name": "python:raise",
+        "args": [{"kind": "var", "name": "ValueError"}],
+    }
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert _runtime_failure_loci(contract) == [
+        {
+            "effectKind": PANIC_FREEDOM_EFFECT_KIND,
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "explicit-raise",
+            "exceptionClass": "ValueError",
+            "argTerm": {"kind": "var", "name": "ValueError"},
+            "file": "raises.py",
+            "line": 2,
+            "col": 5,
+        }
+    ]
+
+
+def test_multiple_raise_sites_keep_distinct_runtime_failure_loci() -> None:
+    source = (
+        "def f(flag):\n"
+        "    if flag:\n"
+        "        raise ValueError\n"
+        "    raise RuntimeError\n"
+    )
+
+    result = lift_source(source, "multi_raise.py")
+
+    contract = _contract(result.ir, ".f")
+    assert result.refusals == []
+    assert contract["effects"] == [{"kind": "panics"}]
+    loci = _runtime_failure_loci(contract)
+    assert [locus["exceptionClass"] for locus in loci] == ["ValueError", "RuntimeError"]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(3, 9), (4, 5)]
+    assert all(locus["effectKind"] == PANIC_FREEDOM_EFFECT_KIND for locus in loci)
+    assert all(locus["callee"] == RUNTIME_FAILURE_SITE_CONCEPT for locus in loci)
+    assert all(locus["subkind"] == "explicit-raise" for locus in loci)
+
+
+def test_bare_raise_emits_runtime_failure_locus_with_unit_arg() -> None:
+    source = "def f():\n    raise\n"
+
+    result = lift_source(source, "bare_raise.py")
+
+    contract = _contract(result.ir, ".f")
+    assert result.refusals == []
+    assert _runtime_failure_loci(contract) == [
+        {
+            "effectKind": PANIC_FREEDOM_EFFECT_KIND,
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "explicit-raise",
+            "argTerm": {
+                "kind": "const",
+                "value": None,
+                "sort": {"kind": "primitive", "name": "Unit"},
+            },
+            "file": "bare_raise.py",
+            "line": 2,
+            "col": 5,
+        }
+    ]
 
 
 def test_compile_lift_roundtrip_preserves_cf_guarded_none_if_body() -> None:

--- a/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
@@ -195,7 +195,7 @@ fn python_source_raise_mint_preserves_runtime_failure_locus_and_enumerates_calls
             "argTerm": {"kind": "var", "name": "ValueError"},
             "file": "boom.py",
             "line": 2,
-            "col": 5
+            "col": 4
         })],
         "mint must preserve the python-source runtime-failure panicLoci row"
     );

--- a/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde_json::{json, Value as Json};
+
+const RUNTIME_FAILURE_SITE_CONCEPT: &str = "concept:panic-freedom.leaf.runtime-failure-site";
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn python_source_lift_src() -> PathBuf {
+    repo_root()
+        .join("implementations")
+        .join("python")
+        .join("provekit-lift-python-source")
+        .join("src")
+}
+
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn python_available() -> bool {
+    Command::new("python3")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-py-source-runtime-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+fn write_executable(path: &Path, body: &str) {
+    use std::io::Write as _;
+    {
+        let mut file = fs::File::create(path).expect("create script");
+        file.write_all(body.as_bytes()).expect("write script");
+        file.sync_all().expect("sync script");
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(path).expect("stat script").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).expect("chmod script");
+    }
+}
+
+fn build_python_lift_source() -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let pythonpath = python_source_lift_src()
+        .into_os_string()
+        .into_string()
+        .expect("Python lift source root must be UTF-8");
+    let quoted_pythonpath = shell_single_quote(&pythonpath);
+    let script = std::env::temp_dir().join(format!(
+        "provekit-lift-python-source-{}-{}.sh",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    let body = format!(
+        "#!/bin/sh\nPYTHON=${{PYTHON:-python3}}\n\
+         PYTHONPATH={quoted_pythonpath}${{PYTHONPATH:+:$PYTHONPATH}}\n\
+         export PYTHONPATH\n\
+         exec \"$PYTHON\" -c \"from provekit_lift_python_source.rpc import run_rpc; run_rpc()\"\n"
+    );
+    write_executable(&script, &body);
+    script
+}
+
+fn stage_python_source_project(lift_script: &Path) -> PathBuf {
+    let project = unique_dir("project");
+    fs::write(
+        project.join("boom.py"),
+        "def boom():\n    raise ValueError\n",
+    )
+    .expect("write boom.py");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("python-source"))
+        .expect("mkdir .provekit/lift/python-source");
+    fs::write(
+        provekit.join("config.toml"),
+        r#"[[plugins]]
+name = "python-source"
+kind = "lift"
+surface = "python-source"
+"#,
+    )
+    .expect("write config.toml");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("python-source")
+            .join("manifest.toml"),
+        format!(
+            r#"name = "python-source"
+version = "0.1.0-draft"
+protocol_version = "provekit-lift/1"
+kind = "lift"
+command = ["{}", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["python-source"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+"#,
+            lift_script.display()
+        ),
+    )
+    .expect("write manifest.toml");
+
+    project
+}
+
+fn run_mint(project: &Path) {
+    let out = Command::new(provekit_bin())
+        .arg("mint")
+        .arg("--project")
+        .arg(project)
+        .arg("--out")
+        .arg(project)
+        .arg("--no-attest")
+        .arg("--quiet")
+        .output()
+        .expect("spawn provekit mint");
+    assert!(
+        out.status.success(),
+        "provekit mint must succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn contract_runtime_failure_loci(pool: &provekit_verifier::types::MementoPool) -> Vec<Json> {
+    pool.mementos
+        .values()
+        .filter(|env| provekit_verifier::types::memento_kind(env) == Some("contract"))
+        .filter_map(|env| provekit_verifier::types::memento_body_field(env, "panicLoci"))
+        .filter_map(|value| value.as_array())
+        .flat_map(|items| items.iter().cloned())
+        .collect()
+}
+
+#[test]
+fn python_source_raise_mint_preserves_runtime_failure_locus_and_enumerates_callsite() {
+    if !python_available() {
+        eprintln!("python3 not on PATH: skipping python-source runtime-failure mint test");
+        return;
+    }
+    let lift_script = build_python_lift_source();
+    let project = stage_python_source_project(&lift_script);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "python-source proof must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let loci = contract_runtime_failure_loci(&pool);
+    assert_eq!(
+        loci,
+        vec![json!({
+            "effectKind": "concept:panic-freedom",
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "explicit-raise",
+            "exceptionClass": "ValueError",
+            "argTerm": {"kind": "var", "name": "ValueError"},
+            "file": "boom.py",
+            "line": 2,
+            "col": 5
+        })],
+        "mint must preserve the python-source runtime-failure panicLoci row"
+    );
+
+    let callsites = provekit_verifier::enumerate_callsites::run(&pool);
+    let runtime_failure_sites: Vec<_> = callsites
+        .iter()
+        .filter(|cs| cs.panic_site && cs.callee.as_deref() == Some(RUNTIME_FAILURE_SITE_CONCEPT))
+        .collect();
+    assert_eq!(
+        runtime_failure_sites.len(),
+        1,
+        "verifier must surface exactly one substrate runtime-failure panic site; got {callsites:#?}"
+    );
+    assert_eq!(runtime_failure_sites[0].file.as_deref(), Some("boom.py"));
+    assert_eq!(runtime_failure_sites[0].line, Some(2));
+    assert!(
+        runtime_failure_sites[0].bridge_target_cid.is_empty(),
+        "no bridge exists yet, so the surfaced callsite must remain undecidable"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}


### PR DESCRIPTION
## Summary

Slice 3 of #1828. The python-source lifter now emits substrate-tagged `panicLoci` entries for each `ast.Raise` occurrence while preserving the existing `python:raise` body term and deduped `{"kind":"panics"}` effect.

This keeps the RPC seam intact: the Python kit owns Python AST semantics, the Rust CLI preserves proof data opaquely, and the verifier consumes the existing `panicLoci` channel without learning Python syntax.

## Design Notes

- Adds optional `panicLoci` support to python-source function contracts.
- Emits one per-raise row with `effectKind=concept:panic-freedom`, `callee=concept:panic-freedom.leaf.runtime-failure-site`, `subkind=explicit-raise`, `argTerm`, file/line/col, and best-effort `exceptionClass`.
- Leaves kit declaration unchanged. `subkind` is per-emission proof data, not declaration vocabulary.
- Leaves `libprovekit`, `provekit-verifier`, and `provekit-cli/src` unchanged.

## Expected Count Shift

Python proofs can now surface previously uncounted `raise` statements as substrate-vocabulary panic-site callsites. With no bridge present, these callsites remain undecidable. That is the honest federation outcome: the substrate vocabulary is recognized, and discharge is deferred to future bridge work rather than silently proving or dropping the site.

## Validation

- `python3 -m pytest implementations/python/provekit-lift-python-source/tests -q` - 116 passed
- `rustfmt --edition 2021 --check implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs`
- `git diff --check`
- Path scope grep: no `libprovekit`, no `provekit-verifier`, no `provekit-cli/src` changes
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture` - 6 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_mint_python_source_runtime_failure -- --nocapture` - 1 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_verify_python_production_bridge -- --nocapture` - 5 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_verify_python_division_unsound -- --nocapture` - 2 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo run -p provekit-cli -- doctor --target ../../implementations/python --mode strict --json`, plus jq assertion for ok, python-source vocabulary, and cross-kit consistency
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-lift --bin provekit-lift`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` - 1 passed in 115s

Note: whole-workspace `cargo fmt --all --check` is currently noisy from unrelated pre-existing formatting drift. The new Rust test file is rustfmt-clean and `git diff --check` is clean.