### PR TITLE
[codex] python-source supports plain Assign Store slice subscripts (#1837 slice 8)

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/compiler.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/compiler.py
@@ -172,8 +172,19 @@ def _expr(term: Json) -> ast.expr:
     if name == "python:attribute":
         return ast.Attribute(value=_expr(args[0]), attr=_const_string(args[1]), ctx=ast.Load())
     if name == "python:subscript":
-        return ast.Subscript(value=_expr(args[0]), slice=_expr(args[1]), ctx=ast.Load())
+        return ast.Subscript(value=_expr(args[0]), slice=_slice_or_expr(args[1]), ctx=ast.Load())
     raise ValueError(f"unsupported python operation in expression position: {name}")
+
+
+def _slice_or_expr(term: Json) -> ast.expr | ast.slice:
+    if _name(term) == "python:slice":
+        args = term.get("args", [])
+        return ast.Slice(
+            lower=None if _is_none_const(args[0]) else _expr(args[0]),
+            upper=None if _is_none_const(args[1]) else _expr(args[1]),
+            step=None if _is_none_const(args[2]) else _expr(args[2]),
+        )
+    return _expr(term)
 
 
 def _target(term: Json) -> ast.expr:

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -277,7 +277,7 @@ class _Emitter:
         if isinstance(node, ast.Assign):
             if len(node.targets) != 1:
                 raise _UnsupportedSyntax(node, "multiple-target assignment is refused")
-            target = self.target(node.targets[0])
+            target = self.assign_target(node.targets[0])
             self._record_write_if_nonlocal(node.targets[0])
             return ctor("python:assign", target, self.expr(node.value))
         if isinstance(node, ast.AugAssign):
@@ -407,6 +407,24 @@ class _Emitter:
             )
             return term
         raise _UnsupportedSyntax(node, f"unsupported assignment target: {type(node).__name__}")
+
+    def assign_target(self, node: ast.expr) -> Json:
+        if isinstance(node, ast.Subscript) and isinstance(node.slice, ast.Slice):
+            term = ctor(
+                "python:subscript",
+                self.expr(node.value),
+                self.slice_index(node.slice),
+            )
+            self.effects.add_panics()
+            self.panic_loci.append(
+                self.runtime_failure_locus(
+                    node,
+                    term,
+                    subkind="subscript-write",
+                )
+            )
+            return term
+        return self.target(node)
 
     def augassign_target(self, node: ast.expr) -> Json:
         if isinstance(node, ast.Name):
@@ -599,6 +617,12 @@ class _Emitter:
         if isinstance(node.slice, ast.Slice):
             raise _UnsupportedSyntax(node.slice, "slice subscripts are refused")
         return self.expr(node.slice)
