### PR TITLE
TestNG generalization: assertion vocab is learned, not framework-hardcoded (classifier diff = 0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,8 @@ SHOWCASE_RUNS = \
 	examples/tokio-mutex-implication-edge/run.sh \
 	examples/polars-showcase/run.sh \
 	examples/numpy-attribute-safety-showcase/run.sh \
-	examples/java-test-assertion-consistency/run.sh
+	examples/java-test-assertion-consistency/run.sh \
+	examples/testng-assertion-consistency/run.sh
 
 .PHONY: test-showcases
 test-showcases:
@@ -295,13 +296,15 @@ test-showcases:
 	    -p sugar-lift-rust-tests --bin rust_test_assertions_rpc \
 	    -p sugar-lift-java-tests --bin java_test_assertions_rpc \
 	    -p sugar-lift-java-tests --bin java_junit_witness_rpc \
-	    -p sugar-lift-java-tests --bin java_junit_discharge_cli >/dev/null || exit $$?; \
+	    -p sugar-lift-java-tests --bin java_junit_discharge_cli \
+	    -p sugar-lift-java-tests --bin java_testng_witness_rpc \
+	    -p sugar-lift-java-tests --bin java_testng_discharge_cli >/dev/null || exit $$?; \
 	  remote_host="$${BCARGO_REMOTE_HOST:-battleaxe}"; \
 	  remote_tag="$$(printf '%s' "$$(pwd -P)" | shasum 2>/dev/null | cut -c1-12)"; \
 	  remote_tag="$${remote_tag:-default}"; \
 	  remote_root="$${BCARGO_REMOTE_ROOT:-/home/tsavo/remote/sugar-bcargo-$$remote_tag}"; \
 	  remote_repo="$$remote_root/sugar"; \
-	  remote_cmd="cd $$(printf '%q' "$$remote_repo") && SHOWCASES_ON_REMOTE=1 POLARS_SHOWCASE_ON_REMOTE=1 POLARS_SHOWCASE_SKIP_LOCAL_BUILD=1 NUMPY_ATTR_SHOWCASE_ON_REMOTE=1 NUMPY_ATTR_SHOWCASE_SKIP_LOCAL_BUILD=1 JAVA_ASSERT_SHOWCASE_ON_REMOTE=1 JAVA_ASSERT_SHOWCASE_SKIP_LOCAL_BUILD=1 make test-showcases"; \
+	  remote_cmd="cd $$(printf '%q' "$$remote_repo") && SHOWCASES_ON_REMOTE=1 POLARS_SHOWCASE_ON_REMOTE=1 POLARS_SHOWCASE_SKIP_LOCAL_BUILD=1 NUMPY_ATTR_SHOWCASE_ON_REMOTE=1 NUMPY_ATTR_SHOWCASE_SKIP_LOCAL_BUILD=1 JAVA_ASSERT_SHOWCASE_ON_REMOTE=1 JAVA_ASSERT_SHOWCASE_SKIP_LOCAL_BUILD=1 TESTNG_ASSERT_SHOWCASE_ON_REMOTE=1 TESTNG_ASSERT_SHOWCASE_SKIP_LOCAL_BUILD=1 make test-showcases"; \
 	  ssh -o BatchMode=yes "$$remote_host" "bash -lc $$(printf '%q' "$$remote_cmd")"; \
 	  exit $$?; \
 	fi; \

--- a/examples/testng-assertion-consistency/.gitignore
+++ b/examples/testng-assertion-consistency/.gitignore
@@ -1,0 +1,8 @@
+*.proof
+.prove.json
+.verify.json
+.verify_recompute.json
+**/.sugar/runs/
+**/.sugar/witnesses/
+**/target/
+

--- a/examples/testng-assertion-consistency/README.md
+++ b/examples/testng-assertion-consistency/README.md
@@ -1,0 +1,17 @@
+# TestNG assertion consistency showcase
+
+This mirrors `examples/java-test-assertion-consistency`, but points the unchanged
+Java assertion-vocabulary lifter at a second real framework: TestNG.
+
+The vocab source is the real `org.testng.Assert` class from the pinned TestNG
+jar, read through `javap -classpath ... -public org.testng.Assert`.
+Signature-derived tolerance overloads such as
+`assertEquals(double, double, double)` are classified as approximate and are not
+lifted as exact equality. Exact equality and truth for the jar body gap come
+from the declared override file under `.sugar/vocab-exceptions/`, not from an
+in-code TestNG table.
+
+The good twin proves both axes: scalar assertion consistency discharges, and
+the real TestNG suite passes. The bad twin is contradictory: consistency refuses
+and the real TestNG suite fails.
+

--- a/examples/testng-assertion-consistency/bad/.sugar/config.toml
+++ b/examples/testng-assertion-consistency/bad/.sugar/config.toml
@@ -1,0 +1,22 @@
+[[plugins]]
+name = "java-test-assertions-lift"
+kind = "lift"
+surface = "java-test-assertions"
+emit = "ir-document"
+
+[[plugins]]
+name = "java-testng-witness-lift"
+kind = "lift"
+surface = "java-testng-witness"
+
+[solvers]
+default = "z3"
+
+[solvers.dispatch]
+linear_arithmetic = "z3"
+default = "z3"
+
+[solvers.z3]
+binary = "z3"
+flags = ["-smt2", "-in"]
+

--- a/examples/testng-assertion-consistency/bad/.sugar/lift/java-test-assertions/manifest.toml.in
+++ b/examples/testng-assertion-consistency/bad/.sugar/lift/java-test-assertions/manifest.toml.in
@@ -1,0 +1,12 @@
+name = "java-test-assertions-lift"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/java_test_assertions_rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["java-test-assertions"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+

--- a/examples/testng-assertion-consistency/bad/.sugar/lift/java-testng-witness/manifest.toml.in
+++ b/examples/testng-assertion-consistency/bad/.sugar/lift/java-testng-witness/manifest.toml.in
@@ -1,0 +1,14 @@
+name = "java-testng-witness-lift"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/java_testng_witness_rpc"]
+discharge_command = ["@BIN_DIR@/java_testng_discharge_cli"]
+witness_tool = "testng"
+resolve_witness_command = ["@BIN_DIR@/java_testng_witness_rpc"]
+resolve_witness_method = "sugar.plugin.resolve_witness"
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["java-testng-witness"]
+

--- a/examples/testng-assertion-consistency/bad/.sugar/vocab-exceptions/org.testng.Assert.json
+++ b/examples/testng-assertion-consistency/bad/.sugar/vocab-exceptions/org.testng.Assert.json
@@ -1,0 +1,7 @@
+{
+  "overrides": {
+    "equality": ["assertEquals"],
+    "truth": ["assertTrue"]
+  }
+}
+

--- a/examples/testng-assertion-consistency/bad/src/main/java/demo/ScalarBox.java
+++ b/examples/testng-assertion-consistency/bad/src/main/java/demo/ScalarBox.java
@@ -1,0 +1,10 @@
+package demo;
+
+public final class ScalarBox {
+    private ScalarBox() {}
+
+    public static int scalarSum() {
+        return 2 + 4;
+    }
+}
+

--- a/examples/testng-assertion-consistency/bad/src/test/java/demo/ScalarTest.java
+++ b/examples/testng-assertion-consistency/bad/src/test/java/demo/ScalarTest.java
@@ -1,0 +1,14 @@
+package demo;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+public final class ScalarTest {
+    @Test
+    public void scalarSumContradiction() {
+        assertEquals(ScalarBox.scalarSum(), 6);
+        assertEquals(ScalarBox.scalarSum(), 7);
+    }
+}
+

--- a/examples/testng-assertion-consistency/good/.sugar/config.toml
+++ b/examples/testng-assertion-consistency/good/.sugar/config.toml
@@ -1,0 +1,22 @@
+[[plugins]]
+name = "java-test-assertions-lift"
+kind = "lift"
+surface = "java-test-assertions"
+emit = "ir-document"
+
+[[plugins]]
+name = "java-testng-witness-lift"
+kind = "lift"
+surface = "java-testng-witness"
+
+[solvers]
+default = "z3"
+
+[solvers.dispatch]
+linear_arithmetic = "z3"
+default = "z3"
+
+[solvers.z3]
+binary = "z3"
+flags = ["-smt2", "-in"]
+

--- a/examples/testng-assertion-consistency/good/.sugar/lift/java-test-assertions/manifest.toml.in
+++ b/examples/testng-assertion-consistency/good/.sugar/lift/java-test-assertions/manifest.toml.in
@@ -1,0 +1,12 @@
+name = "java-test-assertions-lift"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/java_test_assertions_rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["java-test-assertions"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+

--- a/examples/testng-assertion-consistency/good/.sugar/lift/java-testng-witness/manifest.toml.in
+++ b/examples/testng-assertion-consistency/good/.sugar/lift/java-testng-witness/manifest.toml.in
@@ -1,0 +1,14 @@
+name = "java-testng-witness-lift"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/java_testng_witness_rpc"]
+discharge_command = ["@BIN_DIR@/java_testng_discharge_cli"]
+witness_tool = "testng"
+resolve_witness_command = ["@BIN_DIR@/java_testng_witness_rpc"]
+resolve_witness_method = "sugar.plugin.resolve_witness"
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["java-testng-witness"]
+

--- a/examples/testng-assertion-consistency/good/.sugar/vocab-exceptions/org.testng.Assert.json
+++ b/examples/testng-assertion-consistency/good/.sugar/vocab-exceptions/org.testng.Assert.json
@@ -1,0 +1,7 @@
+{
+  "overrides": {
+    "equality": ["assertEquals"],
+    "truth": ["assertTrue"]
+  }
+}
+

--- a/examples/testng-assertion-consistency/good/src/main/java/demo/ScalarBox.java
+++ b/examples/testng-assertion-consistency/good/src/main/java/demo/ScalarBox.java
@@ -1,0 +1,10 @@
+package demo;
+
+public final class ScalarBox {
+    private ScalarBox() {}
+
+    public static int scalarSum() {
+        return 2 + 4;
+    }
+}
+

--- a/examples/testng-assertion-consistency/good/src/test/java/demo/ScalarTest.java
+++ b/examples/testng-assertion-consistency/good/src/test/java/demo/ScalarTest.java
@@ -1,0 +1,15 @@
+package demo;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+public final class ScalarTest {
+    @Test
+    public void scalarSumIsSix() {
+        assertEquals(ScalarBox.scalarSum(), 6);
+        assertTrue(ScalarBox.scalarSum() == 6);
+    }
+}
+

--- a/examples/testng-assertion-consistency/run.sh
+++ b/examples/testng-assertion-consistency/run.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+RUST="$REPO/implementations/rust"
+BIN_DIR="$RUST/target/debug"
+SUGAR="$BIN_DIR/sugar"
+ASSERT_RPC="$BIN_DIR/java_test_assertions_rpc"
+WITNESS_RPC="$BIN_DIR/java_testng_witness_rpc"
+DISCHARGE_CLI="$BIN_DIR/java_testng_discharge_cli"
+
+TESTNG_VERSION="${TESTNG_VERSION:-7.10.2}"
+SLF4J_VERSION="${SLF4J_VERSION:-1.7.36}"
+JCOMMANDER_VERSION="${JCOMMANDER_VERSION:-1.82}"
+TESTNG_DIR="${SUGAR_TESTNG_DIR:-/tmp/sugar-testng}"
+TESTNG_JAR="${SUGAR_TESTNG_JAR:-$TESTNG_DIR/testng-${TESTNG_VERSION}.jar}"
+SLF4J_JAR="${SUGAR_SLF4J_JAR:-$TESTNG_DIR/slf4j-api-${SLF4J_VERSION}.jar}"
+JCOMMANDER_JAR="${SUGAR_JCOMMANDER_JAR:-$TESTNG_DIR/jcommander-${JCOMMANDER_VERSION}.jar}"
+MAVEN_BASE="${MAVEN_BASE:-https://repo1.maven.org/maven2}"
+
+for suite in good bad; do
+  if [ ! -d "$HERE/$suite" ]; then
+    echo "missing suite directory: $HERE/$suite" >&2
+    exit 1
+  fi
+done
+
+if [ "${TESTNG_ASSERT_SHOWCASE_ON_REMOTE:-0}" != "1" ] \
+  && [ "${TESTNG_ASSERT_SHOWCASE_USE_BCARGO:-1}" != "0" ] \
+  && [ "$(uname -s)" != "Linux" ]; then
+  echo "== run TestNG assertion showcase on battleaxe via bcargo =="
+  "$REPO/bin/bcargo" build --manifest-path "$RUST/Cargo.toml" \
+    -p sugar-cli --bin sugar \
+    -p sugar-lift-java-tests --bin java_test_assertions_rpc \
+    -p sugar-lift-java-tests --bin java_testng_witness_rpc \
+    -p sugar-lift-java-tests --bin java_testng_discharge_cli >/dev/null
+
+  remote_host="${BCARGO_REMOTE_HOST:-battleaxe}"
+  remote_tag="$(printf '%s' "$(cd "$REPO" && pwd -P)" | shasum 2>/dev/null | cut -c1-12)"
+  remote_tag="${remote_tag:-default}"
+  remote_root="${BCARGO_REMOTE_ROOT:-/home/tsavo/remote/sugar-bcargo-${remote_tag}}"
+  remote_repo="$remote_root/sugar"
+  remote_cmd="cd $(printf '%q' "$remote_repo") && TESTNG_ASSERT_SHOWCASE_ON_REMOTE=1 TESTNG_ASSERT_SHOWCASE_SKIP_LOCAL_BUILD=1 examples/testng-assertion-consistency/run.sh"
+  ssh -o BatchMode=yes "$remote_host" "bash -lc $(printf '%q' "$remote_cmd")"
+  exit $?
+fi
+
+if [ "${TESTNG_ASSERT_SHOWCASE_SKIP_LOCAL_BUILD:-0}" != "1" ]; then
+  echo "== build proof binaries =="
+  cargo build --manifest-path "$RUST/Cargo.toml" \
+    -p sugar-cli --bin sugar \
+    -p sugar-lift-java-tests --bin java_test_assertions_rpc \
+    -p sugar-lift-java-tests --bin java_testng_witness_rpc \
+    -p sugar-lift-java-tests --bin java_testng_discharge_cli >/dev/null
+fi
+
+for bin in "$SUGAR" "$ASSERT_RPC" "$WITNESS_RPC" "$DISCHARGE_CLI"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing executable: $bin" >&2
+    exit 1
+  fi
+done
+
+if ! command -v javac >/dev/null 2>&1 || ! command -v java >/dev/null 2>&1; then
+  echo "missing JDK on this host; run this showcase on battleaxe/Linux" >&2
+  exit 1
+fi
+
+fetch_jar() {
+  local path="$1"
+  local url="$2"
+  if [ -f "$path" ]; then
+    return 0
+  fi
+  mkdir -p "$(dirname "$path")"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$path"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q "$url" -O "$path"
+  else
+    echo "neither curl nor wget is available to fetch $url" >&2
+    exit 1
+  fi
+}
+
+echo "== fetch pinned TestNG jars =="
+fetch_jar "$TESTNG_JAR" "$MAVEN_BASE/org/testng/testng/${TESTNG_VERSION}/testng-${TESTNG_VERSION}.jar"
+fetch_jar "$SLF4J_JAR" "$MAVEN_BASE/org/slf4j/slf4j-api/${SLF4J_VERSION}/slf4j-api-${SLF4J_VERSION}.jar"
+fetch_jar "$JCOMMANDER_JAR" "$MAVEN_BASE/com/beust/jcommander/${JCOMMANDER_VERSION}/jcommander-${JCOMMANDER_VERSION}.jar"
+
+TESTNG_CP="$TESTNG_JAR:$SLF4J_JAR:$JCOMMANDER_JAR"
+export SUGAR_TESTNG_CLASSPATH="$TESTNG_CP"
+export SUGAR_JAVA_ASSERT_CLASSPATH="$TESTNG_CP"
+
+echo "== derive assertion vocabulary from real TestNG jar =="
+javap -classpath "$TESTNG_CP" -public org.testng.Assert \
+  | grep -E 'assertEquals\(double, double, double|assertEquals\(double\[\], double\[\], double|assertTrue\(boolean\)' \
+  | sed 's/^/real-testng-signature: /'
+echo "vocab override: .sugar/vocab-exceptions/org.testng.Assert.json declares equality/truth for the jar body gap; javap-signature tolerance overloads remain Approx"
+
+render_manifests() {
+  local suite="$1"
+  local base="$HERE/$suite/.sugar/lift"
+
+  sed "s|@BIN_DIR@|$BIN_DIR|g" \
+    "$base/java-test-assertions/manifest.toml.in" \
+    > "$base/java-test-assertions/manifest.toml"
+
+  sed "s|@BIN_DIR@|$BIN_DIR|g" \
+    "$base/java-testng-witness/manifest.toml.in" \
+    > "$base/java-testng-witness/manifest.toml"
+}
+
+clean_suite() {
+  local suite="$1"
+  local dir="$HERE/$suite"
+  rm -f "$dir"/blake3-512:*.proof "$dir/.prove.json" "$dir/.verify.json" "$dir/.verify_recompute.json"
+  rm -rf "$dir/.sugar/runs" "$dir/.sugar/witnesses" "$dir/target"
+}
+
+json_status() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import re
+import sys
+
+path, kind = sys.argv[1:3]
+text = open(path, "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+rows = data.get("rows") or data.get("obligations") or (data if isinstance(data, list) else [])
+for row in rows:
+    prop = row.get("property") or row.get("predicate") or ""
+    if kind == "consistency" and prop.startswith("consistency:") and "witness-package" not in prop:
+        print(row.get("status") or row.get("result") or "")
+        raise SystemExit(0)
+    if kind == "witness" and "witness-package" in prop:
+        print(row.get("status") or row.get("result") or "")
+        raise SystemExit(0)
+print("MISSING")
+PY
+}
+
+run_suite() {
+  local suite="$1"
+  local expect_consistency="$2"
+  local expect_witness="$3"
+  local dir="$HERE/$suite"
+
+  render_manifests "$suite"
+  clean_suite "$suite"
+
+  echo "== mint $suite =="
+  (cd "$dir" && "$SUGAR" mint --out .) >/dev/null
+
+  local proof
+  proof="$(find "$dir" -maxdepth 1 -name 'blake3-512:*.proof' -print -quit)"
+  if [ -z "$proof" ]; then
+    echo "$suite did not mint a proof" >&2
+    exit 1
+  fi
+
+  echo "== prove $suite =="
+  set +e
+  (cd "$dir" && "$SUGAR" prove . --json) > "$dir/.prove.json" 2>&1
+  local prove_rc=$?
+  set -e
+
+  local got_consistency got_witness
+  got_consistency="$(json_status "$dir/.prove.json" consistency)"
+  got_witness="$(json_status "$dir/.prove.json" witness)"
+
+  if [ "$expect_consistency" = "discharged" ]; then
+    if [ "$got_consistency" != "discharged" ]; then
+      echo "$suite consistency expected discharged, got $got_consistency" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  else
+    if [ "$got_consistency" = "discharged" ] || [ "$got_consistency" = "MISSING" ]; then
+      echo "$suite consistency expected refusal, got $got_consistency" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+    if [ "$prove_rc" -eq 0 ]; then
+      echo "$suite expected prove to refuse, but prove exited 0" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  fi
+
+  if [ "$expect_witness" = "discharged" ]; then
+    if [ "$got_witness" != "discharged" ]; then
+      echo "$suite witness expected discharged, got $got_witness" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  else
+    if [ "$got_witness" = "discharged" ] || [ "$got_witness" = "MISSING" ]; then
+      echo "$suite witness expected refusal, got $got_witness" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  fi
+
+  echo "$suite consistency=$got_consistency witness=$got_witness"
+}
+
+run_suite good discharged discharged
+run_suite bad refused refused
+
+echo "TestNG learned-assertion showcase self-check passed"

--- a/implementations/rust/sugar-lift-java-tests/Cargo.toml
+++ b/implementations/rust/sugar-lift-java-tests/Cargo.toml
@@ -30,5 +30,13 @@ path = "src/bin/java_junit_witness_rpc.rs"
 name = "java_junit_discharge_cli"
 path = "src/bin/java_junit_discharge_cli.rs"
 
+[[bin]]
+name = "java_testng_witness_rpc"
+path = "src/bin/java_testng_witness_rpc.rs"
+
+[[bin]]
+name = "java_testng_discharge_cli"
+path = "src/bin/java_testng_discharge_cli.rs"
+
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/implementations/rust/sugar-lift-java-tests/src/bin/java_testng_discharge_cli.rs
+++ b/implementations/rust/sugar-lift-java-tests/src/bin/java_testng_discharge_cli.rs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// TestNG witness discharge command. Re-runs the suite and refuses unless the
+// pinned bundle reproduces and every test passed.
+
+use std::path::Path;
+
+use sugar_lift_java_tests as kit;
+
+fn emit(verdict: &str, reason: &str) -> i32 {
+    let line = serde_json::json!({"verdict": verdict, "reason": reason});
+    println!("{line}");
+    if verdict == "DISCHARGED" {
+        0
+    } else {
+        1
+    }
+}
+
+fn run() -> i32 {
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+    if argv.len() < 2 {
+        return emit("REFUSED", "usage: <witness.proof> <project_dir>");
+    }
+    let proof_path = &argv[0];
+    let project_dir = &argv[1];
+
+    let evidence_json = match std::fs::read_to_string(proof_path) {
+        Ok(s) => s,
+        Err(e) => return emit("REFUSED", &format!("discharge error: read proof: {e}")),
+    };
+    let pd = match kit::parse_evidence_proof_data(&evidence_json) {
+        Ok(v) => v,
+        Err(e) => return emit("REFUSED", &format!("discharge error: {e}")),
+    };
+    if pd.get("kind").and_then(|v| v.as_str()) != Some("witness-package") {
+        return emit(
+            "REFUSED",
+            "discharge error: proofData is not a witness-package",
+        );
+    }
+    let Some(package_cid) = pd.get("packageCid").and_then(|v| v.as_str()) else {
+        return emit("REFUSED", "discharge error: proofData missing packageCid");
+    };
+    let code_files = kit::memento_str_list(&pd, "codeFiles");
+    let (verdict, reason) =
+        kit::discharge_testng_bundle(package_cid, &code_files, Path::new(project_dir));
+    emit(&verdict, &reason)
+}
+
+fn main() {
+    std::process::exit(run());
+}

--- a/implementations/rust/sugar-lift-java-tests/src/bin/java_testng_witness_rpc.rs
+++ b/implementations/rust/sugar-lift-java-tests/src/bin/java_testng_witness_rpc.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// TestNG witness lift/resolve RPC.
+
+use std::io::{BufRead, Write};
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+use sugar_lift_java_tests as kit;
+
+const KIT_ID: &str = "java-testng-witness";
+const KIT_VERSION: &str = env!("CARGO_PKG_VERSION");
+const SURFACE: &str = "java-testng-witness";
+const KIT_DECLARATION_RPC_METHOD: &str = "sugar.plugin.kit_declaration";
+const RESOLVE_WITNESS_RPC_METHOD: &str = "sugar.plugin.resolve_witness";
+const TESTNG_PACKAGE_KIND: &str = "testng-test-witness-package";
+
+fn send(obj: &Value) {
+    let mut out = std::io::stdout().lock();
+    let _ = writeln!(out, "{}", serde_json::to_string(obj).unwrap_or_default());
+    let _ = out.flush();
+}
+
+fn err_reply(id: &Value, msg: String) -> Value {
+    json!({"jsonrpc": "2.0", "id": id, "error": {"code": -32603, "message": msg}})
+}
+
+fn resolve_root(params: &Value) -> PathBuf {
+    params
+        .get("workspace_root")
+        .and_then(Value::as_str)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn handle_lift(id: &Value, params: &Value) -> Value {
+    let root = resolve_root(params);
+    match kit::lift_testng_project(&root) {
+        Ok(Some(result)) => {
+            let _ = kit::write_bundle_package(&root, &result.bundle_cid, &result.bundle_bytes);
+            json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": {
+                    "kind": "ir-document",
+                    "ir": result.ir,
+                    "witness_mementos": result.mementos,
+                    "implications": [],
+                    "diagnostics": [],
+                    "warnings": [],
+                }
+            })
+        }
+        Ok(None) => json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {
+                "kind": "ir-document",
+                "ir": [],
+                "witness_mementos": [],
+                "implications": [],
+                "diagnostics": [],
+                "warnings": [],
+            }
+        }),
+        Err(e) => err_reply(id, e),
+    }
+}
+
+fn handle_resolve_witness(id: &Value, params: &Value) -> Value {
+    let memento = params.get("memento").cloned().unwrap_or(Value::Null);
+    let cid = memento
+        .get("witness_cid")
+        .and_then(Value::as_str)
+        .or_else(|| params.get("witness_cid").and_then(Value::as_str));
+    let Some(cid) = cid else {
+        return err_reply(id, "resolve_witness requires a witness_cid".to_string());
+    };
+    let cid = cid.to_string();
+    let ws = params.get("workspace_root").and_then(Value::as_str);
+    let package_dir = params.get("package_dir").and_then(Value::as_str);
+
+    if let Some(pd) = package_dir {
+        let pdir = if Path::new(pd).is_absolute() {
+            PathBuf::from(pd)
+        } else {
+            PathBuf::from(ws.unwrap_or(".")).join(pd)
+        };
+        let path = pdir.join(kit::cid_filename(&cid, ".witness"));
+        if path.is_file() {
+            if let Ok(bytes) = std::fs::read(&path) {
+                return json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "witness_cid": cid,
+                        "body_b64": kit::b64(&bytes),
+                        "resolved_by": "package",
+                    }
+                });
+            }
+        }
+    }
+
+    let witness_kind = memento.get("witness_kind").and_then(Value::as_str);
+    if let (Some(ws), Some(TESTNG_PACKAGE_KIND)) = (ws, witness_kind) {
+        let code_files = kit::memento_str_list(&memento, "code_files");
+        match kit::recompute_testng_bundle_body(Path::new(ws), &code_files, &cid) {
+            Ok(bytes) => {
+                return json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "witness_cid": cid,
+                        "body_b64": kit::b64(&bytes),
+                        "resolved_by": "recompute",
+                    }
+                });
+            }
+            Err(e) => return err_reply(id, e),
+        }
+    }
+
+    err_reply(
+        id,
+        format!("cannot resolve witness body for {cid}: no package file and not re-runnable"),
+    )
+}
+
+fn kit_declaration() -> Value {
+    json!({
+        "kit": {"id": KIT_ID, "language": "java", "version": KIT_VERSION},
+        "rpc": {"methods": [
+            {"name": "initialize", "required": true},
+            {"name": KIT_DECLARATION_RPC_METHOD, "required": true},
+            {"name": "lift", "required": true},
+            {"name": RESOLVE_WITNESS_RPC_METHOD, "required": false},
+            {"name": "shutdown", "required": false},
+        ]},
+        "proofResolution": {"strategy": "testng"},
+        "effectKinds": [],
+        "effectLeaves": [],
+        "guardPredicates": [],
+        "controlCarriers": [],
+        "residueCategories": [],
+    })
+}
+
+fn handle(id: &Value, method: &str, params: &Value) -> Value {
+    match method {
+        "initialize" => json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {
+                "name": "sugar-lift-java-testng-witness-rpc",
+                "version": KIT_VERSION,
+                "protocol_version": "pep/1.7.0",
+                "capabilities": {
+                    "authoring_surfaces": [SURFACE],
+                    "ir_version": "v1.1.0",
+                    "emits_signed_mementos": true,
+                },
+            }
+        }),
+        KIT_DECLARATION_RPC_METHOD => {
+            json!({"jsonrpc": "2.0", "id": id, "result": kit_declaration()})
+        }
+        "lift" => handle_lift(id, params),
+        RESOLVE_WITNESS_RPC_METHOD => handle_resolve_witness(id, params),
+        "shutdown" => json!({"jsonrpc": "2.0", "id": id, "result": Value::Null}),
+        other => err_reply(id, format!("unknown method: {other}")),
+    }
+}
+
+fn main() {
+    let stdin = std::io::stdin();
+    for line in stdin.lock().lines() {
+        let Ok(line) = line else { break };
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(msg): Result<Value, _> = serde_json::from_str(line) else {
+            continue;
+        };
+        let method = msg.get("method").and_then(Value::as_str).unwrap_or("");
+        let id = msg.get("id").cloned().unwrap_or(Value::Null);
+        let params = msg.get("params").cloned().unwrap_or(Value::Null);
+        send(&handle(&id, method, &params));
+    }
+}

