### PR TITLE
[codex] TS source kit exposes provekit.plugin.kit_declaration (#1866)

### DIFF
--- a/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
+++ b/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
@@ -1,9 +1,21 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use tempfile::TempDir;
 
 use provekit_claim_envelope::{KitDeclaration, KIT_DECLARATION_RPC_METHOD};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .expect("repo root")
+        .to_path_buf()
+}
+
+fn typescript_env_enabled() -> bool {
+    std::env::var("BCARGO_TYPESCRIPT_ENV").map_or(false, |value| value == "1")
+}
 
 fn make_executable(path: &Path, body: &str) {
     fs::write(path, body).expect("write stub");
@@ -204,6 +216,67 @@ done
         .methods
         .iter()
         .any(|method| method.name == "provekit.plugin.lift_implications"));
+}
+
+#[test]
+fn loader_dispatches_to_typescript_source_kit_declaration() {
+    if !typescript_env_enabled() {
+        eprintln!("skipping: BCARGO_TYPESCRIPT_ENV is not enabled");
+        return;
+    }
+
+    let repo = repo_root();
+    let typescript_dir = repo.join("implementations/typescript");
+    let command = [
+        "npx".to_string(),
+        "tsx".to_string(),
+        "src/lift/typescript-source/bin.ts".to_string(),
+        "--rpc".to_string(),
+    ];
+
+    let declaration: KitDeclaration =
+        provekit_cli::kit_declaration::load_kit_declaration_with_command(
+            &command,
+            Some(&typescript_dir),
+        )
+        .expect("load TypeScript source kit declaration");
+
+    assert_eq!(declaration.kit.id, "typescript-source");
+    assert_eq!(declaration.kit.language, "typescript");
+    assert_eq!(declaration.kit.version, "0.1.0-draft");
+    assert_eq!(declaration.proof_resolution.strategy, "npm");
+    assert_eq!(declaration.effect_kinds, ["concept:panic-freedom"]);
+    assert_eq!(declaration.effect_leaves.len(), 1);
+    assert_eq!(
+        declaration.effect_leaves[0].surface.as_deref(),
+        Some("typescript-source")
+    );
+    assert_eq!(declaration.effect_leaves[0].local, "ts:throw");
+    assert_eq!(
+        declaration.effect_leaves[0].concept,
+        "concept:panic-freedom.leaf.runtime-failure-site"
+    );
+    assert!(declaration.guard_predicates.is_empty());
+    assert!(declaration.control_carriers.is_empty());
+    assert!(declaration.residue_categories.is_empty());
+
+    let required_by_name = declaration
+        .rpc
+        .methods
+        .iter()
+        .map(|method| (method.name.as_str(), method.required))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    assert_eq!(
+        required_by_name,
+        std::collections::BTreeMap::from([
+            ("initialize", true),
+            (KIT_DECLARATION_RPC_METHOD, true),
+            ("lift", true),
+            ("compile", false),
+            ("provekit.plugin.recognize", false),
+            ("shutdown", false),
+        ])
+    );
 }
 
 #[test]

