### PR TITLE
[codex] python-source supports AnnAssign slice subscripts (#1837 slice 11)

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -293,7 +293,7 @@ class _Emitter:
                 target = self.annassign_target_without_value(node.target)
                 value = ctor("python:no_value")
             else:
-                target = self.target(node.target)
+                target = self.assign_target(node.target)
                 self._record_write_if_nonlocal(node.target)
                 value = self.expr(node.value)
             return ctor("python:ann_assign", target, annotation, value)
@@ -481,6 +481,12 @@ class _Emitter:
                 str_const(node.attr),
             )
         if isinstance(node, ast.Subscript):
+            if isinstance(node.slice, ast.Slice):
+                return ctor(
+                    "python:subscript",
+                    self.expr(node.value),
+                    self.slice_index(node.slice),
+                )
             return ctor(
                 "python:subscript",
                 self.expr(node.value),

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -1087,34 +1087,6 @@ def test_compile_lift_roundtrip_preserves_slice_assign_body(source: str) -> None
     assert canonical_json_bytes(relifted_body) == canonical_json_bytes(body)
 
 
-@pytest.mark.parametrize(
-    ("source", "module", "function_name"),
-    [
-        (
-            "def f(xs, a, b, value):\n    xs[a:b]: int = value\n    return xs\n",
-            "slice_annassign_refusal.py",
-            "slice_annassign_refusal.f",
-        ),
-    ],
-)
-def test_non_augassign_slice_subscripts_remain_refused_for_slice_10_scope(
-    source: str,
-    module: str,
-    function_name: str,
-) -> None:
-    result = lift_source(source, module)
-
-    assert result.refusals == [
-        {
-            "kind": "unhandled-syntax",
-            "function": function_name,
-            "line": 2,
-            "reason": "slice subscripts are refused",
-        }
-    ]
-    assert len(result.ir) == 1
-
-
 def test_name_augassign_lifts_to_aug_assign_without_runtime_failure_loci() -> None:
     source = "def f(x, y):\n    x += y\n    return x\n"
 
@@ -1601,6 +1573,274 @@ def test_direct_subscript_annassign_with_value_emits_store_write_locus_only() ->
     assert body["args"][0] == _ann_assign(target, _var("int"), _var("y"))
 
 
+def test_direct_slice_annassign_without_value_does_not_access_final_subscript() -> None:
+    source = "def f(xs, a, b):\n    xs[a:b]: int\n    return xs\n"
+
+    result = lift_source(source, "slice_annassign_no_value.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    body = contract["post"]["args"][1]
+    target = _subscript(_var("xs"), _slice(_var("a"), _var("b"), _none_const()))
+    assert contract["effects"] == []
+    assert contract.get("panicLoci", []) == []
+    assert body["args"][0] == _ann_assign(target, _var("int"), _no_value())
+
+
+def test_direct_slice_annassign_with_value_emits_store_write_locus_only() -> None:
+    source = "def f(xs, a, b, value):\n    xs[a:b]: int = value\n    return xs\n"
+
+    result = lift_source(source, "slice_annassign_value.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    target = _subscript(_var("xs"), _slice(_var("a"), _var("b"), _none_const()))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "xs[a:b]"},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == ["subscript-write"]
+    assert [locus["argTerm"] for locus in loci] == [target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 4)]
+    assert "exceptionClass" not in loci[0]
+    assert body["args"][0] == _ann_assign(target, _var("int"), _var("value"))
+
+
+@pytest.mark.parametrize(
+    ("source_target", "expected_target", "expected_write"),
+    [
+        (
+            "xs[a:b:c]",
+            _subscript(_var("xs"), _slice(_var("a"), _var("b"), _var("c"))),
+            "xs[a:b:c]",
+        ),
+        (
+            "xs[:b]",
+            _subscript(_var("xs"), _slice(_none_const(), _var("b"), _none_const())),
+            "xs[:b]",
+        ),
+        (
+            "xs[a:]",
+            _subscript(_var("xs"), _slice(_var("a"), _none_const(), _none_const())),
+            "xs[a:]",
+        ),
+        (
+            "xs[:]",
+            _subscript(_var("xs"), _slice(_none_const(), _none_const(), _none_const())),
+            "xs[:]",
+        ),
+    ],
+)
+def test_slice_annassign_preserves_slice_shape_with_and_without_value(
+    source_target: str,
+    expected_target: dict[str, object],
+    expected_write: str,
+) -> None:
+    no_value_source = f"def f(xs, a, b, c):\n    {source_target}: int\n    return xs\n"
+    with_value_source = f"def f(xs, a, b, c, value):\n    {source_target}: int = value\n    return xs\n"
+
+    no_value = lift_source(no_value_source, "slice_annassign_shape_no_value.py")
+    with_value = lift_source(with_value_source, "slice_annassign_shape_value.py")
+
+    assert no_value.refusals == []
+    no_value_contract = _contract(no_value.ir, ".f")
+    no_value_body = no_value_contract["post"]["args"][1]
+    assert no_value_contract["effects"] == []
+    assert no_value_contract.get("panicLoci", []) == []
+    assert no_value_body["args"][0] == _ann_assign(
+        expected_target, _var("int"), _no_value()
+    )
+
+    assert with_value.refusals == []
+    with_value_contract = _contract(with_value.ir, ".f")
+    with_value_loci = _runtime_failure_loci(with_value_contract)
+    with_value_body = with_value_contract["post"]["args"][1]
+    assert with_value_contract["effects"] == [
+        {"kind": "writes", "target": expected_write},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in with_value_loci] == ["subscript-write"]
+    assert [locus["argTerm"] for locus in with_value_loci] == [expected_target]
+    assert [(locus["line"], locus["col"]) for locus in with_value_loci] == [(2, 4)]
+    assert with_value_body["args"][0] == _ann_assign(
+        expected_target, _var("int"), _var("value")
+    )
+
+
+def test_nested_slice_annassign_without_value_emits_only_intermediate_receiver_locus() -> None:
+    source = "def f(obj, a, b):\n    obj.inner[a:b]: int\n    return obj\n"
+
+    result = lift_source(source, "nested_slice_annassign_no_value.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    obj_inner = _attr(_var("obj"), "inner")
+    target = _subscript(obj_inner, _slice(_var("a"), _var("b"), _none_const()))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert [locus["subkind"] for locus in loci] == ["attribute-access"]
+    assert [locus["argTerm"] for locus in loci] == [obj_inner]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 4)]
+    assert loci[0]["exceptionClass"] == "AttributeError"
+    assert body["args"][0] == _ann_assign(target, _var("int"), _no_value())
+
+
+def test_nested_slice_annassign_with_value_reuses_store_target_navigation_once() -> None:
+    source = "def f(obj, a, b, value):\n    obj.inner[a:b]: int = value\n    return obj\n"
+
+    result = lift_source(source, "nested_slice_annassign_value.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    obj_inner = _attr(_var("obj"), "inner")
+    target = _subscript(obj_inner, _slice(_var("a"), _var("b"), _none_const()))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "obj.inner[a:b]"},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == [
+        "attribute-access",
+        "subscript-write",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [obj_inner, target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 4), (2, 4)]
+    assert loci[0]["exceptionClass"] == "AttributeError"
+    assert "exceptionClass" not in loci[1]
+    assert body["args"][0] == _ann_assign(target, _var("int"), _var("value"))
+
+
+def test_slice_annassign_bound_expressions_resurface_load_loci_without_final_no_value_access() -> None:
+    source = "def f(xs, obj):\n    xs[obj.i:obj.j]: int\n    return xs\n"
+
+    result = lift_source(source, "slice_annassign_bounds_no_value.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    obj_i = _attr(_var("obj"), "i")
+    obj_j = _attr(_var("obj"), "j")
+    target = _subscript(_var("xs"), _slice(obj_i, obj_j, _none_const()))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert [locus["subkind"] for locus in loci] == [
+        "attribute-access",
+        "attribute-access",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [obj_i, obj_j]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 7), (2, 13)]
+    assert all(locus["exceptionClass"] == "AttributeError" for locus in loci)
+    assert body["args"][0] == _ann_assign(target, _var("int"), _no_value())
+
+
+def test_slice_annassign_bound_expressions_resurface_load_loci_before_write() -> None:
+    source = "def f(xs, obj, value):\n    xs[obj.i:obj.j]: int = value\n    return xs\n"
+
+    result = lift_source(source, "slice_annassign_bounds_value.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    obj_i = _attr(_var("obj"), "i")
+    obj_j = _attr(_var("obj"), "j")
+    target = _subscript(_var("xs"), _slice(obj_i, obj_j, _none_const()))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "xs[obj.i:obj.j]"},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == [
+        "attribute-access",
+        "attribute-access",
+        "subscript-write",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [obj_i, obj_j, target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [
+        (2, 7),
+        (2, 13),
+        (2, 4),
+    ]
+    assert [locus.get("exceptionClass") for locus in loci] == [
+        "AttributeError",
+        "AttributeError",
+        None,
+    ]
+    assert body["args"][0] == _ann_assign(target, _var("int"), _var("value"))
+
+
+def test_slice_annassign_receiver_is_evaluated_before_slice_bounds() -> None:
+    source = (
+        "def f(obj, other, value):\n"
+        "    obj.inner[other.i:other.j]: int = value\n"
+        "    return obj\n"
+    )
+
+    result = lift_source(source, "slice_annassign_order.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    obj_inner = _attr(_var("obj"), "inner")
+    other_i = _attr(_var("other"), "i")
+    other_j = _attr(_var("other"), "j")
+    target = _subscript(obj_inner, _slice(other_i, other_j, _none_const()))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert contract["effects"] == [
+        {"kind": "writes", "target": "obj.inner[other.i:other.j]"},
+        {"kind": "panics"},
+    ]
+    assert [locus["subkind"] for locus in loci] == [
+        "attribute-access",
+        "attribute-access",
+        "attribute-access",
+        "subscript-write",
+    ]
+    assert [locus["argTerm"] for locus in loci] == [
+        obj_inner,
+        other_i,
+        other_j,
+        target,
+    ]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [
+        (2, 4),
+        (2, 14),
+        (2, 22),
+        (2, 4),
+    ]
+    assert body["args"][0] == _ann_assign(target, _var("int"), _var("value"))
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "def f(xs, a, b):\n    xs[a:b]: int\n    return xs\n",
+        "def f(xs, a, b, value):\n    xs[a:b]: int = value\n    return xs\n",
+        "def f(xs, a, b, value):\n    xs[:b]: int = value\n    xs[a:]: int = value\n    xs[:]: int = value\n    return xs\n",
+        "def f(xs, a, b, c, value):\n    xs[a:b:c]: int = value\n    return xs\n",
+    ],
+)
+def test_compile_lift_roundtrip_preserves_slice_annassign_body(source: str) -> None:
+    lifted = lift_source(source, "roundtrip_slice_annassign.py")
+    assert lifted.refusals == []
+    contract = _contract(lifted.ir, ".f")
+    body = contract["post"]["args"][1]
+
+    compiled = compile_body_term(
+        body,
+        fn_name="f",
+        formals=[str(formal) for formal in contract["formals"]],
+    )
+    relifted = lift_source(compiled, "roundtrip_slice_annassign.py")
+    assert relifted.refusals == []
+    relifted_body = _contract(relifted.ir, ".f")["post"]["args"][1]
+
+    assert canonical_json_bytes(relifted_body) == canonical_json_bytes(body)
+
+
 def test_nested_annassign_without_value_emits_only_intermediate_navigation_loci() -> None:
     source = (
         "def f(obj, xs, ys, i):\n"
@@ -1780,6 +2020,43 @@ def test_compile_lift_roundtrip_preserves_name_annassign_explicit_none_value() -
 
     assert canonical_json_bytes(relifted_body) == canonical_json_bytes(body)
     assert "x: int = None" in compiled
+
+
+@pytest.mark.parametrize(
+    ("source", "module", "reason"),
+    [
+        (
+            "def f(a, b, pair):\n    a, b = pair\n    return a\n",
+            "tuple_unpacking_refusal.py",
+            "unsupported assignment target: Tuple",
+        ),
+        (
+            "def f(a, b, pair):\n    [a, b] = pair\n    return a\n",
+            "list_unpacking_refusal.py",
+            "unsupported assignment target: List",
+        ),
+        (
+            "def f(value):\n    if (x := value):\n        return x\n    return value\n",
+            "walrus_refusal.py",
+            "walrus expressions are refused",
+        ),
+    ],
+)
+def test_slice_11_keeps_tuple_list_unpacking_and_walrus_out_of_scope(
+    source: str,
+    module: str,
+    reason: str,
+) -> None:
+    result = lift_source(source, module)
+
+    assert result.refusals == [
+        {
+            "kind": "unhandled-syntax",
+            "function": f"{module.removesuffix('.py')}.f",
+            "line": 2,
+            "reason": reason,
+        }
+    ]
 
 
 def test_none_guarded_attribute_access_emits_one_runtime_failure_locus() -> None:

--- a/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
@@ -368,6 +368,52 @@ emits_signed_mementos = false
     project
 }
 
+fn stage_python_slice_annassign_project(lift_script: &Path) -> PathBuf {
+    let project = unique_dir("slice-annassign-project");
+    fs::write(
+        project.join("slice_annassign.py"),
+        "def slice_annotate(obj, xs, a, b, c, value):\n    xs[a:b]: int\n    xs[a:b]: int = value\n    xs[a:b:c]: int\n    xs[a:b:c]: int = value\n    xs[:b]: int\n    xs[:b]: int = value\n    xs[a:]: int\n    xs[a:]: int = value\n    xs[:]: int\n    xs[:]: int = value\n    obj.inner[a:b]: int\n    obj.inner[a:b]: int = value\n    xs[obj.i:obj.j]: int\n    xs[obj.i:obj.j]: int = value\n    return value\n",
+    )
+    .expect("write slice_annassign.py");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("python-source"))
+        .expect("mkdir .provekit/lift/python-source");
+    fs::write(
+        provekit.join("config.toml"),
+        r#"[[plugins]]
+name = "python-source"
+kind = "lift"
+surface = "python-source"
+"#,
+    )
+    .expect("write config.toml");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("python-source")
+            .join("manifest.toml"),
+        format!(
+            r#"name = "python-source"
+version = "0.1.0-draft"
+protocol_version = "provekit-lift/1"
+kind = "lift"
+command = ["{}", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["python-source"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+"#,
+            lift_script.display()
+        ),
+    )
+    .expect("write manifest.toml");
+
+    project
+}
+
 fn stage_python_augassign_project(lift_script: &Path) -> PathBuf {
     let project = unique_dir("augassign-project");
     fs::write(
@@ -1392,6 +1438,210 @@ fn python_source_slice_augassign_mint_preserves_runtime_failure_loci_and_enumera
             (Some(8), true),
         ],
         "no bridges exist yet, so surfaced slice AugAssign callsites must remain undecidable"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn python_source_slice_annassign_mint_preserves_runtime_failure_loci_and_enumerates_callsites() {
+    if !python_available() {
+        eprintln!(
+            "python3 not on PATH: skipping python-source slice AnnAssign runtime-failure mint test"
+        );
+        return;
+    }
+    let lift_script = build_python_lift_source();
+    let project = stage_python_slice_annassign_project(&lift_script);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "python-source slice AnnAssign proof must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let obj_inner = ir_attr(ir_var("obj"), "inner");
+    let obj_i = ir_attr(ir_var("obj"), "i");
+    let obj_j = ir_attr(ir_var("obj"), "j");
+    let loci = contract_runtime_failure_loci(&pool);
+    assert_eq!(
+        loci,
+        vec![
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_var("a"), ir_var("b"), ir_none())),
+                "file": "slice_annassign.py",
+                "line": 3,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_var("a"), ir_var("b"), ir_var("c"))),
+                "file": "slice_annassign.py",
+                "line": 5,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_none(), ir_var("b"), ir_none())),
+                "file": "slice_annassign.py",
+                "line": 7,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_var("a"), ir_none(), ir_none())),
+                "file": "slice_annassign.py",
+                "line": 9,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(ir_var("xs"), ir_slice(ir_none(), ir_none(), ir_none())),
+                "file": "slice_annassign.py",
+                "line": 11,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": obj_inner,
+                "file": "slice_annassign.py",
+                "line": 12,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": ir_attr(ir_var("obj"), "inner"),
+                "file": "slice_annassign.py",
+                "line": 13,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(
+                    ir_attr(ir_var("obj"), "inner"),
+                    ir_slice(ir_var("a"), ir_var("b"), ir_none())
+                ),
+                "file": "slice_annassign.py",
+                "line": 13,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": obj_i,
+                "file": "slice_annassign.py",
+                "line": 14,
+                "col": 7
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": obj_j,
+                "file": "slice_annassign.py",
+                "line": 14,
+                "col": 13
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": ir_attr(ir_var("obj"), "i"),
+                "file": "slice_annassign.py",
+                "line": 15,
+                "col": 7
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": ir_attr(ir_var("obj"), "j"),
+                "file": "slice_annassign.py",
+                "line": 15,
+                "col": 13
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-write",
+                "argTerm": ir_subscript(
+                    ir_var("xs"),
+                    ir_slice(ir_attr(ir_var("obj"), "i"), ir_attr(ir_var("obj"), "j"), ir_none())
+                ),
+                "file": "slice_annassign.py",
+                "line": 15,
+                "col": 4
+            }),
+        ],
+        "mint must preserve python-source slice AnnAssign runtime-failure panicLoci rows"
+    );
+
+    let callsites = provekit_verifier::enumerate_callsites::run(&pool);
+    let runtime_failure_sites: Vec<_> = callsites
+        .iter()
+        .filter(|cs| cs.panic_site && cs.callee.as_deref() == Some(RUNTIME_FAILURE_SITE_CONCEPT))
+        .collect();
+    // Unlike slice AugAssign, AnnAssign never emits a paired final
+    // subscript-access row. The thirteen panicLoci rows above therefore surface
+    // as thirteen unique CallSites without the #1839 access/write collapse.
+    assert_eq!(
+        runtime_failure_sites.len(),
+        13,
+        "verifier must surface thirteen slice AnnAssign runtime-failure obligations; got {callsites:#?}"
+    );
+    assert!(
+        runtime_failure_sites
+            .iter()
+            .all(|cs| cs.file.as_deref() == Some("slice_annassign.py")),
+        "all surfaced slice AnnAssign callsites must preserve slice_annassign.py provenance: {runtime_failure_sites:#?}"
+    );
+    assert_eq!(
+        runtime_failure_sites
+            .iter()
+            .map(|cs| (cs.line, cs.bridge_target_cid.is_empty()))
+            .collect::<Vec<_>>(),
+        vec![
+            (Some(3), true),
+            (Some(5), true),
+            (Some(7), true),
+            (Some(9), true),
+            (Some(11), true),
+            (Some(12), true),
+            (Some(13), true),
+            (Some(13), true),
+            (Some(14), true),
+            (Some(14), true),
+            (Some(15), true),
+            (Some(15), true),
+            (Some(15), true),
+        ],
+        "no bridges exist yet, so surfaced slice AnnAssign callsites must remain undecidable"
     );
 
     let _ = fs::remove_dir_all(&project);


