### PR TITLE
Construct chunked-reader WithSugar exit contracts

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/keyword_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/keyword_call_sugar.py
@@ -253,9 +253,27 @@ class KeywordCallSugar(
                 term_args.append(
                     ctor("kw", [str_const(name), value.to_term(owner=str(self.site))])
                 )
+            target = self.import_target or self.target_name
+            exit_suppression = (
+                _static_exit_suppression_contract(
+                    self.import_target, (*pos_values, *(v for _, v in kw_pairs))
+                )
+                if self.import_target is not None
+                else None
+            )
+            if exit_suppression is None:
+                # Chunked pandas readers are TextFileReader: digged __exit__
+                # never suppresses. Only constant truthy chunksize/iterator
+                # prove the reader face; unknown kwargs stay undecidable.
+                exit_suppression = _chunked_pandas_reader_exit_contract(
+                    target, kw_pairs
+                )
+            receiver_floor = (
+                pos_values[0] if self.receiver is not None and pos_values else None
+            )
             return Complete(
                 CallSiteValue(
-                    target_name=self.import_target or self.target_name,
+                    target_name=target,
                     arg_values=pos_values,
                     parameters=tuple(n for n, _ in kw_pairs),
                     term=ctor(
@@ -269,12 +287,12 @@ class KeywordCallSugar(
                     ),
                     body=None,
                     site=self.site,
-                    exit_suppression=(
-                        _static_exit_suppression_contract(
-                            self.import_target, (*pos_values, *(v for _, v in kw_pairs))
-                        )
-                        if self.import_target is not None
-                        else None
+                    exit_suppression=exit_suppression,
+                    # Mirror MethodCallSugar: the receiver's runtime type
+                    # selects the method result / manager face. Exact imported
+                    # free functions leave this absent.
+                    runtime_dispatch_receiver=(
+                        receiver_floor if self.import_target is None else None
                     ),
                 )
             )
@@ -296,3 +314,42 @@ class KeywordCallSugar(
 
 def _pandas_option_callback_binding(key: str) -> str:
     return f"__sugar_pandas_option_callback__:{key}"
+
+
+def _chunked_pandas_reader_exit_contract(
+    target_name: str, kw_pairs: tuple[tuple[str, object], ...]
+):
+    """Dig TextFileReader's non-suppressing ``__exit__`` for chunked CSV reads.
+
+    ``pandas.read_csv`` / ``read_table`` (and method spellings) return a
+    ``TextFileReader`` when ``chunksize`` is a non-zero constant or
+    ``iterator`` is literally true. That class's digged ``__exit__`` only
+    closes the handle and cannot return truthy, so exceptional bodies
+    propagate. Missing install source or non-constant kwargs stay ``None``.
+    """
+    base = target_name.rsplit(".", 1)[-1]
+    if base not in {"read_csv", "read_table"}:
+        return None
+    if not _kwargs_prove_chunked_reader(kw_pairs):
+        return None
+    from sugar_lift_py_tests.sugar.install_source_dig import resolve_class_exit_contract
+
+    return resolve_class_exit_contract("pandas.io.parsers.readers.TextFileReader")
+
+
+def _kwargs_prove_chunked_reader(kw_pairs: tuple[tuple[str, object], ...]) -> bool:
+    """True only when kwargs lift-time-prove a TextFileReader return face."""
+    from sugar_lift_py_tests.floor import TermValue
+
+    for name, value in kw_pairs:
+        if name == "chunksize":
+            if isinstance(value, TermValue) and bool(value.value):
+                return True
+        elif name == "iterator":
+            if isinstance(value, TermValue) and value.value is True:
+                return True
+            # TrueBoolLiteralSugar reduces to a TermValue(True) in most paths;
+            # also accept the typed true-literal floor when present.
+            if type(value).__name__ == "TrueBoolLiteralSugar":
+                return True
+    return False

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_callsite_exit_contract.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_callsite_exit_contract.py
@@ -518,6 +518,132 @@ def test_numpy_assert_raises_regex_suppresses_the_exact_exception() -> None:
     assert not payload.effects
 
 
+def test_external_error_raised_issue_representative_completes() -> None:
+    """#5129 locus: pandas/tests/util/test_util.py external_error_raised with-body."""
+    payload = lift_file_payload(
+        "import pandas._testing as tm\n"
+        "def test_external_error_raised():\n"
+        "    with tm.external_error_raised(TypeError):\n"
+        "        raise TypeError('Should not check this error message')\n",
+        "pandas/tests/util/test_util.py",
+    )
+
+    assert not payload.effects
+
+
+def test_guarded_pytest_raises_or_nullcontext_issue_representative_completes() -> None:
+    """#5129 locus: guarded manager choice like style/test_style.py:740."""
+    payload = lift_file_payload(
+        "import contextlib\n"
+        "import pytest\n"
+        "def test_map_subset(slice_):\n"
+        "    if isinstance(slice_, list):\n"
+        "        ctx = pytest.raises(KeyError, match='C')\n"
+        "    else:\n"
+        "        ctx = contextlib.nullcontext()\n"
+        "    with ctx:\n"
+        "        result = 1\n"
+        "    return result\n",
+        "pandas/tests/io/formats/style/test_style.py",
+    )
+
+    assert not any(
+        type(row.effect).__name__ == "ContextManagerExitRuntimeEffect"
+        for row in payload.effects
+    )
+
+
+def test_chunked_read_csv_reader_proves_non_suppressing_exit() -> None:
+    """Keyword chunksize=1 selects TextFileReader whose digged __exit__ propagates."""
+    from sugar_lift_py_tests.sugar.keyword_call_sugar import (
+        _chunked_pandas_reader_exit_contract,
+    )
+
+    contract = _chunked_pandas_reader_exit_contract(
+        "read_csv",
+        (("chunksize", TermValue(1)),),
+    )
+    assert contract == ExitSuppressionContract.never_suppresses()
+    assert (
+        _chunked_pandas_reader_exit_contract(
+            "read_csv",
+            (("chunksize", TermValue(0)),),
+        )
+        is None
+    )
+    assert (
+        _chunked_pandas_reader_exit_contract(
+            "project.open",
+            (("chunksize", TermValue(1)),),
+        )
+        is None
+    )
+
+
+def test_chunked_reader_raise_carrying_with_body_propagates() -> None:
+    """#5129 optional mass: with reader from read_csv(..., chunksize=1) + raise."""
+    payload = lift_file_payload(
+        "def test_context_manager(parser, path):\n"
+        "    reader = parser.read_csv(path, chunksize=1)\n"
+        "    try:\n"
+        "        with reader:\n"
+        "            raise AssertionError\n"
+        "    except AssertionError:\n"
+        "        return 1\n",
+        "pandas/tests/io/parser/common/test_file_buffer_url.py",
+    )
+
+    assert not any(
+        "WithSugar" in type(row.effect).__name__
+        or "ContextManagerExit" in type(row.effect).__name__
+        for row in payload.effects
+    )
+
+
+def test_keyword_method_call_sets_runtime_dispatch_receiver() -> None:
+    """Keyword method calls carry the receiver for sealed runtime manager exit."""
+    from dataclasses import replace
+
+    from sugar_lift_py_tests.claim import SugarRole
+    from sugar_lift_py_tests.context import FactoryBuildContext
+    from sugar_lift_py_tests.factory import SourceFragment
+    from sugar_lift_py_tests.factory.build import build_node, default_catalog
+    from sugar_lift_py_tests.ir import make_var
+
+    call = (
+        SourceFragment.from_source("parser.read_csv(path, chunksize=1)\n", "t.py")
+        .statements()[0]
+        .statements()[0]
+        .expr_value()
+    )
+    ctx = FactoryBuildContext(filename="t.py", catalog=default_catalog())
+    temporal = ctx.temporal.bind_value(
+        "parser", SymbolicValue(make_var("parser"))
+    ).bind_value("path", SymbolicValue(make_var("path")))
+    ctx = replace(ctx, temporal=temporal)
+    outcome = build_node(
+        call, filename="t.py", role=SugarRole.TERM, ctx=ctx
+    ).sugar.desugar(ctx)
+    manager = outcome.value
+    assert isinstance(manager, CallSiteValue)
+    assert manager.runtime_dispatch_receiver is not None
+    assert manager.exit_suppression == ExitSuppressionContract.never_suppresses()
+
+
+def test_symbolic_chunksize_does_not_invent_reader_exit_contract() -> None:
+    from sugar_lift_py_tests.sugar.keyword_call_sugar import (
+        _chunked_pandas_reader_exit_contract,
+    )
+
+    assert (
+        _chunked_pandas_reader_exit_contract(
+            "read_csv",
+            (("chunksize", SymbolicValue(make_var("n"))),),
+        )
+        is None
+    )
+
+
 @pytest.mark.parametrize(
     ("coordinate", "exception_name"),
     (


### PR DESCRIPTION
## Summary

Part of #5129

Constructs remaining lift-time-decidable `WithSugar` context-manager faces after #5146:

- **Keyword method calls** (`parser.read_csv(path, chunksize=1)`) now set `runtime_dispatch_receiver` (mirrors `MethodCallSugar`) so sealed `ContextManagerExitRuntimeEffect` is available when dig fails.
- **Chunked pandas readers**: when `read_csv` / `read_table` kwargs prove a constant truthy `chunksize` or literal `iterator=True`, dig `pandas.io.parsers.readers.TextFileReader.__exit__` and attach its non-suppressing exit contract. Raise-carrying `with reader:` bodies therefore propagate (correct: `__exit__` only closes).
- **Issue representatives** pinned as focused regression tests (both already completed by #5146; kept green).

Hard law: no RuntimeEffect for ground values; no empty success; symbolic `chunksize` does not invent a contract; unresolved managers stay loud.

**DO NOT MERGE** — issue lane is non-closing / do-not-merge.

## Predicted Epsilon R

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `WithSugar` panic terminals | −1 (optional mass) | `test_file_buffer_url.py` retires FromSugar panic |
| issue verified-live (2) | 0 (already 0 post-#5146) | pins only |
| `silent` | 0 | floor |
| typed RuntimeEffect constructors | 0 | existing sealed door only |

## Receipts

Bounded named representatives (current main + this commit, pandas installed):

| File | Before (issue / #5146 note) | After |
| --- | --- | --- |
| `pandas/tests/util/test_util.py` | WithSugar raise-carrying / completed #5146 | **COMPLETED** facts=6 effects=0 |
| `pandas/tests/io/formats/style/test_style.py` | GuardedValue / completed #5146 | **COMPLETED** facts=295 effects=89 (no WithSugar) |
| `pandas/tests/io/parser/common/test_file_buffer_url.py:418` | WithSugar raise-carrying | **COMPLETED** facts=19 effects=2 (ConditionalExpression only) |
| `pandas/tests/io/excel/test_xlrd.py` | advanced past WithSugar | still advanced (now `CallSiteValue.append_with`) |

`silent=0`. Discrimination: constant `chunksize=1` constructs never-suppresses; `chunksize=0` / symbolic / non-reader names stay `None`.

## Test plan

```bash
cd implementations/python/sugar-lift-py-tests
python -m pip install -e '.[test]' pandas numpy
PYTHONPATH=src:tests python -c 'import test_with_callsite_exit_contract as t; ...'
# focused pins exercised:
# - test_external_error_raised_issue_representative_completes
# - test_guarded_pytest_raises_or_nullcontext_issue_representative_completes
# - test_chunked_read_csv_reader_proves_non_suppressing_exit
# - test_chunked_reader_raise_carrying_with_body_propagates
# - test_keyword_method_call_sets_runtime_dispatch_receiver
# - test_symbolic_chunksize_does_not_invent_reader_exit_contract
# - existing with-callsite exit suite subset (guarded enter, static contracts, unproven loud)
python -m black --check src/sugar_lift_py_tests/sugar/keyword_call_sugar.py tests/test_with_callsite_exit_contract.py
```

## Floors preserved

- Unknown / unproven exit contracts still FactoryPanic
- Symbolic chunksize does not invent TextFileReader
- No ground-value RuntimeEffect; no quiet None arm
- No tests deleted for green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add chunked-reader exit contracts for pandas `read_csv`/`read_table` with-sugar calls
> - Adds `_chunked_pandas_reader_exit_contract` to [keyword_call_sugar.py](https://github.com/TSavo/sugar/pull/5161/files#diff-11c795578a06fd054e82f0e3d2af907f0778351634671889f77674d19cd3aca2) which resolves a `never_suppresses()` exit contract for `read_csv`/`read_table` calls when kwargs prove a chunked reader at lift time (constant truthy `chunksize` or `iterator=True`).
> - Adds `_kwargs_prove_chunked_reader` to inspect kw_pairs and determine if the return type is provably a `TextFileReader`.
> - Updates `KeywordCallSugar._collect_kwargs` to attach the computed exit contract and a `runtime_dispatch_receiver` to the returned `CallSiteValue` for method calls.
> - Adds six tests in [test_with_callsite_exit_contract.py](https://github.com/TSavo/sugar/pull/5161/files#diff-2b83f4f9746739fcd0dcabbc232e3df86ee8d6857f14d9996620a053ef3e0b95) covering proven/symbolic chunksize, method receiver population, and exception propagation through with-bodies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b859f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->