### PR TITLE
Authenticate remaining SciPy import-identity callee universes

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -62,6 +62,11 @@ class CalleeUniverseSupport(Enum):
     FOO = auto()
     TO_DT = auto()
     NUMPY_ARRAY_TOBYTES = auto()
+    MATH_ISCLOSE = auto()
+    NUMPY_RESULT_TYPE = auto()
+    SCIPY_LINALG_ISSYMMETRIC = auto()
+    SCIPY_LINALG_ISHERMITIAN = auto()
+    SCIPY_FFT_GET_WORKERS = auto()
 
 
 _DTYPE_RESULT_SUPPORT = {
@@ -161,6 +166,13 @@ _IMPORTED_SUPPORT = {
     "numpy.lib.stride_tricks.as_strided.tobytes": (
         CalleeUniverseSupport.NUMPY_ARRAY_TOBYTES
     ),
+    # SciPy verified-live import identities remaining after numpy all/dtype
+    # merges (#5457–#5461). Provenance via imported_call_identity only.
+    "math.isclose": CalleeUniverseSupport.MATH_ISCLOSE,
+    "numpy.result_type": CalleeUniverseSupport.NUMPY_RESULT_TYPE,
+    "scipy.linalg.issymmetric": CalleeUniverseSupport.SCIPY_LINALG_ISSYMMETRIC,
+    "scipy.linalg.ishermitian": CalleeUniverseSupport.SCIPY_LINALG_ISHERMITIAN,
+    "scipy.fft.get_workers": CalleeUniverseSupport.SCIPY_FFT_GET_WORKERS,
 }
 
 _BUILTIN_COORDINATES = frozenset({"type", "dtype", "all", "list", "set", "hasattr"})

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -54,6 +54,11 @@ _AUTHENTICATED_COORDINATES = frozenset(
         "pathlib.Path.resolve",
         "json.loads",
         "dataclasses.asdict",
+        "math.isclose",
+        "numpy.result_type",
+        "scipy.linalg.issymmetric",
+        "scipy.linalg.ishermitian",
+        "scipy.fft.get_workers",
         *_CONVERTER_COORDINATES,
     }
 )
@@ -83,6 +88,11 @@ _OWNED_IMPORTED_SUPPORT = frozenset(
         CalleeUniverseSupport.REGEX_SEARCH,
         CalleeUniverseSupport.JSON_LOADS,
         CalleeUniverseSupport.DATACLASSES_ASDICT,
+        CalleeUniverseSupport.MATH_ISCLOSE,
+        CalleeUniverseSupport.NUMPY_RESULT_TYPE,
+        CalleeUniverseSupport.SCIPY_LINALG_ISSYMMETRIC,
+        CalleeUniverseSupport.SCIPY_LINALG_ISHERMITIAN,
+        CalleeUniverseSupport.SCIPY_FFT_GET_WORKERS,
     }
 )
 
