### PR TITLE
sugar-check: the pip wedge (behavioral semver for Python, reformat-canonical)

### DIFF
--- a/tools/sugar-check/.pre-commit-hooks.yaml
+++ b/tools/sugar-check/.pre-commit-hooks.yaml
@@ -1,0 +1,10 @@
+- id: sugar-check
+  name: sugar-check (behavioral semver)
+  description: >-
+    Diff the working tree's behavior against the last commit and report the
+    required version bump. Pins on the pytest-contract set, so it is quiet on
+    refactors and loud only on a real behavior change.
+  entry: sugar-check check --rev HEAD
+  language: python
+  pass_filenames: false
+  always_run: true

--- a/tools/sugar-check/README.md
+++ b/tools/sugar-check/README.md
@@ -1,0 +1,28 @@
+# sugar-check
+
+Behavioral semver for Python packages. The pip wedge for [Sugar](../../docs/explanation/behavioral-versioning.md).
+
+```
+sugar-check check --rev <git-rev> [--require none|minor|major]
+sugar-check diff <a> <b>            # passthrough to `sugar diff`
+```
+
+`check` lifts the working tree and the baseline revision into **pytest-derived
+behavior contracts** (the test assertion *is* the contract), diffs them, and
+fails if the version bump is dishonest. The fingerprint is reformat-stable:
+refactor the implementation and the behavior CID holds; only a changed promise
+moves it.
+
+## pre-commit
+
+```yaml
+repos:
+  - repo: https://github.com/TSavo/provekit
+    rev: <sha>
+    hooks:
+      - id: sugar-check
+```
+
+Requires the `sugar` binary (`SUGAR_BIN` or PATH) and `sugar_lift_py_tests`
+importable. Baseline is a git revision today; the PyPI-release baseline is the
+next increment.

--- a/tools/sugar-check/pyproject.toml
+++ b/tools/sugar-check/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "sugar-check"
+version = "0.1.0"
+description = "Behavioral semver for Python packages: sugar diff over the harvested pytest contracts."
+requires-python = ">=3.9"
+# Requires the sugar pytest lifter importable in this interpreter, and the
+# `sugar` binary on PATH (or SUGAR_BIN). sugar-lift-py-tests is published from
+# this monorepo; install it alongside (pip install -e implementations/python/sugar-lift-py-tests).
+dependencies = []
+
+[project.scripts]
+sugar-check = "sugar_check.__main__:main"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/tools/sugar-check/src/sugar_check/__init__.py
+++ b/tools/sugar-check/src/sugar_check/__init__.py
@@ -1,0 +1,4 @@
+"""Behavioral semver for Python packages. See `sugar_check.__main__`."""
+from .__main__ import main
+
+__all__ = ["main"]

