### PR TITLE
[codex] python-source supports walrus operator (NamedExpr) (#1837 slice 12)

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/compiler.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/compiler.py
@@ -173,6 +173,8 @@ def _expr(term: Json) -> ast.expr:
         return ast.Attribute(value=_expr(args[0]), attr=_const_string(args[1]), ctx=ast.Load())
     if name == "python:subscript":
         return ast.Subscript(value=_expr(args[0]), slice=_slice_or_expr(args[1]), ctx=ast.Load())
+    if name == "python:walrus":
+        return ast.NamedExpr(target=_walrus_target(args[0]), value=_expr(args[1]))
     raise ValueError(f"unsupported python operation in expression position: {name}")
 
 
@@ -190,6 +192,14 @@ def _slice_or_expr(term: Json) -> ast.expr | ast.slice:
 def _target(term: Json) -> ast.expr:
     expr = _expr(term)
     return _with_context(expr, ast.Store())
+
+
+def _walrus_target(term: Json) -> ast.Name:
+    expr = _expr(term)
+    if not isinstance(expr, ast.Name):
+        raise ValueError(f"walrus target is not a name: {ast.dump(expr)}")
+    expr.ctx = ast.Store()
+    return expr
 
 
 def _with_context(expr: ast.expr, ctx: ast.expr_context) -> ast.expr:

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -569,6 +569,13 @@ class _Emitter:
                 )
             )
             return term
+        if isinstance(node, ast.NamedExpr):
+            if not isinstance(node.target, ast.Name):
+                raise _UnsupportedSyntax(
+                    node.target,
+                    f"unsupported walrus target: {type(node.target).__name__}",
+                )
+            return ctor("python:walrus", var(node.target.id), self.expr(node.value))
         raise _UnsupportedSyntax(node, f"unhandled expression kind: {type(node).__name__}")
 
     def constant(self, node: ast.Constant) -> Json:
@@ -783,8 +790,6 @@ def _contains_refused_control(fn: ast.FunctionDef) -> _UnsupportedSyntax | None:
             return _UnsupportedSyntax(child, "generators are refused")
         if isinstance(child, ast.Await):
             return _UnsupportedSyntax(child, "await expressions are refused")
-        if isinstance(child, ast.NamedExpr):
-            return _UnsupportedSyntax(child, "walrus expressions are refused")
     return None
 
 

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -176,6 +176,22 @@ def _ann_assign(
     }
 
 
+def _walrus(target: dict[str, object], value: dict[str, object]) -> dict[str, object]:
+    return {
+        "kind": "ctor",
+        "name": "python:walrus",
+        "args": [target, value],
+    }
+
+
+def _call(name: str, *args: dict[str, object]) -> dict[str, object]:
+    return {
+        "kind": "ctor",
+        "name": "python:call",
+        "args": [_str_const(name), *args],
+    }
+
+
 def _ctor_names(node: object) -> list[str]:
     if isinstance(node, dict):
         names = [str(node["name"])] if node.get("kind") == "ctor" else []
