### PR TITLE
Tokio mutex implication edge: post(acquire) discharges pre(critical-section)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,6 +277,7 @@ SHOWCASE_RUNS = \
 	examples/tokio-effect-consistency/run.sh \
 	examples/tokio-await-implication-edge/run.sh \
 	examples/tokio-channel-implication-edge/run.sh \
+	examples/tokio-mutex-implication-edge/run.sh \
 	examples/polars-showcase/run.sh \
 	examples/numpy-attribute-safety-showcase/run.sh \
 	examples/java-test-assertion-consistency/run.sh

--- a/examples/tokio-mutex-implication-edge/.gitignore
+++ b/examples/tokio-mutex-implication-edge/.gitignore
@@ -1,0 +1,9 @@
+*.proof
+.prove.json
+.verify.json
+.verify_recompute.json
+**/.sugar/runs/
+**/.sugar/witnesses/
+**/target/
+Cargo.lock
+**/.sugar/lift/*/manifest.toml

--- a/examples/tokio-mutex-implication-edge/README.md
+++ b/examples/tokio-mutex-implication-edge/README.md
@@ -1,0 +1,17 @@
+# Tokio mutex implication edge
+
+This showcase proves one narrow async effect edge for `tokio::sync::Mutex`:
+the protected data invariant established at `Mutex::new(producer().await)`
+discharges the precondition of the critical-section consumer at
+`consumer(*m.lock().await)`. The call result is bound inside an inner block
+before returning, so the `MutexGuard` temporary is dropped before the local
+mutex while the lifted term still contains the critical-section consumer call.
+
+The lock is treated only as a typed conduit for the protected value. The
+receipt does not prove lock release, guard `Drop`, RAII, deadlock freedom,
+lock ordering, acquisition cardinality, interleaving, data-race freedom,
+`Send`/`Sync`, or Rust type/borrow/drop facts. Those are either compiler
+legality facts for compiling programs or outside this proof lane.
+
+Both twins compile and type-check. The bad twin fails only because the
+protected data invariant is too weak for the critical-section precondition.

--- a/examples/tokio-mutex-implication-edge/bad/.sugar/config.toml
+++ b/examples/tokio-mutex-implication-edge/bad/.sugar/config.toml
@@ -1,0 +1,29 @@
+[[plugins]]
+name = "rust-fn-contracts"
+surface = "rust-fn-contracts"
+emit = "ir-document"
+
+[[plugins]]
+name = "rust-implications"
+surface = "rust-implications"
+
+[[plugins]]
+name = "rust-cargo-test-witness"
+surface = "rust-cargo-test-witness"
+
+[platform_profile]
+language = "rust"
+family = "concept:family:sugar"
+library = "tokio-mutex-implication-edge-bad"
+version = "0.1.0"
+
+[solvers]
+mode = "first-wins"
+portfolio = ["z3"]
+
+[solvers.z3]
+binary = "z3"
+ir_compiler = "smt-lib-v2.6"
+flags = ["-smt2", "-in"]
+timeout_seconds = 30
+version = "4.x"

--- a/examples/tokio-mutex-implication-edge/bad/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
+++ b/examples/tokio-mutex-implication-edge/bad/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
@@ -1,0 +1,13 @@
+name = "rust-cargo-test-witness-lift"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/witness_rpc"]
+discharge_command = ["@BIN_DIR@/discharge_cli"]
+witness_tool = "cargo-test"
+resolve_witness_command = ["@BIN_DIR@/witness_rpc"]
+resolve_witness_method = "sugar.plugin.resolve_witness"
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["rust-cargo-test-witness"]

--- a/examples/tokio-mutex-implication-edge/bad/.sugar/lift/rust-fn-contracts/manifest.toml.in
+++ b/examples/tokio-mutex-implication-edge/bad/.sugar/lift/rust-fn-contracts/manifest.toml.in
@@ -1,0 +1,3 @@
+name = "rust-fn-contracts-lift"
+command = ["@BIN_DIR@/sugar-walk-rpc", "--rpc"]
+working_dir = "."

--- a/examples/tokio-mutex-implication-edge/bad/.sugar/lift/rust-implications/manifest.toml.in
+++ b/examples/tokio-mutex-implication-edge/bad/.sugar/lift/rust-implications/manifest.toml.in
@@ -1,0 +1,5 @@
+name = "rust-implications-lift"
+command = ["@BIN_DIR@/sugar-walk-rpc", "--rpc"]
+working_dir = "."
+method = "sugar.plugin.lift_implications"
+phase = "consumer"

--- a/examples/tokio-mutex-implication-edge/bad/Cargo.toml
+++ b/examples/tokio-mutex-implication-edge/bad/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "tokio-mutex-implication-edge-bad"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "=1.43.0", features = ["macros", "rt", "sync"] }

--- a/examples/tokio-mutex-implication-edge/bad/src/lib.rs
+++ b/examples/tokio-mutex-implication-edge/bad/src/lib.rs
@@ -1,0 +1,29 @@
+use tokio::sync::Mutex;
+
+pub async fn producer() -> i64 {
+    tokio::task::yield_now().await;
+    5
+}
+
+pub fn consumer(x: i64) -> i64 {
+    assert!(x == 6);
+    6
+}
+
+pub async fn edge() -> i64 {
+    let m = Mutex::new(producer().await);
+    {
+        let x = consumer(*m.lock().await);
+        x
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::edge;
+
+    #[tokio::test]
+    async fn mutex_protected_data_does_not_satisfy_critical_section_pre() {
+        assert_eq!(edge().await, 6);
+    }
+}

--- a/examples/tokio-mutex-implication-edge/good/.sugar/config.toml
+++ b/examples/tokio-mutex-implication-edge/good/.sugar/config.toml
@@ -1,0 +1,29 @@
+[[plugins]]
+name = "rust-fn-contracts"
+surface = "rust-fn-contracts"
+emit = "ir-document"
+
+[[plugins]]
+name = "rust-implications"
+surface = "rust-implications"
+
+[[plugins]]
+name = "rust-cargo-test-witness"
+surface = "rust-cargo-test-witness"
+
+[platform_profile]
+language = "rust"
+family = "concept:family:sugar"
+library = "tokio-mutex-implication-edge-good"
+version = "0.1.0"
+
+[solvers]
+mode = "first-wins"
+portfolio = ["z3"]
+
+[solvers.z3]
+binary = "z3"
+ir_compiler = "smt-lib-v2.6"
+flags = ["-smt2", "-in"]
+timeout_seconds = 30
+version = "4.x"

--- a/examples/tokio-mutex-implication-edge/good/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
+++ b/examples/tokio-mutex-implication-edge/good/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
@@ -1,0 +1,13 @@
+name = "rust-cargo-test-witness-lift"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/witness_rpc"]
+discharge_command = ["@BIN_DIR@/discharge_cli"]
+witness_tool = "cargo-test"
+resolve_witness_command = ["@BIN_DIR@/witness_rpc"]
+resolve_witness_method = "sugar.plugin.resolve_witness"
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["rust-cargo-test-witness"]

--- a/examples/tokio-mutex-implication-edge/good/.sugar/lift/rust-fn-contracts/manifest.toml.in
+++ b/examples/tokio-mutex-implication-edge/good/.sugar/lift/rust-fn-contracts/manifest.toml.in
@@ -1,0 +1,3 @@
+name = "rust-fn-contracts-lift"
+command = ["@BIN_DIR@/sugar-walk-rpc", "--rpc"]
+working_dir = "."

--- a/examples/tokio-mutex-implication-edge/good/.sugar/lift/rust-implications/manifest.toml.in
+++ b/examples/tokio-mutex-implication-edge/good/.sugar/lift/rust-implications/manifest.toml.in
@@ -1,0 +1,5 @@
+name = "rust-implications-lift"
+command = ["@BIN_DIR@/sugar-walk-rpc", "--rpc"]
+working_dir = "."
+method = "sugar.plugin.lift_implications"
+phase = "consumer"

--- a/examples/tokio-mutex-implication-edge/good/Cargo.toml
+++ b/examples/tokio-mutex-implication-edge/good/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "tokio-mutex-implication-edge-good"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "=1.43.0", features = ["macros", "rt", "sync"] }

--- a/examples/tokio-mutex-implication-edge/good/src/lib.rs
+++ b/examples/tokio-mutex-implication-edge/good/src/lib.rs
@@ -1,0 +1,29 @@
+use tokio::sync::Mutex;
+
+pub async fn producer() -> i64 {
+    tokio::task::yield_now().await;
+    6
+}
+
+pub fn consumer(x: i64) -> i64 {
+    assert!(x == 6);
+    6
+}
+
+pub async fn edge() -> i64 {
+    let m = Mutex::new(producer().await);
+    {
+        let x = consumer(*m.lock().await);
+        x
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::edge;
+
+    #[tokio::test]
+    async fn mutex_protected_data_satisfies_critical_section_pre() {
+        assert_eq!(edge().await, 6);
+    }
+}

--- a/examples/tokio-mutex-implication-edge/run.sh
+++ b/examples/tokio-mutex-implication-edge/run.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+RUST="$REPO/implementations/rust"
+BIN_DIR="$RUST/target/debug"
+SUGAR="$BIN_DIR/sugar"
+WALK_RPC="$BIN_DIR/sugar-walk-rpc"
+WITNESS_RPC="$BIN_DIR/witness_rpc"
+DISCHARGE_CLI="$BIN_DIR/discharge_cli"
+
+for suite in good bad; do
+  if [ ! -d "$HERE/$suite" ]; then
+    echo "missing suite directory: $HERE/$suite" >&2
+    exit 1
+  fi
+done
+
+if [ "${TOKIO_MUTEX_EDGE_SHOWCASE_ON_REMOTE:-0}" != "1" ] \
+  && [ "${TOKIO_MUTEX_EDGE_SHOWCASE_USE_BCARGO:-1}" != "0" ] \
+  && [ "$(uname -s)" != "Linux" ]; then
+  echo "== run tokio mutex implication edge showcase on battleaxe via bcargo =="
+  "$REPO/bin/bcargo" build --manifest-path "$RUST/Cargo.toml" \
+    -p sugar-cli --bin sugar \
+    -p sugar-walk --bin sugar-walk-rpc \
+    -p sugar-lift-rust-cargo-test-witness --bin witness_rpc \
+    -p sugar-lift-rust-cargo-test-witness --bin discharge_cli >/dev/null
+
+  remote_host="${BCARGO_REMOTE_HOST:-battleaxe}"
+  remote_tag="$(printf '%s' "$(cd "$REPO" && pwd -P)" | shasum 2>/dev/null | cut -c1-12)"
+  remote_tag="${remote_tag:-default}"
+  remote_root="${BCARGO_REMOTE_ROOT:-/home/tsavo/remote/sugar-bcargo-${remote_tag}}"
+  remote_repo="$remote_root/sugar"
+  remote_cmd="cd $(printf '%q' "$remote_repo") && TOKIO_MUTEX_EDGE_SHOWCASE_ON_REMOTE=1 TOKIO_MUTEX_EDGE_SHOWCASE_SKIP_LOCAL_BUILD=1 examples/tokio-mutex-implication-edge/run.sh"
+  ssh -o BatchMode=yes "$remote_host" "bash -lc $(printf '%q' "$remote_cmd")"
+  exit $?
+fi
+
+if [ "${TOKIO_MUTEX_EDGE_SHOWCASE_SKIP_LOCAL_BUILD:-0}" != "1" ]; then
+  echo "== build local proof binaries =="
+  cargo build --manifest-path "$RUST/Cargo.toml" \
+    -p sugar-cli --bin sugar \
+    -p sugar-walk --bin sugar-walk-rpc \
+    -p sugar-lift-rust-cargo-test-witness --bin witness_rpc \
+    -p sugar-lift-rust-cargo-test-witness --bin discharge_cli >/dev/null
+fi
+
+for bin in "$SUGAR" "$WALK_RPC" "$WITNESS_RPC" "$DISCHARGE_CLI"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing executable: $bin" >&2
+    exit 1
+  fi
+done
+
+render_manifests() {
+  local suite="$1"
+  local base="$HERE/$suite/.sugar/lift"
+
+  sed "s|@BIN_DIR@|$BIN_DIR|g" \
+    "$base/rust-fn-contracts/manifest.toml.in" \
+    > "$base/rust-fn-contracts/manifest.toml"
+
+  sed "s|@BIN_DIR@|$BIN_DIR|g" \
+    "$base/rust-implications/manifest.toml.in" \
+    > "$base/rust-implications/manifest.toml"
+
+  sed "s|@BIN_DIR@|$BIN_DIR|g" \
+    "$base/rust-cargo-test-witness/manifest.toml.in" \
+    > "$base/rust-cargo-test-witness/manifest.toml"
+}
+
+clean_suite() {
+  local suite="$1"
+  local dir="$HERE/$suite"
+  rm -f "$dir"/blake3-512:*.proof "$dir/.prove.json" "$dir/.verify.json" "$dir/.verify_recompute.json"
+  rm -rf "$dir/.sugar/runs" "$dir/.sugar/witnesses" "$dir/target"
+}
+
+row_status() {
+  local path="$1"
+  local kind="$2"
+  python3 - "$path" "$kind" <<'PY'
+import json
+import re
+import sys
+
+path, kind = sys.argv[1], sys.argv[2]
+text = open(path, "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+rows = data.get("rows") or data.get("obligations") or (data if isinstance(data, list) else [])
+for row in rows:
+    prop = row.get("property") or row.get("predicate") or ""
+    if kind == "witness":
+        if "witness-package" in prop:
+            print(row.get("status") or row.get("result") or "")
+            raise SystemExit(0)
+    else:
+        if "witness-package" in prop:
+            continue
+        if row.get("bridge") == "consumer" or row.get("callee") == "consumer":
+            print(row.get("status") or row.get("result") or "")
+            raise SystemExit(0)
+print("MISSING")
+PY
+}
+
+witness_verdict() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+
+text = open(sys.argv[1], "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+for witness in data.get("witnessDimension", {}).get("witnesses", []):
+    verdict = witness.get("verdict")
+    if verdict:
+        print(verdict)
+        raise SystemExit(0)
+print("MISSING")
+PY
+}
+
+run_suite() {
+  local suite="$1"
+  local expect_edge="$2"
+  local expect_witness="$3"
+  local dir="$HERE/$suite"
+
+  render_manifests "$suite"
+  clean_suite "$suite"
+
+  echo "== compile/type-check $suite =="
+  (cd "$dir" && cargo check --quiet)
+
+  echo "== mint $suite =="
+  (cd "$dir" && "$SUGAR" mint --out .) >/dev/null
+
+  local proof
+  proof="$(find "$dir" -maxdepth 1 -name 'blake3-512:*.proof' -print -quit)"
+  if [ -z "$proof" ]; then
+    echo "$suite did not mint a proof" >&2
+    exit 1
+  fi
+
+  echo "== prove $suite =="
+  set +e
+  (cd "$dir" && "$SUGAR" prove . --json) > "$dir/.prove.json" 2>&1
+  set -e
+
+  local got_edge got_witness
+  got_edge="$(row_status "$dir/.prove.json" edge)"
+  got_witness="$(row_status "$dir/.prove.json" witness)"
+
+  if [ "$expect_edge" = "discharged" ]; then
+    if [ "$got_edge" != "discharged" ]; then
+      echo "$suite mutex implication edge expected discharged, got $got_edge" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  else
+    if [ "$got_edge" = "discharged" ] || [ "$got_edge" = "MISSING" ]; then
+      echo "$suite mutex implication edge expected refusal, got $got_edge" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  fi
+
+  if [ "$expect_witness" = "discharged" ]; then
+    if [ "$got_witness" != "discharged" ]; then
+      echo "$suite witness expected discharged, got $got_witness" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+
+    echo "== verify $suite witness =="
+    set +e
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify.json" 2>&1
+    set -e
+    local verify_verdict
+    verify_verdict="$(witness_verdict "$dir/.verify.json")"
+    if [ "$verify_verdict" != "verified" ]; then
+      echo "$suite witness verification expected verified, got $verify_verdict" >&2
+      cat "$dir/.verify.json" >&2
+      exit 1
+    fi
+  else
+    if [ "$got_witness" = "discharged" ] || [ "$got_witness" = "MISSING" ]; then
+      echo "$suite witness expected refusal, got $got_witness" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  fi
+
+  echo "$suite mutex_edge=$got_edge witness=$got_witness"
+}
+
+echo "EFFECT: tokio Mutex is treated as a typed conduit carrying a protected data invariant from acquisition into the critical section."
+echo "SCOPE: self-checking only the mutex_edge row (bridge=consumer with argTerm through mutex:guard:m); compiled Rust legality is assumed, and no lock release, guard Drop/RAII, deadlock, lock ordering, acquisition cardinality, interleaving, data-race, Send/Sync, or Rust type/borrow/drop property is claimed."
+run_suite good discharged discharged
+run_suite bad refused refused
+
+echo "tokio mutex implication edge showcase self-check passed"

--- a/implementations/rust/sugar-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/sugar-walk/src/bin/walk_rpc.rs
@@ -691,8 +691,21 @@ struct TrackedChannelConduit {
     recv_sites: Vec<(usize, usize)>,
 }
 
+#[derive(Debug, Clone)]
+struct TrackedMutexConduit {
+    mutex: String,
+    producer: Option<String>,
+    escaped: bool,
+    lock_sites: BTreeSet<(usize, usize)>,
+    allowed_lock_sites: BTreeSet<(usize, usize)>,
+}
+
 fn channel_recv_source_symbol(rx: &str) -> String {
     format!("channel:recv:{rx}")
+}
+
+fn mutex_guard_source_symbol(mutex: &str) -> String {
+    format!("mutex:guard:{mutex}")
 }
 
 fn collect_tokio_mpsc_channel_conduit_callsites(file: &syn::File, rel_path: &str) -> Vec<CallSite> {
@@ -886,6 +899,174 @@ fn collect_tokio_mpsc_channel_conduit_callsites(file: &syn::File, rel_path: &str
     visitor.into_callsites()
 }
 
+fn collect_tokio_mutex_guard_conduit_callsites(file: &syn::File, rel_path: &str) -> Vec<CallSite> {
+    use syn::visit::Visit;
+
+    struct V<'a> {
+        rel_path: &'a str,
+        mutexes: Vec<TrackedMutexConduit>,
+    }
+
+    impl<'a> V<'a> {
+        fn mutex_by_name_mut(&mut self, name: &str) -> Option<&mut TrackedMutexConduit> {
+            self.mutexes.iter_mut().find(|mutex| mutex.mutex == name)
+        }
+
+        fn mutex_names(&self) -> BTreeSet<String> {
+            self.mutexes
+                .iter()
+                .map(|mutex| mutex.mutex.clone())
+                .collect()
+        }
+
+        fn mark_escaped_if_mutex_is_used_opaquely(&mut self, expr: &syn::Expr) {
+            let mutexes = self.mutex_names();
+            if mutexes.is_empty() {
+                return;
+            }
+            for name in expr_ident_roots(expr) {
+                if mutexes.contains(&name) {
+                    if let Some(mutex) = self.mutex_by_name_mut(&name) {
+                        mutex.escaped = true;
+                    }
+                }
+            }
+        }
+
+        fn mark_allowed_mutex_guard_arg(&mut self, expr: &syn::Expr) -> bool {
+            let mut matched = false;
+            for mutex in &mut self.mutexes {
+                if let Some(site) = mutex_guard_access_lock_site(expr, &mutex.mutex) {
+                    mutex.allowed_lock_sites.insert(site);
+                    matched = true;
+                }
+            }
+            matched
+        }
+
+        fn into_callsites(self) -> Vec<CallSite> {
+            let mut out = Vec::new();
+            for mutex in self.mutexes {
+                if mutex.escaped || mutex.lock_sites != mutex.allowed_lock_sites {
+                    continue;
+                }
+                let Some(producer) = mutex.producer else {
+                    continue;
+                };
+                for (line, col) in mutex.lock_sites {
+                    out.push(CallSite {
+                        callee: mutex_guard_source_symbol(&mutex.mutex),
+                        contract_callee: producer.clone(),
+                        callee_crate: None,
+                        is_method: false,
+                        disambiguated_callee: None,
+                        disambiguated_crate: None,
+                        unsupported_reason: None,
+                        file: self.rel_path.to_string(),
+                        line,
+                        col,
+                    });
+                }
+            }
+            out
+        }
+    }
+
+    impl<'ast, 'a> Visit<'ast> for V<'a> {
+        fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
+            let saved = std::mem::take(&mut self.mutexes);
+            syn::visit::visit_item_fn(self, node);
+            let current = std::mem::take(&mut self.mutexes);
+            self.mutexes = saved;
+            self.mutexes.extend(current);
+        }
+
+        fn visit_local(&mut self, node: &'ast syn::Local) {
+            if let Some((mutex, producer)) = tokio_mutex_binding(node) {
+                self.mutexes.push(TrackedMutexConduit {
+                    mutex,
+                    producer,
+                    escaped: false,
+                    lock_sites: BTreeSet::new(),
+                    allowed_lock_sites: BTreeSet::new(),
+                });
+                syn::visit::visit_local(self, node);
+                return;
+            }
+
+            let mutex_names = self.mutex_names();
+            for bound in pat_bound_idents(&node.pat) {
+                if mutex_names.contains(&bound) {
+                    if let Some(mutex) = self.mutex_by_name_mut(&bound) {
+                        mutex.escaped = true;
+                    }
+                }
+            }
+            if let Some(init) = &node.init {
+                let uses_mutex = expr_ident_roots(&init.expr)
+                    .iter()
+                    .any(|name| mutex_names.contains(name));
+                if uses_mutex && expr_as_call(&init.expr).is_none() {
+                    self.mark_escaped_if_mutex_is_used_opaquely(&init.expr);
+                }
+            }
+            syn::visit::visit_local(self, node);
+        }
+
+        fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+            for arg in &node.args {
+                if !self.mark_allowed_mutex_guard_arg(arg) {
+                    self.mark_escaped_if_mutex_is_used_opaquely(arg);
+                }
+            }
+            syn::visit::visit_expr_call(self, node);
+        }
+
+        fn visit_expr_assign(&mut self, node: &'ast syn::ExprAssign) {
+            let roots = expr_assignment_roots(&node.left);
+            for mutex in &mut self.mutexes {
+                if roots.contains(&mutex.mutex) {
+                    mutex.escaped = true;
+                }
+            }
+            syn::visit::visit_expr_assign(self, node);
+        }
+
+        fn visit_expr_binary(&mut self, node: &'ast syn::ExprBinary) {
+            if binop_is_assignment(&node.op) {
+                let roots = expr_assignment_roots(&node.left);
+                for mutex in &mut self.mutexes {
+                    if roots.contains(&mutex.mutex) {
+                        mutex.escaped = true;
+                    }
+                }
+            }
+            syn::visit::visit_expr_binary(self, node);
+        }
+
+        fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+            if let Some(mutex_name) = expr_bare_ident_name(&node.receiver) {
+                if let Some(mutex) = self.mutex_by_name_mut(&mutex_name) {
+                    if node.method == "lock" && node.args.is_empty() {
+                        let start = node.method.span().start();
+                        mutex.lock_sites.insert((start.line, start.column));
+                    } else {
+                        mutex.escaped = true;
+                    }
+                }
+            }
+            syn::visit::visit_expr_method_call(self, node);
+        }
+    }
+
+    let mut visitor = V {
+        rel_path,
+        mutexes: Vec::new(),
+    };
+    visitor.visit_file(file);
+    visitor.into_callsites()
+}
+
 fn tokio_mpsc_channel_binding(local: &syn::Local) -> Option<(String, String)> {
     let init = local.init.as_ref()?;
     if !expr_is_tokio_mpsc_channel_call(&init.expr) {
@@ -900,6 +1081,13 @@ fn tokio_mpsc_channel_binding(local: &syn::Local) -> Option<(String, String)> {
     let tx = pat_single_ident(tuple.elems.first()?)?;
     let rx = pat_single_ident(tuple.elems.iter().nth(1)?)?;
     Some((tx, rx))
+}
+
+fn tokio_mutex_binding(local: &syn::Local) -> Option<(String, Option<String>)> {
+    let init = local.init.as_ref()?;
+    let producer = tokio_mutex_new_producer(&init.expr)?;
+    let mutex = pat_single_ident(&local.pat)?;
+    Some((mutex, producer))
 }
 
 fn pat_single_ident(pat: &syn::Pat) -> Option<String> {
@@ -927,19 +1115,78 @@ fn expr_is_tokio_mpsc_channel_call(expr: &syn::Expr) -> bool {
         && segments.iter().any(|segment| segment == "mpsc")
 }
 
+fn tokio_mutex_new_producer(expr: &syn::Expr) -> Option<Option<String>> {
+    let syn::Expr::Call(call) = expr else {
+        return None;
+    };
+    let syn::Expr::Path(path) = &*call.func else {
+        return None;
+    };
+    let segments = path
+        .path
+        .segments
+        .iter()
+        .map(|segment| segment.ident.to_string())
+        .collect::<Vec<_>>();
+    if segments.last().is_some_and(|leaf| leaf == "new")
+        && segments.iter().any(|segment| segment == "Mutex")
+        && call.args.len() == 1
+    {
+        Some(
+            call.args
+                .first()
+                .and_then(channel_send_payload_zero_arg_producer),
+        )
+    } else {
+        None
+    }
+}
+
 fn channel_send_payload_zero_arg_producer(expr: &syn::Expr) -> Option<String> {
     match expr {
         syn::Expr::Await(await_expr) => channel_send_payload_zero_arg_producer(&await_expr.base),
         syn::Expr::Paren(paren) => channel_send_payload_zero_arg_producer(&paren.expr),
         syn::Expr::Group(group) => channel_send_payload_zero_arg_producer(&group.expr),
-        syn::Expr::Reference(reference) => {
-            channel_send_payload_zero_arg_producer(&reference.expr)
-        }
+        syn::Expr::Reference(reference) => channel_send_payload_zero_arg_producer(&reference.expr),
         syn::Expr::Call(call) if call.args.is_empty() => {
             let syn::Expr::Path(path) = &*call.func else {
                 return None;
             };
-            path.path.segments.last().map(|segment| segment.ident.to_string())
+            path.path
+                .segments
+                .last()
+                .map(|segment| segment.ident.to_string())
+        }
+        _ => None,
+    }
+}
+
+fn mutex_guard_access_lock_site(expr: &syn::Expr, mutex: &str) -> Option<(usize, usize)> {
+    match expr {
+        syn::Expr::Unary(unary) => match unary.op {
+            syn::UnOp::Deref(_) => mutex_lock_site(&unary.expr, mutex),
+            _ => None,
+        },
+        syn::Expr::Paren(paren) => mutex_guard_access_lock_site(&paren.expr, mutex),
+        syn::Expr::Group(group) => mutex_guard_access_lock_site(&group.expr, mutex),
+        syn::Expr::Reference(reference) => mutex_guard_access_lock_site(&reference.expr, mutex),
+        _ => None,
+    }
+}
+
+fn mutex_lock_site(expr: &syn::Expr, mutex: &str) -> Option<(usize, usize)> {
+    match expr {
+        syn::Expr::Await(await_expr) => mutex_lock_site(&await_expr.base, mutex),
+        syn::Expr::Paren(paren) => mutex_lock_site(&paren.expr, mutex),
+        syn::Expr::Group(group) => mutex_lock_site(&group.expr, mutex),
+        syn::Expr::Reference(reference) => mutex_lock_site(&reference.expr, mutex),
+        syn::Expr::MethodCall(method) if method.method == "lock" && method.args.is_empty() => {
+            if expr_bare_ident_name(&method.receiver).as_deref() == Some(mutex) {
+                let start = method.method.span().start();
+                Some((start.line, start.column))
+            } else {
+                None
+            }
         }
         _ => None,
     }
@@ -5059,6 +5306,9 @@ fn lift_implications(params: &Value) -> Result<Value, String> {
         callsites.extend(collect_tokio_mpsc_channel_conduit_callsites(
             &file, &rel_path,
         ));
+        callsites.extend(collect_tokio_mutex_guard_conduit_callsites(
+            &file, &rel_path,
+        ));
         let file_callsite_count = callsites.len();
         if file_callsite_count > 0 {
             debug!(
@@ -7264,8 +7514,7 @@ fn extract_boundary_attr(item_fn: &syn::ItemFn) -> Option<BoundaryTarget> {
     for attr in &item_fn.attrs {
         let path = attr.path();
         let segments: Vec<_> = path.segments.iter().collect();
-        if segments.len() == 2 && segments[0].ident == "sugar" && segments[1].ident == "boundary"
-        {
+        if segments.len() == 2 && segments[0].ident == "sugar" && segments[1].ident == "boundary" {
             if let Ok(meta_list) = attr.meta.require_list() {
                 let args = parse_attr_named_args(&meta_list.tokens);
                 let concept = args.string("concept").unwrap_or_default();
@@ -13072,6 +13321,116 @@ pub async fn edge(flag: bool) -> i64 {
             !ir.iter()
                 .any(|entry| entry["sourceSymbol"] == "channel:recv:rx"),
             "ambiguous sends must not produce a channel conduit bridge"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_emits_mutex_guard_conduit_bridge_from_protected_value() {
+        let src = r##"
+pub async fn producer() -> i64 {
+    6
+}
+
+pub fn consumer(x: i64) -> i64 {
+    assert!(x == 6);
+    6
+}
+
+pub async fn edge() -> i64 {
+    let m = tokio::sync::Mutex::new(producer().await);
+    {
+        let x = consumer(*m.lock().await);
+        x
+    }
+}
+"##;
+        let root = temp_workspace("lift_implications_mutex_guard_conduit");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), src).expect("write source");
+
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": [
+                { "name": "producer@src/lib.rs:2:4",
+                  "contract_cid": "blake3-512:666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666" },
+                { "name": "consumer@src/lib.rs:6:4",
+                  "contract_cid": "blake3-512:777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777" }
+            ],
+        }))
+        .expect("lift_implications");
+
+        let ir = resp["ir"].as_array().expect("ir array");
+        let mutex = ir
+            .iter()
+            .find(|e| e["sourceSymbol"] == "mutex:guard:m")
+            .expect("mutex guard conduit bridge");
+        assert_eq!(mutex["kind"], "bridge");
+        assert_eq!(
+            mutex["targetContractCid"],
+            "blake3-512:666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lift_implications_refuses_mutex_guard_conduit_when_protected_value_is_ambiguous() {
+        let src = r##"
+pub async fn producer_six() -> i64 {
+    6
+}
+
+pub async fn producer_five() -> i64 {
+    5
+}
+
+pub fn consumer(x: i64) -> i64 {
+    assert!(x == 6);
+    6
+}
+
+pub async fn edge(flag: bool) -> i64 {
+    let m = tokio::sync::Mutex::new(if flag {
+        producer_six().await
+    } else {
+        producer_five().await
+    });
+    {
+        let x = consumer(*m.lock().await);
+        x
+    }
+}
+"##;
+        let root = temp_workspace("lift_implications_mutex_ambiguous_protected_value");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        let rel = "src/lib.rs";
+        fs::write(root.join(rel), src).expect("write source");
+
+        let resp = lift_implications(&json!({
+            "workspace_root": root.to_string_lossy(),
+            "source_paths": [rel],
+            "contract_bindings": [
+                { "name": "producer_six@src/lib.rs:2:4",
+                  "contract_cid": "blake3-512:888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888" },
+                { "name": "producer_five@src/lib.rs:6:4",
+                  "contract_cid": "blake3-512:999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999" },
+                { "name": "consumer@src/lib.rs:10:4",
+                  "contract_cid": "blake3-512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+            ],
+        }))
+        .expect("lift_implications");
+
+        let ir = resp["ir"].as_array().expect("ir array");
+        assert!(
+            !ir.iter()
+                .any(|entry| entry["sourceSymbol"] == "mutex:guard:m"),
+            "ambiguous protected values must not produce a mutex guard conduit bridge"
         );
 
         let _ = fs::remove_dir_all(root);

--- a/implementations/rust/sugar-walk/src/lift.rs
+++ b/implementations/rust/sugar-walk/src/lift.rs
@@ -2615,6 +2615,10 @@ fn lift_expr_to_term_inner(expr: &Expr, ctx: &mut LiftCtx) -> Option<IrTerm> {
                 expr_root_ident(&m.receiver)
                     .map(|rx| format!("channel:recv:{rx}"))
                     .unwrap_or_else(|| format!("method:{}", m.method))
+            } else if m.method == "lock" && m.args.is_empty() {
+                expr_root_ident(&m.receiver)
+                    .map(|mutex| format!("mutex:guard:{mutex}"))
+                    .unwrap_or_else(|| format!("method:{}", m.method))
             } else {
                 format!("method:{}", m.method)
             };
@@ -2783,8 +2787,13 @@ fn lift_expr_to_term_inner(expr: &Expr, ctx: &mut LiftCtx) -> Option<IrTerm> {
         }
         Expr::Block(block_expr) => {
             // A block expression `{ ...; tail }` lifts to the lift of its
-            // trailing expression (the block's value). Leading statements
-            // do not contribute to the returned value term.
+            // trailing expression (the block's value). For the compiler-forced
+            // pattern `{ let x = value; x }`, substitute the immediately
+            // preceding immutable binding into the tail so the returned value
+            // term survives without broader data-flow analysis.
+            if let Some(term) = lift_immediate_block_result_binding(&block_expr.block.stmts, ctx) {
+                return Some(term);
+            }
             let tail = block_expr.block.stmts.last()?;
             match tail {
                 Stmt::Expr(e, None) => lift_expr_to_term_inner(e, ctx),
@@ -2911,6 +2920,22 @@ fn lift_expr_to_term_inner(expr: &Expr, ctx: &mut LiftCtx) -> Option<IrTerm> {
         }
         _ => None,
     }
+}
+
+fn lift_immediate_block_result_binding(stmts: &[Stmt], ctx: &mut LiftCtx) -> Option<IrTerm> {
+    let [prefix @ .., Stmt::Expr(Expr::Path(tail), None)] = stmts else {
+        return None;
+    };
+    let tail_name = tail.path.get_ident()?.to_string();
+    let Stmt::Local(local) = prefix.last()? else {
+        return None;
+    };
+    let (bound_name, mutable) = local_binding_ident(local)?;
+    if mutable || bound_name != tail_name {
+        return None;
+    }
+    let init = &local.init.as_ref()?.expr;
+    lift_expr_to_term_inner(init, ctx)
 }
 
 fn bin_op_to_predicate_name(op: &BinOp) -> Option<&'static str> {
@@ -3163,6 +3188,48 @@ mod tests {
                         "kind": "ctor",
                         "name": "channel:recv:rx",
                         "args": [{"kind": "var", "name": "rx"}]
+                    }]
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn tokio_mutex_lock_lifts_as_receiver_specific_guard_conduit() {
+        let expr: Expr = syn::parse_str("*m.lock().await").unwrap();
+        let term = lift_expr_to_term(&expr).unwrap();
+        let json = serde_json::to_value(&term).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "kind": "ctor",
+                "name": "await",
+                "args": [{
+                    "kind": "ctor",
+                    "name": "mutex:guard:m",
+                    "args": [{"kind": "var", "name": "m"}]
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn block_result_binding_preserves_mutex_guard_conduit_term() {
+        let expr: Expr = syn::parse_str("{ let x = consumer(*m.lock().await); x }").unwrap();
+        let term = lift_expr_to_term(&expr).unwrap();
+        let json = serde_json::to_value(&term).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "kind": "ctor",
+                "name": "consumer",
+                "args": [{
+                    "kind": "ctor",
+                    "name": "await",
+                    "args": [{
+                        "kind": "ctor",
+                        "name": "mutex:guard:m",
+                        "args": [{"kind": "var", "name": "m"}]
                     }]
                 }]
             })


### PR DESCRIPTION
## Tokio mutex implication edge: `post(acquire) ⊨ pre(critical-section)`

The third and final effect edge (after await #1975, channel #1980). A `tokio::sync::Mutex<T>` is a **typed conduit** carrying a protected **data invariant** `P`: acquiring the guard is a producer whose post is that the protected value satisfies `P`; the critical section using `*guard` is a consumer whose pre must be discharged by `P`. The lock boundary is only the seam where acquire-post meets critical-section-pre.

**Strictly `post ⊨ pre` on the protected data invariant.** Compiler legality facts (Drop/RAII/lock-release, Send/Sync, data-race, types/borrows) are **axioms** — the program compiled, so they hold; we never re-prove them. No lock-release/deadlock/lock-order/cardinality/interleaving (model-checker).

- `sugar-walk`: closed local `Mutex::new(producer().await)` emits `mutex:guard:m`; `*m.lock().await` lifts as `await(mutex:guard:m(m))`; bridge reuses the existing `post ⊨ pre` path. Ambiguous protected values **refuse** (trichotomy, not matching).
- `block_result_binding_preserves_mutex_guard_conduit_term`: the sound rewrite `{ let x = E; x }` → `E` keeps the seam liftable through a type-legal guard-drop block.

### Two-twin showcase `examples/tokio-mutex-implication-edge` (real tokio `=1.43.0`, `#[tokio::test]`, battleaxe)
**Both twins compile and type-check.** GOOD → `mutex_edge=discharged witness=discharged`. BAD (producer returns 5, consumer requires 6) → compiles cleanly, fails *only* the semantic edge → `mutex_edge=unsatisfied witness=unsatisfied`.

### Acceptance (verified by me, real exit captured)
- `../../bin/bcargo test --workspace --no-fail-fast` → **2559 passed / 0 failed**.
- `run.sh` exit 0 — I re-ran it: both twins type-check, good discharged, bad flips to unsatisfied.
- `make ci` PASS incl all 12 showcases; `grep -rn 'concept_name\|conceptName' implementations/` → 0.

Completes the effects implication-edge triad — await, channel, mutex — each the same `post ⊨ pre` relocated to where the effect crosses, none reinventing rustc or a model checker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
