### PR TITLE
Burn follow-up: residual doc + dep cleanup after #1960

### DIFF
--- a/docs/explanation/landing.md
+++ b/docs/explanation/landing.md
@@ -78,7 +78,7 @@ There is no central authority that decides what a protocol version means. The by
   `verify-protocol`, `proof`, `protocol`, `mint`, `dump`, `hash`, `implicate`,
   `link`, `compose`, `emit`, `materialize`, and kit-oriented gates. Bug Zoo is
   checked by the self-contained runner under `menagerie/bug-zoo/`.
-- A Rust workspace of libraries: `provekit-canonicalizer`, `provekit-claim-envelope`, `provekit-proof-envelope`, `provekit-ir-symbolic`, `provekit-verifier`, `provekit-macros`, `provekit-lift`, `provekit-lift-proptest`, `provekit-lift-contracts`.
+- A Rust workspace of libraries: `provekit-canonicalizer`, `provekit-claim-envelope`, `provekit-proof-envelope`, `provekit-ir-symbolic`, `provekit-verifier`, `provekit-lift`, `provekit-lift-proptest`, `provekit-lift-contracts`.
 - Per-language kits, verifier libs, lift adapters, and self-contract attestations.
 - A protocol catalog at `protocol/specs/2026-04-30-protocol-catalog.json`, protocol extension specs, proof-protocol fixtures, and PEP evolution witnesses.
 

--- a/docs/quickstart-extender.md
+++ b/docs/quickstart-extender.md
@@ -426,7 +426,6 @@ docs/
 
 examples/
   polyglot-rust-go/   -- canonical cross-language demo (rust callee + go caller)
-  build_script_demo/  -- provekit-build build.rs integration
 
 .provekit/
   self-contracts-attestations/  -- per-kit signed attestation envelopes

--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -60,14 +60,12 @@ serde_json = { version = "1", features = ["preserve_order"] }
 walkdir = "2"
 toml = "0.8"
 rayon = "1.10"
-# Proc-macro authoring stack
+# syn/quote/proc-macro2: AST parsing + token manipulation used by the lift
+# adapters (sugar-lift, sugar-lift-contracts, sugar-walk, etc.). NOT a
+# contract-authoring macro stack: the substrate ships no bespoke proc-macro.
 syn = { version = "2", features = ["full", "extra-traits", "visit"] }
 quote = "1"
 proc-macro2 = "1"
-# Distributed-slice registration for #[provekit::contract] / #[provekit::verify]
-inventory = "0.3"
-# Trybuild for compile-fail / pass UI tests on the macros
-trybuild = "1"
 # Temp dirs/files for kits that compile + run emitted source in tests
 tempfile = "3"
 

--- a/implementations/rust/sugar-lift/README.md
+++ b/implementations/rust/sugar-lift/README.md
@@ -37,9 +37,12 @@ sits **beneath** them.
 Future adapters drop in the same way: `kani`, `prusti`,
 `hypothesis-py`, `deal-py`, `bean-validation-java`, `zod-ts`.
 
-`provekit-macros` is the **fallback** for greenfield code where the
-developer doesn't already have an annotation library. The recommended
-adoption order is: lift first, mint-via-macros only when greenfield.
+There is no bespoke contract-authoring macro. Greenfield code without an
+existing annotation library is handled the same way as everything else:
+write the contract in a native annotation library (or as native source
+the lift adapters already understand), then lift it. A contract only
+enters the substrate by being lifted from native source, never by a
+`provekit`-specific attribute.
 
 ## Usage
 

--- a/implementations/rust/sugar-lift/src/lib.rs
+++ b/implementations/rust/sugar-lift/src/lib.rs
@@ -15,10 +15,10 @@
 //   `provekit-lift` reads what's already there and promotes it to a
 //   content-addressed signed contract.
 //
-//   The macros in `provekit-macros` are a fallback for greenfield code
-//   where the developer doesn't already have an annotation library.
-//   Adoption path looks like: lift first, mint-via-macros only when
-//   greenfield.
+//   There is no bespoke contract-authoring macro. Greenfield code is
+//   handled the same way: write the contract in a native annotation
+//   library (or as native source the adapters understand), then lift it.
+//   A contract only enters the substrate by being lifted.
 //
 // LIBRARY API:
 //
@@ -704,8 +704,8 @@ fn print_help() {
            ProvekIt does NOT compete with proptest, contracts, kani, prusti,\n  \
            hypothesis-py, deal-py, bean-validation-java, zod-ts. It sits\n  \
            BENEATH them. We promote what you already have to content-addressed\n  \
-           signed contracts. The macros in provekit-macros are the fallback\n  \
-           for greenfield code."
+           signed contracts. A contract only enters the substrate by being\n  \
+           lifted from native source, never via a bespoke authoring macro."
     );
 }
 


### PR DESCRIPTION
## Burn follow-up: residual doc + dep cleanup after #1960

#1960 deleted the bespoke `#[provekit::contract]` / `#[provekit::verify]` attribute crates (`sugar-macros`, `sugar-macros-rt`, `sugar-build`) but left references to them and the old greenfield-fallback narrative behind. This sweeps the residue so nothing advertises a deleted authoring path.

**Cleaned (5 files):**
- `docs/explanation/landing.md` — drop `provekit-macros` from the crate list.
- `docs/quickstart-extender.md` — drop the deleted `build_script_demo` example.
- `sugar-lift/README.md` + `src/lib.rs` — remove the "`provekit-macros` is the fallback for greenfield code" story. There is no authoring macro; greenfield code is lifted like everything else. A contract only enters the substrate by being lifted from native source.
- `implementations/rust/Cargo.toml` — drop now-orphaned `inventory` and `trybuild` workspace deps (only the deleted macros used them; verified no member references them). Reword the `syn`/`quote`/`proc-macro2` comment: they're the lift adapters' AST stack, not a contract-authoring macro stack.

**Acceptance:** `bcargo build --workspace` green (exit 0); the identical change on the prior branch also ran `bcargo test --workspace` green (2570 passed / 0 failed). No code-path change — doc/comment text plus removal of two unused workspace deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
