### PR TITLE
ci: stop the maven-shade dependency-reduced-pom flake

### DIFF
--- a/implementations/java/provekit-emit-java-assertj/pom.xml
+++ b/implementations/java/provekit-emit-java-assertj/pom.xml
@@ -47,6 +47,7 @@
                         <goals><goal>shade</goal></goals>
                         <configuration>
                             <outputFile>${project.build.directory}/provekit-emit-java-assertj.jar</outputFile>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>

--- a/implementations/java/provekit-emit-java-junit/pom.xml
+++ b/implementations/java/provekit-emit-java-junit/pom.xml
@@ -61,6 +61,7 @@
                         <goals><goal>shade</goal></goals>
                         <configuration>
                             <outputFile>${project.build.directory}/provekit-emit-java-junit.jar</outputFile>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>

--- a/implementations/java/provekit-lift-java-assertj/pom.xml
+++ b/implementations/java/provekit-lift-java-assertj/pom.xml
@@ -40,6 +40,7 @@
                         <goals><goal>shade</goal></goals>
                         <configuration>
                             <outputFile>${project.build.directory}/provekit-lift-java-assertj.jar</outputFile>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>com.provekit.lift.Main</mainClass>

--- a/implementations/java/provekit-lift-java-core/pom.xml
+++ b/implementations/java/provekit-lift-java-core/pom.xml
@@ -42,6 +42,7 @@
                         <goals><goal>shade</goal></goals>
                         <configuration>
                             <outputFile>${project.build.directory}/provekit-lsp-java.jar</outputFile>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>com.provekit.lift.Main</mainClass>

--- a/implementations/java/provekit-lift-java-testng/pom.xml
+++ b/implementations/java/provekit-lift-java-testng/pom.xml
@@ -39,6 +39,7 @@
                         <goals><goal>shade</goal></goals>
                         <configuration>
                             <outputFile>${project.build.directory}/provekit-lift-java-testng.jar</outputFile>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>com.provekit.lift.Main</mainClass>

--- a/implementations/java/provekit-realize-java-core/pom.xml
+++ b/implementations/java/provekit-realize-java-core/pom.xml
@@ -142,6 +142,7 @@
                         <goals><goal>shade</goal></goals>
                         <configuration>
                             <outputFile>${project.build.directory}/provekit-realize-java.jar</outputFile>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>


### PR DESCRIPTION
The maven-shade-plugin's `dependency-reduced-pom.xml` flakes "Non-readable POM ... input contained no data" on the reused self-hosted runner, failing emit-java-junit ~half the time — the recurring flake that forced a CI rerun on nearly every PR this session. Set `<createDependencyReducedPom>false</createDependencyReducedPom>` on every java shade execution that lacked it. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configurations across multiple Java modules to streamline and optimize the packaging process by controlling the generation of intermediate build artifacts. This enhancement improves overall build efficiency, reduces unnecessary package overhead, eliminates redundant files, and ensures cleaner, more efficient deployments without affecting the core functionality or user-facing behavior of the software.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->