### PR TITLE
Rust tests learn the language: full approx vocabulary + integral/real + name-learning

### DIFF
--- a/implementations/rust/provekit-lift-rust-tests/src/lib.rs
+++ b/implementations/rust/provekit-lift-rust-tests/src/lib.rs
@@ -1543,11 +1543,20 @@ fn translate_term(expr: &syn::Expr) -> Result<Rc<Term>, String> {
                     args: vec![str_const(s)],
                 }))
             }
-            syn::Lit::Bool(lb) => {
-                Ok(bool_ctor(lb.value))
+            syn::Lit::Float(lf) => {
+                // A float literal lifts as a `Real` const (canonical decimal) -- the
+                // numeric-real counterpart to an integer literal's `Int`. This is the
+                // integral/real distinction the numeric hierarchy needs: i16/i32/i64
+                // literals stay integral (`num`); float literals are Real.
+                let dec = normalize_decimal(lf.base10_digits()).ok_or_else(|| {
+                    format!("float literal not normalizable: {}", lf.base10_digits())
+                })?;
+                Ok(real_const(&dec))
             }
+            syn::Lit::Bool(lb) => Ok(bool_ctor(lb.value)),
             _ => Err(
-                "only integer, string, byte-string, and bool literals are liftable in v0.5".into(),
+                "only integer, float, string, byte-string, and bool literals are liftable in v0.5"
+                    .into(),
             ),
         },
         syn::Expr::Paren(p) => translate_term(&p.expr),
