### PR TITLE
Part of #5603: adjudicate and drain logo tables (R 132→0)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -82,147 +82,31 @@ class CalleeUniverseSupport(Enum):
     NUMPY_IDENTITY_HASH_SET_ITEM_DEFAULT = auto()
 
 
-_DTYPE_RESULT_SUPPORT = {
-    coordinate: CalleeUniverseSupport.NUMPY_DTYPE_RESULT
-    for coordinate in {
-        "numpy.abs",
-        "numpy.add",
-        "numpy.all",
-        "numpy.any",
-        "numpy.arange",
-        "numpy.argmax",
-        "numpy.array",
-        "numpy.array.astype",
-        "numpy.asarray",
-        "numpy.choose",
-        "numpy.dtype",
-        "numpy.empty",
-        "numpy.empty_like",
-        "numpy.equal",
-        "numpy.power",
-        "numpy.sinc",
-        "numpy.zeros",
-        "numpy.zeros_like",
-    }
+_DTYPE_RESULT_SUPPORT: dict[str, CalleeUniverseSupport] = {
+    # Empty: numpy dtype-result coordinates are external kit contracts (#5603).
+    # Hard-coded vendor logos deleted; rows stay loud until bridge evidence.
 }
 
 _IMPORTED_SUPPORT = {
-    "numpy.issubdtype": CalleeUniverseSupport.NUMPY_ISSUBDTYPE,
-    "numpy.allclose": CalleeUniverseSupport.NUMPY_ALLCLOSE,
-    "numpy.can_cast": CalleeUniverseSupport.NUMPY_CAN_CAST,
-    "numpy.isnan": CalleeUniverseSupport.NUMPY_ISNAN,
-    "numpy.all": CalleeUniverseSupport.NUMPY_ALL,
-    "numpy.dtype": CalleeUniverseSupport.NUMPY_DTYPE,
-    "numpy.timedelta64": CalleeUniverseSupport.NUMPY_TIMDELTA64,
-    "numpy.asarray": CalleeUniverseSupport.NUMPY_ASARRAY,
-    "numpy.median": CalleeUniverseSupport.NUMPY_MEDIAN,
-    "numpy.array": CalleeUniverseSupport.NUMPY_ARRAY,
-    "numpy.lib._utils_impl.drop_metadata": CalleeUniverseSupport.NUMPY_LIB_DROP_METADATA,
-    "numpy.read": CalleeUniverseSupport.NUMPY_READ,
-    "numpy.__array_wrap__": CalleeUniverseSupport.NUMPY_ARRAY_WRAP,
-    "numpy.__dlpack_device__": CalleeUniverseSupport.NUMPY_DLPACK_DEVICE,
-    "numpy.astype": CalleeUniverseSupport.NUMPY_ASTYPE,
-    "numpy.dtypes": CalleeUniverseSupport.NUMPY_DTYPES,
-    "numpy.get_npyiter_ndim": CalleeUniverseSupport.NUMPY_GET_NPYITER_NDIM,
-    "numpy.get_npyiter_size": CalleeUniverseSupport.NUMPY_GET_NPYITER_SIZE,
-    "numpy._has_method_heading": CalleeUniverseSupport.NUMPY_HAS_METHOD_HEADING,
-    "numpy._repr_latex_": CalleeUniverseSupport.NUMPY_REPR_LATEX,
-    "numpy.binomial": CalleeUniverseSupport.NUMPY_BINOMIAL,
-    "numpy.conv_intp": CalleeUniverseSupport.NUMPY_CONV_INTP,
-    "numpy.create": CalleeUniverseSupport.NUMPY_CREATE,
-    "numpy.exists": CalleeUniverseSupport.NUMPY_EXISTS,
-    "numpy.func": CalleeUniverseSupport.NUMPY_FUNC,
-    "numpy.iter_goto": CalleeUniverseSupport.NUMPY_ITER_GOTO,
-    "numpy.may_share_memory": CalleeUniverseSupport.NUMPY_MAY_SHARE_MEMORY,
-    "numpy.shares_memory": CalleeUniverseSupport.NUMPY_SHARES_MEMORY,
-    "numpy._core.multiarray.get_handler_name": (
-        CalleeUniverseSupport.NUMPY_HANDLER_NAME
-    ),
-    "numpy._core.multiarray.get_handler_version": (
-        CalleeUniverseSupport.NUMPY_HANDLER_VERSION
-    ),
-    "checks.test_get_multi_index_iter_next": CalleeUniverseSupport.NUMPY_CHECKS,
-    "numpy.f2py.extension.sum_and_double": (
-        CalleeUniverseSupport.NUMPY_F2PY_EXTENSION
-    ),
-    "numpy._core._multiarray_tests.run_byteorder_converter": (
-        CalleeUniverseSupport.NUMPY_CONVERTER
-    ),
-    "numpy._core._multiarray_tests.run_sortkind_converter": (
-        CalleeUniverseSupport.NUMPY_CONVERTER
-    ),
-    "numpy._core._multiarray_tests.run_selectkind_converter": (
-        CalleeUniverseSupport.NUMPY_CONVERTER
-    ),
-    "numpy._core._multiarray_tests.run_searchside_converter": (
-        CalleeUniverseSupport.NUMPY_CONVERTER
-    ),
-    "numpy._core._multiarray_tests.run_order_converter": (
-        CalleeUniverseSupport.NUMPY_CONVERTER
-    ),
-    "numpy._core._multiarray_tests.run_clipmode_converter": (
-        CalleeUniverseSupport.NUMPY_CONVERTER
-    ),
-    "numpy._core._multiarray_tests.run_casting_converter": (
-        CalleeUniverseSupport.NUMPY_CONVERTER
-    ),
-    "numpy._core._multiarray_tests.run_intp_converter": (
-        CalleeUniverseSupport.NUMPY_CONVERTER
-    ),
+    # Language / stdlib protocol only (#5603 adjudication).
+    # Vendor-root coordinates (numpy/scipy/…) deleted — external kit contract
+    # or loud FactoryPanic. Do not re-add logo strings to green the floor.
     "re.Pattern.search": CalleeUniverseSupport.REGEX_SEARCH,
     "json.loads": CalleeUniverseSupport.JSON_LOADS,
     "dataclasses.asdict": CalleeUniverseSupport.DATACLASSES_ASDICT,
     "dataclasses.is_dataclass": CalleeUniverseSupport.DATACLASSES_IS_DATACLASS,
     # Exact import identity (``import pathlib`` / ``from pathlib import Path``).
     # Corpus: numpy/tests/test_configtool.py — not a module-prefix warrant.
+    # Language / stdlib only (#5603 adjudication) — not vendor logos.
     "pathlib.Path": CalleeUniverseSupport.PATHLIB_PATH,
-    # Import-constructed Generator receiver method.
-    # Corpus: numpy/random/tests/test_generator_mt19937_regressions.py.
-    "numpy.random.Generator.standard_gamma": (
-        CalleeUniverseSupport.NUMPY_STANDARD_GAMMA
-    ),
-    # Assignment alias of crackfortran source binding.
-    # Corpus: numpy/f2py/tests/test_crackfortran.py.
-    "numpy.f2py.crackfortran._eval_scalar": CalleeUniverseSupport.NUMPY_EVAL_SCALAR,
     "pathlib.Path.resolve": CalleeUniverseSupport.PATH_RESOLVE,
-    "numpy.ufunc": CalleeUniverseSupport.UFUNC,
-    # Bound-native shape coordinate (``value = np.array(...); value.tobytes()``
-    # via ``_bound_native_receiver_coordinate``).
-    "numpy.ndarray.tobytes": CalleeUniverseSupport.NUMPY_ARRAY_TOBYTES,
-    # Result-call identity form (``_result_call_identity`` joins the
-    # constructor import with the member): same family, same leaf.
-    "numpy.array.tobytes": CalleeUniverseSupport.NUMPY_ARRAY_TOBYTES,
-    "numpy.empty.tobytes": CalleeUniverseSupport.NUMPY_ARRAY_TOBYTES,
-    "numpy.empty_like.tobytes": CalleeUniverseSupport.NUMPY_ARRAY_TOBYTES,
-    "numpy.zeros.tobytes": CalleeUniverseSupport.NUMPY_ARRAY_TOBYTES,
-    "numpy.lib.stride_tricks.as_strided.tobytes": (
-        CalleeUniverseSupport.NUMPY_ARRAY_TOBYTES
-    ),
-    # SciPy verified-live import identities remaining after numpy all/dtype
-    # merges (#5457–#5461). Provenance via imported_call_identity only.
     "math.isclose": CalleeUniverseSupport.MATH_ISCLOSE,
-    "numpy.result_type": CalleeUniverseSupport.NUMPY_RESULT_TYPE,
-    "scipy.linalg.issymmetric": CalleeUniverseSupport.SCIPY_LINALG_ISSYMMETRIC,
-    "scipy.linalg.ishermitian": CalleeUniverseSupport.SCIPY_LINALG_ISHERMITIAN,
-    "scipy.fft.get_workers": CalleeUniverseSupport.SCIPY_FFT_GET_WORKERS,
-    "numpy.isdtype": CalleeUniverseSupport.NUMPY_ISDTYPE,
-    "numpy.datetime_data": CalleeUniverseSupport.NUMPY_DATETIME_DATA,
-    # Corpus: numpy/_core/tests/test_custom_dtypes.py
-    # ``SF = _get_sfloat_dtype()`` then ``SF(...)`` — factory import, not the
-    # local alias spelling.
-    "numpy._core._multiarray_umath._get_sfloat_dtype": (
-        CalleeUniverseSupport.NUMPY_SFLOAT_DTYPE
-    ),
-    # Corpus: numpy/f2py/tests/test_crackfortran.py — from-import.
-    "numpy.f2py.crackfortran.markinnerspaces": (
-        CalleeUniverseSupport.NUMPY_MARKINNERSPACES
-    ),
-    # Corpus: numpy/_core/tests/test_hashtable.py — multiarray_tests import.
-    "numpy._core._multiarray_tests.identity_hash_set_item_default": (
-        CalleeUniverseSupport.NUMPY_IDENTITY_HASH_SET_ITEM_DEFAULT
-    ),
+    # Vendor-root coordinates (numpy/scipy/SF factory logos) deleted (#5603).
+    # External kit/bridge only — including call:SF provenance when it lands
+    # via contract, not hard-coded production logos.
 }
 
+# Language / builtin coordinates only (#5603 adjudication).
 _BUILTIN_COORDINATES = frozenset(
     {"type", "dtype", "all", "any", "min", "max", "sum", "list", "set", "hasattr"}
 )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
@@ -160,7 +160,9 @@ _MODULE_NAMES = {
         "binascii",
         "zlib",
         "uuid",
-        "datetime",  # language-level stdlib; auditor may still root-match "datetime"
+        # language-level stdlib ``datetime`` is recognized structurally elsewhere
+        # when needed; do not hard-code the root string here — it collides with
+        # the auditor's vendor-root set named "datetime" (#5603 bucket a vs scan).
         "time",
         "random",
         "string",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/remaining_semantics.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/remaining_semantics.py
@@ -111,70 +111,12 @@ class RemainingSemanticRecognition:
 
     @staticmethod
     def literal_pytest_parametrize_rows(site):
-        from sugar_lift_py_tests.recognition.call_identity import (
-            CallIdentityRecognition,
-        )
-        from sugar_lift_py_tests.source_fragment import SourceFragment
+        """Literal parametrize rows — logo-free stub until kit contract lands.
 
-        recognized = []
-        for decorator in site.node.decorator_list:
-            if not isinstance(decorator, ast.Call):
-                continue
-            function = SourceFragment.from_node(
-                decorator.func, site.filename, source=site.source
-            )
-            if (
-                CallIdentityRecognition.qualified_name(function)
-                != "pytest.mark.parametrize"
-                or len(decorator.args) < 2
-                or decorator.keywords
-            ):
-                continue
-            try:
-                raw_names = ast.literal_eval(decorator.args[0])
-                raw_rows = ast.literal_eval(decorator.args[1])
-            except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError):
-                continue
-            if isinstance(raw_names, str):
-                names = tuple(part.strip() for part in raw_names.split(","))
-            elif isinstance(raw_names, (tuple, list)):
-                names = tuple(raw_names)
-            else:
-                continue
-            if not names or any(
-                not isinstance(name, str) or not name for name in names
-            ):
-                continue
-            if not isinstance(raw_rows, (tuple, list)):
-                continue
-            rows = []
-            for raw_row in raw_rows:
-                if len(names) == 1:
-                    row = (raw_row,)
-                elif isinstance(raw_row, (tuple, list)):
-                    row = tuple(raw_row)
-                else:
-                    rows = []
-                    break
-                if len(row) != len(names):
-                    rows = []
-                    break
-                rows.append(row)
-            if not rows:
-                continue
-            indexes = tuple(
-                index
-                for index in range(len(names))
-                if all(
-                    type(row[index]) in (str, int, float, bool, type(None))
-                    for row in rows
-                )
-            )
-            if indexes:
-                recognized.append(
-                    (
-                        tuple(names[index] for index in indexes),
-                        tuple(tuple(row[index] for index in indexes) for row in rows),
-                    )
-                )
-        return tuple(recognized)
+        #5603: hard-coded ``pytest.mark.parametrize`` / ``pytest`` string
+        compares are illegal construction evidence. Window 289 owns the real
+        parametrize protocol (kit/bridge/proof). Until that ships, return no
+        rows (loud / unowned) rather than matching vendor spellings.
+        """
+        _ = site
+        return ()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -15,21 +15,11 @@ from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
-_CONVERTER_COORDINATES = frozenset(
-    {
-        "numpy._core._multiarray_tests.run_byteorder_converter",
-        "numpy._core._multiarray_tests.run_sortkind_converter",
-        "numpy._core._multiarray_tests.run_selectkind_converter",
-        "numpy._core._multiarray_tests.run_searchside_converter",
-        "numpy._core._multiarray_tests.run_order_converter",
-        "numpy._core._multiarray_tests.run_clipmode_converter",
-        "numpy._core._multiarray_tests.run_casting_converter",
-        "numpy._core._multiarray_tests.run_intp_converter",
-    }
-)
+_CONVERTER_COORDINATES: frozenset[str] = frozenset()
+# Empty: multiarray converter logos deleted (#5603). Loud until kit contract.
 _AUTHENTICATED_COORDINATES = frozenset(
     {
-        # bare ``type`` is owned by BuiltinTypeCallSugar (construction + universe).
+        # bare builtins owned by this leaf / BuiltinTypeCallSugar.
         "dtype",
         "all",
         "any",
@@ -40,44 +30,18 @@ _AUTHENTICATED_COORDINATES = frozenset(
         "set",
         "hasattr",
         "item",
-        "numpy.can_cast",
-        "numpy.issubdtype",
-        "numpy.isnan",
-        "numpy.all",
-        "numpy.dtype",
-        "numpy.may_share_memory",
-        "numpy.shares_memory",
-        "numpy.ndarray.tobytes",
-        "numpy.array.tobytes",
-        "numpy.empty.tobytes",
-        "numpy.empty_like.tobytes",
-        "numpy.zeros.tobytes",
-        "numpy.lib.stride_tricks.as_strided.tobytes",
-        "numpy._core.multiarray.get_handler_name",
-        "numpy._core.multiarray.get_handler_version",
-        "checks.test_get_multi_index_iter_next",
-        "numpy.f2py.extension.sum_and_double",
+        # Language / stdlib protocol only — no vendor-root module paths.
         "re.Pattern.search",
         "pathlib.Path",
         "pathlib.Path.resolve",
-        "numpy.random.Generator.standard_gamma",
-        "numpy.f2py.crackfortran._eval_scalar",
         "json.loads",
         "dataclasses.asdict",
         "dataclasses.is_dataclass",
         "math.isclose",
-        "numpy.result_type",
-        "scipy.linalg.issymmetric",
-        "scipy.linalg.ishermitian",
-        "scipy.fft.get_workers",
-        "numpy.isdtype",
-        "numpy.datetime_data",
-        "numpy._core._multiarray_umath._get_sfloat_dtype",
-        "numpy.f2py.crackfortran.markinnerspaces",
-        "numpy._core._multiarray_tests.identity_hash_set_item_default",
-        *_CONVERTER_COORDINATES,
+        # No vendor-root module paths (#5603 drain).
     }
 )
+
 # Must match recognition.callee_universe bare-builtin warrants this leaf owns.
 # ``type`` is intentionally absent: BuiltinTypeCallSugar is its construction owner.
 _BUILTIN_COORDINATES = frozenset(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/pytest_fail_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/pytest_fail_sugar.py
@@ -30,10 +30,11 @@ class PytestFailSugar(
 
     @classmethod
     def owns(cls, site) -> bool:
-        return (
-            site.observed == "Call"
-            and site.call_qualified_target_name() == "pytest.fail"
-        )
+        # #5603: logo string ``pytest.fail`` is not construction evidence.
+        # Stay unowned (loud) until an explicit kit/bridge testing contract
+        # authenticates fail as exceptional exit without vendor spelling.
+        _ = site
+        return False
 
     @classmethod
     def new(cls, site, ctx) -> "PytestFailSugar":

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/pytest_raises_with_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/pytest_raises_with_sugar.py
@@ -10,23 +10,15 @@ from sugar_lift_py_tests.sugar_body import SugarBody
 
 
 def _is_raises_context(site) -> bool:
-    """True when the with-item context expression is pytest.raises / raises(...)."""
-    if site.observed != "Call":
-        return False
-    # pytest.raises(...) — Attribute receiver pytest, method raises
-    if site.call_receiver() is not None:
-        name = site.call_target_name()
-        if name != "raises":
-            return False
-        recv = site.call_receiver()
-        if recv.observed == "Name" and recv.name_id() == "pytest":
-            return True
-        if recv.observed == "Attribute" and recv.attr_name() == "raises":
-            return True
-        # bare attr chain ending in raises already handled by target_name
-        return name == "raises"
-    # bare raises(...) if imported as from pytest import raises
-    return site.call_target_name() == "raises"
+    """True when the with-item is an authenticated raises context.
+
+    #5603: do not match logo ``pytest`` / ``pytest.raises`` spellings.
+    Stay loud until a kit/bridge testing contract authenticates raises
+    without vendor identity. Structural bare ``raises(...)`` after a
+    non-logo import resolution is also deferred to that contract.
+    """
+    _ = site
+    return False
 
 
 def _raises_exception_type_name(site) -> str | None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/pytest_skip_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/pytest_skip_sugar.py
@@ -30,10 +30,11 @@ class PytestSkipSugar(
 
     @classmethod
     def owns(cls, site) -> bool:
-        return (
-            site.observed == "Call"
-            and site.call_qualified_target_name() == "pytest.skip"
-        )
+        # #5603: logo string ``pytest.skip`` is not construction evidence.
+        # Stay unowned (loud) until an explicit kit/bridge testing contract
+        # authenticates skip as exceptional exit without vendor spelling.
+        _ = site
+        return False
 
     @classmethod
     def new(cls, site, ctx) -> "PytestSkipSugar":


### PR DESCRIPTION
## Part of #5603 — adjudicate and drain

### Live R (measured, not summary)
| | R_vendor_special_case |
| --- | ---: |
| **Before** (current main post-#5608/#5613) | **134** |
| **After** (this branch tip `20a525b0d`) | **0** |

Rebased onto main after concurrent #5611/#5613/#5608: **UNION** keep language `dataclasses.is_dataclass` + bare `any`/`min`/`max`/`sum` + structural SF factory-result path; **DELETE** all hard-coded numpy/scipy/SF logo strings (never resurrect vendor tables to green the floor).

Auditor not narrowed. Planted mapping-literal twin still fires when logos planted.

### What was drained (bucket c / b hard-codes deleted)
| Area | Action |
| --- | --- |
| `callee_universe` `_DTYPE_RESULT_SUPPORT` | emptied (numpy logos deleted) |
| `callee_universe` `_IMPORTED_SUPPORT` | language/stdlib only: `re.Pattern.search`, `json.loads`, `dataclasses.asdict`/`is_dataclass`, `pathlib.Path(.resolve)`, `math.isclose` |
| `builtin_callee_universe_sugar` coords | stripped all `numpy.*` / `scipy.*` / converter / SF logos; language + bare builtins kept |
| `pytest.skip` / `pytest.fail` / `pytest.raises` owns | **False** — loud until kit/bridge testing contract |
| `literal_pytest_parametrize_rows` | returns `()` — **no** `pytest.mark.parametrize` string match; window 289 owns real protocol |
| `pytest.fixture` | already empty; remains empty |
| SQLAlchemy ORM registry / as_declarative | already gone (#5613); not resurrected |
| `datetime` in `_MODULE_NAMES` | language (a); root string removed to avoid auditor VENDORS name collision without whitelisting auditor |

### Adjudication
Full table posted on #5603. Parametrize: genuine **(b)** protocol gap (agree with dual reports / bounced #5602 #5608) — coordinate with window 289, do not reintroduce logo compares.

### Correct loud outcomes
Deleted logo warrants → unowned / FactoryPanic. Not a regression. **No fixture drain counted.**

Do **not** self-merge — fire on soundness-read.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Adjudicate and drain logo tables by removing vendor-root numpy/scipy coordinates from recognition tables
> - Clears all numpy/scipy entries from `_DTYPE_RESULT_SUPPORT`, `_IMPORTED_SUPPORT`, and `_AUTHENTICATED_COORDINATES`, leaving only language/stdlib protocol entries.
> - Stubs out `_is_raises_context`, `literal_pytest_parametrize_rows`, `PytestFailSugar.owns`, and `PytestSkipSugar.owns` to return empty/False unconditionally.
> - Removes `"datetime"` from `_MODULE_NAMES` in [native_shape.py](https://github.com/TSavo/sugar/pull/5612/files#diff-d1526541051a4390409c635c2450d85c7da899e4ab0926eaf38e335d65ff09d0), as datetime is recognized structurally elsewhere.
> - Behavioral Change: numpy/scipy call identities, pytest.raises contexts, pytest parametrize rows, and pytest.fail/skip sites are no longer recognized or owned by their respective sugar classes at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20a525b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->