### PR TITLE
Authenticate bare any/min/max/sum and dataclasses.is_dataclass universes

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -58,6 +58,7 @@ class CalleeUniverseSupport(Enum):
     NUMPY_EVAL_SCALAR = auto()
     JSON_LOADS = auto()
     DATACLASSES_ASDICT = auto()
+    DATACLASSES_IS_DATACLASS = auto()
     PATH_RESOLVE = auto()
     UFUNC = auto()
     T0 = auto()
@@ -157,6 +158,7 @@ _IMPORTED_SUPPORT = {
     "re.Pattern.search": CalleeUniverseSupport.REGEX_SEARCH,
     "json.loads": CalleeUniverseSupport.JSON_LOADS,
     "dataclasses.asdict": CalleeUniverseSupport.DATACLASSES_ASDICT,
+    "dataclasses.is_dataclass": CalleeUniverseSupport.DATACLASSES_IS_DATACLASS,
     # Exact import identity (``import pathlib`` / ``from pathlib import Path``).
     # Corpus: numpy/tests/test_configtool.py — not a module-prefix warrant.
     "pathlib.Path": CalleeUniverseSupport.PATHLIB_PATH,
@@ -193,7 +195,9 @@ _IMPORTED_SUPPORT = {
     "numpy.datetime_data": CalleeUniverseSupport.NUMPY_DATETIME_DATA,
 }
 
-_BUILTIN_COORDINATES = frozenset({"type", "dtype", "all", "list", "set", "hasattr"})
+_BUILTIN_COORDINATES = frozenset(
+    {"type", "dtype", "all", "any", "min", "max", "sum", "list", "set", "hasattr"}
+)
 # Attribute leaves that can still resolve into an imported authenticated
 # coordinate (``np.can_cast``, ``np.all``, converter helpers, …). Class-body
 # aliases (``self.conv = mt.run_byteorder_converter``) use arbitrary attr
@@ -257,9 +261,7 @@ def recognize_callee_universe(
     return support
 
 
-def _target_matches_call(
-    target: str | None, coordinate: str | None, site
-) -> bool:
+def _target_matches_call(target: str | None, coordinate: str | None, site) -> bool:
     """Accept full identity, identity leaf, or the call's written leaf/target.
 
     Local assignment aliases (``eval_scalar = crackfortran._eval_scalar``)
@@ -377,9 +379,7 @@ class CalleeUniverseRecognition:
         attr = site.call_target_name()
         if attr is None:
             return None
-        if attr == "item" and _receiver_has_imported_call_definition(
-            site, receiver
-        ):
+        if attr == "item" and _receiver_has_imported_call_definition(site, receiver):
             return attr
         receiver_name = receiver.name_id()
         method, class_def = _enclosing_method_and_class(site)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -32,6 +32,10 @@ _AUTHENTICATED_COORDINATES = frozenset(
         # bare ``type`` is owned by BuiltinTypeCallSugar (construction + universe).
         "dtype",
         "all",
+        "any",
+        "min",
+        "max",
+        "sum",
         "list",
         "set",
         "hasattr",
@@ -57,6 +61,7 @@ _AUTHENTICATED_COORDINATES = frozenset(
         "numpy.f2py.crackfortran._eval_scalar",
         "json.loads",
         "dataclasses.asdict",
+        "dataclasses.is_dataclass",
         "math.isclose",
         "numpy.result_type",
         "scipy.linalg.issymmetric",
@@ -70,7 +75,7 @@ _AUTHENTICATED_COORDINATES = frozenset(
 # Must match recognition.callee_universe bare-builtin warrants this leaf owns.
 # ``type`` is intentionally absent: BuiltinTypeCallSugar is its construction owner.
 _BUILTIN_COORDINATES = frozenset(
-    {"dtype", "all", "list", "set", "hasattr"}
+    {"dtype", "all", "any", "min", "max", "sum", "list", "set", "hasattr"}
 )
 _RECEIVER_COORDINATES = frozenset({"item"})
 # Leaf spellings that can still resolve into an authenticated coordinate.
@@ -93,6 +98,7 @@ _OWNED_IMPORTED_SUPPORT = frozenset(
         CalleeUniverseSupport.REGEX_SEARCH,
         CalleeUniverseSupport.JSON_LOADS,
         CalleeUniverseSupport.DATACLASSES_ASDICT,
+        CalleeUniverseSupport.DATACLASSES_IS_DATACLASS,
         CalleeUniverseSupport.MATH_ISCLOSE,
         CalleeUniverseSupport.NUMPY_RESULT_TYPE,
         CalleeUniverseSupport.SCIPY_LINALG_ISSYMMETRIC,
@@ -168,6 +174,10 @@ class BuiltinCalleeUniverseSugar(
         return (
             _coordinate_witness("dtype", "'i4'", "'i8'"),
             _coordinate_witness("all", "True", "False"),
+            _coordinate_witness("any", "True", "False"),
+            _coordinate_witness("min", "0", "1"),
+            _coordinate_witness("max", "0", "1"),
+            _coordinate_witness("sum", "0", "1"),
             _coordinate_witness("list", "[]", "[0]"),
             _coordinate_witness("set", "[]", "[0]"),
             _coordinate_witness("hasattr", "True", "False"),
@@ -187,12 +197,30 @@ class BuiltinCalleeUniverseSugar(
             _numpy_isnan_witness(),
             _numpy_all_witness(),
             _numpy_dtype_witness(),
-            *(_numpy_batch_witness(name) for name in (
-                "timedelta64", "read", "__array_wrap__", "__dlpack_device__",
-                "astype", "dtypes", "get_npyiter_ndim", "get_npyiter_size",
-                "asarray", "drop_metadata", "_has_method_heading", "_repr_latex_",
-                "binomial", "conv_intp", "create", "exists", "func", "iter_goto", "median",
-            )),
+            *(
+                _numpy_batch_witness(name)
+                for name in (
+                    "timedelta64",
+                    "read",
+                    "__array_wrap__",
+                    "__dlpack_device__",
+                    "astype",
+                    "dtypes",
+                    "get_npyiter_ndim",
+                    "get_npyiter_size",
+                    "asarray",
+                    "drop_metadata",
+                    "_has_method_heading",
+                    "_repr_latex_",
+                    "binomial",
+                    "conv_intp",
+                    "create",
+                    "exists",
+                    "func",
+                    "iter_goto",
+                    "median",
+                )
+            ),
             _numpy_may_share_memory_witness(),
             _numpy_shares_memory_witness(),
             _numpy_array_tobytes_witness(),
@@ -204,11 +232,18 @@ class BuiltinCalleeUniverseSugar(
             _numpy_dtype_result_witness(),
             _json_loads_witness(),
             _dataclasses_asdict_witness(),
+            _dataclasses_is_dataclass_witness(),
             _path_resolve_coordinate_witness(),
             _ufunc_coordinate_witness(),
-            *(_bound_leaf_coordinate_witness(name) for name in (
-                "t0", "selectedintkind", "foo", "to_Dt",
-            )),
+            *(
+                _bound_leaf_coordinate_witness(name)
+                for name in (
+                    "t0",
+                    "selectedintkind",
+                    "foo",
+                    "to_Dt",
+                )
+            ),
             _math_isclose_witness(),
             _numpy_result_type_witness(),
             _scipy_linalg_issymmetric_witness(),
@@ -492,13 +527,7 @@ def _numpy_dtype_result_witness():
 
 
 def _json_loads_witness():
-    prefix = (
-        "import json\n"
-        "\n"
-        "def A():\n"
-        "    return json.loads('0')\n"
-        "\n"
-    )
+    prefix = "import json\n" "\n" "def A():\n" "    return json.loads('0')\n" "\n"
     return _call_pair(
         name="json_loads_universe_coordinate",
         owner_sugar="BuiltinCalleeUniverseSugar",
@@ -511,11 +540,7 @@ def _json_loads_witness():
 
 def _math_isclose_witness():
     prefix = (
-        "import math\n"
-        "\n"
-        "def A():\n"
-        "    return math.isclose(1.0, 1.0)\n"
-        "\n"
+        "import math\n" "\n" "def A():\n" "    return math.isclose(1.0, 1.0)\n" "\n"
     )
     return _call_pair(
         name="math_isclose_universe_coordinate",
@@ -615,6 +640,28 @@ def _dataclasses_asdict_witness():
         lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
         family="builtin-universe-coordinate",
     )
+
+
+def _dataclasses_is_dataclass_witness():
+    prefix = (
+        "from dataclasses import is_dataclass, dataclass\n"
+        "\n"
+        "@dataclass\n"
+        "class Point:\n"
+        "    x: int\n"
+        "\n"
+        "def A():\n"
+        "    return is_dataclass(Point)\n"
+        "\n"
+    )
+    return _call_pair(
+        name="dataclasses_is_dataclass_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
 
 def _pathlib_path_witness():
     """Import-bound ``pathlib.Path`` constructor (corpus: test_configtool)."""

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
@@ -28,6 +28,10 @@ from sugar_lift_py_tests.witness_harness import run_source_through_real_solver
 def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
     assert {
         "all",
+        "any",
+        "min",
+        "max",
+        "sum",
         "list",
         "set",
         "hasattr",
@@ -46,9 +50,15 @@ def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
         "re.Pattern.search",
         "json.loads",
         "dataclasses.asdict",
+        "dataclasses.is_dataclass",
+        "math.isclose",
     } <= (BuiltinCalleeUniverseSugar.universe_coordinates)
     assert {
         "all_builtin_universe_coordinate",
+        "any_builtin_universe_coordinate",
+        "min_builtin_universe_coordinate",
+        "max_builtin_universe_coordinate",
+        "sum_builtin_universe_coordinate",
         "list_builtin_universe_coordinate",
         "set_builtin_universe_coordinate",
         "hasattr_builtin_universe_coordinate",
@@ -68,6 +78,8 @@ def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
         "regex_search_builtin_universe_coordinate",
         "json_loads_universe_coordinate",
         "dataclasses_asdict_universe_coordinate",
+        "dataclasses_is_dataclass_universe_coordinate",
+        "math_isclose_universe_coordinate",
     } <= {pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()}
 
 
@@ -367,6 +379,154 @@ def test_unwarranted_hasattr_receiver_is_not_factory_owned(source: str) -> None:
 
 def test_hasattr_witness_pair_is_enrolled() -> None:
     assert "hasattr_builtin_universe_coordinate" in {
+        pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
+    }
+
+
+@pytest.mark.parametrize(
+    ("callee", "source"),
+    [
+        ("any", "def test_any(value):\n    assert any(value)\n"),
+        ("min", "def test_min(value):\n    assert min(value) == 0\n"),
+        ("max", "def test_max(value):\n    assert max(value) == 0\n"),
+        ("sum", "def test_sum(value):\n    assert sum(value) == 0\n"),
+    ],
+)
+def test_authenticated_bare_builtin_selects_one_factory_owner(
+    callee: str, source: str
+) -> None:
+    context = FactoryBuildContext(
+        filename=f"{callee}_call.py",
+        catalog=default_catalog(),
+    )
+    built = build_node(
+        _bare_builtin_call_site(source, callee),
+        filename=f"{callee}_call.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize("callee", ["any", "min", "max", "sum"])
+def test_unwarranted_bare_builtin_receiver_is_not_factory_owned(callee: str) -> None:
+    sources = [
+        f"def test_{callee}({callee}, value):\n    assert {callee}(value)\n",
+        (
+            f"def test_{callee}(value):\n"
+            f"    assert {callee}(value)\n"
+            f"    {callee} = replacement\n"
+        ),
+    ]
+    context = FactoryBuildContext(
+        filename=f"{callee}_call.py",
+        catalog=default_catalog(),
+    )
+    for source in sources:
+        built = build_node(
+            _bare_builtin_call_site(source, callee),
+            filename=f"{callee}_call.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize("callee", ["any", "min", "max", "sum"])
+def test_bare_builtin_witness_pair_is_enrolled(callee: str) -> None:
+    assert f"{callee}_builtin_universe_coordinate" in {
+        pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
+    }
+
+
+def test_authenticated_dataclasses_is_dataclass_selects_one_factory_owner() -> None:
+    source = (
+        "import dataclasses\n"
+        "\n"
+        "def test_is_dataclass(value):\n"
+        "    assert dataclasses.is_dataclass(value) == dataclasses.is_dataclass(value)\n"
+    )
+    context = FactoryBuildContext(
+        filename="dataclasses_is_dataclass.py",
+        catalog=default_catalog(),
+    )
+    built = build_node(
+        _stdlib_attr_call_site(source, "is_dataclass", "dataclasses_is_dataclass.py"),
+        filename="dataclasses_is_dataclass.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+def test_authenticated_from_import_is_dataclass_selects_one_factory_owner() -> None:
+    source = (
+        "from dataclasses import is_dataclass\n"
+        "\n"
+        "def test_is_dataclass(value):\n"
+        "    assert is_dataclass(value) == is_dataclass(value)\n"
+    )
+    context = FactoryBuildContext(
+        filename="is_dataclass_from.py",
+        catalog=default_catalog(),
+    )
+    built = build_node(
+        _stdlib_name_call_site(source, "is_dataclass", "is_dataclass_from.py"),
+        filename="is_dataclass_from.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "import dataclasses\n"
+            "\n"
+            "def test_is_dataclass(dataclasses, value):\n"
+            "    assert dataclasses.is_dataclass(value)\n"
+        ),
+        (
+            "import dataclasses\n"
+            "\n"
+            "def test_is_dataclass(value):\n"
+            "    assert dataclasses.is_dataclass(value)\n"
+            "    dataclasses = replacement\n"
+        ),
+        (
+            "import math as dataclasses\n"
+            "\n"
+            "def test_is_dataclass(value):\n"
+            "    assert dataclasses.is_dataclass(value)\n"
+        ),
+        (
+            "def test_is_dataclass(value):\n"
+            "    assert dataclasses.is_dataclass(value)\n"
+        ),
+    ],
+)
+def test_unwarranted_is_dataclass_receiver_is_not_factory_owned(source: str) -> None:
+    context = FactoryBuildContext(
+        filename="dataclasses_is_dataclass.py",
+        catalog=default_catalog(),
+    )
+    built = build_node(
+        _stdlib_attr_call_site(source, "is_dataclass", "dataclasses_is_dataclass.py"),
+        filename="dataclasses_is_dataclass.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_dataclasses_is_dataclass_witness_pair_is_enrolled() -> None:
+    assert "dataclasses_is_dataclass_universe_coordinate" in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
 
@@ -1096,7 +1256,10 @@ def test_numpy_can_cast_requires_authenticated_receiver() -> None:
         temporal=TemporalContext.empty().bind_value(
             "np",
             ImportAliasValue(
-                "numpy", "np", import_target="numpy", install_source_checked=True,
+                "numpy",
+                "np",
+                import_target="numpy",
+                install_source_checked=True,
                 resolved_value=TermValue("numpy"),
             ),
         ),
@@ -1105,9 +1268,11 @@ def test_numpy_can_cast_requires_authenticated_receiver() -> None:
     assert isinstance(sugar, BuiltinCalleeUniverseSugar)
 
     lying = FactoryBuildContext(
-        filename="numpy_can_cast.py", catalog=default_catalog(), temporal=TemporalContext.empty().bind_value(
+        filename="numpy_can_cast.py",
+        catalog=default_catalog(),
+        temporal=TemporalContext.empty().bind_value(
             "np", ImportAliasValue("other", "np", import_target="other")
-        )
+        ),
     )
     with pytest.raises(FactoryPanic):
         BuiltinCalleeUniverseSugar.new(site, lying)
@@ -1317,6 +1482,8 @@ def test_dataclasses_asdict_witness_pair_is_enrolled() -> None:
     assert "dataclasses_asdict_universe_coordinate" in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
+
+
 def _leaf_attr_call_site(source: str, leaf: str) -> SourceFragment:
     call = next(
         node
@@ -1366,10 +1533,7 @@ def test_instance_module_attribute_call_authenticates(leaf: str) -> None:
 
 @pytest.mark.parametrize("leaf", ["t0", "selectedintkind", "foo", "to_Dt"])
 def test_unresolved_leaf_attribute_call_stays_unowned(leaf: str) -> None:
-    source = (
-        f"def test_a(module):\n"
-        f"    assert module.{leaf}(1) == (1,)\n"
-    )
+    source = f"def test_a(module):\n" f"    assert module.{leaf}(1) == (1,)\n"
     site = _leaf_attr_call_site(source, leaf)
     assert recognize_callee_universe(f"call:{leaf}", site=site) is None
     built = build_node(
@@ -1401,7 +1565,9 @@ def test_selectedintkind_assignment_from_instance_module_authenticates() -> None
         site,
         filename="selectedintkind.py",
         role=SugarRole.TERM,
-        ctx=FactoryBuildContext(filename="selectedintkind.py", catalog=default_catalog()),
+        ctx=FactoryBuildContext(
+            filename="selectedintkind.py", catalog=default_catalog()
+        ),
     )
     assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
 
@@ -1448,10 +1614,7 @@ def test_path_resolve_authenticates_unresolved_stays_loud() -> None:
         "    path = pathlib.Path(value)\n"
         "    assert path.resolve() is not None\n"
     )
-    bad = (
-        "def test_a(path):\n"
-        "    assert path.resolve() is not None\n"
-    )
+    bad = "def test_a(path):\n" "    assert path.resolve() is not None\n"
     good_site = _leaf_attr_call_site(good, "resolve")
     bad_site = _leaf_attr_call_site(bad, "resolve")
     assert recognize_callee_universe("call:resolve", site=good_site) is not None
@@ -1502,10 +1665,7 @@ def _import_leaf_call_site(source: str, leaf: str, filename: str) -> SourceFragm
 
 def test_authenticated_math_isclose_selects_one_factory_owner() -> None:
     source = (
-        "import math\n"
-        "\n"
-        "def test_close(a, b):\n"
-        "    assert math.isclose(a, b)\n"
+        "import math\n" "\n" "def test_close(a, b):\n" "    assert math.isclose(a, b)\n"
     )
     context = FactoryBuildContext(filename="math_isclose.py", catalog=default_catalog())
     built = build_node(
@@ -1533,10 +1693,7 @@ def test_authenticated_math_isclose_selects_one_factory_owner() -> None:
             "    assert math.isclose(a, b)\n"
             "    math = replacement\n"
         ),
-        (
-            "def test_close(a, b):\n"
-            "    assert math.isclose(a, b)\n"
-        ),
+        ("def test_close(a, b):\n" "    assert math.isclose(a, b)\n"),
     ],
 )
 def test_unwarranted_math_isclose_is_not_factory_owned(source: str) -> None:
@@ -1589,10 +1746,7 @@ def test_authenticated_numpy_result_type_selects_one_factory_owner() -> None:
             "    assert np.result_type(a, b) == a\n"
             "    np = replacement\n"
         ),
-        (
-            "def test_rt(a, b):\n"
-            "    assert numpy.result_type(a, b) == a\n"
-        ),
+        ("def test_rt(a, b):\n" "    assert numpy.result_type(a, b) == a\n"),
     ],
 )
 def test_unwarranted_numpy_result_type_is_not_factory_owned(source: str) -> None:
@@ -1638,10 +1792,7 @@ def test_authenticated_numpy_isdtype_selects_one_factory_owner() -> None:
             "def test_id(np, dt):\n"
             "    assert np.isdtype(dt, 'real floating')\n"
         ),
-        (
-            "def test_id(dt):\n"
-            "    assert isdtype(dt, 'real floating')\n"
-        ),
+        ("def test_id(dt):\n" "    assert isdtype(dt, 'real floating')\n"),
     ],
 )
 def test_unwarranted_numpy_isdtype_is_not_factory_owned(source: str) -> None:
@@ -1689,10 +1840,7 @@ def test_authenticated_numpy_datetime_data_selects_one_factory_owner() -> None:
             "def test_dd(np, dt):\n"
             "    assert np.datetime_data(dt) == 0\n"
         ),
-        (
-            "def test_dd(dt):\n"
-            "    assert datetime_data(dt) == 0\n"
-        ),
+        ("def test_dd(dt):\n" "    assert datetime_data(dt) == 0\n"),
     ],
 )
 def test_unwarranted_numpy_datetime_data_is_not_factory_owned(source: str) -> None:
@@ -1741,10 +1889,7 @@ def test_authenticated_scipy_issymmetric_selects_one_factory_owner() -> None:
             "def test_sym(issymmetric, a):\n"
             "    assert issymmetric(a)\n"
         ),
-        (
-            "def test_sym(a):\n"
-            "    assert scipy.linalg.issymmetric(a)\n"
-        ),
+        ("def test_sym(a):\n" "    assert scipy.linalg.issymmetric(a)\n"),
     ],
 )
 def test_unwarranted_scipy_issymmetric_is_not_factory_owned(source: str) -> None:
@@ -1791,10 +1936,7 @@ def test_authenticated_scipy_ishermitian_selects_one_factory_owner() -> None:
             "def test_herm(ishermitian, a):\n"
             "    assert ishermitian(a)\n"
         ),
-        (
-            "def test_herm(a):\n"
-            "    assert scipy.linalg.ishermitian(a)\n"
-        ),
+        ("def test_herm(a):\n" "    assert scipy.linalg.ishermitian(a)\n"),
     ],
 )
 def test_unwarranted_scipy_ishermitian_is_not_factory_owned(source: str) -> None:
@@ -1847,10 +1989,7 @@ def test_authenticated_scipy_fft_get_workers_selects_one_factory_owner() -> None
             "    assert fft.get_workers() == 1\n"
             "    fft = replacement\n"
         ),
-        (
-            "def test_workers():\n"
-            "    assert scipy.fft.get_workers() == 1\n"
-        ),
+        ("def test_workers():\n" "    assert scipy.fft.get_workers() == 1\n"),
     ],
 )
 def test_unwarranted_scipy_fft_get_workers_is_not_factory_owned(source: str) -> None:
@@ -1877,10 +2016,7 @@ def test_pathlib_path_authenticates_unresolved_stays_loud() -> None:
         "def test_a(value):\n"
         "    assert pathlib.Path(value) is not None\n"
     )
-    bad = (
-        "def test_a(pathlib, value):\n"
-        "    assert pathlib.Path(value) is not None\n"
-    )
+    bad = "def test_a(pathlib, value):\n" "    assert pathlib.Path(value) is not None\n"
     good_site = _leaf_attr_call_site(good, "Path")
     bad_site = _leaf_attr_call_site(bad, "Path")
     assert recognize_callee_universe("call:pathlib.Path", site=good_site) is not None
@@ -1921,14 +2057,17 @@ def test_standard_gamma_authenticates_helper_and_direct_unresolved_stays_loud() 
         "    assert mt19937.standard_gamma(0.0) == 0.0\n"
     )
     lookalike = (
-        "def test_gamma(mt19937):\n"
-        "    assert mt19937.standard_gamma(0.0) == 0.0\n"
+        "def test_gamma(mt19937):\n" "    assert mt19937.standard_gamma(0.0) == 0.0\n"
     )
     helper_site = _leaf_attr_call_site(helper, "standard_gamma")
     direct_site = _leaf_attr_call_site(direct, "standard_gamma")
     bad_site = _leaf_attr_call_site(lookalike, "standard_gamma")
-    assert recognize_callee_universe("call:standard_gamma", site=helper_site) is not None
-    assert recognize_callee_universe("call:standard_gamma", site=direct_site) is not None
+    assert (
+        recognize_callee_universe("call:standard_gamma", site=helper_site) is not None
+    )
+    assert (
+        recognize_callee_universe("call:standard_gamma", site=direct_site) is not None
+    )
     assert recognize_callee_universe("call:standard_gamma", site=bad_site) is None
     for site, expect_owned in (
         (helper_site, True),
@@ -1962,10 +2101,7 @@ def test_subrout_default_authenticates_unresolved_module_stays_loud() -> None:
         "    def test_a(self):\n"
         "        assert self.module.subrout_default(200, 12) == 212\n"
     )
-    bad = (
-        "def test_a(module):\n"
-        "    assert module.subrout_default(200, 12) == 212\n"
-    )
+    bad = "def test_a(module):\n" "    assert module.subrout_default(200, 12) == 212\n"
     good_site = _leaf_attr_call_site(good, "subrout_default")
     bad_site = _leaf_attr_call_site(bad, "subrout_default")
     assert recognize_callee_universe("call:subrout_default", site=good_site) is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_universe_coverage_gap.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_universe_coverage_gap.py
@@ -138,9 +138,7 @@ def test_import_constructed_item_receiver_emits_no_universe_gap() -> None:
 
     payload = lift_file_payload(source, "item_covered_fixture.py")
 
-    assert any(
-        edge.get("targetSymbol") == "call:item" for edge in payload.call_edges
-    )
+    assert any(edge.get("targetSymbol") == "call:item" for edge in payload.call_edges)
     assert _universe_gaps(payload) == []
 
 
@@ -168,6 +166,22 @@ def test_unresolved_item_receiver_stays_unclassified() -> None:
         (
             "all",
             "def test_all(value):\n    assert all(value)\n",
+        ),
+        (
+            "any",
+            "def test_any(value):\n    assert any(value)\n",
+        ),
+        (
+            "min",
+            "def test_min(value):\n    assert min(value) == 0\n",
+        ),
+        (
+            "max",
+            "def test_max(value):\n    assert max(value) == 0\n",
+        ),
+        (
+            "sum",
+            "def test_sum(value):\n    assert sum(value) == 0\n",
         ),
         (
             "list",
@@ -212,7 +226,18 @@ def test_authenticated_builtin_coordinate_emits_no_universe_gap(
     )
     assert _universe_gaps(payload) == []
 
-    if callee in {"type", "dtype", "all", "list", "set", "hasattr"}:
+    if callee in {
+        "type",
+        "dtype",
+        "all",
+        "any",
+        "min",
+        "max",
+        "sum",
+        "list",
+        "set",
+        "hasattr",
+    }:
         node = ast.parse(f"{callee}(value)", mode="eval").body
         context = FactoryBuildContext(
             filename="coordinate.py", catalog=default_catalog()
@@ -226,9 +251,7 @@ def test_authenticated_builtin_coordinate_emits_no_universe_gap(
         # bare type() is BuiltinTypeCallSugar; remaining builtins share the
         # BuiltinCalleeUniverseSugar universe-coordinate leaf.
         expected = (
-            "BuiltinTypeCallSugar"
-            if callee == "type"
-            else "BuiltinCalleeUniverseSugar"
+            "BuiltinTypeCallSugar" if callee == "type" else "BuiltinCalleeUniverseSugar"
         )
         assert built.audit_row.selected == expected
 
@@ -241,17 +264,15 @@ def test_py_subscript_floor_coordinate_is_not_a_callee_universe_gap() -> None:
     locus. That must not demand BuiltinCalleeUniverse coverage.
     """
 
-    source = (
-        "def test_index(values):\n"
-        "    assert values.astype(int)[()] == 0\n"
-    )
+    source = "def test_index(values):\n" "    assert values.astype(int)[()] == 0\n"
     payload = lift_file_payload(source, "py_subscript_floor.py")
 
     assert any(
-        edge.get("targetSymbol") == "call:py.subscript"
-        for edge in payload.call_edges
+        edge.get("targetSymbol") == "call:py.subscript" for edge in payload.call_edges
     )
-    assert not any(gap.ast_kind == "call:py.subscript" for gap in _universe_gaps(payload))
+    assert not any(
+        gap.ast_kind == "call:py.subscript" for gap in _universe_gaps(payload)
+    )
 
 
 def test_bare_subscript_under_assert_is_not_a_callee_universe_gap() -> None:
@@ -259,14 +280,25 @@ def test_bare_subscript_under_assert_is_not_a_callee_universe_gap() -> None:
     payload = lift_file_payload(source, "bare_subscript.py")
 
     assert any(
-        edge.get("targetSymbol") == "call:py.subscript"
-        for edge in payload.call_edges
+        edge.get("targetSymbol") == "call:py.subscript" for edge in payload.call_edges
     )
     assert _universe_gaps(payload) == []
 
 
 @pytest.mark.parametrize(
-    "callee", ["get_handler_name", "conv", "all", "list", "set", "hasattr"]
+    "callee",
+    [
+        "get_handler_name",
+        "conv",
+        "all",
+        "any",
+        "min",
+        "max",
+        "sum",
+        "list",
+        "set",
+        "hasattr",
+    ],
 )
 def test_shadowed_authenticated_coordinate_stays_unclassified(callee: str) -> None:
     source = f"def test_shadowed({callee}):\n" f"    assert {callee}(5) == 5\n"
@@ -575,9 +607,7 @@ def test_non_numpy_import_refutes_numpy_dtype_support() -> None:
         and isinstance(node.func, ast.Attribute)
         and node.func.attr == "dtype"
     )
-    site = SourceFragment.from_node(
-        call, "numpy_dtype_lying_fixture.py", source=source
-    )
+    site = SourceFragment.from_node(call, "numpy_dtype_lying_fixture.py", source=source)
 
     assert recognize_callee_universe("call:numpy.dtype", site=site) is None
 
@@ -956,8 +986,7 @@ def test_authenticated_numpy_shares_memory_has_universe_support() -> None:
             "call:numpy.shares_memory",
         ),
         (
-            "def test_values(left, right):\n"
-            "    assert shares_memory(left, right)\n",
+            "def test_values(left, right):\n" "    assert shares_memory(left, right)\n",
             "call:shares_memory",
         ),
     ),
