### PR TITLE
Rust tests: integer WIDTH refinement + externalized macro exceptions

### DIFF
--- a/implementations/rust/provekit-lift-rust-tests/src/lib.rs
+++ b/implementations/rust/provekit-lift-rust-tests/src/lib.rs
@@ -202,6 +202,7 @@ pub fn lift_file_with_skip(
     source_path: &str,
     skip: &BTreeSet<String>,
 ) -> AdapterOutput {
+    load_assertion_exceptions_for(source_path);
     let mut out = AdapterOutput::default();
     walk_items(&file.items, source_path, skip, &mut out);
     out
@@ -230,6 +231,7 @@ pub fn lift_file_with_evidence_and_skip(
     source_bytes: &[u8],
     skip: &BTreeSet<String>,
 ) -> AdapterOutput {
+    load_assertion_exceptions_for(source_path);
     let source_cid = blake3_512_of(source_bytes);
     // Build a map from bare function name to &syn::ItemFn for all non-test top-level
     // functions in this file. Used by `visit_test_fn_with_evidence` to compute
@@ -1203,14 +1205,67 @@ fn subst_vars_in_term(t: &Rc<Term>, substitutions: &BTreeMap<String, Rc<Term>>) 
     }
 }
 
-/// Map an assertion-macro name to its canonical handler, LEARNING the kind from the
-/// name's shape rather than a closed hand-list. The std assertions are matched
-/// exactly; any other `assert*` macro is classified by the tolerance-family semantic
-/// its name carries (`abs_diff`/`relative`/`ulps`), so a sibling or re-exported macro
-/// (another crate's `assert_abs_diff_eq`, a `debug_assert_relative_eq`, ...) is
-/// recognised WITHOUT a hardcoded entry -- the Rust mirror of deriving the vocabulary
-/// from source, where the macro name is the readable signal. None for a non-assertion.
+thread_local! {
+    /// EXTERNALIZED per-workspace assertion-macro classifications, loaded at lift
+    /// time from `.provekit/vocab-exceptions/rust-assertions.json`. Maps a macro name
+    /// to a kind. A library/workspace classifies a macro whose NAME carries no
+    /// tolerance signal (e.g. float_cmp's `assert_approx_eq!`) by DROPPING this data
+    /// file -- no lifter code change -- the Rust mirror of the Python
+    /// `.provekit/vocab-exceptions/<module>.json`.
+    static ASSERTION_EXCEPTIONS: std::cell::RefCell<BTreeMap<String, String>> =
+        std::cell::RefCell::new(BTreeMap::new());
+}
+
+/// Walk up from `source_path` to a workspace `.provekit/vocab-exceptions/
+/// rust-assertions.json` and load its `{macro: kind}` classifications into the
+/// thread-local. Called at each lift entry; empty (no file) means pure name-learning.
+fn load_assertion_exceptions_for(source_path: &str) {
+    let map = read_assertion_exceptions(source_path).unwrap_or_default();
+    ASSERTION_EXCEPTIONS.with(|m| *m.borrow_mut() = map);
+}
+
+fn read_assertion_exceptions(source_path: &str) -> Option<BTreeMap<String, String>> {
+    let mut dir = std::path::Path::new(source_path).parent();
+    while let Some(d) = dir {
+        let candidate = d
+            .join(".provekit")
+            .join("vocab-exceptions")
+            .join("rust-assertions.json");
+        if candidate.is_file() {
+            let text = std::fs::read_to_string(&candidate).ok()?;
+            return serde_json::from_str::<BTreeMap<String, String>>(&text).ok();
+        }
+        dir = d.parent();
+    }
+    None
+}
+
+/// Map an externalized exception `kind` to a canonical handler. `refuse` routes to
+/// the ulps handler (claimed + loud-refused).
+fn kind_to_canonical(kind: &str) -> Option<&'static str> {
+    Some(match kind {
+        "eq" => "assert_eq",
+        "ne" => "assert_ne",
+        "truth" => "assert",
+        "matches" => "assert_matches",
+        "abs_diff" => "assert_abs_diff_eq",
+        "relative" => "assert_relative_eq",
+        "ulps" | "refuse" => "assert_ulps_eq",
+        _ => return None,
+    })
+}
+
+/// Map an assertion-macro name to its canonical handler. An EXTERNALIZED exception
+/// (workspace data) wins first; otherwise LEARN the kind from the name's shape rather
+/// than a closed hand-list. The std assertions match exactly; any other `assert*`
+/// macro is classified by the tolerance-family semantic its name carries
+/// (`abs_diff`/`relative`/`ulps`), so a sibling or re-exported macro is recognised
+/// WITHOUT a hardcoded entry -- the Rust mirror of deriving the vocabulary from
+/// source, where the macro name is the readable signal. None for a non-assertion.
 fn canonical_assertion_name(name: &str) -> Option<&'static str> {
