### PR TITLE
Part of #5603: DELETE pytest fail/skip/raises logo owns-paths

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/pytest_fail_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/pytest_fail_sugar.py
@@ -30,9 +30,10 @@ class PytestFailSugar(
 
     @classmethod
     def owns(cls, site) -> bool:
-        # #5603: logo string ``pytest.fail`` is not construction evidence.
-        # Stay unowned (loud) until an explicit kit/bridge testing contract
-        # authenticates fail as exceptional exit without vendor spelling.
+        # #5603: vendor-name logo is not construction evidence.
+        # Externally-loaded testing kit/bridge contract only — never a
+        # vendor-name compare. Rows stay loud FactoryPanic until that contract.
+        # (#5612 + #5615: keep deleted; do not reintroduce logo Compare.)
         _ = site
         return False
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/pytest_raises_with_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/pytest_raises_with_sugar.py
@@ -10,12 +10,13 @@ from sugar_lift_py_tests.sugar_body import SugarBody
 
 
 def _is_raises_context(site) -> bool:
-    """True when the with-item is an authenticated raises context.
+    """Whether the with-item context is an authenticated raises CM.
 
-    #5603: do not match logo ``pytest`` / ``pytest.raises`` spellings.
-    Stay loud until a kit/bridge testing contract authenticates raises
-    without vendor identity. Structural bare ``raises(...)`` after a
-    non-logo import resolution is also deferred to that contract.
+    #5603: vendor-name logo compares are not construction evidence. Until an
+    explicit kit/bridge testing contract authenticates the raises context
+    manager, this is always False — rows stay loud FactoryPanic. Never
+    reintroduce vendor-name string matches here.
+    (#5612 + #5615: keep deleted.)
     """
     _ = site
     return False

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/pytest_skip_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/pytest_skip_sugar.py
@@ -30,9 +30,10 @@ class PytestSkipSugar(
 
     @classmethod
     def owns(cls, site) -> bool:
-        # #5603: logo string ``pytest.skip`` is not construction evidence.
-        # Stay unowned (loud) until an explicit kit/bridge testing contract
-        # authenticates skip as exceptional exit without vendor spelling.
+        # #5603: vendor-name logo is not construction evidence.
+        # Externally-loaded testing kit/bridge contract only — never a
+        # vendor-name compare. Rows stay loud FactoryPanic until that contract.
+        # (#5612 + #5615: keep deleted; do not reintroduce logo Compare.)
         _ = site
         return False
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_raise_protocol.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_raise_protocol.py
@@ -64,17 +64,15 @@ def test_guarded_raises_as_binding_is_not_definite_in_continuation() -> None:
     assert guarded.extend_scope(original) is original
 
 
-def test_symbolic_if_with_pytest_raises_constructs_guarded_fact() -> None:
-    block = compose_block(
-        "    if p:\n"
-        "        with pytest.raises(ValueError):\n"
-        "            raise ValueError()\n",
-        {"p": SymbolicValue(make_var("p"))},
-    )
-
-    formulas = block.inv_contribution()
-    assert formulas
-    assert all("implies" in repr(formula) for formula in formulas)
+def test_symbolic_if_with_pytest_raises_stays_loud_without_kit_contract() -> None:
+    """#5603: raises logo deleted — nested with-form is not constructed testimony."""
+    with pytest.raises(FactoryPanic):
+        compose_block(
+            "    if p:\n"
+            "        with pytest.raises(ValueError):\n"
+            "            raise ValueError()\n",
+            {"p": SymbolicValue(make_var("p"))},
+        )
 
 
 def test_unrepresentable_guard_context_stays_loud() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_pytest_raises_with_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pytest_raises_with_sugar.py
@@ -1,106 +1,56 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-"""RaiseSugar + PytestRaisesWithSugar — raises testimony floor."""
+"""#5603: PytestRaisesWithSugar logo path deleted — rows stay loud.
+
+Bucket (b): testing kit/bridge contract only. Raise statement construction is
+orthogonal and still owned; pytest.raises with-forms are not.
+"""
 
 from __future__ import annotations
 
+import ast
+
 import pytest
 
+from sugar_lift_py_tests.claim import SugarRole
+from sugar_lift_py_tests.context.factory_build_context import FactoryBuildContext
+from sugar_lift_py_tests.factory.build import build_node, default_catalog
 from sugar_lift_py_tests.factory.factory_gap import FactoryPanic
-from sugar_lift_py_tests.idd.lift_coverage_accounting import account_lift_coverage
-from sugar_lift_py_tests.idd.lift_coverage_census import census_source
-from sugar_lift_py_tests.lift_rpc import audit_lift_file, lift_file_payload
+from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+from sugar_lift_py_tests.sugar.pytest_raises_with_sugar import PytestRaisesWithSugar
 
 
-def _audit_rpc(source: str) -> dict:
-    payload, _gaps = audit_lift_file(source, "t.py", hold_panic=True)
-    with pytest.raises(FactoryPanic):
-        lift_file_payload(source, "t.py")
-    return payload.to_rpc()
-
-
-def test_raise_statement_not_unresolved() -> None:
-    src = (
+def test_raise_statement_still_constructs_without_pytest_logo() -> None:
+    """Plain raise is language-level; not gated on testing-framework logos."""
+    source = (
         "def boom():\n"
         "    raise ValueError('x')\n"
-        "def test_b():\n"
-        "    assert True\n"
     )
-    rpc = _audit_rpc(src)
-    reasons = " ".join(
-        str(r.get("reason") or "")
-        for r in ((rpc.get("factoryAuditSummary") or {}).get("unresolvedSites") or [])
+    raise_node = next(
+        node for node in ast.walk(ast.parse(source)) if isinstance(node, ast.Raise)
     )
-    assert "raise.raise_sugar" not in reasons
-    assert "observed=Raise" not in reasons, reasons
+    site = SourceFragment.from_node(raise_node, "t.py", source=source)
+    ctx = FactoryBuildContext(filename="t.py", catalog=default_catalog())
+    built = build_node(site, filename="t.py", role=SugarRole.STATEMENT, ctx=ctx)
+    assert built.audit_row.selected == "RaiseSugar"
 
 
-def test_pytest_raises_states_inv() -> None:
-    src = (
+def test_pytest_raises_with_stays_loud_without_kit_contract() -> None:
+    source = (
         "import pytest\n"
+        "def boom():\n"
+        "    raise ValueError('x')\n"
         "def test_r():\n"
         "    with pytest.raises(ValueError):\n"
         "        boom()\n"
-        "    assert 1 == 1\n"
-        "def boom():\n"
-        "    raise ValueError('x')\n"
     )
-    rpc = _audit_rpc(src)
-    fas = rpc.get("factoryAuditSummary") or {}
-    reasons = " ".join(
-        str(r.get("reason") or "") for r in (fas.get("unresolvedSites") or [])
+    with_node = next(
+        node for node in ast.walk(ast.parse(source)) if isinstance(node, ast.With)
     )
-    assert "observed=Raise" not in reasons, reasons
-    # testimony should include pytest.raises inv and the assert
-    ir = rpc.get("ir") or []
-    names = [i.get("name") for i in ir]
-    assert any(n and "assertion" in str(n) for n in names) or any(
-        "pytest.raises" in str(i) for i in ir
-    ), (names, ir[:3])
-    ax = account_lift_coverage(census_source(src, file="t.py"), rpc).to_json()[
-        "assertions"
-    ]
-    assert ax["silently_unaccounted"] == 0
-    # ground assert may lift or refuse; raises path must not silent
-    assert ax["lifted_cited"] + ax["refused_loud"] == ax["stated"]
-
-
-def test_pytest_raises_as_exc_info_binds() -> None:
-    src = (
-        "import pytest\n"
-        "def boom():\n"
-        "    raise ValueError('missing key')\n"
-        "def test_r():\n"
-        "    with pytest.raises(ValueError) as exc_info:\n"
-        "        boom()\n"
-        "    assert 'missing' in str(exc_info.value)\n"
-    )
-    rpc = _audit_rpc(src)
-    reasons = " ".join(
-        str(r.get("reason") or "")
-        for r in ((rpc.get("factoryAuditSummary") or {}).get("unresolvedSites") or [])
-    )
-    assert "bind `exc_info`" not in reasons, reasons
-    ax = account_lift_coverage(census_source(src, file="t.py"), rpc).to_json()[
-        "assertions"
-    ]
-    assert ax["silently_unaccounted"] == 0
-    assert ax["stated"] == 1
-
-
-def test_raises_message_in_str_lifts() -> None:
-    src = (
-        "import pytest\n"
-        "def boom():\n"
-        "    raise ValueError('missing key')\n"
-        "def test_r():\n"
-        "    with pytest.raises(ValueError) as exc_info:\n"
-        "        boom()\n"
-        "    assert 'missing' in str(exc_info.value)\n"
-    )
-    rpc = _audit_rpc(src)
-    ax = account_lift_coverage(census_source(src, file="t.py"), rpc).to_json()[
-        "assertions"
-    ]
-    assert ax["stated"] == 1
-    assert ax["silently_unaccounted"] == 0
-    assert ax["lifted_cited"] == 1, ax
+    site = SourceFragment.from_node(with_node, "t.py", source=source)
+    assert PytestRaisesWithSugar.owns(site) is False
+    ctx = FactoryBuildContext(filename="t.py", catalog=default_catalog())
+    try:
+        built = build_node(site, filename="t.py", role=SugarRole.STATEMENT, ctx=ctx)
+        assert built.audit_row.selected != "PytestRaisesWithSugar"
+    except FactoryPanic as raised:
+        assert raised.info.observed in {"With", "Call", "pytest"}

--- a/implementations/python/sugar-lift-py-tests/tests/test_pytest_sugar_logo_deletion.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pytest_sugar_logo_deletion.py
@@ -1,0 +1,196 @@
+"""#5603: pytest fail/skip/raises logo owns-paths are DELETED.
+
+Bucket (b): externally-loaded testing kit/bridge contract — not hard-coded
+vendor spelling. Deletion-verification mirrors the SQLAlchemy #5613 pattern:
+prove the logo compare is gone; authentic-looking forms stay loud.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+
+from sugar_lift_py_tests.claim import SugarRole
+from sugar_lift_py_tests.context.factory_build_context import FactoryBuildContext
+from sugar_lift_py_tests.factory.build import build_node, default_catalog
+from sugar_lift_py_tests.factory.factory_gap import FactoryPanic
+from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+from sugar_lift_py_tests.sugar.pytest_fail_sugar import PytestFailSugar
+from sugar_lift_py_tests.sugar.pytest_raises_with_sugar import (
+    PytestRaisesWithSugar,
+    _is_raises_context,
+)
+from sugar_lift_py_tests.sugar.pytest_skip_sugar import PytestSkipSugar
+
+
+def _call_site(source: str, leaf: str) -> SourceFragment:
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and (
+            (isinstance(node.func, ast.Attribute) and node.func.attr == leaf)
+            or (isinstance(node.func, ast.Name) and node.func.id == leaf)
+        )
+    )
+    return SourceFragment.from_node(call, f"{leaf}_call.py", source=source)
+
+
+def _with_site(source: str) -> SourceFragment:
+    with_node = next(
+        node for node in ast.walk(ast.parse(source)) if isinstance(node, ast.With)
+    )
+    return SourceFragment.from_node(with_node, "raises_with.py", source=source)
+
+
+def test_pytest_fail_logo_owns_is_deleted() -> None:
+    """Deletion-verification: owns never authenticates via ``pytest.fail`` spelling."""
+    source = (
+        "import pytest\n"
+        "\n"
+        "def test_it():\n"
+        "    pytest.fail('nope')\n"
+    )
+    site = _call_site(source, "fail")
+    assert PytestFailSugar.owns(site) is False
+    # Source of owns must not reintroduce a Compare against a vendor spelling.
+    owns_src = inspect.getsource(PytestFailSugar.owns)
+    assert "call_qualified_target_name" not in owns_src
+    assert "==" not in owns_src
+
+
+def test_pytest_skip_logo_owns_is_deleted() -> None:
+    source = (
+        "import pytest\n"
+        "\n"
+        "def test_it():\n"
+        "    pytest.skip('nope')\n"
+    )
+    site = _call_site(source, "skip")
+    assert PytestSkipSugar.owns(site) is False
+    owns_src = inspect.getsource(PytestSkipSugar.owns)
+    assert "call_qualified_target_name" not in owns_src
+    assert "==" not in owns_src
+
+
+def test_pytest_raises_logo_context_is_deleted() -> None:
+    source = (
+        "import pytest\n"
+        "\n"
+        "def test_it():\n"
+        "    with pytest.raises(ValueError):\n"
+        "        raise ValueError('x')\n"
+    )
+    with_site = _with_site(source)
+    assert PytestRaisesWithSugar.owns(with_site) is False
+    ctx = with_site.with_context_expr(0)
+    assert _is_raises_context(ctx) is False
+    helper_src = inspect.getsource(_is_raises_context)
+    # No vendor-root spelling and no Compare on a name id in the body.
+    assert "pytest" not in helper_src
+    assert "name_id" not in helper_src
+    assert "==" not in helper_src
+
+
+@pytest.mark.parametrize(
+    ("source", "leaf", "owner"),
+    [
+        (
+            "import pytest\n\ndef test_it():\n    pytest.fail('x')\n",
+            "fail",
+            PytestFailSugar,
+        ),
+        (
+            "import pytest\n\ndef test_it():\n    pytest.skip('x')\n",
+            "skip",
+            PytestSkipSugar,
+        ),
+        (
+            "from pytest import fail\n\ndef test_it():\n    fail('x')\n",
+            "fail",
+            PytestFailSugar,
+        ),
+        (
+            "from pytest import skip\n\ndef test_it():\n    skip('x')\n",
+            "skip",
+            PytestSkipSugar,
+        ),
+    ],
+)
+def test_authentic_looking_fail_skip_stays_outside_logo_owner(
+    source: str, leaf: str, owner
+) -> None:
+    """Even import-looking forms must not select the logo-deleted Sugar."""
+    site = _call_site(source, leaf)
+    assert owner.owns(site) is False
+    ctx = FactoryBuildContext(filename=f"{leaf}_call.py", catalog=default_catalog())
+    built = build_node(site, filename=f"{leaf}_call.py", role=SugarRole.TERM, ctx=ctx)
+    assert built.audit_row.selected != owner.__name__
+
+
+def test_authentic_looking_pytest_raises_with_stays_loud() -> None:
+    source = (
+        "import pytest\n"
+        "\n"
+        "def test_it():\n"
+        "    with pytest.raises(ValueError):\n"
+        "        raise ValueError('x')\n"
+    )
+    site = _with_site(source)
+    assert PytestRaisesWithSugar.owns(site) is False
+    ctx = FactoryBuildContext(filename="raises_with.py", catalog=default_catalog())
+    # With may fall through to WithSugar or panic — never PytestRaisesWithSugar.
+    try:
+        built = build_node(
+            site, filename="raises_with.py", role=SugarRole.STATEMENT, ctx=ctx
+        )
+        assert built.audit_row.selected != "PytestRaisesWithSugar"
+    except FactoryPanic as raised:
+        assert raised.info.observed in {"With", "Call"}
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        # Lookalike: local name pytest, not the package
+        (
+            "class pytest:\n"
+            "    @staticmethod\n"
+            "    def fail(msg):\n"
+            "        raise RuntimeError(msg)\n"
+            "\n"
+            "def test_it():\n"
+            "    pytest.fail('x')\n"
+        ),
+        (
+            "def fail(msg):\n"
+            "    raise RuntimeError(msg)\n"
+            "\n"
+            "def test_it():\n"
+            "    fail('x')\n"
+        ),
+        (
+            "class pytest:\n"
+            "    @staticmethod\n"
+            "    def raises(exc):\n"
+            "        return nullcontext()\n"
+            "\n"
+            "def test_it():\n"
+            "    with pytest.raises(ValueError):\n"
+            "        pass\n"
+        ),
+    ],
+)
+def test_lookalike_fail_skip_raises_never_owned_by_logo_sugar(source: str) -> None:
+    """Lying twin: lookalikes must not authenticate even if logos returned."""
+    if "with " in source:
+        site = _with_site(source)
+        assert PytestRaisesWithSugar.owns(site) is False
+    elif "skip" in source:
+        site = _call_site(source, "skip")
+        assert PytestSkipSugar.owns(site) is False
+    else:
+        site = _call_site(source, "fail")
+        assert PytestFailSugar.owns(site) is False

--- a/implementations/python/sugar-lift-py-tests/tests/test_try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_try_sugar.py
@@ -209,32 +209,28 @@ def test_try_threads_binding_from_only_reduced_continuing_path() -> None:
     assert block.statements[-1].value == TermValue(5)
 
 
-def test_try_threads_body_binding_past_terminal_pytest_fail_handler() -> None:
-    block = compose_block(
-        "    try:\n"
-        "        result = 5\n"
-        "    except ValueError:\n"
-        "        pytest.fail('missing signature')\n"
-        "    return result\n"
-    )
-
-    assert isinstance(block, BlockValue)
-    assert isinstance(block.statements[-1], ReturnValue)
-    assert block.statements[-1].value == TermValue(5)
+def test_try_terminal_pytest_fail_handler_stays_loud_without_kit_contract() -> None:
+    """#5603: fail logo deleted — handler is not a constructed exceptional exit."""
+    with pytest.raises(FactoryPanic):
+        compose_block(
+            "    try:\n"
+            "        result = 5\n"
+            "    except ValueError:\n"
+            "        pytest.fail('missing signature')\n"
+            "    return result\n"
+        )
 
 
-def test_try_threads_body_binding_past_terminal_pytest_skip_handler() -> None:
-    block = compose_block(
-        "    try:\n"
-        "        result = 5\n"
-        "    except ValueError:\n"
-        "        pytest.skip('unsupported input')\n"
-        "    return result\n"
-    )
-
-    assert isinstance(block, BlockValue)
-    assert isinstance(block.statements[-1], ReturnValue)
-    assert block.statements[-1].value == TermValue(5)
+def test_try_terminal_pytest_skip_handler_stays_loud_without_kit_contract() -> None:
+    """#5603: skip logo deleted — handler is not a constructed exceptional exit."""
+    with pytest.raises(FactoryPanic):
+        compose_block(
+            "    try:\n"
+            "        result = 5\n"
+            "    except ValueError:\n"
+            "        pytest.skip('unsupported input')\n"
+            "    return result\n"
+        )
 
 
 def test_nonterminal_pytest_method_does_not_grant_body_binding() -> None:
@@ -247,9 +243,10 @@ def test_nonterminal_pytest_method_does_not_grant_body_binding() -> None:
             "    return result\n"
         )
 
-    assert raised.value.info.owner == "TemporalContext"
-    assert raised.value.info.observed == "result"
-    assert raised.value.info.requested == "value"
+    # Loud residual: either the unbound pytest name or the body binding past a
+    # non-terminal handler — never a silent success path.
+    assert raised.value.info.owner in {"TemporalContext", "python.factory"}
+    assert raised.value.info.observed in {"result", "pytest", "Call"}
 
 
 TRY_SUCCESS_SENTINEL = (


### PR DESCRIPTION
## Part of #5603 (pytest Sugar logo owns-path slice)

### Live R (extended auditor #5607, current main `d6e1ea670`)
| | R_vendor_special_case |
| --- | ---: |
| **Before** | **134** |
| **After** | **131** (Δ −3) |
| auditor_errors | 0 |

Claim posted on #5603 before work. Not colliding with:
- **427** / bulk numpy+scipy tables (PR #5612)
- **289** parametrize protocol
- SQLAlchemy (#5613 done)

### Adjudication
| Coordinate | Bucket | Verdict |
| --- | --- | --- |
| `call_qualified_target_name() == "pytest.fail"` | **(b)** | **DELETE** — testing kit/bridge only |
| `call_qualified_target_name() == "pytest.skip"` | **(b)** | **DELETE** |
| `recv.name_id() == "pytest"` (raises with-context) | **(b)** | **DELETE** |

**(a)** does not apply. Classes remain registered for a future kit contract; `owns` is always False so logo spelling never constructs.

### Changes
- `PytestFailSugar.owns` / `PytestSkipSugar.owns` → always False (no logo Compare)
- `_is_raises_context` → always False (no vendor name match)
- Deletion-verification tests (`test_pytest_sugar_logo_deletion.py`)
- Residual tests expect loud try/raises paths

### Hard law
- Loud residual is correct; no drain counted on these logos
- Auditor not narrowed
- Do **not** self-merge — soundness-read only

### Validation
```text
pytest --noconftest test_pytest_sugar_logo_deletion + related residual → 17 passed
vendor_special_case_law.py → R=131; three pytest sugar files scan clean
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Delete vendor-name logo ownership checks from pytest fail/skip/raises sugar
> - Removes any vendor-name or equality-based logo comparisons from `PytestFailSugar.owns`, `PytestSkipSugar.owns`, and the `_is_raises_context` helper; all three now unconditionally return `False` until an external kit/bridge contract exists.
> - Updates tests in [`test_pytest_raises_with_sugar.py`](https://github.com/TSavo/sugar/pull/5615/files#diff-e1e014db629e08b23b1ff53d1c60b02fde9276bc99da2c5e5b43ffb79ed93799), [`test_try_sugar.py`](https://github.com/TSavo/sugar/pull/5615/files#diff-003511e53cd42e6d957096ad77405a3cd4d44dec2f466b34a0b02a71c270d262), and [`test_guarded_raise_protocol.py`](https://github.com/TSavo/sugar/pull/5615/files#diff-3bb3df56311594269100e3b74f061e4b43266293c5d45dd7531848194308cd51) to expect `FactoryPanic` instead of successful construction when pytest-specific AST nodes are encountered.
> - Adds a new test file [`test_pytest_sugar_logo_deletion.py`](https://github.com/TSavo/sugar/pull/5615/files#diff-521c2ee50ad10b978607029a0328a1115a4f86905b9c7dcbcb74562deb945945) that directly asserts `owns` returns `False`, that source code contains no vendor-name comparisons, and that lookalike call sites are never selected by the logo-deleted sugars.
> - Behavioral Change: `with pytest.raises` contexts and `pytest.fail`/`pytest.skip` call sites that previously may have been recognized now always go unowned, causing `FactoryPanic` instead of producing implication formulas.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6e5623.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->