### PR TITLE
sugar diff: key the verdict on the behavior CID set (renames are not breaks)

### DIFF
--- a/implementations/rust/sugar-cli/src/cmd_diff.rs
+++ b/implementations/rust/sugar-cli/src/cmd_diff.rs
@@ -5,22 +5,25 @@
 //!
 //! Each proof set lifts to a `{contract-name -> CID}` table (`name_to_cid` in
 //! the loaded `MementoPool`). The CID is the name-stripped, content-addressed
-//! identity of the contract's pre/post: its *behavior*. So we do set arithmetic
-//! over the two tables and classify every contract into the trichotomy:
+//! identity of the contract's pre/post: its *behavior*.
 //!
-//!   unchanged  same name, same CID   (implementation churned, behavior held)
-//!   changed    same name, new CID    (behavior moved: the loud case)
-//!   added      name only in AFTER    (new surface, additive)
-//!   removed    name only in BEFORE   (surface dropped, breaking)
+//! The verdict is driven by the CID SET, not the name set, because names are
+//! sugar. We invert each table to `CID -> {names}` and classify by behavior:
 //!
-//! The exit code is the product: nonzero when behavior moved or surface dropped.
-//! That one fact makes `diff` a CI gate, a pre-publish hook, and an install-time
-//! hook with the same binary. A behavior-preserving refactor under a stable
-//! contract name prints `behavior delta: none` and exits 0.
+//!   held      a CID present both sides under the same name(s)
+//!   renamed   a CID present both sides, but its name(s) changed (pure rename)
+//!   new       a CID only in AFTER  (genuinely new behavior -- additive)
+//!   lost      a CID only in BEFORE (behavior actually gone -- breaking)
 //!
-//! (MVP keys by contract name, so it catches behavior-change under a stable
-//! name. A pure contract *rename* shows as removed+added of the same CID; a
-//! later increment can add the CID-set view that collapses that to `unchanged`.)
+//! A pure rename has zero new and zero lost behaviors, so it is `bump: none`,
+//! exit 0. That is the whole point: rename a contract, churn its implementation,
+//! reformat 2700 files -- as long as no behavior-CID appears or disappears, the
+//! behavior delta is none and the gate stays green. Only a CID that vanishes
+//! (lost) or appears (new) moves the needle.
+//!
+//! The exit code is the product: nonzero when a behavior is lost. That one fact
+//! makes the same binary a CI gate, a pre-publish hook (refuse a dishonest
+//! version bump), and an install-time hook (refuse a silent dependency mutation).
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
@@ -38,27 +41,41 @@ pub struct DiffArgs {
     pub after: PathBuf,
 }
 
