### PR TITLE
[codex] python-source emits Store-write runtime-failure-site loci with nested Load re-surface (#1837)

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -261,7 +261,6 @@ class _Emitter:
         self.effects = effects
         self.source_path = source_path
         self.panic_loci = panic_loci
-        self._suppress_runtime_failure_loci = 0
 
     def statements(self, statements: list[ast.stmt]) -> Json:
         emitted: list[Json] = []
@@ -360,30 +359,37 @@ class _Emitter:
         if isinstance(node, ast.Name):
             return var(node.id)
         if isinstance(node, ast.Attribute):
-            return ctor(
+            term = ctor(
                 "python:attribute",
-                self.store_target_expr(node.value),
+                self.expr(node.value),
                 str_const(node.attr),
             )
-        if isinstance(node, ast.Subscript):
-            return ctor(
-                "python:subscript",
-                self.store_target_expr(node.value),
-                self.store_target_subscript_index(node),
+            self.effects.add_panics()
+            self.panic_loci.append(
+                self.runtime_failure_locus(
+                    node,
+                    term,
+                    subkind="attribute-write",
+                    exception_class="AttributeError",
+                )
             )
+            return term
+        if isinstance(node, ast.Subscript):
+            term = ctor(
+                "python:subscript",
+                self.expr(node.value),
+                self.subscript_index(node),
+            )
+            self.effects.add_panics()
+            self.panic_loci.append(
+                self.runtime_failure_locus(
+                    node,
+                    term,
+                    subkind="subscript-write",
+                )
+            )
+            return term
         raise _UnsupportedSyntax(node, f"unsupported assignment target: {type(node).__name__}")
-
-    def store_target_expr(self, node: ast.expr) -> Json:
-        self._suppress_runtime_failure_loci += 1
-        try:
-            return self.expr(node)
-        finally:
-            self._suppress_runtime_failure_loci -= 1
-
-    def store_target_subscript_index(self, node: ast.Subscript) -> Json:
-        if isinstance(node.slice, ast.Slice):
-            raise _UnsupportedSyntax(node.slice, "slice subscripts are refused")
-        return self.store_target_expr(node.slice)
 
     def expr(self, node: ast.expr) -> Json:
         if isinstance(node, ast.Constant):
@@ -416,28 +422,26 @@ class _Emitter:
             return self.call(node)
         if isinstance(node, ast.Attribute):
             term = ctor("python:attribute", self.expr(node.value), str_const(node.attr))
-            if self._suppress_runtime_failure_loci == 0:
-                self.effects.add_panics()
-                self.panic_loci.append(
-                    self.runtime_failure_locus(
-                        node,
-                        term,
-                        subkind="attribute-access",
-                        exception_class="AttributeError",
-                    )
+            self.effects.add_panics()
+            self.panic_loci.append(
+                self.runtime_failure_locus(
+                    node,
+                    term,
+                    subkind="attribute-access",
+                    exception_class="AttributeError",
                 )
+            )
             return term
         if isinstance(node, ast.Subscript):
             term = ctor("python:subscript", self.expr(node.value), self.subscript_index(node))
-            if self._suppress_runtime_failure_loci == 0:
-                self.effects.add_panics()
-                self.panic_loci.append(
-                    self.runtime_failure_locus(
-                        node,
-                        term,
-                        subkind="subscript-access",
-                    )
+            self.effects.add_panics()
+            self.panic_loci.append(
+                self.runtime_failure_locus(
+                    node,
+                    term,
+                    subkind="subscript-access",
                 )
+            )
             return term
         raise _UnsupportedSyntax(node, f"unhandled expression kind: {type(node).__name__}")
 

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -470,7 +470,7 @@ def test_mixed_runtime_failure_sites_share_deduped_panics_effect() -> None:
     assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 8), (3, 8), (4, 4)]
 
 
-def test_attribute_and_subscript_store_targets_are_not_slice4_runtime_failure_loci() -> None:
+def test_attribute_and_subscript_store_targets_emit_runtime_failure_loci() -> None:
     source = (
         "def f(obj, xs, key, value):\n"
         "    obj.name = value\n"
@@ -485,11 +485,50 @@ def test_attribute_and_subscript_store_targets_are_not_slice4_runtime_failure_lo
     assert contract["effects"] == [
         {"kind": "writes", "target": "obj.name"},
         {"kind": "writes", "target": "xs[key]"},
+        {"kind": "panics"},
     ]
-    assert contract.get("panicLoci", []) == []
+    assert _runtime_failure_loci(contract) == [
+        {
+            "effectKind": PANIC_FREEDOM_EFFECT_KIND,
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "attribute-write",
+            "exceptionClass": "AttributeError",
+            "argTerm": {
+                "kind": "ctor",
+                "name": "python:attribute",
+                "args": [
+                    {"kind": "var", "name": "obj"},
+                    {
+                        "kind": "const",
+                        "value": "name",
+                        "sort": {"kind": "primitive", "name": "String"},
+                    },
+                ],
+            },
+            "file": "store_targets.py",
+            "line": 2,
+            "col": 4,
+        },
+        {
+            "effectKind": PANIC_FREEDOM_EFFECT_KIND,
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "subscript-write",
+            "argTerm": {
+                "kind": "ctor",
+                "name": "python:subscript",
+                "args": [
+                    {"kind": "var", "name": "xs"},
+                    {"kind": "var", "name": "key"},
+                ],
+            },
+            "file": "store_targets.py",
+            "line": 3,
+            "col": 4,
+        },
+    ]
 
 
-def test_nested_attribute_and_subscript_store_targets_do_not_leak_runtime_failure_loci() -> None:
+def test_nested_attribute_and_subscript_store_targets_resurface_load_loci() -> None:
     source = (
         "def f(obj, xs, ys, i, value):\n"
         "    obj.inner.name = value\n"
@@ -504,8 +543,102 @@ def test_nested_attribute_and_subscript_store_targets_do_not_leak_runtime_failur
     assert contract["effects"] == [
         {"kind": "writes", "target": "obj.inner.name"},
         {"kind": "writes", "target": "xs[ys[i]]"},
+        {"kind": "panics"},
     ]
-    assert contract.get("panicLoci", []) == []
+    assert _runtime_failure_loci(contract) == [
+        {
+            "effectKind": PANIC_FREEDOM_EFFECT_KIND,
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "attribute-access",
+            "exceptionClass": "AttributeError",
+            "argTerm": {
+                "kind": "ctor",
+                "name": "python:attribute",
+                "args": [
+                    {"kind": "var", "name": "obj"},
+                    {
+                        "kind": "const",
+                        "value": "inner",
+                        "sort": {"kind": "primitive", "name": "String"},
+                    },
+                ],
+            },
+            "file": "nested_store_targets.py",
+            "line": 2,
+            "col": 4,
+        },
+        {
+            "effectKind": PANIC_FREEDOM_EFFECT_KIND,
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "attribute-write",
+            "exceptionClass": "AttributeError",
+            "argTerm": {
+                "kind": "ctor",
+                "name": "python:attribute",
+                "args": [
+                    {
+                        "kind": "ctor",
+                        "name": "python:attribute",
+                        "args": [
+                            {"kind": "var", "name": "obj"},
+                            {
+                                "kind": "const",
+                                "value": "inner",
+                                "sort": {"kind": "primitive", "name": "String"},
+                            },
+                        ],
+                    },
+                    {
+                        "kind": "const",
+                        "value": "name",
+                        "sort": {"kind": "primitive", "name": "String"},
+                    },
+                ],
+            },
+            "file": "nested_store_targets.py",
+            "line": 2,
+            "col": 4,
+        },
+        {
+            "effectKind": PANIC_FREEDOM_EFFECT_KIND,
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "subscript-access",
+            "argTerm": {
+                "kind": "ctor",
+                "name": "python:subscript",
+                "args": [
+                    {"kind": "var", "name": "ys"},
+                    {"kind": "var", "name": "i"},
+                ],
+            },
+            "file": "nested_store_targets.py",
+            "line": 3,
+            "col": 7,
+        },
+        {
+            "effectKind": PANIC_FREEDOM_EFFECT_KIND,
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "subscript-write",
+            "argTerm": {
+                "kind": "ctor",
+                "name": "python:subscript",
+                "args": [
+                    {"kind": "var", "name": "xs"},
+                    {
+                        "kind": "ctor",
+                        "name": "python:subscript",
+                        "args": [
+                            {"kind": "var", "name": "ys"},
+                            {"kind": "var", "name": "i"},
+                        ],
+                    },
+                ],
+            },
+            "file": "nested_store_targets.py",
+            "line": 3,
+            "col": 4,
+        },
+    ]
 
 
 def test_none_guarded_attribute_access_emits_one_runtime_failure_locus() -> None:

--- a/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
@@ -184,6 +184,52 @@ emits_signed_mementos = false
     project
 }
 
+fn stage_python_store_project(lift_script: &Path) -> PathBuf {
+    let project = unique_dir("store-project");
+    fs::write(
+        project.join("store.py"),
+        "def write(obj, xs, ys, i, key, value):\n    obj.name = value\n    xs[key] = value\n    obj.inner.name = value\n    xs[ys[i]] = value\n    return value\n",
+    )
+    .expect("write store.py");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("python-source"))
+        .expect("mkdir .provekit/lift/python-source");
+    fs::write(
+        provekit.join("config.toml"),
+        r#"[[plugins]]
+name = "python-source"
+kind = "lift"
+surface = "python-source"
+"#,
+    )
+    .expect("write config.toml");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("python-source")
+            .join("manifest.toml"),
+        format!(
+            r#"name = "python-source"
+version = "0.1.0-draft"
+protocol_version = "provekit-lift/1"
+kind = "lift"
+command = ["{}", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["python-source"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+"#,
+            lift_script.display()
+        ),
+    )
+    .expect("write manifest.toml");
+
+    project
+}
+
 fn run_mint(project: &Path) {
     let out = Command::new(provekit_bin())
         .arg("mint")
@@ -343,6 +389,179 @@ fn python_source_access_mint_preserves_runtime_failure_loci_and_enumerates_calls
             .iter()
             .all(|cs| cs.bridge_target_cid.is_empty()),
         "no bridges exist yet, so surfaced access callsites must remain undecidable"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn python_source_store_mint_preserves_runtime_failure_loci_and_enumerates_callsites() {
+    if !python_available() {
+        eprintln!("python3 not on PATH: skipping python-source store runtime-failure mint test");
+        return;
+    }
+    let lift_script = build_python_lift_source();
+    let project = stage_python_store_project(&lift_script);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "python-source store proof must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let loci = contract_runtime_failure_loci(&pool);
+    assert_eq!(
+        loci,
+        vec![
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-write",
+                "exceptionClass": "AttributeError",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:attribute",
+                    "args": [
+                        {"kind": "var", "name": "obj"},
+                        {"kind": "const", "value": "name", "sort": {"kind": "primitive", "name": "String"}}
+                    ]
+                },
+                "file": "store.py",
+                "line": 2,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:subscript",
+                    "args": [
+                        {"kind": "var", "name": "xs"},
+                        {"kind": "var", "name": "key"}
+                    ]
+                },
+                "file": "store.py",
+                "line": 3,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:attribute",
+                    "args": [
+                        {"kind": "var", "name": "obj"},
+                        {"kind": "const", "value": "inner", "sort": {"kind": "primitive", "name": "String"}}
+                    ]
+                },
+                "file": "store.py",
+                "line": 4,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-write",
+                "exceptionClass": "AttributeError",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:attribute",
+                    "args": [
+                        {
+                            "kind": "ctor",
+                            "name": "python:attribute",
+                            "args": [
+                                {"kind": "var", "name": "obj"},
+                                {"kind": "const", "value": "inner", "sort": {"kind": "primitive", "name": "String"}}
+                            ]
+                        },
+                        {"kind": "const", "value": "name", "sort": {"kind": "primitive", "name": "String"}}
+                    ]
+                },
+                "file": "store.py",
+                "line": 4,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:subscript",
+                    "args": [
+                        {"kind": "var", "name": "ys"},
+                        {"kind": "var", "name": "i"}
+                    ]
+                },
+                "file": "store.py",
+                "line": 5,
+                "col": 7
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:subscript",
+                    "args": [
+                        {"kind": "var", "name": "xs"},
+                        {
+                            "kind": "ctor",
+                            "name": "python:subscript",
+                            "args": [
+                                {"kind": "var", "name": "ys"},
+                                {"kind": "var", "name": "i"}
+                            ]
+                        }
+                    ]
+                },
+                "file": "store.py",
+                "line": 5,
+                "col": 4
+            }),
+        ],
+        "mint must preserve python-source store runtime-failure panicLoci rows"
+    );
+
+    let callsites = provekit_verifier::enumerate_callsites::run(&pool);
+    let runtime_failure_sites: Vec<_> = callsites
+        .iter()
+        .filter(|cs| cs.panic_site && cs.callee.as_deref() == Some(RUNTIME_FAILURE_SITE_CONCEPT))
+        .collect();
+    assert_eq!(
+        runtime_failure_sites.len(),
+        6,
+        "verifier must surface exactly six substrate runtime-failure panic sites; got {callsites:#?}"
+    );
+    assert!(
+        runtime_failure_sites
+            .iter()
+            .all(|cs| cs.file.as_deref() == Some("store.py")),
+        "all surfaced Store callsites must preserve store.py provenance: {runtime_failure_sites:#?}"
+    );
+    assert_eq!(
+        runtime_failure_sites
+            .iter()
+            .map(|cs| (cs.line, cs.bridge_target_cid.is_empty()))
+            .collect::<Vec<_>>(),
+        vec![
+            (Some(2), true),
+            (Some(3), true),
+            (Some(4), true),
+            (Some(4), true),
+            (Some(5), true),
+            (Some(5), true),
+        ],
+        "no bridges exist yet, so surfaced store callsites must remain undecidable"
     );
 
     let _ = fs::remove_dir_all(&project);


