### PR TITLE
[codex] python-source supports tight tuple/list unpacking (#1837 slice 13)

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/compiler.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/compiler.py
@@ -85,6 +85,11 @@ def _stmt(term: Json) -> ast.stmt:
     args = term.get("args", [])
     if name == "python:assign":
         return ast.Assign(targets=[_target(args[0])], value=_expr(args[1]))
+    if name == "python:unpack_assign":
+        return ast.Assign(
+            targets=[_unpack_target(args[0], args[1])],
+            value=_expr(args[2]),
+        )
     if name == "python:aug_assign":
         return ast.AugAssign(
             target=_target(args[0]),
@@ -192,6 +197,28 @@ def _slice_or_expr(term: Json) -> ast.expr | ast.slice:
 def _target(term: Json) -> ast.expr:
     expr = _expr(term)
     return _with_context(expr, ast.Store())
+
+
+def _unpack_target(kind_term: Json, targets_term: Json) -> ast.expr:
+    kind = _const_string(kind_term)
+    if _name(targets_term) != "python:unpack_targets":
+        raise ValueError(f"expected python:unpack_targets: {targets_term!r}")
+    targets = [_unpack_name_target(term) for term in targets_term.get("args", [])]
+    if not targets:
+        raise ValueError("unpack target must contain at least one name")
+    if kind == "tuple":
+        return ast.Tuple(elts=targets, ctx=ast.Store())
+    if kind == "list":
+        return ast.List(elts=targets, ctx=ast.Store())
+    raise ValueError(f"unsupported unpack target kind: {kind}")
+
+
+def _unpack_name_target(term: Json) -> ast.Name:
+    expr = _expr(term)
+    if not isinstance(expr, ast.Name):
+        raise ValueError(f"unpack target is not a name: {ast.dump(expr)}")
+    expr.ctx = ast.Store()
+    return expr
 
 
 def _walrus_target(term: Json) -> ast.Name:

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -277,8 +277,21 @@ class _Emitter:
         if isinstance(node, ast.Assign):
             if len(node.targets) != 1:
                 raise _UnsupportedSyntax(node, "multiple-target assignment is refused")
-            target = self.assign_target(node.targets[0])
-            self._record_write_if_nonlocal(node.targets[0])
+            target_node = node.targets[0]
+            if isinstance(target_node, (ast.Tuple, ast.List)):
+                value = self.expr(node.value)
+                term = self.unpack_assign(target_node, value)
+                self.effects.add_panics()
+                self.panic_loci.append(
+                    self.runtime_failure_locus(
+                        target_node,
+                        term,
+                        subkind="iter-unpack",
+                    )
+                )
+                return term
+            target = self.assign_target(target_node)
+            self._record_write_if_nonlocal(target_node)
             return ctor("python:assign", target, self.expr(node.value))
         if isinstance(node, ast.AugAssign):
             op = _BINOPS.get(type(node.op))
@@ -425,6 +438,27 @@ class _Emitter:
             )
             return term
         return self.target(node)
+
+    def unpack_assign(self, node: ast.expr, value: Json) -> Json:
+        if isinstance(node, ast.Tuple):
+            kind = "tuple"
+        elif isinstance(node, ast.List):
+            kind = "list"
+        else:
+            raise _UnsupportedSyntax(node, f"unsupported assignment target: {type(node).__name__}")
+        if not node.elts:
+            raise _UnsupportedSyntax(node, f"unsupported assignment target: {type(node).__name__}")
+        targets: list[Json] = []
+        for element in node.elts:
+            if not isinstance(element, ast.Name):
+                raise _UnsupportedSyntax(node, f"unsupported assignment target: {type(node).__name__}")
+            targets.append(var(element.id))
+        return ctor(
+            "python:unpack_assign",
+            str_const(kind),
+            ctor("python:unpack_targets", *targets),
+            value,
+        )
 
     def augassign_target(self, node: ast.expr) -> Json:
         if isinstance(node, ast.Name):

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -192,6 +192,26 @@ def _call(name: str, *args: dict[str, object]) -> dict[str, object]:
     }
 
 
