### PR TITLE
Re-earn call:numpy.all + call:numpy.dtype via kit protocol (#5408, #5407)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -118,14 +118,26 @@ _IMPORTED_SUPPORT = {
     # land via contract, not hard-coded production logos.
 }
 
+# Kit-loaded import identities (overlay). Empty by construction — vendor-rooted
+# coordinates such as ``numpy.all`` / ``numpy.dtype`` arrive only through
+# ``load_imported_callee_protocol`` (#5618 empty-kit pattern). Production
+# recognition never hard-codes logo table keys.
+_PROTOCOL_IMPORTED_SUPPORT: dict[str, CalleeUniverseSupport] = {}
+
 # Language / builtin coordinates only (#5603 adjudication).
 _BUILTIN_COORDINATES = frozenset(
     {"type", "dtype", "all", "any", "min", "max", "sum", "list", "set", "hasattr"}
 )
-# Attribute leaves that can still resolve into an imported authenticated
-# coordinate (``np.can_cast``, ``np.all``, converter helpers, …). Class-body
-# aliases (``self.conv = mt.run_byteorder_converter``) use arbitrary attr
-# names and never match this set — they take the method-coordinate path only.
+# Attribute leaves that can still resolve into an authenticated imported
+# coordinate. Class-body aliases use arbitrary attr names and never match —
+# they take the method-coordinate path only. Includes kit-loaded leaves.
+def _imported_attribute_leaves() -> frozenset[str]:
+    return frozenset(
+        identity.rsplit(".", 1)[-1]
+        for identity in (*_IMPORTED_SUPPORT, *_PROTOCOL_IMPORTED_SUPPORT)
+    )
+
+
 _IMPORTED_ATTRIBUTE_LEAVES = frozenset(
     identity.rsplit(".", 1)[-1] for identity in _IMPORTED_SUPPORT
 )
@@ -246,9 +258,38 @@ def _target_matches_call(target: str | None, coordinate: str | None, site) -> bo
 def recognize_authenticated_callee_identity(
     identity: str | None,
 ) -> CalleeUniverseSupport | None:
-    """Type an identity only after lexical/source provenance authenticated it."""
+    """Type an identity only after lexical/source provenance authenticated it.
 
-    return _IMPORTED_SUPPORT.get(identity)
+    Production language/stdlib table first; then kit-loaded overlay. Vendor
+    identities (``numpy.all``, ``numpy.dtype``, …) are never hard-coded in
+    production — they arrive only via ``load_imported_callee_protocol``.
+    """
+
+    if identity is None:
+        return None
+    return _IMPORTED_SUPPORT.get(identity) or _PROTOCOL_IMPORTED_SUPPORT.get(
+        identity
+    )
+
+
+def load_imported_callee_protocol(
+    coordinates: dict[str, CalleeUniverseSupport],
+) -> None:
+    """Install import-identity coordinates from a kit/bridge contract.
+
+    Production stays empty of vendor-root keys. Tests and future kit loaders
+    call this with coordinates proved by external evidence — not hard-coded
+    logos in the recognition module itself (#5618 pattern).
+    """
+
+    _PROTOCOL_IMPORTED_SUPPORT.clear()
+    _PROTOCOL_IMPORTED_SUPPORT.update(coordinates)
+
+
+def clear_imported_callee_protocol() -> None:
+    """Remove kit-loaded import-identity coordinates (test isolation / unload)."""
+
+    _PROTOCOL_IMPORTED_SUPPORT.clear()
 
 
 class CalleeUniverseRecognition:
@@ -301,7 +342,8 @@ class CalleeUniverseRecognition:
             # full ``imported_call_identity`` for every ``random.X`` /
             # ``module.Y`` Call is the factory.select residual after
             # parsed_locus_index drained the AST-walk half of the path.
-            if target in (_IMPORTED_ATTRIBUTE_LEAVES | _DTYPE_RESULT_ATTRIBUTE_LEAVES):
+            leaves = _imported_attribute_leaves() | _DTYPE_RESULT_ATTRIBUTE_LEAVES
+            if target in leaves:
                 imported = _result_call_identity(site)
                 if recognize_authenticated_callee_identity(imported) is not None:
                     return imported
