### PR TITLE
Re-earn call:numpy.isnat via import provenance

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -22,6 +22,7 @@ class CalleeUniverseSupport(Enum):
 
     NUMPY_DTYPE_RESULT = auto()
     NUMPY_ISSUBDTYPE = auto()
+    NUMPY_ISNAT = auto()
     NUMPY_ALLCLOSE = auto()
     NUMPY_CAN_CAST = auto()
     NUMPY_ISNAN = auto()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -65,6 +65,7 @@ _OWNED_IMPORTED_SUPPORT = frozenset(
     | {
         CalleeUniverseSupport.NUMPY_CAN_CAST,
         CalleeUniverseSupport.NUMPY_ISSUBDTYPE,
+        CalleeUniverseSupport.NUMPY_ISNAT,
         CalleeUniverseSupport.NUMPY_ISNAN,
         CalleeUniverseSupport.NUMPY_ALL,
         CalleeUniverseSupport.NUMPY_DTYPE,

--- a/implementations/python/sugar-lift-py-tests/tests/test_imported_callee_protocol_numpy_isnat.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_imported_callee_protocol_numpy_isnat.py
@@ -1,0 +1,229 @@
+"""Re-earn call:numpy.isnat (#5402) via kit protocol.
+
+Architecture (same class as #5902 numpy.all / numpy.dtype and #5400
+numpy.issubdtype):
+
+1. **Import/source provenance** — ``imported_call_identity`` resolves the
+   binding chain (import / assignment, shadow-aware). Spelling alone never
+   expands.
+2. **Empty kit protocol** — production ``_PROTOCOL_IMPORTED_SUPPORT`` is empty.
+   ``numpy.isnat`` arrives only through ``load_imported_callee_protocol``.
+   No logo string Compare, no name whitelist, no inline isinstance/AST matcher.
+
+Law: no logo string decides construction. MISSING/refused stays loud.
+
+Honest residual: mint is a separate process; in-memory protocol load does not
+reach full-corpus mint. Rows without a process-level kit loader stay
+FactoryPanic — correct, not silent success.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from sugar_lift_py_tests.claim import SugarRole
+from sugar_lift_py_tests.context.factory_build_context import FactoryBuildContext
+from sugar_lift_py_tests.factory.build import build_node, default_catalog
+from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+from sugar_lift_py_tests.kit_rpc.factory_walk_row_dto import FactoryWalkRedRowDto
+from sugar_lift_py_tests.lift_rpc import lift_file_payload
+from sugar_lift_py_tests.recognition.callee_universe import (
+    CalleeUniverseRecognition,
+    CalleeUniverseSupport,
+    clear_imported_callee_protocol,
+    imported_call_identity,
+    load_imported_callee_protocol,
+    recognize_authenticated_callee_identity,
+    recognize_callee_universe,
+)
+from sugar_lift_py_tests.sugar.builtin_callee_universe_sugar import (
+    BuiltinCalleeUniverseSugar,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_imported_callee_protocol():
+    clear_imported_callee_protocol()
+    yield
+    clear_imported_callee_protocol()
+
+
+def _call_site(source: str, *, attr: str = "isnat"):
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == attr
+        ):
+            return SourceFragment.from_node(node, "t.py", source=source)
+    raise AssertionError(f"no call site attr={attr!r}")
+
+
+def _load_isnat_protocol() -> None:
+    load_imported_callee_protocol(
+        {"numpy.isnat": CalleeUniverseSupport.NUMPY_ISNAT}
+    )
+
+
+def _universe_gaps(payload) -> list[FactoryWalkRedRowDto]:
+    return [
+        row
+        for row in payload.factory_walk
+        if isinstance(row, FactoryWalkRedRowDto)
+        and "callee universe coverage" in row.reason
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Empty-by-construction
+# ---------------------------------------------------------------------------
+
+
+def test_protocol_empty_by_construction_leaves_isnat_loud() -> None:
+    assert recognize_authenticated_callee_identity("numpy.isnat") is None
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_isnat(value):\n"
+        "    assert np.isnat(value)\n"
+    )
+    site = _call_site(source)
+    assert imported_call_identity(site) == "numpy.isnat"
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe(site=site) is None
+    assert not BuiltinCalleeUniverseSugar.owns(site)
+
+
+# ---------------------------------------------------------------------------
+# Truthful twin — import-bound + protocol → green
+# ---------------------------------------------------------------------------
+
+
+def test_truthful_numpy_isnat_attr_under_protocol() -> None:
+    _load_isnat_protocol()
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_isnat(value):\n"
+        "    assert np.isnat(value)\n"
+    )
+    site = _call_site(source)
+    assert imported_call_identity(site) == "numpy.isnat"
+    assert CalleeUniverseRecognition.coordinate(site) == "numpy.isnat"
+    assert (
+        recognize_callee_universe("call:numpy.isnat", site=site)
+        is CalleeUniverseSupport.NUMPY_ISNAT
+    )
+    assert BuiltinCalleeUniverseSugar.owns(site)
+    built = build_node(
+        site,
+        filename="t.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="t.py", catalog=default_catalog()),
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    payload = lift_file_payload(source, "isnat_covered_fixture.py")
+    assert any(
+        edge.get("targetSymbol") == "call:numpy.isnat"
+        for edge in payload.call_edges
+    )
+    assert _universe_gaps(payload) == []
+
+
+def test_truthful_from_import_isnat_under_protocol() -> None:
+    _load_isnat_protocol()
+    source = (
+        "from numpy import isnat\n"
+        "\n"
+        "def test_isnat(value):\n"
+        "    assert isnat(value)\n"
+    )
+    tree = ast.parse(source)
+    call = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "isnat"
+    )
+    site = SourceFragment.from_node(call, "t.py", source=source)
+    assert imported_call_identity(site) == "numpy.isnat"
+    assert (
+        recognize_callee_universe("call:numpy.isnat", site=site)
+        is CalleeUniverseSupport.NUMPY_ISNAT
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lying twins — refuse even with real coordinates loaded
+# ---------------------------------------------------------------------------
+
+
+def test_lying_parameter_shadow_stays_loud_under_protocol() -> None:
+    _load_isnat_protocol()
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_isnat(np, value):\n"
+        "    assert np.isnat(value)\n"
+    )
+    site = _call_site(source)
+    assert imported_call_identity(site) is None
+    assert recognize_callee_universe(site=site) is None
+    assert not BuiltinCalleeUniverseSugar.owns(site)
+    payload = lift_file_payload(source, "isnat_shadowed_fixture.py")
+    assert [g.ast_kind for g in _universe_gaps(payload)] == ["call:numpy.isnat"]
+
+
+def test_lying_late_rebind_stays_loud_under_protocol() -> None:
+    _load_isnat_protocol()
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_isnat(value):\n"
+        "    assert np.isnat(value)\n"
+        "    np = replacement\n"
+    )
+    site = _call_site(source)
+    assert imported_call_identity(site) is None
+    assert recognize_callee_universe(site=site) is None
+    assert not BuiltinCalleeUniverseSugar.owns(site)
+
+
+def test_lying_math_as_np_stays_loud_under_protocol() -> None:
+    """Lookalike module alias is not numpy even when protocol is loaded."""
+
+    _load_isnat_protocol()
+    source = (
+        "import math as np\n"
+        "\n"
+        "def test_isnat(value):\n"
+        "    assert np.isnat(value)\n"
+    )
+    site = _call_site(source)
+    # math has no isnat import identity matching the protocol key.
+    identity = imported_call_identity(site)
+    assert identity != "numpy.isnat"
+    assert recognize_callee_universe(site=site) is None
+    assert not BuiltinCalleeUniverseSugar.owns(site)
+
+
+def test_lying_fqn_without_import_stays_loud_under_protocol() -> None:
+    _load_isnat_protocol()
+    source = (
+        "def test_isnat(value):\n"
+        "    assert numpy.isnat(value)\n"
+    )
+    site = _call_site(source)
+    assert imported_call_identity(site) is None
+    assert recognize_callee_universe(site=site) is None
+    assert not BuiltinCalleeUniverseSugar.owns(site)
+
+
+def test_production_tables_never_embed_isnat_logo() -> None:
+    from sugar_lift_py_tests.recognition.callee_universe import _IMPORTED_SUPPORT
+
+    assert "numpy.isnat" not in _IMPORTED_SUPPORT


### PR DESCRIPTION
Part of #5402

## What

`call:numpy.isnat` was previously drained via a `_IMPORTED_SUPPORT` logo table that was deleted (#5603/#5614), so its rows went loud again — correctly, since the drain depended on a hard-coded vendor string. This re-earns the drain by import/source provenance, following the exact pattern #5903 used for `call:numpy.issubdtype`.

## How

- Added `CalleeUniverseSupport.NUMPY_ISNAT` to `recognition/callee_universe.py`.
- Added it to `BuiltinCalleeUniverseSugar._OWNED_IMPORTED_SUPPORT` in `sugar/builtin_callee_universe_sugar.py`.
- No new logo strings anywhere. Authentication is entirely through the existing `imported_call_identity` binding-chain resolver (import/assignment, shadow-aware) plus the pre-existing empty-by-construction `load_imported_callee_protocol` kit overlay. Production `_IMPORTED_SUPPORT` stays empty of vendor keys — verified by a dedicated test.

## Twins (new file `test_imported_callee_protocol_numpy_isnat.py`, 8 tests, all passing)

- `test_protocol_empty_by_construction_leaves_isnat_loud` — with no kit contract loaded, `numpy.isnat` stays `FactoryPanic`/unowned (this is the default, honest state).
- `test_truthful_numpy_isnat_attr_under_protocol` / `test_truthful_from_import_isnat_under_protocol` — with the kit coordinate loaded, `np.isnat(...)` and `from numpy import isnat; isnat(...)` authenticate and lift with zero callee-universe gaps.
- `test_lying_parameter_shadow_stays_loud_under_protocol` — `def f(np, ...): np.isnat(...)` (np shadowed as a parameter) stays loud even with the protocol loaded.
- `test_lying_late_rebind_stays_loud_under_protocol` — `np` reassigned later in the function revokes the import warrant.
- `test_lying_math_as_np_stays_loud_under_protocol` — `import math as np` then `np.isnat(...)` does NOT authenticate (lookalike alias refuted).
- `test_lying_fqn_without_import_stays_loud_under_protocol` — bare `numpy.isnat(...)` with no import in scope stays loud.
- `test_production_tables_never_embed_isnat_logo` — asserts `"numpy.isnat"` is absent from the production `_IMPORTED_SUPPORT` dict.

Each lying twin was confirmed to fail before the production change (protocol load alone was not sufficient without the `NUMPY_ISNAT` enum member + ownership wiring) and pass after.

## Honest residual

Same as #5903/#5902: `load_imported_callee_protocol` is an in-memory kit/bridge overlay exercised by tests. There is no process-level kit loader wired into full-corpus mint yet, so real corpus rows without that loader stay `FactoryPanic` — correct, not a silent success. This PR earns the *mechanism*; full corpus drain still requires a kit contract to load real coordinates at mint time.

## Verification

- `implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py`: `R_vendor_special_case = 0` (green, `auditor_errors = 0`).
- New test file: 8/8 passing.
- `test_builtin_callee_universe_sugar.py -k "issubdtype or isnat"`: 5/5 passing (untouched issubdtype tests from #5903 remain green).
- `py_compile` and `git diff --check`: clean.

## Known pre-existing red (not touched by this PR)

Running the full `test_builtin_callee_universe_sugar.py` file on current `main` shows 42 pre-existing failures unrelated to this change (`numpy.can_cast`, `numpy.isnan`, `numpy.dtype` result, `scipy.linalg.issymmetric/ishermitian`, `scipy.fft.get_workers`, `SF`/sfloat factory-result, several witness-enrollment/bad-twin assertions, etc.) — all stale tests from the same #5603 vendor-logo deletion sweep, unrelated to `numpy.isnat`/`numpy.issubdtype`. None of the failing test names reference `isnat` or `issubdtype`. Flagging for visibility; out of scope for this PR.

Not merging — leaving for coordinator soundness read per lane discipline.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `numpy.isnat` recognition via import provenance in callee universe
> - Adds `CalleeUniverseSupport.NUMPY_ISNAT` to the enum in [callee_universe.py](https://github.com/TSavo/sugar/pull/5904/files#diff-72e9f915afa350390348a1c277d0c2047b26a0182bb4780c57baf73f30fdcaa8), shifting auto-assigned values of all subsequent members by +1.
> - Includes `NUMPY_ISNAT` in the owned-imported support set so `numpy.isnat` is treated as owned when resolved via import provenance.
> - Adds a new test module covering attribute-import and from-import recognition, plus shadowing/mis-binding cases that must remain unrecognized.
> - Risk: the +1 shift in auto-assigned enum values may break any code that stores or compares raw integer values of members declared after `NUMPY_ISNAT`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c8a21a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->