### PR TITLE
[codex] bcargo prepends remote target/debug to PATH for binary spawn

### DIFF
--- a/bin/bcargo
+++ b/bin/bcargo
@@ -270,14 +270,16 @@ done
 provision_steps=()
 cargo_env=()
 cargo_env+=("BCARGO_TYPESCRIPT_ENV=$(quote_sh "$provision_typescript_env")")
+path_prefix="$remote_target_dir/$profile"
 if [[ "$provision_python_env" != "0" ]]; then
   provision_steps+=("BCARGO_PYTHON_VENV=$(quote_sh "$remote_python_venv") make --quiet bcargo-python-kit-env")
   cargo_env+=("PYTHON=$(quote_sh "$remote_python")")
-  cargo_env+=("PATH=$(quote_sh "$remote_python_bin"):\$PATH")
+  path_prefix="$path_prefix:$remote_python_bin"
 fi
 if [[ "$provision_typescript_env" != "0" ]]; then
   provision_steps+=("BCARGO_TYPESCRIPT_ENV_DIR=$(quote_sh "$remote_typescript_env") make --quiet bcargo-typescript-kit-env")
 fi
+cargo_env+=("PATH=$(quote_sh "$path_prefix"):\$PATH")
 
 if ((${#provision_steps[@]} == 0)); then
   inner="cd $(quote_sh "$remote_cwd") && "


### PR DESCRIPTION
## Summary

Closes inherited blocker on Phase 5 K-multiplication: `bcargo` did not include the remote Rust target bin directory in `PATH` when running cargo commands. That caused `self-check --oracle` to fail when runtime code spawned sibling binaries by name, especially `provekit-linkerd`.

This mirrors the existing Python env `PATH` injection pattern, but keeps `target/<profile>` first so freshly built Rust binaries win over any ambient install. This is an infrastructure-only change. There is no Rust production source diff.

## Evidence

- Empirical oracle smoke via `bcargo` reached three successful `provekit-linkerd` spawns across dependency mint, shim resolution, and target mint, with no `No such file` spawn failure.
- Stopped the long oracle smoke before the fast gate run to avoid same-remote-root `rsync --delete` collision. The spawn-by-name evidence was already captured, and K measurement belongs to the follow-up RealizeRequest slice.
- Verified PATH ordering with Python env enabled: `target/debug` first, `python-kit-env/bin` second, then existing `PATH`.

## Validation

- `bash -n bin/bcargo`
- `git diff --check`
- Production-source diff against `main` is empty for:
  - `implementations/rust/libprovekit/src`
  - `implementations/rust/provekit-verifier/src`
  - `implementations/rust/provekit-cli/src`
  - `implementations/rust/provekit-doctor/src`
- `BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 ../../bin/bcargo test -p provekit-cli --test self_check_golden` 1/1 passed in 116s
- `BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 ../../bin/bcargo test -p provekit-cli --test kit_declaration_rpc` 12/12 passed
- `BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 ../../bin/bcargo test -p provekit-lift --test kit_declaration_rpc` 1/1 passed
- `BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 ../../bin/bcargo test -p provekit-walk --test kit_declaration_rpc` 1/1 passed
- `BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 ../../bin/bcargo test -p provekit-cli --test compose_rpc_smoke` 2/2 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved remote build environment setup to properly include cargo target directories and Python virtual environment paths
  * Refined TypeScript environment provisioning to prevent unintended PATH modifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->