### PR TITLE
[codex] Python lifter coverage for NumPy visibility

### DIFF
--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/compiler.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/compiler.py
@@ -48,16 +48,28 @@ def _source_unit_bytes(ir: list[Json]) -> str | None:
 
 def _compile_contract(contract: Json) -> ast.FunctionDef:
     fn_name = _source_function_name(str(contract["fnName"]))
-    formals = [
-        ast.arg(arg=str(name), annotation=None, type_comment=None)
-        for name in contract.get("formals", [])
-    ]
     body = _stmt_list(_contract_term(contract))
     if not body:
         body = [ast.Pass()]
+    args = _arguments(contract)
     return ast.FunctionDef(
         name=fn_name,
-        args=ast.arguments(
+        args=args,
+        body=body,
+        decorator_list=[],
+        returns=None,
+        type_comment=None,
+    )
+
+
+def _arguments(contract: Json) -> ast.arguments:
+    shape = contract.get("parameterShape")
+    if not shape:
+        formals = [
+            ast.arg(arg=str(name), annotation=None, type_comment=None)
+            for name in contract.get("formals", [])
+        ]
+        return ast.arguments(
             posonlyargs=[],
             args=formals,
             vararg=None,
@@ -65,12 +77,59 @@ def _compile_contract(contract: Json) -> ast.FunctionDef:
             kw_defaults=[],
             kwarg=None,
             defaults=[],
-        ),
-        body=body,
-        decorator_list=[],
-        returns=None,
-        type_comment=None,
+        )
+
+    posonlyargs: list[ast.arg] = []
+    args: list[ast.arg] = []
+    positional_defaults: list[Json | None] = []
+    vararg: ast.arg | None = None
+    kwonlyargs: list[ast.arg] = []
+    kw_defaults: list[ast.expr | None] = []
+    kwarg: ast.arg | None = None
+
+    for raw_entry in shape:
+        if not isinstance(raw_entry, dict):
+            raise ValueError(f"parameterShape entry is not an object: {raw_entry!r}")
+        name = str(raw_entry["name"])
+        kind = str(raw_entry["kind"])
+        arg = ast.arg(arg=name, annotation=None, type_comment=None)
+        default = raw_entry.get("default")
+        if kind == "positional-only":
+            posonlyargs.append(arg)
+            positional_defaults.append(default if isinstance(default, dict) else None)
+        elif kind == "positional-or-keyword":
+            args.append(arg)
+            positional_defaults.append(default if isinstance(default, dict) else None)
+        elif kind == "vararg":
+            vararg = arg
+        elif kind == "keyword-only":
+            kwonlyargs.append(arg)
+            kw_defaults.append(_expr(default) if isinstance(default, dict) else None)
+        elif kind == "kwarg":
+            kwarg = arg
+        else:
+            raise ValueError(f"unsupported parameter kind: {kind}")
+
+    defaults = _trailing_defaults(positional_defaults)
+    return ast.arguments(
+        posonlyargs=posonlyargs,
+        args=args,
+        vararg=vararg,
+        kwonlyargs=kwonlyargs,
+        kw_defaults=kw_defaults,
+        kwarg=kwarg,
+        defaults=defaults,
     )
+
+
+def _trailing_defaults(defaults: list[Json | None]) -> list[ast.expr]:
+    first_default = next((index for index, value in enumerate(defaults) if value is not None), None)
+    if first_default is None:
+        return []
+    trailing = defaults[first_default:]
+    if any(value is None for value in trailing):
+        raise ValueError("positional parameter defaults must be trailing")
+    return [_expr(value) for value in trailing if value is not None]
 
 
 def _stmt_list(term: Json) -> list[ast.stmt]:

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/compiler.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/compiler.py
@@ -121,6 +121,13 @@ def _stmt(term: Json) -> ast.stmt:
             body=_stmt_list(then_branch) or [ast.Pass()],
             orelse=[] if _name(else_branch) == "python:pass" else _stmt_list(else_branch),
         )
+    if name == "python:try":
+        return ast.Try(
+            body=_stmt_list(args[0]) or [ast.Pass()],
+            handlers=_except_handlers(args[1]),
+            orelse=[] if _name(args[2]) == "python:pass" else _stmt_list(args[2]),
+            finalbody=[] if _name(args[3]) == "python:pass" else _stmt_list(args[3]),
+        )
     if name == "python:while":
         return ast.While(test=_expr(args[0]), body=_stmt_list(args[1]), orelse=[])
     if name == "python:for":
