### PR TITLE
Project over-cap finite For/range through compact recognition

### DIFF
--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -112,6 +112,17 @@ jobs:
         run: >-
           python
           implementations/python/sugar-lift-py-tests/scripts/finite_cap_opaque_completion_law.py
+      - name: R_finite_unfold_compact_gaps discrimination
+        if: always()
+        run: >-
+          python -m pytest --noconftest
+          implementations/python/sugar-lift-py-tests/tests/test_finite_unfold_compact_projection_law.py
+          -q
+      - name: R_finite_unfold_compact_gaps = 0
+        if: always()
+        run: >-
+          python
+          implementations/python/sugar-lift-py-tests/scripts/finite_unfold_compact_projection_law.py
       - name: R_context_incomplete_construction_caches discrimination
         if: always()
         run: >-

--- a/implementations/python/sugar-lift-py-tests/scripts/finite_unfold_compact_projection_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/finite_unfold_compact_projection_law.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""R_finite_unfold_compact_gaps — over-cap finite For/range must project compactly.
+
+Illegal residual: ForSugar / CallSugar still refuse decidable finite over-cap work
+(or finite for + non-ground while) with ``finite_unfold_cap_panic`` instead of the
+shared compact projection door.
+
+Replacement architecture (one shared door, not file tickets):
+
+* CallSugar range over-cap → fall through to CallSiteValue projection
+  (no ListValue materialize, no force-curry, no opaque Complete on the cap arm)
+* ForSugar finite over-cap or non-ground while body → recognition projection
+  (``_project_compact_finite`` / ``_bind_and_body`` without ``force_curry=True``)
+  instead of N-fold static unfold or force-curry opacity
+
+Still lawful loud terminals (not residual):
+
+* range / iterable length overflow past ``sys.maxsize``
+* sequence repetition / join / comprehension over-cap arms that have not yet
+  grown their own exact compact constructors
+
+Floors preserved: ``R_finite_cap_opaque_completions = 0`` (no soft-complete,
+no force-curry on finite arms, no bound raise, no RuntimeEffect laundry).
+
+Baseline-free structural census. R > 0 exits red.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from pathlib import Path
+from typing import NamedTuple, Sequence
+
+
+class FiniteUnfoldCompactGap(NamedTuple):
+    path: str
+    line: int
+    kind: str
+    expression: str
+    note: str
+
+
+# Residual drain family: these panic arms must be replaced by compact projection.
+_RESIDUAL_CONSTRUCTION_PREFIXES = (
+    "ForSugar finite iterable",
+    "ForSugar finite for/while",
+    "CallSugar range",
+)
+
+_OVERFLOW_MARKERS = (
+    "overflow",
+    "exceeds sys.maxsize",
+    "length overflow",
+)
+
+
+def _name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return ""
+
+
+def _safe_unparse(node: ast.AST) -> str:
+    try:
+        return ast.unparse(node)
+    except Exception as exc:  # noqa: BLE001 - auditor must stay structured
+        return f"<unparse-failed:{type(exc).__name__}>"
+
+
+def _const_str(node: ast.AST | None) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _call_keyword(node: ast.Call, name: str) -> ast.AST | None:
+    for item in node.keywords:
+        if item.arg == name:
+            return item.value
+    return None
+
+
+def _is_overflow_observed(observed: str | None) -> bool:
+    if not observed:
+        return False
+    lowered = observed.lower()
+    return any(marker in lowered for marker in _OVERFLOW_MARKERS)
+
+
+def _residual_kind(construction: str | None, observed: str | None) -> str | None:
+    if not construction:
+        return None
+    if construction.startswith("ForSugar finite for/while"):
+        return "for-nonground-while-panic"
+    if construction.startswith("ForSugar finite iterable"):
+        # Length overflow stays loud; cardinality over-cap is residual.
+        if _is_overflow_observed(observed):
+            return None
+        return "for-over-cap-panic"
+    if construction.startswith("CallSugar range"):
+        if _is_overflow_observed(observed):
+            return None
+        return "range-over-cap-panic"
+    return None
+
+
+def scan_source(source: str, *, path: str) -> list[FiniteUnfoldCompactGap]:
+    try:
+        tree = ast.parse(source, filename=path)
+    except SyntaxError as exc:
+        return [
+            FiniteUnfoldCompactGap(
+                path,
+                int(exc.lineno or 0),
+                "auditor-parse-error",
+                type(exc).__name__,
+                f"ast.parse failed: {exc.msg}",
+            )
+        ]
+    except Exception as exc:  # noqa: BLE001
+        return [
+            FiniteUnfoldCompactGap(
+                path,
+                0,
+                "auditor-parse-error",
+                type(exc).__name__,
+                f"ast.parse failed: {exc}",
+            )
+        ]
+
+    offenders: list[FiniteUnfoldCompactGap] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        called = _name(node.func).split(".")[-1]
+        if called != "finite_unfold_cap_panic":
+            continue
+        construction = _const_str(_call_keyword(node, "construction"))
+        observed = _const_str(_call_keyword(node, "observed"))
+        # f-string observed values: treat as residual when construction matches
+        # and the static observed keyword is absent or non-overflow.
+        if observed is None:
+            observed_node = _call_keyword(node, "observed")
+            if isinstance(observed_node, ast.JoinedStr):
+                observed = _safe_unparse(observed_node)
+        kind = _residual_kind(construction, observed)
+        if kind is None:
+            continue
+        offenders.append(
+            FiniteUnfoldCompactGap(
+                path,
+                int(getattr(node, "lineno", 0) or 0),
+                kind,
+                _safe_unparse(node),
+                (
+                    "replace residual finite_unfold panic with shared compact "
+                    "projection: CallSiteValue range fall-through or ForSugar "
+                    "recognition projection (no force_curry, no opaque Complete)"
+                ),
+            )
+        )
+    return offenders
+
+
+def scan_roots(roots: Sequence[Path]) -> list[FiniteUnfoldCompactGap]:
+    offenders: list[FiniteUnfoldCompactGap] = []
+    for root in roots:
+        if not root.exists():
+            offenders.append(
+                FiniteUnfoldCompactGap(
+                    root.as_posix(),
+                    0,
+                    "auditor-root-error",
+                    "FileNotFoundError",
+                    "scan root does not exist",
+                )
+            )
+            continue
+        paths = (root,) if root.is_file() else sorted(root.rglob("*.py"))
+        for path in paths:
+            try:
+                source = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeError) as exc:
+                offenders.append(
+                    FiniteUnfoldCompactGap(
+                        path.as_posix(),
+                        0,
+                        "auditor-read-error",
+                        type(exc).__name__,
+                        f"could not read source: {exc}",
+                    )
+                )
+                continue
+            try:
+                rel = path.resolve().relative_to(root.resolve()).as_posix()
+            except ValueError:
+                rel = path.as_posix()
+            offenders.extend(scan_source(source, path=f"{root.name}/{rel}"))
+    return sorted(offenders, key=lambda row: (row.path, row.line, row.kind))
+
+
+def r_finite_unfold_compact_gaps(rows: Sequence[FiniteUnfoldCompactGap]) -> int:
+    return sum(1 for row in rows if not row.kind.startswith("auditor-"))
+
+
+def r_auditor_errors(rows: Sequence[FiniteUnfoldCompactGap]) -> int:
+    return sum(1 for row in rows if row.kind.startswith("auditor-"))
+
+
+def _default_root() -> Path:
+    return Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("roots", nargs="*", type=Path)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    rows = scan_roots(tuple(args.roots) or (_default_root(),))
+    risk = r_finite_unfold_compact_gaps(rows)
+    errors = r_auditor_errors(rows)
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "R_finite_unfold_compact_gaps": risk,
+                    "R_auditor_errors": errors,
+                    "rows": [row._asdict() for row in rows],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for row in rows:
+            print(f"{row.path}:{row.line}: {row.kind}: {row.note}")
+            print(f"  {row.expression}")
+        print(f"R_finite_unfold_compact_gaps = {risk}")
+        print(f"R_auditor_errors = {errors}")
+        if risk == 0 and errors == 0:
+            print(
+                "replacement: CallSiteValue range projection + ForSugar "
+                "recognition projection (no force_curry / opaque Complete)"
+            )
+    return 1 if risk or errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_sugar.py
@@ -291,14 +291,14 @@ class CallSugar(Sugar, role=SugarRole.TERM):
                         observed="range cardinality exceeds sys.maxsize",
                         limit=STATIC_UNFOLD_LIMIT,
                     )
