### PR TITLE
idd: census vendor logos in dispatch tables; empty fixture registry

### DIFF
--- a/docs/ledgers/vendor-table-literal-recensus.md
+++ b/docs/ledgers/vendor-table-literal-recensus.md
@@ -1,0 +1,129 @@
+# R_vendor_special_case table-literal recensus
+
+Instrument extended to census dispatch **dict/set/tuple/list** literals
+in addition to comparisons and `isinstance`. Logo string is never
+sufficient construction evidence.
+
+- **R_vendor_special_case** = `193`
+- **auditor_errors** = `0`
+- **fixture production**: `_FIXTURE_DECORATORS = {}` — `pytest.fixture` removed;
+  fixture-dependent rows stay **loud** until kit/bridge/proof contract.
+
+## By vendor
+
+| vendor | loci |
+| --- | ---: |
+| `numpy` | 132 |
+| `pandas` | 30 |
+| `sqlalchemy` | 8 |
+| `pytest` | 7 |
+| `scipy` | 6 |
+| `pydantic` | 4 |
+| `sklearn` | 4 |
+| `datetime` | 1 |
+| `requests` | 1 |
+
+## By path
+
+| path | loci |
+| --- | ---: |
+| `recognition/native_shape.py` | 93 |
+| `recognition/callee_universe.py` | 68 |
+| `sugar/builtin_callee_universe_sugar.py` | 28 |
+| `recognition/remaining_semantics.py` | 1 |
+| `sugar/pytest_fail_sugar.py` | 1 |
+| `sugar/pytest_raises_with_sugar.py` | 1 |
+| `sugar/pytest_skip_sugar.py` | 1 |
+
+## recognition/native_shape.py coordinates (adjudication queue)
+
+Every entry is **illegal logo branch** until replaced by kit/bridge/proof
+contract evidence (not a production mapping literal).
+
+- `'datetime'`
+- `'numpy'`
+- `'numpy.ScalarType.index'`
+- `'numpy.__array_namespace__'`
+- `'numpy.__eq__'`
+- `'numpy.__ge__'`
+- `'numpy.__gt__'`
+- `'numpy.__le__'`
+- `'numpy.__lt__'`
+- `'numpy.__ne__'`
+- `'numpy._utils.asbytes'`
+- `'numpy.add'`
+- `'numpy.all'`
+- `'numpy.arange'`
+- `'numpy.array'`
+- `'numpy.divide'`
+- `'numpy.ediff1d'`
+- `'numpy.empty'`
+- `'numpy.empty_like'`
+- `'numpy.errstate'`
+- `'numpy.finfo'`
+- `'numpy.floor_divide'`
+- `'numpy.isnat'`
+- `'numpy.lib.stride_tricks.as_strided'`
+- `'numpy.maximum'`
+- `'numpy.minimum'`
+- `'numpy.mod'`
+- `'numpy.multiply'`
+- `'numpy.ndarray.tobytes'`
+- `'numpy.nditer'`
+- `'numpy.power'`
+- `'numpy.prod'`
+- `'numpy.random.Generator'`
+- `'numpy.random.Generator.standard_gamma'`
+- `'numpy.random.randint'`
+- `'numpy.result_type'`
+- `'numpy.subtract'`
+- `'numpy.testing._private.utils.assert_raises'`
+- `'numpy.testing._private.utils.assert_raises_regex'`
+- `'numpy.testing.assert_raises'`
+- `'numpy.testing.assert_raises_regex'`
+- `'numpy.zeros'`
+- `'pandas'`
+- `'pandas.DatetimeIndex'`
+- `'pandas.HDFStore'`
+- `'pandas.Index'`
+- `'pandas.IntervalIndex'`
+- `'pandas.IntervalIndex.from_breaks'`
+- `'pandas.MultiIndex.from_arrays'`
+- `'pandas.PeriodIndex'`
+- `'pandas.RangeIndex'`
+- `'pandas.TimedeltaIndex'`
+- `'pandas._config.config.options'`
+- `'pandas._config.config.register_option'`
+- `'pandas._config.config.reset_option'`
+- `'pandas._config.config.set_option'`
+- `'pandas._testing.assert_produces_warning'`
+- `'pandas._testing.external_error_raised'`
+- `'pandas._testing.raises_chained_assignment_error'`
+- `'pandas.api.extensions'`
+- `'pandas.core.indexes.api.Index'`
+- `'pandas.core.indexes.datetimes.date_range'`
+- `'pandas.core.indexes.extension'`
+- `'pandas.core.indexes.period.period_range'`
+- `'pandas.core.indexes.timedeltas.timedelta_range'`
+- `'pandas.option_context'`
+- `'pandas.util._decorators'`
+- `'pydantic'`
+- `'pydantic.dataclasses'`
+- `'pytest'`
+- `'pytest.approx'`
+- `'pytest.warns'`
+- `'requests'`
+- `'sklearn.utils'`
+- `'sklearn.utils.deprecation'`
+- `'sqlalchemy.ext.declarative'`
+- `'sqlalchemy.orm'`
+- `'sqlalchemy.orm.registry'`
+
+## Adjudication classes
+
+| class | meaning |
+| --- | --- |
+| language/builtin protocol | stdlib-only coordinates outside VENDORS (not listed here) |
+| externally loaded kit/bridge/proof contract | future load path — **not** production recognition literals |
+| illegal logo branch | every row above until contract evidence exists |
+

