### PR TITLE
Project over-cap store-body For through compact recognition

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/for_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/for_sugar.py
@@ -16,6 +16,24 @@ STATIC_UNFOLD_LIMIT = 1024
 # work projects through the shared compact recognition door — never force-curry
 # opacity, never soft Complete, never a bound raise (#5338 / #5375 / #5383).
 BRANCHED_STATIC_UNFOLD_LIMIT = 8
+# Static unfold × subscript/attribute store multiplies setitem post-state
+# super-linearly (product: shortest_path star_graph 9× ~2s; 99× hard timeout).
+# Same compact door and budget as branched bodies (#5338 post-#5574).
+STORE_BODY_STATIC_UNFOLD_LIMIT = BRANCHED_STATIC_UNFOLD_LIMIT
+
+# Body sugars whose reduce cites subscript/attribute post-state. Simple
+# Name augassign (`total += x`) stays on the pure static-unfold budget;
+# store faces do not.
+_STORE_BODY_SUGAR_NAMES = frozenset(
+    {
+        "SubscriptAugAssignSugar",
+        "ResidualSubscriptAugAssignSugar",
+        "SubscriptAssignSugar",
+        "AttributeAugAssignSugar",
+        "NestedAttributeAugAssignSugar",
+        "SelectedAttributeAugAssignSugar",
+    }
+)
 
 
 def is_ground_loop_datum(value) -> bool:
@@ -240,6 +258,8 @@ class ForSugar(Sugar, role=SugarRole.STATEMENT):
             limit = STATIC_UNFOLD_LIMIT
             if self._body_has_branching_statement():
                 limit = min(limit, BRANCHED_STATIC_UNFOLD_LIMIT)
+            if self._body_has_store_statement():
+                limit = min(limit, STORE_BODY_STATIC_UNFOLD_LIMIT)
             needs_compact = element_count > limit or (
                 self._body_has_while() and self._while_reads_non_ground_outer(ctx)
             )
@@ -252,9 +272,10 @@ class ForSugar(Sugar, role=SugarRole.STATEMENT):
         """Shared compact For door for finite work outside the unfold budget.
 
         Recognition projection: bind the target to ``py.iter_elem`` and reduce
-        the body once. Covers branched over-cap lists, pure over-cap
-        materialize, and non-ground while under a finite for. Does not
-        force-curry, soft-complete, truncate, or mint RuntimeEffect.
+        the body once. Covers branched over-cap lists, store-body over-cap
+        lists, pure over-cap materialize, and non-ground while under a finite
+        for. Does not force-curry, soft-complete, truncate, or mint
+        RuntimeEffect.
         """
         return self._bind_and_body(iterable, ctx)
 
