### PR TITLE
[codex] TS lifter supports object literal ProofIR terms (#1859)

### DIFF
--- a/implementations/rust/provekit-cli/tests/cmd_mint_typescript_source_runtime_failure.rs
+++ b/implementations/rust/provekit-cli/tests/cmd_mint_typescript_source_runtime_failure.rs
@@ -71,6 +71,10 @@ fn stage_typescript_source_project() -> PathBuf {
         r#"export function fail(reason: unknown): void {
   throw reason;
 }
+
+export function failObject(): void {
+  throw { code: 500, message: "bad" };
+}
 "#,
     )
     .expect("write src/panic.ts");
@@ -164,41 +168,98 @@ fn typescript_source_throw_mint_preserves_runtime_failure_locus_and_enumerates_c
         pool.load_errors
     );
 
-    let loci = contract_runtime_failure_loci(&pool);
+    let mut loci = contract_runtime_failure_loci(&pool);
+    loci.sort_by_key(|locus| locus.get("line").and_then(Json::as_i64).unwrap_or_default());
     assert_eq!(
         loci,
-        vec![json!({
-            "effectKind": "concept:panic-freedom",
-            "callee": RUNTIME_FAILURE_SITE_CONCEPT,
-            "subkind": "explicit-throw",
-            "argTerm": {
-                "kind": "var",
-                "name": "reason"
-            },
-            "file": "src/panic.ts",
-            "line": 2,
-            "col": 2
-        })],
+        vec![
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "explicit-throw",
+                "argTerm": {
+                    "kind": "var",
+                    "name": "reason"
+                },
+                "file": "src/panic.ts",
+                "line": 2,
+                "col": 2
+            }),
+            json!({
+                "effectKind": "concept:panic-freedom",
+                "callee": RUNTIME_FAILURE_SITE_CONCEPT,
+                "subkind": "explicit-throw",
+                "argTerm": {
+                    "kind": "ctor",
+                    "name": "ts:object-literal",
+                    "args": [
+                        {
+                            "kind": "ctor",
+                            "name": "ts:property",
+                            "args": [
+                                {
+                                    "kind": "const",
+                                    "sort": { "kind": "primitive", "name": "String" },
+                                    "value": "code"
+                                },
+                                {
+                                    "kind": "const",
+                                    "sort": { "kind": "primitive", "name": "Int" },
+                                    "value": 500
+                                }
+                            ]
+                        },
+                        {
+                            "kind": "ctor",
+                            "name": "ts:property",
+                            "args": [
+                                {
+                                    "kind": "const",
+                                    "sort": { "kind": "primitive", "name": "String" },
+                                    "value": "message"
+                                },
+                                {
+                                    "kind": "const",
+                                    "sort": { "kind": "primitive", "name": "String" },
+                                    "value": "bad"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "file": "src/panic.ts",
+                "line": 6,
+                "col": 2
+            }),
+        ],
         "mint must preserve the typescript-source runtime-failure panicLoci row"
     );
 
     let callsites = provekit_verifier::enumerate_callsites::run(&pool);
-    let runtime_failure_sites: Vec<_> = callsites
+    let mut runtime_failure_sites: Vec<_> = callsites
         .iter()
         .filter(|cs| cs.panic_site && cs.callee.as_deref() == Some(RUNTIME_FAILURE_SITE_CONCEPT))
         .collect();
+    runtime_failure_sites.sort_by_key(|cs| cs.line.unwrap_or_default());
     assert_eq!(
         runtime_failure_sites.len(),
-        1,
-        "verifier must surface exactly one TypeScript runtime-failure panic site; got {callsites:#?}"
+        2,
+        "verifier must surface exactly two TypeScript runtime-failure panic sites; got {callsites:#?}"
     );
     assert_eq!(
         runtime_failure_sites[0].file.as_deref(),
         Some("src/panic.ts")
     );
     assert_eq!(runtime_failure_sites[0].line, Some(2));
+    assert_eq!(
+        runtime_failure_sites[1].file.as_deref(),
+        Some("src/panic.ts")
+    );
+    assert_eq!(runtime_failure_sites[1].line, Some(6));
     assert!(
-        runtime_failure_sites[0].bridge_target_cid.is_empty(),
+        runtime_failure_sites
+            .iter()
+            .all(|site| site.bridge_target_cid.is_empty()),
         "no bridge exists yet, so the surfaced callsite must remain undecidable"
     );
 

--- a/implementations/typescript/src/lift/typescript-source/index.test.ts
+++ b/implementations/typescript/src/lift/typescript-source/index.test.ts
@@ -585,6 +585,10 @@ function newErrorThrow(): void {
   throw new Error("bad");
 }
 
+function objectThrow(): void {
+  throw { code: 500, message: "bad" };
+}
+
 function ok(): number {
   return 1;
 }
@@ -647,6 +651,55 @@ function ok(): number {
         },
         file: "src/throws.ts",
         line: 10,
+        col: 2,
+      },
+    ]);
+
+    expect(contractNamed(result, "src/throws.ts:objectThrow").panicLoci).toEqual([
+      {
+        effectKind: "concept:panic-freedom",
+        callee: RUNTIME_FAILURE_SITE_CONCEPT,
+        subkind: "explicit-throw",
+        argTerm: {
+          kind: "ctor",
+          name: "ts:object-literal",
+          args: [
+            {
+              kind: "ctor",
+              name: "ts:property",
+              args: [
+                {
+                  kind: "const",
+                  sort: { kind: "primitive", name: "String" },
+                  value: "code",
+                },
+                {
+                  kind: "const",
+                  sort: { kind: "primitive", name: "Number" },
+                  value: 500,
+                },
+              ],
+            },
+            {
+              kind: "ctor",
+              name: "ts:property",
+              args: [
+                {
+                  kind: "const",
+                  sort: { kind: "primitive", name: "String" },
+                  value: "message",
+                },
+                {
+                  kind: "const",
+                  sort: { kind: "primitive", name: "String" },
+                  value: "bad",
+                },
+              ],
+            },
+          ],
+        },
+        file: "src/throws.ts",
+        line: 14,
         col: 2,
       },
     ]);