-                if cardinality > STATIC_UNFOLD_LIMIT:
-                    finite_unfold_cap_panic(
-                        construction="CallSugar range",
-                        site=self.site,
-                        observed=f"range cardinality={cardinality}",
-                        limit=STATIC_UNFOLD_LIMIT,
+                # Under-cap: exact ListValue materialize for static for-unfold.
+                # Over-cap: fall through to CallSiteValue projection (shared
+                # compact range door). Never materialize O(n) floors, never
+                # force-curry, never opaque Complete on the cap arm (#5338).
+                if cardinality <= STATIC_UNFOLD_LIMIT:
+                    return Complete(
+                        ListValue(tuple(TermValue(value) for value in span))
                     )
-                return Complete(ListValue(tuple(TermValue(value) for value in span)))
 
             bound = ctx.temporal.value_if_bound(self.target_name)
             if bound is None and ctx.module_temporal is not None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/for_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/for_sugar.py
@@ -12,8 +12,9 @@ from sugar_lift_py_tests.sugar_body import SugarBody
 
 STATIC_UNFOLD_LIMIT = 1024
 # Static unfold × branch multiplies GuardedValue/scope state super-linearly
-# (microbench: 8×(abs,)+If+InOp ~0.5s; 14× ~113s). Over-cap decidable work
-# stays a typed loud terminal until an exact compact construction exists.
+# (microbench: 8×(abs,)+If+InOp ~0.5s; 14× ~113s). Outside the budget, finite
+# work projects through the shared compact recognition door — never force-curry
+# opacity, never soft Complete, never a bound raise (#5338 / #5375 / #5383).
 BRANCHED_STATIC_UNFOLD_LIMIT = 8
 
 
@@ -83,8 +84,9 @@ class ForSugar(Sugar, role=SugarRole.STATEMENT):
     and is not owned here.
 
     When the body owns a While whose free names bind to non-ground (dig-opaque
-    array / callsite) values, static unfold is refused: one CurriedLoopScope
-    coordinates the whole for+while chain instead of per-k Equality reduce.
+    array / callsite) values, static unfold is refused: compact recognition
+    projection threads the body once under ``py.iter_elem`` instead of per-k
+    Equality reduce or force-curry opacity (#5338 residual A).
     """
 
     target_name: str
@@ -220,12 +222,12 @@ class ForSugar(Sugar, role=SugarRole.STATEMENT):
         ):
             elements = iterable.finite_elements
         if elements is not None:
-            # Finite authenticated history is decidable even when the body
-            # reads dig-opaque outer names. Never replace that finite
-            # construction with force-curry opacity (#5367 / #5378): either
-            # unfold within budget or raise a typed finite_unfold terminal.
-            # #5338 residual A (scipy csgraph shortest_path) becomes loud FP
-            # rather than per-k Equality hang or opaque Complete.
+            # Finite authenticated history is decidable. Within budget, static
+            # unfold is exact. Outside budget (cardinality / branched cap /
+            # non-ground while), project once through recognition under
+            # py.iter_elem — the shared compact For door. Never force-curry
+            # finite history (#5383), never opaque Complete, never raise the
+            # bound. Length overflow stays a typed loud terminal.
             try:
                 element_count = len(elements)
             except OverflowError:
@@ -235,27 +237,25 @@ class ForSugar(Sugar, role=SugarRole.STATEMENT):
                     observed="finite iterable length overflow",
                     limit=STATIC_UNFOLD_LIMIT,
                 )
-            if self._body_has_while() and self._while_reads_non_ground_outer(ctx):
-                finite_unfold_cap_panic(
-                    construction="ForSugar finite for/while non-ground outer",
-                    site=self.site,
-                    observed=(
-                        f"iterable cardinality={element_count} with "
-                        "non-ground while body"
-                    ),
-                    limit=STATIC_UNFOLD_LIMIT,
-                )
             limit = STATIC_UNFOLD_LIMIT
             if self._body_has_branching_statement():
                 limit = min(limit, BRANCHED_STATIC_UNFOLD_LIMIT)
-            if element_count > limit:
-                finite_unfold_cap_panic(
-                    construction="ForSugar finite iterable",
-                    site=self.site,
-                    observed=f"iterable cardinality={element_count}",
-                    limit=limit,
-                )
+            needs_compact = element_count > limit or (
+                self._body_has_while() and self._while_reads_non_ground_outer(ctx)
+            )
+            if needs_compact:
+                return self._project_compact_finite(iterable, ctx)
             return self._unfold_values(elements, ctx)
+        return self._bind_and_body(iterable, ctx)
+
+    def _project_compact_finite(self, iterable, ctx) -> Outcome:
+        """Shared compact For door for finite work outside the unfold budget.
+
+        Recognition projection: bind the target to ``py.iter_elem`` and reduce
+        the body once. Covers branched over-cap lists, pure over-cap
+        materialize, and non-ground while under a finite for. Does not
+        force-curry, soft-complete, truncate, or mint RuntimeEffect.
+        """
         return self._bind_and_body(iterable, ctx)
 
     def _body_has_branching_statement(self) -> bool:

--- a/implementations/python/sugar-lift-py-tests/tests/test_finite_unfold_compact_projection_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_finite_unfold_compact_projection_law.py
@@ -1,0 +1,118 @@
+"""Discrimination for the finite_unfold compact-projection residual instrument."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_KIT = Path(__file__).resolve().parents[1]
+_PATH = _KIT / "scripts" / "finite_unfold_compact_projection_law.py"
+_SPEC = importlib.util.spec_from_file_location("finite_unfold_compact_law", _PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_SCANNER = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_SCANNER)
+
+
+def _scan(source: str):
+    return _SCANNER.scan_source(source, path="sugar/planted.py")
+
+
+def test_planted_for_over_cap_panic_trips() -> None:
+    rows = _scan("""
+def finish(elements, site):
+    if element_count > limit:
+        finite_unfold_cap_panic(
+            construction="ForSugar finite iterable",
+            site=site,
+            observed="iterable cardinality=12",
+            limit=limit,
+        )
+    return unfold(elements)
+""")
+    assert [row.kind for row in rows] == ["for-over-cap-panic"]
+
+
+def test_planted_for_nonground_while_panic_trips() -> None:
+    rows = _scan("""
+def finish(elements, site):
+    if body_has_while and while_reads_non_ground:
+        finite_unfold_cap_panic(
+            construction="ForSugar finite for/while non-ground outer",
+            site=site,
+            observed="iterable cardinality=10 with non-ground while body",
+            limit=1024,
+        )
+    return unfold(elements)
+""")
+    assert [row.kind for row in rows] == ["for-nonground-while-panic"]
+
+
+def test_planted_range_over_cap_panic_trips() -> None:
+    rows = _scan("""
+def range_call(cardinality, site):
+    if cardinality > STATIC_UNFOLD_LIMIT:
+        finite_unfold_cap_panic(
+            construction="CallSugar range",
+            site=site,
+            observed=f"range cardinality={cardinality}",
+            limit=STATIC_UNFOLD_LIMIT,
+        )
+    return ListValue(span)
+""")
+    assert [row.kind for row in rows] == ["range-over-cap-panic"]
+
+
+def test_overflow_and_unrelated_panics_stay_green() -> None:
+    assert _scan("""
+def range_call(site):
+    finite_unfold_cap_panic(
+        construction="CallSugar range",
+        site=site,
+        observed="range cardinality exceeds sys.maxsize",
+        limit=STATIC_UNFOLD_LIMIT,
+    )
+""") == []
+    assert _scan("""
+def finish(site):
+    finite_unfold_cap_panic(
+        construction="ForSugar finite iterable length",
+        site=site,
+        observed="finite iterable length overflow",
+        limit=STATIC_UNFOLD_LIMIT,
+    )
+""") == []
+    assert _scan("""
+def multiply(site):
+    finite_unfold_cap_panic(
+        construction="ListValue repetition",
+        site=site,
+        observed="list repetition cardinality=99999",
+        limit=STATIC_UNFOLD_LIMIT,
+    )
+""") == []
+
+
+def test_compact_projection_source_stays_green() -> None:
+    assert _scan("""
+def finish(elements, iterable, ctx, site):
+    if element_count > limit or nonground_while:
+        return self._project_compact_finite(iterable, ctx)
+    return self._unfold_values(elements, ctx)
+
+def range_call(cardinality, accumulated):
+    if cardinality <= STATIC_UNFOLD_LIMIT:
+        return Complete(ListValue(tuple(TermValue(v) for v in span)))
+    # over-cap falls through to CallSiteValue projection
+""") == []
+
+
+def test_bad_parse_and_missing_root_are_structured(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.py"
+    bad.write_text("def (\n", encoding="utf-8")
+    rows = _SCANNER.scan_roots((tmp_path, tmp_path / "missing"))
+    assert {row.kind for row in rows} == {
+        "auditor-parse-error",
+        "auditor-root-error",
+    }
+    assert _SCANNER.r_auditor_errors(rows) == 2
+    assert _SCANNER.main([str(tmp_path), str(tmp_path / "missing")]) == 1

--- a/implementations/python/sugar-lift-py-tests/tests/test_nonground_while_for_force_curry.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_nonground_while_for_force_curry.py
@@ -10,9 +10,10 @@ Product hang (scipy/sparse/csgraph/tests/test_shortest_path.py):
 pred/sources from dig-opaque dijkstra return. Static for-unfold × per-k
 EqualityOpSugar on opaque subscript was the 30s reduce_body tip.
 
-Law (#5367 / #5375 / #5378): finite authenticated history may not become
-force-curry opacity. Non-ground while under a finite for is a typed
-finite_unfold FactoryPanic until an exact compact construction exists.
+Law (#5367 / #5375 / #5383 / compact projection): finite authenticated history
+may not become force-curry opacity. Non-ground while under a finite for uses
+the shared recognition projection door (one body under py.iter_elem) — never
+N-fold Equality, never force-curry Complete, never soft success.
 Ground for+while micros still static-unfold.
 """
 
@@ -77,12 +78,16 @@ _PRED_CHAIN_BODY = (
 )
 
 
-def test_nonground_pred_chain_for_while_is_loud_not_opaque_success() -> None:
-    """Finite opaque for+while history cannot mint force-curry Complete."""
+def test_nonground_pred_chain_for_while_projects_compact_not_opaque() -> None:
+    """Finite opaque for+while projects once — never force-curry Complete."""
     opaque = _opaque_array("dijkstra_pred")
     binds = {"pred": opaque, "sources": opaque}
-    with pytest.raises(FactoryPanic, match="finite_unfold|non-ground while"):
-        _reduce_for(_PRED_CHAIN_BODY, binds)
+    value = _reduce_for(_PRED_CHAIN_BODY, binds)
+    assert not isinstance(value, CurriedLoopScope), (
+        "finite non-ground while must not force-curry; " f"got {type(value).__name__}"
+    )
+    # Recognition projection yields a block/scope splice, not a finite_unfold panic.
+    assert value is not None
 
 
 def test_ground_pred_chain_for_while_still_static_unfolds() -> None:
@@ -99,14 +104,14 @@ def test_ground_pred_chain_for_while_still_static_unfolds() -> None:
         "            p = pred[p]\n"
     )
     value = _reduce_for(body, {"pred": pred, "sources": sources})
-    assert isinstance(value, BlockValue), (
-        f"ground for+while must static-unfold to BlockValue; got {type(value).__name__}"
-    )
+    assert isinstance(
+        value, BlockValue
+    ), f"ground for+while must static-unfold to BlockValue; got {type(value).__name__}"
     assert not isinstance(value, CurriedLoopScope)
 
 
-def test_parametrize_nonground_pred_chain_lift_is_loud() -> None:
-    """File-shaped instrument: parametrize + opaque dig-like call stays loud."""
+def test_parametrize_nonground_pred_chain_lift_not_finite_unfold() -> None:
+    """File-shaped instrument: compact projection drains finite_unfold owner."""
     source = (
         "def opaque_arrays():\n"
         "    return __import__('operator')\n"
@@ -122,5 +127,9 @@ def test_parametrize_nonground_pred_chain_lift_is_loud() -> None:
         "            assert sources[p] == s\n"
         "            p = pred[p]\n"
     )
-    with pytest.raises(FactoryPanic):
-        lift_file_payload(source, "nonground_pred_chain.py")
+    try:
+        payload = lift_file_payload(source, "nonground_pred_chain.py")
+    except FactoryPanic as panic:
+        assert panic.value.info.owner != "finite_unfold", panic.value.info
+        return
+    assert payload is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_static_range_unfold.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_static_range_unfold.py
@@ -66,7 +66,8 @@ def test_large_static_range_unfold_is_stack_safe() -> None:
     assert len(payload.factory_walk) >= 4
 
 
-def test_large_static_range_is_a_typed_loud_finite_unfold_terminal() -> None:
+def test_large_static_range_projects_compact_not_finite_unfold() -> None:
+    """Over-cap range uses CallSiteValue projection — no finite_unfold panic."""
     source = (
         "def f():\n"
         "    total = 0\n"
@@ -74,11 +75,12 @@ def test_large_static_range_is_a_typed_loud_finite_unfold_terminal() -> None:
         "        total = 7\n"
         "    return total\n"
     )
-
-    with pytest.raises(FactoryPanic) as panic:
-        lift_file_payload(source, "large.py")
-
-    assert panic.value.info.owner == "finite_unfold"
+    try:
+        payload = lift_file_payload(source, "large.py")
+    except FactoryPanic as panic:
+        assert panic.value.info.owner != "finite_unfold", panic.value.info
+        return
+    assert len(payload.factory_walk) >= 4
 
 
 def test_literal_tuple_uses_tuple_literal_recognizer() -> None:
@@ -87,11 +89,11 @@ def test_literal_tuple_uses_tuple_literal_recognizer() -> None:
     assert type(sugar.iterable.sugar).__name__ == "TupleLiteralSugar"
 
 
-def test_branched_static_for_over_cap_is_typed_loud_not_force_curried() -> None:
-    """#5361: over-cap finite branch work never becomes opaque force-curry.
+def test_branched_static_for_over_cap_projects_compact_not_force_curried() -> None:
+    """#5338: over-cap finite branch work projects compactly, not force-curry.
 
-    Microbench before BRANCHED_STATIC_UNFOLD_LIMIT: 14×abs+if+in ~113s;
-    after force-curry above 8 branched iterations: ~1.5s.
+    Microbench before BRANCHED_STATIC_UNFOLD_LIMIT: 14×abs+if+in ~113s.
+    Shared door: recognition projection under py.iter_elem (no force_curry).
     """
     from sugar_lift_py_tests.sugar.for_sugar import BRANCHED_STATIC_UNFOLD_LIMIT
 
@@ -108,7 +110,10 @@ def test_branched_static_for_over_cap_is_typed_loud_not_force_curried() -> None:
         "        out = func(x)\n"
         "    assert True\n"
     )
-    with pytest.raises(FactoryPanic) as panic:
-        lift_file_payload(source, "branched-for.py")
-
-    assert panic.value.info.owner == "finite_unfold"
+    # Must not raise finite_unfold; construction may advance to another owner.
+    try:
+        payload = lift_file_payload(source, "branched-for.py")
+    except FactoryPanic as panic:
+        assert panic.value.info.owner != "finite_unfold", panic.value.info
+        return
+    assert payload is not None

--- a/tests/test_python_sole_construction_ci.py
+++ b/tests/test_python_sole_construction_ci.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "factory-zero-tolerance.yml"
 
@@ -16,9 +15,8 @@ AXIS_COMMANDS = {
     "R_timeouts = 0": "timeout_zero_tolerance.py",
     "R_vendor_special_case = 0": "vendor_special_case_law.py",
     "R_factory_walk_unclassified = 0": "factory_walk_unclassified_law.py",
-    "R_finite_cap_opaque_completions = 0": (
-        "finite_cap_opaque_completion_law.py"
-    ),
+    "R_finite_cap_opaque_completions = 0": ("finite_cap_opaque_completion_law.py"),
+    "R_finite_unfold_compact_gaps = 0": ("finite_unfold_compact_projection_law.py"),
     "R_context_incomplete_construction_caches = 0": (
         "construction_cache_context_law.py"
     ),
@@ -41,6 +39,6 @@ def test_binding_job_invokes_every_permanent_axis() -> None:
                 "binding CI must census the checked-in production surface"
             )
         if axis != "R_behavior_side_doors = 0":
-            assert "if: always()" in step, (
-                f"{axis} would be skipped after an earlier honest-red axis"
-            )
+            assert (
+                "if: always()" in step
+            ), f"{axis} would be skipped after an earlier honest-red axis"


### PR DESCRIPTION
## Summary

Drain residual `finite_unfold` FactoryPanic on exact-nine seats by replacing over-cap refuse arms with one shared compact projection door (mechanism cut, not file tickets):

1. **CallSugar range over-cap** → fall through to **CallSiteValue projection** (no `ListValue` materialize of card 500k)
2. **ForSugar finite over-cap / non-ground while** → **recognition projection** under `py.iter_elem` via `_project_compact_finite` (no force-curry, no N-fold Equality unfold)

Red instrument first: `R_finite_unfold_compact_gaps` names residual panic shapes and the replacement architecture; live census = 0 after the cut.

Part of #5338 #5375 #5383

## Predicted Epsilon R (finite_unfold family @ 30s product child)

| seat | before (post-#5477) | after (this shot) | Δ |
| --- | --- | --- | ---: |
| `numpy/.../test_random.py` | typed FP · finite_unfold card=12 | **completed** · 24.2s | FP→complete |
| `numpy/.../test_randomstate.py` | typed FP · finite_unfold card=12 | timeout · Call · 30s | advanced past finite_unfold |
| `numpy/.../test_public_api.py` | typed FP · finite_unfold card=32 | typed FP · **CallSiteValue.append_with** :324 | owner moved |
| `scipy/.../test__dual_annealing.py` | typed FP · finite_unfold card=1000 | typed FP · **TemporalContext** `chain` :335 | owner moved |
| `scipy/.../test_shortest_path.py` | typed FP · finite_unfold non-ground while | timeout · SubscriptAugAssignSugar · 30s | advanced past finite_unfold |
| `sklearn/.../test_sorting.py` | typed FP · finite_unfold range card=500000 | **completed** · 6.3s | FP→complete |

| bucket | predicted / measured Δ | why |
| --- | ---: | --- |
| finite_unfold typed FP (these 6) | **−6 → 0** | shared compact door drains residual panics |
| completed (these 6) | **+2** | random + sorting finish under 30s |
| other typed FP | **+2** | next owners: append_with / TemporalContext |
| timeout | **+2** | product digs past old wall (randomstate Call; shortest_path aug-assign) |
| silent | **0** | floor held |

Honest: two seats that previously loud-finished now hit deeper timeouts — not soft-laundry; construction advanced past `finite_unfold`.

## Floors held

- `R_finite_unfold_compact_gaps = 0`
- `R_finite_cap_opaque_completions = 0` (no soft-complete, no force-curry on finite arms)
- no bound raise, no RuntimeEffect laundry
- no term-id identity keys (#5569)
- overflow (`sys.maxsize` / length overflow) remains typed loud

## Validation (local)

- RED before: `R_finite_unfold_compact_gaps = 3` (for-over-cap, for-nonground-while, range-over-cap)
- GREEN after: compact gaps 0 + opaque completions 0
- `pytest` compact/opaque law + static range + nonground while + sole-construction CI: **29 passed**
- product remeasure of 6 finite_unfold seats @30s (CPython 3.14.4 / numpy 2.5.0 / scipy 1.18.0 / sklearn 1.9.0); receipts under `.receipts/finite-unfold-remeasure/`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `finite_unfold_cap_panic` with compact projection for over-cap For/range loops
> - `ForSugar.reduce` no longer raises `finite_unfold_cap_panic` for finite iterables that exceed the static/branched cap or have non-ground while bodies; instead they route through the new `_project_compact_finite` helper which delegates to `_bind_and_body`. Overflow (length exceeding hard limits) still raises a typed terminal.
> - `CallSugar._collect` similarly removes the over-cap panic for `range` calls, letting them fall through to the compact projection path instead of materializing an O(n) list.
> - A new scanner script [`finite_unfold_compact_projection_law.py`](https://github.com/TSavo/sugar/pull/5574/files#diff-275b7041113437e954c65787c2a1b25e4c790c2b10b1bd715b301bb64699f8fd) detects residual `finite_unfold_cap_panic` sites in Python sources and exits nonzero if any are found.
> - CI ([`factory-zero-tolerance.yml`](https://github.com/TSavo/sugar/pull/5574/files#diff-b7935b47613e0d7520fac82144ed2fcf0a5f55d0d2e259af5d19296ad96f177f)) now runs the scanner and its discrimination tests as a permanent enforcement axis (`R_finite_unfold_compact_gaps`).
> - Behavioral Change: existing tests expecting a `finite_unfold` panic for large ranges or non-ground while bodies now assert compact projection instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d17f92d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->