### PR TITLE
Authenticate numpy.isdtype and datetime_data callee universes

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -70,6 +70,8 @@ class CalleeUniverseSupport(Enum):
     SCIPY_LINALG_ISSYMMETRIC = auto()
     SCIPY_LINALG_ISHERMITIAN = auto()
     SCIPY_FFT_GET_WORKERS = auto()
+    NUMPY_ISDTYPE = auto()
+    NUMPY_DATETIME_DATA = auto()
 
 
 _DTYPE_RESULT_SUPPORT = {
@@ -187,6 +189,8 @@ _IMPORTED_SUPPORT = {
     "scipy.linalg.issymmetric": CalleeUniverseSupport.SCIPY_LINALG_ISSYMMETRIC,
     "scipy.linalg.ishermitian": CalleeUniverseSupport.SCIPY_LINALG_ISHERMITIAN,
     "scipy.fft.get_workers": CalleeUniverseSupport.SCIPY_FFT_GET_WORKERS,
+    "numpy.isdtype": CalleeUniverseSupport.NUMPY_ISDTYPE,
+    "numpy.datetime_data": CalleeUniverseSupport.NUMPY_DATETIME_DATA,
 }
 
 _BUILTIN_COORDINATES = frozenset({"type", "dtype", "all", "list", "set", "hasattr"})

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -62,6 +62,8 @@ _AUTHENTICATED_COORDINATES = frozenset(
         "scipy.linalg.issymmetric",
         "scipy.linalg.ishermitian",
         "scipy.fft.get_workers",
+        "numpy.isdtype",
+        "numpy.datetime_data",
         *_CONVERTER_COORDINATES,
     }
 )
@@ -212,6 +214,8 @@ class BuiltinCalleeUniverseSugar(
             _scipy_linalg_issymmetric_witness(),
             _scipy_linalg_ishermitian_witness(),
             _scipy_fft_get_workers_witness(),
+            _numpy_isdtype_witness(),
+            _numpy_datetime_data_witness(),
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
@@ -783,5 +787,39 @@ def _bound_leaf_coordinate_witness(name: str):
         owner_sugar="BuiltinCalleeUniverseSugar",
         truthful=truthful,
         lying=lying,
+        family="builtin-universe-coordinate",
+    )
+
+
+def _numpy_isdtype_witness():
+    prefix = (
+        "import numpy as np\n"
+        "\n"
+        "def A():\n"
+        "    return np.isdtype(np.float64, 'real floating')\n"
+        "\n"
+    )
+    return _call_pair(
+        name="numpy_isdtype_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _numpy_datetime_data_witness():
+    prefix = (
+        "import numpy as np\n"
+        "\n"
+        "def A():\n"
+        "    return np.datetime_data(np.dtype('M8[D]'))\n"
+        "\n"
+    )
+    return _call_pair(
+        name="numpy_datetime_data_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
         family="builtin-universe-coordinate",
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
@@ -38,6 +38,8 @@ def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
         "numpy.all",
         "numpy.dtype",
         "numpy.shares_memory",
+        "numpy.isdtype",
+        "numpy.datetime_data",
         "numpy.ndarray.tobytes",
         "numpy._core.multiarray.get_handler_name",
         "numpy._core._multiarray_tests.run_byteorder_converter",
@@ -58,6 +60,8 @@ def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
         "numpy_dtype_universe_coordinate",
         "numpy_dtype_result_universe_coordinate",
         "numpy_shares_memory_universe_coordinate",
+        "numpy_isdtype_universe_coordinate",
+        "numpy_datetime_data_universe_coordinate",
         "numpy_array_tobytes_universe_coordinate",
         "get_handler_name_builtin_universe_coordinate",
         "conv_builtin_universe_coordinate",
@@ -1604,6 +1608,108 @@ def test_unwarranted_numpy_result_type_is_not_factory_owned(source: str) -> None
 
 def test_numpy_result_type_witness_pair_is_enrolled() -> None:
     assert "numpy_result_type_universe_coordinate" in {
+        pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
+    }
+
+
+def test_authenticated_numpy_isdtype_selects_one_factory_owner() -> None:
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_id(dt):\n"
+        "    assert np.isdtype(dt, 'real floating')\n"
+    )
+    context = FactoryBuildContext(filename="isdtype.py", catalog=default_catalog())
+    built = build_node(
+        _import_leaf_call_site(source, "isdtype", "isdtype.py"),
+        filename="isdtype.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "import numpy as np\n"
+            "\n"
+            "def test_id(np, dt):\n"
+            "    assert np.isdtype(dt, 'real floating')\n"
+        ),
+        (
+            "def test_id(dt):\n"
+            "    assert isdtype(dt, 'real floating')\n"
+        ),
+    ],
+)
+def test_unwarranted_numpy_isdtype_is_not_factory_owned(source: str) -> None:
+    context = FactoryBuildContext(filename="isdtype.py", catalog=default_catalog())
+    built = build_node(
+        _import_leaf_call_site(source, "isdtype", "isdtype.py"),
+        filename="isdtype.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_numpy_isdtype_witness_pair_is_enrolled() -> None:
+    assert "numpy_isdtype_universe_coordinate" in {
+        pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
+    }
+
+
+def test_authenticated_numpy_datetime_data_selects_one_factory_owner() -> None:
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_dd(dt):\n"
+        "    assert np.datetime_data(dt) == np.datetime_data(dt)\n"
+    )
+    context = FactoryBuildContext(
+        filename="datetime_data.py", catalog=default_catalog()
+    )
+    built = build_node(
+        _import_leaf_call_site(source, "datetime_data", "datetime_data.py"),
+        filename="datetime_data.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "import numpy as np\n"
+            "\n"
+            "def test_dd(np, dt):\n"
+            "    assert np.datetime_data(dt) == 0\n"
+        ),
+        (
+            "def test_dd(dt):\n"
+            "    assert datetime_data(dt) == 0\n"
+        ),
+    ],
+)
+def test_unwarranted_numpy_datetime_data_is_not_factory_owned(source: str) -> None:
+    context = FactoryBuildContext(
+        filename="datetime_data.py", catalog=default_catalog()
+    )
+    built = build_node(
+        _import_leaf_call_site(source, "datetime_data", "datetime_data.py"),
+        filename="datetime_data.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_numpy_datetime_data_witness_pair_is_enrolled() -> None:
+    assert "numpy_datetime_data_universe_coordinate" in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_universe_coverage_gap.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_universe_coverage_gap.py
@@ -973,6 +973,94 @@ def test_unowned_shares_memory_lookalikes_stay_loud(
     assert [gap.ast_kind for gap in gaps] == [expected_kind]
 
 
+def test_authenticated_numpy_isdtype_has_universe_support() -> None:
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_values(dt):\n"
+        "    assert np.isdtype(dt, 'real floating')\n"
+    )
+
+    payload = lift_file_payload(source, "isdtype_covered_fixture.py")
+
+    assert any(
+        edge.get("targetSymbol") == "call:numpy.isdtype"
+        for edge in payload.call_edges
+    )
+    assert _universe_gaps(payload) == []
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_kind"),
+    (
+        (
+            "import numpy as np\n"
+            "def test_values(np, dt):\n"
+            "    assert np.isdtype(dt, 'real floating')\n",
+            "call:numpy.isdtype",
+        ),
+        (
+            "def test_values(dt):\n"
+            "    assert isdtype(dt, 'real floating')\n",
+            "call:isdtype",
+        ),
+    ),
+)
+def test_unowned_isdtype_lookalikes_stay_loud(
+    source: str, expected_kind: str
+) -> None:
+    """Parameter shadow and unimported spelling stay loud universe gaps."""
+
+    payload = lift_file_payload(source, "isdtype_unowned_fixture.py")
+
+    gaps = _universe_gaps(payload)
+    assert [gap.ast_kind for gap in gaps] == [expected_kind]
+
+
+def test_authenticated_numpy_datetime_data_has_universe_support() -> None:
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_values(dt):\n"
+        "    assert np.datetime_data(dt) == np.datetime_data(dt)\n"
+    )
+
+    payload = lift_file_payload(source, "datetime_data_covered_fixture.py")
+
+    assert any(
+        edge.get("targetSymbol") == "call:numpy.datetime_data"
+        for edge in payload.call_edges
+    )
+    assert _universe_gaps(payload) == []
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_kind"),
+    (
+        (
+            "import numpy as np\n"
+            "def test_values(np, dt):\n"
+            "    assert np.datetime_data(dt) == 0\n",
+            "call:numpy.datetime_data",
+        ),
+        (
+            "def test_values(dt):\n"
+            "    assert datetime_data(dt) == 0\n",
+            "call:datetime_data",
+        ),
+    ),
+)
+def test_unowned_datetime_data_lookalikes_stay_loud(
+    source: str, expected_kind: str
+) -> None:
+    """Parameter shadow and unimported spelling stay loud universe gaps."""
+
+    payload = lift_file_payload(source, "datetime_data_unowned_fixture.py")
+
+    gaps = _universe_gaps(payload)
+    assert [gap.ast_kind for gap in gaps] == [expected_kind]
+
+
 def test_module_scope_numpy_from_import_has_universe_support() -> None:
     """Module-level imports establish the name; do not revoke as free-var shadow."""
 


