### PR TITLE
op-cid increment B: strip the concept: prefix, byte-identically Rust+Python

### DIFF
--- a/examples/polars-showcase/run.sh
+++ b/examples/polars-showcase/run.sh
@@ -5,7 +5,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
 RUST="$REPO/implementations/rust"
 BIN_DIR="$RUST/target/debug"
-PROVEKIT="$BIN_DIR/provekit"
+PROVEKIT="$BIN_DIR/sugar"
 ASSERT_RPC="$BIN_DIR/rust_test_assertions_rpc"
 WITNESS_RPC="$BIN_DIR/witness_rpc"
 DISCHARGE_CLI="$BIN_DIR/discharge_cli"
@@ -22,7 +22,7 @@ if [ "${POLARS_SHOWCASE_ON_REMOTE:-0}" != "1" ] \
   && [ "$(uname -s)" != "Linux" ]; then
   echo "== run polars showcase on battleaxe via bcargo =="
   "$REPO/bin/bcargo" build --manifest-path "$RUST/Cargo.toml" \
-    -p sugar-cli --bin provekit \
+    -p sugar-cli --bin sugar \
     -p sugar-lift-rust-tests --bin rust_test_assertions_rpc \
     -p sugar-lift-rust-cargo-test-witness --bin witness_rpc \
     -p sugar-lift-rust-cargo-test-witness --bin discharge_cli >/dev/null
@@ -40,7 +40,7 @@ fi
 if [ "${POLARS_SHOWCASE_SKIP_LOCAL_BUILD:-0}" != "1" ]; then
   echo "== build local proof binaries =="
   cargo build --manifest-path "$RUST/Cargo.toml" \
-    -p sugar-cli --bin provekit \
+    -p sugar-cli --bin sugar \
     -p sugar-lift-rust-tests --bin rust_test_assertions_rpc \
     -p sugar-lift-rust-cargo-test-witness --bin witness_rpc \
     -p sugar-lift-rust-cargo-test-witness --bin discharge_cli >/dev/null

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/__init__.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/__init__.py
@@ -25,7 +25,12 @@ from .canonicalizer import (
     encode_jcs,
     jcs_hash,
 )