--- a/implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
@@ -3,14 +3,20 @@
 
 Sugar, factory, and recognition may dispatch on source shape and first-class
 Sugar/value types. They may not decide behavior by matching a specific vendor
-module/class name or by applying ``isinstance`` to a vendor class.
+module/class name, by applying ``isinstance`` to a vendor class, or by
+embedding vendor spellings as keys/values in dispatch dictionaries, sets,
+tuples, lists, or registry initializers.
+
+A logo string is never sufficient construction evidence — relocating a vendor
+name from a comparison into a mapping literal must not green this floor.
 
 Scanned vendor roots: numpy, pandas, datetime, scipy, pydantic, sqlalchemy,
-cryptography, requests.
+cryptography, requests, pytest, sklearn.
 
 Exit 1 whenever R_vendor_special_case > 0. There is no baseline, threshold, or
-allowlist. Replacement: register the source shape and construct/reduce it
-through the ordinary Sugar + SugarBody + floor path.
+allowlist. Replacement: source shape → registered Sugar → SugarBody children →
+floor; fixture/vendor semantics only via explicit kit/bridge/proof contract,
+never production recognition coordinates.
 
 Portability: every load/parse failure is a loud structured diagnostic row (or
 process-level structured ERROR exit), never an unhandled process crash. Windows
@@ -38,6 +44,16 @@ VENDORS = frozenset(
         "sqlalchemy",
         "cryptography",
         "requests",
+        "pytest",
+        "sklearn",
+    }
+)
+
+_LOGO_DISPATCH_KINDS = frozenset(
+    {
+        "vendor-name-match",
+        "vendor-isinstance",
+        "vendor-table-literal",
     }
 )
 
@@ -138,6 +154,48 @@ def _isinstance_vendor(node: ast.Call) -> str | None:
         if vendor is not None:
             return vendor
     return None
+
+
+def _table_literal_vendor_hits(node: ast.AST) -> list[tuple[str, str]]:
+    """Vendor logos embedded as dispatch table / registry constants.
+
+    Hits Constant string (or nested tuple/list/set of strings) that name a
+    scanned vendor root when they appear as:
+
+    - dict keys or values
+    - set / list / tuple elements
+    - nested tuple keys used by registry initializers
+
+    Returns (vendor, expression) pairs. One Constant may contribute one hit.
+    """
+    hits: list[tuple[str, str]] = []
+
+    def consider_constant(constant: ast.Constant) -> None:
+        if not isinstance(constant.value, str):
+            return
+        vendor = _vendor_from_text(constant.value)
+        if vendor is None:
+            return
+        hits.append((vendor, repr(constant.value)))
+
+    def walk_collection(collection: ast.AST) -> None:
+        if isinstance(collection, ast.Constant):
+            consider_constant(collection)
+            return
+        if isinstance(collection, ast.Tuple | ast.List | ast.Set):
+            for elt in collection.elts:
+                walk_collection(elt)
+            return
+        if isinstance(collection, ast.Dict):
+            for key, value in zip(collection.keys, collection.values, strict=False):
+                if key is not None:
+                    walk_collection(key)
+                if value is not None:
+                    walk_collection(value)
+
+    if isinstance(node, (ast.Dict, ast.Set, ast.List, ast.Tuple)):
+        walk_collection(node)
+    return hits
 
 
 def _rel_path(root: Path, path: Path) -> str:
@@ -264,6 +322,26 @@ def scan_file(path: Path, *, rel: str) -> list[VendorSpecialCase]:
                             ),
                         )
                     )
+            elif isinstance(node, (ast.Dict, ast.Set, ast.List, ast.Tuple)):
+                # Only top-level-ish collection literals that embed logos as
+                # dispatch coordinates. Nested collections are visited as their
+                # own walk nodes too; de-dupe by (line, vendor, expression).
+                for vendor, expression in _table_literal_vendor_hits(node):
+                    offenders.append(
+                        VendorSpecialCase(
+                            path=rel,
+                            line=getattr(node, "lineno", 0) or 0,
+                            kind="vendor-table-literal",
+                            vendor=vendor,
+                            expression=expression,
+                            note=(
+                                "logo string in dispatch dict/set/tuple/list is "
+                                "still vendor identity; relocate into kit/"
+                                "bridge/proof contract or delete — never "
+                                "construction evidence"
+                            ),
+                        )
+                    )
     except Exception as exc:  # noqa: BLE001 — per-file containment
         offenders.append(
             VendorSpecialCase(
@@ -275,7 +353,16 @@ def scan_file(path: Path, *, rel: str) -> list[VendorSpecialCase]:
                 note=f"scan aborted for file: {exc}",
             )
         )
-    return offenders
+    # De-dupe nested collection double-counts: same path/line/kind/vendor/expr.
+    deduped: list[VendorSpecialCase] = []
+    seen: set[tuple[str, int, str, str, str]] = set()
+    for row in offenders:
+        key = (row.path, row.line, row.kind, row.vendor, row.expression)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(row)
+    return deduped
 
 
 def scan_roots(roots: Sequence[Path]) -> list[VendorSpecialCase]:
@@ -334,11 +421,7 @@ def r_vendor_special_case(offenders: Sequence[VendorSpecialCase]) -> int:
     # They still fail the run (exit 1) via main when present, but are counted
     # separately from R_vendor_special_case so a portable crash-fix does not
     # inflate the logo-dispatch floor.
-    return sum(
-        1
-        for row in offenders
-        if row.kind in {"vendor-name-match", "vendor-isinstance"}
-    )
+    return sum(1 for row in offenders if row.kind in _LOGO_DISPATCH_KINDS)
 
 
 def r_auditor_errors(offenders: Sequence[VendorSpecialCase]) -> int:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
@@ -178,16 +178,14 @@ _NATIVE_DECORATORS = {
     "functools.wraps": NativeShape.IMPLEMENTATION_PRESERVING_DECORATOR,
 }
 
-# Fixture / inject-provider protocol: registered import coordinates only.
-# Consumers authenticate via recognize_native_fixture_decorator(qualified),
-# never by comparing against a vendor-name string literal in recognition code.
+# Fixture / inject-provider protocol coordinates.
 #
