### PR TITLE
Project append on curried For list post-states through list_append

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -337,6 +337,10 @@ class CallSiteValue(FloorValue):
         index is a ground int (unpack residual: ``handles`` from a returned
         triple). ``iter_elem`` of a proven list-of-lists (or a listcomp whose
         element expression is a list literal) rebinds through ``py.list_append``.
+        A curried For post-state (``loop:…`` target) that carried a list via
+        append-rebind is still list-shaped: further appends rebind through
+        ``py.list_append`` without re-digging the loop body. Chained
+        ``list.append`` / ``py.list_append`` coordinates do the same.
         Opaque cast/subscript/iter faces stay loud; a call result is not proof
         that the receiver is a mutable list. Never mint RuntimeEffect over a
         ground list proof.
@@ -351,7 +355,22 @@ class CallSiteValue(FloorValue):
             return isinstance(floor, (ListValue, ComprehensionValue))
 
         def is_constructed_list_callsite(receiver: CallSiteValue) -> bool:
-            if receiver.target_name in {"builtins.list", "list", "split"}:
+            # Proven list constructors and post-states that already rebind through
+            # ``py.list_append``. ``loop:…`` is the curried For floor's single
+            # (or projected) list-shaped carried output after append-rebinding
+            # iterations (#5338 / public_api residual after #5574). ``list.append``
+            # is the coordinate this door itself mints — chained appends must not
+            # re-panic. Content identity stays on term CID (#5569).
+            if receiver.target_name in {
+                "builtins.list",
+                "list",
+                "split",
+                "list.append",
+            }:
+                return True
+            if receiver.target_name.startswith("loop:"):
+                return True
+            if getattr(receiver.term, "name", None) == "py.list_append":
                 return True
             if receiver.target_name == "copy" and receiver.arg_values:
                 base = receiver.arg_values[0]

--- a/implementations/python/sugar-lift-py-tests/tests/test_append_rebind.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_append_rebind.py
@@ -120,6 +120,84 @@ def test_append_on_callsite_rebinds_to_list_append_coordinate() -> None:
     assert returned.value.term.name == "py.list_append"
 
 
