### PR TITLE
Broaden java contract lift: @Max/@Size/@NotNull/range (edge unchanged)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,7 @@ SHOWCASE_RUNS = \
 	examples/numpy-attribute-safety-showcase/run.sh \
 	examples/java-test-assertion-consistency/run.sh \
 	examples/java-implication-edge/run.sh \
+	examples/java-contract-breadth/run.sh \
 	examples/testng-assertion-consistency/run.sh
 
 .PHONY: test-showcases
@@ -307,7 +308,7 @@ test-showcases:
 	  remote_tag="$${remote_tag:-default}"; \
 	  remote_root="$${BCARGO_REMOTE_ROOT:-/home/tsavo/remote/sugar-bcargo-$$remote_tag}"; \
 	  remote_repo="$$remote_root/sugar"; \
-	  remote_cmd="cd $$(printf '%q' "$$remote_repo") && SHOWCASES_ON_REMOTE=1 POLARS_SHOWCASE_ON_REMOTE=1 POLARS_SHOWCASE_SKIP_LOCAL_BUILD=1 NUMPY_ATTR_SHOWCASE_ON_REMOTE=1 NUMPY_ATTR_SHOWCASE_SKIP_LOCAL_BUILD=1 JAVA_ASSERT_SHOWCASE_ON_REMOTE=1 JAVA_ASSERT_SHOWCASE_SKIP_LOCAL_BUILD=1 JAVA_EDGE_SHOWCASE_ON_REMOTE=1 JAVA_EDGE_SHOWCASE_SKIP_LOCAL_BUILD=1 TESTNG_ASSERT_SHOWCASE_ON_REMOTE=1 TESTNG_ASSERT_SHOWCASE_SKIP_LOCAL_BUILD=1 make test-showcases"; \
+	  remote_cmd="cd $$(printf '%q' "$$remote_repo") && SHOWCASES_ON_REMOTE=1 POLARS_SHOWCASE_ON_REMOTE=1 POLARS_SHOWCASE_SKIP_LOCAL_BUILD=1 NUMPY_ATTR_SHOWCASE_ON_REMOTE=1 NUMPY_ATTR_SHOWCASE_SKIP_LOCAL_BUILD=1 JAVA_ASSERT_SHOWCASE_ON_REMOTE=1 JAVA_ASSERT_SHOWCASE_SKIP_LOCAL_BUILD=1 JAVA_EDGE_SHOWCASE_ON_REMOTE=1 JAVA_EDGE_SHOWCASE_SKIP_LOCAL_BUILD=1 JAVA_CONTRACT_BREADTH_SHOWCASE_ON_REMOTE=1 JAVA_CONTRACT_BREADTH_SHOWCASE_SKIP_LOCAL_BUILD=1 TESTNG_ASSERT_SHOWCASE_ON_REMOTE=1 TESTNG_ASSERT_SHOWCASE_SKIP_LOCAL_BUILD=1 make test-showcases"; \
 	  ssh -o BatchMode=yes "$$remote_host" "bash -lc $$(printf '%q' "$$remote_cmd")"; \
 	  exit $$?; \
 	fi; \

