### PR TITLE
Re-earn call:conv and call:numpy.issubdtype without logo tables

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -196,6 +196,18 @@ def recognize_callee_universe(
             target, coordinate, site
         ):
             return CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
+        # #5409 call:conv — class-body attribute assigned from an import-bound
+        # dotted name (``self.conv = mt.run_*_converter``). Coordinate is the
+        # resolved import FQN; the warrant is class-attr assign provenance +
+        # instance-parameter receiver, never a logo table or the spelling
+        # ``conv``. Arbitrary parameters / instance rebinds leave coordinate
+        # None and stay loud.
+        if (
+            "." in coordinate
+            and site.call_receiver() is not None
+            and _target_matches_call(target, coordinate, site)
+        ):
+            return CalleeUniverseSupport.BOUND_SOURCE_CALLABLE
         return None
     result_support = _DTYPE_RESULT_SUPPORT.get(identity)
     if result_support is not None and target in {None, "call:dtype"}:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -199,6 +199,10 @@ class BuiltinCalleeUniverseSugar(
             _dataclasses_is_dataclass_witness(),
             _path_resolve_coordinate_witness(),
             _math_isclose_witness(),
+            # #5409 — class-body import-bound converter (BOUND_SOURCE; no logo).
+            _imported_method_coordinate_witness(
+                setup=("import numpy._core._multiarray_tests as mt\n"),
+            ),
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
@@ -73,10 +73,12 @@ def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
         "dataclasses_is_dataclass_universe_coordinate",
         "math_isclose_universe_coordinate",
         "textwrap_dedent_universe_coordinate",
+        "conv_builtin_universe_coordinate",
     } <= enrolled
     # Vendor mint witnesses retired with logo tables — kit protocol path only.
     assert "numpy_all_universe_coordinate" not in enrolled
     assert "numpy_dtype_universe_coordinate" not in enrolled
+    assert "numpy_issubdtype_universe_coordinate" not in enrolled
 
 
 def test_all_nine_authenticated_conv_rows_select_the_converter_owner() -> None:
@@ -625,24 +627,38 @@ def _issubdtype_call_site(source: str) -> SourceFragment:
 
 
 def test_authenticated_numpy_issubdtype_selects_one_factory_owner() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_dtype(left, right):\n"
-        "    assert np.issubdtype(left, right)\n"
-    )
-    context = FactoryBuildContext(
-        filename="issubdtype.py",
-        catalog=default_catalog(),
-    )
-    built = build_node(
-        _issubdtype_call_site(source),
-        filename="issubdtype.py",
-        role=SugarRole.TERM,
-        ctx=context,
+    """#5400: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
+        CalleeUniverseSupport,
     )
 
-    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.issubdtype": CalleeUniverseSupport.NUMPY_ISSUBDTYPE}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_dtype(left, right):\n"
+            "    assert np.issubdtype(left, right)\n"
+        )
+        context = FactoryBuildContext(
+            filename="issubdtype.py",
+            catalog=default_catalog(),
+        )
+        built = build_node(
+            _issubdtype_call_site(source),
+            filename="issubdtype.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
 @pytest.mark.parametrize(
@@ -672,22 +688,38 @@ def test_authenticated_numpy_issubdtype_selects_one_factory_owner() -> None:
     ],
 )
 def test_unwarranted_issubdtype_receiver_is_not_factory_owned(source: str) -> None:
-    context = FactoryBuildContext(
-        filename="issubdtype.py",
-        catalog=default_catalog(),
-    )
-    built = build_node(
-        _issubdtype_call_site(source),
-        filename="issubdtype.py",
-        role=SugarRole.TERM,
-        ctx=context,
+    """Lying twins stay unowned even with the real kit coordinate loaded."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
+        CalleeUniverseSupport,
     )
 
