### PR TITLE
[codex] python-source supports ast.AnnAssign with empirically-correct emission (#1837 slice 7)

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/compiler.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/compiler.py
@@ -91,6 +91,14 @@ def _stmt(term: Json) -> ast.stmt:
             op=_augop(_const_string(args[1])),
             value=_expr(args[2]),
         )
+    if name == "python:ann_assign":
+        target = _target(args[0])
+        return ast.AnnAssign(
+            target=target,
+            annotation=_expr(args[1]),
+            value=None if _is_none_const(args[2]) else _expr(args[2]),
+            simple=1 if isinstance(target, ast.Name) else 0,
+        )
     if name == "python:return":
         value = None if _is_none_const(args[0]) else _expr(args[0])
         return ast.Return(value=value)

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/compiler.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/compiler.py
@@ -96,7 +96,7 @@ def _stmt(term: Json) -> ast.stmt:
         return ast.AnnAssign(
             target=target,
             annotation=_expr(args[1]),
-            value=None if _is_none_const(args[2]) else _expr(args[2]),
+            value=None if _is_no_value(args[2]) else _expr(args[2]),
             simple=1 if isinstance(target, ast.Name) else 0,
         )
     if name == "python:return":
@@ -259,6 +259,10 @@ def _const_string(term: Json) -> str:
 
 def _is_none_const(term: Any) -> bool:
     return isinstance(term, dict) and term.get("kind") == "const" and term.get("value") is None
+
+
+def _is_no_value(term: Any) -> bool:
+    return isinstance(term, dict) and term.get("kind") == "ctor" and term.get("name") == "python:no_value"
 
 
 _BINOPS: dict[str, type[ast.operator]] = {

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -291,7 +291,7 @@ class _Emitter:
             annotation = self.annotation_expr(node.annotation)
             if node.value is None:
                 target = self.annassign_target_without_value(node.target)
-                value = none_const()
+                value = ctor("python:no_value")
             else:
                 target = self.target(node.target)
                 self._record_write_if_nonlocal(node.target)

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -287,6 +287,16 @@ class _Emitter:
             target = self.augassign_target(node.target)
             self._record_write_if_nonlocal(node.target)
             return ctor("python:aug_assign", target, str_const(op), self.expr(node.value))
+        if isinstance(node, ast.AnnAssign):
+            annotation = self.annotation_expr(node.annotation)
+            if node.value is None:
+                target = self.annassign_target_without_value(node.target)
+                value = none_const()
+            else:
+                target = self.target(node.target)
+                self._record_write_if_nonlocal(node.target)
+                value = self.expr(node.value)
+            return ctor("python:ann_assign", target, annotation, value)
         if isinstance(node, ast.If):
             condition = self.expr(node.test)
             then_branch = self.statements(node.body)
@@ -440,6 +450,44 @@ class _Emitter:
             )
             return term
         raise _UnsupportedSyntax(node, f"unsupported augmented assignment target: {type(node).__name__}")
