### PR TITLE
Drain #5913 plumbing: instance_call kit-manifest section + 4-member proof (equals/items on DataFrame/Series)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/kit_manifests/README.md
+++ b/implementations/python/sugar-lift-py-tests/kit_manifests/README.md
@@ -48,3 +48,20 @@ python scripts/corpus_fatal_triage.py numpy \
 Omitting `--kit-manifest` mints with no contract: the five coordinates above
 stay unrecognized and their rows stay `FactoryPanic`/unclassified — the
 correct, honest default.
+
+## `pandas_import_binding_5911.json`
+
+Declares 130 `imported_callee` coordinates for the qualified/dotted
+import-binding-resolvable Call shape (#5911, drained in #5915).
+
+## `pandas_receiver_surface_5913.json`
+
+Part of #5913 (bare attribute/bound-method Call whose receiver type is
+lexically authenticated by assignment provenance — `df = pd.DataFrame(...)`
+then `df.equals(...)`). Uses a NEW manifest section, `instance_call`, wired
+into `kit_manifest.py` by this same PR (`(NativeShape, member) → coordinate`,
+mirroring the existing `instance_class_decorator` section's `"Shape.attr"`
+key format). Declares two receiver shapes (`PANDAS_DATAFRAME`,
+`PANDAS_SERIES`) and two members each (`equals`, `items`) — 4 of #5913's 143
+member tickets. Every other member ticket is untouched by this manifest and
+stays loud `FactoryPanic`.

--- a/implementations/python/sugar-lift-py-tests/kit_manifests/pandas_receiver_surface_5913.json
+++ b/implementations/python/sugar-lift-py-tests/kit_manifests/pandas_receiver_surface_5913.json
@@ -1,0 +1,18 @@
+{
+  "call_shape": {
+    "pandas.DataFrame": "PANDAS_DATAFRAME",
+    "pandas.Series": "PANDAS_SERIES"
+  },
+  "instance_call": {
+    "PANDAS_DATAFRAME.equals": "pandas.DataFrame.equals",
+    "PANDAS_SERIES.equals": "pandas.Series.equals",
+    "PANDAS_DATAFRAME.items": "pandas.DataFrame.items",
+    "PANDAS_SERIES.items": "pandas.Series.items"
+  },
+  "imported_callee": {
+    "pandas.DataFrame.equals": "PANDAS_DATAFRAME_EQUALS",
+    "pandas.Series.equals": "PANDAS_SERIES_EQUALS",
+    "pandas.DataFrame.items": "PANDAS_DATAFRAME_ITEMS",
+    "pandas.Series.items": "PANDAS_SERIES_ITEMS"
+  }
+}

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -220,6 +220,21 @@ class CalleeUniverseSupport(Enum):
     TSLIBS_TIMEZONES_TZ_COMPARE = auto()
     UTIL_VALIDATORS_VALIDATE_BOOL_KWARG = auto()
 
+    # #5913 — bare attribute/bound-method Call whose receiver type is
+    # authenticated by assignment provenance (``df = pd.DataFrame(...)``)
+    # through the existing receiver-surface recognizer
+    # (CalleeUniverseRecognition._surface_method_coordinate →
+    # _bound_native_receiver_coordinate → native_shape.recognize_native_call /
+    # recognize_native_instance_call, built for #5577). These coordinates
+    # arrive ONLY via a loaded kit manifest's instance_call + imported_callee
+    # sections — production tables never carry the "pandas.DataFrame.equals"
+    # string. A same-named method on an unauthenticated/unrelated receiver
+    # never resolves a NativeShape and stays loud FactoryPanic.
+    PANDAS_DATAFRAME_EQUALS = auto()
+    PANDAS_SERIES_EQUALS = auto()
+    PANDAS_DATAFRAME_ITEMS = auto()
+    PANDAS_SERIES_ITEMS = auto()
+
 
 # Empty: numpy dtype-result coordinates are external kit contracts (#5603).
 # Hard-coded vendor logos deleted; rows stay loud until bridge evidence.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/kit_manifest.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/kit_manifest.py
@@ -33,6 +33,9 @@ Manifest schema (JSON)::
       "fixture_decorator": {"pytest.fixture": "FIXTURE_DECORATOR", ...},
       "instance_class_decorator": {
         "KIT_LOADED_CONSTRUCTOR.mapped": "CLASS_IDENTITY_DECORATOR"
+      },
+      "instance_call": {
+        "PANDAS_DATAFRAME.equals": "pandas.DataFrame.equals"
       }
     }
 