+    if let Some(kind) = ASSERTION_EXCEPTIONS.with(|m| m.borrow().get(name).cloned()) {
+        return kind_to_canonical(&kind);
+    }
     match name {
         "assert_eq" => Some("assert_eq"),
         "assert_ne" => Some("assert_ne"),
@@ -1991,6 +2046,40 @@ mod tests {
         // non-assertions and unknown assert-shaped names are not misclassified
         assert_eq!(canonical_assertion_name("println"), None);
         assert_eq!(canonical_assertion_name("assert_something_else"), None);
+    }
+
+    #[test]
+    fn externalized_exception_classifies_a_non_semantic_macro_name() {
+        ASSERTION_EXCEPTIONS.with(|m| m.borrow_mut().clear());
+        // float_cmp's `assert_approx_eq!` carries no abs_diff/relative/ulps signal,
+        // so the name-learner alone returns None.
+        assert_eq!(canonical_assertion_name("assert_approx_eq"), None);
+        // a workspace classifies it as DATA -> recognised, no lifter code change.
+        ASSERTION_EXCEPTIONS.with(|m| {
+            m.borrow_mut().insert("assert_approx_eq".into(), "abs_diff".into());
+            m.borrow_mut().insert("strict_check".into(), "refuse".into());
+        });
+        assert_eq!(canonical_assertion_name("assert_approx_eq"), Some("assert_abs_diff_eq"));
+        // `refuse` routes to the claimed-but-refused handler
+        assert_eq!(canonical_assertion_name("strict_check"), Some("assert_ulps_eq"));
+        ASSERTION_EXCEPTIONS.with(|m| m.borrow_mut().clear());
+    }
+
+    #[test]
+    fn read_assertion_exceptions_walks_up_to_the_workspace_file() {
+        use std::io::Write;
+        let base = std::env::temp_dir().join(format!("pk-rust-exc-{}", std::process::id()));
+        let vx = base.join(".provekit").join("vocab-exceptions");
+        std::fs::create_dir_all(&vx).unwrap();
+        std::fs::File::create(vx.join("rust-assertions.json"))
+            .unwrap()
+            .write_all(br#"{"assert_approx_eq": "abs_diff"}"#)
+            .unwrap();
+        let src = base.join("tests").join("t.rs");
+        std::fs::create_dir_all(src.parent().unwrap()).unwrap();
+        let map = read_assertion_exceptions(src.to_str().unwrap()).unwrap();
+        assert_eq!(map.get("assert_approx_eq").map(String::as_str), Some("abs_diff"));
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[test]

--- a/implementations/rust/provekit-lift-rust-tests/src/lib.rs
+++ b/implementations/rust/provekit-lift-rust-tests/src/lib.rs
@@ -644,13 +644,93 @@ struct AssertionCallsite {
     arg_sig: Option<String>,
 }
 
+/// The closed range `[lo, hi]` of a fixed-width Rust integer type, as i64 bounds.
+/// `hi` is None for widths whose maximum exceeds i64 (u64/usize/u128); the lower
+/// bound (>= 0 for unsigned) still applies. None for a non-integer type.
+fn int_type_bounds(name: &str) -> Option<(Option<i64>, Option<i64>)> {
+    Some(match name {
+        "i8" => (Some(-128), Some(127)),
+        "i16" => (Some(-32768), Some(32767)),
+        "i32" => (Some(-2_147_483_648), Some(2_147_483_647)),
+        "i64" | "isize" => (Some(i64::MIN), Some(i64::MAX)),
+        "u8" => (Some(0), Some(255)),
+        "u16" => (Some(0), Some(65535)),
+        "u32" => (Some(0), Some(4_294_967_295)),
+        "u64" | "usize" | "u128" => (Some(0), None), // unsigned: lower bound only
+        "i128" => (None, None),                       // 128-bit: bounds exceed i64
+        _ => return None,
+    })
+}
+
+/// The integer-width REFINEMENT for `<term> as <ty>`: a value of a fixed-width
+/// integer type is bounded to that type's range. Emitted as range constraints
+/// (`lo <= term ∧ term <= hi`) -- the integral+width refinement of the numeric
+/// hierarchy, with real teeth (bounds/overflow) and using only existing primitives.
+fn int_type_bound_formulas(ty: &syn::Type, term: &Rc<Term>) -> Vec<Rc<Formula>> {
+    let name = match ty {
+        syn::Type::Path(p) => match p.path.segments.last() {
+            Some(seg) => seg.ident.to_string(),
+            None => return vec![],
+        },
+        _ => return vec![],
+    };
+    let (lo, hi) = match int_type_bounds(&name) {
+        Some(b) => b,
+        None => return vec![],
+    };
+    let mut out = Vec::new();
+    if let Some(lo) = lo {
+        out.push(lte(num(lo), term.clone())); // lo <= term
+    }
+    if let Some(hi) = hi {
+        out.push(lte(term.clone(), num(hi))); // term <= hi
+    }
+    out
+}
+
+/// Walk the observed assertion exprs for `<e> as <intN>` casts and emit a width
+/// refinement for each (recursing through transparent wrappers + binary operands).
+fn collect_int_width_refinements(exprs: &[syn::Expr]) -> Vec<Rc<Formula>> {
+    fn walk(e: &syn::Expr, out: &mut Vec<Rc<Formula>>) {
+        match e {
+            syn::Expr::Cast(c) => {
+                if let Ok(term) = translate_term(&c.expr) {
+                    out.extend(int_type_bound_formulas(&c.ty, &term));
+                }
+                walk(&c.expr, out);
+            }
+            syn::Expr::Paren(p) => walk(&p.expr, out),
+            syn::Expr::Reference(r) => walk(&r.expr, out),
+            syn::Expr::Unary(u) => walk(&u.expr, out),
+            syn::Expr::Binary(b) => {
+                walk(&b.left, out);
+                walk(&b.right, out);
+            }
+            _ => {}
+        }
+    }
+    let mut out = Vec::new();
+    for e in exprs {
+        walk(e, &mut out);
+    }
+    out
+}
+
 fn lift_assertion_macro_at_callsites(
     mac: &syn::Macro,
     source_path: &str,
     bindings: &BTreeMap<String, BoundCall>,
 ) -> Result<Vec<LiftedCallsiteAssertion>, String> {
-    let formula = lift_assertion_macro(mac)?;
+    let mut formula = lift_assertion_macro(mac)?;
     let exprs = assertion_observed_exprs(mac)?;
+    // Conjoin the integer-width refinements (`<x> as i32` -> x in range) so the
+    // contract carries the bound; substitution below keys them to the same callsite.
+    let refinements = collect_int_width_refinements(&exprs);
+    if !refinements.is_empty() {
+        let mut parts = vec![formula];
+        parts.extend(refinements);
+        formula = and_(parts);
+    }
     let mut callsites = Vec::new();
     let mut substitutions: BTreeMap<String, Rc<Term>> = BTreeMap::new();
     for expr in &exprs {
@@ -1911,6 +1991,31 @@ mod tests {
         // non-assertions and unknown assert-shaped names are not misclassified
         assert_eq!(canonical_assertion_name("println"), None);
         assert_eq!(canonical_assertion_name("assert_something_else"), None);
+    }
+
+    #[test]
+    fn integer_cast_adds_a_width_range_refinement() {
+        // `compute(a) as i32` -> the contract carries compute()'s i32 bounds.
+        let exprs: Vec<syn::Expr> =
+            vec![syn::parse_quote!(compute(a) as i32), syn::parse_quote!(5)];
+        let refs = collect_int_width_refinements(&exprs);
+        assert_eq!(refs.len(), 2, "i32 contributes a lower and an upper bound");
+        let dump = format!("{refs:?}");
+        assert!(dump.contains("2147483647"), "i32 max present: {dump}");
+        assert!(dump.contains("2147483648"), "i32 min present: {dump}");
+    }
+
+    #[test]
+    fn unsigned_64bit_cast_adds_only_the_lower_bound() {
+        // usize/u64 upper exceeds i64; emit the >= 0 lower bound only (still sound).
+        let exprs: Vec<syn::Expr> = vec![syn::parse_quote!(n as usize)];
+        assert_eq!(collect_int_width_refinements(&exprs).len(), 1);
+    }
+
+    #[test]
+    fn non_integer_cast_adds_no_refinement() {
+        let exprs: Vec<syn::Expr> = vec![syn::parse_quote!(x as f64)];
+        assert!(collect_int_width_refinements(&exprs).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
The two follow-ups flagged after #1940/#1941, now done.

**1. Integer WIDTH refinement.** `translate_term` dropped the cast type; now
`lift_assertion_macro_at_callsites` scans operand `<e> as <intN>` casts and conjoins
the width refinement — a fixed-width integer value is bounded to its range:

```
assert_eq!(compute() as i32, 5)
  ->  compute() == 5  ∧  -2147483648 <= compute()  ∧  compute() <= 2147483647
```

The integral+width refinement of the numeric hierarchy, with real bounds/overflow
teeth, using only existing primitives. i8..i64 + u8..u32 get both bounds; u64/usize/
u128 emit the `>= 0` lower bound only (upper exceeds i64); i128/non-integer add none.

**2. Externalized macro exceptions.** The name-learner (#1941) classifies the approx
family + siblings from the macro name, but a crate whose name carries no tolerance
signal (float_cmp's `assert_approx_eq!`) went unclassified. Now the vocabulary is
also extensible by DATA — the Rust mirror of the Python `.provekit/vocab-exceptions/`:
`read_assertion_exceptions` walks up to a workspace
`.provekit/vocab-exceptions/rust-assertions.json` ({macro: kind}) and loads it at each
lift entry; `canonical_assertion_name` consults it first. `{"assert_approx_eq":
"abs_diff"}` makes float_cmp's macro lift as a tolerance bound; `"<macro>": "refuse"`
claims + loud-refuses. A library classifies a macro by dropping a file, never code.

56 crate tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)