### PR TITLE
TypeScript source lifter emits runtime-failure loci

### DIFF
--- a/implementations/rust/provekit-cli/tests/cmd_mint_typescript_source_runtime_failure.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_typescript_source_runtime_failure.rs
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::{json, Value as Json};
+
+const RUNTIME_FAILURE_SITE_CONCEPT: &str = "concept:panic-freedom.leaf.runtime-failure-site";
+
+fn provekit_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn typescript_env_enabled() -> bool {
+    std::env::var("BCARGO_TYPESCRIPT_ENV").map_or(true, |value| value != "0")
+}
+
+fn skip_when_typescript_env_disabled(test_name: &str) -> bool {
+    if typescript_env_enabled() {
+        return false;
+    }
+    eprintln!("skipping: BCARGO_TYPESCRIPT_ENV=0 for {test_name}");
+    true
+}
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+fn tsx_cli() -> Option<PathBuf> {
+    let path = repo_root()
+        .join("node_modules")
+        .join("tsx")
+        .join("dist")
+        .join("cli.mjs");
+    path.exists().then_some(path)
+}
+
+fn unique_dir(suffix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let p = std::env::temp_dir().join(format!("provekit-ts-source-runtime-{stamp}-{suffix}"));
+    fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+fn stage_typescript_source_project() -> PathBuf {
+    let tsx = tsx_cli().expect("tsx CLI must exist; run pnpm install at repo root");
+    let project = unique_dir("project");
+    fs::create_dir_all(project.join("src")).expect("mkdir src");
+    fs::write(
+        project.join("src").join("panic.ts"),
+        r#"export function fail(reason: unknown): void {
+  throw reason;
+}
+"#,
+    )
+    .expect("write src/panic.ts");
+
+    let provekit = project.join(".provekit");
+    fs::create_dir_all(provekit.join("lift").join("typescript-source"))
+        .expect("mkdir .provekit/lift/typescript-source");
+    fs::write(
+        provekit.join("config.toml"),
+        r#"[[plugins]]
+name = "typescript-source"
+surface = "typescript-source"
+layer = "verify"
+"#,
+    )
+    .expect("write config.toml");
+
+    let ts_source_bin = repo_root()
+        .join("implementations")
+        .join("typescript")
+        .join("src")
+        .join("lift")
+        .join("typescript-source")
+        .join("bin.ts");
+    fs::write(
+        provekit
+            .join("lift")
+            .join("typescript-source")
+            .join("manifest.toml"),
+        format!(
+            "name = \"typescript-source\"\ncommand = [\"node\", \"{}\", \"{}\", \"--rpc\"]\nworking_dir = \".\"\n",
+            tsx.display(),
+            ts_source_bin.display()
+        ),
+    )
+    .expect("write manifest.toml");
+
+    project
+}
+
+fn run_mint(project: &Path) {
+    let out = Command::new(provekit_bin())
+        .arg("mint")
+        .arg("--project")
+        .arg(project)
+        .arg("--out")
+        .arg(project)
+        .arg("--no-attest")
+        .arg("--quiet")
+        .output()
+        .expect("spawn provekit mint");
+    assert!(
+        out.status.success(),
+        "provekit mint must succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn contract_runtime_failure_loci(pool: &provekit_verifier::types::MementoPool) -> Vec<Json> {
+    pool.mementos
+        .values()
+        .filter(|env| provekit_verifier::types::memento_kind(env) == Some("contract"))
+        .filter_map(|env| provekit_verifier::types::memento_body_field(env, "panicLoci"))
+        .filter_map(|value| value.as_array())
+        .flat_map(|items| items.iter().cloned())
+        .collect()
+}
+
+#[test]
+fn typescript_source_throw_mint_preserves_runtime_failure_locus_and_enumerates_callsite() {
+    if skip_when_typescript_env_disabled("TypeScript source runtime-failure mint test") {
+        return;
+    }
+    if !node_available() {
+        eprintln!("node not on PATH: skipping TypeScript source runtime-failure mint test");
+        return;
+    }
+    if tsx_cli().is_none() {
+        eprintln!("tsx not installed at repo root: skipping; run pnpm install at repo root");
+        return;
+    }
+
+    let project = stage_typescript_source_project();
+    run_mint(&project);
+
+    let pool = provekit_verifier::load_all_proofs::run(&project);
+    assert!(
+        pool.load_errors.is_empty(),
+        "typescript-source proof must load cleanly: {:?}",
+        pool.load_errors
+    );
+
+    let loci = contract_runtime_failure_loci(&pool);
+    assert_eq!(
+        loci,
+        vec![json!({
+            "effectKind": "concept:panic-freedom",
+            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+            "subkind": "explicit-throw",
+            "argTerm": {
+                "kind": "var",
+                "name": "reason"
+            },
+            "file": "src/panic.ts",
+            "line": 2,
+            "col": 2
+        })],
+        "mint must preserve the typescript-source runtime-failure panicLoci row"
+    );
+
+    let callsites = provekit_verifier::enumerate_callsites::run(&pool);
+    let runtime_failure_sites: Vec<_> = callsites
+        .iter()
+        .filter(|cs| cs.panic_site && cs.callee.as_deref() == Some(RUNTIME_FAILURE_SITE_CONCEPT))
+        .collect();
+    assert_eq!(
+        runtime_failure_sites.len(),
+        1,
+        "verifier must surface exactly one TypeScript runtime-failure panic site; got {callsites:#?}"
+    );
+    assert_eq!(
+        runtime_failure_sites[0].file.as_deref(),
+        Some("src/panic.ts")
+    );
+    assert_eq!(runtime_failure_sites[0].line, Some(2));
+    assert!(
+        runtime_failure_sites[0].bridge_target_cid.is_empty(),
+        "no bridge exists yet, so the surfaced callsite must remain undecidable"
+    );
+
+    let _ = fs::remove_dir_all(&project);
+}

--- a/implementations/typescript/src/lift/typescript-source/index.test.ts
+++ b/implementations/typescript/src/lift/typescript-source/index.test.ts
@@ -30,6 +30,14 @@ function canonicalCid(value: unknown): string {
   return computeCid(canonicalEncode(value));
 }
 
+const RUNTIME_FAILURE_SITE_CONCEPT = "concept:panic-freedom.leaf.runtime-failure-site";
+
+function contractNamed(result: { declarations: Record<string, any>[] }, fnName: string): Record<string, any> {
+  const contract = result.declarations.find((decl) => decl.fnName === fnName);
+  expect(contract).toBeDefined();
+  return contract!;
+}
+
 function installTypeScriptShimProof(
   projectRoot: string,
   packageName: string,
@@ -561,6 +569,89 @@ function missingBoth(x: string): string { return x; }
       { kind: "unresolved_call", name: "missing" },
       { kind: "opaque_loop", loopCid: expect.stringMatching(/^blake3-512:[0-9a-f]{128}$/) },
     ]);