--- a/implementations/typescript/src/lift/typescript-source/bin.test.ts
+++ b/implementations/typescript/src/lift/typescript-source/bin.test.ts
@@ -1,0 +1,85 @@
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const KIT_DECLARATION_RPC_METHOD = "provekit.plugin.kit_declaration";
+const TYPESCRIPT_SOURCE_DIR = join(process.cwd(), "implementations/typescript");
+
+function runRpc(requests: Array<Record<string, unknown>>): Array<Record<string, any>> {
+  const input = `${requests.map((request) => JSON.stringify(request)).join("\n")}\n`;
+  const completed = spawnSync("npx", ["tsx", "src/lift/typescript-source/bin.ts", "--rpc"], {
+    cwd: TYPESCRIPT_SOURCE_DIR,
+    input,
+    encoding: "utf8",
+  });
+
+  expect(completed.status, completed.stderr).toBe(0);
+  return completed.stdout
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as Record<string, any>);
+}
+
+describe("typescript-source kit_declaration RPC", () => {
+  it("returns the empirically declared TypeScript source surface", () => {
+    const responses = runRpc([
+      { jsonrpc: "2.0", id: 1, method: "initialize" },
+      { jsonrpc: "2.0", id: 2, method: KIT_DECLARATION_RPC_METHOD },
+      { jsonrpc: "2.0", id: 3, method: "shutdown" },
+    ]);
+
+    const declaration = responses.find((response) => response.id === 2);
+    expect(declaration).toBeDefined();
+    expect(declaration).not.toHaveProperty("error");
+    expect(declaration!.result).toEqual({
+      kit: {
+        id: "typescript-source",
+        language: "typescript",
+        version: "0.1.0-draft",
+      },
+      rpc: {
+        methods: [
+          { name: "initialize", required: true },
+          { name: KIT_DECLARATION_RPC_METHOD, required: true },
+          { name: "lift", required: true },
+          { name: "compile", required: false },
+          { name: "provekit.plugin.recognize", required: false },
+          { name: "shutdown", required: false },
+        ],
+      },
+      proofResolution: { strategy: "npm" },
+      effectKinds: ["concept:panic-freedom"],
+      effectLeaves: [
+        {
+          surface: "typescript-source",
+          local: "ts:throw",
+          concept: "concept:panic-freedom.leaf.runtime-failure-site",
+        },
+      ],
+      guardPredicates: [],
+      controlCarriers: [],
+      residueCategories: [],
+    });
+  });
+
+  it("returns a deterministic kit_declaration response", () => {
+    const [first, second] = runRpc([
+      { jsonrpc: "2.0", id: 7, method: KIT_DECLARATION_RPC_METHOD },
+      { jsonrpc: "2.0", id: 8, method: KIT_DECLARATION_RPC_METHOD },
+    ]);
+
+    expect(first).not.toHaveProperty("error");
+    expect(second).not.toHaveProperty("error");
+    expect(first.result).toEqual(second.result);
+  });
+
+  it("keeps initialize separate from kit_declaration content", () => {
+    const initialize = runRpc([{ jsonrpc: "2.0", id: 1, method: "initialize" }])[0];
+
+    expect(initialize).not.toHaveProperty("error");
+    expect(initialize.result.name).toBe("provekit-lift-typescript-source");
+    expect(initialize.result).not.toHaveProperty("effectKinds");
+    expect(initialize.result).not.toHaveProperty("effectLeaves");
+    expect(initialize.result).not.toHaveProperty("kit");
+  });
+});

--- a/implementations/typescript/src/lift/typescript-source/bin.ts
+++ b/implementations/typescript/src/lift/typescript-source/bin.ts
@@ -13,6 +13,7 @@ import { normalizeTypeScriptSourceVerifyDocument } from "./verify.js";
 const DIALECT = "typescript-source";
 const SURFACE_ALIASES = new Set([DIALECT, "typescript-bind"]);
 const VERSION = "0.1.0-draft";
