### PR TITLE
Fix shares_memory alias silent twin from #5427

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -288,14 +288,14 @@ class CalleeUniverseRecognition:
 
         if not site.source:
             return None
-        # Plain Name call: resolve import/assignment identity, then accept only
-        # when the result is an authenticated support coordinate. Leaf spelling
-        # is a fast path; from-import aliases (``shares_memory as overlaps``)
-        # still authenticate when identity maps to a registered coordinate.
-        identity = imported_call_identity(site)
-        if recognize_authenticated_callee_identity(identity) is not None:
-            return identity
-        return None
+        # Plain Name call: only resolve import identity when the leaf can still
+        # land on an authenticated imported coordinate. From-import aliases
+        # whose spelling is not a registered leaf remain loud — the universe
+        # gap auditor keys belonging by leaf spelling, so alias greens would
+        # be silent twins.
+        if target not in _IMPORTED_ATTRIBUTE_LEAVES:
+            return None
+        return imported_call_identity(site)
 
     @classmethod
     def _name_is_unshadowed(cls, site, name: str) -> bool:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -158,12 +158,6 @@ class BuiltinCalleeUniverseSugar(
             _coordinate_witness("hasattr", "True", "False"),
             _item_receiver_coordinate_witness(),
             _imported_coordinate_witness(
-                name="numpy_shares_memory",
-                setup=("from numpy import shares_memory\n"),
-                callee="shares_memory",
-                argument="5, 5",
-            ),
-            _imported_coordinate_witness(
                 name="get_handler_name",
                 setup=("from numpy._core.multiarray import get_handler_name\n"),
                 callee="get_handler_name",
@@ -185,6 +179,7 @@ class BuiltinCalleeUniverseSugar(
                 "binomial", "conv_intp", "create", "exists", "func", "iter_goto", "median",
             )),
             _numpy_may_share_memory_witness(),
+            _numpy_shares_memory_witness(),
             _numpy_array_tobytes_witness(),
             _bound_source_callable_witness(),
             _numpy_dtype_result_witness(),
@@ -383,6 +378,23 @@ def _numpy_may_share_memory_witness():
     )
     return _call_pair(
         name="numpy_may_share_memory_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _numpy_shares_memory_witness():
+    prefix = (
+        "import numpy as np\n"
+        "\n"
+        "def A():\n"
+        "    return np.shares_memory(np.array([1]), np.array([1]))\n"
+        "\n"
+    )
+    return _call_pair(
+        name="numpy_shares_memory_universe_coordinate",
         owner_sugar="BuiltinCalleeUniverseSugar",
         truthful=prefix + "def test_a():\n    assert A() == A()\n",
         lying=prefix + "def test_a():\n    assert A() != A()\n",

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
@@ -57,7 +57,7 @@ def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
         "numpy_all_universe_coordinate",
         "numpy_dtype_universe_coordinate",
         "numpy_dtype_result_universe_coordinate",
-        "numpy_shares_memory_builtin_universe_coordinate",
+        "numpy_shares_memory_universe_coordinate",
         "numpy_array_tobytes_universe_coordinate",
         "get_handler_name_builtin_universe_coordinate",
         "conv_builtin_universe_coordinate",

--- a/implementations/python/sugar-lift-py-tests/tests/test_universe_coverage_gap.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_universe_coverage_gap.py
@@ -946,23 +946,6 @@ def test_authenticated_numpy_shares_memory_has_universe_support() -> None:
     assert _universe_gaps(payload) == []
 
 
-def test_authenticated_shares_memory_from_import_alias_has_universe_support() -> None:
-    source = (
-        "from numpy import shares_memory as overlaps\n"
-        "\n"
-        "def test_values(left, right):\n"
-        "    assert overlaps(left, right)\n"
-    )
-
-    payload = lift_file_payload(source, "shares_memory_alias_fixture.py")
-
-    assert any(
-        edge.get("targetSymbol") == "call:numpy.shares_memory"
-        for edge in payload.call_edges
-    )
-    assert _universe_gaps(payload) == []
-
-
 @pytest.mark.parametrize(
     ("source", "expected_kind"),
     (
@@ -982,6 +965,8 @@ def test_authenticated_shares_memory_from_import_alias_has_universe_support() ->
 def test_unowned_shares_memory_lookalikes_stay_loud(
     source: str, expected_kind: str
 ) -> None:
+    """Parameter shadow and unimported spelling stay loud universe gaps."""
+
     payload = lift_file_payload(source, "shares_memory_unowned_fixture.py")
 
     gaps = _universe_gaps(payload)


### PR DESCRIPTION
## Summary

Fix-forward for a silent/lying twin introduced by #5427:

- Universe gap auditor keys belonging by **leaf spelling**
- From-import alias test (`shares_memory as overlaps`) greened with empty gaps while edges stayed `call:numpy._core.multiarray.shares_memory` and `BuiltinCalleeUniverseSugar` did not own
- That is silent green, not authenticated coverage

## Change

- Restore leaf-gated plain-Name coordinate resolution
- Dotted `np.shares_memory` witness (same shape as may_share_memory)
- Drop alias coverage test

## Floors

- R_behavior_side_doors = 0
- R_ownership = 0
- Dotted green; shadow/unimported still loud
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix silent `shares_memory` from-import alias handling in callee universe recognition
> - Fixes a bug (#5427) where a bare-name `shares_memory` from-import alias was silently matched by `CalleeUniverseRecognition.coordinate()`. The method now short-circuits unless the target is in `_IMPORTED_ATTRIBUTE_LEAVES`, returning `None` otherwise.
> - Replaces the from-import alias witness in `BuiltinCalleeUniverseSugar.witnesses()` with a new `numpy_shares_memory_universe_coordinate` witness that exercises `np.shares_memory` via an `import numpy as np` pattern.
> - Removes the test asserting from-import aliasing of `numpy.shares_memory` had universe support, as that path is no longer recognized.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1668f6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->