@@ -330,6 +346,162 @@ def test_compare_three_chain_mixed_ops_lifts_to_pairwise_and_composition(
     assert result.refusals == []
     assert _compare_pairs(body) == expected_pairs
     assert _ctor_names(body).count("python:and") == 2
+
+
+def test_walrus_literal_rhs_lifts_without_runtime_failure_loci_or_effects() -> None:
+    source = "def f():\n    return (x := 42)\n"
+
+    result = lift_source(source, "walrus_literal.py")
+
+    contract = _contract(result.ir, ".f")
+    body = contract["post"]["args"][1]
+    assert result.refusals == []
+    assert contract["effects"] == []
+    assert contract.get("panicLoci", []) == []
+    assert body == {
+        "kind": "ctor",
+        "name": "python:return",
+        "args": [
+            _walrus(
+                _var("x"),
+                {"kind": "const", "value": 42, "sort": {"kind": "primitive", "name": "Int"}},
+            )
+        ],
+    }
+
+
+def test_walrus_name_rhs_lifts_to_expression_position_assignment() -> None:
+    source = "def f(y):\n    return (x := y)\n"
+
+    result = lift_source(source, "walrus_name.py")
+
+    contract = _contract(result.ir, ".f")
+    body = contract["post"]["args"][1]
+    assert result.refusals == []
+    assert contract["effects"] == []
+    assert contract.get("panicLoci", []) == []
+    assert body["args"][0] == _walrus(_var("x"), _var("y"))
+
+
+def test_walrus_attribute_rhs_preserves_attribute_runtime_failure_locus() -> None:
+    source = "def f(obj):\n    return (x := obj.name)\n"
+
+    result = lift_source(source, "walrus_attr.py")
+
+    contract = _contract(result.ir, ".f")
+    target = _attr(_var("obj"), "name")
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert result.refusals == []
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert [locus["subkind"] for locus in loci] == ["attribute-access"]
+    assert [locus["argTerm"] for locus in loci] == [target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 17)]
+    assert [locus.get("exceptionClass") for locus in loci] == ["AttributeError"]
+    assert body["args"][0] == _walrus(_var("x"), target)
+
+
+def test_walrus_subscript_rhs_preserves_subscript_runtime_failure_locus() -> None:
+    source = "def f(xs, key):\n    return (x := xs[key])\n"
+
+    result = lift_source(source, "walrus_subscript.py")
+
+    contract = _contract(result.ir, ".f")
+    target = _subscript(_var("xs"), _var("key"))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert result.refusals == []
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert [locus["subkind"] for locus in loci] == ["subscript-access"]
+    assert [locus["argTerm"] for locus in loci] == [target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 17)]
+    assert body["args"][0] == _walrus(_var("x"), target)
+
+
+def test_walrus_slice_rhs_preserves_slice_runtime_failure_locus() -> None:
+    source = "def f(xs, a, b):\n    return (x := xs[a:b])\n"
+
+    result = lift_source(source, "walrus_slice.py")
+
+    contract = _contract(result.ir, ".f")
+    target = _subscript(_var("xs"), _slice(_var("a"), _var("b"), _none_const()))
+    loci = _runtime_failure_loci(contract)
+    body = contract["post"]["args"][1]
+    assert result.refusals == []
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert [locus["subkind"] for locus in loci] == ["subscript-access"]
+    assert [locus["argTerm"] for locus in loci] == [target]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 17)]
+    assert body["args"][0] == _walrus(_var("x"), target)
+
+
+def test_walrus_if_condition_lifts_condition_as_expression() -> None:
+    source = (
+        "def f(compute, fallback):\n"
+        "    if (x := compute()):\n"
+        "        return x\n"
+        "    return fallback\n"
+    )
+
+    result = lift_source(source, "walrus_if.py")
+
+    contract = _contract(result.ir, ".f")
+    body = contract["post"]["args"][1]
+    assert result.refusals == []
+    assert contract["effects"] == [{"kind": "unresolved_call", "name": "compute"}]
+    assert contract.get("panicLoci", []) == []
+    assert body["name"] == "python:seq"
+    condition = body["args"][0]
+    assert condition["name"] == "python:if"
+    assert condition["args"][0] == _walrus(_var("x"), _call("compute"))
+
+
+def test_walrus_while_condition_lifts_condition_as_expression() -> None:
+    source = (
+        "def f(next_value):\n"
+        "    while (x := next_value()):\n"
+        "        return x\n"
+        "    return None\n"
+    )
+
+    result = lift_source(source, "walrus_while.py")
+
+    contract = _contract(result.ir, ".f")
+    body = contract["post"]["args"][1]
+    assert result.refusals == []
+    assert {"kind": "unresolved_call", "name": "next_value"} in contract["effects"]
+    assert any(effect["kind"] == "opaque_loop" for effect in contract["effects"])
+    assert contract.get("panicLoci", []) == []
+    assert body["name"] == "python:seq"
+    loop = body["args"][0]
+    assert loop["name"] == "python:while"
+    assert loop["args"][0] == _walrus(_var("x"), _call("next_value"))
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "def f(y):\n    return (x := y)\n",
+        "def f(compute, fallback):\n    if (x := compute()):\n        return x\n    return fallback\n",
+    ],
+)
+def test_compile_lift_roundtrip_preserves_walrus_body(source: str) -> None:
+    lifted = lift_source(source, "roundtrip_walrus.py")
+    assert lifted.refusals == []
+    contract = _contract(lifted.ir, ".f")
+    body = contract["post"]["args"][1]
+
+    compiled = compile_body_term(
+        body,
+        fn_name="f",
+        formals=[str(formal) for formal in contract["formals"]],
+    )
+    relifted = lift_source(compiled, "roundtrip_walrus.py")
+    assert relifted.refusals == []
+    relifted_body = _contract(relifted.ir, ".f")["post"]["args"][1]
+
+    assert canonical_json_bytes(relifted_body) == canonical_json_bytes(body)
+    assert ":=" in compiled
 
 
 def test_if_is_none_lifts_to_cf_guarded_option_guards() -> None:
@@ -2036,9 +2208,9 @@ def test_compile_lift_roundtrip_preserves_name_annassign_explicit_none_value() -
             "unsupported assignment target: List",
         ),
         (
-            "def f(value):\n    if (x := value):\n        return x\n    return value\n",
-            "walrus_refusal.py",
-            "walrus expressions are refused",
+            "def f(xs, compute):\n    return [y for x in xs if (y := compute(x))]\n",
+            "walrus_listcomp_refusal.py",
+            "unhandled expression kind: ListComp",
         ),
     ],
 )

--- a/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
@@ -414,6 +414,52 @@ emits_signed_mementos = false
     project
 }
 
+fn stage_python_walrus_project(lift_script: &Path) -> PathBuf {
+    let project = unique_dir("walrus-project");
+    fs::write(
+        project.join("walrus.py"),
+        "def capture(obj, xs, key, a, b):\n    literal = (local := 42)\n    name = (same := literal)\n    attr = (x := obj.name)\n    item = (y := xs[key])\n    slice_value = (z := xs[a:b])\n    if (guard := obj.flag):\n        return attr\n    while (line := xs[key]):\n        return line\n    return slice_value\n",
+    )
+    .expect("write walrus.py");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("python-source"))
+        .expect("mkdir .provekit/lift/python-source");
+    fs::write(
+        provekit.join("config.toml"),
+        r#"[[plugins]]
+name = "python-source"
+kind = "lift"
+surface = "python-source"
+"#,
+    )
+    .expect("write config.toml");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("python-source")
+            .join("manifest.toml"),
+        format!(
+            r#"name = "python-source"
+version = "0.1.0-draft"
+protocol_version = "provekit-lift/1"
+kind = "lift"
+command = ["{}", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["python-source"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+"#,
+            lift_script.display()
+        ),
+    )
+    .expect("write manifest.toml");
+
+    project
+}
+
 fn stage_python_augassign_project(lift_script: &Path) -> PathBuf {
     let project = unique_dir("augassign-project");
     fs::write(
@@ -1642,6 +1688,116 @@ fn python_source_slice_annassign_mint_preserves_runtime_failure_loci_and_enumera
             (Some(15), true),
         ],
         "no bridges exist yet, so surfaced slice AnnAssign callsites must remain undecidable"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn python_source_walrus_mint_preserves_rhs_runtime_failure_loci_and_enumerates_callsites() {
+    if !python_available() {
+        eprintln!("python3 not on PATH: skipping python-source walrus runtime-failure mint test");
+        return;
+    }
+    let lift_script = build_python_lift_source();
+    let project = stage_python_walrus_project(&lift_script);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "python-source walrus proof must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let xs_key = ir_subscript(ir_var("xs"), ir_var("key"));
+    let loci = contract_runtime_failure_loci(&pool);
+    assert_eq!(
+        loci,
+        vec![
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": ir_attr(ir_var("obj"), "name"),
+                "file": "walrus.py",
+                "line": 4,
+                "col": 17
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": xs_key,
+                "file": "walrus.py",
+                "line": 5,
+                "col": 17
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": ir_subscript(
+                    ir_var("xs"),
+                    ir_slice(ir_var("a"), ir_var("b"), ir_none())
+                ),
+                "file": "walrus.py",
+                "line": 6,
+                "col": 24
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": ir_attr(ir_var("obj"), "flag"),
+                "file": "walrus.py",
+                "line": 7,
+                "col": 17
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": ir_subscript(ir_var("xs"), ir_var("key")),
+                "file": "walrus.py",
+                "line": 9,
+                "col": 19
+            }),
+        ],
+        "mint must preserve python-source walrus RHS runtime-failure panicLoci rows"
+    );
+
+    let callsites = provekit_verifier::enumerate_callsites::run(&pool);
+    let runtime_failure_sites: Vec<_> = callsites
+        .iter()
+        .filter(|cs| cs.panic_site && cs.callee.as_deref() == Some(RUNTIME_FAILURE_SITE_CONCEPT))
+        .collect();
+    assert_eq!(
+        runtime_failure_sites.len(),
+        5,
+        "verifier must surface five walrus RHS runtime-failure obligations; got {callsites:#?}"
+    );
+    assert!(
+        runtime_failure_sites
+            .iter()
+            .all(|cs| cs.file.as_deref() == Some("walrus.py")),
+        "all surfaced walrus callsites must preserve walrus.py provenance: {runtime_failure_sites:#?}"
+    );
+    assert_eq!(
+        runtime_failure_sites
+            .iter()
+            .map(|cs| (cs.line, cs.bridge_target_cid.is_empty()))
+            .collect::<Vec<_>>(),
+        vec![
+            (Some(4), true),
+            (Some(5), true),
+            (Some(6), true),
+            (Some(7), true),
+            (Some(9), true),
+        ],
+        "no bridges exist yet, so surfaced walrus callsites must remain undecidable"
     );
 
     let _ = fs::remove_dir_all(&project);


