### PR TITLE
Python class-shapes capstone: attribute-safety proven on real numpy, both axes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #
 # Mainline targets:
 #   make help: print this help
-#   make ci: check-cargo-entrypoint + the acid test (test-all)
+#   make ci: check-cargo-entrypoint + the acid test + showcase receipts
 #   make test-all: the acid test -- test-rust + test-python
 #
 # `test-rust` runs the rust workspace (including the crate-pair inheritance
@@ -56,8 +56,9 @@ help:
 	@echo "Sugar: top-level orchestrator"
 	@echo ""
 	@echo "Mainline:"
-	@echo "  make ci             check-cargo-entrypoint + the acid test (test-all)"
+	@echo "  make ci             check-cargo-entrypoint + the acid test + showcase receipts"
 	@echo "  make test-all       the acid test: test-rust + test-python"
+	@echo "  make test-showcases run the checked-in end-to-end showcase receipts"
 	@echo ""
 	@echo "Per-language build:"
 	@echo "  make build-rust     cargo build --release (workspace)"
@@ -267,10 +268,52 @@ test-all: check-no-concept-name
 	fi; \
 	echo "==== test-all: PASS ===="
 
+SHOWCASE_RUNS = \
+	examples/numpy-showcase/run.sh \
+	examples/pandas-showcase/run.sh \
+	examples/rust-boundary-showcase/run.sh \
+	examples/rust-witness-showcase/run.sh \
+	examples/rust-test-assertion-consistency/run.sh \
+	examples/polars-showcase/run.sh \
+	examples/numpy-attribute-safety-showcase/run.sh
+
+.PHONY: test-showcases
+test-showcases:
+	@set -e; \
+	if [ "$${SHOWCASES_ON_REMOTE:-0}" != "1" ] && [ "$$(uname -s)" != "Linux" ] && [ "$${USE_BCARGO:-1}" != "0" ]; then \
+	  echo "==== test-showcases on battleaxe via bcargo ===="; \
+	  $(BCARGO) build --manifest-path implementations/rust/Cargo.toml \
+	    -p sugar-cli --bin sugar \
+	    -p sugar-walk --bin sugar-walk-rpc \
+	    -p sugar-lift-rust-cargo-test-witness --bin witness_rpc \
+	    -p sugar-lift-rust-cargo-test-witness --bin discharge_cli \
+	    -p sugar-lift-rust-tests --bin rust_test_assertions_rpc >/dev/null || exit $$?; \
+	  remote_host="$${BCARGO_REMOTE_HOST:-battleaxe}"; \
+	  remote_tag="$$(printf '%s' "$$(pwd -P)" | shasum 2>/dev/null | cut -c1-12)"; \
+	  remote_tag="$${remote_tag:-default}"; \
+	  remote_root="$${BCARGO_REMOTE_ROOT:-/home/tsavo/remote/sugar-bcargo-$$remote_tag}"; \
+	  remote_repo="$$remote_root/sugar"; \
+	  remote_cmd="cd $$(printf '%q' "$$remote_repo") && SHOWCASES_ON_REMOTE=1 POLARS_SHOWCASE_ON_REMOTE=1 POLARS_SHOWCASE_SKIP_LOCAL_BUILD=1 NUMPY_ATTR_SHOWCASE_ON_REMOTE=1 NUMPY_ATTR_SHOWCASE_SKIP_LOCAL_BUILD=1 make test-showcases"; \
+	  ssh -o BatchMode=yes "$$remote_host" "bash -lc $$(printf '%q' "$$remote_cmd")"; \
+	  exit $$?; \
+	fi; \
+	failed=""; \
+	for s in $(SHOWCASE_RUNS); do \
+	  echo ""; \
+	  echo "==== $$s ===="; \
+	  "$$s" || failed="$$failed $$s"; \
+	done; \
+	echo ""; \
+	if [ -n "$$failed" ]; then \
+	  echo "==== test-showcases FAIL:$$failed ===="; \
+	  exit 1; \
+	fi; \
+	echo "==== test-showcases: PASS ===="
+
 # --- CI alias ----------------------------------------------------------------
 
 .PHONY: ci
-ci: check-cargo-entrypoint test-all
+ci: check-cargo-entrypoint test-all test-showcases
 	@echo ""
 	@echo "==== ci: PASS ===="
 