+
+    def slice_index(self, node: ast.Slice) -> Json:
+        lower = none_const() if node.lower is None else self.expr(node.lower)
+        upper = none_const() if node.upper is None else self.expr(node.upper)
+        step = none_const() if node.step is None else self.expr(node.step)
+        return ctor("python:slice", lower, upper, step)
 
     def none_guarded_if(
         self,

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -134,6 +134,14 @@ def _subscript(value: dict[str, object], index: dict[str, object]) -> dict[str, 
     return {"kind": "ctor", "name": "python:subscript", "args": [value, index]}
 
 
+def _slice(
+    lower: dict[str, object],
+    upper: dict[str, object],
+    step: dict[str, object],
+) -> dict[str, object]:
+    return {"kind": "ctor", "name": "python:slice", "args": [lower, upper, step]}
+
+
 def _none_const() -> dict[str, object]:
     return {
         "kind": "const",
@@ -693,6 +701,223 @@ def test_nested_attribute_and_subscript_store_targets_resurface_load_loci() -> N
             "col": 4,
         },
     ]
+
+
+def test_slice_assign_emits_subscript_write_runtime_failure_locus() -> None:
+    source = "def f(xs, a, b, value):\n    xs[a:b] = value\n    return xs\n"
+
+    result = lift_source(source, "slice_assign.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    target = _subscript(_var("xs"), _slice(_var("a"), _var("b"), _none_const()))
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "xs[a:b]"},
+        {"kind": "panics"},
+    ]
+    assert _runtime_failure_loci(contract) == [
+        {
+            "effectKind": PANIC_FREEDOM_EFFECT_KIND,
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "subscript-write",
+            "argTerm": target,
+            "file": "slice_assign.py",
+            "line": 2,
+            "col": 4,
+        }
+    ]
+    assert body["args"][0] == {
+        "kind": "ctor",
+        "name": "python:assign",
+        "args": [target, _var("value")],
+    }
+
+
+@pytest.mark.parametrize(
+    ("source_target", "expected_target", "expected_write"),
+    [
+        (
+            "xs[a:b:c]",
+            _subscript(_var("xs"), _slice(_var("a"), _var("b"), _var("c"))),
+            "xs[a:b:c]",
+        ),
+        (
+            "xs[:b]",
+            _subscript(_var("xs"), _slice(_none_const(), _var("b"), _none_const())),
+            "xs[:b]",
+        ),
+        (
+            "xs[a:]",
+            _subscript(_var("xs"), _slice(_var("a"), _none_const(), _none_const())),
+            "xs[a:]",
+        ),
+        (
+            "xs[:]",
+            _subscript(_var("xs"), _slice(_none_const(), _none_const(), _none_const())),
+            "xs[:]",
+        ),
+    ],
+)
+def test_slice_assign_preserves_slice_shape_in_body_and_locus(
+    source_target: str,
+    expected_target: dict[str, object],
+    expected_write: str,
+) -> None:
+    source = f"def f(xs, a, b, c, value):\n    {source_target} = value\n    return xs\n"
+
+    result = lift_source(source, "slice_assign_shape.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [
+        {"kind": "writes", "target": expected_write},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == ["subscript-write"]
+    assert [locus["argTerm"] for locus in loci] == [expected_target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 4)]
+    assert "exceptionClass" not in loci[0]
+    assert body["args"][0] == {
+        "kind": "ctor",
+        "name": "python:assign",
+        "args": [expected_target, _var("value")],
+    }
+
+
+def test_nested_slice_assign_receiver_emits_intermediate_access_and_slice_write() -> None:
+    source = "def f(obj, a, b, value):\n    obj.inner[a:b] = value\n    return obj\n"
+
+    result = lift_source(source, "nested_slice_assign.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    obj_inner = _attr(_var("obj"), "inner")
+    target = _subscript(obj_inner, _slice(_var("a"), _var("b"), _none_const()))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "obj.inner[a:b]"},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == [
+        "attribute-access",
+        "subscript-write",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [obj_inner, target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 4), (2, 4)]
+    assert loci[0]["exceptionClass"] == "AttributeError"
+    assert "exceptionClass" not in loci[1]
+    assert body["args"][0] == {
+        "kind": "ctor",
+        "name": "python:assign",
+        "args": [target, _var("value")],
+    }
+
+
+def test_slice_assign_bound_expressions_resurface_load_loci_before_slice_write() -> None:
+    source = "def f(xs, obj, value):\n    xs[obj.i:obj.j] = value\n    return xs\n"
+
+    result = lift_source(source, "slice_assign_bounds.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    obj_i = _attr(_var("obj"), "i")
+    obj_j = _attr(_var("obj"), "j")
+    target = _subscript(_var("xs"), _slice(obj_i, obj_j, _none_const()))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "xs[obj.i:obj.j]"},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == [
+        "attribute-access",
+        "attribute-access",
+        "subscript-write",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [obj_i, obj_j, target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [
+        (2, 7),
+        (2, 13),
+        (2, 4),
+    ]
+    assert [locus.get("exceptionClass") for locus in loci] == [
+        "AttributeError",
+        "AttributeError",
+        None,
+    ]
+    assert body["args"][0] == {
+        "kind": "ctor",
+        "name": "python:assign",
+        "args": [target, _var("value")],
+    }
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "def f(xs, a, b, value):\n    xs[a:b] = value\n    return xs\n",
+        "def f(xs, a, b, value):\n    xs[:b] = value\n    xs[a:] = value\n    xs[:] = value\n    return xs\n",
+        "def f(xs, a, b, c, value):\n    xs[a:b:c] = value\n    return xs\n",
+    ],
+)
+def test_compile_lift_roundtrip_preserves_slice_assign_body(source: str) -> None:
+    lifted = lift_source(source, "roundtrip_slice_assign.py")
+    assert lifted.refusals == []
+    contract = _contract(lifted.ir, ".f")
+    body = contract["post"]["args"][1]
+
+    compiled = compile_body_term(
+        body,
+        fn_name="f",
+        formals=[str(formal) for formal in contract["formals"]],
+    )
+    relifted = lift_source(compiled, "roundtrip_slice_assign.py")
+    assert relifted.refusals == []
+    relifted_body = _contract(relifted.ir, ".f")["post"]["args"][1]
+
+    assert canonical_json_bytes(relifted_body) == canonical_json_bytes(body)
+
+
+@pytest.mark.parametrize(
+    ("source", "module", "function_name"),
+    [
+        (
+            "def f(xs, a, b):\n    value = xs[a:b]\n    return value\n",
+            "slice_load_refusal.py",
+            "slice_load_refusal.f",
+        ),
+        (
+            "def f(xs, a, b, value):\n    xs[a:b] += value\n    return xs\n",
+            "slice_augassign_refusal.py",
+            "slice_augassign_refusal.f",
+        ),
+        (
+            "def f(xs, a, b, value):\n    xs[a:b]: int = value\n    return xs\n",
+            "slice_annassign_refusal.py",
+            "slice_annassign_refusal.f",
+        ),
+    ],
+)
+def test_non_assign_slice_subscripts_remain_refused_for_slice_8_scope(
+    source: str,
+    module: str,
+    function_name: str,
+) -> None:
+    result = lift_source(source, module)
+
+    assert result.refusals == [
+        {
+            "kind": "unhandled-syntax",
+            "function": function_name,
+            "line": 2,
+            "reason": "slice subscripts are refused",
+        }
+    ]
+    assert len(result.ir) == 1
 
 
 def test_name_augassign_lifts_to_aug_assign_without_runtime_failure_loci() -> None:

--- a/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
@@ -230,6 +230,52 @@ emits_signed_mementos = false
     project
 }
 
+fn stage_python_slice_assign_project(lift_script: &Path) -> PathBuf {
+    let project = unique_dir("slice-assign-project");
+    fs::write(
+        project.join("slice.py"),
+        "def slice_write(obj, xs, a, b, c, value):\n    xs[a:b] = value\n    xs[a:b:c] = value\n    xs[:b] = value\n    xs[a:] = value\n    xs[:] = value\n    obj.inner[a:b] = value\n    xs[obj.i:obj.j] = value\n    return value\n",
+    )
+    .expect("write slice.py");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("python-source"))
+        .expect("mkdir .provekit/lift/python-source");
+    fs::write(
+        provekit.join("config.toml"),
+        r#"[[plugins]]
+name = "python-source"
+kind = "lift"
+surface = "python-source"
+"#,
+    )
+    .expect("write config.toml");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("python-source")
+            .join("manifest.toml"),
+        format!(
+            r#"name = "python-source"
+version = "0.1.0-draft"
+protocol_version = "provekit-lift/1"
+kind = "lift"
+command = ["{}", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["python-source"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+"#,
+            lift_script.display()
+        ),
+    )
+    .expect("write manifest.toml");
+
+    project
+}
+
 fn stage_python_augassign_project(lift_script: &Path) -> PathBuf {
     let project = unique_dir("augassign-project");
     fs::write(
@@ -349,6 +395,30 @@ fn contract_runtime_failure_loci(pool: &provekit_verifier::types::MementoPool) -
         .filter_map(|value| value.as_array())
         .flat_map(|items| items.iter().cloned())
         .collect()
+}
+
+fn ir_var(name: &str) -> Json {
+    json!({"kind": "var", "name": name})
+}
+
+fn ir_str(value: &str) -> Json {
+    json!({"kind": "const", "value": value, "sort": {"kind": "primitive", "name": "String"}})
+}
+
+fn ir_none() -> Json {
+    json!({"kind": "const", "value": null, "sort": {"kind": "primitive", "name": "Unit"}})
+}
+
+fn ir_attr(value: Json, name: &str) -> Json {
+    json!({"kind": "ctor", "name": "python:attribute", "args": [value, ir_str(name)]})
+}
+
+fn ir_slice(lower: Json, upper: Json, step: Json) -> Json {
+    json!({"kind": "ctor", "name": "python:slice", "args": [lower, upper, step]})
+}
+
+fn ir_subscript(value: Json, index: Json) -> Json {
+    json!({"kind": "ctor", "name": "python:subscript", "args": [value, index]})
 }
 
 #[test]
@@ -654,6 +724,174 @@ fn python_source_store_mint_preserves_runtime_failure_loci_and_enumerates_callsi
             (Some(5), true),
         ],
         "no bridges exist yet, so surfaced store callsites must remain undecidable"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn python_source_slice_assign_mint_preserves_runtime_failure_loci_and_enumerates_callsites() {
+    if !python_available() {
+        eprintln!(
+            "python3 not on PATH: skipping python-source slice Assign runtime-failure mint test"
+        );
+        return;
+    }
+    let lift_script = build_python_lift_source();
+    let project = stage_python_slice_assign_project(&lift_script);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "python-source slice Assign proof must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let obj_inner = ir_attr(ir_var("obj"), "inner");
+    let obj_i = ir_attr(ir_var("obj"), "i");
+    let obj_j = ir_attr(ir_var("obj"), "j");
+    let loci = contract_runtime_failure_loci(&pool);
+    assert_eq!(
+        loci,
+        vec![
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_var("a"), ir_var("b"), ir_none())),
+                "file": "slice.py",
+                "line": 2,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_var("a"), ir_var("b"), ir_var("c"))),
+                "file": "slice.py",
+                "line": 3,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_none(), ir_var("b"), ir_none())),
+                "file": "slice.py",
+                "line": 4,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_var("a"), ir_none(), ir_none())),
+                "file": "slice.py",
+                "line": 5,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_none(), ir_none(), ir_none())),
+                "file": "slice.py",
+                "line": 6,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": obj_inner,
+                "file": "slice.py",
+                "line": 7,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(
+                    ir_attr(ir_var("obj"), "inner"),
+                    ir_slice(ir_var("a"), ir_var("b"), ir_none())
+                ),
+                "file": "slice.py",
+                "line": 7,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": obj_i,
+                "file": "slice.py",
+                "line": 8,
+                "col": 7
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": obj_j,
+                "file": "slice.py",
+                "line": 8,
+                "col": 13
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(
+                    ir_var("xs"),
+                    ir_slice(ir_attr(ir_var("obj"), "i"), ir_attr(ir_var("obj"), "j"), ir_none())
+                ),
+                "file": "slice.py",
+                "line": 8,
+                "col": 4
+            }),
+        ],
+        "mint must preserve python-source slice Assign runtime-failure panicLoci rows"
+    );
+
+    let callsites = provekit_verifier::enumerate_callsites::run(&pool);
+    let runtime_failure_sites: Vec<_> = callsites
+        .iter()
+        .filter(|cs| cs.panic_site && cs.callee.as_deref() == Some(RUNTIME_FAILURE_SITE_CONCEPT))
+        .collect();
+    assert_eq!(
+        runtime_failure_sites.len(),
+        10,
+        "verifier must surface exactly ten slice Assign runtime-failure obligations; got {callsites:#?}"
+    );
+    assert!(
+        runtime_failure_sites
+            .iter()
+            .all(|cs| cs.file.as_deref() == Some("slice.py")),
+        "all surfaced slice Assign callsites must preserve slice.py provenance: {runtime_failure_sites:#?}"
+    );
+    assert_eq!(
+        runtime_failure_sites
+            .iter()
+            .map(|cs| (cs.line, cs.bridge_target_cid.is_empty()))
+            .collect::<Vec<_>>(),
+        vec![
+            (Some(2), true),
+            (Some(3), true),
+            (Some(4), true),
+            (Some(5), true),
+            (Some(6), true),
+            (Some(7), true),
+            (Some(7), true),
+            (Some(8), true),
+            (Some(8), true),
+            (Some(8), true),
+        ],
+        "no bridges exist yet, so surfaced slice Assign callsites must remain undecidable"
     );
 
     let _ = fs::remove_dir_all(&project);


