### PR TITLE
[codex] Go source kit exposes provekit.plugin.kit_declaration (#1867)

### DIFF
--- a/implementations/go/provekit-lift-go/kit_declaration.go
+++ b/implementations/go/provekit-lift-go/kit_declaration.go
@@ -1,0 +1,72 @@
+package liftgo
+
+const KitDeclarationRPCMethod = "provekit.plugin.kit_declaration"
+
+type KitDeclarationKit struct {
+	ID       string `json:"id"`
+	Language string `json:"language"`
+	Version  string `json:"version"`
+}
+
+type KitDeclarationMethod struct {
+	Name     string `json:"name"`
+	Required bool   `json:"required"`
+}
+
+type KitDeclarationRPC struct {
+	Methods []KitDeclarationMethod `json:"methods"`
+}
+
+type KitDeclarationProofResolution struct {
+	Strategy string `json:"strategy"`
+}
+
+type KitDeclarationEffectLeaf struct {
+	Surface string `json:"surface"`
+	Local   string `json:"local"`
+	Concept string `json:"concept"`
+}
+
+type KitDeclaration struct {
+	Kit               KitDeclarationKit             `json:"kit"`
+	RPC               KitDeclarationRPC             `json:"rpc"`
+	ProofResolution   KitDeclarationProofResolution `json:"proofResolution"`
+	EffectKinds       []string                      `json:"effectKinds"`
+	EffectLeaves      []KitDeclarationEffectLeaf    `json:"effectLeaves"`
+	GuardPredicates   []any                         `json:"guardPredicates"`
+	ControlCarriers   []any                         `json:"controlCarriers"`
+	ResidueCategories []any                         `json:"residueCategories"`
+}
+
+func KitDeclarationResult() KitDeclaration {
+	return KitDeclaration{
+		Kit: KitDeclarationKit{
+			ID:       "go-source",
+			Language: "go",
+			Version:  Version,
+		},
+		RPC: KitDeclarationRPC{
+			Methods: []KitDeclarationMethod{
+				{Name: "initialize", Required: true},
+				{Name: KitDeclarationRPCMethod, Required: true},
+				{Name: "lift", Required: true},
+				{Name: "provekit.plugin.lift_implications", Required: false},
+				{Name: "compile", Required: false},
+				{Name: "provekit.plugin.recognize", Required: false},
+				{Name: "shutdown", Required: false},
+			},
+		},
+		ProofResolution: KitDeclarationProofResolution{Strategy: "go-mod"},
+		EffectKinds:     []string{panicFreedomConceptName},
+		EffectLeaves: []KitDeclarationEffectLeaf{
+			{
+				Surface: "go-source",
+				Local:   "go:panic",
+				Concept: runtimeFailureSiteConceptID,
+			},
+		},
+		GuardPredicates:   []any{},
+		ControlCarriers:   []any{},
+		ResidueCategories: []any{},
+	}
+}

--- a/implementations/go/provekit-lift-go/kit_declaration_test.go
+++ b/implementations/go/provekit-lift-go/kit_declaration_test.go
@@ -1,0 +1,132 @@
+package liftgo
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const kitDeclarationRPCMethod = "provekit.plugin.kit_declaration"
+
+func runRPCForKitDeclarationTest(t *testing.T, requests []string) []map[string]any {
+	t.Helper()
+	input := strings.Join(requests, "\n") + "\n"
+	var out bytes.Buffer
+	if err := RunRPC(strings.NewReader(input), &out); err != nil {
+		t.Fatalf("RunRPC: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	responses := make([]map[string]any, 0, len(lines))
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var response map[string]any
+		if err := json.Unmarshal([]byte(line), &response); err != nil {
+			t.Fatalf("parse RPC response %q: %v", line, err)
+		}
+		responses = append(responses, response)
+	}
+	return responses
+}
+
+func responseByID(t *testing.T, responses []map[string]any, id float64) map[string]any {
+	t.Helper()
+	for _, response := range responses {
+		if response["id"] == id {
+			return response
+		}
+	}
+	t.Fatalf("missing response id %.0f in %#v", id, responses)
+	return nil
+}
+
+func expectedGoSourceKitDeclaration() map[string]any {
+	return map[string]any{
+		"kit": map[string]any{
+			"id":       "go-source",
+			"language": "go",
+			"version":  "0.1.0-draft",
+		},
+		"rpc": map[string]any{
+			"methods": []any{
+				map[string]any{"name": "initialize", "required": true},
+				map[string]any{"name": kitDeclarationRPCMethod, "required": true},
+				map[string]any{"name": "lift", "required": true},
+				map[string]any{"name": "provekit.plugin.lift_implications", "required": false},
+				map[string]any{"name": "compile", "required": false},
+				map[string]any{"name": "provekit.plugin.recognize", "required": false},
+				map[string]any{"name": "shutdown", "required": false},
+			},
+		},
+		"proofResolution": map[string]any{"strategy": "go-mod"},
+		"effectKinds":     []any{"concept:panic-freedom"},
+		"effectLeaves": []any{
+			map[string]any{
+				"surface": "go-source",
+				"local":   "go:panic",
+				"concept": "concept:panic-freedom.leaf.runtime-failure-site",
+			},
+		},
+		"guardPredicates":   []any{},
+		"controlCarriers":   []any{},
+		"residueCategories": []any{},
+	}
+}
+
+func TestKitDeclarationReturnsEmpiricalGoSourceSurface(t *testing.T) {
+	responses := runRPCForKitDeclarationTest(t, []string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"provekit.plugin.kit_declaration"}`,
+		`{"jsonrpc":"2.0","id":3,"method":"shutdown"}`,
+	})
+
+	declaration := responseByID(t, responses, 2)
+	if errValue, ok := declaration["error"]; ok {
+		t.Fatalf("kit_declaration returned error: %#v", errValue)
+	}
+	if !reflect.DeepEqual(declaration["result"], expectedGoSourceKitDeclaration()) {
+		t.Fatalf("kit_declaration result mismatch:\n got: %#v\nwant: %#v", declaration["result"], expectedGoSourceKitDeclaration())
+	}
+}
+
+func TestKitDeclarationResponseIsDeterministic(t *testing.T) {
+	responses := runRPCForKitDeclarationTest(t, []string{
+		`{"jsonrpc":"2.0","id":7,"method":"provekit.plugin.kit_declaration"}`,
+		`{"jsonrpc":"2.0","id":8,"method":"provekit.plugin.kit_declaration"}`,
+	})
+
+	first := responseByID(t, responses, 7)
+	second := responseByID(t, responses, 8)
+	if errValue, ok := first["error"]; ok {
+		t.Fatalf("first kit_declaration returned error: %#v", errValue)
+	}
+	if errValue, ok := second["error"]; ok {
+		t.Fatalf("second kit_declaration returned error: %#v", errValue)
+	}
+	if !reflect.DeepEqual(first["result"], second["result"]) {
+		t.Fatalf("kit_declaration not deterministic:\nfirst:  %#v\nsecond: %#v", first["result"], second["result"])
+	}
+}
+
+func TestInitializeStaysSeparateFromKitDeclarationContent(t *testing.T) {
+	responses := runRPCForKitDeclarationTest(t, []string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`,
+	})
+
+	initialize := responseByID(t, responses, 1)
+	if errValue, ok := initialize["error"]; ok {
+		t.Fatalf("initialize returned error: %#v", errValue)
+	}
+	result, ok := initialize["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("initialize result = %#v, want object", initialize["result"])
+	}
+	for _, forbidden := range []string{"effectKinds", "effectLeaves", "kit"} {
+		if _, ok := result[forbidden]; ok {
+			t.Fatalf("initialize result must not contain kit declaration field %q: %#v", forbidden, result)
+		}
+	}
+}

