### PR TITLE
Tokio channel implication edge: post(send) discharges pre(recv)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,6 +276,7 @@ SHOWCASE_RUNS = \
 	examples/rust-test-assertion-consistency/run.sh \
 	examples/tokio-effect-consistency/run.sh \
 	examples/tokio-await-implication-edge/run.sh \
+	examples/tokio-channel-implication-edge/run.sh \
 	examples/polars-showcase/run.sh \
 	examples/numpy-attribute-safety-showcase/run.sh \
 	examples/java-test-assertion-consistency/run.sh

--- a/examples/tokio-channel-implication-edge/.gitignore
+++ b/examples/tokio-channel-implication-edge/.gitignore
@@ -1,0 +1,9 @@
+*.proof
+.prove.json
+.verify.json
+.verify_recompute.json
+**/.sugar/runs/
+**/.sugar/witnesses/
+**/target/
+Cargo.lock
+**/.sugar/lift/*/manifest.toml

--- a/examples/tokio-channel-implication-edge/README.md
+++ b/examples/tokio-channel-implication-edge/README.md
@@ -1,0 +1,19 @@
+# Tokio Channel Implication Edge
+
+This showcase proves the narrow channel edge:
+
+`send(producer).post |= recv-side consumer.pre` through a local
+`tokio::sync::mpsc` conduit.
+
+The good twin sends a value from a producer whose postcondition establishes
+`result == 6`, receives from the channel, then passes that value to a consumer
+whose precondition requires `x == 6`. The bad twin weakens the send-side
+producer postcondition to `result == 5` while the recv-side consumer still
+requires `x == 6`, so the channel implication edge refuses.
+
+Scope: this is only the element-contract implication row. It does not prove
+which send pairs with which recv, message ordering, channel cardinality,
+interleavings, locks, deadlock freedom, data-race freedom, or Rust type/borrow
+rules.
+
+The witness axis is the real `#[tokio::test]` cargo test run.

--- a/examples/tokio-channel-implication-edge/bad/.sugar/config.toml
+++ b/examples/tokio-channel-implication-edge/bad/.sugar/config.toml
@@ -1,0 +1,29 @@
+[[plugins]]
+name = "rust-fn-contracts"
+surface = "rust-fn-contracts"
+emit = "ir-document"
+
+[[plugins]]
+name = "rust-implications"
+surface = "rust-implications"
+
+[[plugins]]
+name = "rust-cargo-test-witness"
+surface = "rust-cargo-test-witness"
+
+[platform_profile]
+language = "rust"
+family = "concept:family:sugar"
+library = "tokio-channel-implication-edge-bad"
+version = "0.1.0"
+
+[solvers]
+mode = "first-wins"
+portfolio = ["z3"]
+
+[solvers.z3]
+binary = "z3"
+ir_compiler = "smt-lib-v2.6"
+flags = ["-smt2", "-in"]
+timeout_seconds = 30
+version = "4.x"

--- a/examples/tokio-channel-implication-edge/bad/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
+++ b/examples/tokio-channel-implication-edge/bad/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
@@ -1,0 +1,13 @@
+name = "rust-cargo-test-witness-lift"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/witness_rpc"]
+discharge_command = ["@BIN_DIR@/discharge_cli"]
+witness_tool = "cargo-test"
+resolve_witness_command = ["@BIN_DIR@/witness_rpc"]
+resolve_witness_method = "sugar.plugin.resolve_witness"
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["rust-cargo-test-witness"]

--- a/examples/tokio-channel-implication-edge/bad/.sugar/lift/rust-fn-contracts/manifest.toml.in
+++ b/examples/tokio-channel-implication-edge/bad/.sugar/lift/rust-fn-contracts/manifest.toml.in
@@ -1,0 +1,3 @@
+name = "rust-fn-contracts-lift"
+command = ["@BIN_DIR@/sugar-walk-rpc", "--rpc"]
+working_dir = "."

--- a/examples/tokio-channel-implication-edge/bad/.sugar/lift/rust-implications/manifest.toml.in
+++ b/examples/tokio-channel-implication-edge/bad/.sugar/lift/rust-implications/manifest.toml.in
@@ -1,0 +1,5 @@
+name = "rust-implications-lift"
+command = ["@BIN_DIR@/sugar-walk-rpc", "--rpc"]
+working_dir = "."
+method = "sugar.plugin.lift_implications"
+phase = "consumer"

--- a/examples/tokio-channel-implication-edge/bad/Cargo.toml
+++ b/examples/tokio-channel-implication-edge/bad/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "tokio-channel-implication-edge-bad"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "=1.43.0", features = ["macros", "rt", "sync"] }

--- a/examples/tokio-channel-implication-edge/bad/src/lib.rs
+++ b/examples/tokio-channel-implication-edge/bad/src/lib.rs
@@ -1,0 +1,29 @@
+use tokio::sync::mpsc;
+
+pub async fn producer() -> i64 {
+    tokio::task::yield_now().await;
+    5
+}
+
+pub fn consumer(x: i64) -> i64 {
+    assert!(x == 6);
+    6
+}
+
+pub async fn edge() -> i64 {
+    let (tx, mut rx) = mpsc::channel::<i64>(1);
+    tx.send(producer().await)
+        .await
+        .expect("local receiver remains alive");
+    consumer(rx.recv().await.expect("one value was sent"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::edge;
+
+    #[tokio::test]
+    async fn channel_send_post_does_not_satisfy_recv_consumer_pre() {
+        assert_eq!(edge().await, 6);
+    }
+}

--- a/examples/tokio-channel-implication-edge/good/.sugar/config.toml
+++ b/examples/tokio-channel-implication-edge/good/.sugar/config.toml
@@ -1,0 +1,29 @@
+[[plugins]]
+name = "rust-fn-contracts"
+surface = "rust-fn-contracts"
+emit = "ir-document"
+
+[[plugins]]
+name = "rust-implications"
+surface = "rust-implications"
+
+[[plugins]]
+name = "rust-cargo-test-witness"
+surface = "rust-cargo-test-witness"
+
+[platform_profile]
+language = "rust"
+family = "concept:family:sugar"
+library = "tokio-channel-implication-edge-good"
+version = "0.1.0"
+
+[solvers]
+mode = "first-wins"
+portfolio = ["z3"]
+
+[solvers.z3]
+binary = "z3"
+ir_compiler = "smt-lib-v2.6"
+flags = ["-smt2", "-in"]
+timeout_seconds = 30
+version = "4.x"

--- a/examples/tokio-channel-implication-edge/good/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
+++ b/examples/tokio-channel-implication-edge/good/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
@@ -1,0 +1,13 @@
+name = "rust-cargo-test-witness-lift"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/witness_rpc"]
+discharge_command = ["@BIN_DIR@/discharge_cli"]
+witness_tool = "cargo-test"
+resolve_witness_command = ["@BIN_DIR@/witness_rpc"]
+resolve_witness_method = "sugar.plugin.resolve_witness"
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["rust-cargo-test-witness"]

--- a/examples/tokio-channel-implication-edge/good/.sugar/lift/rust-fn-contracts/manifest.toml.in
+++ b/examples/tokio-channel-implication-edge/good/.sugar/lift/rust-fn-contracts/manifest.toml.in
@@ -1,0 +1,3 @@
+name = "rust-fn-contracts-lift"
+command = ["@BIN_DIR@/sugar-walk-rpc", "--rpc"]
+working_dir = "."

--- a/examples/tokio-channel-implication-edge/good/.sugar/lift/rust-implications/manifest.toml.in
+++ b/examples/tokio-channel-implication-edge/good/.sugar/lift/rust-implications/manifest.toml.in
@@ -1,0 +1,5 @@
+name = "rust-implications-lift"
+command = ["@BIN_DIR@/sugar-walk-rpc", "--rpc"]
+working_dir = "."
+method = "sugar.plugin.lift_implications"
+phase = "consumer"

--- a/examples/tokio-channel-implication-edge/good/Cargo.toml
+++ b/examples/tokio-channel-implication-edge/good/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "tokio-channel-implication-edge-good"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "=1.43.0", features = ["macros", "rt", "sync"] }

--- a/examples/tokio-channel-implication-edge/good/src/lib.rs
+++ b/examples/tokio-channel-implication-edge/good/src/lib.rs
@@ -1,0 +1,29 @@
+use tokio::sync::mpsc;
+
+pub async fn producer() -> i64 {
+    tokio::task::yield_now().await;
+    6
+}
+
+pub fn consumer(x: i64) -> i64 {
+    assert!(x == 6);
+    6
+}
+
+pub async fn edge() -> i64 {
+    let (tx, mut rx) = mpsc::channel::<i64>(1);
+    tx.send(producer().await)
+        .await
+        .expect("local receiver remains alive");
+    consumer(rx.recv().await.expect("one value was sent"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::edge;
+
+    #[tokio::test]
+    async fn channel_send_post_satisfies_recv_consumer_pre() {
+        assert_eq!(edge().await, 6);
+    }
+}

--- a/examples/tokio-channel-implication-edge/run.sh
+++ b/examples/tokio-channel-implication-edge/run.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+RUST="$REPO/implementations/rust"
+BIN_DIR="$RUST/target/debug"
+SUGAR="$BIN_DIR/sugar"
+WALK_RPC="$BIN_DIR/sugar-walk-rpc"
+WITNESS_RPC="$BIN_DIR/witness_rpc"
+DISCHARGE_CLI="$BIN_DIR/discharge_cli"
+
+for suite in good bad; do
+  if [ ! -d "$HERE/$suite" ]; then
+    echo "missing suite directory: $HERE/$suite" >&2
+    exit 1
+  fi
+done
+
+if [ "${TOKIO_CHANNEL_EDGE_SHOWCASE_ON_REMOTE:-0}" != "1" ] \
+  && [ "${TOKIO_CHANNEL_EDGE_SHOWCASE_USE_BCARGO:-1}" != "0" ] \
+  && [ "$(uname -s)" != "Linux" ]; then
+  echo "== run tokio channel implication edge showcase on battleaxe via bcargo =="
+  "$REPO/bin/bcargo" build --manifest-path "$RUST/Cargo.toml" \
+    -p sugar-cli --bin sugar \
+    -p sugar-walk --bin sugar-walk-rpc \
+    -p sugar-lift-rust-cargo-test-witness --bin witness_rpc \
+    -p sugar-lift-rust-cargo-test-witness --bin discharge_cli >/dev/null
+
+  remote_host="${BCARGO_REMOTE_HOST:-battleaxe}"
+  remote_tag="$(printf '%s' "$(cd "$REPO" && pwd -P)" | shasum 2>/dev/null | cut -c1-12)"
+  remote_tag="${remote_tag:-default}"
+  remote_root="${BCARGO_REMOTE_ROOT:-/home/tsavo/remote/sugar-bcargo-${remote_tag}}"
+  remote_repo="$remote_root/sugar"
+  remote_cmd="cd $(printf '%q' "$remote_repo") && TOKIO_CHANNEL_EDGE_SHOWCASE_ON_REMOTE=1 TOKIO_CHANNEL_EDGE_SHOWCASE_SKIP_LOCAL_BUILD=1 examples/tokio-channel-implication-edge/run.sh"
+  ssh -o BatchMode=yes "$remote_host" "bash -lc $(printf '%q' "$remote_cmd")"
+  exit $?
+fi
+
+if [ "${TOKIO_CHANNEL_EDGE_SHOWCASE_SKIP_LOCAL_BUILD:-0}" != "1" ]; then
+  echo "== build local proof binaries =="
+  cargo build --manifest-path "$RUST/Cargo.toml" \
+    -p sugar-cli --bin sugar \
+    -p sugar-walk --bin sugar-walk-rpc \
+    -p sugar-lift-rust-cargo-test-witness --bin witness_rpc \
+    -p sugar-lift-rust-cargo-test-witness --bin discharge_cli >/dev/null
+fi
+
+for bin in "$SUGAR" "$WALK_RPC" "$WITNESS_RPC" "$DISCHARGE_CLI"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing executable: $bin" >&2
+    exit 1
+  fi
+done
+
+render_manifests() {
+  local suite="$1"
+  local base="$HERE/$suite/.sugar/lift"
+
+  sed "s|@BIN_DIR@|$BIN_DIR|g" \
+    "$base/rust-fn-contracts/manifest.toml.in" \
+    > "$base/rust-fn-contracts/manifest.toml"
+
+  sed "s|@BIN_DIR@|$BIN_DIR|g" \
+    "$base/rust-implications/manifest.toml.in" \
+    > "$base/rust-implications/manifest.toml"
+
+  sed "s|@BIN_DIR@|$BIN_DIR|g" \
+    "$base/rust-cargo-test-witness/manifest.toml.in" \
+    > "$base/rust-cargo-test-witness/manifest.toml"
+}
+
+clean_suite() {
+  local suite="$1"
+  local dir="$HERE/$suite"
+  rm -f "$dir"/blake3-512:*.proof "$dir/.prove.json" "$dir/.verify.json" "$dir/.verify_recompute.json"
+  rm -rf "$dir/.sugar/runs" "$dir/.sugar/witnesses" "$dir/target"
+}
+
+edge_status() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path, "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+rows = data.get("rows") or data.get("obligations") or (data if isinstance(data, list) else [])
+for row in rows:
+    prop = row.get("property") or row.get("predicate") or ""
+    if "witness-package" in prop:
+        continue
+    if row.get("bridge") == "consumer" or row.get("callee") == "consumer":
+        print(row.get("status") or row.get("result") or "")
+        raise SystemExit(0)
+print("MISSING")
+PY
+}
+
+witness_status() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path, "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+rows = data.get("rows") or data.get("obligations") or (data if isinstance(data, list) else [])
+for row in rows:
+    prop = row.get("property") or row.get("predicate") or ""
+    if "witness-package" in prop:
+        print(row.get("status") or row.get("result") or "")
+        raise SystemExit(0)
+print("MISSING")
+PY
+}
+
+witness_verdict() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+
+text = open(sys.argv[1], "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+for witness in data.get("witnessDimension", {}).get("witnesses", []):
+    verdict = witness.get("verdict")
+    if verdict:
+        print(verdict)
+        raise SystemExit(0)
+print("MISSING")
+PY
+}
+
+witness_recompute_strategy() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+
+text = open(sys.argv[1], "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+for witness in data.get("witnessDimension", {}).get("witnesses", []):
+    checks = witness.get("checks") or []
+    if "content-address:recompute" in checks:
+        print("content-address:recompute")
+        raise SystemExit(0)
+print("MISSING")
+PY
+}
+
+run_suite() {
+  local suite="$1"
+  local expect_edge="$2"
+  local expect_witness="$3"
+  local dir="$HERE/$suite"
+
+  render_manifests "$suite"
+  clean_suite "$suite"
+
+  echo "== mint $suite =="
+  (cd "$dir" && "$SUGAR" mint --out .) >/dev/null
+
+  local proof
+  proof="$(find "$dir" -maxdepth 1 -name 'blake3-512:*.proof' -print -quit)"
+  if [ -z "$proof" ]; then
+    echo "$suite did not mint a proof" >&2
+    exit 1
+  fi
+
+  echo "== prove $suite =="
+  set +e
+  (cd "$dir" && "$SUGAR" prove . --json) > "$dir/.prove.json" 2>&1
+  set -e
+
+  local got_edge got_witness
+  got_edge="$(edge_status "$dir/.prove.json")"
+  got_witness="$(witness_status "$dir/.prove.json")"
+
+  if [ "$expect_edge" = "discharged" ]; then
+    if [ "$got_edge" != "discharged" ]; then
+      echo "$suite channel implication edge expected discharged, got $got_edge" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  else
+    if [ "$got_edge" = "discharged" ] || [ "$got_edge" = "MISSING" ]; then
+      echo "$suite channel implication edge expected refusal, got $got_edge" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  fi
+
+  if [ "$expect_witness" = "discharged" ]; then
+    if [ "$got_witness" != "discharged" ]; then
+      echo "$suite witness expected discharged, got $got_witness" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+
+    echo "== verify $suite witness =="
+    set +e
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify.json" 2>&1
+    set -e
+    local verify_verdict
+    verify_verdict="$(witness_verdict "$dir/.verify.json")"
+    if [ "$verify_verdict" != "verified" ]; then
+      echo "$suite witness verification expected verified, got $verify_verdict" >&2
+      cat "$dir/.verify.json" >&2
+      exit 1
+    fi
+
+    rm -rf "$dir/.sugar/witnesses"
+    set +e
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify_recompute.json" 2>&1
+    set -e
+    local recompute_strategy
+    recompute_strategy="$(witness_recompute_strategy "$dir/.verify_recompute.json")"
+    if [ "$recompute_strategy" != "content-address:recompute" ]; then
+      echo "$suite witness recompute expected content-address:recompute, got $recompute_strategy" >&2
+      cat "$dir/.verify_recompute.json" >&2
+      exit 1
+    fi
+  else
+    if [ "$got_witness" = "discharged" ] || [ "$got_witness" = "MISSING" ]; then
+      echo "$suite witness expected refusal, got $got_witness" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  fi
+
+  echo "$suite channel_edge=$got_edge witness=$got_witness"
+}
+
+echo "EFFECT: tokio mpsc is treated as a typed conduit where every accepted send-side producer post must imply the recv-side consumer pre."
+echo "SCOPE: self-checking only the channel_edge row (bridge=consumer with argTerm through channel:recv:rx); no send/recv matching, ordering, cardinality, interleaving, lock/deadlock/data-race, or Rust type/borrow/drop property is claimed."
+run_suite good discharged discharged
+run_suite bad refused refused
+
+echo "tokio channel implication edge showcase self-check passed"

--- a/implementations/rust/sugar-verifier/src/handshake.rs
+++ b/implementations/rust/sugar-verifier/src/handshake.rs
@@ -157,13 +157,29 @@ fn producer_lookup_term(arg: &Json) -> &Json {
     let Some("ctor") = arg.get("kind").and_then(|v| v.as_str()) else {
         return arg;
     };
-    if arg.get("name").and_then(|v| v.as_str()) != Some("await") {
-        return arg;
+    match arg.get("name").and_then(|v| v.as_str()) {
+        Some("await") => arg
+            .get("args")
+            .and_then(|v| v.as_array())
+            .and_then(|args| args.first())
+            .unwrap_or(arg),
+        Some("method:unwrap" | "method:expect") => arg
+            .get("args")
+            .and_then(|v| v.as_array())
+            .and_then(|args| args.first())
+            .map(producer_lookup_term)
+            .filter(is_channel_recv_lookup_term)
+            .unwrap_or(arg),
+        _ => arg,
     }
-    arg.get("args")
-        .and_then(|v| v.as_array())
-        .and_then(|args| args.first())
-        .unwrap_or(arg)
+}
+
+fn is_channel_recv_lookup_term(term: &&Json) -> bool {
+    term.get("kind").and_then(|v| v.as_str()) == Some("ctor")
+        && term
+            .get("name")
+            .and_then(|v| v.as_str())
+            .is_some_and(|name| name.starts_with("channel:recv:"))
 }
 
 /// Wrap a bare producer post in `forall result. post`, binding the output
@@ -349,6 +365,60 @@ mod tests {
         assert!(
             locate_producer_post(&arg_term, &pool_mementos, &bridges_by_symbol).is_none(),
             "await over a non-call term must not invent a producer post"
+        );
+    }
+
+    #[test]
+    fn locate_producer_post_resolves_channel_recv_through_await_unwrap_or_expect_seam() {
+        let producer_cid = "blake3-512:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+        let mut pool_mementos = BTreeMap::new();
+        pool_mementos.insert(producer_cid.to_string(), contract_with_post(6));
+        let mut bridges_by_symbol = BTreeMap::new();
+        bridges_by_symbol.insert("channel:recv:rx".to_string(), bridge_to(producer_cid));
+
+        for wrapper in ["method:unwrap", "method:expect"] {
+            let arg_term = Some(json!({
+                "kind": "ctor",
+                "name": wrapper,
+                "args": [
+                    {
+                        "kind": "ctor",
+                        "name": "await",
+                        "args": [
+                            {"kind": "ctor", "name": "channel:recv:rx", "args": [
+                                {"kind": "var", "name": "rx"}
+                            ]}
+                        ]
+                    }
+                ]
+            }));
+
+            let (post, _) = locate_producer_post(&arg_term, &pool_mementos, &bridges_by_symbol)
+                .unwrap_or_else(|| panic!("{wrapper} channel recv seam should resolve"));
+            assert_eq!(post["kind"], "forall");
+            assert_eq!(post["name"], "result");
+        }
+    }
+
+    #[test]
+    fn locate_producer_post_does_not_treat_plain_unwrap_as_channel_edge() {
+        let producer_cid = "blake3-512:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+        let mut pool_mementos = BTreeMap::new();
+        pool_mementos.insert(producer_cid.to_string(), contract_with_post(6));
+        let mut bridges_by_symbol = BTreeMap::new();
+        bridges_by_symbol.insert("producer".to_string(), bridge_to(producer_cid));
+
+        let arg_term = Some(json!({
+            "kind": "ctor",
+            "name": "method:unwrap",
+            "args": [
+                {"kind": "ctor", "name": "producer", "args": []}
+            ]
+        }));
+
+        assert!(
+            locate_producer_post(&arg_term, &pool_mementos, &bridges_by_symbol).is_none(),
+            "plain unwrap must remain outside the channel implication seam"
         );
     }
 }

--- a/implementations/rust/sugar-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/sugar-walk/src/bin/walk_rpc.rs
@@ -681,6 +681,305 @@ struct CallSite {
     col: usize,
 }
 
+#[derive(Debug, Clone)]
+struct TrackedChannelConduit {
+    tx: String,
+    rx: String,
+    producer: Option<String>,
+    ambiguous: bool,
+    escaped: bool,
+    recv_sites: Vec<(usize, usize)>,
+}
+
+fn channel_recv_source_symbol(rx: &str) -> String {
+    format!("channel:recv:{rx}")
+}
+
+fn collect_tokio_mpsc_channel_conduit_callsites(file: &syn::File, rel_path: &str) -> Vec<CallSite> {
+    use syn::visit::Visit;
+
+    struct V<'a> {
+        rel_path: &'a str,
+        channels: Vec<TrackedChannelConduit>,
+    }
+
+    impl<'a> V<'a> {
+        fn channel_by_tx_mut(&mut self, tx: &str) -> Option<&mut TrackedChannelConduit> {
+            self.channels.iter_mut().find(|channel| channel.tx == tx)
+        }
+
+        fn channel_by_rx_mut(&mut self, rx: &str) -> Option<&mut TrackedChannelConduit> {
+            self.channels.iter_mut().find(|channel| channel.rx == rx)
+        }
+
+        fn endpoint_names(&self) -> BTreeSet<String> {
+            self.channels
+                .iter()
+                .flat_map(|channel| [channel.tx.clone(), channel.rx.clone()])
+                .collect()
+        }
+
+        fn mark_escaped_if_endpoint_is_used_opaquely(&mut self, expr: &syn::Expr) {
+            let endpoints = self.endpoint_names();
+            if endpoints.is_empty() {
+                return;
+            }
+            for name in expr_ident_roots(expr) {
+                if endpoints.contains(&name) {
+                    for channel in &mut self.channels {
+                        if channel.tx == name || channel.rx == name {
+                            channel.escaped = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        fn into_callsites(self) -> Vec<CallSite> {
+            let mut out = Vec::new();
+            for channel in self.channels {
+                if channel.escaped || channel.ambiguous {
+                    continue;
+                }
+                let Some(producer) = channel.producer else {
+                    continue;
+                };
+                for (line, col) in channel.recv_sites {
+                    out.push(CallSite {
+                        callee: channel_recv_source_symbol(&channel.rx),
+                        contract_callee: producer.clone(),
+                        callee_crate: None,
+                        is_method: false,
+                        disambiguated_callee: None,
+                        disambiguated_crate: None,
+                        unsupported_reason: None,
+                        file: self.rel_path.to_string(),
+                        line,
+                        col,
+                    });
+                }
+            }
+            out
+        }
+    }
+
+    impl<'ast, 'a> Visit<'ast> for V<'a> {
+        fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
+            let saved = std::mem::take(&mut self.channels);
+            syn::visit::visit_item_fn(self, node);
+            let current = std::mem::take(&mut self.channels);
+            self.channels = saved;
+            self.channels.extend(current);
+        }
+
+        fn visit_local(&mut self, node: &'ast syn::Local) {
+            if let Some((tx, rx)) = tokio_mpsc_channel_binding(node) {
+                self.channels.push(TrackedChannelConduit {
+                    tx,
+                    rx,
+                    producer: None,
+                    ambiguous: false,
+                    escaped: false,
+                    recv_sites: Vec::new(),
+                });
+                syn::visit::visit_local(self, node);
+                return;
+            }
+
+            let endpoints = self.endpoint_names();
+            for bound in pat_bound_idents(&node.pat) {
+                if endpoints.contains(&bound) {
+                    for channel in &mut self.channels {
+                        if channel.tx == bound || channel.rx == bound {
+                            channel.escaped = true;
+                        }
+                    }
+                }
+            }
+            if let Some(init) = &node.init {
+                let uses_endpoint = expr_ident_roots(&init.expr)
+                    .iter()
+                    .any(|name| endpoints.contains(name));
+                let allowed_recv = self
+                    .channels
+                    .iter()
+                    .any(|channel| expr_is_channel_recv_chain(&init.expr, &channel.rx));
+                if uses_endpoint && !allowed_recv {
+                    self.mark_escaped_if_endpoint_is_used_opaquely(&init.expr);
+                }
+            }
+            syn::visit::visit_local(self, node);
+        }
+
+        fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+            for arg in &node.args {
+                let allowed_recv = self
+                    .channels
+                    .iter()
+                    .any(|channel| expr_is_channel_recv_chain(arg, &channel.rx));
+                if !allowed_recv {
+                    self.mark_escaped_if_endpoint_is_used_opaquely(arg);
+                }
+            }
+            syn::visit::visit_expr_call(self, node);
+        }
+
+        fn visit_expr_assign(&mut self, node: &'ast syn::ExprAssign) {
+            let roots = expr_assignment_roots(&node.left);
+            for channel in &mut self.channels {
+                if roots.contains(&channel.tx) || roots.contains(&channel.rx) {
+                    channel.escaped = true;
+                }
+            }
+            syn::visit::visit_expr_assign(self, node);
+        }
+
+        fn visit_expr_binary(&mut self, node: &'ast syn::ExprBinary) {
+            if binop_is_assignment(&node.op) {
+                let roots = expr_assignment_roots(&node.left);
+                for channel in &mut self.channels {
+                    if roots.contains(&channel.tx) || roots.contains(&channel.rx) {
+                        channel.escaped = true;
+                    }
+                }
+            }
+            syn::visit::visit_expr_binary(self, node);
+        }
+
+        fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+            if let Some(tx) = expr_bare_ident_name(&node.receiver) {
+                if let Some(channel) = self.channel_by_tx_mut(&tx) {
+                    if node.method == "send" && node.args.len() == 1 {
+                        let producer = node
+                            .args
+                            .first()
+                            .and_then(channel_send_payload_zero_arg_producer);
+                        match (&channel.producer, producer) {
+                            (None, Some(producer)) => channel.producer = Some(producer),
+                            (Some(existing), Some(producer)) if existing == &producer => {}
+                            _ => channel.ambiguous = true,
+                        }
+                    } else {
+                        channel.escaped = true;
+                    }
+                }
+            }
+            if let Some(rx) = expr_bare_ident_name(&node.receiver) {
+                if let Some(channel) = self.channel_by_rx_mut(&rx) {
+                    if node.method == "recv" && node.args.is_empty() {
+                        let start = node.method.span().start();
+                        channel.recv_sites.push((start.line, start.column));
+                    } else {
+                        channel.escaped = true;
+                    }
+                }
+            }
+            syn::visit::visit_expr_method_call(self, node);
+        }
+    }
+
+    let mut visitor = V {
+        rel_path,
+        channels: Vec::new(),
+    };
+    visitor.visit_file(file);
+    visitor.into_callsites()
+}
+
+fn tokio_mpsc_channel_binding(local: &syn::Local) -> Option<(String, String)> {
+    let init = local.init.as_ref()?;
+    if !expr_is_tokio_mpsc_channel_call(&init.expr) {
+        return None;
+    }
+    let syn::Pat::Tuple(tuple) = &local.pat else {
+        return None;
+    };
+    if tuple.elems.len() != 2 {
+        return None;
+    }
+    let tx = pat_single_ident(tuple.elems.first()?)?;
+    let rx = pat_single_ident(tuple.elems.iter().nth(1)?)?;
+    Some((tx, rx))
+}
+
+fn pat_single_ident(pat: &syn::Pat) -> Option<String> {
+    match pat {
+        syn::Pat::Ident(ident) => Some(ident.ident.to_string()),
+        syn::Pat::Type(typed) => pat_single_ident(&typed.pat),
+        _ => None,
+    }
+}
+
+fn expr_is_tokio_mpsc_channel_call(expr: &syn::Expr) -> bool {
+    let syn::Expr::Call(call) = expr else {
+        return false;
+    };
+    let syn::Expr::Path(path) = &*call.func else {
+        return false;
+    };
+    let segments = path
+        .path
+        .segments
+        .iter()
+        .map(|segment| segment.ident.to_string())
+        .collect::<Vec<_>>();
+    segments.last().is_some_and(|leaf| leaf == "channel")
+        && segments.iter().any(|segment| segment == "mpsc")
+}
+
+fn channel_send_payload_zero_arg_producer(expr: &syn::Expr) -> Option<String> {
+    match expr {
+        syn::Expr::Await(await_expr) => channel_send_payload_zero_arg_producer(&await_expr.base),
+        syn::Expr::Paren(paren) => channel_send_payload_zero_arg_producer(&paren.expr),
+        syn::Expr::Group(group) => channel_send_payload_zero_arg_producer(&group.expr),
+        syn::Expr::Reference(reference) => {
+            channel_send_payload_zero_arg_producer(&reference.expr)
+        }
+        syn::Expr::Call(call) if call.args.is_empty() => {
+            let syn::Expr::Path(path) = &*call.func else {
+                return None;
+            };
+            path.path.segments.last().map(|segment| segment.ident.to_string())
+        }
+        _ => None,
+    }
+}
+
+fn expr_is_channel_recv_chain(expr: &syn::Expr, rx: &str) -> bool {
+    match expr {
+        syn::Expr::MethodCall(method)
+            if (method.method == "unwrap" || method.method == "expect") =>
+        {
+            expr_is_channel_recv_chain(&method.receiver, rx)
+        }
+        syn::Expr::Await(await_expr) => expr_is_channel_recv_chain(&await_expr.base, rx),
+        syn::Expr::Paren(paren) => expr_is_channel_recv_chain(&paren.expr, rx),
+        syn::Expr::Group(group) => expr_is_channel_recv_chain(&group.expr, rx),
+        syn::Expr::Reference(reference) => expr_is_channel_recv_chain(&reference.expr, rx),
+        syn::Expr::MethodCall(method) if method.method == "recv" && method.args.is_empty() => {
+            expr_bare_ident_name(&method.receiver).as_deref() == Some(rx)
+        }
+        _ => false,
+    }
+}
+
+fn expr_ident_roots(expr: &syn::Expr) -> BTreeSet<String> {
+    let mut roots = BTreeSet::new();
+    struct V<'a> {
+        roots: &'a mut BTreeSet<String>,
+    }
+    impl<'ast, 'a> syn::visit::Visit<'ast> for V<'a> {
+        fn visit_expr_path(&mut self, node: &'ast syn::ExprPath) {
+            if node.path.segments.len() == 1 {
+                self.roots.insert(node.path.segments[0].ident.to_string());
+            }
+            syn::visit::visit_expr_path(self, node);
+        }
+    }
+    syn::visit::Visit::visit_expr(&mut V { roots: &mut roots }, expr);
+    roots
+}
+
 #[derive(Debug, Clone, Copy, Default)]
 struct OracleObservation {
     requested: bool,
@@ -4757,6 +5056,9 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
             &function_postconditions,
             &mut callsites,
         );
+        callsites.extend(collect_tokio_mpsc_channel_conduit_callsites(
+            &file, &rel_path,
+        ));
         let file_callsite_count = callsites.len();
         if file_callsite_count > 0 {
             debug!(
@@ -12611,6 +12913,165 @@ pub async fn caller() -> i64 {
         assert_eq!(
             producer["targetContractCid"],
             "blake3-512:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_emits_channel_conduit_bridge_from_send_to_recv() {
+        let src = r##"
+pub async fn producer() -> i64 {
+    6
+}
+
+pub fn consumer(x: i64) -> i64 {
+    assert!(x == 6);
+    6
+}
+
+pub async fn edge() -> i64 {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<i64>(1);
+    tx.send(producer().await).await.unwrap();
+    let value = rx.recv().await.unwrap();
+    consumer(value)
+}
+"##;
+        let root = temp_workspace("lift_implications_channel_conduit");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), src).expect("write source");
+
+        let contract_bindings = json!([
+            { "name": "producer@src/lib.rs:2:4",
+              "contract_cid": "blake3-512:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd" },
+            { "name": "consumer@src/lib.rs:6:4",
+              "contract_cid": "blake3-512:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" },
+        ]);
+
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": contract_bindings,
+        }))
+        .expect("lift_implications");
+
+        let ir = resp["ir"].as_array().expect("ir array");
+        let channel = ir
+            .iter()
+            .find(|e| e["sourceSymbol"] == "channel:recv:rx")
+            .expect("channel recv conduit bridge");
+        assert_eq!(channel["kind"], "bridge");
+        assert_eq!(
+            channel["targetContractCid"],
+            "blake3-512:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_emits_channel_conduit_bridge_for_direct_recv_consumer_arg() {
+        let src = r##"
+pub async fn producer() -> i64 {
+    6
+}
+
+pub fn consumer(x: i64) -> i64 {
+    assert!(x == 6);
+    6
+}
+
+pub async fn edge() -> i64 {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<i64>(1);
+    tx.send(producer().await).await.expect("send");
+    consumer(rx.recv().await.expect("recv"))
+}
+"##;
+        let root = temp_workspace("lift_implications_channel_direct_recv_arg");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), src).expect("write source");
+
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": [
+                { "name": "producer@src/lib.rs:2:4",
+                  "contract_cid": "blake3-512:444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444" },
+                { "name": "consumer@src/lib.rs:6:4",
+                  "contract_cid": "blake3-512:555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555" }
+            ],
+        }))
+        .expect("lift_implications");
+
+        let ir = resp["ir"].as_array().expect("ir array");
+        let channel = ir
+            .iter()
+            .find(|e| e["sourceSymbol"] == "channel:recv:rx")
+            .expect("channel recv conduit bridge");
+        assert_eq!(
+            channel["targetContractCid"],
+            "blake3-512:444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_refuses_channel_conduit_when_sends_have_multiple_producers() {
+        let src = r##"
+pub async fn producer_six() -> i64 {
+    6
+}
+
+pub async fn producer_five() -> i64 {
+    5
+}
+
+pub fn consumer(x: i64) -> i64 {
+    assert!(x == 6);
+    6
+}
+
+pub async fn edge(flag: bool) -> i64 {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<i64>(2);
+    if flag {
+        tx.send(producer_six().await).await.unwrap();
+    } else {
+        tx.send(producer_five().await).await.unwrap();
+    }
+    let value = rx.recv().await.unwrap();
+    consumer(value)
+}
+"##;
+        let root = temp_workspace("lift_implications_channel_ambiguous_sends");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), src).expect("write source");
+
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": [
+                { "name": "producer_six@src/lib.rs:2:4",
+                  "contract_cid": "blake3-512:111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111" },
+                { "name": "producer_five@src/lib.rs:6:4",
+                  "contract_cid": "blake3-512:222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222" },
+                { "name": "consumer@src/lib.rs:10:4",
+                  "contract_cid": "blake3-512:333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333" }
+            ],
+        }))
+        .expect("lift_implications");
+
+        let ir = resp["ir"].as_array().expect("ir array");
+        assert!(
+            !ir.iter()
+                .any(|entry| entry["sourceSymbol"] == "channel:recv:rx"),
+            "ambiguous sends must not produce a channel conduit bridge"
         );
 
         let _ = fs::remove_dir_all(root);

--- a/implementations/rust/sugar-walk/src/lift.rs
+++ b/implementations/rust/sugar-walk/src/lift.rs
@@ -2611,8 +2611,15 @@ fn lift_expr_to_term_inner(expr: &Expr, ctx: &mut LiftCtx) -> Option<IrTerm> {
                 let lifted = lift_expr_to_term_inner(a, ctx)?;
                 args.push(lifted);
             }
+            let method_name = if m.method == "recv" && m.args.is_empty() {
+                expr_root_ident(&m.receiver)
+                    .map(|rx| format!("channel:recv:{rx}"))
+                    .unwrap_or_else(|| format!("method:{}", m.method))
+            } else {
+                format!("method:{}", m.method)
+            };
             let value = IrTerm::Ctor {
-                name: format!("method:{}", m.method),
+                name: method_name,
                 args,
             };
             if let Some(guard) = assertion_guard_for_partial(&m.method, &receiver, ctx) {
@@ -3137,6 +3144,29 @@ mod tests {
             json
         );
         assert!(json.contains("\"x\""));
+    }
+
+    #[test]
+    fn tokio_mpsc_recv_lifts_as_receiver_specific_channel_conduit() {
+        let expr: Expr = syn::parse_str("rx.recv().await.unwrap()").unwrap();
+        let term = lift_expr_to_term(&expr).unwrap();
+        let json = serde_json::to_value(&term).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "kind": "ctor",
+                "name": "method:unwrap",
+                "args": [{
+                    "kind": "ctor",
+                    "name": "await",
+                    "args": [{
+                        "kind": "ctor",
+                        "name": "channel:recv:rx",
+                        "args": [{"kind": "var", "name": "rx"}]
+                    }]
+                }]
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Tokio channel implication edge: `post(send) ⊨ pre(recv)`

The implication edge relocated to a channel seam. A tokio mpsc channel is a **typed conduit** carrying an element contract: every `tx.send(v)` is a producer establishing post `P` on the value; `rx.recv()` is a consumer that may assume `P`, and the recv-side consumer's pre must be discharged by `P`. The channel is only the seam where send-post meets recv-pre.

**Strictly `post ⊨ pre` on the element contract.** No send/recv matching, ordering, cardinality, interleaving (model-checker); no type/borrow/drop or Send/Sync (rustc); no lock/deadlock/data-race.

- `sugar-walk`: a closed local mpsc conduit emits `channel:recv:rx` targeting the send-payload producer contract; `rx.recv().await.unwrap()` lifts to `method:unwrap(await(channel:recv:rx(rx)))`. **Ambiguous multiple-producer sends refuse / emit no conduit bridge** — the trichotomy: one clear producer post → edge; ambiguity → loud-refuse, *not* matching.
- `sugar-verifier`: resolves the consumer argTerm through the channel seam to reuse the existing `post ⊨ pre` path; plain `unwrap` stays outside.
- RED-first pins.

### Two-twin showcase `examples/tokio-channel-implication-edge` (real tokio `=1.43.0`, `tokio::sync::mpsc`, `#[tokio::test]`, battleaxe)
GOOD → `channel_edge=discharged witness=discharged`. BAD (send-post doesn't entail recv-pre) → `channel_edge=unsatisfied witness=unsatisfied`. Receipt scoped loudly to the channel-edge row.

**Known scope (honest):** proven for the direct `consumer(rx.recv().await.expect(...))` shape. The `let x = rx.recv()...; consumer(x)` form hits a **pre-existing** let-substitution gap (not a channel regression); the showcase uses the proven direct shape rather than inventing analysis. The let-substitution gap is a separate follow-up.

### Acceptance (verified by me, real exit captured)
- `../../bin/bcargo test --workspace --no-fail-fast` → **2555 passed / 0 failed**.
- `run.sh` exit 0 — I re-ran it: SCOPE banner, good discharged, bad flips to unsatisfied.
- `make ci` PASS; `grep -rn 'concept_name\|conceptName' implementations/` → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
