### PR TITLE
Sugar cutover increment 2: CLI binary provekit -> sugar (sugar lift / sugar prove)

### DIFF
--- a/.github/ISSUE_TEMPLATE/kit-coverage.yml
+++ b/.github/ISSUE_TEMPLATE/kit-coverage.yml
@@ -56,7 +56,7 @@ body:
       label: Conformance dogfood
       options:
         - label: "`.provekit/self-contracts-attestations/<kit>.json` produced via substrate-side mint (no kit-specific mint code)"
-        - label: "`provekit prove --kit=<kit>` passes against canonical contracts"
+        - label: "`sugar prove --kit=<kit>` passes against canonical contracts"
         - label: Bundle CID is real (not a placeholder)
   - type: textarea
     id: status

--- a/.github/actions/provekit-verify/action.yml
+++ b/.github/actions/provekit-verify/action.yml
@@ -8,7 +8,7 @@ branding:
 
 inputs:
   working-directory:
-    description: 'Directory in which to run `provekit verify`. Defaults to the repository root.'
+    description: 'Directory in which to run `sugar verify`. Defaults to the repository root.'
     required: false
     default: '.'
   fail-on-decay:
@@ -35,7 +35,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Run provekit verify
+    - name: Run sugar verify
       id: verify
       shell: bash
       working-directory: ${{ inputs.working-directory }}
@@ -52,7 +52,7 @@ runs:
         # Capture the JSON report. We run twice: once with --json to capture
         # the machine-readable verdict, once without for human-friendly logs.
         # The duplicate run is cheap because the cache is warm on the second
-        # call. Both go through `provekit verify`: the standing-
+        # call. Both go through `sugar verify`: the standing-
         # runtime gate, no LLM, no network.
         npx -y "provekit@${PROVEKIT_VERSION}" verify --json $verbose_flag > provekit-report.json 2> provekit-report.err
         json_exit=$?

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ build-all: build-rust build-python
 
 .PHONY: build-rust
 build-rust:
-	$(call CARGO_SYNC_BINS,provekit provekit-lift) build --release --manifest-path implementations/rust/Cargo.toml
+	$(call CARGO_SYNC_BINS,sugar provekit-lift) build --release --manifest-path implementations/rust/Cargo.toml
 
 .PHONY: build-rust-cli
 build-rust-cli:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Correctness is `k(I) = t`: a program `k` applied to an input/precondition `I`
 produces an output/postcondition `t`. A `.proof` is a kept promise made
 checkable. The program, the input, and the result are each content-addressed
 and pinned, so the claim names exactly what it is about and cannot be silently
-rebound. `provekit verify` lets a stranger recompute the guarantee.
+rebound. `sugar verify` lets a stranger recompute the guarantee.
 
 A `.proof` is discharged **two independent ways, and both must agree**:
 
@@ -34,7 +34,7 @@ A `.proof` is discharged **two independent ways, and both must agree**:
   refused.
 
 The numpy showcase (`examples/numpy-showcase/`) discharges both on a real
-library operation. `provekit prove` reports `discharged: 2`: one obligation
+library operation. `sugar prove` reports `discharged: 2`: one obligation
 "test assertions mutually consistent ... [solver 'z3' returned sat]", one
 "witnessed by recompute (kit): re-ran on pinned code; assertions held; witness
 CID reproduced." A `np.add(2,3)` asserted both `== 5` and `== 6` is refused
@@ -65,7 +65,7 @@ all of numpy inside it.
   RESOLVES the witness body. The Rust CLI BLAKE3's the body itself and compares
   to the pinned CID. A wrong body for a CID (broken oracle) is distinguished
   from an honest re-run that differs (drift).
