### PR TITLE
Authenticate numpy callee families (batch)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -78,6 +78,8 @@ class CalleeUniverseSupport(Enum):
     NUMPY_DATETIME_DATA = auto()
     NUMPY_MARKINNERSPACES = auto()
     NUMPY_IDENTITY_HASH_SET_ITEM_DEFAULT = auto()
+    TEXTWRAP_DEDENT = auto()
+    NUMPY_SCALAR_TO_DEVICE = auto()
 
 
 _DTYPE_RESULT_SUPPORT = {
@@ -213,6 +215,17 @@ _IMPORTED_SUPPORT = {
     "numpy._core._multiarray_tests.identity_hash_set_item_default": (
         CalleeUniverseSupport.NUMPY_IDENTITY_HASH_SET_ITEM_DEFAULT
     ),
+    # stdlib import identity (#5561).
+    "textwrap.dedent": CalleeUniverseSupport.TEXTWRAP_DEDENT,
+    # Result-call identity only (#5563): ``scalar = np.int64(1); scalar.to_device(...)``.
+    # Parameter receivers (including pytest.parametrize injection) stay loud —
+    # no logo-string decorator match; window 289 owns the real parametrize contract.
+    "numpy.int64.to_device": CalleeUniverseSupport.NUMPY_SCALAR_TO_DEVICE,
+    "numpy.uint64.to_device": CalleeUniverseSupport.NUMPY_SCALAR_TO_DEVICE,
+    "numpy.float64.to_device": CalleeUniverseSupport.NUMPY_SCALAR_TO_DEVICE,
+    "numpy.complex128.to_device": CalleeUniverseSupport.NUMPY_SCALAR_TO_DEVICE,
+    "numpy.bool.to_device": CalleeUniverseSupport.NUMPY_SCALAR_TO_DEVICE,
+    "numpy.bool_.to_device": CalleeUniverseSupport.NUMPY_SCALAR_TO_DEVICE,
 }
 
 _BUILTIN_COORDINATES = frozenset(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -74,6 +74,13 @@ _AUTHENTICATED_COORDINATES = frozenset(
         "numpy.datetime_data",
         "numpy.f2py.crackfortran.markinnerspaces",
         "numpy._core._multiarray_tests.identity_hash_set_item_default",
+        "textwrap.dedent",
+        "numpy.int64.to_device",
+        "numpy.uint64.to_device",
+        "numpy.float64.to_device",
+        "numpy.complex128.to_device",
+        "numpy.bool.to_device",
+        "numpy.bool_.to_device",
         *_CONVERTER_COORDINATES,
     }
 )
@@ -279,6 +286,12 @@ class BuiltinCalleeUniverseSugar(
             _numpy_datetime_data_witness(),
             _numpy_markinnerspaces_witness(),
             _numpy_identity_hash_set_item_default_witness(),
+            # #5555 / #5564 — multi-hop self.module.<leaf> bound-source twins
+            # (non-vacuous conjunction). #5561 textwrap. #5563 constructor to_device.
+            _bound_module_member_witness("type_subroutine"),
+            _bound_module_member_witness("simple_subroutine"),
+            _textwrap_dedent_witness(),
+            _numpy_to_device_witness(),
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
@@ -1006,6 +1019,67 @@ def _numpy_identity_hash_set_item_default_witness():
     )
     return _call_pair(
         name="numpy_identity_hash_set_item_default_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _bound_module_member_witness(member: str):
+    """Truthful/lying twin for multi-hop ``self.module.<member>`` bound-source."""
+
+    call = f"self.module.{member}(1)"
+    prefix = (
+        "class _Mod:\n"
+        "    @staticmethod\n"
+        f"    def {member}(*args):\n"
+        "        return args\n"
+        "\n"
+        "class Host:\n"
+        "    module = _Mod\n"
+        "\n"
+        "    def test_a(self):\n"
+    )
+    return _call_pair(
+        name=f"{member.replace('_', '-')}_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + f"        assert {call} == {call} and {call} == {call}\n",
+        lying=prefix + f"        assert {call} == {call} and {call} != {call}\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _textwrap_dedent_witness():
+    prefix = (
+        "import textwrap\n"
+        "\n"
+        "def A():\n"
+        "    return textwrap.dedent('x')\n"
+        "\n"
+    )
+    return _call_pair(
+        name="textwrap_dedent_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _numpy_to_device_witness():
+    """Constructor-bound scalar only — not parametrize-injected parameters."""
+
+    prefix = (
+        "import numpy as np\n"
+        "\n"
+        "def A():\n"
+        "    scalar = np.int64(1)\n"
+        "    return scalar.to_device('cpu')\n"
+        "\n"
+    )
+    return _call_pair(
+        name="numpy_to_device_universe_coordinate",
         owner_sugar="BuiltinCalleeUniverseSugar",
         truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
         lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
@@ -54,6 +54,8 @@ def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
         "dataclasses.asdict",
         "dataclasses.is_dataclass",
         "math.isclose",
+        "textwrap.dedent",
+        "numpy.int64.to_device",
     } <= (BuiltinCalleeUniverseSugar.universe_coordinates)
     assert {
         "all_builtin_universe_coordinate",
@@ -84,6 +86,10 @@ def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
         "dataclasses_asdict_universe_coordinate",
         "dataclasses_is_dataclass_universe_coordinate",
         "math_isclose_universe_coordinate",
+        "textwrap_dedent_universe_coordinate",
+        "numpy_to_device_universe_coordinate",
+        "type-subroutine_universe_coordinate",
+        "simple-subroutine_universe_coordinate",
     } <= {pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()}
 
 
@@ -2279,3 +2285,175 @@ def test_identity_hash_set_item_default_witness_pair_is_enrolled() -> None:
     assert "numpy_identity_hash_set_item_default_universe_coordinate" in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
+
+
+def test_authenticated_textwrap_dedent_selects_one_factory_owner() -> None:
+    source = (
+        "import textwrap\n"
+        "\n"
+        "def test_dedent(payload):\n"
+        "    assert textwrap.dedent(payload) == textwrap.dedent(payload)\n"
+    )
+    built = build_node(
+        _stdlib_attr_call_site(source, "dedent", "textwrap_dedent.py"),
+        filename="textwrap_dedent.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(
+            filename="textwrap_dedent.py",
+            catalog=default_catalog(),
+        ),
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "import textwrap\n"
+            "\n"
+            "def test_dedent(textwrap, payload):\n"
+            "    assert textwrap.dedent(payload) == textwrap.dedent(payload)\n"
+        ),
+        (
+            "import math as textwrap\n"
+            "\n"
+            "def test_dedent(payload):\n"
+            "    assert textwrap.dedent(payload) == textwrap.dedent(payload)\n"
+        ),
+        (
+            "def test_dedent(payload):\n"
+            "    assert textwrap.dedent(payload) == textwrap.dedent(payload)\n"
+        ),
+    ],
+)
+def test_unwarranted_textwrap_dedent_receiver_is_not_factory_owned(source: str) -> None:
+    built = build_node(
+        _stdlib_attr_call_site(source, "dedent", "textwrap_dedent.py"),
+        filename="textwrap_dedent.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(
+            filename="textwrap_dedent.py",
+            catalog=default_catalog(),
+        ),
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_authenticated_to_device_selects_one_factory_owner() -> None:
+    """Constructor-bound scalar — import identity of np.int64 + member."""
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_to_device():\n"
+        "    scalar = np.int64(1)\n"
+        "    assert scalar.to_device('cpu') is scalar\n"
+    )
+    built = build_node(
+        _method_call_site(source, "to_device"),
+        filename="to_device.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="to_device.py", catalog=default_catalog()),
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+def test_parametrized_to_device_stays_loud_without_logo_match() -> None:
+    """Corpus form injects the receiver via decorator parameters.
+
+    No structural decorator provenance without a vendor-literal match on
+    pytest.mark.parametrize (ruled illegal; window 289 owns the real contract).
+    The row stays loud — that is the correct outcome.
+    """
+
+    source = (
+        "import pytest\n"
+        "import numpy as np\n"
+        "\n"
+        "class TestDevice:\n"
+        "    scalars = [np.int64(1), np.float64(1.0)]\n"
+        "\n"
+        "    @pytest.mark.parametrize('scalar', scalars)\n"
+        "    def test_to_device(self, scalar):\n"
+        "        assert scalar.to_device('cpu') is scalar\n"
+    )
+    filename = "numpy/_core/tests/test_scalar_methods.py"
+    built = build_node(
+        _method_call_site(source, "to_device"),
+        filename=filename,
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename=filename, catalog=default_catalog()),
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "def test_to_device(scalar):\n    assert scalar.to_device('cpu') is scalar\n",
+        (
+            "import numpy as np\n"
+            "\n"
+            "def test_to_device():\n"
+            "    scalar = np.int64(1)\n"
+            "    scalar = replacement\n"
+            "    assert scalar.to_device('cpu') is scalar\n"
+        ),
+    ],
+)
+def test_unwarranted_to_device_receiver_is_not_factory_owned(source: str) -> None:
+    built = build_node(
+        _method_call_site(source, "to_device"),
+        filename="to_device.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="to_device.py", catalog=default_catalog()),
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize("member", ["type_subroutine", "simple_subroutine"])
+def test_bound_f2py_module_member_selects_one_factory_owner(member: str) -> None:
+    source = (
+        "from . import util\n"
+        "\n"
+        "class TestExtension(util.F2PyTest):\n"
+        "    sources = ['x.f']\n"
+        "\n"
+        "    def test_member(self):\n"
+        f"        assert self.module.{member}(0) == 0\n"
+    )
+    filename = "numpy/f2py/tests/test_regression.py"
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == member
+    )
+    site = SourceFragment.from_node(call, filename, source=source)
+    built = build_node(
+        site,
+        filename=filename,
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename=filename, catalog=default_catalog()),
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    assert (
+        recognize_callee_universe(f"call:{member}", site=site)
+        is CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
+    )
+
+
+@pytest.mark.parametrize("member", ["type_subroutine", "simple_subroutine"])
+def test_unwarranted_f2py_module_member_is_not_factory_owned(member: str) -> None:
+    source = (
+        "def test_member(module):\n"
+        f"    assert module.{member}(0) == 0\n"
+    )
+    built = build_node(
+        _method_call_site(source, member),
+        filename="x.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="x.py", catalog=default_catalog()),
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"


### PR DESCRIPTION
Part of #5564, #5563, #5561, #5555

## Bounce fix (this push)

**Removed** every `pytest` / `pytest.mark.parametrize` logo-string path
(`full != "pytest.mark.parametrize"`, `origin == "pytest"`, helper
`_parametrized_numpy_scalar_receiver`). Window 289 owns the real
parametrize contract — this PR does **not** reimplement it.

**Corpus `to_device` via `@pytest.mark.parametrize` stays LOUD** (correct):
```python
@pytest.mark.parametrize("scalar", scalars)
def test_to_device(self, scalar):
    assert scalar.to_device("cpu") is scalar
```
Instrument: `test_parametrized_to_device_stays_loud_without_logo_match`.

## What authenticates (import/source provenance only)

| family | issue | path |
| --- | --- | --- |
| `call:textwrap.dedent` | #5561 | import identity |
| `call:type_subroutine` | #5564 | multi-hop `self.module.<leaf>` bound-source + twins |
| `call:simple_subroutine` | #5555 | same bound-source + twins |
| `call:to_device` | #5563 | **constructor-bound only**: `scalar = np.int64(1); scalar.to_device(...)` via `_result_call_identity` → enrolled result forms |

## Rebase

- Reset onto current `main` (post-#5608 / #5613)
- UNION: kept every existing family entry on main (including call:SF)
- Did **not** resurrect `sqlalchemy.testing.config.fixture` (#5585)
- Did **not** resurrect SQLAlchemy ORM registry/as_declarative coordinates (#5613)
- No Compare/endswith logo match on pytest

## Floors (audited before push)

| instrument | result |
| --- | --- |
| logo Compare path on pytest in recognition | **absent** |
| `R_ownership` | **0** |
| `R_vendor_special_case` | **146** (main tip baseline **134**; **+12** from the six constructor `to_device` result-identity keys × two support tables — same table shape as existing `tobytes`/`isdtype`. Not a Compare logo branch.) |

## Validation

```
17 focused discrimination + witness twins green
assignment to_device → BuiltinCalleeUniverseSugar
parametrize/parameter to_device → not BuiltinCalleeUniverseSugar (loud)
```

Do not self-merge — soundness-read merge when ready.