### PR TITLE
op-cid foundation (increment A): canonical op_cid + dual-read

### DIFF
--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/__init__.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/__init__.py
@@ -25,6 +25,7 @@ from .canonicalizer import (
     encode_jcs,
     jcs_hash,
 )
+from .op_cid import local_op_cid, local_operator_shape, op_cid_from_shape
 from .ir import (
     Bool,
     BridgeDecl,
@@ -158,6 +159,8 @@ __all__ = [
     "locus_to_value",
     "lt",
     "lte",
+    "local_op_cid",
+    "local_operator_shape",
     "make_var",
     "mint_bridge",
     "mint_contract",
@@ -165,6 +168,7 @@ __all__ = [
     "ne",
     "not_",
     "num",
+    "op_cid_from_shape",
     "or_",
     "prove_contract",
     "str_const",

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/op_cid.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/op_cid.py
@@ -1,0 +1,57 @@
+"""Canonical op CID derivation shared by Python lifters.
+
+An operation CID is the canonical JSON CID of the operation shape. The shape
+defines the operation; caller-facing names remain sugar around that preimage.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .canonicalizer import (
+    Value,
+    blake3_512_of,
+    encode_jcs,
+    varr,
+    vbool,
+    vint,
+    vnull,
+    vobj,
+    vstr,
+)
+
+
+Json = Any
+
+
+def op_cid_from_shape(shape: Json) -> str:
+    return blake3_512_of(encode_jcs(_json_to_value(shape)).encode("utf-8"))
+
+
+def local_operator_shape(name: str) -> dict[str, Json]:
+    return {"kind": "local-operator", "name": name}
+
+
+def local_op_cid(name: str) -> str:
+    return op_cid_from_shape(local_operator_shape(name))
+
+
+def _json_to_value(value: Json) -> Value:
+    if value is None:
+        return vnull()
+    if isinstance(value, bool):
+        return vbool(value)
+    if isinstance(value, int):
+        return vint(value)
+    if isinstance(value, str):
+        return vstr(value)
+    if isinstance(value, list):
+        return varr([_json_to_value(item) for item in value])
+    if isinstance(value, dict):
+        pairs: list[tuple[str, Value]] = []
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError("canonical JSON object keys must be str")
+            pairs.append((key, _json_to_value(item)))
+        return vobj(pairs)
+    raise TypeError(f"unsupported canonical JSON value: {type(value).__name__}")

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
@@ -11,6 +11,7 @@ from typing import Any, Iterable
 from provekit_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs
 from provekit_lift_py_tests.decorators import _parse_expr_string
 from provekit_lift_py_tests.ir import formula_to_value
+from provekit_lift_py_tests.op_cid import local_op_cid
 
 from .ast_template import function_body_template, function_param_names
 from .canonical import cid_of_json, template_cid_of_json
@@ -422,6 +423,9 @@ def _library_binding_entry_for_function(
     concept_name = binding.get("concept_name")
     if concept_name:
         entry["concept_name"] = concept_name
+    op_cid = binding.get("op_cid")
+    if op_cid:
+        entry["op_cid"] = op_cid
     # Provenance: `derived` marks a zero-code universal-lift binding (no
     # @sugar.bind), distinct from a `declared` one. Emitted only when derived,
     # so tagged shims stay byte-identical. Lets recognize keep the project's own
@@ -454,6 +458,7 @@ def _sugar_bind_decorator(
         concept = _keyword_str(decorator, "concept")
         library = _keyword_str(decorator, "library")
         symbol = _keyword_str(decorator, "symbol")
+        op_cid = _keyword_str(decorator, "op_cid")
         # Symbol-keyed identity is the path forward (e.g. `numpy.add`): a sugar
         # binding IS its fully-qualified library symbol — the join key the linker
         # resolves against and the recognizer canonicalizes aliased calls to
@@ -465,6 +470,8 @@ def _sugar_bind_decorator(
                 result["symbol"] = symbol
             if concept:
                 result["concept_name"] = concept
+            if op_cid:
+                result["op_cid"] = op_cid
             loss = _keyword_str_list(decorator, "loss")
             if loss is not None:
                 result["loss"] = loss
@@ -978,9 +985,9 @@ def _operand_symbol(node: ast.AST) -> str | None:
 def _operand_slot(value: Json) -> Json:
     if (
         isinstance(value, dict)
-        and isinstance(value.get("concept_name"), str)
         and isinstance(value.get("op_cid"), str)
         and isinstance(value.get("args"), list)
+        and ("concept_name" not in value or isinstance(value.get("concept_name"), str))
     ):
         return value
     if isinstance(value, dict) and (
@@ -1587,7 +1594,7 @@ def _concept_citation_diag(
 
 
 def _local_op_cid(name: str) -> str:
-    return cid_of_json({"kind": "local-operator", "name": name})
+    return local_op_cid(name)
 
 
 def _valid_emitted_by(value: Json) -> bool:

--- a/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
@@ -19,7 +19,7 @@ if str(PKG_SRC) not in sys.path:
 if str(REALIZER_SRC) not in sys.path:
     sys.path.insert(0, str(REALIZER_SRC))
 
-from provekit_lift_python_source.bind_lifter import lift_source
+from provekit_lift_python_source.bind_lifter import _operand_slot, lift_source
 from provekit_lift_python_source.bind_rpc import dispatch, initialize_result
 from provekit_lift_py_tests.canonicalizer import blake3_512_of
 from provekit_lift_python_source.canonical import cid_of_json
@@ -695,6 +695,15 @@ def test_bind_lift_preserves_operator_concept_cid_atoms() -> None:
         assert set(atoms[0]) == {"args", "concept_name", "op_cid"}
         assert all(arg == {} for arg in atoms[0]["args"])
         _assert_absent_keys(atoms[0], {"kind", "op", "file", "fn_line", "line", "column"})
+
+
+def test_operand_slot_accepts_op_cid_only_operation_atoms() -> None:
+    atom = {
+        "op_cid": _local_op_cid("concept:add"),
+        "args": [{}, {}],
+    }
+
+    assert _operand_slot(atom) == atom
 
 
 def test_bind_lift_operator_atoms_make_distinct_term_shape_cids() -> None:

--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/realizer.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/realizer.py
@@ -49,6 +49,7 @@ class BodyTemplateEntry:
     requires_return_type: str | None
     loss_record_contribution: dict[str, Any] | None = None
     target_library_tag: str | None = None
+    op_cid: str | None = None
 
 
 @dataclass(frozen=True)
@@ -95,6 +96,10 @@ class BodyTemplateResourceError(Exception):
         self.missing_resources = missing_resources
 
 
+class BodyTemplateOpCidError(Exception):
+    pass
+
+
 class OperandBindingMisalignmentError(Exception):
     def __init__(self, missing_positions: list[list[int]], extra_positions: list[list[int]]):
         self.missing_positions = missing_positions
@@ -112,6 +117,7 @@ def emit_stub(
     param_types: list[str],
     return_type: str,
     concept_name: str,
+    op_cid: str | None = None,
     contract: dict[str, Any] | None = None,
     transported_op: dict[str, Any] | None = None,
     sugar_cids: list[str] | None = None,
@@ -213,7 +219,13 @@ def emit_stub(
                 )
                 if missing:
                     raise MissingTemplateError(missing)
-            body = body_template_for(concept_name, params, param_types, return_type)
+            body = body_template_for(
+                concept_name,
+                params,
+                param_types,
+                return_type,
+                op_cid=op_cid,
+            )
             if body is None:
                 missing = missing_templates_for(
                     function,
@@ -667,6 +679,8 @@ def body_template_for(
     params: list[str],
     param_types: list[str],
     return_type: str,
+    *,
+    op_cid: str | None = None,
 ) -> str | None:
     return _body_template_for_entries(
         entries(),
@@ -674,6 +688,7 @@ def body_template_for(
         params,
         param_types,
         return_type,
+        op_cid=op_cid,
     )
 
 
@@ -769,6 +784,7 @@ class _MissingTemplateCollector:
                     template_params,
                     template_types,
                     self.return_type,
+                    op_cid=_tree_op_cid(tree),
                 )
                 is None
             ):
@@ -1372,7 +1388,13 @@ def _lower_shape_expression(
         )
     if concept_name in {"concept:skip", "skip"} and not arg_exprs:
         return TermExpression(text="None", type_name="None")
-    template = _body_template_expression_for(concept_name, arg_exprs, arg_types, context.return_type)
+    template = _body_template_expression_for(
+        concept_name,
+        arg_exprs,
+        arg_types,
+        context.return_type,
+        op_cid=_shape_op_cid(shape),
+    )
     if template is None:
         return None
     return TermExpression(
@@ -1441,6 +1463,12 @@ def _literal_term(value: Any) -> TermExpression:
 def _shape_concept_name(shape: dict[str, Any]) -> str:
     value = shape.get("concept_name", shape.get("conceptName"))
     return value.strip() if isinstance(value, str) else ""
+
+
+def _shape_op_cid(shape: dict[str, Any]) -> str | None:
+    value = shape.get("op_cid", shape.get("opCid"))
+    stripped = value.strip() if isinstance(value, str) else ""
+    return stripped or None
 
 
 def _shape_args(shape: dict[str, Any]) -> list[dict[str, Any]]:
@@ -1513,7 +1541,13 @@ def _lower_tree_body(
             return None
         if child_body.body:
             child_bodies.append(child_body.body)
-    body = body_template_for(concept_name, params, param_types, return_type)
+    body = body_template_for(
+        concept_name,
+        params,
+        param_types,
+        return_type,
+        op_cid=_tree_op_cid(tree),
+    )
     if body is None:
         return None
     if child_bodies:
@@ -1524,6 +1558,12 @@ def _lower_tree_body(
 def _tree_concept_name(tree: dict[str, Any]) -> str:
     value = tree.get("conceptName", tree.get("concept_name"))
     return value.strip() if isinstance(value, str) else ""
+
+
+def _tree_op_cid(tree: dict[str, Any]) -> str | None:
+    value = tree.get("opCid", tree.get("op_cid"))
+    stripped = value.strip() if isinstance(value, str) else ""
+    return stripped or None
 
 
 def _tree_operation_kind(tree: dict[str, Any]) -> str:
@@ -1556,12 +1596,37 @@ def _body_template_for_entries(
     params: list[str],
     param_types: list[str],
     return_type: str,
+    *,
+    op_cid: str | None = None,
 ) -> str | None:
     mapped_param_types = [map_source_type(ty) for ty in param_types]
     mapped_return_type = map_source_type(return_type)
-    for entry in body_entries:
-        if entry.concept_name not in candidate_names:
-            continue
+    if op_cid:
+        has_op_cid_index = any(entry.op_cid for entry in body_entries)
+        op_entries = tuple(entry for entry in body_entries if entry.op_cid == op_cid)
+        if not op_entries and has_op_cid_index:
+            raise BodyTemplateOpCidError(f"op_cid not found in body templates: {op_cid}")
+        if op_entries:
+            op_names = {entry.concept_name for entry in op_entries}
+            if len(op_names) > 1:
+                names = ", ".join(sorted(op_names))
+                raise BodyTemplateOpCidError(f"op_cid collision for {op_cid}: {names}")
+            if candidate_names and op_names.isdisjoint(candidate_names):
+                expected = ", ".join(candidate_names)
+                actual = ", ".join(sorted(op_names))
+                raise BodyTemplateOpCidError(
+                    f"op_cid mismatch for {op_cid}: candidate={expected}; template={actual}"
+                )
+            search_entries = op_entries
+        else:
+            search_entries = tuple(
+                entry for entry in body_entries if entry.concept_name in candidate_names
+            )
+    else:
+        search_entries = tuple(
+            entry for entry in body_entries if entry.concept_name in candidate_names
+        )
+    for entry in search_entries:
         if not _entry_signature_matches(
             entry,
             len(params),
@@ -1861,12 +1926,15 @@ def _body_template_expression_for(
     params: list[str],
     param_types: list[str],
     return_type: str,
+    *,
+    op_cid: str | None = None,
 ) -> str | None:
     return _body_template_expression_for_candidates(
         (concept_name, concept_name.removeprefix("concept:")),
         params,
         param_types,
         return_type,
+        op_cid=op_cid,
     )
 
 
@@ -1875,6 +1943,8 @@ def _body_template_expression_for_candidates(
     params: list[str],
     param_types: list[str],
     return_type: str,
+    *,
+    op_cid: str | None = None,
 ) -> str | None:
     body = _body_template_for_entries(
         entries(),
@@ -1882,6 +1952,7 @@ def _body_template_expression_for_candidates(
         params,
         param_types,
         return_type,
+        op_cid=op_cid,
     )
     if body is None:
         return None
@@ -2469,6 +2540,7 @@ def _parse_entry_array(
         if not isinstance(guard, dict):
             guard = {}
         concept_name = item.get("concept_name")
+        op_cid = item.get("op_cid", item.get("opCid"))
         template_kind = template.get("kind")
         template_text = template.get("template")
         loss_record_contribution = item.get("loss_record_contribution")
@@ -2497,6 +2569,7 @@ def _parse_entry_array(
                 target_library_tag=target_library_tag
                 if isinstance(target_library_tag, str)
                 else default_library_tag,
+                op_cid=op_cid if isinstance(op_cid, str) else None,
             )
         )
     return tuple(out)

--- a/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/rpc.py
+++ b/implementations/python/provekit-realize-python-core/src/provekit_realize_python_core/rpc.py
@@ -146,6 +146,9 @@ def _emit_one(params: dict[str, Any]) -> dict[str, Any]:
         param_types=_string_list(params.get("param_types")),
         return_type=str(params.get("return_type", "")),
         concept_name=str(params.get("concept_name", "")),
+        op_cid=params.get("op_cid", params.get("opCid"))
+        if isinstance(params.get("op_cid", params.get("opCid")), str)
+        else None,
         contract=params.get("contract") if isinstance(params.get("contract"), dict) else None,
         transported_op=params.get("transported_op")
         if isinstance(params.get("transported_op"), dict)
@@ -245,6 +248,8 @@ def _body_template_entry_json(entry: Any) -> dict[str, Any]:
         "emission_template": {"kind": entry.template_kind, "template": entry.template},
         "signature_guard": guard,
     }
+    if entry.op_cid is not None:
+        result["op_cid"] = entry.op_cid
     if entry.target_library_tag is not None:
         result["target_library_tag"] = entry.target_library_tag
     return result

--- a/implementations/python/provekit-realize-python-core/tests/test_realizer.py
+++ b/implementations/python/provekit-realize-python-core/tests/test_realizer.py
@@ -17,6 +17,7 @@ if str(PKG_SRC) not in sys.path:
 import provekit_realize_python_core.realizer as realizer
 from provekit_realize_python_core.realizer import (
     BodyTemplateEntry,
+    BodyTemplateOpCidError,
     MissingTemplateError,
     emit_stub,
 )
@@ -1194,6 +1195,95 @@ def test_named_term_tree_walk_emits_composed_body(monkeypatch) -> None:
         "extension": "py",
     }
     assert "NotImplementedError" not in result["source"]
+
+
+def test_body_template_dispatch_prefers_op_cid_when_present(monkeypatch) -> None:
+    op_cid = _cid("a")
+    monkeypatch.setattr(
+        realizer,
+        "entries",
+        lambda: (
+            BodyTemplateEntry(
+                concept_name="concept:add",
+                op_cid=op_cid,
+                template_kind="verbatim",
+                template="return ${param0} + 1",
+                min_params=1,
+                max_params=1,
+                requires_param_types=None,
+                requires_return_type=None,
+            ),
+        ),
+    )
+
+    assert (
+        realizer.body_template_for(
+            "concept:add",
+            ["x"],
+            ["int"],
+            "int",
+            op_cid=op_cid,
+        )
+        == "return x + 1"
+    )
+
+
+def test_body_template_dispatch_falls_back_when_no_templates_publish_op_cid(monkeypatch) -> None:
+    monkeypatch.setattr(
+        realizer,
+        "entries",
+        lambda: (
+            BodyTemplateEntry(
+                concept_name="concept:add",
+                template_kind="verbatim",
+                template="return ${param0} + 1",
+                min_params=1,
+                max_params=1,
+                requires_param_types=None,
+                requires_return_type=None,
+            ),
+        ),
+    )
+
+    assert (
+        realizer.body_template_for(
+            "concept:add",
+            ["x"],
+            ["int"],
+            "int",
+            op_cid=_cid("legacy"),
+        )
+        == "return x + 1"
+    )
+
+
+def test_body_template_dispatch_refuses_op_cid_concept_mismatch(monkeypatch) -> None:
+    op_cid = _cid("b")
+    monkeypatch.setattr(
+        realizer,
+        "entries",
+        lambda: (
+            BodyTemplateEntry(
+                concept_name="concept:add",
+                op_cid=op_cid,
+                template_kind="verbatim",
+                template="return ${param0} + 1",
+                min_params=1,
+                max_params=1,
+                requires_param_types=None,
+                requires_return_type=None,
+            ),
+        ),
+    )
+
+    with pytest.raises(BodyTemplateOpCidError, match="op_cid mismatch"):
+        realizer.body_template_for(
+            "concept:sub",
+            ["x"],
+            ["int"],
+            "int",
+            op_cid=op_cid,
+        )
 
 
 def test_named_term_tree_missing_node_concept_refuses_loudly() -> None:

--- a/implementations/rust/libsugar/src/canonical.rs
+++ b/implementations/rust/libsugar/src/canonical.rs
@@ -2,9 +2,9 @@
 
 use std::sync::Arc;
 
-use sugar_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 use serde::Serialize;
 use serde_json::Value as Json;
+use sugar_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 
 use crate::{ProvekitError, Result};
 
@@ -27,6 +27,11 @@ pub fn json_jcs(value: &Json) -> Result<String> {
 pub fn json_cid(value: &Json) -> Result<String> {
     let jcs = json_jcs(value)?;
     Ok(blake3_512_of(jcs.as_bytes()))
+}
+
+/// Canonical operation identity: an op CID is the JSON CID of the op shape.
+pub fn op_cid_from_shape(shape: &Json) -> Result<String> {
+    json_cid(shape)
 }
 
 pub fn is_blake3_512_cid(value: &str) -> bool {

--- a/implementations/rust/libsugar/src/core/bind.rs
+++ b/implementations/rust/libsugar/src/core/bind.rs
@@ -2,13 +2,13 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value as Json};
 use sugar_canonicalizer::blake3_512_of;
 use sugar_ir_types::{
     GapKind, IrFormula, IrTerm, OptionStatus, ResolutionOption, ResolutionOptionKind, Sort,
     TransportGapMemento,
 };
-use serde::{Deserialize, Serialize};
-use serde_json::{json, Value as Json};
 use thiserror::Error;
 
 use super::primitives::address;
@@ -1266,7 +1266,7 @@ impl GrammarOpRegistry {
 
     fn cid(&self, name: &str) -> Option<Cid> {
         let shape = grammar_op_shape(name)?;
-        let cid = crate::canonical::json_cid(&shape).ok()?;
+        let cid = crate::canonical::op_cid_from_shape(&shape).ok()?;
         Cid::try_from(cid.as_str()).ok()
     }
 

--- a/implementations/rust/libsugar/src/core/lower_plugin.rs
+++ b/implementations/rust/libsugar/src/core/lower_plugin.rs
@@ -2,9 +2,9 @@
 
 use std::path::{Path, PathBuf};
 
-use sugar_ir_types::Sort;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use sugar_ir_types::Sort;
 
 use super::bind::{concept_bind_result_cid, named_term_document_from_bind_payload, NamedTerm};
 use super::primitives::address;
@@ -25,6 +25,13 @@ pub struct RealizeRequest {
     pub param_types: Vec<String>,
     pub return_type: String,
     pub concept_name: String,
+    #[serde(
+        default,
+        rename = "opCid",
+        alias = "op_cid",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub op_cid: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub named_term_tree: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -840,6 +847,7 @@ fn invocation_from_tree_node(
         param_types,
         return_type,
         concept_name,
+        op_cid: node_string(node, &["opCid", "op_cid"]),
         named_term_tree: Some(node.clone()),
         term_shape: node
             .get("termShape")
@@ -1307,6 +1315,7 @@ pub fn request_from_spec(spec: &Value) -> Result<RealizeRequest, String> {
         param_types: string_array_field(spec, &["paramTypes", "param_types"])?,
         return_type: required_string_field(spec, &["returnType", "return_type"])?,
         concept_name: required_string_field(spec, &["conceptName", "concept_name"])?,
+        op_cid: string_field_optional(spec, &["opCid", "op_cid"]),
         named_term_tree: non_null_field(spec, &["namedTermTree", "named_term_tree"]).cloned(),
         term_shape: non_null_field(spec, &["termShape", "term_shape"]).cloned(),
         operand_bindings: value_array_field(spec, &["operandBindings", "operand_bindings"]),

--- a/implementations/rust/libsugar/tests/op_cid_cross_language.rs
+++ b/implementations/rust/libsugar/tests/op_cid_cross_language.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use libsugar::canonical::op_cid_from_shape;
+use serde_json::{json, Value};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("..")
+}
+
+fn python_op_cid_from_shape(shape: &Value) -> String {
+    let root = repo_root();
+    let py_path = [
+        root.join("implementations/python/provekit-lift-py-tests/src"),
+        root.join("implementations/python/provekit-lift-python-source/src"),
+    ]
+    .into_iter()
+    .map(|path| path.to_string_lossy().into_owned())
+    .collect::<Vec<_>>()
+    .join(":");
+
+    let mut child = Command::new("python3")
+        .env("PYTHONPATH", py_path)
+        .arg("-c")
+        .arg(
+            "import json, sys\n\
+             from provekit_lift_py_tests.op_cid import op_cid_from_shape\n\
+             print(op_cid_from_shape(json.loads(sys.stdin.read())))\n",
+        )
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn python3 for op_cid agreement");
+
+    {
+        let stdin = child.stdin.as_mut().expect("python stdin");
+        stdin
+            .write_all(shape.to_string().as_bytes())
+            .expect("write shape JSON to python");
+    }
+
+    let output = child.wait_with_output().expect("wait for python op_cid");
+    assert!(
+        output.status.success(),
+        "python op_cid helper failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("python stdout utf8")
+        .trim()
+        .to_string()
+}
+
+#[test]
+fn op_cid_from_shape_is_byte_identical_in_rust_and_python_for_local_operator() {
+    let shape = json!({
+        "kind": "local-operator",
+        "name": "concept:add"
+    });
+
+    let rust = op_cid_from_shape(&shape).expect("rust op_cid");
+    let python = python_op_cid_from_shape(&shape);
+
+    assert_eq!(rust, python);
+}
+
+#[test]
+fn op_cid_from_shape_is_byte_identical_in_rust_and_python_for_grammar_operator() {
+    let sort = |name: &str| json!({ "kind": "ctor", "name": name, "args": [] });
+    let shape = json!({
+        "kind": "grammar-op",
+        "formalSorts": [sort("Stmt"), sort("Stmt")],
+        "returnSort": sort("Stmt"),
+        "pre": { "kind": "atomic", "name": "true", "args": [] },
+        "post": {
+            "arity": ["Stmt", "Stmt"],
+            "result": "Stmt",
+            "wpRule": {
+                "kind": "apply",
+                "fn": "wp_slot_0",
+                "args": [{
+                    "kind": "apply",
+                    "fn": "wp_slot_1",
+                    "args": [{ "kind": "var", "name": "Q" }]
+                }]
+            }
+        },
+        "effects": [{ "kind": "effect-polymorphic", "rule": "union(slot_0.effects, slot_1.effects)" }]
+    });
+
+    let rust = op_cid_from_shape(&shape).expect("rust op_cid");
+    let python = python_op_cid_from_shape(&shape);
+    let registry = libsugar::core::grammar_op_cid("concept:seq")
+        .expect("concept:seq grammar op")
+        .to_string();
+
+    assert_eq!(rust, python);
+    assert_eq!(rust, registry);
+}

--- a/implementations/rust/libsugar/tests/op_cid_schema.rs
+++ b/implementations/rust/libsugar/tests/op_cid_schema.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use libsugar::core::RealizeRequest;
+use serde_json::{json, Value};
+
+#[test]
+fn realize_request_accepts_op_cid_alongside_concept_name() {
+    let request: RealizeRequest = serde_json::from_value(json!({
+        "function": "materialize_add",
+        "params": ["x"],
+        "param_types": ["int"],
+        "return_type": "int",
+        "concept_name": "concept:add",
+        "op_cid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "mode": null,
+        "modes": [],
+        "contract": null,
+        "sugar_cids": [],
+        "sugar_plugins": [],
+        "family": null,
+        "library_version": null
+    }))
+    .expect("RealizeRequest with op_cid decodes");
+
+    assert_eq!(request.concept_name, "concept:add");
+    assert_eq!(
+        request.op_cid.as_deref(),
+        Some("blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    );
+
+    let serialized: Value = serde_json::to_value(&request).expect("serialize request");
+    assert_eq!(serialized["concept_name"], "concept:add");
+    assert_eq!(
+        serialized["opCid"],
+        "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    );
+}

--- a/implementations/rust/sugar-cli/src/cmd_mint.rs
+++ b/implementations/rust/sugar-cli/src/cmd_mint.rs
@@ -2441,6 +2441,11 @@ fn mint_library_sugar_binding_entry(decl: &Value) -> Result<(String, Vec<u8>), S
         .get("concept_name")
         .and_then(|v| v.as_str())
         .filter(|s| !s.trim().is_empty());
+    let op_cid = decl
+        .get("op_cid")
+        .or_else(|| decl.get("opCid"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty());
     if symbol.is_none() && concept_name.is_none() {
         return Err(
             "`library-sugar-binding-entry` missing `symbol` (or legacy `concept_name`)".to_string(),
@@ -2459,6 +2464,9 @@ fn mint_library_sugar_binding_entry(decl: &Value) -> Result<(String, Vec<u8>), S
         header.insert("conceptName".to_string(), json!(concept_name));
     }
     header.insert("kind".to_string(), json!("library-sugar-binding-entry"));
+    if let Some(op_cid) = op_cid {
+        header.insert("opCid".to_string(), json!(op_cid));
+    }
     header.insert("signatureShapeCid".to_string(), json!(signature_shape_cid));
     if let Some(symbol) = symbol {
         header.insert("symbol".to_string(), json!(symbol));
@@ -2562,6 +2570,7 @@ fn mint_realization_memento(decl: &Value) -> Result<(String, Vec<u8>), String> {
     }
     let target_language = required_str(decl, "target_language", "realization-memento")?;
     let concept_name = required_str(decl, "concept_name", "realization-memento")?;
+    let op_cid = optional_str(decl, "op_cid").or_else(|| optional_str(decl, "opCid"));
     let library = required_str(decl, "library", "realization-memento")?;
     let source_function_name = required_str(decl, "source_function_name", "realization-memento")?;
 
@@ -2577,6 +2586,10 @@ fn mint_realization_memento(decl: &Value) -> Result<(String, Vec<u8>), String> {
         },
         "schemaVersion": "1",
     });
+    let mut envelope = envelope;
+    if let Some(op_cid) = op_cid {
+        envelope["header"]["opCid"] = json!(op_cid);
+    }
     let canonical = encode_jcs(&json_to_cvalue(&envelope));
     let cid = blake3_512_of(canonical.as_bytes());
     Ok((cid, canonical.into_bytes()))
@@ -3034,6 +3047,59 @@ mod tests {
         let e = &entries[0];
         assert!(e.get("family").is_none(), "no family stamped");
         assert!(e.get("library_version").is_none(), "no version stamped");
+    }
+
+    #[test]
+    fn mint_library_sugar_binding_entry_preserves_op_cid_when_present() {
+        let (_cid, bytes) = mint_library_sugar_binding_entry(&json!({
+            "kind": "library-sugar-binding-entry",
+            "target_language": "python",
+            "target_library_tag": "numpy",
+            "symbol": "numpy.add",
+            "concept_name": "concept:add",
+            "op_cid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "signature_shape_cid": "blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "body_source": {
+                "source_cid": "blake3-512:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            }
+        }))
+        .expect("mint library sugar binding entry");
+        let envelope: Value = serde_json::from_slice(&bytes).expect("canonical JSON envelope");
+
+        assert_eq!(envelope["header"]["conceptName"], "concept:add");
+        assert_eq!(
+            envelope["header"]["opCid"],
+            "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        assert_eq!(
+            envelope["body"]["op_cid"],
+            "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+    }
+
+    #[test]
+    fn mint_realization_memento_preserves_op_cid_when_present() {
+        let (_cid, bytes) = mint_realization_memento(&json!({
+            "kind": "realization-memento",
+            "realization_kind": "boundary",
+            "target_language": "python",
+            "concept_name": "concept:add",
+            "op_cid": "blake3-512:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+            "library": "numpy",
+            "source_function_name": "add"
+        }))
+        .expect("mint realization memento");
+        let envelope: Value = serde_json::from_slice(&bytes).expect("canonical JSON envelope");
+
+        assert_eq!(envelope["header"]["conceptName"], "concept:add");
+        assert_eq!(
+            envelope["header"]["opCid"],
+            "blake3-512:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+        );
+        assert_eq!(
+            envelope["body"]["op_cid"],
+            "blake3-512:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## op-cid foundation (increment A): canonical op_cid + dual-read

First of three increments retiring `concept_name` in favor of a content-addressed op identity. **Purely additive** — no field deleted, no `.proof` churn intended this increment.

### What lands
- **`op_cid_from_shape(shape) = json_cid(shape)`** — the canonical intrinsic operator identity, byte-identical in Rust (`libsugar`) and Python (`provekit_lift_py_tests.op_cid`). Proven by `tests/op_cid_cross_language.rs`, which spawns `python3` and asserts both implementations return the same CID for the same shape (real cross-language agreement, no mock).
- **bind / lower_plugin / cmd_mint** — additive `op_cid` fields alongside the existing `concept_name`; dual-read with a **loud refuse on mismatch** (no silent divergence). `concept_name` stays; nothing removed.
- **Python realizer/rpc/lifters** mirror the additive `op_cid` surface.
- Tests: `op_cid_cross_language.rs`, `op_cid_schema.rs`, plus Python `test_realizer`/`test_bind_lifter` coverage.

### Roadmap
- **A (this PR):** canonical helper + dual-read foundation.
- **B:** strip the `concept:` prefix from op shapes byte-identically in Rust and Python (intended CID churn).
- **C:** delete `concept_name` + add the zero-grep gate.

### Acceptance (verified on battleaxe, from `implementations/rust`)
- `bcargo build --workspace` → exit 0 ("Finished dev profile in 42.33s").
- `bcargo test --workspace --no-fail-fast` → exit 0, **2576 passed / 0 failed**, including `op_cid_cross_language` (Rust↔Python byte-identical) and `op_cid_schema`.
- Rebased clean onto `8a1ff66ed` (#1961 bin-flip showcase fixes); no op-cid file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added operation content ID (CID) support to track and identify operations by their content hash across the system
  * Enabled operation-specific template selection during code realization for more precise code generation
  * Extended minting tools to preserve operation identities in generated artifacts

* **Tests**
  * Added cross-language consistency tests verifying operation CID computation between implementations
  * Added unit tests covering operation-specific template dispatch and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->