### PR TITLE
fix(python): fixture providers without vendor-name dispatch (#5421 fix-forward)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/class_decorator.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/class_decorator.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import ast
 from typing import TYPE_CHECKING
 
 from sugar_lift_py_tests.recognition.native_shape import (
     NativeShape,
     recognize_native_call,
     recognize_native_class_decorator,
+    recognize_native_fixture_decorator,
     recognize_native_instance_class_decorator,
 )
 from sugar_lift_py_tests.recognition.visible_declarations import (
@@ -24,6 +26,7 @@ def class_decorators_preserve_identity(statement) -> bool:
         root = SourceFragment.from_source(statement.source, statement.filename or "")
     except (SyntaxError, TypeError):
         return False
+    del root
 
     imported: dict[str, str] = {}
     constructed: dict[str, NativeShape] = {}
@@ -67,7 +70,15 @@ def class_decorators_preserve_identity(statement) -> bool:
             return False
         head, separator, tail = dotted.partition(".")
         if head in shadowed_parameters:
-            return False
+            fixture_shape = _fixture_parameter_native_shape(statement, head)
+            if fixture_shape is None or not separator:
+                return False
+            decorator_shape = recognize_native_instance_class_decorator(
+                fixture_shape, tail
+            )
+            if decorator_shape is not NativeShape.CLASS_IDENTITY_DECORATOR:
+                return False
+            continue
         if head in constructed:
             if not separator:
                 return False
@@ -85,6 +96,304 @@ def class_decorators_preserve_identity(statement) -> bool:
         if decorator_shape is not NativeShape.CLASS_IDENTITY_DECORATOR:
             return False
     return True
+
+
+def _fixture_parameter_native_shape(statement, parameter: str) -> NativeShape | None:
+    """Authenticate an injected fixture through its source-declared provider."""
+    from sugar_lift_python_source.source_tables import parsed_parents
+
+    parsed = parsed_parents(getattr(statement, "source", "") or "")
+    if parsed is None:
+        return None
+    tree, parents = parsed
+    target = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if type(node) is type(statement.node)
+            and getattr(node, "lineno", None) == statement.line
+            and getattr(node, "col_offset", None) == statement.col
+        ),
+        None,
+    )
+    if target is None:
+        return None
+    path = [target]
+    while path[-1] in parents:
+        path.append(parents[path[-1]])
+    function = next(
+        (
+            node
+            for node in path
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ),
+        None,
+    )
+    owner = next((node for node in path[1:] if isinstance(node, ast.ClassDef)), None)
+    if (
+        function is None
+        or owner is None
+        or parameter not in _function_parameter_names(function)
+    ):
+        return None
+
+    imports = _module_imports(tree)
+    local_classes = {
+        node.name: node for node in tree.body if isinstance(node, ast.ClassDef)
+    }
+    from sugar_lift_py_tests.sugar.install_source_dig import (
+        resolve_install_source_class_method,
+    )
+
+    for qualified_base in _qualified_class_bases(
+        owner, imports, local_classes, frozenset()
+    ):
+        provider = resolve_install_source_class_method(qualified_base, parameter)
+        if provider is None:
+            continue
+        shape = _fixture_provider_native_shape(provider)
+        if shape is not None:
+            return shape
+    return None
+
+
+def _fixture_provider_native_shape(provider) -> NativeShape | None:
+    """Read the provider body only at the already-resolved source seat.
+
+    Match by exact module + line/col (content seat), never by bare method name
+    across the module — two classes can declare identically named fixtures.
+    """
+    from sugar_lift_python_source.source_oracle import installed_module_source
+
+    module_name = getattr(provider.node, "_sugar_defining_module", None)
+    if not module_name:
+        return None
+    installed = installed_module_source(module_name)
+    if installed is None:
+        return None
+    source, _, _ = installed
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+    imports = _module_imports(tree, module_name)
+    function = _function_at_provider_seat(tree, provider)
+    if function is None or not _is_authenticated_fixture(function, imports):
+        return None
+    constructed: dict[str, NativeShape] = {}
+    for node in ast.walk(function):
+        if isinstance(node, ast.Assign):
+            shape = _ast_call_native_shape(node.value, imports)
+            if shape is None:
+                continue
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    constructed[target.id] = shape
+        elif isinstance(node, (ast.Yield, ast.Return)):
+            value = node.value
+            if isinstance(value, ast.Name) and value.id in constructed:
+                return constructed[value.id]
+            shape = _ast_call_native_shape(value, imports)
+            if shape is not None:
+                return shape
+    return None
+
+
+def _function_at_provider_seat(
+    tree: ast.Module, provider
+) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    """Locate the FunctionDef at the provider's exact source seat.
+
+    Seat identity: function name + lineno + col_offset from the already-resolved
+    provider fragment. Name-only search is illegal (mismatched class fixtures).
+    """
+    target_name = provider.function_name()
+    target_line = getattr(provider, "line", None)
+    target_col = getattr(provider, "col", None)
+    if target_name is None or target_line is None or target_col is None:
+        return None
+    for function in ast.walk(tree):
+        if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if function.name != target_name:
+            continue
+        if getattr(function, "lineno", None) != target_line:
+            continue
+        if getattr(function, "col_offset", None) != target_col:
+            continue
+        return function
+    return None
+
+
+def _is_authenticated_fixture(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+    imports: dict[str, str],
+) -> bool:
+    """True when a decorator is a registered fixture protocol shape.
+
+    Uses native_shape recognition tables — never a vendor-name string compare
+    in this module (R_vendor_special_case floor).
+    """
+    for decorator in function.decorator_list:
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        qualified = _qualified_ast_name(target, imports)
+        if (
+            recognize_native_fixture_decorator(qualified)
+            is NativeShape.FIXTURE_DECORATOR
+        ):
+            return True
+    return False
+
+
+def _ast_call_native_shape(
+    node: ast.AST | None, imports: dict[str, str]
+) -> NativeShape | None:
+    if not isinstance(node, ast.Call):
+        return None
+    return recognize_native_call(_qualified_ast_name(node.func, imports))
+
+
+def _qualified_ast_name(node: ast.AST, imports: dict[str, str]) -> str | None:
+    dotted = _ast_dotted_name(node)
+    if dotted is None:
+        return None
+    head, separator, tail = dotted.partition(".")
+    origin = imports.get(head)
+    if origin is None:
+        return None
+    return f"{origin}.{tail}" if separator else origin
+
+
+def _ast_dotted_name(node: ast.AST) -> str | None:
+    parts: list[str] = []
+    cursor = node
+    while isinstance(cursor, ast.Attribute):
+        parts.append(cursor.attr)
+        cursor = cursor.value
+    if not isinstance(cursor, ast.Name):
+        return None
+    parts.append(cursor.id)
+    return ".".join(reversed(parts))
+
+
+def _module_imports(tree: ast.Module, module_name: str | None = None) -> dict[str, str]:
+    """Module-level import map with later rebinds revoking import warrants.
+
+    Sequential Assign / AnnAssign / FunctionDef / ClassDef / For / With that
+    store names clear those bindings so a later ``config = ...`` cannot keep
+    the earlier import warrant (lying twin).
+    """
+    imported: dict[str, str] = {}
+    for declaration in tree.body:
+        if isinstance(declaration, ast.Import):
+            for alias in declaration.names:
+                bound = alias.asname or alias.name.split(".", 1)[0]
+                imported[bound] = alias.name if alias.asname else bound
+            continue
+        if isinstance(declaration, ast.ImportFrom):
+            module = _absolute_import_module(
+                module_name, declaration.module, declaration.level
+            )
+            if module is None:
+                continue
+            for alias in declaration.names:
+                if alias.name != "*":
+                    imported[alias.asname or alias.name] = f"{module}.{alias.name}"
+            continue
+        for bound in _top_level_stored_names(declaration):
+            imported.pop(bound, None)
+    return imported
+
+
+def _top_level_stored_names(declaration: ast.AST) -> frozenset[str]:
+    if isinstance(declaration, ast.Assign):
+        names: list[str] = []
+        for target in declaration.targets:
+            names.extend(_ast_store_names(target))
+        return frozenset(names)
+    if isinstance(declaration, ast.AnnAssign) and isinstance(
+        declaration.target, ast.Name
+    ):
+        return frozenset((declaration.target.id,))
+    if isinstance(declaration, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return frozenset((declaration.name,))
+    if isinstance(declaration, (ast.For, ast.AsyncFor)):
+        return frozenset(_ast_store_names(declaration.target))
+    if isinstance(declaration, (ast.With, ast.AsyncWith)):
+        names = []
+        for item in declaration.items:
+            if item.optional_vars is not None:
+                names.extend(_ast_store_names(item.optional_vars))
+        return frozenset(names)
+    return frozenset()
+
+
+def _ast_store_names(target: ast.AST) -> list[str]:
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, (ast.Tuple, ast.List)):
+        names: list[str] = []
+        for elt in target.elts:
+            names.extend(_ast_store_names(elt))
+        return names
+    return []
+
+
+def _absolute_import_module(
+    defining_module: str | None, imported: str | None, level: int
+) -> str | None:
+    if level == 0:
+        return imported
+    if defining_module is None:
+        return None
+    package = defining_module.split(".")[:-1]
+    if level > len(package):
+        return None
+    prefix = package[: len(package) - level + 1]
+    if imported:
+        prefix.extend(imported.split("."))
+    return ".".join(prefix)
+
+
+def _qualified_class_bases(
+    owner: ast.ClassDef,
+    imports: dict[str, str],
+    local_classes: dict[str, ast.ClassDef],
+    resolving: frozenset[str],
+) -> tuple[str, ...]:
+    resolved: list[str] = []
+    for base in owner.bases:
+        dotted = _ast_dotted_name(base)
+        if dotted is None:
+            continue
+        head, separator, tail = dotted.partition(".")
+        origin = imports.get(head)
+        if origin is not None:
+            resolved.append(f"{origin}.{tail}" if separator else origin)
+            continue
+        local = local_classes.get(head) if not separator else None
+        if local is not None and head not in resolving:
+            resolved.extend(
+                _qualified_class_bases(
+                    local,
+                    imports,
+                    local_classes,
+                    resolving | frozenset((head,)),
+                )
+            )
+    return tuple(resolved)
+
+
+def _function_parameter_names(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> frozenset[str]:
+    args = function.args
+    names = [arg.arg for arg in (*args.posonlyargs, *args.args, *args.kwonlyargs)]
+    if args.vararg is not None:
+        names.append(args.vararg.arg)
+    if args.kwarg is not None:
+        names.append(args.kwarg.arg)
+    return frozenset(names)
 
 
 def _constructed_native_shape(declaration, imported) -> NativeShape | None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
@@ -52,6 +52,7 @@ class NativeShape(Enum):
     ASSERTING_MANAGER = auto()
     CLASS_IDENTITY_DECORATOR = auto()
     IMPLEMENTATION_PRESERVING_DECORATOR = auto()
+    FIXTURE_DECORATOR = auto()
     SQLALCHEMY_ORM_REGISTRY = auto()
     GENERIC_CLASS = auto()
     PYDANTIC_BASE_MODEL = auto()
@@ -173,6 +174,14 @@ _IDENTITY_DECORATORS = {
 
 _NATIVE_DECORATORS = {
     "functools.wraps": NativeShape.IMPLEMENTATION_PRESERVING_DECORATOR,
+}
+
+# Fixture / inject-provider protocol: registered import coordinates only.
+# Consumers authenticate via recognize_native_fixture_decorator(qualified),
+# never by comparing against a vendor-name string literal in recognition code.
+_FIXTURE_DECORATORS = {
+    "pytest.fixture": NativeShape.FIXTURE_DECORATOR,
+    "sqlalchemy.testing.config.fixture": NativeShape.FIXTURE_DECORATOR,
 }
 
 _NATIVE_INSTANCE_CLASS_DECORATORS = {
@@ -316,6 +325,16 @@ def recognize_native_decorator(target: str | None) -> NativeShape | None:
     """Recognize a decorator only from its authenticated import coordinate."""
 
     return _NATIVE_DECORATORS.get(target)
+
+
+def recognize_native_fixture_decorator(target: str | None) -> NativeShape | None:
+    """Recognize a fixture/provider decorator from its import coordinate only.
+
+    Shape registration lives here; recognition code must never compare a
+    resolved name to a hard-coded vendor spelling (R_vendor_special_case).
+    """
+
+    return _FIXTURE_DECORATORS.get(target)
 
 
 def recognize_native_class_import(module: str, name: str) -> NativeShape | None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_fixture_provider_seat_authentication.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_fixture_provider_seat_authentication.py
@@ -1,0 +1,259 @@
+"""#5421 fix-forward: fixture providers without vendor-name dispatch.
+
+Permanent floors:
+- R_vendor_special_case = 0 (no hard-coded vendor spelling compares)
+- Provider bodies are anchored to exact source seats (module + line/col)
+- Lying twins stay loud: dual class fixtures, lookalike imports, shadow, mismatch
+"""
+
+from __future__ import annotations
+
+import ast
+
+from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+from sugar_lift_py_tests.sugar.class_def_sugar import ClassDefSugar
+
+
+def _user_class_site(source: str) -> SourceFragment:
+    class_node = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ClassDef) and node.name == "User"
+    )
+    return SourceFragment.from_node(class_node, "t.py", source=source)
+
+
+def _provider_fragment(provider_source: str, method_name: str, module: str):
+    tree = ast.parse(provider_source)
+    provider = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == method_name
+    )
+    setattr(provider, "_sugar_defining_module", module)
+    return SourceFragment.from_node(
+        provider, f"{module.replace('.', '/')}.py", source=provider_source
+    )
+
+
+def test_pytest_fixture_protocol_authenticates_without_sqlalchemy_name(
+    monkeypatch,
+) -> None:
+    """Registered fixture protocol (pytest.fixture) is enough — no SA logo."""
+    provider_source = (
+        "import pytest\n"
+        "from sqlalchemy.orm import registry\n"
+        "class FixtureBase:\n"
+        "    @pytest.fixture()\n"
+        "    def registry(self, metadata):\n"
+        "        value = registry(metadata=metadata)\n"
+        "        yield value\n"
+    )
+    fragment = _provider_fragment(provider_source, "registry", "example.fixtures")
+    monkeypatch.setattr(
+        "sugar_lift_py_tests.sugar.install_source_dig."
+        "resolve_install_source_class_method",
+        lambda qualified, method: (
+            fragment if (qualified, method) == ("example.FixtureBase", "registry") else None
+        ),
+    )
+    monkeypatch.setattr(
+        "sugar_lift_python_source.source_oracle.installed_module_source",
+        lambda module: (
+            (provider_source, "example/fixtures.py", "cid")
+            if module == "example.fixtures"
+            else None
+        ),
+    )
+    source = (
+        "from example import FixtureBase\n"
+        "class TestThing(FixtureBase):\n"
+        "    def test_it(self, registry):\n"
+        "        @registry.mapped\n"
+        "        class User:\n"
+        "            pass\n"
+    )
+    assert ClassDefSugar.owns(_user_class_site(source)) is True
+
+
+def test_identical_fixture_names_in_two_classes_use_exact_seat(
+    monkeypatch,
+) -> None:
+    """Name-only search would pick WrongBase.registry (first in module)."""
+    provider_source = (
+        "from sqlalchemy.testing import config\n"
+        "from sqlalchemy.orm import registry\n"
+        "class WrongBase:\n"
+        "    @config.fixture()\n"
+        "    def registry(self, metadata):\n"
+        "        yield object()  # not a native registry shape\n"
+        "\n"
+        "class FixtureBase:\n"
+        "    @config.fixture()\n"
+        "    def registry(self, metadata):\n"
+        "        value = registry(metadata=metadata)\n"
+        "        yield value\n"
+    )
+    tree = ast.parse(provider_source)
+    fixture_base = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "FixtureBase"
+    )
+    correct = next(
+        node
+        for node in fixture_base.body
+        if isinstance(node, ast.FunctionDef) and node.name == "registry"
+    )
+    wrong = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "WrongBase"
+        for child in node.body
+        if isinstance(child, ast.FunctionDef) and child.name == "registry"
+        for node in [child]
+    )
+    setattr(correct, "_sugar_defining_module", "example.fixtures")
+    fragment = SourceFragment.from_node(
+        correct, "example/fixtures.py", source=provider_source
+    )
+    # Seat must be the FixtureBase method, not the earlier WrongBase twin.
+    assert correct.lineno != wrong.lineno
+    monkeypatch.setattr(
+        "sugar_lift_py_tests.sugar.install_source_dig."
+        "resolve_install_source_class_method",
+        lambda qualified, method: (
+            fragment if (qualified, method) == ("example.FixtureBase", "registry") else None
+        ),
+    )
+    monkeypatch.setattr(
+        "sugar_lift_python_source.source_oracle.installed_module_source",
+        lambda module: (
+            (provider_source, "example/fixtures.py", "cid")
+            if module == "example.fixtures"
+            else None
+        ),
+    )
+    source = (
+        "from example import FixtureBase\n"
+        "class TestThing(FixtureBase):\n"
+        "    def test_it(self, registry):\n"
+        "        @registry.mapped\n"
+        "        class User:\n"
+        "            pass\n"
+    )
+    assert ClassDefSugar.owns(_user_class_site(source)) is True
+
+
+def test_imported_lookalike_config_fixture_stays_loud(monkeypatch) -> None:
+    """Lookalike `config.fixture` from a non-registered module is not a fixture."""
+    provider_source = (
+        "from pretend.testing import config\n"
+        "from sqlalchemy.orm import registry\n"
+        "class FixtureBase:\n"
+        "    @config.fixture()\n"
+        "    def registry(self, metadata):\n"
+        "        value = registry(metadata=metadata)\n"
+        "        yield value\n"
+    )
+    fragment = _provider_fragment(provider_source, "registry", "example.fixtures")
+    monkeypatch.setattr(
+        "sugar_lift_py_tests.sugar.install_source_dig."
+        "resolve_install_source_class_method",
+        lambda qualified, method: (
+            fragment if (qualified, method) == ("example.FixtureBase", "registry") else None
+        ),
+    )
+    monkeypatch.setattr(
+        "sugar_lift_python_source.source_oracle.installed_module_source",
+        lambda module: (
+            (provider_source, "example/fixtures.py", "cid")
+            if module == "example.fixtures"
+            else None
+        ),
+    )
+    source = (
+        "from example import FixtureBase\n"
+        "class TestThing(FixtureBase):\n"
+        "    def test_it(self, registry):\n"
+        "        @registry.mapped\n"
+        "        class User:\n"
+        "            pass\n"
+    )
+    assert ClassDefSugar.owns(_user_class_site(source)) is False
+
+
+def test_aliased_shadowed_fixture_decorator_stays_loud(monkeypatch) -> None:
+    provider_source = (
+        "from sqlalchemy.testing import config\n"
+        "from sqlalchemy.orm import registry\n"
+        "config = type('C', (), {'fixture': staticmethod(lambda: (lambda f: f))})()\n"
+        "class FixtureBase:\n"
+        "    @config.fixture()\n"
+        "    def registry(self, metadata):\n"
+        "        value = registry(metadata=metadata)\n"
+        "        yield value\n"
+    )
+    fragment = _provider_fragment(provider_source, "registry", "example.fixtures")
+    monkeypatch.setattr(
+        "sugar_lift_py_tests.sugar.install_source_dig."
+        "resolve_install_source_class_method",
+        lambda qualified, method: (
+            fragment if (qualified, method) == ("example.FixtureBase", "registry") else None
+        ),
+    )
+    monkeypatch.setattr(
+        "sugar_lift_python_source.source_oracle.installed_module_source",
+        lambda module: (
+            (provider_source, "example/fixtures.py", "cid")
+            if module == "example.fixtures"
+            else None
+        ),
+    )
+    source = (
+        "from example import FixtureBase\n"
+        "class TestThing(FixtureBase):\n"
+        "    def test_it(self, registry):\n"
+        "        @registry.mapped\n"
+        "        class User:\n"
+        "            pass\n"
+    )
+    assert ClassDefSugar.owns(_user_class_site(source)) is False
+
+
+def test_mismatched_provider_class_stays_loud(monkeypatch) -> None:
+    """Resolver returns None for wrong class — parameter stays unauthenticated."""
+    provider_source = (
+        "from sqlalchemy.testing import config\n"
+        "from sqlalchemy.orm import registry\n"
+        "class OtherBase:\n"
+        "    @config.fixture()\n"
+        "    def registry(self, metadata):\n"
+        "        value = registry(metadata=metadata)\n"
+        "        yield value\n"
+    )
+    fragment = _provider_fragment(provider_source, "registry", "example.fixtures")
+    monkeypatch.setattr(
+        "sugar_lift_py_tests.sugar.install_source_dig."
+        "resolve_install_source_class_method",
+        lambda qualified, method: (
+            fragment if (qualified, method) == ("example.OtherBase", "registry") else None
+        ),
+    )
+    monkeypatch.setattr(
+        "sugar_lift_python_source.source_oracle.installed_module_source",
+        lambda module: (
+            (provider_source, "example/fixtures.py", "cid")
+            if module == "example.fixtures"
+            else None
+        ),
+    )
+    source = (
+        "from example import FixtureBase\n"
+        "class TestThing(FixtureBase):\n"
+        "    def test_it(self, registry):\n"
+        "        @registry.mapped\n"
+        "        class User:\n"
+        "            pass\n"
+    )
+    assert ClassDefSugar.owns(_user_class_site(source)) is False


