### PR TITLE
bitflags 2.6.0 wall logo: 9 exact vendor rows, z3-discharged, CI-gated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,8 @@ SHOWCASE_RUNS = \
 	examples/semver-showcase/run.sh \
 	examples/base64-showcase/run.sh \
 	examples/uuid-showcase/run.sh \
-	examples/itertools-showcase/run.sh
+	examples/itertools-showcase/run.sh \
+	examples/bitflags-showcase/run.sh
 
 .PHONY: test-showcases
 test-showcases:

--- a/examples/bitflags-showcase/.gitignore
+++ b/examples/bitflags-showcase/.gitignore
@@ -1,0 +1,10 @@
+*/.sugar/runs/
+*/.sugar/witnesses/
+*/.sugar/lying-discharge.sh
+*/.sugar/lift/rust-cargo-test-witness/manifest.toml
+*/.sugar/lift/rust-test-assertions/manifest.toml
+*/target/
+*/Cargo.lock
+*/blake3-512:*.proof
+*/.prove*.json
+*/.verify*.json

--- a/examples/bitflags-showcase/bad/.sugar/config.toml
+++ b/examples/bitflags-showcase/bad/.sugar/config.toml
@@ -1,0 +1,26 @@
+[[plugins]]
+name = "rust-test-assertions-lift"
+kind = "lift"
+surface = "rust-test-assertions"
+emit = "ir-document"
+
+[[plugins]]
+name = "rust-cargo-test-witness-lift"
+kind = "lift"
+surface = "rust-cargo-test-witness"
+
+[solvers]
+default = "z3"
+
+[solvers.dispatch]
+linear_arithmetic = "z3"
+default = "z3"
+
+[solvers.z3]
+binary = "z3"
+flags = ["-smt2", "-in"]
+
+[platform_profile]
+language = "rust"
+library = "bitflags"
+version = "2.6.0"

--- a/examples/bitflags-showcase/bad/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
+++ b/examples/bitflags-showcase/bad/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
@@ -1,0 +1,13 @@
+name = "rust-cargo-test-witness-lift"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/witness_rpc"]
+discharge_command = ["@BIN_DIR@/discharge_cli"]
+witness_tool = "cargo-test"
+resolve_witness_command = ["@BIN_DIR@/witness_rpc"]
+resolve_witness_method = "sugar.plugin.resolve_witness"
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["rust-cargo-test-witness"]