-from .op_cid import local_op_cid, local_operator_shape, op_cid_from_shape
+from .op_cid import (
+    bare_local_operator_name,
+    local_op_cid,
+    local_operator_shape,
+    op_cid_from_shape,
+)
 from .ir import (
     Bool,
     BridgeDecl,
@@ -159,6 +164,7 @@ __all__ = [
     "locus_to_value",
     "lt",
     "lte",
+    "bare_local_operator_name",
     "local_op_cid",
     "local_operator_shape",
     "make_var",

--- a/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/op_cid.py
+++ b/implementations/python/provekit-lift-py-tests/src/provekit_lift_py_tests/op_cid.py
@@ -22,14 +22,19 @@ from .canonicalizer import (
 
 
 Json = Any
+LEGACY_CONCEPT_PREFIX = "concept:"
 
 
 def op_cid_from_shape(shape: Json) -> str:
     return blake3_512_of(encode_jcs(_json_to_value(shape)).encode("utf-8"))
 
 
+def bare_local_operator_name(name: str) -> str:
+    return name.removeprefix(LEGACY_CONCEPT_PREFIX)
+
+
 def local_operator_shape(name: str) -> dict[str, Json]:
-    return {"kind": "local-operator", "name": name}
+    return {"kind": "local-operator", "name": bare_local_operator_name(name)}
 
 
 def local_op_cid(name: str) -> str:

--- a/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/src/provekit_lift_python_source/bind_lifter.py
@@ -11,7 +11,6 @@ from typing import Any, Iterable
 from provekit_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs
 from provekit_lift_py_tests.decorators import _parse_expr_string
 from provekit_lift_py_tests.ir import formula_to_value
-from provekit_lift_py_tests.op_cid import local_op_cid
 
 from .ast_template import function_body_template, function_param_names
 from .canonical import cid_of_json, template_cid_of_json
@@ -1594,7 +1593,7 @@ def _concept_citation_diag(
 
 
 def _local_op_cid(name: str) -> str:
-    return local_op_cid(name)
+    return cid_of_json({"kind": "local-operator", "name": name.removeprefix("concept:")})
 
 
 def _valid_emitted_by(value: Json) -> bool:

--- a/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
+++ b/implementations/python/provekit-lift-python-source/tests/test_bind_lifter.py
@@ -22,6 +22,7 @@ if str(REALIZER_SRC) not in sys.path:
 from provekit_lift_python_source.bind_lifter import _operand_slot, lift_source
 from provekit_lift_python_source.bind_rpc import dispatch, initialize_result
 from provekit_lift_py_tests.canonicalizer import blake3_512_of
+from provekit_lift_py_tests.op_cid import local_op_cid
 from provekit_lift_python_source.canonical import cid_of_json
 from provekit_realize_python_core.realizer import emit_stub
 
@@ -197,7 +198,7 @@ def _concept_diagnostics(result: object) -> set[str]:
 
 
 def _local_op_cid(name: str) -> str:
-    return cid_of_json({"kind": "local-operator", "name": name})
+    return local_op_cid(name)
 
 
 def _walk_objects(value: object) -> list[dict]:

--- a/implementations/rust/libsugar/src/canonical.rs
+++ b/implementations/rust/libsugar/src/canonical.rs
@@ -8,6 +8,8 @@ use sugar_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 
 use crate::{ProvekitError, Result};
 
+const LEGACY_CONCEPT_PREFIX: &str = "concept:";
+
 pub fn serializable_jcs<T: Serialize>(value: &T) -> Result<String> {
     let json = serde_json::to_value(value)
         .map_err(|e| ProvekitError::Message(format!("serialize JSON: {e}")))?;
@@ -32,6 +34,21 @@ pub fn json_cid(value: &Json) -> Result<String> {
 /// Canonical operation identity: an op CID is the JSON CID of the op shape.
 pub fn op_cid_from_shape(shape: &Json) -> Result<String> {
     json_cid(shape)
+}
+
+pub fn local_operator_shape(name: &str) -> Json {
+    serde_json::json!({
+        "kind": "local-operator",
+        "name": bare_local_operator_name(name),
+    })
+}
+
+pub fn local_op_cid(name: &str) -> Result<String> {
+    op_cid_from_shape(&local_operator_shape(name))
+}
+
+pub fn bare_local_operator_name(name: &str) -> &str {
+    name.strip_prefix(LEGACY_CONCEPT_PREFIX).unwrap_or(name)
 }
 
 pub fn is_blake3_512_cid(value: &str) -> bool {

--- a/implementations/rust/libsugar/tests/op_cid_cross_language.rs
+++ b/implementations/rust/libsugar/tests/op_cid_cross_language.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
-use libsugar::canonical::op_cid_from_shape;
+use libsugar::canonical::{local_op_cid, local_operator_shape, op_cid_from_shape};
 use serde_json::{json, Value};
 
 fn repo_root() -> PathBuf {
@@ -14,7 +14,7 @@ fn repo_root() -> PathBuf {
         .join("..")
 }
 
-fn python_op_cid_from_shape(shape: &Value) -> String {
+fn run_python_op_cid_helper(script: &str, input: &Value) -> String {
     let root = repo_root();
     let py_path = [
         root.join("implementations/python/provekit-lift-py-tests/src"),
@@ -28,11 +28,7 @@ fn python_op_cid_from_shape(shape: &Value) -> String {
     let mut child = Command::new("python3")
         .env("PYTHONPATH", py_path)
         .arg("-c")
-        .arg(
-            "import json, sys\n\
-             from provekit_lift_py_tests.op_cid import op_cid_from_shape\n\
-             print(op_cid_from_shape(json.loads(sys.stdin.read())))\n",
-        )
+        .arg(script)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -42,8 +38,8 @@ fn python_op_cid_from_shape(shape: &Value) -> String {
     {
         let stdin = child.stdin.as_mut().expect("python stdin");
         stdin
-            .write_all(shape.to_string().as_bytes())
-            .expect("write shape JSON to python");
+            .write_all(input.to_string().as_bytes())
+            .expect("write JSON to python");
     }
 
     let output = child.wait_with_output().expect("wait for python op_cid");
@@ -58,6 +54,36 @@ fn python_op_cid_from_shape(shape: &Value) -> String {
         .to_string()
 }
 
+fn python_op_cid_from_shape(shape: &Value) -> String {
+    run_python_op_cid_helper(
+        "import json, sys\n\
+         from provekit_lift_py_tests.op_cid import op_cid_from_shape\n\
+         print(op_cid_from_shape(json.loads(sys.stdin.read())))\n",
+        shape,
+    )
+}
+
+fn python_local_operator_shape(name: &str) -> Value {
+    let output = run_python_op_cid_helper(
+        "import json, sys\n\
+         from provekit_lift_py_tests.op_cid import local_operator_shape\n\
+         params = json.loads(sys.stdin.read())\n\
+         print(json.dumps(local_operator_shape(params['name']), separators=(',', ':'), sort_keys=True))\n",
+        &json!({ "name": name }),
+    );
+    serde_json::from_str(&output).expect("python local_operator_shape JSON")
+}
+
+fn python_local_op_cid(name: &str) -> String {
+    run_python_op_cid_helper(
+        "import json, sys\n\
+         from provekit_lift_py_tests.op_cid import local_op_cid\n\
+         params = json.loads(sys.stdin.read())\n\
+         print(local_op_cid(params['name']))\n",
+        &json!({ "name": name }),
+    )
+}
+
 #[test]
 fn op_cid_from_shape_is_byte_identical_in_rust_and_python_for_local_operator() {
     let shape = json!({
@@ -68,6 +94,23 @@ fn op_cid_from_shape_is_byte_identical_in_rust_and_python_for_local_operator() {
     let rust = op_cid_from_shape(&shape).expect("rust op_cid");
     let python = python_op_cid_from_shape(&shape);
 
+    assert_eq!(rust, python);
+}
+
+#[test]
+fn local_operator_shape_strips_concept_prefix_before_op_cid() {
+    let bare_shape = json!({
+        "kind": "local-operator",
+        "name": "add"
+    });
+
+    let rust_shape = local_operator_shape("concept:add");
+    let python_shape = python_local_operator_shape("concept:add");
+    let rust = local_op_cid("concept:add").expect("rust bare local op_cid");
+    let python = python_local_op_cid("concept:add");
+
+    assert_eq!(rust_shape, bare_shape);
+    assert_eq!(python_shape, bare_shape);
     assert_eq!(rust, python);
 }
 

--- a/implementations/rust/sugar-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/sugar-walk/src/bin/walk_rpc.rs
@@ -25,6 +25,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
 use base64::Engine;
+use libsugar::canonical::local_op_cid as canonical_local_op_cid;
 use libsugar::concept::panic_freedom;
 use sugar_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 use sugar_claim_envelope::{
@@ -9849,7 +9850,7 @@ fn local_op_cid(concept_name: &str) -> Option<&'static str> {
     if let Some(cid) = cids.get(concept_name) {
         return Some(*cid);
     }
-    let cid = blake3_512_of(concept_name.as_bytes());
+    let cid = canonical_local_op_cid(concept_name).ok()?;
     let cid = Box::leak(cid.into_boxed_str()) as &'static str;
     cids.insert(concept_name.to_string(), cid);
     Some(cid)


### PR DESCRIPTION
## op-cid increment B: strip the `concept:` prefix, byte-identically Rust+Python

Second of three. Removes the legacy `concept:` prefix from local-operator op shapes so the canonical `op_cid` is computed over the **bare** shape — applied **identically** in Rust and Python. The CID churn is **intentional**.

### Changes (8 files)
- **`libsugar::canonical`** — `bare_local_operator_name` (`strip_prefix("concept:")`), `local_operator_shape {kind:"local-operator", name:<bare>}`, `local_op_cid`.
- **`provekit_lift_py_tests.op_cid`** + **`bind_lifter`** — mirror the same bare-shape preimage (`removeprefix("concept:")`), byte-identical to Rust.
- **`sugar-walk/walk_rpc`** — local op CIDs now call the `libsugar` canonical helper instead of raw `blake3_512_of(concept_name)` string-hashing (retires the ad-hoc hashing this migration exists to kill; the field `concept_name` is untouched — it's a memoization cache, not a deletion).
- **`examples/polars-showcase/run.sh`** — fix the stale `sugar-cli` bin name (`provekit` → `sugar`) so the cutover showcase runs.

`concept_name` is **untouched** — its deletion + zero-grep gate is increment **C**.

### RED-first
`op_cid_cross_language` failed exactly because Python `local_operator_shape("concept:add")` still emitted `"concept:add"`; GREEN once both languages strip to `{kind:"local-operator", name:"add"}`.

### Acceptance (verified from `implementations/rust`, real exit captured)
- `../../bin/bcargo build --workspace` → exit 0.
- `../../bin/bcargo test --workspace --no-fail-fast` → exit 0, **2577 passed / 0 failed**, including `op_cid_cross_language` (Rust↔Python byte-identical) and `op_cid_schema`.
- `make ci` PASS; showcases green: numpy, pandas, rust-boundary, rust-witness, rust-test-assertion-consistency, polars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
