### PR TITLE
Authenticate json.loads and dataclasses.asdict callee universes

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -52,6 +52,8 @@ class CalleeUniverseSupport(Enum):
     NUMPY_CONVERTER = auto()
     REGEX_SEARCH = auto()
     BOUND_SOURCE_CALLABLE = auto()
+    JSON_LOADS = auto()
+    DATACLASSES_ASDICT = auto()
 
 
 _DTYPE_RESULT_SUPPORT = {
@@ -134,6 +136,8 @@ _IMPORTED_SUPPORT = {
         CalleeUniverseSupport.NUMPY_CONVERTER
     ),
     "re.Pattern.search": CalleeUniverseSupport.REGEX_SEARCH,
+    "json.loads": CalleeUniverseSupport.JSON_LOADS,
+    "dataclasses.asdict": CalleeUniverseSupport.DATACLASSES_ASDICT,
 }
 
 _BUILTIN_COORDINATES = frozenset({"type", "dtype", "all", "list", "set", "hasattr"})

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -44,6 +44,8 @@ _AUTHENTICATED_COORDINATES = frozenset(
         "numpy.may_share_memory",
         "numpy._core.multiarray.get_handler_name",
         "re.Pattern.search",
+        "json.loads",
+        "dataclasses.asdict",
         *_CONVERTER_COORDINATES,
     }
 )
@@ -71,6 +73,8 @@ _OWNED_IMPORTED_SUPPORT = frozenset(
         CalleeUniverseSupport.NUMPY_HANDLER_NAME,
         CalleeUniverseSupport.NUMPY_CONVERTER,
         CalleeUniverseSupport.REGEX_SEARCH,
+        CalleeUniverseSupport.JSON_LOADS,
+        CalleeUniverseSupport.DATACLASSES_ASDICT,
     }
 )
 
