### PR TITLE
Authenticate markinnerspaces and identity_hash_set_item_default

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -72,6 +72,8 @@ class CalleeUniverseSupport(Enum):
     SCIPY_FFT_GET_WORKERS = auto()
     NUMPY_ISDTYPE = auto()
     NUMPY_DATETIME_DATA = auto()
+    NUMPY_MARKINNERSPACES = auto()
+    NUMPY_IDENTITY_HASH_SET_ITEM_DEFAULT = auto()
 
 
 _DTYPE_RESULT_SUPPORT = {
@@ -191,6 +193,14 @@ _IMPORTED_SUPPORT = {
     "scipy.fft.get_workers": CalleeUniverseSupport.SCIPY_FFT_GET_WORKERS,
     "numpy.isdtype": CalleeUniverseSupport.NUMPY_ISDTYPE,
     "numpy.datetime_data": CalleeUniverseSupport.NUMPY_DATETIME_DATA,
+    # Corpus: numpy/f2py/tests/test_crackfortran.py — from-import.
+    "numpy.f2py.crackfortran.markinnerspaces": (
+        CalleeUniverseSupport.NUMPY_MARKINNERSPACES
+    ),
+    # Corpus: numpy/_core/tests/test_hashtable.py — multiarray_tests import.
+    "numpy._core._multiarray_tests.identity_hash_set_item_default": (
+        CalleeUniverseSupport.NUMPY_IDENTITY_HASH_SET_ITEM_DEFAULT
+    ),
 }
 
 _BUILTIN_COORDINATES = frozenset({"type", "dtype", "all", "list", "set", "hasattr"})

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -64,6 +64,8 @@ _AUTHENTICATED_COORDINATES = frozenset(
         "scipy.fft.get_workers",
         "numpy.isdtype",
         "numpy.datetime_data",
+        "numpy.f2py.crackfortran.markinnerspaces",
+        "numpy._core._multiarray_tests.identity_hash_set_item_default",
         *_CONVERTER_COORDINATES,
     }
 )
@@ -216,6 +218,8 @@ class BuiltinCalleeUniverseSugar(
             _scipy_fft_get_workers_witness(),
             _numpy_isdtype_witness(),
             _numpy_datetime_data_witness(),
+            _numpy_markinnerspaces_witness(),
+            _numpy_identity_hash_set_item_default_witness(),
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
@@ -818,6 +822,52 @@ def _numpy_datetime_data_witness():
     )
     return _call_pair(
         name="numpy_datetime_data_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _numpy_markinnerspaces_witness():
+    """Direct from-import of crackfortran.markinnerspaces (corpus locus shape)."""
+    prefix = (
+        "from numpy.f2py.crackfortran import markinnerspaces\n"
+        "\n"
+        "def A(value):\n"
+        "    return markinnerspaces(value)\n"
+        "\n"
+    )
+    return _call_pair(
+        name="numpy_markinnerspaces_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=(
+            prefix + "def test_a():\n    assert A('x y') == A('x y') and A('x y') == A('x y')\n"
+        ),
+        lying=(
+            prefix + "def test_a():\n    assert A('x y') == A('x y') and A('x y') != A('x y')\n"
+        ),
+        family="builtin-universe-coordinate",
+    )
+
+
+def _numpy_identity_hash_set_item_default_witness():
+    """From-import of multiarray_tests.identity_hash_set_item_default."""
+    # Determinism twin: same call returns equal values under conjunction.
+    prefix = (
+        "from numpy._core._multiarray_tests import (\n"
+        "    create_identity_hash,\n"
+        "    identity_hash_set_item_default,\n"
+        ")\n"
+        "\n"
+        "def A():\n"
+        "    ht = create_identity_hash(1)\n"
+        "    key = (0,)\n"
+        "    return identity_hash_set_item_default(ht, key, 1)\n"
+        "\n"
+    )
+    return _call_pair(
+        name="numpy_identity_hash_set_item_default_universe_coordinate",
         owner_sugar="BuiltinCalleeUniverseSugar",
         truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
         lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
@@ -40,6 +40,8 @@ def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
         "numpy.shares_memory",
         "numpy.isdtype",
         "numpy.datetime_data",
+        "numpy.f2py.crackfortran.markinnerspaces",
+        "numpy._core._multiarray_tests.identity_hash_set_item_default",
         "numpy.ndarray.tobytes",
         "numpy._core.multiarray.get_handler_name",
         "numpy._core._multiarray_tests.run_byteorder_converter",
@@ -62,6 +64,8 @@ def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
         "numpy_shares_memory_universe_coordinate",
         "numpy_isdtype_universe_coordinate",
         "numpy_datetime_data_universe_coordinate",
+        "numpy_markinnerspaces_universe_coordinate",
+        "numpy_identity_hash_set_item_default_universe_coordinate",
         "numpy_array_tobytes_universe_coordinate",
         "get_handler_name_builtin_universe_coordinate",
         "conv_builtin_universe_coordinate",
@@ -2027,3 +2031,115 @@ def test_numpy_batch_four_witness_pairs_are_enrolled() -> None:
         "numpy_subrout_default_universe_coordinate",
         "numpy_eval_scalar_universe_coordinate",
     } <= names
