### PR TITLE
[codex] Sync implementations/java in bcargo

### DIFF
--- a/bin/bcargo
+++ b/bin/bcargo
@@ -194,6 +194,7 @@ sync_dir .provekit/realize
 sync_dir implementations/rust
 sync_dir implementations/python
 sync_dir implementations/go
+sync_dir implementations/java
 sync_dir examples
 sync_dir menagerie
 sync_dir tools


### PR DESCRIPTION
## Summary

Adds `implementations/java` to the `bcargo` sync set so Rust integration tests can run Java kit federation smokes on `battleaxe`.

## Why

#1849 needs a production-path Java source federation smoke under the required `bcargo` workflow. The RED test currently reaches `battleaxe`, but the remote checkout lacks `implementations/java`, so Maven cannot package `provekit-lift-java-source` there. This mirrors the existing language-root sync precedent from #1813 and #1820.

## Validation

- `bash -n bin/bcargo`
- `git diff --check`
- `BCARGO_PYTHON_ENV=0 ../../bin/bcargo --version`
- Confirmed remote path exists: `implementations/java/provekit-lift-java-source`