### PR DESCRIPTION
Part of #5593, #5601

## Change

Batch-drain two NumPy callee families via the single `CalleeUniverseSupport` recognizer:

| family | rows | representative locus |
|---|---:|---|
| `call:numpy.isdtype` | 6 | `numpy/_core/tests/test_numerictypes.py:453` |
| `call:numpy.datetime_data` | 1 | `numpy/_core/tests/test_scalar_ctors.py:60` |

Authentication is import/source provenance only (`import numpy as np` → `np.isdtype` / `np.datetime_data`). No vendor-name string match, name whitelist, or inline AST side door.

Each family owns a truthful/lying twin pair on `BuiltinCalleeUniverseSugar`. The lying twin refutes deterministic call substitution. Parameter-shadowed and unimported lookalikes remain loud universe gaps / not factory-owned.

## Conservation

- Focused discrimination: 16 passed (auth + unowned lookalikes + enrollment for both families).
- Red-first: removing the support entries fails auth ownership and leaves `call:numpy.isdtype` universe gaps.
- `R_vendor_special_case = 0`.

Do not merge without coordinator soundness review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate `numpy.isdtype` and `numpy.datetime_data` callee universes
> Adds `numpy.isdtype` and `numpy.datetime_data` as recognized, authenticated coordinates in the callee universe system.
>
> - Adds enum members and import-identity entries in [`callee_universe.py`](https://github.com/TSavo/sugar/pull/5604/files#diff-72e9f915afa350390348a1c277d0c2047b26a0182bb4780c57baf73f30fdcaa8) for both functions.
> - Registers witness pairs and authenticated coordinates in [`builtin_callee_universe_sugar.py`](https://github.com/TSavo/sugar/pull/5604/files#diff-98e9ae8e3cbb10a2e6c95f0bdeca86f0b85002634b901733d0b6070886cdab5f), enabling ownership checks and enrollment.
> - Adds tests confirming authenticated calls are owned, lookalike calls are rejected, and witness pairs are enrolled correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8959c02.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->