+
+
+def test_authenticated_numpy_markinnerspaces_selects_one_factory_owner() -> None:
+    source = (
+        "from numpy.f2py.crackfortran import markinnerspaces\n"
+        "\n"
+        "def test_mark(s):\n"
+        "    assert markinnerspaces(s) == markinnerspaces(s)\n"
+    )
+    context = FactoryBuildContext(
+        filename="markinnerspaces.py", catalog=default_catalog()
+    )
+    built = build_node(
+        _import_leaf_call_site(source, "markinnerspaces", "markinnerspaces.py"),
+        filename="markinnerspaces.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "from numpy.f2py.crackfortran import markinnerspaces\n"
+            "\n"
+            "def test_mark(markinnerspaces, s):\n"
+            "    assert markinnerspaces(s) == s\n"
+        ),
+        (
+            "def test_mark(s):\n"
+            "    assert markinnerspaces(s) == s\n"
+        ),
+    ],
+)
+def test_unwarranted_numpy_markinnerspaces_is_not_factory_owned(source: str) -> None:
+    context = FactoryBuildContext(
+        filename="markinnerspaces.py", catalog=default_catalog()
+    )
+    built = build_node(
+        _import_leaf_call_site(source, "markinnerspaces", "markinnerspaces.py"),
+        filename="markinnerspaces.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_numpy_markinnerspaces_witness_pair_is_enrolled() -> None:
+    assert "numpy_markinnerspaces_universe_coordinate" in {
+        pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
+    }
+
+
+def test_authenticated_identity_hash_set_item_default_selects_one_factory_owner() -> None:
+    source = (
+        "from numpy._core._multiarray_tests import identity_hash_set_item_default\n"
+        "\n"
+        "def test_hash(ht, key, value):\n"
+        "    assert identity_hash_set_item_default(ht, key, value) is value\n"
+    )
+    context = FactoryBuildContext(
+        filename="identity_hash.py", catalog=default_catalog()
+    )
+    built = build_node(
+        _import_leaf_call_site(
+            source, "identity_hash_set_item_default", "identity_hash.py"
+        ),
+        filename="identity_hash.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "from numpy._core._multiarray_tests import identity_hash_set_item_default\n"
+            "\n"
+            "def test_hash(identity_hash_set_item_default, ht, key, value):\n"
+            "    assert identity_hash_set_item_default(ht, key, value) is value\n"
+        ),
+        (
+            "def test_hash(ht, key, value):\n"
+            "    assert identity_hash_set_item_default(ht, key, value) is value\n"
+        ),
+    ],
+)
+def test_unwarranted_identity_hash_set_item_default_is_not_factory_owned(
+    source: str,
+) -> None:
+    context = FactoryBuildContext(
+        filename="identity_hash.py", catalog=default_catalog()
+    )
+    built = build_node(
+        _import_leaf_call_site(
+            source, "identity_hash_set_item_default", "identity_hash.py"
+        ),
+        filename="identity_hash.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_identity_hash_set_item_default_witness_pair_is_enrolled() -> None:
+    assert "numpy_identity_hash_set_item_default_universe_coordinate" in {
+        pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
+    }

--- a/implementations/python/sugar-lift-py-tests/tests/test_universe_coverage_gap.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_universe_coverage_gap.py
@@ -1061,6 +1061,95 @@ def test_unowned_datetime_data_lookalikes_stay_loud(
     assert [gap.ast_kind for gap in gaps] == [expected_kind]
 
 
+
+def test_authenticated_numpy_markinnerspaces_has_universe_support() -> None:
+    source = (
+        "from numpy.f2py.crackfortran import markinnerspaces\n"
+        "\n"
+        "def test_values(s):\n"
+        "    assert markinnerspaces(s) == markinnerspaces(s)\n"
+    )
+
+    payload = lift_file_payload(source, "markinnerspaces_covered_fixture.py")
+
+    assert any(
+        edge.get("targetSymbol") == "call:numpy.f2py.crackfortran.markinnerspaces"
+        or edge.get("targetSymbol") == "call:markinnerspaces"
+        for edge in payload.call_edges
+    )
+    assert _universe_gaps(payload) == []
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_kind"),
+    (
+        (
+            "from numpy.f2py.crackfortran import markinnerspaces\n"
+            "def test_values(markinnerspaces, s):\n"
+            "    assert markinnerspaces(s) == s\n",
+            "call:markinnerspaces",
+        ),
+        (
+            "def test_values(s):\n"
+            "    assert markinnerspaces(s) == s\n",
+            "call:markinnerspaces",
+        ),
+    ),
+)
+def test_unowned_markinnerspaces_lookalikes_stay_loud(
+    source: str, expected_kind: str
+) -> None:
+    payload = lift_file_payload(source, "markinnerspaces_unowned_fixture.py")
+
+    gaps = _universe_gaps(payload)
+    assert [gap.ast_kind for gap in gaps] == [expected_kind]
+
+
+def test_authenticated_identity_hash_set_item_default_has_universe_support() -> None:
+    source = (
+        "from numpy._core._multiarray_tests import identity_hash_set_item_default\n"
+        "\n"
+        "def test_values(ht, key, value):\n"
+        "    assert identity_hash_set_item_default(ht, key, value) is value\n"
+    )
+
+    payload = lift_file_payload(source, "identity_hash_covered_fixture.py")
+
+    assert any(
+        edge.get("targetSymbol")
+        == "call:numpy._core._multiarray_tests.identity_hash_set_item_default"
+        or edge.get("targetSymbol") == "call:identity_hash_set_item_default"
+        for edge in payload.call_edges
+    )
+    assert _universe_gaps(payload) == []
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_kind"),
+    (
+        (
+            "from numpy._core._multiarray_tests import identity_hash_set_item_default\n"
+            "def test_values(identity_hash_set_item_default, ht, key, value):\n"
+            "    assert identity_hash_set_item_default(ht, key, value) is value\n",
+            "call:identity_hash_set_item_default",
+        ),
+        (
+            "def test_values(ht, key, value):\n"
+            "    assert identity_hash_set_item_default(ht, key, value) is value\n",
+            "call:identity_hash_set_item_default",
+        ),
+    ),
+)
+def test_unowned_identity_hash_set_item_default_lookalikes_stay_loud(
+    source: str, expected_kind: str
+) -> None:
+    payload = lift_file_payload(source, "identity_hash_unowned_fixture.py")
+
+    gaps = _universe_gaps(payload)
+    assert [gap.ast_kind for gap in gaps] == [expected_kind]
+
+
+
 def test_module_scope_numpy_from_import_has_universe_support() -> None:
     """Module-level imports establish the name; do not revoke as free-var shadow."""
 


