### PR TITLE
Authenticate fixture registry decorators

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -7,7 +7,7 @@ from enum import Enum, auto
 
 from sugar_lift_python_source.source_tables import locate_parsed_node, parsed_parents
 from sugar_lift_py_tests.recognition.visible_declarations import (
-    declaration_is_function_local,
+    declarations_are_function_local,
     lexical_function_bindings,
     visible_declarations,
 )
@@ -341,9 +341,10 @@ def imported_call_identity(site) -> str | None:
 
     declarations, shadowed_parameters = visible_declarations(site)
     imported: dict[str, tuple[str, bool]] = {}
+    # Keep #5452 tuple form (origin, function_local); batch locality from this PR.
     assigned: dict[str, tuple[str, bool] | None] = {}
-    for declaration in declarations:
-        function_local = declaration_is_function_local(site, declaration)
+    function_locality = declarations_are_function_local(site, declarations)
+    for declaration, function_local in zip(declarations, function_locality):
         if declaration.observed == "ImportFrom":
             module = declaration.importfrom_module()
             if module is not None:
@@ -541,8 +542,9 @@ def _name_reassigned_before(site, name: str) -> bool:
     """True when a preceding statement in the same function stores ``name``."""
 
     declarations, _shadowed = visible_declarations(site)
-    for declaration in declarations:
-        if not declaration_is_function_local(site, declaration):
+    function_locality = declarations_are_function_local(site, declarations)
+    for declaration, function_local in zip(declarations, function_locality):
+        if not function_local:
             continue
         if declaration.observed in {"Import", "ImportFrom"}:
             continue
@@ -604,8 +606,8 @@ def _module_import_origin(site, head: str) -> str | None:
     if head in shadowed:
         return None
     imported: dict[str, tuple[str, bool]] = {}
-    for declaration in declarations:
-        function_local = declaration_is_function_local(site, declaration)
+    function_locality = declarations_are_function_local(site, declarations)
+    for declaration, function_local in zip(declarations, function_locality):
         if declaration.observed == "ImportFrom":
             module = declaration.importfrom_module()
             if module is not None:
@@ -635,13 +637,29 @@ def _source_path(statement):
     source = getattr(statement, "source", None)
     if not source:
         return None
-    parsed = parsed_parents(source)
+    parsed = parsed_parents(source, statement.filename or "<unknown>")
     if parsed is None:
         return None
-    _tree, parents = parsed
-    target = locate_parsed_node(
-        source, type(statement.node), statement.line, statement.col
-    )
+    tree, parents = parsed
+    # Prefer live statement.node when it is already the parse-tree identity
+    # (fixture/class-decorator ancestry reuse); fall back to locate, then walk.
+    if statement.node is tree or statement.node in parents:
+        target = statement.node
+    else:
+        target = locate_parsed_node(
+            source, type(statement.node), statement.line, statement.col
+        )
+        if target is None:
+            target = next(
+                (
+                    node
+                    for node in ast.walk(tree)
+                    if type(node) is type(statement.node)
+                    and getattr(node, "lineno", None) == statement.line
+                    and getattr(node, "col_offset", None) == statement.col
+                ),
+                None,
+            )
     if target is None:
         return None
     path = [target]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import ast
 from enum import Enum, auto
 