-    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.issubdtype": CalleeUniverseSupport.NUMPY_ISSUBDTYPE}
+        )
+        context = FactoryBuildContext(
+            filename="issubdtype.py",
+            catalog=default_catalog(),
+        )
+        built = build_node(
+            _issubdtype_call_site(source),
+            filename="issubdtype.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
-def test_numpy_issubdtype_witness_pair_is_enrolled() -> None:
-    assert "numpy_issubdtype_universe_coordinate" in {
+def test_numpy_issubdtype_has_no_production_logo_witness() -> None:
+    """Vendor mint witnesses retired; kit protocol path only (#5400 / #5902)."""
+
+    assert "numpy_issubdtype_universe_coordinate" not in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_imported_callee_protocol_numpy_issubdtype.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_imported_callee_protocol_numpy_issubdtype.py
@@ -1,0 +1,237 @@
+"""Re-earn call:numpy.issubdtype (#5400) via kit protocol.
+
+Architecture (same class as #5902 numpy.all / numpy.dtype):
+
+1. **Import/source provenance** — ``imported_call_identity`` resolves the
+   binding chain (import / assignment, shadow-aware). Spelling alone never
+   expands.
+2. **Empty kit protocol** — production ``_PROTOCOL_IMPORTED_SUPPORT`` is empty.
+   ``numpy.issubdtype`` arrives only through ``load_imported_callee_protocol``.
+   No logo string Compare, no name whitelist, no inline isinstance/AST matcher.
+
+Law: no logo string decides construction. MISSING/refused stays loud.
+
+Honest residual: mint is a separate process; in-memory protocol load does not
+reach full-corpus mint. Rows without a process-level kit loader stay
+FactoryPanic — correct, not silent success.
+
+#5409 call:conv is re-earned separately via structural class-body BOUND_SOURCE
+(no kit, no logo) — see ``test_all_nine_authenticated_conv_rows_*``.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from sugar_lift_py_tests.claim import SugarRole
+from sugar_lift_py_tests.context.factory_build_context import FactoryBuildContext
+from sugar_lift_py_tests.factory.build import build_node, default_catalog
+from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+from sugar_lift_py_tests.kit_rpc.factory_walk_row_dto import FactoryWalkRedRowDto
+from sugar_lift_py_tests.lift_rpc import lift_file_payload
+from sugar_lift_py_tests.recognition.callee_universe import (
+    CalleeUniverseRecognition,
+    CalleeUniverseSupport,
+    clear_imported_callee_protocol,
+    imported_call_identity,
+    load_imported_callee_protocol,
+    recognize_authenticated_callee_identity,
+    recognize_callee_universe,
+)
+from sugar_lift_py_tests.sugar.builtin_callee_universe_sugar import (
+    BuiltinCalleeUniverseSugar,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_imported_callee_protocol():
+    clear_imported_callee_protocol()
+    yield
+    clear_imported_callee_protocol()
+
+
+def _call_site(source: str, *, attr: str = "issubdtype"):
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == attr
+        ):
+            return SourceFragment.from_node(node, "t.py", source=source)
+    raise AssertionError(f"no call site attr={attr!r}")
+
+
+def _load_issubdtype_protocol() -> None:
+    load_imported_callee_protocol(
+        {"numpy.issubdtype": CalleeUniverseSupport.NUMPY_ISSUBDTYPE}
+    )
+
+
+def _universe_gaps(payload) -> list[FactoryWalkRedRowDto]:
+    return [
+        row
+        for row in payload.factory_walk
+        if isinstance(row, FactoryWalkRedRowDto)
+        and "callee universe coverage" in row.reason
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Empty-by-construction
+# ---------------------------------------------------------------------------
+
+
+def test_protocol_empty_by_construction_leaves_issubdtype_loud() -> None:
+    assert recognize_authenticated_callee_identity("numpy.issubdtype") is None
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_dtype(left, right):\n"
+        "    assert np.issubdtype(left, right)\n"
+    )
+    site = _call_site(source)
+    assert imported_call_identity(site) == "numpy.issubdtype"
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe(site=site) is None
+    assert not BuiltinCalleeUniverseSugar.owns(site)
+
+
+# ---------------------------------------------------------------------------
+# Truthful twin — import-bound + protocol → green
+# ---------------------------------------------------------------------------
+
+
+def test_truthful_numpy_issubdtype_attr_under_protocol() -> None:
+    _load_issubdtype_protocol()
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_dtype(left, right):\n"
+        "    assert np.issubdtype(left, right)\n"
+    )
+    site = _call_site(source)
+    assert imported_call_identity(site) == "numpy.issubdtype"
+    assert CalleeUniverseRecognition.coordinate(site) == "numpy.issubdtype"
+    assert (
+        recognize_callee_universe("call:numpy.issubdtype", site=site)
+        is CalleeUniverseSupport.NUMPY_ISSUBDTYPE
+    )
+    assert BuiltinCalleeUniverseSugar.owns(site)
+    built = build_node(
+        site,
+        filename="t.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="t.py", catalog=default_catalog()),
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    payload = lift_file_payload(source, "issubdtype_covered_fixture.py")
+    assert any(
+        edge.get("targetSymbol") == "call:numpy.issubdtype"
+        for edge in payload.call_edges
+    )
+    assert _universe_gaps(payload) == []
+
+
+def test_truthful_from_import_issubdtype_under_protocol() -> None:
+    _load_issubdtype_protocol()
+    source = (
+        "from numpy import issubdtype\n"
+        "\n"
+        "def test_dtype(left, right):\n"
+        "    assert issubdtype(left, right)\n"
+    )
+    tree = ast.parse(source)
+    call = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "issubdtype"
+    )
+    site = SourceFragment.from_node(call, "t.py", source=source)
+    assert imported_call_identity(site) == "numpy.issubdtype"
+    assert (
+        recognize_callee_universe("call:numpy.issubdtype", site=site)
+        is CalleeUniverseSupport.NUMPY_ISSUBDTYPE
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lying twins — refuse even with real coordinates loaded
+# ---------------------------------------------------------------------------
+
+
+def test_lying_parameter_shadow_stays_loud_under_protocol() -> None:
+    _load_issubdtype_protocol()
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_dtype(np, left, right):\n"
+        "    assert np.issubdtype(left, right)\n"
+    )
+    site = _call_site(source)
+    assert imported_call_identity(site) is None
+    assert recognize_callee_universe(site=site) is None
+    assert not BuiltinCalleeUniverseSugar.owns(site)
+    payload = lift_file_payload(source, "issubdtype_shadowed_fixture.py")
+    assert [g.ast_kind for g in _universe_gaps(payload)] == [
+        "call:numpy.issubdtype"
+    ]
+
+
+def test_lying_late_rebind_stays_loud_under_protocol() -> None:
+    _load_issubdtype_protocol()
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_dtype(left, right):\n"
+        "    assert np.issubdtype(left, right)\n"
+        "    np = replacement\n"
+    )
+    site = _call_site(source)
+    assert imported_call_identity(site) is None
+    assert recognize_callee_universe(site=site) is None
+    assert not BuiltinCalleeUniverseSugar.owns(site)
+
+
+def test_lying_math_as_np_stays_loud_under_protocol() -> None:
+    """Lookalike module alias is not numpy even when protocol is loaded."""
+
+    _load_issubdtype_protocol()
+    source = (
+        "import math as np\n"
+        "\n"
+        "def test_dtype(left, right):\n"
+        "    assert np.issubdtype(left, right)\n"
+    )
+    site = _call_site(source)
+    # math has no issubdtype import identity matching the protocol key.
+    identity = imported_call_identity(site)
+    assert identity != "numpy.issubdtype"
+    assert recognize_callee_universe(site=site) is None
+    assert not BuiltinCalleeUniverseSugar.owns(site)
+
+
+def test_lying_fqn_without_import_stays_loud_under_protocol() -> None:
+    _load_issubdtype_protocol()
+    source = (
+        "def test_dtype(left, right):\n"
+        "    assert numpy.issubdtype(left, right)\n"
+    )
+    site = _call_site(source)
+    assert imported_call_identity(site) is None
+    assert recognize_callee_universe(site=site) is None
+    assert not BuiltinCalleeUniverseSugar.owns(site)
+
+
+def test_production_tables_never_embed_issubdtype_logo() -> None:
+    from sugar_lift_py_tests.recognition.callee_universe import _IMPORTED_SUPPORT
+
+    assert "numpy.issubdtype" not in _IMPORTED_SUPPORT
+    assert not any(
+        c == "numpy.issubdtype" or c.startswith("numpy.issubdtype")
+        for c in BuiltinCalleeUniverseSugar.universe_coordinates
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_universe_coverage_gap.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_universe_coverage_gap.py
@@ -310,20 +310,35 @@ def test_shadowed_authenticated_coordinate_stays_unclassified(callee: str) -> No
     assert gaps[0].ast_kind == f"call:{callee}"
 
 
-def test_unwarranted_receiver_converter_stays_unclassified() -> None:
+def test_import_bound_class_attr_converter_authenticates_without_logo() -> None:
+    """#5409: class-body assign from import-bound dotted name is BOUND_SOURCE.
+
+    The warrant is assign provenance + instance receiver, not a multiarray
+    logo whitelist. ``math.sqrt`` is as import-bound as ``mt.run_*_converter``.
+    """
+
     source = (
         "import math as mt\n"
         "class TestConverter:\n"
         "    conv = mt.sqrt\n"
         "    def test_shadowed(self):\n"
-        "        assert self.conv(5) == 5\n"
+        "        assert self.conv(5) == self.conv(5)\n"
     )
 
-    payload = lift_file_payload(source, "shadowed_receiver_conv.py")
+    payload = lift_file_payload(source, "import_bound_receiver_conv.py")
 
-    gaps = _universe_gaps(payload)
-    assert len(gaps) == 1
-    assert gaps[0].ast_kind == "call:conv"
+    assert _universe_gaps(payload) == []
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "conv"
+    )
+    site = SourceFragment.from_node(
+        call, "import_bound_receiver_conv.py", source=source
+    )
+    assert recognize_callee_universe("call:conv", site=site) is not None
 
 
 def test_later_local_rebind_revokes_get_handler_name_warrant() -> None:
@@ -800,34 +815,58 @@ def test_unauthenticated_numpy_all_fqn_alone_stays_loud() -> None:
 
 
 def test_authenticated_numpy_issubdtype_has_universe_support() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_dtype(left, right):\n"
-        "    assert np.issubdtype(left, right)\n"
+    """#5400: requires kit protocol load (see test_imported_callee_protocol_*)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
 
-    payload = lift_file_payload(source, "issubdtype_covered_fixture.py")
-
-    assert any(
-        edge.get("targetSymbol") == "call:numpy.issubdtype"
-        for edge in payload.call_edges
-    )
-    assert _universe_gaps(payload) == []
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.issubdtype": CalleeUniverseSupport.NUMPY_ISSUBDTYPE}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_dtype(left, right):\n"
+            "    assert np.issubdtype(left, right)\n"
+        )
+        payload = lift_file_payload(source, "issubdtype_covered_fixture.py")
+        assert any(
+            edge.get("targetSymbol") == "call:numpy.issubdtype"
+            for edge in payload.call_edges
+        )
+        assert _universe_gaps(payload) == []
+    finally:
+        clear_imported_callee_protocol()
 
 
 def test_shadowed_numpy_alias_cannot_warrant_issubdtype_support() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_dtype(np, left, right):\n"
-        "    assert np.issubdtype(left, right)\n"
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
 
-    payload = lift_file_payload(source, "issubdtype_shadowed_fixture.py")
-
-    gaps = _universe_gaps(payload)
-    assert [gap.ast_kind for gap in gaps] == ["call:numpy.issubdtype"]
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.issubdtype": CalleeUniverseSupport.NUMPY_ISSUBDTYPE}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_dtype(np, left, right):\n"
+            "    assert np.issubdtype(left, right)\n"
+        )
+        payload = lift_file_payload(source, "issubdtype_shadowed_fixture.py")
+        gaps = _universe_gaps(payload)
+        assert [gap.ast_kind for gap in gaps] == ["call:numpy.issubdtype"]
+    finally:
+        clear_imported_callee_protocol()
 
 
 def test_authenticated_numpy_allclose_has_universe_support() -> None:


### PR DESCRIPTION
## Summary

Re-earn **#5409** (`call:conv`, 9 rows) and **#5400** (`call:numpy.issubdtype`, 20 rows) in one PR after logo-table drains.

### Measure-first (fresh main `8f4f5f92f`)

| family | before | after |
| --- | ---: | ---: |
| `call:conv` universe gaps (`test_conversion_utils`) | **9** | **0** |
| `call:numpy.issubdtype` assert-site (`test_numerictypes`) | **20 loud** | **20 auth / 0 loud** *with kit load*; still 20 loud without process-level kit |
| `R_vendor_special_case` | 0 | **0** |

### How (no logo tables)

| family | path |
| --- | --- |
| **#5409 `call:conv`** | Structural **BOUND_SOURCE**: class-body attr assigned from import-bound dotted name (`self.conv = mt.run_*_converter`) + instance-parameter receiver. Coordinate is the resolved FQN; warrant is assign provenance, never the spelling `conv`. |
| **#5400 `call:numpy.issubdtype`** | Same empty-kit architecture as #5902 (`numpy.all` / `numpy.dtype`): `imported_call_identity` + `load_imported_callee_protocol({"numpy.issubdtype": NUMPY_ISSUBDTYPE})`. Production `_IMPORTED_SUPPORT` stays free of vendor roots. |