--- a/examples/numpy-attribute-safety-showcase/.gitignore
+++ b/examples/numpy-attribute-safety-showcase/.gitignore
@@ -1,0 +1,13 @@
+*.proof
+.prove.json
+.verify.json
+.verify_recompute.json
+.pytest-good.out
+.pytest-bad.out
+**/.sugar/runs/
+**/.sugar/witnesses/
+**/.sugar/lift/*/manifest.toml
+**/__pycache__/
+**/.pytest_cache/
+.venv/
+

--- a/examples/numpy-attribute-safety-showcase/README.md
+++ b/examples/numpy-attribute-safety-showcase/README.md
@@ -1,0 +1,25 @@
+# Numpy Attribute-Safety Showcase
+
+This is the Python class-shapes capstone. It proves a small real numpy wrapper
+on two axes:
+
+- `python-source` lifts classShapes and attribute-safety obligations from the
+  library source. The good suite discharges every `self.<attr>` access from
+  guaranteed-present classShapes attributes. The bad suite accesses a
+  non-guaranteed attribute and must refuse.
+- `python-pytest-witness` reruns pytest over the same suite. The good suite
+  passes with a real `numpy.ndarray`; the bad suite raises `AttributeError`.
+
+The source lifter is scoped to each suite's `src/` directory so the proof axis
+only sees the library under test. The witness axis runs pytest over the whole
+suite with real numpy installed in the showcase venv.
+
+## Scope
+
+This showcase proves attribute read/access presence, not whole-program
+panic-freedom. The `__init__` assignments that create `self.values` and
+`self.scale` still surface as attribute-write panic loci in the verifier report,
+and they remain undecidable here. That is intentional and loud: Slice 2 proves
+that reads such as `self.values` and `self.scale` are present when classShapes
+guarantees them. Attribute-write panic-safety is a separate property and is out
+of scope for this showcase.

--- a/examples/numpy-attribute-safety-showcase/bad/.sugar/config.toml
+++ b/examples/numpy-attribute-safety-showcase/bad/.sugar/config.toml
@@ -1,0 +1,23 @@
+[[plugins]]
+name = "python-source"
+kind = "lift"
+surface = "python-source"
+workspace_override = "src"
+emit = "ir-document"
+
+[[plugins]]
+name = "pytest-witness-lift"
+kind = "lift"
+surface = "python-pytest-witness"
+
+[solvers]
+default = "z3"
+
+[solvers.dispatch]
+linear_arithmetic = "z3"
+default = "z3"
+
+[solvers.z3]
+binary = "z3"
+flags = ["-smt2", "-in"]
+

--- a/examples/numpy-attribute-safety-showcase/bad/.sugar/lift/python-pytest-witness/manifest.toml.in
+++ b/examples/numpy-attribute-safety-showcase/bad/.sugar/lift/python-pytest-witness/manifest.toml.in
@@ -1,0 +1,14 @@
+name = "pytest-witness-lift"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["/usr/bin/env", "PYTHONPATH=@SUITE_SRC@", "@PYTHON@", "-m", "sugar_pytest_witness.lift_lsp"]
+discharge_command = ["/usr/bin/env", "PYTHONPATH=@SUITE_SRC@", "@PYTHON@", "-m", "sugar_pytest_witness.discharge_cli"]
+witness_tool = "pytest"
+resolve_witness_command = ["/usr/bin/env", "PYTHONPATH=@SUITE_SRC@", "@PYTHON@", "-m", "sugar_pytest_witness.lift_lsp"]
+resolve_witness_method = "sugar.plugin.resolve_witness"
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["python-pytest-witness"]
+