@@ -169,15 +176,32 @@ def _expr(term: Json) -> ast.expr:
             comparators=[_expr(args[2])],
         )
     if name == "python:call":
+        positional: list[ast.expr] = []
+        keywords: list[ast.keyword] = []
+        for arg in args[1:]:
+            if _name(arg) == "python:kwarg":
+                keyword_args = arg.get("args", [])
+                keywords.append(
+                    ast.keyword(
+                        arg=_const_string(keyword_args[0]),
+                        value=_expr(keyword_args[1]),
+                    )
+                )
+            else:
+                positional.append(_expr(arg))
         return ast.Call(
             func=_dotted_expr(_const_string(args[0])),
-            args=[_expr(arg) for arg in args[1:]],
-            keywords=[],
+            args=positional,
+            keywords=keywords,
         )
     if name == "python:attribute":
         return ast.Attribute(value=_expr(args[0]), attr=_const_string(args[1]), ctx=ast.Load())
     if name == "python:subscript":
         return ast.Subscript(value=_expr(args[0]), slice=_slice_or_expr(args[1]), ctx=ast.Load())
+    if name == "python:tuple":
+        return ast.Tuple(elts=[_expr(arg) for arg in args], ctx=ast.Load())
+    if name == "python:list":
+        return ast.List(elts=[_expr(arg) for arg in args], ctx=ast.Load())
     if name == "python:walrus":
         return ast.NamedExpr(target=_walrus_target(args[0]), value=_expr(args[1]))
     raise ValueError(f"unsupported python operation in expression position: {name}")
@@ -219,6 +243,23 @@ def _unpack_name_target(term: Json) -> ast.Name:
         raise ValueError(f"unpack target is not a name: {ast.dump(expr)}")
     expr.ctx = ast.Store()
     return expr
+
+
+def _except_handlers(term: Json) -> list[ast.ExceptHandler]:
+    if _name(term) != "python:except_handlers":
+        raise ValueError(f"expected python:except_handlers: {term!r}")
+    return [_except_handler(handler) for handler in term.get("args", [])]
+
+
+def _except_handler(term: Json) -> ast.ExceptHandler:
+    if _name(term) != "python:except_handler":
+        raise ValueError(f"expected python:except_handler: {term!r}")
+    args = term.get("args", [])
+    return ast.ExceptHandler(
+        type=None if _is_none_const(args[0]) else _expr(args[0]),
+        name=None if _is_none_const(args[1]) else _const_string(args[1]),
+        body=_stmt_list(args[2]) or [ast.Pass()],
+    )
 
 
 def _walrus_target(term: Json) -> ast.Name:

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/ir.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/ir.py
@@ -87,6 +87,7 @@ def function_contract(
     source_path: str,
     line: int,
     panic_loci: list[Json] | None = None,
+    parameter_shape: list[Json] | None = None,
 ) -> Json:
     contract = {
         "schemaVersion": "1",
@@ -104,6 +105,8 @@ def function_contract(
     }
     if panic_loci:
         contract["panicLoci"] = list(panic_loci)
+    if parameter_shape:
+        contract["parameterShape"] = list(parameter_shape)
     return contract
 
 

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -270,6 +270,14 @@ class _Emitter:
             emitted.append(self.statement(statement))
         return fold_seq(emitted)
 
+    def statements_with_extra_locals(self, statements: list[ast.stmt], extra_locals: set[str]) -> Json:
+        previous = self.locals
+        self.locals = self.locals | extra_locals
+        try:
+            return self.statements(statements)
+        finally:
+            self.locals = previous
+
     def statement(self, node: ast.stmt) -> Json:
         if isinstance(node, ast.Return):
             value = none_const() if node.value is None else self.expr(node.value)
@@ -381,11 +389,16 @@ class _Emitter:
     def except_handler(self, node: ast.ExceptHandler) -> Json:
         exception_type = none_const() if node.type is None else self.expr(node.type)
         name = none_const() if node.name is None else str_const(node.name)
+        body = (
+            self.statements_with_extra_locals(node.body, {node.name})
+            if node.name is not None
+            else self.statements(node.body)
+        )
         return ctor(
             "python:except_handler",
             exception_type,
             name,
-            self.statements(node.body),
+            body,
         )
 
     def runtime_failure_locus(

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -893,6 +893,13 @@ def _literal_default(node: ast.expr) -> Json:
             return str_const(value)
         if value is None:
             return none_const()
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+        operand = node.operand
+        if isinstance(operand, ast.Constant) and type(operand.value) is int:
+            value = operand.value
+            if isinstance(node.op, ast.USub):
+                value = -value
+            return int_const(value)
     if isinstance(node, ast.Tuple):
         return ctor("python:tuple", *[_literal_default(element) for element in node.elts])
     if isinstance(node, ast.List):

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/lifter.py
@@ -323,6 +323,20 @@ class _Emitter:
                 then_branch,
                 else_branch,
             )
+        if isinstance(node, ast.Try):
+            handlers = [
+                self.except_handler(handler)
+                for handler in node.handlers
+            ]
+            return ctor(
+                "python:try",
+                self.statements(node.body),
+                ctor("python:except_handlers", *handlers),
+                self.statements(node.orelse) if node.orelse else pass_stmt(),
+                self.statements(node.finalbody) if node.finalbody else pass_stmt(),
+            )
+        if isinstance(node, ast.With):
+            raise _UnsupportedSyntax(node, "with statements are refused")
         if isinstance(node, ast.While):
             if node.orelse:
                 raise _UnsupportedSyntax(node, "while/else is refused")
@@ -363,6 +377,16 @@ class _Emitter:
             )
             return ctor("python:raise", value)
         raise _UnsupportedSyntax(node, f"unhandled statement kind: {type(node).__name__}")