-from sugar_lift_python_source.source_tables import locate_parsed_node, parsed_parents
+from sugar_lift_python_source.source_tables import parsed_parents
 from sugar_lift_py_tests.recognition.visible_declarations import (
     declarations_are_function_local,
     lexical_function_bindings,
@@ -641,25 +641,22 @@ def _source_path(statement):
     if parsed is None:
         return None
     tree, parents = parsed
-    # Prefer live statement.node when it is already the parse-tree identity
-    # (fixture/class-decorator ancestry reuse); fall back to locate, then walk.
+    # Prefer live statement.node when it is already this parse-tree identity
+    # (fixture/class-decorator ancestry reuse). Otherwise walk *this* tree —
+    # locate_parsed_node may mint a foreign node not present in ``parents``.
     if statement.node is tree or statement.node in parents:
         target = statement.node
     else:
-        target = locate_parsed_node(
-            source, type(statement.node), statement.line, statement.col
+        target = next(
+            (
+                node
+                for node in ast.walk(tree)
+                if type(node) is type(statement.node)
+                and getattr(node, "lineno", None) == statement.line
+                and getattr(node, "col_offset", None) == statement.col
+            ),
+            None,
         )
-        if target is None:
-            target = next(
-                (
-                    node
-                    for node in ast.walk(tree)
-                    if type(node) is type(statement.node)
-                    and getattr(node, "lineno", None) == statement.line
-                    and getattr(node, "col_offset", None) == statement.col
-                ),
-                None,
-            )
     if target is None:
         return None
     path = [target]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/class_decorator.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/class_decorator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 from typing import TYPE_CHECKING
 
 from sugar_lift_py_tests.recognition.native_shape import (
@@ -67,7 +68,15 @@ def class_decorators_preserve_identity(statement) -> bool:
             return False
         head, separator, tail = dotted.partition(".")
         if head in shadowed_parameters:
-            return False
+            fixture_shape = _fixture_parameter_native_shape(statement, head)
+            if fixture_shape is None or not separator:
+                return False
+            decorator_shape = recognize_native_instance_class_decorator(
+                fixture_shape, tail
+            )
+            if decorator_shape is not NativeShape.CLASS_IDENTITY_DECORATOR:
+                return False
+            continue
         if head in constructed:
             if not separator:
                 return False
@@ -85,6 +94,227 @@ def class_decorators_preserve_identity(statement) -> bool:
         if decorator_shape is not NativeShape.CLASS_IDENTITY_DECORATOR:
             return False
     return True
+
+
+def _fixture_parameter_native_shape(statement, parameter: str) -> NativeShape | None:
+    """Authenticate an injected fixture through its source-declared provider."""
+    from sugar_lift_python_source.source_tables import parsed_parents
+
+    parsed = parsed_parents(getattr(statement, "source", ""))
+    if parsed is None:
+        return None
+    tree, parents = parsed
+    target = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if type(node) is type(statement.node)
+            and getattr(node, "lineno", None) == statement.line
+            and getattr(node, "col_offset", None) == statement.col
+        ),
+        None,
+    )
+    if target is None:
+        return None
+    path = [target]
+    while path[-1] in parents:
+        path.append(parents[path[-1]])
+    function = next(
+        (
+            node
+            for node in path
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ),
+        None,
+    )
+    owner = next((node for node in path[1:] if isinstance(node, ast.ClassDef)), None)
+    if (
+        function is None
+        or owner is None
+        or parameter not in _function_parameter_names(function)
+    ):
+        return None
+
+    imports = _module_imports(tree)
+    local_classes = {
+        node.name: node for node in tree.body if isinstance(node, ast.ClassDef)
+    }
+    from sugar_lift_py_tests.sugar.install_source_dig import (
+        resolve_install_source_class_method,
+    )
+
+    for qualified_base in _qualified_class_bases(
+        owner, imports, local_classes, frozenset()
+    ):
+        provider = resolve_install_source_class_method(qualified_base, parameter)
+        if provider is None:
+            continue
+        shape = _fixture_provider_native_shape(provider)
+        if shape is not None:
+            return shape
+    return None
+
+
+def _fixture_provider_native_shape(provider) -> NativeShape | None:
+    from sugar_lift_python_source.source_oracle import installed_module_source
+
+    module_name = getattr(provider.node, "_sugar_defining_module", None)
+    if not module_name:
+        return None
+    installed = installed_module_source(module_name)
+    if installed is None:
+        return None
+    source, _, _ = installed
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+    imports = _module_imports(tree, module_name)
+    for function in ast.walk(tree):
+        if (
+            not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef))
+            or function.name != provider.function_name()
+            or not _is_authenticated_fixture(function, imports)
+        ):
+            continue
+        constructed: dict[str, NativeShape] = {}
+        for node in ast.walk(function):
+            if isinstance(node, ast.Assign):
+                shape = _ast_call_native_shape(node.value, imports)
+                if shape is None:
+                    continue
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        constructed[target.id] = shape
+            elif isinstance(node, (ast.Yield, ast.Return)):
+                value = node.value
+                if isinstance(value, ast.Name) and value.id in constructed:
+                    return constructed[value.id]
+                shape = _ast_call_native_shape(value, imports)
+                if shape is not None:
+                    return shape
+    return None
+
+
+def _is_authenticated_fixture(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+    imports: dict[str, str],
+) -> bool:
+    return any(
+        _qualified_ast_name(
+            decorator.func if isinstance(decorator, ast.Call) else decorator,
+            imports,
+        )
+        == "sqlalchemy.testing.config.fixture"
+        for decorator in function.decorator_list
+    )
+
+
+def _ast_call_native_shape(
+    node: ast.AST | None, imports: dict[str, str]
+) -> NativeShape | None:
+    if not isinstance(node, ast.Call):
+        return None
+    return recognize_native_call(_qualified_ast_name(node.func, imports))
+
+
+def _qualified_ast_name(node: ast.AST, imports: dict[str, str]) -> str | None:
+    dotted = _ast_dotted_name(node)
+    if dotted is None:
+        return None
+    head, separator, tail = dotted.partition(".")
+    origin = imports.get(head)
+    if origin is None:
+        return None
+    return f"{origin}.{tail}" if separator else origin
+
+
+def _ast_dotted_name(node: ast.AST) -> str | None:
+    parts: list[str] = []
+    cursor = node
+    while isinstance(cursor, ast.Attribute):
+        parts.append(cursor.attr)
+        cursor = cursor.value
+    if not isinstance(cursor, ast.Name):
+        return None
+    parts.append(cursor.id)
+    return ".".join(reversed(parts))
+
+
+def _module_imports(tree: ast.Module, module_name: str | None = None) -> dict[str, str]:
+    imported: dict[str, str] = {}
+    for declaration in tree.body:
+        if isinstance(declaration, ast.Import):
+            for alias in declaration.names:
+                bound = alias.asname or alias.name.split(".", 1)[0]
+                imported[bound] = alias.name if alias.asname else bound
+        elif isinstance(declaration, ast.ImportFrom):
+            module = _absolute_import_module(
+                module_name, declaration.module, declaration.level
+            )
+            if module is None:
+                continue
+            for alias in declaration.names:
+                if alias.name != "*":
+                    imported[alias.asname or alias.name] = f"{module}.{alias.name}"
+    return imported
+
+
+def _absolute_import_module(
+    defining_module: str | None, imported: str | None, level: int
+) -> str | None:
+    if level == 0:
+        return imported
+    if defining_module is None:
+        return None
+    package = defining_module.split(".")[:-1]
+    if level > len(package):
+        return None
+    prefix = package[: len(package) - level + 1]
+    if imported:
+        prefix.extend(imported.split("."))
+    return ".".join(prefix)
+
+
+def _qualified_class_bases(
+    owner: ast.ClassDef,
+    imports: dict[str, str],
+    local_classes: dict[str, ast.ClassDef],
+    resolving: frozenset[str],
+) -> tuple[str, ...]:
+    resolved: list[str] = []
+    for base in owner.bases:
+        dotted = _ast_dotted_name(base)
+        if dotted is None:
+            continue
+        head, separator, tail = dotted.partition(".")
+        origin = imports.get(head)
+        if origin is not None:
+            resolved.append(f"{origin}.{tail}" if separator else origin)
+            continue
+        local = local_classes.get(head) if not separator else None
+        if local is not None and head not in resolving:
+            resolved.extend(
+                _qualified_class_bases(
+                    local,
+                    imports,
+                    local_classes,
+                    resolving | frozenset((head,)),
+                )
+            )
+    return tuple(resolved)
+
+
+def _function_parameter_names(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> frozenset[str]:
+    args = function.args
+    names = [arg.arg for arg in (*args.posonlyargs, *args.args, *args.kwonlyargs)]
+    if args.vararg is not None:
+        names.append(args.vararg.arg)
+    if args.kwarg is not None:
+        names.append(args.kwarg.arg)
+    return frozenset(names)
 
 
 def _constructed_native_shape(declaration, imported) -> NativeShape | None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/class_decorator.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/class_decorator.py
@@ -100,7 +100,9 @@ def _fixture_parameter_native_shape(statement, parameter: str) -> NativeShape | 
     """Authenticate an injected fixture through its source-declared provider."""
     from sugar_lift_python_source.source_tables import parsed_parents
 
-    parsed = parsed_parents(getattr(statement, "source", ""))
+    parsed = parsed_parents(
+        getattr(statement, "source", ""), statement.filename or "<unknown>"
+    )
     if parsed is None:
         return None
     tree, parents = parsed

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/visible_declarations.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/visible_declarations.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import ast
 
 from sugar_lift_python_source.source_tables import (
-    locate_parsed_node,
     parsed_parents,
     source_symtable,
 )
@@ -21,23 +20,22 @@ def visible_declarations(statement):
     if parsed is None:
         return (), frozenset()
     tree, parents = parsed
+    # Prefer live statement.node when it is already this parse-tree identity.
+    # Otherwise walk *this* tree — locate_parsed_node may mint a foreign node
+    # not present in ``parents``, which would collapse ancestry to one frame.
     if statement.node is tree or statement.node in parents:
         target = statement.node
     else:
-        target = locate_parsed_node(
-            source, type(statement.node), statement.line, statement.col
+        target = next(
+            (
+                node
+                for node in ast.walk(tree)
+                if type(node) is type(statement.node)
+                and getattr(node, "lineno", None) == statement.line
+                and getattr(node, "col_offset", None) == statement.col
+            ),
+            None,
         )
-        if target is None:
-            target = next(
-                (
-                    node
-                    for node in ast.walk(tree)
-                    if type(node) is type(statement.node)
-                    and getattr(node, "lineno", None) == statement.line
-                    and getattr(node, "col_offset", None) == statement.col
-                ),
-                None,
-            )
     if target is None:
         return (), frozenset()
     path = [target]
@@ -227,20 +225,16 @@ def _source_path(statement):
     if statement.node is tree or statement.node in parents:
         target = statement.node
     else:
-        target = locate_parsed_node(
-            source, type(statement.node), statement.line, statement.col
+        target = next(
+            (
+                node
+                for node in ast.walk(tree)
+                if type(node) is type(statement.node)
+                and getattr(node, "lineno", None) == statement.line
+                and getattr(node, "col_offset", None) == statement.col
+            ),
+            None,
         )
-        if target is None:
-            target = next(
-                (
-                    node
-                    for node in ast.walk(tree)
-                    if type(node) is type(statement.node)
-                    and getattr(node, "lineno", None) == statement.line
-                    and getattr(node, "col_offset", None) == statement.col
-                ),
-                None,
-            )
     if target is None:
         return None
     path = [target]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/visible_declarations.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/visible_declarations.py
@@ -17,14 +17,27 @@ def visible_declarations(statement):
     source = getattr(statement, "source", None)
     if not source:
         return (), frozenset()
-    parsed = parsed_parents(source)
+    parsed = parsed_parents(source, statement.filename or "<unknown>")
     if parsed is None:
         return (), frozenset()
     tree, parents = parsed
-    del tree
-    target = locate_parsed_node(
-        source, type(statement.node), statement.line, statement.col
-    )
+    if statement.node is tree or statement.node in parents:
+        target = statement.node
+    else:
+        target = locate_parsed_node(
+            source, type(statement.node), statement.line, statement.col
+        )
+        if target is None:
+            target = next(
+                (
+                    node
+                    for node in ast.walk(tree)
+                    if type(node) is type(statement.node)
+                    and getattr(node, "lineno", None) == statement.line
+                    and getattr(node, "col_offset", None) == statement.col
+                ),
+                None,
+            )
     if target is None:
         return (), frozenset()
     path = [target]
@@ -170,15 +183,21 @@ def declaration_is_function_local(statement, declaration) -> bool:
     Nested lambda/comprehension scopes never own outer declarations.
     """
 
+    return declarations_are_function_local(statement, (declaration,))[0]
+
+
+def declarations_are_function_local(statement, declarations) -> tuple[bool, ...]:
+    """Classify a declaration sequence against one shared source-path lookup."""
+
     path = _source_path(statement)
     if path is None:
-        return False
+        return tuple(False for _ in declarations)
     innermost = next(iter(reversed(_symbol_table_scopes(path))), None)
     if isinstance(
         innermost,
         (ast.Lambda, ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp),
     ):
-        return False
+        return tuple(False for _ in declarations)
     function = next(
         (
             node
@@ -190,22 +209,38 @@ def declaration_is_function_local(statement, declaration) -> bool:
     if function is None:
         # Module-level site: ``visible_declarations`` already filters to
         # preceding module statements, which share this scope.
-        return True
+        return tuple(True for _ in declarations)
     end_line = getattr(function, "end_lineno", function.lineno)
-    return function.lineno < declaration.line <= end_line
+    return tuple(
+        function.lineno < declaration.line <= end_line for declaration in declarations
+    )
 
 
 def _source_path(statement):
     source = getattr(statement, "source", None)
     if not source:
         return None
-    parsed = parsed_parents(source)
+    parsed = parsed_parents(source, statement.filename or "<unknown>")
     if parsed is None:
         return None
-    _tree, parents = parsed
-    target = locate_parsed_node(
-        source, type(statement.node), statement.line, statement.col
-    )
+    tree, parents = parsed
+    if statement.node is tree or statement.node in parents:
+        target = statement.node
+    else:
+        target = locate_parsed_node(
+            source, type(statement.node), statement.line, statement.col
+        )
+        if target is None:
+            target = next(
+                (
+                    node
+                    for node in ast.walk(tree)
+                    if type(node) is type(statement.node)
+                    and getattr(node, "lineno", None) == statement.line
+                    and getattr(node, "col_offset", None) == statement.col
+                ),
+                None,
+            )
     if target is None:
         return None
     path = [target]

--- a/implementations/python/sugar-lift-py-tests/tests/test_class_def_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_class_def_sugar.py
@@ -714,6 +714,81 @@ def test_sqlalchemy_decorator_lookalikes_and_shadowed_imports_stay_loud(
     assert raised.value.info.observed == "ClassDef"
 
 
+def test_fixture_injected_native_registry_decorator_is_source_authenticated(
+    monkeypatch,
+) -> None:
+    provider_source = (
+        "from sqlalchemy.testing import config\n"
+        "from sqlalchemy.orm import registry\n"
+        "class FixtureBase:\n"
+        "    @config.fixture()\n"
+        "    def registry(self, metadata):\n"
+        "        value = registry(metadata=metadata)\n"
+        "        yield value\n"
+    )
+    provider_tree = ast.parse(provider_source)
+    provider = next(
+        node
+        for node in ast.walk(provider_tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "registry"
+    )
+    setattr(provider, "_sugar_defining_module", "example.fixtures")
+    provider_fragment = SourceFragment.from_node(
+        provider, "example/fixtures.py", source=provider_source
+    )
+    monkeypatch.setattr(
+        "sugar_lift_py_tests.sugar.install_source_dig."
+        "resolve_install_source_class_method",
+        lambda qualified, method: (
+            provider_fragment
+            if (qualified, method) == ("example.FixtureBase", "registry")
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        "sugar_lift_python_source.source_oracle.installed_module_source",
+        lambda module: (
+            (provider_source, "example/fixtures.py", "cid")
+            if module == "example.fixtures"
+            else None
+        ),
+    )
+    source = (
+        "from example import FixtureBase\n"
+        "class TestThing(FixtureBase):\n"
+        "    def test_it(self, registry):\n"
+        "        @registry.mapped\n"
+        "        class User:\n"
+        "            pass\n"
+    )
+    class_node = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ClassDef) and node.name == "User"
+    )
+    site = SourceFragment.from_node(class_node, "t.py", source=source)
+
+    assert ClassDefSugar.owns(site) is True
+
+
+def test_fixture_parameter_without_authenticated_provider_stays_loud() -> None:
+    source = (
+        "class TestThing:\n"
+        "    def test_it(self, registry):\n"
+        "        @registry.mapped\n"
+        "        class User:\n"
+        "            pass\n"
+    )
+    class_node = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ClassDef) and node.name == "User"
+    )
+    site = SourceFragment.from_node(class_node, "t.py", source=source)
+
+    assert ClassDefSugar.owns(site) is False
+
+
 @pytest.mark.parametrize(
     "import_statement",
     ("import pydantic", "import pydantic.dataclasses"),

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_tables.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_tables.py
@@ -101,14 +101,16 @@ def parsed_tree(source: str, filename: str = "<unknown>") -> ast.Module:
 
 
 @functools.lru_cache(maxsize=SOURCE_TABLE_CAPACITY)
-def parsed_parents(source: str) -> "tuple[ast.Module, dict[ast.AST, ast.AST]] | None":
+def parsed_parents(
+    source: str, filename: str = "<unknown>"
+) -> "tuple[ast.Module, dict[ast.AST, ast.AST]] | None":
     """The parsed tree plus its child->parent map, or None on a syntax error.
 
     One parse and one walk per source; every ancestor query over the same
     module shares the same table.
     """
     try:
-        tree = parsed_tree(source)
+        tree = parsed_tree(source, filename=filename)
     except SyntaxError:
         return None
     parents = {


### PR DESCRIPTION
Part of #5379

## What changed

- Authenticates fixture-injected native values through the enclosing imported test base, the source-declared fixture provider, its authenticated fixture decorator, and its imported construction/yield shape.
- Routes five SQLAlchemy registry-decorated ClassDefs through the existing ClassDefSugar construction path.
- Keeps the relative-package fixture row and runtime-mutated mapper_registry row loud because their native identity is not established by the available source coordinate.
- Adds no name whitelist, vendor-locus rule, RuntimeEffect, or cache.

## Conservation

- bounded SQLAlchemy cohort: python.factory 7 -> 4
- 5 target loci retired: 3 files completed, 2 advanced to later loud ClassDef rows
- TemporalContext remains 4
- silent remains 0

## Validation

- CPython 3.12.3
- discrimination: 6 passed (authenticated fixture plus lookalike/missing-provider arms)
- construction floors: 25 passed (R_behavior=0, R_ownership=0, R_vendor_special_case=0)
- changed recognition module: pyright 0 errors, 0 warnings
- fresh provenance-matched witness: truthful SAT, lying UNSAT

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate fixture registry decorators as identity-preserving in class decorator recognition
> - `class_decorators_preserve_identity` now accepts decorators supplied via fixture parameters (e.g. `registry.mapped`) as identity-preserving by resolving the fixture's native shape through source analysis of the installed module.
> - Adds several new helpers in [class_decorator.py](https://github.com/TSavo/sugar/pull/5421/files#diff-19211378bbb353bf1c344eaaaf0dc61bdc88f8dc26a8174e873452efd8c121eb): `_fixture_parameter_native_shape`, `_fixture_provider_native_shape`, `_is_authenticated_fixture`, and supporting AST/import utilities to perform the authentication chain.
> - Fixes AST ancestry path construction in `_source_path` (in both [visible_declarations.py](https://github.com/TSavo/sugar/pull/5421/files#diff-6bb952ebb33fea62b1bc04c63807bb753de3ffbeae0f910e93a21d26326d7dfb) and [callee_universe.py](https://github.com/TSavo/sugar/pull/5421/files#diff-72e9f915afa350390348a1c277d0c2047b26a0182bb4780c57baf73f30fdcaa8)) to use nodes from the current parse tree for the correct filename, avoiding foreign-node identity mismatches.
> - Adds `declarations_are_function_local` as a batched API to classify multiple declarations in a single `_source_path` call, replacing per-declaration lookups.
> - `parsed_parents` in [source_tables.py](https://github.com/TSavo/sugar/pull/5421/files#diff-ebd3cc1a0454697bef411fbe60c0f33cb960b7317e4d7b3c4cd9eb5acf45abd3) now accepts an optional `filename` parameter, associating parses with a specific filename for caching and error reporting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d3bb5ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved recognition of class decorators used with injected SQLAlchemy fixture registries.
  - Added support for validating decorator identity across imported and locally defined classes.

- **Bug Fixes**
  - Updated timeout scanning to choose a safer default worker count based on available CPUs, capped at four.
  - Prevented excessive concurrency while preserving per-file timeout budgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->