### PR TITLE
feat(lsp): Python editor LSP — provekit prove becomes a red squiggle

### DIFF
--- a/docs/quickstart-end-user.md
+++ b/docs/quickstart-end-user.md
@@ -184,12 +184,22 @@ kit's config and manifest before a run.
 
 ## Editor integration
 
-A real editor integration (an inline red squiggle when a contract is violated)
-is a roadmap item, not a shipped `provekit` subcommand. The `provekit-lsp` and
-`provekit-linkerd` binaries exist in the repo, but the editor workflow is not
-driven by any current CLI subcommand and is not covered here. The kit RPC
-surface that exists today is a batch plugin protocol the CLI spawns per
-invocation; see [docs/quickstart-extender.md](quickstart-extender.md).
+For Python, the red squiggle is shipped. `provekit-editor-lsp-python` is a
+persistent editor language server (LSP wire protocol) that renders `provekit
+prove` directly: open a file in an LSP-capable editor and a contradicted
+contract surfaces as an inline error diagnostic on the offending call. On open
+and save it re-evaluates your project as it is on disk (it lifts the current
+source into an isolated workspace and proves it, so the squiggle tracks the
+buffer and never writes to your tree) and maps each unsatisfied obligation back
+to its callsite. The squiggle on `np.add(2, 3) == 6` in the Step 4 consumer is
+the same verdict prove prints, and it clears the moment you fix it to `== 5`. The
+server is a thin client: verification still lives in the rust CLI; the editor
+just renders it.
+
+The cross-language, daemon-routed editor server (the `provekit-lsp` /
+`provekit-linkerd` binaries) is still a roadmap item. The Python server above is
+the language-native path; see [docs/quickstart-extender.md](quickstart-extender.md)
+for how it is built and how to add one for another language.
 
 ## When something goes wrong
 

--- a/docs/quickstart-extender.md
+++ b/docs/quickstart-extender.md
@@ -240,15 +240,39 @@ witness package of CID-named bodies (see
 [docs/how-to/publishing-a-proof.md](how-to/publishing-a-proof.md)). The kit never
 grades itself.
 
-### Future direction: a real editor LSP (not yet built)
+### A real editor LSP (shipped for Python)
 
 A real editor language server, where a `provekit prove` or `verify`
 contradiction surfaces as an inline diagnostic (a red squiggle on the offending
-line), is the next gap, not a shipped feature. One kit,
-`implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/lsp.py`,
-carries the seed: it advertises an `analyzeDocument` method and a `parse` path
-that returns `diagnostics`. That seed is where the editor integration would grow.
-Today it is a batch plugin handler, not a persistent server an editor holds open.
+line), exists for Python:
+`implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/editor_lsp.py`,
+exposed as the `provekit-editor-lsp-python` console script. Unlike the batch
+lift plugin (`lsp.py`, the provekit-lift/1 NDJSON protocol the CLI spawns per
+invocation), this is a persistent stdio server speaking the LSP base wire
+protocol (Content-Length-framed JSON-RPC): `initialize`, `didOpen`, `didChange`,
+`didSave`, `publishDiagnostics`.
+
+It is a thin client over `provekit prove`. On open and save it runs `provekit
+prove --json` over the document's project, and for each unsatisfied obligation it
+recovers the callsite from the report's `#euf#` property term, matches it against
+the document AST, and publishes an `Error`-severity diagnostic on that call. The
+prove runner is injected, so the protocol is testable without the toolchain
+(`tests/test_editor_lsp.py` drives the wire with the real captured report, plus a
+skip-guarded end-to-end test that spawns the real CLI). Verification stays in the
+rust CLI; the server never grades correctness itself.
+
+Two boundaries are deliberate. Diagnostics refresh on open and save (against the
+on-disk project); live dirty-buffer analysis ("squiggle as you type") would need
+a buffer overlay so prove does not run against stale disk, and is not done yet.
+And this is the Python-kit-native server; the cross-language, linker-daemon-routed
+editor server (the rust `provekit-lsp` / `provekit-linkerd` binaries) is still
+roadmap. To add a squiggle server for another language, mirror `editor_lsp.py`:
+the wire protocol and prove-report rendering are language-agnostic; only the
+callsite-recovery AST pass is language-specific.
+
+The older `lsp.py` `analyzeDocument` method (a forward-propagation demo over a
+fixed `checkPositive` contract) remains as-is; it predates this server and backs
+the `provekit_lsp` forward-propagator demo and the rust linker tests.
 
 ## Extend the protocol
 

--- a/implementations/python/provekit-lift-py-tests/pyproject.toml
+++ b/implementations/python/provekit-lift-py-tests/pyproject.toml
@@ -22,6 +22,9 @@ test = ["pytest>=7"]
 [project.scripts]
 provekit-lsp-python = "provekit_lift_py_tests.lsp:main"
 provekit-lift-python = "provekit_lift_py_tests.lsp:main"
