### PR TITLE
[codex] bcargo provisions TypeScript env (BCARGO_TYPESCRIPT_ENV)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,8 @@ BCARGO_PYTHON_VENV ?= /tmp/provekit-bcargo-python-kit-env
 BCARGO_PYTHON_BIN := $(BCARGO_PYTHON_VENV)/bin
 BCARGO_PYTHON := $(BCARGO_PYTHON_BIN)/python
 BCARGO_PYTHON_ENV_STAMP := $(BCARGO_PYTHON_VENV)/.provekit-python-kits.stamp
+BCARGO_TYPESCRIPT_ENV_DIR ?= /tmp/provekit-bcargo-typescript-kit-env
+BCARGO_TYPESCRIPT_ENV_STAMP := $(BCARGO_TYPESCRIPT_ENV_DIR)/.provekit-typescript-kits.stamp
 PYTHON_KIT_EDITABLES = \
 	-e examples/provekit-shim-python-sqlite3 \
 	-e examples/provekit-shim-python-aiosqlite \
@@ -718,6 +720,30 @@ $(BCARGO_PYTHON_ENV_STAMP): Makefile $(wildcard implementations/python/*/pyproje
 	$(BCARGO_PYTHON) -m pip install --quiet --no-cache-dir pytest $(PYTHON_KIT_EDITABLES)
 	mkdir -p $(dir $(BCARGO_PYTHON_ENV_STAMP))
 	touch $(BCARGO_PYTHON_ENV_STAMP)
+
+.PHONY: bcargo-typescript-kit-env
+bcargo-typescript-kit-env: $(BCARGO_TYPESCRIPT_ENV_STAMP)
+
+$(BCARGO_TYPESCRIPT_ENV_STAMP): Makefile package.json pnpm-lock.yaml \
+		implementations/typescript/provekit-emit-typescript-vitest/package.json \
+		implementations/typescript/provekit-emit-typescript-vitest/package-lock.json \
+		implementations/typescript/provekit-realize-typescript-core/package.json \
+		implementations/typescript/provekit-realize-typescript-core/package-lock.json \
+		implementations/typescript/provekit-realize-typescript-better-sqlite3/package.json \
+		implementations/typescript/provekit-realize-typescript-better-sqlite3/package-lock.json \
+		implementations/typescript/provekit-realize-typescript-pg/package.json \
+		implementations/typescript/provekit-realize-typescript-pg/package-lock.json \
+		examples/provekit-shim-typescript-better-sqlite3/package.json \
+		examples/provekit-shim-typescript-better-sqlite3/provekit.proof \
+		examples/provekit-shim-typescript-pg/package.json \
+		examples/provekit-shim-typescript-pg/provekit.proof
+	pnpm install --frozen-lockfile
+	npm --prefix implementations/typescript/provekit-emit-typescript-vitest ci
+	npm --prefix implementations/typescript/provekit-realize-typescript-core ci
+	npm --prefix implementations/typescript/provekit-realize-typescript-better-sqlite3 ci
+	npm --prefix implementations/typescript/provekit-realize-typescript-pg ci
+	mkdir -p $(dir $(BCARGO_TYPESCRIPT_ENV_STAMP))
+	touch $(BCARGO_TYPESCRIPT_ENV_STAMP)
 
 .PHONY: check-cross-language-proof-parity-scope
 check-cross-language-proof-parity-scope:

--- a/bin/bcargo
+++ b/bin/bcargo
@@ -16,6 +16,8 @@ Environment:
   BCARGO_REMOTE_HOST   SSH host alias to use (default: battleaxe)
   BCARGO_REMOTE_ROOT   Remote scratch root (default: /home/tsavo/remote/provekit-bcargo)
   BCARGO_PYTHON_ENV    Set to 0 to skip remote Python kit env provisioning
+  BCARGO_TYPESCRIPT_ENV
+                       Set to 0 to skip remote TypeScript kit env provisioning
 EOF
 }
 
@@ -91,7 +93,9 @@ remote_repo="$remote_root/provekit"
 remote_python_venv="$remote_root/python-kit-env"
 remote_python_bin="$remote_python_venv/bin"
 remote_python="$remote_python_bin/python"
+remote_typescript_env="$remote_root/typescript-kit-env"
 provision_python_env="${BCARGO_PYTHON_ENV:-1}"
+provision_typescript_env="${BCARGO_TYPESCRIPT_ENV:-1}"
 ssh_bin="${BCARGO_SSH:-ssh}"
 rsync_bin="${BCARGO_RSYNC:-rsync}"
 
@@ -181,6 +185,8 @@ sync_file() {
 sync_file Cargo.toml
 sync_file Cargo.lock
 sync_file Makefile
+sync_file package.json
+sync_file pnpm-lock.yaml
 sync_file rust-toolchain
 sync_file rust-toolchain.toml
 # Repo-root workspace config and hand-authored plugin manifests. Generated
@@ -195,6 +201,7 @@ sync_dir implementations/rust
 sync_dir implementations/python
 sync_dir implementations/go
 sync_dir implementations/java
+sync_dir implementations/typescript
 sync_dir examples
 sync_dir menagerie
 sync_dir tools
@@ -260,10 +267,34 @@ for arg in "$@"; do
   remote_args+=("$(quote_sh "$arg")")
 done
 
-if [[ "$provision_python_env" == "0" ]]; then
-  inner="cd $(quote_sh "$remote_cwd") && exec cargo"
+provision_steps=()
+cargo_env=()
+cargo_env+=("BCARGO_TYPESCRIPT_ENV=$(quote_sh "$provision_typescript_env")")
+if [[ "$provision_python_env" != "0" ]]; then
+  provision_steps+=("BCARGO_PYTHON_VENV=$(quote_sh "$remote_python_venv") make --quiet bcargo-python-kit-env")
+  cargo_env+=("PYTHON=$(quote_sh "$remote_python")")
+  cargo_env+=("PATH=$(quote_sh "$remote_python_bin"):\$PATH")
+fi
+if [[ "$provision_typescript_env" != "0" ]]; then
+  provision_steps+=("BCARGO_TYPESCRIPT_ENV_DIR=$(quote_sh "$remote_typescript_env") make --quiet bcargo-typescript-kit-env")
+fi
+
+if ((${#provision_steps[@]} == 0)); then
+  inner="cd $(quote_sh "$remote_cwd") && "
+  for assignment in "${cargo_env[@]}"; do
+    inner+="$assignment "
+  done
+  inner+="exec cargo"
 else
-  inner="cd $(quote_sh "$remote_repo") && BCARGO_PYTHON_VENV=$(quote_sh "$remote_python_venv") make --quiet bcargo-python-kit-env && cd $(quote_sh "$remote_cwd") && PYTHON=$(quote_sh "$remote_python") PATH=$(quote_sh "$remote_python_bin"):\$PATH exec cargo"
+  inner="cd $(quote_sh "$remote_repo")"
+  for step in "${provision_steps[@]}"; do
+    inner+=" && $step"
+  done
+  inner+=" && cd $(quote_sh "$remote_cwd") && "
+  for assignment in "${cargo_env[@]}"; do
+    inner+="$assignment "
+  done
+  inner+="exec cargo"
 fi
 for arg in "${remote_args[@]}"; do
   inner+=" $arg"

--- a/implementations/rust/provekit-cli/tests/cmd_emit_typescript_vitest.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_emit_typescript_vitest.rs
@@ -29,6 +29,18 @@ fn node_available() -> bool {
         .unwrap_or(false)
 }
 
+fn typescript_env_enabled() -> bool {
+    std::env::var("BCARGO_TYPESCRIPT_ENV").map_or(true, |value| value != "0")
+}
+
+fn skip_when_typescript_env_disabled(test_name: &str) -> bool {
+    if typescript_env_enabled() {
+        return false;
+    }
+    eprintln!("skipping: BCARGO_TYPESCRIPT_ENV=0 for {test_name}");
+    true
+}
+
 fn typescript_vitest_emitter_available() -> bool {
     let emitter = repo_root()
         .join("implementations")
@@ -86,6 +98,9 @@ fn install_emit_registration(project: &Path) {
 
 #[test]
 fn emit_typescript_vitest_dispatches_real_emitter_and_vitest_checks_output() {
+    if skip_when_typescript_env_disabled("TypeScript Vitest emitter test") {
+        return;
+    }
     if !node_available() {
         eprintln!("skipping: node not on PATH");
         return;

--- a/implementations/rust/provekit-cli/tests/cmd_recognize_typescript_parity.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_recognize_typescript_parity.rs
@@ -40,6 +40,18 @@ fn z3_available() -> bool {
         .unwrap_or(false)
 }
 
+fn typescript_env_enabled() -> bool {
+    std::env::var("BCARGO_TYPESCRIPT_ENV").map_or(true, |value| value != "0")
+}
+
+fn skip_when_typescript_env_disabled(test_name: &str) -> bool {
+    if typescript_env_enabled() {
+        return false;
+    }
+    eprintln!("skipping: BCARGO_TYPESCRIPT_ENV=0 for {test_name}");
+    true
+}
+
 fn tsx_cli() -> Option<PathBuf> {
     let path = repo_root()
         .join("node_modules")
@@ -312,6 +324,9 @@ fn assert_no_vacuous_rows(report: &Json) {
 
 #[test]
 fn typescript_recognize_write_self_resolves_package_proofs_and_proves() {
+    if skip_when_typescript_env_disabled("TypeScript recognizer parity test") {
+        return;
+    }
     if !node_available() || tsx_cli().is_none() {
         eprintln!("skipping TypeScript recognizer parity test: node/tsx unavailable");
         return;
@@ -344,6 +359,9 @@ fn typescript_recognize_write_self_resolves_package_proofs_and_proves() {
 
 #[test]
 fn typescript_recognize_returns_no_tags_for_non_matching_source() {
+    if skip_when_typescript_env_disabled("TypeScript recognizer non-match test") {
+        return;
+    }
     if !node_available() || tsx_cli().is_none() {
         eprintln!("skipping TypeScript recognizer non-match test: node/tsx unavailable");
         return;

--- a/implementations/rust/provekit-cli/tests/cmd_verify_typescript_production_bridge.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_verify_typescript_production_bridge.rs
@@ -36,6 +36,18 @@ fn z3_available() -> bool {
         .unwrap_or(false)
 }
 
+fn typescript_env_enabled() -> bool {
+    std::env::var("BCARGO_TYPESCRIPT_ENV").map_or(true, |value| value != "0")
+}
+
+fn skip_when_typescript_env_disabled(test_name: &str) -> bool {
+    if typescript_env_enabled() {
+        return false;
+    }
+    eprintln!("skipping: BCARGO_TYPESCRIPT_ENV=0 for {test_name}");
+    true
+}
+
 fn node_available() -> bool {
     Command::new("node")
         .arg("--version")
@@ -190,6 +202,9 @@ fn json_contains_str(value: &Json, needle: &str) -> bool {
 
 #[test]
 fn typescript_mint_auto_writes_body_discharge_bridge_from_real_lifters() {
+    if skip_when_typescript_env_disabled("TypeScript production-bridge bridge-writer test") {
+        return;
+    }
     if !node_available() {
         eprintln!("node not on PATH: skipping TypeScript production-bridge bridge-writer test");
         return;
@@ -254,6 +269,9 @@ fn typescript_mint_auto_writes_body_discharge_bridge_from_real_lifters() {
 
 #[test]
 fn typescript_production_path_double_discharges_and_mints_witness() {
+    if skip_when_typescript_env_disabled("TypeScript production-bridge positive test") {
+        return;
+    }
     if !node_available() {
         eprintln!("node not on PATH: skipping TypeScript production-bridge positive test");
         return;
@@ -302,6 +320,9 @@ fn typescript_production_path_double_discharges_and_mints_witness() {
 
 #[test]
 fn typescript_production_path_broken_body_fails_unsatisfied_no_witness() {
+    if skip_when_typescript_env_disabled("TypeScript production-bridge negative test") {
+        return;
+    }
     if !node_available() {
         eprintln!("node not on PATH: skipping TypeScript production-bridge negative test");
         return;
@@ -350,6 +371,9 @@ fn typescript_production_path_broken_body_fails_unsatisfied_no_witness() {
 
 #[test]
 fn typescript_production_path_refuses_planted_contradictory_implication() {
+    if skip_when_typescript_env_disabled("TypeScript contradictory-implication test") {
+        return;
+    }
     if !node_available() {
         eprintln!("node not on PATH: skipping TypeScript contradictory-implication test");
         return;


### PR DESCRIPTION
Closes #1855.

## Summary

This mirrors the existing `BCARGO_PYTHON_ENV` pattern for TypeScript kit provisioning on the bcargo remote. When `BCARGO_TYPESCRIPT_ENV=1` or unset, `bcargo` now syncs TypeScript source inputs and provisions the remote TypeScript environment before running Cargo. When `BCARGO_TYPESCRIPT_ENV=0`, the existing TypeScript Rust integration tests skip with an explicit disclosure message.

## What changed

- Sync root `package.json`, root `pnpm-lock.yaml`, and `implementations/typescript` to the bcargo remote checkout.
- Keep `node_modules` excluded from rsync.
- Add `bcargo-typescript-kit-env` with a stamp outside the synced repo under `remote_root/typescript-kit-env`.
- Provision root `pnpm install --frozen-lockfile`.
- Provision TypeScript package deps with `npm --prefix ... ci` for:
  - `provekit-emit-typescript-vitest`
  - `provekit-realize-typescript-core`
  - `provekit-realize-typescript-better-sqlite3`
  - `provekit-realize-typescript-pg`
- Gate the existing TypeScript production bridge, recognizer parity, and Vitest emitter Rust tests on `BCARGO_TYPESCRIPT_ENV=0`.

## Scope boundaries

- No TypeScript lift or emission behavior changes.
- No panicLoci work.
- No manifest/config behavior changes.
- No TypeScript version or lockfile edits.
- No Path A production verifier or CLI source changes.

## Review fix cycle

Codex review surfaced existing Rust integration tests that exercise TypeScript realize kits: `cmd_materialize_integration::materialize_*` and `library_tag_dispatch_test::dispatch_realize_routes_typescript_sql_library_tags_to_distinct_kits`.

Empirical verification on the original PR scope confirmed the issue: on a fresh bcargo remote, the cited dispatch test returned identical `throw new Error(...)` stubs for the better-sqlite3 and pg routes. Root + emitter provisioning was insufficient because those kits resolve shim proofs from their own package `node_modules`.

The slice now provisions all TypeScript realize package deps in the same stamped target. The stamp invalidation set includes root package files, the emitter package files, all TypeScript realize package files, and the TypeScript shim package/proof inputs for better-sqlite3 and pg.

## Validation

- RED: current `bcargo` sync plus remote assertion failed because `implementations/typescript`, root package files, `node_modules/tsx`, and emitter Vitest deps were missing.
- Review RED: `BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test library_tag_dispatch_test dispatch_realize_routes_typescript_sql_library_tags_to_distinct_kits -- --nocapture` failed with both TypeScript SQL library tags returning the same throw stub.
- `bash -n bin/bcargo`
- `git diff --check`
- `BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 ../../bin/bcargo test -p provekit-cli --test cmd_verify_typescript_production_bridge --test cmd_recognize_typescript_parity --test cmd_emit_typescript_vitest -- --nocapture`
- `BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_verify_typescript_production_bridge --test cmd_recognize_typescript_parity --test cmd_emit_typescript_vitest -- --nocapture`
- Remote file and stamp presence check passed, including realize kit shim proofs under package `node_modules`.
- Stamp invalidation rebuilt for original package inputs and for each TypeScript realize kit lockfile.
- `BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test library_tag_dispatch_test dispatch_realize_routes_typescript_sql_library_tags_to_distinct_kits -- --nocapture`
- `BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_materialize_integration -- --nocapture`
- `BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc -p provekit-cli`
- `BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo build -p provekit-lift --bin provekit-lift`
- `BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture`
- `BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_verify_python_production_bridge --test cmd_verify_python_division_unsound --test cmd_mint_python_source_runtime_failure --test cmd_mint_java_source_runtime_failure --test cmd_mint_go_source_runtime_failure -- --nocapture`
- `BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-walk --test kit_declaration_rpc -- --nocapture`

## Notes

The earlier advisory used `provekit-walk-rpc` as a package name. Current Cargo structure is package `provekit-walk` with binary `provekit-walk-rpc`, so validation uses the current package/bin syntax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable TypeScript kit environment provisioning, allowing you to enable or disable TypeScript support as needed.

* **Chores**
  * TypeScript integration tests are now conditional, executing only when TypeScript support is configured and enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->