@@ -984,8 +1013,7 @@ def test_authenticated_numpy_isdtype_has_universe_support() -> None:
     payload = lift_file_payload(source, "isdtype_covered_fixture.py")
 
     assert any(
-        edge.get("targetSymbol") == "call:numpy.isdtype"
-        for edge in payload.call_edges
+        edge.get("targetSymbol") == "call:numpy.isdtype" for edge in payload.call_edges
     )
     assert _universe_gaps(payload) == []
 
@@ -1000,15 +1028,12 @@ def test_authenticated_numpy_isdtype_has_universe_support() -> None:
             "call:numpy.isdtype",
         ),
         (
-            "def test_values(dt):\n"
-            "    assert isdtype(dt, 'real floating')\n",
+            "def test_values(dt):\n" "    assert isdtype(dt, 'real floating')\n",
             "call:isdtype",
         ),
     ),
 )
-def test_unowned_isdtype_lookalikes_stay_loud(
-    source: str, expected_kind: str
-) -> None:
+def test_unowned_isdtype_lookalikes_stay_loud(source: str, expected_kind: str) -> None:
     """Parameter shadow and unimported spelling stay loud universe gaps."""
 
     payload = lift_file_payload(source, "isdtype_unowned_fixture.py")
@@ -1044,8 +1069,7 @@ def test_authenticated_numpy_datetime_data_has_universe_support() -> None:
             "call:numpy.datetime_data",
         ),
         (
-            "def test_values(dt):\n"
-            "    assert datetime_data(dt) == 0\n",
+            "def test_values(dt):\n" "    assert datetime_data(dt) == 0\n",
             "call:datetime_data",
         ),
     ),
