### PR TITLE
Authenticate numpy callee families (batch)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -53,6 +53,9 @@ class CalleeUniverseSupport(Enum):
     NUMPY_CONVERTER = auto()
     REGEX_SEARCH = auto()
     BOUND_SOURCE_CALLABLE = auto()
+    PATHLIB_PATH = auto()
+    NUMPY_STANDARD_GAMMA = auto()
+    NUMPY_EVAL_SCALAR = auto()
     JSON_LOADS = auto()
     DATACLASSES_ASDICT = auto()
     PATH_RESOLVE = auto()
@@ -152,6 +155,17 @@ _IMPORTED_SUPPORT = {
     "re.Pattern.search": CalleeUniverseSupport.REGEX_SEARCH,
     "json.loads": CalleeUniverseSupport.JSON_LOADS,
     "dataclasses.asdict": CalleeUniverseSupport.DATACLASSES_ASDICT,
+    # Exact import identity (``import pathlib`` / ``from pathlib import Path``).
+    # Corpus: numpy/tests/test_configtool.py — not a module-prefix warrant.
+    "pathlib.Path": CalleeUniverseSupport.PATHLIB_PATH,
+    # Import-constructed Generator receiver method.
+    # Corpus: numpy/random/tests/test_generator_mt19937_regressions.py.
+    "numpy.random.Generator.standard_gamma": (
+        CalleeUniverseSupport.NUMPY_STANDARD_GAMMA
+    ),
+    # Assignment alias of crackfortran source binding.
+    # Corpus: numpy/f2py/tests/test_crackfortran.py.
+    "numpy.f2py.crackfortran._eval_scalar": CalleeUniverseSupport.NUMPY_EVAL_SCALAR,
     "pathlib.Path.resolve": CalleeUniverseSupport.PATH_RESOLVE,
     "numpy.ufunc": CalleeUniverseSupport.UFUNC,
     # Bound-native shape coordinate (``value = np.array(...); value.tobytes()``
@@ -219,11 +233,7 @@ def recognize_callee_universe(
         support = recognize_authenticated_callee_identity(coordinate)
         if support is None:
             return None
-        leaf = coordinate.rsplit(".", 1)[-1]
-        if target is not None and target not in {
-            f"call:{coordinate}",
-            f"call:{leaf}",
-        }:
+        if not _target_matches_call(target, coordinate, site):
             return None
         return support
     result_support = _DTYPE_RESULT_SUPPORT.get(identity)
@@ -238,10 +248,33 @@ def recognize_callee_universe(
         if target is not None and target != f"call:{leaf}":
             return None
         return support
-    leaf = identity.rsplit(".", 1)[-1]
-    if target is not None and target not in {f"call:{identity}", f"call:{leaf}"}:
+    if not _target_matches_call(target, identity, site):
         return None
     return support
+
+
+def _target_matches_call(
+    target: str | None, coordinate: str | None, site
+) -> bool:
+    """Accept full identity, identity leaf, or the call's written leaf/target.
+
+    Local assignment aliases (``eval_scalar = crackfortran._eval_scalar``)
+    spell a different leaf than the import tail; the call-site name is the
+    edge target the universe audit demands.
+    """
+
+    if target is None:
+        return True
+    if coordinate is None:
+        return False
+    allowed = {f"call:{coordinate}", f"call:{coordinate.rsplit('.', 1)[-1]}"}
+    call_leaf = site.call_target_name()
+    if call_leaf is not None:
+        allowed.add(f"call:{call_leaf}")
+    qualified = site.call_qualified_target_name()
+    if qualified is not None:
+        allowed.add(f"call:{qualified}")
+    return target in allowed
 
 
 def recognize_authenticated_callee_identity(
@@ -498,21 +531,10 @@ def _bound_native_receiver_coordinate(
 ) -> str | None:
     """Resolve a member through the latest source-authenticated receiver binding."""
 
-    shape = None
-    declarations, shadowed_parameters = visible_declarations(site)
-    if receiver_name in shadowed_parameters:
+    origin = _assigned_imported_call_identity(site, receiver_name)
+    if origin is None:
         return None
-    for declaration in declarations:
-        stored = declaration.stored_or_deleted_names()
-        if receiver_name not in stored:
-            continue
-        shape = None
-        if declaration.observed != "Assign" or len(stored) != 1:
-            continue
-        value = declaration.assign_value()
-        if value.observed != "Call":
-            continue
-        shape = recognize_native_call(imported_call_identity(value))
+    shape = recognize_native_call(origin)
     if shape is None:
         return None
     return recognize_native_instance_call(shape, member)
@@ -602,7 +624,11 @@ def _result_call_identity(site) -> str | None:
 
 
 def _assigned_imported_call_identity(site, name: str) -> str | None:
-    """Follow one visible assignment whose value is an authenticated import call."""
+    """Follow one visible assignment whose value is an authenticated import call.
+
+    Also resolves same-class helpers whose sole statement is
+    ``return ImportedCtor(...)`` (corpus: ``mt19937 = self._create_generator()``).
+    """
 
     declarations, shadowed_parameters = visible_declarations(site)
     if name in shadowed_parameters:
@@ -618,8 +644,49 @@ def _assigned_imported_call_identity(site, name: str) -> str | None:
         value = declaration.assign_value()
         if value.observed != "Call":
             return None
-        return imported_call_identity(value)
+        direct = imported_call_identity(value)
+        if direct is not None:
+            return direct
+        return _same_class_helper_return_imported_identity(site, value)
     return None
+
+
+def _same_class_helper_return_imported_identity(site, call_value) -> str | None:
+    """Resolve ``x = self.helper()`` when helper returns one import-bound Call."""
+
+    receiver = call_value.call_receiver()
+    if receiver is None or receiver.observed != "Name":
+        return None
+    method_name = call_value.call_target_name()
+    if method_name is None:
+        return None
+    enclosing_method, class_def = _enclosing_method_and_class(site)
+    if class_def is None or enclosing_method is None:
+        return None
+    instance_param = _instance_parameter_name(enclosing_method)
+    if instance_param is None or receiver.name_id() != instance_param:
+        return None
+    helper = None
+    for statement in class_def.body:
+        if (
+            isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and statement.name == method_name
+        ):
+            helper = statement
+            break
+    if helper is None:
+        return None
+    if len(helper.body) != 1 or not isinstance(helper.body[0], ast.Return):
+        return None
+    ret_val = helper.body[0].value
+    if ret_val is None or not isinstance(ret_val, ast.Call):
+        return None
+    from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+
+    ret_frag = SourceFragment.from_node(
+        ret_val, site.filename or "", source=site.source
+    )
+    return imported_call_identity(ret_frag)
 
 
 def _enclosing_method_and_class(site):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
@@ -60,6 +60,7 @@ class NativeShape(Enum):
     REGEX_PATTERN = auto()
     PATH = auto()
     NUMPY_ARRAY = auto()
+    NUMPY_GENERATOR = auto()
 
 
 _CALL_SHAPES = {
@@ -131,6 +132,7 @@ _CALL_SHAPES = {
     "numpy.empty_like": NativeShape.NUMPY_ARRAY,
     "numpy.zeros": NativeShape.NUMPY_ARRAY,
     "numpy.lib.stride_tricks.as_strided": NativeShape.NUMPY_ARRAY,
+    "numpy.random.Generator": NativeShape.NUMPY_GENERATOR,
 }
 
 _NEVER_SUPPRESSING_MANAGERS = {
@@ -200,6 +202,9 @@ _NATIVE_INSTANCE_CALLS = {
     (NativeShape.REGEX_PATTERN, "search"): "re.Pattern.search",
     (NativeShape.PATH, "resolve"): "pathlib.Path.resolve",
     (NativeShape.NUMPY_ARRAY, "tobytes"): "numpy.ndarray.tobytes",
+    (NativeShape.NUMPY_GENERATOR, "standard_gamma"): (
+        "numpy.random.Generator.standard_gamma"
+    ),
 }
 
 _CLASS_IMPORT_SHAPES = {

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -51,7 +51,10 @@ _AUTHENTICATED_COORDINATES = frozenset(
         "numpy.lib.stride_tricks.as_strided.tobytes",
         "numpy._core.multiarray.get_handler_name",
         "re.Pattern.search",
+        "pathlib.Path",
         "pathlib.Path.resolve",
+        "numpy.random.Generator.standard_gamma",
+        "numpy.f2py.crackfortran._eval_scalar",
         "json.loads",
         "dataclasses.asdict",
         "math.isclose",
@@ -192,6 +195,10 @@ class BuiltinCalleeUniverseSugar(
             _numpy_shares_memory_witness(),
             _numpy_array_tobytes_witness(),
             _bound_source_callable_witness(),
+            _pathlib_path_witness(),
+            _numpy_standard_gamma_witness(),
+            _numpy_subrout_default_witness(),
+            _numpy_eval_scalar_witness(),
             _numpy_dtype_result_witness(),
             _json_loads_witness(),
             _dataclasses_asdict_witness(),
@@ -604,6 +611,109 @@ def _dataclasses_asdict_witness():
         lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
         family="builtin-universe-coordinate",
     )
+
+def _pathlib_path_witness():
+    """Import-bound ``pathlib.Path`` constructor (corpus: test_configtool)."""
+    prefix = (
+        "import pathlib\n"
+        "\n"
+        "def A(value):\n"
+        "    return pathlib.Path(value)\n"
+        "\n"
+    )
+    return _call_pair(
+        name="pathlib_path_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix
+        + "def test_a():\n    assert A('.') == A('.') and A('.') == A('.')\n",
+        lying=prefix
+        + "def test_a():\n    assert A('.') == A('.') and A('.') != A('.')\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _numpy_standard_gamma_witness():
+    """Generator-bound standard_gamma via import-constructed receiver."""
+    prefix = (
+        "from numpy.random import MT19937, Generator\n"
+        "\n"
+        "def A():\n"
+        "    mt19937 = Generator(MT19937(1))\n"
+        "    return mt19937.standard_gamma(0.0)\n"
+        "\n"
+    )
+    return _call_pair(
+        name="numpy_standard_gamma_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _numpy_subrout_default_witness():
+    """Multi-hop instance-module call ``self.module.subrout_default``."""
+    truthful = (
+        "class _Mod:\n"
+        "    @staticmethod\n"
+        "    def subrout_default(a, b):\n"
+        "        return a + b\n"
+        "\n"
+        "class Host:\n"
+        "    module = _Mod\n"
+        "\n"
+        "    def test_a(self):\n"
+        "        assert (\n"
+        "            self.module.subrout_default(200, 12)\n"
+        "            == self.module.subrout_default(200, 12)\n"
+        "            and self.module.subrout_default(200, 12)\n"
+        "            == self.module.subrout_default(200, 12)\n"
+        "        )\n"
+    )
+    lying = (
+        "class _Mod:\n"
+        "    @staticmethod\n"
+        "    def subrout_default(a, b):\n"
+        "        return a + b\n"
+        "\n"
+        "class Host:\n"
+        "    module = _Mod\n"
+        "\n"
+        "    def test_a(self):\n"
+        "        assert (\n"
+        "            self.module.subrout_default(200, 12)\n"
+        "            == self.module.subrout_default(200, 12)\n"
+        "            and self.module.subrout_default(200, 12)\n"
+        "            != self.module.subrout_default(200, 12)\n"
+        "        )\n"
+    )
+    return _call_pair(
+        name="numpy_subrout_default_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=truthful,
+        lying=lying,
+        family="builtin-universe-coordinate",
+    )
+
+
+def _numpy_eval_scalar_witness():
+    """Assignment alias of crackfortran._eval_scalar (corpus locus shape)."""
+    prefix = (
+        "from numpy.f2py import crackfortran\n"
+        "\n"
+        "def A():\n"
+        "    eval_scalar = crackfortran._eval_scalar\n"
+        "    return eval_scalar('123', {})\n"
+        "\n"
+    )
+    return _call_pair(
+        name="numpy_eval_scalar_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
 
 def _path_resolve_coordinate_witness():
     prefix = (

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
@@ -1762,3 +1762,162 @@ def test_scipy_fft_get_workers_witness_pair_is_enrolled() -> None:
     assert "scipy_fft_get_workers_universe_coordinate" in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
+
+
+def test_pathlib_path_authenticates_unresolved_stays_loud() -> None:
+    good = (
+        "import pathlib\n"
+        "\n"
+        "def test_a(value):\n"
+        "    assert pathlib.Path(value) is not None\n"
+    )
+    bad = (
+        "def test_a(pathlib, value):\n"
+        "    assert pathlib.Path(value) is not None\n"
+    )
+    good_site = _leaf_attr_call_site(good, "Path")
+    bad_site = _leaf_attr_call_site(bad, "Path")
+    assert recognize_callee_universe("call:pathlib.Path", site=good_site) is not None
+    assert recognize_callee_universe("call:pathlib.Path", site=bad_site) is None
+    good_built = build_node(
+        good_site,
+        filename="pathlib_path.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="pathlib_path.py", catalog=default_catalog()),
+    )
+    bad_built = build_node(
+        bad_site,
+        filename="pathlib_path.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="pathlib_path.py", catalog=default_catalog()),
+    )
+    assert good_built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    assert bad_built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_standard_gamma_authenticates_helper_and_direct_unresolved_stays_loud() -> None:
+    helper = (
+        "from numpy.random import MT19937, Generator\n"
+        "\n"
+        "class TestRegression:\n"
+        "    def _create_generator(self):\n"
+        "        return Generator(MT19937(121263137472525314065))\n"
+        "\n"
+        "    def test_gamma_0(self):\n"
+        "        mt19937 = self._create_generator()\n"
+        "        assert mt19937.standard_gamma(0.0) == 0.0\n"
+    )
+    direct = (
+        "from numpy.random import MT19937, Generator\n"
+        "\n"
+        "def test_gamma():\n"
+        "    mt19937 = Generator(MT19937(1))\n"
+        "    assert mt19937.standard_gamma(0.0) == 0.0\n"
+    )
+    lookalike = (
+        "def test_gamma(mt19937):\n"
+        "    assert mt19937.standard_gamma(0.0) == 0.0\n"
+    )
+    helper_site = _leaf_attr_call_site(helper, "standard_gamma")
+    direct_site = _leaf_attr_call_site(direct, "standard_gamma")
+    bad_site = _leaf_attr_call_site(lookalike, "standard_gamma")
+    assert recognize_callee_universe("call:standard_gamma", site=helper_site) is not None
+    assert recognize_callee_universe("call:standard_gamma", site=direct_site) is not None
+    assert recognize_callee_universe("call:standard_gamma", site=bad_site) is None
+    for site, expect_owned in (
+        (helper_site, True),
+        (direct_site, True),
+        (bad_site, False),
+    ):
+        built = build_node(
+            site,
+            filename="standard_gamma.py",
+            role=SugarRole.TERM,
+            ctx=FactoryBuildContext(
+                filename="standard_gamma.py", catalog=default_catalog()
+            ),
+        )
+        if expect_owned:
+            assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+        else:
+            assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_subrout_default_authenticates_unresolved_module_stays_loud() -> None:
+    good = (
+        "class _Mod:\n"
+        "    @staticmethod\n"
+        "    def subrout_default(a, b):\n"
+        "        return a + b\n"
+        "\n"
+        "class Host:\n"
+        "    module = _Mod\n"
+        "\n"
+        "    def test_a(self):\n"
+        "        assert self.module.subrout_default(200, 12) == 212\n"
+    )
+    bad = (
+        "def test_a(module):\n"
+        "    assert module.subrout_default(200, 12) == 212\n"
+    )
+    good_site = _leaf_attr_call_site(good, "subrout_default")
+    bad_site = _leaf_attr_call_site(bad, "subrout_default")
+    assert recognize_callee_universe("call:subrout_default", site=good_site) is not None
+    assert recognize_callee_universe("call:subrout_default", site=bad_site) is None
+    good_built = build_node(
+        good_site,
+        filename="subrout.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="subrout.py", catalog=default_catalog()),
+    )
+    bad_built = build_node(
+        bad_site,
+        filename="subrout.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="subrout.py", catalog=default_catalog()),
+    )
+    assert good_built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    assert bad_built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_eval_scalar_authenticates_parameter_lookalike_stays_loud() -> None:
+    good = (
+        "from numpy.f2py import crackfortran\n"
+        "\n"
+        "class TestEval:\n"
+        "    def test_eval_scalar(self):\n"
+        "        eval_scalar = crackfortran._eval_scalar\n"
+        "        assert eval_scalar('123', {}) == '123'\n"
+    )
+    bad = (
+        "def test_eval_scalar(eval_scalar):\n"
+        "    assert eval_scalar('123', {}) == '123'\n"
+    )
+    good_site = _bare_call_site(good, "eval_scalar")
+    bad_site = _bare_call_site(bad, "eval_scalar")
+    assert recognize_callee_universe("call:eval_scalar", site=good_site) is not None
+    assert recognize_callee_universe("call:eval_scalar", site=bad_site) is None
+    good_built = build_node(
+        good_site,
+        filename="eval_scalar.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="eval_scalar.py", catalog=default_catalog()),
+    )
+    bad_built = build_node(
+        bad_site,
+        filename="eval_scalar.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="eval_scalar.py", catalog=default_catalog()),
+    )
+    assert good_built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    assert bad_built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_numpy_batch_four_witness_pairs_are_enrolled() -> None:
+    names = {pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()}
+    assert {
+        "pathlib_path_universe_coordinate",
+        "numpy_standard_gamma_universe_coordinate",
+        "numpy_subrout_default_universe_coordinate",
+        "numpy_eval_scalar_universe_coordinate",
+    } <= names


### PR DESCRIPTION
Part of #5556, #5557, #5552, #5468

## Summary

Batch-drain four NumPy unclassified callee families through the one `CalleeUniverseSupport` recognizer via import/source provenance (no vendor-name whitelist, no inline isinstance/AST side door):

| Family | Rows | Provenance |
|---|---:|---|
| `call:standard_gamma` | 1 | `numpy.random.Generator` receiver (direct ctor or same-class single-return helper) |
| `call:subrout_default` | 1 | multi-hop `self.module.subrout_default` (BOUND_SOURCE) |
| `call:pathlib.Path` | 1 | exact `pathlib.Path` import identity (not a module-prefix warrant) |
| `call:eval_scalar` | 4 | `eval_scalar = crackfortran._eval_scalar` assignment alias |

Each family has a truthful/lying twin pair. Lying twins refute via load-bearing conjunction; unresolved or lookalike receivers stay unowned / FactoryPanic-path.

## Validation

- `R_vendor_special_case = 0` (vendor_special_case_law.py GREEN)
- `R_ownership = 0` (factory_ownership_law.py GREEN — sole-construction floor)
- Focused recognition + witness twins: 9 passed
  - pathlib / standard_gamma / subrout_default / eval_scalar authenticate + lying lookalikes stay loud
  - four universe-coordinate witness pairs refute bad twins through real solver

Epsilon R: `R_factory_walk_unclassified` −7 (1+1+1+4) for these families once recensed on this tip.

Do not self-merge — soundness-read merge when ready.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate numpy callee families for `pathlib.Path`, `numpy.random.Generator.standard_gamma`, and `numpy.f2py.crackfortran._eval_scalar`
> - Adds `NUMPY_GENERATOR`, `NUMPY_STANDARD_GAMMA`, `NUMPY_EVAL_SCALAR`, and `PATHLIB_PATH` to the `CalleeUniverseSupport` enum and extends `_IMPORTED_SUPPORT` mappings to recognize these identities.
> - Introduces `_same_class_helper_return_imported_identity` to resolve import-bound identities propagated through single-return same-class helper methods (e.g. `x = self.helper()`).
> - Replaces inline target matching in `recognize_callee_universe` with a `_target_matches_call` helper that also considers the site's `call_target_name` and `call_qualified_target_name`, making target filtering more permissive.
> - Adds four new witness pairs and corresponding tests covering direct construction, helper-return, multi-hop attribute access, and local assignment alias patterns.
> - Behavioral Change: `_bound_native_receiver_coordinate` now delegates receiver origin resolution to `_assigned_imported_call_identity`, which may recognize receiver constructs that were previously unmatched.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f866b41.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->