### PR TITLE
[codex] python-source supports ast.AugAssign with evaluation-once Load+Store loci (#1837 slice 6)

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/compiler.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/compiler.py
@@ -85,6 +85,12 @@ def _stmt(term: Json) -> ast.stmt:
     args = term.get("args", [])
     if name == "python:assign":
         return ast.Assign(targets=[_target(args[0])], value=_expr(args[1]))
+    if name == "python:aug_assign":
+        return ast.AugAssign(
+            target=_target(args[0]),
+            op=_augop(_const_string(args[1])),
+            value=_expr(args[2]),
+        )
     if name == "python:return":
         value = None if _is_none_const(args[0]) else _expr(args[0])
         return ast.Return(value=value)
@@ -203,6 +209,13 @@ def _cmpop(op: str) -> ast.cmpop:
     if op not in mapping:
         raise ValueError(f"unsupported comparison operator: {op}")
     return mapping[op]()
+
+
+def _augop(op: str) -> ast.operator:
+    operator = _BINOPS.get(op)
+    if operator is None:
+        raise ValueError(f"unsupported augmented assignment operator: {op}")
+    return operator()
 
 
 def _contract_term(contract: Json) -> Json:

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -280,6 +280,13 @@ class _Emitter:
             target = self.target(node.targets[0])
             self._record_write_if_nonlocal(node.targets[0])
             return ctor("python:assign", target, self.expr(node.value))
+        if isinstance(node, ast.AugAssign):
+            op = _BINOPS.get(type(node.op))
+            if op is None:
+                raise _UnsupportedSyntax(node, f"unsupported binary operator: {type(node.op).__name__}")
+            target = self.augassign_target(node.target)
+            self._record_write_if_nonlocal(node.target)
+            return ctor("python:aug_assign", target, str_const(op), self.expr(node.value))
         if isinstance(node, ast.If):
             condition = self.expr(node.test)
             then_branch = self.statements(node.body)
@@ -390,6 +397,49 @@ class _Emitter:
             )
             return term
         raise _UnsupportedSyntax(node, f"unsupported assignment target: {type(node).__name__}")
+
+    def augassign_target(self, node: ast.expr) -> Json:
+        if isinstance(node, ast.Name):
+            return var(node.id)
+        if isinstance(node, ast.Attribute):
+            term = ctor("python:attribute", self.expr(node.value), str_const(node.attr))
+            self.effects.add_panics()
+            self.panic_loci.append(
+                self.runtime_failure_locus(
+                    node,
+                    term,
+                    subkind="attribute-access",
+                    exception_class="AttributeError",
+                )
+            )
+            self.panic_loci.append(
+                self.runtime_failure_locus(
+                    node,
+                    term,
+                    subkind="attribute-write",
+                    exception_class="AttributeError",
+                )
+            )
+            return term
+        if isinstance(node, ast.Subscript):
+            term = ctor("python:subscript", self.expr(node.value), self.subscript_index(node))
+            self.effects.add_panics()
+            self.panic_loci.append(
+                self.runtime_failure_locus(
+                    node,
+                    term,
+                    subkind="subscript-access",
+                )
+            )
+            self.panic_loci.append(
+                self.runtime_failure_locus(
+                    node,
+                    term,
+                    subkind="subscript-write",
+                )
+            )
+            return term
+        raise _UnsupportedSyntax(node, f"unsupported augmented assignment target: {type(node).__name__}")
 
     def expr(self, node: ast.expr) -> Json:
         if isinstance(node, ast.Constant):

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -114,6 +114,36 @@ def _runtime_failure_loci(contract: dict[str, object]) -> list[dict[str, object]
     return [locus for locus in loci if isinstance(locus, dict)]
 
 
+def _var(name: str) -> dict[str, object]:
+    return {"kind": "var", "name": name}
+
+
+def _str_const(value: str) -> dict[str, object]:
+    return {
+        "kind": "const",
+        "value": value,
+        "sort": {"kind": "primitive", "name": "String"},
+    }
+
+
+def _attr(value: dict[str, object], name: str) -> dict[str, object]:
+    return {"kind": "ctor", "name": "python:attribute", "args": [value, _str_const(name)]}
+
+
+def _subscript(value: dict[str, object], index: dict[str, object]) -> dict[str, object]:
+    return {"kind": "ctor", "name": "python:subscript", "args": [value, index]}
+
+
+def _aug_assign(
+    target: dict[str, object], op: str, value: dict[str, object]
+) -> dict[str, object]:
+    return {
+        "kind": "ctor",
+        "name": "python:aug_assign",
+        "args": [target, _str_const(op), value],
+    }
+
+
 def _ctor_names(node: object) -> list[str]:
     if isinstance(node, dict):
         names = [str(node["name"])] if node.get("kind") == "ctor" else []
@@ -639,6 +669,180 @@ def test_nested_attribute_and_subscript_store_targets_resurface_load_loci() -> N
             "col": 4,
         },
     ]