@@ -166,6 +170,8 @@ class BuiltinCalleeUniverseSugar(
             _numpy_may_share_memory_witness(),
             _bound_source_callable_witness(),
             _numpy_dtype_result_witness(),
+            _json_loads_witness(),
+            _dataclasses_asdict_witness(),
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
@@ -399,6 +405,45 @@ def _numpy_dtype_result_witness():
     )
     return _call_pair(
         name="numpy_dtype_result_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _json_loads_witness():
+    prefix = (
+        "import json\n"
+        "\n"
+        "def A():\n"
+        "    return json.loads('0')\n"
+        "\n"
+    )
+    return _call_pair(
+        name="json_loads_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        # Conjunction makes deterministic call substitution load-bearing.
+        truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _dataclasses_asdict_witness():
+    prefix = (
+        "from dataclasses import asdict, dataclass\n"
+        "\n"
+        "@dataclass\n"
+        "class Point:\n"
+        "    x: int\n"
+        "\n"
+        "def A():\n"
+        "    return asdict(Point(0))\n"
+        "\n"
+    )
+    return _call_pair(
+        name="dataclasses_asdict_universe_coordinate",
         owner_sugar="BuiltinCalleeUniverseSugar",
         truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
         lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
@@ -40,6 +40,8 @@ def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
         "numpy._core.multiarray.get_handler_name",
         "numpy._core._multiarray_tests.run_byteorder_converter",
         "re.Pattern.search",
+        "json.loads",
+        "dataclasses.asdict",
     } <= (BuiltinCalleeUniverseSugar.universe_coordinates)
     assert {
         "all_builtin_universe_coordinate",
@@ -56,6 +58,8 @@ def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
         "get_handler_name_builtin_universe_coordinate",
         "conv_builtin_universe_coordinate",
         "regex_search_builtin_universe_coordinate",
+        "json_loads_universe_coordinate",
+        "dataclasses_asdict_universe_coordinate",
     } <= {pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()}
 
 
@@ -1099,3 +1103,209 @@ def test_numpy_can_cast_requires_authenticated_receiver() -> None:
     )
     with pytest.raises(FactoryPanic):
         BuiltinCalleeUniverseSugar.new(site, lying)
+
+
+def _stdlib_attr_call_site(source: str, member: str, filename: str) -> SourceFragment:
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == member
+    )
+    return SourceFragment.from_node(call, filename, source=source)
+
+
+def _stdlib_name_call_site(source: str, name: str, filename: str) -> SourceFragment:
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == name
+    )
+    return SourceFragment.from_node(call, filename, source=source)
+
+
+def test_authenticated_json_loads_selects_one_factory_owner() -> None:
+    source = (
+        "import json\n"
+        "\n"
+        "def test_loads(payload):\n"
+        "    assert json.loads(payload) == json.loads(payload)\n"
+    )
+    context = FactoryBuildContext(
+        filename="json_loads.py",
+        catalog=default_catalog(),
+    )
+    built = build_node(
+        _stdlib_attr_call_site(source, "loads", "json_loads.py"),
+        filename="json_loads.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+def test_authenticated_from_import_json_loads_selects_one_factory_owner() -> None:
+    source = (
+        "from json import loads\n"
+        "\n"
+        "def test_loads(payload):\n"
+        "    assert loads(payload) == loads(payload)\n"
+    )
+    context = FactoryBuildContext(
+        filename="json_loads_from.py",
+        catalog=default_catalog(),
+    )
+    built = build_node(
+        _stdlib_name_call_site(source, "loads", "json_loads_from.py"),
+        filename="json_loads_from.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "import json\n"
+            "\n"
+            "def test_loads(json, payload):\n"
+            "    assert json.loads(payload) == json.loads(payload)\n"
+        ),
+        (
+            "import json\n"
+            "\n"
+            "def test_loads(payload):\n"
+            "    assert json.loads(payload) == json.loads(payload)\n"
+            "    json = replacement\n"
+        ),
+        (
+            "import math as json\n"
+            "\n"
+            "def test_loads(payload):\n"
+            "    assert json.loads(payload) == json.loads(payload)\n"
+        ),
+        (
+            "def test_loads(payload):\n"
+            "    assert json.loads(payload) == json.loads(payload)\n"
+        ),
+    ],
+)
+def test_unwarranted_json_loads_receiver_is_not_factory_owned(source: str) -> None:
+    context = FactoryBuildContext(
+        filename="json_loads.py",
+        catalog=default_catalog(),
+    )
+    built = build_node(
+        _stdlib_attr_call_site(source, "loads", "json_loads.py"),
+        filename="json_loads.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_json_loads_witness_pair_is_enrolled() -> None:
+    assert "json_loads_universe_coordinate" in {
+        pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
+    }
+
+
+def test_authenticated_dataclasses_asdict_selects_one_factory_owner() -> None:
+    source = (
+        "import dataclasses\n"
+        "\n"
+        "def test_asdict(value):\n"
+        "    assert dataclasses.asdict(value) == dataclasses.asdict(value)\n"
+    )
+    context = FactoryBuildContext(
+        filename="dataclasses_asdict.py",
+        catalog=default_catalog(),
+    )
+    built = build_node(
+        _stdlib_attr_call_site(source, "asdict", "dataclasses_asdict.py"),
+        filename="dataclasses_asdict.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+def test_authenticated_from_import_asdict_selects_one_factory_owner() -> None:
+    source = (
+        "from dataclasses import asdict\n"
+        "\n"
+        "def test_asdict(value):\n"
+        "    assert asdict(value) == asdict(value)\n"
+    )
+    context = FactoryBuildContext(
+        filename="asdict_from.py",
+        catalog=default_catalog(),
+    )
+    built = build_node(
+        _stdlib_name_call_site(source, "asdict", "asdict_from.py"),
+        filename="asdict_from.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "import dataclasses\n"
+            "\n"
+            "def test_asdict(dataclasses, value):\n"
+            "    assert dataclasses.asdict(value) == dataclasses.asdict(value)\n"
+        ),
+        (
+            "import dataclasses\n"
+            "\n"
+            "def test_asdict(value):\n"
+            "    assert dataclasses.asdict(value) == dataclasses.asdict(value)\n"
+            "    dataclasses = replacement\n"
+        ),
+        (
+            "import math as dataclasses\n"
+            "\n"
+            "def test_asdict(value):\n"
+            "    assert dataclasses.asdict(value) == dataclasses.asdict(value)\n"
+        ),
+        (
+            "def test_asdict(value):\n"
+            "    assert dataclasses.asdict(value) == dataclasses.asdict(value)\n"
+        ),
+    ],
+)
+def test_unwarranted_dataclasses_asdict_receiver_is_not_factory_owned(
+    source: str,
+) -> None:
+    context = FactoryBuildContext(
+        filename="dataclasses_asdict.py",
+        catalog=default_catalog(),
+    )
+    built = build_node(
+        _stdlib_attr_call_site(source, "asdict", "dataclasses_asdict.py"),
+        filename="dataclasses_asdict.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_dataclasses_asdict_witness_pair_is_enrolled() -> None:
+    assert "dataclasses_asdict_universe_coordinate" in {
+        pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
+    }

--- a/implementations/python/sugar-lift-py-tests/tests/test_universe_coverage_gap.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_universe_coverage_gap.py
@@ -1004,3 +1004,255 @@ def test_floor_protocol_method_named_test_is_not_an_assertion_source() -> None:
         for edge in payload.call_edges
     )
     assert _universe_gaps(payload) == []
