### PR TITLE
Re-earn call:numpy.isnan via import provenance

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_imported_callee_protocol_numpy_isnan.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_imported_callee_protocol_numpy_isnan.py
@@ -1,0 +1,246 @@
+"""Re-earn call:numpy.isnan (#5404) via kit protocol.
+
+Architecture (same class as #5902 numpy.all/numpy.dtype, #5903 issubdtype):
+
+1. **Import/source provenance** — ``imported_call_identity`` resolves the
+   binding chain (import / assignment, shadow-aware). Spelling alone never
+   expands.
+2. **Empty kit protocol** — production ``_PROTOCOL_IMPORTED_SUPPORT`` is empty.
+   ``numpy.isnan`` arrives only through ``load_imported_callee_protocol``. No
+   logo string compare, no name whitelist, no inline isinstance/AST matcher.
+
+Law: no logo string decides construction. MISSING/refused stays loud.
+
+Measurement (current main, post-#5612/#5614 logo-table deletion): direct
+single-file lift of a minimal reproduction of the corpus shape
+(``div = np.floor_divide(...); assert np.isnan(div)``, matching
+``numpy/_core/tests/test_umath.py``) shows ``call:numpy.isnan`` genuinely
+unclassified before this change. The full representative file
+(``test_umath.py``) cannot be lifted whole today: it panics on an unrelated
+pre-existing Sugar-ordering ambiguity around line 213
+(``Call candidates=[CallSugar, BuiltinCalleeUniverseSugar,
+BuiltinTypeCallSugar]``) that blocks completion independent of this family and
+is out of scope here.
+
+Honest residual: mint is a separate process; in-memory protocol load does not
+reach full-corpus mint. Rows without a process-level kit loader stay
+FactoryPanic — correct, not silent success.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from sugar_lift_py_tests.claim import SugarRole
+from sugar_lift_py_tests.context.factory_build_context import FactoryBuildContext
+from sugar_lift_py_tests.factory.build import build_node, default_catalog
+from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+from sugar_lift_py_tests.kit_rpc.factory_walk_row_dto import FactoryWalkRedRowDto
+from sugar_lift_py_tests.lift_rpc import lift_file_payload
+from sugar_lift_py_tests.recognition.callee_universe import (
+    CalleeUniverseRecognition,
+    CalleeUniverseSupport,
+    clear_imported_callee_protocol,
+    imported_call_identity,
+    load_imported_callee_protocol,
+    recognize_authenticated_callee_identity,
+    recognize_callee_universe,
+)
+from sugar_lift_py_tests.sugar.builtin_callee_universe_sugar import (
+    BuiltinCalleeUniverseSugar,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_imported_callee_protocol():
+    clear_imported_callee_protocol()
+    yield
+    clear_imported_callee_protocol()
+
+
+def _call_site(source: str, *, attr: str = "isnan"):
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == attr
+        ):
+            return SourceFragment.from_node(node, "t.py", source=source)
+    raise AssertionError(f"no call site attr={attr!r}")
+
+
+def _load_isnan_protocol() -> None:
+    load_imported_callee_protocol(
+        {"numpy.isnan": CalleeUniverseSupport.NUMPY_ISNAN}
+    )
+
+
+def _universe_gaps(payload) -> list[FactoryWalkRedRowDto]:
+    return [
+        row
+        for row in payload.factory_walk
+        if isinstance(row, FactoryWalkRedRowDto)
+        and "callee universe coverage" in row.reason
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Empty-by-construction
+# ---------------------------------------------------------------------------
+
+
+def test_protocol_empty_by_construction_leaves_isnan_loud() -> None:
+    assert recognize_authenticated_callee_identity("numpy.isnan") is None
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_isnan(div):\n"
+        "    assert np.isnan(div), f'div: {div}'\n"
+    )
+    site = _call_site(source)
+    assert imported_call_identity(site) == "numpy.isnan"
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe(site=site) is None
+    assert not BuiltinCalleeUniverseSugar.owns(site)
+    payload = lift_file_payload(source, "isnan_uncovered_fixture.py")
+    assert [g.ast_kind for g in _universe_gaps(payload)] == ["call:numpy.isnan"]
+
+
+# ---------------------------------------------------------------------------
+# Truthful twin — import-bound + protocol → green
+# ---------------------------------------------------------------------------
+
+
+def test_truthful_numpy_isnan_attr_under_protocol() -> None:
+    _load_isnan_protocol()
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_isnan(div):\n"
+        "    assert np.isnan(div), f'div: {div}'\n"
+    )
+    site = _call_site(source)
+    assert imported_call_identity(site) == "numpy.isnan"
+    assert CalleeUniverseRecognition.coordinate(site) == "numpy.isnan"
+    assert (
+        recognize_callee_universe("call:numpy.isnan", site=site)
+        is CalleeUniverseSupport.NUMPY_ISNAN
+    )
+    assert BuiltinCalleeUniverseSugar.owns(site)
+    built = build_node(
+        site,
+        filename="t.py",
+        role=SugarRole.TERM,
+        ctx=FactoryBuildContext(filename="t.py", catalog=default_catalog()),
+    )
+    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    payload = lift_file_payload(source, "isnan_covered_fixture.py")
+    assert any(
+        edge.get("targetSymbol") == "call:numpy.isnan" for edge in payload.call_edges
+    )
+    assert _universe_gaps(payload) == []
+
+
+def test_truthful_from_import_isnan_under_protocol() -> None:
+    _load_isnan_protocol()
+    source = (
+        "from numpy import isnan\n"
+        "\n"
+        "def test_isnan(div):\n"
+        "    assert isnan(div), f'div: {div}'\n"
+    )
+    tree = ast.parse(source)
+    call = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "isnan"
+    )
+    site = SourceFragment.from_node(call, "t.py", source=source)
+    assert imported_call_identity(site) == "numpy.isnan"
+    assert (
+        recognize_callee_universe("call:numpy.isnan", site=site)
+        is CalleeUniverseSupport.NUMPY_ISNAN
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lying twins — refuse even with the real coordinate loaded
+# ---------------------------------------------------------------------------
+
+
+def test_lying_parameter_shadow_stays_loud_under_protocol() -> None:
+    _load_isnan_protocol()
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_isnan(np, div):\n"
+        "    assert np.isnan(div), f'div: {div}'\n"
+    )
+    site = _call_site(source)
+    assert imported_call_identity(site) is None
+    assert recognize_callee_universe(site=site) is None
+    assert not BuiltinCalleeUniverseSugar.owns(site)
+    payload = lift_file_payload(source, "isnan_shadowed_fixture.py")
+    assert [g.ast_kind for g in _universe_gaps(payload)] == ["call:numpy.isnan"]
+
+
+def test_lying_late_rebind_stays_loud_under_protocol() -> None:
+    _load_isnan_protocol()
+    source = (
+        "import numpy as np\n"
+        "\n"
+        "def test_isnan(div, replacement):\n"
+        "    result = np.isnan(div)\n"
+        "    np = replacement\n"
+        "    return result\n"
+    )
+    site = _call_site(source)
+    assert imported_call_identity(site) is None
+    assert recognize_callee_universe(site=site) is None
+    assert not BuiltinCalleeUniverseSugar.owns(site)
+
+
+def test_lying_math_as_np_stays_loud_under_protocol() -> None:
+    """Lookalike module alias is not numpy even when protocol is loaded."""
+
+    _load_isnan_protocol()
+    source = (
+        "import math as np\n"
+        "\n"
+        "def test_isnan(div):\n"
+        "    assert np.isnan(div), f'div: {div}'\n"
+    )
+    site = _call_site(source)
+    # math.isnan does not exist as a registered coordinate under this key —
+    # the import origin resolves to math, never numpy.
+    identity = imported_call_identity(site)
+    assert identity != "numpy.isnan"
+    assert recognize_callee_universe(site=site) is None
+    assert not BuiltinCalleeUniverseSugar.owns(site)
+
+
+def test_lying_fqn_without_import_stays_loud_under_protocol() -> None:
+    _load_isnan_protocol()
+    source = (
+        "def test_isnan(div):\n"
+        "    assert numpy.isnan(div), f'div: {div}'\n"
+    )
+    site = _call_site(source)
+    assert imported_call_identity(site) is None
+    assert recognize_callee_universe(site=site) is None
+    assert not BuiltinCalleeUniverseSugar.owns(site)
+
+
+def test_production_tables_never_embed_isnan_logo() -> None:
+    from sugar_lift_py_tests.recognition.callee_universe import _IMPORTED_SUPPORT
+
+    assert "numpy.isnan" not in _IMPORTED_SUPPORT
+    assert not any(
+        c == "numpy.isnan" or c.startswith("numpy.isnan")
+        for c in BuiltinCalleeUniverseSugar.universe_coordinates
+    )


### PR DESCRIPTION
Part of #5404

## Measurement (before)

`call:numpy.isnan` (16 historical verified-live, rep `numpy/_core/tests/test_umath.py:716`) went loud again after the logo-table deletion (#5612/#5614), as already established by the board reconcile comments on #5404.

The whole representative file cannot currently be lifted in one pass: it panics on a pre-existing, **unrelated** Sugar-ordering ambiguity around `test_umath.py:213` (`Call candidates=[CallSugar, BuiltinCalleeUniverseSugar, BuiltinTypeCallSugar]`), which blocks full-file completion independent of this family. That is out of scope for this PR.

To get an honest measurement despite that, I lifted a minimal single-file reproduction of the corpus shape:

```python
import numpy as np

def test_isnan_snip(dtype):
    fnan = np.array(np.nan, dtype=dtype)
    fone = np.array(1.0, dtype=dtype)
    div = np.floor_divide(fnan, fone)
    assert np.isnan(div), f"div: {div}"
```

— measured **1/1** unclassified `call:numpy.isnan` row on current `origin/main` (`d10fc7a47`), confirming the family is genuinely loud, not a stale/incomplete recensus artifact.

## Fix

Same architecture class as #5902 (`numpy.all`/`numpy.dtype`) and #5903 (`numpy.issubdtype`): `imported_call_identity` already resolves `np.isnan` to the exact import binding chain (shadow-aware); production `_PROTOCOL_IMPORTED_SUPPORT` stays **empty**; only a loaded kit contract supplies `CalleeUniverseSupport.NUMPY_ISNAN` (already declared on the enum from a prior campaign — no new enum member needed).

**No production recognizer code change was required.** The generic protocol-overlay machinery in `recognition/callee_universe.py` already handles any import-resolved leaf once a coordinate is loaded via `load_imported_callee_protocol`. This PR adds only the test module proving the discrimination, matching `test_imported_callee_protocol_numpy_issubdtype.py`'s shape:

- `test_protocol_empty_by_construction_leaves_isnan_loud` — no contract loaded ⇒ stays FactoryPanic
- `test_truthful_numpy_isnan_attr_under_protocol` / `test_truthful_from_import_isnan_under_protocol` — truthful twins, contract loaded ⇒ authenticate
- `test_lying_parameter_shadow_stays_loud_under_protocol`
- `test_lying_late_rebind_stays_loud_under_protocol`
- `test_lying_math_as_np_stays_loud_under_protocol`
- `test_lying_fqn_without_import_stays_loud_under_protocol`
- `test_production_tables_never_embed_isnan_logo` — hard-law regression guard

All 8 tests pass locally (`.venv` + repo `PYTHONPATH`).

## Honest residual (named, not counted as drained)

In-memory protocol load does not reach full-corpus mint — there is no process-level kit loader wired into `corpus_fatal_triage.py`. **Real corpus rows stay `FactoryPanic` until a kit/bridge loader lands.** This is the correct, non-silent outcome per the established #5902/#5903 pattern, not a regression introduced here.

## Verification

- `pytest implementations/python/sugar-lift-py-tests/tests/test_imported_callee_protocol_numpy_isnan.py -q` → `8 passed`
- `python implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py` → `R_vendor_special_case = 0`
- Confirmed the 61 pre-existing failures in `test_universe_coverage_gap.py` / `test_builtin_callee_universe_sugar.py` (stale tests expecting logo witnesses removed in earlier drains, e.g. `numpy_isnan_witness_pair_is_enrolled`, `numpy_sfloat_dtype_universe_coordinate`) reproduce identically on bare `origin/main` without this change — pre-existing debt, not introduced by this PR.

No merge — coordinator does the soundness read.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add import provenance tests for `numpy.isnan` callee universe recognition
> Adds a test module verifying that `numpy.isnan` is recognized as a callee universe coordinate only when import provenance can be established via the imported callee protocol.
>
> - Tests cover the full recognition path: `imported_call_identity` → `recognize_callee_universe` → `BuiltinCalleeUniverseSugar` ownership → `lift_file_payload` edges.
> - "Truthful" cases confirm that attribute calls (`np.isnan`) and `from numpy import isnan` calls resolve correctly after loading the protocol mapping `numpy.isnan` → `CalleeUniverseSupport.NUMPY_ISNAN`.
> - "Lying" cases confirm that parameter shadowing, late rebinding, non-numpy aliases, and bare FQN references without imports all remain unrecognized and produce universe gap rows.
> - A guard test asserts that the `numpy.isnan` coordinate is never embedded in production tables or `BuiltinCalleeUniverseSugar.universe_coordinates`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3677215.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->