+# The persistent editor language server (LSP wire protocol; renders `provekit
+# prove` as red squiggles). Distinct from the batch lift plugin above.
+provekit-editor-lsp-python = "provekit_lift_py_tests.editor_lsp:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/editor_lsp.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/editor_lsp.py
@@ -1,0 +1,528 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# provekit editor LSP: a REAL editor language server for Python.
+#
+# This is the "red squiggle" gap, closed. The batch lift plugin (`lsp.py`) speaks
+# the provekit-lift/1 NDJSON protocol the CLI spawns per invocation; it is NOT a
+# server an editor holds open. THIS module is: a persistent stdio server speaking
+# the Language Server Protocol base wire format (Content-Length-framed JSON-RPC),
+# so an editor that opens a Python file gets diagnostics back.
+#
+# The diagnostic IS the `provekit prove` verdict. On didOpen/didSave the server
+# evaluates the document's project AS IT IS ON DISK and turns every unsatisfied
+# obligation into an LSP Diagnostic with severity Error -- the red squiggle. The
+# headline case: a consumer that asserts `np.add(2,3) == 6` while inheriting
+# `== 5` from a vendor `.proof` in `.provekit/imports/`. `prove` reports that
+# callsite UNSAT (the conjoined contracts contradict); the squiggle lands on the
+# offending call, and CLEARS when the source is fixed to `== 5`.
+#
+# Because `prove` reads minted `.proof` artifacts (not source), the server mints
+# the current source into a FRESH isolated workspace and proves that -- so the
+# squiggle tracks the buffer on save, not stale mint output, and never writes to
+# the user's tree. See `run_prove_report`.
+#
+# TRUST BOUNDARY: verification lives in the rust CLI, exactly as everywhere else.
+# This server is a thin client: it spawns `provekit prove`, reads its machine
+# report, and renders it. It never decides correctness itself. The prove-runner
+# is injectable so the wire protocol is testable without the toolchain.
+#
+# This is DISTINCT from the rust `provekit-lsp` crate, which is the cross-language
+# linker-daemon-routed editor server (roadmap). This one is the Python-kit-native
+# server that renders `provekit prove` directly.
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from typing import Any, BinaryIO, Dict, List, Optional, Tuple
+
+# LSP DiagnosticSeverity. 1 = Error (the red squiggle).
+SEVERITY_ERROR = 1
+SEVERITY_WARNING = 2
+
+SERVER_NAME = "provekit-editor-lsp-python"
+SERVER_VERSION = "0.1.0"
+DIAGNOSTIC_SOURCE = "provekit"
+
+
+# ---------------------------------------------------------------------------
+# LSP base wire protocol: Content-Length-framed JSON-RPC over stdio.
+# ---------------------------------------------------------------------------
+
+
+def read_message(stream: BinaryIO) -> Optional[dict]:
+    """Read one LSP message: `Content-Length: N\\r\\n` headers, blank line, N
+    bytes of JSON. Returns None at EOF (the editor closed the pipe)."""
+    headers: Dict[str, str] = {}
+    while True:
+        line = stream.readline()
+        if not line:
+            return None
+        line = line.rstrip(b"\r\n")
+        if line == b"":
+            break  # end of headers
+        if b":" in line:
+            key, _, val = line.partition(b":")
+            headers[key.strip().decode("ascii").lower()] = val.strip().decode("ascii")
+    length = int(headers.get("content-length", "0"))
+    if length <= 0:
+        return None
+    body = stream.read(length)
+    if len(body) < length:
+        return None
+    try:
+        return json.loads(body.decode("utf-8"))
+    except json.JSONDecodeError:
+        return None
+
+
+def write_message(stream: BinaryIO, obj: dict) -> None:
+    """Frame and write one LSP message."""
+    body = json.dumps(obj, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    stream.write(b"Content-Length: " + str(len(body)).encode("ascii") + b"\r\n\r\n")
+    stream.write(body)
+    stream.flush()
+
+
+# ---------------------------------------------------------------------------
+# Anchoring: a prove violation -> a source range in THIS document.
+#
+# The verifier's consistency rows carry `file: null, line: null` (a conjoined
+# contradiction is a property of a callsite term, not a single source line). The
+# anchor lives in the `property` string: `consistency:<callee>#euf#...(<args>)...`.
+# We decode the callee + literal int args and find the matching call node in the
+# document's AST -- that call's line is where the squiggle belongs.
+# ---------------------------------------------------------------------------
+
+_PROPERTY_CALLEE = re.compile(r"^(?:consistency:)?(?P<callee>[A-Za-z_][\w.]*)#euf#")
+_PROPERTY_ARGS = re.compile(r"\(([^)]*)\)")
+_INT_ARG = re.compile(r"i:(-?\d+)")
+
+
+def _decode_property(property_str: str) -> Optional[Tuple[str, List[int]]]:
+    """Decode `consistency:numpy.add#euf#c:callresult_numpy_add_a2(i:2,i:3)::assertion`
+    into ("numpy.add", [2, 3]). Returns None when the shape is not a callsite EUF
+    term (e.g. a whole-test property we cannot anchor to a specific call)."""
+    m = _PROPERTY_CALLEE.match(property_str)
+    if not m:
+        return None
+    callee = m.group("callee")
+    args: List[int] = []
+    arg_match = _PROPERTY_ARGS.search(property_str)
+    if arg_match:
+        args = [int(x) for x in _INT_ARG.findall(arg_match.group(1))]
+    return callee, args
+
+
+def _module_aliases(tree: ast.Module) -> Dict[str, str]:
+    """Map the names bound by imports to their module: `import numpy as np` ->
+    {np: numpy}; `import numpy` -> {numpy: numpy}; `import a.b` binds top-level
+    `a` -> a (Python binds the top package, not the submodule)."""
+    aliases: Dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.asname:
+                    aliases[alias.asname] = alias.name
+                else:
+                    top = alias.name.split(".")[0]
+                    aliases[top] = top
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                bound = alias.asname or alias.name
+                aliases[bound] = f"{node.module}.{alias.name}"
+    return aliases
+
+
+def _qualified_callee(func: ast.expr, aliases: Dict[str, str]) -> Optional[str]:
+    """Resolve a call's func expression to a dotted callee, applying import
+    aliases at the head: `np.add` -> `numpy.add`."""
+    parts: List[str] = []
+    cur: Optional[ast.expr] = func
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        head = aliases.get(cur.id, cur.id)
+        parts.append(head)
+    else:
+        return None
+    parts.reverse()
+    return ".".join(parts)
+
+
+def _int_args(call: ast.Call) -> Optional[List[int]]:
+    """The call's positional args IF they are all integer literals (matching the
+    EUF arg signature `(i:2,i:3)`). Returns None when any arg isn't an int."""
+    out: List[int] = []
+    for arg in call.args:
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, int) and not isinstance(arg.value, bool):
+            out.append(arg.value)
+        elif (
+            isinstance(arg, ast.UnaryOp)
+            and isinstance(arg.op, ast.USub)
+            and isinstance(arg.operand, ast.Constant)
+            and isinstance(arg.operand.value, int)
+        ):
+            out.append(-arg.operand.value)
+        else:
+            return None
+    return out
+
+
+def _find_callsites(tree: ast.Module, callee: str, args: List[int]) -> List[ast.Call]:
+    """Every call in the document whose resolved callee + integer args match."""
+    aliases = _module_aliases(tree)
+    hits: List[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if _qualified_callee(node.func, aliases) != callee:
+            continue
+        if args and _int_args(node) != args:
+            continue
+        hits.append(node)
+    return hits
+
+
+def _range_of(node: ast.AST) -> Dict[str, Dict[str, int]]:
+    """LSP Range (0-based lines/characters) covering an AST node."""
+    start_line = max(getattr(node, "lineno", 1) - 1, 0)
+    start_char = getattr(node, "col_offset", 0)
+    end_line = max(getattr(node, "end_lineno", getattr(node, "lineno", 1)) - 1, 0)
+    end_char = getattr(node, "end_col_offset", start_char)
+    return {
+        "start": {"line": start_line, "character": start_char},
+        "end": {"line": end_line, "character": end_char},
+    }
+
+
+def _whole_line_range(line_1based: int) -> Dict[str, Dict[str, int]]:
+    line = max(line_1based - 1, 0)
+    return {"start": {"line": line, "character": 0}, "end": {"line": line, "character": 200}}
+
+
+# ---------------------------------------------------------------------------
+# The analysis: prove report + document text -> LSP diagnostics.
+# ---------------------------------------------------------------------------
+
+
+def syntax_diagnostics(text: str, path: str) -> List[Dict[str, Any]]:
+    try:
+        ast.parse(text, filename=path)
+        return []
+    except SyntaxError as e:
+        line = e.lineno or 1
+        char = max((e.offset or 1) - 1, 0)
+        return [
+            {
+                "range": {
+                    "start": {"line": max(line - 1, 0), "character": char},
+                    "end": {"line": max(line - 1, 0), "character": char + 1},
+                },
+                "severity": SEVERITY_ERROR,
+                "source": DIAGNOSTIC_SOURCE,
+                "code": "provekit.parse_error",
+                "message": str(e),
+            }
+        ]
+
+
+def _row_is_violation(row: dict) -> bool:
+    status = str(row.get("status", ""))
+    return status not in ("discharged", "ok", "vacuous", "")
+
+
+def prove_diagnostics(text: str, path: str, report: dict) -> List[Dict[str, Any]]:
+    """Turn a `provekit prove --json` report into diagnostics for THIS document.
+
+    A violation row's callsite is decoded from its `property` and matched against
+    calls in this file. Only rows whose call lives here produce a squiggle (prove
+    is project-wide; a diagnostic belongs in the file holding the offending call).
+    """
+    try:
+        tree = ast.parse(text, filename=path)
+    except SyntaxError:
+        return []  # syntax errors are reported separately; can't anchor on a broken tree
+
+    diagnostics: List[Dict[str, Any]] = []
+    for row in report.get("rows", []):
+        if not _row_is_violation(row):
+            continue
+        message = str(row.get("reason") or row.get("property") or "obligation unsatisfied")
+        code = str(row.get("property") or "provekit.unsatisfied")
+        decoded = _decode_property(str(row.get("property", "")))
+
+        ranges: List[Dict[str, Dict[str, int]]] = []
+        # 1. The producer told us a concrete line: trust it.
+        if row.get("file") and row.get("line"):
+            same_file = os.path.basename(str(row["file"])) == os.path.basename(path)
+            if same_file:
+                ranges.append(_whole_line_range(int(row["line"])))
+        # 2. Otherwise recover the callsite from the document AST.
+        if not ranges and decoded is not None:
+            callee, args = decoded
+            ranges = [_range_of(c) for c in _find_callsites(tree, callee, args)]
+
+        for rng in ranges:
+            diagnostics.append(
+                {
+                    "range": rng,
+                    "severity": SEVERITY_ERROR,
+                    "source": DIAGNOSTIC_SOURCE,
+                    "code": code,
+                    "message": message,
+                }
+            )
+    return diagnostics
+
+
+def diagnostics_for(
+    text: str,
+    path: str,
+    *,
+    prove_report: Optional[dict] = None,
+) -> List[Dict[str, Any]]:
+    """All diagnostics for a document. Syntax errors always; prove-backed
+    squiggles when a report is supplied (syntax errors suppress prove, since a
+    broken parse has no trustworthy callsites)."""
+    syn = syntax_diagnostics(text, path)
+    if syn:
+        return syn
+    if prove_report is None:
+        return []
+    return prove_diagnostics(text, path, prove_report)
+
+
+# ---------------------------------------------------------------------------
+# The prove runner (the injectable trust boundary).
+# ---------------------------------------------------------------------------
+
+
+def find_project_root(path: str) -> Optional[str]:
+    """Walk up from a file to the nearest directory containing `.provekit/`."""
+    cur = os.path.dirname(os.path.abspath(path))
+    while True:
+        if os.path.isdir(os.path.join(cur, ".provekit")):
+            return cur
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            return None
+        cur = parent
+
+
+def _provekit_binary() -> Optional[str]:
+    env = os.environ.get("PROVEKIT_CLI")
+    if env and os.path.exists(env):
+        return env
+    return shutil.which("provekit")
+
+
+def _parse_report(stdout: str) -> Optional[dict]:
+    for chunk in (stdout, stdout.strip()):
+        try:
+            return json.loads(chunk)
+        except (json.JSONDecodeError, TypeError):
+            continue
+    start = stdout.find("{")  # a pretty header may precede the JSON
+    if start >= 0:
+        try:
+            return json.loads(stdout[start:])
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def run_prove_report(path: str) -> Optional[dict]:
+    """Evaluate the document's project AS IT IS ON DISK NOW and return the
+    `provekit prove --json` report.
+
+    `prove` reads MINTED `.proof` artifacts, not source -- so a bare `prove` would
+    report the last mint, and the squiggle would lag the edit (and re-minting in
+    place accumulates stale CID-named proofs that re-introduce the contradiction).
+    Instead we mint the current source into a FRESH isolated workspace and prove
+    THAT: the project's config + inherited `.provekit/imports/` proofs are copied
+    in, `mint` lifts the live source into the temp dir, and `prove` runs against
+    only those. The user's tree is never written to, and there is no stale
+    accumulation -- the report reflects exactly what is on disk.
+
+    Returns None when there is no project, no CLI, or mint/prove cannot run -- the
+    editor shows no provekit diagnostics rather than a wrong one.
+    """
+    root = find_project_root(path)
+    if root is None:
+        return None
+    binary = _provekit_binary()
+    if binary is None:
+        return None
+    config = os.path.join(root, ".provekit", "config.toml")
+    if not os.path.isfile(config):
+        return None
+
+    import tempfile
+
+    workspace = tempfile.mkdtemp(prefix="provekit-lsp-")
+    try:
+        ws_provekit = os.path.join(workspace, ".provekit")
+        ws_imports = os.path.join(ws_provekit, "imports")
+        os.makedirs(ws_imports, exist_ok=True)
+        shutil.copy(config, os.path.join(ws_provekit, "config.toml"))
+        src_imports = os.path.join(root, ".provekit", "imports")
+        if os.path.isdir(src_imports):
+            for name in os.listdir(src_imports):
+                if name.endswith(".proof"):
+                    shutil.copy(os.path.join(src_imports, name), os.path.join(ws_imports, name))
+        try:
+            # mint reads the project's source + manifests in place (cwd=root) and
+            # writes the freshly-lifted proof into the isolated workspace.
+            mint = subprocess.run(
+                [binary, "mint", "--out", workspace, "--quiet"],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            if mint.returncode != 0:
+                return None
+            prove = subprocess.run(
+                [binary, "prove", "--json", workspace],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+        return _parse_report(prove.stdout)
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# The server.
+# ---------------------------------------------------------------------------
+
+
+def _uri_to_path(uri: str) -> str:
+    if uri.startswith("file://"):
+        rest = uri[len("file://"):]
+        # file:///abs/path -> /abs/path
+        return rest if rest.startswith("/") else rest
+    return uri
+
+
+class Server:
+    """A persistent LSP server. `prove_runner` is injected so the wire protocol
+    is testable without the rust toolchain (the default runs the real CLI)."""
+
+    def __init__(self, instream: BinaryIO, outstream: BinaryIO, prove_runner=run_prove_report):
+        self._in = instream
+        self._out = outstream
+        self._prove = prove_runner
+        self._docs: Dict[str, str] = {}
+        self._shutdown = False
+
+    # -- transport ---------------------------------------------------------
+
+    def _notify(self, method: str, params: dict) -> None:
+        write_message(self._out, {"jsonrpc": "2.0", "method": method, "params": params})
+
+    def _reply(self, msg_id: Any, result: Any) -> None:
+        write_message(self._out, {"jsonrpc": "2.0", "id": msg_id, "result": result})
+
+    # -- diagnostics -------------------------------------------------------
+
+    def _publish(self, uri: str, *, run_prove: bool) -> None:
+        text = self._docs.get(uri, "")
+        path = _uri_to_path(uri)
+        report = self._prove(path) if run_prove else None
+        diags = diagnostics_for(text, path, prove_report=report)
+        self._notify("textDocument/publishDiagnostics", {"uri": uri, "diagnostics": diags})
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def _on_initialize(self, msg_id: Any) -> None:
+        self._reply(
+            msg_id,
+            {
+                "capabilities": {
+                    # 1 = full document sync (the editor sends the whole text).
+                    "textDocumentSync": {"openClose": True, "change": 1, "save": True},
+                },
+                "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
+            },
+        )
+
+    def handle(self, msg: dict) -> bool:
+        """Dispatch one message. Returns False when the server should stop."""
+        method = msg.get("method")
+        msg_id = msg.get("id")
+        params = msg.get("params") or {}
+
+        if method == "initialize":
+            self._on_initialize(msg_id)
+        elif method == "initialized":
+            pass  # notification, no reply
+        elif method == "textDocument/didOpen":
+            doc = params.get("textDocument", {})
+            uri = doc.get("uri", "")
+            self._docs[uri] = doc.get("text", "")
+            self._publish(uri, run_prove=True)
+        elif method == "textDocument/didChange":
+            uri = params.get("textDocument", {}).get("uri", "")
+            changes = params.get("contentChanges", [])
+            if changes:
+                # Full-sync: the last change carries the whole document.
+                self._docs[uri] = changes[-1].get("text", self._docs.get(uri, ""))
+            # On edit, refresh syntax only (cheap, live); prove-backed squiggles
+            # refresh on save, against the on-disk project.
+            self._publish(uri, run_prove=False)
+        elif method == "textDocument/didSave":
+            uri = params.get("textDocument", {}).get("uri", "")
+            if "text" in params:
+                self._docs[uri] = params["text"]
+            self._publish(uri, run_prove=True)
+        elif method == "textDocument/didClose":
+            uri = params.get("textDocument", {}).get("uri", "")
+            self._docs.pop(uri, None)
+            self._notify("textDocument/publishDiagnostics", {"uri": uri, "diagnostics": []})
+        elif method == "shutdown":
+            self._shutdown = True
+            self._reply(msg_id, None)
+        elif method == "exit":
+            return False
+        elif msg_id is not None:
+            # Unknown request: reply with a MethodNotFound error so the client
+            # isn't left waiting.
+            write_message(
+                self._out,
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "error": {"code": -32601, "message": f"method not found: {method}"},
+                },
+            )
+        return True
+
+    def serve_forever(self) -> int:
+        while True:
+            msg = read_message(self._in)
+            if msg is None:
+                break
+            if not self.handle(msg):
+                break
+        return 0 if self._shutdown else 1
+
+
+def main() -> None:
+    server = Server(sys.stdin.buffer, sys.stdout.buffer)
+    sys.exit(server.serve_forever())
+
+
+if __name__ == "__main__":
+    main()

--- a/implementations/python/provekit-lift-py-tests/tests/test_editor_lsp.py
+++ b/implementations/python/provekit-lift-py-tests/tests/test_editor_lsp.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Wire-level tests for the editor LSP: drive the server over the real
+# Content-Length-framed LSP protocol and assert the diagnostics it publishes.
+#
+# The prove-runner is injected with the REAL `provekit prove --json` report shape
+# (captured from the numpy inheritance contradiction), so these run hermetically
+# without the rust toolchain. A skip-guarded integration test exercises the live
+# CLI end to end.
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from provekit_lift_py_tests import editor_lsp as e
+
+
+# --- wire helpers -------------------------------------------------------------
+
+
+def _frame(obj: dict) -> bytes:
+    body = json.dumps(obj).encode("utf-8")
+    return b"Content-Length: " + str(len(body)).encode() + b"\r\n\r\n" + body
+
+
+def _drive(messages, prove_runner):
+    """Feed framed `messages` through a Server and return the parsed outbound
+    messages (replies + notifications), in order."""
+    instream = io.BytesIO(b"".join(_frame(m) for m in messages))
+    outstream = io.BytesIO()
+    server = e.Server(instream, outstream, prove_runner=prove_runner)
+    server.serve_forever()
+    outstream.seek(0)
+    out = []
+    while True:
+        msg = e.read_message(outstream)
+        if msg is None:
+            break
+        out.append(msg)
+    return out
+
+
+def _diagnostics(out, uri):
+    for msg in out:
+        if msg.get("method") == "textDocument/publishDiagnostics" and msg["params"]["uri"] == uri:
+            return msg["params"]["diagnostics"]
+    return None
+
+
+# The REAL violation report `provekit prove --json` emits for the np.add(2,3)
+# ==6-vs-inherited-==5 contradiction (file/line null -> anchored via the AST).
+_CONTRADICTION_REPORT = {
+    "violations": 1,
+    "rows": [
+        {
+            "property": "consistency:numpy.add#euf#c:callresult_numpy_add_a2(i:2,i:3)::assertion",
+            "status": "unsatisfied",
+            "reason": (
+                "test assertions contradictory about callsite "
+                "`numpy.add#euf#c:callresult_numpy_add_a2(i:2,i:3)::assertion` "
+                "[solver 'z3' returned unsat (obligation holds)]"
+            ),
+            "file": None,
+            "line": None,
+        }
+    ],
+}
+_DISCHARGED_REPORT = {
+    "violations": 0,
+    "rows": [
+        {
+            "property": "consistency:numpy.add#euf#c:callresult_numpy_add_a2(i:2,i:3)::assertion",
+            "status": "discharged",
+            "file": None,
+            "line": None,
+        }
+    ],
+}
+
+_CONSUMER_BAD = "import numpy as np\n\n\ndef test_c():\n    assert np.add(2, 3) == 6\n"
+_CONSUMER_OK = "import numpy as np\n\n\ndef test_c():\n    assert np.add(2, 3) == 5\n"
+_URI = "file:///proj/test_consumer.py"
+
+
+def _open_seq(uri, text):
+    return [
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        {"jsonrpc": "2.0", "method": "initialized", "params": {}},
+        {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {"textDocument": {"uri": uri, "languageId": "python", "version": 1, "text": text}},
+        },
+        {"jsonrpc": "2.0", "id": 2, "method": "shutdown"},
+        {"jsonrpc": "2.0", "method": "exit"},
+    ]
+
+
+# --- lifecycle ----------------------------------------------------------------
+
+
+def test_initialize_advertises_textdocumentsync():
+    out = _drive(
+        [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            {"jsonrpc": "2.0", "id": 2, "method": "shutdown"},
+            {"jsonrpc": "2.0", "method": "exit"},
+        ],
+        prove_runner=lambda _p: None,
+    )
+    init = next(m for m in out if m.get("id") == 1)
+    caps = init["result"]["capabilities"]
+    assert caps["textDocumentSync"]["openClose"] is True
+    assert caps["textDocumentSync"]["save"] is True
+    assert init["result"]["serverInfo"]["name"] == e.SERVER_NAME
+
+
+def test_shutdown_then_exit_is_clean():
+    # serve_forever returns 0 only when shutdown preceded exit; we assert the
+    # shutdown reply is null per spec.
+    out = _drive(
+        [
+            {"jsonrpc": "2.0", "id": 9, "method": "shutdown"},
+            {"jsonrpc": "2.0", "method": "exit"},
+        ],
+        prove_runner=lambda _p: None,
+    )
+    assert next(m for m in out if m.get("id") == 9)["result"] is None
+
+
+# --- the squiggle (positive + negative discrimination) ------------------------
+
+
+def test_didopen_contradiction_squiggles_the_offending_call():
+    out = _drive(_open_seq(_URI, _CONSUMER_BAD), prove_runner=lambda _p: _CONTRADICTION_REPORT)
+    diags = _diagnostics(out, _URI)
+    assert diags, "the contradicting consumer must publish a diagnostic"
+    assert len(diags) == 1
+    d = diags[0]
+    assert d["severity"] == e.SEVERITY_ERROR, "a prove contradiction is an ERROR squiggle"
+    assert d["source"] == "provekit"
+    # the np.add(2, 3) call is on source line 5 -> 0-based line 4
+    assert d["range"]["start"]["line"] == 4, d["range"]
+    assert "contradictory" in d["message"]
+
+
+def test_didopen_consistent_consumer_publishes_no_diagnostics():
+    out = _drive(_open_seq(_URI, _CONSUMER_OK), prove_runner=lambda _p: _DISCHARGED_REPORT)
+    assert _diagnostics(out, _URI) == [], "the agreeing consumer must have a clean buffer"
+
+
+def test_syntax_error_squiggles_without_running_prove():
+    ran = {"prove": False}
+
+    def runner(_path):
+        ran["prove"] = True
+        return _CONTRADICTION_REPORT
+
+    uri = "file:///proj/broken.py"
+    out = _drive(_open_seq(uri, "def f(:\n    pass\n"), prove_runner=runner)
+    diags = _diagnostics(out, uri)
+    assert diags and diags[0]["code"] == "provekit.parse_error"
+    assert diags[0]["severity"] == e.SEVERITY_ERROR
+
+
+def test_didchange_refreshes_syntax_without_prove():
+    # didChange must not spawn prove (it would race the on-disk project); it
+    # refreshes the cheap syntax check against the live buffer.
+    calls = {"n": 0}
+
+    def runner(_path):
+        calls["n"] += 1
+        return _DISCHARGED_REPORT
+
+    msgs = [
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {"textDocument": {"uri": _URI, "text": _CONSUMER_OK}},
+        },
+        {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {"textDocument": {"uri": _URI, "version": 2}, "contentChanges": [{"text": "def f(:\n  pass\n"}]},
+        },
+        {"jsonrpc": "2.0", "id": 2, "method": "shutdown"},
+        {"jsonrpc": "2.0", "method": "exit"},
+    ]
+    out = _drive(msgs, prove_runner=runner)
+    # didOpen ran prove once; didChange did NOT.
+    assert calls["n"] == 1, "didChange must not spawn prove"
+    # the last publish for the uri reflects the now-broken buffer (syntax error).
+    last = [m for m in out if m.get("method") == "textDocument/publishDiagnostics" and m["params"]["uri"] == _URI][-1]
+    assert last["params"]["diagnostics"][0]["code"] == "provekit.parse_error"
+
+
+# --- decode unit edges --------------------------------------------------------
+
+
+def test_decode_property_non_callsite_is_unanchorable():
+    # A whole-test property (no #euf# callsite term) can't be anchored to a call.
+    assert e._decode_property("consistency:test_roundtrip") is None
+    assert e._decode_property("numpy.add#euf#c:callresult_numpy_add_a2(i:2,i:3)") == ("numpy.add", [2, 3])
+
+
+# --- live CLI integration (skip-guarded) -------------------------------------
+
+_REPO = Path(__file__).resolve().parents[4]
+_BIN = _REPO / "implementations" / "rust" / "target" / "debug" / "provekit"
+_PYSRC = ":".join(
+    str(_REPO / "implementations" / "python" / pkg / "src")
+    for pkg in ("provekit-lift-py-tests", "provekit-lift-python-source", "provekit-lift-py-numpy-testing")
+)
+try:
+    import numpy  # noqa: F401
+
+    _numpy_ok = True
+except Exception:
+    _numpy_ok = False
+
+
+def _live_project(tmp_path, surface, module):
+    solvers = (
+        '[solvers]\ndefault = "z3"\n[solvers.dispatch]\n'
+        'linear_arithmetic = "z3"\ndefault = "z3"\n[solvers.z3]\nbinary = "z3"\nflags = ["-smt2", "-in"]\n'
+    )
+    d = tmp_path
+    (d / ".provekit" / "lift" / surface).mkdir(parents=True, exist_ok=True)
+    (d / ".provekit" / "imports").mkdir(parents=True, exist_ok=True)
+    (d / ".provekit" / "config.toml").write_text(
+        f'[[plugins]]\nname = "{surface}-lift"\nkind = "lift"\nsurface = "{surface}"\n{solvers}'
+    )
+    (d / ".provekit" / "lift" / surface / "manifest.toml").write_text(
+        f'name = "{surface}-lift"\nversion = "0.1.0"\nkind = "lift"\n'
+        f'command = ["{sys.executable}", "-m", "{module}"]\nworking_dir = "{d}"\n'
+        f'[capabilities]\nauthoring_surfaces = ["{surface}"]\n'
+    )
+    return d
+
+
+@pytest.mark.skipif(
+    not (_BIN.exists() and _numpy_ok and shutil.which("z3")),
+    reason="needs the built provekit CLI + numpy + z3 on PATH",
+)
+@pytest.mark.parametrize("asserted, expect_squiggle", [(6, True), (5, False)], ids=["==6-squiggles", "==5-clears"])
+def test_live_cli_squiggle_tracks_source(tmp_path, monkeypatch, asserted, expect_squiggle):
+    """The real thing, AND the discriminator: drive the server with the DEFAULT
+    runner (which mints the live source into an isolated workspace, then proves).
+    The ==6 source must squiggle; the ==5 source must come back CLEAN -- proving
+    the verdict tracks the buffer, not stale mint artifacts. No in-project mint:
+    the server does the minting, against whatever is on disk."""
+    monkeypatch.setenv("PROVEKIT_CLI", str(_BIN))
+    monkeypatch.setenv("PYTHONPATH", _PYSRC)
+    env = dict(os.environ, PYTHONPATH=_PYSRC)
+
+    vendor = _live_project(tmp_path / "vendor", "python-numpy-testing", "provekit_lift_py_numpy_testing.lsp")
+    (vendor / "test_vendor.py").write_text(
+        "import numpy as np\nfrom numpy.testing import assert_equal\n"
+        "def test_vendor():\n    assert_equal(np.add(2, 3), 5)\n"
+    )
+    assert subprocess.run(
+        [str(_BIN), "mint", "--out", ".", "--quiet"], cwd=str(vendor), env=env, capture_output=True, text=True
+    ).returncode == 0
+    proof = next(vendor.glob("blake3-512:*.proof"))
+
+    consumer = _live_project(tmp_path / "consumer", "python-tests", "provekit_lift_py_tests.lsp")
+    shutil.copy(proof, consumer / ".provekit" / "imports")
+    src = f"import numpy as np\n\n\ndef test_c():\n    assert np.add(2, 3) == {asserted}\n"
+    cfile = consumer / "test_consumer.py"
+    cfile.write_text(src)
+
+    uri = f"file://{cfile}"
+    out = _drive(_open_seq(uri, src), prove_runner=e.run_prove_report)
+    diags = _diagnostics(out, uri)
+    if expect_squiggle:
+        assert diags, f"==6 must squiggle (inherits ==5); got {diags}"
+        assert diags[0]["severity"] == e.SEVERITY_ERROR
+        assert diags[0]["range"]["start"]["line"] == 4
+    else:
+        assert diags == [], f"==5 agrees with numpy -> the buffer must be clean; got {diags}"


### PR DESCRIPTION
Closes the documented editor-integration gap for Python: the seed `lsp.py` advertised an `analyzeDocument` method but was a batch plugin, not a server an editor holds open. This ships a real one.

## What

`provekit_lift_py_tests/editor_lsp.py` — a persistent stdio language server speaking the **LSP base wire protocol** (Content-Length-framed JSON-RPC): `initialize` / `initialized` / `didOpen` / `didChange` / `didSave` / `didClose` / `publishDiagnostics` / `shutdown` / `exit`. Console script: `provekit-editor-lsp-python`.

The diagnostic **is** the `provekit prove` verdict. Open a Python file in an LSP editor; a contradicted contract surfaces as an inline Error squiggle on the offending call. The headline case is the inheritance chain: a consumer asserting `np.add(2, 3) == 6` while inheriting `== 5` from a vendor `.proof` gets a squiggle on `np.add(2, 3)` — the same callsite `prove` refuses — and it **clears** when you fix it to `== 5`.

## Two design points worth review

1. **Tracks source, not stale mint.** `prove` reads minted `.proof` artifacts, not source, and re-minting in place *accumulates* stale CID-named proofs that re-introduce a fixed contradiction. So on open/save the server mints the current source into a **fresh isolated workspace** (project config + inherited `.provekit/imports/` proofs copied in) and proves that. The user's tree is never written to; no accumulation; the verdict reflects exactly what's on disk. Verification stays in the rust CLI — the server is a thin client that never grades correctness itself.

2. **The anchor.** A conjoined contradiction is a consistency row with `file: null, line: null` (the verdict is a property of a callsite *term*, not one source line). The callsite lives in the row's `property` (`consistency:numpy.add#euf#...(i:2,i:3)::assertion`); the server decodes the callee + integer args and matches them against the document AST, so the squiggle lands on the right call.

## Tests

`tests/test_editor_lsp.py` drives the **real LSP wire** (Content-Length frames):
- hermetic, with the real captured prove report: positive (`==6` → Error on the call line), negative (`==5` → clean), syntax-error, `didChange`-no-prove, decode edges
- skip-guarded **live** test that spawns the real CLI and **discriminates source-tracking**: `==6` squiggles, `==5` comes back clean

Full `provekit-lift-py-tests` suite: **349 passed, 3 skipped**, no regression. The older `lsp.py` `analyzeDocument` forward-propagation demo (backing `provekit_lsp` + the rust linker tests) is untouched.

## Deferred (stated, not implied complete)

- Live dirty-buffer analysis ("squiggle as you type") needs a buffer overlay so prove doesn't run against stale disk; diagnostics refresh on open/save.
- This is the Python-kit-native server; the cross-language, linker-daemon-routed rust `provekit-lsp` editor server remains roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Python editor integration is now available, showing proof violations as inline diagnostics pinpointed to the exact callsites causing issues
  * Automatic re-evaluation when files are opened or saved

* **Documentation**
  * Updated quickstart guides to describe the Python editor workflow and cross-language roadmap

<!-- end of auto-generated comment: release notes by coderabbit.ai -->