@@ -764,6 +817,89 @@ function ok(): number {
     const reliftedBodyTerm = rhs(secondContract);
     expect([...canonicalEncode(reliftedBodyTerm)]).toEqual([...canonicalEncode(originalBodyTerm)]);
     expect(canonicalCid(reliftedBodyTerm)).toBe(canonicalCid(originalBodyTerm));
+  });
+
+  it("round-trips object literal body terms through the AST printer", () => {
+    const first = liftTypeScriptSourceText(
+      `function payload(): unknown {
+  return { code: 500, "message": "bad", 1: false, nested: { retry: false } };
+}
+`,
+      "src/object-roundtrip.ts",
+    );
+    expect(first.refusals).toEqual([]);
+
+    const firstContract = first.declarations.find((decl) => decl.fnName === "src/object-roundtrip.ts:payload")!;
+    const originalBodyTerm = rhs(firstContract);
+    expect(originalBodyTerm).toMatchObject({
+      kind: "ctor",
+      name: "ts:object-literal",
+    });
+
+    const compiled = compileTypeScriptSourceBodyIr(originalBodyTerm, {
+      functionName: "payload",
+      formals: firstContract.formals,
+      formalSorts: firstContract.formalSorts,
+      returnSort: firstContract.returnSort,
+    });
+    const second = liftTypeScriptSourceText(compiled, "src/object-roundtrip.ts");
+
+    expect(second.refusals).toEqual([]);
+    const secondContract = second.declarations.find((decl) => decl.fnName === "src/object-roundtrip.ts:payload")!;
+    const reliftedBodyTerm = rhs(secondContract);
+    expect([...canonicalEncode(reliftedBodyTerm)]).toEqual([...canonicalEncode(originalBodyTerm)]);
+    expect(canonicalCid(reliftedBodyTerm)).toBe(canonicalCid(originalBodyTerm));
+  });
+
+  it("emits shorthand object literal properties as explicit key-value terms", () => {
+    const result = liftTypeScriptSourceText(
+      `function payload(code: number): unknown {
+  return { code };
+}
+`,
+      "src/object-shorthand.ts",
+    );
+
+    expect(result.refusals).toEqual([]);
+    const contract = contractNamed(result, "src/object-shorthand.ts:payload");
+    expect(rhs(contract)).toEqual({
+      kind: "ctor",
+      name: "ts:object-literal",
+      args: [
+        {
+          kind: "ctor",
+          name: "ts:property",
+          args: [
+            {
+              kind: "const",
+              sort: { kind: "primitive", name: "String" },
+              value: "code",
+            },
+            { kind: "var", name: "code" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("continues refusing array literals instead of conflating them with object literals", () => {
+    const result = liftTypeScriptSourceText(
+      `function payload(): unknown {
+  return [1, 2, 3];
+}
+`,
+      "src/array-refusal.ts",
+    );
+
+    expect(result.declarations.filter((decl) => !decl.fnName.endsWith(":<source-unit>"))).toEqual([]);
+    expect(result.refusals).toEqual([
+      {
+        kind: "ArrayLiteralExpression",
+        function: "src/array-refusal.ts:payload",
+        line: 2,
+        reason: expect.stringContaining("ArrayLiteralExpression"),
+      },
+    ]);
   });
 
   it("rejects source paths that escape the workspace root", () => {

--- a/implementations/typescript/src/lift/typescript-source/index.test.ts
+++ b/implementations/typescript/src/lift/typescript-source/index.test.ts
@@ -882,6 +882,64 @@ function ok(): number {
     });
   });
 
+  it("refuses __proto__ object literal prototype setter forms", () => {
+    const cases = [
+      ["identifier key", "return { __proto__: value };"],
+      ["double-quoted key", 'return { "__proto__": value };'],
+      ["single-quoted key", "return { '__proto__': value };"],
+    ];
+
+    for (const [label, statement] of cases) {
+      const result = liftTypeScriptSourceText(
+        `function payload(value: unknown): unknown {
+  ${statement}
+}
+`,
+        `src/proto-${label.replaceAll(" ", "-")}.ts`,
+      );
+
+      expect(result.declarations.filter((decl) => !decl.fnName.endsWith(":<source-unit>"))).toEqual([]);
+      expect(result.refusals).toEqual([
+        {
+          kind: expect.any(String),
+          function: expect.stringContaining(":payload"),
+          line: 2,
+          reason: expect.stringContaining("__proto__ prototype setter"),
+        },
+      ]);
+    }
+  });
+
+  it("round-trips __proto__ shorthand object literal properties without prototype setter syntax", () => {
+    const first = liftTypeScriptSourceText(
+      `function payload(__proto__: unknown): unknown {
+  return { __proto__ };
+}
+`,
+      "src/proto-shorthand-roundtrip.ts",
+    );
+    expect(first.refusals).toEqual([]);
+
+    const firstContract = contractNamed(first, "src/proto-shorthand-roundtrip.ts:payload");
+    const originalBodyTerm = rhs(firstContract);
+    const compiled = compileTypeScriptSourceBodyIr(originalBodyTerm, {
+      functionName: "payload",
+      formals: firstContract.formals,
+      formalSorts: firstContract.formalSorts,
+      returnSort: firstContract.returnSort,
+    });
+
+    expect(compiled).toContain("return { __proto__ };");
+    expect(compiled).not.toContain("\"__proto__\"");
+
+    const second = liftTypeScriptSourceText(compiled, "src/proto-shorthand-roundtrip.ts");
+    expect(second.refusals).toEqual([]);
+    const secondContract = contractNamed(second, "src/proto-shorthand-roundtrip.ts:payload");
+    const reliftedBodyTerm = rhs(secondContract);
+    expect([...canonicalEncode(reliftedBodyTerm)]).toEqual([...canonicalEncode(originalBodyTerm)]);
+    expect(canonicalCid(reliftedBodyTerm)).toBe(canonicalCid(originalBodyTerm));
+  });
+
   it("continues refusing array literals instead of conflating them with object literals", () => {
     const result = liftTypeScriptSourceText(
       `function payload(): unknown {

--- a/implementations/typescript/src/lift/typescript-source/index.ts
+++ b/implementations/typescript/src/lift/typescript-source/index.ts
@@ -1434,6 +1434,9 @@ function emitObjectLiteralExpression(expr: ts.ObjectLiteralExpression, context: 
       if (name === null) {
         throw new UnsupportedSyntaxError(property.name, "computed object literal property names are not handled");
       }
+      if (name === "__proto__") {
+        throw new UnsupportedSyntaxError(property.name, "__proto__ prototype setter object literal properties are not handled");
+      }
       properties.push(ctor("ts:property", stringConst(name), emitExpression(property.initializer, context)));
       continue;
     }
@@ -2089,7 +2092,18 @@ function objectLiteralPropertyFromTerm(term: IrTerm): ts.ObjectLiteralElementLik
   if (!key || key.kind !== "const" || typeof key.value !== "string") {
     throw new Error("cannot compile object literal property with non-string key");
   }
-  return ts.factory.createPropertyAssignment(ts.factory.createStringLiteral(key.value), expressionFromTerm(args[1]));
+  const value = args[1];
+  if (canEmitShorthandProperty(key.value, value)) {
+    return ts.factory.createShorthandPropertyAssignment(key.value);
+  }
+  const propertyName = key.value === "__proto__"
+    ? ts.factory.createComputedPropertyName(ts.factory.createStringLiteral(key.value))
+    : ts.factory.createStringLiteral(key.value);
+  return ts.factory.createPropertyAssignment(propertyName, expressionFromTerm(value));
+}
+
+function canEmitShorthandProperty(name: string, value: IrTerm | undefined): boolean {
+  return value?.kind === "var" && value.name === name && /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name);
 }
 
 function binaryTokenForCtor(name: string): ts.BinaryOperator | null {

--- a/implementations/typescript/src/lift/typescript-source/index.ts
+++ b/implementations/typescript/src/lift/typescript-source/index.ts
@@ -1393,6 +1393,7 @@ function emitExpression(expr: ts.Expression, context: FunctionContext): IrTerm {
     return ctor("ts:ite", emitExpression(expr.condition, context), emitExpression(expr.whenTrue, context), emitExpression(expr.whenFalse, context));
   }
   if (ts.isCallExpression(expr)) return emitCallExpression(expr, context);
+  if (ts.isObjectLiteralExpression(expr)) return emitObjectLiteralExpression(expr, context);
   if (ts.isTypeOfExpression(expr)) return ctor("ts:typeof", emitExpression(expr.expression, context));
   if (ts.isPropertyAccessExpression(expr)) {
     if (expr.questionDotToken) {
@@ -1423,6 +1424,29 @@ function emitExpression(expr: ts.Expression, context: FunctionContext): IrTerm {
     throw new UnsupportedSyntaxError(expr, "function expressions are not handled");
   }
   throw new UnsupportedSyntaxError(expr, `expression kind ${syntaxKindName(expr)} is not handled`);
+}
+
+function emitObjectLiteralExpression(expr: ts.ObjectLiteralExpression, context: FunctionContext): IrTerm {
+  const properties: IrTerm[] = [];
+  for (const property of expr.properties) {
+    if (ts.isPropertyAssignment(property)) {
+      const name = nameFromPropertyName(property.name);
+      if (name === null) {
+        throw new UnsupportedSyntaxError(property.name, "computed object literal property names are not handled");
+      }
+      properties.push(ctor("ts:property", stringConst(name), emitExpression(property.initializer, context)));
+      continue;
+    }
+    if (ts.isSpreadAssignment(property)) {
+      throw new UnsupportedSyntaxError(property, "object literal spread properties are not handled");
+    }
+    if (ts.isShorthandPropertyAssignment(property)) {
+      properties.push(ctor("ts:property", stringConst(property.name.text), emitExpression(property.name, context)));
+      continue;
+    }
+    throw new UnsupportedSyntaxError(property, `object literal property kind ${syntaxKindName(property)} is not handled`);
+  }
+  return ctor("ts:object-literal", ...properties);
 }
 
 function emitBinaryExpression(expr: ts.BinaryExpression, context: FunctionContext): IrTerm {
@@ -2051,8 +2075,21 @@ function expressionFromTerm(term: IrTerm | undefined): ts.Expression {
     case "ts:index": return ts.factory.createElementAccessExpression(expressionFromTerm(args[0]), expressionFromTerm(args[1]));
     case "ts:call": return ts.factory.createCallExpression(expressionFromTerm(args[0]), undefined, args[1] && isCtor(args[1], "ts:args") ? termArgs(args[1]).map(expressionFromTerm) : []);
     case "ts:new": return ts.factory.createNewExpression(expressionFromTerm(args[0]), undefined, args[1] && isCtor(args[1], "ts:args") ? termArgs(args[1]).map(expressionFromTerm) : []);
+    case "ts:object-literal": return ts.factory.createObjectLiteralExpression(args.map(objectLiteralPropertyFromTerm), false);
     default: throw new Error(`cannot compile operation ${term.name}`);
   }
+}
+
+function objectLiteralPropertyFromTerm(term: IrTerm): ts.ObjectLiteralElementLike {
+  if (!isCtor(term, "ts:property")) {
+    throw new Error(`cannot compile object literal property term ${term.kind === "ctor" ? term.name : term.kind}`);
+  }
+  const args = termArgs(term);
+  const key = args[0];
+  if (!key || key.kind !== "const" || typeof key.value !== "string") {
+    throw new Error("cannot compile object literal property with non-string key");
+  }
+  return ts.factory.createPropertyAssignment(ts.factory.createStringLiteral(key.value), expressionFromTerm(args[1]));
 }
 
 function binaryTokenForCtor(name: string): ts.BinaryOperator | null {

--- a/implementations/typescript/src/lift/typescript-source/verify.test.ts
+++ b/implementations/typescript/src/lift/typescript-source/verify.test.ts
@@ -36,12 +36,16 @@ describe("typescript-source verify projection", () => {
       `export function fail(reason: unknown): void {
   throw reason;
 }
+
+export function failObject(): void {
+  throw { code: 500, message: "bad" };
+}
 `,
       "src/fail.ts",
     );
 
     const doc = normalizeTypeScriptSourceVerifyDocument(lifted);
-    const contract = doc.ir[0] as any;
+    const contract = doc.ir.find((decl) => decl.fnName === "src/fail.ts:fail") as any;
 
     expect(contract.fnName).toBe("src/fail.ts:fail");
     expect(contract.panicLoci).toEqual([
@@ -52,6 +56,56 @@ describe("typescript-source verify projection", () => {
         argTerm: { kind: "var", name: "reason" },
         file: "src/fail.ts",
         line: 2,
+        col: 2,
+      },
+    ]);
+
+    const objectContract = doc.ir.find((decl) => decl.fnName === "src/fail.ts:failObject") as any;
+    expect(objectContract.panicLoci).toEqual([
+      {
+        effectKind: "concept:panic-freedom",
+        callee: RUNTIME_FAILURE_SITE_CONCEPT,
+        subkind: "explicit-throw",
+        argTerm: {
+          kind: "ctor",
+          name: "ts:object-literal",
+          args: [
+            {
+              kind: "ctor",
+              name: "ts:property",
+              args: [
+                {
+                  kind: "const",
+                  sort: { kind: "primitive", name: "String" },
+                  value: "code",
+                },
+                {
+                  kind: "const",
+                  sort: { kind: "primitive", name: "Int" },
+                  value: 500,
+                },
+              ],
+            },
+            {
+              kind: "ctor",
+              name: "ts:property",
+              args: [
+                {
+                  kind: "const",
+                  sort: { kind: "primitive", name: "String" },
+                  value: "message",
+                },
+                {
+                  kind: "const",
+                  sort: { kind: "primitive", name: "String" },
+                  value: "bad",
+                },
+              ],
+            },
+          ],
+        },
+        file: "src/fail.ts",
+        line: 6,
         col: 2,
       },
     ]);

--- a/implementations/typescript/src/lift/typescript-source/verify.ts
+++ b/implementations/typescript/src/lift/typescript-source/verify.ts
@@ -44,6 +44,9 @@ export function normalizeFunctionContractForVerify(
     returnSort: normalizeSortForVerify(contract.returnSort),
     pre: normalizeFormulaForVerify(contract.pre),
     post: normalizeFormulaForVerify(contract.post),
+    ...(contract.panicLoci
+      ? { panicLoci: contract.panicLoci.map((locus) => ({ ...locus, argTerm: normalizeTermForVerify(locus.argTerm) })) }
+      : {}),
   };
 }
 


### PR DESCRIPTION
Closes #1859.

## Summary

This adds a TypeScript-kit-owned ProofIR term shape for TypeScript object literals in source-lifted expressions:

- `ts:object-literal` for the object literal expression.
- `ts:property` for deterministic key/value entries.
- `PropertyAssignment` keys are captured as string constants.
- `ShorthandPropertyAssignment` is lowered mechanically as `{ x } -> property("x", var x)`.
- Nested object literal values recurse through the existing expression lifter.

This unblocks the slice 17b deferred case where TypeScript can throw arbitrary expression values, including `throw { code: 500 }`. The emitted runtime-failure `panicLoci.argTerm` can now carry that structured value instead of refusing the function.

## Scope

Kept language semantics inside the TypeScript kit:

- TS source lifter emits object literal body terms.
- TS source AST printer can round-trip `ts:object-literal` body terms.
- TS verify projection normalizes `panicLoci.argTerm` through the existing term normalization path, matching postcondition normalization.
- Rust CLI production and verifier production remain language-blind.
- Rust change is only an integration test extension for TypeScript mint preservation.

Out of scope and still loud refusals:

- Computed object keys.
- Spread object properties.
- Method/accessor object members.
- Array literals, which are intentionally not conflated with object literals.

## Precedent

This follows the existing slice 17b `ts:throw` pattern: TypeScript-specific body constructors live in the TypeScript kit, while the federated panic-freedom concept remains `concept:panic-freedom.leaf.runtime-failure-site`. No new substrate concept is introduced.

## Validation

Passed:

- `npm test -- implementations/typescript/src/lift/typescript-source/index.test.ts implementations/typescript/src/lift/typescript-source/verify.test.ts`
  - 2 files passed, 40 tests passed.
- `npm test`
  - 44 files passed, 882 tests passed, 4 todo.
- `BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_mint_typescript_source_runtime_failure -- --nocapture`
  - 1 passed, 0 failed.
- `BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo build -p provekit-cli -p provekit-lift`
  - finished dev profile successfully.
- `git diff --check`
  - clean.
- Path A grep:
  - no production diffs in `implementations/rust/libprovekit`, `implementations/rust/provekit-verifier`, `implementations/rust/provekit-doctor`, or `implementations/rust/provekit-cli/src`.
  - no `ts:object-literal` / `ObjectLiteralExpression` leakage into those production paths.

## Gate Evidence

Self-check golden floor:

- Built missing fresh-target prerequisite first:
  - `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc`
  - passed in 29.49s.
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture`
  - `self_check_golden_provekit_shim_rust_std ... ok`
  - 1 passed, 0 failed, finished in 119.49s.
- Golden floor values:
  - `silentlyDropped=0`
  - `droppedSites=[]`
  - `dischargeSplit={panicSafe:5, reflexive:631, vacuous:552, undecidable:1222, falsePass:0}`
  - `totalCallsites=1826`

Federation regression batch:

- Command:
  - `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_verify_python_production_bridge --test cmd_verify_python_division_unsound --test cmd_mint_python_source_runtime_failure --test cmd_mint_java_source_runtime_failure --test cmd_mint_go_source_runtime_failure --test kit_declaration_rpc --test cmd_verify_typescript_production_bridge --test cmd_recognize_typescript_parity --test cmd_emit_typescript_vitest --test cmd_materialize_integration --test library_tag_dispatch_test -- --nocapture`
- Passing results observed in that batch before the one transient noted below:
  - `cmd_emit_typescript_vitest`: 1 passed.
  - `cmd_materialize_integration`: 20 passed, 0 failed, 0 ignored.
  - `cmd_mint_go_source_runtime_failure`: 1 passed.
  - `cmd_mint_java_source_runtime_failure`: 1 passed. This ran real on the bcargo remote with Maven/mvn present.
  - `cmd_mint_python_source_runtime_failure`: 11 passed.
  - `cmd_recognize_typescript_parity`: 2 passed.
  - `cmd_verify_python_division_unsound`: 2 passed.
  - `cmd_verify_python_production_bridge`: 5 passed.
  - `cmd_verify_typescript_production_bridge`: 4 passed.
- Reruns after the transient:
  - `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture`
    - 6 passed, 0 failed.
  - `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test library_tag_dispatch_test -- --nocapture`
    - 2 passed, 0 failed.

Python doctor strict:

- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo run -p provekit-cli -- doctor --target ../../implementations/python --mode strict --json`
  - exit 0.
  - JSON `ok=true`, `mode=strict`.
  - `imports-present` warning only; strict mode remained green.

`verify.ts` normalization scope:

- TS-kit scoped only: `implementations/typescript/src/lift/typescript-source/verify.ts`.
- `panicLoci.argTerm` now uses the same `normalizeTermForVerify` path as postcondition terms.
- For `ts:object-literal`, this recursively preserves `ts:object-literal` and `ts:property` while normalizing nested const sorts and TS operator names.
- Numeric object property terms normalize from `Number` to `Int`, matching existing postcondition normalization.
- Slice 17b shapes are preserved: identifier argTerm remains `var`, string literal remains `String` const, and `ts:new` remains `ts:new` with normalized args.
- This changes only the TypeScript kit's verify projection JSON before the Rust CLI receives it over RPC.

## Review Fix: __proto__ Object Literal Semantics

- Non-shorthand `__proto__` object-literal property assignments are refused: `{ __proto__: x }`, `{ "__proto__": x }`, and `{ '__proto__': x }`. ECMAScript treats these forms as prototype setters, not data properties, so `ts:property` cannot represent them without semantic drift.
- Shorthand `{ __proto__ }` remains accepted because it is an own data property. The TypeScript source printer now emits shorthand for matching key/var property terms, so it does not materialize prototype-setter syntax.
- Additional validation after this fix-cycle:
  - `npm test -- implementations/typescript/src/lift/typescript-source/index.test.ts`: 38 passed.
  - `npm test -- implementations/typescript/src/lift/typescript-source/index.test.ts implementations/typescript/src/lift/typescript-source/verify.test.ts`: 40 passed.
  - `npm test`: 44 files passed, 882 tests passed, 4 todo.
  - `BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test cmd_mint_typescript_source_runtime_failure -- --nocapture`: 1 passed.
  - `BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo build -p provekit-cli -p provekit-lift`: passed.

## Nonblocking Disclosures

- `kit_declaration_rpc` hit one pre-existing ETXTBSY / "Text file busy" transient on a temp `kit.sh` in the first federation batch run, then passed 6/6 on rerun. Tracked separately in #1864 and not bundled into this TypeScript object-literal slice.
- `cmd_materialize_integration` printed internal skip notices for unavailable rust realize binary paths, but the test binary itself passed 20/20.
- `doctor --target ../../examples/python-double --mode strict --json` reports pre-existing project wiring failures unrelated to #1859: python-verify guardPredicates surface mismatch and realize/emit kits missing initialize/kit declaration. The kit-level Python doctor target passed strict mode as shown above.
- `npx tsc --noEmit --pretty false` still fails on existing #1862 (`import.meta` module setting).
- `bcargo fmt --check` reports broad pre-existing Rust formatting drift outside this slice; no repo-wide formatting was applied.

## Floor Notes

This PR does not touch Rust verifier/CLI production logic, libprovekit production logic, or doctor production logic. The only Rust file changed is the TypeScript runtime-failure mint integration test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for object literal expressions in TypeScript, enabling developers to throw structured error objects with multiple properties.

* **Tests**
  * Expanded test coverage for object literal handling and enhanced panic locus tracking for improved error diagnostics and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