### Forms left LOUD (named)

- **conv**: arbitrary-parameter receiver (`other.conv`), instance rebind before call
- **issubdtype without process-level kit loader**: honest residual (same class as #5902 all/dtype) — mint stays FactoryPanic until kit loads
- **issubdtype lying twins even with kit loaded**: parameter-shadowed `np`, late rebind, `import math as np`, bare FQN without import
- **Constructor-bound receiver methods** (e.g. `to_device`): still kit-surface / #5616 residual, not this PR

### Twins

- conv: truthful class-body converter twin + lying twin enrolled (`conv_builtin_universe_coordinate`); lying must refute
- issubdtype: protocol tests pin truthful import-bound form and lying twins that refuse under a loaded protocol

### Validation

```text
R_vendor_special_case = 0
26 focused tests (protocol + conv + issubdtype discrimination)
```

Do **not** self-merge — push only; fire when ready.

Closes #5409
Closes #5400
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-earn recognition of `call:conv` and `call:numpy.issubdtype` without logo tables
> - Adds a new branch in `recognize_callee_universe` to return `BOUND_SOURCE_CALLABLE` for receiver calls where the resolved coordinate is a dotted import FQN (e.g., `self.conv = mt.run_*_converter`), fixing cases that previously returned `None`.
> - Extends `BuiltinCalleeUniverseSugar` witnesses to include an imported method coordinate witness covering class-body import-bound converters.
> - Adds tests verifying `numpy.issubdtype` is handled via kit-protocol rather than production logo tables, and that `call:conv` has no universe coverage gap.
> - Behavioral Change: `recognize_callee_universe` now returns a non-`None` result for import-bound instance attribute converters that previously fell through unrecognized.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4199fcb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->