### PR DESCRIPTION
## Summary

Slice 8 of the #1828 Python substrate expansion arc, tracked under #1837. The python-source lifter now supports plain `Assign` Store slice targets like `xs[a:b] = value`, `xs[a:b:c] = value`, and omitted-bound variants by emitting `python:subscript(receiver, python:slice(lower_or_none, upper_or_none, step_or_none))` with the existing `subscript-write` panic locus.

This stays kit-side. There are no verifier, doctor, libprovekit, or CLI production-code changes, and no declaration change. The existing `python:subscript` concept still covers the runtime-failure surface.

Empirical Python bytecode shape from the slice 8 inspection:

- `xs[a:b] = value` evaluates the RHS, receiver, lower, and upper, then uses `STORE_SLICE`.
- `xs[a:b:c] = value` builds a slice object and uses `STORE_SUBSCR`.
- Receiver navigation like `obj.inner[a:b] = value` and bound expressions like `xs[obj.i:obj.j] = value` surface their normal attribute-access load loci before the final slice write locus.

Out of scope is explicit and pinned: Load slice, AugAssign slice, and AnnAssign slice still refuse with `slice subscripts are refused`. Locus ordering continues to follow the current Assign path; #1841 tracks the broader ordering issue separately.

Closes #1837.

## Validation

- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q -k slice` => 13 passed
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q` => 69 passed
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests -q` => 158 passed
- `rustfmt --edition 2021 --check implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs` => pass
- `git diff --check` => pass
- Precise grep over CLI/libprovekit/verifier for `python:slice`, `slice subscripts`, `Slice`, `subscript-write` => no matches
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_mint_python_source_runtime_failure -- --nocapture` => 6 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc --test cmd_verify_python_production_bridge --test cmd_verify_python_division_unsound -- --nocapture` => 6 + 5 + 2 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo run -p provekit-cli -- doctor --target ../python --mode strict --json` => `ok: true`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc` => pass
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-lift --bin provekit-lift` => pass
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` => 1 passed in 116.53s
