### PR TITLE
Authenticate NumPy dtype itemsize universe

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -63,7 +63,10 @@ class CalleeUniverseRecognition:
         if receiver is not None:
             if not site.source:
                 return None
-            return cls._method_coordinate(site, receiver)
+            method_coordinate = cls._method_coordinate(site, receiver)
+            if method_coordinate is not None:
+                return method_coordinate
+            return imported_call_identity(site)
 
         target = site.call_target_name()
         if target is None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -29,6 +29,7 @@ _AUTHENTICATED_COORDINATES = frozenset(
         "type",
         "dtype",
         "all",
+        "numpy.dtype",
         "numpy._core.multiarray.get_handler_name",
         *_CONVERTER_COORDINATES,
     }
@@ -78,6 +79,7 @@ class BuiltinCalleeUniverseSugar(
             _imported_method_coordinate_witness(
                 setup=("import numpy._core._multiarray_tests as mt\n"),
             ),
+            _numpy_dtype_itemsize_witness(),
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
@@ -134,5 +136,22 @@ def _imported_method_coordinate_witness(*, setup: str):
         owner_sugar="BuiltinCalleeUniverseSugar",
         truthful=truthful,
         lying=lying,
+        family="builtin-universe-coordinate",
+    )
+
+
+def _numpy_dtype_itemsize_witness():
+    prefix = (
+        "import numpy as np\n"
+        "\n"
+        "def A():\n"
+        "    return np.dtype(np.int64).itemsize\n"
+        "\n"
+    )
+    return _call_pair(
+        name="numpy_dtype_itemsize_builtin_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=(prefix + "def test_a():\n" + "    assert A() == A()\n"),
+        lying=(prefix + "def test_a():\n" + "    assert A() != A()\n"),
         family="builtin-universe-coordinate",
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
@@ -15,11 +15,13 @@ def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
         "all",
         "numpy._core.multiarray.get_handler_name",
         "numpy._core._multiarray_tests.run_byteorder_converter",
+        "numpy.dtype",
     } <= (BuiltinCalleeUniverseSugar.universe_coordinates)
     assert {
         "all_builtin_universe_coordinate",
         "get_handler_name_builtin_universe_coordinate",
         "conv_builtin_universe_coordinate",
+        "numpy_dtype_itemsize_builtin_universe_coordinate",
     } <= {pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()}
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_universe_coverage_gap.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_universe_coverage_gap.py
@@ -127,6 +127,13 @@ def test_builtin_covered_callee_emits_no_universe_gap() -> None:
             "    def test_converter(self):\n"
             "        assert self.conv(5) == self.conv(5)\n",
         ),
+        (
+            "itemsize",
+            "import numpy as np\n"
+            "def test_itemsize():\n"
+            "    assert np.dtype(np.int64).itemsize "
+            "== np.dtype(np.int64).itemsize\n",
+        ),
     ],
 )
 def test_authenticated_builtin_coordinate_emits_no_universe_gap(
@@ -183,6 +190,26 @@ def test_unwarranted_receiver_converter_stays_unclassified() -> None:
     gaps = _universe_gaps(payload)
     assert len(gaps) == 1
     assert gaps[0].ast_kind == "call:conv"
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "import math as np\n"
+        "def test_itemsize():\n"
+        "    assert np.dtype(1).itemsize == np.dtype(1).itemsize\n",
+        "import numpy as np\n"
+        "np = object()\n"
+        "def test_itemsize():\n"
+        "    assert np.dtype(1).itemsize == np.dtype(1).itemsize\n",
+    ),
+)
+def test_unwarranted_itemsize_receiver_stays_unclassified(source: str) -> None:
+    payload = lift_file_payload(source, "unwarranted_itemsize.py")
+
+    gaps = _universe_gaps(payload)
+    assert len(gaps) == 2
+    assert {gap.ast_kind for gap in gaps} == {"call:itemsize"}
 
 
 def test_later_local_rebind_revokes_get_handler_name_warrant() -> None:


### PR DESCRIPTION
Part of #5390

## What changed

- Extend the existing `CalleeUniverseRecognition` seam to authenticate a visible, unshadowed imported-module receiver.
- Admit only the exact `numpy.dtype` coordinate to `BuiltinCalleeUniverseSugar`, delegating construction to the existing `MethodCallSugar` owner.
- Add an `np.dtype(...).itemsize` truthful/lying witness pair.
- Keep `math as np`, reassigned `np`, and other receiver lookalikes unclassified and loud.

This is stacked on #5389 so it reuses that PR’s one recognition seam instead of duplicating it. It will be rebased/retargeted to main after #5389 lands.

## RED / GREEN

- RED: enrollment and authenticated itemsize coverage both failed; the two wrong-receiver twins already stayed unclassified.
- GREEN remote on battleaxe Python 3.12.3: 15 focused tests passed.
- Broader local pure-Python gates: 29 passed; pyright 0 errors.

## Conservation

NumPy shard 0/8 denominator: 51 files / 18 assertion-bearing / 13 completed.

- `call:itemsize`: 2 -> 0
- Aggregate branch `R_factory_walk_unclassified`: 69 after both #5389 and this stacked change
- Classified mass from this PR: exactly 2 rows
- silent: 0
- no cache, RuntimeEffect, blanket inert rule, or empty-success arm

## Pending receipt

The direct remote truthful/lying real-solver witness is pending because battleaxe is refusing additional SSH sessions before pytest starts. Failed/refused transport was not counted as green. Keep draft until that fresh witness runs.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate NumPy dtype itemsize callee coordinates in universe coverage
> - Adds `CalleeUniverseRecognition.coordinate` in [`callee_universe.py`](https://github.com/TSavo/sugar/pull/5395/files#diff-72e9f915afa350390348a1c277d0c2047b26a0182bb4780c57baf73f30fdcaa8) to resolve call site callee coordinates using source-aware visibility, handling imports, aliases, receiver attributes, and local shadowing/assignment.
> - Expands `BuiltinCalleeUniverseSugar` in [`builtin_callee_universe_sugar.py`](https://github.com/TSavo/sugar/pull/5395/files#diff-98e9ae8e3cbb10a2e6c95f0bdeca86f0b85002634b901733d0b6070886cdab5f) with authenticated coordinates for `numpy.dtype`, `numpy._core.multiarray.get_handler_name`, and NumPy converter functions, plus new witness generators for each.
> - Renames `_visible_declarations` to `visible_declarations` in [`class_decorator.py`](https://github.com/TSavo/sugar/pull/5395/files#diff-19211378bbb353bf1c344eaaaf0dc61bdc88f8dc26a8174e873452efd8c121eb) and updates `_call_nodes_by_locus` in [`universe_coverage.py`](https://github.com/TSavo/sugar/pull/5395/files#diff-7ebc06dd7d5535234c84a3fde5ff86ed07305340e7a60cd9378f765aed76b7b5) to pass source context when constructing `SourceFragment` instances.
> - Adds tests verifying authenticated coordinates for the new numpy builtins and edge cases (shadowed parameters, unrelated imports, unwarranted itemsize receivers).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e546ec. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->