### PR TITLE
Re-earn call:item and call:extractor without logo tables

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -163,21 +163,28 @@ def recognize_callee_universe(
             if target is not None and target != f"call:{leaf}":
                 return None
             return CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
-        # Nested FunctionDef binding (structural source provenance, no logo).
+        # Nested FunctionDef / Assign-lambda / for-unpacked lambda (#5411).
         local = _local_source_function_identity(site)
         if local is not None:
             if not _target_matches_call(target, local, site):
                 return None
             return CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
+        # Receiver-surface / item receiver coordinate (e.g. arr.item()).
         coordinate = CalleeUniverseRecognition.coordinate(site)
         if coordinate is None:
             return None
         support = recognize_authenticated_callee_identity(coordinate)
-        if support is None:
-            return None
-        if not _target_matches_call(target, coordinate, site):
-            return None
-        return support
+        if support is not None:
+            if not _target_matches_call(target, coordinate, site):
+                return None
+            return support
+        # Bare surface leaves such as ``item`` after import-authenticated
+        # constructor binding (#5410) — coordinate is the member leaf itself.
+        if coordinate == site.call_target_name() and _target_matches_call(
+            target, coordinate, site
+        ):
+            return CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
+        return None
     result_support = _DTYPE_RESULT_SUPPORT.get(identity)
     if result_support is not None and target in {None, "call:dtype"}:
         return result_support
@@ -194,14 +201,21 @@ def recognize_callee_universe(
         # coordinate is the surface FQN (``re.Pattern.search``). Prefer the
         # Assign-bound surface registry over the raw result join.
         surface = CalleeUniverseRecognition._surface_method_coordinate(site)
-        if surface is None:
-            return None
-        support = recognize_authenticated_callee_identity(surface)
-        if support is None:
-            return None
-        if not _target_matches_call(target, surface, site):
-            return None
-        return support
+        if surface is not None:
+            support = recognize_authenticated_callee_identity(surface)
+            if support is not None and _target_matches_call(target, surface, site):
+                return support
+        # Import-authenticated constructor receiver + bare member leaf
+        # (``arr = np.array(...); arr.item()`` — #5410). Result identity may
+        # be ``numpy.array.item`` without a logo table entry.
+        coordinate = CalleeUniverseRecognition.coordinate(site)
+        if (
+            coordinate is not None
+            and coordinate == site.call_target_name()
+            and _target_matches_call(target, coordinate, site)
+        ):
+            return CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
+        return None
     if not _target_matches_call(target, identity, site):
         return None
     return support
@@ -662,10 +676,20 @@ def _bare_factory_result_callable_identity(site) -> str | None:
 
 
 def _local_source_function_identity(site) -> str | None:
-    """Authenticate a bare call to a visible nested/module FunctionDef.
+    """Authenticate a bare call through local source-callable provenance.
 
-    Source provenance is the FunctionDef binding itself. Later assignments or
-    imports of the same name revoke the warrant; parameters always revoke.
+    Forms (leaf spelling alone grants nothing):
+
+    1. Nested FunctionDef in the enclosing function
+       (``def extractor(x): ...`` then ``extractor(res)``).
+    2. Function-local Assign of a Lambda
+       (``extractor = lambda res: res`` then ``extractor(res)``).
+    3. For-unpacked name fed by a same-module generator FunctionDef that
+       assigns a Lambda to that name before yielding it
+       (numpy ``interesting_binop_operands`` → ``for …, extractor, …``).
+
+    Parameters, rebinds to non-callables, and unresolved for-iterables stay
+    loud. No vendor logo strings.
     """
 
     if site is None or site.observed != "Call" or site.call_receiver() is not None:
@@ -676,23 +700,136 @@ def _local_source_function_identity(site) -> str | None:
     declarations, shadowed_parameters = visible_declarations(site)
     if target in shadowed_parameters:
         return None
+
+    # (1) Nested FunctionDef / (2) Assign of Lambda in enclosing function.
     binding = None
+    lambda_assign = None
     for declaration in declarations:
         if declaration.observed in {"FunctionDef", "AsyncFunctionDef"}:
             if declaration.function_name() == target:
                 binding = declaration
+                lambda_assign = None
             continue
-        if target in declaration.stored_or_deleted_names():
-            # Assign / import / delete after the def shadows the function.
-            binding = None
-    if binding is None:
+        if target not in declaration.stored_or_deleted_names():
+            continue
+        # Later store of the name revokes a prior FunctionDef.
+        binding = None
+        if (
+            declaration.observed == "Assign"
+            and declaration.stored_or_deleted_names() == frozenset({target})
+            and declaration.assign_value().observed == "Lambda"
+            and declaration_is_function_local(site, declaration)
+        ):
+            lambda_assign = declaration
+        else:
+            lambda_assign = None
+    if binding is not None and declaration_is_function_local(site, binding):
+        return target
+    if lambda_assign is not None:
+        return target
+
+    # (3) For-unpacked lambda from a local generator FunctionDef.
+    return _for_unpacked_lambda_identity(site, target)
+
+
+def _for_unpacked_lambda_identity(site, target: str) -> str | None:
+    """For-target name fed by a generator that assigns ``target = lambda …``."""
+
+    path = _source_path(site)
+    if path is None:
         return None
-    # Module-level ``def A`` witness wrappers stay outside this family so they
-    # cannot steal BuiltinCalleeUniverse ownership from the inner call. Nested
-    # corpus helpers (``def _compare_dtypes`` inside a test) remain in scope.
-    if not declaration_is_function_local(site, binding):
+    for_node = None
+    for node in reversed(path):
+        if isinstance(node, ast.For):
+            for_node = node
+            break
+    if for_node is None:
+        return None
+    if target not in _for_target_names(for_node.target):
+        return None
+
+    # Resolve for.iter to a same-module FunctionDef (Call or Name→Assign Call).
+    gen_def = _generator_function_def_for_iter(site, for_node.iter)
+    if gen_def is None:
+        return None
+    if not _function_assigns_lambda_to(gen_def, target):
         return None
     return target
+
+
+def _for_target_names(target: ast.AST) -> frozenset[str]:
+    names: set[str] = set()
+
+    def walk(node: ast.AST) -> None:
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+            return
+        if isinstance(node, ast.Tuple | ast.List):
+            for elt in node.elts:
+                walk(elt)
+
+    walk(target)
+    return frozenset(names)
+
+
+def _generator_function_def_for_iter(site, iter_node: ast.AST) -> ast.FunctionDef | None:
+    """Resolve ``for … in name()`` / ``for … in name`` to a module FunctionDef."""
+
+    from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+
+    filename = site.filename or ""
+    source = site.source
+    if not source:
+        return None
+
+    gen_name: str | None = None
+    if isinstance(iter_node, ast.Call) and isinstance(iter_node.func, ast.Name):
+        gen_name = iter_node.func.id
+    elif isinstance(iter_node, ast.Name):
+        # ``to_check = interesting_binop_operands(...); for … in to_check``
+        # Build a synthetic Call site at the for.iter Name for declaration walk.
+        name_site = SourceFragment.from_node(iter_node, filename, source=source)
+        declarations, _ = visible_declarations(name_site)
+        binding = None
+        for declaration in declarations:
+            if iter_node.id not in declaration.stored_or_deleted_names():
+                continue
+            binding = declaration
+        if (
+            binding is not None
+            and binding.observed == "Assign"
+            and binding.stored_or_deleted_names() == frozenset({iter_node.id})
+            and binding.assign_value().observed == "Call"
+        ):
+            call_func = binding.assign_value().call_func()
+            if call_func is not None and call_func.observed == "Name":
+                gen_name = call_func.name_id()
+    if gen_name is None:
+        return None
+
+    path = _source_path(site)
+    if path is None:
+        return None
+    tree = path[0]
+    for stmt in getattr(tree, "body", ()):
+        if isinstance(stmt, ast.FunctionDef) and stmt.name == gen_name:
+            return stmt
+    return None
+
+
+def _function_assigns_lambda_to(func: ast.FunctionDef, name: str) -> bool:
+    """True when ``func`` assigns a Lambda to ``name`` (possibly in nested fors)."""
+
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Assign):
+            continue
+        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+            continue
+        if node.targets[0].id != name:
+            continue
+        if isinstance(node.value, ast.Lambda):
+            return True
+    return False
 
 
 def _f2py_extension_coordinate(site) -> str | None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_item_extractor_re_earn_5410_5411.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_item_extractor_re_earn_5410_5411.py
@@ -1,0 +1,183 @@
+"""Re-earn call:item (#5410) and call:extractor (#5411) without logo tables.
+
+Measurement (main, post-#5614/#5612 logo deletion):
+
+- call:item — still drained by surviving provenance:
+  Assign-bound import constructor (``arr = np.array(...); arr.item()``) via
+  ``_receiver_has_imported_call_definition`` + receiver leaf ``item``.
+  Lookalike parameter receivers stay unowned.
+- call:extractor — was loud for for-unpacked lambdas from
+  ``interesting_binop_operands``; re-earned via Assign-lambda and for-unpacked
+  lambda provenance (no vendor logos).
+
+Lying twins must refute; bare/wrong bindings stay FactoryPanic / unowned.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+from sugar_lift_py_tests.kit_rpc.factory_walk_row_dto import FactoryWalkRedRowDto
+from sugar_lift_py_tests.lift_rpc import lift_file_payload
+from sugar_lift_py_tests.recognition.callee_universe import (
+    CalleeUniverseRecognition,
+    CalleeUniverseSupport,
+    recognize_callee_universe,
+)
+from sugar_lift_py_tests.sugar.builtin_callee_universe_sugar import (
+    BuiltinCalleeUniverseSugar,
+)
+
+
+def _site(source: str, *, attr: str | None = None, name: str | None = None):
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+        if attr and isinstance(node.func, ast.Attribute) and node.func.attr == attr:
+            return SourceFragment.from_node(node, "t.py", source=source)
+        if name and isinstance(node.func, ast.Name) and node.func.id == name:
+            return SourceFragment.from_node(node, "t.py", source=source)
+    raise AssertionError("no site")
+
+
+def _universe_gaps(source: str, leaf: str) -> list:
+    payload = lift_file_payload(source, f"{leaf}.py")
+    return [
+        row
+        for row in payload.factory_walk
+        if isinstance(row, FactoryWalkRedRowDto)
+        and "callee universe coverage" in row.reason
+        and leaf in str(row.ast_kind)
+    ]
+
+
+# --- #5410 call:item (still drained by provenance; lock it) ---
+
+
+def test_item_assign_bound_import_ctor_still_authenticates() -> None:
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_a():\n"
+        "    arr = np.array([1], dtype=object)\n"
+        "    assert arr.item() == 1\n"
+    )
+    site = _site(source, attr="item")
+    assert CalleeUniverseRecognition.coordinate(site) == "item"
+    assert BuiltinCalleeUniverseSugar.owns(site) is True
+    assert (
+        recognize_callee_universe("call:item", site=site)
+        is CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
+    )
+    assert _universe_gaps(source, "item") == []
+
+
+def test_item_lookalike_parameter_receiver_stays_loud() -> None:
+    source = (
+        "def test_a(arr):\n"
+        "    assert arr.item() == 1\n"
+    )
+    site = _site(source, attr="item")
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert BuiltinCalleeUniverseSugar.owns(site) is False
+    assert recognize_callee_universe(site=site) is None
+
+
+def test_item_rebind_revokes_receiver_warrant() -> None:
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_a(other):\n"
+        "    arr = np.array([1], dtype=object)\n"
+        "    arr = other\n"
+        "    assert arr.item() == 1\n"
+    )
+    site = _site(source, attr="item")
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert BuiltinCalleeUniverseSugar.owns(site) is False
+
+
+# --- #5411 call:extractor ---
+
+
+def test_extractor_assign_lambda_authenticates() -> None:
+    source = (
+        "def test_a(res):\n"
+        "    extractor = lambda x: x\n"
+        "    assert extractor(res) == 0\n"
+    )
+    site = _site(source, name="extractor")
+    assert CalleeUniverseRecognition.coordinate(site) == "extractor"
+    assert BuiltinCalleeUniverseSugar.owns(site) is True
+    assert (
+        recognize_callee_universe("call:extractor", site=site)
+        is CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
+    )
+    assert _universe_gaps(source, "extractor") == []
+
+
+def test_extractor_for_unpacked_lambda_from_generator_authenticates() -> None:
+    """Corpus shape: interesting_binop_operands → for …, extractor, …"""
+
+    source = (
+        "def interesting_binop_operands(val1, val2, dtype):\n"
+        "    extractor = lambda res: res\n"
+        "    yield val1, val2, extractor, 'scalars'\n"
+        "\n"
+        "def test_signed_division_overflow(res):\n"
+        "    to_check = interesting_binop_operands(1, -1, 'i')\n"
+        "    for op1, op2, extractor, operand_identifier in to_check:\n"
+        "        assert extractor(res) == 0\n"
+    )
+    site = _site(source, name="extractor")
+    assert CalleeUniverseRecognition.coordinate(site) == "extractor"
+    assert BuiltinCalleeUniverseSugar.owns(site) is True
+    assert (
+        recognize_callee_universe("call:extractor", site=site)
+        is CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
+    )
+    assert _universe_gaps(source, "extractor") == []
+
+
+def test_extractor_for_direct_generator_call_authenticates() -> None:
+    source = (
+        "def interesting():\n"
+        "    extractor = lambda res: res\n"
+        "    yield 1, extractor\n"
+        "\n"
+        "def test_a(res):\n"
+        "    for op1, extractor in interesting():\n"
+        "        assert extractor(res) == 0\n"
+    )
+    site = _site(source, name="extractor")
+    assert BuiltinCalleeUniverseSugar.owns(site) is True
+    assert _universe_gaps(source, "extractor") == []
+
+
+def test_extractor_lookalike_parameter_stays_loud() -> None:
+    source = (
+        "def test_a(extractor, res):\n"
+        "    assert extractor(res) == 0\n"
+    )
+    site = _site(source, name="extractor")
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert BuiltinCalleeUniverseSugar.owns(site) is False
+    assert _universe_gaps(source, "extractor")  # still a universe gap
+
+
+def test_extractor_for_without_lambda_in_generator_stays_loud() -> None:
+    """Lying twin: generator yields a non-lambda third binding."""
+
+    source = (
+        "def interesting():\n"
+        "    extractor = 1\n"
+        "    yield 1, extractor\n"
+        "\n"
+        "def test_a(res):\n"
+        "    for op1, extractor in interesting():\n"
+        "        assert extractor(res) == 0\n"
+    )
+    site = _site(source, name="extractor")
+    assert BuiltinCalleeUniverseSugar.owns(site) is False
+    assert CalleeUniverseRecognition.coordinate(site) is None


### PR DESCRIPTION
Part of #5410, #5411

## Claim

CLAIMED (our codex-iterm fleet, window 427) after verifying neither issue had a live in-progress claim (old “Done + merged” comments only).

## MEASURE FIRST (fresh main, pre-change)

Historical ranking pin `0f4748f` (pre-#5451/#5446): `call:item` **9**, `call:extractor` **8**.

**Live measurement on current main** (post logo-table deletion #5612/#5614):

| family | honest shape | factory-walk universe gaps | owns |
|--------|--------------|---------------------------:|------|
| `call:item` `arr = np.array(...); arr.item()` | Assign-bound import ctor | **0** | True |
| `call:item` lookalike param `arr` | no ctor Assign | loud | False |
| `call:extractor` nested `def extractor` | local FunctionDef | **0** | True |
| `call:extractor` assign `lambda` | Assign Lambda | **1 (loud)** before this PR | False |
| `call:extractor` for-unpacked from generator | umath shape | **1 (loud)** before this PR | False |

### #5410 call:item
**Still drained** by surviving provenance (`_receiver_has_imported_call_definition` + receiver leaf `item` — no vendor logo table). This PR locks that path in `recognize_callee_universe` and adds lying twins (param / rebind).

### #5411 call:extractor  
**Genuinely loud** for the corpus shape (for-unpacked lambdas from `interesting_binop_operands`). Re-earned via import/source provenance only:

1. nested FunctionDef (already)
2. function-local `extractor = lambda …`
3. for-target fed by same-module generator that assigns `extractor = lambda …`

No kit logo tables. Lookalike parameter / for without lambda stay loud.

## Validation

- 8 focused twins/instruments passed
- `R_vendor_special_case = 0`

Do not self-merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-earn `call:item` and `call:extractor` recognition without logo tables
> - `recognize_callee_universe` now returns `BOUND_SOURCE_CALLABLE` when a receiver coordinate matches the bare call leaf and the target check passes, even if the coordinate lacks a registered authenticated identity (e.g., `arr.item()` after an import-authenticated constructor assignment).
> - `_local_source_function_identity` now authenticates calls to names assigned a lambda within the function body, or obtained via for-unpacking from a same-module generator that assigns a lambda to that name before yielding it.
> - Parameters and non-callable rebinds continue to revoke the warrant and remain unrecognized.
> - Tests in [`test_item_extractor_re_earn_5410_5411.py`](https://github.com/TSavo/sugar/pull/5621/files#diff-2b70b9909641669ff00d8dc569fa5ef48341681c56d7b36cb18a4290543c4038) cover both new recognition paths and confirm that non-warranted scenarios stay loud.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 163510d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->