### PR TITLE
[codex] self-check: prove RealizeRequest serialization totality

### DIFF
--- a/implementations/rust/provekit-cli/.provekit/contracts/infallible_serialize.toml
+++ b/implementations/rust/provekit-cli/.provekit/contracts/infallible_serialize.toml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Rust-kit manifest for serde_json Result totality specific to provekit-cli.
+# The Rust kit reads this as side metadata during lifting; the CLI/verifier
+# receive only the emitted contract/bridge IR over RPC.
+
+[[serde_json]]
+function = "to_value"
+type_crate = "libprovekit"
+type_name = "RealizeRequest"
+contract = "serde_json_to_value__realize_request"
+reason = "RealizeRequest derives Serialize over strings, vectors, options, serde_json::Value, BTreeMap<String,String>, and nested Serialize payloads used by realize RPC parameters"

--- a/implementations/rust/provekit-cli/.provekit/residue.toml
+++ b/implementations/rust/provekit-cli/.provekit/residue.toml
@@ -66,11 +66,3 @@ callee = "method:expect"
 category = "lock_poisoning_residue"
 tier_to_close = "irreducible"
 reason = "diagnostics lock push in record_fallback_diagnostic can panic only if another thread panicked while recording fallback diagnostics."
-
-[[tier_to_close]]
-file = "src/kit_dispatch.rs"
-line = 2416
-callee = "method:expect"
-category = "D-lib"
-tier_to_close = "provekit-cli per-type infallible serialization for RealizeRequest"
-reason = "serde_json::to_value(RealizeRequest) is expected to be total for this CLI-owned request type, but needs a manifest-backed per-type serialization totality proof."


### PR DESCRIPTION
## Summary

Adds a provekit-cli-local Rust-kit totality manifest for `serde_json::to_value(RealizeRequest)` and removes the matching `kit_dispatch.rs:2416` D-lib residue row once the self-check proves it. The Rust kit owns the Rust/serde semantics through `.provekit/contracts/infallible_serialize.toml`; the CLI/verifier still see only proof data over RPC.

This is the first narrow Phase 5 K-multiplication slice for `RealizeRequest` serialization totality.

## Evidence

Both runs used identical infrastructure: `bcargo`, battleaxe rust-analyzer on stable 1.96.0, oracle enabled, and default convergence.

| metric | clean main | this branch |
| --- | ---: | ---: |
| `panicSafe` | 12 | 13 |
| `falsePass` | 0 | 0 |
| `silentlyDropped` | 0 | 0 |
| `droppedSites` | 0 | 0 |
| `panicCensus` | 54 | 54 |
| `tierToClose` | 9 | 8 |
| `unproven` | 34 | 33 |
| bridges emitted | 2818 | 2819 |
| no-contract-for-callee gaps | 4255 | 4254 |
| unsupported-macro-callsite gaps | 1033 | 1033 |
| oracle resolved | 4066/4160 | 4066/4160 |

Normalized row diff by status/file/line/callee/category/tier is exactly one row:

```
src/kit_dispatch.rs:2416 method:expect
  main:   unproven, D-lib, provekit-cli per-type infallible serialization for RealizeRequest
  branch: proven
```

Raw reason diffs are only first-wins solver ordering noise.

## Validation

- `git diff --check`
- clean main baseline self-check:
  `NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 ../../bin/bcargo --config env.PROVEKIT_LINKERD_LOG=/tmp/main-baseline-29b-linkerd.log run -p provekit-cli -- self-check --target implementations/rust/provekit-cli --oracle --json > /tmp/main-baseline-29b.json 2> /tmp/main-baseline-29b.stderr`
- branch self-check:
  `BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 ../../bin/bcargo --config env.PROVEKIT_LINKERD_LOG=/tmp/29b-linkerd-after-ra.log run -p provekit-cli -- self-check --target implementations/rust/provekit-cli --oracle --json > /tmp/29b-after-ra.json 2> /tmp/29b-after-ra.stderr`

## Follow-up

The GOAL doc still references an older `provekit-cli` K=21 / `panicCensus=53` measurement. The current reproducible bcargo+battleaxe RA baseline on clean main is K=12 / `panicCensus=54`; re-baselining those docs should be a separate PR so this slice stays focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal serialization and configuration infrastructure for the Rust toolkit to improve build consistency and self-validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->