### PR TITLE
Author + measure kit manifest for numpy.all/dtype/issubdtype/isnat/isnan (#5907)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/kit_manifests/README.md
+++ b/implementations/python/sugar-lift-py-tests/kit_manifests/README.md
@@ -1,0 +1,50 @@
+# Kit manifests (#5907)
+
+This directory holds **declared** kit/bridge contract manifests — evidence
+files consumed by `sugar_lift_py_tests.recognition.kit_manifest` via the
+`SUGAR_KIT_MANIFEST` environment variable / `corpus_fatal_triage.py
+--kit-manifest` flag (wired in #5908).
+
+## Law
+
+- **Nothing here loads by default.** No script, test fixture, or production
+  import path reads a file in this directory implicitly. A manifest only
+  takes effect when a caller explicitly names its path.
+- **A manifest is a declared, hashed act**, not ambient configuration. Every
+  load computes and records the file's sha256 so the loaded contract is
+  traceable to the exact bytes that authorized it.
+- **Without a manifest, rows stay loud.** `R_vendor_special_case = 0` and
+  the empty-by-construction default (#5618, #5907) both depend on that: a
+  relocated or copy-pasted vendor coordinate into production recognition
+  tables is exactly the deleted logo-table pattern and must never happen —
+  declaring a coordinate here, and loading it explicitly at mint time, is
+  the only lawful path.
+
+## `numpy_families_5907.json`
+
+Declares the five `imported_callee` coordinates for the families re-earned
+and merged as of #5907's follow-up:
+
+| Coordinate | Family / issue |
+| --- | --- |
+| `numpy.all` | #5902 / #5408 |
+| `numpy.dtype` | #5902 / #5407 |
+| `numpy.issubdtype` | #5903 / #5400 |
+| `numpy.isnat` | #5904 / #5402 |
+| `numpy.isnan` | #5905 / #5404 |
+
+`call:conv` (#5903 / #5409) is **not** in this manifest — that family was
+re-earned via structural assign provenance (`BOUND_SOURCE_CALLABLE`) in
+production recognition itself, not via a loaded kit coordinate, so it needs
+no manifest entry.
+
+Usage (mint with the contract declared):
+
+```bash
+python scripts/corpus_fatal_triage.py numpy \
+  --kit-manifest implementations/python/sugar-lift-py-tests/kit_manifests/numpy_families_5907.json
+```
+
+Omitting `--kit-manifest` mints with no contract: the five coordinates above
+stay unrecognized and their rows stay `FactoryPanic`/unclassified — the
+correct, honest default.

--- a/implementations/python/sugar-lift-py-tests/kit_manifests/numpy_families_5907.json
+++ b/implementations/python/sugar-lift-py-tests/kit_manifests/numpy_families_5907.json
@@ -1,0 +1,9 @@
+{
+  "imported_callee": {
+    "numpy.all": "NUMPY_ALL",
+    "numpy.dtype": "NUMPY_DTYPE",
+    "numpy.issubdtype": "NUMPY_ISSUBDTYPE",
+    "numpy.isnat": "NUMPY_ISNAT",
+    "numpy.isnan": "NUMPY_ISNAN"
+  }
+}

--- a/implementations/python/sugar-lift-py-tests/tests/test_kit_manifest_numpy_families_5907.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_kit_manifest_numpy_families_5907.py
@@ -1,0 +1,195 @@
+"""#5907: the real, checked-in kit manifest reaches real corpus mint children.
+
+#5908 wired a process-level ``SUGAR_KIT_MANIFEST`` loader into
+``corpus_fatal_triage._child_payload``, proven with an inline/tmp-path
+manifest for one coordinate (``numpy.issubdtype``). This module is the next
+increment: it points that loader at the actual repo-tracked manifest,
+``kit_manifests/numpy_families_5907.json``, which declares all five
+coordinates re-earned across #5902 (``numpy.all``, ``numpy.dtype``), #5903
+(``numpy.issubdtype``), #5904 (``numpy.isnat``), and #5905 (``numpy.isnan``).
+
+Each test mints the exact same minimal source through
+``corpus_fatal_triage._child_payload`` twice — once with
+``SUGAR_KIT_MANIFEST`` unset (the empty-by-construction default) and once
+pointed at the real manifest file on disk — and asserts:
+
+1. Without the manifest, every one of the five families stays in
+   ``unclassified_rows`` (loud, FactoryWalk-unclassified).
+2. With the manifest, all five authenticate (row count 0) and the child's
+   testimony carries provenance (path + sha256 of the *real* file, not an
+   inline stand-in).
+3. A lying twin (``import math as np`` lookalike alias) for one of the
+   families stays loud even with the real manifest loaded — the manifest
+   authenticates identity via import provenance, not spelling.
+
+If the checked-in manifest is ever deleted, edited to drop a coordinate, or
+the loader wiring from #5908 regresses, the "with manifest" assertions here
+fail loudly — this is the fails-before/passes-after receipt for the
+increment, using the actual file that ships in the repo instead of a
+throwaway tmp fixture.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from corpus_fatal_triage import _child_payload  # noqa: E402
+
+from sugar_lift_py_tests.recognition.kit_manifest import (  # noqa: E402
+    KIT_MANIFEST_ENV_VAR,
+    clear_all_kit_protocols,
+)
+
+MANIFEST_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "kit_manifests"
+    / "numpy_families_5907.json"
+)
+
+# (family label, truthful source, ast_kind expected in unclassified_rows)
+FAMILIES = [
+    (
+        "numpy.all",
+        "import numpy as np\n\ndef test_all(value):\n    assert np.all(value)\n",
+        "call:numpy.all",
+    ),
+    (
+        "numpy.dtype",
+        "import numpy as np\n\ndef test_dtype(value):\n"
+        "    assert np.dtype(value) == np.dtype(value)\n",
+        "call:numpy.dtype",
+    ),
+    (
+        "numpy.issubdtype",
+        "import numpy as np\n\ndef test_issubdtype(left, right):\n"
+        "    assert np.issubdtype(left, right)\n",
+        "call:numpy.issubdtype",
+    ),
+    (
+        "numpy.isnat",
+        "import numpy as np\n\ndef test_isnat(dtype):\n"
+        "    value = np.array('NaT', dtype=dtype)\n"
+        "    assert np.isnat(value)\n",
+        "call:numpy.isnat",
+    ),
+    (
+        "numpy.isnan",
+        "import numpy as np\n\ndef test_isnan(value):\n"
+        "    assert np.isnan(value)\n",
+        "call:numpy.isnan",
+    ),
+]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_kit_protocols(monkeypatch):
+    monkeypatch.delenv(KIT_MANIFEST_ENV_VAR, raising=False)
+    clear_all_kit_protocols()
+    yield
+    clear_all_kit_protocols()
+
+
+def test_manifest_file_exists_and_declares_five_coordinates() -> None:
+    import json
+
+    assert MANIFEST_PATH.is_file()
+    document = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    assert document["imported_callee"] == {
+        "numpy.all": "NUMPY_ALL",
+        "numpy.dtype": "NUMPY_DTYPE",
+        "numpy.issubdtype": "NUMPY_ISSUBDTYPE",
+        "numpy.isnat": "NUMPY_ISNAT",
+        "numpy.isnan": "NUMPY_ISNAN",
+    }
+
+
+@pytest.mark.parametrize("family,source,ast_kind", FAMILIES)
+def test_family_stays_loud_without_manifest(
+    tmp_path: Path, family: str, source: str, ast_kind: str
+) -> None:
+    src = tmp_path / "no_contract.py"
+    src.write_text(source, encoding="utf-8")
+
+    testimony, returncode = _child_payload(src, f"demo/{family}/no_contract.py")
+
+    assert returncode == 0
+    assert testimony["outcome"] == "completed"
+    assert testimony["kit_manifest"] is None
+    matching = [
+        row
+        for row in testimony["unclassified_rows"]
+        if row.get("ast_kind") == ast_kind
+    ]
+    assert matching, f"{family}: expected loud {ast_kind!r} row with no manifest"
+
+
+@pytest.mark.parametrize("family,source,ast_kind", FAMILIES)
+def test_family_authenticates_with_real_manifest(
+    tmp_path: Path, monkeypatch, family: str, source: str, ast_kind: str
+) -> None:
+    monkeypatch.setenv(KIT_MANIFEST_ENV_VAR, str(MANIFEST_PATH))
+    src = tmp_path / "with_contract.py"
+    src.write_text(source, encoding="utf-8")
+
+    testimony, returncode = _child_payload(src, f"demo/{family}/with_contract.py")
+
+    assert returncode == 0
+    assert testimony["outcome"] == "completed"
+    matching = [
+        row
+        for row in testimony["unclassified_rows"]
+        if row.get("ast_kind") == ast_kind
+    ]
+    assert matching == [], f"{family}: still loud with real manifest loaded"
+
+    provenance = testimony["kit_manifest"]
+    assert provenance is not None
+    assert provenance["path"] == str(MANIFEST_PATH)
+    assert provenance["loaded_counts"] == {"imported_callee": 5}
+
+    import hashlib
+
+    expected_sha256 = hashlib.sha256(
+        MANIFEST_PATH.read_text(encoding="utf-8").encode("utf-8")
+    ).hexdigest()
+    assert provenance["sha256"] == expected_sha256
+
+
+def test_lying_lookalike_alias_stays_loud_under_real_manifest(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """``import math as np`` must not borrow the numpy.isnan coordinate.
+
+    Proves the real manifest authenticates identity (import provenance),
+    not the bare attribute spelling ``.isnan`` — a loaded coordinate does
+    not make a lookalike module authenticate.
+    """
+
+    monkeypatch.setenv(KIT_MANIFEST_ENV_VAR, str(MANIFEST_PATH))
+    src = tmp_path / "lookalike.py"
+    src.write_text(
+        "import math as np\n\ndef test_isnan(value):\n"
+        "    assert np.isnan(value)\n",
+        encoding="utf-8",
+    )
+
+    testimony, returncode = _child_payload(src, "demo/lookalike.py")
+
+    assert returncode == 0
+    assert testimony["outcome"] == "completed"
+    assert not [
+        row
+        for row in testimony["unclassified_rows"]
+        if row.get("ast_kind") == "call:numpy.isnan"
+    ]
+    assert any(
+        row.get("ast_kind") == "call:math.isnan"
+        for row in testimony["unclassified_rows"]
+    )
+    assert testimony["kit_manifest"] is not None


### PR DESCRIPTION
Part of #5907
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

----
## Summary by Gitar

- **New kit manifests:**
    - Added `numpy_families_5907.json` to declare imported callables for `numpy` families.
    - Added `README.md` documenting the manifest protocol and loading requirements.
- **New testing infrastructure:**
    - Added `test_kit_manifest_numpy_families_5907.py` to verify manifest loading, authentication, and provenance tracking for the five numpy families.
    - Implemented tests to ensure correct handling of lookalike aliases that lack proper import provenance.

<sub>This will update automatically on new commits.</sub>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add kit manifest and tests for numpy `all`, `dtype`, `issubdtype`, `isnat`, and `isnan`
> - Adds [numpy_families_5907.json](https://github.com/TSavo/sugar/pull/5910/files#diff-48badf04f0de1a893141042d652341e9477f411a159cdec1c2dc832ef1636a5e), a manifest declaring five `imported_callee` coordinates mapped to family labels for `numpy.all`, `numpy.dtype`, `numpy.issubdtype`, `numpy.isnat`, and `numpy.isnan`.
> - Adds tests covering: manifest file integrity, that each family remains unclassified without a manifest loaded, that all five families authenticate correctly when the manifest is active, and that aliased lookalike imports (e.g. `import math as np`) are not mis-authenticated.
> - Adds a [README](https://github.com/TSavo/sugar/pull/5910/files#diff-42d4470aea1e9d179513a23caf4c4dd4eb273293e9b39302179868400eae3414) documenting manifest loading via `SUGAR_KIT_MANIFEST` env var or `--kit-manifest` flag, hashing rules, and usage examples.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ea3f8e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->