### PR DESCRIPTION
## What changed

Slice 11 of #1828, tracked under #1837, teaches the Python source lifter to handle AnnAssign slice subscript targets such as `xs[a:b]: int` and `xs[a:b]: int = value`, including stepped slices, omitted bounds, nested receivers, and complex bound expressions.

The production change is intentionally narrow:

- with-value AnnAssign now reuses `assign_target(node.target)`, matching the existing store path
- no-value AnnAssign adds an `ast.Subscript` plus `ast.Slice` branch in `annassign_target_without_value`
- the no-value branch evaluates the receiver and slice bounds but emits no final access/write locus

This reuses `python:ann_assign`, `python:slice`, `python:subscript`, and `python:no_value` from prior slices. There are no new constructors, compiler changes, declaration changes, verifier changes, doctor changes, libprovekit changes, or CLI production changes.

## Semantics

Python bytecode confirms the slice 7 AnnAssign shape applies to slice targets:

- `xs[a:b]: int` evaluates `xs`, `a`, and `b`, then discards them. It does not load or store the final slice.
- `xs[a:b]: int = value` uses store behavior, including `STORE_SLICE` for two-bound slices.
- stepped slices use `BUILD_SLICE` plus subscript store behavior.

Receiver-before-bounds evaluation remains preserved from slice 9.

