### PR TITLE
[codex] Java source kit emits runtime-failure panicLoci for throw statements (#1837 slice 14)

### DIFF
--- a/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaSourceLifter.java
+++ b/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/JavaSourceLifter.java
@@ -67,6 +67,9 @@ import javax.tools.SimpleJavaFileObject;
 import javax.tools.ToolProvider;
 
 public final class JavaSourceLifter {
+    private static final String PANIC_FREEDOM_EFFECT_KIND = "concept:panic-freedom";
+    private static final String RUNTIME_FAILURE_SITE_CONCEPT = "concept:panic-freedom.leaf.runtime-failure-site";
+
     public LiftResult liftSource(String path, String source) {
         List<Jcs.Json> declarations = new ArrayList<>();
         List<Jcs.Json> diagnosticsJson = new ArrayList<>();
@@ -88,6 +91,7 @@ public final class JavaSourceLifter {
             List.of(),
             sort("Int"),
             eq(var("result"), sourceUnitTerm),
+            List.of(),
             List.of(),
             path,
             1,
@@ -248,7 +252,7 @@ public final class JavaSourceLifter {
                 return null;
             }
             try {
-                Emitter emitter = new Emitter(parsed, getCurrentPath().getCompilationUnit(), fnName);
+                Emitter emitter = new Emitter(parsed, getCurrentPath().getCompilationUnit(), path, fnName);
                 for (VariableElement param : executable.getParameters()) {
                     emitter.addLocal(param.getSimpleName().toString());
                 }
@@ -272,6 +276,7 @@ public final class JavaSourceLifter {
                     // Undecidable.
                     eq(var("result"), postValue),
                     emitter.effectsJson(),
+                    emitter.panicLociJson(),
                     path,
                     line,
                     1
@@ -296,13 +301,16 @@ public final class JavaSourceLifter {
     private static final class Emitter {
         private final Parsed parsed;
         private final CompilationUnitTree unit;
+        private final String sourcePath;
         private final String fnName;
         private final Set<String> locals = new LinkedHashSet<>();
         private final Map<String, Effect> effects = new LinkedHashMap<>();
+        private final List<Jcs.Json> panicLoci = new ArrayList<>();
 
-        Emitter(Parsed parsed, CompilationUnitTree unit, String fnName) {
+        Emitter(Parsed parsed, CompilationUnitTree unit, String sourcePath, String fnName) {
             this.parsed = parsed;
             this.unit = unit;
+            this.sourcePath = sourcePath;
             this.fnName = fnName;
         }
 
@@ -330,7 +338,15 @@ public final class JavaSourceLifter {
                 case THROW -> {
                     addEffect(Effect.panics());
                     ThrowTree t = (ThrowTree) tree;
-                    yield ctor("java:throw", emitExpression(new TreePath(path, t.getExpression())));
+                    TreePath expressionPath = new TreePath(path, t.getExpression());
+                    Jcs.Json thrownValue = emitExpression(expressionPath);
+                    panicLoci.add(runtimeFailureLocus(
+                        path,
+                        thrownValue,
+                        "explicit-throw",
+                        exceptionClass(t.getExpression())
+                    ));
+                    yield ctor("java:throw", thrownValue);
                 }
                 case EMPTY_STATEMENT -> skip();
                 default -> throw refuse(path, "unhandled statement kind: " + tree.getKind());
@@ -545,8 +561,36 @@ public final class JavaSourceLifter {
                 .toList();
         }
 
+        private List<Jcs.Json> panicLociJson() {
+            return List.copyOf(panicLoci);
+        }
+
         private void addEffect(Effect effect) {
             effects.putIfAbsent(effect.sortKey(), effect);
+        }
+
+        private Jcs.Obj runtimeFailureLocus(TreePath path, Jcs.Json argTerm, String subkind, String exceptionClass) {
+            List<Object> fields = new ArrayList<>(List.of(
+                "effectKind", Jcs.string(PANIC_FREEDOM_EFFECT_KIND),
+                "callee", Jcs.string(RUNTIME_FAILURE_SITE_CONCEPT),
+                "subkind", Jcs.string(subkind),
+                "argTerm", argTerm,
+                "file", Jcs.string(sourcePath),
+                "line", Jcs.integer(lineOf(parsed.trees(), unit, path.getLeaf())),
+                "col", Jcs.integer(columnOf(parsed.trees(), unit, path.getLeaf()))
+            ));
+            if (exceptionClass != null && !exceptionClass.isEmpty()) {
+                fields.add("exceptionClass");
+                fields.add(Jcs.string(exceptionClass));
+            }
+            return Jcs.object(fields.toArray());
+        }
+
+        private String exceptionClass(ExpressionTree expression) {
+            if (expression instanceof NewClassTree created) {
+                return created.getIdentifier().toString();
+            }
+            return null;
         }
 
         private RefuseException refuse(TreePath path, String reason) {
@@ -678,6 +722,13 @@ public final class JavaSourceLifter {
         return (int) unit.getLineMap().getLineNumber(pos);
     }
 
+    private static int columnOf(Trees trees, CompilationUnitTree unit, Tree tree) {
+        SourcePositions positions = trees.getSourcePositions();
+        long pos = positions.getStartPosition(unit, tree);
+        if (pos < 0 || unit.getLineMap() == null) return 0;
+        return (int) unit.getLineMap().getColumnNumber(pos);
+    }
+
     private static Jcs.Obj wrapSeqFromContracts(List<Jcs.Json> decls, int start) {
         List<Jcs.Json> terms = new ArrayList<>();
         for (int i = start; i < decls.size(); i++) {
@@ -699,8 +750,19 @@ public final class JavaSourceLifter {
         return (Jcs.Obj) result;
     }
 
-    private static Jcs.Obj functionContract(String fnName, List<String> formals, List<Jcs.Json> formalSorts, Jcs.Obj returnSort, Jcs.Obj post, List<Jcs.Json> effects, String file, int line, int col) {
-        return Jcs.object(
+    private static Jcs.Obj functionContract(
+        String fnName,
+        List<String> formals,
+        List<Jcs.Json> formalSorts,
+        Jcs.Obj returnSort,
+        Jcs.Obj post,
+        List<Jcs.Json> effects,
+        List<Jcs.Json> panicLoci,
+        String file,
+        int line,
+        int col
+    ) {
+        List<Object> fields = new ArrayList<>(List.of(
             "schemaVersion", Jcs.string("1"),
             "kind", Jcs.string("function-contract"),
             "fnName", Jcs.string(fnName),
@@ -713,7 +775,12 @@ public final class JavaSourceLifter {
             "effects", Jcs.array(effects),
             "locus", Jcs.object("file", Jcs.string(file), "line", Jcs.integer(line), "col", Jcs.integer(col)),
             "autoMintedMementos", Jcs.array()
-        );
+        ));
+        if (!panicLoci.isEmpty()) {
+            fields.add("panicLoci");
+            fields.add(Jcs.array(panicLoci));
+        }
+        return Jcs.object(fields.toArray());
     }
 
     private static Jcs.Obj trueFormula() {

--- a/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/JavaSourceLifterTest.java
+++ b/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/JavaSourceLifterTest.java
@@ -138,6 +138,55 @@ class JavaSourceLifterTest {
     }
 
     @Test
+    void throwStatementsEmitExplicitThrowRuntimeFailureLoci() {
+        String source = """
+            class C {
+              int f(int x) {
+                if (x < 0) {
+                  throw new IllegalArgumentException("neg");
+                }
+                throw new IllegalStateException("pos");
+              }
+            }
+            """;
+
+        JavaSourceLifter.LiftResult result = new JavaSourceLifter().liftSource("C.java", source);
+
+        assertTrue(result.refusals().isEmpty(), result.refusals().toString());
+        Jcs.Obj contract = contractByName(result, "C.f(int)");
+        Jcs.Arr effects = contract.arrayField("effects");
+        assertEquals(1, effects.values().size());
+        assertEquals("panics", effects.objectAt(0).stringField("kind"));
+
+        Jcs.Arr loci = contract.arrayField("panicLoci");
+        assertEquals(2, loci.values().size(), Jcs.encode(contract));
+
+        Jcs.Obj first = loci.objectAt(0);
+        assertEquals("concept:panic-freedom", first.stringField("effectKind"));
+        assertEquals("concept:panic-freedom.leaf.runtime-failure-site", first.stringField("callee"));
+        assertEquals("explicit-throw", first.stringField("subkind"));
+        assertEquals("IllegalArgumentException", first.stringField("exceptionClass"));
+        assertEquals("C.java", first.stringField("file"));
+        assertEquals(4, ((Jcs.Num) first.get("line")).value());
+        assertEquals(7, ((Jcs.Num) first.get("col")).value());
+        Jcs.Obj firstArg = first.objectField("argTerm");
+        assertEquals("java:new", firstArg.stringField("name"));
+        assertEquals("IllegalArgumentException", firstArg.arrayField("args").objectAt(0).stringField("value"));
+
+        Jcs.Obj second = loci.objectAt(1);
+        assertEquals("concept:panic-freedom", second.stringField("effectKind"));
+        assertEquals("concept:panic-freedom.leaf.runtime-failure-site", second.stringField("callee"));
+        assertEquals("explicit-throw", second.stringField("subkind"));
+        assertEquals("IllegalStateException", second.stringField("exceptionClass"));
+        assertEquals("C.java", second.stringField("file"));
+        assertEquals(6, ((Jcs.Num) second.get("line")).value());
+        assertEquals(5, ((Jcs.Num) second.get("col")).value());
+        Jcs.Obj secondArg = second.objectField("argTerm");
+        assertEquals("java:new", secondArg.stringField("name"));
+        assertEquals("IllegalStateException", secondArg.arrayField("args").objectAt(0).stringField("value"));
+    }
+
+    @Test
     void sourceUnitCompilerRoundTripsToByteIdenticalLiftedTerm() {
         String source = """
             class C {
@@ -153,6 +202,32 @@ class JavaSourceLifterTest {
         JavaSourceLifter.LiftResult second = lifter.liftSource("C.java", compiled);
 
         assertEquals(Jcs.encode(first.sourceUnitTerm()), Jcs.encode(second.sourceUnitTerm()));
+    }
+
+    @Test
+    void throwSourceUnitCompilerRoundTripsToByteIdenticalLiftedTerm() {
+        String source = """
+            class C {
+              int f(int x) {
+                throw new IllegalStateException("boom");
+              }
+            }
+            """;
+
+        JavaSourceLifter lifter = new JavaSourceLifter();
+        JavaSourceLifter.LiftResult first = lifter.liftSource("C.java", source);
+        String compiled = new JavaSourceCompiler().compile(first.sourceUnitTerm());
+        JavaSourceLifter.LiftResult second = lifter.liftSource("C.java", compiled);
+
+        assertEquals(Jcs.encode(first.sourceUnitTerm()), Jcs.encode(second.sourceUnitTerm()));
+    }
+
+    private static Jcs.Obj contractByName(JavaSourceLifter.LiftResult result, String fnName) {
+        return result.declarations().stream()
+            .map(Jcs.Obj.class::cast)
+            .filter(o -> fnName.equals(o.stringField("fnName")))
+            .findFirst()
+            .orElseThrow();
     }
 
     private static void assertAllOpsAreJavaNamespaced(Jcs.Json value) {


### PR DESCRIPTION
## Summary

First cross-language extension of the #1828 substrate expansion arc. The Java source kit's direct `JavaSourceLifter` surface now emits `concept:panic-freedom.leaf.runtime-failure-site` `panicLoci` for Java `ThrowTree` statements.

This mirrors the Python source runtime-failure pattern at the substrate concept layer while keeping the kit-owned diagnostic subkind source-syntax aligned:

- Python keyword `raise` uses `explicit-raise`.
- Java keyword `throw` uses `explicit-throw`.
- The federated identity remains the shared `concept:panic-freedom.leaf.runtime-failure-site` concept.

Java `throw` semantics are grounded in JLS 14.18: a throw statement evaluates its expression, then completes abruptly with the thrown value, with `null` becoming `NullPointerException`. Source: https://docs.oracle.com/javase/specs/jls/se21/html/jls-14.html#jls-14.18

## What Changed

- `JavaSourceLifter` now collects one runtime-failure locus per `ThrowTree`.
- Each locus carries:
  - `effectKind = concept:panic-freedom`
  - `callee = concept:panic-freedom.leaf.runtime-failure-site`
  - `subkind = explicit-throw`
  - `argTerm = <thrown expression term>`
  - best-effort `exceptionClass` for `new X(...)`
  - Java source `file`, `line`, and `col`
- Function contracts include `panicLoci` only when nonempty, preserving the existing shape for non-panic-bearing contracts.
- Tests cover two throw sites, deduped `panics` effect, exception class extraction, source provenance, arg terms, and throw roundtrip preservation.

## Scope Boundary

This PR is Java kit-side only. It does not change the Rust CLI, verifier, doctor, or libprovekit.

The current manifest/RPC production path for `java-source` does not reach `JavaSourceLifter`; it routes through `BindRpcServer`/`JavaBindLifter`. That operational federation gap is tracked separately in #1849. This PR intentionally lands the direct-surface emission machinery first and keeps the dispatch repair as a separate slice.

## Validation

RED/GREEN:

- RED: `mvn -pl provekit-lift-java-source -am -Dtest=JavaSourceLifterTest test` failed on missing `panicLoci`.
- GREEN: `mvn -pl provekit-lift-java-source -am -Dtest=JavaSourceLifterTest test` passed, 8 tests.

Java gates:

- `mvn -pl provekit-lift-java-source -am test` passed.
  - `provekit-ir`: 36 tests
  - `provekit-lift-java-core`: 14 tests
  - `provekit-lift-java-source`: 56 tests
- `mvn -pl provekit-lift-java-source -am package` passed and produced the shaded Java source kit jar.

Rust cross-cutting regressions:

- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc --test cmd_verify_python_production_bridge --test cmd_verify_python_division_unsound -- --nocapture` passed.
  - `kit_declaration_rpc`: 6 tests
  - `cmd_verify_python_production_bridge`: 5 tests
  - `cmd_verify_python_division_unsound`: 2 tests
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc` passed.
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-lift --bin provekit-lift` passed.
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` passed, 1 test, 121.31s.

Other checks:

- `git diff --check` passed.
- Path A grep over `origin/main...HEAD` produced zero output for `libprovekit`, `provekit-verifier`, and `provekit-cli/src`.