@@ -1313,10 +1337,7 @@ def test_later_local_rebind_revokes_json_loads_import_warrant() -> None:
 def test_unauthenticated_json_loads_fqn_alone_stays_loud() -> None:
     """Lying twin: FQN spelling without import provenance must not silence."""
 
-    source = (
-        "def test_loads(payload):\n"
-        "    assert json.loads(payload) is not None\n"
-    )
+    source = "def test_loads(payload):\n" "    assert json.loads(payload) is not None\n"
 
     payload = lift_file_payload(source, "json_loads_unauthenticated_fqn.py")
 
@@ -1439,8 +1460,7 @@ def test_unauthenticated_asdict_fqn_alone_stays_loud() -> None:
     """Lying twin: FQN spelling without import provenance must not silence."""
 
     source = (
-        "def test_asdict(value):\n"
-        "    assert dataclasses.asdict(value) is not None\n"
+        "def test_asdict(value):\n" "    assert dataclasses.asdict(value) is not None\n"
     )
 
     payload = lift_file_payload(source, "asdict_unauthenticated_fqn.py")
@@ -1461,3 +1481,250 @@ def test_unauthenticated_asdict_fqn_alone_stays_loud() -> None:
     )
     assert CalleeUniverseRecognition.coordinate(site) is None
     assert recognize_callee_universe("call:dataclasses.asdict", site=site) is None
