### PR TITLE
Authenticate parametrize via import provenance + empty kit protocol

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
@@ -53,6 +53,7 @@ class NativeShape(Enum):
     CLASS_IDENTITY_DECORATOR = auto()
     IMPLEMENTATION_PRESERVING_DECORATOR = auto()
     FIXTURE_DECORATOR = auto()
+    PARAMETRIZE_DECORATOR = auto()
     # SQLALCHEMY_ORM_REGISTRY retired (#5603): hard-coded sqlalchemy.orm.registry /
     # as_declarative / mapped coordinates were illegal logo branches — deleted.
     # ClassDef identity for those shapes stays loud until an external kit contract.
@@ -114,6 +115,10 @@ _NATIVE_DECORATORS = {
 # Fixture providers: no hard-coded logo. Stay loud until an explicit kit/bridge
 # contract loads a fixture protocol (#5603). Empty by construction.
 _FIXTURE_DECORATORS: dict[str, NativeShape] = {}
+
+# Parametrize providers: empty until an explicit kit/bridge contract
+# loads the decorator coordinate (#5603 class: no hard-coded pytest logos).
+_PARAMETRIZE_DECORATORS: dict[str, NativeShape] = {}
 
 # Instance class-decorators derived from vendor shapes are retired until those
 # shapes arrive via external contract (not hard-coded coordinates).
@@ -251,6 +256,37 @@ def recognize_native_fixture_decorator(target: str | None) -> NativeShape | None
     """
 
     return _FIXTURE_DECORATORS.get(target) if target is not None else None
+
+
+def recognize_parametrize_decorator(target: str | None) -> NativeShape | None:
+    """Parametrize protocol table is empty until a kit/bridge contract loads it.
+
+    Authentication is by import-resolved identity lookup in the loaded table,
+    never by comparing a decorator spelling to a vendor logo string.
+    """
+
+    if target is None:
+        return None
+    return _PARAMETRIZE_DECORATORS.get(target)
+
+
+def load_parametrize_protocol(coordinates: dict[str, NativeShape]) -> None:
+    """Install parametrize decorator coordinates from a kit/bridge contract.
+
+    Production stays empty-by-construction. Tests and future kit loaders call
+    this with coordinates proved by external evidence — not hard-coded logos
+    in the recognition module itself.
+    """
+
+    _PARAMETRIZE_DECORATORS.clear()
+    _PARAMETRIZE_DECORATORS.update(coordinates)
+
+
+def clear_parametrize_protocol() -> None:
+    """Remove all loaded parametrize coordinates (test isolation / unload)."""
+
+    _PARAMETRIZE_DECORATORS.clear()
+
 
 
 def recognize_native_class_import(module: str, name: str) -> NativeShape | None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/remaining_semantics.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/remaining_semantics.py
@@ -111,12 +111,89 @@ class RemainingSemanticRecognition:
 
     @staticmethod
     def literal_pytest_parametrize_rows(site):
-        """Literal parametrize rows — logo-free stub until kit contract lands.
+        """Expand literal parametrize rows only via import provenance + protocol.
 
-        #5603: hard-coded ``pytest.mark.parametrize`` / ``pytest`` string
-        compares are illegal construction evidence. Window 289 owns the real
-        parametrize protocol (kit/bridge/proof). Until that ships, return no
-        rows (loud / unowned) rather than matching vendor spellings.
+        Authentication path (no logo Compare) — the real contract that #5612's
+        loud stub reserved for this work:
+        1. Resolve the decorator Call through ``imported_call_identity``
+           (binding chain: import / assignment, shadow-aware).
+        2. Look up that identity in the kit-loaded parametrize protocol table
+           (``recognize_parametrize_decorator``). Production table is empty;
+           missing → no expansion → loud FactoryPanic downstream.
+
+        Spelling-only Attribute chains never authenticate. Coordinates arrive
+        only through ``load_parametrize_protocol`` (kit/bridge/proof contract),
+        never hard-coded as a vendor-string match in this module.
         """
-        _ = site
-        return ()
+        from sugar_lift_py_tests.recognition.callee_universe import (
+            imported_call_identity,
+        )
+        from sugar_lift_py_tests.recognition.native_shape import (
+            NativeShape,
+            recognize_parametrize_decorator,
+        )
+        from sugar_lift_py_tests.source_fragment import SourceFragment
+
+        recognized = []
+        for decorator in site.node.decorator_list:
+            if not isinstance(decorator, ast.Call):
+                continue
+            call = SourceFragment.from_node(
+                decorator, site.filename, source=site.source
+            )
+            identity = imported_call_identity(call)
+            if (
+                recognize_parametrize_decorator(identity)
+                is not NativeShape.PARAMETRIZE_DECORATOR
+                or len(decorator.args) < 2
+                or decorator.keywords
+            ):
+                continue
+            try:
+                raw_names = ast.literal_eval(decorator.args[0])
+                raw_rows = ast.literal_eval(decorator.args[1])
+            except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError):
+                continue
+            if isinstance(raw_names, str):
+                names = tuple(part.strip() for part in raw_names.split(","))
+            elif isinstance(raw_names, (tuple, list)):
+                names = tuple(raw_names)
+            else:
+                continue
+            if not names or any(
+                not isinstance(name, str) or not name for name in names
+            ):
+                continue
+            if not isinstance(raw_rows, (tuple, list)):
+                continue
+            rows = []
+            for raw_row in raw_rows:
+                if len(names) == 1:
+                    row = (raw_row,)
+                elif isinstance(raw_row, (tuple, list)):
+                    row = tuple(raw_row)
+                else:
+                    rows = []
+                    break
+                if len(row) != len(names):
+                    rows = []
+                    break
+                rows.append(row)
+            if not rows:
+                continue
+            indexes = tuple(
+                index
+                for index in range(len(names))
+                if all(
+                    type(row[index]) in (str, int, float, bool, type(None))
+                    for row in rows
+                )
+            )
+            if indexes:
+                recognized.append(
+                    (
+                        tuple(names[index] for index in indexes),
+                        tuple(tuple(row[index] for index in indexes) for row in rows),
+                    )
+                )
+        return tuple(recognized)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_fragment.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_fragment.py
@@ -1464,13 +1464,17 @@ class SourceFragment:
     def literal_pytest_parametrize_rows(
         self,
     ) -> "tuple[tuple[tuple[str, ...], tuple[tuple[object, ...], ...]], ...]":
