### PR TITLE
cargo-sugar: the package-manager wedge (cargo subcommand)

### DIFF
--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "cargo-sugar",
     "sugar-canonicalizer",
     "sugar-plugin-loader",
     "sugar-proof-envelope",

--- a/implementations/rust/cargo-sugar/Cargo.toml
+++ b/implementations/rust/cargo-sugar/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cargo-sugar"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "cargo subcommand: behavioral semver for Rust crates (sugar diff against the last published version)."
+
+[[bin]]
+name = "cargo-sugar"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+serde_json = { workspace = true }

--- a/implementations/rust/cargo-sugar/src/crates_io.rs
+++ b/implementations/rust/cargo-sugar/src/crates_io.rs
@@ -1,0 +1,106 @@
+//! Resolve and download a crate's last published version from crates.io.
+//!
+//! Network plumbing is shelled to `curl` and `tar` (already required on any CI
+//! runner) to avoid pulling an HTTP/TLS stack into the workspace. The URL
+//! construction and JSON parsing are pure functions, unit-tested without network.
+
+use std::path::Path;
+use std::process::Command;
+
+const USER_AGENT: &str = "cargo-sugar (behavioral semver; github.com/TSavo/sugar)";
+
+fn api_url(name: &str) -> String {
+    format!("https://crates.io/api/v1/crates/{name}")
+}
+
+fn download_url(name: &str, version: &str) -> String {
+    format!("https://crates.io/api/v1/crates/{name}/{version}/download")
+}
+
+/// The latest publishable version from the crates.io crate metadata JSON:
+/// prefer `crate.max_stable_version`, fall back to `crate.newest_version`.
+fn parse_latest(json: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(json).ok()?;
+    let krate = v.get("crate")?;
+    krate
+        .get("max_stable_version")
+        .and_then(|s| s.as_str())
+        .or_else(|| krate.get("newest_version").and_then(|s| s.as_str()))
+        .map(str::to_string)
+}
+
+fn curl(args: &[&str]) -> Result<Vec<u8>, String> {
+    let out = Command::new("curl")
+        .args(["-sSL", "-A", USER_AGENT])
+        .args(args)
+        .output()
+        .map_err(|e| format!("curl: {e} (curl is required)"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "curl failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    Ok(out.stdout)
+}
+
+pub fn latest_version(name: &str) -> Result<String, String> {
+    let body = curl(&[&api_url(name)])?;
+    let text = String::from_utf8_lossy(&body);
+    parse_latest(&text)
+        .ok_or_else(|| format!("crates.io: no published version found for `{name}`"))
+}
+
+/// Download `name`@`version` and extract its crate root directly into `dst`
+/// (strips the `<name>-<version>/` top-level dir so `dst/Cargo.toml` exists).
+pub fn download_and_extract(name: &str, version: &str, dst: &Path) -> Result<(), String> {
+    let bytes = curl(&[&download_url(name, version)])?;
+    // crates.io serves a gzip-compressed tar (`.crate`). Pipe it to tar.
+    use std::io::Write;
+    let mut tar = Command::new("tar")
+        .args(["-xz", "--strip-components=1", "-C", &dst.to_string_lossy()])
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("tar: {e}"))?;
+    tar.stdin
+        .take()
+        .expect("tar stdin")
+        .write_all(&bytes)
+        .map_err(|e| format!("tar stdin: {e}"))?;
+    if !tar.wait().map_err(|e| format!("tar wait: {e}"))?.success() {
+        return Err(format!("tar failed to extract {name}@{version}"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_api_and_download_urls() {
+        assert_eq!(api_url("serde"), "https://crates.io/api/v1/crates/serde");
+        assert_eq!(
+            download_url("serde", "1.0.203"),
+            "https://crates.io/api/v1/crates/serde/1.0.203/download"
+        );
+    }
+
+    #[test]
+    fn parses_max_stable_version() {
+        let json = r#"{"crate":{"id":"serde","max_stable_version":"1.0.203","newest_version":"1.0.204-beta"}}"#;
+        assert_eq!(parse_latest(json).as_deref(), Some("1.0.203"));
+    }
+
+    #[test]
+    fn falls_back_to_newest_when_no_stable() {
+        let json = r#"{"crate":{"id":"x","newest_version":"0.1.0-alpha"}}"#;
+        assert_eq!(parse_latest(json).as_deref(), Some("0.1.0-alpha"));
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert_eq!(parse_latest("not json"), None);
+        assert_eq!(parse_latest("{}"), None);
+    }
+}

--- a/implementations/rust/cargo-sugar/src/main.rs
+++ b/implementations/rust/cargo-sugar/src/main.rs
@@ -1,0 +1,256 @@
+//! `cargo sugar`: behavioral semver for Rust crates.
+//!
+//! The package-manager wedge. `cargo sugar check` lifts the current crate and
+//! the last published version, diffs their behavior with `sugar diff`, and fails
+//! if the version bump in Cargo.toml is dishonest about what the code does.
+//!
+//! It needs nothing from crates.io or the crate author: it mints BOTH sides
+//! itself, so it works on day one for any crate. That dissolves the bootstrap
+//! problem -- you do not need an ecosystem of published proofs to start.
+//!
+//! Trojan-horse positioning: this is "cargo-semver-checks, but it catches a
+//! behavior change, not just an API-signature change." Nobody adopts a worldview;
+//! they add one line to a workflow and get a green or red check. The
+//! content-addressed-contract machinery stays entirely under the hood.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use clap::{Parser, Subcommand};
+
+mod crates_io;
+
+#[derive(Parser)]
+#[command(name = "cargo-sugar", bin_name = "cargo sugar", version, about)]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// Behavioral diff between two proof sets or git revisions. Passes through
+    /// to `sugar diff` (so `cargo sugar diff ...` == `sugar diff ...`).
+    Diff {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Behavioral semver check: diff the current crate against a baseline (the
+    /// last crates.io release by default, or a git revision) and enforce the bump.
+    Check(CheckArgs),
+}
+
+#[derive(clap::Args)]
+struct CheckArgs {
+    /// Baseline a git revision instead of the last crates.io release.
+    #[arg(long, value_name = "REV")]
+    rev: Option<String>,
+    /// Baseline a specific crates.io version (default: the latest published).
+    #[arg(long, value_name = "VERSION")]
+    version: Option<String>,
+    /// Fail unless the behavior delta fits within this bump (none|minor|major).
+    #[arg(long, value_name = "BUMP")]
+    require: Option<String>,
+    /// With --rev, the project subdirectory within the revision's tree.
+    #[arg(long, default_value = ".")]
+    path: String,
+}
+
+fn sugar_bin() -> String {
+    std::env::var("SUGAR_BIN").unwrap_or_else(|_| "sugar".to_string())
+}
+
+fn main() -> std::process::ExitCode {
+    // cargo invokes `cargo sugar X` as `cargo-sugar sugar X`; drop the leading
+    // subcommand token so clap sees the real arguments.
+    let mut args: Vec<String> = std::env::args().collect();
+    if args.get(1).map(String::as_str) == Some("sugar") {
+        args.remove(1);
+    }
+    let cli = Cli::parse_from(args);
+    match run(cli) {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("cargo sugar: {e}");
+            std::process::ExitCode::from(2)
+        }
+    }
+}
+
+fn run(cli: Cli) -> Result<std::process::ExitCode, String> {
+    match cli.cmd {
+        Cmd::Diff { args } => {
+            let status = Command::new(sugar_bin())
+                .arg("diff")
+                .args(&args)
+                .status()
+                .map_err(|e| format!("spawn `{} diff`: {e}", sugar_bin()))?;
+            Ok(exit_from(status.code().unwrap_or(1)))
+        }
+        Cmd::Check(a) => check(a),
+    }
+}
+
+fn exit_from(code: i32) -> std::process::ExitCode {
+    std::process::ExitCode::from(u8::try_from(code).unwrap_or(1))
+}
+
+/// Read `name` and `version` out of `./Cargo.toml` (the `[package]` table).
+fn crate_identity() -> Result<(String, String), String> {
+    let text = std::fs::read_to_string("Cargo.toml")
+        .map_err(|e| format!("read ./Cargo.toml: {e} (run from a crate root)"))?;
+    parse_package_identity(&text).ok_or_else(|| "no [package] name/version in Cargo.toml".into())
+}
+
+fn parse_package_identity(toml: &str) -> Option<(String, String)> {
+    let mut in_package = false;
+    let (mut name, mut version) = (None, None);
+    for line in toml.lines() {
+        let t = line.trim();
+        if t.starts_with('[') {
+            in_package = t == "[package]";
+            continue;
+        }
+        if !in_package {
+            continue;
+        }
+        if let Some(v) = t.strip_prefix("name").and_then(|r| toml_str_value(r)) {
+            name = Some(v);
+        } else if let Some(v) = t.strip_prefix("version").and_then(|r| toml_str_value(r)) {
+            version = Some(v);
+        }
+    }
+    Some((name?, version?))
+}
+
+/// `= "value"` -> `value`. Ignores workspace-inherited values (`= { ... }`).
+fn toml_str_value(rest: &str) -> Option<String> {
+    let after_eq = rest.trim_start().strip_prefix('=')?.trim();
+    let inner = after_eq.strip_prefix('"')?;
+    let end = inner.find('"')?;
+    Some(inner[..end].to_string())
+}
+
+/// Extract a git `rev:path` subtree into `dst` via `git archive | tar`.
+fn extract_git(rev: &str, path: &str, dst: &Path) -> Result<(), String> {
+    let treeish = if path == "." || path.is_empty() {
+        rev.to_string()
+    } else {
+        format!("{rev}:{path}")
+    };
+    let archive = Command::new("git")
+        .args(["archive", "--format=tar", &treeish])
+        .output()
+        .map_err(|e| format!("git archive: {e}"))?;
+    if !archive.status.success() {
+        return Err(format!(
+            "git archive {treeish}: {}",
+            String::from_utf8_lossy(&archive.stderr).trim()
+        ));
+    }
+    let mut tar = Command::new("tar")
+        .args(["-x", "-C", &dst.to_string_lossy()])
+        .stdin(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("tar: {e}"))?;
+    use std::io::Write;
+    tar.stdin
+        .take()
+        .expect("tar stdin")
+        .write_all(&archive.stdout)
+        .map_err(|e| format!("tar stdin: {e}"))?;
+    if !tar.wait().map_err(|e| format!("tar wait: {e}"))?.success() {
+        return Err("tar extract failed".into());
+    }
+    Ok(())
+}
+
+/// Mint a crate's proofs into `out_dir`. Bootstraps `.sugar/` if the crate has
+/// none (a downloaded crate won't), then runs `sugar mint`.
+fn mint(project: &Path, out_dir: &Path) -> Result<(), String> {
+    let sugar = sugar_bin();
+    if !project.join(".sugar").join("config.toml").exists() {
+        let _ = Command::new(&sugar)
+            .arg("init")
+            .current_dir(project)
+            .status();
+    }
+    let status = Command::new(&sugar)
+        .args(["mint", "--project"])
+        .arg(project)
+        .arg("--out")
+        .arg(out_dir)
+        .status()
+        .map_err(|e| format!("spawn `{sugar} mint`: {e}"))?;
+    if !status.success() {
+        return Err(format!("`sugar mint --project {}` failed", project.display()));
+    }
+    Ok(())
+}
+
+fn check(a: CheckArgs) -> Result<std::process::ExitCode, String> {
+    let (name, version) = crate_identity()?;
+    let scratch = std::env::temp_dir().join(format!("cargo-sugar-{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&scratch);
+    let base_src = scratch.join("baseline-src");
+    let base_out = scratch.join("baseline-proofs");
+    let cur_out = scratch.join("current-proofs");
+    std::fs::create_dir_all(&base_src).map_err(|e| format!("mkdir: {e}"))?;
+
+    // 1. resolve + materialize the baseline source.
+    let baseline_label = if let Some(rev) = &a.rev {
+        extract_git(rev, &a.path, &base_src)?;
+        format!("git {rev}")
+    } else {
+        let v = match &a.version {
+            Some(v) => v.clone(),
+            None => crates_io::latest_version(&name)?,
+        };
+        crates_io::download_and_extract(&name, &v, &base_src)?;
+        format!("crates.io {name} {v}")
+    };
+
+    // 2. mint both sides.
+    eprintln!("cargo sugar: current crate {name} {version} vs baseline {baseline_label}");
+    mint(Path::new("."), &cur_out)?;
+    mint(&base_src, &base_out)?;
+
+    // 3. diff the two proof sets and enforce the bump.
+    let mut cmd = Command::new(sugar_bin());
+    cmd.arg("diff").arg(&base_out).arg(&cur_out);
+    if let Some(req) = &a.require {
+        cmd.args(["--require", req]);
+    }
+    let status = cmd
+        .status()
+        .map_err(|e| format!("spawn `{} diff`: {e}", sugar_bin()))?;
+    let _ = std::fs::remove_dir_all(&scratch);
+    Ok(exit_from(status.code().unwrap_or(1)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_package_name_and_version() {
+        let toml = "[package]\nname = \"serde\"\nversion = \"1.0.203\"\nedition = \"2021\"\n";
+        assert_eq!(
+            parse_package_identity(toml),
+            Some(("serde".to_string(), "1.0.203".to_string()))
+        );
+    }
+
+    #[test]
+    fn ignores_other_tables_and_workspace_inherited() {
+        let toml = "[package]\nname = \"x\"\nversion.workspace = true\n\n[dependencies]\nname = \"not-this\"\n";
+        // version is workspace-inherited (not a string literal), so identity is incomplete.
+        assert_eq!(parse_package_identity(toml), None);
+    }
+
+    #[test]
+    fn toml_str_value_extracts_quoted() {
+        assert_eq!(toml_str_value(" = \"abc\"").as_deref(), Some("abc"));
+        assert_eq!(toml_str_value(".workspace = true"), None);
+    }
+}


### PR DESCRIPTION
The first board of the Trojan horse. `cargo sugar` is a cargo subcommand (a `cargo-sugar` binary on PATH, the `cargo-semver-checks` model), so adoption is one line in a workflow and nobody adopts a worldview.

- **`cargo sugar diff <a> <b> [flags]`** — behavioral diff, delegates to `sugar diff`. The cargo-native entry. **Validated e2e**: identity → `behavior: none`/exit 0; `--frozen` cross-demo → exit 1; `--help` lists both verbs.
- **`cargo sugar check [--rev R | --version V] [--require BUMP]`** — diff the current crate against a baseline and enforce the bump. The keystone: it mints *both* sides itself (lift working tree + fetch-and-lift the prior release), so it needs nothing from crates.io or the author and works day one. Pitch: "cargo-semver-checks that catches behavior, not just signatures."

**Tested:** 7 unit tests on the crates.io resolver (URL building, `max_stable_version` parse, fallback, garbage) + the `Cargo.toml` identity parser (incl. workspace-inherited rejection). `cargo sugar diff` proven e2e.

**Scaffolded, e2e pending (honest scope):** `check`'s full pipeline is wired (git/crates.io baseline → `sugar init` → `sugar mint` → `sugar diff`) with its network/parse boundaries unit-tested, but minting an arbitrary *downloaded* crate end-to-end is the next increment. Remaining hats: public-surface scoping, lifter-provenance pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Introduced `cargo-sugar`, a new CLI tool for validating crate changes
- `diff` subcommand compares versions and displays detected changes
- `check` subcommand validates current crate against a baseline from crates.io or git repository
- Automatically enforces version bump requirements based on change detection
- Supports both published versions and historical git revisions as baselines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->