### PR TITLE
rust kit: multiply libprovekit catalog K

### DIFF
--- a/docs/self-application/GOAL-provekit-proves-provekit.md
+++ b/docs/self-application/GOAL-provekit-proves-provekit.md
@@ -239,7 +239,7 @@ is now the active arc; see Phase 5.
   23 total `panicSite=true` bridges pinned to shim-std. #1898 tracks the
   remaining libprovekit lifter rows; #1899 tracks replacing the self-check
   staging workaround with a manifest-driven dependency proof DAG.
-- **Slice 31 catalog K multiplication (this PR, 2026-06-03).** The Rust kit
+- **Slice 31 catalog K multiplication (#1902, 2026-06-03).** The Rust kit
   gained manifest-backed lifter support for constructor-local type inference,
   direct `Option` field match/if-let bindings, source-site-gated
   function-postcondition routing, and immediate `serde_json::to_value(...).expect`
@@ -714,7 +714,7 @@ labeling.
   - #1785 (doctor PR 6) no-silent-failure floor aggregation.
   - #1787 (doctor PR 7) `provekit release-gate` command and v1 evidence
     receipt.
-  - Slice 31 catalog K multiplication (this PR): Rust-kit manifest-backed
+  - #1902 (Slice 31 catalog K multiplication): Rust-kit manifest-backed
     lifter support plus libprovekit serde/function catalog entries. Current
     reproducible baselines: libprovekit K=22 and provekit-cli K=30, with
     `falsePass=0`, `silentlyDropped=0`, and `droppedSites=[]` on both crates.

--- a/docs/self-application/GOAL-provekit-proves-provekit.md
+++ b/docs/self-application/GOAL-provekit-proves-provekit.md
@@ -239,6 +239,20 @@ is now the active arc; see Phase 5.
   23 total `panicSite=true` bridges pinned to shim-std. #1898 tracks the
   remaining libprovekit lifter rows; #1899 tracks replacing the self-check
   staging workaround with a manifest-driven dependency proof DAG.
+- **Slice 31 catalog K multiplication (this PR, 2026-06-03).** The Rust kit
+  gained manifest-backed lifter support for constructor-local type inference,
+  direct `Option` field match/if-let bindings, source-site-gated
+  function-postcondition routing, and immediate `serde_json::to_value(...).expect`
+  panic receiver routing parallel to the existing function-postcondition wire.
+  The libprovekit catalogs added audited serde/function entries for
+  `BridgeHeaderV14`, `Witness`, `Term`, `Verb`, `IrFormula`,
+  `serializable_jcs(&canonical)`, `json_jcs(&value)`, and `json_cid(&value)`.
+  Cold self-checks landed the predicted close-list exactly: libprovekit moves
+  to `panicSafe=22` with `falsePass=0`, `silentlyDropped=0`, `droppedSites=[]`;
+  provekit-cli moves to `panicSafe=30` with `falsePass=0`,
+  `silentlyDropped=0`, `droppedSites=[]`. #1898 now tracks only the remaining
+  libprovekit gap census, and the independent provekit-cli rows move to
+  slice-33 tracking in #1901.
 
 ### Phase 3 - RESIDUE NAMED + V1 RELEASE - DONE
 
@@ -262,12 +276,14 @@ Phase 5 K movement is measured on reproducible self-check infrastructure:
 `bcargo`, battleaxe rust-analyzer on stable 1.96.0, oracle enabled, and
 rust-analyzer readiness gating. The convergence harness is no longer part of
 the product baseline. The current `provekit-cli` target reports
-`panicCensus=54`, `panicSafe=20`, `falsePass=0`, `silentlyDropped=0`, and
+`panicCensus=54`, `panicSafe=30`, `falsePass=0`, `silentlyDropped=0`, and
 `droppedSites=[]`. Clean main before #1896 was K=12 on the same
 infrastructure; #1896 moved exactly one closeable D-lib row,
 `src/kit_dispatch.rs:2416 method:expect`, from unproven to proven. The
 readiness-signal closure then restored deterministic dependency and target
-oracle readiness, moving the reproducible baseline to K=20.
+oracle readiness, moving the reproducible baseline to K=20. Slice 31 then
+closed 10 imported libprovekit-backed rows in the provekit-cli cascade,
+moving the reproducible baseline to K=30.
 
 The #1774 reproducibility caveat is closed: the release gate validates the
 dependency-proof state as part of doctor release-gate mode before accepting the
@@ -276,10 +292,11 @@ measurement setup and is not the current Phase 5 baseline.
 
 | Category | Count | Closing mechanism |
 |---|---|---|
-| proven K | 20 panic-safe | Current reproducible K after readiness-signal gating replaces convergence. D-lib, C `json!`, B guarded-panic, and D-fn tiers remain the closing mechanisms, now measured against the cold bcargo + battleaxe RA baseline. |
+| proven K | 30 panic-safe | Current reproducible K after readiness-signal gating replaces convergence and slice 31's catalog-backed libprovekit cascade lands. D-lib, C `json!`, B guarded-panic, D-fn, and audited catalog-backed serde/function entries remain the closing mechanisms, measured against the cold bcargo + battleaxe RA baseline. |
 | residue | 8 honest residue | Mutex `.lock().expect()` rows. Honest residue; "lock is total" would be unsound. |
 | closeable tier-to-close | 0 named D-lib rows | #1896 closed the `RealizeRequest` serialization row with provekit-cli-owned per-type D-lib manifest coverage, mirroring libprovekit's `infallible_serialize.toml` pattern. |
-| raw unproven | 26 | Still honest unproven rows in the panic census. They are not labeled panic-safe, not silently dropped, and not allowed to inflate K. |
+| independent provekit-cli unproven | 8 | `cmd_emit`, `cmd_mint`, `cmd_protocol` x3, `doctor_oracle`, and `kit_dispatch` x2. Tracked separately from #1898 in #1901. |
+| imported libprovekit parked rows | 8 | Remaining libprovekit rows propagated through dependency import: 3 NoBridge physical sites, 1 residue, and 4 catalog-excluded solver rows. |
 
 The honest read: Rust v1 is not K == N. It is K covering the provable buckets,
 residue named, hard floor never violated, and doctor/release-gate green.
@@ -333,6 +350,23 @@ Rust v1 release-gate score: `panicCensus=36`, `panicSafe=12`,
 `falsePass=0`, `silentlyDropped=0`, `droppedSites=[]`; the receipt records
 12 proven panic-safe rows, 1 honest residue row, and 23 raw unproven rows.
 The floor remains intact.
+
+Post-slice-31 libprovekit score: `panicSafe=22`, `falsePass=0`,
+`silentlyDropped=0`, `droppedSites=[]`, with
+`panicCensus={proven:22, residue:1, unproven:11}`. The slice closes 10
+additional libprovekit rows:
+`src/core/emit_obligation.rs:62`, `src/core/lower_plugin.rs:155`,
+`src/core/source_transform_kit.rs:296`, `src/core/source_transform_kit.rs:307`,
+`src/core/source_transform_kit.rs:308`, `src/core/types.rs:2070`,
+`src/core/types.rs:2093`, `src/core/types.rs:2180`, `src/wp/tests.rs:578`,
+and `src/compose.rs:1410`. The remaining libprovekit rows are named:
+3 NoBridge physical sites (`src/compose.rs:1157`,
+`src/core/source_transform.rs:645`, `src/core/source_transform.rs:1055`) that
+account for 6 rows, 4 catalog-excluded solver rows
+(`src/core/types.rs:1193`, `src/core/types.rs:1198`,
+`src/core/types.rs:1946`, `src/desugar.rs:489`) split as
+invariant-from-construction x3 plus generic monomorphization x1, and 1 honest
+residue row (`src/core/platform_semantics.rs:42`).
 
 ## The metric (the one number we watch)
 
@@ -483,10 +517,10 @@ Phase 5 has two parallel levers:
 
 The number that moves: K (panic-safe sites discharged via sound reasoning) on
 real production code in each language. Today on Rust self-application, the
-reproducible Phase 5 baseline is K=20 on provekit-cli after the readiness
-signal closure; libprovekit last documented K=12. Earlier provekit-cli K=21
-references came from a different measurement setup and are not the current
-baseline. On Python / TS / Go / Java production targets: not yet measured at
+reproducible Phase 5 baseline is K=30 on provekit-cli after slice 31 and K=22
+on libprovekit. Earlier provekit-cli K=21 references came from a different
+measurement setup and are not the current baseline. On Python / TS / Go / Java
+production targets: not yet measured at
 the K level; each language emits panicLoci but discharge tier infrastructure is
 Rust-only today. A vendor running today sees mostly "I don't know" verdicts. To
 shift to "I want to deploy this," the K-per-language number has to be in the
@@ -496,7 +530,7 @@ differential vs unit tests has to be visible.
 **Phase 5 staging (T direction 2026-06-02): dogfood is the gold standard,
 then third-party parity per language.**
 1. **Dogfood depth first.** Drive Rust self-application K into vendor-
-   meaningful range (current reproducible K=20 -> into the hundreds on
+   meaningful range (current reproducible K=30 -> into the hundreds on
    `provekit-cli` and `libprovekit`) via shim catalog expansion and discharge
    tier work. This
    is the proof that the technique scales on a real codebase before we ask
@@ -529,7 +563,7 @@ and the pattern repeats per language.
   reqwest, clap, anyhow, thiserror, others). Per-crate
   `infallible_serialize.toml` and equivalent manifests mature into a
   catalog.
-- Target: K from 21 to 100+ on `provekit-cli`, K from 12 to 50+ on
+- Target: K from 30 to 100+ on `provekit-cli`, K from 22 to 50+ on
   `libprovekit`, with ZERO source modifications.
 - **Pitch artifact**: pick one popular OSS Rust crate, prove it end-to-end,
   publish the differential vs its unit test suite as the vendor onboarding
@@ -680,6 +714,10 @@ labeling.
   - #1785 (doctor PR 6) no-silent-failure floor aggregation.
   - #1787 (doctor PR 7) `provekit release-gate` command and v1 evidence
     receipt.
+  - Slice 31 catalog K multiplication (this PR): Rust-kit manifest-backed
+    lifter support plus libprovekit serde/function catalog entries. Current
+    reproducible baselines: libprovekit K=22 and provekit-cli K=30, with
+    `falsePass=0`, `silentlyDropped=0`, and `droppedSites=[]` on both crates.
 - **Open follow-ups**:
   - #1757 self-check golden drift reached main without gate update.
   - #1763 self-check should fail closed when requested oracle host cannot

--- a/docs/self-application/GOAL-provekit-proves-provekit.md
+++ b/docs/self-application/GOAL-provekit-proves-provekit.md
@@ -249,10 +249,13 @@ is now the active arc; see Phase 5.
   `serializable_jcs(&canonical)`, `json_jcs(&value)`, and `json_cid(&value)`.
   Cold self-checks landed the predicted close-list exactly: libprovekit moves
   to `panicSafe=22` with `falsePass=0`, `silentlyDropped=0`, `droppedSites=[]`;
-  provekit-cli moves to `panicSafe=30` with `falsePass=0`,
-  `silentlyDropped=0`, `droppedSites=[]`. #1898 now tracks only the remaining
-  libprovekit gap census, and the independent provekit-cli rows move to
-  slice-33 tracking in #1901.
+  provekit-cli moves to `panicSafe=32` with `falsePass=0`,
+  `silentlyDropped=0`, `droppedSites=[]`. The predicted provekit-cli cascade was
+  K=30; two additional `kit_dispatch.rs` JSON-RPC request serialization sites
+  discharged through SMT solvers after slice-31 manifest enrichment, not through
+  catalog blessing or the `to_value` routing wire. #1898 now tracks only the
+  remaining libprovekit gap census, and the independent provekit-cli rows move
+  to slice-33 tracking in #1901.
 
 ### Phase 3 - RESIDUE NAMED + V1 RELEASE - DONE
 
@@ -276,14 +279,15 @@ Phase 5 K movement is measured on reproducible self-check infrastructure:
 `bcargo`, battleaxe rust-analyzer on stable 1.96.0, oracle enabled, and
 rust-analyzer readiness gating. The convergence harness is no longer part of
 the product baseline. The current `provekit-cli` target reports
-`panicCensus=54`, `panicSafe=30`, `falsePass=0`, `silentlyDropped=0`, and
+`panicCensus=54`, `panicSafe=32`, `falsePass=0`, `silentlyDropped=0`, and
 `droppedSites=[]`. Clean main before #1896 was K=12 on the same
 infrastructure; #1896 moved exactly one closeable D-lib row,
 `src/kit_dispatch.rs:2416 method:expect`, from unproven to proven. The
 readiness-signal closure then restored deterministic dependency and target
 oracle readiness, moving the reproducible baseline to K=20. Slice 31 then
 closed 10 imported libprovekit-backed rows in the provekit-cli cascade,
-moving the reproducible baseline to K=30.
+and exposed 2 additional solver-side `kit_dispatch` closes, moving the
+reproducible baseline to K=32.
 
 The #1774 reproducibility caveat is closed: the release gate validates the
 dependency-proof state as part of doctor release-gate mode before accepting the
@@ -292,10 +296,10 @@ measurement setup and is not the current Phase 5 baseline.
 
 | Category | Count | Closing mechanism |
 |---|---|---|
-| proven K | 30 panic-safe | Current reproducible K after readiness-signal gating replaces convergence and slice 31's catalog-backed libprovekit cascade lands. D-lib, C `json!`, B guarded-panic, D-fn, and audited catalog-backed serde/function entries remain the closing mechanisms, measured against the cold bcargo + battleaxe RA baseline. |
+| proven K | 32 panic-safe | Current reproducible K after readiness-signal gating replaces convergence and slice 31's catalog-backed libprovekit cascade lands. D-lib, C `json!`, B guarded-panic, D-fn, audited catalog-backed serde/function entries, and 2 solver-side `kit_dispatch` JSON-RPC request serialization closes remain the closing mechanisms, measured against the cold bcargo + battleaxe RA baseline. |
 | residue | 8 honest residue | Mutex `.lock().expect()` rows. Honest residue; "lock is total" would be unsound. |
 | closeable tier-to-close | 0 named D-lib rows | #1896 closed the `RealizeRequest` serialization row with provekit-cli-owned per-type D-lib manifest coverage, mirroring libprovekit's `infallible_serialize.toml` pattern. |
-| independent provekit-cli unproven | 8 | `cmd_emit`, `cmd_mint`, `cmd_protocol` x3, `doctor_oracle`, and `kit_dispatch` x2. Tracked separately from #1898 in #1901. |
+| independent provekit-cli unproven | 6 | `cmd_emit`, `cmd_mint`, `cmd_protocol` x3, and `doctor_oracle`. Tracked separately from #1898 in #1901. |
 | imported libprovekit parked rows | 8 | Remaining libprovekit rows propagated through dependency import: 3 NoBridge physical sites, 1 residue, and 4 catalog-excluded solver rows. |
 
 The honest read: Rust v1 is not K == N. It is K covering the provable buckets,
@@ -517,7 +521,7 @@ Phase 5 has two parallel levers:
 
 The number that moves: K (panic-safe sites discharged via sound reasoning) on
 real production code in each language. Today on Rust self-application, the
-reproducible Phase 5 baseline is K=30 on provekit-cli after slice 31 and K=22
+reproducible Phase 5 baseline is K=32 on provekit-cli after slice 31 and K=22
 on libprovekit. Earlier provekit-cli K=21 references came from a different
 measurement setup and are not the current baseline. On Python / TS / Go / Java
 production targets: not yet measured at
@@ -530,7 +534,7 @@ differential vs unit tests has to be visible.
 **Phase 5 staging (T direction 2026-06-02): dogfood is the gold standard,
 then third-party parity per language.**
 1. **Dogfood depth first.** Drive Rust self-application K into vendor-
-   meaningful range (current reproducible K=30 -> into the hundreds on
+   meaningful range (current reproducible K=32 -> into the hundreds on
    `provekit-cli` and `libprovekit`) via shim catalog expansion and discharge
    tier work. This
    is the proof that the technique scales on a real codebase before we ask
@@ -563,7 +567,7 @@ and the pattern repeats per language.
   reqwest, clap, anyhow, thiserror, others). Per-crate
   `infallible_serialize.toml` and equivalent manifests mature into a
   catalog.
-- Target: K from 30 to 100+ on `provekit-cli`, K from 22 to 50+ on
+- Target: K from 32 to 100+ on `provekit-cli`, K from 22 to 50+ on
   `libprovekit`, with ZERO source modifications.
 - **Pitch artifact**: pick one popular OSS Rust crate, prove it end-to-end,
   publish the differential vs its unit test suite as the vendor onboarding
@@ -716,7 +720,7 @@ labeling.
     receipt.
   - #1902 (Slice 31 catalog K multiplication): Rust-kit manifest-backed
     lifter support plus libprovekit serde/function catalog entries. Current
-    reproducible baselines: libprovekit K=22 and provekit-cli K=30, with
+    reproducible baselines: libprovekit K=22 and provekit-cli K=32, with
     `falsePass=0`, `silentlyDropped=0`, and `droppedSites=[]` on both crates.
 - **Open follow-ups**:
   - #1757 self-check golden drift reached main without gate update.

--- a/implementations/rust/libprovekit/.provekit/contracts/function_postconditions.toml
+++ b/implementations/rust/libprovekit/.provekit/contracts/function_postconditions.toml
@@ -25,3 +25,39 @@ arg0_path = "CONCEPT_BIND_RESULT"
 contract = "concept_op_catalog_cid__concept_bind_result"
 post_predicate = "is_some"
 reason = "grammar_op_shape(CONCEPT_BIND_RESULT) has a fixed primitive arm and json_cid returns a valid CID"
+
+[[functions]]
+call_kind = "associated"
+callee_crate = "libprovekit"
+type_path = "crate::canonical"
+callee = "serializable_jcs"
+source_file = "src/core/lower_plugin.rs"
+source_line = 154
+arg0_path = "canonical"
+contract = "canonical_serializable_jcs__parametric_sort_expansion"
+post_predicate = "is_ok"
+reason = "ParametricSortExpansion::compose_cid builds canonical with json! from string literal keys, constructor_cid, and Vec<String> arg_cids before serializable_jcs; closes src/core/lower_plugin.rs:155"
+
+[[functions]]
+call_kind = "associated"
+callee_crate = "libprovekit"
+type_path = "crate::canonical"
+callee = "json_jcs"
+source_file = "src/core/source_transform_kit.rs"
+source_line = 307
+arg0_path = "value"
+contract = "canonical_json_jcs__source_transform_bridge_header"
+post_predicate = "is_ok"
+reason = "Bridge header value is produced from BridgeHeaderV14 then augmented with string fields targetContractCid and targetLayer before json_jcs; closes src/core/source_transform_kit.rs:307"
+
+[[functions]]
+call_kind = "associated"
+callee_crate = "libprovekit"
+type_path = "crate::canonical"
+callee = "json_cid"
+source_file = "src/core/source_transform_kit.rs"
+source_line = 308
+arg0_path = "value"
+contract = "canonical_json_cid__source_transform_bridge_header"
+post_predicate = "is_ok"
+reason = "Same BridgeHeaderV14-derived value as the adjacent json_jcs audit; json_cid delegates through json_jcs then hashes; closes src/core/source_transform_kit.rs:308"

--- a/implementations/rust/libprovekit/.provekit/contracts/infallible_serialize.toml
+++ b/implementations/rust/libprovekit/.provekit/contracts/infallible_serialize.toml
@@ -32,4 +32,36 @@ function = "to_value"
 type_crate = "libprovekit"
 type_name = "Term"
 contract = "serde_json_to_value__term"
-reason = "Term derives Serialize over Cid-as-string, strings, Vec<Term>, serde_json::Value, and Sort"
+reason = "Term derives Serialize at src/core/types.rs:125 over Cid-as-string, strings, Vec<Term>, serde_json::Value, and Sort; closes src/core/types.rs:2093 via claim.payload field binding"
+
+[[serde_json]]
+function = "to_value"
+type_crate = "provekit_ir_types"
+type_name = "BridgeHeaderV14"
+contract = "serde_json_to_value__bridge_header_v14"
+reason = "BridgeHeaderV14 derives Serialize at provekit-ir-types/src/lib.rs:68 over strings plus BridgeTarget string-CID payloads; closes src/core/emit_obligation.rs:62 and src/core/source_transform_kit.rs:296"
+audited_for_crate = "provekit_ir_types"
+audited_at = "2026-06-03"
+
+[[serde_json]]
+function = "to_value"
+type_crate = "libprovekit"
+type_name = "Witness"
+contract = "serde_json_to_value__witness"
+reason = "Witness derives Serialize at src/core/types.rs:698 over serde_json::Value, Cid/string-like fields, and Serialize-derived chain witnesses; closes src/core/types.rs:2070"
+
+[[serde_json]]
+function = "to_value"
+type_crate = "libprovekit"
+type_name = "Verb"
+contract = "serde_json_to_value__verb"
+reason = "Verb derives Serialize at src/core/types.rs:1241 as a two-variant enum; closes src/core/types.rs:2180"
+
+[[serde_json]]
+function = "to_value"
+type_crate = "provekit_ir_types"
+type_name = "IrFormula"
+contract = "serde_json_to_value__ir_formula"
+reason = "IrFormula derives Serialize at provekit-ir-types/src/lib.rs:398 over strings, vectors, boxes, Sort, and IrTerm; closes src/wp/tests.rs:578 and predicted D-lib side effect src/compose.rs:1410"
+audited_for_crate = "provekit_ir_types"
+audited_at = "2026-06-03"

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -827,6 +827,8 @@ struct FunctionPostconditionRule {
     type_path: Option<String>,
     receiver_path: Option<String>,
     callee: String,
+    source_file: Option<String>,
+    source_line: Option<usize>,
     arg0: FunctionPostconditionArg0,
     contract: String,
     post_predicate: String,
@@ -1028,6 +1030,21 @@ impl FunctionPostconditionsManifest {
             let post_predicate =
                 required_toml_string_for(&path, &context, table, "post_predicate")?;
             let reason = required_toml_string_for(&path, &context, table, "reason")?;
+            let source_file = table
+                .get("source_file")
+                .and_then(toml::Value::as_str)
+                .map(ToString::to_string);
+            let source_line = table
+                .get("source_line")
+                .map(|_| required_toml_u64_for(&path, &context, table, "source_line"))
+                .transpose()?
+                .map(|line| line as usize);
+            if source_file.is_some() != source_line.is_some() {
+                return Err(format!(
+                    "{} `{context}` must set `source_file` and `source_line` together",
+                    path.display()
+                ));
+            }
             if !seen_contracts.insert(contract.clone()) {
                 return Err(format!(
                     "{} duplicate function postcondition contract `{contract}`",
@@ -1038,21 +1055,32 @@ impl FunctionPostconditionsManifest {
             let (type_path, receiver_path, arg0) = match call_kind {
                 FunctionPostconditionCallKind::Associated => {
                     let type_path = required_toml_string_for(&path, &context, table, "type_path")?;
-                    let format_literal =
-                        required_toml_string_for(&path, &context, table, "arg0_format_literal")?;
-                    let repeat_literal =
-                        required_toml_string_for(&path, &context, table, "arg0_repeat_literal")?;
-                    let repeat_count =
-                        required_toml_u64_for(&path, &context, table, "arg0_repeat_count")?;
-                    (
-                        Some(type_path),
-                        None,
+                    let arg0 = if let Some(arg0_path) =
+                        table.get("arg0_path").and_then(toml::Value::as_str)
+                    {
+                        FunctionPostconditionArg0::Path(arg0_path.to_string())
+                    } else {
+                        let format_literal = required_toml_string_for(
+                            &path,
+                            &context,
+                            table,
+                            "arg0_format_literal",
+                        )?;
+                        let repeat_literal = required_toml_string_for(
+                            &path,
+                            &context,
+                            table,
+                            "arg0_repeat_literal",
+                        )?;
+                        let repeat_count =
+                            required_toml_u64_for(&path, &context, table, "arg0_repeat_count")?;
                         FunctionPostconditionArg0::FormatRepeat {
                             format_literal,
                             repeat_literal,
                             repeat_count,
-                        },
-                    )
+                        }
+                    };
+                    (Some(type_path), None, arg0)
                 }
                 FunctionPostconditionCallKind::Method => {
                     let receiver_path =
@@ -1072,6 +1100,8 @@ impl FunctionPostconditionsManifest {
                 type_path,
                 receiver_path,
                 callee,
+                source_file,
+                source_line,
                 arg0,
                 contract,
                 post_predicate,
@@ -1090,6 +1120,8 @@ impl FunctionPostconditionsManifest {
         func: &syn::Expr,
         args: &syn::punctuated::Punctuated<syn::Expr, syn::Token![,]>,
         current_crate: &str,
+        source_file: &str,
+        source_line: usize,
     ) -> Option<&FunctionPostconditionRule> {
         let (type_path, callee) = associated_call_path_and_leaf(func)?;
         self.rules.iter().find_map(|rule| {
@@ -1102,17 +1134,30 @@ impl FunctionPostconditionsManifest {
             if rule.type_path.as_deref() != Some(type_path.as_str()) {
                 return None;
             }
-            let FunctionPostconditionArg0::FormatRepeat {
-                format_literal,
-                repeat_literal,
-                repeat_count,
-            } = &rule.arg0
-            else {
+            if !function_postcondition_source_matches(rule, source_file, source_line) {
                 return None;
-            };
+            }
             let arg0 = only_call_arg(args)?;
-            if !expr_matches_format_repeat(arg0, format_literal, repeat_literal, *repeat_count) {
-                return None;
+            match &rule.arg0 {
+                FunctionPostconditionArg0::FormatRepeat {
+                    format_literal,
+                    repeat_literal,
+                    repeat_count,
+                } => {
+                    if !expr_matches_format_repeat(
+                        arg0,
+                        format_literal,
+                        repeat_literal,
+                        *repeat_count,
+                    ) {
+                        return None;
+                    }
+                }
+                FunctionPostconditionArg0::Path(expected_arg) => {
+                    if expr_path_text(arg0).as_deref() != Some(expected_arg.as_str()) {
+                        return None;
+                    }
+                }
             }
             Some(rule)
         })
@@ -1123,8 +1168,10 @@ impl FunctionPostconditionsManifest {
         func: &syn::Expr,
         args: &syn::punctuated::Punctuated<syn::Expr, syn::Token![,]>,
         current_crate: &str,
+        source_file: &str,
+        source_line: usize,
     ) -> Option<(String, String)> {
-        self.rule_for_associated_call(func, args, current_crate)
+        self.rule_for_associated_call(func, args, current_crate, source_file, source_line)
             .map(|rule| (current_crate.to_string(), rule.contract.clone()))
     }
 
@@ -1132,6 +1179,8 @@ impl FunctionPostconditionsManifest {
         &self,
         node: &syn::ExprMethodCall,
         current_crate: &str,
+        source_file: &str,
+        source_line: usize,
     ) -> Option<&FunctionPostconditionRule> {
         let callee = node.method.to_string();
         self.rules.iter().find_map(|rule| {
@@ -1142,6 +1191,9 @@ impl FunctionPostconditionsManifest {
                 return None;
             }
             if expr_path_text(&node.receiver) != rule.receiver_path {
+                return None;
+            }
+            if !function_postcondition_source_matches(rule, source_file, source_line) {
                 return None;
             }
             let FunctionPostconditionArg0::Path(expected_arg) = &rule.arg0 else {
@@ -1159,8 +1211,10 @@ impl FunctionPostconditionsManifest {
         &self,
         node: &syn::ExprMethodCall,
         current_crate: &str,
+        source_file: &str,
+        source_line: usize,
     ) -> Option<(String, String)> {
-        self.rule_for_method_call(node, current_crate)
+        self.rule_for_method_call(node, current_crate, source_file, source_line)
             .map(|rule| (current_crate.to_string(), rule.contract.clone()))
     }
 
@@ -1168,26 +1222,66 @@ impl FunctionPostconditionsManifest {
         &self,
         receiver: &syn::Expr,
         current_crate: &str,
+        source_file: &str,
         panic_leaf: &str,
     ) -> Option<(String, String)> {
         let rule = match receiver {
             syn::Expr::Call(call) => {
-                self.rule_for_associated_call(&call.func, &call.args, current_crate)
+                let start = call.func.span().start();
+                self.rule_for_associated_call(
+                    &call.func,
+                    &call.args,
+                    current_crate,
+                    source_file,
+                    start.line,
+                )
             }
-            syn::Expr::MethodCall(method) => self.rule_for_method_call(method, current_crate),
+            syn::Expr::MethodCall(method) => {
+                let start = method.method.span().start();
+                self.rule_for_method_call(method, current_crate, source_file, start.line)
+            }
             syn::Expr::Paren(paren) => {
-                return self.panic_partial_for_receiver(&paren.expr, current_crate, panic_leaf);
+                return self.panic_partial_for_receiver(
+                    &paren.expr,
+                    current_crate,
+                    source_file,
+                    panic_leaf,
+                );
             }
             syn::Expr::Group(group) => {
-                return self.panic_partial_for_receiver(&group.expr, current_crate, panic_leaf);
+                return self.panic_partial_for_receiver(
+                    &group.expr,
+                    current_crate,
+                    source_file,
+                    panic_leaf,
+                );
             }
             syn::Expr::Reference(reference) => {
-                return self.panic_partial_for_receiver(&reference.expr, current_crate, panic_leaf);
+                return self.panic_partial_for_receiver(
+                    &reference.expr,
+                    current_crate,
+                    source_file,
+                    panic_leaf,
+                );
             }
             _ => None,
         }?;
         let stem = panic_stem_for_post_predicate(&rule.post_predicate)?;
         disambiguated_partial_leaf(stem, panic_leaf).map(|leaf| ("std".to_string(), leaf))
+    }
+}
+
+fn function_postcondition_source_matches(
+    rule: &FunctionPostconditionRule,
+    source_file: &str,
+    source_line: usize,
+) -> bool {
+    match (rule.source_file.as_deref(), rule.source_line) {
+        (Some(expected_file), Some(expected_line)) => {
+            expected_file == source_file && expected_line == source_line
+        }
+        (None, None) => true,
+        _ => false,
     }
 }
 
@@ -1423,6 +1517,17 @@ struct EnumVariantTypeMap {
     variants: HashMap<(String, String), VariantFieldTypes>,
 }
 
+#[derive(Debug, Clone, Default)]
+struct StructFieldTypeMap {
+    fields: HashMap<(String, String, String), FieldTypeIdentity>,
+}
+
+#[derive(Debug, Clone)]
+struct FieldTypeIdentity {
+    type_id: TypeIdentity,
+    option_inner: Option<TypeIdentity>,
+}
+
 #[derive(Debug, Clone)]
 enum VariantFieldTypes {
     Named(HashMap<String, TypeIdentity>),
@@ -1445,6 +1550,117 @@ fn collect_enum_variant_type_map(
         &mut map,
     );
     map
+}
+
+fn collect_struct_field_type_map(
+    file: &syn::File,
+    use_map: &HashMap<String, String>,
+    local_type_names: &BTreeSet<String>,
+    current_crate: &str,
+) -> StructFieldTypeMap {
+    let mut map = StructFieldTypeMap::default();
+    collect_struct_field_type_map_in_items(
+        &file.items,
+        use_map,
+        local_type_names,
+        current_crate,
+        &mut map,
+    );
+    map
+}
+
+fn collect_struct_field_type_map_in_items(
+    items: &[syn::Item],
+    use_map: &HashMap<String, String>,
+    local_type_names: &BTreeSet<String>,
+    current_crate: &str,
+    out: &mut StructFieldTypeMap,
+) {
+    for item in items {
+        match item {
+            syn::Item::Struct(item_struct) => {
+                let struct_type = TypeIdentity {
+                    krate: current_crate.to_string(),
+                    head: item_struct.ident.to_string(),
+                };
+                let syn::Fields::Named(named) = &item_struct.fields else {
+                    continue;
+                };
+                for field in &named.named {
+                    let Some(ident) = field.ident.as_ref() else {
+                        continue;
+                    };
+                    let Some(field_type) = field_type_identity_for(
+                        strip_reference_type(&field.ty),
+                        use_map,
+                        local_type_names,
+                        current_crate,
+                    ) else {
+                        continue;
+                    };
+                    out.fields.insert(
+                        (
+                            struct_type.krate.clone(),
+                            struct_type.head.clone(),
+                            ident.to_string(),
+                        ),
+                        field_type,
+                    );
+                }
+            }
+            syn::Item::Mod(item_mod) => {
+                if let Some((_, ref nested)) = item_mod.content {
+                    collect_struct_field_type_map_in_items(
+                        nested,
+                        use_map,
+                        local_type_names,
+                        current_crate,
+                        out,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn field_type_identity_for(
+    ty: &syn::Type,
+    use_map: &HashMap<String, String>,
+    local_type_names: &BTreeSet<String>,
+    current_crate: &str,
+) -> Option<FieldTypeIdentity> {
+    Some(FieldTypeIdentity {
+        type_id: type_identity_for(ty, use_map, local_type_names, current_crate)?,
+        option_inner: option_inner_type_identity_for(ty, use_map, local_type_names, current_crate),
+    })
+}
+
+fn option_inner_type_identity_for(
+    ty: &syn::Type,
+    use_map: &HashMap<String, String>,
+    local_type_names: &BTreeSet<String>,
+    current_crate: &str,
+) -> Option<TypeIdentity> {
+    let syn::Type::Path(path) = ty else {
+        return None;
+    };
+    let segment = path.path.segments.last()?;
+    if segment.ident != "Option" {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+    let syn::GenericArgument::Type(inner_ty) = args.args.first()? else {
+        return None;
+    };
+    type_identity_for(
+        strip_reference_type(inner_ty),
+        use_map,
+        local_type_names,
+        current_crate,
+    )
 }
 
 fn collect_enum_variant_type_map_in_items(
@@ -1623,6 +1839,60 @@ fn bind_pattern_type_id(
     }
 }
 
+fn bind_option_pattern_type_id(
+    pat: &syn::Pat,
+    inner_type: &TypeIdentity,
+    local_types: &mut HashMap<String, String>,
+    value_types: &mut HashMap<String, TypeIdentity>,
+) {
+    match pat {
+        syn::Pat::TupleStruct(tuple_struct)
+            if tuple_struct
+                .path
+                .segments
+                .last()
+                .map(|segment| segment.ident == "Some")
+                .unwrap_or(false)
+                && tuple_struct.elems.len() == 1 =>
+        {
+            if let Some(inner_pat) = tuple_struct.elems.first() {
+                bind_pattern_type_id_direct(inner_pat, inner_type, local_types, value_types);
+            }
+        }
+        syn::Pat::Reference(reference) => {
+            bind_option_pattern_type_id(&reference.pat, inner_type, local_types, value_types);
+        }
+        syn::Pat::Or(or_pat) => {
+            for case in &or_pat.cases {
+                bind_option_pattern_type_id(case, inner_type, local_types, value_types);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn bind_pattern_type_id_direct(
+    pat: &syn::Pat,
+    type_id: &TypeIdentity,
+    local_types: &mut HashMap<String, String>,
+    value_types: &mut HashMap<String, TypeIdentity>,
+) {
+    match pat {
+        syn::Pat::Ident(ident) => {
+            bind_value_type(
+                &ident.ident.to_string(),
+                type_id.clone(),
+                local_types,
+                value_types,
+            );
+        }
+        syn::Pat::Reference(reference) => {
+            bind_pattern_type_id_direct(&reference.pat, type_id, local_types, value_types);
+        }
+        _ => {}
+    }
+}
+
 fn bind_value_type(
     name: &str,
     type_id: TypeIdentity,
@@ -1723,6 +1993,7 @@ fn collect_callsites_in_items(
     local_type_names: &BTreeSet<String>,
     current_crate: &str,
     enum_variant_types: &EnumVariantTypeMap,
+    struct_field_types: &StructFieldTypeMap,
     infallible_serialize: &InfallibleSerializeManifest,
     function_postconditions: &FunctionPostconditionsManifest,
     out: &mut Vec<CallSite>,
@@ -1743,6 +2014,7 @@ fn collect_callsites_in_items(
                     local_type_names,
                     current_crate,
                     enum_variant_types,
+                    struct_field_types,
                     infallible_serialize,
                     function_postconditions,
                     &param_type_map,
@@ -1773,6 +2045,7 @@ fn collect_callsites_in_items(
                             local_type_names,
                             current_crate,
                             enum_variant_types,
+                            struct_field_types,
                             infallible_serialize,
                             function_postconditions,
                             &param_type_map,
@@ -1794,6 +2067,7 @@ fn collect_callsites_in_items(
                         local_type_names,
                         current_crate,
                         enum_variant_types,
+                        struct_field_types,
                         infallible_serialize,
                         function_postconditions,
                         out,
@@ -1813,6 +2087,7 @@ fn collect_callsites_in_block(
     local_type_names: &BTreeSet<String>,
     current_crate: &str,
     enum_variant_types: &EnumVariantTypeMap,
+    struct_field_types: &StructFieldTypeMap,
     infallible_serialize: &InfallibleSerializeManifest,
     function_postconditions: &FunctionPostconditionsManifest,
     // Phase-2 Tier D-lib: param name -> concrete type identity for syntactic
@@ -1831,6 +2106,7 @@ fn collect_callsites_in_block(
         local_types: HashMap<String, String>,
         value_types: HashMap<String, TypeIdentity>,
         enum_variant_types: &'a EnumVariantTypeMap,
+        struct_field_types: &'a StructFieldTypeMap,
         infallible_serialize: &'a InfallibleSerializeManifest,
         function_postconditions: &'a FunctionPostconditionsManifest,
         param_type_map: &'a HashMap<String, TypeIdentity>,
@@ -1841,6 +2117,85 @@ fn collect_callsites_in_block(
             self.value_types
                 .get(name)
                 .or_else(|| self.param_type_map.get(name))
+        }
+
+        fn expr_type_identity(&self, expr: &syn::Expr) -> Option<TypeIdentity> {
+            match expr {
+                syn::Expr::Path(path) if path.path.segments.len() == 1 => path
+                    .path
+                    .segments
+                    .first()
+                    .and_then(|segment| self.value_type(&segment.ident.to_string()).cloned()),
+                syn::Expr::Field(field) => {
+                    let receiver = self.expr_type_identity(&field.base)?;
+                    let field_name = match &field.member {
+                        syn::Member::Named(ident) => ident.to_string(),
+                        syn::Member::Unnamed(_) => return None,
+                    };
+                    self.struct_field_types
+                        .fields
+                        .get(&(receiver.krate, receiver.head, field_name))
+                        .map(|field| field.type_id.clone())
+                }
+                syn::Expr::Reference(reference) => self.expr_type_identity(&reference.expr),
+                syn::Expr::Paren(paren) => self.expr_type_identity(&paren.expr),
+                syn::Expr::Group(group) => self.expr_type_identity(&group.expr),
+                _ => None,
+            }
+        }
+
+        fn expr_option_inner_type_identity(&self, expr: &syn::Expr) -> Option<TypeIdentity> {
+            match expr {
+                syn::Expr::Field(field) => {
+                    let receiver = self.expr_type_identity(&field.base)?;
+                    let field_name = match &field.member {
+                        syn::Member::Named(ident) => ident.to_string(),
+                        syn::Member::Unnamed(_) => return None,
+                    };
+                    self.struct_field_types
+                        .fields
+                        .get(&(receiver.krate, receiver.head, field_name))
+                        .and_then(|field| field.option_inner.clone())
+                }
+                syn::Expr::Reference(reference) => {
+                    self.expr_option_inner_type_identity(&reference.expr)
+                }
+                syn::Expr::Paren(paren) => self.expr_option_inner_type_identity(&paren.expr),
+                syn::Expr::Group(group) => self.expr_option_inner_type_identity(&group.expr),
+                _ => None,
+            }
+        }
+
+        fn serde_json_panic_partial_for_receiver(
+            &self,
+            receiver: &syn::Expr,
+            panic_leaf: &str,
+        ) -> Option<(String, String)> {
+            match receiver {
+                syn::Expr::Call(call) => {
+                    let (producer, producer_crate, _) =
+                        call_expr_callee(&call.func, self.use_map, self.current_crate)?;
+                    if !needs_arg_type_resolution(producer_crate.as_deref(), &producer) {
+                        return None;
+                    }
+                    let arg = call.args.first()?;
+                    let type_id = self.expr_type_identity(arg)?;
+                    self.infallible_serialize
+                        .contract_for(&producer, &type_id)?;
+                    disambiguated_partial_leaf("result", panic_leaf)
+                        .map(|leaf| ("std".to_string(), leaf))
+                }
+                syn::Expr::Paren(paren) => {
+                    self.serde_json_panic_partial_for_receiver(&paren.expr, panic_leaf)
+                }
+                syn::Expr::Group(group) => {
+                    self.serde_json_panic_partial_for_receiver(&group.expr, panic_leaf)
+                }
+                syn::Expr::Reference(reference) => {
+                    self.serde_json_panic_partial_for_receiver(&reference.expr, panic_leaf)
+                }
+                _ => None,
+            }
         }
     }
     impl<'ast, 'a> Visit<'ast> for V<'a> {
@@ -1857,11 +2212,10 @@ fn collect_callsites_in_block(
                 let disambiguated_target =
                     if needs_arg_type_resolution(callee_crate.as_deref(), &callee) {
                         node.args.first().and_then(|a| {
-                            let name = expr_bare_ident_name(a)?;
-                            let type_id = self.value_type(&name)?;
+                            let type_id = self.expr_type_identity(a)?;
                             disambiguated_serde_json_totality_target(
                                 &callee,
-                                type_id,
+                                &type_id,
                                 self.infallible_serialize,
                                 self.current_crate,
                             )
@@ -1874,6 +2228,8 @@ fn collect_callsites_in_block(
                         &node.func,
                         &node.args,
                         self.current_crate,
+                        self.rel_path,
+                        start.line,
                     )
                 });
                 self.out.push(CallSite {
@@ -1949,11 +2305,15 @@ fn collect_callsites_in_block(
                 .is_none()
                 .then(|| {
                     if is_panic_leaf(&callee) {
-                        self.function_postconditions.panic_partial_for_receiver(
-                            &node.receiver,
-                            self.current_crate,
-                            &callee,
-                        )
+                        self.serde_json_panic_partial_for_receiver(&node.receiver, &callee)
+                            .or_else(|| {
+                                self.function_postconditions.panic_partial_for_receiver(
+                                    &node.receiver,
+                                    self.current_crate,
+                                    self.rel_path,
+                                    &callee,
+                                )
+                            })
                     } else {
                         None
                     }
@@ -1976,8 +2336,12 @@ fn collect_callsites_in_block(
                 .as_ref()
                 .is_none()
                 .then(|| {
-                    self.function_postconditions
-                        .target_for_method_call(node, self.current_crate)
+                    self.function_postconditions.target_for_method_call(
+                        node,
+                        self.current_crate,
+                        self.rel_path,
+                        start.line,
+                    )
                 })
                 .flatten();
             self.out.push(CallSite {
@@ -2007,12 +2371,19 @@ fn collect_callsites_in_block(
         }
         fn visit_expr_match(&mut self, node: &'ast syn::ExprMatch) {
             self.visit_expr(&node.expr);
-            let scrutinee_type =
-                expr_bare_ident_name(&node.expr).and_then(|name| self.value_type(&name).cloned());
+            let scrutinee_type = self.expr_type_identity(&node.expr);
+            let option_inner_type = self.expr_option_inner_type_identity(&node.expr);
             for arm in &node.arms {
                 let saved_local_types = self.local_types.clone();
                 let saved_value_types = self.value_types.clone();
-                if let Some(type_id) = scrutinee_type.as_ref() {
+                if let Some(inner_type) = option_inner_type.as_ref() {
+                    bind_option_pattern_type_id(
+                        &arm.pat,
+                        inner_type,
+                        &mut self.local_types,
+                        &mut self.value_types,
+                    );
+                } else if let Some(type_id) = scrutinee_type.as_ref() {
                     bind_pattern_type_id(
                         &arm.pat,
                         type_id,
@@ -2027,6 +2398,29 @@ fn collect_callsites_in_block(
                 self.visit_expr(&arm.body);
                 self.local_types = saved_local_types;
                 self.value_types = saved_value_types;
+            }
+        }
+        fn visit_expr_if(&mut self, node: &'ast syn::ExprIf) {
+            let syn::Expr::Let(expr_let) = &*node.cond else {
+                syn::visit::visit_expr_if(self, node);
+                return;
+            };
+            self.visit_expr(&expr_let.expr);
+            let saved_local_types = self.local_types.clone();
+            let saved_value_types = self.value_types.clone();
+            if let Some(inner_type) = self.expr_option_inner_type_identity(&expr_let.expr) {
+                bind_option_pattern_type_id(
+                    &expr_let.pat,
+                    &inner_type,
+                    &mut self.local_types,
+                    &mut self.value_types,
+                );
+            }
+            self.visit_block(&node.then_branch);
+            self.local_types = saved_local_types;
+            self.value_types = saved_value_types;
+            if let Some((_else_token, else_branch)) = &node.else_branch {
+                self.visit_expr(else_branch);
             }
         }
         fn visit_expr_index(&mut self, node: &'ast syn::ExprIndex) {
@@ -2064,21 +2458,39 @@ fn collect_callsites_in_block(
                 self.local_type_names,
                 self.current_crate,
             );
-            let explicit = explicit_type.as_ref().map(|type_id| type_id.krate.clone());
-            let inferred = node.init.as_ref().and_then(|init| {
+            let mut inferred_type = None;
+            let inferred_crate = node.init.as_ref().and_then(|init| {
                 self.visit_expr(&init.expr);
-                expr_return_crate(
+                inferred_type = expr_constructed_type_identity(
                     &init.expr,
                     self.use_map,
-                    self.fn_return_crates,
                     self.local_type_names,
                     self.current_crate,
-                )
+                );
+                inferred_type
+                    .as_ref()
+                    .map(|type_id| type_id.krate.clone())
+                    .or_else(|| {
+                        expr_return_crate(
+                            &init.expr,
+                            self.use_map,
+                            self.fn_return_crates,
+                            self.local_type_names,
+                            self.current_crate,
+                        )
+                    })
             });
-            if let (Some(name), Some(krate)) = (pat_ident_name(&node.pat), explicit.or(inferred)) {
-                self.local_types.insert(name, krate);
+            let local_type = explicit_type.clone().or(inferred_type);
+            if let (Some(name), Some(krate)) = (
+                pat_ident_name(&node.pat),
+                local_type
+                    .as_ref()
+                    .map(|type_id| type_id.krate.clone())
+                    .or(inferred_crate),
+            ) {
+                self.local_types.insert(name.clone(), krate);
             }
-            if let (Some(name), Some(type_id)) = (pat_ident_name(&node.pat), explicit_type) {
+            if let (Some(name), Some(type_id)) = (pat_ident_name(&node.pat), local_type) {
                 self.value_types.insert(name, type_id);
             }
         }
@@ -2095,6 +2507,7 @@ fn collect_callsites_in_block(
             .collect(),
         value_types: param_type_map.clone(),
         enum_variant_types,
+        struct_field_types,
         infallible_serialize,
         function_postconditions,
         param_type_map,
@@ -2636,6 +3049,57 @@ fn type_identity_for(
     Some(TypeIdentity { krate, head })
 }
 
+fn expr_constructed_type_identity(
+    expr: &syn::Expr,
+    use_map: &HashMap<String, String>,
+    local_type_names: &BTreeSet<String>,
+    current_crate: &str,
+) -> Option<TypeIdentity> {
+    match expr {
+        syn::Expr::Struct(expr_struct) => {
+            type_identity_for_path(&expr_struct.path, use_map, local_type_names, current_crate)
+        }
+        syn::Expr::Paren(paren) => {
+            expr_constructed_type_identity(&paren.expr, use_map, local_type_names, current_crate)
+        }
+        syn::Expr::Group(group) => {
+            expr_constructed_type_identity(&group.expr, use_map, local_type_names, current_crate)
+        }
+        _ => None,
+    }
+}
+
+fn type_identity_for_path(
+    path: &syn::Path,
+    use_map: &HashMap<String, String>,
+    local_type_names: &BTreeSet<String>,
+    current_crate: &str,
+) -> Option<TypeIdentity> {
+    let head = path.segments.last()?.ident.to_string();
+    let segs: Vec<String> = path
+        .segments
+        .iter()
+        .map(|segment| segment.ident.to_string())
+        .collect();
+    let krate = if segs.len() >= 2 {
+        resolve_path_root_crate(segs.first()?, use_map, current_crate)
+    } else {
+        use_map
+            .get(&head)
+            .map(|root| resolve_path_root_crate(root, use_map, current_crate))
+            .or_else(|| {
+                if !current_crate.is_empty() && local_type_names.contains(&head) {
+                    Some(current_crate.to_string())
+                } else if is_std_prelude_panic_type(&head) {
+                    Some("std".to_string())
+                } else {
+                    None
+                }
+            })?
+    };
+    Some(TypeIdentity { krate, head })
+}
+
 fn strip_reference_type(ty: &syn::Type) -> &syn::Type {
     match ty {
         syn::Type::Reference(r) => strip_reference_type(&r.elem),
@@ -3106,6 +3570,8 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
         let local_type_names = collect_local_type_names(&file);
         let enum_variant_types =
             collect_enum_variant_type_map(&file, &use_map, &local_type_names, &current_crate);
+        let struct_field_types =
+            collect_struct_field_type_map(&file, &use_map, &local_type_names, &current_crate);
         let fn_return_crates =
             function_return_crates(&file, &use_map, &local_type_names, &current_crate);
         let mut callsites: Vec<CallSite> = Vec::new();
@@ -3118,6 +3584,7 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
             &local_type_names,
             &current_crate,
             &enum_variant_types,
+            &struct_field_types,
             &infallible_serialize,
             &function_postconditions,
             &mut callsites,
@@ -4510,7 +4977,9 @@ fn function_contract_lift(params: &Value) -> Result<Value, String> {
     let total_fnc = entries.len();
     let eligible = entries
         .iter()
-        .filter(|e| body_discharge_policy_from_object_with_default(e, false).body_discharge_eligible)
+        .filter(|e| {
+            body_discharge_policy_from_object_with_default(e, false).body_discharge_eligible
+        })
         .count();
     let mut refusal_by_reason: std::collections::BTreeMap<String, usize> =
         std::collections::BTreeMap::new();
@@ -10482,6 +10951,13 @@ pub fn bitwise_not() -> i64 {
             .expect("write function postconditions manifest");
     }
 
+    fn source_line_containing(src: &str, needle: &str) -> usize {
+        src.lines()
+            .position(|line| line.contains(needle))
+            .unwrap_or_else(|| panic!("missing source line containing `{needle}`"))
+            + 1
+    }
+
     fn write_residue_manifest(root: &Path, body: &str) {
         let provekit_dir = root.join(".provekit");
         fs::create_dir_all(&provekit_dir).expect("create .provekit dir");
@@ -11947,6 +12423,339 @@ reason = "grammar_op_shape(CONCEPT_BIND_RESULT) has a fixed primitive arm and js
     }
 
     #[test]
+    fn lift_implications_disambiguates_constructor_locals_for_infallible_serde_manifest() {
+        let src = r##"
+use serde_json as sj;
+
+pub struct BridgeHeaderV14 {
+    name: String,
+}
+
+pub struct Other {
+    name: String,
+}
+
+macro_rules! make_header {
+    () => {
+        BridgeHeaderV14 {
+            name: "macro".to_string(),
+        }
+    };
+}
+
+pub fn audited_constructor() {
+    let header = BridgeHeaderV14 {
+        name: "ok".to_string(),
+    };
+    sj::to_value(header).unwrap();
+}
+
+pub fn explicit_type_wins() {
+    let header: Other = BridgeHeaderV14 {
+        name: "wrong".to_string(),
+    }.into();
+    sj::to_value(header).unwrap();
+}
+
+pub fn macro_constructor_does_not_bind() {
+    let header = make_header!();
+    sj::to_value(header).unwrap();
+}
+"##;
+        let root = temp_workspace("lift_implications_constructor_local_type");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "consumer-crate"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .expect("write Cargo.toml");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), src).expect("write source");
+        write_infallible_serialize_manifest(
+            &root,
+            r#"
+[[serde_json]]
+function = "to_value"
+type_crate = "consumer_crate"
+type_name = "BridgeHeaderV14"
+contract = "serde_json_to_value__bridge_header_v14"
+reason = "BridgeHeaderV14 derives Serialize over serde_json-infallible fields"
+"#,
+        );
+
+        let expected_cid = "blake3-512:abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab";
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": [{
+                "name": "serde_json_to_value__bridge_header_v14",
+                "library": "consumer_crate",
+                "contract_cid": expected_cid,
+                "bodyDischargeEligible": false,
+                "bodyDischargeRefusalReason": "totality-axiom"
+            }],
+        }))
+        .expect("lift_implications");
+
+        let hits: Vec<&Value> = resp["ir"]
+            .as_array()
+            .expect("ir array")
+            .iter()
+            .filter(|entry| entry["sourceSymbol"] == "to_value")
+            .filter(|entry| entry["targetContractCid"] == expected_cid)
+            .collect();
+        assert_eq!(
+            hits.len(),
+            1,
+            "only the direct local struct constructor should bind to the manifest type; explicit-type and macro locals must not borrow it: {resp:#?}"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_disambiguates_option_field_match_bindings_for_infallible_serde_manifest() {
+        let src = r##"
+use serde_json as sj;
+
+pub struct Claim {
+    witness: Option<Witness>,
+    other: Option<Other>,
+}
+
+pub struct Witness {
+    value: String,
+}
+
+pub struct Other {
+    value: String,
+}
+
+pub fn audited_option_field(claim: &Claim) {
+    match &claim.witness {
+        Some(witness) => {
+            sj::to_value(witness).unwrap();
+        }
+        None => {}
+    }
+}
+
+pub fn audited_option_field_if_let(claim: &Claim) {
+    if let Some(witness) = &claim.witness {
+        sj::to_value(witness).unwrap();
+    }
+}
+
+pub fn shadowed_binding_does_not_remain_typed(claim: &Claim) {
+    match &claim.witness {
+        Some(witness) => {
+            let witness = Other {
+                value: "shadow".to_string(),
+            };
+            sj::to_value(witness).unwrap();
+        }
+        None => {}
+    }
+}
+
+pub fn method_receiver_does_not_bind(claim: &Claim) {
+    match claim.witness.as_ref() {
+        Some(witness) => {
+            sj::to_value(witness).unwrap();
+        }
+        None => {}
+    }
+}
+
+pub fn if_let_method_receiver_does_not_bind(claim: &Claim) {
+    if let Some(witness) = claim.witness.as_ref() {
+        sj::to_value(witness).unwrap();
+    }
+}
+
+pub fn wrong_field_does_not_bind(claim: &Claim) {
+    match &claim.other {
+        Some(witness) => {
+            sj::to_value(witness).unwrap();
+        }
+        None => {}
+    }
+}
+"##;
+        let root = temp_workspace("lift_implications_option_field_bindings");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "consumer-crate"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .expect("write Cargo.toml");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), src).expect("write source");
+        write_infallible_serialize_manifest(
+            &root,
+            r#"
+[[serde_json]]
+function = "to_value"
+type_crate = "consumer_crate"
+type_name = "Witness"
+contract = "serde_json_to_value__witness"
+reason = "Witness derives Serialize over serde_json-infallible fields"
+"#,
+        );
+
+        let expected_cid = "blake3-512:bcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbc";
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": [{
+                "name": "serde_json_to_value__witness",
+                "library": "consumer_crate",
+                "contract_cid": expected_cid,
+                "bodyDischargeEligible": false,
+                "bodyDischargeRefusalReason": "totality-axiom"
+            }],
+        }))
+        .expect("lift_implications");
+
+        let hits: Vec<&Value> = resp["ir"]
+            .as_array()
+            .expect("ir array")
+            .iter()
+            .filter(|entry| entry["sourceSymbol"] == "to_value")
+            .filter(|entry| entry["targetContractCid"] == expected_cid)
+            .collect();
+        assert_eq!(
+            hits.len(),
+            2,
+            "only direct Option field patterns over &claim.witness should bind witness to Witness; shadowed, method-derived, and wrong-field bindings must not borrow it: {resp:#?}"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_matches_function_postconditions_by_arg0_path_without_fuzzy_borrowing() {
+        let src = r##"
+pub mod canonical {
+    pub fn json_jcs(_value: &serde_json::Value) -> Result<String, String> {
+        panic!()
+    }
+}
+
+pub mod other {
+    pub fn json_jcs(_value: &serde_json::Value) -> Result<String, String> {
+        panic!()
+    }
+}
+
+pub fn audited(value: serde_json::Value, other_value: serde_json::Value) {
+    crate::canonical::json_jcs(&value).expect("audited value canonicalizes");
+    crate::canonical::json_jcs(&other_value).expect("wrong arg");
+    crate::other::json_jcs(&value).expect("wrong function path");
+}
+
+pub fn same_shape_later(value: serde_json::Value) {
+    crate::canonical::json_jcs(&value).expect("same shape, wrong source site");
+}
+"##;
+        let root = temp_workspace("lift_implications_arg0_path_postconditions");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "consumer-crate"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .expect("write Cargo.toml");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), src).expect("write source");
+        let audited_line = source_line_containing(src, "audited value canonicalizes");
+        write_function_postconditions_manifest(
+            &root,
+            &format!(
+                r#"
+[[functions]]
+call_kind = "associated"
+callee_crate = "consumer_crate"
+type_path = "crate::canonical"
+callee = "json_jcs"
+source_file = "src/lib.rs"
+source_line = {audited_line}
+arg0_path = "value"
+contract = "canonical_json_jcs__audited_value"
+post_predicate = "is_ok"
+reason = "The audited value is known to contain only canonicalizable JSON primitives"
+"#,
+            ),
+        );
+
+        let post_cid = "blake3-512:cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd";
+        let result_expect_cid = "blake3-512:dededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededededede";
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": [
+                {
+                    "name": "canonical_json_jcs__audited_value",
+                    "library": "consumer_crate",
+                    "contract_cid": post_cid,
+                    "bodyDischargeEligible": false,
+                    "bodyDischargeRefusalReason": "totality-axiom"
+                },
+                {
+                    "name": "result_expect@std/src/result.rs:2:1",
+                    "library": "std",
+                    "contract_cid": result_expect_cid,
+                    "body_bearing": true,
+                    "has_pre": true
+                }
+            ],
+        }))
+        .expect("lift_implications");
+
+        let ir = resp["ir"].as_array().expect("ir array");
+        let post_hits: Vec<&Value> = ir
+            .iter()
+            .filter(|entry| {
+                entry["sourceSymbol"] == "json_jcs" && entry["targetContractCid"] == post_cid
+            })
+            .collect();
+        assert_eq!(
+            post_hits.len(),
+            1,
+            "only crate::canonical::json_jcs(&value) may bridge to the audited postcondition: {resp:#?}"
+        );
+        let panic_targets: Vec<&str> = ir
+            .iter()
+            .filter(|entry| entry["sourceSymbol"] == "method:expect")
+            .filter_map(|entry| entry["targetContractCid"].as_str())
+            .collect();
+        assert_eq!(
+            panic_targets,
+            vec![result_expect_cid],
+            "only the audited receiver should route its expect panic leaf through result_expect: {resp:#?}"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn lift_implications_disambiguates_blessed_match_bindings_from_manifest() {
         let src = r##"
 pub enum Dialect {
@@ -12156,6 +12965,97 @@ reason = "project-local totality axiom for dependency Sort serialization"
             .find(|entry| entry["sourceSymbol"] == "to_string")
             .expect("serde_json::to_string bridge for external type identity");
         assert_eq!(bridge["targetContractCid"], sort_cid);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_routes_external_to_value_expect_for_line_broken_receiver() {
+        let src = r##"
+use dep_crate::{IrFormula, IrTerm};
+
+pub fn formula_to_canonical(f: &IrFormula, g: &IrTerm) {
+    let serde =
+        serde_json::to_value(f).expect("IrFormula serializes");
+    serde_json::to_value(g).expect("wrong arg type");
+    serde_json::to_string(f).expect("wrong serde function");
+    let through_var = serde_json::to_value(f);
+    through_var.expect("non-immediate receiver");
+    drop(serde);
+}
+"##;
+        let root = temp_workspace("lift_implications_external_to_value_expect");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "consumer-crate"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .expect("write Cargo.toml");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), src).expect("write source");
+        write_infallible_serialize_manifest(
+            &root,
+            r#"
+[[serde_json]]
+function = "to_value"
+type_crate = "dep_crate"
+type_name = "IrFormula"
+contract = "serde_json_to_value__ir_formula"
+reason = "project-local totality axiom for dependency IrFormula serialization"
+"#,
+        );
+
+        let producer_cid = "blake3-512:abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab";
+        let result_expect_cid = "blake3-512:babababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababa";
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": [
+                {
+                    "name": "serde_json_to_value__ir_formula",
+                    "library": "consumer_crate",
+                    "contract_cid": producer_cid,
+                    "bodyDischargeEligible": false,
+                    "bodyDischargeRefusalReason": "totality-axiom"
+                },
+                {
+                    "name": "result_expect@std/src/result.rs:2:1",
+                    "library": "std",
+                    "contract_cid": result_expect_cid,
+                    "body_bearing": true,
+                    "has_pre": true
+                }
+            ],
+        }))
+        .expect("lift implications");
+
+        let ir = resp["ir"].as_array().expect("ir array");
+        let producer_hits: Vec<&Value> = ir
+            .iter()
+            .filter(|entry| entry["sourceSymbol"] == "to_value")
+            .filter(|entry| entry["targetContractCid"] == producer_cid)
+            .collect();
+        assert_eq!(
+            producer_hits.len(),
+            2,
+            "both direct serde_json::to_value(f) producer calls should bridge to the external IrFormula totality contract; wrong arg type and wrong serde function must not: {resp:#?}"
+        );
+        let panic_targets: Vec<&str> = ir
+            .iter()
+            .filter(|entry| entry["sourceSymbol"] == "method:expect")
+            .filter_map(|entry| entry["targetContractCid"].as_str())
+            .collect();
+        assert_eq!(
+            panic_targets,
+            vec![result_expect_cid],
+            "only the immediate serde_json::to_value(f).expect(...) receiver should route through Result::expect; wrong arg type, wrong serde function, and through-var receiver must not: {resp:#?}"
+        );
 
         let _ = fs::remove_dir_all(root);
     }

--- a/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/provekit-walk/src/bin/walk_rpc.rs
@@ -2199,6 +2199,18 @@ fn collect_callsites_in_block(
         }
     }
     impl<'ast, 'a> Visit<'ast> for V<'a> {
+        // Let-binding inference mutates these maps while traversing a block.
+        // Bracket block traversal so nested blocks, if/loop bodies, and
+        // closures cannot leak inferred bindings into later outer callsites.
+        // Match/if-let pattern binders keep their narrower save/restore below.
+        fn visit_block(&mut self, node: &'ast syn::Block) {
+            let saved_local_types = self.local_types.clone();
+            let saved_value_types = self.value_types.clone();
+            syn::visit::visit_block(self, node);
+            self.local_types = saved_local_types;
+            self.value_types = saved_value_types;
+        }
+
         fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
             if let Some((callee, callee_crate, contract_callee)) =
                 call_expr_callee(&node.func, self.use_map, self.current_crate)
@@ -10958,6 +10970,61 @@ pub fn bitwise_not() -> i64 {
             + 1
     }
 
+    fn manifest_to_value_hit_count(temp_name: &str, src: &str, type_name: &str) -> usize {
+        let root = temp_workspace(temp_name);
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::write(
+            root.join("Cargo.toml"),
+            r#"
+[package]
+name = "consumer-crate"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .expect("write Cargo.toml");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), src).expect("write source");
+        write_infallible_serialize_manifest(
+            &root,
+            &format!(
+                r#"
+[[serde_json]]
+function = "to_value"
+type_crate = "consumer_crate"
+type_name = "{type_name}"
+contract = "serde_json_to_value__scope_probe"
+reason = "scope discipline probe"
+"#,
+            ),
+        );
+
+        let expected_cid = "blake3-512:abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab";
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": [{
+                "name": "serde_json_to_value__scope_probe",
+                "library": "consumer_crate",
+                "contract_cid": expected_cid,
+                "bodyDischargeEligible": false,
+                "bodyDischargeRefusalReason": "totality-axiom"
+            }],
+        }))
+        .expect("lift_implications");
+
+        let count = resp["ir"]
+            .as_array()
+            .expect("ir array")
+            .iter()
+            .filter(|entry| entry["sourceSymbol"] == "to_value")
+            .filter(|entry| entry["targetContractCid"] == expected_cid)
+            .count();
+        let _ = fs::remove_dir_all(root);
+        count
+    }
+
     fn write_residue_manifest(root: &Path, body: &str) {
         let provekit_dir = root.join(".provekit");
         fs::create_dir_all(&provekit_dir).expect("create .provekit dir");
@@ -12643,6 +12710,325 @@ reason = "Witness derives Serialize over serde_json-infallible fields"
         );
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn constructor_local_type_does_not_escape_nested_block_scope() {
+        let src = r##"
+use serde_json as sj;
+
+pub struct BridgeHeaderV14 {
+    name: String,
+}
+
+pub struct Other {
+    name: String,
+}
+
+pub fn block_scope(header: Other) {
+    {
+        let header = BridgeHeaderV14 {
+            name: "inner".to_string(),
+        };
+        drop(header);
+    }
+    sj::to_value(header).unwrap();
+}
+"##;
+        assert_eq!(
+            manifest_to_value_hit_count("constructor_scope_nested_block", src, "BridgeHeaderV14"),
+            0,
+            "constructor-local type inferred inside a nested block must not type the post-block binding"
+        );
+    }
+
+    #[test]
+    fn constructor_local_type_does_not_escape_match_arm_scope() {
+        let src = r##"
+use serde_json as sj;
+
+pub struct BridgeHeaderV14 {
+    name: String,
+}
+
+pub struct Other {
+    name: String,
+}
+
+pub fn match_scope(header: Other, flag: bool) {
+    match flag {
+        true => {
+            let header = BridgeHeaderV14 {
+                name: "inner".to_string(),
+            };
+            drop(header);
+        }
+        false => {}
+    }
+    sj::to_value(header).unwrap();
+}
+"##;
+        assert_eq!(
+            manifest_to_value_hit_count("constructor_scope_match_arm", src, "BridgeHeaderV14"),
+            0,
+            "constructor-local type inferred inside a match arm must not type the post-match binding"
+        );
+    }
+
+    #[test]
+    fn constructor_local_type_does_not_escape_if_branch_scope() {
+        let src = r##"
+use serde_json as sj;
+
+pub struct BridgeHeaderV14 {
+    name: String,
+}
+
+pub struct Other {
+    name: String,
+}
+
+pub fn if_scope(header: Other, flag: bool) {
+    if flag {
+        let header = BridgeHeaderV14 {
+            name: "inner".to_string(),
+        };
+        drop(header);
+    }
+    sj::to_value(header).unwrap();
+}
+"##;
+        assert_eq!(
+            manifest_to_value_hit_count("constructor_scope_if_branch", src, "BridgeHeaderV14"),
+            0,
+            "constructor-local type inferred inside an if branch must not type the post-if binding"
+        );
+    }
+
+    #[test]
+    fn constructor_local_type_does_not_escape_loop_body_scope() {
+        let src = r##"
+use serde_json as sj;
+
+pub struct BridgeHeaderV14 {
+    name: String,
+}
+
+pub struct Other {
+    name: String,
+}
+
+pub fn loop_scope(header: Other) {
+    loop {
+        let header = BridgeHeaderV14 {
+            name: "inner".to_string(),
+        };
+        drop(header);
+        break;
+    }
+    sj::to_value(header).unwrap();
+}
+"##;
+        assert_eq!(
+            manifest_to_value_hit_count("constructor_scope_loop_body", src, "BridgeHeaderV14"),
+            0,
+            "constructor-local type inferred inside a loop body must not type the post-loop binding"
+        );
+    }
+
+    #[test]
+    fn constructor_local_type_does_not_escape_closure_body_scope() {
+        let src = r##"
+use serde_json as sj;
+
+pub struct BridgeHeaderV14 {
+    name: String,
+}
+
+pub struct Other {
+    name: String,
+}
+
+pub fn closure_scope(header: Other) {
+    let _f = || {
+        let header = BridgeHeaderV14 {
+            name: "inner".to_string(),
+        };
+        drop(header);
+    };
+    sj::to_value(header).unwrap();
+}
+"##;
+        assert_eq!(
+            manifest_to_value_hit_count("constructor_scope_closure_body", src, "BridgeHeaderV14"),
+            0,
+            "constructor-local type inferred inside a closure body must not type the post-closure binding"
+        );
+    }
+
+    #[test]
+    fn option_field_binding_does_not_escape_if_let_scope() {
+        let src = r##"
+use serde_json as sj;
+
+pub struct Claim {
+    witness: Option<Witness>,
+}
+
+pub struct Witness {
+    value: String,
+}
+
+pub struct Other {
+    value: String,
+}
+
+pub fn if_let_scope(claim: &Claim, witness: Other) {
+    if let Some(witness) = &claim.witness {
+        drop(witness);
+    }
+    sj::to_value(witness).unwrap();
+}
+"##;
+        assert_eq!(
+            manifest_to_value_hit_count("option_scope_if_let", src, "Witness"),
+            0,
+            "Option field binding inside if-let must not type the post-if binding"
+        );
+    }
+
+    #[test]
+    fn option_field_binding_does_not_escape_match_scope() {
+        let src = r##"
+use serde_json as sj;
+
+pub struct Claim {
+    witness: Option<Witness>,
+}
+
+pub struct Witness {
+    value: String,
+}
+
+pub struct Other {
+    value: String,
+}
+
+pub fn match_scope(claim: &Claim, witness: Other) {
+    match &claim.witness {
+        Some(witness) => {
+            drop(witness);
+        }
+        None => {}
+    }
+    sj::to_value(witness).unwrap();
+}
+"##;
+        assert_eq!(
+            manifest_to_value_hit_count("option_scope_match", src, "Witness"),
+            0,
+            "Option field binding inside match must not type the post-match binding"
+        );
+    }
+
+    #[test]
+    fn option_field_binding_does_not_escape_nested_block_scope() {
+        let src = r##"
+use serde_json as sj;
+
+pub struct Claim {
+    witness: Option<Witness>,
+}
+
+pub struct Witness {
+    value: String,
+}
+
+pub struct Other {
+    value: String,
+}
+
+pub fn block_scope(claim: &Claim, witness: Other) {
+    {
+        if let Some(witness) = &claim.witness {
+            drop(witness);
+        }
+    }
+    sj::to_value(witness).unwrap();
+}
+"##;
+        assert_eq!(
+            manifest_to_value_hit_count("option_scope_nested_block", src, "Witness"),
+            0,
+            "Option field binding inside a nested block must not type the post-block binding"
+        );
+    }
+
+    #[test]
+    fn option_field_binding_does_not_escape_loop_body_scope() {
+        let src = r##"
+use serde_json as sj;
+
+pub struct Claim {
+    witness: Option<Witness>,
+}
+
+pub struct Witness {
+    value: String,
+}
+
+pub struct Other {
+    value: String,
+}
+
+pub fn loop_scope(claim: &Claim, witness: Other) {
+    loop {
+        if let Some(witness) = &claim.witness {
+            drop(witness);
+        }
+        break;
+    }
+    sj::to_value(witness).unwrap();
+}
+"##;
+        assert_eq!(
+            manifest_to_value_hit_count("option_scope_loop_body", src, "Witness"),
+            0,
+            "Option field binding inside a loop body must not type the post-loop binding"
+        );
+    }
+
+    #[test]
+    fn option_field_binding_does_not_escape_closure_body_scope() {
+        let src = r##"
+use serde_json as sj;
+
+pub struct Claim {
+    witness: Option<Witness>,
+}
+
+pub struct Witness {
+    value: String,
+}
+
+pub struct Other {
+    value: String,
+}
+
+pub fn closure_scope(claim: &Claim, witness: Other) {
+    let _f = || {
+        if let Some(witness) = &claim.witness {
+            drop(witness);
+        }
+    };
+    sj::to_value(witness).unwrap();
+}
+"##;
+        assert_eq!(
+            manifest_to_value_hit_count("option_scope_closure_body", src, "Witness"),
+            0,
+            "Option field binding inside a closure body must not type the post-closure binding"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Slice 31 multiplies the dogfood K baseline by adding manifest-backed Rust-kit lifter support plus libprovekit catalog entries. It keeps the CLI/verifier language-blind: Rust-specific producer recognition, type binding, and panic-partial routing stay in the Rust kit and project manifests.

This intentionally ships parallel routing wires for `function_postcondition` and `infallible_serialize` instead of stopping for a unified routing-engine refactor. That is the breadth-first direction in [[feedback_breadth_first_consolidation_second]]: prove the four-language product path first, consolidate against a known-working baseline later.

## Scoreboards

Cold libprovekit self-check:

```json
{
  "target": "implementations/rust/libprovekit",
  "dischargeSplit": {
    "panicSafe": 22,
    "reflexive": 666,
    "vacuous": 194,
    "undecidable": 1476,
    "falsePass": 0
  },
  "silentlyDropped": 0,
  "droppedSites": [],
  "oracle": {"requested": true, "engaged": true, "attempted": 2742, "resolved": 2507},
  "bridges": {"emitted": 2345},
  "liftGaps": {"no-contract-for-callee": 2858, "panic-site-unproven": 4, "unsupported-macro-callsite": 423},
  "panicCensus": {"proven": 22, "residue": 1, "unproven": 11}
}
```

Cold provekit-cli cascade:

```json
{
  "target": "implementations/rust/provekit-cli",
  "dischargeSplit": {
    "panicSafe": 32,
    "reflexive": 1183,
    "vacuous": 401,
    "undecidable": 2478,
    "falsePass": 0
  },
  "silentlyDropped": 0,
  "droppedSites": [],
  "oracle": {"requested": true, "engaged": true, "attempted": 4170, "resolved": 4078},
  "bridges": {"emitted": 2838},
  "liftGaps": {"no-contract-for-callee": 4261, "unsupported-macro-callsite": 1036},
  "panicCensus": {"proven": 32, "residue": 8, "unproven": 14}
}
```

Floor invariants are explicit per crate:

| target | silentlyDropped | falsePass | droppedSites |
|---|---:|---:|---|
| libprovekit | 0 | 0 | `[]` |
| provekit-cli | 0 | 0 | `[]` |

## Prediction vs Observed

| entry | predicted close-list | observed |
|---|---|---|
| `serde_json_to_value__bridge_header_v14` | `src/core/emit_obligation.rs:62`, `src/core/source_transform_kit.rs:296` | closed both |
| `canonical_serializable_jcs__parametric_sort_expansion` | `src/core/lower_plugin.rs:155` | closed |
| `canonical_json_jcs__source_transform_bridge_header` | `src/core/source_transform_kit.rs:307` | closed |
| `canonical_json_cid__source_transform_bridge_header` | `src/core/source_transform_kit.rs:308` | closed |
| `serde_json_to_value__witness` | `src/core/types.rs:2070` | closed |
| `serde_json_to_value__term` | `src/core/types.rs:2093` | closed |
| `serde_json_to_value__verb` | `src/core/types.rs:2180` | closed |
| `serde_json_to_value__ir_formula` | `src/wp/tests.rs:578`, predicted side effect `src/compose.rs:1410` | closed both |

Cascade delta:

| target | before K | predicted K | observed K | delta |
|---|---:|---:|---:|---:|
| libprovekit | 12 | 22 | 22 | +10 |
| provekit-cli | 20 | 30 | 32 | +12 |
| aggregate self-application gates | 32 | 52 | 54 | +22 |

The slice-31 prediction gate closed exactly: every predicted row close was confirmed by the cold gates, and no floor invariant moved. Observed K is +2 above prediction because `src/kit_dispatch.rs:1305` and `src/kit_dispatch.rs:2130` discharged through SMT after manifest enrichment. They are not catalog-blessed and not routed by the `to_value` wire; both are `serde_json::to_string(&req).expect(...)` over JSON-RPC request values.

Stable honest discovery beyond prediction:

| site | prior status | stable observed status | route |
|---|---|---|---|
| `src/kit_dispatch.rs:1305 method:expect` | unproven, `vampire` unsatisfied | proven, `vampire` discharged | solver-side, not catalog/routing-wire |
| `src/kit_dispatch.rs:2130 method:expect` | unproven, `vampire` unsatisfied | proven, `z3` discharged | solver-side, not catalog/routing-wire |

## Lifter Support

Adds five reversible-default Rust-kit lifter features:

- Constructor-local type inference for direct struct constructors, with explicit-type and macro-constructor discrimination.
- Scope discipline for inferred `local_types`/`value_types`: nested blocks, if/loop bodies, and closures cannot leak constructor-local bindings into later outer callsites; match/if-let binders keep their narrower save/restore path.
- Direct `Option` field match and if-let binding support, with shadowing, method-receiver, and wrong-field discrimination.
- `arg0_path` function postconditions with source file/source line gating, including same-shape wrong-line discrimination.
- Immediate `serde_json::to_value(...).expect(...)` receiver routing parallel to `function_postcondition`, with wrong-arg, wrong-function, and through-var discrimination.

Discrimination tests cover:

- `lift_implications_disambiguates_constructor_locals_for_infallible_serde_manifest`
- constructor-local scope probes: nested block, match arm, if branch, loop body, closure body
- Option binding scope probes: if-let, match, nested block, loop body, closure body
- `lift_implications_disambiguates_option_field_match_bindings_for_infallible_serde_manifest`
- `lift_implications_matches_function_postconditions_by_arg0_path_without_fuzzy_borrowing`
- `lift_implications_routes_external_to_value_expect_for_line_broken_receiver`
- broader manifest filters: `infallible` and `function_postcondition`
- package-level `provekit-walk` gate including the source_file/source_line filter tests

## Honest Exclusions

The remaining libprovekit rows are not inflated into K:

- NoBridge physical sites: `src/compose.rs:1157`, `src/core/source_transform.rs:645`, `src/core/source_transform.rs:1055`.
- Catalog-excluded solver rows: `src/core/types.rs:1193`, `src/core/types.rs:1198`, `src/core/types.rs:1946`, `src/desugar.rs:489`.
- Row classification: invariant-from-construction x3, generic monomorphization x1.
- Residue: `src/core/platform_semantics.rs:42`.

#1898 now tracks only the post-slice-31 libprovekit gap census. #1901 tracks the 6 remaining independent provekit-cli rows after the two stable solver-side `kit_dispatch` discoveries. #1899 remains the manifest-driven dependency proof DAG follow-up.

This builds on [[project_provekit_readiness_signal_replaces_convergence]]: slice 30 made the cold readiness baseline measurable; slice 31 moves K on that baseline.

## Verification

- `NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 /Users/tsavo/provekit/bin/bcargo --sync-bin provekit-realize-rust build -p provekit-realize-rust-core --bin provekit-realize-rust`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 /Users/tsavo/provekit/bin/bcargo test -p provekit-walk --test platform_semantics -- --nocapture`
- `NO_COLOR=1 BCARGO_PYTHON_ENV=0 BCARGO_TYPESCRIPT_ENV=0 /Users/tsavo/provekit/bin/bcargo test -p provekit-walk -- --nocapture`
- Focused green tests:
  - `bcargo test -p provekit-walk infallible -- --nocapture`
  - `bcargo test -p provekit-walk function_postcondition -- --nocapture`
  - `bcargo test -p provekit-walk lift_implications_matches_function_postconditions_by_arg0_path_without_fuzzy_borrowing -- --nocapture`
  - `bcargo test -p provekit-walk lift_implications_disambiguates_option_field_match_bindings_for_infallible_serde_manifest -- --nocapture`
  - `bcargo test -p provekit-walk lift_implications_routes_external_to_value_expect_for_line_broken_receiver -- --nocapture`
  - `bcargo test -p provekit-walk scope -- --nocapture`
- Cold self-check artifacts captured locally:
  - `/tmp/slice31-libprovekit-after-scope.json`
  - `/tmp/slice31-provekit-cli-after-scope.json`
  - `/tmp/slice31-provekit-cli-rerun.json`