+
+    def except_handler(self, node: ast.ExceptHandler) -> Json:
+        exception_type = none_const() if node.type is None else self.expr(node.type)
+        name = none_const() if node.name is None else str_const(node.name)
+        return ctor(
+            "python:except_handler",
+            exception_type,
+            name,
+            self.statements(node.body),
+        )
 
     def runtime_failure_locus(
         self,
@@ -603,6 +627,10 @@ class _Emitter:
                 )
             )
             return term
+        if isinstance(node, ast.Tuple):
+            return ctor("python:tuple", *[self.expr(element) for element in node.elts])
+        if isinstance(node, ast.List):
+            return ctor("python:list", *[self.expr(element) for element in node.elts])
         if isinstance(node, ast.NamedExpr):
             if not isinstance(node.target, ast.Name):
                 raise _UnsupportedSyntax(
@@ -650,11 +678,12 @@ class _Emitter:
         return result
 
     def call(self, node: ast.Call) -> Json:
-        if node.keywords:
-            raise _UnsupportedSyntax(node, "keyword arguments are refused")
         for arg in node.args:
             if isinstance(arg, ast.Starred):
                 raise _UnsupportedSyntax(arg, "starred call arguments are refused")
+        for keyword in node.keywords:
+            if keyword.arg is None:
+                raise _UnsupportedSyntax(keyword, "starred call arguments are refused")
         if isinstance(node.func, ast.Attribute):
             self.expr(node.func)
         callee = _callee_name(node.func)
@@ -662,7 +691,12 @@ class _Emitter:
             self.effects.add_io()
         else:
             self.effects.add_unresolved_call(callee)
-        return ctor("python:call", str_const(callee), *[self.expr(arg) for arg in node.args])
+        args = [self.expr(arg) for arg in node.args]
+        args.extend(
+            ctor("python:kwarg", str_const(str(keyword.arg)), self.expr(keyword.value))
+            for keyword in node.keywords
+        )
+        return ctor("python:call", str_const(callee), *args)
 
     def subscript_index(self, node: ast.Subscript) -> Json:
         if isinstance(node.slice, ast.Slice):
@@ -754,19 +788,11 @@ def _lift_function(
         non_authoring = [d for d in node.decorator_list if not is_authoring_decorator(d)]
         if non_authoring:
             raise _UnsupportedSyntax(node, "decorated functions are refused")
-        if node.args.vararg is not None or node.args.kwarg is not None:
-            raise _UnsupportedSyntax(node, "*args and **kwargs are refused")
-        if node.args.posonlyargs:
-            raise _UnsupportedSyntax(node, "positional-only parameters are refused")
-        if node.args.kwonlyargs:
-            raise _UnsupportedSyntax(node, "keyword-only parameters are refused")
-        if node.args.defaults or node.args.kw_defaults:
-            raise _UnsupportedSyntax(node, "default parameter values are refused")
+        formals, parameter_shape = _parameter_shape(node)
         refused = _contains_refused_control(node)
         if refused is not None:
             raise refused
 
-        formals = [arg.arg for arg in node.args.args]
         locals_ = _function_locals(node, formals)
         effects = _EffectSet()
         panic_loci: list[Json] = []
@@ -787,6 +813,11 @@ def _lift_function(
             source_path=source_path,
             line=node.lineno,
             panic_loci=panic_loci,
+            parameter_shape=(
+                parameter_shape
+                if _has_nontrivial_parameter_shape(parameter_shape)
+                else None
+            ),
         )
     except _UnsupportedSyntax as exc:
         result.refusals.append(
@@ -798,6 +829,75 @@ def _lift_function(
             )
         )
         return None
+
+
+def _parameter_shape(node: ast.FunctionDef) -> tuple[list[str], list[Json]]:
+    formals: list[str] = []
+    shape: list[Json] = []
+    positional = [*node.args.posonlyargs, *node.args.args]
+    defaults = list(node.args.defaults)
+    default_offset = len(positional) - len(defaults)
+    default_by_index = {
+        index + default_offset: default
+        for index, default in enumerate(defaults)
+    }
+
+    for index, arg in enumerate(node.args.posonlyargs):
+        entry: Json = {"name": arg.arg, "kind": "positional-only"}
+        if index in default_by_index:
+            entry["default"] = _literal_default(default_by_index[index])
+        formals.append(arg.arg)
+        shape.append(entry)
+
+    for local_index, arg in enumerate(node.args.args):
+        index = len(node.args.posonlyargs) + local_index
+        entry = {"name": arg.arg, "kind": "positional-or-keyword"}
+        if index in default_by_index:
+            entry["default"] = _literal_default(default_by_index[index])
+        formals.append(arg.arg)
+        shape.append(entry)
+
+    if node.args.vararg is not None:
+        formals.append(node.args.vararg.arg)
+        shape.append({"name": node.args.vararg.arg, "kind": "vararg"})
+
+    for arg, default in zip(node.args.kwonlyargs, node.args.kw_defaults, strict=True):
+        entry = {"name": arg.arg, "kind": "keyword-only"}
+        if default is not None:
+            entry["default"] = _literal_default(default)
+        formals.append(arg.arg)
+        shape.append(entry)
+
+    if node.args.kwarg is not None:
+        formals.append(node.args.kwarg.arg)
+        shape.append({"name": node.args.kwarg.arg, "kind": "kwarg"})
+
+    return formals, shape
+
+
+def _has_nontrivial_parameter_shape(shape: list[Json]) -> bool:
+    return any(
+        entry.get("kind") != "positional-or-keyword" or "default" in entry
+        for entry in shape
+    )
+
+
+def _literal_default(node: ast.expr) -> Json:
+    if isinstance(node, ast.Constant):
+        value = node.value
+        if isinstance(value, bool):
+            return bool_const(value)
+        if isinstance(value, int):
+            return int_const(value)
+        if isinstance(value, str):
+            return str_const(value)
+        if value is None:
+            return none_const()
+    if isinstance(node, ast.Tuple):
+        return ctor("python:tuple", *[_literal_default(element) for element in node.elts])
+    if isinstance(node, ast.List):
+        return ctor("python:list", *[_literal_default(element) for element in node.elts])
+    raise _UnsupportedSyntax(node, "non-literal default parameter values are refused")
 
 
 def _refusal(

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -2532,6 +2532,13 @@ def test_b1_signature_forms_lift_body_and_preserve_parameter_shape() -> None:
         "args": [_tuple(_var("a"), _var("b"), _var("items"), _var("c"), _var("d"), _var("kwargs"))],
     }
 
+    compiled = compile_ir_document([contract])
+    relifted = lift_source(compiled, "b1_signature.py")
+    relifted_contract = _contract(relifted.ir, ".f")
+    assert relifted.refusals == []
+    assert relifted_contract["formals"] == contract["formals"]
+    assert relifted_contract["parameterShape"] == contract["parameterShape"]
+
 
 def test_b1_signed_integer_defaults_are_literal_parameter_shape() -> None:
     source = "def f(axis=-1, *, step=+2):\n    return (axis, step)\n"
@@ -2603,6 +2610,41 @@ def test_b1_try_lifts_opaque_and_retains_inner_raise_locus() -> None:
     loci = _runtime_failure_loci(contract)
     assert [locus["subkind"] for locus in loci] == ["explicit-raise"]
     assert loci[0]["exceptionClass"] == "ValueError"
+
+
+def test_b1_except_handler_name_is_handler_local_not_module_global() -> None:
+    source = (
+        "err = 'module'\n"
+        "def f():\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError as err:\n"
+        "        return err\n"
+    )
+
+    result = lift_source(source, "b1_except_alias.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    assert {"kind": "reads", "target": "err"} not in contract["effects"]
+
+
+def test_b1_except_handler_name_does_not_leak_after_handler() -> None:
+    source = (
+        "err = 'module'\n"
+        "def f():\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError as err:\n"
+        "        pass\n"
+        "    return err\n"
+    )
+
+    result = lift_source(source, "b1_except_alias_after.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    assert {"kind": "reads", "target": "err"} in contract["effects"]
 
 
 def test_b1_with_statement_remains_refused() -> None:

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -192,6 +192,38 @@ def _call(name: str, *args: dict[str, object]) -> dict[str, object]:
     }
 
 
+def _kwarg(name: str, value: dict[str, object]) -> dict[str, object]:
+    return {
+        "kind": "ctor",
+        "name": "python:kwarg",
+        "args": [_str_const(name), value],
+    }
+
+
+def _tuple(*items: dict[str, object]) -> dict[str, object]:
+    return {"kind": "ctor", "name": "python:tuple", "args": list(items)}
+
+
+def _list(*items: dict[str, object]) -> dict[str, object]:
+    return {"kind": "ctor", "name": "python:list", "args": list(items)}
+
+
+def _bool_const(value: bool) -> dict[str, object]:
+    return {
+        "kind": "const",
+        "value": value,
+        "sort": {"kind": "primitive", "name": "Bool"},
+    }
+
+
+def _int_const(value: int) -> dict[str, object]:
+    return {
+        "kind": "const",
+        "value": value,
+        "sort": {"kind": "primitive", "name": "Int"},
+    }
+
+
 def _unpack_targets(*targets: dict[str, object]) -> dict[str, object]:
     return {
         "kind": "ctor",
@@ -2422,6 +2454,176 @@ def test_slice_13_keeps_complex_unpacking_and_listcomp_out_of_scope(
             "function": f"{module.removesuffix('.py')}.f",
             "line": 2,
             "reason": reason,
+        }
+    ]
+
+
+def test_b1_tuple_and_list_literals_lift_as_faithful_body_terms() -> None:
+    source = (
+        "def f(a, b):\n"
+        "    pair = (a, b)\n"
+        "    xs = [a, b]\n"
+        "    return pair\n"
+    )
+
+    result = lift_source(source, "b1_literals.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    body = contract["post"]["args"][1]
+    statements = body["args"][0]["args"]
+    assert statements[0] == {
+        "kind": "ctor",
+        "name": "python:assign",
+        "args": [_var("pair"), _tuple(_var("a"), _var("b"))],
+    }
+    assert statements[1] == {
+        "kind": "ctor",
+        "name": "python:assign",
+        "args": [_var("xs"), _list(_var("a"), _var("b"))],
+    }
+
+
+def test_b1_keyword_call_arguments_preserve_names_and_order() -> None:
+    source = "def f(a, b):\n    return make(a, dtype=b, copy=False)\n"
+
+    result = lift_source(source, "b1_kwargs.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    body = contract["post"]["args"][1]
+    assert body == {
+        "kind": "ctor",
+        "name": "python:return",
+        "args": [
+            _call(
+                "make",
+                _var("a"),
+                _kwarg("dtype", _var("b")),
+                _kwarg("copy", _bool_const(False)),
+            )
+        ],
+    }
+
+
+def test_b1_signature_forms_lift_body_and_preserve_parameter_shape() -> None:
+    source = (
+        "def f(a, /, b=None, *items, c=True, d=(1, 'x'), **kwargs):\n"
+        "    return (a, b, items, c, d, kwargs)\n"
+    )
+
+    result = lift_source(source, "b1_signature.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    assert contract["formals"] == ["a", "b", "items", "c", "d", "kwargs"]
+    assert contract["parameterShape"] == [
+        {"name": "a", "kind": "positional-only"},
+        {"name": "b", "kind": "positional-or-keyword", "default": _none_const()},
+        {"name": "items", "kind": "vararg"},
+        {"name": "c", "kind": "keyword-only", "default": _bool_const(True)},
+        {"name": "d", "kind": "keyword-only", "default": _tuple(_int_const(1), _str_const("x"))},
+        {"name": "kwargs", "kind": "kwarg"},
+    ]
+    body = contract["post"]["args"][1]
+    assert body == {
+        "kind": "ctor",
+        "name": "python:return",
+        "args": [_tuple(_var("a"), _var("b"), _var("items"), _var("c"), _var("d"), _var("kwargs"))],
+    }
+
+
+def test_b1_nonliteral_default_remains_refused_as_definition_time_hazard() -> None:
+    result = lift_source("def f(x=make()):\n    return x\n", "b1_default_refusal.py")
+
+    assert result.refusals == [
+        {
+            "kind": "unhandled-syntax",
+            "function": "b1_default_refusal.f",
+            "line": 1,
+            "reason": "non-literal default parameter values are refused",
+        }
+    ]
+
+
+def test_b1_try_lifts_opaque_and_retains_inner_raise_locus() -> None:
+    source = (
+        "def f(flag):\n"
+        "    try:\n"
+        "        if flag:\n"
+        "            raise ValueError\n"
+        "    except ValueError:\n"
+        "        return 0\n"
+        "    return 1\n"
+    )
+
+    result = lift_source(source, "b1_try.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    body = contract["post"]["args"][1]
+    first_stmt = body["args"][0]
+    assert first_stmt["name"] == "python:try"
+    loci = _runtime_failure_loci(contract)
+    assert [locus["subkind"] for locus in loci] == ["explicit-raise"]
+    assert loci[0]["exceptionClass"] == "ValueError"
+
+
+def test_b1_with_statement_remains_refused() -> None:
+    source = "def f(lock):\n    with lock:\n        return 1\n"
+
+    result = lift_source(source, "b1_with_refusal.py")
+
+    assert result.refusals == [
+        {
+            "kind": "unhandled-syntax",
+            "function": "b1_with_refusal.f",
+            "line": 2,
+            "reason": "with statements are refused",
+        }
+    ]
+
+
+def test_b1_decorated_functions_remain_deferred() -> None:
+    source = (
+        "def dispatcher(a):\n"
+        "    return (a,)\n"
+        "\n"
+        "@array_function_dispatch(dispatcher)\n"
+        "def f(a):\n"
+        "    return a.name\n"
+    )
+
+    result = lift_source(source, "b1_decorator_refusal.py")
+
+    assert result.refusals == [
+        {
+            "kind": "unhandled-syntax",
+            "function": "b1_decorator_refusal.f",
+            "line": 5,
+            "reason": "decorated functions are refused",
+        }
+    ]
+
+
+def test_b1_starred_call_and_dynamic_callee_stay_out_of_scope() -> None:
+    starred = lift_source("def f(xs):\n    return make(*xs)\n", "b1_starred_call.py")
+    dynamic = lift_source("def f(factory):\n    return factory()(1)\n", "b1_dynamic_callee.py")
+
+    assert starred.refusals == [
+        {
+            "kind": "unhandled-syntax",
+            "function": "b1_starred_call.f",
+            "line": 2,
+            "reason": "starred call arguments are refused",
+        }
+    ]
+    assert dynamic.refusals == [
+        {
+            "kind": "unhandled-syntax",
+            "function": "b1_dynamic_callee.f",
+            "line": 2,
+            "reason": "unsupported callee kind: Call",
         }
     ]
 

--- a/implementations/python/provekit-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_lifter.py
@@ -2533,6 +2533,19 @@ def test_b1_signature_forms_lift_body_and_preserve_parameter_shape() -> None:
     }
 
 
+def test_b1_signed_integer_defaults_are_literal_parameter_shape() -> None:
+    source = "def f(axis=-1, *, step=+2):\n    return (axis, step)\n"
+
+    result = lift_source(source, "b1_signed_defaults.py")
+
+    assert result.refusals == []
+    contract = _contract(result.ir, ".f")
+    assert contract["parameterShape"] == [
+        {"name": "axis", "kind": "positional-or-keyword", "default": _int_const(-1)},
+        {"name": "step", "kind": "keyword-only", "default": _int_const(2)},
+    ]
+
+
 def test_b1_nonliteral_default_remains_refused_as_definition_time_hazard() -> None:
     result = lift_source("def f(x=make()):\n    return x\n", "b1_default_refusal.py")
 
@@ -2540,6 +2553,29 @@ def test_b1_nonliteral_default_remains_refused_as_definition_time_hazard() -> No
         {
             "kind": "unhandled-syntax",
             "function": "b1_default_refusal.f",
+            "line": 1,
+            "reason": "non-literal default parameter values are refused",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("source", "module"),
+    [
+        ("def f(x=-y):\n    return x\n", "b1_unary_name_default_refusal.py"),
+        ("def f(x=~0):\n    return x\n", "b1_unary_invert_default_refusal.py"),
+    ],
+)
+def test_b1_unary_defaults_remain_refused_unless_signed_integer_literal(
+    source: str,
+    module: str,
+) -> None:
+    result = lift_source(source, module)
+
+    assert result.refusals == [
+        {
+            "kind": "unhandled-syntax",
+            "function": f"{module.removesuffix('.py')}.f",
             "line": 1,
             "reason": "non-literal default parameter values are refused",
         }


### PR DESCRIPTION
## Summary

Python lifter coverage (B1): NumPy Python-layer surface visibility.

This extends the Python source lifter to cover the low-risk B1 surface needed before any NumPy discharge work:

- tuple/list expression terms and keyword call arguments
- nontrivial parameter shapes for positional-only, keyword-only, vararg, kwarg, and literal defaults
- literal-defaults-only gate, including signed integer literal defaults such as `axis=-1`; non-literal defaults remain refused
- opaque `try` terms that retain inner panic loci without claiming catch/suppression discharge
- `except ... as name` is handler-scoped for local/global read classification
- explicit `with` refusal

This is kit-side Python lifter/compiler work only: no verifier or discharge changes.

## NumPy Visibility Gate

Target: NumPy selected-more 12-module recon scratch.

Before B1:

- 35 IR functions
- 214 refusals
- 45 runtime-failure loci

After B1:

- 113 IR functions
- 136 refusals
- 191 runtime-failure loci
- diagnostics: 0
- opacity: 0
- callEdges: 0

The signed-default and try-handler review follow-ups did not change this selected-more sample's aggregate counts, which remain 113 / 136 / 191.

The K delta is intentionally +0. Quick prove over the B1 mint reports 190 total callsites, 0 discharged, 190 violations/undecidable, all `NoBridgeTarget`. The win here is visibility: NumPy's Python-layer panic surface is now measurable instead of hidden by lifter refusals.

Floors from the prove gate:

- `falsePass=0`
- `silentlyDropped=0`
- `droppedSites=[]`
- `loadErrors=[]`

The mint/prove count difference, 191 loci vs 190 rows, was inspected: the only aggregate mismatch is `numpy/ma/extras.py:1347`, where two `aux[:-1]` occurrences on the same line produce the same obligation. This is a benign same-obligation collapse, not a dropped site.

## Deferrals

These remain intentionally out of B1:

- decorators: 72 remaining refusals, deferred to B2 with wrapper/opacity semantics
- non-literal defaults: definition-time panic loci need a dedicated model
- `with`, `JoinedStr`, comprehensions/generators, starred/dynamic callees, imports
- attribute-safety discharge and runtime leaf bridge/catalog work

## Validation

- RED: added B1 tests for the new forms; initial B1 run had 7 failing gates; signed-default follow-up had a targeted RED for `axis=-1`; try-handler follow-up had REDs for handler alias local/global scoping and parameterShape round-trip
- GREEN: `PYTHONPATH=implementations/python/provekit-lift-python-source/src pytest implementations/python/provekit-lift-python-source/tests -q` -> 228 passed
- `git diff --check` -> clean
- NumPy B1 mint/prove gate as summarized above
