### PR TITLE
[codex] Normalize Java source and Go verify-facing runtime versions (#1873)

### DIFF
--- a/implementations/go/cmd/provekit-lift-go-verify/kit_declaration.go
+++ b/implementations/go/cmd/provekit-lift-go-verify/kit_declaration.go
@@ -7,7 +7,7 @@ func kitDeclarationResult() map[string]any {
 		"kit": map[string]any{
 			"id":       "go",
 			"language": "go",
-			"version":  "0.1.0",
+			"version":  Version,
 		},
 		"rpc": map[string]any{
 			"methods": []any{

--- a/implementations/go/cmd/provekit-lift-go-verify/kit_declaration_test.go
+++ b/implementations/go/cmd/provekit-lift-go-verify/kit_declaration_test.go
@@ -48,7 +48,7 @@ func expectedGoVerifyKitDeclaration() map[string]any {
 		"kit": map[string]any{
 			"id":       "go",
 			"language": "go",
-			"version":  "0.1.0",
+			"version":  "0.1.0-draft",
 		},
 		"rpc": map[string]any{
 			"methods": []any{
@@ -120,6 +120,9 @@ func TestInitializeStaysSeparateFromKitDeclarationContent(t *testing.T) {
 	result, ok := initialize["result"].(map[string]any)
 	if !ok {
 		t.Fatalf("initialize result = %#v, want object", initialize["result"])
+	}
+	if result["version"] != "0.1.0-draft" {
+		t.Fatalf("initialize version = %#v, want 0.1.0-draft", result["version"])
 	}
 	for _, forbidden := range []string{"effectKinds", "effectLeaves", "kit"} {
 		if _, ok := result[forbidden]; ok {

--- a/implementations/go/cmd/provekit-lift-go-verify/main.go
+++ b/implementations/go/cmd/provekit-lift-go-verify/main.go
@@ -47,6 +47,8 @@ import (
 	lifgotests "github.com/tsavo/provekit/go/provekit-lift-go-tests"
 )
 
+const Version = "0.1.0-draft"
+
 func main() {
 	if len(os.Args) > 1 && os.Args[1] == "--rpc" {
 		if err := runRPC(os.Stdin, os.Stdout); err != nil {
@@ -125,7 +127,7 @@ func runRPC(stdin io.Reader, stdout io.Writer) error {
 		case "initialize":
 			writeJSON(stdout, successResponse(req.ID, map[string]any{
 				"name":             "provekit-lift-go-verify",
-				"version":          "0.1.0",
+				"version":          Version,
 				"protocol_version": "pep/1.7.0",
 				"capabilities": map[string]any{
 					"authoring_surfaces": []string{"go"},

--- a/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/KitDeclaration.java
+++ b/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/KitDeclaration.java
@@ -14,7 +14,7 @@ final class KitDeclaration {
             "kit", Jcs.object(
                 "id", Jcs.string("java-source"),
                 "language", Jcs.string("java"),
-                "version", Jcs.string("0.1.0")
+                "version", Jcs.string(SourceRpcServer.VERSION)
             ),
             "rpc", Jcs.object(
                 "methods", Jcs.array(

--- a/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/SourceRpcServer.java
+++ b/implementations/java/provekit-lift-java-source/src/main/java/com/provekit/lift/java_source/SourceRpcServer.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 public final class SourceRpcServer {
     private static final String KIT_ID = "java";
+    static final String VERSION = "0.1.0-draft";
 
     private SourceRpcServer() {}
 
@@ -61,7 +62,7 @@ public final class SourceRpcServer {
                 "kit_id", Jcs.string(KIT_ID),
                 "name", Jcs.string("provekit-lift-java-source"),
                 "protocol_version", Jcs.string("pep/1.7.0"),
-                "version", Jcs.string("0.1.0")
+                "version", Jcs.string(VERSION)
             )
         );
     }

--- a/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/SourceRpcServerTest.java
+++ b/implementations/java/provekit-lift-java-source/src/test/java/com/provekit/lift/java_source/SourceRpcServerTest.java
@@ -19,6 +19,7 @@ class SourceRpcServerTest {
         Jcs.Obj result = response.objectField("result");
 
         assertEquals("provekit-lift-java-source", result.stringField("name"));
+        assertEquals("0.1.0-draft", result.stringField("version"));
         assertEquals("pep/1.7.0", result.stringField("protocol_version"));
         Jcs.Obj capabilities = result.objectField("capabilities");
         assertTrue(Jcs.encode(capabilities.arrayField("authoring_surfaces")).contains("java-source"));
@@ -36,7 +37,7 @@ class SourceRpcServerTest {
         Jcs.Obj kit = result.objectField("kit");
         assertEquals("java-source", kit.stringField("id"));
         assertEquals("java", kit.stringField("language"));
-        assertEquals("0.1.0", kit.stringField("version"));
+        assertEquals("0.1.0-draft", kit.stringField("version"));
 
         assertEquals("maven", result.objectField("proofResolution").stringField("strategy"));
         assertEquals("concept:panic-freedom", result.arrayField("effectKinds").stringAt(0).value());

--- a/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
+++ b/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
@@ -534,7 +534,7 @@ fn loader_dispatches_to_go_verify_kit_declaration() {
 
     assert_eq!(declaration.kit.id, "go");
     assert_eq!(declaration.kit.language, "go");
-    assert_eq!(declaration.kit.version, "0.1.0");
+    assert_eq!(declaration.kit.version, "0.1.0-draft");
     assert_eq!(declaration.proof_resolution.strategy, "go-mod");
     assert_eq!(declaration.effect_kinds, ["concept:panic-freedom"]);
     assert_eq!(declaration.effect_leaves.len(), 1);
@@ -583,7 +583,7 @@ fn loader_dispatches_to_java_source_kit_declaration() {
 
     assert_eq!(declaration.kit.id, "java-source");
     assert_eq!(declaration.kit.language, "java");
-    assert_eq!(declaration.kit.version, "0.1.0");
+    assert_eq!(declaration.kit.version, "0.1.0-draft");
     assert_eq!(declaration.proof_resolution.strategy, "maven");
     assert_eq!(declaration.effect_kinds, ["concept:panic-freedom"]);
     assert_eq!(declaration.effect_leaves.len(), 1);


### PR DESCRIPTION
Closes #1873.

## Summary

This normalizes the two affected kit runtime surfaces to the version already configured in their manifests: `0.1.0-draft`.

- Java source now has one `SourceRpcServer.VERSION` constant used by both `initialize` and `provekit.plugin.kit_declaration`.
- Go verify-facing now has one `Version` constant used by both `initialize` and `provekit.plugin.kit_declaration`.
- Java, Go, and Rust integration tests now assert the manifest-aligned version for both affected kit entries.

## Convention Map

| Kit | Runtime | Manifest | Status |
| --- | --- | --- | --- |
| Python source | `0.1.0-draft` | `0.1.0-draft` | consistent, pre-existing |
| TypeScript source | `0.1.0-draft` | `0.1.0-draft` | consistent, pre-existing |
| Go source | `0.1.0-draft` | `0.1.0-draft` | consistent, pre-existing |
| Java source | `0.1.0` to `0.1.0-draft` | `0.1.0-draft` | normalized here |
| Go verify-facing | `0.1.0` to `0.1.0-draft` | `0.1.0-draft` | normalized here |
| Java core | `0.1.0` | `0.1.0` | consistent, not drift |

## Out Of Scope

- Java core stays at `0.1.0`; its runtime and manifest already agree.
- Language-blind doctor enforcement of manifest/runtime version consistency is tracked separately in #1878.
- Java core initialize capability advertisement alignment remains separate in #1876.

## Validation

RED observed:

- Java `SourceRpcServerTest` failed because initialize and kit declaration returned `0.1.0` while tests expected `0.1.0-draft`.
- Go verify-facing tests failed because initialize and kit declaration returned `0.1.0` while tests expected `0.1.0-draft`.
- Rust `kit_declaration_rpc` failed for both Go verify-facing and Java source on `0.1.0` versus `0.1.0-draft`.

GREEN gates:

- `mvn -B -ntp -pl provekit-lift-java-source -am -Dtest=SourceRpcServerTest test`
- `mvn -B -ntp -pl provekit-lift-java-source -am test`
- `go test ./cmd/provekit-lift-go-verify -run 'Test(KitDeclarationReturnsEmpiricalGoVerifySurface|InitializeStaysSeparateFromKitDeclarationContent)' -count=1`
- `go test ./...`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo build -p provekit-walk --bin provekit-walk-rpc -p provekit-lift --bin provekit-lift -p provekit-cli`
- federation regression batch exited 0
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo run -p provekit-cli -- doctor --target ../../implementations/python --mode strict --json` returned `ok: true`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=1 BCARGO_TYPESCRIPT_ENV=1 ../../bin/bcargo test -p provekit-cli --test self_check_golden -- --nocapture` passed 1/1 in 116.41s
- `git diff --check`
- Path A production diff proxy produced no output for Rust production source directories