+
+
+def test_authenticated_json_loads_has_universe_support() -> None:
+    source = (
+        "import json\n"
+        "\n"
+        "def test_loads(payload):\n"
+        "    assert json.loads(payload) is not None\n"
+    )
+
+    payload = lift_file_payload(source, "json_loads_covered_fixture.py")
+
+    assert any(
+        edge.get("targetSymbol") == "call:json.loads" for edge in payload.call_edges
+    )
+    assert _universe_gaps(payload) == []
+
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "loads"
+    )
+    site = SourceFragment.from_node(
+        call, "json_loads_covered_fixture.py", source=source
+    )
+    assert CalleeUniverseRecognition.coordinate(site) == "json.loads"
+    context = FactoryBuildContext(
+        filename="json_loads_covered_fixture.py", catalog=default_catalog()
+    )
+    built = build_node(
+        site,
+        filename="json_loads_covered_fixture.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+def test_authenticated_from_import_json_loads_has_universe_support() -> None:
+    # Prefer non-equality use of the free parameter so install-source dig does
+    # not recurse into the stdlib json body under this fixture.
+    source = (
+        "from json import loads\n"
+        "\n"
+        "def test_loads(payload):\n"
+        "    assert loads(payload) is not None\n"
+    )
+
+    payload = lift_file_payload(source, "json_loads_from_covered.py")
+
+    assert any(
+        edge.get("targetSymbol") == "call:json.loads" for edge in payload.call_edges
+    )
+    assert _universe_gaps(payload) == []
+
+
+def test_shadowed_json_alias_cannot_warrant_loads_support() -> None:
+    """Lying twin: parameter receiver is not the authenticated json import."""
+
+    source = (
+        "import json\n"
+        "\n"
+        "def test_loads(json, payload):\n"
+        "    assert json.loads(payload) is not None\n"
+    )
+
+    payload = lift_file_payload(source, "json_loads_shadowed_fixture.py")
+
+    gaps = _universe_gaps(payload)
+    assert [gap.ast_kind for gap in gaps] == ["call:json.loads"]
+
+
+def test_later_local_rebind_revokes_json_loads_import_warrant() -> None:
+    """Lying twin: later function-local rebind must break false recognition."""
+
+    source = (
+        "import json\n"
+        "\n"
+        "def test_loads(payload):\n"
+        "    assert json.loads(payload) is not None\n"
+        "    json = replacement\n"
+    )
+
+    payload = lift_file_payload(source, "json_loads_late_rebind.py")
+
+    gaps = _universe_gaps(payload)
+    assert [gap.ast_kind for gap in gaps] == ["call:json.loads"]
+
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "loads"
+    )
+    site = SourceFragment.from_node(call, "json_loads_late_rebind.py", source=source)
+    assert CalleeUniverseRecognition.coordinate(site) is None
+
+
+def test_unauthenticated_json_loads_fqn_alone_stays_loud() -> None:
+    """Lying twin: FQN spelling without import provenance must not silence."""
+
+    source = (
+        "def test_loads(payload):\n"
+        "    assert json.loads(payload) is not None\n"
+    )
+
+    payload = lift_file_payload(source, "json_loads_unauthenticated_fqn.py")
+
+    gaps = _universe_gaps(payload)
+    assert gaps
+    assert all("loads" in gap.ast_kind for gap in gaps)
+
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "loads"
+    )
+    site = SourceFragment.from_node(
+        call, "json_loads_unauthenticated_fqn.py", source=source
+    )
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe("call:json.loads", site=site) is None
+
+
+def test_authenticated_dataclasses_asdict_has_universe_support() -> None:
+    source = (
+        "import dataclasses\n"
+        "\n"
+        "def test_asdict(value):\n"
+        "    assert dataclasses.asdict(value) is not None\n"
+    )
+
+    payload = lift_file_payload(source, "asdict_covered_fixture.py")
+
+    assert any(
+        edge.get("targetSymbol") == "call:dataclasses.asdict"
+        for edge in payload.call_edges
+    )
+    assert _universe_gaps(payload) == []
+
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "asdict"
+    )
+    site = SourceFragment.from_node(call, "asdict_covered_fixture.py", source=source)
+    assert CalleeUniverseRecognition.coordinate(site) == "dataclasses.asdict"
+    context = FactoryBuildContext(
+        filename="asdict_covered_fixture.py", catalog=default_catalog()
+    )
+    built = build_node(
+        site,
+        filename="asdict_covered_fixture.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+def test_authenticated_from_import_asdict_has_universe_support() -> None:
+    source = (
+        "from dataclasses import asdict\n"
+        "\n"
+        "def test_asdict(value):\n"
+        "    assert asdict(value) is not None\n"
+    )
+
+    payload = lift_file_payload(source, "asdict_from_covered.py")
+
+    assert any(
+        edge.get("targetSymbol") == "call:dataclasses.asdict"
+        for edge in payload.call_edges
+    )
+    assert _universe_gaps(payload) == []
+
+
+def test_shadowed_dataclasses_alias_cannot_warrant_asdict_support() -> None:
+    """Lying twin: parameter receiver is not the authenticated dataclasses import."""
+
+    source = (
+        "import dataclasses\n"
+        "\n"
+        "def test_asdict(dataclasses, value):\n"
+        "    assert dataclasses.asdict(value) is not None\n"
+    )
+
+    payload = lift_file_payload(source, "asdict_shadowed_fixture.py")
+
+    gaps = _universe_gaps(payload)
+    assert [gap.ast_kind for gap in gaps] == ["call:dataclasses.asdict"]
+
+
+def test_later_local_rebind_revokes_asdict_import_warrant() -> None:
+    """Lying twin: later function-local rebind must break false recognition."""
+
+    source = (
+        "from dataclasses import asdict\n"
+        "\n"
+        "def test_asdict(value):\n"
+        "    assert asdict(value) is not None\n"
+        "    asdict = replacement\n"
+    )
+
+    payload = lift_file_payload(source, "asdict_late_rebind.py")
+
+    gaps = _universe_gaps(payload)
+    assert [gap.ast_kind for gap in gaps] == ["call:dataclasses.asdict"]
+
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "asdict"
+    )
+    site = SourceFragment.from_node(call, "asdict_late_rebind.py", source=source)
+    assert CalleeUniverseRecognition.coordinate(site) is None
+
+
+def test_unauthenticated_asdict_fqn_alone_stays_loud() -> None:
+    """Lying twin: FQN spelling without import provenance must not silence."""
+
+    source = (
+        "def test_asdict(value):\n"
+        "    assert dataclasses.asdict(value) is not None\n"
+    )
+
+    payload = lift_file_payload(source, "asdict_unauthenticated_fqn.py")
+
+    gaps = _universe_gaps(payload)
+    assert gaps
+    assert all("asdict" in gap.ast_kind for gap in gaps)
+
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "asdict"
+    )
+    site = SourceFragment.from_node(
+        call, "asdict_unauthenticated_fqn.py", source=source
+    )
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe("call:dataclasses.asdict", site=site) is None


