### PR TITLE
[codex] Java source kit exposes provekit.plugin.kit_declaration (#1868)

### DIFF
--- a/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/KitDeclaration.java
+++ b/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/KitDeclaration.java
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.provekit.lift.java_source;
+
+import com.provekit.ir.Jcs;
+
+final class KitDeclaration {
+    static final String RPC_METHOD = "provekit.plugin.kit_declaration";
+
+    private KitDeclaration() {}
+
+    static Jcs.Obj toJson() {
+        return Jcs.object(
+            "kit", Jcs.object(
+                "id", Jcs.string("java-source"),
+                "language", Jcs.string("java"),
+                "version", Jcs.string("0.1.0")
+            ),
+            "rpc", Jcs.object(
+                "methods", Jcs.array(
+                    rpcMethod("initialize", true),
+                    rpcMethod(RPC_METHOD, true),
+                    rpcMethod("lift", true),
+                    rpcMethod("shutdown", false)
+                )
+            ),
+            "proofResolution", Jcs.object("strategy", Jcs.string("maven")),
+            "effectKinds", Jcs.array(Jcs.string("concept:panic-freedom")),
+            "effectLeaves", Jcs.array(
+                Jcs.object(
+                    "surface", Jcs.string("java-source"),
+                    "local", Jcs.string("java:throw"),
+                    "concept", Jcs.string("concept:panic-freedom.leaf.runtime-failure-site")
+                )
+            ),
+            "guardPredicates", Jcs.array(),
+            "controlCarriers", Jcs.array(),
+            "residueCategories", Jcs.array()
+        );
+    }
+
+    private static Jcs.Obj rpcMethod(String name, boolean required) {
+        return Jcs.object(
+            "name", Jcs.string(name),
+            "required", Jcs.bool(required)
+        );
+    }
+}

--- a/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/SourceRpcServer.java
+++ b/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/SourceRpcServer.java
@@ -37,6 +37,11 @@ public final class SourceRpcServer {
         if (method == null) return error(id, -32600, "INVALID_REQUEST: missing method");
         return switch (method) {
             case "initialize" -> initialize(id);
+            case KitDeclaration.RPC_METHOD -> Jcs.object(
+                "id", id,
+                "jsonrpc", Jcs.string("2.0"),
+                "result", KitDeclaration.toJson()
+            );
             case "lift" -> lift(id, request.get("params"));
             case "shutdown" -> Jcs.object("jsonrpc", Jcs.string("2.0"), "id", id, "result", Jcs.nullValue());
             default -> error(id, -32601, "METHOD_NOT_FOUND: " + method);

--- a/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/SourceRpcServerTest.java
+++ b/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/SourceRpcServerTest.java
@@ -26,6 +26,65 @@ class SourceRpcServerTest {
     }
 
     @Test
+    void kitDeclarationReturnsEmpiricalJavaSourceSurface() throws Exception {
+        Jcs.Obj response = handle(
+            "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"provekit.plugin.kit_declaration\",\"params\":{}}"
+        );
+        assertNoRpcError(response);
+        Jcs.Obj result = response.objectField("result");
+
+        Jcs.Obj kit = result.objectField("kit");
+        assertEquals("java-source", kit.stringField("id"));
+        assertEquals("java", kit.stringField("language"));
+        assertEquals("0.1.0", kit.stringField("version"));
+
+        assertEquals("maven", result.objectField("proofResolution").stringField("strategy"));
+        assertEquals("concept:panic-freedom", result.arrayField("effectKinds").stringAt(0).value());
+
+        Jcs.Arr effectLeaves = result.arrayField("effectLeaves");
+        assertEquals(1, effectLeaves.values().size(), Jcs.encode(result));
+        Jcs.Obj leaf = effectLeaves.objectAt(0);
+        assertEquals("java-source", leaf.stringField("surface"));
+        assertEquals("java:throw", leaf.stringField("local"));
+        assertEquals("concept:panic-freedom.leaf.runtime-failure-site", leaf.stringField("concept"));
+
+        assertTrue(result.arrayField("guardPredicates").isEmpty());
+        assertTrue(result.arrayField("controlCarriers").isEmpty());
+        assertTrue(result.arrayField("residueCategories").isEmpty());
+
+        assertMethodRequired(result, "initialize", true);
+        assertMethodRequired(result, "provekit.plugin.kit_declaration", true);
+        assertMethodRequired(result, "lift", true);
+        assertMethodRequired(result, "shutdown", false);
+    }
+
+    @Test
+    void kitDeclarationResponseIsDeterministic() throws Exception {
+        Jcs.Obj firstResponse = handle(
+            "{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"provekit.plugin.kit_declaration\",\"params\":{}}"
+        );
+        Jcs.Obj secondResponse = handle(
+            "{\"jsonrpc\":\"2.0\",\"id\":8,\"method\":\"provekit.plugin.kit_declaration\",\"params\":{}}"
+        );
+        assertNoRpcError(firstResponse);
+        assertNoRpcError(secondResponse);
+        Jcs.Obj first = firstResponse.objectField("result");
+        Jcs.Obj second = secondResponse.objectField("result");
+
+        assertEquals(Jcs.encode(first), Jcs.encode(second));
+    }
+
+    @Test
+    void initializeStaysSeparateFromKitDeclarationContent() throws Exception {
+        Jcs.Obj response = handle("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}");
+        Jcs.Obj result = response.objectField("result");
+
+        assertEquals(null, result.get("kit"));
+        assertEquals(null, result.get("effectKinds"));
+        assertEquals(null, result.get("effectLeaves"));
+    }
+
+    @Test
     void liftReturnsFunctionContractWithExplicitThrowRuntimeFailureLocus() throws Exception {
         Files.writeString(temp.resolve("Thrower.java"), """
 public class Thrower {
@@ -84,6 +143,20 @@ return x;
             .filter(o -> fnName.equals(o.stringFieldOrNull("fnName")))
             .findFirst()
             .orElseThrow();
+    }
+
+    private static void assertNoRpcError(Jcs.Obj response) {
+        assertEquals(null, response.get("error"), Jcs.encode(response));
+    }
+
+    private static void assertMethodRequired(Jcs.Obj declaration, String name, boolean required) {
+        Jcs.Arr methods = declaration.objectField("rpc").arrayField("methods");
+        Jcs.Obj method = methods.values().stream()
+            .map(Jcs.Obj.class::cast)
+            .filter(candidate -> name.equals(candidate.stringFieldOrNull("name")))
+            .findFirst()
+            .orElseThrow();
+        assertEquals(required, method.boolField("required"), Jcs.encode(method));
     }
 
     private static String jsonEncodeString(String s) {

--- a/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
+++ b/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
@@ -1,5 +1,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
 
@@ -24,6 +27,103 @@ fn command_available(command: &str) -> bool {
         .map_or(false, |output| output.status.success())
 }
 
+fn run_with_timeout(cmd: &mut Command, timeout: Duration) -> std::io::Result<Output> {
+    let mut child = cmd.spawn()?;
+    let started = Instant::now();
+    loop {
+        if child.try_wait()?.is_some() {
+            return child.wait_with_output();
+        }
+        if started.elapsed() >= timeout {
+            let _ = child.kill();
+            return child.wait_with_output();
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn java_bin() -> Option<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(java_home) = std::env::var_os("JAVA_HOME") {
+        candidates.push(PathBuf::from(java_home).join("bin").join("java"));
+    }
+    candidates.push(PathBuf::from("java"));
+    candidates.push(PathBuf::from(
+        "/usr/local/opt/openjdk/libexec/openjdk.jdk/Contents/Home/bin/java",
+    ));
+    candidates.push(PathBuf::from(
+        "/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home/bin/java",
+    ));
+
+    candidates.into_iter().find(|candidate| {
+        run_with_timeout(
+            Command::new(candidate).arg("-version"),
+            Duration::from_secs(5),
+        )
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+    })
+}
+
+fn maven_available() -> bool {
+    run_with_timeout(Command::new("mvn").arg("-version"), Duration::from_secs(8))
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn java_source_kit_command() -> Option<Vec<String>> {
+    static JAVA_SOURCE_KIT_COMMAND: OnceLock<Option<Vec<String>>> = OnceLock::new();
+    JAVA_SOURCE_KIT_COMMAND
+        .get_or_init(|| {
+            let Some(java) = java_bin() else {
+                eprintln!("skipping: no working java binary found");
+                return None;
+            };
+            if !maven_available() {
+                eprintln!("skipping: mvn is unavailable");
+                return None;
+            }
+
+            let root = repo_root();
+            let java_root = root.join("implementations").join("java");
+            let mut mvn = Command::new("mvn");
+            mvn.current_dir(&java_root).args([
+                "-B",
+                "-ntp",
+                "-pl",
+                "provekit-lift-java-source",
+                "-am",
+                "-DskipTests",
+                "package",
+            ]);
+            let out =
+                run_with_timeout(&mut mvn, Duration::from_secs(120)).expect("spawn mvn package");
+            assert!(
+                out.status.success(),
+                "mvn package provekit-lift-java-source failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr)
+            );
+
+            let jar = java_root
+                .join("provekit-lift-java-source")
+                .join("target")
+                .join("provekit-lift-java-source.jar");
+            assert!(
+                jar.exists(),
+                "maven build produced no jar at {}",
+                jar.display()
+            );
+            Some(vec![
+                java.display().to_string(),
+                "-jar".to_string(),
+                jar.display().to_string(),
+                "--rpc".to_string(),
+            ])
+        })
+        .clone()
+}
+
 fn make_executable(path: &Path, body: &str) {
     fs::write(path, body).expect("write stub");
     let mut perms = fs::metadata(path).expect("metadata").permissions();
@@ -33,6 +133,10 @@ fn make_executable(path: &Path, body: &str) {
         perms.set_mode(0o755);
     }
     fs::set_permissions(path, perms).expect("chmod");
+}
+
+fn shell_stub_command(path: &Path) -> Vec<String> {
+    vec!["sh".to_string(), path.display().to_string()]
 }
 
 #[test]
@@ -67,7 +171,7 @@ done
 
     let declaration: KitDeclaration =
         provekit_cli::kit_declaration::load_kit_declaration_with_command(
-            &[stub.display().to_string()],
+            &shell_stub_command(&stub),
             Some(td.path()),
         )
         .expect("load declaration");
@@ -103,7 +207,7 @@ done
     );
 
     let err = provekit_cli::kit_declaration::load_kit_declaration_with_command(
-        &[stub.display().to_string()],
+        &shell_stub_command(&stub),
         Some(td.path()),
     )
     .expect_err("conflicting declaration should fail");
@@ -135,7 +239,7 @@ done
     );
 
     let err = provekit_cli::kit_declaration::load_kit_declaration_with_command(
-        &[stub.display().to_string()],
+        &shell_stub_command(&stub),
         Some(td.path()),
     )
     .expect_err("missing declaration method should fail");
@@ -172,7 +276,7 @@ done
 
     let declaration: KitDeclaration =
         provekit_cli::kit_declaration::load_kit_declaration_with_command(
-            &[stub.display().to_string()],
+            &shell_stub_command(&stub),
             Some(td.path()),
         )
         .expect("load declaration");
@@ -209,7 +313,7 @@ done
 
     let declaration: KitDeclaration =
         provekit_cli::kit_declaration::load_kit_declaration_with_command(
-            &[stub.display().to_string()],
+            &shell_stub_command(&stub),
             Some(td.path()),
         )
         .expect("load declaration");
@@ -349,6 +453,58 @@ fn loader_dispatches_to_go_source_kit_declaration() {
 }
 
 #[test]
+fn loader_dispatches_to_java_source_kit_declaration() {
+    let Some(command) = java_source_kit_command() else {
+        return;
+    };
+
+    let repo = repo_root();
+    let java_source_dir = repo.join("implementations/java");
+
+    let declaration: KitDeclaration =
+        provekit_cli::kit_declaration::load_kit_declaration_with_command(
+            &command,
+            Some(&java_source_dir),
+        )
+        .expect("load Java source kit declaration");
+
+    assert_eq!(declaration.kit.id, "java-source");
+    assert_eq!(declaration.kit.language, "java");
+    assert_eq!(declaration.kit.version, "0.1.0");
+    assert_eq!(declaration.proof_resolution.strategy, "maven");
+    assert_eq!(declaration.effect_kinds, ["concept:panic-freedom"]);
+    assert_eq!(declaration.effect_leaves.len(), 1);
+    assert_eq!(
+        declaration.effect_leaves[0].surface.as_deref(),
+        Some("java-source")
+    );
+    assert_eq!(declaration.effect_leaves[0].local, "java:throw");
+    assert_eq!(
+        declaration.effect_leaves[0].concept,
+        "concept:panic-freedom.leaf.runtime-failure-site"
+    );
+    assert!(declaration.guard_predicates.is_empty());
+    assert!(declaration.control_carriers.is_empty());
+    assert!(declaration.residue_categories.is_empty());
+
+    let required_by_name = declaration
+        .rpc
+        .methods
+        .iter()
+        .map(|method| (method.name.as_str(), method.required))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    assert_eq!(
+        required_by_name,
+        std::collections::BTreeMap::from([
+            ("initialize", true),
+            (KIT_DECLARATION_RPC_METHOD, true),
+            ("lift", true),
+            ("shutdown", false),
+        ])
+    );
+}
+
+#[test]
 fn loader_rejects_kit_declaration_response_id_mismatch() {
     let td = TempDir::new().expect("tempdir");
     let stub = td.path().join("kit.sh");
@@ -369,7 +525,7 @@ done
     );
 
     let err = provekit_cli::kit_declaration::load_kit_declaration_with_command(
-        &[stub.display().to_string()],
+        &shell_stub_command(&stub),
         Some(td.path()),
     )
     .expect_err("response id mismatch should fail");


### PR DESCRIPTION
## Summary

Closes #1868 and closes #1865 umbrella. Kit declaration parity is now complete across the four configured source/runtime surfaces in this parity run: Python, TypeScript, Go, and Java.

This slice adds `provekit.plugin.kit_declaration` to the Java source RPC server. The declaration is empirical and source-only: `java-source` / `java` / `0.1.0`, `proofResolution.strategy = "maven"`, `concept:panic-freedom`, and the verified Java source runtime-failure leaf `java:throw -> concept:panic-freedom.leaf.runtime-failure-site`. The empirical absences remain explicit empty lists for `guardPredicates`, `controlCarriers`, and `residueCategories` per #856.

The PR also stabilizes the shell-stub tests in `kit_declaration_rpc.rs` by invoking temporary shell stubs through `sh <path>` instead of direct exec. The broad batch re-surfaced the recurring Linux `ETXTBSY` failure pattern already seen around #1855, #1863, and #1869. This is a test-only harness fix, leaves real Python/TypeScript/Go/Java kit commands unchanged, and partially addresses #1864 for this recurring kit-declaration harness path.

## Design Notes

- Java source only: Java core `RpcServer` declaration is deferred to #1872.
- Version normalization is deferred to #1873. This PR returns `0.1.0` because it matches `SourceRpcServer.initialize`; the manifest currently says `0.1.0-draft` on main.
- `proofResolution.strategy = "maven"` is manager-level, matching the existing `pip` / `npm` / `go-mod` pattern.
- No Rust CLI/verifier production semantics were introduced. The CLI remains language-blind at the RPC seam.

## Precedent

- TypeScript source kit declaration: #1866 / #1869.
- Go source kit declaration: #1867 / #1871 (`a547f88f`).
- Java throw runtime-failure emission: #1850.
- Python remains the existing kit-declaration reference surface.

## Floor Invariants

| Field | Value |
| --- | ---: |
| `silentlyDropped` | 0 |
| `falsePass` | 0 |
| `panicSafe` | 5 |
| `reflexive` | 631 |
| `vacuous` | 552 |
| `undecidable` | 1222 |
| `totalCallsites` | 1826 |
| `droppedSites` | `[]` |

## Verification

- RED: `mvn -q -f implementations/java/pom.xml -pl provekit-lift-java-source -am -Dtest=SourceRpcServerTest test` failed with `METHOD_NOT_FOUND: provekit.plugin.kit_declaration` before implementation.
- RED: `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc loader_dispatches_to_java_source_kit_declaration -- --nocapture` failed with `RpcError { method: "provekit.plugin.kit_declaration", message: "METHOD_NOT_FOUND: provekit.plugin.kit_declaration" }` before implementation.
- PASS: `mvn -q -f implementations/java/pom.xml -pl provekit-lift-java-source -am -Dtest=SourceRpcServerTest test` (6/6).
- PASS: `mvn -q -f implementations/java/pom.xml -pl provekit-lift-java-source,provekit-lift-java-core -am -Dtest=SourceRpcServerTest,JavaSourceLifterTest,JavaImplicationLiftRpcTest,RecognizeHandlerTest,VerifyLiftTest,ProductionWalkTest test`.
- PASS: `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc -p provekit-lift --bin provekit-lift -p provekit-cli`.
- PASS: `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture` (9/9, Python + TypeScript + Go + Java dispatch).
- PASS: federation regression batch for Python bridge/unsound, Python/Java/Go/TypeScript runtime-failure minting, kit declarations, TypeScript bridge/recognize/emit, materialize integration, and library tag dispatch.
- PASS: `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo run -p provekit-cli -- doctor --target ../../implementations/python --mode strict --json` returned `ok: true` (`releaseReady: false`, existing resolver/import warnings only).
- PASS: `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden` (1/1, 113.53s).
- PASS: `git diff --check`.
- PASS: Path A production diff zero: `git diff main -- implementations/rust/libprovekit/src implementations/rust/provekit-verifier/src implementations/rust/provekit-cli/src implementations/rust/provekit-doctor/src` produced no output.