-/// The behavior delta between two `{contract-name -> CID}` tables.
+/// `name -> CID`, as loaded from a proof set.
+type Table = BTreeMap<String, String>;
+/// `CID -> {names}`: a behavior and every contract name that denotes it.
+type ByCid = BTreeMap<String, BTreeSet<String>>;
+
+fn invert(t: &Table) -> ByCid {
+    let mut m: ByCid = BTreeMap::new();
+    for (name, cid) in t {
+        m.entry(cid.clone()).or_default().insert(name.clone());
+    }
+    m
+}
+
+/// The behavior delta between two proof sets, keyed by CID.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct Summary {
-    pub unchanged: u32,
-    pub changed: u32,
-    pub added: u32,
-    pub removed: u32,
-    pub deltas: Vec<String>,
+    pub new_behaviors: u32,
+    pub lost_behaviors: u32,
+    pub held: u32,
+    pub renamed: u32,
+    pub lines: Vec<String>,
 }
 
 impl Summary {
-    /// A break is exactly "a published contract's behavior moved or vanished."
+    /// A break is exactly "a behavior that existed no longer does." A rename is
+    /// not a break: the behavior is still there under a new name.
     pub fn breaking(&self) -> bool {
-        self.changed > 0 || self.removed > 0
+        self.lost_behaviors > 0
     }
 
-    /// The honest-semver bump the delta implies.
+    /// The honest-semver bump the behavior delta implies.
     pub fn bump(&self) -> &'static str {
-        if self.breaking() {
+        if self.lost_behaviors > 0 {
             "MAJOR"
-        } else if self.added > 0 {
+        } else if self.new_behaviors > 0 {
             "minor"
         } else {
             "none"
@@ -66,28 +83,51 @@ impl Summary {
     }
 }
 
-/// Pure comparison: classify every contract name across both tables. This is the
+fn short(cid: &str) -> String {
+    // strip the `blake3-512:` prefix if present, keep a recognizable head
+    let hex = cid.rsplit(':').next().unwrap_or(cid);
+    format!("{}…", &hex[..hex.len().min(12)])
+}
+
+fn names(set: &BTreeSet<String>) -> String {
+    set.iter().cloned().collect::<Vec<_>>().join(", ")
+}
+
+/// Pure comparison: classify every behavior CID across both tables. This is the
 /// whole feature; `run` is just IO around it.
-pub fn summarize(before: &BTreeMap<String, String>, after: &BTreeMap<String, String>) -> Summary {
+pub fn summarize(before: &Table, after: &Table) -> Summary {
+    let b = invert(before);
+    let a = invert(after);
     let mut s = Summary::default();
-    let names: BTreeSet<&String> = before.keys().chain(after.keys()).collect();
-    for name in names {
-        match (before.get(name), after.get(name)) {
-            (Some(x), Some(y)) if x == y => s.unchanged += 1,
-            (Some(x), Some(y)) => {
-                s.changed += 1;
-                s.deltas
-                    .push(format!("  changed    {name}\n             {x}\n          -> {y}"));
+    let cids: BTreeSet<&String> = b.keys().chain(a.keys()).collect();
+    for cid in cids {
+        match (b.get(cid), a.get(cid)) {
+            (Some(bn), Some(an)) => {
+                // behavior preserved on both sides
+                s.held += bn.intersection(an).count() as u32;
+                if bn != an {
+                    s.renamed += 1;
+                    let from: Vec<String> = bn.difference(an).cloned().collect();
+                    let to: Vec<String> = an.difference(bn).cloned().collect();
+                    s.lines.push(format!(
+                        "  renamed    {} -> {}   (behavior {} held)",
+                        from.join(", "),
+                        to.join(", "),
+                        short(cid)
+                    ));
+                }
             }
-            (None, Some(_)) => {
-                s.added += 1;
-                s.deltas.push(format!("  added      {name}"));
+            (Some(bn), None) => {
+                s.lost_behaviors += 1;
+                s.lines
+                    .push(format!("  lost       {}   ({})", names(bn), short(cid)));
             }
-            (Some(_), None) => {
-                s.removed += 1;
-                s.deltas.push(format!("  removed    {name}"));
+            (None, Some(an)) => {
+                s.new_behaviors += 1;
+                s.lines
+                    .push(format!("  new        {}   ({})", names(an), short(cid)));
             }
-            (None, None) => unreachable!("name came from the union of both key sets"),
+            (None, None) => unreachable!("cid came from the union of both key sets"),
         }
     }
     s
@@ -98,15 +138,15 @@ pub fn run(args: DiffArgs) -> u8 {
     let after = load_all_proofs::run(&args.after);
     let s = summarize(&before.name_to_cid, &after.name_to_cid);
 
-    for d in &s.deltas {
-        println!("{d}");
+    for line in &s.lines {
+        println!("{line}");
     }
-    if !s.deltas.is_empty() {
+    if !s.lines.is_empty() {
         println!();
     }
     println!(
-        "behavior delta: {} changed, {} removed, {} added; {} unchanged",
-        s.changed, s.removed, s.added, s.unchanged
+        "behavior: {} new, {} lost, {} held, {} renamed",
+        s.new_behaviors, s.lost_behaviors, s.held, s.renamed
     );
     println!("required bump: {}", s.bump());
 
@@ -121,7 +161,7 @@ pub fn run(args: DiffArgs) -> u8 {
 mod tests {
     use super::*;
 
-    fn table(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+    fn table(pairs: &[(&str, &str)]) -> Table {
         pairs
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
@@ -129,41 +169,51 @@ mod tests {
     }
 
     #[test]
-    fn identity_is_all_unchanged_no_bump() {
+    fn identity_holds_all_behaviors_no_bump() {
         let a = table(&[("f", "cid1"), ("g", "cid2")]);
         let s = summarize(&a, &a);
-        assert_eq!((s.unchanged, s.changed, s.added, s.removed), (2, 0, 0, 0));
+        assert_eq!((s.held, s.new_behaviors, s.lost_behaviors, s.renamed), (2, 0, 0, 0));
         assert!(!s.breaking());
         assert_eq!(s.bump(), "none");
     }
 
     #[test]
-    fn same_name_new_cid_is_major_and_breaking() {
-        // behavior moved under a stable contract name: the loud case.
+    fn pure_rename_is_renamed_not_breaking() {
+        // THE headline: same behavior CID, new contract name. Names are sugar,
+        // so this is `renamed`, zero behavior delta, bump none, exit ok.
+        let s = summarize(&table(&[("old_name", "cidA")]), &table(&[("new_name", "cidA")]));
+        assert_eq!((s.renamed, s.new_behaviors, s.lost_behaviors, s.held), (1, 0, 0, 0));
+        assert!(!s.breaking());
+        assert_eq!(s.bump(), "none");
+    }
+
+    #[test]
+    fn behavior_moved_under_stable_name_is_major() {
+        // name held, CID replaced: old behavior lost, new behavior gained.
         let s = summarize(&table(&[("f", "cid1")]), &table(&[("f", "cid2")]));
-        assert_eq!((s.changed, s.unchanged), (1, 0));
+        assert_eq!((s.lost_behaviors, s.new_behaviors), (1, 1));
         assert!(s.breaking());
         assert_eq!(s.bump(), "MAJOR");
     }
 
     #[test]
-    fn added_only_is_minor_not_breaking() {
+    fn added_only_is_minor() {
         let s = summarize(
             &table(&[("f", "cid1")]),
             &table(&[("f", "cid1"), ("g", "cid2")]),
         );
-        assert_eq!((s.added, s.unchanged), (1, 1));
+        assert_eq!((s.new_behaviors, s.lost_behaviors, s.held), (1, 0, 1));
         assert!(!s.breaking());
         assert_eq!(s.bump(), "minor");
     }
 
     #[test]
-    fn removed_contract_is_major_and_breaking() {
+    fn lost_behavior_is_major_and_breaking() {
         let s = summarize(
             &table(&[("f", "cid1"), ("g", "cid2")]),
             &table(&[("f", "cid1")]),
         );
-        assert_eq!((s.removed, s.unchanged), (1, 1));
+        assert_eq!((s.lost_behaviors, s.held), (1, 1));
         assert!(s.breaking());
         assert_eq!(s.bump(), "MAJOR");
     }


### PR DESCRIPTION
The first `sugar diff` increment keyed by contract *name*, so a pure rename (same behavior-CID, new name) showed as removed + added — a false break. Names are sugar; a rename is not a behavior change.

This inverts each proof set to `CID -> {names}` and classifies by behavior: `held` / `renamed` / `new` / `lost`. The verdict follows the CID set — `lost > 0` is MAJOR and breaking, `new > 0` is minor, and a **pure rename is `bump: none`, exit 0**, because no behavior-CID appeared or disappeared.

**Validated on real numpy proofs:**
- identity → `0 new, 0 lost, 2 held`, none, exit 0
- showcase vs consumer-demo → `2 new, 2 lost` (each behavior-CID named), MAJOR, exit 1
- 5 unit tests incl. `pure_rename_is_renamed_not_breaking`

🤖 Generated with [Claude Code](https://claude.com/claude-code)