### PR TITLE
[codex] Java core RpcServer exposes kit_declaration (#1872)

### DIFF
--- a/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/KitDeclaration.java
+++ b/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/KitDeclaration.java
@@ -1,0 +1,43 @@
+package com.provekit.lift;
+
+import com.provekit.ir.Jcs;
+
+final class KitDeclaration {
+    static final String RPC_METHOD = "provekit.plugin.kit_declaration";
+
+    private KitDeclaration() {}
+
+    static Jcs.Obj toJson() {
+        return Jcs.object(
+            "kit", Jcs.object(
+                "id", Jcs.string("java"),
+                "language", Jcs.string("java"),
+                "version", Jcs.string("0.1.0")
+            ),
+            "rpc", Jcs.object(
+                "methods", Jcs.array(
+                    rpcMethod("initialize", true),
+                    rpcMethod(RPC_METHOD, true),
+                    rpcMethod("parse", true),
+                    rpcMethod("provekit.plugin.lift_implications", true),
+                    rpcMethod("lift", false),
+                    rpcMethod("provekit.plugin.recognize", false),
+                    rpcMethod("shutdown", false)
+                )
+            ),
+            "proofResolution", Jcs.object("strategy", Jcs.string("maven")),
+            "effectKinds", Jcs.array(),
+            "effectLeaves", Jcs.array(),
+            "guardPredicates", Jcs.array(),
+            "controlCarriers", Jcs.array(),
+            "residueCategories", Jcs.array()
+        );
+    }
+
+    private static Jcs.Obj rpcMethod(String name, boolean required) {
+        return Jcs.object(
+            "name", Jcs.string(name),
+            "required", Jcs.bool(required)
+        );
+    }
+}

--- a/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/RpcServer.java
+++ b/implementations/java/provekit-lift-java-core/src/main/java/com/provekit/lift/RpcServer.java
@@ -30,6 +30,7 @@ public class RpcServer {
             String method = extractMethod(line);
             switch (method) {
                 case "initialize" -> sendResponse(id, initResult());
+                case KitDeclaration.RPC_METHOD -> sendResponse(id, Jcs.encode(KitDeclaration.toJson()));
                 case "parse" -> {
                     // Daemon-conformant wire protocol: {path, source} -> {declarations, callEdges, warnings}.
                     // Uses decodeJsonString to correctly handle source code with embedded quotes/escapes.

--- a/implementations/java/provekit-lift-java-core/src/test/java/com/provekit/lift/RpcServerKitDeclarationTest.java
+++ b/implementations/java/provekit-lift-java-core/src/test/java/com/provekit/lift/RpcServerKitDeclarationTest.java
@@ -1,0 +1,101 @@
+package com.provekit.lift;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.provekit.ir.Jcs;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class RpcServerKitDeclarationTest {
+    @Test
+    void kitDeclarationReturnsEmpiricalJavaCoreSurface() throws Exception {
+        Jcs.Obj response = invoke(
+            "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"provekit.plugin.kit_declaration\",\"params\":{}}"
+        );
+        assertNoRpcError(response);
+        Jcs.Obj result = response.objectField("result");
+
+        Jcs.Obj kit = result.objectField("kit");
+        assertEquals("java", kit.stringField("id"));
+        assertEquals("java", kit.stringField("language"));
+        assertEquals("0.1.0", kit.stringField("version"));
+
+        assertEquals("maven", result.objectField("proofResolution").stringField("strategy"));
+        assertTrue(result.arrayField("effectKinds").isEmpty(), Jcs.encode(result));
+        assertTrue(result.arrayField("effectLeaves").isEmpty(), Jcs.encode(result));
+        assertTrue(result.arrayField("guardPredicates").isEmpty(), Jcs.encode(result));
+        assertTrue(result.arrayField("controlCarriers").isEmpty(), Jcs.encode(result));
+        assertTrue(result.arrayField("residueCategories").isEmpty(), Jcs.encode(result));
+
+        assertEquals(7, result.objectField("rpc").arrayField("methods").values().size());
+        assertMethodRequired(result, "initialize", true);
+        assertMethodRequired(result, "provekit.plugin.kit_declaration", true);
+        assertMethodRequired(result, "parse", true);
+        assertMethodRequired(result, "provekit.plugin.lift_implications", true);
+        assertMethodRequired(result, "lift", false);
+        assertMethodRequired(result, "provekit.plugin.recognize", false);
+        assertMethodRequired(result, "shutdown", false);
+    }
+
+    @Test
+    void kitDeclarationResponseIsDeterministic() throws Exception {
+        Jcs.Obj firstResponse = invoke(
+            "{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"provekit.plugin.kit_declaration\",\"params\":{}}"
+        );
+        Jcs.Obj secondResponse = invoke(
+            "{\"jsonrpc\":\"2.0\",\"id\":8,\"method\":\"provekit.plugin.kit_declaration\",\"params\":{}}"
+        );
+        assertNoRpcError(firstResponse);
+        assertNoRpcError(secondResponse);
+
+        assertEquals(
+            Jcs.encode(firstResponse.objectField("result")),
+            Jcs.encode(secondResponse.objectField("result"))
+        );
+    }
+
+    @Test
+    void initializeStaysSeparateFromKitDeclarationContent() throws Exception {
+        Jcs.Obj response = invoke("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}");
+        Jcs.Obj result = response.objectField("result");
+
+        assertEquals("provekit-lsp-java", result.stringField("name"));
+        assertEquals("0.1.0", result.stringField("version"));
+        assertEquals(null, result.get("kit"));
+        assertEquals(null, result.get("proofResolution"));
+        assertEquals(null, result.get("effectKinds"));
+        assertEquals(null, result.get("effectLeaves"));
+    }
+
+    private static Jcs.Obj invoke(String request) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        try (PrintStream capture = new PrintStream(bytes, true, StandardCharsets.UTF_8)) {
+            System.setOut(capture);
+            RpcServer server = new RpcServer();
+            Method handle = RpcServer.class.getDeclaredMethod("handle", String.class);
+            handle.setAccessible(true);
+            handle.invoke(server, request);
+        } finally {
+            System.setOut(original);
+        }
+        return (Jcs.Obj) Jcs.parse(bytes.toString(StandardCharsets.UTF_8).trim());
+    }
+
+    private static void assertNoRpcError(Jcs.Obj response) {
+        assertEquals(null, response.get("error"), Jcs.encode(response));
+    }
+
+    private static void assertMethodRequired(Jcs.Obj declaration, String name, boolean required) {
+        Jcs.Arr methods = declaration.objectField("rpc").arrayField("methods");
+        Jcs.Obj method = methods.values().stream()
+            .map(Jcs.Obj.class::cast)
+            .filter(candidate -> name.equals(candidate.stringFieldOrNull("name")))
+            .findFirst()
+            .orElseThrow();
+        assertEquals(required, method.boolField("required"), Jcs.encode(method));
+    }
+}

--- a/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
+++ b/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
@@ -71,6 +71,11 @@ fn maven_available() -> bool {
         .unwrap_or(false)
 }
 
+fn java_maven_lock() -> &'static Mutex<()> {
+    static JAVA_MAVEN_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    JAVA_MAVEN_LOCK.get_or_init(|| Mutex::new(()))
+}
+
 fn java_source_kit_command() -> Option<Vec<String>> {
     static JAVA_SOURCE_KIT_COMMAND: OnceLock<Option<Vec<String>>> = OnceLock::new();
     JAVA_SOURCE_KIT_COMMAND
@@ -84,6 +89,7 @@ fn java_source_kit_command() -> Option<Vec<String>> {
                 return None;
             }
 
+            let _guard = java_maven_lock().lock().expect("lock Java Maven package");
             let root = repo_root();
             let java_root = root.join("implementations").join("java");
             let mut mvn = Command::new("mvn");
@@ -109,6 +115,60 @@ fn java_source_kit_command() -> Option<Vec<String>> {
                 .join("provekit-lift-java-source")
                 .join("target")
                 .join("provekit-lift-java-source.jar");
+            assert!(
+                jar.exists(),
+                "maven build produced no jar at {}",
+                jar.display()
+            );
+            Some(vec![
+                java.display().to_string(),
+                "-jar".to_string(),
+                jar.display().to_string(),
+                "--rpc".to_string(),
+            ])
+        })
+        .clone()
+}
+
+fn java_core_kit_command() -> Option<Vec<String>> {
+    static JAVA_CORE_KIT_COMMAND: OnceLock<Option<Vec<String>>> = OnceLock::new();
+    JAVA_CORE_KIT_COMMAND
+        .get_or_init(|| {
+            let Some(java) = java_bin() else {
+                eprintln!("skipping: no working java binary found");
+                return None;
+            };
+            if !maven_available() {
+                eprintln!("skipping: mvn is unavailable");
+                return None;
+            }
+
+            let _guard = java_maven_lock().lock().expect("lock Java Maven package");
+            let root = repo_root();
+            let java_root = root.join("implementations").join("java");
+            let mut mvn = Command::new("mvn");
+            mvn.current_dir(&java_root).args([
+                "-B",
+                "-ntp",
+                "-pl",
+                "provekit-lift-java-core",
+                "-am",
+                "-DskipTests",
+                "package",
+            ]);
+            let out =
+                run_with_timeout(&mut mvn, Duration::from_secs(120)).expect("spawn mvn package");
+            assert!(
+                out.status.success(),
+                "mvn package provekit-lift-java-core failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr)
+            );
+
+            let jar = java_root
+                .join("provekit-lift-java-core")
+                .join("target")
+                .join("provekit-lsp-java.jar");
             assert!(
                 jar.exists(),
                 "maven build produced no jar at {}",
@@ -552,6 +612,52 @@ fn loader_dispatches_to_java_source_kit_declaration() {
             ("initialize", true),
             (KIT_DECLARATION_RPC_METHOD, true),
             ("lift", true),
+            ("shutdown", false),
+        ])
+    );
+}
+
+#[test]
+fn loader_dispatches_to_java_core_kit_declaration() {
+    let Some(command) = java_core_kit_command() else {
+        return;
+    };
+
+    let repo = repo_root();
+    let java_dir = repo.join("implementations/java");
+
+    let declaration: KitDeclaration =
+        provekit_cli::kit_declaration::load_kit_declaration_with_command(
+            &command,
+            Some(&java_dir),
+        )
+        .expect("load Java core kit declaration");
+
+    assert_eq!(declaration.kit.id, "java");
+    assert_eq!(declaration.kit.language, "java");
+    assert_eq!(declaration.kit.version, "0.1.0");
+    assert_eq!(declaration.proof_resolution.strategy, "maven");
+    assert!(declaration.effect_kinds.is_empty());
+    assert!(declaration.effect_leaves.is_empty());
+    assert!(declaration.guard_predicates.is_empty());
+    assert!(declaration.control_carriers.is_empty());
+    assert!(declaration.residue_categories.is_empty());
+
+    let required_by_name = declaration
+        .rpc
+        .methods
+        .iter()
+        .map(|method| (method.name.as_str(), method.required))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    assert_eq!(
+        required_by_name,
+        std::collections::BTreeMap::from([
+            ("initialize", true),
+            (KIT_DECLARATION_RPC_METHOD, true),
+            ("parse", true),
+            ("provekit.plugin.lift_implications", true),
+            ("lift", false),
+            ("provekit.plugin.recognize", false),
             ("shutdown", false),
         ])
     );


### PR DESCRIPTION
Closes #1872.

## Summary

- Adds `provekit.plugin.kit_declaration` to Java core `RpcServer`.
- Declares Java core as kit `java`, language `java`, version `0.1.0`, `proofResolution.strategy = maven`.
- Uses the audited Option A capability shape: empty `effectKinds`, `effectLeaves`, `guardPredicates`, `controlCarriers`, and `residueCategories`, because Java core emits contracts, implications, bridges, and recognizer tags but no panic-freedom leaf vocabulary.
- Extends Java and Rust declaration tests, including a shared Java Maven package lock in the Rust integration harness to avoid parallel shade-plugin races between Java source and Java core declaration tests.

## Follow-up

- Filed #1876 for the separate Java core initialize-vs-dispatch capability mismatch. This PR does not normalize initialize output; it only declares the current honest surface.

## Verification

- RED: `mvn -B -ntp -pl provekit-lift-java-core -Dtest=RpcServerKitDeclarationTest test` failed with `unknown method: provekit.plugin.kit_declaration` before implementation.
- RED: `bcargo test -p provekit-cli --test kit_declaration_rpc loader_dispatches_to_java_core_kit_declaration -- --nocapture` failed with `RpcError unknown method` before implementation.
- GREEN: `mvn -B -ntp -pl provekit-lift-java-core -Dtest=RpcServerKitDeclarationTest test` passed 3/3.
- GREEN: `mvn -B -ntp -pl provekit-lift-java-core test` passed 17/17.
- GREEN: `bcargo build -p provekit-walk --bin provekit-walk-rpc -p provekit-lift --bin provekit-lift -p provekit-cli` passed.
- GREEN: `bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture` passed 11/11.
- GREEN: federation batch over Python, Java, Go, TypeScript, materialize, and library tag dispatch passed after serializing Java Maven package steps.
- GREEN: `bcargo run -p provekit-cli -- doctor --target ../../implementations/python --mode strict --json` returned `ok: true`.
- GREEN: `bcargo test -p provekit-cli --test self_check_golden -- --nocapture` passed 1/1.
- GREEN: `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added kit declaration endpoint that exposes kit metadata (id, language, version), available RPC methods with required/optional status, and proof resolution strategy.

* **Tests**
  * Added comprehensive test suite validating kit declaration responses, determinism, and functionality across Java implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->