-  (`implementations/rust/provekit-cli/src/witness_verify.rs`,
+  (`implementations/rust/sugar-cli/src/witness_verify.rs`,
   `implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/witness_oracle.py`.)
 - A contract is already a CID. So the `.proof` is pure correctness identity:
   source, witness, and contract are all resolved-and-recomputed, never trusted.
@@ -82,7 +82,7 @@ numpy version. `numpy.add` is a C ufunc with no python body, so it is simply not
 among the python functions lifted; the thousands that are python all lift.
 
 The vendor ships the `.proof` plus a separately deployed witness package
-(`<cid>.witness`, the audit material). A consumer runs `provekit verify`, which
+(`<cid>.witness`, the audit material). A consumer runs `sugar verify`, which
 recomputes everything:
 
 ```
@@ -135,7 +135,7 @@ sugar-facet is a materializer), and resolve dependency `.proof` artifacts
 through the package manager and filesystem rules of their ecosystem. Kits never
 verify: they only resolve bodies over RPC.
 
-**The CLI owns proof computation over normalized data.** The `provekit` CLI is
+**The CLI owns proof computation over normalized data.** The `sugar` CLI is
 language-agnostic. It loads `.proof` artifacts, speaks RPC to configured kits,
 normalizes claims, composes implications, conjoins same-named contracts, runs
 the solver, recomputes witnesses, and reports discharge status. The CLI does not
@@ -176,51 +176,52 @@ expensive proof work by making prior commitments content-addressed and reusable.
 
 ## What the CLI does
 
-> _Naming: the project is now **Sugar**, but the CLI binary and crates still
-> carry the `provekit` name until the code cutover. The rename is staged because
-> it is content-addressed — renaming the kits re-mints every `.proof` — so it
-> lands as one coordinated swing. Commands below use today's `provekit`; they
-> become `sugar <verb>` after the cutover._
+> _Naming: the project is **Sugar**. The Rust crates (`sugar-*`) and the CLI
+> binary (`sugar`) have been renamed. The proofchain identity layer — kit ids,
+> wire tokens, and `.proof` producer strings — still carries the `provekit`
+> name, frozen on purpose: it is content-addressed, so re-minting it under the
+> `sugar` name is a separate, deliberate swing. The dependency graph is sugar;
+> the CID identity is still provekit. Names are sugar, CID is identity._
 
-The canonical CLI is the Rust `provekit` binary. Run `provekit --help` for the
+The canonical CLI is the Rust `sugar` binary. Run `sugar --help` for the
 authoritative list; the current subcommands include:
 
-- `provekit mint`: dispatch the configured lift plugins and write `.proof`
+- `sugar mint`: dispatch the configured lift plugins and write `.proof`
   artifacts. This is the verb that actually drives lifting in every example
   here.
-- `provekit prove`: run the six-stage verifier. Load proofs, resolve dependency
+- `sugar prove`: run the six-stage verifier. Load proofs, resolve dependency
   proofs through kits, enumerate callsites, conjoin same-named contracts, solve
   obligations, recompute witnesses, and report discharge status.
-- `provekit verify`: verify a kit end to end. Lift its contract claims,
+- `sugar verify`: verify a kit end to end. Lift its contract claims,
   discharge each via the solver-dispatch table, recompute witnesses with the kit
   oracle untrusted, and emit a signed per-claim receipt. This is the gate verb.
-- `provekit dump`: pretty-print a `.proof` envelope (members, bodies,
+- `sugar dump`: pretty-print a `.proof` envelope (members, bodies,
   signatures).
-- `provekit hash`: compute the BLAKE3-512 CID of a file or stdin.
-- `provekit implicate` (alias `imp`): mint an implication memento (antecedent
+- `sugar hash`: compute the BLAKE3-512 CID of a file or stdin.
+- `sugar implicate` (alias `imp`): mint an implication memento (antecedent
   CID to consequent CID) via z3.
-- `provekit compose`: the JSON-RPC transport for the canonical compose
+- `sugar compose`: the JSON-RPC transport for the canonical compose
   primitive.
-- `provekit recognize`: scan source for shapes matching published sugar binding
+- `sugar recognize`: scan source for shapes matching published sugar binding
   templates and emit tags (the reverse direction of `materialize`).
-- `provekit materialize`: materialize concept-citation carriers into
+- `sugar materialize`: materialize concept-citation carriers into
   library-bound source via realize kits.
-- `provekit bind`: bind concept contracts to source code (the eight-verb
+- `sugar bind`: bind concept contracts to source code (the eight-verb
   pipeline against arbitrary user code).
-- `provekit emit`: emit target/framework test artifacts from neutral contract
+- `sugar emit`: emit target/framework test artifacts from neutral contract
   predicates.
-- `provekit protocol` / `provekit verify-protocol`: work with protocol catalog
+- `sugar protocol` / `sugar verify-protocol`: work with protocol catalog
   evolution artifacts, and confirm the local install conforms to its embedded
   protocol-catalog CID.
-- `provekit doctor`: validate a kit's config and manifest wiring before a run.
-- `provekit init`: scaffold a project (`provekit.toml`, `.provekit/`, sample
+- `sugar doctor`: validate a kit's config and manifest wiring before a run.
+- `sugar init`: scaffold a project (`provekit.toml`, `.provekit/`, sample
   invariant, GitHub Action).
 
-- `provekit lift`: dispatch the configured lift surface and write its ProofIR
+- `sugar lift`: dispatch the configured lift surface and write its ProofIR
   term JSON. `lift` stops at the lifted terms; `mint` is the verb that envelopes
   them into a signed `.proof`, which is what every example here uses.
 
-The command surface keeps moving as protocol work lands; `provekit --help` is the
+The command surface keeps moving as protocol work lands; `sugar --help` is the
 source of truth.
 
 ## Install
@@ -229,13 +230,13 @@ This repository is build-from-source today. Crates.io publishing is still future
 work. The current install path is:
 
 ```sh
-cargo install --path implementations/rust/provekit-cli
+cargo install --path implementations/rust/sugar-cli
 ```
 
 Verify the installed CLI's embedded protocol catalog:
 
 ```sh
-provekit verify-protocol
+sugar verify-protocol
 ```
 
 For project setup and first runs, start with
@@ -257,7 +258,7 @@ The numpy demos provision their own venv on first run.
 ## Current status
 
 - **Canonical implementation:** the Rust CLI in
-  `implementations/rust/provekit-cli`.
+  `implementations/rust/sugar-cli`.
 - **Protocol catalog:** embedded in the CLI and verified by `provekit
   verify-protocol`. The reference matrix
   ([docs/reference/per-language-status.md](docs/reference/per-language-status.md))

--- a/docs/quickstart-end-user.md
+++ b/docs/quickstart-end-user.md
@@ -28,7 +28,7 @@ z3 --version
 From the repo root:
 
 ```sh
-cargo install --path implementations/rust/provekit-cli
+cargo install --path implementations/rust/sugar-cli
 ```
 
 This installs `provekit` to `~/.cargo/bin/`. If that directory is not on your
@@ -46,7 +46,7 @@ provekit --version
 Confirm the install conforms to the protocol catalog it was built against:
 
 ```sh
-provekit verify-protocol
+sugar verify-protocol
 ```
 
 This prints the expected and actual catalog CIDs and `status: match`. The binary
@@ -159,10 +159,10 @@ cross-proof contract conjoin that makes inherited correctness work.
 ## Step 5: try it on your own project
 
 ```sh
-provekit init
+sugar init
 ```
 
-`provekit init` scaffolds `provekit.toml`, a `.provekit/` directory, a sample
+`sugar init` scaffolds `provekit.toml`, a `.provekit/` directory, a sample
 invariant, and a GitHub Action. From there the flow is:
 
 1. Declare your lift plugins in `.provekit/config.toml` and a manifest under
@@ -179,7 +179,7 @@ invariant, and a GitHub Action. From there the flow is:
 4. `provekit verify --project .` verifies a kit end to end and emits a signed
    per-claim receipt.
 
-The exact manifest wiring depends on your kit. `provekit doctor` validates a
+The exact manifest wiring depends on your kit. `sugar doctor` validates a
 kit's config and manifest before a run.
 
 ## Editor integration

--- a/docs/quickstart-extender.md
+++ b/docs/quickstart-extender.md
@@ -8,7 +8,7 @@ Before reading further: the architectural derivation (`docs/launch/the-pieces-on
 
 Note on the editor path below: the four-stage editor-squiggle pipeline
 (linker daemon plus LSP server plus editor) is the roadmap target, not the
-shipped path. What runs today is a batch plugin protocol: the `provekit` CLI
+shipped path. What runs today is a batch plugin protocol: the `sugar` CLI
 spawns each kit as a subprocess per invocation, drives it over JSON-RPC, and
 reads the result. See "The kit plugin RPC surface" below for the protocol the
 kits actually speak now. The diagram is the intended end state.
@@ -232,7 +232,7 @@ over `resolve_witness`, BLAKE3's those bytes itself, and compares to the pinned
 `witness_cid`. A body the oracle returns that does not recompute is a broken
 oracle, caught because Rust does the math anyway; an honest re-run that differs
 is drift. Both refuse, loudly, and are distinguished.
-(`implementations/rust/provekit-cli/src/witness_verify.rs:1-18`.)
+(`implementations/rust/sugar-cli/src/witness_verify.rs:1-18`.)
 
 So a kit that ships witnesses implements exactly one new method,
 `provekit.plugin.resolve_witness`, declares it in the manifest, and writes a
@@ -242,7 +242,7 @@ grades itself.
 
 ### A real editor LSP (shipped for Python)
 
-A real editor language server, where a `provekit prove` or `verify`
+A real editor language server, where a `sugar prove` or `verify`
 contradiction surfaces as an inline diagnostic (a red squiggle on the offending
 line), exists for Python:
 `implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/editor_lsp.py`,
@@ -252,7 +252,7 @@ invocation), this is a persistent stdio server speaking the LSP base wire
 protocol (Content-Length-framed JSON-RPC): `initialize`, `didOpen`, `didChange`,
 `didSave`, `publishDiagnostics`.
 
