### PR TITLE
Re-earn bare call:type via shadow-aware provenance (#5396)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -289,7 +289,14 @@ class CalleeUniverseRecognition:
 
     @classmethod
     def _name_is_unshadowed(cls, site, name: str) -> bool:
-        """Bare builtin names lose their warrant under parameters or local rebinds."""
+        """Bare builtin names lose their warrant under parameters or local rebinds.
+
+        Nested ClassDef / FunctionDef introduce their own namespaces. Interior
+        stores (a method named ``type``, a class attribute ``type = …``) do
+        **not** shadow the module/function bare builtin under Python semantics.
+        Only the nested definition's own *binding name* (``class type:`` /
+        ``def type:``) or a same-scope assign/import/delete of ``name`` revokes.
+        """
 
         _declarations, shadowed_parameters = visible_declarations(site)
         if name in shadowed_parameters:
@@ -298,8 +305,17 @@ class CalleeUniverseRecognition:
             # A function-local binding of a bare builtin coordinate (parameter
             # or later assignment) is never the builtin coordinate.
             return False
-        # Module-level assignment before the site also revokes.
         for declaration in _declarations:
+            if declaration.observed == "ClassDef":
+                # Class object name only — not body member stores.
+                if declaration.class_name() == name:
+                    return False
+                continue
+            if declaration.observed in {"FunctionDef", "AsyncFunctionDef"}:
+                if declaration.function_name() == name:
+                    return False
+                continue
+            # Same-scope assign / import / delete of the bare name revokes.
             if name in declaration.stored_or_deleted_names():
                 return False
         return True

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_type_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_type_call_sugar.py
@@ -45,3 +45,106 @@ def test_shadowed_type_parameter_stays_outside_partition() -> None:
         site, filename="type_shadow.py", role=SugarRole.TERM, ctx=context
     )
     assert built.audit_row.selected != "BuiltinTypeCallSugar"
+
+
+def test_class_body_type_member_does_not_revoke_later_bare_type() -> None:
+    """Nested class stores named ``type`` must not shadow module bare builtin.
+
+    Corpus (numpy scalarmath/multiarray): a ClassDef earlier in the module
+    with a method or attribute ``type`` was wrongly revoking ``type(res)``
+    universe ownership after logo-table drains. Python keeps the builtin
+    visible outside that class namespace.
+    """
+
+    source = (
+        "class Holder:\n"
+        "    def type(self, value):\n"
+        "        return value\n"
+        "\n"
+        "def test_a(value):\n"
+        "    assert type(value) is int\n"
+    )
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "type"
+        and node.lineno > 3
+    )
+    site = SourceFragment.from_node(call, "type_class_member.py", source=source)
+    context = FactoryBuildContext(
+        filename="type_class_member.py", catalog=default_catalog()
+    )
+    built = build_node(
+        site, filename="type_class_member.py", role=SugarRole.TERM, ctx=context
+    )
+    assert built.audit_row.selected == "BuiltinTypeCallSugar"
+
+
+def test_module_level_type_assignment_still_revokes() -> None:
+    source = (
+        "type = lambda value: value\n"
+        "\n"
+        "def test_a(value):\n"
+        "    assert type(value) is int\n"
+    )
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "type"
+    )
+    site = SourceFragment.from_node(call, "type_assign.py", source=source)
+    context = FactoryBuildContext(filename="type_assign.py", catalog=default_catalog())
+    built = build_node(
+        site, filename="type_assign.py", role=SugarRole.TERM, ctx=context
+    )
+    assert built.audit_row.selected != "BuiltinTypeCallSugar"
+
+
+def test_def_type_function_still_revokes() -> None:
+    source = (
+        "def type(value):\n"
+        "    return value\n"
+        "\n"
+        "def test_a(value):\n"
+        "    assert type(value) is int\n"
+    )
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "type"
+        and node.lineno > 3
+    )
+    site = SourceFragment.from_node(call, "type_def.py", source=source)
+    context = FactoryBuildContext(filename="type_def.py", catalog=default_catalog())
+    built = build_node(
+        site, filename="type_def.py", role=SugarRole.TERM, ctx=context
+    )
+    assert built.audit_row.selected != "BuiltinTypeCallSugar"
+
+
+def test_dtype_attribute_type_call_stays_loud() -> None:
+    """Attribute ``dt.type(...)`` is not bare builtin type — stays unowned."""
+
+    source = (
+        "def test_a(dt):\n"
+        "    assert dt.type(0) is not None\n"
+    )
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "type"
+    )
+    site = SourceFragment.from_node(call, "dtype_type.py", source=source)
+    context = FactoryBuildContext(filename="dtype_type.py", catalog=default_catalog())
+    built = build_node(
+        site, filename="dtype_type.py", role=SugarRole.TERM, ctx=context
+    )
+    assert built.audit_row.selected != "BuiltinTypeCallSugar"


### PR DESCRIPTION
Part of #5396

## Measure first (current main, before this PR)

NumPy test assertion sites with leaf `type` (structural universe path):

| form | authenticated | loud |
| --- | ---: | ---: |
| bare `type(...)` | 105 | **12** |
| attribute `.type(...)` | — | **4** |

Root cause of the 12: `_name_is_unshadowed` treated **ClassDef body stores**
(method/attr named `type`) as module-level shadowing of the bare builtin.
Python does not: the builtin remains visible outside that class namespace.
Logo-table drains did not remove `BuiltinTypeCallSugar`; they exposed this
false-revoke.

## Fix

Shadow-aware provenance only (no logo tables, no name whitelist of callees):

- Nested `ClassDef` / `FunctionDef` **interior** stores do not revoke
- Nested definition **binding name** (`class type:` / `def type:`) still revokes
- Parameters, lexical rebinds, module assigns/imports still revoke

## Outcomes

| form | after |
| --- | --- |
| bare `type(...)` | **117 auth / 0 loud** |
| attribute `.type(...)` | **stays loud** (not bare builtin; needs separate receiver provenance) |

## Twins / discrimination

Existing `BuiltinTypeCallSugar` truthful/lying pair retained. Added:

- class-body `type` member must **not** revoke later bare `type`
- module `type = …` and `def type` still revoke
- parameter shadow still outside partition
- `dt.type(...)` stays unowned

## Floors

| instrument | result |
| --- | --- |
| `R_vendor_special_case` | **0** |
| `R_ownership` | **0** |
| focused type tests | **7 passed** |

Do not self-merge — soundness-read merge when ready.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `_name_is_unshadowed` to not revoke bare `type` builtin on class body member stores
> - In [`_name_is_unshadowed`](https://github.com/TSavo/sugar/pull/5620/files#diff-72e9f915afa350390348a1c277d0c2047b26a0182bb4780c57baf73f30fdcaa8), only class/function *binding names* (e.g. `class type:` or `def type:`) and same-scope assign/import/delete now revoke a bare builtin name.
> - Previously, a method or attribute named `type` inside a class body would incorrectly revoke the bare `type` builtin, preventing `type(value)` calls elsewhere from being recognized as `BuiltinTypeCallSugar`.
> - Four new tests cover the corrected behavior: class member named `type` no longer revokes, module-level assignment still revokes, `def type` still revokes, and attribute calls like `dt.type(...)` remain unowned.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0920db5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->