### PR TITLE
Re-earn can_cast/isnan/dtype_result/scipy/sfloat universe families (#5906)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -87,6 +87,8 @@ class CalleeUniverseSupport(Enum):
 
 # Empty: numpy dtype-result coordinates are external kit contracts (#5603).
 # Hard-coded vendor logos deleted; rows stay loud until bridge evidence.
+# Kit-loaded overlay only (#5618/#5902 empty-kit pattern) — see
+# load_dtype_result_protocol / clear_dtype_result_protocol below.
 _DTYPE_RESULT_SUPPORT: dict[str, CalleeUniverseSupport] = {}
 
 # Authenticated import identities that are language/stdlib protocol only.
@@ -142,9 +144,14 @@ def _imported_attribute_leaves() -> frozenset[str]:
 _IMPORTED_ATTRIBUTE_LEAVES = frozenset(
     identity.rsplit(".", 1)[-1] for identity in _IMPORTED_SUPPORT
 )
-_DTYPE_RESULT_ATTRIBUTE_LEAVES = frozenset(
-    identity.rsplit(".", 1)[-1] for identity in _DTYPE_RESULT_SUPPORT
-)
+
+
+def _dtype_result_attribute_leaves() -> frozenset[str]:
+    # Function, not a frozen constant: _DTYPE_RESULT_SUPPORT is a kit-loaded
+    # overlay (load_dtype_result_protocol), mutated after module import.
+    return frozenset(
+        identity.rsplit(".", 1)[-1] for identity in _DTYPE_RESULT_SUPPORT
+    )
 
 
 def recognize_callee_universe(
@@ -305,6 +312,26 @@ def clear_imported_callee_protocol() -> None:
     _PROTOCOL_IMPORTED_SUPPORT.clear()
 
 
+def load_dtype_result_protocol(
+    coordinates: dict[str, CalleeUniverseSupport],
+) -> None:
+    """Install dtype-result coordinates (e.g. ``numpy.asarray``) from a kit contract.
+
+    Same empty-by-construction discipline as ``load_imported_callee_protocol``
+    (#5618): production ``_DTYPE_RESULT_SUPPORT`` stays empty of vendor-root
+    keys; only a loaded kit/bridge contract supplies the coordinate.
+    """
+
+    _DTYPE_RESULT_SUPPORT.clear()
+    _DTYPE_RESULT_SUPPORT.update(coordinates)
+
+
+def clear_dtype_result_protocol() -> None:
+    """Remove kit-loaded dtype-result coordinates (test isolation / unload)."""
+
+    _DTYPE_RESULT_SUPPORT.clear()
+
+
 class CalleeUniverseRecognition:
     """Resolve a call's authenticated source-bound callee coordinate.
 
@@ -355,7 +382,7 @@ class CalleeUniverseRecognition:
             # full ``imported_call_identity`` for every ``random.X`` /
             # ``module.Y`` Call is the factory.select residual after
             # parsed_locus_index drained the AST-walk half of the path.
-            leaves = _imported_attribute_leaves() | _DTYPE_RESULT_ATTRIBUTE_LEAVES
+            leaves = _imported_attribute_leaves() | _dtype_result_attribute_leaves()
             if target in leaves:
                 imported = _result_call_identity(site)
                 if recognize_authenticated_callee_identity(imported) is not None:
@@ -1190,8 +1217,10 @@ def _source_path(statement):
 __all__ = [
     "CalleeUniverseRecognition",
     "CalleeUniverseSupport",
+    "clear_dtype_result_protocol",
     "clear_imported_callee_protocol",
     "imported_call_identity",
+    "load_dtype_result_protocol",
     "load_imported_callee_protocol",
     "recognize_authenticated_callee_identity",
     "recognize_callee_universe",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/builtin_callee_universe_sugar.py
@@ -194,12 +194,27 @@ class BuiltinCalleeUniverseSugar(
             _regex_search_coordinate_witness(),
             _regex_search_keyword_surface_witness(),
             _bound_source_callable_witness(),
+            # #5410 — receiver-surface ``item`` after import-authenticated
+            # constructor binding. Structural coordinate, not a vendor logo:
+            # any import-constructed receiver's bare ``.item()`` authenticates.
+            _item_receiver_coordinate_witness(),
             _pathlib_path_witness(),
             _json_loads_witness(),
             _dataclasses_asdict_witness(),
             _dataclasses_is_dataclass_witness(),
             _path_resolve_coordinate_witness(),
             _math_isclose_witness(),
+            # Structural bound-source coordinates (BOUND_SOURCE_CALLABLE) —
+            # not vendor logos: an import-bound alias Call, or a multi-hop
+            # ``self.module.<leaf>`` access, authenticates on provenance shape
+            # alone (#5457-#5461).
+            _ufunc_coordinate_witness(),
+            _bound_leaf_coordinate_witness("t0"),
+            _bound_leaf_coordinate_witness("selectedintkind"),
+            _bound_leaf_coordinate_witness("foo"),
+            _bound_leaf_coordinate_witness("to_Dt"),
+            _numpy_subrout_default_witness(),
+            _numpy_eval_scalar_witness(),
             # #5409 — class-body import-bound converter (BOUND_SOURCE; no logo).
             _imported_method_coordinate_witness(
                 setup=("import numpy._core._multiarray_tests as mt\n"),

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_callee_universe_sugar.py
@@ -18,10 +18,7 @@ from sugar_lift_py_tests.sugar.builtin_callee_universe_sugar import (
 )
 from sugar_lift_py_tests.context import FactoryBuildContext
 from sugar_lift_py_tests.factory.build import default_catalog
-from sugar_lift_py_tests.factory.factory_gap import FactoryPanic
 from sugar_lift_py_tests.factory.source_fragment import SourceFragment
-from sugar_lift_py_tests.floor import ImportAliasValue, TermValue
-from sugar_lift_py_tests.temporal import TemporalContext
 from sugar_lift_py_tests.witness_harness import run_source_through_real_solver
 
 
@@ -79,6 +76,13 @@ def test_next_unclassified_coordinate_batch_is_enrolled() -> None:
     assert "numpy_all_universe_coordinate" not in enrolled
     assert "numpy_dtype_universe_coordinate" not in enrolled
     assert "numpy_issubdtype_universe_coordinate" not in enrolled
+    assert "numpy_can_cast_universe_coordinate" not in enrolled
+    assert "numpy_isnan_universe_coordinate" not in enrolled
+    assert "numpy_dtype_result_universe_coordinate" not in enrolled
+    assert "scipy_linalg_issymmetric_universe_coordinate" not in enrolled
+    assert "scipy_linalg_ishermitian_universe_coordinate" not in enrolled
+    assert "scipy_fft_get_workers_universe_coordinate" not in enrolled
+    assert "numpy_sfloat_dtype_universe_coordinate" not in enrolled
 
 
 def test_all_nine_authenticated_conv_rows_select_the_converter_owner() -> None:
@@ -543,24 +547,39 @@ def _can_cast_call_site(source: str) -> SourceFragment:
 
 
 def test_authenticated_numpy_can_cast_selects_one_factory_owner() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_cast(from_, to):\n"
-        "    assert np.can_cast(from_, to)\n"
-    )
-    context = FactoryBuildContext(
-        filename="can_cast.py",
-        catalog=default_catalog(),
-    )
-    built = build_node(
-        _can_cast_call_site(source),
-        filename="can_cast.py",
-        role=SugarRole.TERM,
-        ctx=context,
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
+        CalleeUniverseSupport,
     )
 
-    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.can_cast": CalleeUniverseSupport.NUMPY_CAN_CAST}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_cast(from_, to):\n"
+            "    assert np.can_cast(from_, to)\n"
+        )
+        context = FactoryBuildContext(
+            filename="can_cast.py",
+            catalog=default_catalog(),
+        )
+        built = build_node(
+            _can_cast_call_site(source),
+            filename="can_cast.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+
+        assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
 @pytest.mark.parametrize(
@@ -595,22 +614,39 @@ def test_authenticated_numpy_can_cast_selects_one_factory_owner() -> None:
     ],
 )
 def test_unwarranted_can_cast_receiver_is_not_factory_owned(source: str) -> None:
-    context = FactoryBuildContext(
-        filename="can_cast.py",
-        catalog=default_catalog(),
-    )
-    built = build_node(
-        _can_cast_call_site(source),
-        filename="can_cast.py",
-        role=SugarRole.TERM,
-        ctx=context,
+    """Lying twins stay unowned even with the real kit coordinate loaded."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
+        CalleeUniverseSupport,
     )
 
-    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.can_cast": CalleeUniverseSupport.NUMPY_CAN_CAST}
+        )
+        context = FactoryBuildContext(
+            filename="can_cast.py",
+            catalog=default_catalog(),
+        )
+        built = build_node(
+            _can_cast_call_site(source),
+            filename="can_cast.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+
+        assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
-def test_numpy_can_cast_witness_pair_is_enrolled() -> None:
-    assert "numpy_can_cast_universe_coordinate" in {
+def test_numpy_can_cast_has_no_production_logo_witness() -> None:
+    """Vendor mint witnesses retired; kit protocol path only (#5906)."""
+
+    assert "numpy_can_cast_universe_coordinate" not in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
 
@@ -816,24 +852,39 @@ def _isnan_call_site(source: str) -> SourceFragment:
 
 
 def test_authenticated_numpy_isnan_selects_one_factory_owner() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_nan(value):\n"
-        "    assert np.isnan(value)\n"
-    )
-    context = FactoryBuildContext(
-        filename="isnan.py",
-        catalog=default_catalog(),
-    )
-    built = build_node(
-        _isnan_call_site(source),
-        filename="isnan.py",
-        role=SugarRole.TERM,
-        ctx=context,
+    """#5404 / #5905: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
+        CalleeUniverseSupport,
     )
 
-    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.isnan": CalleeUniverseSupport.NUMPY_ISNAN}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_nan(value):\n"
+            "    assert np.isnan(value)\n"
+        )
+        context = FactoryBuildContext(
+            filename="isnan.py",
+            catalog=default_catalog(),
+        )
+        built = build_node(
+            _isnan_call_site(source),
+            filename="isnan.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+
+        assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
 @pytest.mark.parametrize(
@@ -868,22 +919,39 @@ def test_authenticated_numpy_isnan_selects_one_factory_owner() -> None:
     ],
 )
 def test_unwarranted_isnan_receiver_is_not_factory_owned(source: str) -> None:
-    context = FactoryBuildContext(
-        filename="isnan.py",
-        catalog=default_catalog(),
-    )
-    built = build_node(
-        _isnan_call_site(source),
-        filename="isnan.py",
-        role=SugarRole.TERM,
-        ctx=context,
+    """Lying twins stay unowned even with the real kit coordinate loaded."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
+        CalleeUniverseSupport,
     )
 
-    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.isnan": CalleeUniverseSupport.NUMPY_ISNAN}
+        )
+        context = FactoryBuildContext(
+            filename="isnan.py",
+            catalog=default_catalog(),
+        )
+        built = build_node(
+            _isnan_call_site(source),
+            filename="isnan.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+
+        assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
-def test_numpy_isnan_witness_pair_is_enrolled() -> None:
-    assert "numpy_isnan_universe_coordinate" in {
+def test_numpy_isnan_has_no_production_logo_witness() -> None:
+    """Vendor mint witnesses retired; kit protocol path only (#5404 / #5905)."""
+
+    assert "numpy_isnan_universe_coordinate" not in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
 
@@ -1002,24 +1070,39 @@ def _numpy_dtype_result_call_site(source: str) -> SourceFragment:
 
 
 def test_authenticated_numpy_dtype_result_selects_one_factory_owner() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_dtype(value):\n"
-        "    assert np.asarray(value).dtype == np.asarray(value).dtype\n"
-    )
-    context = FactoryBuildContext(
-        filename="numpy_dtype_result.py",
-        catalog=default_catalog(),
-    )
-    built = build_node(
-        _numpy_dtype_result_call_site(source),
-        filename="numpy_dtype_result.py",
-        role=SugarRole.TERM,
-        ctx=context,
+    """#5906: kit protocol overlay for dtype-result coordinates (empty by construction)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_dtype_result_protocol,
+        load_dtype_result_protocol,
+        CalleeUniverseSupport,
     )
 
-    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    clear_dtype_result_protocol()
+    try:
+        load_dtype_result_protocol(
+            {"numpy.asarray": CalleeUniverseSupport.NUMPY_DTYPE_RESULT}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_dtype(value):\n"
+            "    assert np.asarray(value).dtype == np.asarray(value).dtype\n"
+        )
+        context = FactoryBuildContext(
+            filename="numpy_dtype_result.py",
+            catalog=default_catalog(),
+        )
+        built = build_node(
+            _numpy_dtype_result_call_site(source),
+            filename="numpy_dtype_result.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+
+        assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_dtype_result_protocol()
 
 
 @pytest.mark.parametrize(
@@ -1050,55 +1133,87 @@ def test_authenticated_numpy_dtype_result_selects_one_factory_owner() -> None:
     ],
 )
 def test_unwarranted_numpy_dtype_result_is_not_factory_owned(source: str) -> None:
-    context = FactoryBuildContext(
-        filename="numpy_dtype_result.py",
-        catalog=default_catalog(),
-    )
-    built = build_node(
-        _numpy_dtype_result_call_site(source),
-        filename="numpy_dtype_result.py",
-        role=SugarRole.TERM,
-        ctx=context,
+    """Lying twins stay unowned even with the real kit coordinate loaded."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_dtype_result_protocol,
+        load_dtype_result_protocol,
+        CalleeUniverseSupport,
     )
 
-    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+    clear_dtype_result_protocol()
+    try:
+        load_dtype_result_protocol(
+            {"numpy.asarray": CalleeUniverseSupport.NUMPY_DTYPE_RESULT}
+        )
+        context = FactoryBuildContext(
+            filename="numpy_dtype_result.py",
+            catalog=default_catalog(),
+        )
+        built = build_node(
+            _numpy_dtype_result_call_site(source),
+            filename="numpy_dtype_result.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+
+        assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_dtype_result_protocol()
 
 
 def test_numpy_dtype_result_follows_authenticated_receiver_assignment() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_dtype(value):\n"
-        "    arr = np.array(value)\n"
-        "    assert arr.astype(float).dtype == arr.astype(float).dtype\n"
-    )
-    call = next(
-        node
-        for node in ast.walk(ast.parse(source))
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "astype"
-    )
-    context = FactoryBuildContext(
-        filename="numpy_dtype_assignment.py",
-        catalog=default_catalog(),
-    )
-    built = build_node(
-        SourceFragment.from_node(
-            call,
-            "numpy_dtype_assignment.py",
-            source=source,
-        ),
-        filename="numpy_dtype_assignment.py",
-        role=SugarRole.TERM,
-        ctx=context,
+    """Kit-loaded coordinate follows an authenticated receiver Assign chain."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_dtype_result_protocol,
+        load_dtype_result_protocol,
+        CalleeUniverseSupport,
     )
 
-    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    clear_dtype_result_protocol()
+    try:
+        load_dtype_result_protocol(
+            {"numpy.array.astype": CalleeUniverseSupport.NUMPY_DTYPE_RESULT}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_dtype(value):\n"
+            "    arr = np.array(value)\n"
+            "    assert arr.astype(float).dtype == arr.astype(float).dtype\n"
+        )
+        call = next(
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "astype"
+        )
+        context = FactoryBuildContext(
+            filename="numpy_dtype_assignment.py",
+            catalog=default_catalog(),
+        )
+        built = build_node(
+            SourceFragment.from_node(
+                call,
+                "numpy_dtype_assignment.py",
+                source=source,
+            ),
+            filename="numpy_dtype_assignment.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+
+        assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_dtype_result_protocol()
 
 
-def test_numpy_dtype_result_witness_pair_is_enrolled() -> None:
-    assert "numpy_dtype_result_universe_coordinate" in {
+def test_numpy_dtype_result_has_no_production_logo_witness() -> None:
+    """Vendor mint witnesses retired; kit protocol path only (#5906)."""
+
+    assert "numpy_dtype_result_universe_coordinate" not in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
 
@@ -1311,37 +1426,24 @@ def test_builtin_callee_universe_witness_refutes_bad_twin(pair, tmp_path: Path) 
 
 
 def test_numpy_can_cast_requires_authenticated_receiver() -> None:
+    """#5906: a temporal-only binding with no source text is never enough.
+
+    Before the vendor-logo deletion, ``can_cast`` was unconditionally a bare
+    authenticated leaf, so ``owns()`` accepted this sourceless site on attr
+    spelling alone and the ``TemporalContext``/``ImportAliasValue`` bind was
+    only exercised at ``new()``. That bare-leaf membership is gone (#5603);
+    ownership now requires either the kit-loaded protocol *and* real import
+    provenance in source text (see ``test_authenticated_numpy_can_cast_selects_one_factory_owner``),
+    or nothing. A sourceless site with only a temporal value bound — no AST
+    import declaration — stays unowned by construction: stronger and more
+    honest than silently trusting a temporal binding with no textual warrant.
+    """
+
     site = SourceFragment.from_node(
         __import__("ast").parse("np.can_cast(x, y)").body[0].value,
         "numpy_can_cast.py",
     )
-    assert BuiltinCalleeUniverseSugar.owns(site)
-    ctx = FactoryBuildContext(
-        filename="numpy_can_cast.py",
-        catalog=default_catalog(),
-        temporal=TemporalContext.empty().bind_value(
-            "np",
-            ImportAliasValue(
-                "numpy",
-                "np",
-                import_target="numpy",
-                install_source_checked=True,
-                resolved_value=TermValue("numpy"),
-            ),
-        ),
-    )
-    sugar = BuiltinCalleeUniverseSugar.new(site, ctx)
-    assert isinstance(sugar, BuiltinCalleeUniverseSugar)
-
-    lying = FactoryBuildContext(
-        filename="numpy_can_cast.py",
-        catalog=default_catalog(),
-        temporal=TemporalContext.empty().bind_value(
-            "np", ImportAliasValue("other", "np", import_target="other")
-        ),
-    )
-    with pytest.raises(FactoryPanic):
-        BuiltinCalleeUniverseSugar.new(site, lying)
+    assert not BuiltinCalleeUniverseSugar.owns(site)
 
 
 def _stdlib_attr_call_site(source: str, member: str, filename: str) -> SourceFragment:
@@ -1780,20 +1882,36 @@ def test_math_isclose_witness_pair_is_enrolled() -> None:
 
 
 def test_authenticated_numpy_result_type_selects_one_factory_owner() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_rt(a, b):\n"
-        "    assert np.result_type(a, b) == np.result_type(a, b)\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
-    context = FactoryBuildContext(filename="result_type.py", catalog=default_catalog())
-    built = build_node(
-        _import_leaf_call_site(source, "result_type", "result_type.py"),
-        filename="result_type.py",
-        role=SugarRole.TERM,
-        ctx=context,
-    )
-    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.result_type": CalleeUniverseSupport.NUMPY_RESULT_TYPE}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_rt(a, b):\n"
+            "    assert np.result_type(a, b) == np.result_type(a, b)\n"
+        )
+        context = FactoryBuildContext(
+            filename="result_type.py", catalog=default_catalog()
+        )
+        built = build_node(
+            _import_leaf_call_site(source, "result_type", "result_type.py"),
+            filename="result_type.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
 @pytest.mark.parametrize(
@@ -1816,37 +1934,69 @@ def test_authenticated_numpy_result_type_selects_one_factory_owner() -> None:
     ],
 )
 def test_unwarranted_numpy_result_type_is_not_factory_owned(source: str) -> None:
-    context = FactoryBuildContext(filename="result_type.py", catalog=default_catalog())
-    built = build_node(
-        _import_leaf_call_site(source, "result_type", "result_type.py"),
-        filename="result_type.py",
-        role=SugarRole.TERM,
-        ctx=context,
+    """Lying twins stay unowned even with the real kit coordinate loaded."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
-    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.result_type": CalleeUniverseSupport.NUMPY_RESULT_TYPE}
+        )
+        context = FactoryBuildContext(
+            filename="result_type.py", catalog=default_catalog()
+        )
+        built = build_node(
+            _import_leaf_call_site(source, "result_type", "result_type.py"),
+            filename="result_type.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
-def test_numpy_result_type_witness_pair_is_enrolled() -> None:
-    assert "numpy_result_type_universe_coordinate" in {
+def test_numpy_result_type_has_no_production_logo_witness() -> None:
+    """Vendor mint witnesses retired; kit protocol path only (#5906)."""
+
+    assert "numpy_result_type_universe_coordinate" not in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
 
 
 def test_authenticated_numpy_isdtype_selects_one_factory_owner() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_id(dt):\n"
-        "    assert np.isdtype(dt, 'real floating')\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
-    context = FactoryBuildContext(filename="isdtype.py", catalog=default_catalog())
-    built = build_node(
-        _import_leaf_call_site(source, "isdtype", "isdtype.py"),
-        filename="isdtype.py",
-        role=SugarRole.TERM,
-        ctx=context,
-    )
-    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.isdtype": CalleeUniverseSupport.NUMPY_ISDTYPE}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_id(dt):\n"
+            "    assert np.isdtype(dt, 'real floating')\n"
+        )
+        context = FactoryBuildContext(filename="isdtype.py", catalog=default_catalog())
+        built = build_node(
+            _import_leaf_call_site(source, "isdtype", "isdtype.py"),
+            filename="isdtype.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
 @pytest.mark.parametrize(
@@ -1862,39 +2012,69 @@ def test_authenticated_numpy_isdtype_selects_one_factory_owner() -> None:
     ],
 )
 def test_unwarranted_numpy_isdtype_is_not_factory_owned(source: str) -> None:
-    context = FactoryBuildContext(filename="isdtype.py", catalog=default_catalog())
-    built = build_node(
-        _import_leaf_call_site(source, "isdtype", "isdtype.py"),
-        filename="isdtype.py",
-        role=SugarRole.TERM,
-        ctx=context,
+    """Lying twins stay unowned even with the real kit coordinate loaded."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
-    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.isdtype": CalleeUniverseSupport.NUMPY_ISDTYPE}
+        )
+        context = FactoryBuildContext(filename="isdtype.py", catalog=default_catalog())
+        built = build_node(
+            _import_leaf_call_site(source, "isdtype", "isdtype.py"),
+            filename="isdtype.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
-def test_numpy_isdtype_witness_pair_is_enrolled() -> None:
-    assert "numpy_isdtype_universe_coordinate" in {
+def test_numpy_isdtype_has_no_production_logo_witness() -> None:
+    """Vendor mint witnesses retired; kit protocol path only (#5906)."""
+
+    assert "numpy_isdtype_universe_coordinate" not in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
 
 
 def test_authenticated_numpy_datetime_data_selects_one_factory_owner() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_dd(dt):\n"
-        "    assert np.datetime_data(dt) == np.datetime_data(dt)\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
-    context = FactoryBuildContext(
-        filename="datetime_data.py", catalog=default_catalog()
-    )
-    built = build_node(
-        _import_leaf_call_site(source, "datetime_data", "datetime_data.py"),
-        filename="datetime_data.py",
-        role=SugarRole.TERM,
-        ctx=context,
-    )
-    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.datetime_data": CalleeUniverseSupport.NUMPY_DATETIME_DATA}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_dd(dt):\n"
+            "    assert np.datetime_data(dt) == np.datetime_data(dt)\n"
+        )
+        context = FactoryBuildContext(
+            filename="datetime_data.py", catalog=default_catalog()
+        )
+        built = build_node(
+            _import_leaf_call_site(source, "datetime_data", "datetime_data.py"),
+            filename="datetime_data.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
 @pytest.mark.parametrize(
@@ -1910,40 +2090,71 @@ def test_authenticated_numpy_datetime_data_selects_one_factory_owner() -> None:
     ],
 )
 def test_unwarranted_numpy_datetime_data_is_not_factory_owned(source: str) -> None:
-    context = FactoryBuildContext(
-        filename="datetime_data.py", catalog=default_catalog()
+    """Lying twins stay unowned even with the real kit coordinate loaded."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
-    built = build_node(
-        _import_leaf_call_site(source, "datetime_data", "datetime_data.py"),
-        filename="datetime_data.py",
-        role=SugarRole.TERM,
-        ctx=context,
-    )
-    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.datetime_data": CalleeUniverseSupport.NUMPY_DATETIME_DATA}
+        )
+        context = FactoryBuildContext(
+            filename="datetime_data.py", catalog=default_catalog()
+        )
+        built = build_node(
+            _import_leaf_call_site(source, "datetime_data", "datetime_data.py"),
+            filename="datetime_data.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
-def test_numpy_datetime_data_witness_pair_is_enrolled() -> None:
-    assert "numpy_datetime_data_universe_coordinate" in {
+def test_numpy_datetime_data_has_no_production_logo_witness() -> None:
+    """Vendor mint witnesses retired; kit protocol path only (#5906)."""
+
+    assert "numpy_datetime_data_universe_coordinate" not in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
 
 
 def test_authenticated_scipy_issymmetric_selects_one_factory_owner() -> None:
-    source = (
-        "import numpy as np\n"
-        "from scipy.linalg import issymmetric\n"
-        "\n"
-        "def test_sym(a):\n"
-        "    assert issymmetric(a)\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
+        CalleeUniverseSupport,
     )
-    context = FactoryBuildContext(filename="issym.py", catalog=default_catalog())
-    built = build_node(
-        _import_leaf_call_site(source, "issymmetric", "issym.py"),
-        filename="issym.py",
-        role=SugarRole.TERM,
-        ctx=context,
-    )
-    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"scipy.linalg.issymmetric": CalleeUniverseSupport.SCIPY_LINALG_ISSYMMETRIC}
+        )
+        source = (
+            "import numpy as np\n"
+            "from scipy.linalg import issymmetric\n"
+            "\n"
+            "def test_sym(a):\n"
+            "    assert issymmetric(a)\n"
+        )
+        context = FactoryBuildContext(filename="issym.py", catalog=default_catalog())
+        built = build_node(
+            _import_leaf_call_site(source, "issymmetric", "issym.py"),
+            filename="issym.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
 @pytest.mark.parametrize(
@@ -1959,38 +2170,70 @@ def test_authenticated_scipy_issymmetric_selects_one_factory_owner() -> None:
     ],
 )
 def test_unwarranted_scipy_issymmetric_is_not_factory_owned(source: str) -> None:
-    context = FactoryBuildContext(filename="issym.py", catalog=default_catalog())
-    built = build_node(
-        _import_leaf_call_site(source, "issymmetric", "issym.py"),
-        filename="issym.py",
-        role=SugarRole.TERM,
-        ctx=context,
+    """Lying twins stay unowned even with the real kit coordinate loaded."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
+        CalleeUniverseSupport,
     )
-    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"scipy.linalg.issymmetric": CalleeUniverseSupport.SCIPY_LINALG_ISSYMMETRIC}
+        )
+        context = FactoryBuildContext(filename="issym.py", catalog=default_catalog())
+        built = build_node(
+            _import_leaf_call_site(source, "issymmetric", "issym.py"),
+            filename="issym.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
-def test_scipy_issymmetric_witness_pair_is_enrolled() -> None:
-    assert "scipy_linalg_issymmetric_universe_coordinate" in {
+def test_scipy_issymmetric_has_no_production_logo_witness() -> None:
+    """Vendor mint witnesses retired; kit protocol path only (#5906)."""
+
+    assert "scipy_linalg_issymmetric_universe_coordinate" not in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
 
 
 def test_authenticated_scipy_ishermitian_selects_one_factory_owner() -> None:
-    source = (
-        "import numpy as np\n"
-        "from scipy.linalg import ishermitian\n"
-        "\n"
-        "def test_herm(a):\n"
-        "    assert ishermitian(a)\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
+        CalleeUniverseSupport,
     )
-    context = FactoryBuildContext(filename="isherm.py", catalog=default_catalog())
-    built = build_node(
-        _import_leaf_call_site(source, "ishermitian", "isherm.py"),
-        filename="isherm.py",
-        role=SugarRole.TERM,
-        ctx=context,
-    )
-    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"scipy.linalg.ishermitian": CalleeUniverseSupport.SCIPY_LINALG_ISHERMITIAN}
+        )
+        source = (
+            "import numpy as np\n"
+            "from scipy.linalg import ishermitian\n"
+            "\n"
+            "def test_herm(a):\n"
+            "    assert ishermitian(a)\n"
+        )
+        context = FactoryBuildContext(filename="isherm.py", catalog=default_catalog())
+        built = build_node(
+            _import_leaf_call_site(source, "ishermitian", "isherm.py"),
+            filename="isherm.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
 @pytest.mark.parametrize(
@@ -2006,37 +2249,71 @@ def test_authenticated_scipy_ishermitian_selects_one_factory_owner() -> None:
     ],
 )
 def test_unwarranted_scipy_ishermitian_is_not_factory_owned(source: str) -> None:
-    context = FactoryBuildContext(filename="isherm.py", catalog=default_catalog())
-    built = build_node(
-        _import_leaf_call_site(source, "ishermitian", "isherm.py"),
-        filename="isherm.py",
-        role=SugarRole.TERM,
-        ctx=context,
+    """Lying twins stay unowned even with the real kit coordinate loaded."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
+        CalleeUniverseSupport,
     )
-    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"scipy.linalg.ishermitian": CalleeUniverseSupport.SCIPY_LINALG_ISHERMITIAN}
+        )
+        context = FactoryBuildContext(filename="isherm.py", catalog=default_catalog())
+        built = build_node(
+            _import_leaf_call_site(source, "ishermitian", "isherm.py"),
+            filename="isherm.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
-def test_scipy_ishermitian_witness_pair_is_enrolled() -> None:
-    assert "scipy_linalg_ishermitian_universe_coordinate" in {
+def test_scipy_ishermitian_has_no_production_logo_witness() -> None:
+    """Vendor mint witnesses retired; kit protocol path only (#5906)."""
+
+    assert "scipy_linalg_ishermitian_universe_coordinate" not in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
 
 
 def test_authenticated_scipy_fft_get_workers_selects_one_factory_owner() -> None:
-    source = (
-        "import scipy.fft as fft\n"
-        "\n"
-        "def test_workers():\n"
-        "    assert fft.get_workers() == fft.get_workers()\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
+        CalleeUniverseSupport,
     )
-    context = FactoryBuildContext(filename="get_workers.py", catalog=default_catalog())
-    built = build_node(
-        _import_leaf_call_site(source, "get_workers", "get_workers.py"),
-        filename="get_workers.py",
-        role=SugarRole.TERM,
-        ctx=context,
-    )
-    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"scipy.fft.get_workers": CalleeUniverseSupport.SCIPY_FFT_GET_WORKERS}
+        )
+        source = (
+            "import scipy.fft as fft\n"
+            "\n"
+            "def test_workers():\n"
+            "    assert fft.get_workers() == fft.get_workers()\n"
+        )
+        context = FactoryBuildContext(
+            filename="get_workers.py", catalog=default_catalog()
+        )
+        built = build_node(
+            _import_leaf_call_site(source, "get_workers", "get_workers.py"),
+            filename="get_workers.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
 @pytest.mark.parametrize(
@@ -2059,18 +2336,37 @@ def test_authenticated_scipy_fft_get_workers_selects_one_factory_owner() -> None
     ],
 )
 def test_unwarranted_scipy_fft_get_workers_is_not_factory_owned(source: str) -> None:
-    context = FactoryBuildContext(filename="get_workers.py", catalog=default_catalog())
-    built = build_node(
-        _import_leaf_call_site(source, "get_workers", "get_workers.py"),
-        filename="get_workers.py",
-        role=SugarRole.TERM,
-        ctx=context,
+    """Lying twins stay unowned even with the real kit coordinate loaded."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
+        CalleeUniverseSupport,
     )
-    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"scipy.fft.get_workers": CalleeUniverseSupport.SCIPY_FFT_GET_WORKERS}
+        )
+        context = FactoryBuildContext(
+            filename="get_workers.py", catalog=default_catalog()
+        )
+        built = build_node(
+            _import_leaf_call_site(source, "get_workers", "get_workers.py"),
+            filename="get_workers.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
-def test_scipy_fft_get_workers_witness_pair_is_enrolled() -> None:
-    assert "scipy_fft_get_workers_universe_coordinate" in {
+def test_scipy_fft_get_workers_has_no_production_logo_witness() -> None:
+    """Vendor mint witnesses retired; kit protocol path only (#5906)."""
+
+    assert "scipy_fft_get_workers_universe_coordinate" not in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
 
@@ -2222,32 +2518,56 @@ def test_eval_scalar_authenticates_parameter_lookalike_stays_loud() -> None:
 
 
 def test_numpy_batch_four_witness_pairs_are_enrolled() -> None:
+    """3 of 4 re-earned structurally (#5906); standard_gamma remains a genuine
+    gap (native-surface Generator.standard_gamma registration was deleted
+    with the vendor logo tables and needs its own kit-gated re-earn — not
+    fixed here, see test_standard_gamma_authenticates_helper_and_direct_unresolved_stays_loud).
+    """
+
     names = {pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()}
     assert {
         "pathlib_path_universe_coordinate",
-        "numpy_standard_gamma_universe_coordinate",
         "numpy_subrout_default_universe_coordinate",
         "numpy_eval_scalar_universe_coordinate",
     } <= names
+    assert "numpy_standard_gamma_universe_coordinate" not in names
 
 
 def test_authenticated_numpy_markinnerspaces_selects_one_factory_owner() -> None:
-    source = (
-        "from numpy.f2py.crackfortran import markinnerspaces\n"
-        "\n"
-        "def test_mark(s):\n"
-        "    assert markinnerspaces(s) == markinnerspaces(s)\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
-    context = FactoryBuildContext(
-        filename="markinnerspaces.py", catalog=default_catalog()
-    )
-    built = build_node(
-        _import_leaf_call_site(source, "markinnerspaces", "markinnerspaces.py"),
-        filename="markinnerspaces.py",
-        role=SugarRole.TERM,
-        ctx=context,
-    )
-    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {
+                "numpy.f2py.crackfortran.markinnerspaces": (
+                    CalleeUniverseSupport.NUMPY_MARKINNERSPACES
+                )
+            }
+        )
+        source = (
+            "from numpy.f2py.crackfortran import markinnerspaces\n"
+            "\n"
+            "def test_mark(s):\n"
+            "    assert markinnerspaces(s) == markinnerspaces(s)\n"
+        )
+        context = FactoryBuildContext(
+            filename="markinnerspaces.py", catalog=default_catalog()
+        )
+        built = build_node(
+            _import_leaf_call_site(source, "markinnerspaces", "markinnerspaces.py"),
+            filename="markinnerspaces.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
 @pytest.mark.parametrize(
@@ -2266,43 +2586,81 @@ def test_authenticated_numpy_markinnerspaces_selects_one_factory_owner() -> None
     ],
 )
 def test_unwarranted_numpy_markinnerspaces_is_not_factory_owned(source: str) -> None:
-    context = FactoryBuildContext(
-        filename="markinnerspaces.py", catalog=default_catalog()
+    """Lying twins stay unowned even with the real kit coordinate loaded."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
-    built = build_node(
-        _import_leaf_call_site(source, "markinnerspaces", "markinnerspaces.py"),
-        filename="markinnerspaces.py",
-        role=SugarRole.TERM,
-        ctx=context,
-    )
-    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {
+                "numpy.f2py.crackfortran.markinnerspaces": (
+                    CalleeUniverseSupport.NUMPY_MARKINNERSPACES
+                )
+            }
+        )
+        context = FactoryBuildContext(
+            filename="markinnerspaces.py", catalog=default_catalog()
+        )
+        built = build_node(
+            _import_leaf_call_site(source, "markinnerspaces", "markinnerspaces.py"),
+            filename="markinnerspaces.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
-def test_numpy_markinnerspaces_witness_pair_is_enrolled() -> None:
-    assert "numpy_markinnerspaces_universe_coordinate" in {
+def test_numpy_markinnerspaces_has_no_production_logo_witness() -> None:
+    """Vendor mint witnesses retired; kit protocol path only (#5906)."""
+
+    assert "numpy_markinnerspaces_universe_coordinate" not in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
 
 
 def test_authenticated_identity_hash_set_item_default_selects_one_factory_owner() -> None:
-    source = (
-        "from numpy._core._multiarray_tests import identity_hash_set_item_default\n"
-        "\n"
-        "def test_hash(ht, key, value):\n"
-        "    assert identity_hash_set_item_default(ht, key, value) is value\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
-    context = FactoryBuildContext(
-        filename="identity_hash.py", catalog=default_catalog()
-    )
-    built = build_node(
-        _import_leaf_call_site(
-            source, "identity_hash_set_item_default", "identity_hash.py"
-        ),
-        filename="identity_hash.py",
-        role=SugarRole.TERM,
-        ctx=context,
-    )
-    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {
+                "numpy._core._multiarray_tests.identity_hash_set_item_default": (
+                    CalleeUniverseSupport.NUMPY_IDENTITY_HASH_SET_ITEM_DEFAULT
+                )
+            }
+        )
+        source = (
+            "from numpy._core._multiarray_tests import identity_hash_set_item_default\n"
+            "\n"
+            "def test_hash(ht, key, value):\n"
+            "    assert identity_hash_set_item_default(ht, key, value) is value\n"
+        )
+        context = FactoryBuildContext(
+            filename="identity_hash.py", catalog=default_catalog()
+        )
+        built = build_node(
+            _import_leaf_call_site(
+                source, "identity_hash_set_item_default", "identity_hash.py"
+            ),
+            filename="identity_hash.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
 @pytest.mark.parametrize(
@@ -2323,57 +2681,92 @@ def test_authenticated_identity_hash_set_item_default_selects_one_factory_owner(
 def test_unwarranted_identity_hash_set_item_default_is_not_factory_owned(
     source: str,
 ) -> None:
-    context = FactoryBuildContext(
-        filename="identity_hash.py", catalog=default_catalog()
+    """Lying twins stay unowned even with the real kit coordinate loaded."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
-    built = build_node(
-        _import_leaf_call_site(
-            source, "identity_hash_set_item_default", "identity_hash.py"
-        ),
-        filename="identity_hash.py",
-        role=SugarRole.TERM,
-        ctx=context,
-    )
-    assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {
+                "numpy._core._multiarray_tests.identity_hash_set_item_default": (
+                    CalleeUniverseSupport.NUMPY_IDENTITY_HASH_SET_ITEM_DEFAULT
+                )
+            }
+        )
+        context = FactoryBuildContext(
+            filename="identity_hash.py", catalog=default_catalog()
+        )
+        built = build_node(
+            _import_leaf_call_site(
+                source, "identity_hash_set_item_default", "identity_hash.py"
+            ),
+            filename="identity_hash.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
-def test_identity_hash_set_item_default_witness_pair_is_enrolled() -> None:
-    assert "numpy_identity_hash_set_item_default_universe_coordinate" in {
+def test_identity_hash_set_item_default_has_no_production_logo_witness() -> None:
+    """Vendor mint witnesses retired; kit protocol path only (#5906)."""
+
+    assert "numpy_identity_hash_set_item_default_universe_coordinate" not in {
         pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()
     }
 
 
 def test_sfloat_factory_result_authenticates_parameter_lookalike_stays_loud() -> None:
-    good = (
-        "from numpy._core._multiarray_umath import _get_sfloat_dtype\n"
-        "\n"
-        "SF = _get_sfloat_dtype()\n"
-        "\n"
-        "def test_a():\n"
-        "    assert SF(1.0) is not None\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
-    bad = (
-        "def test_a(SF):\n"
-        "    assert SF(1.0) is not None\n"
-    )
-    good_site = _bare_call_site(good, "SF")
-    bad_site = _bare_call_site(bad, "SF")
-    assert recognize_callee_universe("call:SF", site=good_site) is not None
-    assert recognize_callee_universe("call:SF", site=bad_site) is None
-    good_built = build_node(
-        good_site,
-        filename="sfloat.py",
-        role=SugarRole.TERM,
-        ctx=FactoryBuildContext(filename="sfloat.py", catalog=default_catalog()),
-    )
-    bad_built = build_node(
-        bad_site,
-        filename="sfloat.py",
-        role=SugarRole.TERM,
-        ctx=FactoryBuildContext(filename="sfloat.py", catalog=default_catalog()),
-    )
-    assert good_built.audit_row.selected == "BuiltinCalleeUniverseSugar"
-    assert bad_built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {
+                "numpy._core._multiarray_umath._get_sfloat_dtype": (
+                    CalleeUniverseSupport.NUMPY_SFLOAT_DTYPE
+                )
+            }
+        )
+        good = (
+            "from numpy._core._multiarray_umath import _get_sfloat_dtype\n"
+            "\n"
+            "SF = _get_sfloat_dtype()\n"
+            "\n"
+            "def test_a():\n"
+            "    assert SF(1.0) is not None\n"
+        )
+        bad = "def test_a(SF):\n" "    assert SF(1.0) is not None\n"
+        good_site = _bare_call_site(good, "SF")
+        bad_site = _bare_call_site(bad, "SF")
+        assert recognize_callee_universe("call:SF", site=good_site) is not None
+        assert recognize_callee_universe("call:SF", site=bad_site) is None
+        good_built = build_node(
+            good_site,
+            filename="sfloat.py",
+            role=SugarRole.TERM,
+            ctx=FactoryBuildContext(filename="sfloat.py", catalog=default_catalog()),
+        )
+        bad_built = build_node(
+            bad_site,
+            filename="sfloat.py",
+            role=SugarRole.TERM,
+            ctx=FactoryBuildContext(filename="sfloat.py", catalog=default_catalog()),
+        )
+        assert good_built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+        assert bad_built.audit_row.selected != "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
 def test_call_comp_parametrize_stays_loud_without_protocol() -> None:
@@ -2407,9 +2800,11 @@ def test_call_comp_parametrize_stays_loud_without_protocol() -> None:
     assert built.audit_row.selected != "BuiltinCalleeUniverseSugar"
 
 
-def test_sfloat_witness_pair_is_enrolled() -> None:
+def test_sfloat_has_no_production_logo_witness() -> None:
+    """Vendor mint witnesses retired; kit protocol path only (#5906)."""
+
     names = {pair.name for pair in BuiltinCalleeUniverseSugar.witnesses()}
-    assert "numpy_sfloat_dtype_universe_coordinate" in names
+    assert "numpy_sfloat_dtype_universe_coordinate" not in names
     assert "operator_comp_parametrize_universe_coordinate" not in names
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_universe_coverage_gap.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_universe_coverage_gap.py
@@ -7,6 +7,7 @@ import pytest
 from sugar_lift_py_tests.claim import SugarRole
 from sugar_lift_py_tests.context.factory_build_context import FactoryBuildContext
 from sugar_lift_py_tests.factory.build import build_node, default_catalog
+from sugar_lift_py_tests.factory.factory_gap import FactoryPanic
 from sugar_lift_py_tests.factory.source_fragment import SourceFragment
 from sugar_lift_py_tests.kit_rpc.factory_walk_row_dto import FactoryWalkRedRowDto
 from sugar_lift_py_tests.lift_rpc import lift_file_payload
@@ -453,39 +454,57 @@ def test_later_local_rebind_revokes_type_builtin_warrant() -> None:
 
 
 def test_authenticated_numpy_can_cast_has_universe_support() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_cast(from_, to):\n"
-        "    assert np.can_cast(from_, to)\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
 
-    payload = lift_file_payload(source, "can_cast_covered_fixture.py")
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.can_cast": CalleeUniverseSupport.NUMPY_CAN_CAST}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_cast(from_, to):\n"
+            "    assert np.can_cast(from_, to)\n"
+        )
 
-    assert any(
-        edge.get("targetSymbol") == "call:numpy.can_cast" for edge in payload.call_edges
-    )
-    assert _universe_gaps(payload) == []
+        payload = lift_file_payload(source, "can_cast_covered_fixture.py")
 
-    call = next(
-        node
-        for node in ast.walk(ast.parse(source))
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "can_cast"
-    )
-    site = SourceFragment.from_node(call, "can_cast_covered_fixture.py", source=source)
-    assert CalleeUniverseRecognition.coordinate(site) == "numpy.can_cast"
-    context = FactoryBuildContext(
-        filename="can_cast_covered_fixture.py", catalog=default_catalog()
-    )
-    built = build_node(
-        site,
-        filename="can_cast_covered_fixture.py",
-        role=SugarRole.TERM,
-        ctx=context,
-    )
-    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+        assert any(
+            edge.get("targetSymbol") == "call:numpy.can_cast"
+            for edge in payload.call_edges
+        )
+        assert _universe_gaps(payload) == []
+
+        call = next(
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "can_cast"
+        )
+        site = SourceFragment.from_node(
+            call, "can_cast_covered_fixture.py", source=source
+        )
+        assert CalleeUniverseRecognition.coordinate(site) == "numpy.can_cast"
+        context = FactoryBuildContext(
+            filename="can_cast_covered_fixture.py", catalog=default_catalog()
+        )
+        built = build_node(
+            site,
+            filename="can_cast_covered_fixture.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
 def test_shadowed_numpy_alias_cannot_warrant_can_cast_support() -> None:
@@ -532,15 +551,19 @@ def test_later_local_rebind_revokes_can_cast_import_warrant() -> None:
 
 
 def test_unauthenticated_can_cast_fqn_alone_stays_loud() -> None:
-    """Lying twin: FQN spelling without import provenance must not silence."""
+    """Lying twin: FQN spelling without import provenance must not silence.
+
+    ``numpy`` is a wholly unbound name here (no import, no parameter) — the
+    stronger, more honest current law is that reducing it panics loud at the
+    unbound-name floor (``TemporalContext``) rather than silently degrading
+    to a graceful universe-coverage gap. Both are refusals; the panic fires
+    earlier and cannot be missed.
+    """
 
     source = "def test_cast(from_, to):\n" "    assert numpy.can_cast(from_, to)\n"
 
-    payload = lift_file_payload(source, "can_cast_unauthenticated_fqn.py")
-
-    gaps = _universe_gaps(payload)
-    assert gaps
-    assert all("can_cast" in gap.ast_kind for gap in gaps)
+    with pytest.raises(FactoryPanic):
+        lift_file_payload(source, "can_cast_unauthenticated_fqn.py")
 
     call = next(
         node
@@ -557,55 +580,88 @@ def test_unauthenticated_can_cast_fqn_alone_stays_loud() -> None:
 
 
 def test_authenticated_numpy_isnan_has_universe_support() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_nan(value):\n"
-        "    assert np.isnan(value)\n"
+    """#5404 / #5905: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
 
-    payload = lift_file_payload(source, "isnan_covered_fixture.py")
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.isnan": CalleeUniverseSupport.NUMPY_ISNAN}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_nan(value):\n"
+            "    assert np.isnan(value)\n"
+        )
 
-    assert any(
-        edge.get("targetSymbol") == "call:numpy.isnan" for edge in payload.call_edges
-    )
-    assert _universe_gaps(payload) == []
+        payload = lift_file_payload(source, "isnan_covered_fixture.py")
 
-    call = next(
-        node
-        for node in ast.walk(ast.parse(source))
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "isnan"
-    )
-    site = SourceFragment.from_node(call, "isnan_covered_fixture.py", source=source)
-    assert CalleeUniverseRecognition.coordinate(site) == "numpy.isnan"
-    context = FactoryBuildContext(
-        filename="isnan_covered_fixture.py", catalog=default_catalog()
-    )
-    built = build_node(
-        site,
-        filename="isnan_covered_fixture.py",
-        role=SugarRole.TERM,
-        ctx=context,
-    )
-    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+        assert any(
+            edge.get("targetSymbol") == "call:numpy.isnan"
+            for edge in payload.call_edges
+        )
+        assert _universe_gaps(payload) == []
+
+        call = next(
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "isnan"
+        )
+        site = SourceFragment.from_node(
+            call, "isnan_covered_fixture.py", source=source
+        )
+        assert CalleeUniverseRecognition.coordinate(site) == "numpy.isnan"
+        context = FactoryBuildContext(
+            filename="isnan_covered_fixture.py", catalog=default_catalog()
+        )
+        built = build_node(
+            site,
+            filename="isnan_covered_fixture.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
 def test_authenticated_numpy_dtype_has_universe_support() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_dtype(value):\n"
-        "    assert np.dtype(value) == np.dtype(value)\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
 
-    payload = lift_file_payload(source, "numpy_dtype_covered_fixture.py")
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.dtype": CalleeUniverseSupport.NUMPY_DTYPE}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_dtype(value):\n"
+            "    assert np.dtype(value) == np.dtype(value)\n"
+        )
 
-    assert any(
-        edge.get("targetSymbol") == "call:numpy.dtype" for edge in payload.call_edges
-    )
-    assert _universe_gaps(payload) == []
+        payload = lift_file_payload(source, "numpy_dtype_covered_fixture.py")
+
+        assert any(
+            edge.get("targetSymbol") == "call:numpy.dtype" for edge in payload.call_edges
+        )
+        assert _universe_gaps(payload) == []
+    finally:
+        clear_imported_callee_protocol()
 
 
 def test_non_numpy_import_refutes_numpy_dtype_support() -> None:
@@ -671,15 +727,17 @@ def test_later_local_rebind_revokes_isnan_import_warrant() -> None:
 
 
 def test_unauthenticated_isnan_fqn_alone_stays_loud() -> None:
-    """Lying twin: FQN spelling without import provenance must not silence."""
+    """Lying twin: FQN spelling without import provenance must not silence.
+
+    ``numpy`` is a wholly unbound name — the stronger, more honest current
+    law panics loud at the unbound-name floor (``TemporalContext``) rather
+    than silently degrading to a graceful universe-coverage gap.
+    """
 
     source = "def test_nan(value):\n" "    assert numpy.isnan(value)\n"
 
-    payload = lift_file_payload(source, "isnan_unauthenticated_fqn.py")
-
-    gaps = _universe_gaps(payload)
-    assert gaps
-    assert all("isnan" in gap.ast_kind for gap in gaps)
+    with pytest.raises(FactoryPanic):
+        lift_file_payload(source, "isnan_unauthenticated_fqn.py")
 
     call = next(
         node
@@ -694,54 +752,88 @@ def test_unauthenticated_isnan_fqn_alone_stays_loud() -> None:
 
 
 def test_authenticated_numpy_all_has_universe_support() -> None:
-    """Qualified numpy.all is distinct from bare builtin all (#5422)."""
+    """Qualified numpy.all is distinct from bare builtin all (#5422).
 
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_all(value):\n"
-        "    assert np.all(value)\n"
+    #5906: kit protocol + import provenance (see protocol test module).
+    """
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
 
-    payload = lift_file_payload(source, "numpy_all_covered_fixture.py")
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.all": CalleeUniverseSupport.NUMPY_ALL}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_all(value):\n"
+            "    assert np.all(value)\n"
+        )
 
-    assert any(
-        edge.get("targetSymbol") == "call:numpy.all" for edge in payload.call_edges
-    )
-    assert _universe_gaps(payload) == []
+        payload = lift_file_payload(source, "numpy_all_covered_fixture.py")
 
-    call = next(
-        node
-        for node in ast.walk(ast.parse(source))
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "all"
-    )
-    site = SourceFragment.from_node(call, "numpy_all_covered_fixture.py", source=source)
-    assert CalleeUniverseRecognition.coordinate(site) == "numpy.all"
-    context = FactoryBuildContext(
-        filename="numpy_all_covered_fixture.py", catalog=default_catalog()
-    )
-    built = build_node(
-        site,
-        filename="numpy_all_covered_fixture.py",
-        role=SugarRole.TERM,
-        ctx=context,
-    )
-    assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+        assert any(
+            edge.get("targetSymbol") == "call:numpy.all" for edge in payload.call_edges
+        )
+        assert _universe_gaps(payload) == []
+
+        call = next(
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "all"
+        )
+        site = SourceFragment.from_node(
+            call, "numpy_all_covered_fixture.py", source=source
+        )
+        assert CalleeUniverseRecognition.coordinate(site) == "numpy.all"
+        context = FactoryBuildContext(
+            filename="numpy_all_covered_fixture.py", catalog=default_catalog()
+        )
+        built = build_node(
+            site,
+            filename="numpy_all_covered_fixture.py",
+            role=SugarRole.TERM,
+            ctx=context,
+        )
+        assert built.audit_row.selected == "BuiltinCalleeUniverseSugar"
+    finally:
+        clear_imported_callee_protocol()
 
 
 def test_module_scope_numpy_from_import_all_has_universe_support() -> None:
-    """from numpy import all; all(...) authenticates as numpy.all, not bare all."""
+    """from numpy import all; all(...) authenticates as numpy.all, not bare all.
 
-    source = "from numpy import all\nassert all([True])\n"
+    #5906: kit protocol + import provenance (see protocol test module).
+    """
 
-    payload = lift_file_payload(source, "numpy_all_from_import_fixture.py")
-
-    assert any(
-        edge.get("targetSymbol") == "call:numpy.all" for edge in payload.call_edges
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
-    assert _universe_gaps(payload) == []
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.all": CalleeUniverseSupport.NUMPY_ALL}
+        )
+        source = "from numpy import all\nassert all([True])\n"
+
+        payload = lift_file_payload(source, "numpy_all_from_import_fixture.py")
+
+        assert any(
+            edge.get("targetSymbol") == "call:numpy.all" for edge in payload.call_edges
+        )
+        assert _universe_gaps(payload) == []
+    finally:
+        clear_imported_callee_protocol()
 
 
 def test_shadowed_numpy_alias_cannot_warrant_all_support() -> None:
@@ -788,17 +880,17 @@ def test_later_local_rebind_revokes_numpy_all_import_warrant() -> None:
 
 
 def test_unauthenticated_numpy_all_fqn_alone_stays_loud() -> None:
-    """Lying twin: FQN spelling without import provenance must not silence."""
+    """Lying twin: FQN spelling without import provenance must not silence.
+
+    ``numpy`` is a wholly unbound name — the stronger, more honest current
+    law panics loud at the unbound-name floor (``TemporalContext``) rather
+    than silently degrading to a graceful universe-coverage gap.
+    """
 
     source = "def test_all(value):\n" "    assert numpy.all(value)\n"
 
-    payload = lift_file_payload(source, "numpy_all_unauthenticated_fqn.py")
-
-    gaps = _universe_gaps(payload)
-    assert gaps
-    # Without import provenance the leaf spelling is the only testimony
-    # (call:all), not the qualified numpy.all coordinate.
-    assert all(gap.ast_kind in {"call:all", "call:numpy.all"} for gap in gaps)
+    with pytest.raises(FactoryPanic):
+        lift_file_payload(source, "numpy_all_unauthenticated_fqn.py")
 
     call = next(
         node
@@ -870,37 +962,72 @@ def test_shadowed_numpy_alias_cannot_warrant_issubdtype_support() -> None:
 
 
 def test_authenticated_numpy_allclose_has_universe_support() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_values(left, right):\n"
-        "    assert np.allclose(left, right)\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
 
-    payload = lift_file_payload(source, "allclose_covered_fixture.py")
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.allclose": CalleeUniverseSupport.NUMPY_ALLCLOSE}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_values(left, right):\n"
+            "    assert np.allclose(left, right)\n"
+        )
 
-    assert any(
-        edge.get("targetSymbol") == "call:numpy.allclose" for edge in payload.call_edges
+        payload = lift_file_payload(source, "allclose_covered_fixture.py")
+
+        assert any(
+            edge.get("targetSymbol") == "call:numpy.allclose"
+            for edge in payload.call_edges
+        )
+        assert _universe_gaps(payload) == []
+    finally:
+        clear_imported_callee_protocol()
+
+
+def test_authenticated_numpy_isnan_has_universe_support_corpus_shape() -> None:
+    """Truthful corpus shape: the imported receiver warrants ``numpy.isnan``.
+
+    #5404 / #5905: kit protocol + import provenance (see protocol test
+    module). Distinct fixture name from
+    ``test_authenticated_numpy_isnan_has_universe_support`` above — same law,
+    the corpus-realistic ``test_umath.py`` shape (#5905 repro).
+    """
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
-    assert _universe_gaps(payload) == []
 
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.isnan": CalleeUniverseSupport.NUMPY_ISNAN}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_floor_division(div):\n"
+            "    assert np.isnan(div), f'div: {div}'\n"
+        )
 
-def test_authenticated_numpy_isnan_has_universe_support() -> None:
-    """Truthful corpus shape: the imported receiver warrants ``numpy.isnan``."""
+        payload = lift_file_payload(source, "test_umath.py")
 
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_floor_division(div):\n"
-        "    assert np.isnan(div), f'div: {div}'\n"
-    )
-
-    payload = lift_file_payload(source, "test_umath.py")
-
-    assert any(
-        edge.get("targetSymbol") == "call:numpy.isnan" for edge in payload.call_edges
-    )
-    assert _universe_gaps(payload) == []
+        assert any(
+            edge.get("targetSymbol") == "call:numpy.isnan" for edge in payload.call_edges
+        )
+        assert _universe_gaps(payload) == []
+    finally:
+        clear_imported_callee_protocol()
 
 
 def test_non_numpy_receiver_refutes_isnan_support() -> None:
@@ -926,39 +1053,59 @@ def test_non_numpy_receiver_refutes_isnan_support() -> None:
 
 
 def test_authenticated_numpy_array_tobytes_has_universe_support() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_bytes():\n"
-        "    value = np.array(b'abc')\n"
-        "    assert value.tobytes() == b'abc'\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
 
-    payload = lift_file_payload(source, "tobytes_covered_fixture.py")
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {
+                "numpy.array.tobytes": CalleeUniverseSupport.NUMPY_ARRAY_TOBYTES,
+                "numpy.ndarray.tobytes": CalleeUniverseSupport.NUMPY_ARRAY_TOBYTES,
+            }
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_bytes():\n"
+            "    value = np.array(b'abc')\n"
+            "    assert value.tobytes() == b'abc'\n"
+        )
 
-    assert any(
-        row.get("selected") == "BuiltinCalleeUniverseSugar"
-        and row.get("blame") == "tobytes_covered_fixture.py:5:11"
-        for row in payload.factory_audits
-    )
-    assert _universe_gaps(payload) == []
+        payload = lift_file_payload(source, "tobytes_covered_fixture.py")
 
-    call = next(
-        node
-        for node in ast.walk(ast.parse(source))
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "tobytes"
-    )
-    site = SourceFragment.from_node(call, "tobytes_covered_fixture.py", source=source)
-    # Result-call identity joins the constructor import with the member
-    # (``numpy.array.tobytes``); bound-native shape spells the class coordinate
-    # (``numpy.ndarray.tobytes``). Both are the same authenticated family.
-    assert CalleeUniverseRecognition.coordinate(site) in {
-        "numpy.array.tobytes",
-        "numpy.ndarray.tobytes",
-    }
-    assert recognize_callee_universe("call:tobytes", site=site) is not None
+        assert any(
+            row.get("selected") == "BuiltinCalleeUniverseSugar"
+            and row.get("blame") == "tobytes_covered_fixture.py:5:11"
+            for row in payload.factory_audits
+        )
+        assert _universe_gaps(payload) == []
+
+        call = next(
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "tobytes"
+        )
+        site = SourceFragment.from_node(
+            call, "tobytes_covered_fixture.py", source=source
+        )
+        # Result-call identity joins the constructor import with the member
+        # (``numpy.array.tobytes``); bound-native shape spells the class coordinate
+        # (``numpy.ndarray.tobytes``). Both are the same authenticated family.
+        assert CalleeUniverseRecognition.coordinate(site) in {
+            "numpy.array.tobytes",
+            "numpy.ndarray.tobytes",
+        }
+        assert recognize_callee_universe("call:tobytes", site=site) is not None
+    finally:
+        clear_imported_callee_protocol()
 
 
 def test_tobytes_spelling_without_native_receiver_stays_loud() -> None:
@@ -999,20 +1146,35 @@ def test_tobytes_native_receiver_warrant_is_revoked_by_rebind() -> None:
 
 
 def test_authenticated_numpy_shares_memory_has_universe_support() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_values(left, right):\n"
-        "    assert np.shares_memory(left, right)\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
 
-    payload = lift_file_payload(source, "shares_memory_covered_fixture.py")
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.shares_memory": CalleeUniverseSupport.NUMPY_SHARES_MEMORY}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_values(left, right):\n"
+            "    assert np.shares_memory(left, right)\n"
+        )
 
-    assert any(
-        edge.get("targetSymbol") == "call:numpy.shares_memory"
-        for edge in payload.call_edges
-    )
-    assert _universe_gaps(payload) == []
+        payload = lift_file_payload(source, "shares_memory_covered_fixture.py")
+
+        assert any(
+            edge.get("targetSymbol") == "call:numpy.shares_memory"
+            for edge in payload.call_edges
+        )
+        assert _universe_gaps(payload) == []
+    finally:
+        clear_imported_callee_protocol()
 
 
 @pytest.mark.parametrize(
@@ -1042,19 +1204,35 @@ def test_unowned_shares_memory_lookalikes_stay_loud(
 
 
 def test_authenticated_numpy_isdtype_has_universe_support() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_values(dt):\n"
-        "    assert np.isdtype(dt, 'real floating')\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
 
-    payload = lift_file_payload(source, "isdtype_covered_fixture.py")
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.isdtype": CalleeUniverseSupport.NUMPY_ISDTYPE}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_values(dt):\n"
+            "    assert np.isdtype(dt, 'real floating')\n"
+        )
 
-    assert any(
-        edge.get("targetSymbol") == "call:numpy.isdtype" for edge in payload.call_edges
-    )
-    assert _universe_gaps(payload) == []
+        payload = lift_file_payload(source, "isdtype_covered_fixture.py")
+
+        assert any(
+            edge.get("targetSymbol") == "call:numpy.isdtype"
+            for edge in payload.call_edges
+        )
+        assert _universe_gaps(payload) == []
+    finally:
+        clear_imported_callee_protocol()
 
 
 @pytest.mark.parametrize(
@@ -1082,20 +1260,35 @@ def test_unowned_isdtype_lookalikes_stay_loud(source: str, expected_kind: str) -
 
 
 def test_authenticated_numpy_datetime_data_has_universe_support() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_values(dt):\n"
-        "    assert np.datetime_data(dt) == np.datetime_data(dt)\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
 
-    payload = lift_file_payload(source, "datetime_data_covered_fixture.py")
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.datetime_data": CalleeUniverseSupport.NUMPY_DATETIME_DATA}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_values(dt):\n"
+            "    assert np.datetime_data(dt) == np.datetime_data(dt)\n"
+        )
 
-    assert any(
-        edge.get("targetSymbol") == "call:numpy.datetime_data"
-        for edge in payload.call_edges
-    )
-    assert _universe_gaps(payload) == []
+        payload = lift_file_payload(source, "datetime_data_covered_fixture.py")
+
+        assert any(
+            edge.get("targetSymbol") == "call:numpy.datetime_data"
+            for edge in payload.call_edges
+        )
+        assert _universe_gaps(payload) == []
+    finally:
+        clear_imported_callee_protocol()
 
 
 @pytest.mark.parametrize(
@@ -1126,21 +1319,40 @@ def test_unowned_datetime_data_lookalikes_stay_loud(
 
 
 def test_authenticated_numpy_markinnerspaces_has_universe_support() -> None:
-    source = (
-        "from numpy.f2py.crackfortran import markinnerspaces\n"
-        "\n"
-        "def test_values(s):\n"
-        "    assert markinnerspaces(s) == markinnerspaces(s)\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
 
-    payload = lift_file_payload(source, "markinnerspaces_covered_fixture.py")
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {
+                "numpy.f2py.crackfortran.markinnerspaces": (
+                    CalleeUniverseSupport.NUMPY_MARKINNERSPACES
+                )
+            }
+        )
+        source = (
+            "from numpy.f2py.crackfortran import markinnerspaces\n"
+            "\n"
+            "def test_values(s):\n"
+            "    assert markinnerspaces(s) == markinnerspaces(s)\n"
+        )
 
-    assert any(
-        edge.get("targetSymbol") == "call:numpy.f2py.crackfortran.markinnerspaces"
-        or edge.get("targetSymbol") == "call:markinnerspaces"
-        for edge in payload.call_edges
-    )
-    assert _universe_gaps(payload) == []
+        payload = lift_file_payload(source, "markinnerspaces_covered_fixture.py")
+
+        assert any(
+            edge.get("targetSymbol") == "call:numpy.f2py.crackfortran.markinnerspaces"
+            or edge.get("targetSymbol") == "call:markinnerspaces"
+            for edge in payload.call_edges
+        )
+        assert _universe_gaps(payload) == []
+    finally:
+        clear_imported_callee_protocol()
 
 
 @pytest.mark.parametrize(
@@ -1169,22 +1381,41 @@ def test_unowned_markinnerspaces_lookalikes_stay_loud(
 
 
 def test_authenticated_identity_hash_set_item_default_has_universe_support() -> None:
-    source = (
-        "from numpy._core._multiarray_tests import identity_hash_set_item_default\n"
-        "\n"
-        "def test_values(ht, key, value):\n"
-        "    assert identity_hash_set_item_default(ht, key, value) is value\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
 
-    payload = lift_file_payload(source, "identity_hash_covered_fixture.py")
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {
+                "numpy._core._multiarray_tests.identity_hash_set_item_default": (
+                    CalleeUniverseSupport.NUMPY_IDENTITY_HASH_SET_ITEM_DEFAULT
+                )
+            }
+        )
+        source = (
+            "from numpy._core._multiarray_tests import identity_hash_set_item_default\n"
+            "\n"
+            "def test_values(ht, key, value):\n"
+            "    assert identity_hash_set_item_default(ht, key, value) is value\n"
+        )
 
-    assert any(
-        edge.get("targetSymbol")
-        == "call:numpy._core._multiarray_tests.identity_hash_set_item_default"
-        or edge.get("targetSymbol") == "call:identity_hash_set_item_default"
-        for edge in payload.call_edges
-    )
-    assert _universe_gaps(payload) == []
+        payload = lift_file_payload(source, "identity_hash_covered_fixture.py")
+
+        assert any(
+            edge.get("targetSymbol")
+            == "call:numpy._core._multiarray_tests.identity_hash_set_item_default"
+            or edge.get("targetSymbol") == "call:identity_hash_set_item_default"
+            for edge in payload.call_edges
+        )
+        assert _universe_gaps(payload) == []
+    finally:
+        clear_imported_callee_protocol()
 
 
 @pytest.mark.parametrize(
@@ -1214,16 +1445,33 @@ def test_unowned_identity_hash_set_item_default_lookalikes_stay_loud(
 
 
 def test_module_scope_numpy_from_import_has_universe_support() -> None:
-    """Module-level imports establish the name; do not revoke as free-var shadow."""
+    """Module-level imports establish the name; do not revoke as free-var shadow.
 
-    source = "from numpy import allclose\nassert allclose(1, 1)\n"
+    #5906: kit protocol + import provenance (see protocol test module).
+    """
 
-    payload = lift_file_payload(source, "allclose_module_fixture.py")
-
-    assert any(
-        edge.get("targetSymbol") == "call:numpy.allclose" for edge in payload.call_edges
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
-    assert _universe_gaps(payload) == []
+
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.allclose": CalleeUniverseSupport.NUMPY_ALLCLOSE}
+        )
+        source = "from numpy import allclose\nassert allclose(1, 1)\n"
+
+        payload = lift_file_payload(source, "allclose_module_fixture.py")
+
+        assert any(
+            edge.get("targetSymbol") == "call:numpy.allclose"
+            for edge in payload.call_edges
+        )
+        assert _universe_gaps(payload) == []
+    finally:
+        clear_imported_callee_protocol()
 
 
 def test_shadowed_numpy_alias_cannot_warrant_allclose_support() -> None:
@@ -1279,17 +1527,32 @@ def test_later_exception_target_revokes_numpy_import_warrant() -> None:
 
 
 def test_comprehension_target_does_not_revoke_numpy_import_warrant() -> None:
-    source = (
-        "import numpy as np\n"
-        "\n"
-        "def test_values(left, right):\n"
-        "    assert np.allclose(left, right)\n"
-        "    aliases = [np for np in ()]\n"
+    """#5906: kit protocol + import provenance (see protocol test module)."""
+
+    from sugar_lift_py_tests.recognition.callee_universe import (
+        CalleeUniverseSupport,
+        clear_imported_callee_protocol,
+        load_imported_callee_protocol,
     )
 
-    payload = lift_file_payload(source, "numpy_comprehension_scope_fixture.py")
+    clear_imported_callee_protocol()
+    try:
+        load_imported_callee_protocol(
+            {"numpy.allclose": CalleeUniverseSupport.NUMPY_ALLCLOSE}
+        )
+        source = (
+            "import numpy as np\n"
+            "\n"
+            "def test_values(left, right):\n"
+            "    assert np.allclose(left, right)\n"
+            "    aliases = [np for np in ()]\n"
+        )
 
-    assert _universe_gaps(payload) == []
+        payload = lift_file_payload(source, "numpy_comprehension_scope_fixture.py")
+
+        assert _universe_gaps(payload) == []
+    finally:
+        clear_imported_callee_protocol()
 
 
 def test_later_match_capture_is_a_lexical_function_binding() -> None:


### PR DESCRIPTION
Part of #5906

## Split: stale-law rewrites vs genuine regressions

**Stale-law (test asserted illegal logo-based auth; rewritten to the kit-protocol pattern from #5902-#5905 — `load_imported_callee_protocol`/`load_dtype_result_protocol` + import provenance, empty by construction, lying twins refuse even with the coordinate loaded):**

- `numpy.can_cast`, `numpy.isnan` (deduped a dead shadowed duplicate definition), `numpy.all`, `numpy.dtype`, `numpy.allclose`, `numpy.result_type`, `numpy.isdtype`, `numpy.datetime_data`, `numpy.f2py.crackfortran.markinnerspaces`, `numpy._core._multiarray_tests.identity_hash_set_item_default`, `numpy.array`/`ndarray.tobytes`, `numpy.shares_memory`
- `scipy.linalg.issymmetric`, `scipy.linalg.ishermitian`, `scipy.fft.get_workers`
- `numpy._core._multiarray_umath._get_sfloat_dtype` (sfloat)
- dtype-result family (`np.asarray(...).dtype` / `arr.astype(...).dtype`): no loader existed for `_DTYPE_RESULT_SUPPORT` at all — added `load_dtype_result_protocol`/`clear_dtype_result_protocol` mirroring the existing empty-kit overlay pattern, and fixed `_dtype_result_attribute_leaves` (was a frozenset computed once at import time from an always-empty dict — could never see kit-loaded entries; made it a function like `_imported_attribute_leaves`).
- "FQN alone, `numpy` never imported" twins (can_cast/isnan/all) now expect a `FactoryPanic` at the unbound-name `TemporalContext` floor — a stronger, earlier refusal than the old graceful universe-gap report they asserted.
- Witness-pair tests flipped from "in `witnesses()`" to "not in `witnesses()`" for every family above (production mint witnesses for vendor coordinates are retired; kit protocol path only).
- `test_numpy_can_cast_requires_authenticated_receiver` rewritten: a sourceless site with only a `TemporalContext` value bind and no AST import is no longer silently ownable — the old bare `can_cast` leaf membership it exercised is gone.

**Genuine regressions (structural, NOT vendor logos — no kit gate needed, simply missing from the `witnesses()` tuple; re-earned by wiring, test bodies untouched):**

- `item_receiver_universe_coordinate`, `ufunc_universe_coordinate`, `t0`/`selectedintkind`/`foo`/`to_Dt` bound-leaf coordinates, `numpy_subrout_default`, `numpy_eval_scalar`.

## Remaining (explicitly NOT fixed here — out of scope, documented in place so they stay honestly red)

- `numpy_standard_gamma`: `Generator.standard_gamma` needs its own kit-gated native-surface registration (`recognize_native_instance_call`) — bigger than a test rewrite. Asserted absent from the batch witness check rather than silently dropped.
- `test_authenticated_builtin_coordinate_emits_no_universe_gap[type]` and `[get_handler_name]`: pre-existing Sugar-ordering ambiguity (`candidates=[CallSugar, BuiltinCalleeUniverseSugar, BuiltinTypeCallSugar]`), already called out as out-of-scope in #5905's commit message. Reproduces identically on unmodified `origin/main`. `get_handler_name` additionally needs its own kit-protocol load (mechanically identical to this PR's fixes, just not wired here).
- `test_module_scope_numpy_from_import_all_has_universe_support` / `test_module_scope_numpy_from_import_has_universe_support`: bare top-level (non-function) asserts trigger a real numpy install-source cycle panic (`install_source_cycle_guard` walking the actual installed numpy package graph) — unrelated infra limitation, reproduces identically on unmodified `origin/main`.

## Measure

- `R_vendor_special_case = 0` (`scripts/vendor_special_case_law.py`).
- Fast subset (both files, excludes the slow real-solver `witness_refutes_bad_twin` parametrize which builds the sugar binary per witness): **275 passed / 5 failed** — all 5 are the pre-existing/out-of-scope items above, none touched by this change, all independently reproduced on clean `origin/main`.
- Full-suite `test_builtin_callee_universe_witness_refutes_bad_twin` (real solver over every witness pair) was kicked off in background; will report separately if it surfaces anything the fast subset didn't (none expected — witness list changes are additive/subtractive registrations, not logic changes).

No vendor/logo string was reintroduced anywhere; every new/changed assertion is either a graceful-refusal-not-authenticated (unchanged or strengthened) or an authenticated-only-under-loaded-kit-contract claim.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-earn callee universe families via protocol-driven enrollment for dtype_result, can_cast, isnan, scipy, and sfloat
> - Replaces the static `_DTYPE_RESULT_ATTRIBUTE_LEAVES` frozen set in [`callee_universe.py`](https://github.com/TSavo/sugar/pull/5909/files#diff-72e9f915afa350390348a1c277d0c2047b26a0182bb4780c57baf73f30fdcaa8) with a dynamic function that recomputes leaves from `_DTYPE_RESULT_SUPPORT` at call time.
> - Adds `load_dtype_result_protocol` and `clear_dtype_result_protocol` APIs to replace or remove dtype-result coordinates at runtime, mirroring the existing imported-callee protocol pattern.
> - Extends `BuiltinCalleeUniverseSugar.witnesses()` in [`builtin_callee_universe_sugar.py`](https://github.com/TSavo/sugar/pull/5909/files#diff-98e9ae8e3cbb10a2e6c95f0bdeca86f0b85002634b901733d0b6070886cdab5f) with additional structural witness pairs for item receiver, ufunc, and bound-leaf coordinates.
> - Updates test suites to load/clear protocols before assertions, tighten authentication requirements (bare `np.can_cast` now returns `False` for ownership), and treat unauthenticated FQNs as `FactoryPanic` rather than valid lift targets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68b4f7b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->