### PR TITLE
Prove measurement inputs before running: mount-proof + real docker liveness

### DIFF
--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -104,16 +104,54 @@ sugar_bx_init() {
 
 sugar_bx_sync_workspace() {
   # Local mode runs in the checkout itself: nothing to sync.
-  [[ "${SUGAR_BX_LOCAL:-0}" == 1 ]] && return 0
-  local existing=() rel manifest
-  for rel in "${sync_paths[@]}"; do [[ -e "$SUGAR_BX_REPO_ROOT/$rel" ]] && existing+=("$rel"); done
-  sugar_bx_ssh "rm -rf $(sugar_bx_quote "$SUGAR_BX_REPO/menagerie") && mkdir -p $(sugar_bx_quote "$SUGAR_BX_REPO")"
-  (cd "$SUGAR_BX_REPO_ROOT" && "$SUGAR_BX_RSYNC" -azR --delete "${exclude_args[@]}" "${existing[@]}" "$SUGAR_BX_HOST:$SUGAR_BX_REPO/")
-  manifest="$(mktemp)"
-  if git -C "$SUGAR_BX_REPO_ROOT" ls-files -z >"$manifest" 2>/dev/null; then
-    "$SUGAR_BX_RSYNC" -az "$manifest" "$SUGAR_BX_HOST:$SUGAR_BX_REPO/.bcargo-tracked-manifest"
+  if [[ "${SUGAR_BX_LOCAL:-0}" != 1 ]]; then
+    local existing=() rel manifest
+    for rel in "${sync_paths[@]}"; do [[ -e "$SUGAR_BX_REPO_ROOT/$rel" ]] && existing+=("$rel"); done
+    sugar_bx_ssh "rm -rf $(sugar_bx_quote "$SUGAR_BX_REPO/menagerie") && mkdir -p $(sugar_bx_quote "$SUGAR_BX_REPO")"
+    (cd "$SUGAR_BX_REPO_ROOT" && "$SUGAR_BX_RSYNC" -azR --delete "${exclude_args[@]}" "${existing[@]}" "$SUGAR_BX_HOST:$SUGAR_BX_REPO/")
+    manifest="$(mktemp)"
+    if git -C "$SUGAR_BX_REPO_ROOT" ls-files -z >"$manifest" 2>/dev/null; then
+      "$SUGAR_BX_RSYNC" -az "$manifest" "$SUGAR_BX_HOST:$SUGAR_BX_REPO/.bcargo-tracked-manifest"
+    fi
+    rm -f "$manifest"
   fi
-  rm -f "$manifest"
+}
+
+# A bind mount can start up cleanly and still be empty, stale, or point at an
+# entirely different checkout -- on WSL2 hosts a plain Linux path silently
+# binds an empty directory instead of failing. Stamp a fresh, unpredictable
+# token into the just-synced workspace and require every container that
+# mounts it (see tools/sugar-build/entrypoint.sh) to read the same token back
+# before running anything. An empty or wrong mount cannot produce the token,
+# so it cannot produce a plausible result either: it fails loudly instead.
+SUGAR_BX_MOUNT_PROOF_NAME=".bcargo-mount-proof"
+sugar_bx_write_mount_proof() {
+  local head_sha manifest_sha
+  head_sha="$(git -C "$SUGAR_BX_REPO_ROOT" rev-parse HEAD 2>/dev/null || echo no-head)"
+  manifest_sha="$( (git -C "$SUGAR_BX_REPO_ROOT" ls-files -z 2>/dev/null | shasum -a 256 2>/dev/null || true) | cut -d' ' -f1)"
+  SUGAR_BX_MOUNT_PROOF="${head_sha}:${manifest_sha:-no-manifest}:$$:${RANDOM:-0}:$(date +%s%N 2>/dev/null || date +%s)"
+  if [[ "${SUGAR_BX_LOCAL:-0}" == 1 ]]; then
+    printf '%s' "$SUGAR_BX_MOUNT_PROOF" >"$SUGAR_BX_REPO/$SUGAR_BX_MOUNT_PROOF_NAME"
+  else
+    printf '%s' "$SUGAR_BX_MOUNT_PROOF" | sugar_bx_ssh "cat > $(sugar_bx_quote "$SUGAR_BX_REPO/$SUGAR_BX_MOUNT_PROOF_NAME")"
+  fi
+}
+
+# `systemctl is-active docker` reports active on battleaxe even when
+# /var/run/docker.sock is a dead symlink into Docker Desktop's WSL2 shared
+# sockets and nothing works -- it is a false-healthy reading. Prove the
+# daemon actually answers the API before routing any command through it.
+sugar_bx_require_docker_ready() {
+  local out status
+  set +e
+  out="$(sugar_bx_ssh "docker info" 2>&1)"
+  status=$?
+  set -e
+  if [[ "$status" != 0 ]]; then
+    printf 'sugarbin: crime=false-healthy-docker-daemon host=%s reason=docker-info-failed status=%s detail=%s replacement=fix the Docker Desktop / WSL2 integration or start the daemon -- do not trust `systemctl is-active docker`, it reports active even when the socket is a dead symlink and nothing works\n' \
+      "$SUGAR_BX_HOST" "$status" "${out:-<no output>}" >&2
+    return 70
+  fi
 }
 
 sugar_bx_run_ambient() {
@@ -138,8 +176,22 @@ sugar_bx_run_ambient() {
 }
 
 sugar_bx_docker_bind_source() {
-  local source="$1"
-  sugar_bx_ssh "if command -v wslpath >/dev/null 2>&1; then wslpath -w $(sugar_bx_quote "$source"); else printf '%s\\n' $(sugar_bx_quote "$source"); fi" | tr -d '\r'
+  local source="$1" resolved
+  # On a WSL2 host, Docker Desktop's engine runs in a separate distro: a
+  # plain Linux path like /home/tsavo/... does not fail to bind, it silently
+  # binds an EMPTY directory. Only the Windows UNC form
+  # (\\wsl.localhost\<distro>\...), produced by `wslpath -w`, resolves inside
+  # the engine. If this is a WSL host and wslpath is unavailable, refuse
+  # instead of silently constructing the path form that produces the empty
+  # mount -- that silent fallback is exactly the hazard being closed here.
+  resolved="$(sugar_bx_ssh "if command -v wslpath >/dev/null 2>&1; then wslpath -w $(sugar_bx_quote "$source"); elif grep -qi microsoft /proc/version 2>/dev/null; then printf 'SUGAR_BX_WSLPATH_MISSING\n'; else printf '%s\n' $(sugar_bx_quote "$source"); fi")" || return $?
+  resolved="$(printf '%s' "$resolved" | tr -d '\r')"
+  if [[ "$resolved" == SUGAR_BX_WSLPATH_MISSING ]]; then
+    printf 'sugarbin: crime=empty-bind-mount-risk host=%s source=%s reason=wslpath-unavailable-on-wsl2-host replacement=install wslpath on the remote host; refusing to construct a plain Linux-path bind mount that Docker Desktop silently mounts empty\n' \
+      "$SUGAR_BX_HOST" "$source" >&2
+    return 70
+  fi
+  printf '%s\n' "$resolved"
 }
 
 sugar_bx_build_artifacts_docker() {
@@ -159,6 +211,7 @@ sugar_bx_build_artifacts_docker() {
     --env SUGAR_BINARY_PUBLISH=0
     --env CARGO_TARGET_DIR=/managed-target
     --env SUGAR_BINARY_TARGET_ROOT=/managed-target
+    --env "SUGAR_BX_MOUNT_PROOF=$SUGAR_BX_MOUNT_PROOF"
     --mount "type=bind,src=$workspace_source,dst=/workspace/sugar"
     --mount "type=bind,src=$artifacts_source,dst=/out"
     --mount "type=bind,src=$cache_source,dst=/root/.cache/sugar/binaries"
@@ -178,6 +231,7 @@ sugar_bx_run_docker() {
   local -a docker_args=(docker run --rm
     --workdir "$remote_cwd"
     --env PATH=/opt/sugar/bin:/opt/java/bin:/root/.cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
+    --env "SUGAR_BX_MOUNT_PROOF=$SUGAR_BX_MOUNT_PROOF"
     --mount "type=bind,src=$workspace_source,dst=/workspace/sugar")
   [[ "$network" != none ]] || docker_args+=(--network none)
   if [[ "$has_artifacts" == 1 ]]; then

--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -248,8 +248,10 @@ dispatch_execution_subcommand() {
   [[ -n "$repo_root" ]] || { echo "sugarbin: must be run from inside a git checkout" >&2; return 2; }
   local_cwd="$(pwd -P)"
   sugar_bx_init "$repo_root" "$local_cwd" || return $?
+  [[ "$route_env" != docker ]] || sugar_bx_require_docker_ready || return $?
   sugar_bx_sync_workspace || return $?
   if [[ "$route_env" == docker ]]; then
+    sugar_bx_write_mount_proof || return $?
     local remote_needs="$needs" has_artifacts=0
     if [[ -n "$remote_needs" ]]; then
       sugar_bx_build_artifacts_docker "$core_image" "$remote_needs" "$profile" || return $?

--- a/implementations/rust/sugar-cli/tests/sugarbin_execution_contract.rs
+++ b/implementations/rust/sugar-cli/tests/sugarbin_execution_contract.rs
@@ -100,6 +100,34 @@ fn sugarbin_docker_execution_contract() {
 }
 
 #[test]
+fn sugarbin_mount_proof_guard_contract() {
+    let root = repo_root();
+    let status = Command::new("bash")
+        .arg(root.join("tests/sugarbin_mount_proof_guard.sh"))
+        .arg(&root)
+        .status()
+        .expect("run mount-proof guard contract");
+    assert!(
+        status.success(),
+        "mount-proof guard contract failed: {status}"
+    );
+}
+
+#[test]
+fn sugarbin_docker_daemon_guard_contract() {
+    let root = repo_root();
+    let status = Command::new("bash")
+        .arg(root.join("tests/sugarbin_docker_daemon_guard.sh"))
+        .arg(&root)
+        .status()
+        .expect("run Docker daemon liveness guard contract");
+    assert!(
+        status.success(),
+        "Docker daemon liveness guard contract failed: {status}"
+    );
+}
+
+#[test]
 fn sugarbin_wrapper_compatibility_contract() {
     let root = repo_root();
     let status = Command::new("bash")

--- a/tests/sugarbin_docker_daemon_guard.sh
+++ b/tests/sugarbin_docker_daemon_guard.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Twin for #5914: on battleaxe, `systemctl is-active docker` reports "active"
+# even when /var/run/docker.sock is a dead symlink into Docker Desktop's WSL2
+# shared sockets and nothing actually works -- a false-healthy reading.
+# sugarbin must prove the daemon answers the real API (`docker info`) before
+# routing any command through it, and must fail LOUDLY, attributing the real
+# cause, instead of syncing the workspace and silently producing no result.
+
+repo="${1:?usage: sugarbin_docker_daemon_guard.sh REPO_ROOT}"
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin"
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Fake ssh: `docker info` fails with the exact kind of message a dead-socket
+# WSL2 host produces; anything else (rsync-adjacent mkdir/rm, wslpath, real
+# docker run) succeeds so the test isolates the daemon-liveness gate.
+cat >"$tmp/bin/ssh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$FAKE_SSH_LOG"
+case "$*" in
+  *"docker info"*)
+    echo "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?" >&2
+    exit 1
+    ;;
+  *"wslpath -w"*)
+    path="${*#*wslpath -w \'}"; path="${path%%\'*}"
+    printf 'C:\\wsl%s\r\n' "${path//\//\\}"
+    exit 0
+    ;;
+  *"'docker' 'run'"*)
+    printf '%s\n' "$*" >>"$FAKE_DOCKER_LOG"
+    ;;
+esac
+exit 0
+SH
+cat >"$tmp/bin/rsync" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$FAKE_RSYNC_LOG"
+exit 0
+SH
+chmod +x "$tmp/bin/"*
+: >"$tmp/ssh.log"; : >"$tmp/rsync.log"; : >"$tmp/docker.log"
+
+status=0
+(cd "$repo/implementations/python" && PATH="$tmp/bin:$PATH" \
+  BCARGO_SSH="$tmp/bin/ssh" BCARGO_RSYNC="$tmp/bin/rsync" \
+  BCARGO_REMOTE_ROOT=/home/tsavo/remote/sugar-bcargo-daemon-guard \
+  BCARGO_REAP_DAYS=0 \
+  FAKE_SSH_LOG="$tmp/ssh.log" FAKE_RSYNC_LOG="$tmp/rsync.log" FAKE_DOCKER_LOG="$tmp/docker.log" \
+  "$repo/bin/sugarbin" run --host bx --task python-unit -- -q) \
+  >"$tmp/run.out" 2>"$tmp/run.err" || status=$?
+
+[[ "$status" == 70 ]] || fail "unreachable daemon did not fail loudly (status=$status)"
+grep -Fq 'crime=false-healthy-docker-daemon' "$tmp/run.err" \
+  || fail "daemon failure is not named: $(cat "$tmp/run.err")"
+grep -Fq 'Cannot connect to the Docker daemon' "$tmp/run.err" \
+  || fail "real cause was not attributed: $(cat "$tmp/run.err")"
+[[ ! -s "$tmp/docker.log" ]] \
+  || fail "docker run was invoked despite the daemon being unreachable"
+[[ ! -s "$tmp/run.out" ]] \
+  || fail "a measurement result was produced despite the daemon being unreachable"
+
+echo "PASS: sugarbin Docker daemon liveness guard contract"

--- a/tests/sugarbin_mount_proof_guard.sh
+++ b/tests/sugarbin_mount_proof_guard.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Twin for #5914: WSL2 bind mounts on battleaxe can start successfully and
+# still be empty or point at the wrong tree, because Docker Desktop's engine
+# runs in a separate WSL distro and silently mounts an empty directory for a
+# plain Linux path. That produces plausible-looking output with no error.
+# tools/sugar-build/entrypoint.sh must prove the mounted workspace matches
+# what the caller synced before anything else runs -- including before the
+# toolchain contract checks -- and must fail LOUDLY, never a quiet zero, when
+# it does not.
+
+repo="${1:?usage: sugarbin_mount_proof_guard.sh REPO_ROOT}"
+entrypoint="$repo/tools/sugar-build/entrypoint.sh"
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+workspace="$tmp/workspace/sugar"
+mkdir -p "$workspace"
+
+# 1. Empty mount: no proof file at all (the exact WSL2 empty-bind-mount
+#    shape). The container must refuse before running the payload.
+status=0
+SUGAR_BX_MOUNT_PROOF="expected-token" \
+  SUGAR_BX_MOUNT_PROOF_FILE="$workspace/.bcargo-mount-proof" \
+  bash "$entrypoint" sh -c 'echo "measured $(ls "'"$workspace"'" | wc -l) files" >"'"$tmp"'/empty-mount.out"' \
+  2>"$tmp/empty-mount.err" || status=$?
+[[ "$status" == 70 ]] || fail "empty mount did not fail loudly (status=$status)"
+[[ ! -e "$tmp/empty-mount.out" ]] || fail "empty mount still produced a measurement output"
+grep -Fq 'crime=empty-or-stale-bind-mount' "$tmp/empty-mount.err" \
+  || fail "empty mount error is not named: $(cat "$tmp/empty-mount.err")"
+
+# 2. Wrong/stale mount: a proof file exists but does not match what this run
+#    expects (a different checkout mounted at the same path).
+printf '%s' "some-other-checkouts-token" >"$workspace/.bcargo-mount-proof"
+status=0
+SUGAR_BX_MOUNT_PROOF="expected-token" \
+  SUGAR_BX_MOUNT_PROOF_FILE="$workspace/.bcargo-mount-proof" \
+  bash "$entrypoint" sh -c 'echo measured >"'"$tmp"'/wrong-mount.out"' \
+  2>"$tmp/wrong-mount.err" || status=$?
+[[ "$status" == 70 ]] || fail "wrong mount did not fail loudly (status=$status)"
+[[ ! -e "$tmp/wrong-mount.out" ]] || fail "wrong mount still produced a measurement output"
+grep -Fq 'crime=empty-or-stale-bind-mount' "$tmp/wrong-mount.err" \
+  || fail "wrong mount error is not named: $(cat "$tmp/wrong-mount.err")"
+grep -Fq 'expected=expected-token' "$tmp/wrong-mount.err" || fail "diagnostic omits expected token"
+grep -Fq 'actual=some-other-checkouts-token' "$tmp/wrong-mount.err" || fail "diagnostic omits actual token"
+
+# 3. Matching proof: the guard must get out of the way and let the run
+#    proceed to the next gate (the toolchain contract), not silently swallow
+#    a real, correctly-mounted workspace. We do not have the pinned
+#    toolchain available in this unit-test environment, so the run is
+#    expected to fail at contract_mismatch instead -- proving the mount
+#    guard itself did not fire is exactly what discriminates this case from
+#    cases 1 and 2 above.
+printf '%s' "expected-token" >"$workspace/.bcargo-mount-proof"
+status=0
+SUGAR_BX_MOUNT_PROOF="expected-token" \
+  SUGAR_BX_MOUNT_PROOF_FILE="$workspace/.bcargo-mount-proof" \
+  bash "$entrypoint" sh -c 'echo measured >"'"$tmp"'/ok-mount.out"' \
+  2>"$tmp/ok-mount.err" || status=$?
+! grep -Fq 'crime=empty-or-stale-bind-mount' "$tmp/ok-mount.err" \
+  || fail "matching mount proof was still rejected: $(cat "$tmp/ok-mount.err")"
+
+# 4. No proof requested at all (SUGAR_BX_MOUNT_PROOF unset): the guard is
+#    opt-in per run so ad-hoc/non-bx uses of the image are unaffected.
+status=0
+bash "$entrypoint" sh -c 'echo measured >"'"$tmp"'/unguarded.out"' \
+  2>"$tmp/unguarded.err" || status=$?
+! grep -Fq 'crime=empty-or-stale-bind-mount' "$tmp/unguarded.err" \
+  || fail "guard fired without a requested mount proof"
+
+echo "PASS: sugarbin mount-proof guard contract"

--- a/tools/sugar-build/entrypoint.sh
+++ b/tools/sugar-build/entrypoint.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# A bind mount can start successfully and still be empty or point at the
+# wrong tree: WSL2 hosts silently mount an empty directory when a plain
+# Linux-style path is bound instead of the UNC form the Docker Desktop
+# engine (running in its own WSL distro) can actually resolve. That failure
+# mode produces plausible-looking output with no error, so prove the mounted
+# workspace is the one the caller intended before anything else -- including
+# the toolchain contract below -- runs.
+if [[ -n "${SUGAR_BX_MOUNT_PROOF:-}" ]]; then
+  proof_file="${SUGAR_BX_MOUNT_PROOF_FILE:-/workspace/sugar/.bcargo-mount-proof}"
+  actual="$(cat "$proof_file" 2>/dev/null || true)"
+  if [[ "$actual" != "$SUGAR_BX_MOUNT_PROOF" ]]; then
+    echo "sugarbin: crime=empty-or-stale-bind-mount workspace=$proof_file expected=$SUGAR_BX_MOUNT_PROOF actual=${actual:-<missing>} replacement=verify the bind mount source resolves inside the container -- WSL2 hosts need the UNC \\\\wsl.localhost\\<distro>\\... form, not a plain Linux path, and the workspace must be synced immediately before this run" >&2
+    exit 70
+  fi
+fi
+
 contract_mismatch() {
   echo "managed environment contract mismatch: $1" >&2
   exit 70


### PR DESCRIPTION
Fixes #5914

Battleaxe (WSL2) has two silent-success modes that let a docker-routed run report numbers it never computed: a plain Linux bind-mount path silently mounts an empty directory (Docker Desktop's engine runs in a separate WSL distro), and `systemctl is-active docker` reports `active` even when `/var/run/docker.sock` is a dead symlink and nothing works.

## Fix: one chokepoint

Every docker-routed command (`bin/sugarbin`, `bin/bcargo`, `bin/brun`, `bin/bpytest`) funnels through `bin/lib/sugar-bx.sh` for the mount/daemon plumbing and `tools/sugar-build/entrypoint.sh` (baked in as `ENTRYPOINT` on every image built from `tools/sugar-build/Dockerfile`) for the in-container preflight. Both are edited, not five ad hoc checks:

- **`tools/sugar-build/entrypoint.sh`** now verifies, before anything else — including the toolchain contract checks — that the mounted workspace carries a mount-proof token this run just wrote. An empty or wrong mount cannot produce that token and now fails loudly with a named `crime=empty-or-stale-bind-mount` error instead of silently proceeding to run the payload against nothing.
- **`bin/lib/sugar-bx.sh`** writes a fresh, unpredictable per-run token into the just-synced workspace (`sugar_bx_write_mount_proof`) and passes it into every `docker run` invocation (both the artifact-build container and the task container). It also adds `sugar_bx_require_docker_ready()`, which calls `docker info` — not `systemctl is-active` — before routing anything through docker, and fails loudly with the real daemon error attributed, if the daemon does not actually answer.
- `sugar_bx_docker_bind_source()` now refuses (`crime=empty-bind-mount-risk`) instead of silently falling back to a plain Linux path when `wslpath` is unavailable on a detected WSL2 host — the exact silent fallback that produces the empty mount.

## Twins

- `tests/sugarbin_mount_proof_guard.sh`: unit-tests the entrypoint guard directly — empty mount, wrong/stale mount (mismatched token), matching mount (guard gets out of the way), and unrequested guard (opt-in, doesn't break non-bx image use). Verified this twin **fails against the unpatched entrypoint.sh** (it silently ran the payload / proceeded without the crime tag).
- `tests/sugarbin_docker_daemon_guard.sh`: drives the full `bin/sugarbin` bx-docker route with a faked `docker info` failure and asserts a loud, correctly-attributed `crime=false-healthy-docker-daemon` failure with zero docker invocations and zero output. Verified this twin **fails against the unpatched code** — it returned status 0 with no error and no docker invocation, i.e. exactly the silent-success bug.
- Both wired into `implementations/rust/sugar-cli/tests/sugarbin_execution_contract.rs` alongside the existing bx/docker execution contract tests.
- All pre-existing `tests/sugarbin_*` and `tests/bcargo_*`/`brun_*` shell contracts still pass unmodified (verified locally; the two local-only failures — `sugarbin_artifact_manifest.sh`, `sugarbin_docker_core_offline.sh` — are pre-existing on `origin/main` too, caused by no pinned toolchain/Docker Desktop on this dev Mac, not by this change).

## Also considered: `python-lift-closure` Dockerfile stage

Left undeclared in `sugar-build.toml`. It is not equivalent to an existing capability composition — it carries extra packages (scikit-learn, scipy, joblib, threadpoolctl, narwhals) beyond what the `python-scientific` capability installs. Declaring it reproducibly requires either broadening that capability's package list (affecting every other consumer) or minting a new capability and building + pushing a new pinned `ghcr.io/tsavo/sugar-env` image digest through the image-publish pipeline. That's a real registry-publish action outside what this change can safely do from here, so it's left for a follow-up rather than half-done.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate workspace mounts and Docker daemon liveness before running containers
> - Adds `sugar_bx_write_mount_proof` to write a per-run token (HEAD SHA, manifest SHA, PID, timestamp) to `.bcargo-mount-proof` in the workspace before any Docker container starts.
> - Adds `sugar_bx_require_docker_ready` to gate Docker-routed executions on a successful `docker info` call, exiting 70 with a diagnostic if the daemon is unresponsive.
> - The [entrypoint.sh](https://github.com/TSavo/sugar/pull/5916/files#diff-a9d742f38b5e10924edca17d0a5298b10a7fa3d5c704c534da28c5ef0a9a0dc9) now reads the mount-proof token at container startup and exits 70 if it is missing or mismatched, catching silently empty bind mounts.
> - On WSL hosts without `wslpath`, `sugar_bx_docker_bind_source` now aborts with exit 70 instead of constructing a Linux path that Docker Desktop would mount empty.
> - New contract tests in [sugarbin_execution_contract.rs](https://github.com/TSavo/sugar/pull/5916/files#diff-1ff269e982f5acce30d401d5d04ccda59b2f4ff436af4b6916916eff72f3205b) cover the daemon-guard and mount-proof-guard behaviors via shell test scripts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33cc2b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->