### PR TITLE
Authenticate fixture via import provenance + empty kit protocol

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/class_decorator.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/class_decorator.py
@@ -178,7 +178,9 @@ def _fixture_provider_native_shape(provider) -> NativeShape | None:
         return None
     imports = _module_imports(tree, module_name)
     function = _function_at_provider_seat(tree, provider)
-    if function is None or not _is_authenticated_fixture(function, imports):
+    if function is None or not _is_authenticated_fixture(
+        function, imports, tree=tree
+    ):
         return None
     constructed: dict[str, NativeShape] = {}
     for node in ast.walk(function):
@@ -228,14 +230,29 @@ def _function_at_provider_seat(
 def _is_authenticated_fixture(
     function: ast.FunctionDef | ast.AsyncFunctionDef,
     imports: dict[str, str],
+    *,
+    tree: ast.Module | None = None,
 ) -> bool:
     """True when a decorator is a registered fixture protocol shape.
 
-    Uses native_shape recognition tables — never a vendor-name string compare
-    in this module (R_vendor_special_case floor).
+    Resolves the decorator through the module import map (rebinding revokes
+    warrants) and refuses class-body shadows of the decorator head. Lookup is
+    only in the kit-loaded fixture protocol table — never a vendor-name string
+    Compare in this module (R_vendor_special_case floor).
     """
+    class_shadows = (
+        _enclosing_class_stored_names(function, tree) if tree is not None else frozenset()
+    )
     for decorator in function.decorator_list:
         target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        dotted = _ast_dotted_name(target)
+        if dotted is None:
+            continue
+        head, _sep, _tail = dotted.partition(".")
+        if head in class_shadows:
+            # Class-body rebind of the import head revokes the module warrant
+            # (methods' decorators evaluate in the class body namespace).
+            continue
         qualified = _qualified_ast_name(target, imports)
         if (
             recognize_native_fixture_decorator(qualified)
@@ -243,6 +260,46 @@ def _is_authenticated_fixture(
         ):
             return True
     return False
+
+
+def _enclosing_class_stored_names(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+    tree: ast.Module,
+) -> frozenset[str]:
+    """Names stored on the enclosing class body before ``function`` (shadows)."""
+    owner = _enclosing_class_for_function(function, tree)
+    if owner is None:
+        return frozenset()
+    names: list[str] = []
+    for statement in owner.body:
+        if statement is function:
+            break
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            # Nested defs/classes bind their name but do not replace an import
+            # used as a decorator head in the typical fixture pattern; skip.
+            continue
+        names.extend(_top_level_stored_names(statement))
+    return frozenset(names)
+
+
+def _enclosing_class_for_function(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+    tree: ast.Module,
+) -> ast.ClassDef | None:
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for child in node.body:
+            if child is function:
+                return node
+    # Nested / multi-level: walk
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for child in node.body:
+            if child is function:
+                return node
+    return None
 
 
 def _ast_call_native_shape(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
@@ -54,6 +54,10 @@ class NativeShape(Enum):
     IMPLEMENTATION_PRESERVING_DECORATOR = auto()
     FIXTURE_DECORATOR = auto()
     PARAMETRIZE_DECORATOR = auto()
+    # Kit-loaded constructor receiver (no vendor logo key in production tables).
+    # External kit/bridge/proof contracts install coordinates into protocol
+    # overlays; production recognition never hard-codes vendor-rooted strings.
+    KIT_LOADED_CONSTRUCTOR = auto()
     # SQLALCHEMY_ORM_REGISTRY retired (#5603): hard-coded sqlalchemy.orm.registry /
     # as_declarative / mapped coordinates were illegal logo branches — deleted.
     # ClassDef identity for those shapes stays loud until an external kit contract.
@@ -119,6 +123,10 @@ _FIXTURE_DECORATORS: dict[str, NativeShape] = {}
 # Parametrize providers: empty until an explicit kit/bridge contract
 # loads the decorator coordinate (#5603 class: no hard-coded pytest logos).
 _PARAMETRIZE_DECORATORS: dict[str, NativeShape] = {}
+
+# Kit-loaded call coordinates (overlay on language-only _CALL_SHAPES). Empty
+# by construction — vendor-rooted keys arrive only via load_call_shape_protocol.
+_PROTOCOL_CALL_SHAPES: dict[str, NativeShape] = {}
 
 # Instance class-decorators derived from vendor shapes are retired until those
 # shapes arrive via external contract (not hard-coded coordinates).
@@ -187,7 +195,10 @@ _MODULE_NAMES = {
 
 
 def recognize_native_call(target: str | None) -> NativeShape | None:
-    return _CALL_SHAPES.get(target)
+    """Language table first, then kit-loaded protocol overlay (never logo Compare)."""
+    if target is None:
+        return None
+    return _CALL_SHAPES.get(target) or _PROTOCOL_CALL_SHAPES.get(target)
 
 
 def has_native_shape(target: str | None, shape: NativeShape) -> bool:
@@ -252,10 +263,64 @@ def recognize_native_decorator(target: str | None) -> NativeShape | None:
 def recognize_native_fixture_decorator(target: str | None) -> NativeShape | None:
     """Fixture protocol table is empty until a kit/bridge contract loads it.
 
-    #5603: no hard-coded pytest/vendor fixture logos. Missing → None → loud.
+    Authentication is by import-resolved identity lookup in the loaded table,
+    never by comparing a decorator spelling to a vendor logo string.
+    #5603 / #5617 class: missing → None → loud.
     """
 
-    return _FIXTURE_DECORATORS.get(target) if target is not None else None
+    if target is None:
+        return None
+    return _FIXTURE_DECORATORS.get(target)
+
+
+def load_fixture_protocol(coordinates: dict[str, NativeShape]) -> None:
+    """Install fixture decorator coordinates from a kit/bridge contract.
+
+    Production stays empty-by-construction. Tests and future kit loaders call
+    this with coordinates proved by external evidence — not hard-coded logos
+    in the recognition module itself.
+    """
+
+    _FIXTURE_DECORATORS.clear()
+    _FIXTURE_DECORATORS.update(coordinates)
+
+
+def clear_fixture_protocol() -> None:
+    """Remove all loaded fixture coordinates (test isolation / unload)."""
+
+    _FIXTURE_DECORATORS.clear()
+
+
+def load_call_shape_protocol(coordinates: dict[str, NativeShape]) -> None:
+    """Install call-shape coordinates from a kit/bridge contract (overlay).
+
+    Production language table is unchanged. Vendor-rooted keys must not appear
+    hard-coded in this module; they arrive only through this loader.
+    """
+
+    _PROTOCOL_CALL_SHAPES.clear()
+    _PROTOCOL_CALL_SHAPES.update(coordinates)
+
+
+def clear_call_shape_protocol() -> None:
+    """Remove kit-loaded call-shape coordinates."""
+
+    _PROTOCOL_CALL_SHAPES.clear()
+
+
+def load_instance_class_decorator_protocol(
+    coordinates: dict[tuple[NativeShape, str], NativeShape],
+) -> None:
+    """Install instance class-decorator coordinates from a kit/bridge contract."""
+
+    _NATIVE_INSTANCE_CLASS_DECORATORS.clear()
+    _NATIVE_INSTANCE_CLASS_DECORATORS.update(coordinates)
+
+
+def clear_instance_class_decorator_protocol() -> None:
+    """Remove kit-loaded instance class-decorator coordinates."""
+
+    _NATIVE_INSTANCE_CLASS_DECORATORS.clear()
 
 
 def recognize_parametrize_decorator(target: str | None) -> NativeShape | None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_fixture_provider_seat_authentication.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_fixture_provider_seat_authentication.py
@@ -1,22 +1,50 @@
-"""#5603: fixture providers stay loud without hard-coded fixture logos.
+"""Fixture decorator authentication: import provenance + kit protocol (#5603).
 
-Seat anchoring remains (name + line + col). Fixture *authentication* does not
-use pytest.fixture or any vendor fixture key in production recognition —
-missing kit/bridge contract ⇒ loud (owns False / no identity decorator).
+Same shape as parametrize (#5617):
+- Production protocol tables empty by construction (no logo Compare).
+- Coordinates arrive only via ``load_fixture_protocol`` (and companion kit
+  loaders for call shapes / instance class-decorators used by the fixture
+  yield chain).
+- Provider bodies anchor to exact source seats (module + line + col) — #5581.
+- Lying twins refuse: lookalike, shadow, mismatch, dual-class seat.
+
+Missing kit contract ⇒ loud (owns False). That is correct.
 """
 
 from __future__ import annotations
 
 import ast
 
+import pytest
+
 from sugar_lift_py_tests.factory.source_fragment import SourceFragment
 from sugar_lift_py_tests.recognition.class_decorator import (
     _function_at_provider_seat,
+    _is_authenticated_fixture,
+    _module_imports,
 )
 from sugar_lift_py_tests.recognition.native_shape import (
+    NativeShape,
+    clear_call_shape_protocol,
+    clear_fixture_protocol,
+    clear_instance_class_decorator_protocol,
+    load_call_shape_protocol,
+    load_fixture_protocol,
+    load_instance_class_decorator_protocol,
     recognize_native_fixture_decorator,
 )
 from sugar_lift_py_tests.sugar.class_def_sugar import ClassDefSugar
+
+
+@pytest.fixture(autouse=True)
+def _isolate_fixture_protocols():
+    clear_fixture_protocol()
+    clear_call_shape_protocol()
+    clear_instance_class_decorator_protocol()
+    yield
+    clear_fixture_protocol()
+    clear_call_shape_protocol()
+    clear_instance_class_decorator_protocol()
 
 
 def _user_class_site(source: str) -> SourceFragment:
@@ -41,50 +69,110 @@ def _provider_fragment(provider_source: str, method_name: str, module: str):
     )
 
 
-def test_fixture_protocol_table_is_empty_no_logo() -> None:
+def _load_registry_fixture_kit() -> None:
+    """Kit contract for the registry→mapped fixture chain (not production logos)."""
+    load_fixture_protocol(
+        {
+            "pytest.fixture": NativeShape.FIXTURE_DECORATOR,
+            "sqlalchemy.testing.config.fixture": NativeShape.FIXTURE_DECORATOR,
+        }
+    )
+    load_call_shape_protocol(
+        {"sqlalchemy.orm.registry": NativeShape.KIT_LOADED_CONSTRUCTOR}
+    )
+    load_instance_class_decorator_protocol(
+        {
+            (NativeShape.KIT_LOADED_CONSTRUCTOR, "mapped"): (
+                NativeShape.CLASS_IDENTITY_DECORATOR
+            ),
+        }
+    )
+
+
+def _install_provider(
+    monkeypatch,
+    provider_source: str,
+    *,
+    module: str = "example.fixtures",
+    method: str = "registry",
+    qualified_base: str = "example.FixtureBase",
+):
+    fragment = _provider_fragment(provider_source, method, module)
+    monkeypatch.setattr(
+        "sugar_lift_py_tests.sugar.install_source_dig."
+        "resolve_install_source_class_method",
+        lambda qualified, name: (
+            fragment if (qualified, name) == (qualified_base, method) else None
+        ),
+    )
+    monkeypatch.setattr(
+        "sugar_lift_python_source.source_oracle.installed_module_source",
+        lambda mod: (
+            (provider_source, f"{module.replace('.', '/')}.py", "cid")
+            if mod == module
+            else None
+        ),
+    )
+    return fragment
+
+
+_CONSUMER = (
+    "from example import FixtureBase\n"
+    "class TestThing(FixtureBase):\n"
+    "    def test_it(self, registry):\n"
+    "        @registry.mapped\n"
+    "        class User:\n"
+    "            pass\n"
+)
+
+_TRUTHFUL_PROVIDER = (
+    "import pytest\n"
+    "from sqlalchemy.orm import registry\n"
+    "class FixtureBase:\n"
+    "    @pytest.fixture()\n"
+    "    def registry(self, metadata):\n"
+    "        value = registry(metadata=metadata)\n"
+    "        yield value\n"
+)
+
+
+def test_fixture_protocol_table_is_empty_by_construction() -> None:
     """No hard-coded fixture logo coordinates in production recognition."""
     assert recognize_native_fixture_decorator("pytest.fixture") is None
+    assert recognize_native_fixture_decorator("sqlalchemy.testing.config.fixture") is None
     assert recognize_native_fixture_decorator("any.vendor.fixture") is None
+
+
+def test_import_bound_fixture_authenticates_only_when_protocol_loaded() -> None:
+    """Truthful twin (unit): import-resolved identity + loaded protocol."""
+    provider_source = _TRUTHFUL_PROVIDER
+    tree = ast.parse(provider_source)
+    function = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "registry"
+    )
+    imports = _module_imports(tree)
+    assert _is_authenticated_fixture(function, imports, tree=tree) is False
+    load_fixture_protocol({"pytest.fixture": NativeShape.FIXTURE_DECORATOR})
+    assert _is_authenticated_fixture(function, imports, tree=tree) is True
 
 
 def test_pytest_fixture_provider_stays_loud_without_kit_contract(
     monkeypatch,
 ) -> None:
-    """Honest loud: pytest.fixture alone does not construct (#5603)."""
-    provider_source = (
-        "import pytest\n"
-        "from sqlalchemy.orm import registry\n"
-        "class FixtureBase:\n"
-        "    @pytest.fixture()\n"
-        "    def registry(self, metadata):\n"
-        "        value = registry(metadata=metadata)\n"
-        "        yield value\n"
-    )
-    fragment = _provider_fragment(provider_source, "registry", "example.fixtures")
-    monkeypatch.setattr(
-        "sugar_lift_py_tests.sugar.install_source_dig."
-        "resolve_install_source_class_method",
-        lambda qualified, method: (
-            fragment if (qualified, method) == ("example.FixtureBase", "registry") else None
-        ),
-    )
-    monkeypatch.setattr(
-        "sugar_lift_python_source.source_oracle.installed_module_source",
-        lambda module: (
-            (provider_source, "example/fixtures.py", "cid")
-            if module == "example.fixtures"
-            else None
-        ),
-    )
-    source = (
-        "from example import FixtureBase\n"
-        "class TestThing(FixtureBase):\n"
-        "    def test_it(self, registry):\n"
-        "        @registry.mapped\n"
-        "        class User:\n"
-        "            pass\n"
-    )
-    assert ClassDefSugar.owns(_user_class_site(source)) is False
+    """Honest loud: import-bound pytest.fixture alone does not construct."""
+    _install_provider(monkeypatch, _TRUTHFUL_PROVIDER)
+    assert ClassDefSugar.owns(_user_class_site(_CONSUMER)) is False
+
+
+def test_pytest_fixture_protocol_authenticates_with_kit_contract(
+    monkeypatch,
+) -> None:
+    """Truthful twin (end-to-end): kit loads fixture + yield chain coordinates."""
+    _load_registry_fixture_kit()
+    _install_provider(monkeypatch, _TRUTHFUL_PROVIDER)
+    assert ClassDefSugar.owns(_user_class_site(_CONSUMER)) is True
 
 
 def test_identical_fixture_names_anchor_to_exact_seat() -> None:
@@ -130,22 +218,56 @@ def test_identical_fixture_names_anchor_to_exact_seat() -> None:
     assert seated is not wrong
 
 
-def test_imported_lookalike_config_fixture_stays_loud(monkeypatch) -> None:
+def test_identical_fixture_names_in_two_classes_use_exact_seat(
+    monkeypatch,
+) -> None:
+    """Name-only search would pick WrongBase.registry (first in module)."""
+    _load_registry_fixture_kit()
     provider_source = (
-        "from pretend.testing import config\n"
+        "from sqlalchemy.testing import config\n"
         "from sqlalchemy.orm import registry\n"
+        "class WrongBase:\n"
+        "    @config.fixture()\n"
+        "    def registry(self, metadata):\n"
+        "        yield object()  # not a kit-loaded registry shape\n"
+        "\n"
         "class FixtureBase:\n"
         "    @config.fixture()\n"
         "    def registry(self, metadata):\n"
         "        value = registry(metadata=metadata)\n"
         "        yield value\n"
     )
-    fragment = _provider_fragment(provider_source, "registry", "example.fixtures")
+    tree = ast.parse(provider_source)
+    fixture_base = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "FixtureBase"
+    )
+    correct = next(
+        node
+        for node in fixture_base.body
+        if isinstance(node, ast.FunctionDef) and node.name == "registry"
+    )
+    wrong = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "WrongBase"
+        for child in node.body
+        if isinstance(child, ast.FunctionDef) and child.name == "registry"
+        for node in [child]
+    )
+    setattr(correct, "_sugar_defining_module", "example.fixtures")
+    fragment = SourceFragment.from_node(
+        correct, "example/fixtures.py", source=provider_source
+    )
+    assert correct.lineno != wrong.lineno
     monkeypatch.setattr(
         "sugar_lift_py_tests.sugar.install_source_dig."
         "resolve_install_source_class_method",
         lambda qualified, method: (
-            fragment if (qualified, method) == ("example.FixtureBase", "registry") else None
+            fragment
+            if (qualified, method) == ("example.FixtureBase", "registry")
+            else None
         ),
     )
     monkeypatch.setattr(
@@ -156,18 +278,28 @@ def test_imported_lookalike_config_fixture_stays_loud(monkeypatch) -> None:
             else None
         ),
     )
-    source = (
-        "from example import FixtureBase\n"
-        "class TestThing(FixtureBase):\n"
-        "    def test_it(self, registry):\n"
-        "        @registry.mapped\n"
-        "        class User:\n"
-        "            pass\n"
+    assert ClassDefSugar.owns(_user_class_site(_CONSUMER)) is True
+
+
+def test_imported_lookalike_config_fixture_stays_loud(monkeypatch) -> None:
+    """Lying twin: pretend.testing.config.fixture is not a kit fixture coordinate."""
+    _load_registry_fixture_kit()
+    provider_source = (
+        "from pretend.testing import config\n"
+        "from sqlalchemy.orm import registry\n"
+        "class FixtureBase:\n"
+        "    @config.fixture()\n"
+        "    def registry(self, metadata):\n"
+        "        value = registry(metadata=metadata)\n"
+        "        yield value\n"
     )
-    assert ClassDefSugar.owns(_user_class_site(source)) is False
+    _install_provider(monkeypatch, provider_source)
+    assert ClassDefSugar.owns(_user_class_site(_CONSUMER)) is False
 
 
 def test_aliased_shadowed_fixture_decorator_stays_loud(monkeypatch) -> None:
+    """Lying twin: module rebind of fixture head revokes the import warrant."""
+    _load_registry_fixture_kit()
     provider_source = (
         "from pytest import fixture as real_fixture\n"
         "from sqlalchemy.orm import registry\n"
@@ -178,34 +310,30 @@ def test_aliased_shadowed_fixture_decorator_stays_loud(monkeypatch) -> None:
         "        value = registry(metadata=metadata)\n"
         "        yield value\n"
     )
-    fragment = _provider_fragment(provider_source, "registry", "example.fixtures")
-    monkeypatch.setattr(
-        "sugar_lift_py_tests.sugar.install_source_dig."
-        "resolve_install_source_class_method",
-        lambda qualified, method: (
-            fragment if (qualified, method) == ("example.FixtureBase", "registry") else None
-        ),
+    _install_provider(monkeypatch, provider_source)
+    assert ClassDefSugar.owns(_user_class_site(_CONSUMER)) is False
+
+
+def test_class_body_shadowed_fixture_decorator_stays_loud(monkeypatch) -> None:
+    """Lying twin: class-body rebind of the decorator head refuses auth."""
+    _load_registry_fixture_kit()
+    provider_source = (
+        "import pytest\n"
+        "from sqlalchemy.orm import registry\n"
+        "class FixtureBase:\n"
+        "    pytest = type('P', (), {'fixture': staticmethod(lambda fn: fn)})()\n"
+        "    @pytest.fixture()\n"
+        "    def registry(self, metadata):\n"
+        "        value = registry(metadata=metadata)\n"
+        "        yield value\n"
     )
-    monkeypatch.setattr(
-        "sugar_lift_python_source.source_oracle.installed_module_source",
-        lambda module: (
-            (provider_source, "example/fixtures.py", "cid")
-            if module == "example.fixtures"
-            else None
-        ),
-    )
-    source = (
-        "from example import FixtureBase\n"
-        "class TestThing(FixtureBase):\n"
-        "    def test_it(self, registry):\n"
-        "        @registry.mapped\n"
-        "        class User:\n"
-        "            pass\n"
-    )
-    assert ClassDefSugar.owns(_user_class_site(source)) is False
+    _install_provider(monkeypatch, provider_source)
+    assert ClassDefSugar.owns(_user_class_site(_CONSUMER)) is False
 
 
 def test_mismatched_provider_class_stays_loud(monkeypatch) -> None:
+    """Lying twin: dig resolves OtherBase; consumer inherits FixtureBase."""
+    _load_registry_fixture_kit()
     provider_source = (
         "import pytest\n"
         "from sqlalchemy.orm import registry\n"
@@ -215,28 +343,28 @@ def test_mismatched_provider_class_stays_loud(monkeypatch) -> None:
         "        value = registry(metadata=metadata)\n"
         "        yield value\n"
     )
-    fragment = _provider_fragment(provider_source, "registry", "example.fixtures")
-    monkeypatch.setattr(
-        "sugar_lift_py_tests.sugar.install_source_dig."
-        "resolve_install_source_class_method",
-        lambda qualified, method: (
-            fragment if (qualified, method) == ("example.OtherBase", "registry") else None
-        ),
+    _install_provider(
+        monkeypatch,
+        provider_source,
+        qualified_base="example.OtherBase",
     )
-    monkeypatch.setattr(
-        "sugar_lift_python_source.source_oracle.installed_module_source",
-        lambda module: (
-            (provider_source, "example/fixtures.py", "cid")
-            if module == "example.fixtures"
-            else None
-        ),
-    )
+    assert ClassDefSugar.owns(_user_class_site(_CONSUMER)) is False
+
+
+def test_from_pytest_import_fixture_authenticates_with_protocol() -> None:
+    """Import-from binding resolves to pytest.fixture under loaded protocol."""
+    load_fixture_protocol({"pytest.fixture": NativeShape.FIXTURE_DECORATOR})
     source = (
-        "from example import FixtureBase\n"
-        "class TestThing(FixtureBase):\n"
-        "    def test_it(self, registry):\n"
-        "        @registry.mapped\n"
-        "        class User:\n"
-        "            pass\n"
+        "from pytest import fixture\n"
+        "class FixtureBase:\n"
+        "    @fixture()\n"
+        "    def registry(self):\n"
+        "        yield 0\n"
     )
-    assert ClassDefSugar.owns(_user_class_site(source)) is False
+    tree = ast.parse(source)
+    function = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "registry"
+    )
+    assert _is_authenticated_fixture(function, _module_imports(tree), tree=tree) is True


### PR DESCRIPTION
## Summary

Closes the other #5603 externally-loaded-contract gap after parametrize (#5617): **`pytest.fixture`**.

**Law:** no logo string is sufficient evidence for construction.

### Architecture (achievable — same shape as #5617)

| Path | What shipped |
|------|----------------|
| **(a) Import provenance** | Decorator resolves through module import map (`_qualified_ast_name`); module rebinds revoke warrants; **class-body shadows** of the decorator head refuse auth (methods evaluate in class namespace). |
| **(b) Kit protocol** | Empty `_FIXTURE_DECORATORS` + `load_fixture_protocol` / `clear_fixture_protocol`. Production expands nothing until a kit loads coordinates. |

Companion kit loaders (empty by construction, no production vendor keys):
- `load_call_shape_protocol` — overlay for yield-chain constructors
- `load_instance_class_decorator_protocol` — `(shape, member) → CLASS_IDENTITY`

These let end-to-end `@registry.mapped` ClassDef owns tests inject kit evidence without reintroducing hard-coded sqlalchemy logos (#5613 DELETE stands).

**Seat anchoring (#5581) preserved:** provider body by module + line + col, never bare method name across dual classes.

### Twins

| Twin | Expectation |
|------|-------------|
| Truthful (unit) | import-bound + `load_fixture_protocol` → `_is_authenticated_fixture` True |
| Truthful (e2e) | full kit chain → `ClassDefSugar.owns(User)` True |
| Without kit | import-bound alone → owns False (loud) |
| Lookalike `pretend.testing.config.fixture` | refuses even with real kit loaded |
| Module rebind shadow | refuses |
| Class-body shadow of `pytest` | refuses |
| Mismatched provider class | refuses |
| Dual-class identical names | exact seat (FixtureBase, not WrongBase) |

**Red-first:** illegal Attribute-leaf match (`.fixture` / `pytest.fixture` spelling) makes lookalike + shadow twins expand (FAIL). Provenance restored → green.

### Floors

- **`R_vendor_special_case = 0`** at tip (no `pytest.fixture` in production `src/`)
- No auditor narrowing; MISSING stays loud

### Coordination

- Builds on #5617 parametrize contract shape
- Does not re-adjudicate #5603 / #5612 logo tables or reintroduce SQLAlchemy production keys
- Window 297 owns remaining table adjudication; this is the reserved fixture protocol path

## Validation

```bash
export PYTHONPATH=implementations/python/sugar-lift-python-source/src:implementations/python/sugar-lift-py-tests/src
/Users/tsavo/provekit/.venv/bin/python -m pytest \
  implementations/python/sugar-lift-py-tests/tests/test_fixture_provider_seat_authentication.py -q
# 11 passed

/Users/tsavo/provekit/.venv/bin/python \
  implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
# R_vendor_special_case = 0
```

Do not self-merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate fixtures via import provenance and support dynamic protocol loading for kit-provided coordinates
> - `_is_authenticated_fixture` gains an optional `tree` parameter to check whether a decorator head is shadowed by a class-body binding before authenticating it as a fixture.
> - New `_enclosing_class_stored_names` and `_enclosing_class_for_function` helpers support the class-body shadow check by scanning the enclosing `ast.ClassDef` for names assigned before the method.
> - Adds `load_fixture_protocol`, `clear_fixture_protocol`, `load_call_shape_protocol`, `clear_call_shape_protocol`, `load_instance_class_decorator_protocol`, and `clear_instance_class_decorator_protocol` APIs so kit-provided coordinates can be installed and removed at runtime.
> - Adds `NativeShape.KIT_LOADED_CONSTRUCTOR` and a `_PROTOCOL_CALL_SHAPES` overlay table so kit-loaded call shapes are resolved separately from built-in language shapes.
> - Test suite in [`test_fixture_provider_seat_authentication.py`](https://github.com/TSavo/sugar/pull/5618/files#diff-7777e68f30f1adf11ad2111494d89e4e007e8a9d079b4e5e249ff08015aceeb2) is extensively rewritten to cover empty protocol tables, kit loading, class-body shadowing, and import-from authentication.
> - Behavioral Change: fixtures whose decorator head is rebound in the enclosing class body before the method no longer authenticate when `tree` is supplied.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e1d267.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->