### PR TITLE
[codex] Test harness ETXTBSY safe-write pattern + structural regression pin (#1864)

### DIFF
--- a/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
+++ b/implementations/rust/provekit-cli/tests/kit_declaration_rpc.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::sync::{Mutex, OnceLock};
@@ -185,7 +186,11 @@ fn java_core_kit_command() -> Option<Vec<String>> {
 }
 
 fn make_executable(path: &Path, body: &str) {
-    fs::write(path, body).expect("write stub");
+    {
+        let mut file = fs::File::create(path).expect("create stub");
+        file.write_all(body.as_bytes()).expect("write stub");
+        file.sync_all().expect("sync stub");
+    }
     let mut perms = fs::metadata(path).expect("metadata").permissions();
     #[cfg(unix)]
     {
@@ -197,6 +202,49 @@ fn make_executable(path: &Path, body: &str) {
 
 fn shell_stub_command(path: &Path) -> Vec<String> {
     vec!["sh".to_string(), path.display().to_string()]
+}
+
+#[test]
+fn make_executable_syncs_writer_before_chmod() {
+    let source = include_str!("kit_declaration_rpc.rs");
+    let helper_start = source
+        .find("fn make_executable(path: &Path, body: &str)")
+        .expect("make_executable helper is present");
+    let helper_end = source[helper_start..]
+        .find("\nfn shell_stub_command")
+        .expect("shell_stub_command follows make_executable");
+    let helper = &source[helper_start..helper_start + helper_end];
+
+    assert!(
+        helper.contains("fs::File::create(path)"),
+        "make_executable must create the script with an explicit writer"
+    );
+    assert!(
+        helper.contains("write_all(body.as_bytes())"),
+        "make_executable must write the full script body before chmod/spawn"
+    );
+    assert!(
+        helper.contains("sync_all()"),
+        "make_executable must sync the script before chmod/spawn"
+    );
+    assert!(
+        !helper.contains("fs::write(path, body)"),
+        "make_executable must not rely on fs::write for executable test stubs"
+    );
+
+    let sync_pos = helper
+        .find("sync_all()")
+        .expect("sync_all checked above");
+    let chmod_pos = helper
+        .find("set_permissions")
+        .expect("chmod call remains in helper");
+    let metadata_pos = helper
+        .find("let mut perms")
+        .expect("permission setup remains in helper");
+    assert!(
+        sync_pos < metadata_pos && metadata_pos < chmod_pos,
+        "make_executable must sync and close the writer before chmod"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #1864.

## What changed

`kit_declaration_rpc.rs` now writes shell stubs with the same safe pattern used by `cli_surface.rs::write_executable`:

- `fs::File::create(path)`
- `write_all(body.as_bytes())`
- `sync_all()`
- scoped writer drop before chmod/spawn

The old helper used `fs::write(path, body)` followed immediately by chmod, which left the test harness vulnerable to intermittent ETXTBSY / "Text file busy" behavior on remote and parallel runs.

## Structural pin

Added `make_executable_syncs_writer_before_chmod`, a structural regression test that inspects only the `make_executable` helper body and pins the safe write pattern. That makes the race fix durable instead of relying only on stochastic stress runs.

## Context

Slice 21 stabilized the invocation path by routing shell stubs through `sh <path>`. This slice closes the write path: the stub file is fully written, synced, and the writer fd is dropped before chmod and spawn.

## Verification

| Gate | Result |
| --- | --- |
| RED focused test | Failed as expected: `make_executable must sync the script before chmod/spawn` |
| Focused GREEN | `bcargo test -p provekit-cli --test kit_declaration_rpc make_executable_syncs_writer_before_chmod -- --nocapture` passed |
| Full file | `bcargo test -p provekit-cli --test kit_declaration_rpc -- --nocapture` passed 12/12 |
| Empirical ETXTBSY sample | 5 consecutive full-file `kit_declaration_rpc` runs under `bcargo`; exit 0; zero ETXTBSY observations |
| Federation batch | Existing federation regression batch passed exit 0 |
| Self-check precondition | `bcargo build -p provekit-walk --bin provekit-walk-rpc -p provekit-lift --bin provekit-lift -p provekit-cli` passed |
| Self-check floor | `bcargo test -p provekit-cli --test self_check_golden -- --nocapture` passed 1/1 in 118.80s |
| Whitespace | `git diff --check` passed |
| Path A | Production diff proxy produced no output |

## Floor invariants

This PR changes only an integration test helper. The fresh self-check golden still passed.

| Signal | Status |
| --- | --- |
| silentlyDropped | stable via `self_check_golden` |
| droppedSites | stable via `self_check_golden` |
| falsePass | stable via `self_check_golden` |
| panicSafe | stable via `self_check_golden` |
| reflexive | stable via `self_check_golden` |

## Formatter note

`bcargo fmt -- --check` currently fails on broad pre-existing repo-wide Rust formatting drift in unrelated production files. The touched test file was not listed in that formatter diff, and `git diff --check` is clean for this slice.