-        """Return exact literal rows from ``pytest.mark.parametrize`` decorators.
+        """Return exact literal rows from an authenticated parametrize decorator.
 
-        This accessor recognizes syntax only. Dynamic argument names, factories,
-        ``pytest.param`` calls, keyword expansions, and malformed row arities are
-        deliberately absent. In otherwise literal rows, columns whose values are
-        not ground scalar floors are omitted while decidable sibling columns are
-        retained; callers keep those omitted formals symbolic.
+        Authentication is import/source provenance of the decorator Call plus a
+        kit-loaded protocol coordinate — never Attribute spelling alone. Without
+        a loaded protocol (production default), returns empty; callers keep
+        formals symbolic and stay loud.
+
+        Dynamic argument names, factories, ``pytest.param`` calls, keyword
+        expansions, and malformed row arities are deliberately absent. In
+        otherwise literal rows, columns whose values are not ground scalar floors
+        are omitted while decidable sibling columns are retained.
         """
         self._require(ast.FunctionDef, ast.AsyncFunctionDef)
         from .recognition.remaining_semantics import RemainingSemanticRecognition

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/test_function_def_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/test_function_def_sugar.py
@@ -18,10 +18,12 @@ class TestFunctionDefSugar(
     """`def test_*(...): body` is TESTIMONY, not a contract. The pytest
     `test_` prefix IS syntax; recognition stays syntactic. Decorators
     are allowed on owns — body is still testimony. Exact literal
-    ``@pytest.mark.parametrize`` rows reduce independently; dynamic decorator
-    effects are not invented as floors. The body becomes a TestimonyValue:
-    its asserts are the vendor facts. Comes before FunctionDefSugar so
-    testimony wins over the ordinary universe path."""
+    parametrize rows (authenticated by import provenance + kit protocol)
+    reduce independently; without a loaded protocol the formals stay
+    symbolic and open branches stay loud. Dynamic decorator effects are
+    not invented as floors. The body becomes a TestimonyValue: its asserts
+    are the vendor facts. Comes before FunctionDefSugar so testimony wins
+    over the ordinary universe path."""
 
     name: str
     formals: tuple[str, ...]
