### PR TITLE
Authenticate numpy callee families (batch)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -80,6 +80,8 @@ class CalleeUniverseSupport(Enum):
     NUMPY_SFLOAT_DTYPE = auto()
     NUMPY_MARKINNERSPACES = auto()
     NUMPY_IDENTITY_HASH_SET_ITEM_DEFAULT = auto()
+    # stdlib import identity (#5561) — language protocol, not a vendor logo.
+    TEXTWRAP_DEDENT = auto()
 
 
 # Empty: numpy dtype-result coordinates are external kit contracts (#5603).
@@ -108,6 +110,12 @@ _IMPORTED_SUPPORT = {
     "checks.test_get_multi_index_iter_next": CalleeUniverseSupport.NUMPY_CHECKS,
     # Structural F2Py extension token — no vendor package root in the spelling.
     "f2py.generated_extension": CalleeUniverseSupport.NUMPY_F2PY_EXTENSION,
+    # stdlib (#5561). Corpus also appears under numpy tests; the warrant is the
+    # language import identity, never a vendor module prefix.
+    "textwrap.dedent": CalleeUniverseSupport.TEXTWRAP_DEDENT,
+    # Vendor-root coordinates (numpy/scipy/SF factory logos) deleted (#5603).
+    # External kit/bridge only — including call:SF / call:to_device when they
+    # land via contract, not hard-coded production logos.
 }
 
 # Language / builtin coordinates only (#5603 adjudication).

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -42,6 +42,9 @@ _AUTHENTICATED_COORDINATES = frozenset(
         # Non-vendor-root corpus checks leaf + structural F2Py token.
         "checks.test_get_multi_index_iter_next",
         "f2py.generated_extension",
+        "textwrap.dedent",
+        # No vendor-root module paths (#5603 drain). call:to_device stays loud
+        # until an external kit/bridge contract — do not re-add numpy.* logos.
     }
 )
 