+def _unpack_targets(*targets: dict[str, object]) -> dict[str, object]:
+    return {
+        "kind": "ctor",
+        "name": "python:unpack_targets",
+        "args": list(targets),
+    }
+
+
+def _unpack_assign(
+    kind: str,
+    targets: dict[str, object],
+    value: dict[str, object],
+) -> dict[str, object]:
+    return {
+        "kind": "ctor",
+        "name": "python:unpack_assign",
+        "args": [_str_const(kind), targets, value],
+    }
+
+
 def _ctor_names(node: object) -> list[str]:
     if isinstance(node, dict):
         names = [str(node["name"])] if node.get("kind") == "ctor" else []
@@ -502,6 +522,171 @@ def test_compile_lift_roundtrip_preserves_walrus_body(source: str) -> None:
 
     assert canonical_json_bytes(relifted_body) == canonical_json_bytes(body)
     assert ":=" in compiled
+
+
+def test_tuple_unpack_names_emits_unpack_assign_runtime_failure_locus() -> None:
+    source = "def f(pair):\n    a, b = pair\n    return a\n"
+
+    result = lift_source(source, "tuple_unpack.py")
+
+    contract = _contract(result.ir, ".f")
+    body = contract["post"]["args"][1]
+    unpack = _unpack_assign("tuple", _unpack_targets(_var("a"), _var("b")), _var("pair"))
+    assert result.refusals == []
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert _runtime_failure_loci(contract) == [
+        {
+            "effectKind": PANIC_FREEDOM_EFFECT_KIND,
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "iter-unpack",
+            "argTerm": unpack,
+            "file": "tuple_unpack.py",
+            "line": 2,
+            "col": 4,
+        }
+    ]
+    assert body["name"] == "python:seq"
+    assert body["args"][0] == unpack
+
+
+def test_list_unpack_names_preserves_list_kind_in_unpack_assign() -> None:
+    source = "def f(pair):\n    [a, b] = pair\n    return b\n"
+
+    result = lift_source(source, "list_unpack.py")
+
+    contract = _contract(result.ir, ".f")
+    body = contract["post"]["args"][1]
+    unpack = _unpack_assign("list", _unpack_targets(_var("a"), _var("b")), _var("pair"))
+    assert result.refusals == []
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert _runtime_failure_loci(contract) == [
+        {
+            "effectKind": PANIC_FREEDOM_EFFECT_KIND,
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "iter-unpack",
+            "argTerm": unpack,
+            "file": "list_unpack.py",
+            "line": 2,
+            "col": 4,
+        }
+    ]
+    assert body["name"] == "python:seq"
+    assert body["args"][0] == unpack
+
+
+def test_tuple_unpack_three_names_preserves_all_targets() -> None:
+    source = "def f(triple):\n    a, b, c = triple\n    return c\n"
+
+    result = lift_source(source, "tuple_unpack_three.py")
+
+    contract = _contract(result.ir, ".f")
+    body = contract["post"]["args"][1]
+    unpack = _unpack_assign(
+        "tuple",
+        _unpack_targets(_var("a"), _var("b"), _var("c")),
+        _var("triple"),
+    )
+    assert result.refusals == []
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert _runtime_failure_loci(contract)[0]["argTerm"] == unpack
+    assert _runtime_failure_loci(contract)[0]["subkind"] == "iter-unpack"
+    assert body["args"][0] == unpack
+
+
+def test_single_element_tuple_unpack_preserves_one_target() -> None:
+    source = "def f(single):\n    (a,) = single\n    return a\n"
+
+    result = lift_source(source, "tuple_unpack_single.py")
+
+    contract = _contract(result.ir, ".f")
+    unpack = _unpack_assign("tuple", _unpack_targets(_var("a")), _var("single"))
+    assert result.refusals == []
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert _runtime_failure_loci(contract) == [
+        {
+            "effectKind": PANIC_FREEDOM_EFFECT_KIND,
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "iter-unpack",
+            "argTerm": unpack,
+            "file": "tuple_unpack_single.py",
+            "line": 2,
+            "col": 4,
+        }
+    ]
+
+
+def test_tuple_unpack_rhs_attribute_composes_attribute_and_unpack_loci() -> None:
+    source = "def f(obj):\n    a, b = obj.pair\n    return a\n"
+
+    result = lift_source(source, "tuple_unpack_attr_rhs.py")
+
+    contract = _contract(result.ir, ".f")
+    rhs = _attr(_var("obj"), "pair")
+    unpack = _unpack_assign("tuple", _unpack_targets(_var("a"), _var("b")), rhs)
+    loci = _runtime_failure_loci(contract)
+    assert result.refusals == []
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert [locus["subkind"] for locus in loci] == ["attribute-access", "iter-unpack"]
+    assert [locus["argTerm"] for locus in loci] == [rhs, unpack]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 11), (2, 4)]
+    assert [locus.get("exceptionClass") for locus in loci] == ["AttributeError", None]
+
+
+def test_tuple_unpack_rhs_subscript_composes_subscript_and_unpack_loci() -> None:
+    source = "def f(xs, key):\n    a, b = xs[key]\n    return b\n"
+
+    result = lift_source(source, "tuple_unpack_subscript_rhs.py")
+
+    contract = _contract(result.ir, ".f")
+    rhs = _subscript(_var("xs"), _var("key"))
+    unpack = _unpack_assign("tuple", _unpack_targets(_var("a"), _var("b")), rhs)
+    loci = _runtime_failure_loci(contract)
+    assert result.refusals == []
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert [locus["subkind"] for locus in loci] == ["subscript-access", "iter-unpack"]
+    assert [locus["argTerm"] for locus in loci] == [rhs, unpack]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 11), (2, 4)]
+
+
+def test_tuple_unpack_rhs_slice_composes_slice_and_unpack_loci() -> None:
+    source = "def f(xs, i, j):\n    a, b = xs[i:j]\n    return b\n"
+
+    result = lift_source(source, "tuple_unpack_slice_rhs.py")
+
+    contract = _contract(result.ir, ".f")
+    rhs = _subscript(_var("xs"), _slice(_var("i"), _var("j"), _none_const()))
+    unpack = _unpack_assign("tuple", _unpack_targets(_var("a"), _var("b")), rhs)
+    loci = _runtime_failure_loci(contract)
+    assert result.refusals == []
+    assert contract["effects"] == [{"kind": "panics"}]
+    assert [locus["subkind"] for locus in loci] == ["subscript-access", "iter-unpack"]
+    assert [locus["argTerm"] for locus in loci] == [rhs, unpack]
+    assert [(locus["line"], locus["col"]) for locus in loci] == [(2, 11), (2, 4)]
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "def f(pair):\n    a, b = pair\n    return a\n",
+        "def f(pair):\n    [a, b] = pair\n    return b\n",
+    ],
+)
+def test_compile_lift_roundtrip_preserves_unpack_assign_body(source: str) -> None:
+    lifted = lift_source(source, "roundtrip_unpack.py")
+    assert lifted.refusals == []
+    contract = _contract(lifted.ir, ".f")
+    body = contract["post"]["args"][1]
+
+    compiled = compile_body_term(
+        body,
+        fn_name="f",
+        formals=[str(formal) for formal in contract["formals"]],
+    )
+    relifted = lift_source(compiled, "roundtrip_unpack.py")
+    assert relifted.refusals == []
+    relifted_body = _contract(relifted.ir, ".f")["post"]["args"][1]
+
+    assert canonical_json_bytes(relifted_body) == canonical_json_bytes(body)
 
 
 def test_if_is_none_lifts_to_cf_guarded_option_guards() -> None:
@@ -2198,14 +2383,24 @@ def test_compile_lift_roundtrip_preserves_name_annassign_explicit_none_value() -
     ("source", "module", "reason"),
     [
         (
-            "def f(a, b, pair):\n    a, b = pair\n    return a\n",
-            "tuple_unpacking_refusal.py",
+            "def f(pair):\n    (a, (b, c)) = pair\n    return c\n",
+            "nested_unpacking_refusal.py",
             "unsupported assignment target: Tuple",
         ),
         (
-            "def f(a, b, pair):\n    [a, b] = pair\n    return a\n",
-            "list_unpacking_refusal.py",
-            "unsupported assignment target: List",
+            "def f(pair):\n    a, *rest = pair\n    return rest\n",
+            "starred_unpacking_refusal.py",
+            "unsupported assignment target: Tuple",
+        ),
+        (
+            "def f(obj, pair):\n    obj.a, b = pair\n    return b\n",
+            "attribute_unpack_target_refusal.py",
+            "unsupported assignment target: Tuple",
+        ),
+        (
+            "def f(xs, pair):\n    xs[0], b = pair\n    return b\n",
+            "subscript_unpack_target_refusal.py",
+            "unsupported assignment target: Tuple",
         ),
         (
             "def f(xs, compute):\n    return [y for x in xs if (y := compute(x))]\n",
@@ -2214,7 +2409,7 @@ def test_compile_lift_roundtrip_preserves_name_annassign_explicit_none_value() -
         ),
     ],
 )