+
+    def annassign_target_without_value(self, node: ast.expr) -> Json:
+        if isinstance(node, ast.Name):
+            return var(node.id)
+        if isinstance(node, ast.Attribute):
+            return ctor(
+                "python:attribute",
+                self.expr(node.value),
+                str_const(node.attr),
+            )
+        if isinstance(node, ast.Subscript):
+            return ctor(
+                "python:subscript",
+                self.expr(node.value),
+                self.subscript_index(node),
+            )
+        raise _UnsupportedSyntax(node, f"unsupported annotated assignment target: {type(node).__name__}")
+
+    def annotation_expr(self, node: ast.expr) -> Json:
+        if isinstance(node, ast.Constant):
+            return self.constant(node)
+        if isinstance(node, ast.Name):
+            return var(node.id)
+        if isinstance(node, ast.Attribute):
+            return ctor(
+                "python:attribute",
+                self.annotation_expr(node.value),
+                str_const(node.attr),
+            )
+        if isinstance(node, ast.Subscript):
+            if isinstance(node.slice, ast.Slice):
+                raise _UnsupportedSyntax(node.slice, "slice annotations are refused")
+            return ctor(
+                "python:subscript",
+                self.annotation_expr(node.value),
+                self.annotation_expr(node.slice),
+            )
+        raise _UnsupportedSyntax(node, f"unsupported annotation expression: {type(node).__name__}")
 
     def expr(self, node: ast.expr) -> Json:
         if isinstance(node, ast.Constant):

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -134,6 +134,14 @@ def _subscript(value: dict[str, object], index: dict[str, object]) -> dict[str, 
     return {"kind": "ctor", "name": "python:subscript", "args": [value, index]}
 
 
+def _none_const() -> dict[str, object]:
+    return {
+        "kind": "const",
+        "value": None,
+        "sort": {"kind": "primitive", "name": "Unit"},
+    }
+
+
 def _aug_assign(
     target: dict[str, object], op: str, value: dict[str, object]
 ) -> dict[str, object]:
@@ -141,6 +149,18 @@ def _aug_assign(
         "kind": "ctor",
         "name": "python:aug_assign",
         "args": [target, _str_const(op), value],
+    }
+
+
+def _ann_assign(
+    target: dict[str, object],
+    annotation: dict[str, object],
+    value: dict[str, object],
+) -> dict[str, object]:
+    return {
+        "kind": "ctor",
+        "name": "python:ann_assign",
+        "args": [target, annotation, value],
     }
 
 
@@ -839,6 +859,228 @@ def test_compile_lift_roundtrip_preserves_subscript_augassign_body() -> None:
         formals=[str(formal) for formal in contract["formals"]],
     )
     relifted = lift_source(compiled, "roundtrip_aug_subscript.py")