+
+
+def test_authenticated_dataclasses_is_dataclass_has_universe_support() -> None:
+    source = (
+        "import dataclasses\n"
+        "\n"
+        "def test_is_dataclass(value):\n"
+        "    assert dataclasses.is_dataclass(value) is not None\n"
+    )
+
+    payload = lift_file_payload(source, "is_dataclass_covered_fixture.py")
+
+    assert any(
+        edge.get("targetSymbol") == "call:dataclasses.is_dataclass"
+        for edge in payload.call_edges
+    )
+    assert _universe_gaps(payload) == []
+
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "is_dataclass"
+    )
+    site = SourceFragment.from_node(
+        call, "is_dataclass_covered_fixture.py", source=source
+    )
+    assert CalleeUniverseRecognition.coordinate(site) == "dataclasses.is_dataclass"
+    context = FactoryBuildContext(
+        filename="is_dataclass_covered_fixture.py", catalog=default_catalog()
+    )
+    built = build_node(
+        site,
+        filename="is_dataclass_covered_fixture.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+def test_authenticated_from_import_is_dataclass_has_universe_support() -> None:
+    source = (
+        "from dataclasses import is_dataclass\n"
+        "\n"
+        "def test_is_dataclass(value):\n"
+        "    assert is_dataclass(value) is not None\n"
+    )
+
+    payload = lift_file_payload(source, "is_dataclass_from_covered.py")
+
+    assert any(
+        edge.get("targetSymbol") == "call:dataclasses.is_dataclass"
+        for edge in payload.call_edges
+    )
+    assert _universe_gaps(payload) == []
+
+
+def test_shadowed_dataclasses_alias_cannot_warrant_is_dataclass_support() -> None:
+    """Lying twin: parameter receiver is not the authenticated dataclasses import."""
+
+    source = (
+        "import dataclasses\n"
+        "\n"
+        "def test_is_dataclass(dataclasses, value):\n"
+        "    assert dataclasses.is_dataclass(value) is not None\n"
+    )
+
+    payload = lift_file_payload(source, "is_dataclass_shadowed_fixture.py")
+
+    gaps = _universe_gaps(payload)
+    assert [gap.ast_kind for gap in gaps] == ["call:dataclasses.is_dataclass"]
+
+
+def test_later_local_rebind_revokes_is_dataclass_import_warrant() -> None:
+    """Lying twin: later function-local rebind must break false recognition."""
+
+    source = (
+        "from dataclasses import is_dataclass\n"
+        "\n"
+        "def test_is_dataclass(value):\n"
+        "    assert is_dataclass(value) is not None\n"
+        "    is_dataclass = replacement\n"
+    )
+
+    payload = lift_file_payload(source, "is_dataclass_late_rebind.py")
+
+    gaps = _universe_gaps(payload)
+    assert [gap.ast_kind for gap in gaps] == ["call:dataclasses.is_dataclass"]
+
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "is_dataclass"
+    )
+    site = SourceFragment.from_node(call, "is_dataclass_late_rebind.py", source=source)
+    assert CalleeUniverseRecognition.coordinate(site) is None
+
+
+def test_unauthenticated_is_dataclass_fqn_alone_stays_loud() -> None:
+    """Lying twin: FQN spelling without import provenance must not silence."""
+
+    source = (
+        "def test_is_dataclass(value):\n"
+        "    assert dataclasses.is_dataclass(value) is not None\n"
+    )
+
+    payload = lift_file_payload(source, "is_dataclass_unauthenticated_fqn.py")
+
+    gaps = _universe_gaps(payload)
+    assert gaps
+    assert all("is_dataclass" in gap.ast_kind for gap in gaps)
+
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "is_dataclass"
+    )
+    site = SourceFragment.from_node(
+        call, "is_dataclass_unauthenticated_fqn.py", source=source
+    )
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe("call:dataclasses.is_dataclass", site=site) is None
+
+
+def test_authenticated_math_isclose_has_universe_support() -> None:
+    source = (
+        "import math\n"
+        "\n"
+        "def test_isclose(a, b):\n"
+        "    assert math.isclose(a, b) is not None\n"
+    )
+
+    payload = lift_file_payload(source, "isclose_covered_fixture.py")
+
+    assert any(
+        edge.get("targetSymbol") == "call:math.isclose" for edge in payload.call_edges
+    )
+    assert _universe_gaps(payload) == []
+
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "isclose"
+    )
+    site = SourceFragment.from_node(call, "isclose_covered_fixture.py", source=source)
+    assert CalleeUniverseRecognition.coordinate(site) == "math.isclose"
+    context = FactoryBuildContext(
+        filename="isclose_covered_fixture.py", catalog=default_catalog()
+    )
+    built = build_node(
+        site,
+        filename="isclose_covered_fixture.py",
+        role=SugarRole.TERM,
+        ctx=context,
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+def test_authenticated_from_import_isclose_has_universe_support() -> None:
+    source = (
+        "from math import isclose\n"
+        "\n"
+        "def test_isclose(a, b):\n"
+        "    assert isclose(a, b) is not None\n"
+    )
+
+    payload = lift_file_payload(source, "isclose_from_covered.py")
+
+    assert any(
+        edge.get("targetSymbol") == "call:math.isclose" for edge in payload.call_edges
+    )
+    assert _universe_gaps(payload) == []
+
+
+def test_shadowed_math_alias_cannot_warrant_isclose_support() -> None:
+    """Lying twin: parameter receiver is not the authenticated math import."""
+
+    source = (
+        "import math\n"
+        "\n"
+        "def test_isclose(math, a, b):\n"
+        "    assert math.isclose(a, b) is not None\n"
+    )
+
+    payload = lift_file_payload(source, "isclose_shadowed_fixture.py")
+
+    gaps = _universe_gaps(payload)
+    assert [gap.ast_kind for gap in gaps] == ["call:math.isclose"]
+
+
+def test_later_local_rebind_revokes_isclose_import_warrant() -> None:
+    """Lying twin: later function-local rebind must break false recognition."""
+
+    source = (
+        "from math import isclose\n"
+        "\n"
+        "def test_isclose(a, b):\n"
+        "    assert isclose(a, b) is not None\n"
+        "    isclose = replacement\n"
+    )
+
+    payload = lift_file_payload(source, "isclose_late_rebind.py")
+
+    gaps = _universe_gaps(payload)
+    assert [gap.ast_kind for gap in gaps] == ["call:math.isclose"]
+
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "isclose"
+    )
+    site = SourceFragment.from_node(call, "isclose_late_rebind.py", source=source)
+    assert CalleeUniverseRecognition.coordinate(site) is None
+
+
+def test_unauthenticated_isclose_fqn_alone_stays_loud() -> None:
+    """Lying twin: FQN spelling without import provenance must not silence."""
+
+    source = "def test_isclose(a, b):\n" "    assert math.isclose(a, b) is not None\n"
+
+    payload = lift_file_payload(source, "isclose_unauthenticated_fqn.py")
+
+    gaps = _universe_gaps(payload)
+    assert gaps
+    assert all("isclose" in gap.ast_kind for gap in gaps)
+
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "isclose"
+    )
+    site = SourceFragment.from_node(
+        call, "isclose_unauthenticated_fqn.py", source=source
+    )
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe("call:math.isclose", site=site) is None