@@ -168,6 +171,12 @@ class BuiltinCalleeUniverseSugar(
             _coordinate_witness("list", "[]", "[0]"),
             _coordinate_witness("set", "[]", "[0]"),
             _coordinate_witness("hasattr", "True", "False"),
+            # #5555 / #5564 — multi-hop self.module.<leaf> bound-source twins
+            # (already recognized via BOUND_SOURCE; twins pin discrimination).
+            _bound_module_member_witness("type_subroutine"),
+            _bound_module_member_witness("simple_subroutine"),
+            # #5561 — stdlib import identity.
+            _textwrap_dedent_witness(),
             _checks_test_get_multi_index_iter_next_witness(),
             _compare_dtypes_local_source_witness(),
             _f2py_sum_and_double_witness(),
@@ -926,6 +935,49 @@ def _numpy_sfloat_dtype_witness():
     )
     return _call_pair(
         name="numpy_sfloat_dtype_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
+        lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _bound_module_member_witness(member: str):
+    """Truthful/lying twin for multi-hop ``self.module.<member>`` bound-source."""
+
+    call = f"self.module.{member}(1)"
+    prefix = (
+        "class _Mod:\n"
+        "    @staticmethod\n"
+        f"    def {member}(*args):\n"
+        "        return args\n"
+        "\n"
+        "class Host:\n"
+        "    module = _Mod\n"
+        "\n"
+        "    def test_a(self):\n"
+    )
+    return _call_pair(
+        name=f"{member.replace('_', '-')}_universe_coordinate",
+        owner_sugar="BuiltinCalleeUniverseSugar",
+        truthful=prefix + f"        assert {call} == {call} and {call} == {call}\n",
+        lying=prefix + f"        assert {call} == {call} and {call} != {call}\n",
+        family="builtin-universe-coordinate",
+    )
+
+
+def _textwrap_dedent_witness():
+    """stdlib import identity — language protocol only (#5561)."""
+
+    prefix = (
+        "import textwrap\n"
+        "\n"
+        "def A():\n"
+        "    return textwrap.dedent('x')\n"
+        "\n"
+    )
+    return _call_pair(
+        name="textwrap_dedent_universe_coordinate",
         owner_sugar="BuiltinCalleeUniverseSugar",
         truthful=prefix + "def test_a():\n    assert A() == A() and A() == A()\n",
         lying=prefix + "def test_a():\n    assert A() == A() and A() != A()\n",

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
@@ -2349,3 +2349,167 @@ def test_sfloat_witness_pair_is_enrolled() -> None:
     names = {pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()}
     assert "numpy_sfloat_dtype_universe_coordinate" in names
     assert "operator_comp_parametrize_universe_coordinate" not in names
+
+
+def test_authenticated_textwrap_dedent_selects_one_factory_owner() -> None:
+    source = (
+        "import textwrap\n"
+        "\n"
+        "def test_dedent(payload):\n"
+        "    assert textwrap.dedent(payload) == textwrap.dedent(payload)\n"
+    )
+    built = build_node(
+        _stdlib_attr_call_site(source, "dedent", "textwrap_dedent.py"),
+        filename="textwrap_dedent.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(
+            filename="textwrap_dedent.py",
+            catalog=default_catalog(),
+        ),
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        (
+            "import textwrap\n"
+            "\n"
+            "def test_dedent(textwrap, payload):\n"
+            "    assert textwrap.dedent(payload) == textwrap.dedent(payload)\n"
+        ),
+        (
+            "import math as textwrap\n"
+            "\n"
+            "def test_dedent(payload):\n"
+            "    assert textwrap.dedent(payload) == textwrap.dedent(payload)\n"
+        ),
+        (
+            "def test_dedent(payload):\n"
+            "    assert textwrap.dedent(payload) == textwrap.dedent(payload)\n"
+        ),
+    ],
+)
+def test_unwarranted_textwrap_dedent_receiver_is_not_factory_owned(source: str) -> None:
+    built = build_node(
+        _stdlib_attr_call_site(source, "dedent", "textwrap_dedent.py"),
+        filename="textwrap_dedent.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(
+            filename="textwrap_dedent.py",
+            catalog=default_catalog(),
+        ),
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_constructor_bound_to_device_stays_loud_without_vendor_table() -> None:
+    """#5563 constructor form would need numpy.int64.to_device in production tables.
+
+    Post-#5612, vendor-root coordinates are illegal logo tables. call:to_device
+    stays loud until an external kit/bridge contract — not a re-added logo.
+    """
+
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_to_device():\n"
+        "    scalar = np.int64(1)\n"
+        "    assert scalar.to_device('cpu') is scalar\n"
+    )
+    built = build_node(
+        _method_call_site(source, "to_device"),
+        filename="to_device.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="to_device.py", catalog=default_catalog()),
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_parametrized_to_device_stays_loud_without_logo_match() -> None:
+    """Corpus form injects the receiver via decorator parameters.
+
+    No structural decorator provenance without a vendor-literal match on
+    pytest.mark.parametrize (ruled illegal; window 289 owns the real contract).
+    The row stays loud — that is the correct outcome.
+    """
+
+    source = (
+        "import pytest\n"
+        "import numpy as np\n"
+        "\n"
+        "class TestDevice:\n"
+        "    scalars = [np.int64(1), np.float64(1.0)]\n"
+        "\n"
+        "    @pytest.mark.parametrize('scalar', scalars)\n"
+        "    def test_to_device(self, scalar):\n"
+        "        assert scalar.to_device('cpu') is scalar\n"
+    )
+    filename = "numpy/_core/tests/test_scalar_methods.py"
+    built = build_node(
+        _method_call_site(source, "to_device"),
+        filename=filename,
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename=filename, catalog=default_catalog()),
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+@pytest.mark.parametrize("member", ["type_subroutine", "simple_subroutine"])
+def test_bound_f2py_module_member_selects_one_factory_owner(member: str) -> None:
+    source = (
+        "from . import util\n"
+        "\n"
+        "class TestExtension(util.F2PyTest):\n"
+        "    sources = ['x.f']\n"
+        "\n"
+        "    def test_member(self):\n"
+        f"        assert self.module.{member}(0) == 0\n"
+    )
+    filename = "numpy/f2py/tests/test_regression.py"
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == member
+    )
+    site = SourceFragment.from_node(call, filename, source=source)
+    built = build_node(
+        site,
+        filename=filename,
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename=filename, catalog=default_catalog()),
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    assert (
+        recognize_callee_universe(f"call:{member}", site=site)
+        is CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
+    )
+
+
+@pytest.mark.parametrize("member", ["type_subroutine", "simple_subroutine"])
+def test_unwarranted_f2py_module_member_is_not_factory_owned(member: str) -> None:
+    source = (
+        "def test_member(module):\n"
+        f"    assert module.{member}(0) == 0\n"
+    )
+    built = build_node(
+        _method_call_site(source, member),
+        filename="x.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="x.py", catalog=default_catalog()),
+    )
+    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+
+def test_batch_5564_family_witness_pairs_are_enrolled() -> None:
+    names = {pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()}
+    assert {
+        "textwrap_dedent_universe_coordinate",
+        "type-subroutine_universe_coordinate",
+        "simple-subroutine_universe_coordinate",
+    } <= names
+    # Must not reintroduce a logo-table to_device twin after #5612.
+    assert "numpy_to_device_universe_coordinate" not in names


