### PR TITLE
Fix bin-flip consumers: showcase scripts + Makefile -> sugar CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 
 .DEFAULT_GOAL := help
 
-PROVEKIT := implementations/rust/target/release/provekit
+PROVEKIT := implementations/rust/target/release/sugar
 PYTHON ?= python3
 PYTHON := $(shell command -v '$(PYTHON)' 2>/dev/null || printf '%s\n' '$(PYTHON)')
 MVN ?= mvn

--- a/docs/quickstart-end-user.md
+++ b/docs/quickstart-end-user.md
@@ -35,7 +35,7 @@ This installs `provekit` to `~/.cargo/bin/`. If that directory is not on your
 PATH, add `export PATH="$HOME/.cargo/bin:$PATH"` to your shell config.
 
 If you are working inside the repo and have already run a debug build, the binary
-is at `implementations/rust/target/debug/provekit`; the demo scripts use that
+is at `implementations/rust/target/debug/sugar`; the demo scripts use that
 path directly. Confirm whichever binary you intend to use:
 
 ```sh
@@ -204,7 +204,7 @@ for how it is built and how to add one for another language.
 ## When something goes wrong
 
 `provekit: command not found`: `~/.cargo/bin` is not on your PATH (or you meant
-to use the in-repo `implementations/rust/target/debug/provekit`).
+to use the in-repo `implementations/rust/target/debug/sugar`).
 
 The numpy demos fail to provision: they need `python3` to build a venv and `z3`
 on PATH. The scripts use PEP 668 venvs and never `--break-system-packages`.

--- a/examples/numpy-showcase/run.sh
+++ b/examples/numpy-showcase/run.sh
@@ -28,7 +28,7 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
-BIN="$REPO/implementations/rust/target/debug/provekit"
+BIN="$REPO/implementations/rust/target/debug/sugar"
 PP="$REPO/implementations/python/provekit-lift-python-source/src:$REPO/implementations/python/provekit-lift-py-tests/src"
 
 # The pytest-witness lifter RUNS numpy's test, and the numpy.testing lifter

--- a/examples/numpy-vendor/run.sh
+++ b/examples/numpy-vendor/run.sh
@@ -31,7 +31,7 @@
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
-BIN="$REPO/implementations/rust/target/debug/provekit"
+BIN="$REPO/implementations/rust/target/debug/sugar"
 PP="$REPO/implementations/python/provekit-lift-python-source/src:$REPO/implementations/python/provekit-lift-py-tests/src"
 VENV="${NUMPY_WITNESS_VENV:-/tmp/numpy-witness-venv}"
 

--- a/examples/pandas-showcase/run.sh
+++ b/examples/pandas-showcase/run.sh
@@ -24,7 +24,7 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
-BIN="$REPO/implementations/rust/target/debug/provekit"
+BIN="$REPO/implementations/rust/target/debug/sugar"
 
 # The witness lifter RUNS pandas's tests, so it needs pandas + the kit deps in a
 # venv (PEP 668: never --break-system-packages). The lift manifests point their

--- a/examples/python-guard-shapes/run.sh
+++ b/examples/python-guard-shapes/run.sh
@@ -14,7 +14,7 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
-BIN="$REPO/implementations/rust/target/debug/provekit"
+BIN="$REPO/implementations/rust/target/debug/sugar"
 
 VENV="${PANDAS_WITNESS_VENV:-/tmp/pandas-witness-venv}"
 if [ ! -x "$VENV/bin/python" ]; then

--- a/examples/rust-boundary-showcase/run.sh
+++ b/examples/rust-boundary-showcase/run.sh
@@ -25,7 +25,7 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
-BIN="$REPO/implementations/rust/target/debug/provekit"
+BIN="$REPO/implementations/rust/target/debug/sugar"
 WALK="$REPO/implementations/rust/target/debug/provekit-walk-rpc"
 
 VENDOR="$HERE/vendor"

--- a/scripts/self-apply.sh
+++ b/scripts/self-apply.sh
@@ -16,7 +16,7 @@
 set -uo pipefail
 cd "$(git rev-parse --show-toplevel)" || { echo "not in the provekit repo"; exit 1; }
 
-BIN=implementations/rust/target/debug/provekit
+BIN=implementations/rust/target/debug/sugar
 CLI=implementations/rust/sugar-cli
 IMPORTS="$CLI/.provekit/imports"
 SCRATCH=/tmp/self-apply


### PR DESCRIPTION
## Problem

Increment-2 (#1959) renamed the CLI binary `provekit` -> `sugar`, but several **hardcoded `target/<profile>/provekit` references survived** in run scripts and the Makefile. The inc-2 consumer scan piped through `grep -v /target/` (to skip the build directory), which also discarded these legitimate script references. `make ci` stayed green because it does not run the manual showcases — so the breakage was invisible until a showcase was run by hand. (Surfaced by "does the numpy showcase still work?" — it didn't.)

## Fix

Point the **main CLI** references at `sugar`; leave the **preserved internal bins** (`provekit-lift`, `provekit-walk-rpc`) untouched (only the main CLI bin was renamed):

- `Makefile` `PROVEKIT` var
- `examples/{numpy-showcase,numpy-vendor,pandas-showcase,rust-boundary-showcase,python-guard-shapes}/run.sh` `BIN`
- `scripts/self-apply.sh` `BIN`
- `docs/quickstart-end-user.md` install path

Frozen (historical/dated): `bootstrap/`, `docs/self-application`, `docs/incidents`, `docs/superpowers/plans`, `.briefs/`.

## Verification

`examples/numpy-showcase/run.sh` runs clean end to end — lift → materialize → recognize → mint → prove:

```
PASS: numpy.rot90 proved correct (consistency AND witness); the degenerate refused both ways.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)