### PR TITLE
[codex] Restore tsc --noEmit gate via tsconfig module=node20 (#1862)

### DIFF
--- a/.github/workflows/provekit.yml
+++ b/.github/workflows/provekit.yml
@@ -20,6 +20,8 @@ jobs:
         run: npm install -g pnpm
       - name: Install dependencies
         run: pnpm install
+      - name: Typecheck TypeScript
+        run: pnpm exec tsc --noEmit --pretty false
       - name: Run tests
         run: pnpm test
       # `ProvekIt verify` removed 2026-05-28: this package's package.json

--- a/implementations/typescript/src/lift/typescript-source/bin.test.ts
+++ b/implementations/typescript/src/lift/typescript-source/bin.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 const KIT_DECLARATION_RPC_METHOD = "provekit.plugin.kit_declaration";
 const TYPESCRIPT_SOURCE_DIR = join(process.cwd(), "implementations/typescript");
+const RPC_TEST_TIMEOUT_MS = 30_000;
 
 function runRpc(requests: Array<Record<string, unknown>>): Array<Record<string, any>> {
   const input = `${requests.map((request) => JSON.stringify(request)).join("\n")}\n`;
@@ -60,7 +61,7 @@ describe("typescript-source kit_declaration RPC", () => {
       controlCarriers: [],
       residueCategories: [],
     });
-  });
+  }, RPC_TEST_TIMEOUT_MS);
 
   it("returns a deterministic kit_declaration response", () => {
     const [first, second] = runRpc([
@@ -71,7 +72,7 @@ describe("typescript-source kit_declaration RPC", () => {
     expect(first).not.toHaveProperty("error");
     expect(second).not.toHaveProperty("error");
     expect(first.result).toEqual(second.result);
-  });
+  }, RPC_TEST_TIMEOUT_MS);
 
   it("keeps initialize separate from kit_declaration content", () => {
     const initialize = runRpc([{ jsonrpc: "2.0", id: 1, method: "initialize" }])[0];
@@ -81,5 +82,5 @@ describe("typescript-source kit_declaration RPC", () => {
     expect(initialize.result).not.toHaveProperty("effectKinds");
     expect(initialize.result).not.toHaveProperty("effectLeaves");
     expect(initialize.result).not.toHaveProperty("kit");
-  });
+  }, RPC_TEST_TIMEOUT_MS);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     "rootDir": "implementations/typescript/src",
     "outDir": "dist",
-    "module": "commonjs",
+    "module": "node20",
     "target": "es2022",
-    "moduleResolution": "bundler",
+    "moduleResolution": "nodenext",
     "ignoreDeprecations": "6.0",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Closes #1862.

## What changed

- Switches root `tsconfig.json` from `module: commonjs` to `module: node20` and from `moduleResolution: bundler` to `moduleResolution: nodenext`.
- Adds `pnpm exec tsc --noEmit --pretty false` to `.github/workflows/provekit.yml` so the restored TypeScript typecheck gate stays enforced.
- Adds a test-only 30s timeout to `implementations/typescript/src/lift/typescript-source/bin.test.ts` RPC tests. The assertions and RPC behavior are unchanged.

## Why

`mint-ts-self-contracts.mts` uses `import.meta.url`, and root `pnpm exec tsc --noEmit --pretty false` failed with TS1343 under `module: commonjs`:

```text
implementations/typescript/src/bin/mint-ts-self-contracts.mts(41,48): error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', or 'nodenext'.
```

I tested `es2022`, `nodenext`, and `node20`. `es2022` clears noEmit but emits ESM `import/export` into normal `.js` files, which is unsafe for the package's `type: commonjs` contract. `node20` plus `nodenext` clears noEmit, preserves CommonJS output for normal `.ts` files, and still lets `.mts` emit `.mjs` with `import.meta` intact.

The timeout boy-scout is adjacent and pre-existing: full `pnpm test` surfaced a Vitest 5000ms timeout in the `npx tsx` RPC spawn test, while focused `bin.test.ts` passed and manual RPC returned expected JSON in about 4s. Nearby `lsp/daemon.test.ts` already documents TSX subprocess startup around 7-10s and uses explicit timeout discipline. This PR keeps the CI test gate locally green without changing test assertions.

## Verification

- RED: `pnpm exec tsc --noEmit --pretty false` failed with TS1343 at `mint-ts-self-contracts.mts(41,48)` before the config change.
- `pnpm install --frozen-lockfile`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm run build`
- `pnpm vitest run implementations/typescript/src/bin/mint-ts-self-contracts.test.ts` passed 1 file, 2 tests.
- `pnpm vitest run implementations/typescript/src/lift/typescript-source/bin.test.ts` passed 1 file, 3 tests.
- `pnpm test` passed 45 files, 885 tests, 4 todo.
- `git diff --check`
- Path A production diff check: no changes under Rust `libprovekit`, verifier, CLI src, or doctor src.
- `../../bin/bcargo build --manifest-path implementations/rust/Cargo.toml -p provekit-walk --bin provekit-walk-rpc -p provekit-lift --bin provekit-lift -p provekit-cli`
- `../../bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p provekit-cli --test kit_declaration_rpc loader_dispatches_to_typescript_source_kit_declaration -- --nocapture`

Attempted but not counted as substantive: full `kit_declaration_rpc` under this fresh remote sync passed the TypeScript loader tests, then failed Go/Java tests because those external kit paths/deps were not provisioned in the `bcargo` remote. A targeted TypeScript RPC seam test passed. The TypeScript Vitest emitter integration was also attempted with `BCARGO_TYPESCRIPT_ENV=1`; it passed but skipped the real emitter body because remote emitter deps were unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Applied explicit timeout configuration to RPC test cases to improve test reliability and prevent timeout-related failures in continuous integration environments.

* **Chores**
  * Updated TypeScript compiler configuration to better support Node 20 runtime semantics and modern module resolution patterns.
  * Integrated automated TypeScript type-checking validation into the CI/CD pipeline to improve code quality and catch issues early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->