### PR TITLE
[codex] python-source supports AugAssign slice subscripts (#1837 slice 10)

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -450,7 +450,9 @@ class _Emitter:
             )
             return term
         if isinstance(node, ast.Subscript):
-            term = ctor("python:subscript", self.expr(node.value), self.subscript_index(node))
+            receiver = self.expr(node.value)
+            index = self.slice_index(node.slice) if isinstance(node.slice, ast.Slice) else self.subscript_index(node)
+            term = ctor("python:subscript", receiver, index)
             self.effects.add_panics()
             self.panic_loci.append(
                 self.runtime_failure_locus(

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -1091,18 +1091,13 @@ def test_compile_lift_roundtrip_preserves_slice_assign_body(source: str) -> None
     ("source", "module", "function_name"),
     [
         (
-            "def f(xs, a, b, value):\n    xs[a:b] += value\n    return xs\n",
-            "slice_augassign_refusal.py",
-            "slice_augassign_refusal.f",
-        ),
-        (
             "def f(xs, a, b, value):\n    xs[a:b]: int = value\n    return xs\n",
             "slice_annassign_refusal.py",
             "slice_annassign_refusal.f",
         ),
     ],
 )
-def test_non_load_or_assign_slice_subscripts_remain_refused_for_slice_9_scope(
+def test_non_augassign_slice_subscripts_remain_refused_for_slice_10_scope(
     source: str,
     module: str,
     function_name: str,
@@ -1181,6 +1176,221 @@ def test_subscript_augassign_emits_access_and_write_runtime_failure_loci() -> No
     assert "exceptionClass" not in loci[0]
     assert "exceptionClass" not in loci[1]
     assert body["args"][0] == _aug_assign(target, "python:add", _var("y"))
+
+
+def test_slice_augassign_emits_access_and_write_runtime_failure_loci() -> None:
+    source = "def f(xs, a, b, value):\n    xs[a:b] += value\n    return xs\n"
+
+    result = lift_source(source, "slice_augassign.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    target = _subscript(_var("xs"), _slice(_var("a"), _var("b"), _none_const()))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "xs[a:b]"},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == [
+        "subscript-access",
+        "subscript-write",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [target, target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 4), (2, 4)]
+    assert "exceptionClass" not in loci[0]
+    assert "exceptionClass" not in loci[1]
+    assert body["args"][0] == _aug_assign(target, "python:add", _var("value"))
+
+
+@pytest.mark.parametrize(
+    ("source_target", "expected_target", "expected_write"),
+    [
+        (
+            "xs[a:b:c]",
+            _subscript(_var("xs"), _slice(_var("a"), _var("b"), _var("c"))),
+            "xs[a:b:c]",
+        ),
+        (
+            "xs[:b]",
+            _subscript(_var("xs"), _slice(_none_const(), _var("b"), _none_const())),
+            "xs[:b]",
+        ),
+        (
+            "xs[a:]",
+            _subscript(_var("xs"), _slice(_var("a"), _none_const(), _none_const())),
+            "xs[a:]",
+        ),
+        (
+            "xs[:]",
+            _subscript(_var("xs"), _slice(_none_const(), _none_const(), _none_const())),
+            "xs[:]",
+        ),
+    ],
+)
+def test_slice_augassign_preserves_slice_shape_in_body_and_locus(
+    source_target: str,
+    expected_target: dict[str, object],
+    expected_write: str,
+) -> None:
+    source = f"def f(xs, a, b, c, value):\n    {source_target} += value\n    return xs\n"
+
+    result = lift_source(source, "slice_augassign_shape.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [
+        {"kind": "writes", "target": expected_write},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == [
+        "subscript-access",
+        "subscript-write",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [expected_target, expected_target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 4), (2, 4)]
+    assert "exceptionClass" not in loci[0]
+    assert "exceptionClass" not in loci[1]
+    assert body["args"][0] == _aug_assign(expected_target, "python:add", _var("value"))
+
+
+def test_nested_slice_augassign_receiver_emits_intermediate_access_and_slice_loci() -> None:
+    source = "def f(obj, a, b, value):\n    obj.inner[a:b] += value\n    return obj\n"
+
+    result = lift_source(source, "nested_slice_augassign.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    obj_inner = _attr(_var("obj"), "inner")
+    target = _subscript(obj_inner, _slice(_var("a"), _var("b"), _none_const()))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "obj.inner[a:b]"},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == [
+        "attribute-access",
+        "subscript-access",
+        "subscript-write",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [obj_inner, target, target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 4), (2, 4), (2, 4)]
+    assert loci[0]["exceptionClass"] == "AttributeError"
+    assert "exceptionClass" not in loci[1]
+    assert "exceptionClass" not in loci[2]
+    assert body["args"][0] == _aug_assign(target, "python:add", _var("value"))
+
+
+def test_slice_augassign_bound_expressions_resurface_load_loci_before_slice_loci() -> None:
+    source = "def f(xs, obj, value):\n    xs[obj.i:obj.j] += value\n    return xs\n"
+
+    result = lift_source(source, "slice_augassign_bounds.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    obj_i = _attr(_var("obj"), "i")
+    obj_j = _attr(_var("obj"), "j")
+    target = _subscript(_var("xs"), _slice(obj_i, obj_j, _none_const()))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "xs[obj.i:obj.j]"},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == [
+        "attribute-access",
+        "attribute-access",
+        "subscript-access",
+        "subscript-write",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [obj_i, obj_j, target, target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [
+        (2, 7),
+        (2, 13),
+        (2, 4),
+        (2, 4),
+    ]
+    assert [locus.get("exceptionClass") for locus in loci] == [
+        "AttributeError",
+        "AttributeError",
+        None,
+        None,
+    ]
+    assert body["args"][0] == _aug_assign(target, "python:add", _var("value"))
+
+
+def test_slice_augassign_receiver_is_evaluated_before_slice_bounds() -> None:
+    source = (
+        "def f(obj, other, value):\n"
+        "    obj.inner[other.i:other.j] += value\n"
+        "    return obj\n"
+    )
+
+    result = lift_source(source, "slice_augassign_order.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    obj_inner = _attr(_var("obj"), "inner")
+    other_i = _attr(_var("other"), "i")
+    other_j = _attr(_var("other"), "j")
+    target = _subscript(obj_inner, _slice(other_i, other_j, _none_const()))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "obj.inner[other.i:other.j]"},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == [
+        "attribute-access",
+        "attribute-access",
+        "attribute-access",
+        "subscript-access",
+        "subscript-write",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [
+        obj_inner,
+        other_i,
+        other_j,
+        target,
+        target,
+    ]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [
+        (2, 4),
+        (2, 14),
+        (2, 22),
+        (2, 4),
+        (2, 4),
+    ]
+    assert body["args"][0] == _aug_assign(target, "python:add", _var("value"))
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "def f(xs, a, b, value):\n    xs[a:b] += value\n    return xs\n",
+        "def f(xs, a, b, value):\n    xs[:b] += value\n    xs[a:] += value\n    xs[:] += value\n    return xs\n",
+        "def f(xs, a, b, c, value):\n    xs[a:b:c] += value\n    return xs\n",
+    ],
+)
+def test_compile_lift_roundtrip_preserves_slice_augassign_body(source: str) -> None:
+    lifted = lift_source(source, "roundtrip_slice_augassign.py")
+    assert lifted.refusals == []
+    contract = _contract(lifted.ir, ".f")
+    body = contract["post"]["args"][1]
+
+    compiled = compile_body_term(
+        body,
+        fn_name="f",
+        formals=[str(formal) for formal in contract["formals"]],
+    )
+    relifted = lift_source(compiled, "roundtrip_slice_augassign.py")
+    assert relifted.refusals == []
+    relifted_body = _contract(relifted.ir, ".f")["post"]["args"][1]
+
+    assert canonical_json_bytes(relifted_body) == canonical_json_bytes(body)
 
 
 def test_nested_augassign_targets_evaluate_navigation_once() -> None:

--- a/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
@@ -322,6 +322,52 @@ emits_signed_mementos = false
     project
 }
 
+fn stage_python_slice_augassign_project(lift_script: &Path) -> PathBuf {
+    let project = unique_dir("slice-augassign-project");
+    fs::write(
+        project.join("slice_augassign.py"),
+        "def slice_bump(obj, xs, a, b, c, value):\n    xs[a:b] += value\n    xs[a:b:c] += value\n    xs[:b] += value\n    xs[a:] += value\n    xs[:] += value\n    obj.inner[a:b] += value\n    xs[obj.i:obj.j] += value\n    return value\n",
+    )
+    .expect("write slice_augassign.py");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("python-source"))
+        .expect("mkdir .provekit/lift/python-source");
+    fs::write(
+        provekit.join("config.toml"),
+        r#"[[plugins]]
+name = "python-source"
+kind = "lift"
+surface = "python-source"
+"#,
+    )
+    .expect("write config.toml");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("python-source")
+            .join("manifest.toml"),
+        format!(
+            r#"name = "python-source"
+version = "0.1.0-draft"
+protocol_version = "provekit-lift/1"
+kind = "lift"
+command = ["{}", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["python-source"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+"#,
+            lift_script.display()
+        ),
+    )
+    .expect("write manifest.toml");
+
+    project
+}
+
 fn stage_python_augassign_project(lift_script: &Path) -> PathBuf {
     let project = unique_dir("augassign-project");
     fs::write(
@@ -1106,6 +1152,246 @@ fn python_source_slice_access_mint_preserves_runtime_failure_loci_and_enumerates
             (Some(8), true),
         ],
         "no bridges exist yet, so surfaced slice Load callsites must remain undecidable"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn python_source_slice_augassign_mint_preserves_runtime_failure_loci_and_enumerates_callsites() {
+    if !python_available() {
+        eprintln!(
+            "python3 not on PATH: skipping python-source slice AugAssign runtime-failure mint test"
+        );
+        return;
+    }
+    let lift_script = build_python_lift_source();
+    let project = stage_python_slice_augassign_project(&lift_script);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "python-source slice AugAssign proof must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let obj_inner = ir_attr(ir_var("obj"), "inner");
+    let obj_i = ir_attr(ir_var("obj"), "i");
+    let obj_j = ir_attr(ir_var("obj"), "j");
+    let loci = contract_runtime_failure_loci(&pool);
+    assert_eq!(
+        loci,
+        vec![
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_var("a"), ir_var("b"), ir_none())),
+                "file": "slice_augassign.py",
+                "line": 2,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_var("a"), ir_var("b"), ir_none())),
+                "file": "slice_augassign.py",
+                "line": 2,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_var("a"), ir_var("b"), ir_var("c"))),
+                "file": "slice_augassign.py",
+                "line": 3,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_var("a"), ir_var("b"), ir_var("c"))),
+                "file": "slice_augassign.py",
+                "line": 3,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_none(), ir_var("b"), ir_none())),
+                "file": "slice_augassign.py",
+                "line": 4,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_none(), ir_var("b"), ir_none())),
+                "file": "slice_augassign.py",
+                "line": 4,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_var("a"), ir_none(), ir_none())),
+                "file": "slice_augassign.py",
+                "line": 5,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_var("a"), ir_none(), ir_none())),
+                "file": "slice_augassign.py",
+                "line": 5,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_none(), ir_none(), ir_none())),
+                "file": "slice_augassign.py",
+                "line": 6,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_none(), ir_none(), ir_none())),
+                "file": "slice_augassign.py",
+                "line": 6,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": obj_inner,
+                "file": "slice_augassign.py",
+                "line": 7,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": ir_subscript(
+                    ir_attr(ir_var("obj"), "inner"),
+                    ir_slice(ir_var("a"), ir_var("b"), ir_none())
+                ),
+                "file": "slice_augassign.py",
+                "line": 7,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(
+                    ir_attr(ir_var("obj"), "inner"),
+                    ir_slice(ir_var("a"), ir_var("b"), ir_none())
+                ),
+                "file": "slice_augassign.py",
+                "line": 7,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": obj_i,
+                "file": "slice_augassign.py",
+                "line": 8,
+                "col": 7
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": obj_j,
+                "file": "slice_augassign.py",
+                "line": 8,
+                "col": 13
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": ir_subscript(
+                    ir_var("xs"),
+                    ir_slice(ir_attr(ir_var("obj"), "i"), ir_attr(ir_var("obj"), "j"), ir_none())
+                ),
+                "file": "slice_augassign.py",
+                "line": 8,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(
+                    ir_var("xs"),
+                    ir_slice(ir_attr(ir_var("obj"), "i"), ir_attr(ir_var("obj"), "j"), ir_none())
+                ),
+                "file": "slice_augassign.py",
+                "line": 8,
+                "col": 4
+            }),
+        ],
+        "mint must preserve python-source slice AugAssign runtime-failure panicLoci rows"
+    );
+
+    let callsites = provekit_verifier::enumerate_callsites::run(&pool);
+    let runtime_failure_sites: Vec<_> = callsites
+        .iter()
+        .filter(|cs| cs.panic_site && cs.callee.as_deref() == Some(RUNTIME_FAILURE_SITE_CONCEPT))
+        .collect();
+    // The proof keeps all seventeen panicLoci rows above. CallSite enumeration
+    // deduplicates access/write rows that share callee, file, line, and
+    // argTerm because CallSite does not carry panicLoci subkind (#1839).
+    assert_eq!(
+        runtime_failure_sites.len(),
+        10,
+        "verifier currently surfaces ten unique slice AugAssign runtime-failure obligations; got {callsites:#?}"
+    );
+    assert!(
+        runtime_failure_sites
+            .iter()
+            .all(|cs| cs.file.as_deref() == Some("slice_augassign.py")),
+        "all surfaced slice AugAssign callsites must preserve slice_augassign.py provenance: {runtime_failure_sites:#?}"
+    );
+    assert_eq!(
+        runtime_failure_sites
+            .iter()
+            .map(|cs| (cs.line, cs.bridge_target_cid.is_empty()))
+            .collect::<Vec<_>>(),
+        vec![
+            (Some(2), true),
+            (Some(3), true),
+            (Some(4), true),
+            (Some(5), true),
+            (Some(6), true),
+            (Some(7), true),
+            (Some(7), true),
+            (Some(8), true),
+            (Some(8), true),
+            (Some(8), true),
+        ],
+        "no bridges exist yet, so surfaced slice AugAssign callsites must remain undecidable"
     );
 
     let _ = fs::remove_dir_all(&project);