+    assert relifted.refusals == []
+    relifted_body = _contract(relifted.ir, ".f")["post"]["args"][1]
+
+    assert canonical_json_bytes(relifted_body) == canonical_json_bytes(body)
+
+
+def test_name_annassign_without_value_has_no_runtime_failure_loci_or_effects() -> None:
+    source = "def f():\n    x: int\n    return 0\n"
+
+    result = lift_source(source, "name_annassign_no_value.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == []
+    assert contract.get("panicLoci", []) == []
+    assert body["name"] == "python:seq"
+    assert body["args"][0] == _ann_assign(_var("x"), _var("int"), _none_const())
+
+
+def test_name_annassign_with_value_has_no_runtime_failure_loci_or_effects() -> None:
+    source = "def f(y):\n    x: int = y\n    return x\n"
+
+    result = lift_source(source, "name_annassign_value.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == []
+    assert contract.get("panicLoci", []) == []
+    assert body["args"][0] == _ann_assign(_var("x"), _var("int"), _var("y"))
+
+
+def test_direct_attribute_annassign_without_value_does_not_access_final_attribute() -> None:
+    source = "def f(obj):\n    obj.name: int\n    return obj\n"
+
+    result = lift_source(source, "attr_annassign_no_value.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    body = contract["post"]["args"][1]
+    target = _attr(_var("obj"), "name")
+    assert contract["effects"] == []
+    assert contract.get("panicLoci", []) == []
+    assert body["args"][0] == _ann_assign(target, _var("int"), _none_const())
+
+
+def test_direct_attribute_annassign_with_value_emits_store_write_locus_only() -> None:
+    source = "def f(obj, y):\n    obj.name: int = y\n    return obj\n"
+
+    result = lift_source(source, "attr_annassign_value.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    target = _attr(_var("obj"), "name")
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "obj.name"},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == ["attribute-write"]
+    assert [locus["argTerm"] for locus in loci] == [target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 4)]
+    assert loci[0]["exceptionClass"] == "AttributeError"
+    assert body["args"][0] == _ann_assign(target, _var("int"), _var("y"))
+
+
+def test_direct_subscript_annassign_without_value_does_not_access_final_subscript() -> None:
+    source = "def f(xs, key):\n    xs[key]: int\n    return xs\n"
+
+    result = lift_source(source, "subscript_annassign_no_value.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    body = contract["post"]["args"][1]
+    target = _subscript(_var("xs"), _var("key"))
+    assert contract["effects"] == []
+    assert contract.get("panicLoci", []) == []
+    assert body["args"][0] == _ann_assign(target, _var("int"), _none_const())
+
+
+def test_direct_subscript_annassign_with_value_emits_store_write_locus_only() -> None:
+    source = "def f(xs, key, y):\n    xs[key]: int = y\n    return xs\n"
+
+    result = lift_source(source, "subscript_annassign_value.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    target = _subscript(_var("xs"), _var("key"))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "xs[key]"},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == ["subscript-write"]
+    assert [locus["argTerm"] for locus in loci] == [target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 4)]
+    assert "exceptionClass" not in loci[0]
+    assert body["args"][0] == _ann_assign(target, _var("int"), _var("y"))
+
+
+def test_nested_annassign_without_value_emits_only_intermediate_navigation_loci() -> None:
+    source = (
+        "def f(obj, xs, ys, i):\n"
+        "    obj.inner.name: int\n"
+        "    xs[ys[i]]: int\n"
+        "    return obj\n"
+    )
+
+    result = lift_source(source, "nested_annassign_no_value.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    loci = _runtime_failure_loci(contract)
+    obj_inner = _attr(_var("obj"), "inner")
+    ys_i = _subscript(_var("ys"), _var("i"))
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert [locus["subkind"] for locus in loci] == [
+        "attribute-access",
+        "subscript-access",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [obj_inner, ys_i]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 4), (3, 7)]
+    statements = body["args"][0]["args"]
+    assert statements[0] == _ann_assign(
+        _attr(obj_inner, "name"), _var("int"), _none_const()
+    )
+    assert statements[1] == _ann_assign(
+        _subscript(_var("xs"), ys_i), _var("int"), _none_const()
+    )
+
+
+def test_nested_annassign_with_value_reuses_store_target_navigation_once() -> None:
+    source = (
+        "def f(obj, xs, ys, i, value):\n"
+        "    obj.inner.name: int = value\n"
+        "    xs[ys[i]]: int = value\n"
+        "    return value\n"
+    )
+
+    result = lift_source(source, "nested_annassign_value.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    loci = _runtime_failure_loci(contract)
+    obj_inner = _attr(_var("obj"), "inner")
+    obj_inner_name = _attr(obj_inner, "name")
+    ys_i = _subscript(_var("ys"), _var("i"))
+    xs_ys_i = _subscript(_var("xs"), ys_i)
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "obj.inner.name"},
+        {"kind": "writes", "target": "xs[ys[i]]"},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == [
+        "attribute-access",
+        "attribute-write",
+        "subscript-access",
+        "subscript-write",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [
+        obj_inner,
+        obj_inner_name,
+        ys_i,
+        xs_ys_i,
+    ]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [
+        (2, 4),
+        (2, 4),
+        (3, 7),
+        (3, 4),
+    ]
+    assert [locus["argTerm"] for locus in loci].count(obj_inner) == 1
+    assert [locus["argTerm"] for locus in loci].count(ys_i) == 1
+
+
+def test_no_value_annassign_evaluates_receiver_but_not_final_attribute() -> None:
+    source = "def f(make):\n    make().name: int\n    return 0\n"
+
+    result = lift_source(source, "annassign_receiver_call.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    assert contract["effects"] == [{"kind": "unresolved_call", "name": "make"}]
+    assert contract.get("panicLoci", []) == []
+
+
+def test_compile_lift_roundtrip_preserves_attribute_annassign_body_with_value() -> None:
+    source = "def f(obj, y):\n    obj.name: int = y\n    return obj\n"
+    lifted = lift_source(source, "roundtrip_ann_attr_value.py")
+    assert lifted.refusals == []
+    contract = _contract(lifted.ir, ".f")
+    body = contract["post"]["args"][1]
+
+    compiled = compile_body_term(
+        body,
+        fn_name="f",
+        formals=[str(formal) for formal in contract["formals"]],
+    )
+    relifted = lift_source(compiled, "roundtrip_ann_attr_value.py")
+    assert relifted.refusals == []
+    relifted_body = _contract(relifted.ir, ".f")["post"]["args"][1]
+
+    assert canonical_json_bytes(relifted_body) == canonical_json_bytes(body)
+
+
+def test_compile_lift_roundtrip_preserves_attribute_annassign_body_without_value() -> None:
+    source = "def f(obj):\n    obj.name: int\n    return obj\n"
+    lifted = lift_source(source, "roundtrip_ann_attr_no_value.py")
+    assert lifted.refusals == []
+    contract = _contract(lifted.ir, ".f")
+    body = contract["post"]["args"][1]
+
+    compiled = compile_body_term(
+        body,
+        fn_name="f",
+        formals=[str(formal) for formal in contract["formals"]],
+    )
+    relifted = lift_source(compiled, "roundtrip_ann_attr_no_value.py")
     assert relifted.refusals == []
     relifted_body = _contract(relifted.ir, ".f")["post"]["args"][1]
 

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -142,6 +142,10 @@ def _none_const() -> dict[str, object]:
     }
 
 
+def _no_value() -> dict[str, object]:
+    return {"kind": "ctor", "name": "python:no_value", "args": []}
+
+
 def _aug_assign(
     target: dict[str, object], op: str, value: dict[str, object]
 ) -> dict[str, object]:
@@ -876,7 +880,7 @@ def test_name_annassign_without_value_has_no_runtime_failure_loci_or_effects() -
     assert contract["effects"] == []
     assert contract.get("panicLoci", []) == []
     assert body["name"] == "python:seq"
-    assert body["args"][0] == _ann_assign(_var("x"), _var("int"), _none_const())
+    assert body["args"][0] == _ann_assign(_var("x"), _var("int"), _no_value())
 
 
 def test_name_annassign_with_value_has_no_runtime_failure_loci_or_effects() -> None:
@@ -903,7 +907,7 @@ def test_direct_attribute_annassign_without_value_does_not_access_final_attribut
     target = _attr(_var("obj"), "name")
     assert contract["effects"] == []
     assert contract.get("panicLoci", []) == []
-    assert body["args"][0] == _ann_assign(target, _var("int"), _none_const())
+    assert body["args"][0] == _ann_assign(target, _var("int"), _no_value())
 
 
 def test_direct_attribute_annassign_with_value_emits_store_write_locus_only() -> None:
@@ -938,7 +942,7 @@ def test_direct_subscript_annassign_without_value_does_not_access_final_subscrip
     target = _subscript(_var("xs"), _var("key"))
     assert contract["effects"] == []
     assert contract.get("panicLoci", []) == []
-    assert body["args"][0] == _ann_assign(target, _var("int"), _none_const())
+    assert body["args"][0] == _ann_assign(target, _var("int"), _no_value())
 
 
 def test_direct_subscript_annassign_with_value_emits_store_write_locus_only() -> None:
@@ -987,11 +991,27 @@ def test_nested_annassign_without_value_emits_only_intermediate_navigation_loci(
     assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 4), (3, 7)]
     statements = body["args"][0]["args"]
     assert statements[0] == _ann_assign(
-        _attr(obj_inner, "name"), _var("int"), _none_const()
+        _attr(obj_inner, "name"), _var("int"), _no_value()
     )
     assert statements[1] == _ann_assign(
-        _subscript(_var("xs"), ys_i), _var("int"), _none_const()
+        _subscript(_var("xs"), ys_i), _var("int"), _no_value()
     )
+
+
+def test_annassign_missing_value_and_explicit_none_have_distinct_body_terms() -> None:
+    source = "def f():\n    missing: int\n    explicit: int = None\n    return explicit\n"
+
+    result = lift_source(source, "annassign_none_discrimination.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    body = contract["post"]["args"][1]
+    statements = body["args"][0]["args"]
+    missing = _ann_assign(_var("missing"), _var("int"), _no_value())
+    explicit_none = _ann_assign(_var("explicit"), _var("int"), _none_const())
+    assert statements[0] == missing
+    assert statements[1] == explicit_none
+    assert missing != explicit_none
 
 
 def test_nested_annassign_with_value_reuses_store_target_navigation_once() -> None:
@@ -1085,6 +1105,46 @@ def test_compile_lift_roundtrip_preserves_attribute_annassign_body_without_value
     relifted_body = _contract(relifted.ir, ".f")["post"]["args"][1]
 
     assert canonical_json_bytes(relifted_body) == canonical_json_bytes(body)
+
+
+def test_compile_lift_roundtrip_preserves_name_annassign_without_value() -> None:
+    source = "def f():\n    x: int\n    return 0\n"
+    lifted = lift_source(source, "roundtrip_ann_name_no_value.py")
+    assert lifted.refusals == []
+    contract = _contract(lifted.ir, ".f")
+    body = contract["post"]["args"][1]
+
+    compiled = compile_body_term(
+        body,
+        fn_name="f",
+        formals=[str(formal) for formal in contract["formals"]],
+    )
+    relifted = lift_source(compiled, "roundtrip_ann_name_no_value.py")
+    assert relifted.refusals == []
+    relifted_body = _contract(relifted.ir, ".f")["post"]["args"][1]
+
+    assert canonical_json_bytes(relifted_body) == canonical_json_bytes(body)
+    assert "x: int = None" not in compiled
+
+
+def test_compile_lift_roundtrip_preserves_name_annassign_explicit_none_value() -> None:
+    source = "def f():\n    x: int = None\n    return x\n"
+    lifted = lift_source(source, "roundtrip_ann_name_explicit_none.py")
+    assert lifted.refusals == []
+    contract = _contract(lifted.ir, ".f")
+    body = contract["post"]["args"][1]
+
+    compiled = compile_body_term(
+        body,
+        fn_name="f",
+        formals=[str(formal) for formal in contract["formals"]],
+    )
+    relifted = lift_source(compiled, "roundtrip_ann_name_explicit_none.py")
+    assert relifted.refusals == []
+    relifted_body = _contract(relifted.ir, ".f")["post"]["args"][1]
+
+    assert canonical_json_bytes(relifted_body) == canonical_json_bytes(body)
+    assert "x: int = None" in compiled
 
 
 def test_none_guarded_attribute_access_emits_one_runtime_failure_locus() -> None:

--- a/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
@@ -276,6 +276,52 @@ emits_signed_mementos = false
     project
 }
 
+fn stage_python_annassign_project(lift_script: &Path) -> PathBuf {
+    let project = unique_dir("annassign-project");
+    fs::write(
+        project.join("annassign.py"),
+        "def annotate(obj, xs, ys, i, key, value, make):\n    obj.name: int\n    xs[key]: int\n    obj.name: int = value\n    xs[key]: int = value\n    obj.inner.name: int\n    xs[ys[i]]: int\n    obj.inner.name: int = value\n    xs[ys[i]]: int = value\n    make().name: int\n    return value\n",
+    )
+    .expect("write annassign.py");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("python-source"))
+        .expect("mkdir .provekit/lift/python-source");
+    fs::write(
+        provekit.join("config.toml"),
+        r#"[[plugins]]
+name = "python-source"
+kind = "lift"
+surface = "python-source"
+"#,
+    )
+    .expect("write config.toml");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("python-source")
+            .join("manifest.toml"),
+        format!(
+            r#"name = "python-source"
+version = "0.1.0-draft"
+protocol_version = "provekit-lift/1"
+kind = "lift"
+command = ["{}", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["python-source"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+"#,
+            lift_script.display()
+        ),
+    )
+    .expect("write manifest.toml");
+
+    project
+}
+
 fn run_mint(project: &Path) {
     let out = Command::new(provekit_bin())
         .arg("mint")
@@ -866,6 +912,216 @@ fn python_source_augassign_mint_preserves_runtime_failure_loci_and_enumerates_ca
             (Some(5), true),
         ],
         "no bridges exist yet, so surfaced AugAssign callsites must remain undecidable"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn python_source_annassign_mint_preserves_runtime_failure_loci_and_enumerates_callsites() {
+    if !python_available() {
+        eprintln!(
+            "python3 not on PATH: skipping python-source AnnAssign runtime-failure mint test"
+        );
+        return;
+    }
+    let lift_script = build_python_lift_source();
+    let project = stage_python_annassign_project(&lift_script);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "python-source AnnAssign proof must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let loci = contract_runtime_failure_loci(&pool);
+    assert_eq!(
+        loci,
+        vec![
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-write",
+                "exceptionClass": "AttributeError",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:attribute",
+                    "args": [
+                        {"kind": "var", "name": "obj"},
+                        {"kind": "const", "value": "name", "sort": {"kind": "primitive", "name": "String"}}
+                    ]
+                },
+                "file": "annassign.py",
+                "line": 4,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:subscript",
+                    "args": [
+                        {"kind": "var", "name": "xs"},
+                        {"kind": "var", "name": "key"}
+                    ]
+                },
+                "file": "annassign.py",
+                "line": 5,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:attribute",
+                    "args": [
+                        {"kind": "var", "name": "obj"},
+                        {"kind": "const", "value": "inner", "sort": {"kind": "primitive", "name": "String"}}
+                    ]
+                },
+                "file": "annassign.py",
+                "line": 6,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:subscript",
+                    "args": [
+                        {"kind": "var", "name": "ys"},
+                        {"kind": "var", "name": "i"}
+                    ]
+                },
+                "file": "annassign.py",
+                "line": 7,
+                "col": 7
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:attribute",
+                    "args": [
+                        {"kind": "var", "name": "obj"},
+                        {"kind": "const", "value": "inner", "sort": {"kind": "primitive", "name": "String"}}
+                    ]
+                },
+                "file": "annassign.py",
+                "line": 8,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-write",
+                "exceptionClass": "AttributeError",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:attribute",
+                    "args": [
+                        {
+                            "kind": "ctor",
+                            "name": "python:attribute",
+                            "args": [
+                                {"kind": "var", "name": "obj"},
+                                {"kind": "const", "value": "inner", "sort": {"kind": "primitive", "name": "String"}}
+                            ]
+                        },
+                        {"kind": "const", "value": "name", "sort": {"kind": "primitive", "name": "String"}}
+                    ]
+                },
+                "file": "annassign.py",
+                "line": 8,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:subscript",
+                    "args": [
+                        {"kind": "var", "name": "ys"},
+                        {"kind": "var", "name": "i"}
+                    ]
+                },
+                "file": "annassign.py",
+                "line": 9,
+                "col": 7
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "python:subscript",
+                    "args": [
+                        {"kind": "var", "name": "xs"},
+                        {
+                            "kind": "ctor",
+                            "name": "python:subscript",
+                            "args": [
+                                {"kind": "var", "name": "ys"},
+                                {"kind": "var", "name": "i"}
+                            ]
+                        }
+                    ]
+                },
+                "file": "annassign.py",
+                "line": 9,
+                "col": 4
+            }),
+        ],
+        "mint must preserve python-source AnnAssign runtime-failure panicLoci rows"
+    );
+
+    let callsites = provekit_verifier::enumerate_callsites::run(&pool);
+    let runtime_failure_sites: Vec<_> = callsites
+        .iter()
+        .filter(|cs| cs.panic_site && cs.callee.as_deref() == Some(RUNTIME_FAILURE_SITE_CONCEPT))
+        .collect();
+    assert_eq!(
+        runtime_failure_sites.len(),
+        8,
+        "verifier must surface exactly eight AnnAssign runtime-failure obligations; got {callsites:#?}"
+    );
+    assert!(
+        runtime_failure_sites
+            .iter()
+            .all(|cs| cs.file.as_deref() == Some("annassign.py")),
+        "all surfaced AnnAssign callsites must preserve annassign.py provenance: {runtime_failure_sites:#?}"
+    );
+    assert_eq!(
+        runtime_failure_sites
+            .iter()
+            .map(|cs| (cs.line, cs.bridge_target_cid.is_empty()))
+            .collect::<Vec<_>>(),
+        vec![
+            (Some(4), true),
+            (Some(5), true),
+            (Some(6), true),
+            (Some(7), true),
+            (Some(8), true),
+            (Some(8), true),
+            (Some(9), true),
+            (Some(9), true),
+        ],
+        "no bridges exist yet, so surfaced AnnAssign callsites must remain undecidable"
     );
 
     let _ = fs::remove_dir_all(&project);