+const KIT_DECLARATION_RPC_METHOD = "provekit.plugin.kit_declaration";
 
 interface JsonRpcRequest {
   jsonrpc?: string;
@@ -68,11 +69,45 @@ function dispatch(request: JsonRpcRequest): Record<string, unknown> | null {
       return compileRpc(request);
     case "provekit.plugin.recognize":
       return recognizeRpc(request);
+    case KIT_DECLARATION_RPC_METHOD:
+      return success(request.id, kitDeclarationResult());
     case "shutdown":
       return success(request.id, null);
     default:
       return errorResponse(request.id ?? null, -32601, `METHOD_NOT_FOUND: ${request.method ?? ""}`);
   }
+}
+
+function kitDeclarationResult(): Record<string, unknown> {
+  return {
+    kit: {
+      id: DIALECT,
+      language: "typescript",
+      version: VERSION,
+    },
+    rpc: {
+      methods: [
+        { name: "initialize", required: true },
+        { name: KIT_DECLARATION_RPC_METHOD, required: true },
+        { name: "lift", required: true },
+        { name: "compile", required: false },
+        { name: "provekit.plugin.recognize", required: false },
+        { name: "shutdown", required: false },
+      ],
+    },
+    proofResolution: { strategy: "npm" },
+    effectKinds: ["concept:panic-freedom"],
+    effectLeaves: [
+      {
+        surface: DIALECT,
+        local: "ts:throw",
+        concept: "concept:panic-freedom.leaf.runtime-failure-site",
+      },
+    ],
+    guardPredicates: [],
+    controlCarriers: [],
+    residueCategories: [],
+  };
 }
 
 function liftRpc(request: JsonRpcRequest): Record<string, unknown> {


### PR DESCRIPTION
## Summary

- Exposes `provekit.plugin.kit_declaration` from the TypeScript source kit RPC server.
- Declares the empirically verified TypeScript panic-freedom surface: `ts:throw` maps to `concept:panic-freedom.leaf.runtime-failure-site`.
- Adds a real TypeScript RPC test and a Rust integration test that dispatches through the existing kit declaration loader to the real TS kit.

Closes #1866.

## Design Notes

The TypeScript source kit now declares only the surface it already owns. `guardPredicates`, `controlCarriers`, and `residueCategories` stay empty because the current TS lifter output shows structural source terms like `ts:if` and `ts:throw`, not substrate control carriers. That keeps the #856 honesty-gradient rule intact: declare verified semantics, do not copy another language's shape.

`proofResolution` uses `{ strategy: "npm" }`, matching the manager-level abstraction already used by Python's `{ strategy: "pip" }` declaration. The CLI still learns this through RPC and does not gain TypeScript-specific production behavior.

The new TS determinism test sends two `kit_declaration` requests through one RPC process and compares the response payloads. This tests handler determinism without coupling the assertion to `npx tsx` process startup cost.

## Verification

- `npm test -- implementations/typescript/src/lift/typescript-source/bin.test.ts`
  - 1 file passed, 3 tests passed.
- `npm test`
  - 45 files passed, 885 tests passed, 4 todo.
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc -p provekit-lift --bin provekit-lift -p provekit-cli`
  - passed.
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture`
  - 7 passed.
- Federation regression batch:
  - `cmd_verify_python_production_bridge`
  - `cmd_verify_python_division_unsound`
  - `cmd_mint_python_source_runtime_failure`
  - `cmd_mint_java_source_runtime_failure`
  - `cmd_mint_go_source_runtime_failure`
  - `kit_declaration_rpc`
  - `cmd_verify_typescript_production_bridge`
  - `cmd_recognize_typescript_parity`
  - `cmd_emit_typescript_vitest`
  - `cmd_mint_typescript_source_runtime_failure`
  - `cmd_materialize_integration`
  - `library_tag_dispatch_test`
  - passed on rerun.
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo run -p provekit-cli -- doctor --target ../../implementations/python --mode strict --json`
  - `ok: true`, `releaseReady: false` with existing dependency resolver/import warnings only.
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture`
  - 1 passed.
  - Golden floor stayed stable: `silentlyDropped: 0`, `droppedSites: []`, `panicSafe: 5`, `reflexive: 631`, `falsePass: 0`.
- `git diff --check`
  - clean.
- Rust production diff check:
  - `git diff -- implementations/rust/libprovekit/src implementations/rust/provekit-verifier/src implementations/rust/provekit-cli/src`
  - no output.

## Notes

A first federation batch attempt hit the known transient `Text file busy` temp-script execution flake in `kit_declaration_rpc`; the focused test passed before and after, and the full federation batch passed on rerun. No Rust harness hardening is included in this PR.