### PR DESCRIPTION
## What changed

Slice 10 of #1828, tracked under #1837, teaches the Python source lifter to handle AugAssign slice subscript targets such as `xs[a:b] += value`, stepped slices, omitted bounds, nested receivers, and complex bound expressions.

The production change is intentionally narrow: `augassign_target(ast.Subscript)` now evaluates the receiver first and uses `slice_index` for `ast.Slice`, reusing the existing `python:aug_assign`, `python:subscript`, and `python:slice` term shapes. There are no new constructors, compiler changes, declaration changes, verifier changes, doctor changes, libprovekit changes, or CLI production changes.

## Semantics

Python bytecode uses `BINARY_SLICE` / `STORE_SLICE` for two-bound slice AugAssign and `BUILD_SLICE` plus subscript operations for step variants. The lifter normalizes both into the existing `python:slice` term shape.

Receiver-before-bounds evaluation is preserved from slice 9. Existing subscript access/write panic-locus behavior is reused.

## Runtime-failure evidence

The new Rust mint integration preserves 17 `panicLoci` rows for the fixture. `enumerate_callsites` currently surfaces 10 unique runtime-failure CallSites because access/write rows at the same source line collapse when CallSite lacks panicLoci subkind discrimination. That current behavior is documented in the test and tracked by #1839.