@@ -190,6 +200,11 @@ class BuiltinCalleeUniverseSugar(
             *(_bound_leaf_coordinate_witness(name) for name in (
                 "t0", "selectedintkind", "foo", "to_Dt",
             )),
+            _math_isclose_witness(),
+            _numpy_result_type_witness(),
+            _scipy_linalg_issymmetric_witness(),
+            _scipy_linalg_ishermitian_witness(),
+            _scipy_fft_get_workers_witness(),
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
@@ -477,6 +492,93 @@ def _json_loads_witness():
         name="json_loads_universe_coordinate",
         owner_sugar="BuiltinCalleeUniverseSugar",
         # Conjunction makes deterministic call substitution load-bearing.
+        truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _math_isclose_witness():
+    prefix = (
+        "import math\n"
+        "\n"
+        "def A():\n"
+        "    return math.isclose(1.0, 1.0)\n"
+        "\n"
+    )
+    return _call_pair(
+        name="math_isclose_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _numpy_result_type_witness():
+    prefix = (
+        "import numpy as np\n"
+        "\n"
+        "def A():\n"
+        "    return np.result_type(np.float32, np.float64)\n"
+        "\n"
+    )
+    return _call_pair(
+        name="numpy_result_type_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _scipy_linalg_issymmetric_witness():
+    prefix = (
+        "import numpy as np\n"
+        "from scipy.linalg import issymmetric\n"
+        "\n"
+        "def A():\n"
+        "    return issymmetric(np.eye(2))\n"
+        "\n"
+    )
+    return _call_pair(
+        name="scipy_linalg_issymmetric_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _scipy_linalg_ishermitian_witness():
+    prefix = (
+        "import numpy as np\n"
+        "from scipy.linalg import ishermitian\n"
+        "\n"
+        "def A():\n"
+        "    return ishermitian(np.eye(2))\n"
+        "\n"
+    )
+    return _call_pair(
+        name="scipy_linalg_ishermitian_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _scipy_fft_get_workers_witness():
+    prefix = (
+        "import scipy.fft as fft\n"
+        "\n"
+        "def A():\n"
+        "    return fft.get_workers()\n"
+        "\n"
+    )
+    return _call_pair(
+        name="scipy_fft_get_workers_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
         truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
         lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
         family="builtin-universe-coordinate",

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
@@ -1478,3 +1478,287 @@ def test_batch_six_witness_pairs_are_enrolled() -> None:
         "foo_universe_coordinate",
         "to-Dt_universe_coordinate",
     } <= names
+
+
+# --- SciPy / stdlib import-identity batch (#5457–#5461, window 292) ---
+
+
+def _import_leaf_call_site(source: str, leaf: str, filename: str) -> SourceFragment:
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and (
+            (isinstance(node.func, ast.Attribute) and node.func.attr == leaf)
+            or (isinstance(node.func, ast.Name) and node.func.id == leaf)
+        )
+    )
+    return SourceFragment.from_node(call, filename, source=source)
+
+
+def test_authenticated_math_isclose_selects_one_factory_owner() -> None:
+    source = (
+        "import math\n"
+        "\n"
+        "def test_close(a, b):\n"
+        "    assert math.isclose(a, b)\n"
+    )
+    context = FactoryBuildContext(filename="math_isclose.py", catalog=default_catalog())
+    built = build_node(
+        _import_leaf_call_site(source, "isclose", "math_isclose.py"),
+        filename="math_isclose.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "import math\n"
+            "\n"
+            "def test_close(math, a, b):\n"
+            "    assert math.isclose(a, b)\n"
+        ),
+        (
+            "import math\n"
+            "\n"
+            "def test_close(a, b):\n"
+            "    assert math.isclose(a, b)\n"
+            "    math = replacement\n"
+        ),
+        (
+            "def test_close(a, b):\n"
+            "    assert math.isclose(a, b)\n"
+        ),
+    ],
+)
+def test_unwarranted_math_isclose_is_not_factory_owned(source: str) -> None:
+    context = FactoryBuildContext(filename="math_isclose.py", catalog=default_catalog())
+    built = build_node(
+        _import_leaf_call_site(source, "isclose", "math_isclose.py"),
+        filename="math_isclose.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_math_isclose_witness_pair_is_enrolled() -> None:
+    assert "math_isclose_universe_coordinate" in {
+        pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
+    }
+
+
+def test_authenticated_numpy_result_type_selects_one_factory_owner() -> None:
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_rt(a, b):\n"
+        "    assert np.result_type(a, b) == np.result_type(a, b)\n"
+    )
+    context = FactoryBuildContext(filename="result_type.py", catalog=default_catalog())
+    built = build_node(
+        _import_leaf_call_site(source, "result_type", "result_type.py"),
+        filename="result_type.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "import numpy as np\n"
+            "\n"
+            "def test_rt(np, a, b):\n"
+            "    assert np.result_type(a, b) == a\n"
+        ),
+        (
+            "import numpy as np\n"
+            "\n"
+            "def test_rt(a, b):\n"
+            "    assert np.result_type(a, b) == a\n"
+            "    np = replacement\n"
+        ),
+        (
+            "def test_rt(a, b):\n"
+            "    assert numpy.result_type(a, b) == a\n"
+        ),
+    ],
+)
+def test_unwarranted_numpy_result_type_is_not_factory_owned(source: str) -> None:
+    context = FactoryBuildContext(filename="result_type.py", catalog=default_catalog())
+    built = build_node(
+        _import_leaf_call_site(source, "result_type", "result_type.py"),
+        filename="result_type.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_numpy_result_type_witness_pair_is_enrolled() -> None:
+    assert "numpy_result_type_universe_coordinate" in {
+        pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
+    }
+
+
+def test_authenticated_scipy_issymmetric_selects_one_factory_owner() -> None:
+    source = (
+        "import numpy as np\n"
+        "from scipy.linalg import issymmetric\n"
+        "\n"
+        "def test_sym(a):\n"
+        "    assert issymmetric(a)\n"
+    )
+    context = FactoryBuildContext(filename="issym.py", catalog=default_catalog())
+    built = build_node(
+        _import_leaf_call_site(source, "issymmetric", "issym.py"),
+        filename="issym.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "from scipy.linalg import issymmetric\n"
+            "\n"
+            "def test_sym(issymmetric, a):\n"
+            "    assert issymmetric(a)\n"
+        ),
+        (
+            "def test_sym(a):\n"
+            "    assert scipy.linalg.issymmetric(a)\n"
+        ),
+    ],
+)
+def test_unwarranted_scipy_issymmetric_is_not_factory_owned(source: str) -> None:
+    context = FactoryBuildContext(filename="issym.py", catalog=default_catalog())
+    built = build_node(
+        _import_leaf_call_site(source, "issymmetric", "issym.py"),
+        filename="issym.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_scipy_issymmetric_witness_pair_is_enrolled() -> None:
+    assert "scipy_linalg_issymmetric_universe_coordinate" in {
+        pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
+    }
+
+
+def test_authenticated_scipy_ishermitian_selects_one_factory_owner() -> None:
+    source = (
+        "import numpy as np\n"
+        "from scipy.linalg import ishermitian\n"
+        "\n"
+        "def test_herm(a):\n"
+        "    assert ishermitian(a)\n"
+    )
+    context = FactoryBuildContext(filename="isherm.py", catalog=default_catalog())
+    built = build_node(
+        _import_leaf_call_site(source, "ishermitian", "isherm.py"),
+        filename="isherm.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "from scipy.linalg import ishermitian\n"
+            "\n"
+            "def test_herm(ishermitian, a):\n"
+            "    assert ishermitian(a)\n"
+        ),
+        (
+            "def test_herm(a):\n"
+            "    assert scipy.linalg.ishermitian(a)\n"
+        ),
+    ],
+)
+def test_unwarranted_scipy_ishermitian_is_not_factory_owned(source: str) -> None:
+    context = FactoryBuildContext(filename="isherm.py", catalog=default_catalog())
+    built = build_node(
+        _import_leaf_call_site(source, "ishermitian", "isherm.py"),
+        filename="isherm.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_scipy_ishermitian_witness_pair_is_enrolled() -> None:
+    assert "scipy_linalg_ishermitian_universe_coordinate" in {
+        pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
+    }
+
+
+def test_authenticated_scipy_fft_get_workers_selects_one_factory_owner() -> None:
+    source = (
+        "import scipy.fft as fft\n"
+        "\n"
+        "def test_workers():\n"
+        "    assert fft.get_workers() == fft.get_workers()\n"
+    )
+    context = FactoryBuildContext(filename="get_workers.py", catalog=default_catalog())
+    built = build_node(
+        _import_leaf_call_site(source, "get_workers", "get_workers.py"),
+        filename="get_workers.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "import scipy.fft as fft\n"
+            "\n"
+            "def test_workers(fft):\n"
+            "    assert fft.get_workers() == 1\n"
+        ),
+        (
+            "import scipy.fft as fft\n"
+            "\n"
+            "def test_workers():\n"
+            "    assert fft.get_workers() == 1\n"
+            "    fft = replacement\n"
+        ),
+        (
+            "def test_workers():\n"
+            "    assert scipy.fft.get_workers() == 1\n"
+        ),
+    ],
+)
+def test_unwarranted_scipy_fft_get_workers_is_not_factory_owned(source: str) -> None:
+    context = FactoryBuildContext(filename="get_workers.py", catalog=default_catalog())
+    built = build_node(
+        _import_leaf_call_site(source, "get_workers", "get_workers.py"),
+        filename="get_workers.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_scipy_fft_get_workers_witness_pair_is_enrolled() -> None:
+    assert "scipy_fft_get_workers_universe_coordinate" in {
+        pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
+    }


### PR DESCRIPTION
## Summary

Batch drain of SciPy verified-live families that **still had import-identity gaps** after re-measure at current main.

### Re-measure first (no redundant work)

| Issue | Family | Pre-merge | Current main | Action |
| --- | --- | --- | --- | --- |
| #5453 | `call:all` | 25 | already closed | skip |
| #5455 | `call:bmat` | 20 | **0** (BOUND_SOURCE) | closed |
| #5456 | `call:shape` | 11 | **0** Call-leaf (attr residual) | closed |
| #5457 | `call:math.isclose` | 10 | **10 gaps** | **this PR** |
| #5458 | `call:numpy.result_type` | 10 | **10 gaps** | **this PR** |
| #5459 | `call:scipy.linalg.issymmetric` | 6 | **6 gaps** | **this PR** |
| #5460 | `call:scipy.linalg.ishermitian` | 6 | **6 gaps** | **this PR** |
| #5461 | `call:scipy.fft.get_workers` | 6 | **6 gaps** | **this PR** |
| #5462 | `call:any` | 5 | **0** import (untyped methods) | closed |
| #5463 | `call:format` | 5 | **0** Call-leaf (attr residual) | closed |
| #5464 | `call:max` | 5 | **0** import (untyped methods) | closed |
| #5466 | `call:merge` | 5 | **0** import (instance methods) | closed |

Pin measured: `d404e701e` / SciPy 1.18.0. Loci from `target/recensus-662-0f4748f` scipy shards.

### This PR

Provenance-authenticated entries in the **one** `CalleeUniverseSupport` / `BuiltinCalleeUniverseSugar` door:

- `math.isclose`
- `numpy.result_type`
- `scipy.linalg.issymmetric`
- `scipy.linalg.ishermitian`
- `scipy.fft.get_workers`

Each has truthful/lying witness pair + factory-ownership twins (parameter shadow / rebind / unauthenticated FQN stay unowned). No vendor-name dispatch.

### Validation

```text
# unit ownership / enrollment (solver twins need sugarbin in CI)
pytest tests/test_builtin_callee_universe_sugar.py \
  -k 'math_isclose or result_type or issymmetric or ishermitian or get_workers' \
  --noconftest
# 23 unit passed locally; 5 solver twins need sugar binary (sccache env)
R_vendor_special_case=0 R_behavior_side_doors=0 R_ownership=0 R_factory_panic_catches_outside_audit=0
```

Post-fix remeasure of SciPy representative loci: all five identities → `owns=True`, `selected=BuiltinCalleeUniverseSugar`.

Do **not** self-merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate remaining SciPy import-identity callee universes
> Adds recognition and witness support for five import identities: `math.isclose`, `numpy.result_type`, `scipy.linalg.issymmetric`, `scipy.linalg.ishermitian`, and `scipy.fft.get_workers`.
>
> - New `CalleeUniverseSupport` enum members and `_IMPORTED_SUPPORT` mappings are added in [callee_universe.py](https://github.com/TSavo/sugar/pull/5586/files#diff-72e9f915afa350390348a1c277d0c2047b26a0182bb4780c57baf73f30fdcaa8) so the recognition layer can map these import paths at runtime.
> - `BuiltinCalleeUniverseSugar` in [builtin_callee_universe_sugar.py](https://github.com/TSavo/sugar/pull/5586/files#diff-98e9ae8e3cbb10a2e6c95f0bdeca86f0b85002634b901733d0b6070886cdab5f) gains authenticated coordinates, owned support entries, and a witness function per identity.
> - Tests in [test_builtin_callee_universe_sugar.py](https://github.com/TSavo/sugar/pull/5586/files#diff-4cf523d0449af84e5a94e72b7ba403f9d6a713a9f0bf70db21a7cd083d014f3f) verify factory selection, non-ownership for unwarranted contexts, and witness enrollment for each new identity.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d360b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->