### PR TITLE
Authenticate bound source callables

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -50,6 +50,7 @@ class CalleeUniverseSupport(Enum):
     NUMPY_HANDLER_NAME = auto()
     NUMPY_CONVERTER = auto()
     REGEX_SEARCH = auto()
+    BOUND_SOURCE_CALLABLE = auto()
 
 
 _IMPORTED_SUPPORT = {
@@ -139,8 +140,13 @@ def recognize_callee_universe(
         return None
     support = recognize_authenticated_callee_identity(identity)
     if support is None:
-        return None
-    if target is not None and target != f"call:{identity}":
+        if _bound_source_callable_identity(site) != identity:
+            return None
+        support = CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
+        coordinate = site.call_target_name()
+    else:
+        coordinate = identity
+    if target is not None and target != f"call:{coordinate}":
         return None
     return support
 
@@ -292,7 +298,7 @@ def imported_call_identity(site) -> str | None:
 
     declarations, shadowed_parameters = visible_declarations(site)
     imported: dict[str, tuple[str, bool]] = {}
-    assigned: dict[str, str | None] = {}
+    assigned: dict[str, tuple[str, bool] | None] = {}
     for declaration in declarations:
         function_local = declaration_is_function_local(site, declaration)
         if declaration.observed == "ImportFrom":
@@ -330,13 +336,18 @@ def imported_call_identity(site) -> str | None:
             continue
         origin_entry = imported.get(value_head)
         if origin_entry is None:
+            origin_entry = assigned.get(value_head)
+        if origin_entry is None:
             assigned[bound] = None
             continue
         origin, origin_local = origin_entry
         if value_head in lexical_function_bindings(site) and not origin_local:
             assigned[bound] = None
             continue
-        assigned[bound] = origin if not value_sep else f"{origin}.{value_tail}"
+        assigned[bound] = (
+            origin if not value_sep else f"{origin}.{value_tail}",
+            function_local,
+        )
 
     head, separator, tail = dotted.partition(".")
     if head in shadowed_parameters:
@@ -344,7 +355,13 @@ def imported_call_identity(site) -> str | None:
 
     # Prefer explicit assignment identity for the leaf name (``conv = mt.x``).
     if not separator and head in assigned:
-        return assigned[head]
+        assigned_identity = assigned[head]
+        if assigned_identity is None:
+            return None
+        origin, function_local = assigned_identity
+        if head in lexical_function_bindings(site) and not function_local:
+            return None
+        return origin
 
     resolved = imported.get(head)
     if resolved is None:
@@ -378,6 +395,38 @@ def _bound_native_receiver_coordinate(
     if shape is None:
         return None
     return recognize_native_instance_call(shape, member)
+
+
+def _bound_source_callable_identity(site) -> str | None:
+    """Authenticate a bare call through its exact dotted assignment binding.
+
+    The leaf spelling grants nothing. The call must resolve to a preceding
+    single-name assignment whose dotted receiver chain is itself anchored in
+    lexical import testimony. Parameters and non-dotted/lookalike assignments
+    stay outside this family.
+    """
+
+    if site is None or site.observed != "Call" or site.call_receiver() is not None:
+        return None
+    target = site.call_target_name()
+    if target is None:
+        return None
+    declarations, shadowed_parameters = visible_declarations(site)
+    if target in shadowed_parameters:
+        return None
+    binding = None
+    for declaration in declarations:
+        if target not in declaration.stored_or_deleted_names():
+            continue
+        binding = declaration
+    if binding is None or binding.observed != "Assign":
+        return None
+    if binding.stored_or_deleted_names() != frozenset({target}):
+        return None
+    value_name = binding.assign_value().dotted_expr_name()
+    if value_name is None or "." not in value_name:
+        return None
+    return imported_call_identity(site)
 
 
 def _enclosing_method_and_class(site):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -8,6 +8,7 @@ from sugar_lift_py_tests.recognition.callee_universe import (
     CalleeUniverseSupport,
     CalleeUniverseRecognition,
     recognize_authenticated_callee_identity,
+    recognize_callee_universe,
 )
 from sugar_lift_py_tests.sugar.call_sugar import CallSugar
 from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
@@ -108,7 +109,10 @@ class BuiltinCalleeUniverseSugar(
         receiver = site.call_receiver()
         if receiver is None:
             if target not in _AUTHENTICATED_PLAIN_LEAVES:
-                return False
+                return (
+                    recognize_callee_universe(site=site)
+                    is CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
+                )
         elif receiver.observed != "Name":
             # Only instance-parameter method form can authenticate converters.
             return False
@@ -160,6 +164,7 @@ class BuiltinCalleeUniverseSugar(
                 "binomial", "conv_intp", "create", "exists", "func", "iter_goto", "median",
             )),
             _numpy_may_share_memory_witness(),
+            _bound_source_callable_witness(),
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
@@ -368,5 +373,22 @@ def _numpy_batch_witness(name: str):
         owner_sugar="BuiltinCalleeUniverseSugar",
         truthful=prefix + "def test_a():\n    assert A() == A()\n",
         lying=prefix + "def test_a():\n    assert A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _bound_source_callable_witness():
+    prefix = (
+        "import numpy as np\n"
+        "_ArrayMemoryError = np._core._exceptions._ArrayMemoryError\n"
+        "\n"
+        "def test_a():\n"
+        "    f = _ArrayMemoryError._size_to_string\n"
+    )
+    return _call_pair(
+        name="bound_source_callable_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "    assert f(0) == f(0) and f(0) == f(0)\n",
+        lying=prefix + "    assert f(0) == f(0) and f(0) != f(0)\n",
         family="builtin-universe-coordinate",
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
@@ -9,6 +9,10 @@ from sugar_lift_py_tests.claim import SugarRole
 from sugar_lift_py_tests.context.factory_build_context import FactoryBuildContext
 from sugar_lift_py_tests.factory.build import build_node, default_catalog
 from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+from sugar_lift_py_tests.recognition.callee_universe import (
+    CalleeUniverseSupport,
+    recognize_callee_universe,
+)
 from sugar_lift_py_tests.sugar.builtin_callee_universe_sugar import (
     BuiltinCalleeUniverseSugar,
 )
@@ -521,6 +525,84 @@ def test_unwarranted_issubdtype_receiver_is_not_factory_owned(source: str) -> No
 
 def test_numpy_issubdtype_witness_pair_is_enrolled() -> None:
     assert "numpy_issubdtype_universe_coordinate" in {
+        pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
+    }
+
+
+def _bound_callable_call_site(source: str) -> SourceFragment:
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "f"
+    )
+    return SourceFragment.from_node(call, "bound_callable.py", source=source)
+
+
+def test_import_anchored_receiver_binding_authenticates_bare_callable() -> None:
+    source = (
+        "import numpy as np\n"
+        "_ArrayMemoryError = np._core._exceptions._ArrayMemoryError\n"
+        "\n"
+        "def test_size():\n"
+        "    f = _ArrayMemoryError._size_to_string\n"
+        "    assert f(0) == '0 bytes'\n"
+    )
+    site = _bound_callable_call_site(source)
+
+    assert (
+        recognize_callee_universe("call:f", site=site)
+        is CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
+    )
+    built = build_node(
+        site,
+        filename="bound_callable.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(
+            filename="bound_callable.py",
+            catalog=default_catalog(),
+        ),
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "def test_size():\n    assert f(0) == '0 bytes'\n",
+        (
+            "def test_size(receiver):\n"
+            "    f = receiver._size_to_string\n"
+            "    assert f(0) == '0 bytes'\n"
+        ),
+        (
+            "import numpy as np\n"
+            "_ArrayMemoryError = np._core._exceptions._ArrayMemoryError\n"
+            "\n"
+            "def test_size(f):\n"
+            "    assert f(0) == '0 bytes'\n"
+        ),
+    ],
+)
+def test_unresolved_or_lookalike_f_stays_unowned(source: str) -> None:
+    site = _bound_callable_call_site(source)
+
+    assert recognize_callee_universe("call:f", site=site) is None
+    built = build_node(
+        site,
+        filename="bound_callable.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(
+            filename="bound_callable.py",
+            catalog=default_catalog(),
+        ),
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_bound_source_callable_witness_pair_is_enrolled() -> None:
+    assert "bound_source_callable_universe_coordinate" in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
 


### PR DESCRIPTION
## Summary

Extend the existing callee-universe recognizer so a bare callable alias is owned only when its exact dotted receiver binding resolves through lexical import/source provenance. Unresolved names, parameter receivers, and lookalike `f` bindings remain unowned and loud.

The Sugar keeps construction through `CallSugar`; the new truthful/lying twins place contradictory calls in the same authenticated binding scope so the bad twin refutes.

Part of #5405

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `R_factory_walk_unclassified` | -13 | the 13 verified `call:f` loci resolve to typed `BOUND_SOURCE_CALLABLE` support |
| `mandatory_panics` | 0 | unresolved and lookalike bindings remain unowned |
| `suppressed_descendants` | 0 | no skip, suppression, or allowlist |
| `typed_effects` | 0 | no runtime effect introduced |
| `silent` | 0 | floor preserved |

## Validation

- Python 3.12.3
- `py_compile` on recognizer, Sugar, and focused tests
- focused no-conftest tests: 5 passed (authenticated binding, three negative lookalikes, witness enrollment)
- truthful/lying solver twin: 5-test focused receipt passed before final main rebase; final remote `bin/bpytest` queue produced no output and was stopped rather than treated as green
- exact representative replay: 13 total, 13 classified, 0 unclassified
- `R_vendor_special_case = 0`
- `R_behavior_side_doors = 0`
- `R_ownership = 0`
- `R_factory_panic_catches_outside_audit = 0`
- `R_native_crashes = 0`
- `R_bare_exceptions = 0`
- `R_silent = 0`
- `R_finite_cap_opaque_completions = 0`
- `R_context_incomplete_construction_caches = 0`
- local host-contention telemetry remained honestly red at `R_timeouts = 2`; the live-root unclassified auditor therefore refused global certification despite reporting zero unclassified rows

## Floors preserved

No name whitelist, inline AST side door, blanket inert classification, cache, suppression, or runtime-effect gap. No tests deleted. Unauthenticated calls remain loud.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate bound source callables in callee universe recognition
> - Adds `CalleeUniverseSupport.BOUND_SOURCE_CALLABLE` to handle bare calls (e.g., `f()`) where `f` is assigned from an imported dotted attribute, authenticated via the new `_bound_source_callable_identity` helper in [callee_universe.py](https://github.com/TSavo/sugar/pull/5452/files#diff-72e9f915afa350390348a1c277d0c2047b26a0182bb4780c57baf73f30fdcaa8).
> - Updates `recognize_callee_universe` to fall back to `_bound_source_callable_identity` when standard import authentication fails, using the call target name as the filtering coordinate.
> - Extends `imported_call_identity` to track assignment origins with function-local flags, rejecting non-local origins shadowed by local bindings and resolving chained assignments to import origins.
> - Updates `BuiltinCalleeUniverseSugar.owns` in [builtin_callee_universe_sugar.py](https://github.com/TSavo/sugar/pull/5452/files#diff-98e9ae8e3cbb10a2e6c95f0bdeca86f0b85002634b901733d0b6070886cdab5f) to claim ownership of `BOUND_SOURCE_CALLABLE` sites, and adds a witness for the bound source callable coordinate.
> - Adds tests covering authentication of import-anchored bindings, rejection of unresolved or parameter-shadowed callables, and witness enrollment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 87378f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recognition for bound source callables invoked through assigned receiver chains.
  * Improved attribution of imported and assigned callable identities.
  * Added support for authenticated bare callable calls in built-in callee handling.

* **Bug Fixes**
  * Prevented unresolved or lookalike callable names from being incorrectly recognized or claimed.

* **Tests**
  * Added coverage for bound callable authentication, ownership selection, and witness enrollment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->