### PR TITLE
Fixes #5578: fixture protocol seat, no vendor Compare

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/class_decorator.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/class_decorator.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from sugar_lift_py_tests.recognition.native_shape import (
     NativeShape,
+    recognize_fixture_provider_decorator,
     recognize_native_call,
     recognize_native_class_decorator,
     recognize_native_instance_class_decorator,
@@ -158,43 +159,86 @@ def _fixture_parameter_native_shape(statement, parameter: str) -> NativeShape | 
 
 
 def _fixture_provider_native_shape(provider) -> NativeShape | None:
+    """Read the native yield/return shape of one *exact* provider seat.
+
+    The provider fragment is already resolved to a class method. Re-selection
+    by function name across the module is illegal (#5578 wrong-answer): two
+    classes can share a fixture method spelling. Anchor by name + line + col
+    (and defining module source), never by bare name walk.
+    """
     from sugar_lift_python_source.source_oracle import installed_module_source
 
     module_name = getattr(provider.node, "_sugar_defining_module", None)
-    if not module_name:
-        return None
-    installed = installed_module_source(module_name)
-    if installed is None:
-        return None
-    source, _, _ = installed
+    source = getattr(provider, "source", None) or getattr(
+        provider.node, "_sugar_source", None
+    )
+    if not source:
+        if not module_name:
+            return None
+        installed = installed_module_source(module_name)
+        if installed is None:
+            return None
+        source, _, _ = installed
     try:
         tree = ast.parse(source)
     except SyntaxError:
         return None
     imports = _module_imports(tree, module_name)
-    for function in ast.walk(tree):
-        if (
-            not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef))
-            or function.name != provider.function_name()
-            or not _is_authenticated_fixture(function, imports)
-        ):
+    function = _function_at_exact_seat(
+        tree,
+        name=provider.function_name(),
+        line=provider.line,
+        col=provider.col,
+    )
+    if function is None or not _is_authenticated_fixture(function, imports):
+        return None
+    return _yield_or_return_native_shape(function, imports)
+
+
+def _function_at_exact_seat(
+    tree: ast.Module,
+    *,
+    name: str,
+    line: int,
+    col: int,
+) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    """Locate one FunctionDef by name and source seat — never name alone."""
+
+    if not name or line < 1:
+        return None
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
-        constructed: dict[str, NativeShape] = {}
-        for node in ast.walk(function):
-            if isinstance(node, ast.Assign):
-                shape = _ast_call_native_shape(node.value, imports)
-                if shape is None:
-                    continue
-                for target in node.targets:
-                    if isinstance(target, ast.Name):
-                        constructed[target.id] = shape
-            elif isinstance(node, (ast.Yield, ast.Return)):
-                value = node.value
-                if isinstance(value, ast.Name) and value.id in constructed:
-                    return constructed[value.id]
-                shape = _ast_call_native_shape(value, imports)
-                if shape is not None:
-                    return shape
+        if node.name != name:
+            continue
+        if getattr(node, "lineno", None) != line:
+            continue
+        if getattr(node, "col_offset", None) != col:
+            continue
+        return node
+    return None
+
+
+def _yield_or_return_native_shape(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+    imports: dict[str, str],
+) -> NativeShape | None:
+    constructed: dict[str, NativeShape] = {}
+    for node in ast.walk(function):
+        if isinstance(node, ast.Assign):
+            shape = _ast_call_native_shape(node.value, imports)
+            if shape is None:
+                continue
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    constructed[target.id] = shape
+        elif isinstance(node, (ast.Yield, ast.Return)):
+            value = node.value
+            if isinstance(value, ast.Name) and value.id in constructed:
+                return constructed[value.id]
+            shape = _ast_call_native_shape(value, imports)
+            if shape is not None:
+                return shape
     return None
 
 
@@ -202,14 +246,15 @@ def _is_authenticated_fixture(
     function: ast.FunctionDef | ast.AsyncFunctionDef,
     imports: dict[str, str],
 ) -> bool:
-    return any(
-        _qualified_ast_name(
-            decorator.func if isinstance(decorator, ast.Call) else decorator,
-            imports,
-        )
-        == "sqlalchemy.testing.config.fixture"
-        for decorator in function.decorator_list
-    )
+    """Fixture protocol via import-resolved decorator coordinate, not vendor spelling."""
+
+    for decorator in function.decorator_list:
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if recognize_fixture_provider_decorator(
+            _qualified_ast_name(target, imports)
+        ):
+            return True
+    return False
 
 
 def _ast_call_native_shape(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
@@ -169,6 +169,15 @@ _NATIVE_DECORATORS = {
     "functools.wraps": NativeShape.IMPLEMENTATION_PRESERVING_DECORATOR,
 }
 
+# Fixture *provider* decorators: a loaded testing protocol, never matched by
+# Compare against a vendor-spelled string in call-site recognition. Keys are
+# import coordinates (module, leaf); lookalikes that do not resolve here stay
+# unauthenticated (#5578).
+_FIXTURE_PROVIDER_DECORATORS = {
+    ("pytest", "fixture"): True,
+    ("sqlalchemy.testing.config", "fixture"): True,
+}
+
 _NATIVE_INSTANCE_CLASS_DECORATORS = {
     (NativeShape.SQLALCHEMY_ORM_REGISTRY, "mapped"): (
         NativeShape.CLASS_IDENTITY_DECORATOR
@@ -309,6 +318,21 @@ def recognize_native_decorator(target: str | None) -> NativeShape | None:
     """Recognize a decorator only from its authenticated import coordinate."""
 
     return _NATIVE_DECORATORS.get(target)
+
+
+def recognize_fixture_provider_decorator(target: str | None) -> bool:
+    """True when ``target`` is a registered fixture-provider protocol coordinate.
+
+    Import-resolved only. Spelling ``fixture`` or a lookalike ``config.fixture``
+    that does not resolve to a registered coordinate stays unauthenticated.
+    """
+
+    if target is None:
+        return False
+    module, separator, name = target.rpartition(".")
+    if not separator:
+        return False
+    return bool(_FIXTURE_PROVIDER_DECORATORS.get((module, name)))
 
 
 def recognize_native_class_import(module: str, name: str) -> NativeShape | None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_class_def_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_class_def_sugar.py
@@ -789,6 +789,226 @@ def test_fixture_parameter_without_authenticated_provider_stays_loud() -> None:
     assert ClassDefSugar.owns(site) is False
 
 
+def _user_class_site(source: str) -> SourceFragment:
+    class_node = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ClassDef) and node.name == "User"
+    )
+    return SourceFragment.from_node(class_node, "t.py", source=source)
+
+
+def _provider_fragment(source: str, *, class_name: str, method_name: str, module: str):
+    tree = ast.parse(source)
+    owner = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    )
+    provider = next(
+        node
+        for node in owner.body
+        if isinstance(node, ast.FunctionDef) and node.name == method_name
+    )
+    setattr(provider, "_sugar_defining_module", module)
+    return SourceFragment.from_node(provider, f"{module.replace('.', '/')}.py", source=source)
+
+
+def test_same_named_fixture_methods_in_two_classes_use_exact_seat(
+    monkeypatch,
+) -> None:
+    """#5578 twin (a): identical fixture names — wrong class must not win.
+
+    WrongBase.registry yields a real ORM registry (would authenticate).
+    RightBase.registry yields a bare int (no native class-decorator shape).
+    TestThing inherits RightBase only. Name-only module walk finds WrongBase
+    first and would falsely own; seat-anchored resolve must stay loud.
+    """
+    provider_source = (
+        "from sqlalchemy.testing import config\n"
+        "from sqlalchemy.orm import registry\n"
+        "class WrongBase:\n"
+        "    @config.fixture()\n"
+        "    def registry(self, metadata):\n"
+        "        value = registry(metadata=metadata)\n"
+        "        yield value\n"
+        "class RightBase:\n"
+        "    @config.fixture()\n"
+        "    def registry(self, metadata):\n"
+        "        yield 0\n"
+    )
+    right = _provider_fragment(
+        provider_source,
+        class_name="RightBase",
+        method_name="registry",
+        module="example.fixtures",
+    )
+    monkeypatch.setattr(
+        "sugar_lift_py_tests.sugar.install_source_dig."
+        "resolve_install_source_class_method",
+        lambda qualified, method: (
+            right if (qualified, method) == ("example.RightBase", "registry") else None
+        ),
+    )
+    monkeypatch.setattr(
+        "sugar_lift_python_source.source_oracle.installed_module_source",
+        lambda module: (
+            (provider_source, "example/fixtures.py", "cid")
+            if module == "example.fixtures"
+            else None
+        ),
+    )
+    source = (
+        "from example import RightBase\n"
+        "class TestThing(RightBase):\n"
+        "    def test_it(self, registry):\n"
+        "        @registry.mapped\n"
+        "        class User:\n"
+        "            pass\n"
+    )
+    assert ClassDefSugar.owns(_user_class_site(source)) is False
+
+
+def test_imported_lookalike_config_fixture_stays_loud(monkeypatch) -> None:
+    """#5578 twin (b): local lookalike config.fixture must not authenticate."""
+    provider_source = (
+        "class config:\n"
+        "    @staticmethod\n"
+        "    def fixture(fn=None):\n"
+        "        return fn if fn is not None else (lambda f: f)\n"
+        "from sqlalchemy.orm import registry\n"
+        "class FixtureBase:\n"
+        "    @config.fixture()\n"
+        "    def registry(self, metadata):\n"
+        "        value = registry(metadata=metadata)\n"
+        "        yield value\n"
+    )
+    provider = _provider_fragment(
+        provider_source,
+        class_name="FixtureBase",
+        method_name="registry",
+        module="example.fixtures",
+    )
+    monkeypatch.setattr(
+        "sugar_lift_py_tests.sugar.install_source_dig."
+        "resolve_install_source_class_method",
+        lambda qualified, method: (
+            provider
+            if (qualified, method) == ("example.FixtureBase", "registry")
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        "sugar_lift_python_source.source_oracle.installed_module_source",
+        lambda module: (
+            (provider_source, "example/fixtures.py", "cid")
+            if module == "example.fixtures"
+            else None
+        ),
+    )
+    source = (
+        "from example import FixtureBase\n"
+        "class TestThing(FixtureBase):\n"
+        "    def test_it(self, registry):\n"
+        "        @registry.mapped\n"
+        "        class User:\n"
+        "            pass\n"
+    )
+    assert ClassDefSugar.owns(_user_class_site(source)) is False
+
+
+def test_shadowed_fixture_decorator_stays_loud(monkeypatch) -> None:
+    """#5578 twin (c): local rebinding of fixture leaves the provider unauthenticated."""
+    provider_source = (
+        "from sqlalchemy.testing.config import fixture as real_fixture\n"
+        "from sqlalchemy.orm import registry\n"
+        "fixture = lambda fn: fn\n"
+        "class FixtureBase:\n"
+        "    @fixture()\n"
+        "    def registry(self, metadata):\n"
+        "        value = registry(metadata=metadata)\n"
+        "        yield value\n"
+    )
+    provider = _provider_fragment(
+        provider_source,
+        class_name="FixtureBase",
+        method_name="registry",
+        module="example.fixtures",
+    )
+    monkeypatch.setattr(
+        "sugar_lift_py_tests.sugar.install_source_dig."
+        "resolve_install_source_class_method",
+        lambda qualified, method: (
+            provider
+            if (qualified, method) == ("example.FixtureBase", "registry")
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        "sugar_lift_python_source.source_oracle.installed_module_source",
+        lambda module: (
+            (provider_source, "example/fixtures.py", "cid")
+            if module == "example.fixtures"
+            else None
+        ),
+    )
+    source = (
+        "from example import FixtureBase\n"
+        "class TestThing(FixtureBase):\n"
+        "    def test_it(self, registry):\n"
+        "        @registry.mapped\n"
+        "        class User:\n"
+        "            pass\n"
+    )
+    assert ClassDefSugar.owns(_user_class_site(source)) is False
+
+
+def test_mismatched_provider_class_stays_loud(monkeypatch) -> None:
+    """#5578 twin (d): provider class other than the inherited base stays loud."""
+    provider_source = (
+        "from sqlalchemy.testing import config\n"
+        "from sqlalchemy.orm import registry\n"
+        "class OtherBase:\n"
+        "    @config.fixture()\n"
+        "    def registry(self, metadata):\n"
+        "        value = registry(metadata=metadata)\n"
+        "        yield value\n"
+        "class FixtureBase:\n"
+        "    pass\n"
+    )
+    other = _provider_fragment(
+        provider_source,
+        class_name="OtherBase",
+        method_name="registry",
+        module="example.fixtures",
+    )
+    monkeypatch.setattr(
+        "sugar_lift_py_tests.sugar.install_source_dig."
+        "resolve_install_source_class_method",
+        lambda qualified, method: (
+            # Only OtherBase is resolvable — FixtureBase has no fixture method.
+            other if (qualified, method) == ("example.OtherBase", "registry") else None
+        ),
+    )
+    monkeypatch.setattr(
+        "sugar_lift_python_source.source_oracle.installed_module_source",
+        lambda module: (
+            (provider_source, "example/fixtures.py", "cid")
+            if module == "example.fixtures"
+            else None
+        ),
+    )
+    source = (
+        "from example import FixtureBase\n"
+        "class TestThing(FixtureBase):\n"
+        "    def test_it(self, registry):\n"
+        "        @registry.mapped\n"
+        "        class User:\n"
+        "            pass\n"
+    )
+    assert ClassDefSugar.owns(_user_class_site(source)) is False
+
+
 @pytest.mark.parametrize(
     "import_statement",
     ("import pydantic", "import pydantic.dataclasses"),


### PR DESCRIPTION
## Summary

**Fixes #5578** (stop-the-line: main red after #5421).

### Defect 1 — floor red
`R_vendor_special_case = 1` from hard-coded Compare against
`"sqlalchemy.testing.config.fixture"` in `recognition/class_decorator.py`.

**Fix:** remove that branch. Fixture provider decorators authenticate through
`recognize_fixture_provider_decorator` — an import-resolved **protocol table**
in `native_shape` (same shape pattern as other native coordinates). No
vendor-string Compare in recognition call sites.

### Defect 2 — wrong answer
`_fixture_provider_native_shape` reselected the provider by **function name
across the module**. Two classes with the same fixture method spelling could
authenticate the wrong body.

**Fix:** anchor to the exact source seat (`name` + `line` + `col`) on the
already-resolved provider fragment / defining module source.

### Lying twins (must refute; teeth checked)
| Twin | Confusion | Expected |
| --- | --- | --- |
| (a) | same fixture name in WrongBase (real registry) vs RightBase (yields 0) | stays loud when inheriting RightBase |
| (b) | local lookalike `config.fixture` | stays loud |
| (c) | shadowed `fixture = lambda…` after import | stays loud |
| (d) | provider resolvable only on OtherBase while test inherits FixtureBase | stays loud |

Twin (a) teeth: name-only walk returns `SQLALCHEMY_ORM_REGISTRY` for WrongBase first; seat-anchored RightBase seat returns no native shape.

Truthful path (real `config.fixture` import + correct seat) still owns.

### Live floor (not a summary)
```text
VENDOR-SPECIAL-CASE LAW GREEN: R_vendor_special_case = 0
R_ownership = 0
R_behavior_side_doors = 0
pytest -k 'fixture_injected or same_named_fixture or lookalike or shadowed_fixture or mismatched_provider'  # 6 passed
```

### Hard law
- Did **not** suppress, narrow, or special-case the auditor
- MISSING/refused stays loud (twins (a)–(d))
- No drain claimed against a red floor

Do **not** self-merge — CI + human merge on soundness-read.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix fixture seat resolution to use exact name+line+column matching instead of name-only matching
> - `_fixture_provider_native_shape` now resolves fixture provider methods by exact AST seat (name, line, and column offset) via a new `_function_at_exact_seat` helper, preventing same-named methods in different classes from incorrectly authenticating.
> - `_is_authenticated_fixture` now uses import-resolved decorator names checked against a registry (`_FIXTURE_PROVIDER_DECORATORS`) via `recognize_fixture_provider_decorator`, replacing a hardcoded string equality check for `sqlalchemy.testing.config.fixture`.
> - Local rebindings or lookalike decorators (e.g. a locally defined `config.fixture`) no longer authenticate as fixture providers.
> - Four new tests cover same-named methods in two classes, imported lookalikes, shadowed decorators, and mismatched provider classes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae45573.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->