-It is a thin client over `provekit prove`. On open and save it runs `provekit
+It is a thin client over `sugar prove`. On open and save it runs `provekit
 prove --json` over the document's project, and for each unsatisfied obligation it
 recovers the callsite from the report's `#euf#` property term, matches it against
 the document AST, and publishes an `Error`-severity diagnostic on that call. The

--- a/docs/templates/provekit-example-workflow.yml
+++ b/docs/templates/provekit-example-workflow.yml
@@ -5,7 +5,7 @@
 # copy it into their own repository and have a working CI gate immediately.
 #
 # Drop this verbatim into `.github/workflows/provekit.yml` in your repo.
-# The job runs `npx provekit verify --ci`, which is the standing-
+# The job runs `npx sugar verify --ci`, which is the standing-
 # invariant gate (Z3 only, no LLM, no network). Exit code 1 (violation) fails
 # the workflow.
 
@@ -27,4 +27,4 @@ jobs:
         # `npm install` works without one.
         run: npm ci || npm install
       - name: Sugar verify
-        run: npx provekit verify --ci
+        run: npx sugar verify --ci

--- a/implementations/rust/sugar-cli/Cargo.toml
+++ b/implementations/rust/sugar-cli/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 description = "ProvekIt user-facing CLI: prove / verify / hash / dump / search / ask / init."
 
 [[bin]]
