### PR TITLE
self-check: gate rust-analyzer readiness

### DIFF
--- a/docs/self-application/GOAL-provekit-proves-provekit.md
+++ b/docs/self-application/GOAL-provekit-proves-provekit.md
@@ -227,6 +227,18 @@ is now the active arc; see Phase 5.
   tier-to-close bucket to proven. Earlier provekit-cli K=21 / panicCensus=53
   references are retained as historical measurements from a different setup,
   not the current Phase 5 baseline.
+- **Readiness-signal closure (2026-06-03).** The convergence harness is
+  deleted; rust-analyzer readiness is now the gate. On a cold battleaxe run
+  with `/run/user/1000/provekit`, `/tmp/provekit`, and the rust-analyzer cache
+  cleared, `serverStatus quiescent=true` arrived in 1s for shim-std, 4s for
+  libprovekit, and 4s for provekit-cli. The run reported
+  `panicSafe=20`, `falsePass=0`, `silentlyDropped=0`, `droppedSites=[]`,
+  `panicCensus=54`, `bridges.emitted=2832`, and
+  `oracle={attempted:4173, resolved:4079}`. The dep-libprovekit `.proof`
+  bundle directly contains the 7 required shim-std-pinned panic bridges, with
+  23 total `panicSite=true` bridges pinned to shim-std. #1898 tracks the
+  remaining libprovekit lifter rows; #1899 tracks replacing the self-check
+  staging workaround with a manifest-driven dependency proof DAG.
 
 ### Phase 3 - RESIDUE NAMED + V1 RELEASE - DONE
 
@@ -248,11 +260,14 @@ is now the active arc; see Phase 5.
 
 Phase 5 K movement is measured on reproducible self-check infrastructure:
 `bcargo`, battleaxe rust-analyzer on stable 1.96.0, oracle enabled, and
-default self-check convergence. As of #1896, the `provekit-cli` target reports
-`panicCensus=54`, `panicSafe=13`, `falsePass=0`, `silentlyDropped=0`, and
+rust-analyzer readiness gating. The convergence harness is no longer part of
+the product baseline. The current `provekit-cli` target reports
+`panicCensus=54`, `panicSafe=20`, `falsePass=0`, `silentlyDropped=0`, and
 `droppedSites=[]`. Clean main before #1896 was K=12 on the same
 infrastructure; #1896 moved exactly one closeable D-lib row,
-`src/kit_dispatch.rs:2416 method:expect`, from unproven to proven.
+`src/kit_dispatch.rs:2416 method:expect`, from unproven to proven. The
+readiness-signal closure then restored deterministic dependency and target
+oracle readiness, moving the reproducible baseline to K=20.
 
 The #1774 reproducibility caveat is closed: the release gate validates the
 dependency-proof state as part of doctor release-gate mode before accepting the
@@ -261,10 +276,10 @@ measurement setup and is not the current Phase 5 baseline.
 
 | Category | Count | Closing mechanism |
 |---|---|---|
-| proven K | 13 panic-safe | Current reproducible K after #1896. D-lib, C `json!`, B guarded-panic, and D-fn tiers remain the closing mechanisms, but K is now reported against the reproducible bcargo + battleaxe RA baseline. |
+| proven K | 20 panic-safe | Current reproducible K after readiness-signal gating replaces convergence. D-lib, C `json!`, B guarded-panic, and D-fn tiers remain the closing mechanisms, now measured against the cold bcargo + battleaxe RA baseline. |
 | residue | 8 honest residue | Mutex `.lock().expect()` rows. Honest residue; "lock is total" would be unsound. |
 | closeable tier-to-close | 0 named D-lib rows | #1896 closed the `RealizeRequest` serialization row with provekit-cli-owned per-type D-lib manifest coverage, mirroring libprovekit's `infallible_serialize.toml` pattern. |
-| raw unproven | 33 | Still honest unproven rows in the panic census. They are not labeled panic-safe, not silently dropped, and not allowed to inflate K. |
+| raw unproven | 26 | Still honest unproven rows in the panic census. They are not labeled panic-safe, not silently dropped, and not allowed to inflate K. |
 
 The honest read: Rust v1 is not K == N. It is K covering the provable buckets,
 residue named, hard floor never violated, and doctor/release-gate green.
@@ -468,21 +483,22 @@ Phase 5 has two parallel levers:
 
 The number that moves: K (panic-safe sites discharged via sound reasoning) on
 real production code in each language. Today on Rust self-application, the
-reproducible Phase 5 baseline is K=13 on provekit-cli after #1896; libprovekit
-last documented K=12. Earlier provekit-cli K=21 references came from a
-different measurement setup and are not the current baseline. On Python / TS /
-Go / Java production targets: not yet measured at the K level; each language
-emits panicLoci but discharge tier infrastructure is Rust-only today. A vendor
-running today sees mostly "I don't know" verdicts. To shift to "I want to
-deploy this," the K-per-language number has to be in the hundreds on a real
-codebase, the output has to be actionable, and the value differential vs unit
-tests has to be visible.
+reproducible Phase 5 baseline is K=20 on provekit-cli after the readiness
+signal closure; libprovekit last documented K=12. Earlier provekit-cli K=21
+references came from a different measurement setup and are not the current
+baseline. On Python / TS / Go / Java production targets: not yet measured at
+the K level; each language emits panicLoci but discharge tier infrastructure is
+Rust-only today. A vendor running today sees mostly "I don't know" verdicts. To
+shift to "I want to deploy this," the K-per-language number has to be in the
+hundreds on a real codebase, the output has to be actionable, and the value
+differential vs unit tests has to be visible.
 
 **Phase 5 staging (T direction 2026-06-02): dogfood is the gold standard,
 then third-party parity per language.**
 1. **Dogfood depth first.** Drive Rust self-application K into vendor-
-   meaningful range (current reproducible K=13 -> into the hundreds on `provekit-cli` and
-   `libprovekit`) via shim catalog expansion and discharge tier work. This
+   meaningful range (current reproducible K=20 -> into the hundreds on
+   `provekit-cli` and `libprovekit`) via shim catalog expansion and discharge
+   tier work. This
    is the proof that the technique scales on a real codebase before we ask
    anyone else to point it at theirs.
 2. **Third-party Rust OSS project parity.** Once dogfood "feels eaten" by

--- a/implementations/rust/provekit-cli/src/cmd_mint.rs
+++ b/implementations/rust/provekit-cli/src/cmd_mint.rs
@@ -235,6 +235,7 @@ struct PerPluginDispatch {
 struct OracleObservation {
     requested: bool,
     reachable: bool,
+    ready: bool,
     attempted: u64,
     resolved: u64,
 }
@@ -288,9 +289,11 @@ fn merge_ir_document_responses(per_plugin: Vec<PerPluginDispatch>) -> Result<Val
     let mut seen_implications: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut seen_authorities: std::collections::HashSet<String> = std::collections::HashSet::new();
     for entry in per_plugin {
+        assert_oracle_ready_if_requested(&entry.surface, &entry.response)?;
         let plugin_oracle = oracle_observation_from_lift(&entry.response);
         oracle_observation.requested |= plugin_oracle.requested;
         oracle_observation.reachable |= plugin_oracle.reachable;
+        oracle_observation.ready |= plugin_oracle.ready;
         oracle_observation.attempted += plugin_oracle.attempted;
         oracle_observation.resolved += plugin_oracle.resolved;
 
@@ -377,6 +380,7 @@ fn merge_ir_document_responses(per_plugin: Vec<PerPluginDispatch>) -> Result<Val
         "lift_gaps": lift_gaps,
         "oracle_requested": oracle_observation.requested,
         "oracle_reachable": oracle_observation.reachable,
+        "oracle_ready": oracle_observation.ready,
         "receivers_attempted": oracle_observation.attempted,
         "receivers_resolved": oracle_observation.resolved,
     });
@@ -405,6 +409,11 @@ fn oracle_observation_from_lift(lift: &Value) -> OracleObservation {
             .and_then(Value::as_bool)
             .or_else(|| lift.get("oracle_reachable").and_then(Value::as_bool))
             .unwrap_or(false),
+        ready: nested
+            .and_then(|v| v.get("ready"))
+            .and_then(Value::as_bool)
+            .or_else(|| lift.get("oracle_ready").and_then(Value::as_bool))
+            .unwrap_or(false),
         attempted: nested
             .and_then(|v| v.get("attempted"))
             .and_then(Value::as_u64)
@@ -416,6 +425,17 @@ fn oracle_observation_from_lift(lift: &Value) -> OracleObservation {
             .or_else(|| lift.get("receivers_resolved").and_then(Value::as_u64))
             .unwrap_or(0),
     }
+}
+
+fn assert_oracle_ready_if_requested(surface: &str, lift: &Value) -> Result<(), String> {
+    let oracle = oracle_observation_from_lift(lift);
+    if oracle.requested && oracle.attempted > 0 && !oracle.ready {
+        return Err(format!(
+            "lift surface `{surface}` requested rust-analyzer oracle and found {} receiver query candidate(s), but provekit-linkerd did not report rust-analyzer ready; refusing to mint a syntactic-only proof",
+            oracle.attempted
+        ));
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Default)]
@@ -582,6 +602,8 @@ impl MintKit {
             };
 
             let response = session.response().clone();