+
+
+def test_name_augassign_lifts_to_aug_assign_without_runtime_failure_loci() -> None:
+    source = "def f(x, y):\n    x += y\n    return x\n"
+
+    result = lift_source(source, "name_augassign.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == []
+    assert contract.get("panicLoci", []) == []
+    assert body["name"] == "python:seq"
+    assert body["args"][0] == _aug_assign(_var("x"), "python:add", _var("y"))
+
+
+def test_attribute_augassign_emits_access_and_write_runtime_failure_loci() -> None:
+    source = "def f(obj, y):\n    obj.name += y\n    return obj\n"
+
+    result = lift_source(source, "attribute_augassign.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    target = _attr(_var("obj"), "name")
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "obj.name"},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == [
+        "attribute-access",
+        "attribute-write",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [target, target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 4), (2, 4)]
+    assert all(locus["exceptionClass"] == "AttributeError" for locus in loci)
+    assert body["args"][0] == _aug_assign(target, "python:add", _var("y"))
+
+
+def test_subscript_augassign_emits_access_and_write_runtime_failure_loci() -> None:
+    source = "def f(xs, key, y):\n    xs[key] += y\n    return xs\n"
+
+    result = lift_source(source, "subscript_augassign.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    target = _subscript(_var("xs"), _var("key"))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "xs[key]"},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == [
+        "subscript-access",
+        "subscript-write",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [target, target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 4), (2, 4)]
+    assert "exceptionClass" not in loci[0]
+    assert "exceptionClass" not in loci[1]
+    assert body["args"][0] == _aug_assign(target, "python:add", _var("y"))
+
+
+def test_nested_augassign_targets_evaluate_navigation_once() -> None:
+    source = (
+        "def f(obj, xs, ys, i, y):\n"
+        "    obj.inner.name += y\n"
+        "    xs[ys[i]] += y\n"
+        "    return y\n"
+    )
+
+    result = lift_source(source, "nested_augassign.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    loci = _runtime_failure_loci(contract)
+    obj_inner = _attr(_var("obj"), "inner")
+    obj_inner_name = _attr(obj_inner, "name")
+    ys_i = _subscript(_var("ys"), _var("i"))
+    xs_ys_i = _subscript(_var("xs"), ys_i)
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "obj.inner.name"},
+        {"kind": "writes", "target": "xs[ys[i]]"},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == [
+        "attribute-access",
+        "attribute-access",
+        "attribute-write",
+        "subscript-access",
+        "subscript-access",
+        "subscript-write",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [
+        obj_inner,
+        obj_inner_name,
+        obj_inner_name,
+        ys_i,
+        xs_ys_i,
+        xs_ys_i,
+    ]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [
+        (2, 4),
+        (2, 4),
+        (2, 4),
+        (3, 7),
+        (3, 4),
+        (3, 4),
+    ]
+    assert [locus["argTerm"] for locus in loci].count(obj_inner) == 1
+    assert [locus["argTerm"] for locus in loci].count(ys_i) == 1
+
+
+def test_augassign_complex_rhs_emits_rhs_load_loci_after_target_loci() -> None:
+    source = "def f(obj, xs, key):\n    obj.name += xs[key]\n    return obj\n"
+
+    result = lift_source(source, "augassign_rhs.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    obj_name = _attr(_var("obj"), "name")
+    xs_key = _subscript(_var("xs"), _var("key"))
+    loci = _runtime_failure_loci(contract)
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "obj.name"},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == [
+        "attribute-access",
+        "attribute-write",
+        "subscript-access",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [obj_name, obj_name, xs_key]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 4), (2, 4), (2, 16)]
+
+
+def test_compile_lift_roundtrip_preserves_attribute_augassign_body() -> None:
+    source = "def f(obj, y):\n    obj.name += y\n    return obj\n"
+    lifted = lift_source(source, "roundtrip_aug_attr.py")
+    assert lifted.refusals == []
+    contract = _contract(lifted.ir, ".f")
+    body = contract["post"]["args"][1]
+
+    compiled = compile_body_term(
+        body,
+        fn_name="f",
+        formals=[str(formal) for formal in contract["formals"]],
+    )
+    relifted = lift_source(compiled, "roundtrip_aug_attr.py")
+    assert relifted.refusals == []
+    relifted_body = _contract(relifted.ir, ".f")["post"]["args"][1]
+
+    assert canonical_json_bytes(relifted_body) == canonical_json_bytes(body)
+
+
+def test_compile_lift_roundtrip_preserves_subscript_augassign_body() -> None:
+    source = "def f(xs, key, y):\n    xs[key] += y\n    return xs\n"
+    lifted = lift_source(source, "roundtrip_aug_subscript.py")
+    assert lifted.refusals == []
+    contract = _contract(lifted.ir, ".f")
+    body = contract["post"]["args"][1]
+
+    compiled = compile_body_term(
+        body,
+        fn_name="f",
+        formals=[str(formal) for formal in contract["formals"]],
+    )
+    relifted = lift_source(compiled, "roundtrip_aug_subscript.py")
+    assert relifted.refusals == []
+    relifted_body = _contract(relifted.ir, ".f")["post"]["args"][1]
+
+    assert canonical_json_bytes(relifted_body) == canonical_json_bytes(body)
 
 
 def test_none_guarded_attribute_access_emits_one_runtime_failure_locus() -> None:

--- a/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
@@ -230,6 +230,52 @@ emits_signed_mementos = false
     project
 }
 