-name = "provekit"
+name = "sugar"
 path = "src/main.rs"
 
 [lib]

--- a/implementations/rust/sugar-cli/src/cmd_version.rs
+++ b/implementations/rust/sugar-cli/src/cmd_version.rs
@@ -40,12 +40,12 @@ pub fn run(args: VersionArgs) -> u8 {
 
     if args.out.json {
         let payload = json!({
-            "name": "provekit",
+            "name": "sugar",
             "version": CLI_VERSION,
         });
         println!("{}", serde_json::to_string_pretty(&payload).unwrap());
     } else {
-        println!("{} {}", "provekit".bold(), CLI_VERSION);
+        println!("{} {}", "sugar".bold(), CLI_VERSION);
     }
     crate::EXIT_OK
 }

--- a/implementations/rust/sugar-cli/src/main.rs
+++ b/implementations/rust/sugar-cli/src/main.rs
@@ -57,12 +57,12 @@ pub const EXIT_SOLVER_FAIL: u8 = 3;
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "provekit",
+    name = "sugar",
     version,
-    about = "ProvekIt CLI: per-codebase invariant enforcement at git-commit speed.",
-    long_about = "ProvekIt CLI. Walk .proof catalogs, verify property mementos, \
+    about = "Sugar CLI: per-codebase invariant enforcement at git-commit speed.",
+    long_about = "Sugar CLI. Walk .proof catalogs, verify property mementos, \
 mint implications, hash content. Each subcommand wraps an existing \
-ProvekIt Rust library; the CLI is routing only."
+Sugar Rust library; the CLI is routing only."
 )]
 struct Cli {
     #[command(subcommand)]

--- a/implementations/rust/sugar-cli/tests/bind_kit_path_integration.rs
+++ b/implementations/rust/sugar-cli/tests/bind_kit_path_integration.rs
@@ -22,7 +22,7 @@ use sugar_ir_types::Sort;
 use serde_json::{json, Value};
 
 fn provekit_bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+    PathBuf::from(env!("CARGO_BIN_EXE_sugar"))
 }
 
 fn primitive_sort(name: &str) -> Sort {

--- a/implementations/rust/sugar-cli/tests/cli_surface.rs
+++ b/implementations/rust/sugar-cli/tests/cli_surface.rs
@@ -11,7 +11,7 @@ use libsugar::core::{address, Input, Path as CorePath, PathAlgebra, PathDocument
 use serde_json::json;
 
 fn provekit_bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+    PathBuf::from(env!("CARGO_BIN_EXE_sugar"))
 }
 
 fn repo_root() -> PathBuf {

--- a/implementations/rust/sugar-cli/tests/cmd_bind_integration.rs
+++ b/implementations/rust/sugar-cli/tests/cmd_bind_integration.rs
@@ -8,7 +8,7 @@ use std::process::{Command, Stdio};
 use libsugar::core::{named_term_document_from_bind_payload, Term};
 
 fn provekit_bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+    PathBuf::from(env!("CARGO_BIN_EXE_sugar"))
 }
 
 fn term_document() -> &'static [u8] {

--- a/implementations/rust/sugar-cli/tests/cmd_emit_python_pytest.rs
+++ b/implementations/rust/sugar-cli/tests/cmd_emit_python_pytest.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 use serde_json::Value;
 
 fn provekit_bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+    PathBuf::from(env!("CARGO_BIN_EXE_sugar"))
 }
 
 fn repo_root() -> PathBuf {

--- a/implementations/rust/sugar-cli/tests/cmd_emit_python_unittest.rs
+++ b/implementations/rust/sugar-cli/tests/cmd_emit_python_unittest.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 use serde_json::Value;
 
 fn provekit_bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+    PathBuf::from(env!("CARGO_BIN_EXE_sugar"))
 }
 
 fn repo_root() -> PathBuf {

--- a/implementations/rust/sugar-cli/tests/cmd_mint_python_project_implications.rs
+++ b/implementations/rust/sugar-cli/tests/cmd_mint_python_project_implications.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 fn provekit_bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+    PathBuf::from(env!("CARGO_BIN_EXE_sugar"))
 }
 
 fn repo_root() -> PathBuf {

--- a/implementations/rust/sugar-cli/tests/cmd_mint_python_source_runtime_failure.rs
+++ b/implementations/rust/sugar-cli/tests/cmd_mint_python_source_runtime_failure.rs
@@ -9,7 +9,7 @@ use serde_json::{json, Value as Json};
 const RUNTIME_FAILURE_SITE_CONCEPT: &str = "concept:panic-freedom.leaf.runtime-failure-site";
 
 fn provekit_bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+    PathBuf::from(env!("CARGO_BIN_EXE_sugar"))
 }
 
 fn repo_root() -> PathBuf {

--- a/implementations/rust/sugar-cli/tests/cmd_recognize_no_proof_paths.rs
+++ b/implementations/rust/sugar-cli/tests/cmd_recognize_no_proof_paths.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn provekit_bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+    PathBuf::from(env!("CARGO_BIN_EXE_sugar"))
 }
 
 fn write_fake_recognizer_project(project: &Path) -> PathBuf {

--- a/implementations/rust/sugar-cli/tests/cmd_verify_body_discharge.rs
+++ b/implementations/rust/sugar-cli/tests/cmd_verify_body_discharge.rs
@@ -223,7 +223,7 @@ fn publish_double_project_with_formals(
 }
 
 fn provekit_bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+    PathBuf::from(env!("CARGO_BIN_EXE_sugar"))
 }
 
 fn z3_available() -> bool {

--- a/implementations/rust/sugar-cli/tests/cmd_verify_integration.rs
+++ b/implementations/rust/sugar-cli/tests/cmd_verify_integration.rs
@@ -192,7 +192,7 @@ fn publish_violated_claim_project() -> PathBuf {
 fn provekit_bin() -> PathBuf {
     // CARGO_BIN_EXE_<name> is set by cargo for integration tests of a
     // binary crate.
-    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+    PathBuf::from(env!("CARGO_BIN_EXE_sugar"))
 }
 
 fn z3_available() -> bool {

--- a/implementations/rust/sugar-cli/tests/cmd_verify_production_bridge.rs
+++ b/implementations/rust/sugar-cli/tests/cmd_verify_production_bridge.rs
@@ -40,7 +40,7 @@ use std::process::Command;
 use serde_json::{json, Value as Json};
 
 fn provekit_bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+    PathBuf::from(env!("CARGO_BIN_EXE_sugar"))
 }
 
 fn z3_available() -> bool {

--- a/implementations/rust/sugar-cli/tests/cmd_verify_python_division_unsound.rs
+++ b/implementations/rust/sugar-cli/tests/cmd_verify_python_division_unsound.rs
@@ -34,7 +34,7 @@ use std::process::Command;
 use serde_json::Value as Json;
 
 fn provekit_bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+    PathBuf::from(env!("CARGO_BIN_EXE_sugar"))
 }
 
 fn repo_root() -> PathBuf {

--- a/implementations/rust/sugar-cli/tests/cmd_verify_python_production_bridge.rs
+++ b/implementations/rust/sugar-cli/tests/cmd_verify_python_production_bridge.rs
@@ -42,7 +42,7 @@ use serde_json::Value as Json;
 mod contradiction;
 
 fn provekit_bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+    PathBuf::from(env!("CARGO_BIN_EXE_sugar"))
 }
 
 /// CARGO_MANIFEST_DIR = .../implementations/rust/sugar-cli; three parents up

--- a/implementations/rust/sugar-cli/tests/cmd_verify_rust_division_unsound.rs
+++ b/implementations/rust/sugar-cli/tests/cmd_verify_rust_division_unsound.rs
@@ -44,7 +44,7 @@ use std::process::Command;
 use serde_json::{json, Value as Json};
 
 fn provekit_bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+    PathBuf::from(env!("CARGO_BIN_EXE_sugar"))
 }
 
 fn z3_available() -> bool {
@@ -275,7 +275,7 @@ fn rust_division_seam_transcript() {
 /// `lift::lift_function_postcondition`); it is `syn`-based, no charon needed.
 /// Returns the op-symbol the lifter actually emits for the body's `/`.
 fn production_post_op_for_division() -> String {
-    let bin = std::env::var("CARGO_BIN_EXE_provekit")
+    let bin = std::env::var("CARGO_BIN_EXE_sugar")
         .ok()
         .and_then(|p| {
             // The walk-rpc binary sits next to the provekit binary in the

--- a/implementations/rust/sugar-cli/tests/compose_rpc_smoke.rs
+++ b/implementations/rust/sugar-cli/tests/compose_rpc_smoke.rs
@@ -28,8 +28,8 @@ const PINNED_CID: &str = "blake3-512:36212b7bf7b9ccf264950940a33d64e1cfe88b6f4d8
 fn provekit_bin() -> PathBuf {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let workspace = PathBuf::from(manifest_dir).parent().unwrap().to_path_buf();
-    let release = workspace.join("target").join("release").join("provekit");
-    let debug = workspace.join("target").join("debug").join("provekit");
+    let release = workspace.join("target").join("release").join("sugar");
+    let debug = workspace.join("target").join("debug").join("sugar");
     if release.exists() {
         release
     } else if debug.exists() {

--- a/implementations/rust/sugar-cli/tests/dependency_proof_pool_assembly.rs
+++ b/implementations/rust/sugar-cli/tests/dependency_proof_pool_assembly.rs
@@ -343,7 +343,7 @@ fn voltron_pool_refuses_cross_dependency_violation() {
     install_dependency_proof_stub(&project, &bundle_cid, &proof_bytes);
     fs::remove_file(&proof_path).expect("remove dependency proof path after kit reads it");
 
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_provekit"))
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_sugar"))
         .arg("prove")
         .arg(&project)
         .arg("--z3")
@@ -369,7 +369,7 @@ fn prove_reports_violation_for_contradictory_implication() {
     }
 
     let project = publish_contradictory_implication_project();
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_provekit"))
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_sugar"))
         .arg("prove")
         .arg(&project)
         .arg("--z3")

--- a/implementations/rust/sugar-cli/tests/lift_kit_path_integration.rs
+++ b/implementations/rust/sugar-cli/tests/lift_kit_path_integration.rs
@@ -13,7 +13,7 @@ use sugar_ir_types::Sort;
 use serde_json::json;
 
 fn provekit_bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_provekit"))
+    PathBuf::from(env!("CARGO_BIN_EXE_sugar"))
 }
 
 fn write_executable(path: &Path, contents: &str) {

--- a/implementations/rust/sugar-cli/tests/supply_chain_rails_cli.rs
+++ b/implementations/rust/sugar-cli/tests/supply_chain_rails_cli.rs
@@ -46,7 +46,7 @@ fn write_json(path: &Path, value: &Value) {
 }
 
 fn run_provekit(args: &[&str]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_provekit"))
+    Command::new(env!("CARGO_BIN_EXE_sugar"))
         .args(args)
         .output()
         .unwrap_or_else(|e| panic!("spawn provekit {}: {e}", args.join(" ")))

--- a/implementations/rust/sugar-lsp/src/config.rs
+++ b/implementations/rust/sugar-lsp/src/config.rs
@@ -94,7 +94,7 @@ fn default_server() -> ServerConfig {
 }
 
 fn default_backend() -> String {
-    "provekit".to_string()
+    "sugar".to_string()
 }
 
 pub fn load_config(path: impl AsRef<Path>) -> Result<LspConfig, String> {

--- a/implementations/rust/sugar-verify-build-rs/src/lib.rs
+++ b/implementations/rust/sugar-verify-build-rs/src/lib.rs
@@ -29,14 +29,14 @@ pub fn verify_project() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=.provekit/");
     
     // Run provekit verify
-    let output = Command::new("provekit")
+    let output = Command::new("sugar")
         .arg("verify")
         .current_dir(&manifest_dir)
         .output()?;
     
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("provekit verify failed:\n{}", stderr).into());
+        return Err(format!("sugar verify failed:\n{}", stderr).into());
     }
     
     Ok(())


### PR DESCRIPTION
## What

Flips the user-facing executable `provekit` -> `sugar`. **`sugar lift` / `sugar prove` / `sugar materialize` / `sugar recognize` are now real.** This is the payoff of increment-1's crate rename.

- `[[bin]] name` provekit -> sugar (sugar-cli); clap command name, `cmd_version` self-name, `--help`/`long_about` branding
- `CARGO_BIN_EXE_provekit` -> `CARGO_BIN_EXE_sugar` (19 sites, compiler-enforced)
- bin spawns flipped: `sugar-verify-build-rs` (`Command::new`), `sugar-lsp` default backend binary, `compose_rpc_smoke` `target/*/sugar` path
- script/CI consumers: `Makefile`, `provekit-example-workflow.yml`, the `provekit-verify` action, kit-coverage template
- docs: README + quickstarts flipped to `sugar`; fixed the broken `cargo install --path .../provekit-cli` (the crate is `sugar-cli` since increment-1); rewrote the naming note

## Frozen (deliberately out of scope)

- **`.provekit/`-family dirs** (`~/.config/provekit`, `$XDG_RUNTIME_DIR/provekit`, `target/provekit`) — their own `.provekit/` -> `.sugar/` migration.
- **The `#[provekit::contract]` / `#[provekit::verify]` attribute vocabulary** — this is the bespoke-contract-attribute mistake; it should not exist. Slated for **removal**, not rename (separate cut).
- **LSP diagnostic `source` string, kit-ids, wire tokens** — Layer C identity.

## Verification

`cargo test --workspace`: **2599 passed, 0 failed**. No example/showcase script or doctor check spawns the CLI by name (examples use RPC-bin manifests, which keep their preserved bin names), so the make/showcase gate is unaffected. Binary is now `target/debug/sugar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)