### PR DESCRIPTION
## Summary

Continue full-recensus unclassified drain by descending Sugar-native mass, preferring bare/stdlib over the pydantic method wall.

Authenticate the two largest remaining **stdlib** callee-universe families:

| family | recensus residual (pin `0f4748f`) | local honest-shape ΔR |
| --- | ---: | ---: |
| `call:json.loads` | 43 | −4 → 0 |
| `call:dataclasses.asdict` | 31 | −4 → 0 |
| **total claimed** | **−74** | **−8 measured** |

### Construction
- `CalleeUniverseRecognition` / `_IMPORTED_SUPPORT`: `json.loads`, `dataclasses.asdict`
- `BuiltinCalleeUniverseSugar`: coordinates + truthful/lying witnesses
- Lying twins stay loud: parameter shadow, late rebind, wrong-module alias, unauth FQN
- Import and `from … import` forms both authenticate; keyword calls remain unowned

### Floors (local)
- side doors `R_behavior_side_doors = 0`
- ownership `R_ownership = 0`
- vendor special-case `R_vendor_special_case = 0`
- silent `R_silent = 0` (pre-existing silent-surface scan green)

### Predicted Epsilon R
- `R(unclassified callee universe rows)`: −74 on recensus ranking mass for these two families (stale pin; live residual may be lower if other drains landed)
- Local instrument: −8 gaps on fixed honest-shape fixtures

### Validation
- Focused discrimination (enrollment, owner select, lying twins, universe gap): all pass
- `vendor_special_case_law`, `factory_ownership_law`, `factory_zero_tolerance`: green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate `json.loads` and `dataclasses.asdict` callee universes
> - Adds `CalleeUniverseSupport.JSON_LOADS` and `CalleeUniverseSupport.DATACLASSES_ASDICT` enum members and maps them in the imported support registry so the recognition layer resolves these stdlib calls to explicit support identifiers.
> - Extends `BuiltinCalleeUniverseSugar` to claim factory ownership of authenticated `json.loads` and `dataclasses.asdict` call sites, including witness fixtures for each.
> - Adds tests covering authenticated, from-import, shadowed, and locally-rebound receiver scenarios to verify correct factory selection and universe gap behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8963b72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->