### PR DESCRIPTION
## Summary

Slice 5 of the #1828 substrate expansion arc, tracked under #1837. This extends the python-source lifter so Store contexts for `ast.Attribute` and `ast.Subscript` emit `concept:panic-freedom.leaf.runtime-failure-site` panicLoci.

What changed:
- `obj.attr = value` now emits an `attribute-write` runtime-failure locus with `exceptionClass: AttributeError`.
- `xs[key] = value` now emits a `subscript-write` runtime-failure locus and omits `exceptionClass` because `TypeError`, `KeyError`, and `IndexError` are not statically knowable.
- Nested Store target navigation re-surfaces Load loci. For example, `obj.inner.name = value` emits `attribute-access` for `obj.inner` and `attribute-write` for the outer target.
- The existing `python:attribute` and `python:subscript` effect leaf declarations are reused. No declaration, libprovekit, verifier, doctor, or CLI source changes are needed.

## Design note

Slice 4 suppressed Load loci within Store target lowering because Store contexts were out of scope. Slice 5 brings Store contexts in scope, so nested Load navigation operations re-emit their Load loci because they remain legitimate panic sites. This is honest federation: every operation that can raise gets a locus.

Subkind values remain kit-owned diagnostics only. They are emitted in proof bytes and test evidence, but they do not become verifier semantics, libprovekit taxonomy, or cross-kit consistency keys.

Out of scope for this slice:
- `AugAssign`, such as `obj.attr += x`.
- `AnnAssign`, tuple/list unpacking targets, slice assignments, and walrus expressions.
- Any discharge proof work over these emitted runtime-failure sites.

## Scope

Changed files:
- `implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py`
- `implementations/python/provekit-lift-python-source/tests/test_lifter.py`
- `implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs`

Path-scope check: no changes under `implementations/rust/libprovekit`, `implementations/rust/provekit-verifier`, or `implementations/rust/provekit-cli/src`.

## Validation

- RED direct Store test failed for missing panics/loci before implementation.
- RED nested Store test failed because only outer write loci were emitted before suppression was removed.
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q` -> 35 passed
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests -q` -> 124 passed
- `rustfmt --edition 2021 --check implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs`
- `git diff --check`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_mint_python_source_runtime_failure -- --nocapture` -> 3 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture` -> 6 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_verify_python_production_bridge -- --nocapture` -> 5 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_verify_python_division_unsound -- --nocapture` -> 2 passed
- strict Python doctor -> `ok: true`, `findings: []`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc -p provekit-lift --bin provekit-lift`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` -> 1 passed in 126.45s

Refs #1837.