+  });
+
+  it("emits runtime-failure panic loci for explicit throw statements", () => {
+    const result = liftTypeScriptSourceText(
+      `function stringThrow(): void {
+  throw "boom";
+}
+
+function identifierThrow(err: unknown): void {
+  throw err;
+}
+
+function newErrorThrow(): void {
+  throw new Error("bad");
+}
+
+function ok(): number {
+  return 1;
+}
+`,
+      "src/throws.ts",
+    );
+
+    expect(result.refusals).toEqual([]);
+
+    expect(contractNamed(result, "src/throws.ts:stringThrow").panicLoci).toEqual([
+      {
+        effectKind: "concept:panic-freedom",
+        callee: RUNTIME_FAILURE_SITE_CONCEPT,
+        subkind: "explicit-throw",
+        argTerm: {
+          kind: "const",
+          sort: { kind: "primitive", name: "String" },
+          value: "boom",
+        },
+        file: "src/throws.ts",
+        line: 2,
+        col: 2,
+      },
+    ]);
+
+    expect(contractNamed(result, "src/throws.ts:identifierThrow").panicLoci).toEqual([
+      {
+        effectKind: "concept:panic-freedom",
+        callee: RUNTIME_FAILURE_SITE_CONCEPT,
+        subkind: "explicit-throw",
+        argTerm: { kind: "var", name: "err" },
+        file: "src/throws.ts",
+        line: 6,
+        col: 2,
+      },
+    ]);
+
+    expect(contractNamed(result, "src/throws.ts:newErrorThrow").panicLoci).toEqual([
+      {
+        effectKind: "concept:panic-freedom",
+        callee: RUNTIME_FAILURE_SITE_CONCEPT,
+        subkind: "explicit-throw",
+        argTerm: {
+          kind: "ctor",
+          name: "ts:new",
+          args: [
+            { kind: "var", name: "Error" },
+            {
+              kind: "ctor",
+              name: "ts:args",
+              args: [
+                {
+                  kind: "const",
+                  sort: { kind: "primitive", name: "String" },
+                  value: "bad",
+                },
+              ],
+            },
+          ],
+        },
+        file: "src/throws.ts",
+        line: 10,
+        col: 2,
+      },
+    ]);
+
+    expect(contractNamed(result, "src/throws.ts:ok").panicLoci).toBeUndefined();
   });
 
   it("refuses unsupported syntax instead of emitting unknown or skip fallbacks", () => {

--- a/implementations/typescript/src/lift/typescript-source/index.ts
+++ b/implementations/typescript/src/lift/typescript-source/index.ts
@@ -38,8 +38,19 @@ export interface FunctionContractMemento {
   post: IrFormula;
   bodyCid: string | null;
   effects: TypeScriptSourceEffect[];
+  panicLoci?: TypeScriptSourcePanicLocus[];
   locus: { file: string; line: number; col: number };
   autoMintedMementos: unknown[];
+}
+
+export interface TypeScriptSourcePanicLocus {
+  effectKind: "concept:panic-freedom";
+  callee: "concept:panic-freedom.leaf.runtime-failure-site";
+  subkind: "explicit-throw";
+  argTerm: IrTerm;
+  file: string;
+  line: number;
+  col: number;
 }
 
 export interface TypeScriptLibrarySugarBindingEntry {
@@ -143,6 +154,7 @@ interface FunctionContext extends FileLiftContext {
   functionName: string;
   locals: Set<string>;
   effects: Map<string, TypeScriptSourceEffect>;
+  panicLoci: TypeScriptSourcePanicLocus[];
 }
 
 class UnsupportedSyntaxError extends Error {
@@ -157,6 +169,7 @@ class UnsupportedSyntaxError extends Error {
 
 const TRUE_FORMULA: IrFormula = { kind: "atomic", name: "true", args: [] };
 const RETURN_VALUE: VarTerm = { kind: "var", name: "return_value" };
+const RUNTIME_FAILURE_SITE_CONCEPT = "concept:panic-freedom.leaf.runtime-failure-site";
 const SKIP_DIRS = new Set([
   "node_modules",
   ".git",
@@ -687,6 +700,7 @@ function libraryBindingEntryForFunction(
         functionName: `${modulePath}:${node.name?.text ?? "unknown"}`,
         locals: new Set<string>(formals),
         effects: new Map(),
+        panicLoci: [],
       };
       collectLocalDeclarations(body, functionContext.locals);
       const rawBodyTerm = singleReturnExpression(body)
@@ -1244,6 +1258,7 @@ function liftFunctionLike(
       functionName: fnName,
       locals,
       effects: new Map(),
+      panicLoci: [],
     };
     collectLocalDeclarations(body, locals);
     const bodyTerm = emitBlock(body, functionContext);
@@ -1262,6 +1277,7 @@ function liftFunctionLike(
       post: eqFormula(RETURN_VALUE, postTerm),
       bodyCid: null,
       effects: sortEffects([...functionContext.effects.values()]),
+      ...(functionContext.panicLoci.length > 0 ? { panicLoci: [...functionContext.panicLoci] } : {}),
       locus: { file: fileContext.modulePath, line, col: 1 },
       autoMintedMementos: [],
     };
@@ -1322,8 +1338,19 @@ function emitStatement(stmt: ts.Statement, context: FunctionContext): IrTerm {
     return loopTerm;
   }
   if (ts.isThrowStatement(stmt)) {
+    const argTerm = stmt.expression ? emitExpression(stmt.expression, context) : unitConst();
     addEffect(context, { kind: "panics" });
-    return ctor("ts:throw", stmt.expression ? emitExpression(stmt.expression, context) : unitConst());
+    const start = sourcePosition(context.sourceFile, stmt);
+    context.panicLoci.push({
+      effectKind: "concept:panic-freedom",
+      callee: RUNTIME_FAILURE_SITE_CONCEPT,
+      subkind: "explicit-throw",
+      argTerm,
+      file: context.modulePath,
+      line: start.line,
+      col: start.col,
+    });
+    return ctor("ts:throw", argTerm);
   }
   if (ts.isBreakStatement(stmt)) return ctor("ts:break", unitConst());
   if (ts.isContinueStatement(stmt)) return ctor("ts:continue", unitConst());
@@ -1704,6 +1731,11 @@ function addRefusal(
 
 function lineOf(sourceFile: ts.SourceFile, node: ts.Node): number {
   return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+}
+
+function sourcePosition(sourceFile: ts.SourceFile, node: ts.Node): { line: number; col: number } {
+  const start = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+  return { line: start.line + 1, col: start.character };
 }
 
 function syntaxKindName(node: ts.Node): string {

--- a/implementations/typescript/src/lift/typescript-source/verify.test.ts
+++ b/implementations/typescript/src/lift/typescript-source/verify.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import { liftTypeScriptSourceText } from "./index.js";
 import { normalizeTypeScriptSourceVerifyDocument } from "./verify.js";
 
+const RUNTIME_FAILURE_SITE_CONCEPT = "concept:panic-freedom.leaf.runtime-failure-site";
+
 describe("typescript-source verify projection", () => {
   it("projects TypeScript body contracts into solver-facing ProofIR without source-unit noise", () => {
     const lifted = liftTypeScriptSourceText(
@@ -27,5 +29,31 @@ describe("typescript-source verify projection", () => {
       sort: { kind: "primitive", name: "Int" },
     });
     expect(JSON.stringify(doc.ir)).not.toContain("<source-unit>");
+  });
+
+  it("preserves explicit throw runtime-failure panic loci through verify projection", () => {
+    const lifted = liftTypeScriptSourceText(
+      `export function fail(reason: unknown): void {
+  throw reason;
+}
+`,
+      "src/fail.ts",
+    );
+
+    const doc = normalizeTypeScriptSourceVerifyDocument(lifted);
+    const contract = doc.ir[0] as any;
+
+    expect(contract.fnName).toBe("src/fail.ts:fail");
+    expect(contract.panicLoci).toEqual([
+      {
+        effectKind: "concept:panic-freedom",
+        callee: RUNTIME_FAILURE_SITE_CONCEPT,
+        subkind: "explicit-throw",
+        argTerm: { kind: "var", name: "reason" },
+        file: "src/fail.ts",
+        line: 2,
+        col: 2,
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Closes #1857.

This adds TypeScript source-lifter parity for explicit `throw` runtime-failure loci:

- carries a TypeScript-owned `panicLoci` side channel on function-contract mementos
- emits `concept:panic-freedom.leaf.runtime-failure-site` rows for explicit `throw` statements
- preserves the thrown expression as the `argTerm` for currently supported TS expression forms: string literal, identifier, and `new Error(...)`
- keeps non-throw functions free of `panicLoci`
- verifies the projection path preserves `panicLoci`
- adds a real `provekit mint` integration using `.provekit/config.toml` + `manifest.toml` to invoke the TS kit over RPC, then load/enumerate the minted runtime-failure callsite

The CLI/verifier remain language-blind. TypeScript parsing and syntax semantics stay inside `implementations/typescript`; the Rust-side change is test-only coverage for config/manifest/RPC integration.

## Scope Boundary

This PR intentionally stays within the currently liftable TypeScript source subset. Wider TS lifter capability gaps are tracked separately and linked from #1857:

- #1859: object literal expressions as ProofIR terms
- #1860: `TryStatement` structural lifting
- #1858: async function structural lifting

That boundary matters because JavaScript/TypeScript permits broad thrown values, but the emission slice should be exact for the expressions the TS lifter can already normalize, not aspirational.

Relevant language references:

- TC39 ECMA-262 `ThrowStatement` runtime semantics evaluate the throw expression and throw that value: https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-throw-statement-runtime-semantics-evaluation
- TypeScript docs note JavaScript can throw any value and TypeScript models catch variables around that fact: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html#defaulting-to-the-unknown-type-in-catch-variables

## Verification

RED:

- `pnpm exec vitest run implementations/typescript/src/lift/typescript-source/index.test.ts implementations/typescript/src/lift/typescript-source/verify.test.ts`
  - expected failures: `panicLoci` was `undefined` in lifter output and verify projection

GREEN:

- `pnpm exec vitest run implementations/typescript/src/lift/typescript-source/index.test.ts implementations/typescript/src/lift/typescript-source/verify.test.ts` — 35/35 passed
- `pnpm test` — 44 files passed, 877 passed, 4 todo
- `NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 ../../bin/bcargo test -p provekit-cli --test cmd_mint_typescript_source_runtime_failure -- --nocapture` — passed with explicit skip
- `NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_mint_typescript_source_runtime_failure -- --nocapture` — passed real mint/load/enumerate path
- `NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 ../../bin/bcargo test -p provekit-cli --test cmd_mint_typescript_source_runtime_failure --test cmd_verify_typescript_production_bridge --test cmd_recognize_typescript_parity --test cmd_emit_typescript_vitest -- --nocapture` — passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_mint_typescript_source_runtime_failure --test cmd_verify_typescript_production_bridge --test cmd_recognize_typescript_parity --test cmd_emit_typescript_vitest -- --nocapture` — passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc -p provekit-cli` — passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo build -p provekit-lift --bin provekit-lift` — passed
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` — passed 1/1 in 116.01s
- `git diff --cached --check` — passed

Also rechecked after #1856 merge on synced `main` before this branch:

- `self_check_golden` — passed 1/1 in 123.87s
- TS env=0 smoke — passed with explicit skips
- TS env=1 smoke — passed
- Python/Java/Go runtime-failure federation regression batch — passed

Non-gate note: `pnpm exec tsc --noEmit` currently fails outside this slice on `implementations/typescript/src/bin/mint-ts-self-contracts.mts` because `import.meta` requires an ES module-compatible `--module` setting.
