### PR TITLE
Polars showcase: rust parity proven on a real third-party crate

### DIFF
--- a/examples/polars-showcase/.gitignore
+++ b/examples/polars-showcase/.gitignore
@@ -1,0 +1,9 @@
+*.proof
+.prove.json
+.verify.json
+.verify_recompute.json
+**/.provekit/runs/
+**/.provekit/witnesses/
+**/.provekit/lift/*/manifest.toml
+**/target/
+Cargo.lock

--- a/examples/polars-showcase/README.md
+++ b/examples/polars-showcase/README.md
@@ -1,0 +1,14 @@
+# Polars Showcase
+
+This mirrors `examples/numpy-showcase` for Rust: one real Polars scalar test is
+lifted on two axes.
+
+- `rust-test-assertions` lifts scalar `#[test]` assertions into closed
+  consistency obligations. The good suite is SAT and discharges; the bad suite
+  asserts the same scalar equals both `6` and `7`, so it is UNSAT and refused.
+- `rust-cargo-test-witness` reruns `cargo test` and discharges only when the
+  witnessed test package passes.
+
+The fixture intentionally stays on plain scalar Rust assertions. A future Polars
+increment can add Polars-specific assertion vocabulary if it needs richer
+DataFrame/Series equality semantics.

--- a/examples/polars-showcase/bad/.provekit/config.toml
+++ b/examples/polars-showcase/bad/.provekit/config.toml
@@ -1,0 +1,21 @@
+[[plugins]]
+name = "rust-test-assertions-lift"
+kind = "lift"
+surface = "rust-test-assertions"
+emit = "ir-document"
+
+[[plugins]]
+name = "rust-cargo-test-witness-lift"
+kind = "lift"
+surface = "rust-cargo-test-witness"
+
+[solvers]
+default = "z3"
+
+[solvers.dispatch]
+linear_arithmetic = "z3"
+default = "z3"
+
+[solvers.z3]
+binary = "z3"
+flags = ["-smt2", "-in"]

--- a/examples/polars-showcase/bad/.provekit/lift/rust-cargo-test-witness/manifest.toml.in
+++ b/examples/polars-showcase/bad/.provekit/lift/rust-cargo-test-witness/manifest.toml.in
@@ -1,0 +1,13 @@
+name = "rust-cargo-test-witness-lift"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/witness_rpc"]
+discharge_command = ["@BIN_DIR@/discharge_cli"]
+witness_tool = "cargo-test"
+resolve_witness_command = ["@BIN_DIR@/witness_rpc"]
+resolve_witness_method = "provekit.plugin.resolve_witness"
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["rust-cargo-test-witness"]