+fn stage_python_augassign_project(lift_script: &Path) -> PathBuf {
+    let project = unique_dir("augassign-project");
+    fs::write(
+        project.join("augassign.py"),
+        "def bump(obj, xs, ys, i, key, value):\n    obj.name += value\n    xs[key] += value\n    obj.inner.name += value\n    xs[ys[i]] += value\n    return value\n",
+    )
+    .expect("write augassign.py");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("python-source"))
+        .expect("mkdir .provekit/lift/python-source");
+    fs::write(
+        provekit.join("config.toml"),
+        r#"[[plugins]]
+name = "python-source"
+kind = "lift"
+surface = "python-source"
+"#,
+    )
+    .expect("write config.toml");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("python-source")
+            .join("manifest.toml"),
+        format!(
+            r#"name = "python-source"
+version = "0.1.0-draft"
+protocol_version = "provekit-lift/1"
+kind = "lift"
+command = ["{}", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["python-source"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+"#,
+            lift_script.display()
+        ),
+    )
+    .expect("write manifest.toml");
+
+    project
+}
+
 fn run_mint(project: &Path) {
     let out = Command::new(provekit_bin())
         .arg("mint")
@@ -562,6 +608,264 @@ fn python_source_store_mint_preserves_runtime_failure_loci_and_enumerates_callsi
             (Some(5), true),
         ],
         "no bridges exist yet, so surfaced store callsites must remain undecidable"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn python_source_augassign_mint_preserves_runtime_failure_loci_and_enumerates_callsites() {
+    if !python_available() {
+        eprintln!(
+            "python3 not on PATH: skipping python-source AugAssign runtime-failure mint test"
+        );
+        return;
+    }
+    let lift_script = build_python_lift_source();
+    let project = stage_python_augassign_project(&lift_script);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "python-source AugAssign proof must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let loci = contract_runtime_failure_loci(&pool);
+    assert_eq!(
+        loci,
+        vec![
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:attribute",
+                    "args": [
+                        {"kind": "var", "name": "obj"},
+                        {"kind": "const", "value": "name", "sort": {"kind": "primitive", "name": "String"}}
+                    ]
+                },
+                "file": "augassign.py",
+                "line": 2,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-write",
+                "exceptionClass": "AttributeError",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:attribute",
+                    "args": [
+                        {"kind": "var", "name": "obj"},
+                        {"kind": "const", "value": "name", "sort": {"kind": "primitive", "name": "String"}}
+                    ]
+                },
+                "file": "augassign.py",
+                "line": 2,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:subscript",
+                    "args": [
+                        {"kind": "var", "name": "xs"},
+                        {"kind": "var", "name": "key"}
+                    ]
+                },
+                "file": "augassign.py",
+                "line": 3,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:subscript",
+                    "args": [
+                        {"kind": "var", "name": "xs"},
+                        {"kind": "var", "name": "key"}
+                    ]
+                },
+                "file": "augassign.py",
+                "line": 3,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:attribute",
+                    "args": [
+                        {"kind": "var", "name": "obj"},
+                        {"kind": "const", "value": "inner", "sort": {"kind": "primitive", "name": "String"}}
+                    ]
+                },
+                "file": "augassign.py",
+                "line": 4,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:attribute",
+                    "args": [
+                        {
+                            "kind": "ctor",
+                            "name": "python:attribute",
+                            "args": [
+                                {"kind": "var", "name": "obj"},
+                                {"kind": "const", "value": "inner", "sort": {"kind": "primitive", "name": "String"}}
+                            ]
+                        },
+                        {"kind": "const", "value": "name", "sort": {"kind": "primitive", "name": "String"}}
+                    ]
+                },
+                "file": "augassign.py",
+                "line": 4,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-write",
+                "exceptionClass": "AttributeError",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:attribute",
+                    "args": [
+                        {
+                            "kind": "ctor",
+                            "name": "python:attribute",
+                            "args": [
+                                {"kind": "var", "name": "obj"},
+                                {"kind": "const", "value": "inner", "sort": {"kind": "primitive", "name": "String"}}
+                            ]
+                        },
+                        {"kind": "const", "value": "name", "sort": {"kind": "primitive", "name": "String"}}
+                    ]
+                },
+                "file": "augassign.py",
+                "line": 4,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:subscript",
+                    "args": [
+                        {"kind": "var", "name": "ys"},
+                        {"kind": "var", "name": "i"}
+                    ]
+                },
+                "file": "augassign.py",
+                "line": 5,
+                "col": 7
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:subscript",
+                    "args": [
+                        {"kind": "var", "name": "xs"},
+                        {
+                            "kind": "ctor",
+                            "name": "python:subscript",
+                            "args": [
+                                {"kind": "var", "name": "ys"},
+                                {"kind": "var", "name": "i"}
+                            ]
+                        }
+                    ]
+                },
+                "file": "augassign.py",
+                "line": 5,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:subscript",
+                    "args": [
+                        {"kind": "var", "name": "xs"},
+                        {
+                            "kind": "ctor",
+                            "name": "python:subscript",
+                            "args": [
+                                {"kind": "var", "name": "ys"},
+                                {"kind": "var", "name": "i"}
+                            ]
+                        }
+                    ]
+                },
+                "file": "augassign.py",
+                "line": 5,
+                "col": 4
+            }),
+        ],
+        "mint must preserve python-source AugAssign runtime-failure panicLoci rows"
+    );
+
+    let callsites = provekit_verifier::enumerate_callsites::run(&pool);
+    let runtime_failure_sites: Vec<_> = callsites
+        .iter()
+        .filter(|cs| cs.panic_site && cs.callee.as_deref() == Some(RUNTIME_FAILURE_SITE_CONCEPT))
+        .collect();
+    // The proof keeps all ten panicLoci rows above. CallSite enumeration
+    // currently deduplicates access/write rows that share callee, file, line,
+    // and argTerm because CallSite does not carry panicLoci subkind.
+    assert_eq!(
+        runtime_failure_sites.len(),
+        6,
+        "verifier currently surfaces six unique AugAssign runtime-failure obligations; got {callsites:#?}"
+    );
+    assert!(
+        runtime_failure_sites
+            .iter()
+            .all(|cs| cs.file.as_deref() == Some("augassign.py")),
+        "all surfaced AugAssign callsites must preserve augassign.py provenance: {runtime_failure_sites:#?}"
+    );
+    assert_eq!(
+        runtime_failure_sites
+            .iter()
+            .map(|cs| (cs.line, cs.bridge_target_cid.is_empty()))
+            .collect::<Vec<_>>(),
+        vec![
+            (Some(2), true),
+            (Some(3), true),
+            (Some(4), true),
+            (Some(4), true),
+            (Some(5), true),
+            (Some(5), true),
+        ],
+        "no bridges exist yet, so surfaced AugAssign callsites must remain undecidable"
     );
 
     let _ = fs::remove_dir_all(&project);