--- a/implementations/go/provekit-lift-go/rpc.go
+++ b/implementations/go/provekit-lift-go/rpc.go
@@ -62,6 +62,8 @@ func RunRPCWithDefault(stdin io.Reader, stdout io.Writer, defaultOpts LiftOption
 		switch req.Method {
 		case "initialize":
 			writeRPC(stdout, successResponse(req.ID, InitializeResult()))
+		case KitDeclarationRPCMethod:
+			writeRPC(stdout, successResponse(req.ID, KitDeclarationResult()))
 		case "lift":
 			writeRPC(stdout, handleLift(req.ID, req.Params, defaultOpts))
 		case "provekit.plugin.lift_implications":

--- a/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
+++ b/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
@@ -17,6 +17,13 @@ fn typescript_env_enabled() -> bool {
     std::env::var("BCARGO_TYPESCRIPT_ENV").map_or(false, |value| value == "1")
 }
 
+fn command_available(command: &str) -> bool {
+    std::process::Command::new(command)
+        .arg("version")
+        .output()
+        .map_or(false, |output| output.status.success())
+}
+
 fn make_executable(path: &Path, body: &str) {
     fs::write(path, body).expect("write stub");
     let mut perms = fs::metadata(path).expect("metadata").permissions();
@@ -272,6 +279,68 @@ fn loader_dispatches_to_typescript_source_kit_declaration() {
             ("initialize", true),
             (KIT_DECLARATION_RPC_METHOD, true),
             ("lift", true),
+            ("compile", false),
+            ("provekit.plugin.recognize", false),
+            ("shutdown", false),
+        ])
+    );
+}
+
+#[test]
+fn loader_dispatches_to_go_source_kit_declaration() {
+    if !command_available("go") {
+        eprintln!("skipping: go is not available");
+        return;
+    }
+
+    let repo = repo_root();
+    let go_source_dir = repo.join("implementations/go/provekit-lift-go");
+    let command = [
+        "go".to_string(),
+        "run".to_string(),
+        "./cmd/provekit-lift-go".to_string(),
+        "--rpc".to_string(),
+    ];
+
+    let declaration: KitDeclaration =
+        provekit_cli::kit_declaration::load_kit_declaration_with_command(
+            &command,
+            Some(&go_source_dir),
+        )
+        .expect("load Go source kit declaration");
+
+    assert_eq!(declaration.kit.id, "go-source");
+    assert_eq!(declaration.kit.language, "go");
+    assert_eq!(declaration.kit.version, "0.1.0-draft");
+    assert_eq!(declaration.proof_resolution.strategy, "go-mod");
+    assert_eq!(declaration.effect_kinds, ["concept:panic-freedom"]);
+    assert_eq!(declaration.effect_leaves.len(), 1);
+    assert_eq!(
+        declaration.effect_leaves[0].surface.as_deref(),
+        Some("go-source")
+    );
+    assert_eq!(declaration.effect_leaves[0].local, "go:panic");
+    assert_eq!(
+        declaration.effect_leaves[0].concept,
+        "concept:panic-freedom.leaf.runtime-failure-site"
+    );
+    assert!(declaration.guard_predicates.is_empty());
+    assert!(declaration.control_carriers.is_empty());
+    assert!(declaration.residue_categories.is_empty());
+
+    let required_by_name = declaration
+        .rpc
+        .methods
+        .iter()
+        .map(|method| (method.name.as_str(), method.required))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    assert_eq!(
+        required_by_name,
+        std::collections::BTreeMap::from([
+            ("initialize", true),
+            (KIT_DECLARATION_RPC_METHOD, true),
+            ("lift", true),
+            ("provekit.plugin.lift_implications", false),
             ("compile", false),
             ("provekit.plugin.recognize", false),
             ("shutdown", false),


### PR DESCRIPTION
Closes #1867.
Closes part of #1865.

## Summary

Go source kit RPC now exposes `provekit.plugin.kit_declaration`. The declaration is kit-owned and empirical: it reports only the Go source lifter surface that exists today, then the Rust integration test loads it over the same language-blind kit declaration RPC path already used for Python and TypeScript.

This is the second parity slice under #1865. Slice 19 landed TypeScript in #1869 at 8f588a95. Slice 21 remains Java source kit declaration in #1868.

## Substrate Vocabulary

The declaration reuses existing substrate concepts only:

- `effectKinds`: `concept:panic-freedom`
- `effectLeaves`: `go-source` local `go:panic` maps to `concept:panic-freedom.leaf.runtime-failure-site`
- `guardPredicates`: empty
- `controlCarriers`: empty
- `residueCategories`: empty

The empty collections are intentional under #856 honesty-gradient discipline. Go source currently emits structural Go body ctors such as `go:if`, `go:for`, and `go:range`, not substrate carriers like Python `cf_guarded` or `cf_ite`. It also does not expose a named guard predicate vocabulary or residue declaration surface in this slice.

## Empirical Evidence

Go source kit declaration lives in `implementations/go/provekit-lift-go/kit_declaration.go:41`, and the RPC dispatch is wired at `implementations/go/provekit-lift-go/rpc.go:62`.

The declared panic-freedom vocabulary is backed by existing Go source lifter constants and emission:

- `panicFreedomConceptName`, `runtimeFailureSiteConceptID`, and `explicitPanicSubkind` in `implementations/go/provekit-lift-go/lift.go:23`
- builtin `panic` emits the runtime failure locus and `go:panic` body ctor in `implementations/go/provekit-lift-go/lift.go:856`

The real-loader integration is in `implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs:290`, dispatching `go run ./cmd/provekit-lift-go --rpc` and asserting the parsed declaration through the Rust loader.

Precedents:

- Python source kit declaration shape: `implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/rpc.py:31`
- TypeScript source kit declaration shape: `implementations/typescript/src/lift/typescript-source/bin.ts:81`
- TypeScript slice 19 precedent: #1869, commit 8f588a95
- Go panic emission slice: #1854

## Proof Resolution

`proofResolution.strategy` is `go-mod`. That is the manager-level Go module abstraction, matching the existing pattern where Python declares `pip` and TypeScript declares `npm`. The CLI remains language-blind and consumes this declaration over RPC; it does not learn Go module internals.

## Out Of Scope

- Java kit declaration remains #1868.
- Go verify-facing kit declaration is tracked separately in #1870.
- No new Go lifter capabilities are introduced.
- No Rust CLI, verifier, doctor, or libprovekit production behavior changes are introduced.
- #750, #1858, and #1839 remain architect-call territory.

## Path A Confirmation

Changed files are limited to:

- `implementations/go/provekit-lift-go/kit_declaration.go`
- `implementations/go/provekit-lift-go/kit_declaration_test.go`
- `implementations/go/provekit-lift-go/rpc.go`
- `implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs`

Production Rust diff was verified empty for:

- `implementations/rust/libprovekit/src`
- `implementations/rust/provekit-verifier/src`
- `implementations/rust/provekit-cli/src`
- `implementations/rust/provekit-doctor/src`

## Floor Invariants

`self_check_golden` passed unchanged:

| Field | Value |
|---|---:|
| silentlyDropped | 0 |
| droppedSites | [] |
| totalCallsites | 1826 |
| panicSafe | 5 |
| reflexive | 631 |
| vacuous | 552 |
| undecidable | 1222 |
| falsePass | 0 |

## Verification

- RED Go focused test failed on `METHOD_NOT_FOUND: provekit.plugin.kit_declaration` before implementation.
- RED Rust real-loader failed on the same missing method before implementation, while existing Python and TypeScript declaration tests passed.
- `go test . -run 'TestKitDeclaration(ReturnsEmpiricalGoSourceSurface|ResponseIsDeterministic)|TestInitializeStaysSeparateFromKitDeclarationContent' -count=1 -v`
- `go test ./... -count=1 -v` in `implementations/go/provekit-lift-go`
- nested Go module sweep with `go test ./... -count=1` for all `implementations/go/**/go.mod` modules
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc -p provekit-lift --bin provekit-lift -p provekit-cli`
- federation regression batch: Python, Java, Go, TypeScript mint/verify/recognize/materialize/library-tag tests
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo run -p provekit-cli -- doctor --target ../../implementations/python --mode strict --json` returned `ok: true`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` passed 1/1 in 115.28s
- `git diff --cached --check`
- Path A production Rust diff zero check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Go-source kit now declares its capabilities including RPC method requirements, proof resolution strategy, and runtime effect handling.

* **Tests**
  * Added comprehensive tests validating kit declaration functionality and response consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->