### PR DESCRIPTION
Slice 12 of #1828, tracked under #1837.

## What changed
- Python source lifting now supports `ast.NamedExpr`, the walrus operator.
- The lifter emits `python:walrus(var(name), value)` for simple-name walrus targets.
- The compiler roundtrips `python:walrus` back to `ast.NamedExpr`.
- The old broad `NamedExpr` refusal is removed, while tuple/list unpacking and list comprehensions remain refused.

## Semantics
- `python:walrus` is intentionally distinct from `python:assign`: walrus is expression-position and returns the RHS value while assigning.
- Python syntax only permits a simple name as a walrus target. Attribute, subscript, and tuple targets are rejected by Python before the kit sees valid AST.
- The walrus operation itself emits no runtime-failure locus because the target is a name store.
- RHS attribute, subscript, and slice expressions still emit their existing runtime-failure loci.
- Bytecode inspection showed RHS evaluation followed by `COPY 1` and `STORE_FAST`, preserving the RHS value for the surrounding expression.

## Federation evidence
- The Rust mint integration fixture preserves 5 RHS `panicLoci` rows and surfaces 5 runtime-failure CallSites.
- Literal and name RHS walrus cases produce no runtime-failure loci.
- All surfaced bridge target CIDs remain empty, so the obligations stay honest undecidable sites until a recognizer/materializer supplies contracts.
- #1839 dedup does not apply here: walrus has no access/write pair at the same line, so the shape remains 5 panicLoci -> 5 CallSites.

## Out of scope
- Walrus inside list comprehensions remains blocked by the existing `ListComp` refusal.
- Tuple/list unpacking remains refused for a later slice.

## Verification
- RED: focused walrus/out_of_scope tests initially failed 10 cases for the intended `NamedExpr` refusal and list-comprehension pre-refusal shape
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q -k "walrus or out_of_scope"` -> 12 passed, 103 deselected
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q` -> 115 passed
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests -q` -> 204 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_mint_python_source_runtime_failure -- --nocapture` -> 10 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc --test cmd_verify_python_production_bridge --test cmd_verify_python_division_unsound -- --nocapture` -> 6 passed, 5 passed, 2 passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo run -p provekit-cli -- doctor --target ../python --mode strict --json` -> ok:true with existing resolver warnings
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc` -> passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-lift --bin provekit-lift` -> passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` -> 1 passed in 119.65s
- `git diff --check` -> passed
- `rustfmt --edition 2021 --check implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs` -> passed
- Refined Path A grep over CLI/libprovekit/verifier production Rust found zero walrus or NamedExpr terms

Co-authored-by: Claude <noreply@anthropic.com>