### PR DESCRIPTION
## Summary

Continue full-recensus unclassified drain by descending Sugar-native mass, preferring bare/stdlib over the pydantic method wall (#5577 owns that architecture).

Authenticate the next bare/stdlib callee-universe families after #5575 (`json.loads` / `dataclasses.asdict`):

| family | form | local honest-shape ΔR |
| --- | --- | ---: |
| `call:any` | bare builtin | −1 → 0 |
| `call:min` | bare builtin | −1 → 0 |
| `call:max` | bare builtin | −1 → 0 |
| `call:sum` | bare builtin | −1 → 0 |
| `call:dataclasses.is_dataclass` | import + from-import | −2 → 0 |
| **total measured** | | **−6 → 0** |

`math.isclose` is already authenticated on main; this PR adds gap lying-twin coverage only for that coordinate.

### Construction
- `CalleeUniverseRecognition` / `_BUILTIN_COORDINATES`: `any`, `min`, `max`, `sum`
- `_IMPORTED_SUPPORT`: `dataclasses.is_dataclass` (sibling of `asdict`)
- `BuiltinCalleeUniverseSugar`: coordinates + truthful/lying witnesses
- Lying twins stay loud: parameter shadow, late rebind, wrong-module alias, unauth FQN
- Keyword calls remain unowned; construction stays delegated to `CallSugar`

### Floors (local)
- ownership `R_ownership = 0`
- side doors `R_behavior_side_doors = 0`
- silent pre-green (pre-existing silent-surface scan)
- vendor special-case residual is pre-existing main mass (scipy table literals / pytest name matches); not introduced here

### Predicted Epsilon R
- `R(unclassified callee universe rows)`: −6 local honest-shape family gaps for enrolled coordinates
- Recensus ranking mass for these families left for next full recensus pin (no new pin claimed)

### Validation
- Direct discrimination harness: enrollment, owner select, lying twins, universe gap → green
- Honest shapes for all six forms: gap residual 0; lying twins stay loud
- `factory_ownership_law`, `factory_zero_tolerance`: green
- Black clean on the four changed files

Part of the bare/stdlib BuiltinCalleeUniverse drain (after #5422 `#all`, #5575 `json.loads`/`asdict`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate bare `any`, `min`, `max`, `sum` and `dataclasses.is_dataclass` as callee universe coordinates
> - Adds `any`, `min`, `max`, and `sum` to `_BUILTIN_COORDINATES` in both [callee_universe.py](https://github.com/TSavo/sugar/pull/5611/files#diff-72e9f915afa350390348a1c277d0c2047b26a0182bb4780c57baf73f30fdcaa8) and [builtin_callee_universe_sugar.py](https://github.com/TSavo/sugar/pull/5611/files#diff-98e9ae8e3cbb10a2e6c95f0bdeca86f0b85002634b901733d0b6070886cdab5f), giving them the same owned-universe treatment as `all`.
> - Adds a new `CalleeUniverseSupport.DATACLASSES_IS_DATACLASS` enum member and maps `dataclasses.is_dataclass` as an authenticated imported-support coordinate with a dedicated witness factory.
> - Expands test coverage in [test_builtin_callee_universe_sugar.py](https://github.com/TSavo/sugar/pull/5611/files#diff-4cf523d0449af84e5a94e72b7ba403f9d6a713a9f0bf70db21a7cd083d014f3f) and [test_universe_coverage_gap.py](https://github.com/TSavo/sugar/pull/5611/files#diff-26722cc120585f9c881bb6fe43e95d93d86886ebffcd4c2cb05d1b1f8ae21f6b) for the new coordinates, including negative cases for aliasing, rebinding, and unauthenticated FQNs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d067c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->