### PR TITLE
Wire a process-level kit manifest loader into corpus mint

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py
@@ -74,7 +74,15 @@ def _child_payload(path: Path, rel: str) -> tuple[dict[str, Any], int]:
         from sugar_lift_py_tests.audit_only import collect_factory_panic
         from sugar_lift_py_tests.effect import effect_reason, effect_status
         from sugar_lift_py_tests.lift_rpc import lift_file_payload
+        from sugar_lift_py_tests.recognition.kit_manifest import (
+            load_kit_manifest_from_env,
+        )
 
+        # #5907: load a declared kit/bridge contract into THIS process before
+        # lift, so a real corpus row can authenticate under it. With no
+        # SUGAR_KIT_MANIFEST set, this loads nothing — protocol tables stay
+        # empty by construction and rows stay loud (the law, not a bug).
+        kit_provenance = load_kit_manifest_from_env()
         try:
             source = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
@@ -97,6 +105,9 @@ def _child_payload(path: Path, rel: str) -> tuple[dict[str, Any], int]:
                 "exception_type": "FactoryPanic",
                 "reason": panic_gap.message.splitlines()[-1][:1000],
                 "gap": panic_gap.info,
+                "kit_manifest": (
+                    kit_provenance.to_json() if kit_provenance is not None else None
+                ),
             }, 3
         assert payload is not None
     except KeyboardInterrupt:
@@ -119,6 +130,11 @@ def _child_payload(path: Path, rel: str) -> tuple[dict[str, Any], int]:
         "factory_walk_rows": len(payload.factory_walk),
         "R_factory_walk_unclassified": len(unclassified_rows),
         "unclassified_rows": unclassified_rows,