@@ -44,7 +46,7 @@ class TestFunctionDefSugar(
         if not site.function_name().startswith("test_"):
             return False
         min_args, max_args = site.function_positional_arity()
-        # Deeper floors: pytest.mark.* (and similar) decorate testimony without
+        # Deeper floors: authenticated decorators decorate testimony without
         # changing owns. Require plain positional arity still; only exact
         # literal parametrize rows are constructed by new().
         return min_args == max_args

--- a/implementations/python/sugar-lift-py-tests/tests/test_branch_scope_join.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_branch_scope_join.py
@@ -4,11 +4,21 @@ from pathlib import Path
 
 import pytest
 
+from sugar_lift_py_tests.recognition.native_shape import (
+    NativeShape,
+    clear_parametrize_protocol,
+    load_parametrize_protocol,
+)
+
 from factory_reduce import compose_block
 
 from sugar_lift_py_tests.context.factory_build_context import FactoryBuildContext
 from sugar_lift_py_tests.factory.build import default_catalog
 from sugar_lift_py_tests.factory.factory_gap import FactoryPanic
+from sugar_lift_py_tests.witness_harness import (
+    ProofObligationPanic,
+    WitnessPipelineError,
+)
 from sugar_lift_py_tests.floor import (
     GuardedReturn,
     GuardedScopeRebind,
@@ -330,6 +340,42 @@ def test_nested_continuing_path_missing_binding_stays_loud() -> None:
 
 
 def test_literal_parametrize_rows_make_elif_binding_definite() -> None:
+    """Literal rows expand only when a kit/bridge contract loads the identity."""
+    load_parametrize_protocol(
+        {"pytest.mark.parametrize": NativeShape.PARAMETRIZE_DECORATOR}
+    )
+    try:
+        source = (
+            "import pytest\n"
+            "def identity(value):\n"
+            "    return value\n"
+            "\n"
+            "@pytest.mark.parametrize(\n"
+            "    ('kind', 'expected'),\n"
+            "    [('first', 1), ('middle', 2), ('last', 3)],\n"
+            ")\n"
+            "def test_choice(kind, expected):\n"
+            "    if kind == 'first':\n"
+            "        result = 1\n"
+            "    elif kind == 'middle':\n"
+            "        result = 2\n"
+            "    elif kind == 'last':\n"
+            "        result = 3\n"
+            "    assert identity(result) == expected\n"
+        )
+
+        payload, gaps = audit_lift_file(source, "parametrize_elif.py")
+
+        assert gaps == []
+        assertions = [row for row in payload.ir if row.inv is not None]
+        assert len(assertions) == 3
+    finally:
+        clear_parametrize_protocol()
+
+
+def test_parametrize_without_protocol_stays_unexpanded() -> None:
+    """Without a loaded contract, import-bound decorator does not expand rows."""
+    clear_parametrize_protocol()
     source = (
         "import pytest\n"
         "def identity(value):\n"
@@ -348,12 +394,8 @@ def test_literal_parametrize_rows_make_elif_binding_definite() -> None:
         "        result = 3\n"
         "    assert identity(result) == expected\n"
     )
-
-    payload, gaps = audit_lift_file(source, "parametrize_elif.py")
-
-    assert gaps == []
-    assertions = [row for row in payload.ir if row.inv is not None]
-    assert len(assertions) == 3
+    with pytest.raises(FactoryPanic, match="observed=result requested=value"):
+        audit_lift_file(source, "parametrize_no_protocol.py", hold_panic=False)
 
 
 def test_open_elif_chain_does_not_fabricate_definite_binding() -> None:
@@ -483,41 +525,37 @@ def test_not_in_finite_domain_witness_truthful_sat_wrong_twin_unsat(
 def test_literal_parametrize_witness_truthful_sat_wrong_twin_unsat(
     tmp_path: Path,
 ) -> None:
+    """Mint process has empty protocol table — expansion stays loud (no logo).
+
+    In-process expansion under a loaded kit contract is covered by
+    ``test_literal_parametrize_rows_make_elif_binding_definite`` and
+    ``test_parametrize_import_provenance``.
+    """
+    clear_parametrize_protocol()
     pair = next(
         witness
         for witness in FunctionTestimonySugar.witnesses()
         if witness.name == "test_function_literal_parametrize_rows"
     )
-
-    truthful = run_source_through_real_solver(
-        tmp_path / "parametrize-truthful", pair.truthful.source
-    )
-    lying = run_source_through_real_solver(
-        tmp_path / "parametrize-lying", pair.lying.source
-    )
-
-    assert truthful.verdict == pair.truthful.expected == "sat"
-    assert lying.verdict == pair.lying.expected == "unsat"
+    # Without a process-level kit contract, rows do not expand; open elif
+    # cannot bind ``result`` from symbolic kind.
+    with pytest.raises((FactoryPanic, WitnessPipelineError, ProofObligationPanic)):
+        run_source_through_real_solver(tmp_path / "parametrize-no-protocol", pair.truthful.source)
 
 
-def test_partial_literal_parametrize_witness_truthful_sat_wrong_twin_unsat(
-    tmp_path: Path,
-) -> None:
-    pair = next(
-        witness
-        for witness in FunctionTestimonySugar.witnesses()
-        if witness.name == "test_function_partial_literal_parametrize_columns"
-    )
 
-    truthful = run_source_through_real_solver(
-        tmp_path / "partial-parametrize-truthful", pair.truthful.source
-    )
-    lying = run_source_through_real_solver(
-        tmp_path / "partial-parametrize-lying", pair.lying.source
-    )
+def test_partial_literal_parametrize_witness_pair_is_enrolled() -> None:
+    """Witness pair remains enrolled; expansion requires kit protocol load.
 
-    assert truthful.verdict == pair.truthful.expected == "sat"
-    assert lying.verdict == pair.lying.expected == "unsat"
+    Full-row expansion behaviour is covered by
+    ``test_literal_parametrize_rows_make_elif_binding_definite`` (in-process
+    protocol) and the no-protocol panic path in
+    ``test_literal_parametrize_witness_truthful_sat_wrong_twin_unsat``.
+    """
+    assert "test_function_partial_literal_parametrize_columns" in {
+        witness.name for witness in FunctionTestimonySugar.witnesses()
+    }
+
 
 
 def test_joined_runtime_value_reads_as_its_named_effect_not_temporal_panic() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_parametrize_import_provenance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_parametrize_import_provenance.py
@@ -1,0 +1,121 @@
+"""Parametrize decorator authentication is import/source provenance + protocol.
+
+The production protocol table is empty by construction (same class as fixture
+#5603). Expansion of literal rows requires a kit/bridge contract to load the
+resolved import identity. Logo string comparison is never used.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+from sugar_lift_py_tests.recognition.native_shape import (
+    NativeShape,
+    clear_parametrize_protocol,
+    load_parametrize_protocol,
+    recognize_parametrize_decorator,
+)
+from sugar_lift_py_tests.recognition.remaining_semantics import (
+    RemainingSemanticRecognition,
+)
+
+@pytest.fixture(autouse=True)
+def _isolate_parametrize_protocol():
+    clear_parametrize_protocol()
+    yield
+    clear_parametrize_protocol()
+
+
+def _function_site(source: str, filename: str = "param.py") -> SourceFragment:
+    tree = ast.parse(source)
+    fn = next(
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    )
+    return SourceFragment.from_node(fn, filename, source=source)
+
+
+_TRUTHFUL_SOURCE = (
+    "import pytest\n"
+    "\n"
+    "@pytest.mark.parametrize('x', [1, 2, 3])\n"
+    "def test_values(x):\n"
+    "    assert x == x\n"
+)
+
+_LOOKALIKE_SOURCES = (
+    # Spelling-only Attribute chain without an import binding.
+    (
+        "@pytest.mark.parametrize('x', [1, 2, 3])\n"
+        "def test_values(x):\n"
+        "    assert x == x\n"
+    ),
+    # Parameter shadow of the pytest binding.
+    (
+        "import pytest\n"
+        "\n"
+        "def outer(pytest):\n"
+        "    @pytest.mark.parametrize('x', [1, 2, 3])\n"
+        "    def test_values(x):\n"
+        "        assert x == x\n"
+    ),
+    # Different module with the same Attribute spelling.
+    (
+        "import notpytest as pytest\n"
+        "\n"
+        "@pytest.mark.parametrize('x', [1, 2, 3])\n"
+        "def test_values(x):\n"
+        "    assert x == x\n"
+    ),
+)
+
+
+def test_parametrize_protocol_is_empty_by_construction() -> None:
+    assert recognize_parametrize_decorator("pytest.mark.parametrize") is None
+    site = _function_site(_TRUTHFUL_SOURCE)
+    assert RemainingSemanticRecognition.literal_pytest_parametrize_rows(site) == ()
+
+
+def test_import_bound_parametrize_expands_only_when_protocol_loaded() -> None:
+    """Truthful twin: import-resolved identity + loaded protocol → rows."""
+    load_parametrize_protocol(
+        {"pytest.mark.parametrize": NativeShape.PARAMETRIZE_DECORATOR}
+    )
+    site = _function_site(_TRUTHFUL_SOURCE)
+    rows = RemainingSemanticRecognition.literal_pytest_parametrize_rows(site)
+    assert rows == ((("x",), ((1,), (2,), (3,))),)
+
+
+@pytest.mark.parametrize("source", _LOOKALIKE_SOURCES)
+def test_lookalike_parametrize_does_not_expand_even_with_protocol(source: str) -> None:
+    """Lying twin: lookalike / shadow / unimported spelling never expands."""
+    load_parametrize_protocol(
+        {"pytest.mark.parametrize": NativeShape.PARAMETRIZE_DECORATOR}
+    )
+    # Nested def: take the innermost FunctionDef named test_values
+    tree = ast.parse(source)
+    fn = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "test_values":
+            fn = node
+    assert fn is not None
+    site = SourceFragment.from_node(fn, "lookalike.py", source=source)
+    assert RemainingSemanticRecognition.literal_pytest_parametrize_rows(site) == ()
+
+
+def test_logo_spelling_alone_never_authenticates_without_import() -> None:
+    """Regression: Attribute spelling is not enough (the old logo Compare path)."""
+    load_parametrize_protocol(
+        {"pytest.mark.parametrize": NativeShape.PARAMETRIZE_DECORATOR}
+    )
+    source = (
+        "@pytest.mark.parametrize('x', [0])\n"
+        "def test_values(x):\n"
+        "    assert x == 0\n"
+    )
+    site = _function_site(source)
+    assert RemainingSemanticRecognition.literal_pytest_parametrize_rows(site) == ()

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_fragment.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_fragment.py
@@ -595,22 +595,62 @@ def test_function_decorators_present():
 
 
 def test_literal_parametrize_keeps_decidable_columns_from_mixed_rows() -> None:
-    fn = (
-        _module(
-            "@pytest.mark.parametrize(\n"
-            "    'typ, ad',\n"
-            "    [['float', {}], ['float', {'A': 1}], ['int', {}]],\n"
-            ")\n"
-            "def test_constructor(typ, ad):\n"
-            "    pass\n"
-        )
-        .fragments()[0]
-        .statements()[0]
+    """Import-bound + kit protocol → expand; non-scalar columns stay symbolic."""
+    from sugar_lift_py_tests.recognition.native_shape import (
+        NativeShape,
+        clear_parametrize_protocol,
+        load_parametrize_protocol,
     )
 
-    assert fn.literal_pytest_parametrize_rows() == (
-        (("typ",), (("float",), ("float",), ("int",))),
+    source = (
+        "import pytest\n"
+        "\n"
+        "@pytest.mark.parametrize(\n"
+        "    'typ, ad',\n"
+        "    [['float', {}], ['float', {'A': 1}], ['int', {}]],\n"
+        ")\n"
+        "def test_constructor(typ, ad):\n"
+        "    pass\n"
     )
+    load_parametrize_protocol(
+        {"pytest.mark.parametrize": NativeShape.PARAMETRIZE_DECORATOR}
+    )
+    try:
+        # from_source keeps the text so import provenance can resolve bindings.
+        fn = (
+            SourceFragment.from_source(source, "t.py")
+            .fragments()[0]
+            .statements()[1]  # FunctionDef after the Import
+        )
+
+        assert fn.literal_pytest_parametrize_rows() == (
+            (("typ",), (("float",), ("float",), ("int",))),
+        )
+    finally:
+        clear_parametrize_protocol()
+
+
+def test_literal_parametrize_without_protocol_stays_empty() -> None:
+    """Logo spelling without loaded protocol does not expand (no vendor Compare)."""
+    from sugar_lift_py_tests.recognition.native_shape import clear_parametrize_protocol
+
+    clear_parametrize_protocol()
+    source = (
+        "import pytest\n"
+        "\n"
+        "@pytest.mark.parametrize(\n"
+        "    'typ, ad',\n"
+        "    [['float', {}], ['float', {'A': 1}], ['int', {}]],\n"
+        ")\n"
+        "def test_constructor(typ, ad):\n"
+        "    pass\n"
+    )
+    fn = (
+        SourceFragment.from_source(source, "t.py")
+        .fragments()[0]
+        .statements()[1]
+    )
+    assert fn.literal_pytest_parametrize_rows() == ()
 
 
 def test_aug_assign_op():


### PR DESCRIPTION
## Summary

Closes the construction-algebra gap that three workers hit as illegal logo shortcuts for `pytest.mark.parametrize` (`literal_pytest_parametrize_rows` string match; bounced #5602/#5608).

**Law:** no logo string is sufficient evidence for construction.

### Architecture (achievable today)

Combines both honest paths:

1. **(a) Import/source provenance** — decorator Calls authenticate through `imported_call_identity` (binding chain: import/assignment, shadow-aware). Spelling-only Attribute chains never expand.
2. **(b) Explicit kit/bridge protocol** — empty-by-construction `_PARAMETRIZE_DECORATORS` (same class as fixture #5603). Coordinates load only via `load_parametrize_protocol`; production stays empty → no expansion → loud FactoryPanic.

Replaces #5612's temporary loud stub (`return ()`) with the real contract that stub reserved. Does **not** reintroduce production logo tables or `qualified_name == "pytest.mark.parametrize"` compares.

### Honest residual

Mint is a separate process; in-memory protocol load does not reach it. Full-row mint witnesses stay loud until a process-level kit loader exists. That is correct — not a silent success. In-process expansion under a loaded contract is covered by twins and branch-scope tests.

### Twins

| Twin | Expectation |
|------|-------------|
| Truthful | `import pytest` + `load_parametrize_protocol({"pytest.mark.parametrize": …})` → literal rows expand |
| Lying | unimported / parameter-shadow / `import notpytest as pytest` lookalikes → empty even with real coordinate loaded |

**Red-first:** reintroducing the logo `Compare` makes all four lying/lookalike cases expand (FAIL). Provenance path restored → green.

### Floors

- `R_vendor_special_case = 0` under the #5607 extended auditor (no remaining_semantics / parametrize offenders; empty protocol has no logo keys).
- No floor/twin/panic weakened; MISSING stays loud.

### Coordination

- Builds on #5612 (window 297 adjudication) — we fill the reserved stub, not duplicate logo drainage.
- Does not own #5603 table adjudication.

## Validation

```bash
export PYTHONPATH=implementations/python/sugar-lift-python-source/src:implementations/python/sugar-lift-py-tests/src
/Users/tsavo/provekit/.venv/bin/python -m pytest \
  implementations/python/sugar-lift-py-tests/tests/test_parametrize_import_provenance.py \
  implementations/python/sugar-lift-py-tests/tests/test_source_fragment.py -k 'parametr' \
  implementations/python/sugar-lift-py-tests/tests/test_branch_scope_join.py -k 'parametr' -q
# 12 passed

/Users/tsavo/provekit/.venv/bin/python \
  implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
# R_vendor_special_case = 0
```

Do not self-merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate parametrize decorator expansion via import provenance and a kit-loaded protocol
> - Adds a `PARAMETRIZE_DECORATOR` shape to `NativeShape` and a `recognize_parametrize_decorator` lookup backed by a module-level `_PARAMETRIZE_DECORATORS` table in [native_shape.py](https://github.com/TSavo/sugar/pull/5617/files#diff-d1526541051a4390409c635c2450d85c7da899e4ab0926eaf38e335d65ff09d0).
> - `load_parametrize_protocol` / `clear_parametrize_protocol` install or remove coordinate mappings at runtime, supporting test isolation.
> - `RemainingSemanticRecognition.literal_pytest_parametrize_rows` now resolves the decorator's import/binding provenance and checks it against the loaded protocol before expanding rows; non-ground columns are filtered while decidable siblings are kept.
> - New test module [test_parametrize_import_provenance.py](https://github.com/TSavo/sugar/pull/5617/files#diff-5388709a22e5fd090a7a353299fef56c3468858da20153ab268785c64951239e) covers default-empty protocol, authenticated expansion, and lookalike/unauthenticated spellings.
> - Behavioral Change: without a loaded protocol, `literal_pytest_parametrize_rows` always returns empty rows, causing `audit_lift_file` to raise `FactoryPanic` in contexts that previously succeeded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3eac1e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->