-def test_slice_11_keeps_tuple_list_unpacking_and_walrus_out_of_scope(
+def test_slice_13_keeps_complex_unpacking_and_listcomp_out_of_scope(
     source: str,
     module: str,
     reason: str,

--- a/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_python_source_runtime_failure.rs
@@ -460,6 +460,52 @@ emits_signed_mementos = false
     project
 }
 
+fn stage_python_unpack_project(lift_script: &Path) -> PathBuf {
+    let project = unique_dir("unpack-project");
+    fs::write(
+        project.join("unpack.py"),
+        "def unpack(obj, xs, key, i, j, pair, triple):\n    a, b = pair\n    [c, d] = pair\n    x, y, z = triple\n    m, n = obj.pair\n    p, q = xs[key]\n    r, s = xs[i:j]\n    return r\n",
+    )
+    .expect("write unpack.py");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("python-source"))
+        .expect("mkdir .provekit/lift/python-source");
+    fs::write(
+        provekit.join("config.toml"),
+        r#"[[plugins]]
+name = "python-source"
+kind = "lift"
+surface = "python-source"
+"#,
+    )
+    .expect("write config.toml");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("python-source")
+            .join("manifest.toml"),
+        format!(
+            r#"name = "python-source"
+version = "0.1.0-draft"
+protocol_version = "provekit-lift/1"
+kind = "lift"
+command = ["{}", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["python-source"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+"#,
+            lift_script.display()
+        ),
+    )
+    .expect("write manifest.toml");
+
+    project
+}
+
 fn stage_python_augassign_project(lift_script: &Path) -> PathBuf {
     let project = unique_dir("augassign-project");
     fs::write(
@@ -603,6 +649,18 @@ fn ir_slice(lower: Json, upper: Json, step: Json) -> Json {
 
 fn ir_subscript(value: Json, index: Json) -> Json {
     json!({"kind": "ctor", "name": "python:subscript", "args": [value, index]})
+}
+
+fn ir_unpack_targets(targets: Vec<Json>) -> Json {
+    json!({"kind": "ctor", "name": "python:unpack_targets", "args": targets})
+}
+
+fn ir_unpack_assign(kind: &str, targets: Vec<Json>, value: Json) -> Json {
+    json!({
+        "kind": "ctor",
+        "name": "python:unpack_assign",
+        "args": [ir_str(kind), ir_unpack_targets(targets), value]
+    })
 }
 
 #[test]
@@ -1798,6 +1856,166 @@ fn python_source_walrus_mint_preserves_rhs_runtime_failure_loci_and_enumerates_c
             (Some(9), true),
         ],
         "no bridges exist yet, so surfaced walrus callsites must remain undecidable"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}
+
+#[test]
+fn python_source_unpack_mint_preserves_runtime_failure_loci_and_enumerates_callsites() {
+    if !python_available() {
+        eprintln!("python3 not on PATH: skipping python-source unpack runtime-failure mint test");
+        return;
+    }
+    let lift_script = build_python_lift_source();
+    let project = stage_python_unpack_project(&lift_script);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "python-source unpack proof must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let tuple_pair = ir_unpack_assign("tuple", vec![ir_var("a"), ir_var("b")], ir_var("pair"));
+    let list_pair = ir_unpack_assign("list", vec![ir_var("c"), ir_var("d")], ir_var("pair"));
+    let tuple_triple = ir_unpack_assign(
+        "tuple",
+        vec![ir_var("x"), ir_var("y"), ir_var("z")],
+        ir_var("triple"),
+    );
+    let obj_pair = ir_attr(ir_var("obj"), "pair");
+    let tuple_obj_pair =
+        ir_unpack_assign("tuple", vec![ir_var("m"), ir_var("n")], obj_pair.clone());
+    let xs_key = ir_subscript(ir_var("xs"), ir_var("key"));
+    let tuple_xs_key = ir_unpack_assign("tuple", vec![ir_var("p"), ir_var("q")], xs_key.clone());
+    let xs_slice = ir_subscript(ir_var("xs"), ir_slice(ir_var("i"), ir_var("j"), ir_none()));
+    let tuple_xs_slice =
+        ir_unpack_assign("tuple", vec![ir_var("r"), ir_var("s")], xs_slice.clone());
+    let loci = contract_runtime_failure_loci(&pool);
+    assert_eq!(
+        loci,
+        vec![
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "iter-unpack",
+                "argTerm": tuple_pair,
+                "file": "unpack.py",
+                "line": 2,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "iter-unpack",
+                "argTerm": list_pair,
+                "file": "unpack.py",
+                "line": 3,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "iter-unpack",
+                "argTerm": tuple_triple,
+                "file": "unpack.py",
+                "line": 4,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "attribute-access",
+                "exceptionClass": "AttributeError",
+                "argTerm": obj_pair,
+                "file": "unpack.py",
+                "line": 5,
+                "col": 11
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "iter-unpack",
+                "argTerm": tuple_obj_pair,
+                "file": "unpack.py",
+                "line": 5,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": xs_key,
+                "file": "unpack.py",
+                "line": 6,
+                "col": 11
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "iter-unpack",
+                "argTerm": tuple_xs_key,
+                "file": "unpack.py",
+                "line": 6,
+                "col": 4
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "subscript-access",
+                "argTerm": xs_slice,
+                "file": "unpack.py",
+                "line": 7,
+                "col": 11
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "iter-unpack",
+                "argTerm": tuple_xs_slice,
+                "file": "unpack.py",
+                "line": 7,
+                "col": 4
+            }),
+        ],
+        "mint must preserve python-source unpack runtime-failure panicLoci rows"
+    );
+
+    let callsites = provekit_verifier::enumerate_callsites::run(&pool);
+    let runtime_failure_sites: Vec<_> = callsites
+        .iter()
+        .filter(|cs| cs.panic_site && cs.callee.as_deref() == Some(RUNTIME_FAILURE_SITE_CONCEPT))
+        .collect();
+    assert_eq!(
+        runtime_failure_sites.len(),
+        9,
+        "verifier must surface nine unpack runtime-failure obligations; got {callsites:#?}"
+    );
+    assert!(
+        runtime_failure_sites
+            .iter()
+            .all(|cs| cs.file.as_deref() == Some("unpack.py")),
+        "all surfaced unpack callsites must preserve unpack.py provenance: {runtime_failure_sites:#?}"
+    );
+    assert_eq!(
+        runtime_failure_sites
+            .iter()
+            .map(|cs| (cs.line, cs.bridge_target_cid.is_empty()))
+            .collect::<Vec<_>>(),
+        vec![
+            (Some(2), true),
+            (Some(3), true),
+            (Some(4), true),
+            (Some(5), true),
+            (Some(5), true),
+            (Some(6), true),
+            (Some(6), true),
+            (Some(7), true),
+            (Some(7), true),
+        ],
+        "no bridges exist yet, so surfaced unpack callsites must remain undecidable"
     );
 
     let _ = fs::remove_dir_all(&project);


### PR DESCRIPTION
## What changed

Slice 13 of the Python source runtime-failure arc adds tight tuple/list unpacking support to `provekit-lift-python-source`.

- Lift top-level `ast.Tuple` / `ast.List` assignment targets when every element is an `ast.Name`.
- Emit `python:unpack_assign(kind_const, python:unpack_targets(var(...)), value)` so tuple vs list survives compile roundtrip without raw array-shaped body args.
- Emit one `iter-unpack` runtime-failure locus per unpack site, after any RHS loci, with no `exceptionClass` because the operation can fail as either `TypeError` or `ValueError`.
- Preserve existing Name-assignment semantics: no local-name `writes` effects.
- Keep starred, nested, attribute-element, and subscript-element unpacking refused and pinned by tests.

The Rust CLI change is integration-only: it stages a Python source kit through project `config.toml` and kit `manifest.toml`, mints through RPC, and verifies the resulting proof bytes and callsite enumeration. No Python unpack semantics were added to CLI/verifier/libprovekit production code.

## Why

Python tuple/list unpacking lowers to `UNPACK_SEQUENCE` for the tight supported shape, then `STORE_FAST` per Name element. Nested unpacking uses recursive `UNPACK_SEQUENCE`, starred unpacking uses `UNPACK_EX`, and complex element targets introduce nonlocal stores, so those remain explicit deferred variants.

`iter-unpack` is a kit-owned runtime-failure subkind under the existing runtime-failure-site concept, alongside the existing attribute/subscript/raise subkinds. It represents the unpack operation as one failure surface.

## Validation

- RED checkpoint: focused unpack suite was `9 failed, 5 passed, 112 deselected` before implementation.
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests/test_lifter.py -q -k 'unpack or out_of_scope'`: `14 passed, 112 deselected`
- `python3 -m pytest implementations/python/provekit-lift-python-source/tests -q`: `215 passed`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_mint_python_source_runtime_failure -- --nocapture`: `11 passed`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc --test cmd_verify_python_production_bridge --test cmd_verify_python_division_unsound -- --nocapture`: regression targets passed (`6`, `5`, and `2` tests respectively)
- Built prerequisites with `bcargo build -p provekit-walk --bin provekit-walk-rpc` and `bcargo build -p provekit-lift --bin provekit-lift`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture`: `1 passed`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo run -p provekit-cli -- doctor --target ../python --mode strict --json`: `ok: true` with existing resolver warnings
- `git diff --check`: clean
- Production Rust grep for `python:unpack`, `iter-unpack`, `unpack_assign`, `unpack_targets`: no hits outside the Python kit and the Rust integration test

`bcargo fmt -p provekit-cli --check` still fails on unrelated existing fmt drift in `provekit-cli`; after fixing the one changed-file nit, the changed integration test no longer appears in fmt output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tuple and list unpacking assignments in Python code verification with proper runtime-failure tracking.

* **Tests**
  * Expanded test coverage for unpacking patterns, including runtime-failure loci preservation and various unpacking scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->