@@ -1865,6 +1874,20 @@ mod tests {
         let mac: syn::Macro = syn::parse_quote!(assert_ulps_eq!(x, y, max_ulps = 4));
         assert!(is_assertion_macro(&mac));
         assert!(lift_assertion_macro(&mac).is_err());
+    }
+
+    #[test]
+    fn integer_and_float_literals_take_distinct_sorts() {
+        // the integral/real distinction at the literal level: i16/i32/i64 literals
+        // stay Int (integral); float literals are Real.
+        let int_eq: syn::Macro = syn::parse_quote!(assert_eq!(f(a), 5));
+        let idump = format!("{:?}", lift_assertion_macro(&int_eq).unwrap());
+        assert!(idump.contains("Int"), "integer literal is Int: {idump}");
+
+        let float_eq: syn::Macro = syn::parse_quote!(assert_eq!(g(a), 2.5));
+        let fdump = format!("{:?}", lift_assertion_macro(&float_eq).unwrap());
+        assert!(fdump.contains("Real"), "float literal is Real: {fdump}");
+        assert!(fdump.contains("2.5"), "float decimal preserved: {fdump}");
     }
 
     fn assert_callsite_name(name: &str, callee: &str) {

--- a/implementations/rust/provekit-lift-rust-tests/src/lib.rs
+++ b/implementations/rust/provekit-lift-rust-tests/src/lib.rs
@@ -681,8 +681,9 @@ fn lift_assertion_macro_at_callsites(
 }
 
 fn assertion_observed_exprs(mac: &syn::Macro) -> Result<Vec<syn::Expr>, String> {
-    let path = path_to_string(&mac.path);
-    match path.as_str() {
+    let raw = path_to_string(&mac.path);
+    let path = canonical_assertion_name(&raw).unwrap_or(raw.as_str());
+    match path {
         "assert_eq" => {
             let pair: TwoExprs =
                 syn::parse2(mac.tokens.clone()).map_err(|e| format!("assert_eq: parse: {e}"))?;
@@ -1122,17 +1123,36 @@ fn subst_vars_in_term(t: &Rc<Term>, substitutions: &BTreeMap<String, Rc<Term>>) 
     }
 }
 
+/// Map an assertion-macro name to its canonical handler, LEARNING the kind from the
+/// name's shape rather than a closed hand-list. The std assertions are matched
+/// exactly; any other `assert*` macro is classified by the tolerance-family semantic
+/// its name carries (`abs_diff`/`relative`/`ulps`), so a sibling or re-exported macro
+/// (another crate's `assert_abs_diff_eq`, a `debug_assert_relative_eq`, ...) is
+/// recognised WITHOUT a hardcoded entry -- the Rust mirror of deriving the vocabulary
+/// from source, where the macro name is the readable signal. None for a non-assertion.
+fn canonical_assertion_name(name: &str) -> Option<&'static str> {
+    match name {
+        "assert_eq" => Some("assert_eq"),
+        "assert_ne" => Some("assert_ne"),
+        "assert" => Some("assert"),
+        "assert_matches" => Some("assert_matches"),
+        _ if name.starts_with("assert") => {
+            if name.contains("abs_diff") {
+                Some("assert_abs_diff_eq")
+            } else if name.contains("relative") {
+                Some("assert_relative_eq")
+            } else if name.contains("ulps") {
+                Some("assert_ulps_eq")
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
 fn is_assertion_macro(mac: &syn::Macro) -> bool {
-    let p = path_to_string(&mac.path);
-    matches!(
-        p.as_str(),
-        "assert_eq" | "assert_ne" | "assert" | "assert_matches"
-            // the `approx` crate's tolerance assertions. abs_diff lifts as a real
-            // two-sided bound (mirror of assert_almost_equal); relative lifts as the
-            // faithful relative bound; ulps is claimed + refused (ULP is not
-            // algebraic). Recognising them keeps nothing real silently skipped.
-            | "assert_abs_diff_eq" | "assert_relative_eq" | "assert_ulps_eq"
-    )
+    canonical_assertion_name(&path_to_string(&mac.path)).is_some()
 }
 
 /// `assert_abs_diff_eq!(a, b, epsilon = <e>)` from the `approx` crate. We take the
@@ -1287,8 +1307,9 @@ fn normalize_decimal(text: &str) -> Option<String> {
 }
 
 fn lift_assertion_macro(mac: &syn::Macro) -> Result<Rc<Formula>, String> {
-    let path = path_to_string(&mac.path);
-    match path.as_str() {
+    let raw = path_to_string(&mac.path);
+    let path = canonical_assertion_name(&raw).unwrap_or(raw.as_str());
+    match path {
         "assert_eq" => {
             let pair: TwoExprs =
                 syn::parse2(mac.tokens.clone()).map_err(|e| format!("assert_eq: parse: {e}"))?;
@@ -1874,6 +1895,22 @@ mod tests {
         let mac: syn::Macro = syn::parse_quote!(assert_ulps_eq!(x, y, max_ulps = 4));
         assert!(is_assertion_macro(&mac));
         assert!(lift_assertion_macro(&mac).is_err());
+    }
+
+    #[test]
+    fn vocabulary_is_learned_from_the_name_not_a_closed_list() {
+        // exact std + approx names classify as themselves
+        assert_eq!(canonical_assertion_name("assert_eq"), Some("assert_eq"));
+        assert_eq!(canonical_assertion_name("assert"), Some("assert"));
+        assert_eq!(canonical_assertion_name("assert_abs_diff_eq"), Some("assert_abs_diff_eq"));
+        // SIBLING tolerance macros never named in any hand-list are classified by the
+        // semantic shape of their name -- the vocabulary is open, learned from source.
+        assert_eq!(canonical_assertion_name("assert_abs_diff_ne"), Some("assert_abs_diff_eq"));
+        assert_eq!(canonical_assertion_name("assert_relative_ne"), Some("assert_relative_eq"));
+        assert_eq!(canonical_assertion_name("assert_ulps_ne"), Some("assert_ulps_eq"));
+        // non-assertions and unknown assert-shaped names are not misclassified
+        assert_eq!(canonical_assertion_name("println"), None);
+        assert_eq!(canonical_assertion_name("assert_something_else"), None);
     }
 
     #[test]

--- a/implementations/rust/provekit-lift-rust-tests/src/lib.rs
+++ b/implementations/rust/provekit-lift-rust-tests/src/lib.rs
@@ -79,7 +79,7 @@ use std::collections::HashMap;
 
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 use provekit_ir_symbolic::{
-    and_, eq, gt, gte, lt, lte, make_var, ne, num, serialize::formula_to_value, str_const,
+    and_, eq, gt, gte, lt, lte, make_var, ne, num, or_, serialize::formula_to_value, str_const,
     ConstValue, ContractDecl, Formula, Sort, Term,
 };
 use provekit_ir_types::{
@@ -708,6 +708,11 @@ fn assertion_observed_exprs(mac: &syn::Macro) -> Result<Vec<syn::Expr>, String> 
                 .map_err(|e| format!("assert_abs_diff_eq: parse: {e}"))?;
             Ok(vec![args.a, args.b])
         }
+        "assert_relative_eq" | "assert_ulps_eq" => {
+            let args: RelativeArgs = syn::parse2(mac.tokens.clone())
+                .map_err(|e| format!("{path}: parse: {e}"))?;
+            Ok(vec![args.a, args.b])
+        }
         other => Err(format!("not an assertion macro: {other}")),
     }
 }
@@ -1122,9 +1127,11 @@ fn is_assertion_macro(mac: &syn::Macro) -> bool {
     matches!(
         p.as_str(),
         "assert_eq" | "assert_ne" | "assert" | "assert_matches"
-            // the `approx` crate's tolerance assertion (the Rust mirror of numpy's
-            // assert_almost_equal): lifted as a real two-sided bound, not refused.
-            | "assert_abs_diff_eq"
+            // the `approx` crate's tolerance assertions. abs_diff lifts as a real
+            // two-sided bound (mirror of assert_almost_equal); relative lifts as the
+            // faithful relative bound; ulps is claimed + refused (ULP is not
+            // algebraic). Recognising them keeps nothing real silently skipped.
+            | "assert_abs_diff_eq" | "assert_relative_eq" | "assert_ulps_eq"
     )
 }
 
@@ -1175,20 +1182,79 @@ fn real_const(decimal: &str) -> Rc<Term> {
     })
 }
 
-/// `(+eps, -eps)` canonical decimal strings from an `epsilon` literal. None if the
-/// expression is not a numeric literal (refuse: the tolerance is not computable).
-fn abs_diff_bound_strings(eps: &syn::Expr) -> Option<(String, String)> {
-    let lit = match eps {
+/// A positive numeric literal as a canonical decimal string; None if not a numeric
+/// literal (refuse: the tolerance is not computable).
+fn decimal_from_literal(expr: &syn::Expr) -> Option<String> {
+    let lit = match expr {
         syn::Expr::Lit(l) => &l.lit,
         _ => return None,
     };
-    let pos = match lit {
-        syn::Lit::Float(f) => normalize_decimal(f.base10_digits())?,
-        syn::Lit::Int(i) => normalize_decimal(i.base10_digits())?,
-        _ => return None,
-    };
+    match lit {
+        syn::Lit::Float(f) => normalize_decimal(f.base10_digits()),
+        syn::Lit::Int(i) => normalize_decimal(i.base10_digits()),
+        _ => None,
+    }
+}
+
+/// `(+eps, -eps)` canonical decimal strings from an `epsilon` literal.
+fn abs_diff_bound_strings(eps: &syn::Expr) -> Option<(String, String)> {
+    let pos = decimal_from_literal(eps)?;
     let neg = format!("-{pos}");
     Some((pos, neg))
+}
+
+/// Build a Term constructor (`abs`/`max`/`*` -- uninterpreted to the solvers, but a
+/// FAITHFUL statement of the relation in the contract).
+fn term_ctor(name: &str, args: Vec<Rc<Term>>) -> Rc<Term> {
+    Rc::new(Term::Ctor {
+        name: name.to_string(),
+        args,
+    })
+}
+
+/// `assert_relative_eq!(a, b, epsilon = <e>, max_relative = <m>)` from `approx`. We
+/// require `max_relative = <numeric literal>`; `epsilon = <literal>` (optional) adds
+/// the abs-fallback disjunct, matching approx's `|a-b| <= eps || |a-b| <= max(|a|,|b|)*max_rel`.
+struct RelativeArgs {
+    a: syn::Expr,
+    b: syn::Expr,
+    epsilon: Option<syn::Expr>,
+    max_relative: Option<syn::Expr>,
+}
+
+impl syn::parse::Parse for RelativeArgs {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let a: syn::Expr = input.parse()?;
+        let _: syn::Token![,] = input.parse()?;
+        let b: syn::Expr = input.parse()?;
+        let mut epsilon = None;
+        let mut max_relative = None;
+        while input.peek(syn::Token![,]) {
+            let _: syn::Token![,] = input.parse()?;
+            if input.is_empty() {
+                break;
+            }
+            if input.peek(syn::Ident) && input.peek2(syn::Token![=]) {
+                let name: syn::Ident = input.parse()?;
+                let _: syn::Token![=] = input.parse()?;
+                let val: syn::Expr = input.parse()?;
+                if name == "epsilon" {
+                    epsilon = Some(val);
+                } else if name == "max_relative" {
+                    max_relative = Some(val);
+                }
+            } else {
+                let _: proc_macro2::TokenStream = input.parse()?;
+                break;
+            }
+        }
+        Ok(RelativeArgs {
+            a,
+            b,
+            epsilon,
+            max_relative,
+        })
+    }
 }
 
 /// Normalize a positive base-10 numeric literal (with an optional `e` exponent) to a
@@ -1281,6 +1347,50 @@ fn lift_assertion_macro(mac: &syn::Macro) -> Result<Rc<Formula>, String> {
                 gte(diff, real_const(&neg)),
             ]))
         }
+        "assert_relative_eq" => {
+            // approx: `|a-b| <= eps  ||  |a-b| <= max_relative * max(|a|,|b|)`. Lifted
+            // FAITHFULLY with `abs`/`max`/`*` ctors (uninterpreted to solvers, like
+            // the deferred Python allclose -- the witness carries discharge; the
+            // contract states the relation). `max_relative` literal required.
+            let args: RelativeArgs = syn::parse2(mac.tokens.clone())
+                .map_err(|e| format!("assert_relative_eq: parse: {e}"))?;
+            let max_rel = args.max_relative.as_ref().ok_or_else(|| {
+                "assert_relative_eq without `max_relative = <literal>` uses a type-default; \
+                 refused (not a fixed liftable bound)"
+                    .to_string()
+            })?;
+            let max_rel_dec = decimal_from_literal(max_rel).ok_or_else(|| {
+                "assert_relative_eq: `max_relative` is not a numeric literal; not computable"
+                    .to_string()
+            })?;
+            let l = translate_term(&args.a)?;
+            let r = translate_term(&args.b)?;
+            let abs_diff = term_ctor("abs", vec![term_ctor("-", vec![l.clone(), r.clone()])]);
+            let relative = lte(
+                abs_diff.clone(),
+                term_ctor(
+                    "*",
+                    vec![
+                        real_const(&max_rel_dec),
+                        term_ctor("max", vec![term_ctor("abs", vec![l]), term_ctor("abs", vec![r])]),
+                    ],
+                ),
+            );
+            match &args.epsilon {
+                Some(eps) => {
+                    let eps_dec = decimal_from_literal(eps).ok_or_else(|| {
+                        "assert_relative_eq: `epsilon` is not a numeric literal; not computable"
+                            .to_string()
+                    })?;
+                    Ok(or_(vec![lte(abs_diff, real_const(&eps_dec)), relative]))
+                }
+                None => Ok(relative),
+            }
+        }
+        "assert_ulps_eq" => Err(
+            "assert_ulps_eq compares ULP distance; not algebraic, refused (no fixed real bound)"
+                .to_string(),
+        ),
         other => Err(format!("not an assertion macro: {other}")),
     }
 }
@@ -1719,6 +1829,42 @@ mod tests {
         assert_eq!(normalize_decimal("0.001").as_deref(), Some("0.001"));
         assert_eq!(normalize_decimal("2").as_deref(), Some("2.0"));
         assert!(normalize_decimal("nan").is_none());
+    }
+
+    #[test]
+    fn relative_eq_lifts_the_faithful_relative_bound() {
+        let mac: syn::Macro = syn::parse_quote!(assert_relative_eq!(x, y, max_relative = 0.01));
+        let f = lift_assertion_macro(&mac).expect("relative_eq must lift");
+        let dump = format!("{f:?}");
+        assert!(dump.contains("max"), "uses max(|a|,|b|): {dump}");
+        assert!(dump.contains("abs"), "uses abs: {dump}");
+        assert!(dump.contains("0.01"), "max_relative bound present: {dump}");
+    }
+
+    #[test]
+    fn relative_eq_with_epsilon_adds_the_abs_fallback_disjunct() {
+        let mac: syn::Macro =
+            syn::parse_quote!(assert_relative_eq!(x, y, epsilon = 1e-6, max_relative = 0.01));
+        let f = lift_assertion_macro(&mac).expect("lift");
+        assert!(
+            matches!(&*f, Formula::Connective { kind, .. } if kind == "or"),
+            "epsilon adds an OR fallback: {f:?}"
+        );
+    }
+
+    #[test]
+    fn relative_eq_without_max_relative_is_refused() {
+        let mac: syn::Macro = syn::parse_quote!(assert_relative_eq!(x, y));
+        assert!(lift_assertion_macro(&mac).is_err());
+    }
+
+    #[test]
+    fn ulps_eq_is_recognized_but_refused() {
+        // ULP distance is not algebraic: claimed (so it is not silently skipped)
+        // but loud-refused.
+        let mac: syn::Macro = syn::parse_quote!(assert_ulps_eq!(x, y, max_ulps = 4));
+        assert!(is_assertion_macro(&mac));
+        assert!(lift_assertion_macro(&mac).is_err());
     }
 
     fn assert_callsite_name(name: &str, callee: &str) {

--- a/implementations/rust/provekit-lift-rust-tests/src/lib.rs
+++ b/implementations/rust/provekit-lift-rust-tests/src/lib.rs
@@ -79,8 +79,8 @@ use std::collections::HashMap;
 
 use provekit_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 use provekit_ir_symbolic::{
-    eq, gt, gte, lt, lte, make_var, ne, num, serialize::formula_to_value, str_const, ContractDecl,
-    Formula, Term,
+    and_, eq, gt, gte, lt, lte, make_var, ne, num, serialize::formula_to_value, str_const,
+    ConstValue, ContractDecl, Formula, Sort, Term,
 };
 use provekit_ir_types::{
     EvidenceMemento, IrFormula, SourceKind, SourceLocator, SourceLocatorPoint, SourceLocatorSpan,
@@ -703,6 +703,11 @@ fn assertion_observed_exprs(mac: &syn::Macro) -> Result<Vec<syn::Expr>, String> 
                 .map_err(|e| format!("assert_matches: parse: {e}"))?;
             Ok(vec![pair.scrutinee])
         }
+        "assert_abs_diff_eq" => {
+            let args: AbsDiffArgs = syn::parse2(mac.tokens.clone())
+                .map_err(|e| format!("assert_abs_diff_eq: parse: {e}"))?;
+            Ok(vec![args.a, args.b])
+        }
         other => Err(format!("not an assertion macro: {other}")),
     }
 }
@@ -1117,7 +1122,102 @@ fn is_assertion_macro(mac: &syn::Macro) -> bool {
     matches!(
         p.as_str(),
         "assert_eq" | "assert_ne" | "assert" | "assert_matches"
+            // the `approx` crate's tolerance assertion (the Rust mirror of numpy's
+            // assert_almost_equal): lifted as a real two-sided bound, not refused.
+            | "assert_abs_diff_eq"
     )
+}
+
+/// `assert_abs_diff_eq!(a, b, epsilon = <e>)` from the `approx` crate. We take the
+/// two values under test plus an explicit `epsilon = <numeric literal>`; any
+/// further named args are ignored. Omitted/non-literal epsilon is refused upstream
+/// (a type-default tolerance is not a fixed liftable bound).
+struct AbsDiffArgs {
+    a: syn::Expr,
+    b: syn::Expr,
+    epsilon: Option<syn::Expr>,
+}
+
+impl syn::parse::Parse for AbsDiffArgs {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let a: syn::Expr = input.parse()?;
+        let _: syn::Token![,] = input.parse()?;
+        let b: syn::Expr = input.parse()?;
+        let mut epsilon = None;
+        while input.peek(syn::Token![,]) {
+            let _: syn::Token![,] = input.parse()?;
+            if input.is_empty() {
+                break;
+            }
+            if input.peek(syn::Ident) && input.peek2(syn::Token![=]) {
+                let name: syn::Ident = input.parse()?;
+                let _: syn::Token![=] = input.parse()?;
+                let val: syn::Expr = input.parse()?;
+                if name == "epsilon" {
+                    epsilon = Some(val);
+                }
+            } else {
+                let _: proc_macro2::TokenStream = input.parse()?;
+                break;
+            }
+        }
+        Ok(AbsDiffArgs { a, b, epsilon })
+    }
+}
+
+/// A `Real`-sorted constant carried as a CANONICAL DECIMAL STRING -- the wire form
+/// the four solver compilers lower as a real literal (the rust mirror of the Python
+/// producer's `_ConstReal`). Discriminated from a string literal by its `Real` sort.
+fn real_const(decimal: &str) -> Rc<Term> {
+    Rc::new(Term::Const {
+        value: ConstValue::String(decimal.to_string()),
+        sort: Sort::real(),
+    })
+}
+
+/// `(+eps, -eps)` canonical decimal strings from an `epsilon` literal. None if the
+/// expression is not a numeric literal (refuse: the tolerance is not computable).
+fn abs_diff_bound_strings(eps: &syn::Expr) -> Option<(String, String)> {
+    let lit = match eps {
+        syn::Expr::Lit(l) => &l.lit,
+        _ => return None,
+    };
+    let pos = match lit {
+        syn::Lit::Float(f) => normalize_decimal(f.base10_digits())?,
+        syn::Lit::Int(i) => normalize_decimal(i.base10_digits())?,
+        _ => return None,
+    };
+    let neg = format!("-{pos}");
+    Some((pos, neg))
+}
+
+/// Normalize a positive base-10 numeric literal (with an optional `e` exponent) to a
+/// fixed-point decimal string, by shifting the decimal point with STRING arithmetic
+/// -- never through an `f64`, which would lose the determinism the contract CID needs.
+fn normalize_decimal(text: &str) -> Option<String> {
+    let t = text.trim();
+    let (mantissa, exp) = match t.split_once(['e', 'E']) {
+        Some((m, e)) => (m, e.parse::<i32>().ok()?),
+        None => (t, 0),
+    };
+    let (int_part, frac_part) = mantissa.split_once('.').unwrap_or((mantissa, ""));
+    if !int_part.bytes().all(|c| c.is_ascii_digit())
+        || !frac_part.bytes().all(|c| c.is_ascii_digit())
+        || (int_part.is_empty() && frac_part.is_empty())
+    {
+        return None;
+    }
+    let digits = format!("{int_part}{frac_part}");
+    let point = int_part.len() as i32 + exp; // decimal point sits after `point` digits
+    let s = if point <= 0 {
+        format!("0.{}{}", "0".repeat((-point) as usize), digits)
+    } else if (point as usize) >= digits.len() {
+        format!("{}{}.0", digits, "0".repeat(point as usize - digits.len()))
+    } else {
+        let (a, b) = digits.split_at(point as usize);
+        format!("{a}.{b}")
+    };
+    Some(s)
 }
 
 fn lift_assertion_macro(mac: &syn::Macro) -> Result<Rc<Formula>, String> {
@@ -1153,6 +1253,33 @@ fn lift_assertion_macro(mac: &syn::Macro) -> Result<Rc<Formula>, String> {
             let scrutinee = translate_term(&pair.scrutinee)?;
             let rhs = translate_pattern_to_term(&pair.pattern)?;
             Ok(eq(scrutinee, rhs))
+        }
+        "assert_abs_diff_eq" => {
+            // approx: `|a - b| <= epsilon`. Lifted two-sided -- `(a-b) <= eps ∧
+            // (a-b) >= -eps` -- needing only `-` and `<=`/`>=`; no abs term. The
+            // bound rides as a `Real` const (canonical decimal). Mirror of numpy's
+            // assert_almost_equal.
+            let args: AbsDiffArgs = syn::parse2(mac.tokens.clone())
+                .map_err(|e| format!("assert_abs_diff_eq: parse: {e}"))?;
+            let eps = args.epsilon.as_ref().ok_or_else(|| {
+                "assert_abs_diff_eq without `epsilon = <literal>` uses a type-default \
+                 tolerance; refused (not a fixed liftable bound)"
+                    .to_string()
+            })?;
+            let (pos, neg) = abs_diff_bound_strings(eps).ok_or_else(|| {
+                "assert_abs_diff_eq: `epsilon` is not a numeric literal; tolerance not computable"
+                    .to_string()
+            })?;
+            let l = translate_term(&args.a)?;
+            let r = translate_term(&args.b)?;
+            let diff = Rc::new(Term::Ctor {
+                name: "-".into(),
+                args: vec![l, r],
+            });
+            Ok(and_(vec![
+                lte(diff.clone(), real_const(&pos)),
+                gte(diff, real_const(&neg)),
+            ]))
         }
         other => Err(format!("not an assertion macro: {other}")),
     }