### PR DESCRIPTION
## Summary

Slice 6 of the #1828 substrate expansion arc, tracked under #1837. The python-source lifter now handles `ast.AugAssign` for Name, Attribute, and Subscript targets. It emits an explicit `python:aug_assign(target, op, rhs)` body-term ctor and the compiler roundtrips that ctor back to Python `target op= rhs`.

The implementation uses a dedicated AugAssign target helper so nested targets such as `obj.inner.attr += y` and `xs[ys[i]] += y` evaluate receiver/index navigation once. Final Attribute/Subscript targets emit the expected Load and Store panic loci: `attribute-access` plus `attribute-write`, or `subscript-access` plus `subscript-write`. No new augmented subkind is introduced.

## Federation Note

The AugAssign integration test asserts both shapes currently present in the product. Kit emission preserves all 10 `panicLoci` rows, including subkind diagnostics that distinguish access and write panics. Verifier `enumerate_callsites` currently deduplicates by `(callee, file, line, argTerm)`, so access/write pairs at the same source line collapse into 6 unique `CallSite`s because `CallSite` does not carry subkind. That verifier-side discrimination gap is tracked separately in #1839. This PR documents the current behavior without changing verifier code.

## Scope

In scope:

- `ast.AugAssign` lift for Name, Attribute, and Subscript targets
- `python:aug_assign` body-term ctor
- compiler support for `python:aug_assign` to `ast.AugAssign`
- Load+Store runtime-failure loci for Attribute/Subscript AugAssign targets
- nested evaluation-once tests
- mint integration coverage for config/manifest driven python-source kit registration

Out of scope, still under #1837:

- AnnAssign
- tuple/list unpacking
- slice assignments
- walrus

## Validation

- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q -k augassign` - 7 passed
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q` - 42 passed
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests -q` - 131 passed
- `rustfmt --edition 2021 --check implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs` - passed
- `git diff --check` - passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_mint_python_source_runtime_failure python_source_augassign_mint_preserves_runtime_failure_loci_and_enumerates_callsites -- --nocapture` - 1 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_mint_python_source_runtime_failure -- --nocapture` - 4 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture` - 6 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_verify_python_production_bridge -- --nocapture` - 5 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_verify_python_division_unsound -- --nocapture` - 2 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo run -p provekit-cli -- doctor --target ../python --mode strict --json` - exit 0, `ok: true`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc -p provekit-lift --bin provekit-lift` - passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` - 1 passed in 120.91s

Path scope check: no changes under `implementations/rust/libprovekit`, `implementations/rust/provekit-verifier`, or `implementations/rust/provekit-cli/src`.

Refs #1837.
Refs #1839.