### PR TITLE
[codex] python-source supports Load slice subscripts (#1837 slice 9)

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -549,7 +549,9 @@ class _Emitter:
             )
             return term
         if isinstance(node, ast.Subscript):
-            term = ctor("python:subscript", self.expr(node.value), self.subscript_index(node))
+            receiver = self.expr(node.value)
+            index = self.slice_index(node.slice) if isinstance(node.slice, ast.Slice) else self.subscript_index(node)
+            term = ctor("python:subscript", receiver, index)
             self.effects.add_panics()
             self.panic_loci.append(
                 self.runtime_failure_locus(

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -510,6 +510,211 @@ def test_subscript_load_emits_runtime_failure_locus_and_panics_effect() -> None:
     ]
 
 
+def test_slice_load_emits_subscript_access_runtime_failure_locus() -> None:
+    source = "def f(xs, a, b):\n    value = xs[a:b]\n    return value\n"
+
+    result = lift_source(source, "slice_access.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    target = _subscript(_var("xs"), _slice(_var("a"), _var("b"), _none_const()))
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert _runtime_failure_loci(contract) == [
+        {
+            "effectKind": PANIC_FREEDOM_EFFECT_KIND,
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "subscript-access",
+            "argTerm": target,
+            "file": "slice_access.py",
+            "line": 2,
+            "col": 12,
+        }
+    ]
+    assert body["args"][0] == {
+        "kind": "ctor",
+        "name": "python:assign",
+        "args": [_var("value"), target],
+    }
+
+
+@pytest.mark.parametrize(
+    ("source_expr", "expected_target"),
+    [
+        (
+            "xs[a:b:c]",
+            _subscript(_var("xs"), _slice(_var("a"), _var("b"), _var("c"))),
+        ),
+        (
+            "xs[:b]",
+            _subscript(_var("xs"), _slice(_none_const(), _var("b"), _none_const())),
+        ),
+        (
+            "xs[a:]",
+            _subscript(_var("xs"), _slice(_var("a"), _none_const(), _none_const())),
+        ),
+        (
+            "xs[:]",
+            _subscript(_var("xs"), _slice(_none_const(), _none_const(), _none_const())),
+        ),
+    ],
+)
+def test_slice_load_preserves_slice_shape_in_body_and_locus(
+    source_expr: str,
+    expected_target: dict[str, object],
+) -> None:
+    source = f"def f(xs, a, b, c):\n    value = {source_expr}\n    return value\n"
+
+    result = lift_source(source, "slice_access_shape.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert [locus["subkind"] for locus in loci] == ["subscript-access"]
+    assert [locus["argTerm"] for locus in loci] == [expected_target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 12)]
+    assert "exceptionClass" not in loci[0]
+    assert body["args"][0] == {
+        "kind": "ctor",
+        "name": "python:assign",
+        "args": [_var("value"), expected_target],
+    }
+
+
+def test_nested_slice_load_receiver_emits_intermediate_access_and_slice_access() -> None:
+    source = "def f(obj, a, b):\n    value = obj.inner[a:b]\n    return value\n"
+
+    result = lift_source(source, "nested_slice_access.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    obj_inner = _attr(_var("obj"), "inner")
+    target = _subscript(obj_inner, _slice(_var("a"), _var("b"), _none_const()))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert [locus["subkind"] for locus in loci] == [
+        "attribute-access",
+        "subscript-access",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [obj_inner, target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 12), (2, 12)]
+    assert loci[0]["exceptionClass"] == "AttributeError"
+    assert "exceptionClass" not in loci[1]
+    assert body["args"][0] == {
+        "kind": "ctor",
+        "name": "python:assign",
+        "args": [_var("value"), target],
+    }
+
+
+def test_slice_load_bound_expressions_resurface_load_loci_before_slice_access() -> None:
+    source = "def f(xs, obj):\n    value = xs[obj.i:obj.j]\n    return value\n"
+
+    result = lift_source(source, "slice_access_bounds.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    obj_i = _attr(_var("obj"), "i")
+    obj_j = _attr(_var("obj"), "j")
+    target = _subscript(_var("xs"), _slice(obj_i, obj_j, _none_const()))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert [locus["subkind"] for locus in loci] == [
+        "attribute-access",
+        "attribute-access",
+        "subscript-access",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [obj_i, obj_j, target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [
+        (2, 15),
+        (2, 21),
+        (2, 12),
+    ]
+    assert [locus.get("exceptionClass") for locus in loci] == [
+        "AttributeError",
+        "AttributeError",
+        None,
+    ]
+    assert body["args"][0] == {
+        "kind": "ctor",
+        "name": "python:assign",
+        "args": [_var("value"), target],
+    }
+
+
+def test_slice_load_receiver_is_evaluated_before_slice_bounds() -> None:
+    source = (
+        "def f(obj, other):\n"
+        "    value = obj.inner[other.i:other.j]\n"
+        "    return value\n"
+    )
+
+    result = lift_source(source, "slice_access_order.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    obj_inner = _attr(_var("obj"), "inner")
+    other_i = _attr(_var("other"), "i")
+    other_j = _attr(_var("other"), "j")
+    target = _subscript(obj_inner, _slice(other_i, other_j, _none_const()))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert [locus["subkind"] for locus in loci] == [
+        "attribute-access",
+        "attribute-access",
+        "attribute-access",
+        "subscript-access",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [
+        obj_inner,
+        other_i,
+        other_j,
+        target,
+    ]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [
+        (2, 12),
+        (2, 22),
+        (2, 30),
+        (2, 12),
+    ]
+    assert body["args"][0] == {
+        "kind": "ctor",
+        "name": "python:assign",
+        "args": [_var("value"), target],
+    }
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "def f(xs, a, b):\n    value = xs[a:b]\n    return value\n",
+        "def f(xs, a, b):\n    lower = xs[:b]\n    upper = xs[a:]\n    all_items = xs[:]\n    return all_items\n",
+        "def f(xs, a, b, c):\n    value = xs[a:b:c]\n    return value\n",
+    ],
+)
+def test_compile_lift_roundtrip_preserves_slice_load_body(source: str) -> None:
+    lifted = lift_source(source, "roundtrip_slice_access.py")
+    assert lifted.refusals == []
+    contract = _contract(lifted.ir, ".f")
+    body = contract["post"]["args"][1]
+
+    compiled = compile_body_term(
+        body,
+        fn_name="f",
+        formals=[str(formal) for formal in contract["formals"]],
+    )
+    relifted = lift_source(compiled, "roundtrip_slice_access.py")
+    assert relifted.refusals == []
+    relifted_body = _contract(relifted.ir, ".f")["post"]["args"][1]
+
+    assert canonical_json_bytes(relifted_body) == canonical_json_bytes(body)
+
+
 def test_mixed_runtime_failure_sites_share_deduped_panics_effect() -> None:
     source = (
         "def f(obj, xs, key):\n"
@@ -886,11 +1091,6 @@ def test_compile_lift_roundtrip_preserves_slice_assign_body(source: str) -> None
     ("source", "module", "function_name"),
     [
         (
-            "def f(xs, a, b):\n    value = xs[a:b]\n    return value\n",
-            "slice_load_refusal.py",
-            "slice_load_refusal.f",
-        ),
-        (
             "def f(xs, a, b, value):\n    xs[a:b] += value\n    return xs\n",
             "slice_augassign_refusal.py",
             "slice_augassign_refusal.f",
@@ -902,7 +1102,7 @@ def test_compile_lift_roundtrip_preserves_slice_assign_body(source: str) -> None
         ),
     ],
 )
-def test_non_assign_slice_subscripts_remain_refused_for_slice_8_scope(
+def test_non_load_or_assign_slice_subscripts_remain_refused_for_slice_9_scope(
     source: str,
     module: str,
     function_name: str,

--- a/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
@@ -276,6 +276,52 @@ emits_signed_mementos = false
     project
 }
 
+fn stage_python_slice_access_project(lift_script: &Path) -> PathBuf {
+    let project = unique_dir("slice-access-project");
+    fs::write(
+        project.join("slice_access.py"),
+        "def slice_read(obj, xs, a, b, c):\n    basic = xs[a:b]\n    stepped = xs[a:b:c]\n    lower = xs[:b]\n    upper = xs[a:]\n    all_items = xs[:]\n    nested = obj.inner[a:b]\n    bounded = xs[obj.i:obj.j]\n    return bounded\n",
+    )
+    .expect("write slice_access.py");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("python-source"))
+        .expect("mkdir .provekit/lift/python-source");
+    fs::write(
+        provekit.join("config.toml"),
+        r#"[[plugins]]
+name = "python-source"
+kind = "lift"
+surface = "python-source"
+"#,
+    )
+    .expect("write config.toml");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("python-source")
+            .join("manifest.toml"),
+        format!(
+            r#"name = "python-source"
+version = "0.1.0-draft"
+protocol_version = "provekit-lift/1"
+kind = "lift"
+command = ["{}", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["python-source"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+"#,
+            lift_script.display()
+        ),
+    )
+    .expect("write manifest.toml");
+
+    project
+}
+
 fn stage_python_augassign_project(lift_script: &Path) -> PathBuf {
     let project = unique_dir("augassign-project");
     fs::write(
@@ -892,6 +938,174 @@ fn python_source_slice_assign_mint_preserves_runtime_failure_loci_and_enumerates
             (Some(8), true),
         ],
         "no bridges exist yet, so surfaced slice Assign callsites must remain undecidable"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn python_source_slice_access_mint_preserves_runtime_failure_loci_and_enumerates_callsites() {
+    if !python_available() {
+        eprintln!(
+            "python3 not on PATH: skipping python-source slice Load runtime-failure mint test"
+        );
+        return;
+    }
+    let lift_script = build_python_lift_source();
+    let project = stage_python_slice_access_project(&lift_script);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "python-source slice Load proof must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let obj_inner = ir_attr(ir_var("obj"), "inner");
+    let obj_i = ir_attr(ir_var("obj"), "i");
+    let obj_j = ir_attr(ir_var("obj"), "j");
+    let loci = contract_runtime_failure_loci(&pool);
+    assert_eq!(
+        loci,
+        vec![
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_var("a"), ir_var("b"), ir_none())),
+                "file": "slice_access.py",
+                "line": 2,
+                "col": 12
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_var("a"), ir_var("b"), ir_var("c"))),
+                "file": "slice_access.py",
+                "line": 3,
+                "col": 14
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_none(), ir_var("b"), ir_none())),
+                "file": "slice_access.py",
+                "line": 4,
+                "col": 12
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_var("a"), ir_none(), ir_none())),
+                "file": "slice_access.py",
+                "line": 5,
+                "col": 12
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_none(), ir_none(), ir_none())),
+                "file": "slice_access.py",
+                "line": 6,
+                "col": 16
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": obj_inner,
+                "file": "slice_access.py",
+                "line": 7,
+                "col": 13
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": ir_subscript(
+                    ir_attr(ir_var("obj"), "inner"),
+                    ir_slice(ir_var("a"), ir_var("b"), ir_none())
+                ),
+                "file": "slice_access.py",
+                "line": 7,
+                "col": 13
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": obj_i,
+                "file": "slice_access.py",
+                "line": 8,
+                "col": 17
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": obj_j,
+                "file": "slice_access.py",
+                "line": 8,
+                "col": 23
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": ir_subscript(
+                    ir_var("xs"),
+                    ir_slice(ir_attr(ir_var("obj"), "i"), ir_attr(ir_var("obj"), "j"), ir_none())
+                ),
+                "file": "slice_access.py",
+                "line": 8,
+                "col": 14
+            }),
+        ],
+        "mint must preserve python-source slice Load runtime-failure panicLoci rows"
+    );
+
+    let callsites = provekit_verifier::enumerate_callsites::run(&pool);
+    let runtime_failure_sites: Vec<_> = callsites
+        .iter()
+        .filter(|cs| cs.panic_site && cs.callee.as_deref() == Some(RUNTIME_FAILURE_SITE_CONCEPT))
+        .collect();
+    assert_eq!(
+        runtime_failure_sites.len(),
+        10,
+        "verifier must surface exactly ten slice Load runtime-failure obligations; got {callsites:#?}"
+    );
+    assert!(
+        runtime_failure_sites
+            .iter()
+            .all(|cs| cs.file.as_deref() == Some("slice_access.py")),
+        "all surfaced slice Load callsites must preserve slice_access.py provenance: {runtime_failure_sites:#?}"
+    );
+    assert_eq!(
+        runtime_failure_sites
+            .iter()
+            .map(|cs| (cs.line, cs.bridge_target_cid.is_empty()))
+            .collect::<Vec<_>>(),
+        vec![
+            (Some(2), true),
+            (Some(3), true),
+            (Some(4), true),
+            (Some(5), true),
+            (Some(6), true),
+            (Some(7), true),
+            (Some(7), true),
+            (Some(8), true),
+            (Some(8), true),
+            (Some(8), true),
+        ],
+        "no bridges exist yet, so surfaced slice Load callsites must remain undecidable"
     );
 
     let _ = fs::remove_dir_all(&project);


