### PR TITLE
[codex] Go kit emits explicit-panic runtime-failure-site loci (#1853)

### DIFF
--- a/implementations/go/provekit-lift-go/lift.go
+++ b/implementations/go/provekit-lift-go/lift.go
@@ -201,21 +201,24 @@ func LiftSourceWithOptions(packagePath, sourcePath string, source []byte, opts L
 		pkg = types.NewPackage(packagePath, file.Name.Name)
 	}
 
-	known := map[string]bool{}
-	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok {
-			continue
-		}
-		if obj, ok := info.Defs[fn.Name].(*types.Func); ok {
-			known[obj.FullName()] = true
-		} else {
-			known[fallbackFuncName(packagePath, fn)] = true
-		}
-	}
-
-	var result LiftResult
+	known := knownFunctions(packagePath, []*ast.File{file}, info)
+	result, err := liftCheckedFileWithOptions(packagePath, sourcePath, source, fset, file, pkg, info, known, opts)
 	result.Diagnostics = diagnostics
+	return result, err
+}
+
+func liftCheckedFileWithOptions(
+	packagePath string,
+	sourcePath string,
+	source []byte,
+	fset *token.FileSet,
+	file *ast.File,
+	pkg *types.Package,
+	info *types.Info,
+	known map[string]bool,
+	opts LiftOptions,
+) (LiftResult, error) {
+	var result LiftResult
 	result.Annotations = map[string]*Annotation{}
 	var bodyTerms []any
 	for _, decl := range file.Decls {
@@ -375,7 +378,7 @@ func (l *lifter) liftLeadingGuardPreconditions(stmts []ast.Stmt) ir.IrFormula {
 	var atoms []ir.IrFormula
 	for _, stmt := range stmts {
 		ifStmt, ok := stmt.(*ast.IfStmt)
-		if !ok || ifStmt.Init != nil || ifStmt.Else != nil || !isPanicOnlyBlock(ifStmt.Body) {
+		if !ok || ifStmt.Init != nil || ifStmt.Else != nil || !l.isPanicOnlyBlock(ifStmt.Body) {
 			break
 		}
 		atom, ok := l.guardPreconditionAtom(ifStmt.Cond)
@@ -407,7 +410,7 @@ func (l *lifter) guardPreconditionAtom(cond ast.Expr) (ir.IrFormula, bool) {
 }
 
 // isPanicOnlyBlock reports whether a block is exactly `{ panic(...) }`.
-func isPanicOnlyBlock(b *ast.BlockStmt) bool {
+func (l *lifter) isPanicOnlyBlock(b *ast.BlockStmt) bool {
 	if b == nil || len(b.List) != 1 {
 		return false
 	}
@@ -419,8 +422,7 @@ func isPanicOnlyBlock(b *ast.BlockStmt) bool {
 	if !ok {
 		return false
 	}
-	ident, ok := call.Fun.(*ast.Ident)
-	return ok && ident.Name == "panic"
+	return l.isBuiltinPanicCall(call)
 }
 
 func extractFormals(info *types.Info, fn *ast.FuncDecl) ([]string, []any, map[types.Object]bool, error) {
@@ -886,7 +888,7 @@ func (l *lifter) isBuiltinPanicCall(call *ast.CallExpr) bool {
 		builtin, ok := obj.(*types.Builtin)
 		return ok && builtin.Name() == "panic"
 	}
-	return true
+	return false
 }
 
 func (l *lifter) runtimeFailureLocus(pos token.Pos, argTerm ir.IrTerm) any {
@@ -1391,17 +1393,18 @@ func LiftPathsWithOptions(workspaceRoot string, sourcePaths []string, opts LiftO
 		}
 		files = append(files, expanded...)
 	}
+	groups := map[string][]string{}
 	for _, path := range files {
-		bytes, err := readFile(path)
-		if err != nil {
-			return LiftResult{}, err
-		}
-		rel := path
-		if r, relErr := filepath.Rel(workspaceRoot, path); relErr == nil {
-			rel = r
-		}
 		pkgPath := packagePathFor(modulePath, workspaceRoot, path)
-		lifted, err := LiftSourceWithOptions(pkgPath, rel, bytes, opts)
+		groups[pkgPath] = append(groups[pkgPath], path)
+	}
+	var pkgPaths []string
+	for pkgPath := range groups {
+		pkgPaths = append(pkgPaths, pkgPath)
+	}
+	sort.Strings(pkgPaths)
+	for _, pkgPath := range pkgPaths {
+		lifted, err := liftPackagePathsWithOptions(workspaceRoot, pkgPath, groups[pkgPath], opts)
 		if err != nil {
 			return LiftResult{}, err
 		}
@@ -1418,4 +1421,93 @@ func LiftPathsWithOptions(workspaceRoot string, sourcePaths []string, opts LiftO
 		}
 	}
 	return merged, nil
+}
+
+type parsedGoFile struct {
+	rel    string
+	source []byte
+	file   *ast.File
+}
+
+func liftPackagePathsWithOptions(workspaceRoot string, packagePath string, paths []string, opts LiftOptions) (LiftResult, error) {
+	sort.Strings(paths)
+	fset := token.NewFileSet()
+	var parsed []parsedGoFile
+	var astFiles []*ast.File
+	for _, path := range paths {
+		bytes, err := readFile(path)
+		if err != nil {
+			return LiftResult{}, err
+		}
+		rel := path
+		if r, relErr := filepath.Rel(workspaceRoot, path); relErr == nil {
+			rel = r
+		}
+		file, err := parser.ParseFile(fset, rel, bytes, parser.ParseComments)
+		if err != nil {
+			return LiftResult{}, err
+		}
+		parsed = append(parsed, parsedGoFile{rel: rel, source: bytes, file: file})
+		astFiles = append(astFiles, file)
+	}
+	info := &types.Info{
+		Types:      map[ast.Expr]types.TypeAndValue{},
+		Defs:       map[*ast.Ident]types.Object{},
+		Uses:       map[*ast.Ident]types.Object{},
+		Selections: map[*ast.SelectorExpr]*types.Selection{},
+	}
+	var diagnostics []Diagnostic
+	conf := types.Config{
+		Importer: importer.Default(),
+		Error: func(err error) {
+			diagnostics = append(diagnostics, Diagnostic{Path: packagePath, Message: err.Error()})
+		},
+	}
+	pkg, _ := conf.Check(packagePath, fset, astFiles, info)
+	if pkg == nil {
+		pkgName := packagePath
+		if len(astFiles) > 0 && astFiles[0].Name != nil {
+			pkgName = astFiles[0].Name.Name
+		}
+		pkg = types.NewPackage(packagePath, pkgName)
+	}
+	known := knownFunctions(packagePath, astFiles, info)
+
+	var merged LiftResult
+	merged.Diagnostics = diagnostics
+	for _, item := range parsed {
+		lifted, err := liftCheckedFileWithOptions(packagePath, item.rel, item.source, fset, item.file, pkg, info, known, opts)
+		if err != nil {
+			return LiftResult{}, err
+		}
+		merged.IR = append(merged.IR, lifted.IR...)
+		merged.Contracts = append(merged.Contracts, lifted.Contracts...)
+		merged.SourceUnits = append(merged.SourceUnits, lifted.SourceUnits...)
+		merged.Refusals = append(merged.Refusals, lifted.Refusals...)
+		for fnName, ann := range lifted.Annotations {
+			if merged.Annotations == nil {
+				merged.Annotations = map[string]*Annotation{}
+			}
+			merged.Annotations[fnName] = ann
+		}
+	}
+	return merged, nil
+}
+
+func knownFunctions(packagePath string, files []*ast.File, info *types.Info) map[string]bool {
+	known := map[string]bool{}
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			if obj, ok := info.Defs[fn.Name].(*types.Func); ok {
+				known[obj.FullName()] = true
+			} else {
+				known[fallbackFuncName(packagePath, fn)] = true
+			}
+		}
+	}
+	return known
 }

--- a/implementations/go/provekit-lift-go/lift.go
+++ b/implementations/go/provekit-lift-go/lift.go
@@ -20,6 +20,12 @@ import (
 	"github.com/tsavo/provekit/go/provekit-ir-symbolic/ir"
 )
 
+const (
+	panicFreedomConceptName     = "concept:panic-freedom"
+	runtimeFailureSiteConceptID = "concept:panic-freedom.leaf.runtime-failure-site"
+	explicitPanicSubkind        = "explicit-panic"
+)
+
 type lifter struct {
 	fset       *token.FileSet
 	file       *ast.File
@@ -30,6 +36,7 @@ type lifter struct {
 	locals     map[types.Object]bool
 	knownFuncs map[string]bool
 	effects    *effectSet
+	panicLoci  []any
 	// normalizeCoreArith selects the VERIFY-FACING op dialect: when true, the
 	// arithmetic / comparison operators that map onto SMT-LIB core theories
 	// (Int / Bool) are emitted with their core symbol (`*`, `+`, `<`, ...)
@@ -347,6 +354,7 @@ func liftFunc(fset *token.FileSet, file *ast.File, pkg *types.Package, info *typ
 		Formals:            formals,
 		Kind:               "function-contract",
 		Locus:              Locus{File: &fileName, Line: pos.Line, Col: pos.Column},
+		PanicLoci:          l.panicLoci,
 		Post:               post,
 		Pre:                pre,
 		ReturnSort:         returnSort,
@@ -831,6 +839,7 @@ func (l *lifter) liftIdent(id *ast.Ident) (exprResult, error) {
 }
 
 func (l *lifter) liftCall(call *ast.CallExpr) (exprResult, error) {
+	isBuiltinPanic := l.isBuiltinPanicCall(call)
 	calleeName := l.calleeName(call.Fun)
 	var args []ir.IrTerm
 	var algArgs []any
@@ -842,8 +851,18 @@ func (l *lifter) liftCall(call *ast.CallExpr) (exprResult, error) {
 		args = append(args, lifted.term)
 		algArgs = append(algArgs, lifted.alg)
 	}
-	if calleeName == "panic" {
+	if isBuiltinPanic {
+		if len(args) != 1 {
+			return exprResult{}, errAt(call.Pos(), "panic call with %d args is not modeled", len(args))
+		}
 		l.effects.add(Effect{Kind: "panics"})
+		l.panicLoci = append(l.panicLoci, l.runtimeFailureLocus(call.Pos(), args[0]))
+		sort := irSort(l.info.Types[call].Type)
+		return exprResult{
+			term: ir.MakeCtor("go:panic", args, sort),
+			alg:  op("go:panic", algArgs...),
+			sort: sort,
+		}, nil
 	} else if isIOCall(calleeName) {
 		l.effects.add(Effect{Kind: "io"})
 	} else if calleeName == "unsafe" || strings.HasPrefix(calleeName, "unsafe.") {
@@ -856,6 +875,35 @@ func (l *lifter) liftCall(call *ast.CallExpr) (exprResult, error) {
 	alg := op("go:call", append([]any{map[string]any{"kind": "identifier", "name": calleeName}}, algArgs...)...)
 	sort := irSort(l.info.Types[call].Type)
 	return exprResult{term: ir.MakeCtor("go:call", termArgs, sort), alg: alg, sort: sort}, nil
+}
+
+func (l *lifter) isBuiltinPanicCall(call *ast.CallExpr) bool {
+	id, ok := call.Fun.(*ast.Ident)
+	if !ok || id.Name != "panic" {
+		return false
+	}
+	if obj := l.info.Uses[id]; obj != nil {
+		builtin, ok := obj.(*types.Builtin)
+		return ok && builtin.Name() == "panic"
+	}
+	return true
+}
+
+func (l *lifter) runtimeFailureLocus(pos token.Pos, argTerm ir.IrTerm) any {
+	location := l.fset.Position(pos)
+	col := location.Column - 1
+	if col < 0 {
+		col = 0
+	}
+	return map[string]any{
+		"effectKind": panicFreedomConceptName,
+		"callee":     runtimeFailureSiteConceptID,
+		"subkind":    explicitPanicSubkind,
+		"argTerm":    argTerm,
+		"file":       l.path,
+		"line":       location.Line,
+		"col":        col,
+	}
 }
 
 // liftCompositeLit models unkeyed slice/array literals (`[]T{e0, e1, …}`):

--- a/implementations/go/provekit-lift-go/lift_test.go
+++ b/implementations/go/provekit-lift-go/lift_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -382,6 +383,65 @@ panic("boom")
 	}
 }
 
+func TestShadowedPanicGuardDoesNotSynthesizePrecondition(t *testing.T) {
+	src := `package sample
+
+func panic(x any) {}
+
+func F(bad bool) {
+	if bad {
+		panic("boom")
+	}
+}
+`
+	result, err := LiftSource("example.com/sample", "shadow_guard.go", []byte(src))
+	if err != nil {
+		t.Fatalf("LiftSource: %v", err)
+	}
+	contract := contractNamed(t, result, "example.com/sample.F")
+	assertNoRuntimeFailureLoci(t, contract)
+	gotPre, err := json.Marshal(contract.Pre)
+	if err != nil {
+		t.Fatalf("marshal pre: %v", err)
+	}
+	if strings.Contains(string(gotPre), `"bad"`) {
+		t.Fatalf("shadowed panic guard must not synthesize precondition over bad: %s", gotPre)
+	}
+}
+
+func TestCrossFileShadowedPanicDoesNotEmitRuntimeFailureLocus(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/sample\n\ngo 1.22\n"), 0644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte(`package sample
+
+func panic(x any) {}
+`), 0644); err != nil {
+		t.Fatalf("write a.go: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "b.go"), []byte(`package sample
+
+func F() {
+	panic("boom")
+}
+`), 0644); err != nil {
+		t.Fatalf("write b.go: %v", err)
+	}
+	result, err := LiftPaths(tmpDir, []string{"."})
+	if err != nil {
+		t.Fatalf("LiftPaths: %v", err)
+	}
+	for _, contract := range result.FunctionContracts() {
+		assertNoRuntimeFailureLoci(t, contract)
+		if gotEffects, err := json.Marshal(contract.Effects); err != nil {
+			t.Fatalf("marshal effects: %v", err)
+		} else if strings.Contains(string(gotEffects), `"panics"`) {
+			t.Fatalf("cross-file shadowed panic must not emit panics effect: %s", gotEffects)
+		}
+	}
+}
+
 func TestNonPanicCallsDoNotEmitRuntimeFailureLoci(t *testing.T) {
 	src := `package sample
 
@@ -680,6 +740,17 @@ func functionContractGeneric(t *testing.T, contract FunctionContract) map[string
 		t.Fatalf("contract generic = %#v, want object", generic)
 	}
 	return m
+}
+
+func contractNamed(t *testing.T, result LiftResult, name string) FunctionContract {
+	t.Helper()
+	for _, contract := range result.FunctionContracts() {
+		if contract.FnName == name {
+			return contract
+		}
+	}
+	t.Fatalf("missing contract %q; got %+v", name, result.FunctionContracts())
+	return FunctionContract{}
 }
 
 func sourceUnitBodyTerm(t *testing.T, result LiftResult) map[string]any {

--- a/implementations/go/provekit-lift-go/lift_test.go
+++ b/implementations/go/provekit-lift-go/lift_test.go
@@ -4,8 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
+)
+
+const (
+	panicFreedomEffectKind    = "concept:panic-freedom"
+	runtimeFailureSiteConcept = "concept:panic-freedom.leaf.runtime-failure-site"
 )
 
 const addSource = `package sample
@@ -214,6 +220,206 @@ func F(p *int) int {
 	want := `[{"kind":"writes","target":"example.com/sample.G"},{"kind":"panics"}]`
 	if string(got) != want {
 		t.Fatalf("effects mismatch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestBuiltinPanicEmitsRuntimeFailureLocusAndBodyCtor(t *testing.T) {
+	src := `package sample
+
+func F() {
+panic("boom")
+}
+`
+	result, err := LiftSource("example.com/sample", "panic.go", []byte(src))
+	if err != nil {
+		t.Fatalf("LiftSource: %v", err)
+	}
+	contracts := result.FunctionContracts()
+	if len(contracts) != 1 {
+		t.Fatalf("contracts = %d, refusals=%+v", len(contracts), result.Refusals)
+	}
+	gotEffects, err := json.Marshal(contracts[0].Effects)
+	if err != nil {
+		t.Fatalf("marshal effects: %v", err)
+	}
+	if string(gotEffects) != `[{"kind":"panics"}]` {
+		t.Fatalf("panic effect changed:\n got: %s", gotEffects)
+	}
+
+	body := sourceUnitBodyTerm(t, result)
+	if body["kind"] != "op" || body["name"] != "go:panic" {
+		t.Fatalf("explicit panic must lift to go:panic body term, got: %#v", body)
+	}
+	want := []any{map[string]any{
+		"effectKind": panicFreedomEffectKind,
+		"callee":     runtimeFailureSiteConcept,
+		"subkind":    "explicit-panic",
+		"argTerm": map[string]any{
+			"kind":  "const",
+			"sort":  map[string]any{"kind": "primitive", "name": "String"},
+			"value": "boom",
+		},
+		"file": "panic.go",
+		"line": json.Number("4"),
+		"col":  json.Number("0"),
+	}}
+	if got := runtimeFailureLoci(t, contracts[0]); !reflect.DeepEqual(got, want) {
+		t.Fatalf("panicLoci mismatch:\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestBuiltinPanicRuntimeFailureLocusPreservesIdentifierArg(t *testing.T) {
+	src := `package sample
+
+func F(err any) {
+panic(err)
+}
+`
+	result, err := LiftSource("example.com/sample", "panic_ident.go", []byte(src))
+	if err != nil {
+		t.Fatalf("LiftSource: %v", err)
+	}
+	contracts := result.FunctionContracts()
+	if len(contracts) != 1 {
+		t.Fatalf("contracts = %d, refusals=%+v", len(contracts), result.Refusals)
+	}
+	loci := runtimeFailureLoci(t, contracts[0])
+	if len(loci) != 1 {
+		t.Fatalf("panicLoci = %#v, want one locus", loci)
+	}
+	locus := loci[0].(map[string]any)
+	if locus["subkind"] != "explicit-panic" || locus["line"] != json.Number("4") || locus["col"] != json.Number("0") {
+		t.Fatalf("bad identifier panic locus metadata: %#v", locus)
+	}
+	wantArg := map[string]any{"kind": "var", "name": "err"}
+	if !reflect.DeepEqual(locus["argTerm"], wantArg) {
+		t.Fatalf("panic argTerm mismatch:\n got: %#v\nwant: %#v", locus["argTerm"], wantArg)
+	}
+}
+
+func TestBuiltinPanicRuntimeFailureLocusPreservesCallArg(t *testing.T) {
+	src := `package sample
+
+import "fmt"
+
+func F() {
+panic(fmt.Errorf("boom"))
+}
+`
+	result, err := LiftSource("example.com/sample", "panic_call.go", []byte(src))
+	if err != nil {
+		t.Fatalf("LiftSource: %v", err)
+	}
+	contracts := result.FunctionContracts()
+	if len(contracts) != 1 {
+		t.Fatalf("contracts = %d, refusals=%+v", len(contracts), result.Refusals)
+	}
+	loci := runtimeFailureLoci(t, contracts[0])
+	if len(loci) != 1 {
+		t.Fatalf("panicLoci = %#v, want one locus", loci)
+	}
+	arg, ok := loci[0].(map[string]any)["argTerm"].(map[string]any)
+	if !ok {
+		t.Fatalf("argTerm = %#v, want object", loci[0])
+	}
+	if arg["kind"] != "ctor" || arg["name"] != "go:call" {
+		t.Fatalf("panic call arg must stay as a go:call ctor, got: %#v", arg)
+	}
+	args, ok := arg["args"].([]any)
+	if !ok || len(args) == 0 {
+		t.Fatalf("go:call args = %#v, want nonempty", arg["args"])
+	}
+	head, ok := args[0].(map[string]any)
+	if !ok || head["kind"] != "const" || head["value"] != "fmt.Errorf" {
+		t.Fatalf("go:call head = %#v, want fmt.Errorf const", args[0])
+	}
+}
+
+func TestBuiltinPanicRuntimeFailureLocusPreservesNilArg(t *testing.T) {
+	src := `package sample
+
+func F() {
+panic(nil)
+}
+`
+	result, err := LiftSource("example.com/sample", "panic_nil.go", []byte(src))
+	if err != nil {
+		t.Fatalf("LiftSource: %v", err)
+	}
+	contracts := result.FunctionContracts()
+	if len(contracts) != 1 {
+		t.Fatalf("contracts = %d, refusals=%+v", len(contracts), result.Refusals)
+	}
+	loci := runtimeFailureLoci(t, contracts[0])
+	if len(loci) != 1 {
+		t.Fatalf("panicLoci = %#v, want one locus", loci)
+	}
+	locus := loci[0].(map[string]any)
+	wantArg := map[string]any{"kind": "var", "name": "nil"}
+	if !reflect.DeepEqual(locus["argTerm"], wantArg) {
+		t.Fatalf("nil panic argTerm mismatch:\n got: %#v\nwant: %#v", locus["argTerm"], wantArg)
+	}
+}
+
+func TestShadowedPanicDoesNotEmitRuntimeFailureLocus(t *testing.T) {
+	src := `package sample
+
+func panic(x any) {}
+
+func F() {
+panic("boom")
+}
+`
+	result, err := LiftSource("example.com/sample", "shadow_panic.go", []byte(src))
+	if err != nil {
+		t.Fatalf("LiftSource: %v", err)
+	}
+	if len(result.Refusals) != 0 {
+		t.Fatalf("unexpected refusals: %+v", result.Refusals)
+	}
+	for _, contract := range result.FunctionContracts() {
+		assertNoRuntimeFailureLoci(t, contract)
+	}
+}
+
+func TestNonPanicCallsDoNotEmitRuntimeFailureLoci(t *testing.T) {
+	src := `package sample
+
+func F(xs []int) int {
+return len(xs)
+}
+`
+	result, err := LiftSource("example.com/sample", "len.go", []byte(src))
+	if err != nil {
+		t.Fatalf("LiftSource: %v", err)
+	}
+	contracts := result.FunctionContracts()
+	if len(contracts) != 1 {
+		t.Fatalf("contracts = %d, refusals=%+v", len(contracts), result.Refusals)
+	}
+	assertNoRuntimeFailureLoci(t, contracts[0])
+}
+
+func TestMethodNamedPanicDoesNotEmitRuntimeFailureLocus(t *testing.T) {
+	src := `package sample
+
+type T struct{}
+
+func (t T) Panic() {}
+
+func F(t T) {
+t.Panic()
+}
+`
+	result, err := LiftSource("example.com/sample", "method_panic.go", []byte(src))
+	if err != nil {
+		t.Fatalf("LiftSource: %v", err)
+	}
+	if len(result.Refusals) != 0 {
+		t.Fatalf("unexpected refusals: %+v", result.Refusals)
+	}
+	for _, contract := range result.FunctionContracts() {
+		assertNoRuntimeFailureLoci(t, contract)
 	}
 }
 
@@ -443,4 +649,51 @@ func canonicalTermBytes(t *testing.T, term any) []byte {
 		t.Fatalf("canonical term: %v", err)
 	}
 	return bytes
+}
+
+func runtimeFailureLoci(t *testing.T, contract FunctionContract) []any {
+	t.Helper()
+	generic := functionContractGeneric(t, contract)
+	loci, ok := generic["panicLoci"].([]any)
+	if !ok {
+		t.Fatalf("panicLoci = %#v, want array", generic["panicLoci"])
+	}
+	return loci
+}
+
+func assertNoRuntimeFailureLoci(t *testing.T, contract FunctionContract) {
+	t.Helper()
+	generic := functionContractGeneric(t, contract)
+	if _, ok := generic["panicLoci"]; ok {
+		t.Fatalf("panicLoci must be omitted when empty: %#v", generic["panicLoci"])
+	}
+}
+
+func functionContractGeneric(t *testing.T, contract FunctionContract) map[string]any {
+	t.Helper()
+	generic, err := toGeneric(contract)
+	if err != nil {
+		t.Fatalf("contract to generic: %v", err)
+	}
+	m, ok := generic.(map[string]any)
+	if !ok {
+		t.Fatalf("contract generic = %#v, want object", generic)
+	}
+	return m
+}
+
+func sourceUnitBodyTerm(t *testing.T, result LiftResult) map[string]any {
+	t.Helper()
+	if len(result.SourceUnits) != 1 {
+		t.Fatalf("source units = %d, want one", len(result.SourceUnits))
+	}
+	args, ok := result.SourceUnits[0].Term["args"].([]any)
+	if !ok || len(args) != 2 {
+		t.Fatalf("source-unit args = %#v, want two args", result.SourceUnits[0].Term["args"])
+	}
+	body, ok := args[1].(map[string]any)
+	if !ok {
+		t.Fatalf("source-unit body = %#v, want object", args[1])
+	}
+	return body
 }

--- a/implementations/go/provekit-lift-go/types.go
+++ b/implementations/go/provekit-lift-go/types.go
@@ -36,6 +36,7 @@ type FunctionContract struct {
 	Formals            []string `json:"formals"`
 	Kind               string   `json:"kind"`
 	Locus              Locus    `json:"locus"`
+	PanicLoci          []any    `json:"panicLoci,omitempty"`
 	Post               any      `json:"post"`
 	Pre                any      `json:"pre"`
 	ReturnSort         any      `json:"returnSort"`

--- a/implementations/rust/provekit-cli/tests/cmd_mint_go_source_runtime_failure.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_go_source_runtime_failure.rs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+use serde_json::{json, Value as Json};
+
+const RUNTIME_FAILURE_SITE_CONCEPT: &str = "concept:panic-freedom.leaf.runtime-failure-site";
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-go-source-runtime-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+fn go_source_lift_command() -> Option<Vec<String>> {
+    static GO_SOURCE_LIFT_COMMAND: OnceLock<Option<Vec<String>>> = OnceLock::new();
+    GO_SOURCE_LIFT_COMMAND
+        .get_or_init(|| {
+            if !go_available() {
+                eprintln!("go not on PATH: skipping go-source runtime-failure mint test");
+                return None;
+            }
+            let root = repo_root();
+            let go_module = root
+                .join("implementations")
+                .join("go")
+                .join("provekit-lift-go");
+            let out = std::env::temp_dir().join(format!(
+                "provekit-lift-go-source-runtime-{}",
+                std::process::id()
+            ));
+            let built = Command::new("go")
+                .current_dir(&go_module)
+                .args([
+                    "build",
+                    "-o",
+                    out.to_str().expect("utf8 output path"),
+                    "./cmd/provekit-lift-go",
+                ])
+                .output()
+                .expect("spawn go build");
+            assert!(
+                built.status.success(),
+                "go build provekit-lift-go failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&built.stdout),
+                String::from_utf8_lossy(&built.stderr)
+            );
+            Some(vec![out.display().to_string(), "--rpc".to_string()])
+        })
+        .clone()
+}
+
+fn toml_string_array(values: &[String]) -> String {
+    let quoted = values
+        .iter()
+        .map(|v| format!("\"{}\"", v.replace('\\', "\\\\").replace('"', "\\\"")))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("[{quoted}]")
+}
+
+fn stage_go_source_project(command: &[String]) -> PathBuf {
+    let project = unique_dir("project");
+    fs::write(
+        project.join("go.mod"),
+        "module example.com/sample\n\ngo 1.22\n",
+    )
+    .expect("write go.mod");
+    fs::write(
+        project.join("panic.go"),
+        r#"package sample
+
+func Fail() {
+panic("boom")
+}
+"#,
+    )
+    .expect("write panic.go");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("go-source"))
+        .expect("mkdir .provekit/lift/go-source");
+    fs::write(
+        provekit.join("config.toml"),
+        r#"[[plugins]]
+name = "go-source"
+kind = "lift"
+surface = "go-source"
+"#,
+    )
+    .expect("write config.toml");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("go-source")
+            .join("manifest.toml"),
+        format!(
+            r#"name = "go-source"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = {}
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["go-source"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+"#,
+            toml_string_array(command)
+        ),
+    )
+    .expect("write manifest.toml");
+
+    project
+}
+
+fn run_mint(project: &Path) {
+    let out = Command::new(provekit_bin())
+        .arg("mint")
+        .arg("--project")
+        .arg(project)
+        .arg("--out")
+        .arg(project)
+        .arg("--no-attest")
+        .arg("--quiet")
+        .output()
+        .expect("spawn provekit mint");
+    assert!(
+        out.status.success(),
+        "provekit mint must succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn contract_runtime_failure_loci(pool: &provekit_verifier::types::MementoPool) -> Vec<Json> {
+    pool.mementos
+        .values()
+        .filter(|env| provekit_verifier::types::memento_kind(env) == Some("contract"))
+        .filter_map(|env| provekit_verifier::types::memento_body_field(env, "panicLoci"))
+        .filter_map(|value| value.as_array())
+        .flat_map(|items| items.iter().cloned())
+        .collect()
+}
+
+#[test]
+fn go_source_panic_mint_preserves_runtime_failure_locus_and_enumerates_callsite() {
+    let Some(command) = go_source_lift_command() else {
+        return;
+    };
+    let project = stage_go_source_project(&command);
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "go-source proof must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let loci = contract_runtime_failure_loci(&pool);
+    assert_eq!(
+        loci,
+        vec![json!({
+            "effectKind": "concept:panic-freedom",
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "explicit-panic",
+            "argTerm": {
+                "kind": "const",
+                "sort": {"kind": "primitive", "name": "String"},
+                "value": "boom"
+            },
+            "file": "panic.go",
+            "line": 4,
+            "col": 0
+        })],
+        "mint must preserve the go-source runtime-failure panicLoci row"
+    );
+
+    let callsites = provekit_verifier::enumerate_callsites::run(&pool);
+    let runtime_failure_sites: Vec<_> = callsites
+        .iter()
+        .filter(|cs| cs.panic_site && cs.callee.as_deref() == Some(RUNTIME_FAILURE_SITE_CONCEPT))
+        .collect();
+    assert_eq!(
+        runtime_failure_sites.len(),
+        1,
+        "verifier must surface exactly one Go runtime-failure panic site; got {callsites:#?}"
+    );
+    assert_eq!(runtime_failure_sites[0].file.as_deref(), Some("panic.go"));
+    assert_eq!(runtime_failure_sites[0].line, Some(4));
+    assert!(
+        runtime_failure_sites[0].bridge_target_cid.is_empty(),
+        "no bridge exists yet, so the surfaced callsite must remain undecidable"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}


### PR DESCRIPTION
Closes #1853.

## What changed
- Go source lifter now emits `panicLoci` for direct builtin `panic(...)` calls using the existing `concept:panic-freedom.leaf.runtime-failure-site` concept.
- The kit-owned subkind is `explicit-panic`, and the body term is `go:panic(arg)` instead of generic `go:call(panic, arg)`.
- `panicLoci.argTerm` stores the lifted IR term, covering string literals, identifiers, nil, and call expressions.
- Direct panic recognition uses `ast.Ident{Name:"panic"}` plus `types.Builtin` verification when Go type info is available, so a locally shadowed `panic` function is not misclassified.
- Added a production-path Rust smoke test that stages a Go project, writes config and manifest, runs `provekit mint`, checks the preserved `panicLoci` row, and verifies `enumerate_callsites` surfaces the undecidable runtime-failure site.

## Substrate and kit boundary
- This reuses the existing substrate concept identity. No CLI or verifier production code learns Go semantics.
- Go language semantics stay inside `implementations/go/provekit-lift-go`.
- The only Rust change is an integration test under `provekit-cli/tests`.

## Manifest verification
- `implementations/go/.provekit/lift/go-source/manifest.toml:5` routes `go-source` to `go run ./cmd/provekit-lift-go --rpc` with `working_dir = "provekit-lift-go"`.
- `implementations/go/.provekit/lift/go/manifest.toml:5` routes the separate verify surface to `go run ./cmd/provekit-lift-go-verify --rpc` and is untouched.
- The new federation smoke stages its own project config and manifest and mints through the production CLI path.

## Edge scope
- Covered: direct builtin `panic(...)`, nil argument preservation, identifier arguments, call-expression arguments, non-panic calls, selector methods named `Panic`, same-file shadowed `panic` functions, and cross-file package-scope shadowed `panic` functions.
- Out of scope for this slice: `log.Panic` wrappers, implicit runtime panics such as nil dereference or index out of bounds, and defer/recover semantic discharge.
- Go `token.FileSet` columns are normalized to zero-based `panicLoci.col`.

## Review fix-cycle
- CodeRabbit finding: leading guard preconditions used a name-only `panic` block check, so a shadowed `panic` call could synthesize `pre = !bad`. Fixed by routing guard recognition through the same typed builtin classifier as call lifting.
- Codex review finding: directory lifts type-checked each file separately, so `func panic(x any) {}` in one file and `panic("boom")` in another could be misclassified as the builtin. Fixed by grouping `LiftPathsWithOptions` inputs by package, type-checking each package once, and lifting each file with shared `types.Info` and known functions.
- RED tests were added for both findings and failed before the fix; both are GREEN after the fix.

## Path A confirmation
Diff-scoped check is zero for:
- `implementations/rust/libprovekit`
- `implementations/rust/provekit-verifier`
- `implementations/rust/provekit-doctor`
- `implementations/rust/provekit-cli/src`
- `implementations/go/provekit-lift-go-verify`

## Verification
- `go test ./... -run 'TestShadowedPanicGuardDoesNotSynthesizePrecondition|TestCrossFileShadowedPanicDoesNotEmitRuntimeFailureLocus'` in `implementations/go/provekit-lift-go`
- `go test ./...` in `implementations/go/provekit-lift-go`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_mint_go_source_runtime_failure -- --nocapture`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture`, 1 passed in 114.25s
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_verify_python_production_bridge --test cmd_verify_python_division_unsound --test cmd_mint_python_source_runtime_failure --test cmd_mint_java_source_runtime_failure --test kit_declaration_rpc -- --nocapture`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc -p provekit-lift -p provekit-cli`
- Path A diff check listed above returned no changed files
- `git diff --check`
- `gofmt` on touched Go files

## Notes
- The Java runtime-failure test target now runs the real Java body on bcargo and passed.
- Earlier before this fix-cycle, one `kit_declaration_rpc` run hit a transient `Text file busy` while spawning a temp shell stub; immediate rerun passed 6/6. No related code changed here.
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 ../../bin/bcargo fmt --check` reports existing repo-wide Rust formatting drift in unrelated files. This PR's current diff touches only `implementations/go/provekit-lift-go/lift.go` and `implementations/go/provekit-lift-go/lift_test.go`; `gofmt` and `git diff --check` are clean.

## Precedent
- Mirrors Java explicit throw shape from #1850.
- Mirrors Python explicit raise/runtime-failure family from #1837.
- Follows #1828 closed-state decision to federate runtime-failure sites through the shared concept leaf with kit-owned local subkind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added panic failure site tracking with runtime-failure metadata in function contracts, including file location, line numbers, and panic arguments
  * Panic arguments are now preserved in metadata (identifiers, calls, nil values)

* **Tests**
  * Added test coverage for built-in panic detection and argument shape preservation
  * Added integration test verifying panic metadata survives the minting workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
