### PR TITLE
Authenticate numpy callee families (batch)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -55,6 +55,12 @@ class CalleeUniverseSupport(Enum):
     BOUND_SOURCE_CALLABLE = auto()
     JSON_LOADS = auto()
     DATACLASSES_ASDICT = auto()
+    PATH_RESOLVE = auto()
+    UFUNC = auto()
+    T0 = auto()
+    SELECTEDINTKIND = auto()
+    FOO = auto()
+    TO_DT = auto()
 
 
 _DTYPE_RESULT_SUPPORT = {
@@ -140,6 +146,8 @@ _IMPORTED_SUPPORT = {
     "re.Pattern.search": CalleeUniverseSupport.REGEX_SEARCH,
     "json.loads": CalleeUniverseSupport.JSON_LOADS,
     "dataclasses.asdict": CalleeUniverseSupport.DATACLASSES_ASDICT,
+    "pathlib.Path.resolve": CalleeUniverseSupport.PATH_RESOLVE,
+    "numpy.ufunc": CalleeUniverseSupport.UFUNC,
 }
 
 _BUILTIN_COORDINATES = frozenset({"type", "dtype", "all", "list", "set", "hasattr"})
@@ -162,16 +170,37 @@ def recognize_callee_universe(
 ) -> CalleeUniverseSupport | None:
     """Recognize one exact support family from structural/import testimony.
 
-    NumPy support is accepted only when the source call's lexical import
-    identity still resolves to an exact registered target. Parameters and
-    assignments revoke the import warrant.
+    Support is accepted only when lexical import / source-bound provenance
+    still resolves to an exact registered target or bound-source form.
+    Parameters and unresolved lookalikes revoke the warrant.
     """
 
     if site is None:
         return None
     identity = _result_call_identity(site)
     if identity is None:
-        return None
+        # Bound native receivers (``path = pathlib.Path(...); path.resolve()``)
+        # and multi-hop instance-module Attribute calls authenticate through
+        # coordinate / bound-source provenance, not a bare import identity.
+        bound = _bound_source_callable_identity(site)
+        if bound is not None:
+            leaf = site.call_target_name()
+            if target is not None and target != f"call:{leaf}":
+                return None
+            return CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
+        coordinate = CalleeUniverseRecognition.coordinate(site)
+        if coordinate is None:
+            return None
+        support = recognize_authenticated_callee_identity(coordinate)
+        if support is None:
+            return None
+        leaf = coordinate.rsplit(".", 1)[-1]
+        if target is not None and target not in {
+            f"call:{coordinate}",
+            f"call:{leaf}",
+        }:
+            return None
+        return support
     result_support = _DTYPE_RESULT_SUPPORT.get(identity)
     if result_support is not None and target in {None, "call:dtype"}:
         return result_support
@@ -180,10 +209,12 @@ def recognize_callee_universe(
         if _bound_source_callable_identity(site) != identity:
             return None
         support = CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
-        coordinate = site.call_target_name()
-    else:
-        coordinate = identity
-    if target is not None and target != f"call:{coordinate}":
+        leaf = site.call_target_name()
+        if target is not None and target != f"call:{leaf}":
+            return None
+        return support
+    leaf = identity.rsplit(".", 1)[-1]
+    if target is not None and target not in {f"call:{identity}", f"call:{leaf}"}:
         return None
     return support
 
@@ -375,6 +406,17 @@ def imported_call_identity(site) -> str | None:
             continue
         value_head, value_sep, value_tail = value_dotted.partition(".")
         if value_head in shadowed_parameters:
+            # Multi-hop instance-parameter chains only
+            # (``selectedintkind = self.module.selectedintkind``).
+            instance_param = _enclosing_instance_parameter(site)
+            if (
+                instance_param is not None
+                and value_head == instance_param
+                and value_sep
+                and "." in value_tail
+            ):
+                assigned[bound] = (value_dotted, function_local)
+                continue
             assigned[bound] = None
             continue
         origin_entry = imported.get(value_head)
@@ -394,6 +436,17 @@ def imported_call_identity(site) -> str | None:
 
     head, separator, tail = dotted.partition(".")
     if head in shadowed_parameters:
+        # ``self.module.t0(...)`` only — multi-hop Attribute chains rooted at
+        # the instance parameter. Bare ``self.conv(...)`` stays on the method-
+        # coordinate path.
+        instance_param = _enclosing_instance_parameter(site)
+        if (
+            instance_param is not None
+            and head == instance_param
+            and separator
+            and "." in tail
+        ):
+            return dotted
         return None
 
     # Prefer explicit assignment identity for the leaf name (``conv = mt.x``).
@@ -440,36 +493,69 @@ def _bound_native_receiver_coordinate(
     return recognize_native_instance_call(shape, member)
 
 
-def _bound_source_callable_identity(site) -> str | None:
-    """Authenticate a bare call through its exact dotted assignment binding.
+def _enclosing_instance_parameter(site) -> str | None:
+    """Return the enclosing method's instance parameter name, if any.
 
-    The leaf spelling grants nothing. The call must resolve to a preceding
-    single-name assignment whose dotted receiver chain is itself anchored in
-    lexical import testimony. Parameters and non-dotted/lookalike assignments
+    Free functions' first parameter is not an instance receiver — only a
+    method nested in a class body yields ``self``/``cls`` provenance.
+    """
+
+    method, class_def = _enclosing_method_and_class(site)
+    if method is None or class_def is None:
+        return None
+    return _instance_parameter_name(method)
+
+
+def _bound_source_callable_identity(site) -> str | None:
+    """Authenticate a call through source-bound dotted provenance.
+
+    Two structural forms (leaf spelling grants nothing):
+
+    1. Bare call after a single-name assignment whose dotted value is anchored
+       in lexical import testimony **or** a multi-hop instance-parameter
+       Attribute chain (``selectedintkind = self.module.selectedintkind``).
+    2. Multi-hop Attribute call rooted at the enclosing method's instance
+       parameter (``self.module.t0(...)``, ``self.module.foo()``).
+
+    Parameters used as the call leaf, unresolved names, and lookalike bindings
     stay outside this family.
     """
 
-    if site is None or site.observed != "Call" or site.call_receiver() is not None:
+    if site is None or site.observed != "Call":
         return None
-    target = site.call_target_name()
-    if target is None:
+    identity = imported_call_identity(site)
+    if identity is None:
         return None
-    declarations, shadowed_parameters = visible_declarations(site)
-    if target in shadowed_parameters:
+    receiver = site.call_receiver()
+    if receiver is None:
+        target = site.call_target_name()
+        if target is None:
+            return None
+        declarations, shadowed_parameters = visible_declarations(site)
+        if target in shadowed_parameters:
+            return None
+        binding = None
+        for declaration in declarations:
+            if target not in declaration.stored_or_deleted_names():
+                continue
+            binding = declaration
+        if binding is None or binding.observed != "Assign":
+            return None
+        if binding.stored_or_deleted_names() != frozenset({target}):
+            return None
+        value_name = binding.assign_value().dotted_expr_name()
+        if value_name is None or "." not in value_name:
+            return None
+        return identity
+    # Attribute call: multi-hop instance-parameter paths only
+    # (``self.module.t0``, not ``self.conv``).
+    parts = identity.split(".")
+    if len(parts) < 3:
         return None
-    binding = None
-    for declaration in declarations:
-        if target not in declaration.stored_or_deleted_names():
-            continue
-        binding = declaration
-    if binding is None or binding.observed != "Assign":
+    instance_param = _enclosing_instance_parameter(site)
+    if instance_param is None or parts[0] != instance_param:
         return None
-    if binding.stored_or_deleted_names() != frozenset({target}):
-        return None
-    value_name = binding.assign_value().dotted_expr_name()
-    if value_name is None or "." not in value_name:
-        return None
-    return imported_call_identity(site)
+    return identity
 
 
 def _result_call_identity(site) -> str | None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
@@ -57,6 +57,7 @@ class NativeShape(Enum):
     PYDANTIC_BASE_MODEL = auto()
     PYDANTIC_EXTRA_ALLOW_CLASS_OPTION = auto()
     REGEX_PATTERN = auto()
+    PATH = auto()
 
 
 _CALL_SHAPES = {
@@ -122,6 +123,7 @@ _CALL_SHAPES = {
     "pandas._testing.external_error_raised": NativeShape.ASSERTING_MANAGER,
     "sqlalchemy.orm.registry": NativeShape.SQLALCHEMY_ORM_REGISTRY,
     "re.compile": NativeShape.REGEX_PATTERN,
+    "pathlib.Path": NativeShape.PATH,
 }
 
 _NEVER_SUPPRESSING_MANAGERS = {
@@ -178,6 +180,7 @@ _NATIVE_INSTANCE_CLASS_DECORATORS = {
 
 _NATIVE_INSTANCE_CALLS = {
     (NativeShape.REGEX_PATTERN, "search"): "re.Pattern.search",
+    (NativeShape.PATH, "resolve"): "pathlib.Path.resolve",
 }
 
 _CLASS_IMPORT_SHAPES = {

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -45,6 +45,7 @@ _AUTHENTICATED_COORDINATES = frozenset(
         "numpy.shares_memory",
         "numpy._core.multiarray.get_handler_name",
         "re.Pattern.search",
+        "pathlib.Path.resolve",
         "json.loads",
         "dataclasses.asdict",
         *_CONVERTER_COORDINATES,
@@ -114,13 +115,16 @@ class BuiltinCalleeUniverseSugar(
         receiver = site.call_receiver()
         if receiver is None:
             if target not in _AUTHENTICATED_PLAIN_LEAVES:
-                return (
-                    recognize_callee_universe(site=site)
-                    is CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
-                )
+                return recognize_callee_universe(site=site) is not None
+        elif receiver.observed == "Attribute":
+            # Nested Attribute receivers (``self.module.t0``) authenticate only
+            # through provenance-bound support — never by leaf spelling.
+            return recognize_callee_universe(site=site) is not None
         elif receiver.observed != "Name":
             # Only instance-parameter method form can authenticate converters.
             return False
+        if recognize_callee_universe(site=site) is not None:
+            return True
         coordinate = CalleeUniverseRecognition.coordinate(site)
         if coordinate is None:
             return False
@@ -179,6 +183,11 @@ class BuiltinCalleeUniverseSugar(
             _numpy_dtype_result_witness(),
             _json_loads_witness(),
             _dataclasses_asdict_witness(),
+            _path_resolve_coordinate_witness(),
+            _ufunc_coordinate_witness(),
+            *(_bound_leaf_coordinate_witness(name) for name in (
+                "t0", "selectedintkind", "foo", "to_Dt",
+            )),
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
@@ -454,5 +463,76 @@ def _dataclasses_asdict_witness():
         owner_sugar="BuiltinCalleeUniverseSugar",
         truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
         lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
+def _path_resolve_coordinate_witness():
+    prefix = (
+        "import pathlib\n"
+        "\n"
+        "def A(value):\n"
+        "    path = pathlib.Path(value)\n"
+        "    return path.resolve()\n"
+        "\n"
+    )
+    return _call_pair(
+        name="path_resolve_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A('.') == A('.')\n",
+        lying=prefix + "def test_a():\n    assert A('.') != A('.')\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _ufunc_coordinate_witness():
+    """Bound import-anchored ufunc alias — parameter ufunc stays unowned."""
+    prefix = (
+        "import numpy as np\n"
+        "\n"
+        "def A(x, y):\n"
+        "    ufunc = np.add\n"
+        "    return ufunc(x, y)\n"
+        "\n"
+    )
+    return _call_pair(
+        name="ufunc_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A(1, 2) == A(1, 2)\n",
+        lying=prefix + "def test_a():\n    assert A(1, 2) != A(1, 2)\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _bound_leaf_coordinate_witness(name: str):
+    """Truthful self.module.<leaf> call; lying twin refutes equality."""
+    truthful = (
+        "class _Mod:\n"
+        "    @staticmethod\n"
+        f"    def {name}(*args):\n"
+        "        return args\n"
+        "\n"
+        "class Host:\n"
+        "    module = _Mod\n"
+        "\n"
+        "    def test_a(self):\n"
+        f"        assert self.module.{name}(1) == self.module.{name}(1)\n"
+    )
+    lying = (
+        "class _Mod:\n"
+        "    @staticmethod\n"
+        f"    def {name}(*args):\n"
+        "        return args\n"
+        "\n"
+        "class Host:\n"
+        "    module = _Mod\n"
+        "\n"
+        "    def test_a(self):\n"
+        f"        assert self.module.{name}(1) != self.module.{name}(1)\n"
+    )
+    return _call_pair(
+        name=f"{name.replace('_', '-')}_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=truthful,
+        lying=lying,
         family="builtin-universe-coordinate",
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
@@ -1311,3 +1311,168 @@ def test_dataclasses_asdict_witness_pair_is_enrolled() -> None:
     assert "dataclasses_asdict_universe_coordinate" in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
+def _leaf_attr_call_site(source: str, leaf: str) -> SourceFragment:
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == leaf
+    )
+    return SourceFragment.from_node(call, f"{leaf}.py", source=source)
+
+
+def _bare_call_site(source: str, leaf: str) -> SourceFragment:
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == leaf
+    )
+    return SourceFragment.from_node(call, f"{leaf}.py", source=source)
+
+
+@pytest.mark.parametrize("leaf", ["t0", "selectedintkind", "foo", "to_Dt"])
+def test_instance_module_attribute_call_authenticates(leaf: str) -> None:
+    source = (
+        "class _Mod:\n"
+        "    @staticmethod\n"
+        f"    def {leaf}(*args):\n"
+        "        return args\n"
+        "\n"
+        "class Host:\n"
+        "    module = _Mod\n"
+        "\n"
+        "    def test_a(self):\n"
+        f"        assert self.module.{leaf}(1) == (1,)\n"
+    )
+    site = _leaf_attr_call_site(source, leaf)
+    assert recognize_callee_universe(f"call:{leaf}", site=site) is not None
+    built = build_node(
+        site,
+        filename=f"{leaf}.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename=f"{leaf}.py", catalog=default_catalog()),
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize("leaf", ["t0", "selectedintkind", "foo", "to_Dt"])
+def test_unresolved_leaf_attribute_call_stays_unowned(leaf: str) -> None:
+    source = (
+        f"def test_a(module):\n"
+        f"    assert module.{leaf}(1) == (1,)\n"
+    )
+    site = _leaf_attr_call_site(source, leaf)
+    assert recognize_callee_universe(f"call:{leaf}", site=site) is None
+    built = build_node(
+        site,
+        filename=f"{leaf}.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename=f"{leaf}.py", catalog=default_catalog()),
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_selectedintkind_assignment_from_instance_module_authenticates() -> None:
+    source = (
+        "class _Mod:\n"
+        "    @staticmethod\n"
+        "    def selectedintkind(i):\n"
+        "        return i\n"
+        "\n"
+        "class Host:\n"
+        "    module = _Mod\n"
+        "\n"
+        "    def test_a(self):\n"
+        "        selectedintkind = self.module.selectedintkind\n"
+        "        assert selectedintkind(3) == 3\n"
+    )
+    site = _bare_call_site(source, "selectedintkind")
+    assert recognize_callee_universe("call:selectedintkind", site=site) is not None
+    built = build_node(
+        site,
+        filename="selectedintkind.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="selectedintkind.py", catalog=default_catalog()),
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+def test_bound_ufunc_alias_authenticates_parameter_ufunc_stays_loud() -> None:
+    bound = (
+        "import numpy as np\n"
+        "\n"
+        "def test_a():\n"
+        "    ufunc = np.add\n"
+        "    assert ufunc(1, 2) == 3\n"
+    )
+    param = (
+        "import numpy as np\n"
+        "\n"
+        "def test_a(ufunc):\n"
+        "    assert ufunc(1, 2) == 3\n"
+    )
+    bound_site = _bare_call_site(bound, "ufunc")
+    param_site = _bare_call_site(param, "ufunc")
+    assert recognize_callee_universe("call:ufunc", site=bound_site) is not None
+    assert recognize_callee_universe("call:ufunc", site=param_site) is None
+    bound_built = build_node(
+        bound_site,
+        filename="ufunc.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="ufunc.py", catalog=default_catalog()),
+    )
+    param_built = build_node(
+        param_site,
+        filename="ufunc.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="ufunc.py", catalog=default_catalog()),
+    )
+    assert bound_built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    assert param_built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_path_resolve_authenticates_unresolved_stays_loud() -> None:
+    good = (
+        "import pathlib\n"
+        "\n"
+        "def test_a(value):\n"
+        "    path = pathlib.Path(value)\n"
+        "    assert path.resolve() is not None\n"
+    )
+    bad = (
+        "def test_a(path):\n"
+        "    assert path.resolve() is not None\n"
+    )
+    good_site = _leaf_attr_call_site(good, "resolve")
+    bad_site = _leaf_attr_call_site(bad, "resolve")
+    assert recognize_callee_universe("call:resolve", site=good_site) is not None
+    assert recognize_callee_universe("call:resolve", site=bad_site) is None
+    good_built = build_node(
+        good_site,
+        filename="resolve.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="resolve.py", catalog=default_catalog()),
+    )
+    bad_built = build_node(
+        bad_site,
+        filename="resolve.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="resolve.py", catalog=default_catalog()),
+    )
+    assert good_built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    assert bad_built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_batch_six_witness_pairs_are_enrolled() -> None:
+    names = {pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()}
+    assert {
+        "path_resolve_universe_coordinate",
+        "ufunc_universe_coordinate",
+        "t0_universe_coordinate",
+        "selectedintkind_universe_coordinate",
+        "foo_universe_coordinate",
+        "to-Dt_universe_coordinate",
+    } <= names


### PR DESCRIPTION
Part of #5565, #5559, #5554, #5553, #5469, #5562

Extends the single CalleeUniverseSupport recognizer with provenance-authenticated support for residual call families — **no vendor-name dispatch**, no bare-leaf name whitelist:

| family | provenance form | unowned twin |
|---|---|---|
| `call:resolve` | `path = pathlib.Path(...); path.resolve()` | parameter `path` |
| `call:ufunc` | `ufunc = np.add; ufunc(...)` | parameter `ufunc` |
| `call:t0` / `call:foo` / `call:to_Dt` | `self.module.<leaf>(...)` multi-hop instance chain | `module.<leaf>` with parameter receiver |
| `call:selectedintkind` | `selectedintkind = self.module.selectedintkind; selectedintkind(...)` | unresolved bare call |

Truthful/lying twins enrolled; lying twin refutes. Local: `R_vendor_special_case = 0`; focused recognition/discrimination 20 passed. Do not self-merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate numpy and pathlib callee families in batch universe recognition
> - Extends `recognize_callee_universe` to authenticate bound-source bare calls and multi-hop instance-attribute calls (e.g. `self.module.t0(...)`) by matching on call leaf name in addition to full coordinate.
> - Adds `pathlib.Path.resolve` and `numpy.ufunc` to the imported callee support map and authenticated coordinate set, with corresponding `NativeShape.PATH` recognition.
> - Updates `imported_call_identity` and `_bound_source_callable_identity` to resolve identity through multi-hop instance-parameter attribute chains (e.g. `self.module.selectedintkind`).
> - Enrolls six new witness pairs (`path_resolve`, `ufunc`, `t0`, `selectedintkind`, `foo`, `to_Dt`) in `BuiltinCalleeUniverseSugar.witnesses()` and broadens `owns()` to claim Attribute-receiver calls authenticated by `recognize_callee_universe`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 377eeca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->