--- a/examples/java-contract-breadth/.gitignore
+++ b/examples/java-contract-breadth/.gitignore
@@ -1,0 +1,10 @@
+*.proof
+.prove.json
+.verify.json
+.verify_recompute.json
+**/.sugar/runs/
+**/.sugar/witnesses/
+**/.sugar/lift/*/manifest.toml
+**/target/
+**/*.class
+

--- a/examples/java-contract-breadth/README.md
+++ b/examples/java-contract-breadth/README.md
@@ -1,0 +1,17 @@
+# Java Contract Breadth
+
+This showcase proves Java callsite implication rows:
+
+`producer.post |= consumer.pre`
+
+`java-jsr380-contracts` lifts JSR-380 `@Min`, `@Max`, `@Size`, and
+`@NotNull` annotations into method pre/post contracts. `java-implications`
+then emits callsite bridges for consumers of producer results, reusing the
+same substrate implication machinery as the narrower Java implication edge.
+`java-junit-witness` compiles and runs the JUnit suite as the execution witness
+axis.
+
+The receipt is scoped to the callsite implication rows named in `run.sh`. It
+does not reimplement Bean Validation at runtime and does not prove Java type or
+compiler facts; compiled Java is the legality boundary.
+

--- a/examples/java-contract-breadth/bad/.sugar/config.toml
+++ b/examples/java-contract-breadth/bad/.sugar/config.toml
@@ -1,0 +1,27 @@
+[[plugins]]
+name = "java-jsr380-contracts-lift"
+kind = "lift"
+surface = "java-jsr380-contracts"
+emit = "ir-document"
+
+[[plugins]]
+name = "java-implications-lift"
+kind = "lift"
+surface = "java-implications"
+
+[[plugins]]
+name = "java-junit-witness-lift"
+kind = "lift"
+surface = "java-junit-witness"
+
+[solvers]
+default = "z3"
+
+[solvers.dispatch]
+linear_arithmetic = "z3"
+default = "z3"
+
+[solvers.z3]
+binary = "z3"
+flags = ["-smt2", "-in"]
+

--- a/examples/java-contract-breadth/bad/.sugar/lift/java-implications/manifest.toml.in
+++ b/examples/java-contract-breadth/bad/.sugar/lift/java-implications/manifest.toml.in
@@ -1,0 +1,13 @@
+name = "java-implications-lift"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/java_implications_rpc"]
+working_dir = "."
+phase = "consumer"
+
+[capabilities]
+authoring_surfaces = ["java-implications"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+

--- a/examples/java-contract-breadth/bad/.sugar/lift/java-jsr380-contracts/manifest.toml.in
+++ b/examples/java-contract-breadth/bad/.sugar/lift/java-jsr380-contracts/manifest.toml.in
@@ -1,0 +1,12 @@
+name = "java-jsr380-contracts-lift"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/java_jsr380_contracts_rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["java-jsr380-contracts"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+

--- a/examples/java-contract-breadth/bad/.sugar/lift/java-junit-witness/manifest.toml.in
+++ b/examples/java-contract-breadth/bad/.sugar/lift/java-junit-witness/manifest.toml.in
@@ -1,0 +1,14 @@
+name = "java-junit-witness-lift"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/java_junit_witness_rpc"]
+discharge_command = ["@BIN_DIR@/java_junit_discharge_cli"]
+witness_tool = "junit"
+resolve_witness_command = ["@BIN_DIR@/java_junit_witness_rpc"]
+resolve_witness_method = "sugar.plugin.resolve_witness"
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["java-junit-witness"]
+

--- a/examples/java-contract-breadth/bad/src/main/java/demo/Chain.java
+++ b/examples/java-contract-breadth/bad/src/main/java/demo/Chain.java
@@ -1,0 +1,63 @@
+package demo;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public final class Chain {
+    private Chain() {}
+
+    @Max(100)
+    public static int maxProducer() {
+        return 50;
+    }
+
+    public static int maxConsumer(@Max(10) int value) {
+        return value;
+    }
+
+    public static int maxEdge() {
+        return maxConsumer(maxProducer());
+    }
+
+    @Size(min = 0, max = 100)
+    public static String sizeProducer() {
+        return "too-long-value";
+    }
+
+    public static String sizeConsumer(@Size(min = 0, max = 10) String value) {
+        return value;
+    }
+
+    public static String sizeEdge() {
+        return sizeConsumer(sizeProducer());
+    }
+
+    public static String nullableProducer() {
+        return null;
+    }
+
+    public static String notNullConsumer(@NotNull String value) {
+        return value;
+    }
+
+    public static String notNullEdge() {
+        return notNullConsumer(nullableProducer());
+    }
+
+    @Min(0)
+    @Max(100)
+    public static int rangeProducer() {
+        return 5;
+    }
+
+    public static int rangeConsumer(@Min(10) @Max(90) int value) {
+        return value;
+    }
+
+    public static int rangeEdge() {
+        return rangeConsumer(rangeProducer());
+    }
+}
+

--- a/examples/java-contract-breadth/bad/src/test/java/demo/ChainTest.java
+++ b/examples/java-contract-breadth/bad/src/test/java/demo/ChainTest.java
@@ -1,0 +1,30 @@
+package demo;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class ChainTest {
+    @Test
+    void maxPostDoesNotEntailConsumerPre() {
+        assertTrue(Chain.maxEdge() <= 10);
+    }
+
+    @Test
+    void sizePostDoesNotEntailConsumerPre() {
+        assertTrue(Chain.sizeEdge().length() <= 10);
+    }
+
+    @Test
+    void missingNotNullPostDoesNotEntailConsumerPre() {
+        assertNotNull(Chain.notNullEdge());
+    }
+
+    @Test
+    void rangePostDoesNotEntailConsumerPre() {
+        int value = Chain.rangeEdge();
+        assertTrue(value >= 10 && value <= 90);
+    }
+}
+

--- a/examples/java-contract-breadth/good/.sugar/config.toml
+++ b/examples/java-contract-breadth/good/.sugar/config.toml
@@ -1,0 +1,27 @@
+[[plugins]]
+name = "java-jsr380-contracts-lift"
+kind = "lift"
+surface = "java-jsr380-contracts"
+emit = "ir-document"
+
+[[plugins]]
+name = "java-implications-lift"
+kind = "lift"
+surface = "java-implications"
+
+[[plugins]]
+name = "java-junit-witness-lift"
+kind = "lift"
+surface = "java-junit-witness"
+
+[solvers]
+default = "z3"
+
+[solvers.dispatch]
+linear_arithmetic = "z3"
+default = "z3"
+
+[solvers.z3]
+binary = "z3"
+flags = ["-smt2", "-in"]
+

--- a/examples/java-contract-breadth/good/.sugar/lift/java-implications/manifest.toml.in
+++ b/examples/java-contract-breadth/good/.sugar/lift/java-implications/manifest.toml.in
@@ -1,0 +1,13 @@
+name = "java-implications-lift"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/java_implications_rpc"]
+working_dir = "."
+phase = "consumer"
+
+[capabilities]
+authoring_surfaces = ["java-implications"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+

--- a/examples/java-contract-breadth/good/.sugar/lift/java-jsr380-contracts/manifest.toml.in
+++ b/examples/java-contract-breadth/good/.sugar/lift/java-jsr380-contracts/manifest.toml.in
@@ -1,0 +1,12 @@
+name = "java-jsr380-contracts-lift"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/java_jsr380_contracts_rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["java-jsr380-contracts"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false
+

--- a/examples/java-contract-breadth/good/.sugar/lift/java-junit-witness/manifest.toml.in
+++ b/examples/java-contract-breadth/good/.sugar/lift/java-junit-witness/manifest.toml.in
@@ -1,0 +1,14 @@
+name = "java-junit-witness-lift"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/java_junit_witness_rpc"]
+discharge_command = ["@BIN_DIR@/java_junit_discharge_cli"]
+witness_tool = "junit"
+resolve_witness_command = ["@BIN_DIR@/java_junit_witness_rpc"]
+resolve_witness_method = "sugar.plugin.resolve_witness"
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["java-junit-witness"]
+

--- a/examples/java-contract-breadth/good/src/main/java/demo/Chain.java
+++ b/examples/java-contract-breadth/good/src/main/java/demo/Chain.java
@@ -1,0 +1,64 @@
+package demo;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public final class Chain {
+    private Chain() {}
+
+    @Max(10)
+    public static int maxProducer() {
+        return 6;
+    }
+
+    public static int maxConsumer(@Max(10) int value) {
+        return value;
+    }
+
+    public static int maxEdge() {
+        return maxConsumer(maxProducer());
+    }
+
+    @Size(min = 1, max = 5)
+    public static String sizeProducer() {
+        return "abc";
+    }
+
+    public static String sizeConsumer(@Size(min = 1, max = 5) String value) {
+        return value;
+    }
+
+    public static String sizeEdge() {
+        return sizeConsumer(sizeProducer());
+    }
+
+    @NotNull
+    public static String notNullProducer() {
+        return "value";
+    }
+
+    public static String notNullConsumer(@NotNull String value) {
+        return value;
+    }
+
+    public static String notNullEdge() {
+        return notNullConsumer(notNullProducer());
+    }
+
+    @Min(0)
+    @Max(10)
+    public static int rangeProducer() {
+        return 6;
+    }
+
+    public static int rangeConsumer(@Min(0) @Max(10) int value) {
+        return value;
+    }
+
+    public static int rangeEdge() {
+        return rangeConsumer(rangeProducer());
+    }
+}
+

--- a/examples/java-contract-breadth/good/src/test/java/demo/ChainTest.java
+++ b/examples/java-contract-breadth/good/src/test/java/demo/ChainTest.java
@@ -1,0 +1,19 @@
+package demo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class ChainTest {
+    @Test
+    void broadenedContractsAllHold() {
+        assertEquals(6, Chain.maxEdge());
+        assertEquals("abc", Chain.sizeEdge());
+        assertNotNull(Chain.notNullEdge());
+        assertEquals(6, Chain.rangeEdge());
+        assertTrue(Chain.sizeEdge().length() <= 5);
+    }
+}
+

--- a/examples/java-contract-breadth/run.sh
+++ b/examples/java-contract-breadth/run.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+RUST="$REPO/implementations/rust"
+BIN_DIR="$RUST/target/debug"
+SUGAR="$BIN_DIR/sugar"
+CONTRACT_RPC="$BIN_DIR/java_jsr380_contracts_rpc"
+IMPLICATION_RPC="$BIN_DIR/java_implications_rpc"
+WITNESS_RPC="$BIN_DIR/java_junit_witness_rpc"
+DISCHARGE_CLI="$BIN_DIR/java_junit_discharge_cli"
+JUNIT_VERSION="${JUNIT_VERSION:-1.10.2}"
+JUNIT_JAR="${SUGAR_JUNIT_CONSOLE_JAR:-/tmp/sugar-junit/junit-platform-console-standalone-${JUNIT_VERSION}.jar}"
+JUNIT_URL="https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${JUNIT_VERSION}/junit-platform-console-standalone-${JUNIT_VERSION}.jar"
+VALIDATION_VERSION="${VALIDATION_VERSION:-2.0.1.Final}"
+VALIDATION_JAR="${SUGAR_VALIDATION_API_JAR:-/tmp/sugar-validation/validation-api-${VALIDATION_VERSION}.jar}"
+VALIDATION_URL="https://repo1.maven.org/maven2/javax/validation/validation-api/${VALIDATION_VERSION}/validation-api-${VALIDATION_VERSION}.jar"
+
+CONSUMERS=(maxConsumer sizeConsumer notNullConsumer rangeConsumer)
+
+for suite in good bad; do
+  if [ ! -d "$HERE/$suite" ]; then
+    echo "missing suite directory: $HERE/$suite" >&2
+    exit 1
+  fi
+done
+
+if [ "${JAVA_CONTRACT_BREADTH_SHOWCASE_ON_REMOTE:-0}" != "1" ] \
+  && [ "${JAVA_CONTRACT_BREADTH_SHOWCASE_USE_BCARGO:-1}" != "0" ] \
+  && [ "$(uname -s)" != "Linux" ]; then
+  echo "== run java contract breadth showcase on battleaxe via bcargo =="
+  "$REPO/bin/bcargo" build --manifest-path "$RUST/Cargo.toml" \
+    -p sugar-cli --bin sugar \
+    -p sugar-lift-java-tests --bin java_jsr380_contracts_rpc \
+    -p sugar-lift-java-tests --bin java_implications_rpc \
+    -p sugar-lift-java-tests --bin java_junit_witness_rpc \
+    -p sugar-lift-java-tests --bin java_junit_discharge_cli >/dev/null
+
+  remote_host="${BCARGO_REMOTE_HOST:-battleaxe}"
+  remote_tag="$(printf '%s' "$(cd "$REPO" && pwd -P)" | shasum 2>/dev/null | cut -c1-12)"
+  remote_tag="${remote_tag:-default}"
+  remote_root="${BCARGO_REMOTE_ROOT:-/home/tsavo/remote/sugar-bcargo-${remote_tag}}"
+  remote_repo="$remote_root/sugar"
+  remote_cmd="cd $(printf '%q' "$remote_repo") && JAVA_CONTRACT_BREADTH_SHOWCASE_ON_REMOTE=1 JAVA_CONTRACT_BREADTH_SHOWCASE_SKIP_LOCAL_BUILD=1 examples/java-contract-breadth/run.sh"
+  ssh -o BatchMode=yes "$remote_host" "bash -lc $(printf '%q' "$remote_cmd")"
+  exit $?
+fi
+
+if [ "${JAVA_CONTRACT_BREADTH_SHOWCASE_SKIP_LOCAL_BUILD:-0}" != "1" ]; then
+  echo "== build proof binaries =="
+  cargo build --manifest-path "$RUST/Cargo.toml" \
+    -p sugar-cli --bin sugar \
+    -p sugar-lift-java-tests --bin java_jsr380_contracts_rpc \
+    -p sugar-lift-java-tests --bin java_implications_rpc \
+    -p sugar-lift-java-tests --bin java_junit_witness_rpc \
+    -p sugar-lift-java-tests --bin java_junit_discharge_cli >/dev/null
+fi
+
+for bin in "$SUGAR" "$CONTRACT_RPC" "$IMPLICATION_RPC" "$WITNESS_RPC" "$DISCHARGE_CLI"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing executable: $bin" >&2
+    exit 1
+  fi
+done
+
+if ! command -v javac >/dev/null 2>&1 || ! command -v java >/dev/null 2>&1; then
+  echo "missing JDK on this host; run this showcase on battleaxe/Linux" >&2
+  exit 1
+fi
+
+fetch_jar() {
+  local jar="$1"
+  local url="$2"
+  if [ -f "$jar" ]; then
+    return 0
+  fi
+  mkdir -p "$(dirname "$jar")"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$jar"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q "$url" -O "$jar"
+  else
+    echo "neither curl nor wget is available to fetch $url" >&2
+    exit 1
+  fi
+}
+
+echo "== fetch pinned Java runtime jars =="
+fetch_jar "$JUNIT_JAR" "$JUNIT_URL"
+fetch_jar "$VALIDATION_JAR" "$VALIDATION_URL"
+export SUGAR_JUNIT_CONSOLE_JAR="$JUNIT_JAR"
+export SUGAR_JAVA_EXTRA_CLASSPATH="$VALIDATION_JAR"
+
+render_manifests() {
+  local suite="$1"
+  local base="$HERE/$suite/.sugar/lift"
+
+  sed "s|@BIN_DIR@|$BIN_DIR|g" \
+    "$base/java-jsr380-contracts/manifest.toml.in" \
+    > "$base/java-jsr380-contracts/manifest.toml"
+
+  sed "s|@BIN_DIR@|$BIN_DIR|g" \
+    "$base/java-implications/manifest.toml.in" \
+    > "$base/java-implications/manifest.toml"
+
+  sed "s|@BIN_DIR@|$BIN_DIR|g" \
+    "$base/java-junit-witness/manifest.toml.in" \
+    > "$base/java-junit-witness/manifest.toml"
+}
+
+clean_suite() {
+  local suite="$1"
+  local dir="$HERE/$suite"
+  rm -f "$dir"/blake3-512:*.proof "$dir/.prove.json" "$dir/.verify.json" "$dir/.verify_recompute.json"
+  rm -rf "$dir/.sugar/runs" "$dir/.sugar/witnesses" "$dir/target"
+}
+
+edge_status() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import re
+import sys
+
+text = open(sys.argv[1], "r", encoding="utf-8").read()
+callee = sys.argv[2]
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+rows = data.get("rows") or data.get("obligations") or (data if isinstance(data, list) else [])
+for row in rows:
+    prop = row.get("property") or row.get("predicate") or ""
+    if "witness-package" in prop:
+        continue
+    if row.get("bridge") == callee or row.get("callee") == callee:
+        print(row.get("status") or row.get("result") or "")
+        raise SystemExit(0)
+print("MISSING")
+PY
+}
+
+witness_status() {
+  python3 - "$1" <<'PY'
+import json
+import re
+import sys
+
+text = open(sys.argv[1], "r", encoding="utf-8").read()
+match = re.search(r"(?m)^\{", text)
+if not match:
+    print("MISSING")
+    raise SystemExit(0)
+data = json.loads(text[match.start():])
+rows = data.get("rows") or data.get("obligations") or (data if isinstance(data, list) else [])
+for row in rows:
+    prop = row.get("property") or row.get("predicate") or ""
+    if "witness-package" in prop:
+        print(row.get("status") or row.get("result") or "")
+        raise SystemExit(0)
+print("MISSING")
+PY
+}
+
+run_suite() {
+  local suite="$1"
+  local expect_edge="$2"
+  local expect_witness="$3"
+  local dir="$HERE/$suite"
+
+  render_manifests "$suite"
+  clean_suite "$suite"
+
+  echo "== mint $suite =="
+  (cd "$dir" && "$SUGAR" mint --out .) >/dev/null
+
+  local proof
+  proof="$(find "$dir" -maxdepth 1 -name 'blake3-512:*.proof' -print -quit)"
+  if [ -z "$proof" ]; then
+    echo "$suite did not mint a proof" >&2
+    exit 1
+  fi
+
+  echo "== prove $suite =="
+  set +e
+  (cd "$dir" && "$SUGAR" prove . --json) > "$dir/.prove.json" 2>&1
+  set -e
+
+  local statuses=()
+  local consumer got_edge
+  for consumer in "${CONSUMERS[@]}"; do
+    got_edge="$(edge_status "$dir/.prove.json" "$consumer")"
+    statuses+=("$consumer=$got_edge")
+    if [ "$expect_edge" = "discharged" ]; then
+      if [ "$got_edge" != "discharged" ]; then
+        echo "$suite $consumer expected discharged, got $got_edge" >&2
+        cat "$dir/.prove.json" >&2
+        exit 1
+      fi
+    else
+      if [ "$got_edge" = "discharged" ] || [ "$got_edge" = "MISSING" ]; then
+        echo "$suite $consumer expected refusal, got $got_edge" >&2
+        cat "$dir/.prove.json" >&2
+        exit 1
+      fi
+    fi
+  done
+
+  local got_witness
+  got_witness="$(witness_status "$dir/.prove.json")"
+  if [ "$expect_witness" = "discharged" ]; then
+    if [ "$got_witness" != "discharged" ]; then
+      echo "$suite witness expected discharged, got $got_witness" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  else
+    if [ "$got_witness" = "discharged" ] || [ "$got_witness" = "MISSING" ]; then
+      echo "$suite witness expected refusal, got $got_witness" >&2
+      cat "$dir/.prove.json" >&2
+      exit 1
+    fi
+  fi
+
+  echo "$suite java_edges=${statuses[*]} witness=$got_witness"
+}
+
+echo "EDGE: Java method callsites where producer.post must imply consumer.pre."
+echo "SCOPE: self-checking JSR-380 @Max/@Size/@NotNull/@Min+@Max implication rows; Bean Validation runtime and compiler facts are not re-proven."
+run_suite good discharged discharged
+run_suite bad refused refused
+
+echo "java contract breadth showcase self-check passed"
+

--- a/implementations/rust/sugar-lift-java-tests/src/lib.rs
+++ b/implementations/rust/sugar-lift-java-tests/src/lib.rs
@@ -1062,7 +1062,7 @@ pub struct JavaImplicationLiftOutput {
 struct JavaContractMethod {
     name: String,
     params: Vec<JavaParamContract>,
-    return_min: Option<i64>,
+    return_constraints: Vec<JavaConstraint>,
     return_expr: Option<String>,
     is_test: bool,
 }
@@ -1070,7 +1070,15 @@ struct JavaContractMethod {
 #[derive(Debug, Clone)]
 struct JavaParamContract {
     name: String,
-    min: Option<i64>,
+    constraints: Vec<JavaConstraint>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum JavaConstraint {
+    Min(i64),
+    Max(i64),
+    Size { min: Option<i64>, max: Option<i64> },
+    NotNull,
 }
 
 #[derive(Debug, Clone)]
@@ -1144,25 +1152,22 @@ pub fn lift_java_jsr380_contracts_from_source(
         let pre = method
             .params
             .iter()
-            .find_map(|param| param.min.map(|min| min_formula_json(&param.name, min)));
-        let post = method
-            .return_min
-            .map(|min| min_formula_json("result", min))
-            .or_else(|| {
-                let expr = method.return_expr.as_deref()?;
-                if !expr_contains_call(expr) {
-                    return None;
-                }
-                let term = java_expr_term_json(expr).ok()?;
-                Some(serde_json::json!({
-                    "kind": "atomic",
-                    "name": "=",
-                    "args": [
-                        {"kind": "var", "name": "result"},
-                        term
-                    ]
-                }))
-            });
+            .find_map(|param| constraints_formula_json(&param.name, &param.constraints));
+        let post = constraints_formula_json("result", &method.return_constraints).or_else(|| {
+            let expr = method.return_expr.as_deref()?;
+            if !expr_contains_call(expr) {
+                return None;
+            }
+            let term = java_expr_term_json(expr).ok()?;
+            Some(serde_json::json!({
+                "kind": "atomic",
+                "name": "=",
+                "args": [
+                    {"kind": "var", "name": "result"},
+                    term
+                ]
+            }))
+        });
 
         if pre.is_none() && post.is_none() {
             continue;
@@ -1311,6 +1316,7 @@ fn parse_java_contract_methods(src: &str) -> Vec<JavaContractMethod> {
         };
         let head_start = prefix.rfind(['}', ';']).map(|idx| idx + 1).unwrap_or(0);
         let head = &src[head_start..open];
+        let return_head = &src[head_start..open_paren];
         let params_src = &src[open_paren + 1..close_paren];
         let params = split_args(params_src)
             .iter()
@@ -1321,7 +1327,7 @@ fn parse_java_contract_methods(src: &str) -> Vec<JavaContractMethod> {
         methods.push(JavaContractMethod {
             name,
             params,
-            return_min: find_min_annotation(head),
+            return_constraints: find_jsr380_constraints(return_head),
             return_expr: find_return_expr(body),
             is_test: head.contains("@Test"),
         });
@@ -1331,23 +1337,180 @@ fn parse_java_contract_methods(src: &str) -> Vec<JavaContractMethod> {
 }
 
 fn parse_java_param_contract(raw: &str, idx: usize) -> Option<JavaParamContract> {
-    let min = find_min_annotation(raw);
-    let parsed = parse_param(raw, idx)?;
+    let constraints = find_jsr380_constraints(raw);
+    let stripped = strip_java_annotations(raw);
+    let parsed = parse_param(&stripped, idx)?;
     Some(JavaParamContract {
         name: parsed.name,
-        min,
+        constraints,
     })
 }
 
-fn find_min_annotation(src: &str) -> Option<i64> {
-    for needle in ["@Min(", "@javax.validation.constraints.Min("] {
-        if let Some(found) = src.find(needle) {
-            let start = found + needle.len();
-            let end = src[start..].find(')').map(|idx| start + idx)?;
-            return src[start..end].trim().parse::<i64>().ok();
+fn find_jsr380_constraints(src: &str) -> Vec<JavaConstraint> {
+    let mut constraints = Vec::new();
+    if let Some(min) = find_i64_annotation(src, &["@Min", "@javax.validation.constraints.Min"]) {
+        constraints.push(JavaConstraint::Min(min));
+    }
+    if let Some(max) = find_i64_annotation(src, &["@Max", "@javax.validation.constraints.Max"]) {
+        constraints.push(JavaConstraint::Max(max));
+    }
+    if let Some((min, max)) =
+        find_size_annotation(src, &["@Size", "@javax.validation.constraints.Size"])
+    {
+        constraints.push(JavaConstraint::Size { min, max });
+    }
+    if has_marker_annotation(
+        src,
+        &[
+            "@NotNull",
+            "@javax.validation.constraints.NotNull",
+            "@jakarta.validation.constraints.NotNull",
+        ],
+    ) {
+        constraints.push(JavaConstraint::NotNull);
+    }
+    constraints
+}
+
+fn find_i64_annotation(src: &str, names: &[&str]) -> Option<i64> {
+    let args = find_annotation_args(src, names)?;
+    parse_annotation_i64_value(args)
+}
+
+fn find_size_annotation(src: &str, names: &[&str]) -> Option<(Option<i64>, Option<i64>)> {
+    let args = find_annotation_args(src, names)?;
+    let min = parse_named_i64_arg(args, "min");
+    let max = parse_named_i64_arg(args, "max");
+    if min.is_none() && max.is_none() {
+        None
+    } else {
+        Some((min, max))
+    }
+}
+
+fn find_annotation_args<'a>(src: &'a str, names: &[&str]) -> Option<&'a str> {
+    for name in names {
+        let mut search = 0usize;
+        while let Some(found_rel) = src[search..].find(name) {
+            let found = search + found_rel;
+            let after_name = found + name.len();
+            if !annotation_name_boundary(src, found, after_name) {
+                search = after_name;
+                continue;
+            }
+            let rest = &src[after_name..];
+            let Some(paren_rel) = rest.find('(') else {
+                search = after_name;
+                continue;
+            };
+            if !rest[..paren_rel].trim().is_empty() {
+                search = after_name;
+                continue;
+            }
+            let open = after_name + paren_rel;
+            let close = matching_brace_like(&src[open..], '(', ')').map(|idx| open + idx)?;
+            return Some(&src[open + 1..close]);
         }
     }
     None
+}
+
+fn has_marker_annotation(src: &str, names: &[&str]) -> bool {
+    names.iter().any(|name| {
+        let mut search = 0usize;
+        while let Some(found_rel) = src[search..].find(name) {
+            let found = search + found_rel;
+            let after_name = found + name.len();
+            if annotation_name_boundary(src, found, after_name) {
+                return true;
+            }
+            search = after_name;
+        }
+        false
+    })
+}
+
+fn annotation_name_boundary(src: &str, start: usize, end: usize) -> bool {
+    let before_ok = src[..start]
+        .chars()
+        .next_back()
+        .is_none_or(|ch| !(is_ident_char(ch) || ch == '.'));
+    let after_ok = src[end..]
+        .chars()
+        .next()
+        .is_none_or(|ch| !(is_ident_char(ch) || ch == '.'));
+    before_ok && after_ok
+}
+
+fn parse_annotation_i64_value(args: &str) -> Option<i64> {
+    let trimmed = args.trim();
+    if !trimmed.contains('=') {
+        return parse_i64_literal(trimmed);
+    }
+    parse_named_i64_arg(trimmed, "value")
+}
+
+fn parse_named_i64_arg(args: &str, name: &str) -> Option<i64> {
+    split_args(args).into_iter().find_map(|part| {
+        let (key, value) = part.split_once('=')?;
+        if key.trim() == name {
+            parse_i64_literal(value.trim())
+        } else {
+            None
+        }
+    })
+}
+
+fn parse_i64_literal(raw: &str) -> Option<i64> {
+    raw.trim()
+        .trim_end_matches(['L', 'l'])
+        .replace('_', "")
+        .parse::<i64>()
+        .ok()
+}
+
+fn strip_java_annotations(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut iter = raw.char_indices().peekable();
+    while let Some((idx, ch)) = iter.next() {
+        if ch != '@' {
+            out.push(ch);
+            continue;
+        }
+        while let Some((_, next)) = iter.peek().copied() {
+            if is_ident_char(next) || next == '.' {
+                iter.next();
+            } else {
+                break;
+            }
+        }
+        while let Some((_, next)) = iter.peek().copied() {
+            if next.is_whitespace() {
+                iter.next();
+            } else {
+                break;
+            }
+        }
+        if let Some((_, '(')) = iter.peek().copied() {
+            let mut depth = 0usize;
+            while let Some((_, next)) = iter.next() {
+                match next {
+                    '(' => depth += 1,
+                    ')' => {
+                        depth = depth.saturating_sub(1);
+                        if depth == 0 {
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if idx > 0 && !out.ends_with(' ') {
+            out.push(' ');
+        }
+    }
+    out
 }
 
 fn find_return_expr(body: &str) -> Option<String> {
@@ -1358,6 +1521,33 @@ fn find_return_expr(body: &str) -> Option<String> {
     })
 }
 
+fn constraints_formula_json(
+    var: &str,
+    constraints: &[JavaConstraint],
+) -> Option<serde_json::Value> {
+    let mut operands = Vec::new();
+    for constraint in constraints {
+        match constraint {
+            JavaConstraint::Min(min) => operands.push(min_formula_json(var, *min)),
+            JavaConstraint::Max(max) => operands.push(max_formula_json(var, *max)),
+            JavaConstraint::Size { min, max } => {
+                if let Some(min) = min {
+                    operands.push(size_min_formula_json(var, *min));
+                }
+                if let Some(max) = max {
+                    operands.push(size_max_formula_json(var, *max));
+                }
+            }
+            JavaConstraint::NotNull => operands.push(not_null_formula_json(var)),
+        }
+    }
+    match operands.len() {
+        0 => None,
+        1 => operands.pop(),
+        _ => Some(serde_json::json!({"kind": "and", "operands": operands})),
+    }
+}
+
 fn min_formula_json(var: &str, min: i64) -> serde_json::Value {
     serde_json::json!({
         "kind": "atomic",
@@ -1366,6 +1556,55 @@ fn min_formula_json(var: &str, min: i64) -> serde_json::Value {
             {"kind": "var", "name": var},
             {"kind": "const", "sort": {"kind": "primitive", "name": "Int"}, "value": min}
         ]
+    })
+}
+
+fn max_formula_json(var: &str, max: i64) -> serde_json::Value {
+    serde_json::json!({
+        "kind": "atomic",
+        "name": "≤",
+        "args": [
+            {"kind": "var", "name": var},
+            {"kind": "const", "sort": {"kind": "primitive", "name": "Int"}, "value": max}
+        ]
+    })
+}
+
+fn size_min_formula_json(var: &str, min: i64) -> serde_json::Value {
+    serde_json::json!({
+        "kind": "atomic",
+        "name": "≥",
+        "args": [
+            length_term_json(var),
+            {"kind": "const", "sort": {"kind": "primitive", "name": "Int"}, "value": min}
+        ]
+    })
+}
+
+fn size_max_formula_json(var: &str, max: i64) -> serde_json::Value {
+    serde_json::json!({
+        "kind": "atomic",
+        "name": "≤",
+        "args": [
+            length_term_json(var),
+            {"kind": "const", "sort": {"kind": "primitive", "name": "Int"}, "value": max}
+        ]
+    })
+}
+
+fn length_term_json(var: &str) -> serde_json::Value {
+    serde_json::json!({
+        "kind": "ctor",
+        "name": "length",
+        "args": [{"kind": "var", "name": var}]
+    })
+}
+
+fn not_null_formula_json(var: &str) -> serde_json::Value {
+    serde_json::json!({
+        "kind": "atomic",
+        "name": "not-null",
+        "args": [{"kind": "var", "name": var}]
     })
 }
 

--- a/implementations/rust/sugar-lift-java-tests/tests/java_implication_edge.rs
+++ b/implementations/rust/sugar-lift-java-tests/tests/java_implication_edge.rs
@@ -51,10 +51,135 @@ public final class Chain {
 }
 "#;
 
+const BROAD_GOOD_CHAIN: &str = r#"
+package demo;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public final class Chain {
+    @Max(10)
+    static int maxProducer() {
+        return 6;
+    }
+
+    static int maxConsumer(@Max(10) int value) {
+        return value;
+    }
+
+    @Size(min = 1, max = 5)
+    static String sizeProducer() {
+        return "abc";
+    }
+
+    static int sizeConsumer(@Size(min = 1, max = 5) String value) {
+        return value.length();
+    }
+
+    @NotNull
+    static String notNullProducer() {
+        return "value";
+    }
+
+    static int notNullConsumer(@NotNull String value) {
+        return value.length();
+    }
+
+    @Min(0)
+    @Max(10)
+    static int rangeProducer() {
+        return 6;
+    }
+
+    static int rangeConsumer(@Min(0) @Max(10) int value) {
+        return value;
+    }
+}
+"#;
+
+const BROAD_BAD_CHAIN: &str = r#"
+package demo;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public final class Chain {
+    @Max(100)
+    static int maxProducer() {
+        return 50;
+    }
+
+    static int maxConsumer(@Max(10) int value) {
+        return value;
+    }
+
+    @Size(min = 0, max = 100)
+    static String sizeProducer() {
+        return "too-long-value";
+    }
+
+    static int sizeConsumer(@Size(min = 0, max = 10) String value) {
+        return value.length();
+    }
+
+    static String nullableProducer() {
+        return null;
+    }
+
+    static int notNullConsumer(@NotNull String value) {
+        return value.length();
+    }
+
+    @Min(0)
+    @Max(100)
+    static int rangeProducer() {
+        return 5;
+    }
+
+    static int rangeConsumer(@Min(10) @Max(90) int value) {
+        return value;
+    }
+}
+"#;
+
 fn find_contract<'a>(ir: &'a [serde_json::Value], name: &str) -> &'a serde_json::Value {
     ir.iter()
         .find(|entry| entry["kind"] == "function-contract" && entry["name"] == name)
         .unwrap_or_else(|| panic!("missing function-contract {name}: {ir:#?}"))
+}
+
+fn maybe_contract<'a>(ir: &'a [serde_json::Value], name: &str) -> Option<&'a serde_json::Value> {
+    ir.iter()
+        .find(|entry| entry["kind"] == "function-contract" && entry["name"] == name)
+}
+
+fn atomic_names(formula: &serde_json::Value, out: &mut Vec<String>) {
+    match formula["kind"].as_str() {
+        Some("atomic") => {
+            if let Some(name) = formula["name"].as_str() {
+                out.push(name.to_string());
+            }
+        }
+        Some("and") => {
+            for operand in formula["operands"].as_array().into_iter().flatten() {
+                atomic_names(operand, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn assert_has_atomic(formula: &serde_json::Value, name: &str) {
+    let mut names = Vec::new();
+    atomic_names(formula, &mut names);
+    assert!(
+        names.iter().any(|candidate| candidate == name),
+        "expected formula to contain atomic `{name}`, saw {names:?}: {formula:#?}"
+    );
 }
 
 #[test]
@@ -88,6 +213,90 @@ fn jsr380_min_contracts_lift_return_post_and_param_pre() {
         weakened_producer["post"]["args"][1]["value"], -5,
         "weakening the producer post must be visible to the post|=pre edge"
     );
+}
+
+#[test]
+fn jsr380_breadth_lifts_max_size_notnull_and_combined_range() {
+    let good =
+        lift_java_jsr380_contracts_from_source(BROAD_GOOD_CHAIN, "src/main/java/demo/Chain.java")
+            .expect("lift good broad contracts");
+    assert!(good.diagnostics.is_empty(), "{:#?}", good.diagnostics);
+
+    let max_producer = find_contract(&good.ir, "maxProducer");
+    assert_eq!(max_producer["post"]["name"], "≤");
+    assert_eq!(max_producer["post"]["args"][1]["value"], 10);
+    let max_consumer = find_contract(&good.ir, "maxConsumer");
+    assert_eq!(max_consumer["pre"]["name"], "≤");
+    assert_eq!(max_consumer["pre"]["args"][1]["value"], 10);
+
+    let size_producer = find_contract(&good.ir, "sizeProducer");
+    assert_eq!(size_producer["post"]["kind"], "and");
+    assert_has_atomic(&size_producer["post"], "≥");
+    assert_has_atomic(&size_producer["post"], "≤");
+    assert_eq!(
+        size_producer["post"]["operands"][0]["args"][0],
+        json!({"kind": "ctor", "name": "length", "args": [{"kind": "var", "name": "result"}]})
+    );
+    let size_consumer = find_contract(&good.ir, "sizeConsumer");
+    assert_eq!(size_consumer["pre"]["kind"], "and");
+    assert_has_atomic(&size_consumer["pre"], "≥");
+    assert_has_atomic(&size_consumer["pre"], "≤");
+
+    let not_null_producer = find_contract(&good.ir, "notNullProducer");
+    assert_eq!(not_null_producer["post"]["name"], "not-null");
+    let not_null_consumer = find_contract(&good.ir, "notNullConsumer");
+    assert_eq!(not_null_consumer["pre"]["name"], "not-null");
+
+    let range_producer = find_contract(&good.ir, "rangeProducer");
+    assert_eq!(range_producer["post"]["kind"], "and");
+    assert_has_atomic(&range_producer["post"], "≥");
+    assert_has_atomic(&range_producer["post"], "≤");
+    let range_consumer = find_contract(&good.ir, "rangeConsumer");
+    assert_eq!(range_consumer["pre"]["kind"], "and");
+    assert_has_atomic(&range_consumer["pre"], "≥");
+    assert_has_atomic(&range_consumer["pre"], "≤");
+}
+
+#[test]
+fn jsr380_breadth_discrimination_surfaces_weakened_posts_and_nullness_silence() {
+    let bad =
+        lift_java_jsr380_contracts_from_source(BROAD_BAD_CHAIN, "src/main/java/demo/Chain.java")
+            .expect("lift bad broad contracts");
+    assert!(bad.diagnostics.is_empty(), "{:#?}", bad.diagnostics);
+
+    let max_producer = find_contract(&bad.ir, "maxProducer");
+    assert_eq!(
+        max_producer["post"]["args"][1]["value"], 100,
+        "weakened @Max producer post must stay visible to the implication edge"
+    );
+    let max_consumer = find_contract(&bad.ir, "maxConsumer");
+    assert_eq!(max_consumer["pre"]["args"][1]["value"], 10);
+
+    let size_producer = find_contract(&bad.ir, "sizeProducer");
+    assert_eq!(
+        size_producer["post"]["operands"][1]["args"][1]["value"], 100,
+        "weakened @Size max must stay visible to the implication edge"
+    );
+    let size_consumer = find_contract(&bad.ir, "sizeConsumer");
+    assert_eq!(size_consumer["pre"]["operands"][1]["args"][1]["value"], 10);
+
+    assert!(
+        maybe_contract(&bad.ir, "nullableProducer").is_none(),
+        "unannotated return must not manufacture a @NotNull post"
+    );
+    let not_null_consumer = find_contract(&bad.ir, "notNullConsumer");
+    assert_eq!(not_null_consumer["pre"]["name"], "not-null");
+
+    let range_producer = find_contract(&bad.ir, "rangeProducer");
+    assert_eq!(range_producer["post"]["kind"], "and");
+    assert_eq!(range_producer["post"]["operands"][0]["args"][1]["value"], 0);
+    assert_eq!(
+        range_producer["post"]["operands"][1]["args"][1]["value"],
+        100
+    );
+    let range_consumer = find_contract(&bad.ir, "rangeConsumer");
+    assert_eq!(range_consumer["pre"]["operands"][0]["args"][1]["value"], 10);
+    assert_eq!(range_consumer["pre"]["operands"][1]["args"][1]["value"], 90);
 }
 
 #[test]


### PR DESCRIPTION
## Broaden java contract lift: `@Max`/`@Size`/`@NotNull`/`@Min+@Max` range (edge unchanged)

Widen java's JSR-380 contract-source lift beyond `@Min` so the implication edge composes more real java method contracts — toward a real-third-party-java-library capstone. **Pure contract-source broadening:** the implication edge/bridge/verifier machinery (#1989) is **unchanged** (verified — diff touches only the java kit lib + tests + the new example + Makefile; no `sugar-verifier`/`libsugar`/`sugar-walk` edit).

New lifted constraint types (param=pre, return=post), each a checkable predicate the **existing** edge composes as `post ⊨ pre`:
- `@Max(n)` → `x ≤ n`
- `@Size(min,max)` → length in `[min,max]`
- `@NotNull` → presence. **Nullness honesty:** an `@NotNull` return supplies a non-null post; an *un-annotated* return supplies no nullness post and does **not** discharge an `@NotNull` pre → loud-refuse (silence is not non-null).
- `@Min`+`@Max` → range.

### Two-twin showcase `examples/java-contract-breadth` (real java + JUnit witness, both twins compile)
GOOD → `maxConsumer/sizeConsumer/notNullConsumer/rangeConsumer` all discharged + witness discharged. BAD → per-type weakened post (`@Max(100)`vs`@Max(10)`; `@Size(0,100)`vs`@Size(0,10)`; un-annotated vs `@NotNull`; range `[0,100]`vs`[10,90]`) each compiles and fails *only* the semantic edge → all four unsatisfied + witness unsatisfied. RED-first per-type (`java_implication_edge` 4/0).

### Acceptance (verified by me, real exit captured)
- `../../bin/bcargo test --workspace --no-fail-fast` → **2582 passed / 0 failed**.
- `run.sh` exit 0 — I re-ran it: all four good discharged, all four bad flip to unsatisfied, both axes.
- `make ci` PASS; `grep -rn 'concept_name\|conceptName' implementations/` → 0.

Reuse/add: reused the edge/bridge/verifier + JUnit witness unchanged; added only the JSR-380 contract-source lift breadth + tests + showcase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
