### PR TITLE
Fixes #5578: delete vendor fixture key (no relocation)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
@@ -179,9 +179,12 @@ _NATIVE_DECORATORS = {
 # Fixture / inject-provider protocol: registered import coordinates only.
 # Consumers authenticate via recognize_native_fixture_decorator(qualified),
 # never by comparing against a vendor-name string literal in recognition code.
+#
+# Protocol is the general testing fixture decorator (pytest.fixture). Vendor-
+# specific fixture spellings are intentionally NOT registered — that would be
+# logo dispatch by relocation (#5578 bounce).
 _FIXTURE_DECORATORS = {
     "pytest.fixture": NativeShape.FIXTURE_DECORATOR,
-    "sqlalchemy.testing.config.fixture": NativeShape.FIXTURE_DECORATOR,
 }
 
 _NATIVE_INSTANCE_CLASS_DECORATORS = {

--- a/implementations/python/sugar-lift-py-tests/tests/test_fixture_provider_seat_authentication.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_fixture_provider_seat_authentication.py
@@ -1,9 +1,10 @@
-"""#5421 fix-forward: fixture providers without vendor-name dispatch.
+"""#5578: fixture providers via general pytest.fixture protocol + exact seats.
 
 Permanent floors:
-- R_vendor_special_case = 0 (no hard-coded vendor spelling compares)
+- R_vendor_special_case = 0 by construction (no vendor fixture keys in recognition)
 - Provider bodies are anchored to exact source seats (module + line/col)
 - Lying twins stay loud: dual class fixtures, lookalike imports, shadow, mismatch
+- Protocol authenticates via pytest.fixture only — never a vendor fixture key
 """
 
 from __future__ import annotations
@@ -79,17 +80,20 @@ def test_pytest_fixture_protocol_authenticates_without_sqlalchemy_name(
 def test_identical_fixture_names_in_two_classes_use_exact_seat(
     monkeypatch,
 ) -> None:
-    """Name-only search would pick WrongBase.registry (first in module)."""
+    """Name-only search would pick WrongBase.registry (first in module).
+
+    Both methods use the general pytest.fixture protocol — no vendor fixture key.
+    """
     provider_source = (
-        "from sqlalchemy.testing import config\n"
+        "import pytest\n"
         "from sqlalchemy.orm import registry\n"
         "class WrongBase:\n"
-        "    @config.fixture()\n"
+        "    @pytest.fixture()\n"
         "    def registry(self, metadata):\n"
         "        yield object()  # not a native registry shape\n"
         "\n"
         "class FixtureBase:\n"
-        "    @config.fixture()\n"
+        "    @pytest.fixture()\n"
         "    def registry(self, metadata):\n"
         "        value = registry(metadata=metadata)\n"
         "        yield value\n"
@@ -146,9 +150,9 @@ def test_identical_fixture_names_in_two_classes_use_exact_seat(
 
 
 def test_imported_lookalike_config_fixture_stays_loud(monkeypatch) -> None:
-    """Lookalike `config.fixture` from a non-registered module is not a fixture."""
+    """Lookalike `config.fixture` (including SA testing.config) is not protocol."""
     provider_source = (
-        "from pretend.testing import config\n"
+        "from sqlalchemy.testing import config\n"
         "from sqlalchemy.orm import registry\n"
         "class FixtureBase:\n"
         "    @config.fixture()\n"
@@ -184,12 +188,17 @@ def test_imported_lookalike_config_fixture_stays_loud(monkeypatch) -> None:
 
 
 def test_aliased_shadowed_fixture_decorator_stays_loud(monkeypatch) -> None:
+    """Decorator spelling ``fixture`` after import-as-alias is not protocol-resolved.
+
+    The import binds ``real_fixture``; the decorator uses unbound name ``fixture``
+    (local lambda). Import map has no ``fixture`` key → not authenticated.
+    """
     provider_source = (
-        "from sqlalchemy.testing import config\n"
+        "from pytest import fixture as real_fixture\n"
         "from sqlalchemy.orm import registry\n"
-        "config = type('C', (), {'fixture': staticmethod(lambda: (lambda f: f))})()\n"
+        "fixture = lambda fn: fn\n"
         "class FixtureBase:\n"
-        "    @config.fixture()\n"
+        "    @fixture()\n"
         "    def registry(self, metadata):\n"
         "        value = registry(metadata=metadata)\n"
         "        yield value\n"
@@ -224,10 +233,10 @@ def test_aliased_shadowed_fixture_decorator_stays_loud(monkeypatch) -> None:
 def test_mismatched_provider_class_stays_loud(monkeypatch) -> None:
     """Resolver returns None for wrong class — parameter stays unauthenticated."""
     provider_source = (
-        "from sqlalchemy.testing import config\n"
+        "import pytest\n"
         "from sqlalchemy.orm import registry\n"
         "class OtherBase:\n"
-        "    @config.fixture()\n"
+        "    @pytest.fixture()\n"
         "    def registry(self, metadata):\n"
         "        value = registry(metadata=metadata)\n"
         "        yield value\n"


### PR DESCRIPTION
## Bounce response on #5581

#5581 kept seat anchoring and the four lying twins (requirements 3–4: good) but **relocated** vendor identity into:

```python
"sqlalchemy.testing.config.fixture": NativeShape.FIXTURE_DECORATOR,
```

That is green-by-relocation, not removal. The auditor read zero because table keys are outside its Compare/isinstance scan — the same class of blind-spot burn as before.

## This PR

1. **DELETE** the `"sqlalchemy.testing.config.fixture"` entry entirely (not move, not comment).
2. Protocol path is **pytest.fixture only** — `test_pytest_fixture_protocol_authenticates_without_sqlalchemy_name` proves authentication without any vendor fixture key.
3. Seat anchoring unchanged (`_function_at_provider_seat`: name + lineno + col_offset).
4. Four lying twins still refute; twin (a) truthful path uses `@pytest.fixture`; twin (b) uses SA `config.fixture` as a **lookalike that stays loud** (protocol works without registering it).
5. Live auditor + construction grep:

```text
VENDOR-SPECIAL-CASE LAW GREEN: R_vendor_special_case = 0
grep -rn 'sqlalchemy.testing.config.fixture' implementations/ --include='*.py'  → NO MATCHES
pytest tests/test_fixture_provider_seat_authentication.py --noconftest  → 5 passed
```

If the SA fixture shape is needed in production later, the honest outcome is loud refusal until a non-logo protocol is proven — not a vendor key in the map.

**Fixes #5578.** Do not self-merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `sqlalchemy.testing.config.fixture` from recognized fixture decorators
> - Removes the `'sqlalchemy.testing.config.fixture'` key from the `_FIXTURE_DECORATORS` mapping in [native_shape.py](https://github.com/TSavo/sugar/pull/5585/files#diff-d1526541051a4390409c635c2450d85c7da899e4ab0926eaf38e335d65ff09d0), leaving only `'pytest.fixture'` as a recognized fixture protocol.
> - Updates tests in [test_fixture_provider_seat_authentication.py](https://github.com/TSavo/sugar/pull/5585/files#diff-7777e68f30f1adf11ad2111494d89e4e007e8a9d079b4e5e249ff08015aceeb2) to reflect this: providers using `@config.fixture()` are now expected to stay unrecognized, and a new test asserts that locally shadowed `fixture` decorators are not protocol-resolved.
> - Behavioral Change: call sites decorated with `sqlalchemy.testing.config.fixture` are no longer authenticated as fixture providers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55918f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->