+        # #5907: which kit manifest (if any) was loaded into this child
+        # process before lift — provenance, not silent ambient state.
+        "kit_manifest": (
+            kit_provenance.to_json() if kit_provenance is not None else None
+        ),
         "effects": [
             {
                 "effect": type(row.effect).__name__,
@@ -263,6 +279,11 @@ def _run_parent(args: argparse.Namespace) -> int:
         ]
         env = dict(os.environ)
         env["PYTHONFAULTHANDLER"] = "1"
+        if args.kit_manifest:
+            # #5907: propagate the declared kit manifest to the child process
+            # that actually mints this file. Absolute path so the child's cwd
+            # cannot silently change which contract loads.
+            env["SUGAR_KIT_MANIFEST"] = str(Path(args.kit_manifest).resolve())
         try:
             result = subprocess.run(
                 command,
@@ -356,6 +377,12 @@ def _run_parent(args: argparse.Namespace) -> int:
         retained_loci = retained_loci[:COMPACT_LOCUS_LIMIT]
     report: dict[str, Any] = {
         "package_versions": versions,
+        # #5907: which kit manifest (path only — the child recomputes and
+        # records its own sha256) governed this run. null means every child
+        # minted with no contract: empty-by-construction, rows stay loud.
+        "kit_manifest": (
+            str(Path(args.kit_manifest).resolve()) if args.kit_manifest else None
+        ),
         "shard": {"index": args.shard_index, "count": args.shard_count},
         "census": dict(sorted(assertion_counts.items())),
         "terminal_categories": dict(sorted(categories.items())),
@@ -410,6 +437,15 @@ def main() -> int:
     parser.add_argument("--output")
     parser.add_argument("--child-file")
     parser.add_argument("--child-rel")
+    parser.add_argument(
+        "--kit-manifest",
+        help=(
+            "Path to a kit/bridge contract manifest (#5907) whose declared "
+            "coordinates load into every mint child process before lift. "
+            "Omit to mint with no contract — the empty-by-construction "
+            "default; rows without a matching recognizer stay loud."
+        ),
+    )
     args = parser.parse_args()
     if args.child_file or args.child_rel:
         if not args.child_file or not args.child_rel:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/kit_manifest.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/kit_manifest.py
@@ -1,0 +1,227 @@
+"""Process-level kit/bridge contract loader (#5907).
+
+The empty-by-construction protocol tables in ``native_shape.py`` and
+``callee_universe.py`` (#5618, #5400-class re-earns) only ever get populated
+by calling their ``load_*_protocol`` functions. Tests do that in-process. The
+gap #5907 names: nothing wired those loaders into the actual corpus mint
+path (``corpus_fatal_triage.py``), so no real corpus row ever saw a loaded
+contract — every re-earned family stayed FactoryPanic/unclassified in the
+corpus even though the recognizer was correct.
+
+This module is the bridge: it reads a **kit manifest** — a JSON file that is
+evidence, not ambient configuration — and installs its coordinates into the
+in-memory protocol tables for the current process before mint runs.
+
+Evidence discipline:
+  - The manifest is a file on disk, named explicitly (``--kit-manifest`` /
+    ``SUGAR_KIT_MANIFEST``). Nothing here invents a default path or falls
+    back to a hard-coded dict.
+  - Every load computes and records the manifest's sha256 content hash
+    (its CID) so the loaded contract is traceable to the exact bytes that
+    authorized it, not to "whatever the dict happens to hold right now".
+  - An unrecognized enum name in the manifest is a loud error (``ValueError``),
+    never a silently-dropped coordinate.
+  - With no manifest declared (env var unset, no --kit-manifest), this module
+    installs nothing. The protocol tables stay empty. Rows stay loud. That is
+    the law (#5907 requirement 3), not a bug to route around.
+
+Manifest schema (JSON)::
+
+    {
+      "imported_callee": {"numpy.issubdtype": "NUMPY_ISSUBDTYPE", ...},
+      "call_shape": {"sqlalchemy.orm.registry": "KIT_LOADED_CONSTRUCTOR", ...},
+      "fixture_decorator": {"pytest.fixture": "FIXTURE_DECORATOR", ...},
+      "instance_class_decorator": {
+        "KIT_LOADED_CONSTRUCTOR.mapped": "CLASS_IDENTITY_DECORATOR"
+      }
+    }
+
+Every top-level key is optional; an empty manifest is legal (loads nothing).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from sugar_lift_py_tests.recognition.callee_universe import (
+    CalleeUniverseSupport,
+    clear_imported_callee_protocol,
+    load_imported_callee_protocol,
+)
+from sugar_lift_py_tests.recognition.native_shape import (
+    NativeShape,
+    clear_call_shape_protocol,
+    clear_fixture_protocol,
+    clear_instance_class_decorator_protocol,
+    load_call_shape_protocol,
+    load_fixture_protocol,
+    load_instance_class_decorator_protocol,
+)
+
+KIT_MANIFEST_ENV_VAR = "SUGAR_KIT_MANIFEST"
+
+_IMPORTED_CALLEE_SECTION = "imported_callee"
+_CALL_SHAPE_SECTION = "call_shape"
+_FIXTURE_DECORATOR_SECTION = "fixture_decorator"
+_INSTANCE_CLASS_DECORATOR_SECTION = "instance_class_decorator"
+
+_KNOWN_SECTIONS = frozenset(
+    {
+        _IMPORTED_CALLEE_SECTION,
+        _CALL_SHAPE_SECTION,
+        _FIXTURE_DECORATOR_SECTION,
+        _INSTANCE_CLASS_DECORATOR_SECTION,
+    }
+)
+
+
+@dataclass(frozen=True)
+class KitManifestProvenance:
+    """Receipt for a loaded kit manifest: what loaded, from where, under what hash."""
+
+    path: str
+    sha256: str
+    loaded_counts: dict[str, int] = field(default_factory=dict)
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "path": self.path,
+            "sha256": self.sha256,
+            "loaded_counts": dict(self.loaded_counts),
+        }
+
+
+class KitManifestError(ValueError):
+    """A kit manifest named a coordinate this process cannot honor.
+
+    Raised loudly — never caught to silently drop a coordinate. A manifest
+    that cannot be fully honored is a manifest that must not load partially.
+    """
+
+
+def _resolve_enum(kind: type, name: str, *, section: str, key: str) -> object:
+    try:
+        return kind[name]
+    except KeyError as error:
+        raise KitManifestError(
+            f"kit manifest section {section!r} names unknown "
+            f"{kind.__name__} member {name!r} for coordinate {key!r}"
+        ) from error
+
+
+def clear_all_kit_protocols() -> None:
+    """Unload every kit-loaded protocol table (test isolation / re-load)."""
+
+    clear_imported_callee_protocol()
+    clear_call_shape_protocol()
+    clear_fixture_protocol()
+    clear_instance_class_decorator_protocol()
+
+
+def load_kit_manifest_text(text: str, *, source: str) -> KitManifestProvenance:
+    """Parse and install a kit manifest given as text (source is its label)."""
+
+    try:
+        document = json.loads(text)
+    except json.JSONDecodeError as error:
+        raise KitManifestError(f"kit manifest {source!r} is not valid JSON") from error
+    if not isinstance(document, dict):
+        raise KitManifestError(f"kit manifest {source!r} must be a JSON object")
+    unknown = set(document) - _KNOWN_SECTIONS
+    if unknown:
+        raise KitManifestError(
+            f"kit manifest {source!r} names unknown section(s): {sorted(unknown)}"
+        )
+
+    sha256 = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    counts: dict[str, int] = {}
+
+    imported_callee_raw = document.get(_IMPORTED_CALLEE_SECTION) or {}
+    if imported_callee_raw:
+        coordinates = {
+            key: _resolve_enum(
+                CalleeUniverseSupport, value, section=_IMPORTED_CALLEE_SECTION, key=key
+            )
+            for key, value in imported_callee_raw.items()
+        }
+        load_imported_callee_protocol(coordinates)
+        counts[_IMPORTED_CALLEE_SECTION] = len(coordinates)
+
+    call_shape_raw = document.get(_CALL_SHAPE_SECTION) or {}
+    if call_shape_raw:
+        coordinates = {
+            key: _resolve_enum(NativeShape, value, section=_CALL_SHAPE_SECTION, key=key)
+            for key, value in call_shape_raw.items()
+        }
+        load_call_shape_protocol(coordinates)
+        counts[_CALL_SHAPE_SECTION] = len(coordinates)
+
+    fixture_raw = document.get(_FIXTURE_DECORATOR_SECTION) or {}
+    if fixture_raw:
+        coordinates = {
+            key: _resolve_enum(
+                NativeShape, value, section=_FIXTURE_DECORATOR_SECTION, key=key
+            )
+            for key, value in fixture_raw.items()
+        }
+        load_fixture_protocol(coordinates)
+        counts[_FIXTURE_DECORATOR_SECTION] = len(coordinates)
+
+    instance_class_raw = document.get(_INSTANCE_CLASS_DECORATOR_SECTION) or {}
+    if instance_class_raw:
+        coordinates = {}
+        for key, value in instance_class_raw.items():
+            head, _sep, tail = key.partition(".")
+            if not _sep:
+                raise KitManifestError(
+                    f"kit manifest {source!r} instance_class_decorator key "
+                    f"{key!r} must be 'NativeShapeMember.attr'"
+                )
+            shape = _resolve_enum(
+                NativeShape, head, section=_INSTANCE_CLASS_DECORATOR_SECTION, key=key
+            )
+            result_shape = _resolve_enum(
+                NativeShape,
+                value,
+                section=_INSTANCE_CLASS_DECORATOR_SECTION,
+                key=key,
+            )
+            coordinates[(shape, tail)] = result_shape
+        load_instance_class_decorator_protocol(coordinates)
+        counts[_INSTANCE_CLASS_DECORATOR_SECTION] = len(coordinates)
+
+    return KitManifestProvenance(path=source, sha256=sha256, loaded_counts=counts)
+
+
+def load_kit_manifest_file(path: str | os.PathLike[str]) -> KitManifestProvenance:
+    """Read, hash, and install a kit manifest from an explicit file path.
+
+    The path is evidence: a real file the caller named. There is no implicit
+    default manifest and no ambient dict a coordinate could sneak into.
+    """
+
+    text = Path(path).read_text(encoding="utf-8")
+    return load_kit_manifest_text(text, source=str(path))
+
+
+def load_kit_manifest_from_env(
+    env: dict[str, str] | None = None,
+) -> KitManifestProvenance | None:
+    """Install the manifest named by ``SUGAR_KIT_MANIFEST``, if any.
+
+    Returns ``None`` (and loads nothing) when the variable is unset — the
+    empty-by-construction default. This is the entry point the corpus mint
+    child process calls before lift, so a declared contract reaches real
+    corpus rows without any coordinate ever living in production recognition
+    source.
+    """
+
+    source = env if env is not None else os.environ
+    manifest_path = source.get(KIT_MANIFEST_ENV_VAR)
+    if not manifest_path:
+        return None
+    return load_kit_manifest_file(manifest_path)

--- a/implementations/python/sugar-lift-py-tests/tests/test_kit_manifest_corpus_mint.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_kit_manifest_corpus_mint.py
@@ -1,0 +1,252 @@
+"""#5907: a declared kit manifest reaches the real corpus mint child process.
+
+Prior state: ``load_imported_callee_protocol`` / ``load_call_shape_protocol`` /
+``load_fixture_protocol`` (#5618, proven per-family in #5902-#5905) only ever
+loaded in-memory inside a test. Nothing wired them into
+``corpus_fatal_triage.py``'s mint path, so no real corpus row ever saw a
+loaded contract — every re-earned family stayed loud in the corpus even
+though its recognizer was correct in principle.
+
+This module exercises ``_child_payload`` — the exact function the real
+corpus-mint subprocess runs per file (see ``_run_child`` / ``_run_parent``'s
+``subprocess.run`` call) — with ``SUGAR_KIT_MANIFEST`` toggled, proving:
+
+1. Empty-by-construction: no manifest declared ⇒ the callee-universe gap for
+   ``numpy.issubdtype`` stays in the child's unclassified rows (loud).
+2. Declared contract ⇒ that exact row disappears from the unclassified set
+   (authenticates) and the child testimony carries kit-manifest provenance
+   (path + sha256) traceable to the manifest file, not an ambient dict.
+3. Lying twins (parameter shadow, late rebind, ``import math as np`` lookalike,
+   bare FQN without import) still leave the row unclassified even with the
+   real coordinate loaded — a loaded contract authenticates identity, not
+   spelling.
+
+Reverting the manifest wiring in ``corpus_fatal_triage.py`` (or the loader
+module) makes case 2 fail: the row would stay unclassified even with a
+manifest declared. That is the fails-before / passes-after proof.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from corpus_fatal_triage import _child_payload  # noqa: E402
+
+from sugar_lift_py_tests.recognition.kit_manifest import (  # noqa: E402
+    KIT_MANIFEST_ENV_VAR,
+    KitManifestError,
+    clear_all_kit_protocols,
+    load_kit_manifest_text,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_kit_protocols(monkeypatch):
+    monkeypatch.delenv(KIT_MANIFEST_ENV_VAR, raising=False)
+    clear_all_kit_protocols()
+    yield
+    clear_all_kit_protocols()
+
+
+def _unclassified_issubdtype_rows(testimony: dict) -> list[dict]:
+    return [
+        row
+        for row in testimony["unclassified_rows"]
+        if row.get("ast_kind") == "call:numpy.issubdtype"
+    ]
+
+
+
+
+def _write_manifest(tmp_path: Path, document: dict) -> Path:
+    manifest_path = tmp_path / "kit_manifest.json"
+    manifest_path.write_text(json.dumps(document), encoding="utf-8")
+    return manifest_path
+
+
+_TRUTHFUL_SOURCE = (
+    "import numpy as np\n"
+    "\n"
+    "def test_dtype(left, right):\n"
+    "    assert np.issubdtype(left, right)\n"
+)
+
+_ISSUBDTYPE_MANIFEST = {"imported_callee": {"numpy.issubdtype": "NUMPY_ISSUBDTYPE"}}
+
+
+def test_mint_with_no_manifest_leaves_row_loud(tmp_path: Path) -> None:
+    """Empty-by-construction: no SUGAR_KIT_MANIFEST ⇒ row stays unclassified."""
+
+    source = tmp_path / "no_contract.py"
+    source.write_text(_TRUTHFUL_SOURCE, encoding="utf-8")
+
+    testimony, returncode = _child_payload(source, "demo/no_contract.py")
+
+    assert returncode == 0
+    assert testimony["outcome"] == "completed"
+    assert testimony["kit_manifest"] is None
+    assert len(_unclassified_issubdtype_rows(testimony)) == 1
+
+
+def test_mint_with_declared_manifest_authenticates_row(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Declared contract ⇒ real mint child authenticates the coordinate."""
+
+    manifest_path = _write_manifest(tmp_path, _ISSUBDTYPE_MANIFEST)
+    monkeypatch.setenv(KIT_MANIFEST_ENV_VAR, str(manifest_path))
+    source = tmp_path / "with_contract.py"
+    source.write_text(_TRUTHFUL_SOURCE, encoding="utf-8")
+
+    testimony, returncode = _child_payload(source, "demo/with_contract.py")
+
+    assert returncode == 0
+    assert testimony["outcome"] == "completed"
+    assert _unclassified_issubdtype_rows(testimony) == []
+    manifest_testimony = testimony["kit_manifest"]
+    assert manifest_testimony is not None
+    assert manifest_testimony["path"] == str(manifest_path)
+    assert manifest_testimony["loaded_counts"] == {"imported_callee": 1}
+    import hashlib
+
+    expected_sha256 = hashlib.sha256(
+        manifest_path.read_text(encoding="utf-8").encode("utf-8")
+    ).hexdigest()
+    assert manifest_testimony["sha256"] == expected_sha256
+
+
+def _mint_with_manifest(tmp_path: Path, monkeypatch, source_text: str, name: str):
+    manifest_path = _write_manifest(tmp_path, _ISSUBDTYPE_MANIFEST)
+    monkeypatch.setenv(KIT_MANIFEST_ENV_VAR, str(manifest_path))
+    source = tmp_path / name
+    source.write_text(source_text, encoding="utf-8")
+    return _child_payload(source, f"demo/{name}")
+
+
+def test_lying_parameter_shadow_stays_loud_under_loaded_manifest(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Parameter shadow revokes the import warrant; row stays unclassified."""
+
+    testimony, returncode = _mint_with_manifest(
+        tmp_path,
+        monkeypatch,
+        "import numpy as np\n"
+        "\n"
+        "def test_dtype(np, left, right):\n"
+        "    assert np.issubdtype(left, right)\n",
+        "shadow.py",
+    )
+    assert returncode == 0
+    assert testimony["outcome"] == "completed"
+    assert len(_unclassified_issubdtype_rows(testimony)) == 1
+    assert testimony["kit_manifest"] is not None
+
+
+def test_lying_late_rebind_stays_loud_under_loaded_manifest(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A later rebind of the import name revokes the warrant retroactively."""
+
+    testimony, returncode = _mint_with_manifest(
+        tmp_path,
+        monkeypatch,
+        "import numpy as np\n"
+        "\n"
+        "def test_dtype(left, right):\n"
+        "    assert np.issubdtype(left, right)\n"
+        "    np = replacement\n",
+        "rebind.py",
+    )
+    assert returncode == 0
+    assert testimony["outcome"] == "completed"
+    assert len(_unclassified_issubdtype_rows(testimony)) == 1
+    assert testimony["kit_manifest"] is not None
+
+
+def test_lying_lookalike_module_alias_stays_loud_under_loaded_manifest(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """``import math as np`` is not numpy even though the loaded key is generic.
+
+    The site resolves to ``math.issubdtype`` (a different, unloaded
+    coordinate) — never to ``numpy.issubdtype``. No row is ever labelled
+    with the authenticated coordinate; the real one (``math.issubdtype``)
+    stays unclassified instead.
+    """
+
+    testimony, returncode = _mint_with_manifest(
+        tmp_path,
+        monkeypatch,
+        "import math as np\n"
+        "\n"
+        "def test_dtype(left, right):\n"
+        "    assert np.issubdtype(left, right)\n",
+        "lookalike.py",
+    )
+    assert returncode == 0
+    assert testimony["outcome"] == "completed"
+    assert _unclassified_issubdtype_rows(testimony) == []
+    assert any(
+        row.get("ast_kind") == "call:math.issubdtype"
+        for row in testimony["unclassified_rows"]
+    )
+    assert testimony["kit_manifest"] is not None
+
+
+def test_lying_bare_fqn_without_import_stays_loud_under_loaded_manifest(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A bare ``numpy.issubdtype`` spelling with no import binds nothing.
+
+    Provenance requires an import/source binding, never spelling alone — an
+    unbound bare name is a harder loud outcome (FactoryPanic on the unbound
+    name), not a quiet unclassified row, but it is still refusal, never
+    success.
+    """
+
+    testimony, returncode = _mint_with_manifest(
+        tmp_path,
+        monkeypatch,
+        "def test_dtype(left, right):\n"
+        "    assert numpy.issubdtype(left, right)\n",
+        "bare_fqn.py",
+    )
+    assert returncode == 3
+    assert testimony["outcome"] == "factory-panic"
+    assert testimony["kit_manifest"] is not None
+
+
+def test_manifest_with_unknown_coordinate_fails_loudly(tmp_path: Path) -> None:
+    """A manifest naming an unrecognized enum member errors, never drops silently."""
+
+    with pytest.raises(KitManifestError):
+        load_kit_manifest_text(
+            json.dumps({"imported_callee": {"numpy.issubdtype": "NOT_A_REAL_SHAPE"}}),
+            source="inline",
+        )
+
+
+def test_manifest_loader_installs_nothing_when_uninvoked() -> None:
+    """Importing the loader module alone must not populate any protocol table.
+
+    The loader is evidence (a file the caller names), never ambient
+    configuration — merely importing ``kit_manifest`` must not be equivalent
+    to loading a contract. (The docstring shows an example schema with
+    vendor names for documentation purposes only; those strings never reach
+    a production dict except by an explicit ``load_kit_manifest_*`` call
+    with an actual file, which the tests above exercise.)
+    """
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        recognize_authenticated_callee_identity,
+    )
+
+    assert recognize_authenticated_callee_identity("numpy.issubdtype") is None


### PR DESCRIPTION
Part of #5907

## Gap this closes

The empty-by-construction kit-protocol mechanism (`load_imported_callee_protocol` / `load_call_shape_protocol` / `load_fixture_protocol` / `load_instance_class_decorator_protocol`, #5618) only ever loaded in-memory inside a test process. Nothing wired those loaders into the actual corpus mint path (`corpus_fatal_triage.py`), so no real corpus row ever saw a loaded contract — every family re-earned this session (#5902 numpy.all/dtype, #5903 issubdtype/conv, #5904 isnat, #5905 isnan) was authenticated in principle and stayed loud in the corpus.

## What this adds

`implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/kit_manifest.py` — a loader that reads a **kit manifest**: a JSON file named explicitly via `--kit-manifest` / `SUGAR_KIT_MANIFEST`, never an ambient dict. It installs the manifest's declared coordinates into the four existing protocol tables. Every load records the manifest's sha256 content hash as provenance. An unrecognized enum name in the manifest raises `KitManifestError` loudly — never a silently-dropped coordinate. With no manifest declared, nothing loads: the empty-by-construction default is unchanged.

Wired into `corpus_fatal_triage.py`'s `_child_payload` — the exact function every corpus-mint `subprocess.run` child executes per file — and threaded the declared manifest path from the parent through the child env (`--kit-manifest` CLI flag → `SUGAR_KIT_MANIFEST` env var). Every child testimony now carries `kit_manifest` provenance (path + sha256), and the parent report records which manifest (if any) governed the run.

## Twins (`test_kit_manifest_corpus_mint.py`)

Exercise `_child_payload` directly — the real mint code path:
- no manifest declared → `numpy.issubdtype` call stays an unclassified "callee universe coverage" row (loud, unchanged)
- manifest declaring `numpy.issubdtype` → the row disappears; testimony carries the manifest's path + sha256
- four lying twins with the *real* coordinate loaded (parameter shadow, late rebind, `import math as np` lookalike, bare FQN with no import) all stay loud — refusal takes different honest shapes (unclassified row under a different resolved identity, or a hard `FactoryPanic` for the unbound bare name), never authenticates
- an unknown enum name in a manifest raises `KitManifestError`

**Fails-before / passes-after verified**: reverting only the `corpus_fatal_triage.py` wiring (keeping the loader module itself) makes 6 of the 8 twins fail — `KeyError` on the new `kit_manifest` testimony field, or wrong outcome. Restoring the wiring makes all 8 pass again. This proves the wiring, not happenstance, authenticates rows.

## Verification

- `implementations/python/sugar-lift-py-tests/tests/test_kit_manifest_corpus_mint.py` — 8/8 pass
- `implementations/python/sugar-lift-py-tests/tests/test_corpus_fatal_triage.py` — 4/4 pass (unaffected)
- `scripts/vendor_special_case_law.py` → `R_vendor_special_case = 0` (unchanged)
- Rebased clean onto current `main` (past #5905)

Some `test_builtin_callee_universe_sugar.py` tests fail on this branch, but they fail identically on `main` before this change (confirmed via a clean checkout) — pre-existing, unrelated to this PR (environment numpy/scipy version drift under the pinned interpreter, not this loader).

## What remains (honest residual)

- No live kit manifest is authored yet for the already-merged families (#5902-#5905) — this PR ships the loader/wiring only, per #5907's own required-work item 1 (contract mechanism), not the authoring of a manifest for any specific family. That's the natural next increment: an actual manifest file + a real corpus triage run comparing `R_factory_walk_unclassified` before/after loading it.
- The parent-level `--kit-manifest` flag is exercised only through its env-propagation logic and a doc string; it is not exercised against a full `numpy`/`pandas` corpus run in this PR (that would require a live triage pass, out of scope for this increment).
- Only `imported_callee` is exercised end-to-end by the twins; `call_shape` / `fixture_decorator` / `instance_class_decorator` sections use the same load functions proven correct in #5618 but aren't independently twin-tested here beyond the loader's own coordinate-resolution path.

Do not merge — coordinator merges after a soundness read.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire kit manifest loading into corpus mint child processes
> - Adds [`recognition/kit_manifest.py`](https://github.com/TSavo/sugar/pull/5908/files#diff-89551694e35457ddf574eaba357520bec831734fc69f84fbbf50d0fea9c37e17) with loaders that parse a JSON manifest, resolve coordinates to enum members, populate protocol tables, and return a `KitManifestProvenance` receipt with path, SHA-256, and per-section load counts.
> - The corpus mint child process now calls `load_kit_manifest_from_env` at startup, reading the manifest path from `SUGAR_KIT_MANIFEST`, and includes the provenance in both factory-panic and completed output rows.
> - The parent coordinator accepts a new `--kit-manifest` CLI flag, sets `SUGAR_KIT_MANIFEST` for child processes, and records the absolute manifest path in the aggregated report.
> - Also adds `clear_all_kit_protocols` to reset protocol tables between runs and a new test module covering manifest loading, provenance reporting, and error handling for unknown coordinates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 629e5c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional kit manifest support for corpus triage runs.
  * Manifest data can now authenticate supported protocol mappings and is included in generated testimony and final reports.
  * Reports include manifest provenance, including source path, content hash, and loaded section counts.
  * Invalid or unknown manifest entries now produce clear errors.

* **Bug Fixes**
  * Prevented misleading classifications caused by shadowed names, late rebinding, aliases, or missing imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->