--- a/examples/numpy-attribute-safety-showcase/bad/.sugar/lift/python-source/manifest.toml.in
+++ b/examples/numpy-attribute-safety-showcase/bad/.sugar/lift/python-source/manifest.toml.in
@@ -1,0 +1,12 @@
+name = "python-source"
+version = "0.1.0-draft"
+protocol_version = "sugar-lift/1"
+kind = "lift"
+command = ["@PYTHON@", "-m", "sugar_lift_python_source", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["python-source"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+

--- a/examples/numpy-attribute-safety-showcase/bad/src/numpy_box.py
+++ b/examples/numpy-attribute-safety-showcase/bad/src/numpy_box.py
@@ -1,0 +1,13 @@
+import numpy as np
+from numpy import array as make_array
+from numpy import int64, sum as numpy_sum
+
+
+class NumpyBox:
+    def __init__(self, values):
+        self.values = make_array(values, dtype=int64)
+        self.scale = 2
+
+    def scaled_total(self):
+        total = int(numpy_sum(self.values))
+        return total * self.missing_scale

--- a/examples/numpy-attribute-safety-showcase/bad/tests/test_numpy_box.py
+++ b/examples/numpy-attribute-safety-showcase/bad/tests/test_numpy_box.py
@@ -1,0 +1,10 @@
+import numpy as np
+
+from numpy_box import NumpyBox
+
+
+def test_numpy_box_scaled_total_refuses_when_attribute_is_not_guaranteed():
+    box = NumpyBox([1, 2, 3])
+
+    assert isinstance(box.values, np.ndarray)
+    assert box.scaled_total() == 12

--- a/examples/numpy-attribute-safety-showcase/good/.sugar/config.toml
+++ b/examples/numpy-attribute-safety-showcase/good/.sugar/config.toml
@@ -1,0 +1,23 @@
+[[plugins]]
+name = "python-source"
+kind = "lift"
+surface = "python-source"
+workspace_override = "src"
+emit = "ir-document"
+
+[[plugins]]
+name = "pytest-witness-lift"
+kind = "lift"
+surface = "python-pytest-witness"
+
+[solvers]
+default = "z3"
+
+[solvers.dispatch]
+linear_arithmetic = "z3"
+default = "z3"
+
+[solvers.z3]
+binary = "z3"
+flags = ["-smt2", "-in"]
+

--- a/examples/numpy-attribute-safety-showcase/good/.sugar/lift/python-pytest-witness/manifest.toml.in
+++ b/examples/numpy-attribute-safety-showcase/good/.sugar/lift/python-pytest-witness/manifest.toml.in
@@ -1,0 +1,14 @@
+name = "pytest-witness-lift"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["/usr/bin/env", "PYTHONPATH=@SUITE_SRC@", "@PYTHON@", "-m", "sugar_pytest_witness.lift_lsp"]
+discharge_command = ["/usr/bin/env", "PYTHONPATH=@SUITE_SRC@", "@PYTHON@", "-m", "sugar_pytest_witness.discharge_cli"]
+witness_tool = "pytest"
+resolve_witness_command = ["/usr/bin/env", "PYTHONPATH=@SUITE_SRC@", "@PYTHON@", "-m", "sugar_pytest_witness.lift_lsp"]
+resolve_witness_method = "sugar.plugin.resolve_witness"
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["python-pytest-witness"]
+

--- a/examples/numpy-attribute-safety-showcase/good/.sugar/lift/python-source/manifest.toml.in
+++ b/examples/numpy-attribute-safety-showcase/good/.sugar/lift/python-source/manifest.toml.in
@@ -1,0 +1,12 @@
+name = "python-source"
+version = "0.1.0-draft"
+protocol_version = "sugar-lift/1"
+kind = "lift"
+command = ["@PYTHON@", "-m", "sugar_lift_python_source", "--rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["python-source"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+

--- a/examples/numpy-attribute-safety-showcase/good/src/numpy_box.py
+++ b/examples/numpy-attribute-safety-showcase/good/src/numpy_box.py
@@ -1,0 +1,13 @@
+import numpy as np
+from numpy import array as make_array
+from numpy import int64, sum as numpy_sum
+
+
+class NumpyBox:
+    def __init__(self, values):
+        self.values = make_array(values, dtype=int64)
+        self.scale = 2
+
+    def scaled_total(self):
+        total = int(numpy_sum(self.values))
+        return total * self.scale

--- a/examples/numpy-attribute-safety-showcase/good/tests/test_numpy_box.py
+++ b/examples/numpy-attribute-safety-showcase/good/tests/test_numpy_box.py
@@ -1,0 +1,10 @@
+import numpy as np
+
+from numpy_box import NumpyBox
+
+
+def test_numpy_box_scaled_total_runs_without_attribute_error():
+    box = NumpyBox([1, 2, 3])
+
+    assert isinstance(box.values, np.ndarray)
+    assert box.scaled_total() == 12

--- a/examples/numpy-attribute-safety-showcase/run.sh
+++ b/examples/numpy-attribute-safety-showcase/run.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+RUST="$REPO/implementations/rust"
+BIN_DIR="$RUST/target/debug"
+SUGAR="$BIN_DIR/sugar"
+VENV="${NUMPY_ATTR_SHOWCASE_VENV:-/tmp/sugar-numpy-attribute-safety-venv}"
+PYTHON="$VENV/bin/python"
+PIP="$PYTHON -m pip"
+NUMPY_VERSION="2.4.6"
+STAMP="$VENV/.numpy-attribute-safety-${NUMPY_VERSION}.stamp"
+
+for suite in good bad; do
+  if [ ! -d "$HERE/$suite" ]; then
+    echo "missing suite directory: $HERE/$suite" >&2
+    exit 1
+  fi
+done
+
+if [ "${NUMPY_ATTR_SHOWCASE_ON_REMOTE:-0}" != "1" ] \
+  && [ "${NUMPY_ATTR_SHOWCASE_USE_BCARGO:-1}" != "0" ] \
+  && [ "$(uname -s)" != "Linux" ]; then
+  echo "== run numpy attribute-safety showcase on battleaxe via bcargo =="
+  "$REPO/bin/bcargo" build --manifest-path "$RUST/Cargo.toml" \
+    -p sugar-cli --bin sugar >/dev/null
+
+  remote_host="${BCARGO_REMOTE_HOST:-battleaxe}"
+  remote_tag="$(printf '%s' "$(cd "$REPO" && pwd -P)" | shasum 2>/dev/null | cut -c1-12)"
+  remote_tag="${remote_tag:-default}"
+  remote_root="${BCARGO_REMOTE_ROOT:-/home/tsavo/remote/sugar-bcargo-${remote_tag}}"
+  remote_repo="$remote_root/sugar"
+  remote_cmd="cd $(printf '%q' "$remote_repo") && NUMPY_ATTR_SHOWCASE_ON_REMOTE=1 NUMPY_ATTR_SHOWCASE_SKIP_LOCAL_BUILD=1 examples/numpy-attribute-safety-showcase/run.sh"
+  ssh -o BatchMode=yes "$remote_host" "bash -lc $(printf '%q' "$remote_cmd")"
+  exit $?
+fi
+
+if [ "${NUMPY_ATTR_SHOWCASE_SKIP_LOCAL_BUILD:-0}" != "1" ]; then
+  echo "== build sugar =="
+  cargo build --manifest-path "$RUST/Cargo.toml" -p sugar-cli --bin sugar >/dev/null
+fi
+
+if [ ! -x "$SUGAR" ]; then
+  echo "missing executable: $SUGAR" >&2
+  exit 1
+fi
+
+echo "SCOPE: this showcase proves Python attribute read/access presence via classShapes + pytest witness."
+echo "SCOPE: it does NOT claim whole-program panic-freedom; __init__ attribute-write panic loci remain undecidable and out of scope."
+
+if [ ! -x "$PYTHON" ] || [ ! -f "$STAMP" ]; then
+  echo "== prepare python witness environment =="
+  python3 -m venv "$VENV"
+  $PIP install --quiet --upgrade pip
+  $PIP install --quiet --no-cache-dir \
+    "numpy==$NUMPY_VERSION" \
+    pytest pynacl blake3 cbor2 \
+    -e "$REPO/implementations/python/sugar-lift-py-tests" \
+    -e "$REPO/implementations/python/sugar-lift-python-source" \
+    -e "$REPO/implementations/python/sugar-lift-py-pytest-witness"
+  mkdir -p "$VENV"
+  touch "$STAMP"
+fi
+
+render_one() {
+  local template="$1"
+  local output="$2"
+  local suite_dir="$3"
+  if [ ! -f "$template" ]; then
+    echo "missing manifest template: $template" >&2
+    exit 1
+  fi
+  sed \
+    -e "s|@PYTHON@|$PYTHON|g" \
+    -e "s|@SUITE_SRC@|$suite_dir/src|g" \
+    "$template" > "$output"
+}
+
+render_manifests() {
+  local suite="$1"
+  local suite_dir="$HERE/$suite"
+  local base="$suite_dir/.sugar/lift"
+  render_one \
+    "$base/python-source/manifest.toml.in" \
+    "$base/python-source/manifest.toml" \
+    "$suite_dir"
+  render_one \
+    "$base/python-pytest-witness/manifest.toml.in" \
+    "$base/python-pytest-witness/manifest.toml" \
+    "$suite_dir"
+}
+
+clean_suite() {
+  local suite="$1"
+  local dir="$HERE/$suite"
+  rm -f "$dir"/blake3-512:*.proof "$dir/.prove.json" "$dir/.verify.json" "$dir/.verify_recompute.json"
+  rm -rf "$dir/.sugar/runs" "$dir/.sugar/witnesses" "$dir/.pytest_cache" "$dir/src/__pycache__" "$dir/tests/__pycache__"
+}
+
+json_from_file() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+
+text = open(sys.argv[1], "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    raise SystemExit("no JSON object found")
+print(json.dumps(json.loads(text[match.start():])))
+PY
+}
+
+check_prove_report() {
+  local path="$1"
+  local suite="$2"
+  local expected_attr="$3"
+  local expected_witness="$4"
+  python3 - "$path" "$suite" "$expected_attr" "$expected_witness" <<'PY'
+import json
+import re
+import sys
+
+path, suite, expected_attr, expected_witness = sys.argv[1:5]
+text = open(path, "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    raise SystemExit(f"{suite}: no JSON report found")
+data = json.loads(text[match.start():])
+rows = data.get("rows") or []
+
+attr_rows = [
+    r for r in rows
+    if (r.get("reason") or "").startswith("attribute-safety:")
+]
+if not attr_rows:
+    raise SystemExit(f"{suite}: missing attribute-safety rows")
+
+witness_rows = [
+    r for r in rows
+    if "witness-package" in (r.get("property") or "") or "witness" in (r.get("reason") or "").lower()
+]
+if not witness_rows:
+    raise SystemExit(f"{suite}: missing pytest witness row")
+
+attr_discharged = sum(1 for r in attr_rows if r.get("status") == "discharged")
+attr_refused = [r for r in attr_rows if r.get("status") != "discharged"]
+witness_statuses = [r.get("status") for r in witness_rows]
+other_undecidable = [
+    r for r in rows
+    if r not in attr_rows
+    and r not in witness_rows
+    and r.get("status") != "discharged"
+]
+
+if expected_attr == "discharged":
+    if attr_refused:
+        raise SystemExit(f"{suite}: expected all attribute rows discharged, got {attr_rows}")
+    if not all("classShapes guaranteed-present" in (r.get("reason") or "") for r in attr_rows):
+        raise SystemExit(f"{suite}: discharged attribute rows did not cite classShapes guarantees: {attr_rows}")
+else:
+    if not attr_refused:
+        raise SystemExit(f"{suite}: expected at least one refused attribute row, got {attr_rows}")
+    if not any("not a guaranteed-present" in (r.get("reason") or "") for r in attr_refused):
+        raise SystemExit(f"{suite}: refused attribute row did not name the classShapes falsePass guard: {attr_refused}")
+
+if expected_witness == "discharged":
+    if any(status != "discharged" for status in witness_statuses):
+        raise SystemExit(f"{suite}: expected witness discharged, got {witness_rows}")
+else:
+    if any(status == "discharged" for status in witness_statuses):
+        raise SystemExit(f"{suite}: expected witness refusal, got {witness_rows}")
+
+print(
+    f"{suite}: attr_discharged={attr_discharged} "
+    f"attr_refused={len(attr_refused)} witness_statuses={','.join(str(s) for s in witness_statuses)} "
+    f"out_of_scope_undecidable_rows={len(other_undecidable)}"
+)
+if other_undecidable:
+    files = sorted(
+        {
+            f"{r.get('file')}:{r.get('line')}"
+            for r in other_undecidable
+            if r.get("file") and r.get("line")
+        }
+    )
+    print(
+        f"{suite}: scope note: {len(other_undecidable)} non-attribute-safety rows remain undecidable "
+        f"({', '.join(files)}); these are not counted as proved by this attribute read/access showcase."
+    )
+PY
+}
+
+witness_verdict() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+
+text = open(sys.argv[1], "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+for witness in data.get("witnessDimension", {}).get("witnesses", []):
+    verdict = witness.get("verdict")
+    if verdict:
+        print(verdict)
+        raise SystemExit(0)
+print("MISSING")
+PY
+}
+
+run_pytest_axis() {
+  local suite="$1"
+  local expected="$2"
+  local dir="$HERE/$suite"
+  local out="$HERE/.pytest-$suite.out"
+
+  set +e
+  (cd "$dir" && PYTHONPATH="$dir/src" "$PYTHON" -m pytest -q tests) > "$out" 2>&1
+  local rc=$?
+  set -e
+
+  if [ "$expected" = "pass" ]; then
+    if [ "$rc" -ne 0 ]; then
+      echo "$suite pytest expected pass" >&2
+      cat "$out" >&2
+      exit 1
+    fi
+  else
+    if [ "$rc" -eq 0 ]; then
+      echo "$suite pytest expected AttributeError refusal" >&2
+      cat "$out" >&2
+      exit 1
+    fi
+    if ! grep -q "AttributeError" "$out"; then
+      echo "$suite pytest failed, but not with AttributeError" >&2
+      cat "$out" >&2
+      exit 1
+    fi
+  fi
+  echo "$suite pytest=$expected"
+}
+
+run_suite() {
+  local suite="$1"
+  local expect_attr="$2"
+  local expect_witness="$3"
+  local expect_pytest="$4"
+  local dir="$HERE/$suite"
+
+  render_manifests "$suite"
+  clean_suite "$suite"
+
+  echo "== direct pytest $suite =="
+  run_pytest_axis "$suite" "$expect_pytest"
+
+  echo "== mint $suite =="
+  (cd "$dir" && "$SUGAR" mint --out .) >/dev/null
+
+  local proof
+  proof="$(find "$dir" -maxdepth 1 -name 'blake3-512:*.proof' -print -quit)"
+  if [ -z "$proof" ]; then
+    echo "$suite did not mint a proof" >&2
+    exit 1
+  fi
+
+  echo "== prove $suite =="
+  set +e
+  (cd "$dir" && "$SUGAR" prove . --json) > "$dir/.prove.json" 2>&1
+  local prove_rc=$?
+  set -e
+  : "$prove_rc"
+
+  check_prove_report "$dir/.prove.json" "$suite" "$expect_attr" "$expect_witness"
+
+  if [ "$expect_witness" = "discharged" ]; then
+    echo "== verify $suite witness =="
+    set +e
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify.json" 2>&1
+    local verify_rc=$?
+    set -e
+    : "$verify_rc"
+    local got_verdict
+    got_verdict="$(witness_verdict "$dir/.verify.json")"
+    if [ "$got_verdict" != "verified" ]; then
+      echo "$suite witness verification expected verified, got $got_verdict" >&2
+      cat "$dir/.verify.json" >&2
+      exit 1
+    fi
+  fi
+}
+
+run_suite good discharged discharged pass
+run_suite bad refused refused fail
+
+echo "numpy attribute-safety showcase self-check passed"


### PR DESCRIPTION
## Python class-shapes capstone: attribute-safety proven on real numpy, both axes

Closes the class-shapes attribute-safety arc (Slice 1 catalog #1967, Slice 2 discharge #1968). A polars-grade two-twin showcase on **real numpy (2.4.6)** proving Python attribute read/access presence, both axes agreeing per twin.

`examples/numpy-attribute-safety-showcase/` (good/bad twins, `run.sh` self-check):
- **GOOD** — every accessed attribute is `classShapes` guaranteed-present → obligations **discharge** (consistency: `attr_discharged=2`, citing the guarantee) **and** the program runs (witness: pytest pass, `verify witness=verified`).
- **BAD** — accesses `missing_scale` (not guaranteed-present) → discharge **refuses** (consistency: `attr_refused=1`, naming the falsePass guard) **and** raises `AttributeError` at runtime (witness: pytest fail). Both axes agree per twin.

**Scope is loud, not a silent filter:** the runner prints a SCOPE banner and `out_of_scope_undecidable_rows=2` with file:line — proves attribute read/access presence, **not** whole-program panic-freedom; `__init__` attribute-write panic loci remain undecidable and are explicitly not counted as proved.

Wired into `make test-showcases` alongside numpy/pandas/rust-boundary/rust-witness/rust-test-assertion-consistency/polars; runs on battleaxe via bcargo off-Linux.

### Acceptance (verified by me, real exit captured)
- `examples/numpy-attribute-safety-showcase/run.sh` exit 0 — I re-ran it: both twins, both axes, SCOPE banner, "self-check passed."
- `../../bin/bcargo test --workspace --no-fail-fast` → **2518 passed / 0 failed**.
- `make ci` PASS; `grep -rn 'concept_name\|conceptName' implementations/` → 0.

Source-only diff: `Makefile` + `examples/numpy-attribute-safety-showcase/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a NumPy attribute-safety showcase example demonstrating verification workflows for validating attribute access safety patterns.
  * Integrated showcase testing into the CI pipeline to automatically validate and verify showcase implementations against expected outcomes.

* **Chores**
  * Added configuration files and comprehensive documentation for the showcase verification framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->