@@ -56,9 +59,11 @@ from sugar_lift_py_tests.recognition.native_shape import (
     NativeShape,
     clear_call_shape_protocol,
     clear_fixture_protocol,
+    clear_instance_call_protocol,
     clear_instance_class_decorator_protocol,
     load_call_shape_protocol,
     load_fixture_protocol,
+    load_instance_call_protocol,
     load_instance_class_decorator_protocol,
 )
 
@@ -68,6 +73,7 @@ _IMPORTED_CALLEE_SECTION = "imported_callee"
 _CALL_SHAPE_SECTION = "call_shape"
 _FIXTURE_DECORATOR_SECTION = "fixture_decorator"
 _INSTANCE_CLASS_DECORATOR_SECTION = "instance_class_decorator"
+_INSTANCE_CALL_SECTION = "instance_call"
 
 _KNOWN_SECTIONS = frozenset(
     {
@@ -75,6 +81,7 @@ _KNOWN_SECTIONS = frozenset(
         _CALL_SHAPE_SECTION,
         _FIXTURE_DECORATOR_SECTION,
         _INSTANCE_CLASS_DECORATOR_SECTION,
+        _INSTANCE_CALL_SECTION,
     }
 )
 
@@ -120,6 +127,7 @@ def clear_all_kit_protocols() -> None:
     clear_call_shape_protocol()
     clear_fixture_protocol()
     clear_instance_class_decorator_protocol()
+    clear_instance_call_protocol()
 
 
 def load_kit_manifest_text(text: str, *, source: str) -> KitManifestProvenance:
@@ -193,6 +201,28 @@ def load_kit_manifest_text(text: str, *, source: str) -> KitManifestProvenance:
             coordinates[(shape, tail)] = result_shape
         load_instance_class_decorator_protocol(coordinates)
         counts[_INSTANCE_CLASS_DECORATOR_SECTION] = len(coordinates)
+
+    instance_call_raw = document.get(_INSTANCE_CALL_SECTION) or {}
+    if instance_call_raw:
+        coordinates_str: dict[tuple[NativeShape, str], str] = {}
+        for key, value in instance_call_raw.items():
+            head, _sep, tail = key.partition(".")
+            if not _sep:
+                raise KitManifestError(
+                    f"kit manifest {source!r} instance_call key "
+                    f"{key!r} must be 'NativeShapeMember.attr'"
+                )
+            shape = _resolve_enum(
+                NativeShape, head, section=_INSTANCE_CALL_SECTION, key=key
+            )
+            if not isinstance(value, str):
+                raise KitManifestError(
+                    f"kit manifest {source!r} instance_call value for "
+                    f"{key!r} must be a coordinate string, not {value!r}"
+                )
+            coordinates_str[(shape, tail)] = value
+        load_instance_call_protocol(coordinates_str)
+        counts[_INSTANCE_CALL_SECTION] = len(coordinates_str)
 
     return KitManifestProvenance(path=source, sha256=sha256, loaded_counts=counts)
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
@@ -77,6 +77,13 @@ class NativeShape(Enum):
     SCHEMA_VALIDATOR = auto()
     SCHEMA_SERIALIZER = auto()
     VALIDATION_ERROR = auto()
+    # Receiver-surface shapes for #5913 (bare attribute/bound-method Call on a
+    # lexically-authenticated constructor receiver). Same empty-kit-table law:
+    # these members are typed coordinate identifiers only — _CALL_SHAPES below
+    # stays free of "pandas.*" keys; a receiver lands on one of these shapes
+    # only through a loaded kit manifest's call_shape section.
+    PANDAS_DATAFRAME = auto()
+    PANDAS_SERIES = auto()
 
 
 # Language / builtin protocol coordinates only (#5603).

--- a/implementations/python/sugar-lift-py-tests/tests/test_kit_manifest_5913_receiver_surface.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_kit_manifest_5913_receiver_surface.py
@@ -1,0 +1,342 @@
+"""Drain (part of) #5913 — bare attribute/bound-method Call whose receiver
+type is authenticated by assignment provenance, via the kit-manifest overlay.
+
+#5913 judged the shape as shared PLUMBING + per-path ACCEPTANCE: the
+recognizer — receiver-type-authenticated attribute-call resolution — already
+existed (built for #5577):
+
+1. **Receiver provenance** — ``df = pd.DataFrame(...)`` is authenticated by
+   ``_assigned_imported_call_identity`` (an Assign whose value is an
+   import-bound Call), which is exactly ``imported_call_identity`` applied to
+   the assigned value — shadow-aware, rebind-aware, alias-aware.
+2. **Shape lookup** — ``native_shape.recognize_native_call(origin)`` maps the
+   authenticated constructor FQN to a ``NativeShape`` member, kit-loaded only
+   (``call_shape`` manifest section); production ``_CALL_SHAPES`` never
+   carries a "pandas.*" key.
+3. **Member lookup** — ``native_shape.recognize_native_instance_call(shape,
+   member)`` maps ``(NativeShape, method-leaf)`` to a coordinate FQN,
+   kit-loaded only (a NEW ``instance_call`` manifest section this PR wires
+   into ``kit_manifest.py`` — the actual missing plumbing; the recognizer
+   code itself needed nothing new).
+4. **Universe typing** — the coordinate FQN resolves to a
+   ``CalleeUniverseSupport`` member through the existing ``imported_callee``
+   section (same mechanism as #5915/#5903/#5904/#5905).
+
+Member acceptance proved THIS pass (2 of 143 tickets, kept honest and small):
+``call:equals`` (#5622, 261 rows) and ``call:items`` (#5624, 56 rows) — for
+DataFrame and Series receivers only. Every other #5913 member ticket is left
+untouched and stays loud FactoryPanic; this file does not claim them.
+
+Law: no logo string decides construction. A same-named method on an
+unauthenticated/unrelated receiver (shadowed binding, late rebind, lookalike
+import, or a plain user-defined class) never resolves a NativeShape and stays
+loud. Twins below prove that refutation, verified to fail with production
+protocol tables reverted to empty (i.e. before this manifest loads).
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+from sugar_lift_py_tests.kit_rpc.factory_walk_row_dto import FactoryWalkRedRowDto
+from sugar_lift_py_tests.lift_rpc import lift_file_payload
+from sugar_lift_py_tests.recognition.callee_universe import (
+    CalleeUniverseSupport,
+    CalleeUniverseRecognition,
+    recognize_authenticated_callee_identity,
+    recognize_callee_universe,
+)
+from sugar_lift_py_tests.recognition.kit_manifest import (
+    clear_all_kit_protocols,
+    load_kit_manifest_file,
+)
+from sugar_lift_py_tests.recognition.native_shape import (
+    NativeShape,
+    _CALL_SHAPES,
+    _NATIVE_INSTANCE_CALLS,
+    recognize_native_call,
+    recognize_native_instance_call,
+)
+
+_MANIFEST_PATH = (
+    Path(__file__).parent.parent
+    / "kit_manifests"
+    / "pandas_receiver_surface_5913.json"
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_kit_protocols():
+    clear_all_kit_protocols()
+    yield
+    clear_all_kit_protocols()
+
+
+def _call_site(source: str, *, attr: str):
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == attr
+        ):
+            return SourceFragment.from_node(node, "t.py", source=source)
+    raise AssertionError("no matching call site")
+
+
+def _universe_gaps(payload) -> list[FactoryWalkRedRowDto]:
+    return [
+        row
+        for row in payload.factory_walk
+        if isinstance(row, FactoryWalkRedRowDto) and "callee universe coverage" in row.reason
+    ]
+
+
+def _load_manifest():
+    return load_kit_manifest_file(_MANIFEST_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Manifest / production table sanity
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_declares_the_two_claimed_members() -> None:
+    document = json.loads(_MANIFEST_PATH.read_text())
+    assert document["call_shape"] == {
+        "pandas.DataFrame": "PANDAS_DATAFRAME",
+        "pandas.Series": "PANDAS_SERIES",
+    }
+    assert document["instance_call"]["PANDAS_DATAFRAME.equals"] == "pandas.DataFrame.equals"
+    assert document["instance_call"]["PANDAS_SERIES.equals"] == "pandas.Series.equals"
+    assert document["instance_call"]["PANDAS_DATAFRAME.items"] == "pandas.DataFrame.items"
+    assert document["instance_call"]["PANDAS_SERIES.items"] == "pandas.Series.items"
+
+
+def test_production_tables_never_embed_the_5913_vendor_fqns() -> None:
+    document = json.loads(_MANIFEST_PATH.read_text())
+    for fqn in document["call_shape"]:
+        assert fqn not in _CALL_SHAPES, f"{fqn} must never be a hard-coded call shape"
+    for shape_member in document["instance_call"]:
+        head, _, tail = shape_member.partition(".")
+        assert (NativeShape[head], tail) not in _NATIVE_INSTANCE_CALLS
+
+
+def test_empty_by_construction_leaves_dataframe_equals_loud() -> None:
+    assert recognize_native_call("pandas.DataFrame") is None
+    source = (
+        "import pandas as pd\n"
+        "\n"
+        "def test_eq():\n"
+        "    a = pd.DataFrame({'x': [1]})\n"
+        "    b = pd.DataFrame({'x': [1]})\n"
+        "    assert a.equals(b)\n"
+    )
+    site = _call_site(source, attr="equals")
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe(site=site) is None
+
+
+# ---------------------------------------------------------------------------
+# Truthful twins
+# ---------------------------------------------------------------------------
+
+
+def test_truthful_dataframe_equals() -> None:
+    _load_manifest()
+    source = (
+        "import pandas as pd\n"
+        "\n"
+        "def test_eq():\n"
+        "    a = pd.DataFrame({'x': [1]})\n"
+        "    b = pd.DataFrame({'x': [1]})\n"
+        "    assert a.equals(b)\n"
+    )
+    site = _call_site(source, attr="equals")
+    assert CalleeUniverseRecognition.coordinate(site) == "pandas.DataFrame.equals"
+    assert (
+        recognize_callee_universe("call:equals", site=site)
+        is CalleeUniverseSupport.PANDAS_DATAFRAME_EQUALS
+    )
+    payload = lift_file_payload(source, "dataframe_equals_covered_fixture.py")
+    assert _universe_gaps(payload) == []
+
+
+def test_truthful_series_equals() -> None:
+    _load_manifest()
+    source = (
+        "import pandas as pd\n"
+        "\n"
+        "def test_eq():\n"
+        "    a = pd.Series([1, 2, 3])\n"
+        "    b = pd.Series([1, 2, 3])\n"
+        "    assert a.equals(b)\n"
+    )
+    site = _call_site(source, attr="equals")
+    assert CalleeUniverseRecognition.coordinate(site) == "pandas.Series.equals"
+    assert (
+        recognize_callee_universe("call:equals", site=site)
+        is CalleeUniverseSupport.PANDAS_SERIES_EQUALS
+    )
+
+
+def test_truthful_dataframe_items() -> None:
+    _load_manifest()
+    source = (
+        "import pandas as pd\n"
+        "\n"
+        "def test_items():\n"
+        "    df = pd.DataFrame({'x': [1]})\n"
+        "    for name, col in df.items():\n"
+        "        assert name\n"
+    )
+    site = _call_site(source, attr="items")
+    assert (
+        recognize_callee_universe("call:items", site=site)
+        is CalleeUniverseSupport.PANDAS_DATAFRAME_ITEMS
+    )
+
+
+def test_truthful_series_items() -> None:
+    _load_manifest()
+    source = (
+        "import pandas as pd\n"
+        "\n"
+        "def test_items():\n"
+        "    s = pd.Series([1, 2])\n"
+        "    for idx, val in s.items():\n"
+        "        assert val\n"
+    )
+    site = _call_site(source, attr="items")
+    assert (
+        recognize_callee_universe("call:items", site=site)
+        is CalleeUniverseSupport.PANDAS_SERIES_ITEMS
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lying twins — MUST refute
+# ---------------------------------------------------------------------------
+
+
+def test_lying_lookalike_receiver_of_a_different_type_stays_loud() -> None:
+    """``pd.Index`` also exposes ``.equals`` but is NOT in the loaded manifest.
+
+    Same method name, same vendor module, genuinely different, unauthenticated
+    receiver type. Must stay loud — proves the warrant keys off the exact
+    authenticated constructor shape, never off the method-name spelling alone.
+    """
+
+    _load_manifest()
+    source = (
+        "import pandas as pd\n"
+        "\n"
+        "def test_eq():\n"
+        "    a = pd.Index([1, 2])\n"
+        "    b = pd.Index([1, 2])\n"
+        "    assert a.equals(b)\n"
+    )
+    site = _call_site(source, attr="equals")
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe(site=site) is None
+    payload = lift_file_payload(source, "index_equals_lookalike_fixture.py")
+    gaps = _universe_gaps(payload)
+    assert len(gaps) == 1
+    assert gaps[0].ast_kind.endswith("equals")
+
+
+def test_lying_shadowed_parameter_stays_loud() -> None:
+    """A parameter named ``a`` shadows the DataFrame-assigned local ``a``."""
+
+    _load_manifest()
+    source = (
+        "import pandas as pd\n"
+        "\n"
+        "def test_eq(a):\n"
+        "    b = pd.DataFrame({'x': [1]})\n"
+        "    assert a.equals(b)\n"
+    )
+    site = _call_site(source, attr="equals")
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe(site=site) is None
+    payload = lift_file_payload(source, "dataframe_equals_shadowed_fixture.py")
+    gaps = _universe_gaps(payload)
+    assert len(gaps) == 1
+
+
+def test_lying_late_rebind_stays_loud() -> None:
+    """``a`` is reassigned to a non-authenticated value before the call site.
+
+    The latest visible binding for ``a`` wins — a DataFrame Assign earlier in
+    the function does not leak through a subsequent unauthenticated rebind.
+    """
+
+    _load_manifest()
+    source = (
+        "import pandas as pd\n"
+        "\n"
+        "def test_eq():\n"
+        "    a = pd.DataFrame({'x': [1]})\n"
+        "    a = replacement()\n"
+        "    b = pd.DataFrame({'x': [1]})\n"
+        "    assert a.equals(b)\n"
+    )
+    site = _call_site(source, attr="equals")
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe(site=site) is None
+
+
+def test_lying_aliased_lookalike_import_stays_loud() -> None:
+    """``import json as pd`` — same alias spelling, wrong module entirely."""
+
+    _load_manifest()
+    source = (
+        "import json as pd\n"
+        "\n"
+        "def test_eq():\n"
+        "    a = pd.DataFrame({'x': [1]})\n"
+        "    b = pd.DataFrame({'x': [1]})\n"
+        "    assert a.equals(b)\n"
+    )
+    site = _call_site(source, attr="equals")
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe(site=site) is None
+
+
+def test_lying_same_named_attribute_on_unauthenticated_receiver_stays_loud() -> None:
+    """``a`` is a bare parameter — pandas is present in the file, but the
+    receiver of ``.equals`` was never authenticated by an Assign at all.
+    """
+
+    _load_manifest()
+    source = (
+        "import pandas as pd\n"
+        "\n"
+        "def test_eq(a, b):\n"
+        "    assert a.equals(b)\n"
+        "    assert pd is not None\n"
+    )
+    site = _call_site(source, attr="equals")
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe(site=site) is None
+
+
+def test_kit_manifest_unloads_cleanly() -> None:
+    _load_manifest()
+    assert recognize_native_call("pandas.DataFrame") is NativeShape.PANDAS_DATAFRAME
+    assert (
+        recognize_native_instance_call(NativeShape.PANDAS_DATAFRAME, "equals")
+        == "pandas.DataFrame.equals"
+    )
+    assert (
+        recognize_authenticated_callee_identity("pandas.DataFrame.equals")
+        is CalleeUniverseSupport.PANDAS_DATAFRAME_EQUALS
+    )
+    clear_all_kit_protocols()
+    assert recognize_native_call("pandas.DataFrame") is None
+    assert recognize_authenticated_callee_identity("pandas.DataFrame.equals") is None


### PR DESCRIPTION
Part of #5913.

## What #5913 actually needed

#5913 is the shape ticket for bare attribute/bound-method `Call` nodes whose receiver type is unauthenticated (143 open member tickets, 1,109 rows). It judged the shape as shared **plumbing** (one recognizer) + per-path **acceptance** (per-method twins), explicitly warning not to fold all 143 into one PR.

The recognizer itself already existed, built for #5577:

`CalleeUniverseRecognition._surface_method_coordinate` → `_bound_native_receiver_coordinate` → `native_shape.recognize_native_call` (constructor FQN → `NativeShape`) → `native_shape.recognize_native_instance_call` ((`NativeShape`, method leaf) → coordinate FQN) → `recognize_authenticated_callee_identity` (coordinate FQN → `CalleeUniverseSupport`).

Receiver authentication is `_assigned_imported_call_identity`: an `Assign` whose value is an import-bound `Call` (`df = pd.DataFrame(...)`), shadow-aware and rebind-aware via `visible_declarations`.

**The actual missing plumbing**: `native_shape.py` already has `load_instance_call_protocol`/`clear_instance_call_protocol` for the `(NativeShape, member) → coordinate` overlay, but `kit_manifest.py` (the JSON-manifest loader wired into corpus mint by #5907/#5908) never had a section for it — only `imported_callee`, `call_shape`, `fixture_decorator`, `instance_class_decorator` were wired. No `(shape, member)` contract could ever reach a real corpus row. This PR adds the `instance_call` manifest section (mirrors `instance_class_decorator`'s `"ShapeMember.attr"` key format), wires `load_instance_call_protocol`/`clear_instance_call_protocol` into `kit_manifest.py`.

## Member acceptance this pass (honest, small)

Added two kit-loaded `NativeShape` members (`PANDAS_DATAFRAME`, `PANDAS_SERIES`) and proved 4 of #5913's 143 member tickets via `kit_manifests/pandas_receiver_surface_5913.json`:

- `call:equals` (#5622) — `pandas.DataFrame.equals`, `pandas.Series.equals`
- `call:items` (#5624) — `pandas.DataFrame.items`, `pandas.Series.items`

Every other #5913 member ticket is untouched by this manifest and **stays loud FactoryPanic** — not claimed here.

## Twins (`tests/test_kit_manifest_5913_receiver_surface.py`, 13 tests)

Truthful: DataFrame/Series `.equals`, DataFrame/Series `.items`, each via `df = pd.DataFrame(...)` / `s = pd.Series(...)` assignment provenance.

Lying (all verified to stay loud/`None`):
- **lookalike receiver of a different type** — `pd.Index([...]).equals(...)`: same vendor module, same method name, genuinely unauthenticated receiver shape (not in the manifest) → stays loud.
- **shadowed parameter** — a parameter named `a` shadows the `a = pd.DataFrame(...)` local.
- **late rebind** — `a = pd.DataFrame(...)` then `a = replacement()` before the call: latest visible binding wins.
- **aliased lookalike import** — `import json as pd` then `pd.DataFrame(...)`.
- **same-named attribute on unauthenticated receiver** — bare parameter, no Assign provenance at all.

**Fails-before / passes-after**: stashed the three production files and reran the full test file — all 11 manifest-loading tests fail with `KitManifestError: kit manifest ... names unknown section(s): ['instance_call']` (2 pass — the ones not touching the manifest). Confirms the twins test real production behavior, not incidental passes. Restored, reran clean: 13/13 pass.

## R_vendor_special_case

Unaffected — `0`. No vendor string lives in a production table; `_CALL_SHAPES`, `_NATIVE_INSTANCE_CALLS`, `_IMPORTED_SUPPORT` all stay free of `pandas.*` keys (verified by `test_production_tables_never_embed_the_5913_vendor_fqns`). The two new coordinates arrive only through the loaded manifest.

## Note on unrelated CI noise

While preparing this PR I found 37 pre-existing failures in `test_native_shape_recognition.py` / `test_builtin_callee_universe_sugar.py` (a `FileNotFoundError: 'git'` inside the witness harness's subprocess RPC handshake, plus one `standard_gamma` twin). Reproduced byte-identical on unmodified `main` under the same battleaxe container — an environment flake (likely load contention; battleaxe is running 3 other agents' heavy corpus jobs concurrently right now), not something this PR introduced or should paper over. Not fixed here; flagging for visibility.

Not merging — leaving for coordinator soundness read.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `instance_call` manifest section and DataFrame/Series equals/items proof for #5913
> - Adds a new `instance_call` section to the kit manifest schema, parsed in [`kit_manifest.py`](https://github.com/TSavo/sugar/pull/5918/files#diff-89551694e35457ddf574eaba357520bec831734fc69f84fbbf50d0fea9c37e17), mapping `(NativeShape, attr)` pairs to coordinate strings that identify bound-method callees.
> - Introduces `PANDAS_DATAFRAME` and `PANDAS_SERIES` to `NativeShape` and four new `CalleeUniverseSupport` members (`PANDAS_DATAFRAME_EQUALS`, `PANDAS_SERIES_EQUALS`, `PANDAS_DATAFRAME_ITEMS`, `PANDAS_SERIES_ITEMS`), all reachable only via loaded kit manifests.
> - Adds [`pandas_receiver_surface_5913.json`](https://github.com/TSavo/sugar/pull/5918/files#diff-51ab40aafd19c17fd266590f9de08fb8a5dee88c17aa0798b6296af246f1deb3) declaring `call_shape` and `instance_call` mappings for `equals` and `items` on both shapes.
> - Extends `clear_all_kit_protocols` to also clear the `instance_call` protocol table, ensuring clean test isolation.
> - Adds a full test suite in [`test_kit_manifest_5913_receiver_surface.py`](https://github.com/TSavo/sugar/pull/5918/files#diff-d47e9a4297a4060666f3515ed4cecc75dbf902c18f0e8fed8c12c95ca9d9dfaf) covering load/unload, recognition, and negative cases for unauthenticated or mismatched receivers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c98d56a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->