### PR DESCRIPTION
Part of #5590, #5599

## Change

Batch-drain two unclaimed NumPy callee families via the single `CalleeUniverseSupport` recognizer (import/source provenance only):

| issue | family | rows | representative locus |
|---|---|---:|---|
| #5590 | `call:numpy.f2py.crackfortran.markinnerspaces` | 7 | `numpy/f2py/tests/test_crackfortran.py:140` |
| #5599 | `call:numpy._core._multiarray_tests.identity_hash_set_item_default` | 1 | `numpy/_core/tests/test_hashtable.py:28` |

Corpus authentication:
- `from numpy.f2py.crackfortran import markinnerspaces`
- `from numpy._core._multiarray_tests import identity_hash_set_item_default`

No vendor-name string match in sugar logic, no name whitelist, no inline AST side door. Parameter-shadowed and unimported lookalikes remain not factory-owned / loud universe gaps.

Each family owns a truthful/lying twin on `BuiltinCalleeUniverseSugar` (lying twin contradicts deterministic call substitution).

## Conservation

- Focused discrimination: **16 passed**
- Red-first: removing the support-map entries fails auth ownership (`CallSugar` instead of `BuiltinCalleeUniverseSugar`)
- Sole-construction / `R_vendor_special_case`: main already carries the open table-literal census debt on the import-identity maps (#5606, R≈197 on current main); this PR follows the same import-identity table pattern as #5604 and does not invent a private allowlist

Do not merge without coordinator soundness review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate `markinnerspaces` and `identity_hash_set_item_default` as recognized numpy callees
> Adds authentication support for two numpy symbols: `numpy.f2py.crackfortran.markinnerspaces` and `numpy._core._multiarray_tests.identity_hash_set_item_default`.
>
> - Adds enum members and import mappings in [callee_universe.py](https://github.com/TSavo/sugar/pull/5610/files#diff-72e9f915afa350390348a1c277d0c2047b26a0182bb4780c57baf73f30fdcaa8) so these symbols are recognized at runtime.
> - Adds authenticated coordinates and witness generators in [builtin_callee_universe_sugar.py](https://github.com/TSavo/sugar/pull/5610/files#diff-98e9ae8e3cbb10a2e6c95f0bdeca86f0b85002634b901733d0b6070886cdab5f) to verify truthful vs. lying call behavior via `_call_pair`.
> - Extends tests in [test_builtin_callee_universe_sugar.py](https://github.com/TSavo/sugar/pull/5610/files#diff-4cf523d0449af84e5a94e72b7ba403f9d6a713a9f0bf70db21a7cd083d014f3f) and [test_universe_coverage_gap.py](https://github.com/TSavo/sugar/pull/5610/files#diff-26722cc120585f9c881bb6fe43e95d93d86886ebffcd4c2cb05d1b1f8ae21f6b) to cover ownership selection, negative lookalike cases, and gap detection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 740bdc2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->