### PR TITLE
python-source runtime failure access loci

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -261,6 +261,7 @@ class _Emitter:
         self.effects = effects
         self.source_path = source_path
         self.panic_loci = panic_loci
+        self._suppress_runtime_failure_loci = 0
 
     def statements(self, statements: list[ast.stmt]) -> Json:
         emitted: list[Json] = []
@@ -323,21 +324,34 @@ class _Emitter:
         if isinstance(node, ast.Raise):
             self.effects.add_panics()
             value = none_const() if node.exc is None else self.expr(node.exc)
-            self.panic_loci.append(self.runtime_failure_locus(node, value))
+            self.panic_loci.append(
+                self.runtime_failure_locus(
+                    node,
+                    value,
+                    subkind="explicit-raise",
+                    exception_class=_exception_class(node.exc),
+                )
+            )
             return ctor("python:raise", value)
         raise _UnsupportedSyntax(node, f"unhandled statement kind: {type(node).__name__}")
 
-    def runtime_failure_locus(self, node: ast.Raise, arg_term: Json) -> Json:
+    def runtime_failure_locus(
+        self,
+        node: ast.AST,
+        arg_term: Json,
+        *,
+        subkind: str,
+        exception_class: str | None = None,
+    ) -> Json:
         locus = {
             "effectKind": PANIC_FREEDOM_EFFECT_KIND,
             "callee": RUNTIME_FAILURE_SITE_CONCEPT,
-            "subkind": "explicit-raise",
+            "subkind": subkind,
             "argTerm": arg_term,
             "file": self.source_path,
             "line": int(getattr(node, "lineno", 0) or 0),
             "col": int(getattr(node, "col_offset", 0) or 0),
         }
-        exception_class = _exception_class(node.exc)
         if exception_class:
             locus["exceptionClass"] = exception_class
         return locus
@@ -346,10 +360,30 @@ class _Emitter:
         if isinstance(node, ast.Name):
             return var(node.id)
         if isinstance(node, ast.Attribute):
-            return ctor("python:attribute", self.expr(node.value), str_const(node.attr))
+            return ctor(
+                "python:attribute",
+                self.store_target_expr(node.value),
+                str_const(node.attr),
+            )
         if isinstance(node, ast.Subscript):
-            return ctor("python:subscript", self.expr(node.value), self.subscript_index(node))
+            return ctor(
+                "python:subscript",
+                self.store_target_expr(node.value),
+                self.store_target_subscript_index(node),
+            )
         raise _UnsupportedSyntax(node, f"unsupported assignment target: {type(node).__name__}")
+
+    def store_target_expr(self, node: ast.expr) -> Json:
+        self._suppress_runtime_failure_loci += 1
+        try:
+            return self.expr(node)
+        finally:
+            self._suppress_runtime_failure_loci -= 1
+
+    def store_target_subscript_index(self, node: ast.Subscript) -> Json:
+        if isinstance(node.slice, ast.Slice):
+            raise _UnsupportedSyntax(node.slice, "slice subscripts are refused")
+        return self.store_target_expr(node.slice)
 
     def expr(self, node: ast.expr) -> Json:
         if isinstance(node, ast.Constant):
@@ -381,9 +415,30 @@ class _Emitter:
         if isinstance(node, ast.Call):
             return self.call(node)
         if isinstance(node, ast.Attribute):
-            return ctor("python:attribute", self.expr(node.value), str_const(node.attr))
+            term = ctor("python:attribute", self.expr(node.value), str_const(node.attr))
+            if self._suppress_runtime_failure_loci == 0:
+                self.effects.add_panics()
+                self.panic_loci.append(
+                    self.runtime_failure_locus(
+                        node,
+                        term,
+                        subkind="attribute-access",
+                        exception_class="AttributeError",
+                    )
+                )
+            return term
         if isinstance(node, ast.Subscript):
-            return ctor("python:subscript", self.expr(node.value), self.subscript_index(node))
+            term = ctor("python:subscript", self.expr(node.value), self.subscript_index(node))
+            if self._suppress_runtime_failure_loci == 0:
+                self.effects.add_panics()
+                self.panic_loci.append(
+                    self.runtime_failure_locus(
+                        node,
+                        term,
+                        subkind="subscript-access",
+                    )
+                )
+            return term
         raise _UnsupportedSyntax(node, f"unhandled expression kind: {type(node).__name__}")
 
     def constant(self, node: ast.Constant) -> Json:
@@ -429,6 +484,8 @@ class _Emitter:
         for arg in node.args:
             if isinstance(arg, ast.Starred):
                 raise _UnsupportedSyntax(arg, "starred call arguments are refused")
+        if isinstance(node.func, ast.Attribute):
+            self.expr(node.func)
         callee = _callee_name(node.func)
         if callee == "print":
             self.effects.add_io()
@@ -448,7 +505,7 @@ class _Emitter:
         then_branch: Json,
         else_branch: Json,
     ) -> Json | None:
-        guard = self.none_guard(test)
+        guard = self.none_guard(test, condition)
         if guard is None:
             return None
         then_head, else_head, receiver = guard
@@ -459,10 +516,19 @@ class _Emitter:
             substrate_ctor("cf_guarded", substrate_ctor(else_head, receiver), else_branch),
         )
 
-    def none_guard(self, test: ast.expr) -> tuple[str, str, Json] | None:
+    def none_guard(self, test: ast.expr, condition: Json) -> tuple[str, str, Json] | None:
         if not isinstance(test, ast.Compare):
             return None
         if len(test.ops) != 1 or len(test.comparators) != 1:
+            return None
+        if (
+            not isinstance(condition, dict)
+            or condition.get("kind") != "ctor"
+            or condition.get("name") != "python:compare"
+        ):
+            return None
+        condition_args = condition.get("args")
+        if not isinstance(condition_args, list) or len(condition_args) != 3:
             return None
         raw_op = test.ops[0]
         if not isinstance(raw_op, (ast.Is, ast.IsNot)):
@@ -470,9 +536,9 @@ class _Emitter:
         lhs = test.left
         rhs = test.comparators[0]
         if _is_none_literal(rhs) and not _is_none_literal(lhs):
-            receiver = self.expr(lhs)
+            receiver = condition_args[1]
         elif _is_none_literal(lhs) and not _is_none_literal(rhs):
-            receiver = self.expr(rhs)
+            receiver = condition_args[2]
         else:
             return None
         if isinstance(raw_op, ast.Is):

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/rpc.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/rpc.py
@@ -51,6 +51,16 @@ def kit_declaration_result() -> dict[str, Any]:
                 "surface": SURFACE,
                 "local": "python:raise",
                 "concept": "concept:panic-freedom.leaf.runtime-failure-site",
+            },
+            {
+                "surface": SURFACE,
+                "local": "python:attribute",
+                "concept": "concept:panic-freedom.leaf.runtime-failure-site",
+            },
+            {
+                "surface": SURFACE,
+                "local": "python:subscript",
+                "concept": "concept:panic-freedom.leaf.runtime-failure-site",
             }
         ],
         "guardPredicates": [

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -29,6 +29,21 @@ RUNTIME_FAILURE_EFFECT_LEAF = {
     "local": "python:raise",
     "concept": "concept:panic-freedom.leaf.runtime-failure-site",
 }
+ATTRIBUTE_RUNTIME_FAILURE_EFFECT_LEAF = {
+    "surface": "python-source",
+    "local": "python:attribute",
+    "concept": "concept:panic-freedom.leaf.runtime-failure-site",
+}
+SUBSCRIPT_RUNTIME_FAILURE_EFFECT_LEAF = {
+    "surface": "python-source",
+    "local": "python:subscript",
+    "concept": "concept:panic-freedom.leaf.runtime-failure-site",
+}
+RUNTIME_FAILURE_EFFECT_LEAVES = [
+    RUNTIME_FAILURE_EFFECT_LEAF,
+    ATTRIBUTE_RUNTIME_FAILURE_EFFECT_LEAF,
+    SUBSCRIPT_RUNTIME_FAILURE_EFFECT_LEAF,
+]
 PANIC_FREEDOM_EFFECT_KIND = "concept:panic-freedom"
 RUNTIME_FAILURE_SITE_CONCEPT = "concept:panic-freedom.leaf.runtime-failure-site"
 
@@ -372,6 +387,190 @@ def test_bare_raise_emits_runtime_failure_locus_with_unit_arg() -> None:
     ]
 
 