### PR DESCRIPTION
## Summary

Slice 7 of the #1837 python-source runtime-failure expansion adds `ast.AnnAssign` support in the Python source kit.

- Lift `Name`, `Attribute`, and `Subscript` annotated assignment targets.
- Emit `python:ann_assign(target, annotation, value_or_no_value)` with the annotation preserved as a syntax-only term for compile-lift roundtrip.
- Use `python:no_value()` as the missing-RHS sentinel so `x: int` remains distinct from explicit `x: int = None`.
- Compile `python:ann_assign` back through `ast.AnnAssign`.
- Extend the config/manifest-driven CLI mint integration fixture to prove AnnAssign panic loci travel through RPC and into verifier callsite enumeration.

## Bytecode basis

The emission shape follows CPython behavior rather than treating annotations like normal reads.

- `obj.name: int` in function scope evaluates `obj` and does not perform the final `.name` access.
- `xs[key]: int` evaluates the container/index expressions needed by the target shape, but does not perform a final subscript access.
- Nested no-value targets emit only intermediate navigation loci, for example `obj.inner.name: int` emits the `obj.inner` access but not a final `.name` access.
- With-value AnnAssign mirrors Store target semantics: direct attribute/subscript emits write only, and nested targets emit intermediate Load loci plus the final Store write.