-# Protocol is the general testing fixture decorator (pytest.fixture). Vendor-
-# specific fixture spellings are intentionally NOT registered — that would be
-# logo dispatch by relocation (#5578 bounce).
-_FIXTURE_DECORATORS = {
-    "pytest.fixture": NativeShape.FIXTURE_DECORATOR,
-}
+# Empty by doctrine: no logo string (including ``pytest.fixture``) is
+# sufficient construction evidence. Fixture-dependent ClassDef / parameter
+# rows stay loud until fixture semantics arrive through an explicit
+# kit/bridge/proof contract — not a production recognition mapping.
+# See R_vendor_special_case vendor-table-literal census.
+_FIXTURE_DECORATORS: dict[str, NativeShape] = {}
 
 _NATIVE_INSTANCE_CLASS_DECORATORS = {
     (NativeShape.SQLALCHEMY_ORM_REGISTRY, "mapped"): (

--- a/implementations/python/sugar-lift-py-tests/tests/test_fixture_provider_seat_authentication.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_fixture_provider_seat_authentication.py
@@ -1,10 +1,10 @@
-"""#5578: fixture providers via general pytest.fixture protocol + exact seats.
+"""Fixture providers stay loud until kit/bridge/proof contract evidence.
 
-Permanent floors:
-- R_vendor_special_case = 0 by construction (no vendor fixture keys in recognition)
-- Provider bodies are anchored to exact source seats (module + line/col)
-- Lying twins stay loud: dual class fixtures, lookalike imports, shadow, mismatch
-- Protocol authenticates via pytest.fixture only — never a vendor fixture key
+Doctrine: no logo string (including ``pytest.fixture``) is sufficient
+construction evidence. Production ``_FIXTURE_DECORATORS`` is empty.
+
+Seat anchoring and lying-twin structure remain tested so the future contract
+path cannot reintroduce name-only provider selection or logo compares.
 """
 
 from __future__ import annotations
@@ -12,6 +12,9 @@ from __future__ import annotations
 import ast
 
 from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+from sugar_lift_py_tests.recognition.native_shape import (
+    recognize_native_fixture_decorator,
+)
 from sugar_lift_py_tests.sugar.class_def_sugar import ClassDefSugar
 
 
@@ -37,10 +40,18 @@ def _provider_fragment(provider_source: str, method_name: str, module: str):
     )
 
 
-def test_pytest_fixture_protocol_authenticates_without_sqlalchemy_name(
+def test_no_logo_fixture_coordinate_is_registered() -> None:
+    assert recognize_native_fixture_decorator("pytest.fixture") is None
+    assert (
+        recognize_native_fixture_decorator("sqlalchemy.testing.config.fixture")
+        is None
+    )
+
+
+def test_pytest_fixture_provider_stays_loud_without_kit_contract(
     monkeypatch,
 ) -> None:
-    """Registered fixture protocol (pytest.fixture) is enough — no SA logo."""
+    """Even a perfect seat-anchored pytest.fixture provider stays loud."""
     provider_source = (
         "import pytest\n"
         "from sqlalchemy.orm import registry\n"
@@ -55,7 +66,9 @@ def test_pytest_fixture_protocol_authenticates_without_sqlalchemy_name(
         "sugar_lift_py_tests.sugar.install_source_dig."
         "resolve_install_source_class_method",
         lambda qualified, method: (
-            fragment if (qualified, method) == ("example.FixtureBase", "registry") else None
+            fragment
+            if (qualified, method) == ("example.FixtureBase", "registry")
+            else None
         ),
     )
     monkeypatch.setattr(
@@ -74,23 +87,59 @@ def test_pytest_fixture_protocol_authenticates_without_sqlalchemy_name(
         "        class User:\n"
         "            pass\n"
     )
-    assert ClassDefSugar.owns(_user_class_site(source)) is True
+    assert ClassDefSugar.owns(_user_class_site(source)) is False
 
 
-def test_identical_fixture_names_in_two_classes_use_exact_seat(
+def test_sqlalchemy_config_fixture_provider_stays_loud(monkeypatch) -> None:
+    provider_source = (
+        "from sqlalchemy.testing import config\n"
+        "from sqlalchemy.orm import registry\n"
+        "class FixtureBase:\n"
+        "    @config.fixture()\n"
+        "    def registry(self, metadata):\n"
+        "        value = registry(metadata=metadata)\n"
+        "        yield value\n"
+    )
+    fragment = _provider_fragment(provider_source, "registry", "example.fixtures")
+    monkeypatch.setattr(
+        "sugar_lift_py_tests.sugar.install_source_dig."
+        "resolve_install_source_class_method",
+        lambda qualified, method: (
+            fragment
+            if (qualified, method) == ("example.FixtureBase", "registry")
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        "sugar_lift_python_source.source_oracle.installed_module_source",
+        lambda module: (
+            (provider_source, "example/fixtures.py", "cid")
+            if module == "example.fixtures"
+            else None
+        ),
+    )
+    source = (
+        "from example import FixtureBase\n"
+        "class TestThing(FixtureBase):\n"
+        "    def test_it(self, registry):\n"
+        "        @registry.mapped\n"
+        "        class User:\n"
+        "            pass\n"
+    )
+    assert ClassDefSugar.owns(_user_class_site(source)) is False
+
+
+def test_identical_fixture_names_cannot_false_green_via_name_only(
     monkeypatch,
 ) -> None:
-    """Name-only search would pick WrongBase.registry (first in module).
-
-    Both methods use the general pytest.fixture protocol — no vendor fixture key.
-    """
+    """Seat machinery still resolves exact line/col; protocol remains empty → loud."""
     provider_source = (
         "import pytest\n"
         "from sqlalchemy.orm import registry\n"
         "class WrongBase:\n"
         "    @pytest.fixture()\n"
         "    def registry(self, metadata):\n"
-        "        yield object()  # not a native registry shape\n"
+        "        yield object()\n"
         "\n"
         "class FixtureBase:\n"
         "    @pytest.fixture()\n"
@@ -109,63 +158,17 @@ def test_identical_fixture_names_in_two_classes_use_exact_seat(
         for node in fixture_base.body
         if isinstance(node, ast.FunctionDef) and node.name == "registry"
     )
-    wrong = next(
-        node
-        for node in tree.body
-        if isinstance(node, ast.ClassDef) and node.name == "WrongBase"
-        for child in node.body
-        if isinstance(child, ast.FunctionDef) and child.name == "registry"
-        for node in [child]
-    )
     setattr(correct, "_sugar_defining_module", "example.fixtures")
     fragment = SourceFragment.from_node(
         correct, "example/fixtures.py", source=provider_source
     )
-    # Seat must be the FixtureBase method, not the earlier WrongBase twin.
-    assert correct.lineno != wrong.lineno
     monkeypatch.setattr(
         "sugar_lift_py_tests.sugar.install_source_dig."
         "resolve_install_source_class_method",
         lambda qualified, method: (
-            fragment if (qualified, method) == ("example.FixtureBase", "registry") else None
-        ),
-    )
-    monkeypatch.setattr(
-        "sugar_lift_python_source.source_oracle.installed_module_source",
-        lambda module: (
-            (provider_source, "example/fixtures.py", "cid")
-            if module == "example.fixtures"
+            fragment
+            if (qualified, method) == ("example.FixtureBase", "registry")
             else None
-        ),
-    )
-    source = (
-        "from example import FixtureBase\n"
-        "class TestThing(FixtureBase):\n"
-        "    def test_it(self, registry):\n"
-        "        @registry.mapped\n"
-        "        class User:\n"
-        "            pass\n"
-    )
-    assert ClassDefSugar.owns(_user_class_site(source)) is True
-
-
-def test_imported_lookalike_config_fixture_stays_loud(monkeypatch) -> None:
-    """Lookalike `config.fixture` (including SA testing.config) is not protocol."""
-    provider_source = (
-        "from sqlalchemy.testing import config\n"
-        "from sqlalchemy.orm import registry\n"
-        "class FixtureBase:\n"
-        "    @config.fixture()\n"
-        "    def registry(self, metadata):\n"
-        "        value = registry(metadata=metadata)\n"
-        "        yield value\n"
-    )
-    fragment = _provider_fragment(provider_source, "registry", "example.fixtures")
-    monkeypatch.setattr(
-        "sugar_lift_py_tests.sugar.install_source_dig."
-        "resolve_install_source_class_method",
-        lambda qualified, method: (
-            fragment if (qualified, method) == ("example.FixtureBase", "registry") else None
         ),
     )
     monkeypatch.setattr(
@@ -187,82 +190,52 @@ def test_imported_lookalike_config_fixture_stays_loud(monkeypatch) -> None:
     assert ClassDefSugar.owns(_user_class_site(source)) is False
 
 
-def test_aliased_shadowed_fixture_decorator_stays_loud(monkeypatch) -> None:
-    """Decorator spelling ``fixture`` after import-as-alias is not protocol-resolved.
-
-    The import binds ``real_fixture``; the decorator uses unbound name ``fixture``
-    (local lambda). Import map has no ``fixture`` key → not authenticated.
-    """
-    provider_source = (
-        "from pytest import fixture as real_fixture\n"
-        "from sqlalchemy.orm import registry\n"
-        "fixture = lambda fn: fn\n"
-        "class FixtureBase:\n"
-        "    @fixture()\n"
-        "    def registry(self, metadata):\n"
-        "        value = registry(metadata=metadata)\n"
-        "        yield value\n"
-    )
-    fragment = _provider_fragment(provider_source, "registry", "example.fixtures")
-    monkeypatch.setattr(
-        "sugar_lift_py_tests.sugar.install_source_dig."
-        "resolve_install_source_class_method",
-        lambda qualified, method: (
-            fragment if (qualified, method) == ("example.FixtureBase", "registry") else None
+def test_lookalike_and_shadow_fixture_decorators_stay_loud(monkeypatch) -> None:
+    for provider_source in (
+        (
+            "from pretend.testing import config\n"
+            "from sqlalchemy.orm import registry\n"
+            "class FixtureBase:\n"
+            "    @config.fixture()\n"
+            "    def registry(self, metadata):\n"
+            "        value = registry(metadata=metadata)\n"
+            "        yield value\n"
         ),
-    )
-    monkeypatch.setattr(
-        "sugar_lift_python_source.source_oracle.installed_module_source",
-        lambda module: (
-            (provider_source, "example/fixtures.py", "cid")
-            if module == "example.fixtures"
-            else None
+        (
+            "from sqlalchemy.testing import config\n"
+            "from sqlalchemy.orm import registry\n"
+            "config = type('C', (), {'fixture': staticmethod(lambda: (lambda f: f))})()\n"
+            "class FixtureBase:\n"
+            "    @config.fixture()\n"
+            "    def registry(self, metadata):\n"
+            "        value = registry(metadata=metadata)\n"
+            "        yield value\n"
         ),
-    )
-    source = (
-        "from example import FixtureBase\n"
-        "class TestThing(FixtureBase):\n"
-        "    def test_it(self, registry):\n"
-        "        @registry.mapped\n"
-        "        class User:\n"
-        "            pass\n"
-    )
-    assert ClassDefSugar.owns(_user_class_site(source)) is False
-
-
-def test_mismatched_provider_class_stays_loud(monkeypatch) -> None:
-    """Resolver returns None for wrong class — parameter stays unauthenticated."""
-    provider_source = (
-        "import pytest\n"
-        "from sqlalchemy.orm import registry\n"
-        "class OtherBase:\n"
-        "    @pytest.fixture()\n"
-        "    def registry(self, metadata):\n"
-        "        value = registry(metadata=metadata)\n"
-        "        yield value\n"
-    )
-    fragment = _provider_fragment(provider_source, "registry", "example.fixtures")
-    monkeypatch.setattr(
-        "sugar_lift_py_tests.sugar.install_source_dig."
-        "resolve_install_source_class_method",
-        lambda qualified, method: (
-            fragment if (qualified, method) == ("example.OtherBase", "registry") else None
-        ),
-    )
-    monkeypatch.setattr(
-        "sugar_lift_python_source.source_oracle.installed_module_source",
-        lambda module: (
-            (provider_source, "example/fixtures.py", "cid")
-            if module == "example.fixtures"
-            else None
-        ),
-    )
-    source = (
-        "from example import FixtureBase\n"
-        "class TestThing(FixtureBase):\n"
-        "    def test_it(self, registry):\n"
-        "        @registry.mapped\n"
-        "        class User:\n"
-        "            pass\n"
-    )
-    assert ClassDefSugar.owns(_user_class_site(source)) is False
+    ):
+        fragment = _provider_fragment(provider_source, "registry", "example.fixtures")
+        monkeypatch.setattr(
+            "sugar_lift_py_tests.sugar.install_source_dig."
+            "resolve_install_source_class_method",
+            lambda qualified, method, frag=fragment: (
+                frag
+                if (qualified, method) == ("example.FixtureBase", "registry")
+                else None
+            ),
+        )
+        monkeypatch.setattr(
+            "sugar_lift_python_source.source_oracle.installed_module_source",
+            lambda module, src=provider_source: (
+                (src, "example/fixtures.py", "cid")
+                if module == "example.fixtures"
+                else None
+            ),
+        )
+        source = (
+            "from example import FixtureBase\n"
+            "class TestThing(FixtureBase):\n"
+            "    def test_it(self, registry):\n"
+            "        @registry.mapped\n"
+            "        class User:\n"
+            "            pass\n"
+        )
+        assert ClassDefSugar.owns(_user_class_site(source)) is False

--- a/implementations/python/sugar-lift-py-tests/tests/test_vendor_special_case_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_vendor_special_case_law.py
@@ -36,13 +36,46 @@ def owns(value):
     )
 
     offenders = _SCANNER.scan_roots((sugar,))
+    kinds = {(row.kind, row.vendor) for row in offenders}
 
-    assert [(row.kind, row.vendor) for row in offenders] == [
-        ("vendor-name-match", "pandas"),
-        ("vendor-name-match", "requests"),
-        ("vendor-isinstance", "numpy"),
-    ]
-    assert _SCANNER.r_vendor_special_case(offenders) == 3
+    assert ("vendor-name-match", "pandas") in kinds
+    assert ("vendor-isinstance", "numpy") in kinds
+    # Relocating a logo into a set/dict must still trip — never a green hide.
+    assert ("vendor-table-literal", "requests") in kinds
+    assert _SCANNER.r_vendor_special_case(offenders) >= 3
+
+
+def test_planted_mapping_literal_twin_trips_floor(tmp_path: Path) -> None:
+    """Moving a vendor name from == into a dispatch dict cannot green the floor."""
+    sugar = tmp_path / "sugar"
+    sugar.mkdir()
+    (sugar / "registry.py").write_text(
+        """
+# No comparisons — only a recognition-style registry initializer.
+_CALL_SHAPES = {
+    "numpy.arange": "RANGE_ARRAY",
+    "sqlalchemy.orm.registry": "SQLALCHEMY_ORM_REGISTRY",
+}
+_IDENTITY = {("pandas.api.extensions", "register_series_accessor")}
+_FIXTURE = {"pytest.fixture"}
+""",
+        encoding="utf-8",
+    )
+
+    offenders = _SCANNER.scan_roots((sugar,))
+    kinds = {(row.kind, row.vendor, row.expression) for row in offenders}
+
+    assert ("vendor-table-literal", "numpy", "'numpy.arange'") in kinds
+    assert (
+        "vendor-table-literal",
+        "sqlalchemy",
+        "'sqlalchemy.orm.registry'",
+    ) in kinds
+    assert ("vendor-table-literal", "pandas", "'pandas.api.extensions'") in kinds
+    assert ("vendor-table-literal", "pytest", "'pytest.fixture'") in kinds
+    assert _SCANNER.r_vendor_special_case(offenders) >= 4
+    # Pure mapping hide: no compare / isinstance required
+    assert all(row.kind == "vendor-table-literal" for row in offenders)
 
 
 def test_shape_checks_do_not_trip_floor(tmp_path: Path) -> None:
@@ -59,25 +92,41 @@ def owns(value):
     assert _SCANNER.scan_roots((sugar,)) == []
 
 
+def test_language_protocol_string_without_vendor_root_stays_quiet(
+    tmp_path: Path,
+) -> None:
+    """stdlib / language coordinates are not scanned vendor roots."""
+    sugar = tmp_path / "sugar"
+    sugar.mkdir()
+    (sugar / "lang.py").write_text(
+        """
+_LANG = {
+    "functools.wraps": "IMPLEMENTATION_PRESERVING_DECORATOR",
+    "pathlib.Path": "PATH",
+    "re.compile": "REGEX_PATTERN",
+    "dataclasses.dataclass": True,
+}
+""",
+        encoding="utf-8",
+    )
+
+    assert _SCANNER.scan_roots((sugar,)) == []
+
+
 def test_unreadable_or_invalid_source_is_structured_not_crash(tmp_path: Path) -> None:
     """Windows portability: auditor must not process-crash on bad files (#5253)."""
     sugar = tmp_path / "sugar"
     sugar.mkdir()
-    # Invalid UTF-8 bytes that still look like a .py path
     bad = sugar / "binaryish.py"
     bad.write_bytes(b"\xff\xfe\x00not-valid-python\x00")
-    # Unparseable Python
     (sugar / "syntax_error.py").write_text("def (\n", encoding="utf-8")
-    # Missing root should also not raise
     missing = tmp_path / "does-not-exist"
 
     offenders = _SCANNER.scan_roots((sugar, missing))
     kinds = {row.kind for row in offenders}
     assert "auditor-parse-error" in kinds or "auditor-read-error" in kinds
     assert "auditor-root-error" in kinds
-    # Logo floor stays zero for pure auditor diagnostics
     assert _SCANNER.r_vendor_special_case(offenders) == 0
     assert _SCANNER.r_auditor_errors(offenders) >= 1
-    # CLI exits 1 (red structured), never raises
     code = _SCANNER.main([str(sugar), str(missing)])
     assert code == 1


### PR DESCRIPTION
## Summary

**Doctrine:** no logo string is sufficient evidence for construction. Relocating a vendor name from `==` into a dict/set cannot green `R_vendor_special_case`.

### Auditor
- New kind: `vendor-table-literal` — Constant strings naming scanned vendor roots inside dispatch **dict / set / tuple / list** (and nested registry initializers).
- Counted in `R_vendor_special_case` with name-match and isinstance.
- Scanned roots expanded: **pytest**, **sklearn**.
- Planted **mapping-literal twin** so hide-by-relocation fails forever.

### Fixture
- `_FIXTURE_DECORATORS = {}` — **`pytest.fixture` removed** from production recognition.
- Fixture-dependent ClassDef / parameter rows stay **loud** until kit/bridge/proof contract.

### Recensus (this pin)
- **R_vendor_special_case = 193** (honest red until logo branches drain).
- Ledger: `docs/ledgers/vendor-table-literal-recensus.md`
- Top paths: `native_shape.py` (93), `callee_universe.py` (68), `builtin_callee_universe_sugar.py` (28), plus pytest sugar name-matches.
- Includes SQLAlchemy ORM table coordinates under the same rule.

### Floors
- Instrument is **truthfully red** at R=193 — not a fake green by registry relocation.
- Timeout floor unrelated; fixture five-row drain **not** counted.

### Validation
```
pytest test_vendor_special_case_law.py test_fixture_provider_seat_authentication.py → 10 passed
vendor_special_case_law.py → R=193 (table-literal census live)
```

Part of sole-construction permanent floors. Next: drain illegal logo branches via kit/bridge/proof contracts only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add vendor logo detection in dispatch table literals and empty fixture registry
> - Adds `_table_literal_vendor_hits` to [vendor_special_case_law.py](https://github.com/TSavo/sugar/pull/5605/files#diff-6d74baef6cb0b9ef4a715ef5e178ccae07a7641b3464e7c88d529aa18fb30ce9) to detect vendor name strings embedded in `dict`/`set`/`list`/`tuple` literals, reported as a new `vendor-table-literal` kind in the `R_vendor_special_case` metric.
> - Extends scanned vendors to include `pytest` and `sklearn`; introduces `_LOGO_DISPATCH_KINDS` constant so all three counted kinds share a single definition.
> - Empties `_FIXTURE_DECORATORS` in [native_shape.py](https://github.com/TSavo/sugar/pull/5605/files#diff-d1526541051a4390409c635c2450d85c7da899e4ab0926eaf38e335d65ff09d0), removing `pytest.fixture` registration on the grounds that a logo string alone is not sufficient construction evidence.
> - Updates tests to assert `recognize_native_fixture_decorator('pytest.fixture')` returns `None` and that pytest-fixture-based providers are no longer considered owned.
> - Behavioral Change: code that previously authenticated via `pytest.fixture` decorator recognition will now return `None`/unowned until an explicit contract is registered.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 02e5a70.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->