### PR TITLE
Tokio effects seed: assertion-consistency across .await, both axes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,7 @@ SHOWCASE_RUNS = \
 	examples/rust-boundary-showcase/run.sh \
 	examples/rust-witness-showcase/run.sh \
 	examples/rust-test-assertion-consistency/run.sh \
+	examples/tokio-effect-consistency/run.sh \
 	examples/polars-showcase/run.sh \
 	examples/numpy-attribute-safety-showcase/run.sh \
 	examples/java-test-assertion-consistency/run.sh

--- a/examples/tokio-effect-consistency/.gitignore
+++ b/examples/tokio-effect-consistency/.gitignore
@@ -1,0 +1,9 @@
+*.proof
+.prove.json
+.verify.json
+.verify_recompute.json
+**/.sugar/runs/
+**/.sugar/witnesses/
+**/target/
+Cargo.lock
+**/.sugar/lift/*/manifest.toml

--- a/examples/tokio-effect-consistency/README.md
+++ b/examples/tokio-effect-consistency/README.md
@@ -1,0 +1,13 @@
+# Tokio Effect Consistency Showcase
+
+This is the first Rust async effects slice. It proves that the Rust assertion
+consistency axis survives a real Tokio `.await` boundary, and checks the same
+program with the cargo-test witness axis.
+
+- `good/`: a `#[tokio::test]` assertion over `async_value().await == 6`
+  discharges, and the Tokio test passes.
+- `bad/`: contradictory assertions over the same awaited expression refuse as
+  UNSAT, and the Tokio test fails.
+
+The `.await` term is lifted structurally from Rust syntax. It is not keyed on
+the name `tokio`.

--- a/examples/tokio-effect-consistency/bad/.sugar/config.toml
+++ b/examples/tokio-effect-consistency/bad/.sugar/config.toml
@@ -1,0 +1,21 @@
+[[plugins]]
+name = "rust-test-assertions-lift"
+kind = "lift"
+surface = "rust-test-assertions"
+emit = "ir-document"
+
+[[plugins]]
+name = "rust-cargo-test-witness-lift"
+kind = "lift"
+surface = "rust-cargo-test-witness"
+
+[solvers]
+default = "z3"
+
+[solvers.dispatch]
+linear_arithmetic = "z3"
+default = "z3"
+
+[solvers.z3]
+binary = "z3"
+flags = ["-smt2", "-in"]

--- a/examples/tokio-effect-consistency/bad/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
+++ b/examples/tokio-effect-consistency/bad/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
@@ -1,0 +1,13 @@
+name = "rust-cargo-test-witness-lift"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/witness_rpc"]
+discharge_command = ["@BIN_DIR@/discharge_cli"]
+witness_tool = "cargo-test"
+resolve_witness_command = ["@BIN_DIR@/witness_rpc"]
+resolve_witness_method = "sugar.plugin.resolve_witness"
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["rust-cargo-test-witness"]

--- a/examples/tokio-effect-consistency/bad/.sugar/lift/rust-test-assertions/manifest.toml.in
+++ b/examples/tokio-effect-consistency/bad/.sugar/lift/rust-test-assertions/manifest.toml.in
@@ -1,0 +1,11 @@
+name = "rust-test-assertions-lift"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/rust_test_assertions_rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["rust-test-assertions"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false

--- a/examples/tokio-effect-consistency/bad/Cargo.toml
+++ b/examples/tokio-effect-consistency/bad/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "tokio-effect-consistency-bad"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "=1.43.0", features = ["macros", "rt"] }

--- a/examples/tokio-effect-consistency/bad/src/lib.rs
+++ b/examples/tokio-effect-consistency/bad/src/lib.rs
@@ -1,0 +1,15 @@
+pub async fn async_value() -> i32 {
+    tokio::task::yield_now().await;
+    6
+}
+
+#[cfg(test)]
+mod tests {
+    use super::async_value;
+
+    #[tokio::test]
+    async fn tokio_await_scalar_contradiction() {
+        assert_eq!(async_value().await, 6);
+        assert_eq!(async_value().await, 7);
+    }
+}

--- a/examples/tokio-effect-consistency/good/.sugar/config.toml
+++ b/examples/tokio-effect-consistency/good/.sugar/config.toml
@@ -1,0 +1,21 @@
+[[plugins]]
+name = "rust-test-assertions-lift"
+kind = "lift"
+surface = "rust-test-assertions"
+emit = "ir-document"
+
+[[plugins]]
+name = "rust-cargo-test-witness-lift"
+kind = "lift"
+surface = "rust-cargo-test-witness"
+
+[solvers]
+default = "z3"
+
+[solvers.dispatch]
+linear_arithmetic = "z3"
+default = "z3"
+
+[solvers.z3]
+binary = "z3"
+flags = ["-smt2", "-in"]

--- a/examples/tokio-effect-consistency/good/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
+++ b/examples/tokio-effect-consistency/good/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
@@ -1,0 +1,13 @@
+name = "rust-cargo-test-witness-lift"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/witness_rpc"]
+discharge_command = ["@BIN_DIR@/discharge_cli"]
+witness_tool = "cargo-test"
+resolve_witness_command = ["@BIN_DIR@/witness_rpc"]
+resolve_witness_method = "sugar.plugin.resolve_witness"
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["rust-cargo-test-witness"]

--- a/examples/tokio-effect-consistency/good/.sugar/lift/rust-test-assertions/manifest.toml.in
+++ b/examples/tokio-effect-consistency/good/.sugar/lift/rust-test-assertions/manifest.toml.in
@@ -1,0 +1,11 @@
+name = "rust-test-assertions-lift"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/rust_test_assertions_rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["rust-test-assertions"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false

--- a/examples/tokio-effect-consistency/good/Cargo.toml
+++ b/examples/tokio-effect-consistency/good/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "tokio-effect-consistency-good"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "=1.43.0", features = ["macros", "rt"] }

--- a/examples/tokio-effect-consistency/good/src/lib.rs
+++ b/examples/tokio-effect-consistency/good/src/lib.rs
@@ -1,0 +1,14 @@
+pub async fn async_value() -> i32 {
+    tokio::task::yield_now().await;
+    6
+}
+
+#[cfg(test)]
+mod tests {
+    use super::async_value;
+
+    #[tokio::test]
+    async fn tokio_await_scalar_is_six() {
+        assert_eq!(async_value().await, 6);
+    }
+}

--- a/examples/tokio-effect-consistency/run.sh
+++ b/examples/tokio-effect-consistency/run.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+RUST="$REPO/implementations/rust"
+BIN_DIR="$RUST/target/debug"
+SUGAR="$BIN_DIR/sugar"
+ASSERT_RPC="$BIN_DIR/rust_test_assertions_rpc"
+WITNESS_RPC="$BIN_DIR/witness_rpc"
+DISCHARGE_CLI="$BIN_DIR/discharge_cli"
+
+for suite in good bad; do
+  if [ ! -d "$HERE/$suite" ]; then
+    echo "missing suite directory: $HERE/$suite" >&2
+    exit 1
+  fi
+done
+
+if [ "${TOKIO_EFFECT_SHOWCASE_ON_REMOTE:-0}" != "1" ] \
+  && [ "${TOKIO_EFFECT_SHOWCASE_USE_BCARGO:-1}" != "0" ] \
+  && [ "$(uname -s)" != "Linux" ]; then
+  echo "== run tokio effect showcase on battleaxe via bcargo =="
+  "$REPO/bin/bcargo" build --manifest-path "$RUST/Cargo.toml" \
+    -p sugar-cli --bin sugar \
+    -p sugar-lift-rust-tests --bin rust_test_assertions_rpc \
+    -p sugar-lift-rust-cargo-test-witness --bin witness_rpc \
+    -p sugar-lift-rust-cargo-test-witness --bin discharge_cli >/dev/null
+
+  remote_host="${BCARGO_REMOTE_HOST:-battleaxe}"
+  remote_tag="$(printf '%s' "$(cd "$REPO" && pwd -P)" | shasum 2>/dev/null | cut -c1-12)"
+  remote_tag="${remote_tag:-default}"
+  remote_root="${BCARGO_REMOTE_ROOT:-/home/tsavo/remote/sugar-bcargo-${remote_tag}}"
+  remote_repo="$remote_root/sugar"
+  remote_cmd="cd $(printf '%q' "$remote_repo") && TOKIO_EFFECT_SHOWCASE_ON_REMOTE=1 TOKIO_EFFECT_SHOWCASE_SKIP_LOCAL_BUILD=1 examples/tokio-effect-consistency/run.sh"
+  ssh -o BatchMode=yes "$remote_host" "bash -lc $(printf '%q' "$remote_cmd")"
+  exit $?
+fi
+
+if [ "${TOKIO_EFFECT_SHOWCASE_SKIP_LOCAL_BUILD:-0}" != "1" ]; then
+  echo "== build local proof binaries =="
+  cargo build --manifest-path "$RUST/Cargo.toml" \
+    -p sugar-cli --bin sugar \
+    -p sugar-lift-rust-tests --bin rust_test_assertions_rpc \
+    -p sugar-lift-rust-cargo-test-witness --bin witness_rpc \
+    -p sugar-lift-rust-cargo-test-witness --bin discharge_cli >/dev/null
+fi
+
+for bin in "$SUGAR" "$ASSERT_RPC" "$WITNESS_RPC" "$DISCHARGE_CLI"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing executable: $bin" >&2
+    exit 1
+  fi
+done
+
+render_manifests() {
+  local suite="$1"
+  local base="$HERE/$suite/.sugar/lift"
+
+  sed "s|@BIN_DIR@|$BIN_DIR|g" \
+    "$base/rust-test-assertions/manifest.toml.in" \
+    > "$base/rust-test-assertions/manifest.toml"
+
+  sed "s|@BIN_DIR@|$BIN_DIR|g" \
+    "$base/rust-cargo-test-witness/manifest.toml.in" \
+    > "$base/rust-cargo-test-witness/manifest.toml"
+}
+
+clean_suite() {
+  local suite="$1"
+  local dir="$HERE/$suite"
+  rm -f "$dir"/blake3-512:*.proof "$dir/.prove.json" "$dir/.verify.json" "$dir/.verify_recompute.json"
+  rm -rf "$dir/.sugar/runs" "$dir/.sugar/witnesses" "$dir/target"
+}
+
+json_status() {
+  local path="$1"
+  local mode="$2"
+  python3 - "$path" "$mode" <<'PY'
+import json
+import re
+import sys
+
+path, mode = sys.argv[1], sys.argv[2]
+text = open(path, "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+rows = data.get("rows") or data.get("obligations") or (data if isinstance(data, list) else [])
+for row in rows:
+    prop = row.get("property") or row.get("predicate") or ""
+    if mode == "consistency" and prop.startswith("consistency:") and "witness-package" not in prop:
+        print(row.get("status") or row.get("result") or "")
+        raise SystemExit(0)
+    if mode == "witness" and "witness-package" in prop:
+        print(row.get("status") or row.get("result") or "")
+        raise SystemExit(0)
+print("MISSING")
+PY
+}
+
+witness_verdict() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+
+text = open(sys.argv[1], "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+for witness in data.get("witnessDimension", {}).get("witnesses", []):
+    verdict = witness.get("verdict")
+    if verdict:
+        print(verdict)
+        raise SystemExit(0)
+print("MISSING")
+PY
+}
+
+witness_recompute_strategy() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+
+text = open(sys.argv[1], "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+for witness in data.get("witnessDimension", {}).get("witnesses", []):
+    checks = witness.get("checks") or []
+    if "content-address:recompute" in checks:
+        print("content-address:recompute")
+        raise SystemExit(0)
+print("MISSING")
+PY
+}
+
+run_suite() {
+  local suite="$1"
+  local expect_consistency="$2"
+  local expect_witness="$3"
+  local dir="$HERE/$suite"
+
+  render_manifests "$suite"
+  clean_suite "$suite"
+
+  echo "== mint $suite =="
+  (cd "$dir" && "$SUGAR" mint --out .) >/dev/null
+
+  local proof
+  proof="$(find "$dir" -maxdepth 1 -name 'blake3-512:*.proof' -print -quit)"
+  if [ -z "$proof" ]; then
+    echo "$suite did not mint a proof" >&2
+    exit 1
+  fi
+
+  echo "== prove $suite =="
+  set +e
+  (cd "$dir" && "$SUGAR" prove . --json) > "$dir/.prove.json" 2>&1
+  set -e
+
+  local got_consistency got_witness
+  got_consistency="$(json_status "$dir/.prove.json" consistency)"
+  got_witness="$(json_status "$dir/.prove.json" witness)"
+
+  if [ "$expect_consistency" = "discharged" ]; then
+    if [ "$got_consistency" != "discharged" ]; then
+      echo "$suite consistency expected discharged, got $got_consistency" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  else
+    if [ "$got_consistency" = "discharged" ] || [ "$got_consistency" = "MISSING" ]; then
+      echo "$suite consistency expected refusal, got $got_consistency" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  fi
+
+  if [ "$expect_witness" = "discharged" ]; then
+    if [ "$got_witness" != "discharged" ]; then
+      echo "$suite witness expected discharged, got $got_witness" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+
+    echo "== verify $suite witness =="
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify.json" 2>&1
+    local verify_verdict
+    verify_verdict="$(witness_verdict "$dir/.verify.json")"
+    if [ "$verify_verdict" != "verified" ]; then
+      echo "$suite witness verification expected verified, got $verify_verdict" >&2
+      cat "$dir/.verify.json" >&2
+      exit 1
+    fi
+
+    rm -rf "$dir/.sugar/witnesses"
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify_recompute.json" 2>&1
+    local recompute_strategy
+    recompute_strategy="$(witness_recompute_strategy "$dir/.verify_recompute.json")"
+    if [ "$recompute_strategy" != "content-address:recompute" ]; then
+      echo "$suite witness recompute expected content-address:recompute, got $recompute_strategy" >&2
+      cat "$dir/.verify_recompute.json" >&2
+      exit 1
+    fi
+  else
+    if [ "$got_witness" = "discharged" ] || [ "$got_witness" = "MISSING" ]; then
+      echo "$suite witness expected refusal, got $got_witness" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  fi
+
+  echo "$suite consistency=$got_consistency witness=$got_witness"
+}
+
+echo "EFFECT: Rust .await is lifted as a structural await term inside the assertion-consistency obligation."
+run_suite good discharged discharged
+run_suite bad refused refused
+
+echo "tokio effect consistency showcase self-check passed"

--- a/implementations/rust/sugar-lift-rust-tests/src/lib.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/lib.rs
@@ -247,6 +247,10 @@ fn translate_term(expr: &Expr) -> Result<Rc<Term>, String> {
                 args,
             }))
         }
+        Expr::Await(await_expr) => Ok(Rc::new(Term::Ctor {
+            name: "await".to_string(),
+            args: vec![translate_term(&await_expr.base)?],
+        })),
         Expr::Field(field) => Ok(Rc::new(Term::Ctor {
             name: format!("field:{}", token_key(&field.member)),
             args: vec![translate_term(&field.base)?],

--- a/implementations/rust/sugar-lift-rust-tests/tests/assertion_lift.rs
+++ b/implementations/rust/sugar-lift-rust-tests/tests/assertion_lift.rs
@@ -29,6 +29,37 @@ fn assert_eq_atom(formula: &Formula, expected_rhs: i64) {
     }
 }
 
+fn assert_await_call_eq_atom(formula: &Formula, expected_call: &str, expected_rhs: i64) {
+    match formula {
+        Formula::Atomic { name, args } => {
+            assert_eq!(name, "=");
+            assert_eq!(args.len(), 2);
+            match args[0].as_ref() {
+                Term::Ctor { name, args } => {
+                    assert_eq!(name, "await");
+                    assert_eq!(args.len(), 1);
+                    match args[0].as_ref() {
+                        Term::Ctor { name, args } => {
+                            assert_eq!(name, expected_call);
+                            assert!(args.is_empty());
+                        }
+                        other => panic!("expected awaited call term, got {other:?}"),
+                    }
+                }
+                other => panic!("expected await term lhs, got {other:?}"),
+            }
+            match args[1].as_ref() {
+                Term::Const {
+                    value: ConstValue::Int(value),
+                    ..
+                } => assert_eq!(*value, expected_rhs),
+                other => panic!("expected int rhs, got {other:?}"),
+            }
+        }
+        other => panic!("expected equality atom, got {other:?}"),
+    }
+}
+
 #[test]
 fn lifts_single_assert_eq_as_inv_only_consistency_contract() {
     let src = r#"
@@ -93,4 +124,71 @@ fn scalar_assert_binary() {
     let operands = inv_operands(&out.decls[0]);
     assert_eq!(operands.len(), 1);
     assert_eq_atom(&operands[0], 6);
+}
+
+#[test]
+fn lifts_tokio_async_test_assertion_across_await_boundary() {
+    let src = r#"
+async fn make_value() -> i32 { 6 }
+
+#[tokio::test]
+async fn async_scalar_is_six() {
+    assert_eq!(make_value().await, 6);
+}
+"#;
+    let out = lift_file(&parse(src), "src/lib.rs");
+    assert_eq!(out.seen, 1);
+    assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
+    assert_eq!(out.decls.len(), 1);
+
+    let decl = &out.decls[0];
+    assert_eq!(decl.name, "src/lib.rs::async_scalar_is_six");
+    let operands = inv_operands(decl);
+    assert_eq!(operands.len(), 1);
+    assert_await_call_eq_atom(&operands[0], "call:make_value", 6);
+}
+
+#[test]
+fn conjoins_contradictory_tokio_async_assertions_across_same_await_shape() {
+    let src = r#"
+async fn make_value() -> i32 { 6 }
+
+#[tokio::test]
+async fn async_scalar_contradiction() {
+    assert_eq!(make_value().await, 6);
+    assert_eq!(make_value().await, 7);
+}
+"#;
+    let out = lift_file(&parse(src), "tests/tokio_contradiction.rs");
+    assert_eq!(out.seen, 1);
+    assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
+    assert_eq!(out.decls.len(), 1);
+
+    let decl = &out.decls[0];
+    assert_eq!(
+        decl.name,
+        "tests/tokio_contradiction.rs::async_scalar_contradiction"
+    );
+    let operands = inv_operands(decl);
+    assert_eq!(operands.len(), 2);
+    assert_await_call_eq_atom(&operands[0], "call:make_value", 6);
+    assert_await_call_eq_atom(&operands[1], "call:make_value", 7);
+}
+
+#[test]
+fn await_effect_is_syntax_derived_not_tokio_name_derived() {
+    let src = r#"
+async fn make_value() -> i32 { 6 }
+
+#[demo_runtime::test]
+async fn async_scalar_is_six() {
+    assert_eq!(make_value().await, 6);
+}
+"#;
+    let out = lift_file(&parse(src), "src/lib.rs");
+    assert_eq!(out.seen, 1);
+    assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
+    let operands = inv_operands(&out.decls[0]);
+    assert_eq!(operands.len(), 1);
+    assert_await_call_eq_atom(&operands[0], "call:make_value", 6);
 }


### PR DESCRIPTION
## Tokio effects seed: assertion-consistency across `.await`, both axes

Extends the prove axis to a tokio async **effect**. panic-freedom already proves the throw effect; this seeds the **await effect**: a Rust `.await` is lifted as a **structural await term** inside the existing inv-only assertion-consistency obligation, so assertions in a `#[tokio::test]` async fn over `expr.await` prove the same way synchronous ones do.

- `sugar-lift-rust-tests`: `Expr::Await` → an await term wrapping the awaited expression (minimal, structural; **no new IR semantics, no effect catalog**).
- **Anti-catalog guard (syntax-derived, not name-derived):** `await_effect_is_syntax_derived_not_tokio_name_derived` lifts a `#[demo_runtime::test]` async fn with `.await` — recognition comes from Rust await **syntax**, not a "tokio" name match. Works for any async runtime.
- RED-first: `assertion_lift` 6/0 (3 new await tests went red on unsupported `make_value().await` before the structural lift).

### Two-twin showcase `examples/tokio-effect-consistency`
Real tokio `=1.43.0`, `#[tokio::test]` async fn over `async_value().await`, runs on battleaxe via bcargo: GOOD → `consistency=discharged witness=discharged` (cargo test); BAD → both `unsatisfied`. Both axes agree per twin, like polars/numpy/java.

### Acceptance (verified by me, real exit captured)
- `../../bin/bcargo test --workspace --no-fail-fast` → **2532 passed / 0 failed**.
- `examples/tokio-effect-consistency/run.sh` exit 0 — I re-ran it: EFFECT line, both twins both axes, self-check passed.
- `make ci` PASS; `grep -rn 'concept_name\|conceptName' implementations/` → 0.

First effects-frontier slice; the broader await/channel/mutex effect axis builds on this structural await term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for lifting test assertions across async/await boundaries in Tokio-based tests.

* **Documentation**
  * New example demonstrating assertion consistency validation across async boundaries.

* **Tests**
  * Expanded test suite with async/await expression handling and consistency validation cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->