### PR DESCRIPTION
Part of #5564, #5563, #5561, #5555

Successor to closed/conflicting #5602. Finished the same way as #5608 after the
**#5612 logo-table drain** (R 132→0; production tables language/stdlib only).

## Bounce fix

**No** `pytest` / `pytest.mark.parametrize` logo-string path. Window 289 owns
the real parametrize contract — this PR does not reimplement it.

## Outcomes after #5612 (language/stdlib tables only)

| family | issue | outcome |
| --- | --- | --- |
| `call:textwrap.dedent` | #5561 | **Drained** — stdlib import identity |
| `call:type_subroutine` | #5564 | **Pinned** — multi-hop `self.module` BOUND_SOURCE + twins |
| `call:simple_subroutine` | #5555 | **Pinned** — same BOUND_SOURCE + twins |
| `call:to_device` | #5563 | **Stays loud** — both constructor-bound and parametrize forms |

### Why to_device stays loud

Constructor form (`scalar = np.int64(1); scalar.to_device(...)`) would need
`numpy.int64.to_device` (etc.) hard-coded in production `_IMPORTED_SUPPORT` /
`_AUTHENTICATED_COORDINATES`. Post-#5612 that is an **illegal logo table** —
same class as the pytest-literal bounce. External kit/bridge contract only.
Parametrize-injected receivers stay loud for the same reason plus #5603/289.

Instruments:
- `test_constructor_bound_to_device_stays_loud_without_vendor_table`
- `test_parametrized_to_device_stays_loud_without_logo_match`

## Rebase / union

- Onto current `main` (post-#5608 / #5612 / #5613)
- Did **not** re-add stripped numpy/scipy logos from the #5612 drain
- Did **not** resurrect sqlalchemy fixture key or ORM registry/as_declarative
- Only added stdlib `textwrap.dedent` to language tables

## Floors (before push)

| instrument | result |
| --- | --- |
| pytest logo Compare in recognition | **absent** |
| `R_ownership` | **0** |
| `R_vendor_special_case` | **0** |

## Validation

12 focused discrimination + witness twins green.

Do not self-merge — soundness-read merge when ready.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate numpy callee families for `textwrap.dedent` and bound f2py module members
> - Adds `TEXTWRAP_DEDENT` to the `CalleeUniverseSupport` enum and maps `textwrap.dedent` as an authenticated import identity in [`callee_universe.py`](https://github.com/TSavo/sugar/pull/5616/files#diff-72e9f915afa350390348a1c277d0c2047b26a0182bb4780c57baf73f30fdcaa8).
> - Extends `BuiltinCalleeUniverseSugar` with two new witness helpers: `_textwrap_dedent_witness` for stdlib `textwrap.dedent` calls and `_bound_module_member_witness` for `self.module.<member>(...)` calls (`type_subroutine`, `simple_subroutine`).
> - Adds tests covering authenticated and unwarranted cases for `textwrap.dedent`, bound f2py module members, and vendor-root prohibition (e.g. numpy `to_device` stays unowned without a vendor logo table).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11a4288.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->