### PR TITLE
[codex] Go verify-facing kit exposes provekit.plugin.kit_declaration (#1870)

### DIFF
--- a/implementations/go/cmd/provekit-lift-go-verify/kit_declaration.go
+++ b/implementations/go/cmd/provekit-lift-go-verify/kit_declaration.go
@@ -1,0 +1,33 @@
+package main
+
+const kitDeclarationRPCMethodName = "provekit.plugin.kit_declaration"
+
+func kitDeclarationResult() map[string]any {
+	return map[string]any{
+		"kit": map[string]any{
+			"id":       "go",
+			"language": "go",
+			"version":  "0.1.0",
+		},
+		"rpc": map[string]any{
+			"methods": []any{
+				map[string]any{"name": "initialize", "required": true},
+				map[string]any{"name": kitDeclarationRPCMethodName, "required": true},
+				map[string]any{"name": "lift", "required": true},
+				map[string]any{"name": "shutdown", "required": false},
+			},
+		},
+		"proofResolution": map[string]any{"strategy": "go-mod"},
+		"effectKinds":     []any{"concept:panic-freedom"},
+		"effectLeaves": []any{
+			map[string]any{
+				"surface": "go",
+				"local":   "go:panic",
+				"concept": "concept:panic-freedom.leaf.runtime-failure-site",
+			},
+		},
+		"guardPredicates":   []any{},
+		"controlCarriers":   []any{},
+		"residueCategories": []any{},
+	}
+}

--- a/implementations/go/cmd/provekit-lift-go-verify/kit_declaration_test.go
+++ b/implementations/go/cmd/provekit-lift-go-verify/kit_declaration_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const kitDeclarationRPCMethod = "provekit.plugin.kit_declaration"
+
+func runRPCForKitDeclarationTest(t *testing.T, requests []string) []map[string]any {
+	t.Helper()
+	input := strings.Join(requests, "\n") + "\n"
+	var out bytes.Buffer
+	if err := runRPC(strings.NewReader(input), &out); err != nil {
+		t.Fatalf("runRPC: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	responses := make([]map[string]any, 0, len(lines))
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var response map[string]any
+		if err := json.Unmarshal([]byte(line), &response); err != nil {
+			t.Fatalf("parse RPC response %q: %v", line, err)
+		}
+		responses = append(responses, response)
+	}
+	return responses
+}
+
+func responseByID(t *testing.T, responses []map[string]any, id float64) map[string]any {
+	t.Helper()
+	for _, response := range responses {
+		if response["id"] == id {
+			return response
+		}
+	}
+	t.Fatalf("missing response id %.0f in %#v", id, responses)
+	return nil
+}
+
+func expectedGoVerifyKitDeclaration() map[string]any {
+	return map[string]any{
+		"kit": map[string]any{
+			"id":       "go",
+			"language": "go",
+			"version":  "0.1.0",
+		},
+		"rpc": map[string]any{
+			"methods": []any{
+				map[string]any{"name": "initialize", "required": true},
+				map[string]any{"name": kitDeclarationRPCMethod, "required": true},
+				map[string]any{"name": "lift", "required": true},
+				map[string]any{"name": "shutdown", "required": false},
+			},
+		},
+		"proofResolution": map[string]any{"strategy": "go-mod"},
+		"effectKinds":     []any{"concept:panic-freedom"},
+		"effectLeaves": []any{
+			map[string]any{
+				"surface": "go",
+				"local":   "go:panic",
+				"concept": "concept:panic-freedom.leaf.runtime-failure-site",
+			},
+		},
+		"guardPredicates":   []any{},
+		"controlCarriers":   []any{},
+		"residueCategories": []any{},
+	}
+}
+
+func TestKitDeclarationReturnsEmpiricalGoVerifySurface(t *testing.T) {
+	responses := runRPCForKitDeclarationTest(t, []string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"provekit.plugin.kit_declaration"}`,
+		`{"jsonrpc":"2.0","id":3,"method":"shutdown"}`,
+	})
+
+	declaration := responseByID(t, responses, 2)
+	if errValue, ok := declaration["error"]; ok {
+		t.Fatalf("kit_declaration returned error: %#v", errValue)
+	}
+	if !reflect.DeepEqual(declaration["result"], expectedGoVerifyKitDeclaration()) {
+		t.Fatalf("kit_declaration result mismatch:\n got: %#v\nwant: %#v", declaration["result"], expectedGoVerifyKitDeclaration())
+	}
+}
+
+func TestKitDeclarationResponseIsDeterministic(t *testing.T) {
+	responses := runRPCForKitDeclarationTest(t, []string{
+		`{"jsonrpc":"2.0","id":7,"method":"provekit.plugin.kit_declaration"}`,
+		`{"jsonrpc":"2.0","id":8,"method":"provekit.plugin.kit_declaration"}`,
+	})
+
+	first := responseByID(t, responses, 7)
+	second := responseByID(t, responses, 8)
+	if errValue, ok := first["error"]; ok {
+		t.Fatalf("first kit_declaration returned error: %#v", errValue)
+	}
+	if errValue, ok := second["error"]; ok {
+		t.Fatalf("second kit_declaration returned error: %#v", errValue)
+	}
+	if !reflect.DeepEqual(first["result"], second["result"]) {
+		t.Fatalf("kit_declaration not deterministic:\nfirst:  %#v\nsecond: %#v", first["result"], second["result"])
+	}
+}
+
+func TestInitializeStaysSeparateFromKitDeclarationContent(t *testing.T) {
+	responses := runRPCForKitDeclarationTest(t, []string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`,
+	})
+
+	initialize := responseByID(t, responses, 1)
+	if errValue, ok := initialize["error"]; ok {
+		t.Fatalf("initialize returned error: %#v", errValue)
+	}
+	result, ok := initialize["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("initialize result = %#v, want object", initialize["result"])
+	}
+	for _, forbidden := range []string{"effectKinds", "effectLeaves", "kit"} {
+		if _, ok := result[forbidden]; ok {
+			t.Fatalf("initialize result must not contain kit declaration field %q: %#v", forbidden, result)
+		}
+	}
+}