### PR DESCRIPTION
## Summary

Fix-forward for unacceptable #5421 merge: main had `R_vendor_special_case = 1`.

### Illegal shapes
1. Hard-coded `== "sqlalchemy.testing.config.fixture"` in `recognition/class_decorator.py`
2. Provider body selected by **function name** across the module (wrong class with same fixture name)

### Replacement
1. `NativeShape.FIXTURE_DECORATOR` + `recognize_native_fixture_decorator` registry (pytest.fixture, sqlalchemy.testing.config.fixture as **table keys**, never compare-to-logo in recognition)
2. Provider function matched by **name + lineno + col_offset** of the already-resolved seat
3. Module import map revokes on later top-level rebinds (shadow twin)

### Lying twins (green)
- identical fixture method names in two classes → correct seat only
- imported lookalike `config.fixture` → loud
- aliased/shadowed `config = ...` → loud
- mismatched provider class → loud
- pytest.fixture protocol works without SA logo compare

### Validation
```
vendor_special_case_law.py → R_vendor_special_case = 0
pytest test_fixture_provider_seat_authentication.py + fixture class_def tests → 7 passed
```

Do not count five-row ClassDef fixture drain until this floor is green.

Part of #5421 fix-forward / sole-construction floors.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix fixture providers without vendor-name dispatch in Python class decorator recognition
> - When a class decorator's receiver is a function parameter shadowed by a fixture, `class_decorators_preserve_identity` previously rejected all such parameters; it now authenticates the parameter by resolving its fixture provider and accepts identity-preserving decorators (e.g. `registry.mapped`) accessed through that fixture.
> - Adds `_fixture_parameter_native_shape` and `_fixture_provider_native_shape` helpers in [class_decorator.py](https://github.com/TSavo/sugar/pull/5581/files#diff-19211378bbb353bf1c344eaaaf0dc61bdc88f8dc26a8174e873452efd8c121eb) to locate the fixture provider via installed module source, parse it, and infer the `NativeShape` of the provided value.
> - Adds `recognize_native_fixture_decorator` and `NativeShape.FIXTURE_DECORATOR` in [native_shape.py](https://github.com/TSavo/sugar/pull/5581/files#diff-d1526541051a4390409c635c2450d85c7da899e4ab0926eaf38e335d65ff09d0) to identify registered fixture decorators (`pytest.fixture`, `sqlalchemy.testing.config.fixture`).
> - New tests in [test_fixture_provider_seat_authentication.py](https://github.com/TSavo/sugar/pull/5581/files#diff-7777e68f30f1adf11ad2111494d89e4e007e8a9d079b4e5e249ff08015aceeb2) cover acceptance, exact seat matching for same-named providers, and rejection for lookalike or aliased decorators.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9e2677.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fixture recognition by matching providers to their exact source location, avoiding confusion when multiple providers share a name.
  - Prevented stale import information from affecting recognition after names are reassigned.
  - Added stricter validation for supported fixture decorators, rejecting lookalike or shadowed decorators.

- **Tests**
  - Added coverage for pytest fixtures, duplicate provider names, aliased decorators, unsupported imports, and mismatched provider classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->