+            assert_oracle_ready_if_requested(&step.surface, &response)
+                .map_err(KitError::Transformation)?;
             // Carry forward the first plugin's lift_claim as the
             // session's lift claim. (Future: aggregate claims into a
             // composite — out of scope for the multi-plugin landing.)
@@ -737,6 +759,8 @@ impl MintKit {
             };
 
             let response = session.response().clone();
+            assert_oracle_ready_if_requested(&step.surface, &response)
+                .map_err(KitError::Transformation)?;
             if combined_lift_claim.is_none() {
                 combined_lift_claim = Some(session.claim);
             }
@@ -1467,6 +1491,7 @@ fn dispatch_result_to_value(result: &DispatchResult) -> Value {
         "oracle": {
             "requested": oracle.requested,
             "reachable": oracle.reachable,
+            "ready": oracle.ready,
             "attempted": oracle.attempted,
             "resolved": oracle.resolved,
         },
@@ -3637,6 +3662,7 @@ mod tests {
                 "diagnostics": [],
                 "oracle_requested": true,
                 "oracle_reachable": true,
+                "oracle_ready": true,
                 "receivers_attempted": 7,
                 "receivers_resolved": 3
             }),
@@ -3649,10 +3675,49 @@ mod tests {
             json!({
                 "requested": true,
                 "reachable": true,
+                "ready": true,
                 "attempted": 7,
                 "resolved": 3
             })
         );
