### PR TITLE
Authenticate numpy callee families (batch)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -50,7 +50,10 @@ class CalleeUniverseSupport(Enum):
     NUMPY_MAY_SHARE_MEMORY = auto()
     NUMPY_SHARES_MEMORY = auto()
     NUMPY_HANDLER_NAME = auto()
+    NUMPY_HANDLER_VERSION = auto()
     NUMPY_CONVERTER = auto()
+    NUMPY_CHECKS = auto()
+    NUMPY_F2PY_EXTENSION = auto()
     REGEX_SEARCH = auto()
     BOUND_SOURCE_CALLABLE = auto()
     PATHLIB_PATH = auto()
@@ -129,6 +132,13 @@ _IMPORTED_SUPPORT = {
     "numpy.shares_memory": CalleeUniverseSupport.NUMPY_SHARES_MEMORY,
     "numpy._core.multiarray.get_handler_name": (
         CalleeUniverseSupport.NUMPY_HANDLER_NAME
+    ),
+    "numpy._core.multiarray.get_handler_version": (
+        CalleeUniverseSupport.NUMPY_HANDLER_VERSION
+    ),
+    "checks.test_get_multi_index_iter_next": CalleeUniverseSupport.NUMPY_CHECKS,
+    "numpy.f2py.extension.sum_and_double": (
+        CalleeUniverseSupport.NUMPY_F2PY_EXTENSION
     ),
     "numpy._core._multiarray_tests.run_byteorder_converter": (
         CalleeUniverseSupport.NUMPY_CONVERTER
@@ -222,6 +232,12 @@ def recognize_callee_universe(
         return None
     identity = _result_call_identity(site)
     if identity is None:
+        # Nested FunctionDef binding (e.g. NumPy ``_compare_dtypes``).
+        local = _local_source_function_identity(site)
+        if local is not None:
+            if not _target_matches_call(target, local, site):
+                return None
+            return CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
         # Bound native receivers (``path = pathlib.Path(...); path.resolve()``)
         # and multi-hop instance-module Attribute calls authenticate through
         # coordinate / bound-source provenance, not a bare import identity.
@@ -300,7 +316,9 @@ class CalleeUniverseRecognition:
         receiver = site.call_receiver()
         if receiver is not None:
             if receiver.observed != "Name":
-                return None
+                # Attribute-chain receivers (``self.module.useops.member``) only
+                # authenticate through F2PyTest class import provenance.
+                return _f2py_extension_coordinate(site)
             if not site.source:
                 return None
             target = site.call_target_name()
@@ -337,6 +355,9 @@ class CalleeUniverseRecognition:
 
         if not site.source:
             return None
+        # Nested FunctionDef binding is source provenance for the bare call.
+        if _local_source_function_identity(site) is not None:
+            return target
         # Plain Name call: only resolve import identity when the leaf can still
         # land on an authenticated imported coordinate. From-import aliases
         # whose spelling is not a registered leaf remain loud — the universe
@@ -607,6 +628,109 @@ def _bound_source_callable_identity(site) -> str | None:
     if instance_param is None or parts[0] != instance_param:
         return None
     return identity
+
+
+def _local_source_function_identity(site) -> str | None:
+    """Authenticate a bare call to a visible nested/module FunctionDef.
+
+    Source provenance is the FunctionDef binding itself. Later assignments or
+    imports of the same name revoke the warrant; parameters always revoke.
+    """
+
+    if site is None or site.observed != "Call" or site.call_receiver() is not None:
+        return None
+    target = site.call_target_name()
+    if target is None:
+        return None
+    declarations, shadowed_parameters = visible_declarations(site)
+    if target in shadowed_parameters:
+        return None
+    binding = None
+    for declaration in declarations:
+        if declaration.observed in {"FunctionDef", "AsyncFunctionDef"}:
+            if declaration.function_name() == target:
+                binding = declaration
+            continue
+        if target in declaration.stored_or_deleted_names():
+            # Assign / import / delete after the def shadows the function.
+            binding = None
+    if binding is None:
+        return None
+    # Module-level ``def A`` witness wrappers stay outside this family so they
+    # cannot steal BuiltinCalleeUniverse ownership from the inner call. Nested
+    # corpus helpers (``def _compare_dtypes`` inside a test) remain in scope.
+    if not declaration_is_function_local(site, binding):
+        return None
+    return target
+
+
+def _f2py_extension_coordinate(site) -> str | None:
+    """Authenticate ``self.module...member`` via F2PyTest class import provenance.
+
+    No member-name whitelist: any attribute under the instance's ``module``
+    tree is coordinated once the enclosing class base resolves to F2PyTest
+    through import/relative-import testimony.
+    """
+
+    if site is None or site.observed != "Call" or not site.source:
+        return None
+    member = site.call_target_name()
+    receiver = site.call_receiver()
+    if member is None or receiver is None:
+        return None
+    dotted = receiver.dotted_expr_name()
+    if dotted is None:
+        return None
+    method, class_def = _enclosing_method_and_class(site)
+    if method is None or class_def is None:
+        return None
+    instance = _instance_parameter_name(method)
+    if instance is None:
+        return None
+    module_prefix = f"{instance}.module"
+    if dotted != module_prefix and not dotted.startswith(f"{module_prefix}."):
+        return None
+    if _name_reassigned_before(site, instance):
+        return None
+    if not _class_has_f2py_testimony(class_def, site):
+        return None
+    return f"numpy.f2py.extension.{member}"
+
+
+def _class_has_f2py_testimony(class_def: ast.ClassDef, site) -> bool:
+    """Require an import-resolved F2PyTest base, never the bare spelling alone."""
+
+    from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+
+    filename = site.filename or ""
+    for base in class_def.bases:
+        fragment = SourceFragment.from_node(base, filename, source=site.source)
+        dotted = fragment.dotted_expr_name()
+        if dotted is None:
+            continue
+        head, separator, tail = dotted.partition(".")
+        origin = _module_import_origin(site, head)
+        if origin is None and _relative_import_bound(site, head):
+            origin = head
+        coordinate = origin if not separator else f"{origin}.{tail}"
+        if coordinate == "F2PyTest" or coordinate.endswith(".F2PyTest"):
+            return True
+    return False
+
+
+def _relative_import_bound(site, head: str) -> bool:
+    """True when ``head`` is bound by a package-relative ``from . import …``."""
+
+    declarations, _shadowed = visible_declarations(site)
+    for declaration in declarations:
+        if declaration.observed != "ImportFrom":
+            continue
+        if declaration.importfrom_module() is not None:
+            continue
+        for name, alias in declaration.importfrom_names():
+            if (alias or name) == head:
+                return True
+    return False
 
 
 def _result_call_identity(site) -> str | None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -50,6 +50,9 @@ _AUTHENTICATED_COORDINATES = frozenset(
         "numpy.zeros.tobytes",
         "numpy.lib.stride_tricks.as_strided.tobytes",
         "numpy._core.multiarray.get_handler_name",
+        "numpy._core.multiarray.get_handler_version",
+        "checks.test_get_multi_index_iter_next",
+        "numpy.f2py.extension.sum_and_double",
         "re.Pattern.search",
         "pathlib.Path",
         "pathlib.Path.resolve",
@@ -89,7 +92,10 @@ _OWNED_IMPORTED_SUPPORT = frozenset(
         CalleeUniverseSupport.NUMPY_DTYPE,
         CalleeUniverseSupport.NUMPY_MAY_SHARE_MEMORY,
         CalleeUniverseSupport.NUMPY_HANDLER_NAME,
+        CalleeUniverseSupport.NUMPY_HANDLER_VERSION,
         CalleeUniverseSupport.NUMPY_CONVERTER,
+        CalleeUniverseSupport.NUMPY_CHECKS,
+        CalleeUniverseSupport.NUMPY_F2PY_EXTENSION,
         CalleeUniverseSupport.REGEX_SEARCH,
         CalleeUniverseSupport.JSON_LOADS,
         CalleeUniverseSupport.DATACLASSES_ASDICT,
@@ -135,11 +141,18 @@ class BuiltinCalleeUniverseSugar(
             return False
         receiver = site.call_receiver()
         if receiver is None:
+            # Bound-source / nested FunctionDef warrants take precedence over
+            # bare-leaf spelling (a local ``def dtype`` is not the builtin).
+            if (
+                recognize_callee_universe(site=site)
+                is CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
+            ):
+                return True
             if target not in _AUTHENTICATED_PLAIN_LEAVES:
                 return recognize_callee_universe(site=site) is not None
         elif receiver.observed == "Attribute":
-            # Nested Attribute receivers (``self.module.t0``) authenticate only
-            # through provenance-bound support — never by leaf spelling.
+            # Nested Attribute receivers (``self.module.t0`` / F2Py chains)
+            # authenticate only through provenance-bound support.
             return recognize_callee_universe(site=site) is not None
         elif receiver.observed != "Name":
             # Only instance-parameter method form can authenticate converters.
@@ -178,9 +191,20 @@ class BuiltinCalleeUniverseSugar(
                 callee="get_handler_name",
                 argument="5",
             ),
+            _imported_coordinate_witness(
+                name="get_handler_version",
+                setup=(
+                    "from numpy._core.multiarray import get_handler_version\n"
+                ),
+                callee="get_handler_version",
+                argument="5",
+            ),
             _imported_method_coordinate_witness(
                 setup=("import numpy._core._multiarray_tests as mt\n"),
             ),
+            _checks_test_get_multi_index_iter_next_witness(),
+            _compare_dtypes_local_source_witness(),
+            _f2py_sum_and_double_witness(),
             _regex_search_coordinate_witness(),
             _numpy_can_cast_witness(),
             _numpy_issubdtype_witness(),
@@ -470,6 +494,73 @@ def _bound_source_callable_witness():
         owner_sugar="BuiltinCalleeUniverseSugar",
         truthful=prefix + "    assert f(0) == f(0) and f(0) == f(0)\n",
         lying=prefix + "    assert f(0) == f(0) and f(0) != f(0)\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _checks_test_get_multi_index_iter_next_witness():
+    prefix = (
+        "import checks\n"
+        "\n"
+        "def A():\n"
+        "    return checks.test_get_multi_index_iter_next(0, 0)\n"
+        "\n"
+    )
+    return _call_pair(
+        name="checks_test_get_multi_index_iter_next_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        # Conjunction keeps deterministic call substitution load-bearing.
+        truthful=prefix + "def test_a():\n    assert A() == 0 and A() == 0\n",
+        lying=prefix + "def test_a():\n    assert A() == 0 and A() != 0\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _compare_dtypes_local_source_witness():
+    # Nested FunctionDef matches the corpus shape (``test_drop_metadata``).
+    truthful = (
+        "def test_a():\n"
+        "    def _compare_dtypes(dt1, dt2):\n"
+        "        return dt1\n"
+        "    assert _compare_dtypes(0, 1) == 0 and _compare_dtypes(0, 1) == 0\n"
+    )
+    lying = (
+        "def test_a():\n"
+        "    def _compare_dtypes(dt1, dt2):\n"
+        "        return dt1\n"
+        "    assert _compare_dtypes(0, 1) == 0 and _compare_dtypes(0, 1) != 0\n"
+    )
+    return _call_pair(
+        name="compare_dtypes_local_source_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=truthful,
+        lying=lying,
+        family="builtin-universe-coordinate",
+    )
+
+
+def _f2py_sum_and_double_witness():
+    truthful = (
+        "from . import util\n"
+        "\n"
+        "class TestUsedModule(util.F2PyTest):\n"
+        "    def test_a(self):\n"
+        "        assert self.module.useops.sum_and_double(3, 7) == 0 and "
+        "self.module.useops.sum_and_double(3, 7) == 0\n"
+    )
+    lying = (
+        "from . import util\n"
+        "\n"
+        "class TestUsedModule(util.F2PyTest):\n"
+        "    def test_a(self):\n"
+        "        assert self.module.useops.sum_and_double(3, 7) == 0 and "
+        "self.module.useops.sum_and_double(3, 7) != 0\n"
+    )
+    return _call_pair(
+        name="f2py_sum_and_double_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=truthful,
+        lying=lying,
         family="builtin-universe-coordinate",
     )
 


### PR DESCRIPTION
Part of #5467, #5558, #5470, #5560

## Summary

Batch-drain four NumPy factory-walk unclassified callee families through the single `CalleeUniverseSupport` recognizer, authenticated by import/source provenance only (no name whitelist, no inline AST side door):

| issue | family | rows | provenance |
|------:|--------|-----:|------------|
| #5467 | `call:_compare_dtypes` | 4 | nested function-local `FunctionDef` binding |
| #5558 | `call:sum_and_double` | 1 | `F2PyTest` class import + `self.module…` chain |
| #5470 | `call:get_handler_version` | 4 | `numpy._core.multiarray.get_handler_version` import/assignment identity |
| #5560 | `call:test_get_multi_index_iter_next` | 1 | `import checks` → `checks.test_get_multi_index_iter_next` |

Truthful/lying twins enrolled for each family. Lookalike / missing import / non-F2Py class / missing nested def stay loud.

## Validation

- Locus fixtures: universe-coverage gaps for all four families → 0
- Twin pairs (real solver, `SUGAR_BIN` pinned): 4/4 sat/unsat
- `factory_ownership_law.py`: `R_ownership = 0`
- Pre-existing weak batch twins (`np.timedelta64` etc. without conjunction) remain as on main; not weakened

**Epsilon R / measured local ΔR:** −10 unclassified rows (4+1+4+1).

Do not self-merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate numpy callee families (batch) by recognizing handler version, checks, f2py extension, and local nested function calls
> - Adds three new `CalleeUniverseSupport` identities (`NUMPY_HANDLER_VERSION`, `NUMPY_CHECKS`, `NUMPY_F2PY_EXTENSION`) and maps their import coordinates in [`callee_universe.py`](https://github.com/TSavo/sugar/pull/5609/files#diff-72e9f915afa350390348a1c277d0c2047b26a0182bb4780c57baf73f30fdcaa8).
> - Adds `_local_source_function_identity` to recognize bare calls to locally-defined nested `FunctionDef`s as `BOUND_SOURCE_CALLABLE`, excluding shadowed or overridden definitions.
> - Adds `_f2py_extension_coordinate` to authenticate attribute-chain calls (e.g. `self.module.useops.sum_and_double`) under classes that inherit from `F2PyTest`, using `_class_has_f2py_testimony` and `_relative_import_bound` for import resolution.
> - Updates `BuiltinCalleeUniverseSugar.matches` in [`builtin_callee_universe_sugar.py`](https://github.com/TSavo/sugar/pull/5609/files#diff-98e9ae8e3cbb10a2e6c95f0bdeca86f0b85002634b901733d0b6070886cdab5f) to accept nested local function calls and F2Py attribute chains, and adds corresponding witnesses for all new coordinates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d430aa0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->