--- a/examples/bitflags-showcase/bad/.sugar/lift/rust-test-assertions/manifest.toml.in
+++ b/examples/bitflags-showcase/bad/.sugar/lift/rust-test-assertions/manifest.toml.in
@@ -1,0 +1,11 @@
+name = "rust-test-assertions-lift"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/rust_test_assertions_rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["rust-test-assertions"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false

--- a/examples/bitflags-showcase/bad/Cargo.toml
+++ b/examples/bitflags-showcase/bad/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "bitflags-showcase-bad"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+[dependencies]
+bitflags = "=2.6.0"

--- a/examples/bitflags-showcase/bad/src/lib.rs
+++ b/examples/bitflags-showcase/bad/src/lib.rs
@@ -1,0 +1,23 @@
+use bitflags::bitflags;
+
+bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct Flags: u32 {
+        const A = 1;
+        const B = 2;
+        const C = 4;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Flags;
+
+    #[test]
+    fn test_union_bits_ab_contradiction() {
+        // Negative control derived from bitflags 2.6.0 doc-example for union.
+        // The real result is 3 but we also assert 7, which is a contradiction.
+        assert_eq!((Flags::A | Flags::B).bits(), 3);
+        assert_eq!((Flags::A | Flags::B).bits(), 7);
+    }
+}

--- a/examples/bitflags-showcase/good/.sugar/config.toml
+++ b/examples/bitflags-showcase/good/.sugar/config.toml
@@ -1,0 +1,26 @@
+[[plugins]]
+name = "rust-test-assertions-lift"
+kind = "lift"
+surface = "rust-test-assertions"
+emit = "ir-document"
+
+[[plugins]]
+name = "rust-cargo-test-witness-lift"
+kind = "lift"
+surface = "rust-cargo-test-witness"
+
+[solvers]
+default = "z3"
+
+[solvers.dispatch]
+linear_arithmetic = "z3"
+default = "z3"
+
+[solvers.z3]
+binary = "z3"
+flags = ["-smt2", "-in"]
+
+[platform_profile]
+language = "rust"
+library = "bitflags"
+version = "2.6.0"

--- a/examples/bitflags-showcase/good/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
+++ b/examples/bitflags-showcase/good/.sugar/lift/rust-cargo-test-witness/manifest.toml.in
@@ -1,0 +1,13 @@
+name = "rust-cargo-test-witness-lift"
+version = "0.1.0-draft"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/witness_rpc"]
+discharge_command = ["@BIN_DIR@/discharge_cli"]
+witness_tool = "cargo-test"
+resolve_witness_command = ["@BIN_DIR@/witness_rpc"]
+resolve_witness_method = "sugar.plugin.resolve_witness"
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["rust-cargo-test-witness"]

--- a/examples/bitflags-showcase/good/.sugar/lift/rust-test-assertions/manifest.toml.in
+++ b/examples/bitflags-showcase/good/.sugar/lift/rust-test-assertions/manifest.toml.in
@@ -1,0 +1,11 @@
+name = "rust-test-assertions-lift"
+version = "0.1.0"
+protocol_version = "pep/1.7.0"
+kind = "lift"
+command = ["@BIN_DIR@/rust_test_assertions_rpc"]
+working_dir = "."
+
+[capabilities]
+authoring_surfaces = ["rust-test-assertions"]
+ir_version = "v1.1.0"
+emits_signed_mementos = false

--- a/examples/bitflags-showcase/good/Cargo.toml
+++ b/examples/bitflags-showcase/good/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "bitflags-showcase-good"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+[dependencies]
+bitflags = "=2.6.0"

--- a/examples/bitflags-showcase/good/src/lib.rs
+++ b/examples/bitflags-showcase/good/src/lib.rs
@@ -1,0 +1,78 @@
+use bitflags::bitflags;
+
+bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct Flags: u32 {
+        const A = 1;
+        const B = 2;
+        const C = 4;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Flags;
+
+    #[test]
+    fn test_union_bits_ab_exact_row() {
+        // Vendor source: bitflags 2.6.0 doc-example for union.
+        // A | B has bits() == 1 | 2 == 3.
+        assert_eq!((Flags::A | Flags::B).bits(), 3);
+    }
+
+    #[test]
+    fn test_contains_a_in_ab_exact_row() {
+        // Vendor source: bitflags 2.6.0 doc-example for contains.
+        // A | B contains A.
+        assert!((Flags::A | Flags::B).contains(Flags::A));
+    }
+
+    #[test]
+    fn test_intersection_a_b_empty_exact_row() {
+        // Vendor source: bitflags 2.6.0 doc-example for intersection.
+        // A intersected with B has no bits in common.
+        assert!(Flags::A.intersection(Flags::B).is_empty());
+    }
+
+    #[test]
+    fn test_intersection_ab_a_bits_exact_row() {
+        // Vendor source: bitflags 2.6.0 doc-example for intersection.
+        // (A | B) intersected with A has bits() == 1.
+        assert_eq!((Flags::A | Flags::B).intersection(Flags::A).bits(), 1);
+    }
+
+    #[test]
+    fn test_empty_is_empty_exact_row() {
+        // Vendor source: bitflags 2.6.0 doc-example for empty.
+        // Flags::empty() has no bits set.
+        assert!(Flags::empty().is_empty());
+    }
+
+    #[test]
+    fn test_contains_b_in_abc_exact_row() {
+        // Vendor source: bitflags 2.6.0 doc-example for contains.
+        // A | B | C contains B.
+        assert!((Flags::A | Flags::B | Flags::C).contains(Flags::B));
+    }
+
+    #[test]
+    fn test_union_method_bits_ab_exact_row() {
+        // Vendor source: bitflags 2.6.0 doc-example for union method.
+        // A.union(B).bits() == 3.
+        assert_eq!(Flags::A.union(Flags::B).bits(), 3);
+    }
+
+    #[test]
+    fn test_all_contains_c_exact_row() {
+        // Vendor source: bitflags 2.6.0 doc-example for all.
+        // Flags::all() contains every defined flag, including C.
+        assert!(Flags::all().contains(Flags::C));
+    }
+
+    #[test]
+    fn test_abc_bits_exact_row() {
+        // Vendor source: bitflags 2.6.0 bit value of A|B|C.
+        // A=1, B=2, C=4: combined bits() == 7.
+        assert_eq!((Flags::A | Flags::B | Flags::C).bits(), 7);
+    }
+}

--- a/examples/bitflags-showcase/run.sh
+++ b/examples/bitflags-showcase/run.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# bitflags 2.6.0 showcase: real vendor rows lifted as Rust assertion
+# consistency contracts and witnessed by re-running cargo test.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+RUST="$REPO/implementations/rust"
+BIN_DIR="$RUST/target/debug"
+SUGAR="$BIN_DIR/sugar"
+
+echo "SCOPE: bitflags 2.6.0 exact vendor rows from bitflags tests and doc-examples."
+echo "SCOPE: GOOD claims are point-wise exact contains/bits/intersection/union/is_empty rows; BAD is a contradiction twin."
+echo "SCOPE: residuals = formatting rows, serde feature-gated rows, from_bits_truncate edge rows, named/unnamed flag rows."
+
+echo "== build the CLI + Rust assertion and cargo-test witness lifters =="
+cargo build --manifest-path "$RUST/Cargo.toml" \
+  -p sugar-cli --bin sugar \
+  -p sugar-lift-rust-tests --bin rust_test_assertions_rpc \
+  -p sugar-lift-rust-cargo-test-witness --bin witness_rpc \
+  -p sugar-lift-rust-cargo-test-witness --bin discharge_cli >/dev/null
+
+[ -x "$SUGAR" ] || { echo "FAIL: sugar binary not built at $SUGAR"; exit 1; }
+[ -x "$BIN_DIR/rust_test_assertions_rpc" ] || { echo "FAIL: rust_test_assertions_rpc not built"; exit 1; }
+[ -x "$BIN_DIR/witness_rpc" ] || { echo "FAIL: witness_rpc not built"; exit 1; }
+[ -x "$BIN_DIR/discharge_cli" ] || { echo "FAIL: discharge_cli not built"; exit 1; }
+
+for suite in good bad; do
+  for surface in rust-cargo-test-witness rust-test-assertions; do
+    mfin="$HERE/$suite/.sugar/lift/$surface/manifest.toml.in"
+    mf="$HERE/$suite/.sugar/lift/$surface/manifest.toml"
+    sed "s#@BIN_DIR@#$BIN_DIR#g" "$mfin" > "$mf"
+  done
+  for p in "$HERE/$suite"/blake3-512:*.proof; do [ -e "$p" ] && rm -f "$p"; done
+  rm -rf "$HERE/$suite/.sugar/runs" "$HERE/$suite/.sugar/witnesses" "$HERE/$suite/target" 2>/dev/null || true
+  rm -f "$HERE/$suite"/.prove*.json "$HERE/$suite"/.verify*.json "$HERE/$suite/Cargo.lock" 2>/dev/null || true
+done
+
+pyget() { python3 -c "import sys,json; d=json.load(open(sys.argv[1])); print($2)" "$1"; }
+
+write_lying_discharge() {
+  local script="$1"
+  cat > "$script" <<'SH'
+#!/usr/bin/env sh
+echo '{"verdict":"DISCHARGED","reason":"lying discharge regression"}'
+SH
+  chmod +x "$script"
+}
+
+run_suite() {
+  local suite="$1" expect_consistency="$2" expect_witness="$3"
+  local dir="$HERE/$suite"
+  echo
+  echo "==================== suite: $suite ===================="
+
+  echo "-- mint: lift Rust assertions and cargo-test witness package --"
+  ( cd "$dir" && "$SUGAR" mint --out . ) >/dev/null
+
+  local have_proof=0
+  for p in "$dir"/blake3-512:*.proof; do [ -e "$p" ] && have_proof=1; done
+  [ "$have_proof" = 1 ] || { echo "FAIL[$suite]: mint produced no .proof"; exit 1; }
+
+  echo "-- prove: consistency rows plus witness-package row --"
+  local prove_json="$dir/.prove.json"
+  ( cd "$dir" && "$SUGAR" prove . --json ) > "$prove_json" 2>/dev/null || true
+
+  local consistency_status witness_status
+  consistency_status="$(pyget "$prove_json" "
+','.join([r.get('status') for r in d.get('rows', []) if (r.get('property', '') or '').startswith('consistency:') and 'witness-package' not in (r.get('property', '') or '')]) or 'MISSING'
+")"
+  witness_status="$(pyget "$prove_json" "
+next((r.get('status') for r in d.get('rows', []) if 'witness-package' in (r.get('property', '') or '')), 'MISSING')
+")"
+  echo "   prove consistency statuses: $consistency_status"
+  echo "   prove witness-package status: $witness_status"
+
+  if [ "$expect_consistency" = "DISCHARGE" ]; then
+    echo "$consistency_status" | grep -qv 'unsatisfied' || { echo "FAIL[$suite]: expected consistency discharge, got $consistency_status"; exit 1; }
+  else
+    echo "$consistency_status" | grep -q 'unsatisfied' || { echo "FAIL[$suite]: expected consistency refusal, got $consistency_status"; exit 1; }
+  fi
+
+  if [ "$expect_witness" = "DISCHARGE" ]; then
+    [ "$witness_status" = "discharged" ] || { echo "FAIL[$suite]: expected witness discharge, got $witness_status"; exit 1; }
+  else
+    if [ "$witness_status" = "discharged" ] || [ "$witness_status" = "MISSING" ]; then
+      echo "FAIL[$suite]: expected witness refusal, got $witness_status"
+      exit 1
+    fi
+    echo "-- prove (LYING DISCHARGE): stdout says DISCHARGED, package body still has a failed outcome --"
+    local lie="$dir/.sugar/lying-discharge.sh"
+    write_lying_discharge "$lie"
+    local lie_json="$dir/.prove_lie.json"
+    ( cd "$dir" && SUGAR_WITNESS_DISCHARGE_CARGO_TEST="$lie" "$SUGAR" prove . --json ) > "$lie_json" 2>/dev/null || true
+    local lie_status
+    lie_status="$(pyget "$lie_json" "
+next((r.get('status') for r in d.get('rows', []) if 'witness-package' in (r.get('property', '') or '')), 'MISSING')
+")"
+    echo "   lying-discharge witness-package status: $lie_status"
+    if [ "$lie_status" = "discharged" ]; then
+      echo "FAIL[$suite]: lying discharge stdout flipped a failing witness package"
+      exit 1
+    fi
+  fi
+
+  echo "-- verify durable artifact --"
+  local verify_json="$dir/.verify.json"
+  ( cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json ) > "$verify_json" 2>/dev/null || true
+  python3 - "$suite" "$expect_consistency" "$expect_witness" "$verify_json" <<'PY'
+import json
+import sys
+
+suite, expect_consistency, expect_witness, path = sys.argv[1:]
+receipt = json.load(open(path, encoding="utf-8"))
+rows = receipt.get("rows", [])
+consistency = [
+    r.get("status")
+    for r in rows
+    if (r.get("property") or "").startswith("consistency:")
+    and "witness-package" not in (r.get("property") or "")
+]
+witness = [
+    r.get("status")
+    for r in rows
+    if "witness-package" in (r.get("property") or "")
+]
+if not consistency:
+    raise SystemExit(f"FAIL[{suite}]: durable verify has no consistency rows")
+if expect_consistency == "DISCHARGE":
+    if any(status != "discharged" for status in consistency):
+        raise SystemExit(f"FAIL[{suite}]: durable consistency statuses {consistency}")
+else:
+    if "unsatisfied" not in consistency:
+        raise SystemExit(f"FAIL[{suite}]: durable consistency statuses {consistency}")
+if expect_witness == "DISCHARGE":
+    if witness != ["discharged"]:
+        raise SystemExit(f"FAIL[{suite}]: durable witness statuses {witness}")
+else:
+    if witness == ["discharged"] or not witness:
+        raise SystemExit(f"FAIL[{suite}]: durable witness statuses {witness}")
+verified = any(
+    w.get("verdict") == "verified"
+    for w in receipt.get("witnessDimension", {}).get("witnesses", [])
+)
+if not verified:
+    raise SystemExit(f"FAIL[{suite}]: witness dimension did not verify")
+print(f"   durable consistency statuses: {','.join(consistency)}")
+print(f"   durable witness statuses: {','.join(witness)}")
+print("   durable witness dimension: verified")
+PY
+}
+
+run_suite good DISCHARGE DISCHARGE
+run_suite bad REFUSE REFUSE
+
+echo
+echo "== bitflags 2.6.0 showcase: PASS =="


### PR DESCRIPTION
## Summary

- Adds `examples/bitflags-showcase/` to the correctness wall: `bitflags = "=2.6.0"` pinned exactly.
- 9 GOOD rows covering `contains`, `bits`, `intersection`, `union`, `is_empty`, and `all()` semantics lifted directly from bitflags vendor doc-examples; every row is a real `assert!` or `assert_eq!` over pure flag algebra.
- BAD twin asserts `(Flags::A | Flags::B).bits() == 3` AND `== 7` in the same lifted set; z3 sees UNSAT.
- Lying-discharge gate confirmed: bad suite witness-package stays `unsatisfied` even when stdout claims `DISCHARGED`.
- Wires `examples/bitflags-showcase/run.sh` into `SHOWCASE_RUNS` in the Makefile.
- Zero lifter changes.

## Verified run output

```
==================== suite: good ====================
   prove consistency statuses: discharged,discharged,discharged,discharged,discharged,discharged,discharged,discharged,discharged
   prove witness-package status: discharged
   durable consistency statuses: discharged,discharged,discharged,discharged,discharged,discharged,discharged,discharged,discharged
   durable witness statuses: discharged
   durable witness dimension: verified

==================== suite: bad ====================
   prove consistency statuses: unsatisfied
   prove witness-package status: unsatisfied
   lying-discharge witness-package status: unsatisfied
   durable consistency statuses: unsatisfied
   durable witness statuses: unsatisfied
   durable witness dimension: verified

== bitflags 2.6.0 showcase: PASS ==
```

## Test plan

- [ ] `bash examples/bitflags-showcase/run.sh` exits 0 on Linux CI
- [ ] `cargo test` in `good/` exits 0 (9 tests pass)
- [ ] `cargo test` in `bad/` exits non-zero (contradiction fails at runtime)
- [ ] `cargo fmt --check` passes in both crates
- [ ] No em-dashes or en-dashes anywhere in the new files

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new bitflags library example showcase demonstrating correct and incorrect flag usage patterns.

* **Tests**
  * Included automated test suite validating bitflags operations (union, containment, intersection, bit patterns).

* **Chores**
  * Added configuration and build automation for the new showcase example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->