### PR TITLE
Authenticate call:SF; leave call:comp loud (no pytest logo)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -76,6 +76,8 @@ class CalleeUniverseSupport(Enum):
     SCIPY_FFT_GET_WORKERS = auto()
     NUMPY_ISDTYPE = auto()
     NUMPY_DATETIME_DATA = auto()
+    # SF = _get_sfloat_dtype(); SF(...) — factory-result callable.
+    NUMPY_SFLOAT_DTYPE = auto()
     NUMPY_MARKINNERSPACES = auto()
     NUMPY_IDENTITY_HASH_SET_ITEM_DEFAULT = auto()
 
@@ -205,6 +207,12 @@ _IMPORTED_SUPPORT = {
     "scipy.fft.get_workers": CalleeUniverseSupport.SCIPY_FFT_GET_WORKERS,
     "numpy.isdtype": CalleeUniverseSupport.NUMPY_ISDTYPE,
     "numpy.datetime_data": CalleeUniverseSupport.NUMPY_DATETIME_DATA,
+    # Corpus: numpy/_core/tests/test_custom_dtypes.py
+    # ``SF = _get_sfloat_dtype()`` then ``SF(...)`` — factory import, not the
+    # local alias spelling.
+    "numpy._core._multiarray_umath._get_sfloat_dtype": (
+        CalleeUniverseSupport.NUMPY_SFLOAT_DTYPE
+    ),
     # Corpus: numpy/f2py/tests/test_crackfortran.py — from-import.
     "numpy.f2py.crackfortran.markinnerspaces": (
         CalleeUniverseSupport.NUMPY_MARKINNERSPACES
@@ -246,17 +254,15 @@ def recognize_callee_universe(
         return None
     identity = _result_call_identity(site)
     if identity is None:
-        # Nested FunctionDef binding (e.g. NumPy ``_compare_dtypes``).
-        local = _local_source_function_identity(site)
-        if local is not None:
-            if not _target_matches_call(target, local, site):
-                return None
-            return CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
-        # Bound native receivers (``path = pathlib.Path(...); path.resolve()``)
-        # and multi-hop instance-module Attribute calls authenticate through
-        # coordinate / bound-source provenance, not a bare import identity.
+        # Factory-result callables resolve without a direct imported-call
+        # identity on the Call leaf itself (``SF = factory(); SF(...)``).
         bound = _bound_source_callable_identity(site)
         if bound is not None:
+            support = recognize_authenticated_callee_identity(bound)
+            if support is not None:
+                if not _target_matches_call(target, bound, site):
+                    return None
+                return support
             leaf = site.call_target_name()
             if target is not None and target != f"call:{leaf}":
                 return None
@@ -589,27 +595,33 @@ def _enclosing_instance_parameter(site) -> str | None:
 
 
 def _bound_source_callable_identity(site) -> str | None:
-    """Authenticate a call through source-bound dotted provenance.
+    """Authenticate a call through source-bound provenance.
 
-    Two structural forms (leaf spelling grants nothing):
+    Structural forms (leaf spelling grants nothing):
 
     1. Bare call after a single-name assignment whose dotted value is anchored
-       in lexical import testimony **or** a multi-hop instance-parameter
-       Attribute chain (``selectedintkind = self.module.selectedintkind``).
-    2. Multi-hop Attribute call rooted at the enclosing method's instance
-       parameter (``self.module.t0(...)``, ``self.module.foo()``).
+       in lexical import testimony (``eval_scalar = crackfortran._eval_scalar``).
+    2. Bare call after assignment of an import-authenticated factory Call
+       (``SF = _get_sfloat_dtype()``; then ``SF(...)``).
+    3. Multi-hop Attribute call rooted at the enclosing method's instance
+       parameter (``self.module.t0(...)``).
 
-    Parameters used as the call leaf, unresolved names, and lookalike bindings
-    stay outside this family.
+    Unresolved parameters, lookalike bindings, and non-import values stay
+    outside this family. Pytest-parametrize injection is intentionally not
+    authenticated here — that requires a protocol/bridge contract (#5603),
+    not a vendor-string match on the decorator.
     """
 
     if site is None or site.observed != "Call":
         return None
-    identity = imported_call_identity(site)
-    if identity is None:
-        return None
     receiver = site.call_receiver()
     if receiver is None:
+        factory = _bare_factory_result_callable_identity(site)
+        if factory is not None:
+            return factory
+        identity = imported_call_identity(site)
+        if identity is None:
+            return None
         target = site.call_target_name()
         if target is None:
             return None
@@ -631,6 +643,9 @@ def _bound_source_callable_identity(site) -> str | None:
         return identity
     # Attribute call: multi-hop instance-parameter paths only
     # (``self.module.t0``, not ``self.conv``).
+    identity = imported_call_identity(site)
+    if identity is None:
+        return None
     parts = identity.split(".")
     if len(parts) < 3:
         return None
@@ -638,6 +653,39 @@ def _bound_source_callable_identity(site) -> str | None:
     if instance_param is None or parts[0] != instance_param:
         return None
     return identity
+
+
+def _bare_factory_result_callable_identity(site) -> str | None:
+    """``SF = _get_sfloat_dtype(); SF(...)`` — name bound to factory Call result.
+
+    The factory Call must resolve through import provenance to a registered
+    support coordinate. Parameters and non-Call assignments stay unowned.
+    """
+
+    target = site.call_target_name()
+    if target is None:
+        return None
+    declarations, shadowed_parameters = visible_declarations(site)
+    if target in shadowed_parameters:
+        return None
+    binding = None
+    for declaration in declarations:
+        if target not in declaration.stored_or_deleted_names():
+            continue
+        binding = declaration
+    if binding is None or binding.observed != "Assign":
+        return None
+    if binding.stored_or_deleted_names() != frozenset({target}):
+        return None
+    value = binding.assign_value()
+    if value.observed != "Call":
+        return None
+    factory = imported_call_identity(value)
+    if factory is None:
+        return None
+    if recognize_authenticated_callee_identity(factory) is None:
+        return None
+    return factory
 
 
 def _local_source_function_identity(site) -> str | None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -72,6 +72,7 @@ _AUTHENTICATED_COORDINATES = frozenset(
         "scipy.fft.get_workers",
         "numpy.isdtype",
         "numpy.datetime_data",
+        "numpy._core._multiarray_umath._get_sfloat_dtype",
         "numpy.f2py.crackfortran.markinnerspaces",
         "numpy._core._multiarray_tests.identity_hash_set_item_default",
         *_CONVERTER_COORDINATES,
@@ -120,7 +121,9 @@ _OWNED_IMPORTED_SUPPORT = frozenset(
 class BuiltinCalleeUniverseSugar(
     Sugar,
     role=SugarRole.TERM,
-    comes_before=("CallSugar", "MethodCallSugar"),
+    # ConstructorCallSugar also claims capitalized/factory-result callables
+    # (``SF = _get_sfloat_dtype(); SF(...)``); universe ownership must precede it.
+    comes_before=("CallSugar", "MethodCallSugar", "ConstructorCallSugar"),
 ):
     """Authenticated deterministic call coordinates.
 
@@ -277,6 +280,7 @@ class BuiltinCalleeUniverseSugar(
             _scipy_fft_get_workers_witness(),
             _numpy_isdtype_witness(),
             _numpy_datetime_data_witness(),
+            _numpy_sfloat_dtype_witness(),
             _numpy_markinnerspaces_witness(),
             _numpy_identity_hash_set_item_default_witness(),
         )
@@ -1006,6 +1010,26 @@ def _numpy_identity_hash_set_item_default_witness():
     )
     return _call_pair(
         name="numpy_identity_hash_set_item_default_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _numpy_sfloat_dtype_witness():
+    """Factory-result callable: SF = _get_sfloat_dtype(); SF(...)."""
+    prefix = (
+        "from numpy._core._multiarray_umath import _get_sfloat_dtype\n"
+        "\n"
+        "SF = _get_sfloat_dtype()\n"
+        "\n"
+        "def A():\n"
+        "    return SF(1.0)\n"
+        "\n"
+    )
+    return _call_pair(
+        name="numpy_sfloat_dtype_universe_coordinate",
         owner_sugar="BuiltinCalleeUniverseSugar",
         truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
         lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
@@ -2279,3 +2279,73 @@ def test_identity_hash_set_item_default_witness_pair_is_enrolled() -> None:
     assert "numpy_identity_hash_set_item_default_universe_coordinate" in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
+
+
+def test_sfloat_factory_result_authenticates_parameter_lookalike_stays_loud() -> None:
+    good = (
+        "from numpy._core._multiarray_umath import _get_sfloat_dtype\n"
+        "\n"
+        "SF = _get_sfloat_dtype()\n"
+        "\n"
+        "def test_a():\n"
+        "    assert SF(1.0) is not None\n"
+    )
+    bad = (
+        "def test_a(SF):\n"
+        "    assert SF(1.0) is not None\n"
+    )
+    good_site = _bare_call_site(good, "SF")
+    bad_site = _bare_call_site(bad, "SF")
+    assert recognize_callee_universe("call:SF", site=good_site) is not None
+    assert recognize_callee_universe("call:SF", site=bad_site) is None
+    good_built = build_node(
+        good_site,
+        filename="sfloat.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="sfloat.py", catalog=default_catalog()),
+    )
+    bad_built = build_node(
+        bad_site,
+        filename="sfloat.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="sfloat.py", catalog=default_catalog()),
+    )
+    assert good_built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    assert bad_built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_call_comp_parametrize_stays_loud_without_protocol() -> None:
+    """#5591 call:comp is pytest-parameter injection.
+
+    Honest drain needs a parametrize protocol/bridge (#5603), not a vendor
+    string match on ``pytest.mark.parametrize``. Until that exists, the
+    unresolved parameter form remains unowned (loud FactoryPanic path).
+    """
+
+    corpus_shape = (
+        "import operator\n"
+        "import pytest\n"
+        "\n"
+        "@pytest.mark.parametrize(\n"
+        '    "comp",\n'
+        "    [operator.eq, operator.ne, operator.le, operator.lt, "
+        "operator.ge, operator.gt],\n"
+        ")\n"
+        "def test_integer_comparison(sctype, other_val, comp):\n"
+        "    assert comp(10, other_val) == comp(10, other_val)\n"
+    )
+    site = _bare_call_site(corpus_shape, "comp")
+    assert recognize_callee_universe("call:comp", site=site) is None
+    built = build_node(
+        site,
+        filename="comp.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="comp.py", catalog=default_catalog()),
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_sfloat_witness_pair_is_enrolled() -> None:
+    names = {pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()}
+    assert "numpy_sfloat_dtype_universe_coordinate" in names
+    assert "operator_comp_parametrize_universe_coordinate" not in names


### PR DESCRIPTION
Part of #5591, #5588

## Summary

| Family | Issue | Outcome |
|---|---|---|
| `call:SF` | #5588 | **Drained** — factory-result provenance |
| `call:comp` | #5591 | **Stays loud** — needs parametrize protocol/bridge |

### call:SF (honest drain)

Corpus: `SF = _get_sfloat_dtype(); SF(1.)` (`numpy/_core/tests/test_custom_dtypes.py`).

- Assignment of an import-authenticated factory `Call` resolves to
  `numpy._core._multiarray_umath._get_sfloat_dtype`
- Local alias spelling grants nothing; bare parameter `SF` stays unowned
- `BuiltinCalleeUniverseSugar` comes before `ConstructorCallSugar` so
  capitalized factory-result callables do not fork ownership
- Truthful/lying twins refute

### call:comp (honorable FactoryPanic)

Corpus: `@pytest.mark.parametrize("comp", [operator.eq, …]); comp(...)`.

Authenticating that form requires a **parametrize protocol/bridge** that
resolves the decorator by import/source provenance — **not** a logo string
match on `"pytest.mark.parametrize"`. That gap is tracked for window 297 as
#5603 (locus already filed: `remaining_semantics.py:128`).

This PR **does not** drain `call:comp` with a vendor-string shortcut. The
corpus shape stays unowned (loud).

### Bounce fix (#5608)

Removed `return full == "pytest.mark.parametrize"` (same violation class as
#5602 / `literal_pytest_parametrize_rows`). No logo string decides construction
in this branch.

## Validation

- `R_ownership = 0` (sole-construction / ownership law)
- Recognition + witness twins for SF; pin that `call:comp` stays unowned
- No `pytest.mark.parametrize` string comparison in the recognizer

Do not self-merge — soundness-read merge when ready.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate factory-result callables (e.g. `SF = _get_sfloat_dtype()`) while keeping parameter-injected callables loud
> - Adds `CalleeUniverseSupport.NUMPY_SFLOAT_DTYPE` and registers `numpy._core._multiarray_umath._get_sfloat_dtype` as an authenticated coordinate so calls on its factory result are recognized by `BuiltinCalleeUniverseSugar`.
> - Rewrites `_bound_source_callable_identity` in [callee_universe.py](https://github.com/TSavo/sugar/pull/5608/files#diff-72e9f915afa350390348a1c277d0c2047b26a0182bb4780c57baf73f30fdcaa8) to handle bare calls where the callee name was assigned from a factory `Call` authenticated via import provenance; explicitly excludes pytest-parametrize-injected callables.
> - Updates `recognize_callee_universe` to return the specific `CalleeUniverseSupport` for authenticated bound-source callables instead of the generic `BOUND_SOURCE_CALLABLE`, removing the earlier local `FunctionDef` binding path.
> - Places `BuiltinCalleeUniverseSugar` before `ConstructorCallSugar` in selection order so universe ownership is claimed first for factory-result callables.
> - Behavioral Change: calls on callables bound from authenticated factory results now return a specific support coordinate rather than `BOUND_SOURCE_CALLABLE`; parameter-injected lookalikes (e.g. via `pytest.mark.parametrize`) remain unauthenticated and loud.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6bf3660.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->