All surfaced bridge target CIDs remain empty, so these obligations are honest undecidable runtime-failure sites until a recognizer/materializer supplies contracts.

## Out of scope

AnnAssign slice subscript targets still refuse and remain pinned by Python kit tests for a later slice.

## Verification

Fresh before PR:

- `git diff --check`
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q -k 'slice_augassign or non_augassign'` - 12 passed, 77 deselected
- `rustfmt --edition 2021 --check implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs`

Earlier in this slice before publish:

- RED: new AugAssign slice tests failed on `slice subscripts are refused`, AnnAssign refusal passed
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q` - 89 passed
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests -q` - 178 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_mint_python_source_runtime_failure -- --nocapture` - 8 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc --test cmd_verify_python_production_bridge --test cmd_verify_python_division_unsound -- --nocapture` - 6/5/2 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo run -p provekit-cli -- doctor --target ../python --mode strict --json` - `ok: true` with existing dependency resolver warnings
- Path-A grep over CLI/libprovekit/verifier production Rust found zero matches
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-lift --bin provekit-lift`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` - 1 passed in 118.13s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enabled augmented assignment operators on slice subscripts (e.g., `xs[a:b] += value`)

* **Tests**
  * Added comprehensive test coverage for slice subscript augmented assignments, including runtime failure locus detection, nested slices, evaluation order verification, and roundtrip compilation stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->