## Runtime-failure evidence

The new Rust mint integration preserves 13 `panicLoci` rows for the slice AnnAssign fixture and `enumerate_callsites` surfaces 13 runtime-failure CallSites.

This is intentionally different from slice 10 AugAssign slice behavior. Slice 10 had access/write pairs at the same source line, so CallSite enumeration collapsed rows per #1839. Slice 11 AnnAssign with value emits only a final write locus, and no-value AnnAssign emits only intermediate loci, so there is no access/write pair to collapse. The observed shape is 13 panicLoci to 13 CallSites.

All surfaced bridge target CIDs remain empty, so these obligations are honest undecidable runtime-failure sites until a recognizer/materializer supplies contracts.

## Out of scope

Tuple/list unpacking and walrus expressions remain refused and are pinned by tests for later slices.

## Verification

- RED: focused slice AnnAssign tests failed 15 cases on `slice subscripts are refused`
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q -k 'slice_annassign or annassign or slice or out_of_scope'` - 64 passed, 42 deselected
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q` - 106 passed
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests -q` - 195 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_mint_python_source_runtime_failure -- --nocapture` - 9 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc --test cmd_verify_python_production_bridge --test cmd_verify_python_division_unsound -- --nocapture` - 6/5/2 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo run -p provekit-cli -- doctor --target ../python --mode strict --json` - `ok: true` with existing dependency resolver warnings
- refined Path-A grep over CLI/libprovekit/verifier production Rust found zero Python-specific AnnAssign/slice leaks
- `git diff --check`
- `rustfmt --edition 2021 --check implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-lift --bin provekit-lift`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` - 1 passed in 125.61s