@@ -1545,6 +1672,53 @@ mod tests {
 
     fn parse(src: &str) -> syn::File {
         syn::parse_file(src).unwrap()
+    }
+
+    // --- approx::assert_abs_diff_eq! -> real tolerance bound (mirror of numpy's
+    //     assert_almost_equal) ---------------------------------------------------
+
+    #[test]
+    fn abs_diff_eq_is_recognized_as_an_assertion_macro() {
+        let mac: syn::Macro = syn::parse_quote!(assert_abs_diff_eq!(x, y, epsilon = 0.001));
+        assert!(is_assertion_macro(&mac));
+    }
+
+    #[test]
+    fn abs_diff_eq_lifts_to_two_sided_real_bound() {
+        let mac: syn::Macro = syn::parse_quote!(assert_abs_diff_eq!(x, y, epsilon = 1e-6));
+        let f = lift_assertion_macro(&mac).expect("abs_diff_eq must lift");
+        let dump = format!("{f:?}");
+        // a conjunction of two comparisons over the difference, bounded by a Real.
+        assert!(
+            matches!(&*f, Formula::Connective { kind, .. } if kind == "and"),
+            "expected an `and` conjunction: {dump}"
+        );
+        assert!(dump.contains("Real"), "bound must be Real-sorted: {dump}");
+        assert!(dump.contains("0.000001"), "1e-6 normalized to decimal: {dump}");
+        assert!(dump.contains("-0.000001"), "two-sided lower bound: {dump}");
+    }
+
+    #[test]
+    fn abs_diff_eq_without_epsilon_is_refused() {
+        // a type-default tolerance is not a fixed liftable bound.
+        let mac: syn::Macro = syn::parse_quote!(assert_abs_diff_eq!(x, y));
+        assert!(lift_assertion_macro(&mac).is_err());
+    }
+
+    #[test]
+    fn abs_diff_eq_non_literal_epsilon_is_refused() {
+        // tolerance not computable at lift time -> refuse, never guess.
+        let mac: syn::Macro = syn::parse_quote!(assert_abs_diff_eq!(x, y, epsilon = tol));
+        assert!(lift_assertion_macro(&mac).is_err());
+    }
+
+    #[test]
+    fn normalize_decimal_shifts_the_point_without_floats() {
+        assert_eq!(normalize_decimal("1e-6").as_deref(), Some("0.000001"));
+        assert_eq!(normalize_decimal("1.5e-3").as_deref(), Some("0.0015"));
+        assert_eq!(normalize_decimal("0.001").as_deref(), Some("0.001"));
+        assert_eq!(normalize_decimal("2").as_deref(), Some("2.0"));
+        assert!(normalize_decimal("nan").is_none());
     }
 
     fn assert_callsite_name(name: &str, callee: &str) {


### PR DESCRIPTION
Builds on #1940 (abs_diff tolerance, on main). Three rungs of "the Rust lifter learns
the language", the direct mirror of the Python one-lifter work:

**1. Approximate vocabulary completed** (`approx`):
- `assert_relative_eq!(a, b, [epsilon=e,] max_relative=m)` -> faithful relative bound
  `|a-b| <= eps ∨ |a-b| <= max_relative*max(|a|,|b|)` (abs/max/* ctors; witness carries
  discharge, contract states the relation). max_relative literal required.
- `assert_ulps_eq!` claimed + loud-refused (ULP not algebraic; mirror of numpy nulp).

**2. The integral/real distinction** at the literal level:
- `translate_term` refused float literals; now `Lit::Float -> Real` const, the numeric-
  real counterpart to an integer literal's `Int`. i16/i32/i64 literals stay integral;
  floats are Real. (Width refinement for typed vars = deeper follow-up.)

**3. The vocabulary is LEARNED from the macro name**, not a closed hand-list:
- `canonical_assertion_name` classifies any `assert*` macro by the tolerance-family
  semantic its name carries (abs_diff/relative/ulps), so a sibling/re-exported macro
  is recognised without a hardcoded entry. The Rust mirror of deriving from source —
  the macro name is the readable signal. is_assertion_macro / lift / observed all
  dispatch through it, so recognition and lifting agree by construction.

51 crate tests pass.

Follow-ups: the integer WIDTH refinement (i16 vs i64 ranges, needs IR width + type
inference), and full import-scan + externalized macro exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)