### PR TITLE
Authenticate dtype result universes

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/audit_only/universe_coverage.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/audit_only/universe_coverage.py
@@ -192,13 +192,19 @@ def _has_builtin_universe_claim(site, *, callee: str, catalog, filename: str) ->
     target symbol spells an enrolled coordinate.
     """
 
-    del filename, callee
+    del filename
     if site is None:
         return False
     names = {
         candidate.name for candidate in catalog.candidates_for(SugarRole.TERM, site)
     }
-    return bool(names - _GENERIC_COORDINATE_CLAIMS)
+    if not names - _GENERIC_COORDINATE_CLAIMS:
+        return False
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseRecognition,
+    )
+
+    return CalleeUniverseRecognition.coordinate(site) == callee
 
 
 __all__ = ["universe_absence_reason", "universe_coverage_gaps"]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -20,6 +20,7 @@ from sugar_lift_py_tests.recognition.native_shape import (
 class CalleeUniverseSupport(Enum):
     """A native call coordinate whose universe is carried by existing support."""
 
+    NUMPY_DTYPE_RESULT = auto()
     NUMPY_ISSUBDTYPE = auto()
     NUMPY_ALLCLOSE = auto()
     NUMPY_CAN_CAST = auto()
@@ -52,6 +53,30 @@ class CalleeUniverseSupport(Enum):
     REGEX_SEARCH = auto()
     BOUND_SOURCE_CALLABLE = auto()
 
+
+_DTYPE_RESULT_SUPPORT = {
+    coordinate: CalleeUniverseSupport.NUMPY_DTYPE_RESULT
+    for coordinate in {
+        "numpy.abs",
+        "numpy.add",
+        "numpy.all",
+        "numpy.any",
+        "numpy.arange",
+        "numpy.argmax",
+        "numpy.array",
+        "numpy.array.astype",
+        "numpy.asarray",
+        "numpy.choose",
+        "numpy.dtype",
+        "numpy.empty",
+        "numpy.empty_like",
+        "numpy.equal",
+        "numpy.power",
+        "numpy.sinc",
+        "numpy.zeros",
+        "numpy.zeros_like",
+    }
+}
 
 _IMPORTED_SUPPORT = {
     "numpy.issubdtype": CalleeUniverseSupport.NUMPY_ISSUBDTYPE,
@@ -119,6 +144,9 @@ _BUILTIN_COORDINATES = frozenset({"type", "dtype", "all", "list", "set", "hasatt
 _IMPORTED_ATTRIBUTE_LEAVES = frozenset(
     identity.rsplit(".", 1)[-1] for identity in _IMPORTED_SUPPORT
 )
+_DTYPE_RESULT_ATTRIBUTE_LEAVES = frozenset(
+    identity.rsplit(".", 1)[-1] for identity in _DTYPE_RESULT_SUPPORT
+)
 
 
 def recognize_callee_universe(
@@ -135,9 +163,12 @@ def recognize_callee_universe(
 
     if site is None:
         return None
-    identity = imported_call_identity(site)
+    identity = _result_call_identity(site)
     if identity is None:
         return None
+    result_support = _DTYPE_RESULT_SUPPORT.get(identity)
+    if result_support is not None and target in {None, "call:dtype"}:
+        return result_support
     support = recognize_authenticated_callee_identity(identity)
     if support is None:
         if _bound_source_callable_identity(site) != identity:
@@ -181,10 +212,13 @@ class CalleeUniverseRecognition:
             # full ``imported_call_identity`` for every ``random.X`` /
             # ``module.Y`` Call is the factory.select residual after
             # parsed_locus_index drained the AST-walk half of the path.
-            if target in _IMPORTED_ATTRIBUTE_LEAVES:
-                imported = imported_call_identity(site)
+            if target in (_IMPORTED_ATTRIBUTE_LEAVES | _DTYPE_RESULT_ATTRIBUTE_LEAVES):
+                imported = _result_call_identity(site)
                 if recognize_authenticated_callee_identity(imported) is not None:
                     return imported
+                result_support = _DTYPE_RESULT_SUPPORT.get(imported)
+                if result_support is not None:
+                    return "dtype"
             bound_receiver = _bound_native_receiver_coordinate(
                 site, receiver.name_id(), target
             )
@@ -427,6 +461,45 @@ def _bound_source_callable_identity(site) -> str | None:
     if value_name is None or "." not in value_name:
         return None
     return imported_call_identity(site)
+
+
+def _result_call_identity(site) -> str | None:
+    """Resolve an imported call or one method step on its assigned result."""
+
+    direct = imported_call_identity(site)
+    if direct is not None:
+        return direct
+    receiver = site.call_receiver()
+    if receiver is None or receiver.observed != "Name":
+        return None
+    target = site.call_target_name()
+    if target is None:
+        return None
+    receiver_origin = _assigned_imported_call_identity(site, receiver.name_id())
+    if receiver_origin is None:
+        return None
+    return f"{receiver_origin}.{target}"
+
+
+def _assigned_imported_call_identity(site, name: str) -> str | None:
+    """Follow one visible assignment whose value is an authenticated import call."""
+
+    declarations, shadowed_parameters = visible_declarations(site)
+    if name in shadowed_parameters:
+        return None
+    for declaration in reversed(declarations):
+        if name not in declaration.stored_or_deleted_names():
+            continue
+        if declaration.observed != "Assign":
+            return None
+        stored = declaration.stored_or_deleted_names()
+        if stored != frozenset({name}):
+            return None
+        value = declaration.assign_value()
+        if value.observed != "Call":
+            return None
+        return imported_call_identity(value)
+    return None
 
 
 def _enclosing_method_and_class(site):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -165,6 +165,7 @@ class BuiltinCalleeUniverseSugar(
             )),
             _numpy_may_share_memory_witness(),
             _bound_source_callable_witness(),
+            _numpy_dtype_result_witness(),
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
@@ -333,13 +334,7 @@ def _numpy_all_witness():
 
 
 def _numpy_dtype_witness():
-    prefix = (
-        "import numpy as np\n"
-        "\n"
-        "def A():\n"
-        "    return np.dtype('i4')\n"
-        "\n"
-    )
+    prefix = "import numpy as np\n" "\n" "def A():\n" "    return np.dtype('i4')\n" "\n"
     return _call_pair(
         name="numpy_dtype_universe_coordinate",
         owner_sugar="BuiltinCalleeUniverseSugar",
@@ -390,5 +385,22 @@ def _bound_source_callable_witness():
         owner_sugar="BuiltinCalleeUniverseSugar",
         truthful=prefix + "    assert f(0) == f(0) and f(0) == f(0)\n",
         lying=prefix + "    assert f(0) == f(0) and f(0) != f(0)\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _numpy_dtype_result_witness():
+    prefix = (
+        "import numpy as np\n"
+        "\n"
+        "def A():\n"
+        "    return np.asarray([1]).dtype\n"
+        "\n"
+    )
+    return _call_pair(
+        name="numpy_dtype_result_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
         family="builtin-universe-coordinate",
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
@@ -52,6 +52,7 @@ def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
         "numpy_isnan_universe_coordinate",
         "numpy_all_universe_coordinate",
         "numpy_dtype_universe_coordinate",
+        "numpy_dtype_result_universe_coordinate",
         "get_handler_name_builtin_universe_coordinate",
         "conv_builtin_universe_coordinate",
         "regex_search_builtin_universe_coordinate",
@@ -303,10 +304,7 @@ def test_set_witness_pair_is_enrolled() -> None:
 
 
 def test_authenticated_hasattr_selects_one_factory_owner() -> None:
-    source = (
-        "def test_hasattr(obj, name):\n"
-        "    assert hasattr(obj, name)\n"
-    )
+    source = "def test_hasattr(obj, name):\n" "    assert hasattr(obj, name)\n"
     context = FactoryBuildContext(
         filename="hasattr_call.py",
         catalog=default_catalog(),
@@ -324,10 +322,7 @@ def test_authenticated_hasattr_selects_one_factory_owner() -> None:
 @pytest.mark.parametrize(
     "source",
     [
-        (
-            "def test_hasattr(hasattr, obj, name):\n"
-            "    assert hasattr(obj, name)\n"
-        ),
+        ("def test_hasattr(hasattr, obj, name):\n" "    assert hasattr(obj, name)\n"),
         (
             "def test_hasattr(obj, name):\n"
             "    assert hasattr(obj, name)\n"
@@ -770,6 +765,121 @@ def test_unwarranted_numpy_dtype_receiver_is_not_factory_owned(source: str) -> N
 
 def test_numpy_dtype_witness_pair_is_enrolled() -> None:
     assert "numpy_dtype_universe_coordinate" in {
+        pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
+    }
+
+
+def _numpy_dtype_result_call_site(source: str) -> SourceFragment:
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and (
+            (isinstance(node.func, ast.Attribute) and node.func.attr == "asarray")
+            or (isinstance(node.func, ast.Name) and node.func.id == "asarray")
+        )
+    )
+    return SourceFragment.from_node(call, "numpy_dtype_result.py", source=source)
+
+
+def test_authenticated_numpy_dtype_result_selects_one_factory_owner() -> None:
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_dtype(value):\n"
+        "    assert np.asarray(value).dtype == np.asarray(value).dtype\n"
+    )
+    context = FactoryBuildContext(
+        filename="numpy_dtype_result.py",
+        catalog=default_catalog(),
+    )
+    built = build_node(
+        _numpy_dtype_result_call_site(source),
+        filename="numpy_dtype_result.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "import numpy as np\n"
+            "\n"
+            "def test_dtype(np, value):\n"
+            "    assert np.asarray(value).dtype == value\n"
+        ),
+        (
+            "import numpy as np\n"
+            "\n"
+            "def test_dtype(value):\n"
+            "    assert np.asarray(value).dtype == value\n"
+            "    np = replacement\n"
+        ),
+        (
+            "class PretendNumpy:\n"
+            "    def asarray(self, value):\n"
+            "        return value\n"
+            "\n"
+            "def test_dtype(np, value):\n"
+            "    assert np.asarray(value).dtype == value\n"
+        ),
+        ("def test_dtype(value):\n" "    assert numpy.asarray(value).dtype == value\n"),
+    ],
+)
+def test_unwarranted_numpy_dtype_result_is_not_factory_owned(source: str) -> None:
+    context = FactoryBuildContext(
+        filename="numpy_dtype_result.py",
+        catalog=default_catalog(),
+    )
+    built = build_node(
+        _numpy_dtype_result_call_site(source),
+        filename="numpy_dtype_result.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_numpy_dtype_result_follows_authenticated_receiver_assignment() -> None:
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_dtype(value):\n"
+        "    arr = np.array(value)\n"
+        "    assert arr.astype(float).dtype == arr.astype(float).dtype\n"
+    )
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "astype"
+    )
+    context = FactoryBuildContext(
+        filename="numpy_dtype_assignment.py",
+        catalog=default_catalog(),
+    )
+    built = build_node(
+        SourceFragment.from_node(
+            call,
+            "numpy_dtype_assignment.py",
+            source=source,
+        ),
+        filename="numpy_dtype_assignment.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+def test_numpy_dtype_result_witness_pair_is_enrolled() -> None:
+    assert "numpy_dtype_result_universe_coordinate" in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
 


### PR DESCRIPTION
Part of #5399

## Summary

- Extends the existing `CalleeUniverseRecognition` seam for `call:dtype` projections from authenticated imported call results.
- Receiver identity comes from lexical import/source provenance, including one visible assignment step (`arr = np.array(...); arr.astype(...).dtype`); it never trusts `numpy`, `np`, or `dtype` spellings alone.
- `BuiltinCalleeUniverseSugar` carries a distinct `numpy_dtype_result_universe_coordinate` truthful/lying witness.
- Tightens the audit join so a selected non-generic Sugar testifies only for its exact recognized coordinate; unrelated receiver-call universes remain loud.
- No cache, RuntimeEffect, allowlist, empty success, or suppression.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | +22 | authenticated dtype-result universe testimony replaces the 22 verified-live unclassified rows |
| `mandatory_panics` | 0 | unsupported receivers remain outside ownership |
| `suppressed_descendants` | 0 | no swallow, fallback, or empty arm |
| `typed_effects` | 0 | no effect arm added |
| `silent` | 0 | floor remains zero |

Predicted `R_factory_walk_unclassified(call:dtype)`: 22 -> 0.

## Validation

- CPython 3.12.3.
- RED: authenticated `np.asarray(...).dtype` returned no callee-universe support before construction.
- Representative NumPy 2.5.1 file: `call:dtype` unresolved 4 -> 0; file completed; unrelated five universe gaps remained loud.
- Structural discrimination on final rebase: direct imported receiver and authenticated assignment chain recognize `NUMPY_DTYPE_RESULT`; shadowed parameter, later rebind, fake receiver, and unauthenticated FQN all return `None`.
- Focused construction tests before final rebase: 7 passed.
- Solver twin before final rebase: truthful SAT, lying UNSAT (`1 passed`).
- `py_compile`: green.
- `R_vendor_special_case = 0` on final current-main rebase.
- Family replay measured `call:dtype=0` in every completed candidate file. The local 47-file replay was not certifiable as a full denominator because inherited #5426 timed out 10 files; no false full-denominator completion claim is made.
- Fresh post-rebase solver retry also hit the inherited 180s timeout with no verdict. This PR is held until #5426 restores the shared timeout floor.

## Floors preserved

- `R_vendor_special_case=0` on final rebase.
- `silent=0`; no cache, suppression, empty success, or RuntimeEffect.
- Unauthenticated and unsupported receivers remain loud/unclassified.
- No assertions or tests removed.

Non-closing PR. Do not merge until the shared main timeout floor is green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate dtype result universes for NumPy callee recognition
> - Adds `CalleeUniverseSupport.NUMPY_DTYPE_RESULT` to classify dtype results from authenticated NumPy calls (e.g. `np.asarray(...).dtype`) as a distinct universe type.
> - Extends `CalleeUniverseRecognition.coordinate()` and `recognize_callee_universe()` to resolve `'dtype'` coordinates by tracing one-step attribute access or variable assignment from authenticated imported calls.
> - Fixes `_has_builtin_universe_claim` in [universe_coverage.py](https://github.com/TSavo/sugar/pull/5450/files#diff-7ebc06dd7d5535234c84a3fde5ff86ed07305340e7a60cd9378f765aed76b7b5) to require the resolved call coordinate to match the provided callee, not just the presence of non-generic TERM candidates.
> - Adds witness and test coverage for authenticated and unauthenticated dtype-result scenarios, including assignment-following and shadowing edge cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b01e43.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->