### PR TITLE
sugar-ir-types: CLI-side ProofIR canonicalizer (alpha + pure-let normal form)

### DIFF
--- a/implementations/rust/sugar-ir-types/src/canonicalize.rs
+++ b/implementations/rust/sugar-ir-types/src/canonicalize.rs
@@ -1,0 +1,303 @@
+//! Canonicalization of ProofIR formulas and terms: the alpha + pure-let normal
+//! form that makes a behavior content-address invariant under sugar.
+//!
+//! ARCHITECTURE: this is CLI-side computation over kit-emitted data. The kits
+//! (lifters) emit ProofIR; the substrate computes over it. A kit may emit the
+//! same behavior in different surface shapes -- one emits `let n = x in n*2`,
+//! another emits `x*2` -- and the substrate must compute the SAME identity from
+//! both. So canonicalization happens here, once, uniformly across every
+//! language, never in a lifter.
+//!
+//! A contract's `post` is a pure `IrFormula` over a pure `IrTerm` language;
+//! effects live in a separate row and never appear inside the formula. So two
+//! formulations that differ only in
+//!   (a) bound/local variable NAMES, or
+//!   (b) trivial `let` bindings,
+//! denote the same behavior and MUST share a propertyHash. This module produces
+//! that canonical form, solver-free and deterministic:
+//!
+//!   * pure-let inlining: `let n = e in body` -> `body[n := e]`. Sound because
+//!     the term language is referentially transparent (no effects in it).
+//!   * alpha-canonicalization: binders (Forall/Exists/Choice/Lambda) become
+//!     `$b<depth>`; with [`canonicalize_property`], the interface formals become
+//!     `$arg<i>` and the result binding `$out`. Names are sugar.
+//!
+//! It applies NO equivalence that needs a solver (e.g. `x+x == 2*x`). Semantic
+//! equality is `prove`'s job; the content address stays computable.
+
+use crate::{IrFormula, IrTerm, LetBinding};
+use std::collections::HashMap;
+
+#[derive(Clone, Default)]
+struct Ctx {
+    /// let-bound name -> its already-canonical value term (inlined at use site).
+    subst: HashMap<String, IrTerm>,
+    /// binder / interface-formal name -> canonical name.
+    rename: HashMap<String, String>,
+    /// binder nesting depth, for canonical binder names.
+    depth: usize,
+}
+
+impl Ctx {
+    /// Enter a binder: shadow `name` with a canonical depth-keyed name. Returns
+    /// the scoped child context and the canonical binder name.
+    fn enter(&self, name: &str) -> (Ctx, String) {
+        let canon = format!("$b{}", self.depth);
+        let mut child = self.clone();
+        child.rename.insert(name.to_string(), canon.clone());
+        // a binder shadows any earlier let-substitution for the same name.
+        child.subst.remove(name);
+        child.depth += 1;
+        (child, canon)
+    }
+}
+
+fn canon_term(t: &IrTerm, ctx: &Ctx) -> IrTerm {
+    match t {
+        IrTerm::Var { name } => {
+            if let Some(term) = ctx.subst.get(name) {
+                term.clone()
+            } else if let Some(canon) = ctx.rename.get(name) {
+                IrTerm::Var { name: canon.clone() }
+            } else {
+                IrTerm::Var { name: name.clone() }
+            }
+        }
+        IrTerm::Const { value, sort } => IrTerm::Const {
+            value: value.clone(),
+            sort: sort.clone(),
+        },
+        IrTerm::Ctor { name, args } => IrTerm::Ctor {
+            name: name.clone(),
+            args: args.iter().map(|a| canon_term(a, ctx)).collect(),
+        },
+        IrTerm::Lambda {
+            param_name,
+            param_sort,
+            body,
+        } => {
+            let (child, canon) = ctx.enter(param_name);
+            IrTerm::Lambda {
+                param_name: canon,
+                param_sort: param_sort.clone(),
+                body: Box::new(canon_term(body, &child)),
+            }
+        }
+        IrTerm::Let { bindings, body } => {
+            // Inline every binding left-to-right; later bindings may reference
+            // earlier ones. The `let` node disappears entirely.
+            let mut child = ctx.clone();
+            for LetBinding { name, bound_term } in bindings {
+                let value = canon_term(bound_term, &child);
+                child.rename.remove(name);
+                child.subst.insert(name.clone(), value);
+            }
+            canon_term(body, &child)
+        }
+    }
+}
+
+fn canon_formula(f: &IrFormula, ctx: &Ctx) -> IrFormula {
+    match f {
+        IrFormula::Atomic { name, args } => IrFormula::Atomic {
+            name: name.clone(),
+            args: args.iter().map(|a| canon_term(a, ctx)).collect(),
+        },
+        IrFormula::And { operands } => IrFormula::And {
+            operands: canon_ops(operands, ctx),
+        },
+        IrFormula::Or { operands } => IrFormula::Or {
+            operands: canon_ops(operands, ctx),
+        },
+        IrFormula::Not { operands } => IrFormula::Not {
+            operands: canon_ops(operands, ctx),
+        },
+        IrFormula::Implies { operands } => IrFormula::Implies {
+            operands: canon_ops(operands, ctx),
+        },
+        IrFormula::Forall { name, sort, body } => {
+            let (child, canon) = ctx.enter(name);
+            IrFormula::Forall {
+                name: canon,
+                sort: sort.clone(),
+                body: Box::new(canon_formula(body, &child)),
+            }
+        }
+        IrFormula::Exists { name, sort, body } => {
+            let (child, canon) = ctx.enter(name);
+            IrFormula::Exists {
+                name: canon,
+                sort: sort.clone(),
+                body: Box::new(canon_formula(body, &child)),
+            }
+        }
+        IrFormula::Choice {
+            var_name,
+            sort,
+            body,
+        } => {
+            let (child, canon) = ctx.enter(var_name);
+            IrFormula::Choice {
+                var_name: canon,
+                sort: sort.clone(),
+                body: Box::new(canon_formula(body, &child)),
+            }
+        }
+        IrFormula::Substitute { target, term, var } => IrFormula::Substitute {
+            target: Box::new(canon_formula(target, ctx)),
+            term: canon_term(term, ctx),
+            var: var.clone(),
+        },
+        IrFormula::Apply { args, r#fn } => IrFormula::Apply {
+            args: args.iter().map(|a| canon_formula(a, ctx)).collect(),
+            r#fn: r#fn.clone(),
+        },
+        IrFormula::DivergenceBetween { source, target } => IrFormula::DivergenceBetween {
+            source: Box::new(canon_formula(source, ctx)),
+            target: Box::new(canon_formula(target, ctx)),
+        },
+    }
+}
+
+fn canon_ops(operands: &[IrFormula], ctx: &Ctx) -> Vec<IrFormula> {
+    operands.iter().map(|o| canon_formula(o, ctx)).collect()
+}
+
+/// Canonicalize a formula: alpha-canonicalize binders to `$b<depth>` and inline
+/// pure `let` bindings. Free variables are left unchanged.
+pub fn canonicalize_formula(f: &IrFormula) -> IrFormula {
+    canon_formula(f, &Ctx::default())
+}
+
+/// Canonicalize a contract property for use as behavior identity: as
+/// [`canonicalize_formula`], and additionally rename the interface formals to
+/// positional `$arg<i>` and the result binding to `$out`, so that a parameter
+/// rename is not a behavior change. `formals` are in signature order;
+/// `result_binding` is the variable name the post uses for the result (pass `""`
+/// if there is none).
+pub fn canonicalize_property(
+    post: &IrFormula,
+    formals: &[String],
+    result_binding: &str,
+) -> IrFormula {
+    let mut ctx = Ctx::default();
+    for (i, formal) in formals.iter().enumerate() {
+        ctx.rename.insert(formal.clone(), format!("$arg{i}"));
+    }
+    if !result_binding.is_empty() {
+        ctx.rename
+            .insert(result_binding.to_string(), "$out".to_string());
+    }
+    canon_formula(post, &ctx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Sort;
+
+    fn var(n: &str) -> IrTerm {
+        IrTerm::Var { name: n.into() }
+    }
+    fn mul(a: IrTerm, b: IrTerm) -> IrTerm {
+        IrTerm::Ctor {
+            name: "*".into(),
+            args: vec![a, b],
+        }
+    }
+    fn eq(a: IrTerm, b: IrTerm) -> IrFormula {
+        IrFormula::Atomic {
+            name: "=".into(),
+            args: vec![a, b],
+        }
+    }
+    fn int_sort() -> Sort {
+        Sort::Primitive { name: "Int".into() }
+    }
+
+    /// THE bug: `result = x*2` and `result = (let n = x in n*2)` are the same
+    /// behavior. A reformat that introduces a local must not move the identity.
+    #[test]
+    fn let_inlining_identifies_reformat() {
+        let plain = eq(var("result"), mul(var("x"), var("two")));
+        let with_let = eq(
+            var("result"),
+            IrTerm::Let {
+                bindings: vec![LetBinding {
+                    name: "n".into(),
+                    bound_term: var("x"),
+                }],
+                body: Box::new(mul(var("n"), var("two"))),
+            },
+        );
+        assert_eq!(canonicalize_formula(&plain), canonicalize_formula(&with_let));
+    }
+
+    /// A real behavior change (x*2 vs x*3) must NOT be identified.
+    #[test]
+    fn behavior_change_is_not_identified() {
+        let two = eq(var("result"), mul(var("x"), var("two")));
+        let three = eq(var("result"), mul(var("x"), var("three")));
+        assert_ne!(canonicalize_formula(&two), canonicalize_formula(&three));
+    }
+
+    /// A parameter rename (`double(x){x*2}` vs `double(y){y*2}`) is not a
+    /// behavior change once formals are positional.
+    #[test]
+    fn parameter_rename_is_identified() {
+        let with_x = eq(var("result"), mul(var("x"), var("two")));
+        let with_y = eq(var("result"), mul(var("y"), var("two")));
+        let cx = canonicalize_property(&with_x, &["x".into()], "result");
+        let cy = canonicalize_property(&with_y, &["y".into()], "result");
+        assert_eq!(cx, cy);
+        // and it actually became positional:
+        if let IrFormula::Atomic { args, .. } = &cx {
+            assert_eq!(args[0], var("$out"));
+        } else {
+            panic!("expected atomic");
+        }
+    }
+
+    /// Bound-variable renaming under a quantifier is alpha-invariant.
+    #[test]
+    fn quantifier_alpha_invariance() {
+        let fx = IrFormula::Forall {
+            name: "x".into(),
+            sort: int_sort(),
+            body: Box::new(eq(var("x"), var("x"))),
+        };
+        let fy = IrFormula::Forall {
+            name: "y".into(),
+            sort: int_sort(),
+            body: Box::new(eq(var("y"), var("y"))),
+        };
+        assert_eq!(canonicalize_formula(&fx), canonicalize_formula(&fy));
+    }
+
+    /// Idempotence: canonicalizing twice is canonicalizing once.
+    #[test]
+    fn idempotent() {
+        let f = eq(
+            var("result"),
+            IrTerm::Let {
+                bindings: vec![LetBinding {
+                    name: "n".into(),
+                    bound_term: var("x"),
+                }],
+                body: Box::new(mul(var("n"), var("two"))),
+            },
+        );
+        let once = canonicalize_formula(&f);
+        assert_eq!(once, canonicalize_formula(&once));
+    }
+
+    /// A free const is preserved (sort + value).
+    #[test]
+    fn const_preserved() {
+        let c = IrTerm::Const {
+            value: serde_json::json!(2),
+            sort: int_sort(),
+        };
+        assert_eq!(canon_term(&c, &Ctx::default()), c);
+    }
+}

--- a/implementations/rust/sugar-ir-types/src/lib.rs
+++ b/implementations/rust/sugar-ir-types/src/lib.rs
@@ -9,6 +9,12 @@ use sugar_canonicalizer::{blake3_512_of, encode_jcs, Value as CValue};
 
 pub mod realization_tags;
 
+// Manual extension (not codegen): CLI-side canonicalization of ProofIR for
+// behavior identity. The kits emit ProofIR; the substrate computes the canonical
+// form before hashing. Alpha + pure-let normal form, solver-free.
+pub mod canonicalize;
+pub use canonicalize::{canonicalize_formula, canonicalize_property};
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind")]
 pub enum Declaration {


### PR DESCRIPTION
The substrate primitive for behavior identity. Kits emit ProofIR; the CLI computes over it — so canonicalization lives in the substrate, once, uniformly across every language, never in a lifter.

`canonicalize_formula` / `canonicalize_property` produce the alpha + pure-let normal form of an `IrFormula`:
- **pure-let inlining**: `let n = e in body` → `body[n := e]`. Sound because the post is a pure formula over an effect-free term language (effects are a separate row, by the IR's design).
- **alpha**: binders → `$b<depth>`; interface formals → `$arg<i>`; result → `$out`.

Solver-free, deterministic, idempotent. It applies **no** equivalence that needs a solver (`x+x == 2*x` stays in `prove`); the content address stays computable.

This is the fix the rust reformat-sensitivity demanded, at the correct seam: the `result = n*2` leak is an un-inlined `let` with a leaked binder, normalized away here without touching the lifter.

**6 tests**, incl. `let_inlining_identifies_reformat` and `behavior_change_is_not_identified`. Pure + additive — used nowhere yet; wiring into the propertyHash computation is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Canonicalization module added for ProofIR formulas and properties, providing deterministic normalization through alpha-renaming of bound variables and intelligent inlining of pure bindings
  * Two new public functions now available to canonicalize formulas and properties, enabling deterministic canonical form computation for improved consistency and representation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->