+def test_append_on_loop_callsite_rebinds_through_list_append() -> None:
+    """Curried For list post-state (``loop:…``) stays list-shaped for append.
+
+    Red residual after #5574 compact projection: public_api's second
+    ``module_names.append`` hit ``CallSiteValue(loop:…)`` and panicked.
+    """
+    from sugar_lift_py_tests.ir import ctor
+    from sugar_lift_py_tests.outcome import Complete
+
+    prior = CallSiteValue(
+        target_name="loop:f.py:1",
+        arg_values=(ListValue((TermValue(1),)),),
+        parameters=("xs",),
+        term=ctor("call:loop:f.py:1", ()),
+        body=None,
+        site="f.py:1",
+    )
+    outcome = prior.append_with(TermValue(2), "f.py:2")
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, CallSiteValue)
+    assert outcome.value.target_name == "list.append"
+    assert outcome.value.term.name == "py.list_append"
+
+
+def test_chained_list_append_callsite_rebinds_through_list_append() -> None:
+    """The coordinate ``append_with`` mints must accept a further append."""
+    from sugar_lift_py_tests.ir import ctor
+    from sugar_lift_py_tests.outcome import Complete
+
+    prior = CallSiteValue(
+        target_name="list.append",
+        arg_values=(ListValue((TermValue(1),)), TermValue(2)),
+        parameters=(),
+        term=ctor("py.list_append", ()),
+        body=None,
+        site="f.py:1",
+    )
+    outcome = prior.append_with(TermValue(3), "f.py:2")
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, CallSiteValue)
+    assert outcome.value.target_name == "list.append"
+    assert outcome.value.term.name == "py.list_append"
+
+
+def test_append_after_compact_curried_for_does_not_panic() -> None:
+    """Product shape: over-cap branched for append-carries a list, then appends.
+
+    Before: FactoryPanic owner=CallSiteValue.append_with on loop: post-state.
+    After: construction continues (no append_with panic on that face).
+    """
+    from sugar_lift_py_tests.audit_only import collect_factory_panic
+    from sugar_lift_py_tests.lift_rpc import lift_file_payload
+
+    source = """
+PUBLIC = list(range(32))
+
+def check(x):
+    return False
+
+def test():
+    module_names = []
+    for module_name in PUBLIC:
+        if not check(module_name):
+            module_names.append(module_name)
+    module_names.append(99)
+    return module_names
+"""
+    _payload, gap = collect_factory_panic(
+        "compact_for_append.py",
+        lambda: lift_file_payload(source, "compact_for_append.py"),
+    )
+    if gap is not None:
+        assert "CallSiteValue.append_with" not in gap.message, gap.message
+        assert "loop:" not in gap.message or "append_with" not in gap.message, (
+            gap.message
+        )
+
+
 def test_list_copy_appends_exact_post_state() -> None:
     """``[1].copy().append(2)`` folds exact element history, never opaque."""
     record = compose_block(


### PR DESCRIPTION
## Summary

Exact-nine residual after #5574: largest shared structural family among remaining typed FPs was **`CallSiteValue.append_with` on curried For list post-states** (`loop:…` / chained `list.append`).

### Profile (re-profile on current main)

| seat | tip |
| --- | --- |
| `numpy/tests/test_public_api.py` | typed FP · `CallSiteValue.append_with` · `CallSiteValue(loop::312)` @ `:324` |
| `scipy/.../test__dual_annealing.py` | typed FP · TemporalContext `chain` (separate family: loop-local mutation prebind) |
| `pandas/io/stata.py` | typed FP · ConstructorCallSugar `StataMissingValue` |
| `sklearn/.../test_t_sne.py` | typed FP · install_source_cycle_guard |
| others | completed / deeper timeout (not soft-laundry) |

Shared door (not file tickets): after #5574 compact curried For with append-carried locals, the carried list is bound to `CallSiteValue(loop:site)`. A later `.append` outside that loop panicked because `is_constructed_list_callsite` only recognized `list`/`split`/`copy`/`py.subscript` — not the curried loop post-state this door itself mints (`list.append` / `py.list_append`), nor `loop:`.

### Shared structural cut

Extend `CallSiteValue.append_with`'s list-shaped recognition:

1. `target_name.startswith("loop:")` → rebind through `py.list_append`
2. `target_name == "list.append"` or term `py.list_append` → chained appends same door

No dig of the loop body, no force-curry, no RuntimeEffect, no soft Complete. #5569 content-CID identity keys held (`_term_cycle_key` still uses `_term_content_cid`).

### Red instrument → green

- unit: append on `loop:…` CallSiteValue → `list.append` / `py.list_append`
- unit: chained append on `list.append` coordinate
- product micro: over-cap branched for append-carries list, then appends — no `append_with` panic
- `pytest test_append_rebind.py -k 'loop_callsite or chained_list_append or compact_curried or callsite_rebinds'` → **4 passed**

### Product remeasure @30s (exact-nine identities)

| file | before (post-#5574) | after |
| --- | --- | --- |
| `numpy/tests/test_public_api.py` | typed FP · append_with loop: · ~7s | **completed** · 13.4s |
| dual_annealing | TemporalContext chain | TemporalContext chain (unchanged — separate family) |
| stata | ConstructorCallSugar | ConstructorCallSugar |
| t_sne | install_source_cycle_guard | install_source_cycle_guard |
| test_sorting | completed | completed |
| others | timeout | timeout (honest deeper dig) |

**Epsilon R (this family):** public_api typed FP **−1 → completed**. silent=0 held. No timeout laundry.

### Floors held

- no opaque Complete / soft-success cache
- no bound raise / skip / RuntimeEffect laundry
- no term-id identity keys (#5569)
- residual panics stay loud (TemporalContext chain, ConstructorCallSugar, cycle guard)

### Validation

```text
pytest test_append_rebind.py -k 'loop_callsite or chained_list_append or compact_curried or callsite_rebinds' --noconftest  # 4 passed
product remeasure test_public_api @30s via corpus_fatal_triage → completed
```

Part of #5338 / #5574 residual.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `CallSiteValue.append_with` to handle curried `For` list post-states via `py.list_append`
> - Broadens `is_constructed_list_callsite` in [`call_site_value.py`](https://github.com/TSavo/sugar/pull/5583/files#diff-8c40ae10c3e0722cf284a5e0bb43d2d29524ce10b6eb590893ccfcab4785689a) to recognize `loop:`-prefixed target names, `list.append` targets, and callsites whose term name is `py.list_append` as list-shaped.
> - When a curried `For` post-state carries a list via append-rebind, further appends now rebind through `py.list_append` instead of panicking.
> - Adds three tests in [`test_append_rebind.py`](https://github.com/TSavo/sugar/pull/5583/files#diff-d25979e0c01024250676d4f9f1901a006ea5fc7d70b14770401ebe7b69b3e73d) covering loop post-state rebind, chained `list.append` rebind, and absence of `FactoryPanic` after a compact curried `for`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c4cb0f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->