--- a/implementations/rust/sugar-lift-java-tests/src/lib.rs
+++ b/implementations/rust/sugar-lift-java-tests/src/lib.rs
@@ -1055,6 +1055,11 @@ fn is_numeric_literal(expr: &str) -> bool {
 pub const WITNESS_SIGNER_SEED: Ed25519Seed = [0x77u8; 32];
 const SIGNER_SEED_ENV: &str = "SUGAR_WITNESS_SIGNER_SEED";
 const JUNIT_JAR_ENV: &str = "SUGAR_JUNIT_CONSOLE_JAR";
+const TESTNG_CLASSPATH_ENV: &str = "SUGAR_TESTNG_CLASSPATH";
+const JUNIT_TEST_WITNESS_KIND: &str = "junit-test-witness";
+const JUNIT_PACKAGE_KIND: &str = "junit-test-witness-package";
+const TESTNG_TEST_WITNESS_KIND: &str = "testng-test-witness";
+const TESTNG_PACKAGE_KIND: &str = "testng-test-witness-package";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedTest {
@@ -1064,6 +1069,7 @@ pub struct ParsedTest {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Witness {
+    pub kind: String,
     pub code_cid: String,
     pub runtime_cid: String,
     pub test_id: String,
@@ -1080,7 +1086,14 @@ impl Witness {
         outcome: &str,
         code_files: &[String],
     ) -> Self {
-        make_witness(code, runtime, test_id, outcome, code_files)
+        make_witness(
+            JUNIT_TEST_WITNESS_KIND,
+            code,
+            runtime,
+            test_id,
+            outcome,
+            code_files,
+        )
     }
 }
 
@@ -1143,10 +1156,19 @@ fn join_with_nul(parts: &[Vec<u8>]) -> Vec<u8> {
 }
 
 pub fn runtime_cid() -> String {
+    runtime_cid_for("junit", JUNIT_JAR_ENV)
+}
+
+pub fn testng_runtime_cid() -> String {
+    runtime_cid_for("testng", TESTNG_CLASSPATH_ENV)
+}
+
+fn runtime_cid_for(tool: &str, classpath_env: &str) -> String {
     let javac = command_version("javac", &["-version"]);
     let java = command_version("java", &["-version"]);
-    let jar = std::env::var(JUNIT_JAR_ENV).unwrap_or_else(|_| "junit-console-unknown".to_string());
-    let desc = format!("javac={javac};java={java};junit={jar}");
+    let classpath =
+        std::env::var(classpath_env).unwrap_or_else(|_| format!("{tool}-classpath-unknown"));
+    let desc = format!("javac={javac};java={java};{tool}={classpath}");
     blake3_512_of(desc.as_bytes())
 }
 
@@ -1166,6 +1188,7 @@ fn command_version(bin: &str, args: &[&str]) -> String {
 }
 
 fn witness_value(
+    kind: &str,
     code: &str,
     runtime: &str,
     test_id: &str,
@@ -1175,7 +1198,7 @@ fn witness_value(
     let mut files = code_files.to_vec();
     files.sort();
     CValue::object([
-        ("kind", CValue::string("junit-test-witness")),
+        ("kind", CValue::string(kind.to_string())),
         ("codeCid", CValue::string(code.to_string())),
         ("codeFiles", CValue::string(files.join(","))),
         ("outcome", CValue::string(outcome.to_string())),
@@ -1186,6 +1209,7 @@ fn witness_value(
 
 pub fn witness_body(w: &Witness) -> Vec<u8> {
     encode_jcs(&witness_value(
+        &w.kind,
         &w.code_cid,
         &w.runtime_cid,
         &w.test_id,
@@ -1196,6 +1220,7 @@ pub fn witness_body(w: &Witness) -> Vec<u8> {
 }
 
 fn make_witness(
+    kind: &str,
     code: &str,
     runtime: &str,
     test_id: &str,
@@ -1204,9 +1229,12 @@ fn make_witness(
 ) -> Witness {
     let mut files = code_files.to_vec();
     files.sort();
-    let body = encode_jcs(&witness_value(code, runtime, test_id, outcome, &files));
+    let body = encode_jcs(&witness_value(
+        kind, code, runtime, test_id, outcome, &files,
+    ));
     let cid = blake3_512_of(body.as_bytes());
     Witness {
+        kind: kind.to_string(),
         code_cid: code.to_string(),
         runtime_cid: runtime.to_string(),
         test_id: test_id.to_string(),
@@ -1276,6 +1304,7 @@ fn xml_unescape(s: &str) -> String {
 }
 
 fn witnesses_from_parsed(
+    kind: &str,
     parsed: &[ParsedTest],
     cc: &str,
     rc: &str,
@@ -1290,7 +1319,7 @@ fn witnesses_from_parsed(
             } else {
                 "failed"
             };
-            make_witness(cc, rc, &p.test_id, outcome, code_files)
+            make_witness(kind, cc, rc, &p.test_id, outcome, code_files)
         })
         .collect()
 }
@@ -1335,7 +1364,13 @@ pub fn run_suite_witnesses(
     let cc = code_cid(project_dir, code_files)?;
     let rc = runtime_cid();
     let parsed = run_junit_suite(project_dir)?;
-    Ok(witnesses_from_parsed(&parsed, &cc, &rc, code_files))
+    Ok(witnesses_from_parsed(
+        JUNIT_TEST_WITNESS_KIND,
+        &parsed,
+        &cc,
+        &rc,
+        code_files,
+    ))
 }
 
 pub fn build_suite_bundle(
@@ -1343,6 +1378,30 @@ pub fn build_suite_bundle(
     code_files: &[String],
 ) -> Result<(Vec<u8>, String, Vec<Witness>), String> {
     let witnesses = run_suite_witnesses(project_dir, code_files)?;
+    Ok(build_bundle(&witnesses))
+}
+
+pub fn run_testng_suite_witnesses(
+    project_dir: &Path,
+    code_files: &[String],
+) -> Result<Vec<Witness>, String> {
+    let cc = code_cid(project_dir, code_files)?;
+    let rc = testng_runtime_cid();
+    let parsed = run_testng_suite(project_dir)?;
+    Ok(witnesses_from_parsed(
+        TESTNG_TEST_WITNESS_KIND,
+        &parsed,
+        &cc,
+        &rc,
+        code_files,
+    ))
+}
+
+pub fn build_testng_suite_bundle(
+    project_dir: &Path,
+    code_files: &[String],
+) -> Result<(Vec<u8>, String, Vec<Witness>), String> {
+    let witnesses = run_testng_suite_witnesses(project_dir, code_files)?;
     Ok(build_bundle(&witnesses))
 }
 
@@ -1410,14 +1469,102 @@ fn run_junit_suite(project_dir: &Path) -> Result<Vec<ParsedTest>, String> {
     Ok(parsed)
 }
 
+fn testng_classpath() -> Result<String, String> {
+    let cp = std::env::var(TESTNG_CLASSPATH_ENV)
+        .map_err(|_| format!("{TESTNG_CLASSPATH_ENV} is not set; cannot run TestNG witness"))?;
+    if cp.trim().is_empty() {
+        return Err(format!("{TESTNG_CLASSPATH_ENV} is empty"));
+    }
+    Ok(cp)
+}
+
+fn run_testng_suite(project_dir: &Path) -> Result<Vec<ParsedTest>, String> {
+    let cp = testng_classpath()?;
+    let (java_files, _) = discover_java_files(project_dir);
+    if java_files.is_empty() {
+        return Err("no Java source files found".to_string());
+    }
+    let test_classes = discover_test_classes(project_dir, &java_files)?;
+    if test_classes.is_empty() {
+        return Err("no TestNG @Test classes found".to_string());
+    }
+
+    let work = project_dir.join("target").join("sugar-java-testng");
+    let classes = work.join("classes");
+    let reports = work.join("reports");
+    let _ = std::fs::remove_dir_all(&work);
+    std::fs::create_dir_all(&classes).map_err(|e| format!("mkdir classes: {e}"))?;
+    std::fs::create_dir_all(&reports).map_err(|e| format!("mkdir reports: {e}"))?;
+
+    let mut javac = Command::new("javac");
+    javac.arg("-cp").arg(&cp).arg("-d").arg(&classes);
+    for rel in &java_files {
+        javac.arg(project_dir.join(rel));
+    }
+    let javac_out = javac.output().map_err(|e| format!("spawn javac: {e}"))?;
+    if !javac_out.status.success() {
+        return Err(format!(
+            "javac failed: {}{}",
+            String::from_utf8_lossy(&javac_out.stdout),
+            String::from_utf8_lossy(&javac_out.stderr)
+        ));
+    }
+
+    let runtime_cp = format!("{cp}:{}", classes.display());
+    let output = Command::new("java")
+        .arg("-cp")
+        .arg(runtime_cp)
+        .arg("org.testng.TestNG")
+        .arg("-testclass")
+        .arg(test_classes.join(","))
+        .arg("-d")
+        .arg(&reports)
+        .output()
+        .map_err(|e| format!("spawn TestNG: {e}"))?;
+    let mut parsed = parse_report_dir(&reports)?;
+    if parsed.is_empty() {
+        return Err(format!(
+            "TestNG produced no test cases; stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    parsed.sort_by(|a, b| a.test_id.cmp(&b.test_id));
+    Ok(parsed)
+}
+
+fn discover_test_classes(project_dir: &Path, java_files: &[String]) -> Result<Vec<String>, String> {
+    let mut out = Vec::new();
+    for rel in java_files {
+        let src = std::fs::read_to_string(project_dir.join(rel))
+            .map_err(|e| format!("read Java source {rel}: {e}"))?;
+        if !src.contains("@Test") {
+            continue;
+        }
+        let Some(class_name) = first_class_name(&src) else {
+            continue;
+        };
+        if let Some(package) = package_name(&src) {
+            out.push(format!("{package}.{class_name}"));
+        } else {
+            out.push(class_name);
+        }
+    }
+    out.sort();
+    out.dedup();
+    Ok(out)
+}
+
 fn parse_report_dir(reports: &Path) -> Result<Vec<ParsedTest>, String> {
     let mut out = Vec::new();
-    for entry in std::fs::read_dir(reports).map_err(|e| format!("read reports dir: {e}"))? {
-        let entry = entry.map_err(|e| format!("read reports entry: {e}"))?;
+    for entry in walkdir::WalkDir::new(reports)
+        .into_iter()
+        .filter_map(Result::ok)
+    {
         let path = entry.path();
         if path.extension().is_some_and(|ext| ext == "xml") {
             let xml = std::fs::read_to_string(&path)
-                .map_err(|e| format!("read junit report {}: {e}", path.display()))?;
+                .map_err(|e| format!("read Java test report {}: {e}", path.display()))?;
             out.extend(parse_junit_xml_reports(&xml));
         }
     }
@@ -1425,6 +1572,45 @@ fn parse_report_dir(reports: &Path) -> Result<Vec<ParsedTest>, String> {
 }
 
 pub fn witness_package_memento(
+    bundle_cid: &str,
+    test_files: &[String],
+    code_files: &[String],
+    count: usize,
+    passed: usize,
+    seed: Option<Ed25519Seed>,
+) -> Result<serde_json::Value, String> {
+    witness_package_memento_for(
+        JUNIT_PACKAGE_KIND,
+        bundle_cid,
+        test_files,
+        code_files,
+        count,
+        passed,
+        seed,
+    )
+}
+
+pub fn testng_witness_package_memento(
+    bundle_cid: &str,
+    test_files: &[String],
+    code_files: &[String],
+    count: usize,
+    passed: usize,
+    seed: Option<Ed25519Seed>,
+) -> Result<serde_json::Value, String> {
+    witness_package_memento_for(
+        TESTNG_PACKAGE_KIND,
+        bundle_cid,
+        test_files,
+        code_files,
+        count,
+        passed,
+        seed,
+    )
+}
+
+fn witness_package_memento_for(
+    witness_kind: &str,
     bundle_cid: &str,
     test_files: &[String],
     code_files: &[String],
@@ -1442,7 +1628,7 @@ pub fn witness_package_memento(
     Ok(serde_json::json!({
         "kind": "witness-memento",
         "witness_cid": bundle_cid,
-        "witness_kind": "junit-test-witness-package",
+        "witness_kind": witness_kind,
         "signer": signer,
         "signature": signature,
         "test_files": tfs,
@@ -1514,9 +1700,36 @@ pub fn junit_witness_package_contract_ir(
     count: usize,
     passed: usize,
 ) -> serde_json::Value {
+    witness_package_contract_ir_for(
+        "junit", bundle_cid, runtime, test_files, code_files, count, passed,
+    )
+}
+
+pub fn testng_witness_package_contract_ir(
+    bundle_cid: &str,
+    runtime: &str,
+    test_files: &[String],
+    code_files: &[String],
+    count: usize,
+    passed: usize,
+) -> serde_json::Value {
+    witness_package_contract_ir_for(
+        "testng", bundle_cid, runtime, test_files, code_files, count, passed,
+    )
+}
+
+fn witness_package_contract_ir_for(
+    tool: &str,
+    bundle_cid: &str,
+    runtime: &str,
+    test_files: &[String],
+    code_files: &[String],
+    count: usize,
+    passed: usize,
+) -> serde_json::Value {
     let proof_data = witness_package_proof_data(bundle_cid, test_files, code_files, count, passed);
     let cert = EvidenceCertificate {
-        tool: "junit".to_string(),
+        tool: tool.to_string(),
         version: runtime.to_string(),
         formula_hash: bundle_cid.to_string(),
         proof_data,
@@ -1596,6 +1809,37 @@ pub fn lift_project(project_dir: &Path) -> Result<Option<LiftProjectResult>, Str
     }))
 }
 
+pub fn lift_testng_project(project_dir: &Path) -> Result<Option<LiftProjectResult>, String> {
+    let (code_files, test_files) = discover_java_files(project_dir);
+    if code_files.is_empty() {
+        return Ok(None);
+    }
+    let (bundle_bytes, bundle_cid, witnesses) =
+        build_testng_suite_bundle(project_dir, &code_files)?;
+    if witnesses.is_empty() {
+        return Ok(None);
+    }
+    let count = witnesses.len();
+    let passed = witnesses.iter().filter(|w| w.outcome == "passed").count();
+    let runtime = testng_runtime_cid();
+    let memento =
+        testng_witness_package_memento(&bundle_cid, &test_files, &code_files, count, passed, None)?;
+    let contract = testng_witness_package_contract_ir(
+        &bundle_cid,
+        &runtime,
+        &test_files,
+        &code_files,
+        count,
+        passed,
+    );
+    Ok(Some(LiftProjectResult {
+        ir: vec![contract],
+        mementos: vec![memento],
+        bundle_cid,
+        bundle_bytes,
+    }))
+}
+
 pub fn parse_evidence_proof_data(evidence_json: &str) -> Result<serde_json::Value, String> {
     let ev: serde_json::Value =
         serde_json::from_str(evidence_json).map_err(|e| format!("parse evidence JSON: {e}"))?;
@@ -1623,7 +1867,37 @@ pub fn discharge_bundle(
     code_files: &[String],
     project_dir: &Path,
 ) -> (String, String) {
-    let (_, cid, witnesses) = match build_suite_bundle(project_dir, code_files) {
+    discharge_bundle_with(
+        "JUnit",
+        bundle_cid,
+        code_files,
+        project_dir,
+        build_suite_bundle,
+    )
+}
+
+pub fn discharge_testng_bundle(
+    bundle_cid: &str,
+    code_files: &[String],
+    project_dir: &Path,
+) -> (String, String) {
+    discharge_bundle_with(
+        "TestNG",
+        bundle_cid,
+        code_files,
+        project_dir,
+        build_testng_suite_bundle,
+    )
+}
+
+fn discharge_bundle_with(
+    label: &str,
+    bundle_cid: &str,
+    code_files: &[String],
+    project_dir: &Path,
+    build: fn(&Path, &[String]) -> Result<(Vec<u8>, String, Vec<Witness>), String>,
+) -> (String, String) {
+    let (_, cid, witnesses) = match build(project_dir, code_files) {
         Ok(t) => t,
         Err(e) => return ("REFUSED".to_string(), format!("discharge error: {e}")),
     };
@@ -1661,7 +1935,7 @@ pub fn discharge_bundle(
     }
     (
         "DISCHARGED".to_string(),
-        format!("suite re-ran; all {n} JUnit witnesses reproduced and passed"),
+        format!("suite re-ran; all {n} {label} witnesses reproduced and passed"),
     )
 }
 
@@ -1675,6 +1949,20 @@ pub fn recompute_bundle_body(
     pinned_cid: &str,
 ) -> Result<Vec<u8>, String> {
     let (buf, rcid, _) = build_suite_bundle(project_dir, code_files)?;
+    if rcid != pinned_cid {
+        return Err(format!(
+            "witness package did not reproduce: recomputed {rcid}, pinned {pinned_cid}"
+        ));
+    }
+    Ok(buf)
+}
+
+pub fn recompute_testng_bundle_body(
+    project_dir: &Path,
+    code_files: &[String],
+    pinned_cid: &str,
+) -> Result<Vec<u8>, String> {
+    let (buf, rcid, _) = build_testng_suite_bundle(project_dir, code_files)?;
     if rcid != pinned_cid {
         return Err(format!(
             "witness package did not reproduce: recomputed {rcid}, pinned {pinned_cid}"

--- a/implementations/rust/sugar-lift-java-tests/tests/assertion_vocab_lift.rs
+++ b/implementations/rust/sugar-lift-java-tests/tests/assertion_vocab_lift.rs
@@ -40,6 +40,7 @@ public final class LearnedAssertions {
 "#;
 
 static JUNIT_JAR_FETCH_LOCK: Mutex<()> = Mutex::new(());
+static TESTNG_JAR_FETCH_LOCK: Mutex<()> = Mutex::new(());
 
 fn real_junit_console_jar() -> String {
     if let Ok(path) = std::env::var("SUGAR_JUNIT_CONSOLE_JAR") {
@@ -83,6 +84,45 @@ fn real_junit_console_jar() -> String {
     path.to_string_lossy().to_string()
 }
 
+fn real_testng_jar() -> String {
+    if let Ok(path) = std::env::var("SUGAR_TESTNG_JAR") {
+        let path = PathBuf::from(path);
+        if path.is_file() {
+            return path.to_string_lossy().to_string();
+        }
+    }
+
+    let version = std::env::var("TESTNG_VERSION").unwrap_or_else(|_| "7.10.2".to_string());
+    let path = PathBuf::from(format!("/tmp/sugar-testng/testng-{version}.jar"));
+    if path.is_file() {
+        return path.to_string_lossy().to_string();
+    }
+
+    let _guard = TESTNG_JAR_FETCH_LOCK.lock().unwrap();
+    if path.is_file() {
+        return path.to_string_lossy().to_string();
+    }
+
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let url =
+        format!("https://repo1.maven.org/maven2/org/testng/testng/{version}/testng-{version}.jar");
+    let status = if command_exists("curl") {
+        Command::new("curl")
+            .args(["-fsSL", &url, "-o"])
+            .arg(&path)
+            .status()
+            .expect("spawn curl")
+    } else {
+        Command::new("wget")
+            .args(["-q", &url, "-O"])
+            .arg(&path)
+            .status()
+            .expect("spawn wget")
+    };
+    assert!(status.success(), "fetch real TestNG jar from {url}");
+    path.to_string_lossy().to_string()
+}
+
 fn command_exists(bin: &str) -> bool {
     Command::new(bin)
         .arg("--version")
@@ -112,6 +152,29 @@ fn assert_eq_atom(formula: &Formula, expected_rhs: i64) {
         }
         other => panic!("expected equality atom, got {other:?}"),
     }
+}
+
+fn assert_method_category(
+    vocab: &sugar_lift_java_tests::AssertionVocab,
+    name: &str,
+    params: &[&str],
+    category: AssertCategory,
+    source: &str,
+) {
+    let method = vocab
+        .methods
+        .iter()
+        .find(|method| {
+            method.name == name
+                && method
+                    .params
+                    .iter()
+                    .map(|param| param.ty.as_str())
+                    .eq(params.iter().copied())
+        })
+        .unwrap_or_else(|| panic!("missing method {name}({})", params.join(", ")));
+    assert_eq!(method.category, category);
+    assert_eq!(method.source, source);
 }
 
 #[test]
@@ -288,6 +351,121 @@ fn real_junit_external_override_supplies_body_gap_without_changing_approx_split(
     let learned_truth = learned
         .classify_call("assertTrue", 1, &["makeValue() == 6".to_string()])
         .expect("override marks assertTrue as truth");
+    assert_eq!(learned_truth.category, AssertCategory::Truth);
+    assert_eq!(learned_truth.source, "external-exception");
+}
+
+#[test]
+fn real_testng_javap_derives_delta_overload_as_approx_from_signature_without_classifier_changes() {
+    let jar = real_testng_jar();
+    let vocab = derive_vocab_from_javap("org.testng.Assert", &jar, &[]).unwrap();
+    let dump = vocab
+        .dump_lines()
+        .into_iter()
+        .filter(|line| line.contains("assertEquals") || line.contains("assertTrue"))
+        .collect::<Vec<_>>();
+    eprintln!("real-testng-derived-vocab: {}", dump.join("; "));
+
+    let approx = vocab
+        .classify_call(
+            "assertEquals",
+            3,
+            &[
+                "makeValue()".to_string(),
+                "6.0".to_string(),
+                "0.01".to_string(),
+            ],
+        )
+        .expect("real TestNG delta overload is learned");
+    assert_eq!(approx.category, AssertCategory::Approx);
+    assert_eq!(approx.source, "javap-signature");
+}
+
+#[test]
+fn real_testng_external_override_supplies_body_gap_without_changing_approx_split() {
+    let jar = real_testng_jar();
+    let tmp = tempfile::tempdir().unwrap();
+    let exc_dir = tmp.path().join(".sugar").join("vocab-exceptions");
+    fs::create_dir_all(&exc_dir).unwrap();
+    fs::write(
+        exc_dir.join("org.testng.Assert.json"),
+        r#"{"overrides":{"equality":["assertEquals"],"truth":["assertTrue"]}}"#,
+    )
+    .unwrap();
+
+    let bare = derive_vocab_from_javap("org.testng.Assert", &jar, &[]).unwrap();
+    let learned = derive_vocab_from_javap(
+        "org.testng.Assert",
+        &jar,
+        &[exc_dir.to_string_lossy().to_string()],
+    )
+    .unwrap();
+    eprintln!(
+        "real-testng-derived-vocab-with-overrides: {}",
+        learned
+            .dump_lines()
+            .into_iter()
+            .filter(|line| line.contains("assertEquals") || line.contains("assertTrue"))
+            .collect::<Vec<_>>()
+            .join("; ")
+    );
+
+    let bare_approx = bare
+        .classify_call(
+            "assertEquals",
+            3,
+            &[
+                "makeValue()".to_string(),
+                "6.0".to_string(),
+                "0.01".to_string(),
+            ],
+        )
+        .expect("bare real TestNG delta overload is learned");
+    let learned_approx = learned
+        .classify_call(
+            "assertEquals",
+            3,
+            &[
+                "makeValue()".to_string(),
+                "6.0".to_string(),
+                "0.01".to_string(),
+            ],
+        )
+        .expect("overridden real TestNG delta overload remains learned");
+    assert_eq!(bare_approx.category, AssertCategory::Approx);
+    assert_eq!(learned_approx.category, AssertCategory::Approx);
+    assert_eq!(learned_approx.source, "javap-signature");
+
+    assert_method_category(
+        &learned,
+        "assertEquals",
+        &["double", "double", "double", "java.lang.String"],
+        AssertCategory::Approx,
+        "javap-signature",
+    );
+
+    let bare_exact = bare
+        .classify_call(
+            "assertEquals",
+            2,
+            &["makeValue()".to_string(), "6".to_string()],
+        )
+        .expect("bare exact overload is present from real TestNG signature");
+    assert_ne!(bare_exact.category, AssertCategory::Equality);
+
+    let learned_exact = learned
+        .classify_call(
+            "assertEquals",
+            2,
+            &["makeValue()".to_string(), "6".to_string()],
+        )
+        .expect("override marks exact overload as equality");
+    assert_eq!(learned_exact.category, AssertCategory::Equality);
+    assert_eq!(learned_exact.source, "external-exception");
+
+    let learned_truth = learned
+        .classify_call("assertTrue", 1, &["makeValue() == 6".to_string()])
+        .expect("override marks TestNG assertTrue as truth");
     assert_eq!(learned_truth.category, AssertCategory::Truth);
     assert_eq!(learned_truth.source, "external-exception");
 }

--- a/implementations/rust/sugar-lift-java-tests/tests/junit_witness.rs
+++ b/implementations/rust/sugar-lift-java-tests/tests/junit_witness.rs
@@ -1,6 +1,7 @@
 use sugar_canonicalizer::blake3_512_of;
 use sugar_lift_java_tests::{
-    build_bundle, junit_witness_package_contract_ir, parse_junit_xml_reports, witness_body,
+    build_bundle, junit_witness_package_contract_ir, parse_junit_xml_reports,
+    testng_witness_package_contract_ir, testng_witness_package_memento, witness_body,
     witness_package_memento, witness_package_proof_data, Witness, WITNESS_SIGNER_SEED,
 };
 use sugar_proof_envelope::ed25519_verify_string;
@@ -88,6 +89,25 @@ fn package_memento_signature_verifies_over_bundle_cid() {
 }
 
 #[test]
+fn testng_package_memento_signature_verifies_over_bundle_cid() {
+    let (_, cid, _) = build_bundle(&[witness("demo.ScalarTest.a", "passed")]);
+    let m = testng_witness_package_memento(
+        &cid,
+        &[".".to_string()],
+        &["src/main/java/demo/Calculator.java".to_string()],
+        1,
+        1,
+        Some(WITNESS_SIGNER_SEED),
+    )
+    .unwrap();
+    assert_eq!(m["witness_cid"], cid);
+    assert_eq!(m["witness_kind"], "testng-test-witness-package");
+    let signer = m["signer"].as_str().unwrap();
+    let signature = m["signature"].as_str().unwrap();
+    assert!(ed25519_verify_string(signer, signature, cid.as_bytes()));
+}
+
+#[test]
 fn contract_ir_carries_junit_custom_evidence() {
     let cid = "blake3-512:bundle";
     let proof_data = witness_package_proof_data(
@@ -115,5 +135,24 @@ fn contract_ir_carries_junit_custom_evidence() {
     assert_eq!(ir["inv"]["name"], "witnessed");
     assert_eq!(ir["evidence"]["proofType"], "custom");
     assert_eq!(ir["evidence"]["certificate"]["tool"], "junit");
+    assert_eq!(ir["evidence"]["certificate"]["formulaHash"], cid);
+}
+
+#[test]
+fn contract_ir_carries_testng_custom_evidence() {
+    let cid = "blake3-512:bundle";
+    let ir = testng_witness_package_contract_ir(
+        cid,
+        RUNTIME_CID,
+        &[".".to_string()],
+        &["src/main/java/demo/Calculator.java".to_string()],
+        2,
+        2,
+    );
+    assert_eq!(ir["kind"], "contract");
+    assert_eq!(ir["name"], "witness-package:blake3-512:bundle");
+    assert_eq!(ir["inv"]["name"], "witnessed");
+    assert_eq!(ir["evidence"]["proofType"], "custom");
+    assert_eq!(ir["evidence"]["certificate"]["tool"], "testng");
     assert_eq!(ir["evidence"]["certificate"]["formulaHash"], cid);
 }


### PR DESCRIPTION
## TestNG generalization: the assertion vocab is LEARNED, not framework-hardcoded

The acid test of the vocab-learning thesis — point the **unchanged** kit at a second framework and it learns *that* framework's vocab the same way it learns JUnit.

**Headline: vocab classifier rust diff = 0 lines.** No hunk touches `derive_vocab_from_javap`, `classify_assert_method`, `carries_tolerance`, `apply_vocab_exceptions`, `classify_call`, or body-delegation (verified: every changed fn in `lib.rs` is a witness fn). The same unchanged classifier, via `javap -classpath <cp> -public org.testng.Assert` on real TestNG 7.10.2, derives TestNG's **own** signature set: `assertEquals(double,double,double)`→Approx, `…,String)`→Approx, `assertEquals(double[],double[],double)`→Approx (an array-delta overload JUnit lacks), `assertEquals(float,float,float)`→Approx. Picking up TestNG's distinct overloads proves it reads TestNG's real signatures, not a JUnit pattern.

- Override is declared data only (`.sugar/vocab-exceptions/org.testng.Assert.json`) for the jar body-gap; signature-derived Approx rows stay Approx (false-pass guard holds).
- The TestNG **witness** is a concrete per-framework backend (expected, like junit-witness vs cargo-test-witness): new bins `java_testng_witness_rpc.rs` (191) + `java_testng_discharge_cli.rs` (53), shared witness-runner delta in `lib.rs` (302/14), Cargo +8. Witness infra, **not** the classifier.
- `assertion_vocab_lift.rs` +178 tests-only (real-TestNG javap approx + override false-pass, RED-first).

### Two-twin showcase `examples/testng-assertion-consistency` (real TestNG 7.10.2 + slf4j/jcommander; twins call real `org.testng.Assert` + `@Test`; battleaxe)
GOOD → `consistency=discharged witness=discharged`. BAD → `consistency=unsatisfied witness=unsatisfied`. `run.sh` dumps the real `org.testng.Assert` javap signatures.

### Acceptance (verified by me, real exit captured)
- **classifier diff = 0 lines** (I confirmed: every changed `lib.rs` fn is a witness fn; no classifier fn line added/removed).
- `../../bin/bcargo test --workspace --no-fail-fast` → **2572 passed / 0 failed**.
- `run.sh` exit 0 — I re-ran it: real TestNG javap signatures, approx, good discharged, bad flips to unsatisfied.
- `make ci` PASS incl all showcases (java real-JUnit + new TestNG); `grep -rn 'concept_name\|conceptName' implementations/` → 0.

JUnit and TestNG are both learned by the same code. The vocab is learned, and the mechanism generalizes across frameworks with zero classifier change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