@@ -319,8 +361,13 @@ class CalleeUniverseRecognition:
         if target in _BUILTIN_COORDINATES:
             # Without source there is no evidence of shadowing; keep the bare
             # builtin warrant. With source, parameters and local rebinds revoke.
+            # Import-bound kit/language coordinates (``from numpy import all``
+            # under a loaded protocol) win over the bare builtin leaf.
             if not site.source:
                 return target
+            imported = imported_call_identity(site)
+            if recognize_authenticated_callee_identity(imported) is not None:
+                return imported
             return target if cls._name_is_unshadowed(site, target) else None
 
         if not site.source:
@@ -333,7 +380,7 @@ class CalleeUniverseRecognition:
         # whose spelling is not a registered leaf remain loud — the universe
         # gap auditor keys belonging by leaf spelling, so alias greens would
         # be silent twins.
-        if target not in _IMPORTED_ATTRIBUTE_LEAVES:
+        if target not in _imported_attribute_leaves():
             return None
         return imported_call_identity(site)
 
@@ -1130,7 +1177,9 @@ def _source_path(statement):
 __all__ = [
     "CalleeUniverseRecognition",
     "CalleeUniverseSupport",
+    "clear_imported_callee_protocol",
     "imported_call_identity",
+    "load_imported_callee_protocol",
     "recognize_authenticated_callee_identity",
     "recognize_callee_universe",
 ]

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
@@ -26,6 +26,13 @@ from sugar_lift_py_tests.witness_harness import run_source_through_real_solver
 
 
 def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
+    """Language/stdlib + structural coordinates only (#5603 / #5614).
+
+    Vendor-root coordinates (``numpy.all``, ``numpy.dtype``, …) are not
+    hard-coded production universe keys. They re-earn via empty kit protocol
+    + import provenance (``load_imported_callee_protocol``; see
+    ``test_imported_callee_protocol_numpy_all_dtype``).
+    """
     assert {
         "all",
         "any",
@@ -36,25 +43,21 @@ def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
         "set",
         "hasattr",
         "item",
-        "numpy.can_cast",
-        "numpy.issubdtype",
-        "numpy.isnan",
-        "numpy.all",
-        "numpy.dtype",
-        "numpy.shares_memory",
-        "numpy.isdtype",
-        "numpy.datetime_data",
-        "numpy.f2py.crackfortran.markinnerspaces",
-        "numpy._core._multiarray_tests.identity_hash_set_item_default",
-        "numpy.ndarray.tobytes",
-        "numpy._core.multiarray.get_handler_name",
-        "numpy._core._multiarray_tests.run_byteorder_converter",
         "re.Pattern.search",
         "json.loads",
         "dataclasses.asdict",
         "dataclasses.is_dataclass",
         "math.isclose",
+        "pathlib.Path",
+        "pathlib.Path.resolve",
+        "textwrap.dedent",
     } <= (BuiltinCalleeUniverseSugar.universe_coordinates)
+    # Production tables must stay free of vendor-root logos.
+    assert not any(
+        c.startswith("numpy.") or c.startswith("scipy.")
+        for c in BuiltinCalleeUniverseSugar.universe_coordinates
+    )
+    enrolled = {pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()}
     assert {
         "all_builtin_universe_coordinate",
         "any_builtin_universe_coordinate",
@@ -64,27 +67,16 @@ def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
         "list_builtin_universe_coordinate",
         "set_builtin_universe_coordinate",
         "hasattr_builtin_universe_coordinate",
-        "item_receiver_universe_coordinate",
-        "numpy_can_cast_universe_coordinate",
-        "numpy_issubdtype_universe_coordinate",
-        "numpy_isnan_universe_coordinate",
-        "numpy_all_universe_coordinate",
-        "numpy_dtype_universe_coordinate",
-        "numpy_dtype_result_universe_coordinate",
-        "numpy_shares_memory_universe_coordinate",
-        "numpy_isdtype_universe_coordinate",
-        "numpy_datetime_data_universe_coordinate",
-        "numpy_markinnerspaces_universe_coordinate",
-        "numpy_identity_hash_set_item_default_universe_coordinate",
-        "numpy_array_tobytes_universe_coordinate",
-        "get_handler_name_builtin_universe_coordinate",
-        "conv_builtin_universe_coordinate",
         "regex_search_builtin_universe_coordinate",
         "json_loads_universe_coordinate",
         "dataclasses_asdict_universe_coordinate",
         "dataclasses_is_dataclass_universe_coordinate",
         "math_isclose_universe_coordinate",
-    } <= {pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()}
+        "textwrap_dedent_universe_coordinate",
+    } <= enrolled
+    # Vendor mint witnesses retired with logo tables — kit protocol path only.
+    assert "numpy_all_universe_coordinate" not in enrolled
+    assert "numpy_dtype_universe_coordinate" not in enrolled
 
 
 def test_all_nine_authenticated_conv_rows_select_the_converter_owner() -> None:
@@ -876,24 +868,37 @@ def _numpy_dtype_call_site(source: str) -> SourceFragment:
 
 
 def test_authenticated_numpy_dtype_selects_one_factory_owner() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_dtype(value):\n"
-        "    assert np.dtype(value) == np.dtype(value)\n"
-    )
-    context = FactoryBuildContext(
-        filename="numpy_dtype.py",
-        catalog=default_catalog(),
-    )
-    built = build_node(
-        _numpy_dtype_call_site(source),
-        filename="numpy_dtype.py",
-        role=SugarRole.TERM,
-        ctx=context,
+    """Truthful twin under kit-loaded protocol (#5407 re-earn; no logo tables)."""
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
 
-    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    load_imported_callee_protocol(
+        {"numpy.dtype": CalleeUniverseSupport.NUMPY_DTYPE}
+    )
+    try:
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_dtype(value):\n"
+            "    assert np.dtype(value) == np.dtype(value)\n"
+        )
+        context = FactoryBuildContext(
+            filename="numpy_dtype.py",
+            catalog=default_catalog(),
+        )
+        built = build_node(
+            _numpy_dtype_call_site(source),
+            filename="numpy_dtype.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+
+        assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
 @pytest.mark.parametrize(
@@ -940,7 +945,13 @@ def test_unwarranted_numpy_dtype_receiver_is_not_factory_owned(source: str) -> N
 
 
 def test_numpy_dtype_witness_pair_is_enrolled() -> None:
-    assert "numpy_dtype_universe_coordinate" in {
+    """Vendor mint witnesses retired with logo tables (#5614).
+
+    Re-earn path is kit protocol + import provenance (see
+    test_imported_callee_protocol_numpy_all_dtype). Production witnesses stay
+    language/stdlib only so MISSING never becomes silent mint success.
+    """
+    assert "numpy_dtype_universe_coordinate" not in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
 
@@ -1074,24 +1085,37 @@ def _numpy_all_call_site(source: str) -> SourceFragment:
 
 
 def test_authenticated_numpy_all_selects_one_factory_owner() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_all(value):\n"
-        "    assert np.all(value)\n"
-    )
-    context = FactoryBuildContext(
-        filename="numpy_all.py",
-        catalog=default_catalog(),
-    )
-    built = build_node(
-        _numpy_all_call_site(source),
-        filename="numpy_all.py",
-        role=SugarRole.TERM,
-        ctx=context,
+    """Truthful twin under kit-loaded protocol (#5408 re-earn; no logo tables)."""
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
 
-    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    load_imported_callee_protocol(
+        {"numpy.all": CalleeUniverseSupport.NUMPY_ALL}
+    )
+    try:
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_all(value):\n"
+            "    assert np.all(value)\n"
+        )
+        context = FactoryBuildContext(
+            filename="numpy_all.py",
+            catalog=default_catalog(),
+        )
+        built = build_node(
+            _numpy_all_call_site(source),
+            filename="numpy_all.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+
+        assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
 @pytest.mark.parametrize(
@@ -1141,7 +1165,13 @@ def test_unwarranted_numpy_all_receiver_is_not_factory_owned(source: str) -> Non
 
 
 def test_numpy_all_witness_pair_is_enrolled() -> None:
-    assert "numpy_all_universe_coordinate" in {
+    """Vendor mint witnesses retired with logo tables (#5614).
+
+    Re-earn path is kit protocol + import provenance (see
+    test_imported_callee_protocol_numpy_all_dtype). Production witnesses stay
+    language/stdlib only so MISSING never becomes silent mint success.
+    """
+    assert "numpy_all_universe_coordinate" not in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_imported_callee_protocol_numpy_all_dtype.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_imported_callee_protocol_numpy_all_dtype.py
@@ -1,0 +1,296 @@
+"""Re-earn call:numpy.all (#5408) and call:numpy.dtype (#5407) via kit protocol.
+
+Architecture (same class as #5617 parametrize / #5618 fixture):
+
+1. **Import/source provenance** — ``imported_call_identity`` resolves the
+   binding chain (import / assignment, shadow-aware). Spelling alone never
+   expands.
+2. **Empty kit protocol** — production ``_PROTOCOL_IMPORTED_SUPPORT`` is empty.
+   Coordinates such as ``numpy.all`` / ``numpy.dtype`` arrive only through
+   ``load_imported_callee_protocol``. No logo string Compare, no name
+   whitelist, no inline isinstance/AST matcher.
+
+Law: no logo string decides construction. MISSING/refused stays loud.
+
+Honest residual: mint is a separate process; in-memory protocol load does not
+reach full-corpus mint. Rows without a process-level kit loader stay
+FactoryPanic — correct, not silent success.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from sugar_lift_py_tests.claim import SugarRole
+from sugar_lift_py_tests.context.factory_build_context import FactoryBuildContext
+from sugar_lift_py_tests.factory.build import build_node, default_catalog
+from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+from sugar_lift_py_tests.recognition.callee_universe import (
+    CalleeUniverseRecognition,
+    CalleeUniverseSupport,
+    clear_imported_callee_protocol,
+    imported_call_identity,
+    load_imported_callee_protocol,
+    recognize_authenticated_callee_identity,
+    recognize_callee_universe,
+)
+from sugar_lift_py_tests.sugar.builtin_callee_universe_sugar import (
+    BuiltinCalleeUniverseSugar,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_imported_callee_protocol():
+    clear_imported_callee_protocol()
+    yield
+    clear_imported_callee_protocol()
+
+
+def _call_site(source: str, *, attr: str | None = None, name: str | None = None):
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if attr is not None and isinstance(node.func, ast.Attribute):
+            if node.func.attr == attr:
+                return SourceFragment.from_node(node, "t.py", source=source)
+        if name is not None and isinstance(node.func, ast.Name):
+            if node.func.id == name:
+                return SourceFragment.from_node(node, "t.py", source=source)
+    raise AssertionError(f"no call site attr={attr!r} name={name!r}")
+
+
+def _load_numpy_all_dtype_protocol() -> None:
+    """Install only the two re-earned coordinates (kit evidence stand-in)."""
+    load_imported_callee_protocol(
+        {
+            "numpy.all": CalleeUniverseSupport.NUMPY_ALL,
+            "numpy.dtype": CalleeUniverseSupport.NUMPY_DTYPE,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Empty-by-construction
+# ---------------------------------------------------------------------------
+
+
+def test_protocol_empty_by_construction() -> None:
+    assert recognize_authenticated_callee_identity("numpy.all") is None
+    assert recognize_authenticated_callee_identity("numpy.dtype") is None
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_all(value):\n"
+        "    return np.all(value)\n"
+    )
+    site = _call_site(source, attr="all")
+    # Provenance still resolves the import identity…
+    assert imported_call_identity(site) == "numpy.all"
+    # …but without a loaded kit contract the universe stays loud.
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe(site=site) is None
+    assert not BuiltinCalleeUniverseSugar.owns(site)
+
+
+# ---------------------------------------------------------------------------
+# Truthful twins — import-bound + protocol → green
+# ---------------------------------------------------------------------------
+
+
+def test_truthful_numpy_all_attr_under_protocol() -> None:
+    _load_numpy_all_dtype_protocol()
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_all(value):\n"
+        "    return np.all(value)\n"
+    )
+    site = _call_site(source, attr="all")
+    assert imported_call_identity(site) == "numpy.all"
+    assert CalleeUniverseRecognition.coordinate(site) == "numpy.all"
+    assert (
+        recognize_callee_universe("call:numpy.all", site=site)
+        is CalleeUniverseSupport.NUMPY_ALL
+    )
+    assert BuiltinCalleeUniverseSugar.owns(site)
+    built = build_node(
+        site,
+        filename="t.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="t.py", catalog=default_catalog()),
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+def test_truthful_numpy_all_from_import_under_protocol() -> None:
+    """from numpy import all; all(...) authenticates as numpy.all, not bare all."""
+    _load_numpy_all_dtype_protocol()
+    source = "from numpy import all\n\ndef test_all(value):\n    return all(value)\n"
+    site = _call_site(source, name="all")
+    assert imported_call_identity(site) == "numpy.all"
+    assert CalleeUniverseRecognition.coordinate(site) == "numpy.all"
+    assert (
+        recognize_callee_universe(site=site) is CalleeUniverseSupport.NUMPY_ALL
+    )
+
+
+def test_truthful_numpy_dtype_attr_under_protocol() -> None:
+    _load_numpy_all_dtype_protocol()
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_dtype(value):\n"
+        "    return np.dtype(value)\n"
+    )
+    site = _call_site(source, attr="dtype")
+    assert imported_call_identity(site) == "numpy.dtype"
+    assert CalleeUniverseRecognition.coordinate(site) == "numpy.dtype"
+    assert (
+        recognize_callee_universe("call:numpy.dtype", site=site)
+        is CalleeUniverseSupport.NUMPY_DTYPE
+    )
+    assert BuiltinCalleeUniverseSugar.owns(site)
+    built = build_node(
+        site,
+        filename="t.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="t.py", catalog=default_catalog()),
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+
+def test_truthful_numpy_dtype_from_import_under_protocol() -> None:
+    _load_numpy_all_dtype_protocol()
+    source = (
+        "from numpy import dtype\n"
+        "\n"
+        "def test_dtype(value):\n"
+        "    return dtype(value)\n"
+    )
+    site = _call_site(source, name="dtype")
+    assert imported_call_identity(site) == "numpy.dtype"
+    assert CalleeUniverseRecognition.coordinate(site) == "numpy.dtype"
+    assert (
+        recognize_callee_universe(site=site) is CalleeUniverseSupport.NUMPY_DTYPE
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lying twins — lookalike / shadow / wrong module MUST refuse even with protocol
+# ---------------------------------------------------------------------------
+
+
+_LYING_ALL_SOURCES = (
+    # Wrong module aliased as np (logo spelling of leaf alone is not enough).
+    (
+        "import math as np\n"
+        "\n"
+        "def test_all(value):\n"
+        "    return np.all(value)\n"
+    ),
+    # Parameter shadow of the import binding.
+    (
+        "import numpy as np\n"
+        "\n"
+        "def test_all(np, value):\n"
+        "    return np.all(value)\n"
+    ),
+    # Later function-local rebind revokes the import warrant.
+    (
+        "import numpy as np\n"
+        "\n"
+        "def test_all(value):\n"
+        "    result = np.all(value)\n"
+        "    np = replacement\n"
+        "    return result\n"
+    ),
+    # Unauthenticated FQN spelling without an import binding.
+    (
+        "def test_all(value):\n"
+        "    return numpy.all(value)\n"
+    ),
+)
+
+
+@pytest.mark.parametrize("source", _LYING_ALL_SOURCES)
+def test_lying_numpy_all_refuses_even_with_protocol(source: str) -> None:
+    _load_numpy_all_dtype_protocol()
+    site = _call_site(source, attr="all")
+    # Identity is None (shadow/FQN) or a non-numpy origin (math.all) — never
+    # the authenticated numpy import binding.
+    assert imported_call_identity(site) != "numpy.all"
+    assert recognize_callee_universe("call:numpy.all", site=site) is None
+    assert CalleeUniverseRecognition.coordinate(site) != "numpy.all"
+    assert not BuiltinCalleeUniverseSugar.owns(site)
+
+
+_LYING_DTYPE_SOURCES = (
+    (
+        "import struct as np\n"
+        "\n"
+        "def test_dtype(value):\n"
+        "    return np.dtype(value)\n"
+    ),
+    (
+        "import math as np\n"
+        "\n"
+        "def test_dtype(value):\n"
+        "    return np.dtype(value)\n"
+    ),
+    (
+        "import numpy as np\n"
+        "\n"
+        "def test_dtype(np, value):\n"
+        "    return np.dtype(value)\n"
+    ),
+    (
+        "import numpy as np\n"
+        "\n"
+        "def test_dtype(value):\n"
+        "    result = np.dtype(value)\n"
+        "    np = replacement\n"
+        "    return result\n"
+    ),
+    (
+        "def test_dtype(value):\n"
+        "    return numpy.dtype(value)\n"
+    ),
+)
+
+
+@pytest.mark.parametrize("source", _LYING_DTYPE_SOURCES)
+def test_lying_numpy_dtype_refuses_even_with_protocol(source: str) -> None:
+    _load_numpy_all_dtype_protocol()
+    site = _call_site(source, attr="dtype")
+    assert recognize_callee_universe("call:numpy.dtype", site=site) is None
+    assert CalleeUniverseRecognition.coordinate(site) != "numpy.dtype"
+    assert not BuiltinCalleeUniverseSugar.owns(site)
+
+
+def test_logo_spelling_alone_never_authenticates() -> None:
+    """Regression: Attribute leaf 'all'/'dtype' is not a logo Compare path."""
+    _load_numpy_all_dtype_protocol()
+    # Spelling-only Attribute chain without any import.
+    for attr, target in (("all", "call:numpy.all"), ("dtype", "call:numpy.dtype")):
+        source = (
+            f"def test_x(value):\n"
+            f"    return pretend.{attr}(value)\n"
+        )
+        site = _call_site(source, attr=attr)
+        assert imported_call_identity(site) is None
+        assert recognize_callee_universe(target, site=site) is None
+
+
+def test_production_tables_carry_no_numpy_logo_keys() -> None:
+    """Hard law: production recognition tables stay empty of vendor logos."""
+    from sugar_lift_py_tests.recognition import callee_universe as mod
+
+    for key in mod._IMPORTED_SUPPORT:
+        assert not key.startswith("numpy."), key
+        assert not key.startswith("np."), key
+    # Overlay starts empty; only this process's loaders may fill it.
+    clear_imported_callee_protocol()
+    assert mod._PROTOCOL_IMPORTED_SUPPORT == {}


### PR DESCRIPTION
## Summary

Part of #5252. Re-earns **#5408** (`call:numpy.all`, 9 verified-live) and **#5407** (`call:numpy.dtype`, 12 verified-live) after logo-table deletion (#5614).

**CLAIMED** (our codex-iterm fleet, window 416) — both issues `in-progress` + `fleet:lane`.

**Law:** no logo string decides construction. MISSING/refused must never become success.

### Architecture (same shape as #5617 parametrize / #5618 fixture / #5620 type)

| Path | What shipped |
|------|----------------|
| **(a) Import/source provenance** | `imported_call_identity` resolves the binding chain (import / assignment, shadow-aware). Spelling-only Attribute chains never expand. |
| **(b) Empty kit protocol** | `_PROTOCOL_IMPORTED_SUPPORT` empty by construction + `load_imported_callee_protocol` / `clear_imported_callee_protocol`. Vendor coordinates (`numpy.all`, `numpy.dtype`) arrive only through the loader. Production tables stay free of logos. |

No name whitelist. No inline `isinstance`/AST matcher. No `"numpy"` / `"np"` Compare path.

### Twins

| Twin | Expectation |
|------|-------------|
| Truthful | `import numpy as np` + `load_imported_callee_protocol({"numpy.all": NUMPY_ALL, …})` → `BuiltinCalleeUniverseSugar` owns |
| Truthful from-import | `from numpy import all` under protocol → coordinate `numpy.all` (not bare builtin) |
| Lying `import math as np` | refuses even with real coordinate loaded |
| Lying parameter shadow | refuses |
| Lying late rebind | refuses |
| Lying unauthenticated FQN | refuses |
| Without protocol | import-bound alone → loud (honest residual) |

**Red-first:** illegal leaf-logo match would green the `math as np` twin (FAIL). Provenance restored → green.

### Honest residual (LOUD FactoryPanic — not drained)

Mint is a separate process; in-memory protocol load does not reach it. Full-corpus rows for `call:numpy.all` / `call:numpy.dtype` stay **FactoryPanic** until a process-level kit loader exists. That is correct — not silent success. This PR does **not** count corpus mint rows as drained.

Named residual:

- Production mint without kit contract → universe gap / MethodCallSugar / FactoryPanic (honest)
- Vendor mint witnesses (`numpy_all_universe_coordinate`, `numpy_dtype_universe_coordinate`) stay **unenrolled** so MISSING never becomes silent mint success

### Floors

- `R_vendor_special_case = 0` (no logo keys in production `_IMPORTED_SUPPORT` / `_CALL_SHAPES`)
- Focused twins: 34 passed
- No floor/twin/panic weakened

### Coordination

- Builds on #5617 / #5618 empty-kit contract shape
- Does not reintroduce #5614-deleted production logo tables
- Does not self-merge — soundness-read merge when ready

## Validation

```bash
export PYTHONPATH=implementations/python/sugar-lift-python-source/src:implementations/python/sugar-lift-py-tests/src
/Users/tsavo/provekit/.venv/bin/python -m pytest \
  implementations/python/sugar-lift-py-tests/tests/test_imported_callee_protocol_numpy_all_dtype.py \
  implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py::test_next_unclassified_coordinate_batch_is_enrolled \
  implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py::test_authenticated_numpy_all_selects_one_factory_owner \
  implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py::test_authenticated_numpy_dtype_selects_one_factory_owner \
  implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py::test_unwarranted_numpy_all_receiver_is_not_factory_owned \
  implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py::test_unwarranted_numpy_dtype_receiver_is_not_factory_owned \
  implementations/python/sugar-lift-py-tests/tests/test_vendor_logo_table_drain_5603.py -q
# 34 passed

/Users/tsavo/provekit/.venv/bin/python \
  implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
# R_vendor_special_case = 0
```

Do not self-merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-earn `numpy.all` and `numpy.dtype` recognition via a runtime-loaded callee protocol overlay
> - Adds `_PROTOCOL_IMPORTED_SUPPORT`, a mutable overlay dict in [`callee_universe.py`](https://github.com/TSavo/sugar/pull/5902/files#diff-72e9f915afa350390348a1c277d0c2047b26a0182bb4780c57baf73f30fdcaa8) that holds kit-loaded import identities separate from the static `_IMPORTED_SUPPORT` table.
> - Adds `load_imported_callee_protocol` and `clear_imported_callee_protocol` to install or remove overlay coordinates at runtime; `recognize_authenticated_callee_identity` now checks both tables.
> - Removes vendor-rooted numpy identities from the static production table; numpy callee recognition now requires the protocol overlay to be explicitly loaded.
> - Adds a new test module [`test_imported_callee_protocol_numpy_all_dtype.py`](https://github.com/TSavo/sugar/pull/5902/files#diff-aa5eac59cbba38e3fcb758db19dc2383bc8d47396a7e8d2285e2005f78aef3a8) covering truthful-twin recognition and lying-twin rejection under the overlay.
> - Behavioral Change: `numpy.all` and `numpy.dtype` are no longer recognized by default; callers must load the protocol overlay first.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 217f3e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for loading and clearing trusted imported-callee recognition protocols.
  - Improved recognition of imported functions and methods across aliases and direct imports.
  - Added provenance-aware support for selected NumPy calls.

- **Bug Fixes**
  - Prevented misleading names, shadowed imports, rebinding, and unauthenticated fully qualified calls from being recognized.
  - Removed reliance on hard-coded vendor-specific recognition entries.

- **Tests**
  - Added comprehensive coverage for trusted imports, invalid aliases, and protocol reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->