@@ -264,6 +285,15 @@ class ForSugar(Sugar, role=SugarRole.STATEMENT):
         Used only to choose the static-unfold budget; recognition is unchanged.
         """
         return self._body_owns_sugar_names({"IfSugar", "MatchSugar", "IfExpSugar"})
+
+    def _body_has_store_statement(self) -> bool:
+        """True when the loop body owns a subscript/attribute store face.
+
+        Used only to choose the static-unfold budget; recognition is unchanged.
+        Store faces multiply setitem post-state under N-fold unfold
+        (shortest_path star_graph residual after #5574).
+        """
+        return self._body_owns_sugar_names(_STORE_BODY_SUGAR_NAMES)
 
     def _body_has_while(self) -> bool:
         """True when the loop body owns a While face (empty-orelse or else)."""

--- a/implementations/python/sugar-lift-py-tests/tests/test_static_range_unfold.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_static_range_unfold.py
@@ -117,3 +117,105 @@ def test_branched_static_for_over_cap_projects_compact_not_force_curried() -> No
         assert panic.value.info.owner != "finite_unfold", panic.value.info
         return
     assert payload is not None
+
+
+def test_subscript_store_static_for_over_cap_projects_compact() -> None:
+    """#5338 post-#5574: finite For + subscript store must not N-fold setitem.
+
+    Product hang: scipy test_shortest_path star_graph
+      for idx in range(1, n): SP_solution[idx] += ...
+    with pytest parametrize n in (10, 100) materializes range and static-unfolds.
+    Per-iteration setitem post-state is super-linear (9× ~2s; 99× times out).
+
+    Shared door with branched over-cap: recognition projection under
+    py.iter_elem when card > BRANCHED_STATIC_UNFOLD_LIMIT — not force-curry,
+    not soft Complete, not bound raise.
+    """
+    from sugar_lift_py_tests.sugar.for_sugar import (
+        BRANCHED_STATIC_UNFOLD_LIMIT,
+        ForSugar,
+    )
+
+    n = BRANCHED_STATIC_UNFOLD_LIMIT + 1
+    indices = ", ".join(str(i) for i in range(1, n + 1))
+    source = (
+        "def test_star_store():\n"
+        f"    idxs = [{indices}]\n"
+        "    xs = [0] * 32\n"
+        "    for idx in idxs:\n"
+        "        xs[idx] += 1\n"
+        "    assert xs[1] == 1\n"
+    )
+
+    unfold_calls: list[int] = []
+    compact_calls: list[object] = []
+    orig_unfold = ForSugar._unfold_values
+    orig_compact = ForSugar._project_compact_finite
+
+    def _spy_unfold(self, values, ctx, entries=()):
+        unfold_calls.append(len(values) if hasattr(values, "__len__") else -1)
+        return orig_unfold(self, values, ctx, entries)
+
+    def _spy_compact(self, iterable, ctx):
+        compact_calls.append(type(iterable).__name__)
+        return orig_compact(self, iterable, ctx)
+
+    ForSugar._unfold_values = _spy_unfold  # type: ignore[method-assign]
+    ForSugar._project_compact_finite = _spy_compact  # type: ignore[method-assign]
+    try:
+        try:
+            payload = lift_file_payload(source, "store-for.py")
+        except FactoryPanic as panic:
+            owner = getattr(panic.info, "owner", None)
+            assert owner != "finite_unfold", panic.info
+            # Still must have preferred compact over unfold for the store body.
+            assert unfold_calls == [], unfold_calls
+            assert compact_calls, "expected compact projection for store body"
+            return
+        assert payload is not None
+        assert unfold_calls == [], f"static unfold must not fire for store body: {unfold_calls}"
+        assert compact_calls, "expected compact projection for store body over branched cap"
+    finally:
+        ForSugar._unfold_values = orig_unfold  # type: ignore[method-assign]
+        ForSugar._project_compact_finite = orig_compact  # type: ignore[method-assign]
+
+
+def test_parametrize_star_store_for_completes_under_product_shape() -> None:
+    """Product micro of shortest_path star_graph store loop must not hang.
+
+    Mirrors parametrize n in (10, 100) × method × directed expansion of
+    ``for idx in range(1, n): SP_solution[idx] += ...``. List store is
+    enough to trip super-linear unfold history; hang is the residual.
+    """
+    import time
+
+    from sugar_lift_py_tests.sugar.for_sugar import BRANCHED_STATIC_UNFOLD_LIMIT
+
+    assert BRANCHED_STATIC_UNFOLD_LIMIT < 10
+    source = (
+        "import pytest\n"
+        "\n"
+        "@pytest.mark.parametrize('n', (10, 100))\n"
+        "@pytest.mark.parametrize('method', ['FW', 'J', 'BF'])\n"
+        "@pytest.mark.parametrize('directed', (True, False))\n"
+        "def test_star_graph(n, method, directed):\n"
+        "    xs = [0] * 128\n"
+        "    for idx in range(1, n):\n"
+        "        xs[idx] += 1\n"
+        "    assert method is not None or directed is not None\n"
+    )
+    t0 = time.perf_counter()
+    try:
+        payload = lift_file_payload(source, "star-store-param.py")
+    except FactoryPanic as panic:
+        info = getattr(panic, "info", None) or getattr(
+            getattr(panic, "value", None), "info", None
+        )
+        owner = getattr(info, "owner", None)
+        assert owner != "finite_unfold", info
+        elapsed = time.perf_counter() - t0
+        assert elapsed < 8.0, f"store-for product micro too slow before panic: {elapsed:.2f}s"
+        return
+    elapsed = time.perf_counter() - t0
+    assert payload is not None
+    assert elapsed < 8.0, f"store-for product micro hung: {elapsed:.2f}s"


### PR DESCRIPTION
## Summary

After #5574 drained residual `finite_unfold` refuse, two exact-nine seats advanced to product timeout. Profiled shared mechanisms; one clear structural hang:

**`scipy/sparse/csgraph/tests/test_shortest_path.py`** — `test_star_graph` expands `@pytest.mark.parametrize('n', (10, 100))` into concrete `range(1, n)` ListValues (card 9 / 99). Body is `SP_solution[idx] += ...` (`SubscriptAugAssignSugar`). Finite For still static-unfolded up to `STATIC_UNFOLD_LIMIT=1024` because store faces were not on the branched budget. Per-iteration setitem post-state is super-linear (9× ~2s; 99× hard timeout under 30s).

**Door (same as branched over-cap):** when the loop body owns a subscript/attribute store sugar, apply `STORE_BODY_STATIC_UNFOLD_LIMIT = BRANCHED_STATIC_UNFOLD_LIMIT` (8). Card > 8 → `_project_compact_finite` once under `py.iter_elem`.

**Not this fix:** `numpy/random/tests/test_randomstate.py` remains **factory_build** volume (`factory.select` crawl; tip Call ~:646). Separate residual; not store-for super-linear unfold.

### Floors held
- no soft-complete / force-curry on finite arms / bound raise
- no term-id identity keys (#5569)
- silent=0

## Red instruments
- `test_subscript_store_static_for_over_cap_projects_compact` — spy: compact fires, unfold does not for store body over cap
- `test_parametrize_star_store_for_completes_under_product_shape` — parametrize n∈(10,100)×method×directed store micro under 8s wall

## Product remeasure @30s (post-fix)
| file | before (#5574) | after |
| --- | --- | --- |
| `scipy/.../test_shortest_path.py` | timeout · SubscriptAugAssignSugar | **completed · 22.1s** |
| `numpy/.../test_randomstate.py` | timeout · Call / factory_build | timeout · Call / factory_build (unchanged family) |

Part of #5338.

## Test plan
- [x] red instruments green
- [x] related static/branched/nonground For suite green
- [x] product remeasure both seats @30s
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cap static unfold for `ForSugar` loops with subscript/attribute store bodies to prefer compact projection
> - Adds `STORE_BODY_STATIC_UNFOLD_LIMIT` and `_STORE_BODY_SUGAR_NAMES` to [for_sugar.py](https://github.com/TSavo/sugar/pull/5579/files#diff-da087a71d9057e648ebf8949fe3e5c8264b4ca98f7d4f95ed02b48ac0df6ff6b) to identify loops whose body contains subscript or attribute store faces.
> - When the iterable length exceeds this limit, `ForSugar` now routes to `_project_compact_finite` (single projection under `py.iter_elem`) instead of static unfold, avoiding N-fold setitem post-state accumulation.
> - Adds `_body_has_store_statement()` helper that delegates to `_body_owns_sugar_names` with the new names set.
> - New tests in [test_static_range_unfold.py](https://github.com/TSavo/sugar/pull/5579/files#diff-c892aa8a6b0f7906d2dc34d00bcf784797839a29c889e8ae8c11631eeb6bf70d) assert compact projection is chosen over unfold for over-cap store-body loops, and that product-shaped store-body loops complete within a time budget.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ddd635.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->