This is why the new integration fixture intentionally has no runtime-failure loci for direct no-value `obj.name: int`, direct no-value `xs[key]: int`, or `make().name: int` final access. The receiver expression is evaluated; the final access is not.

## Scope

- Python kit owns Python AST/runtime semantics.
- The Rust CLI integration remains manifest/config driven and speaks RPC to the Python kit.
- No verifier, libprovekit, doctor, or CLI source changes.
- #1841 remains the follow-up for the pre-existing Assign/AnnAssign target-vs-RHS locus ordering issue.

## Review fix

Codex caught that explicit `x: int = None` previously collapsed to the same body term as missing `x: int`. The fix introduces `python:no_value()` for missing RHS only. Explicit `None` remains the normal `none_const()`, so compile-lift roundtrip preserves both forms distinctly.

## Validation

- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q -k annassign` - 14 passed
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q` - 56 passed
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests -q` - 145 passed
- `rustfmt --edition 2021 --check implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs`
- `git diff --check`
- path-scope grep for verifier/libprovekit/CLI-src leakage - no matches
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_mint_python_source_runtime_failure -- --nocapture` - 5 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture` - 6 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_verify_python_production_bridge --test cmd_verify_python_division_unsound -- --nocapture` - 5 passed + 2 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo run -p provekit-cli -- doctor --target ../python --mode strict --json` - `ok: true`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc -p provekit-lift --bin provekit-lift`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` - 1 passed in 115.68s after the review fix