### PR DESCRIPTION
## Summary

Slice 9 of the #1828 Python substrate expansion arc, tracked under #1837.

This adds plain Load slice subscript support to the Python source lifter:

- `value = xs[a:b]`
- `value = xs[a:b:c]`
- omitted lower, upper, and both bounds
- nested receivers like `obj.inner[a:b]`
- bound expressions like `xs[obj.i:obj.j]`

The implementation reuses the existing `python:slice` term shape from slice 8. There are no compiler changes and no declaration changes. The existing `python:subscript` concept covers Load and Store contexts.

## Semantic correction

This PR also fixes a real Load subscript ordering bug found during the slice 9 review loop. `expr(ast.Subscript)` now evaluates the receiver before the index or slice bounds, matching Python primary evaluation order.

The old ordering happened to pass simple tests:

- `xs[obj.i:obj.j]` had no receiver locus because `xs` is a name.
- `obj.inner[a:b]` had no bound loci because `a` and `b` are names.

The new RED->GREEN test pins the combined case `obj.inner[other.i:other.j]`, where the correct order is receiver locus first, then bound loci, then the outer subscript-access locus.

This is distinct from #1841, which tracks assignment target/RHS locus ordering. This PR is only about Load subscript receiver/index ordering.

## Bytecode note

Observed on Python 3.14.4:

- two-bound slice reads use `BINARY_SLICE`
- stepped slices use `BUILD_SLICE` plus `BINARY_OP []`
- omitted bounds lower through `None` constants or `slice(None, None, None)`

The lifter normalizes those source shapes to the same `python:slice(lower, upper, step)` term shape.

## Language boundary

The CLI remains language-blind. Python slice semantics stay in the Python kit. The Rust integration test uses project `config.toml` plus kit `manifest.toml`, starts the Python source lifter over RPC, mints the proof, and verifies the resulting runtime-failure callsites through the existing verifier surface.

Path-A grep over `implementations/rust/provekit-cli/src`, `implementations/rust/libprovekit`, and `implementations/rust/provekit-verifier` found zero Python slice semantic strings.

## Verification

- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q -k receiver_is_evaluated_before_slice_bounds` - 1 passed
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q -k slice` - 23 passed
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q` - 79 passed
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests -q` - 168 passed
- `rustfmt --edition 2021 --check implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs`
- `git diff --check`
- Path-A grep over CLI/libprovekit/verifier production Rust - zero matches
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_mint_python_source_runtime_failure -- --nocapture` - 7 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc --test cmd_verify_python_production_bridge --test cmd_verify_python_division_unsound -- --nocapture` - 6/5/2 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo run -p provekit-cli -- doctor --target ../python --mode strict --json` - `ok: true`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-lift --bin provekit-lift`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` - 1 passed in 118s