+def test_attribute_load_emits_runtime_failure_locus_and_panics_effect() -> None:
+    source = "def f(obj):\n    return obj.name\n"
+
+    result = lift_source(source, "attr_access.py")
+
+    contract = _contract(result.ir, ".f")
+    assert result.refusals == []
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert _runtime_failure_loci(contract) == [
+        {
+            "effectKind": PANIC_FREEDOM_EFFECT_KIND,
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "attribute-access",
+            "exceptionClass": "AttributeError",
+            "argTerm": {
+                "kind": "ctor",
+                "name": "python:attribute",
+                "args": [
+                    {"kind": "var", "name": "obj"},
+                    {
+                        "kind": "const",
+                        "value": "name",
+                        "sort": {"kind": "primitive", "name": "String"},
+                    },
+                ],
+            },
+            "file": "attr_access.py",
+            "line": 2,
+            "col": 11,
+        }
+    ]
+
+
+def test_subscript_load_emits_runtime_failure_locus_and_panics_effect() -> None:
+    source = "def f(xs, key):\n    return xs[key]\n"
+
+    result = lift_source(source, "subscript_access.py")
+
+    contract = _contract(result.ir, ".f")
+    assert result.refusals == []
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert _runtime_failure_loci(contract) == [
+        {
+            "effectKind": PANIC_FREEDOM_EFFECT_KIND,
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "subscript-access",
+            "argTerm": {
+                "kind": "ctor",
+                "name": "python:subscript",
+                "args": [
+                    {"kind": "var", "name": "xs"},
+                    {"kind": "var", "name": "key"},
+                ],
+            },
+            "file": "subscript_access.py",
+            "line": 2,
+            "col": 11,
+        }
+    ]
+
+
+def test_mixed_runtime_failure_sites_share_deduped_panics_effect() -> None:
+    source = (
+        "def f(obj, xs, key):\n"
+        "    a = obj.name\n"
+        "    b = xs[key]\n"
+        "    raise RuntimeError\n"
+    )
+
+    result = lift_source(source, "mixed_runtime.py")
+
+    contract = _contract(result.ir, ".f")
+    loci = _runtime_failure_loci(contract)
+    assert result.refusals == []
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert [locus["subkind"] for locus in loci] == [
+        "attribute-access",
+        "subscript-access",
+        "explicit-raise",
+    ]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 8), (3, 8), (4, 4)]
+
+
+def test_attribute_and_subscript_store_targets_are_not_slice4_runtime_failure_loci() -> None:
+    source = (
+        "def f(obj, xs, key, value):\n"
+        "    obj.name = value\n"
+        "    xs[key] = value\n"
+        "    return value\n"
+    )
+
+    result = lift_source(source, "store_targets.py")
+
+    contract = _contract(result.ir, ".f")
+    assert result.refusals == []
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "obj.name"},
+        {"kind": "writes", "target": "xs[key]"},
+    ]
+    assert contract.get("panicLoci", []) == []
+
+
+def test_nested_attribute_and_subscript_store_targets_do_not_leak_runtime_failure_loci() -> None:
+    source = (
+        "def f(obj, xs, ys, i, value):\n"
+        "    obj.inner.name = value\n"
+        "    xs[ys[i]] = value\n"
+        "    return value\n"
+    )
+
+    result = lift_source(source, "nested_store_targets.py")
+
+    contract = _contract(result.ir, ".f")
+    assert result.refusals == []
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "obj.inner.name"},
+        {"kind": "writes", "target": "xs[ys[i]]"},
+    ]
+    assert contract.get("panicLoci", []) == []
+
+
+def test_none_guarded_attribute_access_emits_one_runtime_failure_locus() -> None:
+    source = (
+        "def f(obj):\n"
+        "    if obj.name is None:\n"
+        "        return 0\n"
+        "    return 1\n"
+    )
+
+    result = lift_source(source, "attr_guard.py")
+
+    contract = _contract(result.ir, ".f")
+    loci = _runtime_failure_loci(contract)
+    assert result.refusals == []
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert [locus["subkind"] for locus in loci] == ["attribute-access"]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 7)]
+
+
+def test_none_guarded_subscript_access_emits_one_runtime_failure_locus() -> None:
+    source = (
+        "def f(xs, key):\n"
+        "    if xs[key] is None:\n"
+        "        return 0\n"
+        "    return 1\n"
+    )
+
+    result = lift_source(source, "subscript_guard.py")
+
+    contract = _contract(result.ir, ".f")
+    loci = _runtime_failure_loci(contract)
+    assert result.refusals == []
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert [locus["subkind"] for locus in loci] == ["subscript-access"]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 7)]
+
+
+def test_method_call_callee_attribute_emits_runtime_failure_locus() -> None:
+    source = "def f(obj):\n    return obj.method()\n"
+
+    result = lift_source(source, "method_call.py")
+
+    contract = _contract(result.ir, ".f")
+    loci = _runtime_failure_loci(contract)
+    assert result.refusals == []
+    assert {"kind": "panics"} in contract["effects"]
+    assert {"kind": "unresolved_call", "name": "obj.method"} in contract["effects"]
+    assert [locus["subkind"] for locus in loci] == ["attribute-access"]
+    assert loci[0]["exceptionClass"] == "AttributeError"
+    assert loci[0]["argTerm"] == {
+        "kind": "ctor",
+        "name": "python:attribute",
+        "args": [
+            {"kind": "var", "name": "obj"},
+            {
+                "kind": "const",
+                "value": "method",
+                "sort": {"kind": "primitive", "name": "String"},
+            },
+        ],
+    }
+    assert (loci[0]["line"], loci[0]["col"]) == (2, 11)
+
+
 def test_compile_lift_roundtrip_preserves_cf_guarded_none_if_body() -> None:
     source = (
         "def f(x):\n"
@@ -541,7 +740,7 @@ def test_checked_in_python_source_manifest_invokes_module_form_and_declares_kit(
     declaration = next(response for response in responses if response.get("id") == 2)
     assert "error" not in declaration, declaration
     assert declaration["result"]["kit"]["id"] == "python-source"
-    assert declaration["result"]["effectLeaves"] == [RUNTIME_FAILURE_EFFECT_LEAF]
+    assert declaration["result"]["effectLeaves"] == RUNTIME_FAILURE_EFFECT_LEAVES
 
 
 def test_kit_declaration_returns_python_source_lift_surface() -> None:
@@ -566,8 +765,8 @@ def test_kit_declaration_returns_python_source_lift_surface() -> None:
     }
     assert result["proofResolution"] == {"strategy": "pip"}
     assert result["effectKinds"] == ["concept:panic-freedom"]
-    assert result["effectLeaves"] == [RUNTIME_FAILURE_EFFECT_LEAF]
-    assert "subkind" not in result["effectLeaves"][0]
+    assert result["effectLeaves"] == RUNTIME_FAILURE_EFFECT_LEAVES
+    assert all("subkind" not in leaf for leaf in result["effectLeaves"])
     assert result["guardPredicates"] == [
         {
             "surface": "python-source",

--- a/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
@@ -138,6 +138,52 @@ emits_signed_mementos = false
     project
 }
 
+fn stage_python_access_project(lift_script: &Path) -> PathBuf {
+    let project = unique_dir("access-project");
+    fs::write(
+        project.join("access.py"),
+        "def use(obj, xs, key):\n    attr = obj.name\n    item = xs[key]\n    return attr\n",
+    )
+    .expect("write access.py");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("python-source"))
+        .expect("mkdir .provekit/lift/python-source");
+    fs::write(
+        provekit.join("config.toml"),
+        r#"[[plugins]]
+name = "python-source"
+kind = "lift"
+surface = "python-source"
+"#,
+    )
+    .expect("write config.toml");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("python-source")
+            .join("manifest.toml"),
+        format!(
+            r#"name = "python-source"
+version = "0.1.0-draft"
+protocol_version = "provekit-lift/1"
+kind = "lift"
+command = ["{}", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["python-source"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+"#,
+            lift_script.display()
+        ),
+    )
+    .expect("write manifest.toml");
+
+    project
+}
+
 fn run_mint(project: &Path) {
     let out = Command::new(provekit_bin())
         .arg("mint")
@@ -215,6 +261,88 @@ fn python_source_raise_mint_preserves_runtime_failure_locus_and_enumerates_calls
     assert!(
         runtime_failure_sites[0].bridge_target_cid.is_empty(),
         "no bridge exists yet, so the surfaced callsite must remain undecidable"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn python_source_access_mint_preserves_runtime_failure_loci_and_enumerates_callsites() {
+    if !python_available() {
+        eprintln!("python3 not on PATH: skipping python-source access runtime-failure mint test");
+        return;
+    }
+    let lift_script = build_python_lift_source();
+    let project = stage_python_access_project(&lift_script);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "python-source access proof must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let loci = contract_runtime_failure_loci(&pool);
+    assert_eq!(
+        loci,
+        vec![
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:attribute",
+                    "args": [
+                        {"kind": "var", "name": "obj"},
+                        {"kind": "const", "value": "name", "sort": {"kind": "primitive", "name": "String"}}
+                    ]
+                },
+                "file": "access.py",
+                "line": 2,
+                "col": 11
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:subscript",
+                    "args": [
+                        {"kind": "var", "name": "xs"},
+                        {"kind": "var", "name": "key"}
+                    ]
+                },
+                "file": "access.py",
+                "line": 3,
+                "col": 11
+            }),
+        ],
+        "mint must preserve python-source access runtime-failure panicLoci rows"
+    );
+
+    let callsites = provekit_verifier::enumerate_callsites::run(&pool);
+    let runtime_failure_sites: Vec<_> = callsites
+        .iter()
+        .filter(|cs| cs.panic_site && cs.callee.as_deref() == Some(RUNTIME_FAILURE_SITE_CONCEPT))
+        .collect();
+    assert_eq!(
+        runtime_failure_sites.len(),
+        2,
+        "verifier must surface exactly two substrate runtime-failure panic sites; got {callsites:#?}"
+    );
+    assert_eq!(runtime_failure_sites[0].file.as_deref(), Some("access.py"));
+    assert_eq!(runtime_failure_sites[0].line, Some(2));
+    assert_eq!(runtime_failure_sites[1].file.as_deref(), Some("access.py"));
+    assert_eq!(runtime_failure_sites[1].line, Some(3));
+    assert!(
+        runtime_failure_sites
+            .iter()
+            .all(|cs| cs.bridge_target_cid.is_empty()),
+        "no bridges exist yet, so surfaced access callsites must remain undecidable"
     );
 
     let _ = fs::remove_dir_all(&project);


### PR DESCRIPTION
## Summary
- emit runtime-failure panicLoci for Python-source attribute and subscript Load expressions
- mark those Load expressions with the deduped panics effect while leaving Store targets as writes-only for this slice
- declare python:attribute and python:subscript effectLeaves and extend mint/enumeration coverage

## Behavior shift
Functions performing attribute or subscript reads are now marked with the function-level panics effect. Previously these operations were treated as effect-free. This is an honest correction: Python attribute/subscript reads may raise AttributeError, KeyError, IndexError, or TypeError at runtime, so proof counts may now surface additional undecidable panic_site CallSites for these operations.

## Review fixes
- avoid duplicate access panicLoci in special None-guard lowering by reusing the already-emitted compare operands
- include Load-context method-call attribute lookups such as obj.method() in access panicLoci emission

## Scope
- Python kit-side only for emission/declaration
- No libprovekit, verifier, or CLI source changes
- Store targets remain out of scope

Refs #1828.

## Validation
- RED observed first: new tests failed for missing panics effects, missing access panicLoci, missing declaration effectLeaves, duplicate None-guard loci, and missing method-call callee loci
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q` -> 34 passed
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests -q` -> 123 passed
- `rustfmt --edition 2021 --check implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs`
- `git diff --check`
- path leakage grep for libprovekit/provekit-verifier/provekit-cli/src -> zero matches
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_mint_python_source_runtime_failure -- --nocapture` -> 2 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture` -> 6 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_verify_python_production_bridge -- --nocapture` -> 5 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_verify_python_division_unsound -- --nocapture` -> 2 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo run -p provekit-cli -- doctor --target ../../implementations/python --mode strict --json` -> ok=true
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc -p provekit-lift --bin provekit-lift`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` -> 1 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Enhanced runtime failure detection for attribute access and subscript operations in Python code lifting.
* Improved error reporting with specific exception type tracking for different failure scenarios.

**Tests**
* Expanded test coverage for runtime failure scenarios across attribute access, subscript access, and explicit raise statements.
* Added integration tests verifying accurate runtime failure reporting and source location identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->