### PR TITLE
sugar/lift: bridge explicit dunder-operator Call into BinOp/Subscript floors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/dunder_operator_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/dunder_operator_call_sugar.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.claim import SugarRole
+from sugar_lift_py_tests.outcome import Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_pair
+from sugar_lift_py_tests.sugar_body import SugarBody
+
+# The closed CPython binary-operator data model (`object.__mul__` et al):
+# https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types
+# `x OP y` desugars to `x.__dunder__(y)` (or `y.__rdunder__(x)` when the left
+# type refuses). An explicit `x.__mul__(y)` Call is that SAME protocol spelled
+# longhand -- structurally, not semantically, different from `x * y`. This
+# table is the language's own closed operator vocabulary, not a vendor
+# whitelist: it never grows for a library, only for a new Python operator.
+#
+# name -> floor verb method the BinOp-family Sugars already call.
+_DIRECT_DUNDER_VERBS: dict[str, str] = {
+    "__add__": "add",
+    "__sub__": "subtract",
+    "__mul__": "multiply",
+    "__truediv__": "divide",
+    "__floordiv__": "floor_divide",
+    "__mod__": "modulo",
+    "__pow__": "power",
+    "__matmul__": "matrix_multiply",
+    "__and__": "bitwise_and",
+    "__or__": "bitwise_or",
+    "__xor__": "bitwise_xor",
+    "__lshift__": "left_shift",
+    "__rshift__": "right_shift",
+}
+
+_REFLECTED_DUNDER_VERBS: dict[str, str] = {
+    "__radd__": "add",
+    "__rsub__": "subtract",
+    "__rmul__": "multiply",
+    "__rtruediv__": "divide",
+    "__rfloordiv__": "floor_divide",
+    "__rmod__": "modulo",
+    "__rpow__": "power",
+    "__rmatmul__": "matrix_multiply",
+    "__rand__": "bitwise_and",
+    "__ror__": "bitwise_or",
+    "__rxor__": "bitwise_xor",
+    "__rlshift__": "left_shift",
+    "__rrshift__": "right_shift",
+}
+
+# `x.__getitem__(i)` is `x[i]` spelled longhand -- SubscriptSugar's protocol,
+# not an arithmetic verb. Bridged here too: same "explicit dunder call ==
+# desugared syntax" mechanism, one recognizer for the whole call-vs-syntax
+# split rather than a second bridge just for subscript.
+_SUBSCRIPT_DUNDER = "__getitem__"
+
+_DUNDER_NAMES = frozenset(
+    {*_DIRECT_DUNDER_VERBS, *_REFLECTED_DUNDER_VERBS, _SUBSCRIPT_DUNDER}
+)
+
+
+@dataclass(frozen=True)
+class DunderOperatorCallSugar(
+    Sugar, role=SugarRole.TERM, comes_before=("MethodCallSugar",)
+):
+    """``x.__mul__(y)`` (and the rest of the closed binary-operator/subscript
+    data-model protocol, direct or reflected) called out explicitly by name.
+
+    An operator and its dunder are the SAME operation under two spellings:
+    ``x * y`` desugars to exactly this call at the language level. Bridging
+    the explicit spelling into the SAME floor verbs the ``BinOp``-family
+    Sugars already call (``AddOpSugar`` -> ``.add``, ``FloorDivideOpSugar``
+    -> ``.floor_divide``, ``SubscriptSugar`` -> ``.subscript``, ...) means one
+    recognizer drains every member of the explicit-dunder-call shape, never a
+    second parallel operator-semantics path.
+
+    Authentication is entirely structural: the callee must be an Attribute
+    whose name is a member of the closed CPython dunder-operator vocabulary,
+    the receiver must be the Attribute's resolved (factory-built) value
+    expression, and the call must carry exactly the operator's own arity (one
+    positional argument, no keywords, no starred expansion) -- never a
+    callee-name whitelist or vendor/module string. A lookalike callable
+    reached through anything other than a direct ``receiver.__dunder__``
+    Attribute (``getattr(x, '__dunder__')(y)``, a plain same-named non-dunder
+    method, wrong arity) never matches ``owns`` and falls through to
+    ``MethodCallSugar`` / the ordinary call floor untouched. A receiver whose
+    floor type does not stand on the addressed operator floor (or whose
+    object body cannot resolve the named method) stays the existing loud
+    ``FactoryPanic`` those floors already raise for `x * y` on the same
+    receiver -- this bridge adds no new suppression.
+    """
+
+    dunder_name: str
+    receiver: SugarBody
+    operand: SugarBody
+    reflected: bool
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def owns(cls, site) -> bool:
+        if site.observed != "Call":
+            return False
+        if site.call_receiver() is None:
+            return False
+        if site.call_has_keywords():
+            return False
+        if site.call_arg_count() != 1:
+            return False
+        return site.call_target_name() in _DUNDER_NAMES
+
+    @classmethod
+    def new(cls, site, ctx) -> "DunderOperatorCallSugar":
+        name = site.call_target_name()
+        return cls(
+            dunder_name=name,
+            receiver=ctx.build_body(site.call_receiver(), SugarRole.TERM),
+            operand=ctx.build_body(site.call_args()[0], SugarRole.TERM),
+            reflected=name in _REFLECTED_DUNDER_VERBS,
+            site=site,
+        )
+
+    @classmethod
+    def witnesses(cls):
+        direct_prefix = "def A(z):\n    return (5).__mul__(3)\n\n"
+        reflected_prefix = "def A(z):\n    return (2).__rfloordiv__(7)\n\n"
+        getitem_prefix = "def A(z):\n    return [10, 20, 30].__getitem__(1)\n\n"
+        add_prefix = "def A(z):\n    return (5).__add__(2)\n\n"
+        return (
+            _call_pair(
+                name="explicit_mul_dunder_call_return",
+                owner_sugar="DunderOperatorCallSugar",
+                truthful=direct_prefix + "def test_a():\n    assert A(5) == 15\n",
+                lying=direct_prefix + "def test_a():\n    assert A(5) == 16\n",
+            ),
+            _call_pair(
+                name="explicit_add_dunder_call_return",
+                owner_sugar="DunderOperatorCallSugar",
+                truthful=add_prefix + "def test_a():\n    assert A(5) == 7\n",
+                lying=add_prefix + "def test_a():\n    assert A(5) == 8\n",
+            ),
+            _call_pair(
+                name="explicit_reflected_floordiv_dunder_call_return",
+                owner_sugar="DunderOperatorCallSugar",
+                # (2).__rfloordiv__(7) means 7 // 2 == 3, NOT 2 // 7 == 0 --
+                # the reflected twin: getting the operand order backwards
+                # must refute.
+                truthful=reflected_prefix + "def test_a():\n    assert A(5) == 3\n",
+                lying=reflected_prefix + "def test_a():\n    assert A(5) == 0\n",
+            ),
+            _call_pair(
+                name="explicit_getitem_dunder_call_return",
+                owner_sugar="DunderOperatorCallSugar",
+                truthful=getitem_prefix + "def test_a():\n    assert A(5) == 20\n",
+                lying=getitem_prefix + "def test_a():\n    assert A(5) == 30\n",
+            ),
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        return self.receiver.reduce(ctx).and_then(
+            lambda receiver: self.operand.reduce(ctx).and_then(
+                lambda operand: self._finish(receiver, operand, ctx)
+            )
+        )
+
+    def _finish(self, receiver, operand, ctx):
+        from sugar_lift_py_tests.floor import ObjectValue
+
+        if isinstance(receiver, ObjectValue):
+            # The written call names the receiver's OWN method table entry --
+            # reflected or not, `receiver.__dunder__(operand)` always resolves
+            # through the receiver's class body, never a swapped verb.
+            return receiver.call_method_value(
+                self.dunder_name,
+                (operand,),
+                owner=type(self).__name__,
+                blame=self.site,
+                ctx=ctx,
+            )
+        if self.dunder_name == _SUBSCRIPT_DUNDER:
+            return receiver.subscript(operand, self.site)
+        verb = (_REFLECTED_DUNDER_VERBS if self.reflected else _DIRECT_DUNDER_VERBS)[
+            self.dunder_name
+        ]
+        if self.reflected:
+            # `receiver.__rdunder__(operand)` means `operand OP receiver`:
+            # the reflected call's own receiver is the RIGHT operand.
+            return getattr(operand, verb)(receiver, self.site)
+        return getattr(receiver, verb)(operand, self.site)
+
+    def walk_children(self):
+        return (self.receiver, self.operand)

--- a/implementations/python/sugar-lift-py-tests/tests/test_dunder_operator_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dunder_operator_call_sugar.py
@@ -1,0 +1,246 @@
+"""Explicit dunder-operator Call bridge (#5912): ``x.__mul__(y)`` etc routed
+through the SAME floor verbs the ``BinOp``-family Sugars already call.
+
+Truthful/lying twins prove the bridge computes the right answer; the lying
+twins below are the ones that must REFUTE (never match this Sugar, or match
+and disagree with the operator semantics)."""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+from factory_reduce import reduce_value
+
+from sugar_lift_py_tests.claim import SugarRole
+from sugar_lift_py_tests.context.factory_build_context import FactoryBuildContext
+from sugar_lift_py_tests.factory.build import build_node, default_catalog
+from sugar_lift_py_tests.factory import FactoryPanic
+from sugar_lift_py_tests.sugar.dunder_operator_call_sugar import (
+    DunderOperatorCallSugar,
+)
+from sugar_lift_py_tests.witness_harness import run_source_through_real_solver
+from sugar_lift_py_tests.floor import SymbolicValue
+from sugar_lift_py_tests.ir import make_var
+
+
+def _selected(expr: str) -> str:
+    ctx = FactoryBuildContext(filename="t.py", catalog=default_catalog())
+    node = ast.parse(expr, mode="eval").body
+    result = build_node(node, filename="t.py", role=SugarRole.TERM, ctx=ctx)
+    return result.audit_row.selected
+
+
+# ---------------------------------------------------------------------------
+# Truthful: the bridge folds explicit dunder calls to the same value the
+# operator spelling would.
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_mul_dunder_call_selects_the_bridge() -> None:
+    assert _selected("(5).__mul__(3)") == "DunderOperatorCallSugar"
+
+
+def test_explicit_mul_dunder_call_folds_like_the_operator() -> None:
+    assert reduce_value("(5).__mul__(3)").value == reduce_value("5 * 3").value
+
+
+def test_explicit_add_dunder_call_folds_like_the_operator() -> None:
+    assert reduce_value("(5).__add__(2)").value == reduce_value("5 + 2").value
+
+
+def test_explicit_sub_dunder_call_folds_like_the_operator() -> None:
+    assert reduce_value("(5).__sub__(2)").value == reduce_value("5 - 2").value
+
+
+def test_explicit_truediv_dunder_call_folds_like_the_operator() -> None:
+    assert reduce_value("(6).__truediv__(2)").value == reduce_value("6 / 2").value
+
+
+def test_explicit_floordiv_dunder_call_folds_like_the_operator() -> None:
+    assert reduce_value("(7).__floordiv__(2)").value == reduce_value("7 // 2").value
+
+
+def test_explicit_getitem_dunder_call_folds_like_the_subscript() -> None:
+    assert reduce_value("[10, 20, 30].__getitem__(1)").value == reduce_value(
+        "[10, 20, 30][1]"
+    ).value
+
+
+# ---------------------------------------------------------------------------
+# The unclassified factory-walk row itself (#5252 / #5912): on a SYMBOLIC
+# receiver/operand (the shape every recensus row is -- a free variable, not a
+# ground literal) the bridged call must emit the SAME recognized operator
+# ctor term the `BinOp`/`Subscript` spelling emits (``+``, ``*``, ``//``,
+# ``py.subscript``, ...), never the opaque unresolved ``call:__dunder__``
+# CallSiteValue coordinate MethodCallSugar's generic fallback produces for
+# anything it cannot open a body for. The opaque ``call:`` coordinate IS the
+# unclassified residue this bridge drains; this asserts it is gone.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "member_ticket,expr,expected_ctor_name",
+    [
+        ("5761 call:__add__", "x.__add__(y)", "+"),
+        ("5822 call:__sub__", "x.__sub__(y)", "-"),
+        ("5821 call:__mul__", "x.__mul__(y)", "*"),
+        ("5823 call:__truediv__", "x.__truediv__(y)", "/"),
+        ("5820 call:__floordiv__", "x.__floordiv__(y)", "//"),
+        # __rfloordiv__(y) means y // x -- still the SAME "//" ctor, never a
+        # bare unresolved call: coordinate.
+        ("5663 call:__rfloordiv__", "x.__rfloordiv__(y)", "//"),
+    ],
+)
+def test_member_ticket_shape_emits_recognized_operator_ctor(
+    member_ticket, expr, expected_ctor_name
+) -> None:
+    from factory_reduce import reduce_term
+
+    term = reduce_term(
+        expr,
+        binds={
+            "x": SymbolicValue(make_var("x")),
+            "y": SymbolicValue(make_var("y")),
+        },
+    )
+    assert term.name == expected_ctor_name, (
+        f"{member_ticket}: expected recognized ctor `{expected_ctor_name}`, "
+        f"got `{term.name}` (opaque call: coordinate == still unclassified)"
+    )
+    assert not term.name.startswith("call:"), member_ticket
+
+
+def test_member_ticket_getitem_shape_emits_recognized_subscript_ctor() -> None:
+    from factory_reduce import reduce_term
+    from sugar_lift_py_tests.floor import StringValue
+
+    term = reduce_term(
+        "container.__getitem__(i)",
+        binds={
+            "container": StringValue("ABCD"),
+            "i": SymbolicValue(make_var("i")),
+        },
+    )
+    assert term.name == "py.subscript", (
+        f"5762 call:__getitem__: expected recognized ctor `py.subscript`, "
+        f"got `{term.name}` (opaque call: coordinate == still unclassified)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reflected: `x.__rfloordiv__(y)` means `y // x`, not `x // y` -- the operand
+# order is the teeth. #5663 (11 rows) is entirely this shape.
+# ---------------------------------------------------------------------------
+
+
+def test_reflected_rfloordiv_dunder_call_swaps_operand_order() -> None:
+    # (2).__rfloordiv__(7) means 7 // 2 == 3, NOT 2 // 7 == 0.
+    assert reduce_value("(2).__rfloordiv__(7)").value == 3
+    assert reduce_value("(2).__rfloordiv__(7)").value != reduce_value(
+        "(2).__floordiv__(7)"
+    ).value
+
+
+def test_reflected_radd_dunder_call_matches_commutative_operator() -> None:
+    assert reduce_value("(2).__radd__(7)").value == reduce_value("7 + 2").value
+
+
+# ---------------------------------------------------------------------------
+# Lying twins that MUST refute.
+# ---------------------------------------------------------------------------
+
+
+def test_same_named_non_dunder_method_is_not_bridged() -> None:
+    """A lookalike method that merely SHARES a name-shaped string with a
+    dunder (but isn't one) never authenticates: only exact dunder spellings
+    in the closed operator vocabulary own the Call."""
+    node = ast.parse("x.mul(3)", mode="eval").body
+    from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+
+    site = SourceFragment.from_node(node, "t.py")
+    assert DunderOperatorCallSugar.owns(site) is False
+
+
+def test_getattr_indirected_dunder_is_not_bridged() -> None:
+    """``getattr(x, '__mul__')(y)`` reaches the same runtime method but is
+    NOT the ``receiver.__dunder__`` Attribute Call shape -- the callee is a
+    Call (``getattr(...)``), not an Attribute, so this never authenticates
+    structurally and must refute the bridge."""
+    node = ast.parse("getattr(x, '__mul__')(3)", mode="eval").body
+    from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+
+    site = SourceFragment.from_node(node, "t.py")
+    assert DunderOperatorCallSugar.owns(site) is False
+
+
+def test_wrong_arity_dunder_call_is_not_bridged() -> None:
+    """``x.__mul__(y, z)`` (extra positional) or ``x.__mul__()`` (missing
+    operand) is not the operator's own arity and must refute."""
+    from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+
+    for expr in ("x.__mul__(3, 4)", "x.__mul__()"):
+        node = ast.parse(expr, mode="eval").body
+        site = SourceFragment.from_node(node, "t.py")
+        assert DunderOperatorCallSugar.owns(site) is False
+
+
+def test_keyword_dunder_call_is_not_bridged() -> None:
+    """``x.__mul__(other=y)`` is spelled with a keyword, not the operator's
+    positional-only shape, and must refute the bridge."""
+    from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+
+    node = ast.parse("x.__mul__(other=3)", mode="eval").body
+    site = SourceFragment.from_node(node, "t.py")
+    assert DunderOperatorCallSugar.owns(site) is False
+
+
+def test_non_numeric_operand_stays_loud_factory_panic() -> None:
+    """A shadowed/wrong-type operand hits the SAME typed floor gap the
+    operator spelling already raises for ``x * y`` -- the bridge invents no
+    new suppression."""
+    with pytest.raises(FactoryPanic):
+        reduce_value('"a".__mul__("b")')
+
+
+# ---------------------------------------------------------------------------
+# Real-solver truthful/lying twins (end-to-end sat/unsat), mirroring the
+# BinOp-family convention in test_binop_sugar.py.
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_mul_dunder_call_truthful_and_lying_twins_refute(tmp_path) -> None:
+    truthful = run_source_through_real_solver(
+        tmp_path / "truthful",
+        "def A():\n    return (5).__mul__(3)\n\n"
+        "def test_a():\n    assert A() == 15\n",
+    )
+    lying = run_source_through_real_solver(
+        tmp_path / "lying",
+        "def A():\n    return (5).__mul__(3)\n\n"
+        "def test_a():\n    assert A() == 16\n",
+    )
+    assert truthful.verdict == "sat"
+    assert lying.verdict == "unsat"
+    assert "DunderOperatorCallSugar" in truthful.selected_sugars
+    assert "DunderOperatorCallSugar" in lying.selected_sugars
+
+
+def test_explicit_rfloordiv_dunder_call_truthful_and_lying_twins_refute(
+    tmp_path,
+) -> None:
+    truthful = run_source_through_real_solver(
+        tmp_path / "truthful",
+        "def A():\n    return (2).__rfloordiv__(7)\n\n"
+        "def test_a():\n    assert A() == 3\n",
+    )
+    # The lying twin gets the reflected operand order backwards (2 // 7 == 0).
+    lying = run_source_through_real_solver(
+        tmp_path / "lying",
+        "def A():\n    return (2).__rfloordiv__(7)\n\n"
+        "def test_a():\n    assert A() == 0\n",
+    )
+    assert truthful.verdict == "sat"
+    assert lying.verdict == "unsat"
+    assert "DunderOperatorCallSugar" in truthful.selected_sugars
+    assert "DunderOperatorCallSugar" in lying.selected_sugars


### PR DESCRIPTION
Part of #5912

## Mechanism

`x.__mul__(y)` is the operator protocol spelled out longhand: `x * y` desugars to exactly this call. `DunderOperatorCallSugar` (new file: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/dunder_operator_call_sugar.py`) recognizes the closed CPython binary-operator/subscript data-model vocabulary (direct + reflected dunders, plus `__getitem__`), authenticated purely structurally:

- callee must be an `Attribute` whose name is in the closed dunder set (never a vendor/module string)
- exactly one positional argument, no keywords, no starred expansion (the operator's own arity)
- receiver is whatever the Attribute's own value resolves to (no isinstance/runtime-type check)

It then routes through the **same floor verbs** the existing `BinOp`-family Sugars already call (`AddOpSugar` → `.add`, `FloorDivideOpSugar` → `.floor_divide`, `SubscriptSugar` → `.subscript`, ...), or — when the receiver is an `ObjectValue` — through `call_method_value(dunder_name, ...)`, the same mechanism `MatrixMultiplyOpSugar`/`BuiltinDunderCallSugar` already use for user-class dunder dispatch. One recognizer, zero changes to the seven existing per-operator Sugar classes.

Registered `comes_before=("MethodCallSugar",)` so the generic method-call fallback (which currently swallows these calls into an opaque unresolved `call:__mul__(...)` coordinate — the unclassified row) never gets first pick.

## Member tickets drained (measured)

Verified with a dedicated symbolic-operand test (`test_member_ticket_shape_emits_recognized_operator_ctor` / `test_member_ticket_getitem_shape_emits_recognized_subscript_ctor`) asserting the lifted term is the recognized operator ctor (`+`, `-`, `*`, `/`, `//`, `py.subscript`) rather than an opaque `call:__dunder__` coordinate:

| rows | family | ticket | drained |
|---:|---|---|---|
| 11 | `call:__rfloordiv__` | #5663 | yes |
| 2 | `call:__getitem__` | #5762 | yes |
| 2 | `call:__add__` | #5761 | yes |
| 1 | `call:__truediv__` | #5823 | yes |
| 1 | `call:__sub__` | #5822 | yes |
| 1 | `call:__mul__` | #5821 | yes |
| 1 | `call:__floordiv__` | #5820 | yes |

All 19 rows / 7 tickets drained by this one recognizer.

## Twins

- Truthful: `(5).__mul__(3)`, `(5).__add__(2)`, `(2).__rfloordiv__(7)` (reflected — must equal `7 // 2`, not `2 // 7`), `[10,20,30].__getitem__(1)` all fold to the same value the operator spelling produces.
- Lying twin — same-named non-dunder method (`x.mul(y)`): `owns()` returns `False`, never bridged, falls through to `MethodCallSugar`.
- Lying twin — `getattr(x, '__mul__')(y)`: callee is a `Call`, not an `Attribute`; `owns()` returns `False`.
- Lying twin — wrong arity (`x.__mul__(y, z)` / `x.__mul__()`) and keyword form (`x.__mul__(other=y)`): all refused by `owns()`.
- Lying twin — wrong-type operand (`"a".__mul__("b")`): stays the **same** `FactoryPanic` the operator spelling already raises for `"a" * "b"` on that receiver type — no new suppression invented.

**Revert-refutation performed**: removed the recognizer file (both locally and, after discovering an rsync sync-lag in the `bin/bpytest` remote closure, directly on the remote host) and reran `tests/test_dunder_operator_call_sugar.py -k member_ticket`. Without the file, the whole module fails collection (`ModuleNotFoundError`) — confirming the earlier "still passing" result was reading a stale remote copy, not a real twin failure. With the recognizer restored, all 21 unit tests pass.

## R_vendor_special_case

Zero — the recognizer table is the closed CPython operator data model (`__add__`/`__radd__`/... plus `__getitem__`), never a pandas/numpy/vendor name.

## Verification performed

- `bin/bpytest tests/test_dunder_operator_call_sugar.py -k "not truthful_and_lying_twins_refute"` → 21 passed (unit-level: owns/reduce/ctor-shape/coverage checks).
- `bin/bpytest tests/test_factory_ownership_law.py` → 8 passed (registry/ownership-law scanner clean).
- `bin/bpytest tests/test_sugar_witness_instruments.py tests/test_isinstance_call_sugar.py tests/test_callsite_binary_witnesses.py` → same 57 pre-existing failures / 3 pre-existing errors as the unmodified baseline (confirmed by running the identical suite with the change stashed out) — **zero regressions**. These pre-existing failures are all `run_source_through_real_solver`/mint-pipeline tests failing on `FileNotFoundError: git` inside the `python-unit` closure (missing `git` binary in that container), unrelated to this change.
- The two full-solver twin tests I added (`*_truthful_and_lying_twins_refute`) hit the same pre-existing `git`-missing environment gap and are included per repo convention (mirrors `test_binop_sugar.py`'s identical pattern, which fails identically on unmodified main in this closure).

Not merging — leaving for coordinator soundness read per lane convention.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bridge explicit dunder-operator calls into BinOp/Subscript floor semantics
> - Adds `DunderOperatorCallSugar` in [`dunder_operator_call_sugar.py`](https://github.com/TSavo/sugar/pull/5917/files#diff-e717a80f2feb906216469deeb90d1eb0693a3a35c2572998341fb14a30518831) to recognize explicit calls like `x.__add__(y)` or `x.__getitem__(i)` and desugar them to the same floor verbs as infix operators and subscript syntax.
> - Direct dunders dispatch as `receiver.verb(operand)`, reflected dunders (`__radd__`, `__rfloordiv__`, etc.) swap operand order to `operand.verb(receiver)`, and `__getitem__` routes to `receiver.subscript(operand)`.
> - When the receiver is a concrete `ObjectValue`, the exact dunder name is invoked directly on the object's method table rather than mapping through the verb layer.
> - Tests in [`test_dunder_operator_call_sugar.py`](https://github.com/TSavo/sugar/pull/5917/files#diff-fdb5d907d0614a549f32e28b96148457cf77b92384df1ab904c707511edfec88) cover selection, fold parity with operators, reflected operand ordering, non-ownership cases, and end-to-end solver verdicts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4f2bf4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->