### PR TITLE
[codex] Route java-source RPC to JavaSourceLifter (#1849)

### DIFF
--- a/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/Program.java
+++ b/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/Program.java
@@ -3,8 +3,18 @@ package com.provekit.lift.java_source;
 public final class Program {
     private Program() {}
 
+    enum RpcMode {
+        SOURCE,
+        BIND
+    }
+
     public static void main(String[] args) throws Exception {
-        if (args.length == 1 && "--rpc".equals(args[0])) {
+        RpcMode mode = rpcMode(args);
+        if (mode == RpcMode.SOURCE) {
+            SourceRpcServer.run();
+            return;
+        }
+        if (mode == RpcMode.BIND) {
             // PEP 1.7.0 bind-lift surface: emits bind-lift-entry records per
             // protocol/specs/2026-05-13-bind-ir-lift-result.md. cmd_bind
             // dispatches Verb 1 (Lift) here when source_lang=java. The kit
@@ -13,7 +23,16 @@ public final class Program {
             BindRpcServer.run();
             return;
         }
-        System.err.println("usage: java -jar provekit-lift-java-source.jar --rpc");
+        System.err.println("usage: java -jar provekit-lift-java-source.jar --rpc|--bind-rpc");
         System.exit(1);
+    }
+
+    static RpcMode rpcMode(String[] args) {
+        if (args.length != 1) return null;
+        return switch (args[0]) {
+            case "--rpc" -> RpcMode.SOURCE;
+            case "--bind-rpc" -> RpcMode.BIND;
+            default -> null;
+        };
     }
 }

--- a/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/SourceRpcServer.java
+++ b/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/SourceRpcServer.java
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.provekit.lift.java_source;
+
+import com.provekit.ir.Jcs;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class SourceRpcServer {
+    private static final String KIT_ID = "java";
+
+    private SourceRpcServer() {}
+
+    public static void run() throws IOException {
+        BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+        PrintWriter out = new PrintWriter(System.out, true);
+        String line;
+        while ((line = in.readLine()) != null) {
+            if (line.isBlank()) continue;
+            Jcs.Obj response;
+            try {
+                response = handle((Jcs.Obj) Jcs.parse(line));
+            } catch (RuntimeException e) {
+                response = error(Jcs.nullValue(), -32700, "PARSE_ERROR: " + e.getMessage());
+            }
+            out.println(Jcs.encode(response));
+        }
+    }
+
+    static Jcs.Obj handle(Jcs.Obj request) {
+        Jcs.Json id = request.get("id") == null ? Jcs.nullValue() : request.get("id");
+        String method = request.stringFieldOrNull("method");
+        if (method == null) return error(id, -32600, "INVALID_REQUEST: missing method");
+        return switch (method) {
+            case "initialize" -> initialize(id);
+            case "lift" -> lift(id, request.get("params"));
+            case "shutdown" -> Jcs.object("jsonrpc", Jcs.string("2.0"), "id", id, "result", Jcs.nullValue());
+            default -> error(id, -32601, "METHOD_NOT_FOUND: " + method);
+        };
+    }
+
+    private static Jcs.Obj initialize(Jcs.Json id) {
+        return Jcs.object(
+            "id", id,
+            "jsonrpc", Jcs.string("2.0"),
+            "result", Jcs.object(
+                "capabilities", Jcs.object(
+                    "authoring_surfaces", Jcs.array(Jcs.string("java-source")),
+                    "emits_signed_mementos", Jcs.bool(false),
+                    "ir_version", Jcs.string("v1.1.0")
+                ),
+                "kit_id", Jcs.string(KIT_ID),
+                "name", Jcs.string("provekit-lift-java-source"),
+                "protocol_version", Jcs.string("pep/1.7.0"),
+                "version", Jcs.string("0.1.0")
+            )
+        );
+    }
+
+    private static Jcs.Obj lift(Jcs.Json id, Jcs.Json paramsJson) {
+        if (!(paramsJson instanceof Jcs.Obj params)) {
+            return error(id, -32602, "INVALID_PARAMS: params object required");
+        }
+        String workspaceRoot = params.stringFieldOrNull("workspace_root");
+        if (workspaceRoot == null) workspaceRoot = ".";
+
+        List<String> sourcePaths = new ArrayList<>();
+        Jcs.Json sourcePathsJson = params.get("source_paths");
+        if (sourcePathsJson instanceof Jcs.Arr arr) {
+            for (Jcs.Json value : arr.values()) {
+                if (value instanceof Jcs.Str sourcePath) {
+                    sourcePaths.add(sourcePath.value());
+                }
+            }
+        }
+        if (sourcePaths.isEmpty()) sourcePaths.add(".");
+
+        JavaSourceLifter.LiftResult result =
+            new JavaSourceLifter().liftPaths(workspaceRoot, sourcePaths);
+        return Jcs.object(
+            "id", id,
+            "jsonrpc", Jcs.string("2.0"),
+            "result", result.toJson()
+        );
+    }
+
+    private static Jcs.Obj error(Jcs.Json id, int code, String message) {
+        return Jcs.object(
+            "error", Jcs.object("code", Jcs.integer(code), "message", Jcs.string(message)),
+            "id", id,
+            "jsonrpc", Jcs.string("2.0")
+        );
+    }
+}

--- a/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/ProgramDispatchTest.java
+++ b/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/ProgramDispatchTest.java
@@ -1,0 +1,31 @@
+package com.provekit.lift.java_source;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class ProgramDispatchTest {
+    @Test
+    void rpcFlagRoutesToJavaSourceServer() {
+        Program.RpcMode mode = rpcMode("--rpc");
+
+        assertEquals(Program.RpcMode.SOURCE, mode);
+    }
+
+    @Test
+    void bindRpcFlagRoutesToBindServer() {
+        Program.RpcMode mode = rpcMode("--bind-rpc");
+
+        assertEquals(Program.RpcMode.BIND, mode);
+    }
+
+    @Test
+    void unknownFlagHasNoRpcMode() {
+        assertNull(rpcMode("--nope"));
+    }
+
+    private static Program.RpcMode rpcMode(String arg) {
+        return Program.rpcMode(new String[] {arg});
+    }
+}

--- a/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/SourceRpcServerTest.java
+++ b/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/SourceRpcServerTest.java
@@ -1,0 +1,105 @@
+package com.provekit.lift.java_source;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.provekit.ir.Jcs;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SourceRpcServerTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void initializeAdvertisesJavaSourceLiftProtocol() throws Exception {
+        Jcs.Obj response = handle("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}");
+        Jcs.Obj result = response.objectField("result");
+
+        assertEquals("provekit-lift-java-source", result.stringField("name"));
+        assertEquals("pep/1.7.0", result.stringField("protocol_version"));
+        Jcs.Obj capabilities = result.objectField("capabilities");
+        assertTrue(Jcs.encode(capabilities.arrayField("authoring_surfaces")).contains("java-source"));
+        assertEquals("v1.1.0", capabilities.stringField("ir_version"));
+    }
+
+    @Test
+    void liftReturnsFunctionContractWithExplicitThrowRuntimeFailureLocus() throws Exception {
+        Files.writeString(temp.resolve("Thrower.java"), """
+public class Thrower {
+static int fail(int x) {
+if (x < 0) {
+throw new IllegalStateException("neg");
+}
+return x;
+}
+}
+""");
+
+        String request = "{"
+            + "\"jsonrpc\":\"2.0\","
+            + "\"id\":2,"
+            + "\"method\":\"lift\","
+            + "\"params\":{"
+            + "\"surface\":\"java-source\","
+            + "\"workspace_root\":" + jsonEncodeString(temp.toString()) + ","
+            + "\"source_paths\":[\"Thrower.java\"],"
+            + "\"options\":{\"layer\":\"all\",\"identifyOnly\":false}"
+            + "}}";
+
+        Jcs.Obj response = handle(request);
+        Jcs.Obj result = response.objectField("result");
+
+        assertEquals("ir-document", result.stringField("kind"));
+        Jcs.Obj contract = contractByName(result, "Thrower.fail(int)");
+        Jcs.Arr loci = contract.arrayField("panicLoci");
+        assertEquals(1, loci.values().size(), Jcs.encode(contract));
+        Jcs.Obj locus = loci.objectAt(0);
+        assertEquals("concept:panic-freedom", locus.stringField("effectKind"));
+        assertEquals("concept:panic-freedom.leaf.runtime-failure-site", locus.stringField("callee"));
+        assertEquals("explicit-throw", locus.stringField("subkind"));
+        assertEquals("IllegalStateException", locus.stringField("exceptionClass"));
+        assertEquals("Thrower.java", locus.stringField("file"));
+        assertEquals(4, ((Jcs.Num) locus.get("line")).value());
+        assertEquals(1, ((Jcs.Num) locus.get("col")).value());
+        assertEquals("java:new", locus.objectField("argTerm").stringField("name"));
+    }
+
+    @Test
+    void shutdownReturnsNullResult() throws Exception {
+        Jcs.Obj response = handle("{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"shutdown\",\"params\":{}}");
+
+        assertTrue(response.get("result") instanceof Jcs.Null, Jcs.encode(response));
+    }
+
+    private static Jcs.Obj handle(String request) throws Exception {
+        return SourceRpcServer.handle((Jcs.Obj) Jcs.parse(request));
+    }
+
+    private static Jcs.Obj contractByName(Jcs.Obj result, String fnName) {
+        return result.arrayField("ir").values().stream()
+            .map(Jcs.Obj.class::cast)
+            .filter(o -> fnName.equals(o.stringFieldOrNull("fnName")))
+            .findFirst()
+            .orElseThrow();
+    }
+
+    private static String jsonEncodeString(String s) {
+        StringBuilder sb = new StringBuilder("\"");
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"' -> sb.append("\\\"");
+                case '\\' -> sb.append("\\\\");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                default -> sb.append(c);
+            }
+        }
+        sb.append("\"");
+        return sb.toString();
+    }
+}

