### PR TITLE
Fix flaky doctor cross-kit-consistency test (subprocess-spawn race)

### DIFF
--- a/implementations/rust/sugar-cli/src/doctor.rs
+++ b/implementations/rust/sugar-cli/src/doctor.rs
@@ -4831,43 +4831,45 @@ in the job, not on this crate. Not a live regression guard. Tracked in #1926."]
     {
         use libsugar::concept::panic_freedom;
 
-        let td = TempDir::new().unwrap();
-        let kit = td.path();
-        write_declaration_plugins(
-            kit,
-            &[
-                (
-                    "python-source-plugin",
+        // Hermetic: exercise the consistency CHECK directly over constructed
+        // declarations. The previous form spawned a kit-declaration RPC plugin
+        // per surface via run_report_with_context; under parallel test load a
+        // transient subprocess-spawn failure dropped a declaration, so the
+        // cross-kit conflict intermittently went undetected (flaky in CI). The
+        // check is a pure BTreeMap fold, so feed it the declarations directly.
+        let loaded = vec![
+            LoadedKitDeclaration {
+                kind_dir: "lift".to_string(),
+                surface: "python-source".to_string(),
+                declaration: serde_json::from_value(declaration_with_mapping(
                     "python-source",
-                    declaration_with_mapping(
-                        "python-source",
-                        "python",
-                        "python-source",
-                        PANIC_FREEDOM_EFFECT_KIND,
-                        "guardPredicates",
-                        "same-local",
-                        panic_freedom::IS_NONE_CONCEPT,
-                    ),
-                ),
-                (
-                    "python-leaf-plugin",
+                    "python",
+                    "python-source",
+                    PANIC_FREEDOM_EFFECT_KIND,
+                    "guardPredicates",
+                    "same-local",
+                    panic_freedom::IS_NONE_CONCEPT,
+                ))
+                .expect("parse python-source declaration"),
+            },
+            LoadedKitDeclaration {
+                kind_dir: "lift".to_string(),
+                surface: "python-leaf".to_string(),
+                declaration: serde_json::from_value(declaration_with_mapping(
                     "python-leaf",
-                    declaration_with_mapping(
-                        "python-leaf",
-                        "python",
-                        "python-leaf",
-                        PANIC_FREEDOM_EFFECT_KIND,
-                        "effectLeaves",
-                        "same-local",
-                        panic_freedom::METHOD_UNWRAP_CONCEPT,
-                    ),
-                ),
-            ],
-        );
+                    "python",
+                    "python-leaf",
+                    PANIC_FREEDOM_EFFECT_KIND,
+                    "effectLeaves",
+                    "same-local",
+                    panic_freedom::METHOD_UNWRAP_CONCEPT,
+                ))
+                .expect("parse python-leaf declaration"),
+            },
+        ];
 
-        let report = run_report_with_context(kit, DoctorContext::new(DoctorMode::Strict));
-
-        let consistency = check_by_id(&report, "kit.declaration.cross_kit_consistency");
+        let consistency =
+            kit_declaration_cross_kit_consistency_check(DoctorMode::Strict, &loaded);
         assert_eq!(consistency.status, CheckStatus::Fail);
         assert!(
             consistency.detail.contains("same-local"),


### PR DESCRIPTION
## Problem

`doctor_cross_kit_declaration_consistency_fails_same_local_different_categories_across_kits` is flaky in CI (it tripped the post-merge gate on the Sugar increment-1 PR). It passes in isolation and most of the time, fails ~randomly under parallel load.

## Cause

The test called `run_report_with_context`, which loads kit declarations by **spawning a kit-declaration RPC plugin subprocess per surface**. Under parallel test load a transient spawn failure drops one declaration from `loaded_declarations`, so the cross-kit conflict isn't present to detect → `consistency.status` is not `Fail` → assertion fails. The flake is in declaration *acquisition*, not the logic.

## Fix

`kit_declaration_cross_kit_consistency_check` is a pure `BTreeMap` fold over `&[LoadedKitDeclaration]`. The subprocess spawning was incidental harness, not the unit under test. Construct the two `LoadedKitDeclaration` values directly and call the check — no spawn, deterministic by construction.

## Verification

- New form: **20/20 green** in a loop (was intermittently red).
- Full `sugar-cli --lib`: **188 passed, 0 failed**.
- The spawn → parse → check integration path remains covered by the other doctor declaration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored cross-kit consistency validation tests to be self-contained and hermetic, eliminating external process dependencies and improving test reliability and execution performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->