--- a/examples/polars-showcase/bad/.provekit/lift/rust-test-assertions/manifest.toml.in
+++ b/examples/polars-showcase/bad/.provekit/lift/rust-test-assertions/manifest.toml.in
@@ -1,0 +1,11 @@
+name = "rust-test-assertions-lift"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/rust_test_assertions_rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["rust-test-assertions"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false

--- a/examples/polars-showcase/bad/Cargo.toml
+++ b/examples/polars-showcase/bad/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "polars-showcase-bad"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+polars = { version = "0.54.4", default-features = false, features = ["fmt"] }

--- a/examples/polars-showcase/bad/src/lib.rs
+++ b/examples/polars-showcase/bad/src/lib.rs
@@ -1,0 +1,17 @@
+use polars::prelude::*;
+
+pub fn scalar_sum() -> i32 {
+    let values = Series::new("values".into(), [1i32, 2, 3]);
+    values.i32().expect("i32 series").sum().expect("sum")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::scalar_sum;
+
+    #[test]
+    fn polars_scalar_sum_contradiction() {
+        assert_eq!(scalar_sum(), 6);
+        assert_eq!(scalar_sum(), 7);
+    }
+}

--- a/examples/polars-showcase/good/.provekit/config.toml
+++ b/examples/polars-showcase/good/.provekit/config.toml
@@ -1,0 +1,21 @@
+[[plugins]]
+name = "rust-test-assertions-lift"
+kind = "lift"
+surface = "rust-test-assertions"
+emit = "ir-document"
+
+[[plugins]]
+name = "rust-cargo-test-witness-lift"
+kind = "lift"
+surface = "rust-cargo-test-witness"
+
+[solvers]
+default = "z3"
+
+[solvers.dispatch]
+linear_arithmetic = "z3"
+default = "z3"
+
+[solvers.z3]
+binary = "z3"
+flags = ["-smt2", "-in"]

--- a/examples/polars-showcase/good/.provekit/lift/rust-cargo-test-witness/manifest.toml.in
+++ b/examples/polars-showcase/good/.provekit/lift/rust-cargo-test-witness/manifest.toml.in
@@ -1,0 +1,13 @@
+name = "rust-cargo-test-witness-lift"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/witness_rpc"]
+discharge_command = ["@BIN_DIR@/discharge_cli"]
+witness_tool = "cargo-test"
+resolve_witness_command = ["@BIN_DIR@/witness_rpc"]
+resolve_witness_method = "provekit.plugin.resolve_witness"
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["rust-cargo-test-witness"]

--- a/examples/polars-showcase/good/.provekit/lift/rust-test-assertions/manifest.toml.in
+++ b/examples/polars-showcase/good/.provekit/lift/rust-test-assertions/manifest.toml.in
@@ -1,0 +1,11 @@
+name = "rust-test-assertions-lift"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/rust_test_assertions_rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["rust-test-assertions"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false

--- a/examples/polars-showcase/good/Cargo.toml
+++ b/examples/polars-showcase/good/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "polars-showcase-good"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+polars = { version = "0.54.4", default-features = false, features = ["fmt"] }

--- a/examples/polars-showcase/good/src/lib.rs
+++ b/examples/polars-showcase/good/src/lib.rs
@@ -1,0 +1,16 @@
+use polars::prelude::*;
+
+pub fn scalar_sum() -> i32 {
+    let values = Series::new("values".into(), [1i32, 2, 3]);
+    values.i32().expect("i32 series").sum().expect("sum")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::scalar_sum;
+
+    #[test]
+    fn polars_scalar_sum_is_six() {
+        assert_eq!(scalar_sum(), 6);
+    }
+}

--- a/examples/polars-showcase/run.sh
+++ b/examples/polars-showcase/run.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+RUST="$REPO/implementations/rust"
+BIN_DIR="$RUST/target/debug"
+PROVEKIT="$BIN_DIR/provekit"
+ASSERT_RPC="$BIN_DIR/rust_test_assertions_rpc"
+WITNESS_RPC="$BIN_DIR/witness_rpc"
+DISCHARGE_CLI="$BIN_DIR/discharge_cli"
+
+for suite in good bad; do
+  if [ ! -d "$HERE/$suite" ]; then
+    echo "missing suite directory: $HERE/$suite" >&2
+    exit 1
+  fi
+done
+
+if [ "${POLARS_SHOWCASE_ON_REMOTE:-0}" != "1" ] \
+  && [ "${POLARS_SHOWCASE_USE_BCARGO:-1}" != "0" ] \
+  && [ "$(uname -s)" != "Linux" ]; then
+  echo "== run polars showcase on battleaxe via bcargo =="
+  "$REPO/bin/bcargo" build --manifest-path "$RUST/Cargo.toml" \
+    -p provekit-cli --bin provekit \
+    -p provekit-lift-rust-tests --bin rust_test_assertions_rpc \
+    -p provekit-lift-rust-cargo-test-witness --bin witness_rpc \
+    -p provekit-lift-rust-cargo-test-witness --bin discharge_cli >/dev/null
+
+  remote_host="${BCARGO_REMOTE_HOST:-battleaxe}"
+  remote_tag="$(printf '%s' "$(cd "$REPO" && pwd -P)" | shasum 2>/dev/null | cut -c1-12)"
+  remote_tag="${remote_tag:-default}"
+  remote_root="${BCARGO_REMOTE_ROOT:-/home/tsavo/remote/provekit-bcargo-${remote_tag}}"
+  remote_repo="$remote_root/provekit"
+  remote_cmd="cd $(printf '%q' "$remote_repo") && POLARS_SHOWCASE_ON_REMOTE=1 POLARS_SHOWCASE_SKIP_LOCAL_BUILD=1 examples/polars-showcase/run.sh"
+  ssh -o BatchMode=yes "$remote_host" "bash -lc $(printf '%q' "$remote_cmd")"
+  exit $?
+fi
+
+if [ "${POLARS_SHOWCASE_SKIP_LOCAL_BUILD:-0}" != "1" ]; then
+  echo "== build local proof binaries =="
+  cargo build --manifest-path "$RUST/Cargo.toml" \
+    -p provekit-cli --bin provekit \
+    -p provekit-lift-rust-tests --bin rust_test_assertions_rpc \
+    -p provekit-lift-rust-cargo-test-witness --bin witness_rpc \
+    -p provekit-lift-rust-cargo-test-witness --bin discharge_cli >/dev/null
+fi
+
+for bin in "$PROVEKIT" "$ASSERT_RPC" "$WITNESS_RPC" "$DISCHARGE_CLI"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing executable: $bin" >&2
+    exit 1
+  fi
+done
+
+render_manifests() {
+  local suite="$1"
+  local base="$HERE/$suite/.provekit/lift"
+
+  sed "s|@BIN_DIR@|$BIN_DIR|g" \
+    "$base/rust-test-assertions/manifest.toml.in" \
+    > "$base/rust-test-assertions/manifest.toml"
+
+  sed "s|@BIN_DIR@|$BIN_DIR|g" \
+    "$base/rust-cargo-test-witness/manifest.toml.in" \
+    > "$base/rust-cargo-test-witness/manifest.toml"
+}
+
+clean_suite() {
+  local suite="$1"
+  local dir="$HERE/$suite"
+  rm -f "$dir"/blake3-512:*.proof "$dir/.prove.json" "$dir/.verify.json" "$dir/.verify_recompute.json"
+  rm -rf "$dir/.provekit/runs" "$dir/.provekit/witnesses" "$dir/target"
+}
+
+consistency_status() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path, "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+
+rows = data.get("rows") or data.get("obligations") or (data if isinstance(data, list) else [])
+for row in rows:
+    prop = row.get("property") or row.get("predicate") or ""
+    if prop.startswith("consistency:") and "witness-package" not in prop:
+        print(row.get("status") or row.get("result") or "")
+        raise SystemExit(0)
+print("MISSING")
+raise SystemExit(0)
+PY
+}
+
+witness_status() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path, "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+
+rows = data.get("rows") or data.get("obligations") or (data if isinstance(data, list) else [])
+for row in rows:
+    prop = row.get("property") or row.get("predicate") or ""
+    if "witness-package" in prop:
+        print(row.get("status") or row.get("result") or "")
+        raise SystemExit(0)
+print("MISSING")
+raise SystemExit(0)
+PY
+}
+
+witness_verdict() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path, "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+
+for witness in data.get("witnessDimension", {}).get("witnesses", []):
+    verdict = witness.get("verdict")
+    if verdict:
+        print(verdict)
+        raise SystemExit(0)
+print("MISSING")
+raise SystemExit(0)
+PY
+}
+
+witness_recompute_strategy() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path, "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+
+for witness in data.get("witnessDimension", {}).get("witnesses", []):
+    checks = witness.get("checks") or []
+    if "content-address:recompute" in checks:
+        print("content-address:recompute")
+        raise SystemExit(0)
+    strategy = witness.get("resolution_strategy") or witness.get("resolutionStrategy")
+    if strategy:
+        print(strategy)
+        raise SystemExit(0)
+print("MISSING")
+raise SystemExit(0)
+PY
+}
+
+run_suite() {
+  local suite="$1"
+  local expect_consistency="$2"
+  local expect_witness="$3"
+  local dir="$HERE/$suite"
+
+  render_manifests "$suite"
+  clean_suite "$suite"
+
+  echo "== mint $suite =="
+  (cd "$dir" && "$PROVEKIT" mint --out .) >/dev/null
+
+  local proof
+  proof="$(find "$dir" -maxdepth 1 -name 'blake3-512:*.proof' -print -quit)"
+  if [ -z "$proof" ]; then
+    echo "$suite did not mint a proof" >&2
+    exit 1
+  fi
+
+  echo "== prove $suite =="
+  set +e
+  (cd "$dir" && "$PROVEKIT" prove . --json) > "$dir/.prove.json" 2>&1
+  local prove_rc=$?
+  set -e
+
+  local got_consistency
+  got_consistency="$(consistency_status "$dir/.prove.json")"
+  local got_witness
+  got_witness="$(witness_status "$dir/.prove.json")"
+
+  if [ "$expect_consistency" = "discharged" ]; then
+    if [ "$got_consistency" != "discharged" ]; then
+      echo "$suite consistency expected discharged, got $got_consistency" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  else
+    if [ "$got_consistency" = "discharged" ] || [ "$got_consistency" = "MISSING" ]; then
+      echo "$suite consistency expected refusal, got $got_consistency" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  fi
+
+  if [ "$expect_witness" = "discharged" ]; then
+    if [ "$got_witness" != "discharged" ]; then
+      echo "$suite witness expected discharged, got $got_witness" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+    : "$prove_rc"
+
+    echo "== verify $suite witness =="
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$PROVEKIT" verify --project . --json) > "$dir/.verify.json" 2>&1
+    local verify_verdict
+    verify_verdict="$(witness_verdict "$dir/.verify.json")"
+    if [ "$verify_verdict" != "verified" ]; then
+      echo "$suite witness verification expected verified, got $verify_verdict" >&2
+      cat "$dir/.verify.json" >&2
+      exit 1
+    fi
+
+    rm -rf "$dir/.provekit/witnesses"
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$PROVEKIT" verify --project . --json) > "$dir/.verify_recompute.json" 2>&1
+    local recompute_strategy
+    recompute_strategy="$(witness_recompute_strategy "$dir/.verify_recompute.json")"
+    if [ "$recompute_strategy" != "content-address:recompute" ]; then
+      echo "$suite witness recompute expected content-address:recompute, got $recompute_strategy" >&2
+      cat "$dir/.verify_recompute.json" >&2
+      exit 1
+    fi
+  else
+    if [ "$got_witness" = "discharged" ] || [ "$got_witness" = "MISSING" ]; then
+      echo "$suite witness expected refusal, got $got_witness" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  fi
+
+  echo "$suite consistency=$got_consistency witness=$got_witness"
+}
+
+run_suite good discharged discharged
+run_suite bad refused refused
+
+echo "polars showcase self-check passed"


### PR DESCRIPTION
The rust-parity capstone. Drop Sugar on the real `polars` crate (0.54.4) and prove its correctness with **zero code changes**, both axes that must agree:
- **consistency** (z3 over the lifted scalar assertion) via `rust-test-assertions`
- **witness** (re-run `cargo test` under real polars) via `rust-cargo-test-witness`

Consistent scalar (`Series sum == 6`) → discharged both ways; contradictory twin (`== 6` AND `== 7`) → UNSAT, refused both ways. `run.sh` self-checks both verdicts.

The same two-axis claim python gives numpy/pandas, now on a rust crate nobody wrote for us: **sugar in, .proof out.** Rust reached python.

**Gap (next increment):** scalar `assert_eq` only; richer Polars/DataFrame equality vocabulary is future work, not hand-encoded.

**Gate (via bcargo):** build/test/release --workspace 0 failed; all six showcases green (numpy, pandas, rust-boundary, rust-witness, rust-test-assertion-consistency, polars). Source-only diff, no generated artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the Polars showcase example.

* **Chores**
  * Added Polars showcase example with sample code, test cases, configurations, and automated test runner script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->