--- a/implementations/rust/provekit-cli/tests/cmd_mint_java_source_runtime_failure.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_java_source_runtime_failure.rs
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use serde_json::{json, Value as Json};
+
+const RUNTIME_FAILURE_SITE_CONCEPT: &str = "concept:panic-freedom.leaf.runtime-failure-site";
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-java-source-runtime-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+fn run_with_timeout(cmd: &mut Command, timeout: Duration) -> std::io::Result<Output> {
+    let mut child = cmd.spawn()?;
+    let started = Instant::now();
+    loop {
+        if child.try_wait()?.is_some() {
+            return child.wait_with_output();
+        }
+        if started.elapsed() >= timeout {
+            let _ = child.kill();
+            return child.wait_with_output();
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn java_bin() -> Option<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(java_home) = std::env::var_os("JAVA_HOME") {
+        candidates.push(PathBuf::from(java_home).join("bin").join("java"));
+    }
+    candidates.push(PathBuf::from("java"));
+    candidates.push(PathBuf::from(
+        "/usr/local/opt/openjdk/libexec/openjdk.jdk/Contents/Home/bin/java",
+    ));
+    candidates.push(PathBuf::from(
+        "/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home/bin/java",
+    ));
+
+    candidates.into_iter().find(|candidate| {
+        run_with_timeout(
+            Command::new(candidate).arg("-version"),
+            Duration::from_secs(5),
+        )
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+    })
+}
+
+fn maven_available() -> bool {
+    run_with_timeout(Command::new("mvn").arg("-version"), Duration::from_secs(8))
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn java_source_lift_command() -> Option<Vec<String>> {
+    static JAVA_SOURCE_LIFT_COMMAND: OnceLock<Option<Vec<String>>> = OnceLock::new();
+    JAVA_SOURCE_LIFT_COMMAND
+        .get_or_init(|| {
+            let Some(java) = java_bin() else {
+                eprintln!(
+                    "no working java binary found: skipping java-source runtime-failure mint test"
+                );
+                return None;
+            };
+            if !maven_available() {
+                eprintln!("mvn unavailable: skipping java-source runtime-failure mint test");
+                return None;
+            }
+
+            let root = repo_root();
+            let mut mvn = Command::new("mvn");
+            mvn.current_dir(root.join("implementations").join("java"))
+                .args([
+                    "-B",
+                    "-ntp",
+                    "-pl",
+                    "provekit-lift-java-source",
+                    "-am",
+                    "-DskipTests",
+                    "package",
+                ]);
+            let out =
+                run_with_timeout(&mut mvn, Duration::from_secs(120)).expect("spawn mvn package");
+            assert!(
+                out.status.success(),
+                "mvn package provekit-lift-java-source failed\n  stdout: {}\n  stderr: {}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr)
+            );
+            let jar = root
+                .join("implementations")
+                .join("java")
+                .join("provekit-lift-java-source")
+                .join("target")
+                .join("provekit-lift-java-source.jar");
+            assert!(
+                jar.exists(),
+                "maven build produced no jar at {}",
+                jar.display()
+            );
+            Some(vec![
+                java.display().to_string(),
+                "-jar".to_string(),
+                jar.display().to_string(),
+                "--rpc".to_string(),
+            ])
+        })
+        .clone()
+}
+
+fn toml_string_array(values: &[String]) -> String {
+    let quoted = values
+        .iter()
+        .map(|v| format!("\"{}\"", v.replace('\\', "\\\\").replace('"', "\\\"")))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("[{quoted}]")
+}
+
+fn stage_java_source_project(command: &[String]) -> PathBuf {
+    let project = unique_dir("project");
+    fs::write(
+        project.join("Thrower.java"),
+        r#"public class Thrower {
+static int fail(int x) {
+if (x < 0) {
+throw new IllegalStateException("neg");
+}
+return x;
+}
+}
+"#,
+    )
+    .expect("write Thrower.java");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("java-source"))
+        .expect("mkdir .provekit/lift/java-source");
+    fs::write(
+        provekit.join("config.toml"),
+        r#"[[plugins]]
+name = "java-source"
+kind = "lift"
+surface = "java-source"
+"#,
+    )
+    .expect("write config.toml");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("java-source")
+            .join("manifest.toml"),
+        format!(
+            r#"name = "java-source"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = {}
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["java-source"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+"#,
+            toml_string_array(command)
+        ),
+    )
+    .expect("write manifest.toml");
+
+    project
+}
+
+fn run_mint(project: &Path) {
+    let out = Command::new(provekit_bin())
+        .arg("mint")
+        .arg("--project")
+        .arg(project)
+        .arg("--out")
+        .arg(project)
+        .arg("--no-attest")
+        .arg("--quiet")
+        .output()
+        .expect("spawn provekit mint");
+    assert!(
+        out.status.success(),
+        "provekit mint must succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn contract_runtime_failure_loci(pool: &provekit_verifier::types::MementoPool) -> Vec<Json> {
+    pool.mementos
+        .values()
+        .filter(|env| provekit_verifier::types::memento_kind(env) == Some("contract"))
+        .filter_map(|env| provekit_verifier::types::memento_body_field(env, "panicLoci"))
+        .filter_map(|value| value.as_array())
+        .flat_map(|items| items.iter().cloned())
+        .collect()
+}
+
+#[test]
+fn java_source_throw_mint_preserves_runtime_failure_locus_and_enumerates_callsite() {
+    let Some(command) = java_source_lift_command() else {
+        return;
+    };
+    let project = stage_java_source_project(&command);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "java-source proof must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let loci = contract_runtime_failure_loci(&pool);
+    assert_eq!(
+        loci,
+        vec![json!({
+            "effectKind": "concept:panic-freedom",
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "explicit-throw",
+            "exceptionClass": "IllegalStateException",
+            "argTerm": {
+                "kind": "ctor",
+                "name": "java:new",
+                "args": [
+                    {
+                        "kind": "const",
+                        "sort": {"kind": "primitive", "name": "String"},
+                        "value": "IllegalStateException"
+                    },
+                    {
+                        "kind": "const",
+                        "sort": {"kind": "primitive", "name": "String"},
+                        "value": "neg"
+                    }
+                ]
+            },
+            "file": "Thrower.java",
+            "line": 4,
+            "col": 1
+        })],
+        "mint must preserve the java-source runtime-failure panicLoci row"
+    );
+
+    let callsites = provekit_verifier::enumerate_callsites::run(&pool);
+    let runtime_failure_sites: Vec<_> = callsites
+        .iter()
+        .filter(|cs| cs.panic_site && cs.callee.as_deref() == Some(RUNTIME_FAILURE_SITE_CONCEPT))
+        .collect();
+    assert_eq!(
+        runtime_failure_sites.len(),
+        1,
+        "verifier must surface exactly one Java runtime-failure panic site; got {callsites:#?}"
+    );
+    assert_eq!(
+        runtime_failure_sites[0].file.as_deref(),
+        Some("Thrower.java")
+    );
+    assert_eq!(runtime_failure_sites[0].line, Some(4));
+    assert!(
+        runtime_failure_sites[0].bridge_target_cid.is_empty(),
+        "no bridge exists yet, so the surfaced callsite must remain undecidable"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}


### PR DESCRIPTION
Closes #1849.

## Summary

This repairs the Java source lift kit dispatch path so the manifest-driven `--rpc` entrypoint reaches the Java source lifter instead of the bind-lift server.

- `Program --rpc` now routes to a new `SourceRpcServer`.
- `Program --bind-rpc` now routes to the existing `BindRpcServer`.
- `SourceRpcServer` implements initialize, lift, and shutdown over stdio JSON-RPC and delegates lift to `JavaSourceLifter.liftPaths`, returning `LiftResult.toJson()`.
- Adds Java dispatch and source-RPC lifecycle tests.
- Adds a Rust production-path mint smoke test that stages a project-local `.provekit/config.toml` and java-source manifest, runs `provekit mint`, loads the proof pool, and asserts Java explicit-throw `panicLoci` plus the enumerated runtime-failure callsite.

## Root Cause

`implementations/java/.provekit/lift/java-source/manifest.toml` invokes `provekit-lift-java-source.jar --rpc`, but the jar's `Program` previously routed `--rpc` unconditionally to `BindRpcServer`. That meant production mint saw bind-lift entries instead of Java source function-contract IR with panic loci.

The checked-in bind-lift manifest uses `--bind-rpc`; this PR preserves that path and makes the two RPC surfaces explicit.

## Scope

Java kit-side dispatch plus one Rust integration test only.

No CLI, verifier, doctor, or libprovekit production Rust changes. Path A grep was zero for `libprovekit`, `provekit-verifier`, and `provekit-cli/src`.

## Validation

RED first:

- Java focused tests initially failed with missing `Program.rpcMode` and missing `SourceRpcServer`.
- After #1851 enabled bcargo Java sync, the Rust integration smoke reached Maven and failed behaviorally with `kit transform failed: no contracts to mint`, confirming production `--rpc` was still going through bind-lift.

GREEN:

- `mvn -pl provekit-lift-java-source -am -Dtest=ProgramDispatchTest,SourceRpcServerTest,BindRpcServerTest test` - passed, 8 tests.
- `mvn -pl provekit-lift-java-source -am test` - passed, 36 + 14 + 62 tests.
- `mvn -pl provekit-lift-java-source -am package` - passed.
- Jar-level initialize handshakes verified `--rpc` advertises `provekit-lift-java-source` with `java-source`; `--bind-rpc` advertises the bind/LSP server.
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_mint_java_source_runtime_failure -- --nocapture` - passed, 1 test.
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc` - passed.
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-lift --bin provekit-lift` - passed.
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` - passed, 1 test in 122.30s.
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc --test cmd_verify_python_production_bridge --test cmd_verify_python_division_unsound -- --nocapture` - passed, 6 + 5 + 2 tests.
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo run -p provekit-cli -- doctor --target ../python --mode strict --json` - exit 0, `ok: true`.
- `git diff --check` - passed.
- `rustfmt --check implementations/rust/provekit-cli/tests/cmd_mint_java_source_runtime_failure.rs` - passed.

Note: full `bcargo fmt --check --all` currently reports unrelated main-branch Rust formatting drift outside this PR's touched Rust test file, so this PR keeps formatting scoped to the new Rust file.