+    }
+
+    #[test]
+    fn requested_oracle_not_ready_refuses_mint() {
+        let lift = json!({
+            "kind": "ir-document",
+            "ir": [],
+            "diagnostics": [],
+            "oracle_requested": true,
+            "oracle_reachable": true,
+            "oracle_ready": false,
+            "receivers_attempted": 7,
+            "receivers_resolved": 0
+        });
+
+        let err = assert_oracle_ready_if_requested("rust-implications", &lift)
+            .expect_err("requested oracle with candidates must fail when not ready");
+        assert!(
+            err.contains("did not report rust-analyzer ready"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn ready_oracle_with_zero_resolutions_remains_honest_refusal() {
+        let lift = json!({
+            "kind": "ir-document",
+            "ir": [],
+            "diagnostics": [],
+            "oracle_requested": true,
+            "oracle_reachable": true,
+            "oracle_ready": true,
+            "receivers_attempted": 7,
+            "receivers_resolved": 0
+        });
+
+        assert_oracle_ready_if_requested("rust-implications", &lift)
+            .expect("ready oracle may honestly refuse every candidate");
     }
 
     #[test]

--- a/implementations/rust/provekit-cli/src/cmd_self_check.rs
+++ b/implementations/rust/provekit-cli/src/cmd_self_check.rs
@@ -149,6 +149,11 @@ struct MintOutput {
     json: Value,
 }
 
+#[derive(Debug, Default)]
+struct StagedDependencyImportsGuard {
+    staged_files: Vec<PathBuf>,
+}
+
 #[derive(Debug, Clone)]
 struct PanicSiteAnnotation {
     file: String,
@@ -164,17 +169,6 @@ struct PanicSiteAnnotation {
 struct ImportsProofSetSnapshot {
     entries: BTreeSet<String>,
     directory_present: bool,
-}
-
-const ORACLE_CONVERGENCE_STABLE_PASSES: usize = 3;
-const ORACLE_CONVERGENCE_MAX_PASSES: usize = 10;
-const ORACLE_CONVERGENCE_STABLE_PASSES_ENV: &str = "PROVEKIT_ORACLE_CONVERGE_K";
-const ORACLE_CONVERGENCE_MAX_PASSES_ENV: &str = "PROVEKIT_ORACLE_MAX_PASSES";
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum OracleConvergenceDecision {
-    Continue,
-    Done,
 }
 
 pub fn run(args: SelfCheckArgs) -> u8 {
@@ -218,7 +212,7 @@ pub fn run(args: SelfCheckArgs) -> u8 {
             {
                 failed = true;
                 eprintln!(
-                    "self-check --oracle requested but the oracle resolved 0/{} receivers; the census is SYNTACTIC-ONLY (provekit-linkerd unreachable or not warm). Set PROVEKIT_LINKERD_BIN and pre-warm, or run doctor.",
+                    "self-check --oracle requested but the oracle resolved 0/{} receivers; the census is SYNTACTIC-ONLY (provekit-linkerd unreachable or rust-analyzer not ready). Set PROVEKIT_LINKERD_BIN and run doctor.",
                     scoreboard.oracle.attempted
                 );
             }
@@ -248,35 +242,40 @@ fn run_inner(args: &SelfCheckArgs) -> Result<SelfCheckScoreboard, String> {
     let imports = target_abs.join(".provekit").join("imports");
     recreate_imports(&imports)?;
 
+    let libprovekit = repo_root.join("implementations/rust/libprovekit");
+    let shim_std = repo_root.join("examples/provekit-shim-rust-std");
     let dependency_specs = [
-        (
-            "libprovekit",
-            repo_root.join("implementations/rust/libprovekit"),
-        ),
-        (
-            "shim-std",
-            repo_root.join("examples/provekit-shim-rust-std"),
-        ),
+        ("shim-std", shim_std.as_path()),
+        ("libprovekit", libprovekit.as_path()),
     ];
+    let mut dependency_proofs = BTreeMap::new();
     for (name, dep) in dependency_specs {
-        if same_path(&dep, &target_abs) {
+        if same_path(dep, &target_abs) {
             continue;
         }
-        let dep_rel = repo_relative(&repo_root, &dep);
+        let dep_rel = repo_relative(&repo_root, dep);
+        let staged_imports = stage_dependency_imports_for_mint(
+            name,
+            dep,
+            dependency_import_requirements(name, &target_abs, &shim_std),
+            &dependency_proofs,
+        )?;
         info!(
             dependency = name,
             project = %dep_rel,
             "self-check: minting dependency proof"
         );
         let out_dir = scratch.join(format!("dep-{name}"));
-        let minted = mint_project_converged(
+        let minted = mint_project(
             &bin,
             &repo_root,
-            &dep,
+            dep,
             &out_dir,
             dependency_mint_uses_oracle(args.oracle),
         )?;
+        drop(staged_imports);
         copy_proof_to_imports(&minted.proof_file, &imports)?;
+        dependency_proofs.insert(name.to_string(), minted.proof_file.clone());
         let imports_proof_count = count_proof_files(&imports)?;
         info!(
             dependency = name,
@@ -309,8 +308,7 @@ fn run_inner(args: &SelfCheckArgs) -> Result<SelfCheckScoreboard, String> {
         oracle = args.oracle,
         "self-check: minting target"
     );
-    let target_mint =
-        mint_project_converged(&bin, &repo_root, &target_abs, &target_out, args.oracle)?;
+    let target_mint = mint_project(&bin, &repo_root, &target_abs, &target_out, args.oracle)?;
     let target_proof_count = count_proof_files(&target_out)?;
     let imports_proof_count = count_proof_files(&imports)?;
     info!(
@@ -699,183 +697,6 @@ fn dependency_mint_uses_oracle(self_check_oracle: bool) -> bool {
     self_check_oracle
 }
 
-fn mint_project_converged(
-    bin: &Path,
-    repo_root: &Path,
-    project: &Path,
-    out_dir: &Path,
-    oracle: bool,
-) -> Result<MintOutput, String> {
-    if !oracle {
-        return mint_project(bin, repo_root, project, out_dir, false);
-    }
-
-    let (stable_passes, max_passes) = oracle_convergence_thresholds()?;
-    let mut observations = Vec::new();
-    for pass in 1..=max_passes {
-        info!(
-            pass,
-            max_passes, stable_passes, "self-check oracle convergence: mint pass start"
-        );
-        recreate_dir(out_dir)?;
-        let minted = mint_project(bin, repo_root, project, out_dir, true)?;
-        let oracle = oracle_scoreboard(&minted.json);
-        let attempted = oracle.attempted;
-        let resolved = oracle.resolved;
-        observations.push(oracle);
-        let stable_count = oracle_consecutive_stable_count(&observations);
-        info!(
-            pass,
-            max_passes,
-            resolved,
-            attempted,
-            stable_count,
-            stable_passes,
-            "self-check oracle convergence: mint pass complete"
-        );
-        match oracle_convergence_decision(&observations, stable_passes, max_passes)? {
-            OracleConvergenceDecision::Done => {
-                let reason = if resolved == attempted {
-                    "full resolution"
-                } else {
-                    "stable oracle ceiling"
-                };
-                info!(pass, reason, "self-check oracle convergence: accepted");
-                return Ok(minted);
-            }
-            OracleConvergenceDecision::Continue => {
-                info!(pass, max_passes, "self-check oracle convergence: reminting");
-            }
-        }
-    }
-
-    let final_observation = observations
-        .last()
-        .ok_or("oracle convergence ran no mint passes")?;
-    Err(format!(
-        "self-check --oracle did not converge after {max_passes} mint passes; last resolved {}/{} receivers; {}",
-        final_observation.resolved,
-        final_observation.attempted,
-        oracle_convergence_diagnostic(&observations, stable_passes)
-    ))
-}
-
-fn oracle_convergence_decision(
-    observations: &[OracleScoreboard],
-    stable_passes: usize,
-    max_passes: usize,
-) -> Result<OracleConvergenceDecision, String> {
-    let Some(current) = observations.last() else {
-        return Ok(OracleConvergenceDecision::Continue);
-    };
-    if !current.requested {
-        return Ok(OracleConvergenceDecision::Done);
-    }
-    if current.resolved == current.attempted {
-        return Ok(OracleConvergenceDecision::Done);
-    }
-    if observations.len() < stable_passes {
-        return Ok(OracleConvergenceDecision::Continue);
-    }
-    if oracle_observations_stable(observations, stable_passes) {
-        return Ok(OracleConvergenceDecision::Done);
-    }
-    if observations.len() >= max_passes {
-        return Err(format!(
-            "self-check --oracle did not converge after {max_passes} mint passes; last resolved {}/{} receivers; {}",
-            current.resolved,
-            current.attempted,
-            oracle_convergence_diagnostic(observations, stable_passes)
-        ));
-    }
-    Ok(OracleConvergenceDecision::Continue)
-}
-
-fn oracle_observations_stable(observations: &[OracleScoreboard], window: usize) -> bool {
-    if observations.len() < window {
-        return false;
-    }
-    let tail = &observations[observations.len() - window..];
-    let first = &tail[0];
-    tail.iter().all(|observation| {
-        observation.requested == first.requested
-            && observation.attempted == first.attempted
-            && observation.resolved == first.resolved
-    })
-}
-
-fn oracle_convergence_thresholds() -> Result<(usize, usize), String> {
-    let stable_passes = env_usize(
-        ORACLE_CONVERGENCE_STABLE_PASSES_ENV,
-        ORACLE_CONVERGENCE_STABLE_PASSES,
-    )?;
-    let max_passes = env_usize(
-        ORACLE_CONVERGENCE_MAX_PASSES_ENV,
-        ORACLE_CONVERGENCE_MAX_PASSES,
-    )?;
-    if stable_passes == 0 {
-        return Err(format!(
-            "{ORACLE_CONVERGENCE_STABLE_PASSES_ENV} must be greater than zero"
-        ));
-    }
-    if max_passes < stable_passes {
-        return Err(format!(
-            "{ORACLE_CONVERGENCE_MAX_PASSES_ENV} ({max_passes}) must be >= {ORACLE_CONVERGENCE_STABLE_PASSES_ENV} ({stable_passes})"
-        ));
-    }
-    Ok((stable_passes, max_passes))
-}
-
-fn env_usize(name: &str, default: usize) -> Result<usize, String> {
-    let Ok(raw) = std::env::var(name) else {
-        return Ok(default);
-    };
-    raw.parse::<usize>()
-        .map_err(|e| format!("{name} must be a positive integer, got {raw:?}: {e}"))
-}
-
-fn oracle_convergence_diagnostic(
-    observations: &[OracleScoreboard],
-    stable_passes: usize,
-) -> String {
-    let sequence = observations
-        .iter()
-        .enumerate()
-        .map(|(idx, observation)| {
-            format!(
-                "pass{}={}/{}",
-                idx + 1,
-                observation.resolved,
-                observation.attempted
-            )
-        })
-        .collect::<Vec<_>>()
-        .join(", ");
-    let stable_count = oracle_consecutive_stable_count(observations);
-    let current_pair = observations
-        .last()
-        .map(|observation| format!("{}/{}", observation.resolved, observation.attempted))
-        .unwrap_or_else(|| "none".to_string());
-    format!(
-        "oracle sequence [{sequence}], current pair {current_pair} stable for {stable_count}/{stable_passes} passes"
-    )
-}
-
-fn oracle_consecutive_stable_count(observations: &[OracleScoreboard]) -> usize {
-    let Some(current) = observations.last() else {
-        return 0;
-    };
-    observations
-        .iter()
-        .rev()
-        .take_while(|observation| {
-            observation.requested == current.requested
-                && observation.attempted == current.attempted
-                && observation.resolved == current.resolved
-        })
-        .count()
-}
-
 fn prove_project(
     bin: &Path,
     repo_root: &Path,
@@ -951,6 +772,111 @@ fn copy_proof_to_imports(proof_file: &Path, imports: &Path) -> Result<(), String
         )
     })?;
     Ok(())
+}
+
+fn dependency_import_requirements(
+    dependency_name: &str,
+    target_abs: &Path,
+    shim_std: &Path,
+) -> &'static [&'static str] {
+    if dependency_name == "libprovekit" && !same_path(target_abs, shim_std) {
+        &["shim-std"]
+    } else {
+        &[]
+    }
+}
+
+fn stage_dependency_imports_for_mint(
+    dependency_name: &str,
+    dependency_root: &Path,
+    required_dependencies: &[&str],
+    dependency_proofs: &BTreeMap<String, PathBuf>,
+) -> Result<StagedDependencyImportsGuard, String> {
+    let imports = dependency_root.join(".provekit").join("imports");
+    let mut guard = StagedDependencyImportsGuard::default();
+    for required_name in required_dependencies {
+        let proof_file = dependency_proofs.get(*required_name).ok_or_else(|| {
+            format!(
+                "self-check dependency `{dependency_name}` requires `{required_name}` proof before minting; dependency order is incomplete"
+            )
+        })?;
+        guard.stage_proof(&imports, proof_file, dependency_name, required_name)?;
+    }
+    Ok(guard)
+}
+
+impl StagedDependencyImportsGuard {
+    fn stage_proof(
+        &mut self,
+        imports: &Path,
+        proof_file: &Path,
+        dependency_name: &str,
+        required_name: &str,
+    ) -> Result<(), String> {
+        fs::create_dir_all(imports).map_err(|e| format!("mkdir {}: {e}", imports.display()))?;
+        let file_name = proof_file
+            .file_name()
+            .ok_or_else(|| format!("proof path has no file name: {}", proof_file.display()))?;
+        let dest = imports.join(file_name);
+        if dest.exists() {
+            let existing = fs::read(&dest).map_err(|e| format!("read {}: {e}", dest.display()))?;
+            let incoming =
+                fs::read(proof_file).map_err(|e| format!("read {}: {e}", proof_file.display()))?;
+            if existing != incoming {
+                return Err(format!(
+                    "self-check refused to stage `{required_name}` proof for `{dependency_name}`: {} already exists with different bytes",
+                    dest.display()
+                ));
+            }
+            info!(
+                dependency = dependency_name,
+                required_dependency = required_name,
+                proof_file = %proof_file.display(),
+                imports = %imports.display(),
+                "self-check: dependency import already staged"
+            );
+            return Ok(());
+        }
+        fs::copy(proof_file, &dest).map_err(|e| {
+            format!(
+                "stage dependency proof {} to {}: {e}",
+                proof_file.display(),
+                dest.display()
+            )
+        })?;
+        self.staged_files.push(dest.clone());
+        info!(
+            dependency = dependency_name,
+            required_dependency = required_name,
+            proof_file = %proof_file.display(),
+            staged_proof = %dest.display(),
+            "self-check: staged dependency import for dependency mint"
+        );
+        Ok(())
+    }
+}
+
+impl Drop for StagedDependencyImportsGuard {
+    fn drop(&mut self) {
+        for path in self.staged_files.iter().rev() {
+            match fs::remove_file(path) {
+                Ok(()) => {
+                    info!(
+                        staged_proof = %path.display(),
+                        "self-check: removed staged dependency import"
+                    );
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    warn!(
+                        staged_proof = %path.display(),
+                        %error,
+                        "self-check: failed to remove staged dependency import"
+                    );
+                }
+            }
+        }
+    }
 }
 
 fn stage_rpc_dependency_proofs_to_imports<F>(
@@ -1798,15 +1724,6 @@ mod tests {
         })
     }
 
-    fn oracle_obs(attempted: u64, resolved: u64) -> OracleScoreboard {
-        OracleScoreboard {
-            requested: true,
-            engaged: resolved > 0,
-            attempted,
-            resolved,
-        }
-    }
-
     fn load_error(reason: &str) -> LoadError {
         LoadError {
             proof_path: "synthetic.proof".to_string(),
@@ -2115,52 +2032,111 @@ mod tests {
     }
 
     #[test]
-    fn oracle_convergence_waits_through_two_identical_cold_passes() {
-        let observations = [oracle_obs(7, 0), oracle_obs(7, 0)];
+    fn dependency_import_staging_copies_required_proof_and_drop_removes_it() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dependency_root = dir.path().join("libprovekit");
+        let proof_dir = dir.path().join("proofs");
+        fs::create_dir_all(&proof_dir).expect("create proof dir");
+        let proof = proof_dir.join("shim-std.proof");
+        fs::write(&proof, b"shim std proof bytes").expect("write proof");
+        let mut proofs = BTreeMap::new();
+        proofs.insert("shim-std".to_string(), proof.clone());
 
+        let guard = stage_dependency_imports_for_mint(
+            "libprovekit",
+            &dependency_root,
+            &["shim-std"],
+            &proofs,
+        )
+        .expect("stage dependency import");
+
+        let staged = dependency_root
+            .join(".provekit")
+            .join("imports")
+            .join("shim-std.proof");
         assert_eq!(
-            oracle_convergence_decision(&observations, 3, 5).expect("decision"),
-            OracleConvergenceDecision::Continue
+            fs::read(&staged).expect("read staged proof"),
+            b"shim std proof bytes"
+        );
+
+        drop(guard);
+        assert!(
+            !staged.exists(),
+            "drop guard must remove proof staged by this self-check run"
         );
     }
 
     #[test]
-    fn oracle_convergence_accepts_full_resolution_before_min_passes() {
-        let observations = [oracle_obs(7, 0), oracle_obs(7, 7)];
+    fn dependency_import_staging_preserves_existing_identical_proof() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dependency_root = dir.path().join("libprovekit");
+        let imports = dependency_root.join(".provekit").join("imports");
+        fs::create_dir_all(&imports).expect("create imports");
+        let existing = imports.join("shim-std.proof");
+        fs::write(&existing, b"same proof bytes").expect("write existing proof");
+        let proof = dir.path().join("shim-std.proof");
+        fs::write(&proof, b"same proof bytes").expect("write incoming proof");
+        let mut proofs = BTreeMap::new();
+        proofs.insert("shim-std".to_string(), proof);
 
+        let guard = stage_dependency_imports_for_mint(
+            "libprovekit",
+            &dependency_root,
+            &["shim-std"],
+            &proofs,
+        )
+        .expect("identical pre-existing proof should be accepted");
+
+        drop(guard);
         assert_eq!(
-            oracle_convergence_decision(&observations, 3, 5).expect("decision"),
-            OracleConvergenceDecision::Done
+            fs::read(&existing).expect("existing proof remains"),
+            b"same proof bytes",
+            "drop guard must not delete an import that existed before staging"
         );
     }
 
     #[test]
-    fn oracle_convergence_accepts_stable_partial_resolution_after_min_passes() {
-        let observations = [
-            oracle_obs(3720, 3626),
-            oracle_obs(3720, 3626),
-            oracle_obs(3720, 3626),
-        ];
+    fn dependency_import_staging_refuses_existing_different_proof() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dependency_root = dir.path().join("libprovekit");
+        let imports = dependency_root.join(".provekit").join("imports");
+        fs::create_dir_all(&imports).expect("create imports");
+        fs::write(imports.join("shim-std.proof"), b"old bytes").expect("write existing proof");
+        let proof = dir.path().join("shim-std.proof");
+        fs::write(&proof, b"new bytes").expect("write incoming proof");
+        let mut proofs = BTreeMap::new();
+        proofs.insert("shim-std".to_string(), proof);
 
-        assert_eq!(
-            oracle_convergence_decision(&observations, 3, 5).expect("decision"),
-            OracleConvergenceDecision::Done
+        let err = stage_dependency_imports_for_mint(
+            "libprovekit",
+            &dependency_root,
+            &["shim-std"],
+            &proofs,
+        )
+        .expect_err("different pre-existing proof must fail closed");
+        assert!(
+            err.contains("already exists with different bytes"),
+            "unexpected error: {err}"
         );
     }
 
     #[test]
-    fn oracle_convergence_fails_closed_at_max_without_stability() {
-        let observations = [
-            oracle_obs(10, 1),
-            oracle_obs(10, 2),
-            oracle_obs(10, 3),
-            oracle_obs(10, 4),
-            oracle_obs(10, 5),
-        ];
+    fn dependency_import_staging_requires_declared_dependency_proof() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dependency_root = dir.path().join("libprovekit");
+        let proofs = BTreeMap::new();
 
-        let err = oracle_convergence_decision(&observations, 3, 5)
-            .expect_err("nonconverged observations should fail closed");
-        assert!(err.contains("did not converge"), "unexpected error: {err}");
+        let err = stage_dependency_imports_for_mint(
+            "libprovekit",
+            &dependency_root,
+            &["shim-std"],
+            &proofs,
+        )
+        .expect_err("missing required dependency proof must fail closed");
+        assert!(
+            err.contains("requires `shim-std` proof before minting"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/implementations/rust/provekit-cli/src/doctor.rs
+++ b/implementations/rust/provekit-cli/src/doctor.rs
@@ -2863,14 +2863,16 @@ mod tests {
                         discovery: "env".to_string(),
                     },
                     readiness: OracleHostReadiness::Ready {
-                        detail: "provekit-linkerd spawned and answered projectStatus RPC"
+                        detail: "provekit-linkerd spawned and reported rust-analyzer ready"
                             .to_string(),
                     },
                     engagement: OracleHostEngagement::Engaged {
                         detail: "oracle served requests during self-check".to_string(),
                     },
-                    convergence: OracleResolutionConvergence::Deferred {
-                        detail: "resolution convergence is proved at self-check time".to_string(),
+                    convergence: OracleResolutionConvergence::Converged {
+                        detail:
+                            "resolution readiness is gated by linkerd rustAnalyzerReady; convergence harness removed"
+                                .to_string(),
                     },
                 },
             }
@@ -2901,7 +2903,8 @@ mod tests {
                         detail: "engagement is observed at self-check time".to_string(),
                     },
                     convergence: OracleResolutionConvergence::Deferred {
-                        detail: "resolution convergence is proved at self-check time".to_string(),
+                        detail: "oracle readiness cannot be established until the host is locatable"
+                            .to_string(),
                     },
                 },
             }
@@ -2911,6 +2914,9 @@ mod tests {
             let mut adapter = Self::ready();
             adapter.observation.readiness = OracleHostReadiness::NotReady {
                 detail: "spawn failed: permission denied".to_string(),
+            };
+            adapter.observation.convergence = OracleResolutionConvergence::Deferred {
+                detail: "resolution readiness was not reached".to_string(),
             };
             adapter
         }
@@ -5438,7 +5444,7 @@ mod tests {
     }
 
     #[test]
-    fn standalone_oracle_convergence_is_advisory_in_all_modes() {
+    fn oracle_readiness_gate_accounts_for_resolution_convergence_in_all_modes() {
         for mode in [
             DoctorMode::Structural,
             DoctorMode::Strict,
@@ -5457,9 +5463,13 @@ mod tests {
             );
             assert_eq!(converged.severity, CheckSeverity::Advisory);
             assert!(
-                converged.detail.contains("self-check time"),
-                "standalone doctor convergence should be explicitly deferred: {}",
+                converged.detail.contains("rustAnalyzerReady"),
+                "convergence compatibility check should point at the readiness gate: {}",
                 converged.detail
+            );
+            assert_eq!(
+                converged.evidence.get("converged").and_then(Value::as_bool),
+                Some(true)
             );
         }
     }

--- a/implementations/rust/provekit-cli/src/doctor_oracle.rs
+++ b/implementations/rust/provekit-cli/src/doctor_oracle.rs
@@ -112,13 +112,28 @@ impl OracleHostAdapter for RustAnalyzerOracleAdapter {
                     detail: "engagement is observed at self-check time".to_string(),
                 },
                 convergence: OracleResolutionConvergence::Deferred {
-                    detail: "resolution convergence is proved at self-check time".to_string(),
+                    detail: "oracle readiness cannot be established until the host is locatable"
+                        .to_string(),
                 },
             };
         }
 
         let linkerd_path = linkerd.path.expect("linkerd path checked above");
         let readiness = probe_linkerd_readiness(&linkerd_path);
+        let convergence = match &readiness {
+            OracleHostReadiness::Ready { .. } | OracleHostReadiness::Degraded { .. } => {
+                OracleResolutionConvergence::Converged {
+                    detail:
+                        "resolution readiness is gated by linkerd rustAnalyzerReady; convergence harness removed"
+                            .to_string(),
+                }
+            }
+            OracleHostReadiness::NotRequested | OracleHostReadiness::NotReady { .. } => {
+                OracleResolutionConvergence::Deferred {
+                    detail: "resolution readiness was not reached".to_string(),
+                }
+            }
+        };
         OracleHostObservation {
             host: "rust-analyzer".to_string(),
             locatability: OracleHostLocatability::Found {
@@ -130,9 +145,7 @@ impl OracleHostAdapter for RustAnalyzerOracleAdapter {
             engagement: OracleHostEngagement::Unknown {
                 detail: "oracle engagement is observed at self-check time".to_string(),
             },
-            convergence: OracleResolutionConvergence::Deferred {
-                detail: "resolution convergence is proved at self-check time".to_string(),
-            },
+            convergence,
         }
     }
 }
@@ -240,12 +253,10 @@ fn is_executable(path: &Path) -> bool {
 fn probe_linkerd_readiness(binary: &Path) -> OracleHostReadiness {
     #[cfg(unix)]
     {
-        match probe_linkerd_project_status(binary) {
-            Ok(()) => OracleHostReadiness::Ready {
-                detail: "provekit-linkerd spawned and answered projectStatus RPC".to_string(),
-            },
+        match probe_linkerd_rust_analyzer_ready(binary) {
+            Ok(detail) => OracleHostReadiness::Ready { detail },
             Err(error) => OracleHostReadiness::NotReady {
-                detail: format!("provekit-linkerd spawn failed or did not answer RPC: {error}"),
+                detail: format!("provekit-linkerd did not report rust-analyzer ready: {error}"),
             },
         }
     }
@@ -260,7 +271,7 @@ fn probe_linkerd_readiness(binary: &Path) -> OracleHostReadiness {
 }
 
 #[cfg(unix)]
-fn probe_linkerd_project_status(binary: &Path) -> Result<(), String> {
+fn probe_linkerd_rust_analyzer_ready(binary: &Path) -> Result<String, String> {
     use serde_json::json;
     use std::os::unix::net::UnixStream;
     use std::process::{Command, Stdio};
@@ -274,6 +285,9 @@ fn probe_linkerd_project_status(binary: &Path) -> Result<(), String> {
     std::fs::create_dir_all(&dir).map_err(|e| format!("create temp dir: {e}"))?;
     let socket = dir.join("linkerd.sock");
     let snapshot = dir.join("snapshot.bin");
+    let workspace_root =
+        std::env::current_dir().map_err(|e| format!("resolve current workspace: {e}"))?;
+    let ready_timeout_ms = oracle_ready_timeout_ms();
 
     let mut child = Command::new(binary)
         .arg("--socket")
@@ -305,26 +319,55 @@ fn probe_linkerd_project_status(binary: &Path) -> Result<(), String> {
             }
         }
     };
+    stream
+        .set_read_timeout(Some(Duration::from_millis(ready_timeout_ms + 5_000)))
+        .map_err(|e| format!("set readiness read timeout: {e}"))?;
 
     let status = send_rpc(
         &mut stream,
-        &json!({"jsonrpc": "2.0", "id": 1, "method": "projectStatus", "params": {}}),
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "rustAnalyzerReady",
+            "params": {
+                "workspaceRoot": workspace_root,
+                "timeoutMs": ready_timeout_ms,
+            }
+        }),
     )
     .and_then(|resp| {
-        if resp.get("result").is_some() {
-            Ok(())
-        } else {
-            Err(format!(
-                "projectStatus returned non-result response: {resp}"
+        let Some(result) = resp.get("result") else {
+            return Err(format!("rustAnalyzerReady returned non-result response: {resp}"));
+        };
+        let ready = result
+            .get("ready")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let phase = result
+            .get("phase")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let detail = result
+            .get("detail")
+            .and_then(|v| v.as_str())
+            .unwrap_or("no detail");
+        if ready {
+            Ok(format!(
+                "provekit-linkerd spawned and reported rust-analyzer ready ({phase}: {detail})"
             ))
+        } else {
+            Err(format!("phase={phase}; {detail}"))
         }
     });
-    if let Err(error) = status {
-        let _ = child.kill();
-        let _ = child.wait();
-        let _ = std::fs::remove_dir_all(&dir);
-        return Err(error);
-    }
+    let detail = match status {
+        Ok(detail) => detail,
+        Err(error) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = std::fs::remove_dir_all(&dir);
+            return Err(error);
+        }
+    };
 
     let _ = send_rpc(
         &mut stream,
@@ -332,7 +375,15 @@ fn probe_linkerd_project_status(binary: &Path) -> Result<(), String> {
     );
     let _ = child.wait();
     let _ = std::fs::remove_dir_all(&dir);
-    Ok(())
+    Ok(detail)
+}
+
+fn oracle_ready_timeout_ms() -> u64 {
+    std::env::var("PROVEKIT_ORACLE_READY_TIMEOUT_MS")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(300_000)
 }
 
 #[cfg(unix)]

--- a/implementations/rust/provekit-linkerd/src/methods.rs
+++ b/implementations/rust/provekit-linkerd/src/methods.rs
@@ -200,6 +200,82 @@ pub async fn handle_project_status(
 }
 
 // -------------------------------------------------------------------
+// rustAnalyzerReady: resident RA readiness gate
+// -------------------------------------------------------------------
+
+/// Handle a `rustAnalyzerReady` request.
+///
+/// Params:
+/// `{ "workspaceRoot": "/abs/path", "timeoutMs": <optional u64> }`
+///
+/// Returns:
+/// `{ "ready": <bool>, "phase": "spawning|ready|failed", "detail": <str> }`
+///
+/// This is the event-backed readiness seam for proof-producing Rust-kit paths:
+/// linkerd owns the resident rust-analyzer session, `RaOracle::start` consumes
+/// rust-analyzer's LSP progress/serverStatus stream, and callers wait here
+/// before issuing resolution queries. No CLI/verifier language semantics move
+/// across this boundary.
+#[instrument(skip(host, params))]
+pub async fn handle_rust_analyzer_ready(
+    host: Arc<crate::ra_host::RaHost>,
+    params: &Json,
+    id: &Json,
+) -> Json {
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    let workspace_root = match params.get("workspaceRoot").and_then(|v| v.as_str()) {
+        Some(w) => PathBuf::from(w),
+        None => return rpc_error(ERR_INVALID_PARAMS, "missing 'workspaceRoot'", id),
+    };
+    let timeout_ms = params
+        .get("timeoutMs")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(300_000);
+    let timeout = Duration::from_millis(timeout_ms);
+    let host_for_wait = host.clone();
+    let root_for_wait = workspace_root.clone();
+    let phase = match task::spawn_blocking(move || {
+        host_for_wait.wait_until_ready(&root_for_wait, timeout)
+    })
+    .await
+    {
+        Ok(phase) => phase,
+        Err(error) => {
+            return rpc_result(
+                serde_json::json!({
+                    "ready": false,
+                    "phase": "failed",
+                    "detail": format!("rust-analyzer readiness wait task failed: {error}"),
+                }),
+                id,
+            )
+        }
+    };
+    let ready = phase == crate::ra_host::Phase::Ready;
+    let detail = match phase {
+        crate::ra_host::Phase::Ready => {
+            "rust-analyzer workspace indexed and ready".to_string()
+        }
+        crate::ra_host::Phase::Failed => {
+            "rust-analyzer failed to reach readiness; resolutions refuse".to_string()
+        }
+        crate::ra_host::Phase::Spawning => format!(
+            "rust-analyzer still indexing after {timeout_ms}ms; resolutions refuse"
+        ),
+    };
+    rpc_result(
+        serde_json::json!({
+            "ready": ready,
+            "phase": phase.as_str(),
+            "detail": detail,
+        }),
+        id,
+    )
+}
+
+// -------------------------------------------------------------------
 // R8: flushCache
 // -------------------------------------------------------------------
 
@@ -328,6 +404,7 @@ pub async fn handle_resolve_receiver_crate(
     use crate::resolve_cache::{CachedPosition, FileResolution, PosOutcome, ResolutionDeps};
     use provekit_walk::ra_oracle::ResolveQuery;
     use std::collections::BTreeMap;
+    use std::time::Duration;
 
     let workspace_root = match params.get("workspaceRoot").and_then(|v| v.as_str()) {
         Some(w) => PathBuf::from(w),
@@ -406,13 +483,30 @@ pub async fn handle_resolve_receiver_crate(
         );
     }
 
-    // -- Pass 2: RA, only if the resident session is Ready. --
+    // -- Pass 2: RA, after the resident session reaches readiness. --
     let session = host.session_for(&workspace_root);
-    let phase = session.phase();
+    let timeout_ms = params
+        .get("timeoutMs")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(300_000);
+    let session_for_wait = session.clone();
+    let phase = match task::spawn_blocking(move || {
+        session_for_wait.wait_until_ready(Duration::from_millis(timeout_ms))
+    })
+    .await
+    {
+        Ok(phase) => phase,
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                "resolveReceiverCrate: readiness wait task failed; refusing RA-needed misses"
+            );
+            Phase::Failed
+        }
+    };
     if phase != Phase::Ready {
-        // Cold/indexing/failed: do NOT block. Return cache hits gathered so far
-        // with ready:false so the caller refuses the RA-needed misses to Tier
-        // 1/2a. The next mint, once the background index settles, warms.
+        // Indexing timed out or startup failed. Return cache hits gathered so
+        // far with ready:false so the caller refuses RA-needed misses.
         return rpc_result(
             serde_json::json!({ "resolved": Json::Object(resolved), "ready": false }),
             id,

--- a/implementations/rust/provekit-linkerd/src/ra_host.rs
+++ b/implementations/rust/provekit-linkerd/src/ra_host.rs
@@ -13,28 +13,28 @@
 // THE FIX: keep ONE warm `RaOracle` session PER workspace root, indexed ONCE,
 // alive across mints, here in the long-lived daemon.
 //
-// NON-BLOCKING READINESS is the load-bearing constraint (the refuse-floor is
-// non-negotiable): `RaOracle::start` blocks ~260s through the cold index, so it
-// MUST NOT run in the request path. Each session is therefore a dedicated OS
-// thread that owns the `RaOracle`:
+// READINESS is the load-bearing constraint (the refuse-floor is non-negotiable):
+// `RaOracle::start` blocks through rust-analyzer's LSP progress/serverStatus
+// readiness stream. Each session is therefore a dedicated OS thread that owns
+// the `RaOracle`:
 //
 //   - The thread runs `RaOracle::start` (blocking through the cold index), then
 //     flips a `Phase` flag (Spawning -> Ready | Failed) and loops servicing
 //     `ResolveBatch` commands sent over a channel.
-//   - The async daemon handler reads the phase flag (cheap, non-blocking). Not
-//     Ready -> answer immediately so the caller refuses to Tier 1/2a. Ready ->
-//     send the batch and await the result. The first cold mint thus never hangs
-//     for the index; the second (warm) mint resolves.
+//   - The daemon exposes an explicit readiness wait. Proof-producing callers
+//     block once on that readiness signal before resolution, so the first cold
+//     mint is complete instead of baking "not ready yet" into a proof.
 //
 // The cache (resolve_cache.rs) sits IN FRONT of this in the request handler:
 // cache hits never reach RA, so even a cold daemon answers cached files with no
-// spawn. ra_host is consulted only for cache MISSES on a Ready session.
+// spawn. ra_host is consulted for readiness and then for cache misses.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{Receiver, Sender};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
 use provekit_walk::ra_oracle::{RaOracle, ResolveQuery};
 use tracing::{info, warn};
@@ -50,6 +50,16 @@ pub enum Phase {
     /// failed, or RA never reached quiescence). Resolution permanently refuses
     /// for this session; the caller falls back to the syntactic tiers.
     Failed,
+}
+
+impl Phase {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Phase::Spawning => "spawning",
+            Phase::Ready => "ready",
+            Phase::Failed => "failed",
+        }
+    }
 }
 
 /// The classified outcome of resolving one position against the warm session.
@@ -81,7 +91,7 @@ struct BatchCmd {
 
 /// One resident rust-analyzer session for a single workspace root.
 pub struct RaSession {
-    phase: Arc<Mutex<Phase>>,
+    phase: Arc<(Mutex<Phase>, Condvar)>,
     cmd_tx: Sender<BatchCmd>,
     _thread: JoinHandle<()>,
 }
@@ -91,7 +101,7 @@ impl RaSession {
     /// thread runs the (blocking) `RaOracle::start` in the background and flips
     /// the phase when it settles. The phase begins `Spawning`.
     fn spawn(workspace_root: PathBuf) -> RaSession {
-        let phase = Arc::new(Mutex::new(Phase::Spawning));
+        let phase = Arc::new((Mutex::new(Phase::Spawning), Condvar::new()));
         let (cmd_tx, cmd_rx): (Sender<BatchCmd>, Receiver<BatchCmd>) = std::sync::mpsc::channel();
         let phase_thread = phase.clone();
         let thread = std::thread::Builder::new()
@@ -105,9 +115,27 @@ impl RaSession {
         }
     }
 
-    /// Current phase (cheap, non-blocking).
-    pub fn phase(&self) -> Phase {
-        *self.phase.lock().unwrap()
+    /// Block until the resident rust-analyzer session is Ready/Failed or the
+    /// timeout expires. The first cold caller waits for the indexing thread;
+    /// subsequent callers return immediately because the phase is terminal.
+    pub fn wait_until_ready(&self, timeout: Duration) -> Phase {
+        let (lock, cvar) = &*self.phase;
+        let deadline = Instant::now() + timeout;
+        let mut phase = lock.lock().unwrap();
+        loop {
+            match *phase {
+                Phase::Ready | Phase::Failed => return *phase,
+                Phase::Spawning => {}
+            }
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                return *phase;
+            };
+            let (next, wait_result) = cvar.wait_timeout(phase, remaining).unwrap();
+            phase = next;
+            if wait_result.timed_out() {
+                return *phase;
+            }
+        }
     }
 
     /// Resolve a batch against the warm session. ONLY call when phase is Ready;
@@ -139,7 +167,11 @@ fn vec_not_ready(n: usize) -> Vec<PosResult> {
 
 /// The session thread body: start RA (blocking), flip phase, then service
 /// batches until the command channel closes (daemon shutdown).
-fn session_loop(workspace_root: PathBuf, phase: Arc<Mutex<Phase>>, cmd_rx: Receiver<BatchCmd>) {
+fn session_loop(
+    workspace_root: PathBuf,
+    phase: Arc<(Mutex<Phase>, Condvar)>,
+    cmd_rx: Receiver<BatchCmd>,
+) {
     info!(
         workspace = %workspace_root.display(),
         "ra-host: starting resident rust-analyzer session (indexing once, in background)"
@@ -152,7 +184,7 @@ fn session_loop(workspace_root: PathBuf, phase: Arc<Mutex<Phase>>, cmd_rx: Recei
         None => {
             // Oracle off, binary missing, or handshake failed. RaOracle::start
             // already logged the specific cause.
-            *phase.lock().unwrap() = Phase::Failed;
+            set_phase(&phase, Phase::Failed);
             warn!(
                 workspace = %workspace_root.display(),
                 "ra-host: rust-analyzer session failed to start; all resolutions refuse"
@@ -160,12 +192,10 @@ fn session_loop(workspace_root: PathBuf, phase: Arc<Mutex<Phase>>, cmd_rx: Recei
             return;
         }
     };
-    // RaOracle::start returns Some even if quiescence was not reached (it logs a
-    // warning and resolves best-effort). For the resident host we treat that as
-    // Ready: a warm session that reached quiescence resolves fully, and a
-    // best-effort one still classifies NotReady per query via the
-    // ContentModified path, so the refuse-floor holds either way.
-    *phase.lock().unwrap() = Phase::Ready;
+    // RaOracle::start returns Some only after rust-analyzer's readiness signal
+    // reached quiescence. A timeout/failure is Phase::Failed above, never a
+    // best-effort Ready label.
+    set_phase(&phase, Phase::Ready);
     info!(
         workspace = %workspace_root.display(),
         "ra-host: resident rust-analyzer session READY (warm, reused across mints)"
@@ -196,6 +226,12 @@ fn session_loop(workspace_root: PathBuf, phase: Arc<Mutex<Phase>>, cmd_rx: Recei
     );
 }
 
+fn set_phase(phase: &Arc<(Mutex<Phase>, Condvar)>, next: Phase) {
+    let (lock, cvar) = &**phase;
+    *lock.lock().unwrap() = next;
+    cvar.notify_all();
+}
+
 /// The host: owns one resident RA session per absolute workspace root.
 ///
 /// Lives behind an `Arc` shared across daemon clients. Sessions are created
@@ -224,5 +260,11 @@ impl RaHost {
         let session = Arc::new(RaSession::spawn(key.clone()));
         sessions.insert(key, session.clone());
         session
+    }
+
+    /// Wait for the workspace's resident rust-analyzer session to become ready.
+    /// This is the process-global readiness gate exposed over RPC.
+    pub fn wait_until_ready(&self, workspace_root: &Path, timeout: Duration) -> Phase {
+        self.session_for(workspace_root).wait_until_ready(timeout)
     }
 }

--- a/implementations/rust/provekit-linkerd/src/server.rs
+++ b/implementations/rust/provekit-linkerd/src/server.rs
@@ -29,7 +29,8 @@ use tracing::{debug, error, info, warn};
 
 use crate::methods::{
     handle_flush_cache, handle_get_diagnostics, handle_parse_file, handle_project_status,
-    handle_resolve_receiver_crate, rpc_error, shutdown_response, ERR_METHOD_NOT_FOUND,
+    handle_resolve_receiver_crate, handle_rust_analyzer_ready, rpc_error, shutdown_response,
+    ERR_METHOD_NOT_FOUND,
 };
 use crate::ra_host::RaHost;
 use crate::resolve_cache::ResolveCache;
@@ -147,8 +148,8 @@ pub async fn run(config: ServerConfig) -> anyhow::Result<()> {
     };
 
     // Resident rust-analyzer host: one warm session per workspace root, shared
-    // across all clients. Created empty; sessions spawn lazily (non-blocking) on
-    // the first resolveReceiverCrate for a workspace.
+    // across all clients. Created empty; sessions spawn lazily on the first
+    // rustAnalyzerReady or resolveReceiverCrate for a workspace.
     let ra_host = Arc::new(RaHost::new());
 
     // Content-addressed callee-resolution cache (#1705/#1706), persisted in a
@@ -320,6 +321,9 @@ async fn handle_client(
             "parseFile" => handle_parse_file(state.clone(), &params, &id).await,
             "getDiagnostics" => handle_get_diagnostics(state.clone(), &params, &id).await,
             "projectStatus" => handle_project_status(state.clone(), &params, &id).await,
+            "rustAnalyzerReady" => {
+                handle_rust_analyzer_ready(ra_host.clone(), &params, &id).await
+            }
             "flushCache" => handle_flush_cache(state.clone(), &params, &id).await,
             "resolveReceiverCrate" => {
                 handle_resolve_receiver_crate(

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -53,8 +53,8 @@ use tracing::{debug, info, trace, warn};
 // COLD-SPAWNS rust-analyzer per mint; it asks the warm resident daemon via
 // `resolveReceiverCrate` (see `resolve_method_calls_via_oracle`). The oracle is
 // opt-in (PROVEKIT_RESOLVE_ORACLE=rust-analyzer) and refuses (leaves
-// callee_crate = None) when the daemon is unreachable or not yet ready, so the
-// fast path and CI are unaffected. The RA LSP client itself lives in
+// callee_crate = None) when the daemon is unreachable or cannot reach readiness,
+// so the fast path and CI are unaffected. The RA LSP client itself lives in
 // `provekit_walk::ra_oracle` and is imported by the daemon, not this binary.
 
 // The daemon client lives alongside this binary (std-only, synchronous NDJSON).
@@ -678,6 +678,7 @@ struct CallSite {
 struct OracleObservation {
     requested: bool,
     reachable: bool,
+    ready: bool,
     attempted: u64,
     resolved: u64,
 }
@@ -2852,10 +2853,11 @@ fn resolve_method_calls_via_oracle(
     );
     // The resident warm rust-analyzer indexes the workspace ONCE inside the
     // daemon and is reused across mints, fronted by a content-addressed cache.
-    // On a cold daemon this returns empty (ready:false) and we refuse to the
-    // syntactic tiers; the next mint resolves warm. NEVER blocks for the index.
+    // The daemon client waits on linkerd's readiness signal before resolving,
+    // so a cold proof mint does not bake a partially-indexed answer into proof.
     let batch = ra_daemon_client::resolve_receiver_crates(workspace_root, &queries);
     observation.reachable = batch.reachable;
+    observation.ready = batch.ready;
     let resolved = batch.resolutions;
     let resolved_count = resolved.len();
     observation.resolved = resolved_count as u64;
@@ -3498,6 +3500,7 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
         "lift_gaps": gap_count as u64,
         "oracle_requested": oracle_observation.requested,
         "oracle_reachable": oracle_observation.reachable,
+        "oracle_ready": oracle_observation.ready,
         "receivers_attempted": oracle_observation.attempted,
         "receivers_resolved": oracle_observation.resolved,
     }))
@@ -12966,6 +12969,7 @@ pub fn caller() -> i64 {
         assert_eq!(diags[0]["callee"], "completely_unknown_function");
         assert!(resp["oracle_requested"].is_boolean());
         assert_eq!(resp["oracle_reachable"], false);
+        assert_eq!(resp["oracle_ready"], false);
         assert_eq!(resp["receivers_attempted"], 0);
         assert_eq!(resp["receivers_resolved"], 0);
 

--- a/implementations/rust/provekit-walk/src/ra_daemon_client.rs
+++ b/implementations/rust/provekit-walk/src/ra_daemon_client.rs
@@ -8,15 +8,14 @@
 // asks the persistent daemon, which keeps ONE warm rust-analyzer session per
 // workspace root indexed once and reused across mints, fronted by a
 // content-addressed per-file resolution cache (specs #1705/#1706/#1707). The
-// first ever mint of a cold workspace contributes nothing (the daemon answers
-// `ready:false` while RA indexes in the background) and the lifter REFUSES to
-// the syntactic tiers; the second mint resolves from the warm session, and a
+// first ever mint of a cold workspace waits once for the daemon's
+// rust-analyzer readiness signal, then resolves from that indexed session. A
 // later mint with unchanged files resolves from the cache with NO RA spawn.
 //
 // Refuse-floor (supra omnia rectum, spec §1.R2): if the daemon is unreachable,
-// the spawn times out, or the response says `ready:false`, this client returns
-// an EMPTY map. The caller leaves `callee_crate = None` and the call falls back
-// to Tier 1/2a. It NEVER blocks for the index and NEVER guesses an edge.
+// the spawn times out, or readiness fails, this client returns an EMPTY map. The
+// caller leaves `callee_crate = None` and the call falls back to Tier 1/2a. It
+// waits only on linkerd's LSP-backed readiness signal and NEVER guesses an edge.
 //
 // std-only and synchronous, mirroring `provekit-lsp-rust/src/daemon_client.rs`:
 // the parent binary speaks line-framed NDJSON; no async runtime is needed.
@@ -54,17 +53,24 @@ pub struct DaemonResolution {
 #[derive(Debug, Clone, Default)]
 pub struct DaemonResolutionBatch {
     pub reachable: bool,
+    pub ready: bool,
     pub resolutions: HashMap<(String, u32, u32), DaemonResolution>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DaemonReadiness {
+    pub ready: bool,
+    pub phase: Option<String>,
+    pub detail: Option<String>,
 }
 
 /// Ask the resident daemon to resolve a batch of method-call positions in
 /// `workspace_root` to their receiver-defining crate AND receiver-type stem.
 ///
 /// Returns a map from `(file, line, col)` to the resolution. Positions the
-/// daemon refuses (or could not service because RA is not yet ready) are simply
-/// ABSENT from the map: the caller treats absence as refusal and falls back to
-/// the syntactic tiers. A daemon that is unreachable or not-ready yields an empty
-/// map without blocking.
+/// daemon refuses are simply ABSENT from the map: the caller treats absence as
+/// refusal and falls back to the syntactic tiers. A daemon that is unreachable
+/// or cannot reach readiness yields an empty map.
 pub fn resolve_receiver_crates(
     workspace_root: &Path,
     queries: &[DaemonQuery],
@@ -91,6 +97,34 @@ pub fn resolve_receiver_crates(
             return batch;
         }
     };
+    batch.reachable = true;
+
+    let timeout_ms = ready_timeout_ms();
+    match request_readiness(&mut stream, workspace_root, timeout_ms) {
+        Ok(readiness) if readiness.ready => {
+            batch.ready = true;
+            info!(
+                phase = ?readiness.phase,
+                detail = ?readiness.detail,
+                "ra-daemon: rust-analyzer readiness gate passed"
+            );
+        }
+        Ok(readiness) => {
+            warn!(
+                phase = ?readiness.phase,
+                detail = ?readiness.detail,
+                "ra-daemon: rust-analyzer readiness gate did not pass; refusing all method-call resolutions"
+            );
+            return batch;
+        }
+        Err(error) => {
+            warn!(
+                error = %error,
+                "ra-daemon: rust-analyzer readiness RPC failed; refusing all method-call resolutions"
+            );
+            return batch;
+        }
+    }
 
     let q_json: Vec<Json> = queries
         .iter()
@@ -103,6 +137,7 @@ pub fn resolve_receiver_crates(
         "method": "resolveReceiverCrate",
         "params": {
             "workspaceRoot": workspace_root.to_string_lossy(),
+            "timeoutMs": timeout_ms,
             "queries": q_json,
         }
     });
@@ -114,7 +149,6 @@ pub fn resolve_receiver_crates(
             return batch;
         }
     };
-    batch.reachable = true;
 
     if let Some(err_obj) = resp.get("error") {
         warn!(error = %err_obj, "ra-daemon: daemon returned RPC error; refusing");
@@ -131,12 +165,13 @@ pub fn resolve_receiver_crates(
     let resolved_count = resolved_obj.map(|m| m.len()).unwrap_or(0);
 
     if !ready && resolved_count == 0 {
-        // Cold daemon, first mint: RA still indexing and nothing cached. This is
-        // the correct refuse-floor outcome. The NEXT mint will be warm.
+        // Readiness passed, but RA still reported not-ready during resolution
+        // and nothing was cache-resolved. Refuse rather than caching partial
+        // answers or guessing edges.
         info!(
             queries = queries.len(),
-            "ra-daemon: not ready (rust-analyzer still indexing, no cache hits); \
-             refusing to the syntactic tiers. The next mint resolves warm."
+            "ra-daemon: resolution returned not-ready after readiness gate; \
+             refusing to the syntactic tiers"
         );
         return batch;
     }
@@ -173,6 +208,49 @@ pub fn resolve_receiver_crates(
         "ra-daemon: resolveReceiverCrate complete"
     );
     batch
+}
+
+fn request_readiness(
+    stream: &mut UnixStream,
+    workspace_root: &Path,
+    timeout_ms: u64,
+) -> Result<DaemonReadiness, String> {
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 0,
+        "method": "rustAnalyzerReady",
+        "params": {
+            "workspaceRoot": workspace_root.to_string_lossy(),
+            "timeoutMs": timeout_ms,
+        }
+    });
+    let resp = send_one(stream, &req).map_err(|e| format!("rustAnalyzerReady transport: {e}"))?;
+    if let Some(error) = resp.get("error") {
+        return Err(format!("rustAnalyzerReady returned RPC error: {error}"));
+    }
+    let result = resp.get("result").cloned().unwrap_or(Json::Null);
+    Ok(DaemonReadiness {
+        ready: result
+            .get("ready")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        phase: result
+            .get("phase")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        detail: result
+            .get("detail")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+    })
+}
+
+fn ready_timeout_ms() -> u64 {
+    std::env::var("PROVEKIT_ORACLE_READY_TIMEOUT_MS")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(300_000)
 }
 
 /// Parse a `"<file>:<line>:<col>"` position key back into its parts. The file

--- a/implementations/rust/provekit-walk/src/ra_oracle.rs
+++ b/implementations/rust/provekit-walk/src/ra_oracle.rs
@@ -196,10 +196,11 @@ impl RaOracle {
             warn!(
                 workspace = %workspace_root.display(),
                 index_wait_s = INDEX_WAIT.as_secs(),
-                "oracle: rust-analyzer NOT quiescent after the index wait; resolving best-effort. \
-                 On a cold/large workspace this yields few or zero resolutions — the fix is a \
-                 resident warm rust-analyzer (provekit-linkerd) that indexes once and stays up."
+                "oracle: rust-analyzer NOT quiescent after the index wait; refusing rather than \
+                 minting against a partially-indexed analyzer"
             );
+            let _ = oracle.child.kill();
+            return None;
         }
         Some(oracle)
     }


### PR DESCRIPTION
## Summary

This is the slice 30 closure PR. It replaces the self-check oracle convergence harness with a centralized rust-analyzer readiness signal and bundles the shim-std dependency staging fix needed for the same cold self-check path.

Closure statement: convergence harness deleted; readiness signal replaces it; shim-std staging fix bundled as same-cause sibling.

Architectural context: [[project_provekit_readiness_signal_replaces_convergence]].

Closes #1893 by construction: `mint --oracle` now refuses syntactic-only proofs when receiver candidates exist but rust-analyzer readiness was not observed, and self-check no longer accepts stable zero via convergence.

## What changed

- Added linkerd `rustAnalyzerReady` RPC and Condvar-backed `RaSession::wait_until_ready`.
- Gated linkerd receiver resolution on readiness, including direct `resolveReceiverCrate` callers.
- Threaded `oracle_ready` through walk RPC and mint result JSON.
- Made `cmd_mint` fail closed for requested oracle + attempted receivers + not-ready oracle.
- Deleted the self-check convergence harness and tests.
- Minted self-check dependencies in shim-std then libprovekit order, staging required dependency proof bytes with `StagedDependencyImportsGuard` cleanup.
- Updated doctor oracle readiness to call `rustAnalyzerReady` instead of treating convergence as readiness.
- Updated the self-application GOAL doc to record the K=20 readiness baseline.

## Cold gate evidence

Cold setup on battleaxe before the run:

- Killed provekit self-check, provekit-linkerd, and rust-analyzer processes.
- Removed `/run/user/1000/provekit`, `/tmp/provekit`, and `$HOME/.cache/rust-analyzer`.
- Ran through `bcargo` from `implementations/rust` with `--oracle`.

Command shape:

```sh
NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 /usr/bin/time -p /Users/tsavo/provekit/bin/bcargo \
  --config 'env.PROVEKIT_LINKERD_BIN="/home/tsavo/remote/provekit-bcargo-d17ab89f79d4/provekit/implementations/rust/target/debug/provekit-linkerd"' \
  --config 'env.PROVEKIT_LINKERD_LOG="/tmp/slice30-self-check-linkerd.log"' \
  --config 'env.PROVEKIT_LOG_FILE="/tmp/slice30-self-check-child.log"' \
  run -p provekit-cli -- self-check --target implementations/rust/provekit-cli --oracle --json
```

Result:

```json
{
  "dischargeSplit": {
    "panicSafe": 20,
    "falsePass": 0,
    "reflexive": 1183,
    "vacuous": 373,
    "undecidable": 2508
  },
  "silentlyDropped": 0,
  "droppedSites": [],
  "oracle": {
    "requested": true,
    "engaged": true,
    "attempted": 4173,
    "resolved": 4079
  },
  "panicCensusCounts": {
    "proven": 20,
    "residue": 8,
    "unproven": 26
  },
  "bridges": {
    "emitted": 2832,
    "liftGaps": {
      "no-contract-for-callee": 4267,
      "unsupported-macro-callsite": 1036
    }
  }
}
```

Timing:

- Total self-check wall time: `270.74s`.
- Cold shim-std RA readiness: `serverStatus quiescent=true` at `elapsed_s=1`.
- Cold libprovekit RA readiness: `elapsed_s=4`.
- Cold provekit-cli RA readiness: `elapsed_s=4`.

The current 300000ms `PROVEKIT_ORACLE_READY_TIMEOUT_MS` default stays. The cold timings are comfortably below the default; this is a reversible timeout calibration knob, not a behavior fallback.

Residue note: the current reproducible panic census is 20 proven / 8 residue / 26 unproven. The residue rows remain named and do not inflate K.

## CID inspection

I dumped the fresh dep-libprovekit proof directly:

```sh
target/debug/provekit dump --json \
  /tmp/provekit-self-check/implementations-rust-provekit-cli/dep-libprovekit/blake3-512:bce8877a3fcb771aa1674edcb47d180bd14d0d68c82e8344832cb085d71735a2ef249b92273a5ae43ef6f820382dcc907c5cffe42a562606b509b2fe2a76dad9.proof
```

Dump facts:

- `memberCount=3763`
- `targetProofCid` bridge members: `1194`
- `panicSite=true` bridge members pinned to shim-std: `23`
- required seven diagnosis rows present as proof-record bridge members with `targetProofCid=blake3-512:4ec3056a7c2c1243e282ce1271ea47e48870153dabd7658254e9c050a9d3d508f74f7911d6e0b8bbcdfdec8638b8a4000c46b29b3b1527035fd52df4ed092b7c`

Required row-to-bridge pairs:

| row | source symbol | bridge CID | target contract CID |
|---|---|---|---|
| `src/core/bind.rs:550` | `method:expect` | `blake3-512:9697b95fadcb2a386e116ebd4bc9f12369375a48589253bba22764e480e5cc467d6c9515b7e401628b52dacf8080e03472c0af122b810670925fcbfe609231dc` | `blake3-512:9bac2516ef230303d57fd6a4804d698210d05544abf771850c59fe05fdddcba6f580de095aaea7effb7ec421baadecdd79553e3f1082f8b47ff2a1e747c35220` |
| `src/core/lower_plugin.rs:1477` | `method:expect` | `blake3-512:05307cd4de595c137eed6145daa007d7bbae18f59adbc8f3efadcba60ccfd87d39020288f453433f3b1f3176d0f74d4126ba87d986204b5dd0ce1a9eb38803de` | `blake3-512:fb9030946c04fbb82a94f7a80ec0c42ff5f0eb7930531fafc4432578fbab42ad245df9e2eae4d0465282b396991b00f9c069ea0533e46e7583f0f07177c0e44f` |
| `src/core/lower_plugin.rs:1684` | `method:expect` | `blake3-512:7b4bd6e6b37284393570abf6a5952f3254d12cd981bf94cdf1d5c6f9b26bbb0baeb76c72d41d1062c0beb7c716bb75adee360d834c9d8e98bf40722ba435195b` | `blake3-512:fb9030946c04fbb82a94f7a80ec0c42ff5f0eb7930531fafc4432578fbab42ad245df9e2eae4d0465282b396991b00f9c069ea0533e46e7583f0f07177c0e44f` |
| `src/core/types.rs:2105` | `method:expect` | `blake3-512:ac312da1665360d2e48004a03a6bac8e57ac8ceecfc8fc65e0f3a9d62d058f8adb54a25fb7079bb1dce6cd463a0ac5fe8993867198461570e9ffea7e6b737e8a` | `blake3-512:fb9030946c04fbb82a94f7a80ec0c42ff5f0eb7930531fafc4432578fbab42ad245df9e2eae4d0465282b396991b00f9c069ea0533e46e7583f0f07177c0e44f` |
| `src/core/types.rs:2137` | `method:expect` | `blake3-512:c8c4fb53b5c6ae178c24b11bdb5b734ccb9058347748461eb6442ebaff0b0c14240472a34a97d36427c9daba9318e0f0001a5c146519d9ce3e8f760c870f418c` | `blake3-512:fb9030946c04fbb82a94f7a80ec0c42ff5f0eb7930531fafc4432578fbab42ad245df9e2eae4d0465282b396991b00f9c069ea0533e46e7583f0f07177c0e44f` |
| `src/wp.rs:295` | `method:unwrap` | `blake3-512:3f713df1d717abf12a19970fe076e7e27fea6d7e4a172eb9a30c0b2357cb73b65dc849ec7de51f456a67c44c8e4013855d66fc1aac5f49fbd19199a052f8f88d` | `blake3-512:9219f813226eae04f7889bb7bf17eccfa7d8b93f0f67d1c615ada039a0935105f1b3ab4c9e0d781c8c54ecd893eaaa0f7435febf184a35df986701cea2db8bfa` |
| `src/wp/tests.rs:74` | `method:expect` | `blake3-512:defd05dd2409631b40eb2942851bd019b745180b5b7c4c564fcdc92232309d3e5c54a63b993aebcb0ca4d280a2b9e61736748f044c08d145894314107866a908` | `blake3-512:fb9030946c04fbb82a94f7a80ec0c42ff5f0eb7930531fafc4432578fbab42ad245df9e2eae4d0465282b396991b00f9c069ea0533e46e7583f0f07177c0e44f` |

## Follow-ups

- #1898 tracks remaining libprovekit lifter coverage from this cold run. I corrected the issue with the actual 18 libprovekit unproven rows from the final census.
- #1899 tracks replacing the self-check staging workaround with manifest-driven dependency proof DAG resolution.

## Verification

- `NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 /Users/tsavo/provekit/bin/bcargo fmt --all`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 /Users/tsavo/provekit/bin/bcargo test -p provekit-cli dependency_import_staging`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 /Users/tsavo/provekit/bin/bcargo test -p provekit-cli requested_oracle_not_ready_refuses_mint`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 /Users/tsavo/provekit/bin/bcargo test -p provekit-cli ready_oracle_with_zero_resolutions_remains_honest_refusal`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 /Users/tsavo/provekit/bin/bcargo test -p provekit-cli dispatch_result_to_value_propagates_oracle_observation_from_lift`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 /Users/tsavo/provekit/bin/bcargo test -p provekit-walk lift_implications_emits_lift_gap_for_unmatched_callee`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 /Users/tsavo/provekit/bin/bcargo test -p provekit-linkerd`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 /Users/tsavo/provekit/bin/bcargo test -p provekit-cli oracle_readiness_gate_accounts_for_resolution_convergence_in_all_modes`
- `git diff --check`
- cold battleaxe self-check gate above