--- a/tools/sugar-check/src/sugar_check/__main__.py
+++ b/tools/sugar-check/src/sugar_check/__main__.py
@@ -1,0 +1,158 @@
+"""sugar-check: behavioral semver for Python packages (the pip wedge).
+
+`sugar-check check` lifts the current package and a baseline (a git revision)
+into pytest-derived behavior contracts via the sugar pytest lifter, diffs them
+with `sugar diff`, and fails if the version bump is dishonest about what the
+code does.
+
+The fingerprint is the harvested pytest assertion set, which is reformat-stable:
+refactor the implementation and the assertion is unchanged, so the behavior CID
+holds. Only a changed promise (a changed assertion) or an added/removed test
+moves it. That is the whole thesis -- the test is the contract you pin on --
+and it is what makes the diff quiet on refactors and loud only on real change.
+
+Delivered as a pre-commit hook: one stanza in .pre-commit-config.yaml, the most
+frictionlessly adopted artifact in Python tooling. The content-addressed
+machinery stays entirely under the hood.
+
+Requires the `sugar` binary (set SUGAR_BIN or have it on PATH) and the
+`sugar_lift_py_tests` kit importable in this interpreter.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+KIT_MODULE = "sugar_lift_py_tests.lsp"
+
+CONFIG_TOML = """[[plugins]]
+name = "python-tests-lift"
+kind = "lift"
+surface = "python-tests"
+[solvers]
+default = "z3"
+[solvers.dispatch]
+default = "z3"
+[solvers.z3]
+binary = "z3"
+flags = ["-smt2", "-in"]
+"""
+
+SKIP = {".git", ".sugar", "__pycache__", ".venv", "venv", "build", "dist", ".tox", ".pytest_cache"}
+
+
+def sugar_bin() -> str:
+    return os.environ.get("SUGAR_BIN", "sugar")
+
+
+def treeish(rev: str, path: str) -> str:
+    """The git tree-ish for `git archive`: `rev` for the whole tree, `rev:path`
+    for a subtree."""
+    return rev if path in ("", ".") else f"{rev}:{path}"
+
+
+def manifest_toml() -> str:
+    return (
+        'name = "python-tests-lift"\n'
+        'kind = "lift"\n'
+        f'command = ["{sys.executable}", "-m", "{KIT_MODULE}"]\n'
+        'working_dir = "."\n'
+        "[capabilities]\n"
+        'authoring_surfaces = ["python-tests"]\n'
+    )
+
+
+def bootstrap_python(project: Path) -> None:
+    """Stamp the pytest-contract lift config into `project` (idempotent)."""
+    s = project / ".sugar"
+    if (s / "config.toml").exists():
+        return
+    (s / "lift" / "python-tests").mkdir(parents=True, exist_ok=True)
+    (s / "config.toml").write_text(CONFIG_TOML)
+    (s / "lift" / "python-tests" / "manifest.toml").write_text(manifest_toml())
+
+
+def mint(project: Path, out: Path) -> None:
+    bootstrap_python(project)
+    r = subprocess.run([sugar_bin(), "mint", "--project", str(project), "--out", str(out)])
+    if r.returncode != 0:
+        raise SystemExit(f"sugar mint failed for {project}")
+
+
+def copy_current(dst: Path) -> None:
+    dst.mkdir(parents=True, exist_ok=True)
+    for item in os.listdir("."):
+        if item in SKIP:
+            continue
+        src = Path(item)
+        if src.is_dir():
+            shutil.copytree(src, dst / item, ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+        else:
+            shutil.copy2(src, dst / item)
+
+
+def extract_git(rev: str, path: str, dst: Path) -> None:
+    dst.mkdir(parents=True, exist_ok=True)
+    archive = subprocess.run(
+        ["git", "archive", "--format=tar", treeish(rev, path)], stdout=subprocess.PIPE
+    )
+    if archive.returncode != 0:
+        raise SystemExit(f"git archive {treeish(rev, path)} failed")
+    tar = subprocess.run(["tar", "-x", "-C", str(dst)], input=archive.stdout)
+    if tar.returncode != 0:
+        raise SystemExit("tar extract failed")
+
+
+def cmd_check(a: argparse.Namespace) -> int:
+    if not a.rev:
+        raise SystemExit(
+            "baseline required: pass --rev <git-rev> "
+            "(the PyPI-release baseline is the next increment)"
+        )
+    scratch = Path(tempfile.mkdtemp(prefix="sugar-check-"))
+    try:
+        cur_src, cur_out = scratch / "cur", scratch / "cur-proofs"
+        base_src, base_out = scratch / "base", scratch / "base-proofs"
+        copy_current(cur_src)
+        extract_git(a.rev, a.path, base_src)
+        print(f"sugar-check: current tree vs git {a.rev}", file=sys.stderr)
+        mint(cur_src, cur_out)
+        mint(base_src, base_out)
+        cmd = [sugar_bin(), "diff", str(base_out), str(cur_out)]
+        if a.require:
+            cmd += ["--require", a.require]
+        return subprocess.run(cmd).returncode
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+
+
+def cmd_diff(a: argparse.Namespace) -> int:
+    return subprocess.run([sugar_bin(), "diff", *a.args]).returncode
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="sugar-check", description="Behavioral semver for Python packages.")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    c = sub.add_parser("check", help="diff current package behavior against a baseline; enforce the bump")
+    c.add_argument("--rev", help="baseline git revision (e.g. HEAD, the last release tag)")
+    c.add_argument("--path", default=".", help="project subdirectory within the revision tree")
+    c.add_argument("--require", help="fail unless the behavior delta fits this bump (none|minor|major)")
+    c.set_defaults(fn=cmd_check)
+    d = sub.add_parser("diff", help="passthrough to `sugar diff`")
+    d.add_argument("args", nargs=argparse.REMAINDER)
+    d.set_defaults(fn=cmd_diff)
+    return p
+
+
+def main(argv=None) -> int:
+    a = build_parser().parse_args(argv)
+    return a.fn(a)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/sugar-check/tests/test_sugar_check.py
+++ b/tools/sugar-check/tests/test_sugar_check.py
@@ -1,0 +1,18 @@
+from sugar_check.__main__ import treeish, manifest_toml, CONFIG_TOML, KIT_MODULE
+
+
+def test_treeish_whole_tree_vs_subtree():
+    assert treeish("HEAD", ".") == "HEAD"
+    assert treeish("HEAD", "") == "HEAD"
+    assert treeish("v1.2.3", "pkg") == "v1.2.3:pkg"
+
+
+def test_config_declares_pytest_surface():
+    assert 'surface = "python-tests"' in CONFIG_TOML
+    assert "[solvers]" in CONFIG_TOML
+
+
+def test_manifest_targets_the_pytest_lifter():
+    m = manifest_toml()
+    assert KIT_MODULE in m
+    assert 'authoring_surfaces = ["python-tests"]' in m


### PR DESCRIPTION
The Python board of the Trojan horse, as a **pre-commit hook**.

`sugar-check check --rev <rev> [--require BUMP]` lifts the working tree and a baseline into **pytest-derived behavior contracts** (surface `python-tests`), diffs with `sugar diff`, fails on a dishonest bump. `sugar-check diff` passes through.

**The headline: the fingerprint is reformat-canonical** — the exact property cargo-sugar's Rust body-surface lacked. Validated e2e on a git Python package:
- `--require minor` on a real change (`x*2`/`==6` → `x*3`/`==9`) → **exit 1** (`behavior requires MAJOR, exceeds claimed minor`)
- `--require major` → exit 0
- **behavior-preserving reformat (impl rewritten, same test), `--require none` → exit 0.** The body changed; the assertion didn't; the behavior CID held.

This validates the unified cross-language answer: **fingerprint on the harvested test contracts (the promise), not the body.** Implication for cargo-sugar: switch Rust to the `rust-tests` (cargo-test) surface for the same invariance — tracked as its next increment.

Mints both sides itself (no registry/author cooperation). `--rev` (a release tag) works today; PyPI-release baseline is next. 3 unit tests + full check validated e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)