### PR TITLE
Tokio await implication edge: post(before .await) discharges pre(after resume)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,7 @@ SHOWCASE_RUNS = \
 	examples/rust-witness-showcase/run.sh \
 	examples/rust-test-assertion-consistency/run.sh \
 	examples/tokio-effect-consistency/run.sh \
+	examples/tokio-await-implication-edge/run.sh \
 	examples/polars-showcase/run.sh \
 	examples/numpy-attribute-safety-showcase/run.sh \
 	examples/java-test-assertion-consistency/run.sh

--- a/examples/tokio-await-implication-edge/.gitignore
+++ b/examples/tokio-await-implication-edge/.gitignore
@@ -1,0 +1,9 @@
+*.proof
+.prove.json
+.verify.json
+.verify_recompute.json
+**/.sugar/runs/
+**/.sugar/witnesses/
+**/target/
+Cargo.lock
+**/.sugar/lift/*/manifest.toml

--- a/examples/tokio-await-implication-edge/README.md
+++ b/examples/tokio-await-implication-edge/README.md
@@ -1,0 +1,12 @@
+# Tokio Await Implication Edge
+
+This showcase proves the narrow async edge:
+
+`producer.post |= consumer.pre` across `.await`.
+
+The good twin awaits a producer whose postcondition establishes `result == 6`,
+then passes that value to a consumer whose precondition requires `x == 6`.
+The bad twin awaits a producer whose postcondition establishes `result == 5`
+while the consumer still requires `x == 6`, so the implication edge refuses.
+
+The witness axis is the real `#[tokio::test]` cargo test run.

--- a/examples/tokio-await-implication-edge/bad/.sugar/config.toml
+++ b/examples/tokio-await-implication-edge/bad/.sugar/config.toml
@@ -1,0 +1,29 @@
+[[plugins]]
+name = "rust-fn-contracts"
+surface = "rust-fn-contracts"
+emit = "ir-document"
+
+[[plugins]]
+name = "rust-implications"
+surface = "rust-implications"
+
+[[plugins]]
+name = "rust-cargo-test-witness"
+surface = "rust-cargo-test-witness"
+
+[platform_profile]
+language = "rust"
+family = "concept:family:sugar"
+library = "tokio-await-implication-edge-bad"
+version = "0.1.0"
+
+[solvers]
+mode = "first-wins"
+portfolio = ["z3"]
+
+[solvers.z3]
+binary = "z3"
+ir_compiler = "smt-lib-v2.6"
+flags = ["-smt2", "-in"]
+timeout_seconds = 30
+version = "4.x"

--- a/examples/tokio-await-implication-edge/bad/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
+++ b/examples/tokio-await-implication-edge/bad/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
@@ -1,0 +1,13 @@
+name = "rust-cargo-test-witness-lift"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/witness_rpc"]
+discharge_command = ["@BIN_DIR@/discharge_cli"]
+witness_tool = "cargo-test"
+resolve_witness_command = ["@BIN_DIR@/witness_rpc"]
+resolve_witness_method = "sugar.plugin.resolve_witness"
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["rust-cargo-test-witness"]

--- a/examples/tokio-await-implication-edge/bad/.sugar/lift/rust-fn-contracts/manifest.toml.in
+++ b/examples/tokio-await-implication-edge/bad/.sugar/lift/rust-fn-contracts/manifest.toml.in
@@ -1,0 +1,3 @@
+name = "rust-fn-contracts-lift"
+command = ["@BIN_DIR@/sugar-walk-rpc", "--rpc"]
+working_dir = "."

--- a/examples/tokio-await-implication-edge/bad/.sugar/lift/rust-implications/manifest.toml.in
+++ b/examples/tokio-await-implication-edge/bad/.sugar/lift/rust-implications/manifest.toml.in
@@ -1,0 +1,5 @@
+name = "rust-implications-lift"
+command = ["@BIN_DIR@/sugar-walk-rpc", "--rpc"]
+working_dir = "."
+method = "sugar.plugin.lift_implications"
+phase = "consumer"

--- a/examples/tokio-await-implication-edge/bad/Cargo.toml
+++ b/examples/tokio-await-implication-edge/bad/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "tokio-await-implication-edge-bad"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "=1.43.0", features = ["macros", "rt"] }

--- a/examples/tokio-await-implication-edge/bad/src/lib.rs
+++ b/examples/tokio-await-implication-edge/bad/src/lib.rs
@@ -1,0 +1,23 @@
+pub async fn producer() -> i64 {
+    tokio::task::yield_now().await;
+    5
+}
+
+pub fn consumer(x: i64) -> i64 {
+    assert!(x == 6);
+    6
+}
+
+pub async fn edge() -> i64 {
+    consumer(producer().await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::edge;
+
+    #[tokio::test]
+    async fn awaited_post_does_not_satisfy_consumer_pre() {
+        assert_eq!(edge().await, 6);
+    }
+}

--- a/examples/tokio-await-implication-edge/good/.sugar/config.toml
+++ b/examples/tokio-await-implication-edge/good/.sugar/config.toml
@@ -1,0 +1,29 @@
+[[plugins]]
+name = "rust-fn-contracts"
+surface = "rust-fn-contracts"
+emit = "ir-document"
+
+[[plugins]]
+name = "rust-implications"
+surface = "rust-implications"
+
+[[plugins]]
+name = "rust-cargo-test-witness"
+surface = "rust-cargo-test-witness"
+
+[platform_profile]
+language = "rust"
+family = "concept:family:sugar"
+library = "tokio-await-implication-edge-good"
+version = "0.1.0"
+
+[solvers]
+mode = "first-wins"
+portfolio = ["z3"]
+
+[solvers.z3]
+binary = "z3"
+ir_compiler = "smt-lib-v2.6"
+flags = ["-smt2", "-in"]
+timeout_seconds = 30
+version = "4.x"

--- a/examples/tokio-await-implication-edge/good/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
+++ b/examples/tokio-await-implication-edge/good/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
@@ -1,0 +1,13 @@
+name = "rust-cargo-test-witness-lift"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/witness_rpc"]
+discharge_command = ["@BIN_DIR@/discharge_cli"]
+witness_tool = "cargo-test"
+resolve_witness_command = ["@BIN_DIR@/witness_rpc"]
+resolve_witness_method = "sugar.plugin.resolve_witness"
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["rust-cargo-test-witness"]

--- a/examples/tokio-await-implication-edge/good/.sugar/lift/rust-fn-contracts/manifest.toml.in
+++ b/examples/tokio-await-implication-edge/good/.sugar/lift/rust-fn-contracts/manifest.toml.in
@@ -1,0 +1,3 @@
+name = "rust-fn-contracts-lift"
+command = ["@BIN_DIR@/sugar-walk-rpc", "--rpc"]
+working_dir = "."

--- a/examples/tokio-await-implication-edge/good/.sugar/lift/rust-implications/manifest.toml.in
+++ b/examples/tokio-await-implication-edge/good/.sugar/lift/rust-implications/manifest.toml.in
@@ -1,0 +1,5 @@
+name = "rust-implications-lift"
+command = ["@BIN_DIR@/sugar-walk-rpc", "--rpc"]
+working_dir = "."
+method = "sugar.plugin.lift_implications"
+phase = "consumer"

--- a/examples/tokio-await-implication-edge/good/Cargo.toml
+++ b/examples/tokio-await-implication-edge/good/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "tokio-await-implication-edge-good"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "=1.43.0", features = ["macros", "rt"] }

--- a/examples/tokio-await-implication-edge/good/src/lib.rs
+++ b/examples/tokio-await-implication-edge/good/src/lib.rs
@@ -1,0 +1,23 @@
+pub async fn producer() -> i64 {
+    tokio::task::yield_now().await;
+    6
+}
+
+pub fn consumer(x: i64) -> i64 {
+    assert!(x == 6);
+    6
+}
+
+pub async fn edge() -> i64 {
+    consumer(producer().await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::edge;
+
+    #[tokio::test]
+    async fn awaited_post_satisfies_consumer_pre() {
+        assert_eq!(edge().await, 6);
+    }
+}

--- a/examples/tokio-await-implication-edge/run.sh
+++ b/examples/tokio-await-implication-edge/run.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+RUST="$REPO/implementations/rust"
+BIN_DIR="$RUST/target/debug"
+SUGAR="$BIN_DIR/sugar"
+WALK_RPC="$BIN_DIR/sugar-walk-rpc"
+WITNESS_RPC="$BIN_DIR/witness_rpc"
+DISCHARGE_CLI="$BIN_DIR/discharge_cli"
+
+for suite in good bad; do
+  if [ ! -d "$HERE/$suite" ]; then
+    echo "missing suite directory: $HERE/$suite" >&2
+    exit 1
+  fi
+done
+
+if [ "${TOKIO_AWAIT_EDGE_SHOWCASE_ON_REMOTE:-0}" != "1" ] \
+  && [ "${TOKIO_AWAIT_EDGE_SHOWCASE_USE_BCARGO:-1}" != "0" ] \
+  && [ "$(uname -s)" != "Linux" ]; then
+  echo "== run tokio await implication edge showcase on battleaxe via bcargo =="
+  "$REPO/bin/bcargo" build --manifest-path "$RUST/Cargo.toml" \
+    -p sugar-cli --bin sugar \
+    -p sugar-walk --bin sugar-walk-rpc \
+    -p sugar-lift-rust-cargo-test-witness --bin witness_rpc \
+    -p sugar-lift-rust-cargo-test-witness --bin discharge_cli >/dev/null
+
+  remote_host="${BCARGO_REMOTE_HOST:-battleaxe}"
+  remote_tag="$(printf '%s' "$(cd "$REPO" && pwd -P)" | shasum 2>/dev/null | cut -c1-12)"
+  remote_tag="${remote_tag:-default}"
+  remote_root="${BCARGO_REMOTE_ROOT:-/home/tsavo/remote/sugar-bcargo-${remote_tag}}"
+  remote_repo="$remote_root/sugar"
+  remote_cmd="cd $(printf '%q' "$remote_repo") && TOKIO_AWAIT_EDGE_SHOWCASE_ON_REMOTE=1 TOKIO_AWAIT_EDGE_SHOWCASE_SKIP_LOCAL_BUILD=1 examples/tokio-await-implication-edge/run.sh"
+  ssh -o BatchMode=yes "$remote_host" "bash -lc $(printf '%q' "$remote_cmd")"
+  exit $?
+fi
+
+if [ "${TOKIO_AWAIT_EDGE_SHOWCASE_SKIP_LOCAL_BUILD:-0}" != "1" ]; then
+  echo "== build local proof binaries =="
+  cargo build --manifest-path "$RUST/Cargo.toml" \
+    -p sugar-cli --bin sugar \
+    -p sugar-walk --bin sugar-walk-rpc \
+    -p sugar-lift-rust-cargo-test-witness --bin witness_rpc \
+    -p sugar-lift-rust-cargo-test-witness --bin discharge_cli >/dev/null
+fi
+
+for bin in "$SUGAR" "$WALK_RPC" "$WITNESS_RPC" "$DISCHARGE_CLI"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing executable: $bin" >&2
+    exit 1
+  fi
+done
+
+render_manifests() {
+  local suite="$1"
+  local base="$HERE/$suite/.sugar/lift"
+
+  sed "s|@BIN_DIR@|$BIN_DIR|g" \
+    "$base/rust-fn-contracts/manifest.toml.in" \
+    > "$base/rust-fn-contracts/manifest.toml"
+
+  sed "s|@BIN_DIR@|$BIN_DIR|g" \
+    "$base/rust-implications/manifest.toml.in" \
+    > "$base/rust-implications/manifest.toml"
+
+  sed "s|@BIN_DIR@|$BIN_DIR|g" \
+    "$base/rust-cargo-test-witness/manifest.toml.in" \
+    > "$base/rust-cargo-test-witness/manifest.toml"
+}
+
+clean_suite() {
+  local suite="$1"
+  local dir="$HERE/$suite"
+  rm -f "$dir"/blake3-512:*.proof "$dir/.prove.json" "$dir/.verify.json" "$dir/.verify_recompute.json"
+  rm -rf "$dir/.sugar/runs" "$dir/.sugar/witnesses" "$dir/target"
+}
+
+edge_status() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path, "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+rows = data.get("rows") or data.get("obligations") or (data if isinstance(data, list) else [])
+for row in rows:
+    prop = row.get("property") or row.get("predicate") or ""
+    if "witness-package" in prop:
+        continue
+    if row.get("bridge") == "consumer" or row.get("callee") == "consumer":
+        print(row.get("status") or row.get("result") or "")
+        raise SystemExit(0)
+print("MISSING")
+PY
+}
+
+witness_status() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path, "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+rows = data.get("rows") or data.get("obligations") or (data if isinstance(data, list) else [])
+for row in rows:
+    prop = row.get("property") or row.get("predicate") or ""
+    if "witness-package" in prop:
+        print(row.get("status") or row.get("result") or "")
+        raise SystemExit(0)
+print("MISSING")
+PY
+}
+
+witness_verdict() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+
+text = open(sys.argv[1], "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+for witness in data.get("witnessDimension", {}).get("witnesses", []):
+    verdict = witness.get("verdict")
+    if verdict:
+        print(verdict)
+        raise SystemExit(0)
+print("MISSING")
+PY
+}
+
+witness_recompute_strategy() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+
+text = open(sys.argv[1], "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+for witness in data.get("witnessDimension", {}).get("witnesses", []):
+    checks = witness.get("checks") or []
+    if "content-address:recompute" in checks:
+        print("content-address:recompute")
+        raise SystemExit(0)
+print("MISSING")
+PY
+}
+
+run_suite() {
+  local suite="$1"
+  local expect_edge="$2"
+  local expect_witness="$3"
+  local dir="$HERE/$suite"
+
+  render_manifests "$suite"
+  clean_suite "$suite"
+
+  echo "== mint $suite =="
+  (cd "$dir" && "$SUGAR" mint --out .) >/dev/null
+
+  local proof
+  proof="$(find "$dir" -maxdepth 1 -name 'blake3-512:*.proof' -print -quit)"
+  if [ -z "$proof" ]; then
+    echo "$suite did not mint a proof" >&2
+    exit 1
+  fi
+
+  echo "== prove $suite =="
+  set +e
+  (cd "$dir" && "$SUGAR" prove . --json) > "$dir/.prove.json" 2>&1
+  set -e
+
+  local got_edge got_witness
+  got_edge="$(edge_status "$dir/.prove.json")"
+  got_witness="$(witness_status "$dir/.prove.json")"
+
+  if [ "$expect_edge" = "discharged" ]; then
+    if [ "$got_edge" != "discharged" ]; then
+      echo "$suite await implication edge expected discharged, got $got_edge" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  else
+    if [ "$got_edge" = "discharged" ] || [ "$got_edge" = "MISSING" ]; then
+      echo "$suite await implication edge expected refusal, got $got_edge" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  fi
+
+  if [ "$expect_witness" = "discharged" ]; then
+    if [ "$got_witness" != "discharged" ]; then
+      echo "$suite witness expected discharged, got $got_witness" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+
+    echo "== verify $suite witness =="
+    set +e
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify.json" 2>&1
+    set -e
+    local verify_verdict
+    verify_verdict="$(witness_verdict "$dir/.verify.json")"
+    if [ "$verify_verdict" != "verified" ]; then
+      echo "$suite witness verification expected verified, got $verify_verdict" >&2
+      cat "$dir/.verify.json" >&2
+      exit 1
+    fi
+
+    rm -rf "$dir/.sugar/witnesses"
+    set +e
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify_recompute.json" 2>&1
+    set -e
+    local recompute_strategy
+    recompute_strategy="$(witness_recompute_strategy "$dir/.verify_recompute.json")"
+    if [ "$recompute_strategy" != "content-address:recompute" ]; then
+      echo "$suite witness recompute expected content-address:recompute, got $recompute_strategy" >&2
+      cat "$dir/.verify_recompute.json" >&2
+      exit 1
+    fi
+  else
+    if [ "$got_witness" = "discharged" ] || [ "$got_witness" = "MISSING" ]; then
+      echo "$suite witness expected refusal, got $got_witness" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  fi
+
+  echo "$suite await_edge=$got_edge witness=$got_witness"
+}
+
+echo "EFFECT: Rust .await is a structural seam where producer.post must imply consumer.pre."
+echo "SCOPE: self-checking the awaited implication edge row (bridge=consumer); unrelated producer/self-post rows are not this property."
+run_suite good discharged discharged
+run_suite bad refused refused
+
+echo "tokio await implication edge showcase self-check passed"

--- a/implementations/rust/sugar-verifier/src/handshake.rs
+++ b/implementations/rust/sugar-verifier/src/handshake.rs
@@ -122,7 +122,7 @@ pub fn locate_producer_post(
     pool_mementos: &std::collections::BTreeMap<String, Json>,
     bridges_by_symbol: &std::collections::BTreeMap<String, Json>,
 ) -> Option<(Json, String)> {
-    let arg = arg_term.as_ref()?;
+    let arg = producer_lookup_term(arg_term.as_ref()?);
     if arg.get("kind").and_then(|v| v.as_str()) != Some("ctor") {
         return None;
     }
@@ -151,6 +151,19 @@ pub fn locate_producer_post(
     let post = wrap_post_forall(post, producer_body);
     let post_hash = formula_hash(&post);
     Some((post, post_hash))
+}
+
+fn producer_lookup_term(arg: &Json) -> &Json {
+    let Some("ctor") = arg.get("kind").and_then(|v| v.as_str()) else {
+        return arg;
+    };
+    if arg.get("name").and_then(|v| v.as_str()) != Some("await") {
+        return arg;
+    }
+    arg.get("args")
+        .and_then(|v| v.as_array())
+        .and_then(|args| args.first())
+        .unwrap_or(arg)
 }
 
 /// Wrap a bare producer post in `forall result. post`, binding the output
@@ -255,4 +268,87 @@ fn strip_cid_and_sig(env: &Json) -> Json {
         map.remove("producerSignature");
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::BTreeMap;
+
+    fn contract_with_post(post_value: i64) -> Json {
+        json!({
+            "evidence": {
+                "kind": "contract",
+                "body": {
+                    "name": "producer",
+                    "formals": [],
+                    "post": {
+                        "kind": "atomic",
+                        "name": "=",
+                        "args": [
+                            {"kind": "var", "name": "result"},
+                            {"kind": "const", "sort": {"kind": "primitive", "name": "Int"}, "value": post_value}
+                        ]
+                    }
+                }
+            }
+        })
+    }
+
+    fn bridge_to(cid: &str) -> Json {
+        json!({
+            "evidence": {
+                "kind": "bridge",
+                "body": {
+                    "sourceSymbol": "producer",
+                    "targetContractCid": cid
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn locate_producer_post_resolves_through_single_await_seam() {
+        let producer_cid = "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let mut pool_mementos = BTreeMap::new();
+        pool_mementos.insert(producer_cid.to_string(), contract_with_post(6));
+        let mut bridges_by_symbol = BTreeMap::new();
+        bridges_by_symbol.insert("producer".to_string(), bridge_to(producer_cid));
+
+        let arg_term = Some(json!({
+            "kind": "ctor",
+            "name": "await",
+            "args": [
+                {"kind": "ctor", "name": "producer", "args": []}
+            ]
+        }));
+
+        let (post, _) = locate_producer_post(&arg_term, &pool_mementos, &bridges_by_symbol)
+            .expect("await seam should resolve to producer post");
+        assert_eq!(post["kind"], "forall");
+        assert_eq!(post["name"], "result");
+    }
+
+    #[test]
+    fn locate_producer_post_refuses_non_producer_await_base() {
+        let producer_cid = "blake3-512:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let mut pool_mementos = BTreeMap::new();
+        pool_mementos.insert(producer_cid.to_string(), contract_with_post(6));
+        let mut bridges_by_symbol = BTreeMap::new();
+        bridges_by_symbol.insert("producer".to_string(), bridge_to(producer_cid));
+
+        let arg_term = Some(json!({
+            "kind": "ctor",
+            "name": "await",
+            "args": [
+                {"kind": "var", "name": "future"}
+            ]
+        }));
+
+        assert!(
+            locate_producer_post(&arg_term, &pool_mementos, &bridges_by_symbol).is_none(),
+            "await over a non-call term must not invent a producer post"
+        );
+    }
 }

--- a/implementations/rust/sugar-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/sugar-walk/src/bin/walk_rpc.rs
@@ -12574,6 +12574,49 @@ pub fn caller(input: &str) -> i64 {
     }
 
     #[test]
+    fn lift_implications_harvests_producer_call_inside_await_seam() {
+        let src = r##"
+pub async fn producer() -> i64 {
+    6
+}
+
+pub async fn caller() -> i64 {
+    producer().await
+}
+"##;
+        let root = temp_workspace("lift_implications_await_producer");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), src).expect("write source");
+
+        let contract_bindings = json!([
+            { "name": "producer@src/lib.rs:2:4",
+              "contract_cid": "blake3-512:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" },
+        ]);
+
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": contract_bindings,
+        }))
+        .expect("lift_implications");
+
+        let ir = resp["ir"].as_array().expect("ir array");
+        let producer = ir
+            .iter()
+            .find(|e| e["sourceSymbol"] == "producer")
+            .expect("producer bridge under await seam");
+        assert_eq!(producer["kind"], "bridge");
+        assert_eq!(
+            producer["targetContractCid"],
+            "blake3-512:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn lift_implications_emits_residue_manifest_annotations() {
         let root = temp_workspace("lift_implications_residue_annotations");
         let src_dir = root.join("src");

--- a/implementations/rust/sugar-walk/src/lift.rs
+++ b/implementations/rust/sugar-walk/src/lift.rs
@@ -2720,10 +2720,11 @@ fn lift_expr_to_term_inner(expr: &Expr, ctx: &mut LiftCtx) -> Option<IrTerm> {
             Some(term)
         }
         Expr::Await(a) => {
-            // `expr.await` desugars to a state machine that yields and
-            // resumes; for substrate purposes it produces the awaited
-            // value, so we lift as the inner expr.
-            lift_expr_to_term_inner(&a.base, ctx)
+            let base = lift_expr_to_term_inner(&a.base, ctx)?;
+            Some(IrTerm::Ctor {
+                name: "await".to_string(),
+                args: vec![base],
+            })
         }
         Expr::Async(a) => {
             // `async { body }` produces a Future. The substrate sees

--- a/implementations/rust/sugar-walk/src/walk.rs
+++ b/implementations/rust/sugar-walk/src/walk.rs
@@ -413,6 +413,9 @@ fn walk_expr_for_callsites(
         Expr::Try(t) => {
             walk_expr_for_callsites(&t.expr, callee_name, conditions, inner_stmts, hits);
         }
+        Expr::Await(a) => {
+            walk_expr_for_callsites(&a.base, callee_name, conditions, inner_stmts, hits);
+        }
         // Return statements: recurse into the returned expression for
         // callsite discovery.
         Expr::Return(r) => {
@@ -802,6 +805,39 @@ mod tests {
         assert!(
             !json.contains("<expr:"),
             "binary arg must not use token-string placeholder: {}",
+            json
+        );
+    }
+
+    #[test]
+    fn awaited_let_binding_reaches_later_consumer_pre_as_structural_seam() {
+        let caller_src = r#"
+            async fn caller() {
+                let x = producer().await;
+                consumer(x);
+            }
+        "#;
+        let caller_fn: ItemFn = parse_fn(caller_src);
+        let pre = atomic_ge(var("x"), const_int(6));
+
+        let walks = walk_callsites_to_entry(&caller_fn, "consumer", &["x".to_string()], pre);
+
+        assert_eq!(walks.len(), 1, "consumer callsite should be found");
+        let entry_wp = walks[0].entry_wp();
+        let json = serde_json::to_string(entry_wp.as_formula()).unwrap();
+        assert!(
+            json.contains("\"await\""),
+            "await seam should survive let-substitution into consumer pre: {}",
+            json
+        );
+        assert!(
+            json.contains("\"producer\""),
+            "producer call should survive under await seam: {}",
+            json
+        );
+        assert!(
+            !json.contains("\"x\""),
+            "the local x should be substituted by producer().await: {}",
             json
         );
     }

--- a/implementations/rust/sugar-walk/tests/language_coverage.rs
+++ b/implementations/rust/sugar-walk/tests/language_coverage.rs
@@ -177,11 +177,14 @@ fn multi_arg_closure_nests() {
 }
 
 #[test]
-fn await_passes_through_to_inner() {
-    // future.await lifts as just `future`.
+fn await_lifts_as_structural_seam() {
+    // `future.await` is the explicit async seam. It must survive as a term so
+    // the verifier can reuse the existing producer.post -> consumer.pre edge
+    // across the suspension boundary.
     let awaited = lift_expr_to_term(&parse_expr("future.await")).unwrap();
-    let direct = lift_expr_to_term(&parse_expr("future")).unwrap();
-    assert_eq!(awaited, direct);
+    let json = serde_json::to_string(&awaited).unwrap();
+    assert!(json.contains("\"await\""), "await seam missing: {json}");
+    assert!(json.contains("\"future\""), "awaited base missing: {json}");
 }
 
 #[test]


### PR DESCRIPTION
## Tokio await implication edge: `post(before .await) ⊨ pre(after resume)`

The first real *reasoning* across an async effect — the implication lifter relocated to the awaited seam. A Rust `.await` is lifted as a structural `await(term)`; WP discovery recurses through await; the verifier's `locate_producer_post` peels `await(producer())` so the awaited producer's **postcondition** reaches the consumer's **precondition** across the suspension.

**Strictly `post ⊨ pre` at the seam.** No type/borrow/drop reasoning (that's rustc), no interleaving/deadlock/lock reasoning (that's a model-checker). The `.await` is only *where* post meets pre.

- `sugar-walk`: `await_lifts_as_structural_seam`; `awaited_let_binding_reaches_later_consumer_pre_as_structural_seam`.
- `sugar-verifier`: `locate_producer_post_resolves_through_single_await_seam` **and** `locate_producer_post_refuses_non_producer_await_base` (the refusal guard).
- RED-first: each went red on await-term loss / missing producer-post-through-await / seam loss.

### Two-twin showcase `examples/tokio-await-implication-edge` (real tokio `=1.43.0`, `#[tokio::test]` witness, battleaxe)
GOOD — producer post establishes consumer pre across `.await` → `await_edge=discharged witness=discharged`. BAD — producer post does **not** entail consumer pre → `await_edge=unsatisfied witness=unsatisfied`. Consistency receipt scoped loudly to the awaited edge row (`bridge=consumer`).

### Acceptance (verified by me, real exit captured)
- `../../bin/bcargo test --workspace --no-fail-fast` → **2541 passed / 0 failed**; await + refusal tests ran.
- `run.sh` exit 0 — I re-ran it: SCOPE banner, good discharged, bad flips to unsatisfied, self-check passed.
- `make ci` PASS; `grep -rn 'concept_name\|conceptName' implementations/` → 0.

First real cross-effect edge; channel `post(send) ⊨ pre(recv)` and the mutex critical-section edge build on the same machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