--- a/implementations/go/cmd/provekit-lift-go-verify/main.go
+++ b/implementations/go/cmd/provekit-lift-go-verify/main.go
@@ -134,6 +134,8 @@ func runRPC(stdin io.Reader, stdout io.Writer) error {
 			}))
 		case "lift":
 			writeJSON(stdout, handleLift(req.ID, req.Params))
+		case kitDeclarationRPCMethodName:
+			writeJSON(stdout, successResponse(req.ID, kitDeclarationResult()))
 		case "shutdown":
 			writeJSON(stdout, successResponse(req.ID, nil))
 			return nil

--- a/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
+++ b/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
@@ -453,6 +453,59 @@ fn loader_dispatches_to_go_source_kit_declaration() {
 }
 
 #[test]
+fn loader_dispatches_to_go_verify_kit_declaration() {
+    if !command_available("go") {
+        eprintln!("skipping: go is not available");
+        return;
+    }
+
+    let repo = repo_root();
+    let go_dir = repo.join("implementations/go");
+    let command = [
+        "go".to_string(),
+        "run".to_string(),
+        "./cmd/provekit-lift-go-verify".to_string(),
+        "--rpc".to_string(),
+    ];
+
+    let declaration: KitDeclaration =
+        provekit_cli::kit_declaration::load_kit_declaration_with_command(&command, Some(&go_dir))
+            .expect("load Go verify-facing kit declaration");
+
+    assert_eq!(declaration.kit.id, "go");
+    assert_eq!(declaration.kit.language, "go");
+    assert_eq!(declaration.kit.version, "0.1.0");
+    assert_eq!(declaration.proof_resolution.strategy, "go-mod");
+    assert_eq!(declaration.effect_kinds, ["concept:panic-freedom"]);
+    assert_eq!(declaration.effect_leaves.len(), 1);
+    assert_eq!(declaration.effect_leaves[0].surface.as_deref(), Some("go"));
+    assert_eq!(declaration.effect_leaves[0].local, "go:panic");
+    assert_eq!(
+        declaration.effect_leaves[0].concept,
+        "concept:panic-freedom.leaf.runtime-failure-site"
+    );
+    assert!(declaration.guard_predicates.is_empty());
+    assert!(declaration.control_carriers.is_empty());
+    assert!(declaration.residue_categories.is_empty());
+
+    let required_by_name = declaration
+        .rpc
+        .methods
+        .iter()
+        .map(|method| (method.name.as_str(), method.required))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    assert_eq!(
+        required_by_name,
+        std::collections::BTreeMap::from([
+            ("initialize", true),
+            (KIT_DECLARATION_RPC_METHOD, true),
+            ("lift", true),
+            ("shutdown", false),
+        ])
+    );
+}
+
+#[test]
 fn loader_dispatches_to_java_source_kit_declaration() {
     let Some(command) = java_source_kit_command() else {
         return;


### PR DESCRIPTION
Closes #1870.

## Summary

This adds `provekit.plugin.kit_declaration` to the Go verify-facing RPC entrypoint at `implementations/go/cmd/provekit-lift-go-verify`. With slice 20's Go source declaration already landed, this closes Go across both RPC entries: source and verify-facing.

The declaration is kit-owned and empirical:

- `kit.id = "go"`, matching the configured verify-facing authoring surface.
- `language = "go"`.
- `version = "0.1.0"`, matching the verify-facing `initialize` runtime literal.
- `proofResolution.strategy = "go-mod"`.
- `effectKinds = ["concept:panic-freedom"]`.
- `effectLeaves = [{ surface: "go", local: "go:panic", concept: "concept:panic-freedom.leaf.runtime-failure-site" }]`.
- guard predicates, control carriers, and residue categories are empty.

## Empirical Capability

The verify-facing binary uses `liftgo.LiftSourceWithOptions(NormalizeCoreArith=true)`, so it shares the same Go lifter panic emission path as the source kit. During the audit, a live RPC sample over `panic("boom")` produced `panicLoci` with `effectKind: concept:panic-freedom`, `callee: concept:panic-freedom.leaf.runtime-failure-site`, `subkind: explicit-panic`, and the `go:panic` leaf. The declaration reflects that actual output.

The surface is intentionally `go`, not `go-source`. `go-source` belongs to slice 20 (#1867, PR #1871). This slice is the configured verify-facing command in `implementations/go/.provekit/lift/go/manifest.toml`.

## Tests

Added Go unit coverage for:

- declaration response shape,
- deterministic responses inside one RPC process,
- `initialize` staying separate from declaration content.

Added a Rust integration leg to `kit_declaration_rpc.rs` so the CLI loader dispatches to the real Go verify-facing command and validates the declaration. The metadata federation smoke now covers Python, TypeScript source, Go source, Java source, and Go verify-facing.

## Verification

- `go test ./cmd/provekit-lift-go-verify -run 'TestKitDeclaration|TestInitializeStaysSeparate' -count=1` -> ok
- `go test ./...` from `implementations/go` -> ok
- `bcargo build -p provekit-walk --bin provekit-walk-rpc -p provekit-lift --bin provekit-lift -p provekit-cli` -> ok
- `bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture` -> 10/10 ok
- Federation regression batch via `bcargo` -> ok
- `bcargo run -p provekit-cli -- doctor --target ../../implementations/python --mode strict --json` -> `ok: true`, `releaseReady: false`, existing resolver/import warnings only
- `bcargo test -p provekit-cli --test self_check_golden` -> 1/1 ok, 114.59s
- `git diff --check` -> ok
- Production diff proxy over Rust production dirs -> no output

Floor invariants stayed stable through `self_check_golden`: `silentlyDropped = 0`, `droppedSites = []`, `panicSafe = 5`, `reflexive = 631`, `falsePass = 0`.

## Out Of Scope

- Go source kit declaration is already done in slice 20 (#1867, PR #1871).
- Java source kit declaration is already done in slice 21 (#1868, PR #1874).
- Java core `RpcServer` declaration remains #1872.
- Runtime/manifest version normalization is tracked in broadened #1873, including the Go verify-facing `0.1.0` versus `0.1.0-draft` drift.
- No Rust CLI or verifier language-specific behavior is introduced.

## Precedent

This follows the kit-owned declaration pattern from:

- #1866 / PR #1869 for TypeScript source,
- #1867 / PR #1871 for Go source,
- #1868 / PR #1874 for Java source,
- Python kit declaration loader coverage already present in `kit_declaration_rpc.rs`,
- #856 honesty-gradient discipline.
