### PR TITLE
Drain #5913 (increment 3): to_html/_categories_match_up_to_permutation receiver-surface members

### DIFF
--- a/implementations/python/sugar-lift-py-tests/kit_manifests/pandas_receiver_surface_5913.json
+++ b/implementations/python/sugar-lift-py-tests/kit_manifests/pandas_receiver_surface_5913.json
@@ -2,7 +2,8 @@
   "call_shape": {
     "pandas.DataFrame": "PANDAS_DATAFRAME",
     "pandas.Series": "PANDAS_SERIES",
-    "pandas.Index": "PANDAS_INDEX"
+    "pandas.Index": "PANDAS_INDEX",
+    "pandas.Categorical": "PANDAS_CATEGORICAL"
   },
   "instance_call": {
     "PANDAS_DATAFRAME.equals": "pandas.DataFrame.equals",
@@ -14,7 +15,9 @@
     "PANDAS_INDEX.identical": "pandas.Index.identical",
     "PANDAS_INDEX.get_loc": "pandas.Index.get_loc",
     "PANDAS_INDEX.is_": "pandas.Index.is_",
-    "PANDAS_INDEX.slice_locs": "pandas.Index.slice_locs"
+    "PANDAS_INDEX.slice_locs": "pandas.Index.slice_locs",
+    "PANDAS_DATAFRAME.to_html": "pandas.DataFrame.to_html",
+    "PANDAS_CATEGORICAL._categories_match_up_to_permutation": "pandas.Categorical._categories_match_up_to_permutation"
   },
   "imported_callee": {
     "pandas.DataFrame.equals": "PANDAS_DATAFRAME_EQUALS",
@@ -26,6 +29,8 @@
     "pandas.Index.identical": "PANDAS_INDEX_IDENTICAL",
     "pandas.Index.get_loc": "PANDAS_INDEX_GET_LOC",
     "pandas.Index.is_": "PANDAS_INDEX_IS_",
-    "pandas.Index.slice_locs": "PANDAS_INDEX_SLICE_LOCS"
+    "pandas.Index.slice_locs": "PANDAS_INDEX_SLICE_LOCS",
+    "pandas.DataFrame.to_html": "PANDAS_DATAFRAME_TO_HTML",
+    "pandas.Categorical._categories_match_up_to_permutation": "PANDAS_CATEGORICAL_MATCH_UP_TO_PERMUTATION"
   }
 }

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -244,6 +244,23 @@ class CalleeUniverseSupport(Enum):
     PANDAS_INDEX_GET_LOC = auto()
     PANDAS_INDEX_IS_ = auto()
     PANDAS_INDEX_SLICE_LOCS = auto()
+    # #5913 member drain (third increment): call:to_html (#5645, DataFrame),
+    # call:_categories_match_up_to_permutation (#5646, Categorical). Same
+    # empty-by-construction law as above — kit-manifest only. Two other
+    # highest-row candidates this pass (#5625 call:_has_no_reference,
+    # #5647 call:has_reference) were investigated and left loud: every corpus
+    # call site is a chained attribute receiver (`df._mgr` /
+    # `df._mgr.blocks[i].refs`), never a directly-assigned/annotated name of a
+    # known vendor type, so authenticating them needs a genuine recognizer
+    # extension (BlockManager/BlockValuesRefs property-return provenance),
+    # not twins-only acceptance. Two more (#5632 call:drepr, #5642 call:hash)
+    # were investigated and found to be corpus/recensus artifacts, not vendor
+    # attribute calls at all: `drepr` is a locally-bound test-file lambda
+    # (`drepr = lambda x: x._repr_base()`) and `call:hash` is the builtin
+    # `hash(x)` function call, not `x.hash()`. Neither belongs to this shape;
+    # left unclaimed for the same reason #5643 call:lookup was left unclaimed.
+    PANDAS_DATAFRAME_TO_HTML = auto()
+    PANDAS_CATEGORICAL_MATCH_UP_TO_PERMUTATION = auto()
 
     # #5577 pydantic method-receiver drain (first mass increment): the top two
     # ranked pydantic method-mass families (#5577 ranking: to_python 533,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/native_shape.py
@@ -85,6 +85,7 @@ class NativeShape(Enum):
     PANDAS_DATAFRAME = auto()
     PANDAS_SERIES = auto()
     PANDAS_INDEX = auto()
+    PANDAS_CATEGORICAL = auto()
 
 
 # Language / builtin protocol coordinates only (#5603).

--- a/implementations/python/sugar-lift-py-tests/tests/test_kit_manifest_5913_receiver_surface_increment3.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_kit_manifest_5913_receiver_surface_increment3.py
@@ -1,0 +1,326 @@
+"""Drain (part of) #5913, third increment — extends the manifest landed in
+#5918/#5920 (`kit_manifests/pandas_receiver_surface_5913.json`) with two more
+member tickets, using the SAME plumbing (`instance_call` kit-manifest section
+wired to `native_shape.load_instance_call_protocol`, built in #5918).
+
+Member acceptance proved THIS pass:
+
+- ``call:to_html`` (#5645, 18 rows est.) — DataFrame receiver only. The
+  ticket's family also includes ``Styler.to_html`` call sites (e.g.
+  ``Styler(df).format(...).to_html()``), but those receivers are the return
+  value of a chained builder call, not a directly-assigned/annotated name —
+  authenticating that shape honestly needs fluent-builder-return provenance,
+  not just twins. Left for a later increment; this file claims DataFrame
+  rows only.
+- ``call:_categories_match_up_to_permutation`` (#5646, 16 rows est.) —
+  Categorical receiver.
+
+Row counts are #5913's stated ticket-body estimates (reclassified factory-walk
+counts), not a fresh corpus measurement — treated as unverified estimates per
+that issue's own caveat, not claimed as proven ΔR.
+
+Investigated and left loud, NOT claimed, this pass:
+
+- ``call:_has_no_reference`` (#5625, 48 rows est.) and ``call:has_reference``
+  (#5647, 16 rows est.) — every corpus call site is a chained attribute
+  receiver (``df._mgr._has_no_reference(0)``,
+  ``df._mgr.blocks[0].refs.has_reference()``), never a directly-assigned or
+  annotated name of a known vendor type. Authenticating these needs a genuine
+  recognizer extension (BlockManager / BlockValuesRefs property-return
+  provenance), which is out of scope for a twins-only member drain.
+- ``call:drepr`` (#5632, 32 rows est.) — the pinned pandas 3.0.3 test source
+  (``tests/scalar/timedelta/test_formats.py``) defines ``drepr`` as a
+  locally-bound test-file lambda (``drepr = lambda x: x._repr_base()``), not
+  a vendor attribute call at all. This is a corpus/recensus classification
+  artifact, not a `call:X` receiver-surface member.
+- ``call:hash`` (#5642, 22 rows est.) — the pinned pandas 3.0.3 test source
+  (``tests/arrays/interval/test_interval_pyarrow.py``) calls the builtin
+  ``hash(p1)``, not ``p1.hash()``. Same artifact class as ``drepr``.
+
+Every other #5913 member ticket remains untouched and stays loud
+FactoryPanic; this file does not claim them.
+
+Law: no logo string decides construction. A same-named method on an
+unauthenticated/unrelated receiver (shadowed binding, late rebind, lookalike
+import, lookalike vendor type, or a plain user-defined class) never resolves
+a NativeShape/member pair and stays loud. Twins below prove that refutation,
+verified to fail with production protocol tables (i.e. before this manifest
+loads, or with the added JSON entries reverted).
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+from sugar_lift_py_tests.kit_rpc.factory_walk_row_dto import FactoryWalkRedRowDto
+from sugar_lift_py_tests.lift_rpc import lift_file_payload
+from sugar_lift_py_tests.recognition.callee_universe import (
+    CalleeUniverseSupport,
+    CalleeUniverseRecognition,
+    recognize_authenticated_callee_identity,
+    recognize_callee_universe,
+)
+from sugar_lift_py_tests.recognition.kit_manifest import (
+    clear_all_kit_protocols,
+    load_kit_manifest_file,
+)
+from sugar_lift_py_tests.recognition.native_shape import (
+    NativeShape,
+    _CALL_SHAPES,
+    _NATIVE_INSTANCE_CALLS,
+    recognize_native_call,
+    recognize_native_instance_call,
+)
+
+_MANIFEST_PATH = (
+    Path(__file__).parent.parent
+    / "kit_manifests"
+    / "pandas_receiver_surface_5913.json"
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_kit_protocols():
+    clear_all_kit_protocols()
+    yield
+    clear_all_kit_protocols()
+
+
+def _call_site(source: str, *, attr: str):
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == attr
+        ):
+            return SourceFragment.from_node(node, "t.py", source=source)
+    raise AssertionError("no matching call site")
+
+
+def _universe_gaps(payload) -> list[FactoryWalkRedRowDto]:
+    return [
+        row
+        for row in payload.factory_walk
+        if isinstance(row, FactoryWalkRedRowDto) and "callee universe coverage" in row.reason
+    ]
+
+
+def _load_manifest():
+    return load_kit_manifest_file(_MANIFEST_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Manifest / production table sanity
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_declares_the_third_increment_members() -> None:
+    document = json.loads(_MANIFEST_PATH.read_text())
+    assert document["call_shape"]["pandas.Categorical"] == "PANDAS_CATEGORICAL"
+    assert document["instance_call"]["PANDAS_DATAFRAME.to_html"] == "pandas.DataFrame.to_html"
+    assert (
+        document["instance_call"]["PANDAS_CATEGORICAL._categories_match_up_to_permutation"]
+        == "pandas.Categorical._categories_match_up_to_permutation"
+    )
+
+
+def test_production_tables_never_embed_the_increment3_vendor_fqns() -> None:
+    document = json.loads(_MANIFEST_PATH.read_text())
+    for fqn in document["call_shape"]:
+        assert fqn not in _CALL_SHAPES, f"{fqn} must never be a hard-coded call shape"
+    for shape_member in document["instance_call"]:
+        head, _, tail = shape_member.partition(".")
+        assert (NativeShape[head], tail) not in _NATIVE_INSTANCE_CALLS
+
+
+def test_empty_by_construction_leaves_categorical_loud() -> None:
+    assert recognize_native_call("pandas.Categorical") is None
+    source = (
+        "import pandas as pd\n"
+        "\n"
+        "def test_match():\n"
+        "    c1 = pd.Categorical(list('aabca'), categories=list('abc'))\n"
+        "    c2 = pd.Categorical(list('aabca'), categories=list('cab'))\n"
+        "    assert c1._categories_match_up_to_permutation(c2)\n"
+    )
+    site = _call_site(source, attr="_categories_match_up_to_permutation")
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe(site=site) is None
+
+
+# ---------------------------------------------------------------------------
+# Truthful twins
+# ---------------------------------------------------------------------------
+
+
+def test_truthful_dataframe_to_html() -> None:
+    _load_manifest()
+    source = (
+        "import pandas as pd\n"
+        "\n"
+        "def test_to_html():\n"
+        "    df = pd.DataFrame({'x': [1]})\n"
+        "    df.to_html()\n"
+    )
+    site = _call_site(source, attr="to_html")
+    assert CalleeUniverseRecognition.coordinate(site) == "pandas.DataFrame.to_html"
+    assert (
+        recognize_callee_universe("call:to_html", site=site)
+        is CalleeUniverseSupport.PANDAS_DATAFRAME_TO_HTML
+    )
+    payload = lift_file_payload(source, "dataframe_to_html_covered_fixture.py")
+    assert _universe_gaps(payload) == []
+
+
+def test_truthful_categorical_categories_match_up_to_permutation() -> None:
+    _load_manifest()
+    source = (
+        "import pandas as pd\n"
+        "\n"
+        "def test_match():\n"
+        "    c1 = pd.Categorical(list('aabca'), categories=list('abc'))\n"
+        "    c2 = pd.Categorical(list('aabca'), categories=list('cab'))\n"
+        "    assert c1._categories_match_up_to_permutation(c2)\n"
+    )
+    site = _call_site(source, attr="_categories_match_up_to_permutation")
+    assert (
+        recognize_callee_universe(
+            "call:_categories_match_up_to_permutation", site=site
+        )
+        is CalleeUniverseSupport.PANDAS_CATEGORICAL_MATCH_UP_TO_PERMUTATION
+    )
+    payload = lift_file_payload(source, "categorical_match_covered_fixture.py")
+    assert _universe_gaps(payload) == []
+
+
+# ---------------------------------------------------------------------------
+# Lying twins — MUST refute
+# ---------------------------------------------------------------------------
+
+
+def test_lying_lookalike_receiver_of_a_different_vendor_type_stays_loud() -> None:
+    """``pd.Series`` is a real, recognized receiver-surface type (#5918), but
+    it does not expose ``to_html`` in the manifest — only ``pandas.DataFrame``
+    does. Same method name, genuinely different, unauthenticated
+    (shape, member) pair — must stay loud.
+    """
+
+    _load_manifest()
+    source = (
+        "import pandas as pd\n"
+        "\n"
+        "def test_to_html():\n"
+        "    s = pd.Series([1, 2])\n"
+        "    assert s.to_html()\n"
+    )
+    site = _call_site(source, attr="to_html")
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe(site=site) is None
+    payload = lift_file_payload(source, "series_to_html_lookalike_fixture.py")
+    gaps = _universe_gaps(payload)
+    assert len(gaps) == 1
+    assert gaps[0].ast_kind.endswith("to_html")
+
+
+def test_lying_shadowed_parameter_stays_loud() -> None:
+    """A parameter named ``df`` shadows the DataFrame-assigned local ``df``."""
+
+    _load_manifest()
+    source = (
+        "import pandas as pd\n"
+        "\n"
+        "def test_to_html(df):\n"
+        "    other = pd.DataFrame({'x': [1]})\n"
+        "    assert df.to_html()\n"
+    )
+    site = _call_site(source, attr="to_html")
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe(site=site) is None
+    payload = lift_file_payload(source, "dataframe_to_html_shadowed_fixture.py")
+    gaps = _universe_gaps(payload)
+    assert len(gaps) == 1
+
+
+def test_lying_late_rebind_stays_loud() -> None:
+    """``c1`` is reassigned to a non-authenticated value before the call
+    site. The latest visible binding for ``c1`` wins — an earlier Categorical
+    Assign does not leak through a subsequent unauthenticated rebind.
+    """
+
+    _load_manifest()
+    source = (
+        "import pandas as pd\n"
+        "\n"
+        "def test_match():\n"
+        "    c1 = pd.Categorical(list('aabca'), categories=list('abc'))\n"
+        "    c1 = replacement()\n"
+        "    c1._categories_match_up_to_permutation(other)\n"
+    )
+    site = _call_site(source, attr="_categories_match_up_to_permutation")
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe(site=site) is None
+
+
+def test_lying_aliased_lookalike_import_stays_loud() -> None:
+    """``import json as pd`` — same alias spelling, wrong module entirely."""
+
+    _load_manifest()
+    source = (
+        "import json as pd\n"
+        "\n"
+        "def test_to_html():\n"
+        "    df = pd.DataFrame({'x': [1]})\n"
+        "    df.to_html()\n"
+    )
+    site = _call_site(source, attr="to_html")
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe(site=site) is None
+
+
+def test_lying_bare_unauthenticated_receiver_stays_loud() -> None:
+    """``c1`` is a bare parameter — pandas is present in the file, but the
+    receiver was never authenticated by an Assign at all.
+    """
+
+    _load_manifest()
+    source = (
+        "import pandas as pd\n"
+        "\n"
+        "def test_match(c1, c2):\n"
+        "    assert c1._categories_match_up_to_permutation(c2)\n"
+        "    assert pd is not None\n"
+    )
+    site = _call_site(source, attr="_categories_match_up_to_permutation")
+    assert CalleeUniverseRecognition.coordinate(site) is None
+    assert recognize_callee_universe(site=site) is None
+
+
+def test_kit_manifest_unloads_cleanly_increment3() -> None:
+    _load_manifest()
+    assert recognize_native_call("pandas.Categorical") is NativeShape.PANDAS_CATEGORICAL
+    assert (
+        recognize_native_instance_call(
+            NativeShape.PANDAS_CATEGORICAL, "_categories_match_up_to_permutation"
+        )
+        == "pandas.Categorical._categories_match_up_to_permutation"
+    )
+    assert (
+        recognize_authenticated_callee_identity(
+            "pandas.Categorical._categories_match_up_to_permutation"
+        )
+        is CalleeUniverseSupport.PANDAS_CATEGORICAL_MATCH_UP_TO_PERMUTATION
+    )
+    clear_all_kit_protocols()
+    assert recognize_native_call("pandas.Categorical") is None
+    assert (
+        recognize_authenticated_callee_identity(
+            "pandas.Categorical._categories_match_up_to_permutation"
+        )
+        is None
+    )


### PR DESCRIPTION
Part of #5913

Extends the shared manifest (`kit_manifests/pandas_receiver_surface_5913.json`, plumbing landed in #5918, increment 2 in #5920) with two more member tickets:

- `call:to_html` (#5645, 18 rows est.) — DataFrame receiver only.
- `call:_categories_match_up_to_permutation` (#5646, 16 rows est.) — Categorical receiver.

With #5918's 4 and #5920's 5, that is **11 of 143 member tickets**. **132 remain loud, unclaimed.**

**Investigated and explicitly left loud, NOT claimed, this pass** (findings, not guesses):

- `call:_has_no_reference` (#5625, 48 rows est.) and `call:has_reference` (#5647, 16 rows est.) — every corpus call site is a chained attribute receiver (`df._mgr._has_no_reference(0)`, `df._mgr.blocks[0].refs.has_reference()`), never a directly-assigned/annotated name of a known vendor type. Authenticating these needs a genuine recognizer extension (BlockManager/BlockValuesRefs property-return provenance), not twins-only acceptance.
- `call:drepr` (#5632, 32 rows est.) and `call:hash` (#5642, 22 rows est.) — verified against the pinned pandas 3.0.3 test source: `drepr` is a locally-bound test-file lambda (`drepr = lambda x: x._repr_base()`), not a vendor method at all; `call:hash` is the builtin `hash(x)` function call, not `x.hash()`. These are corpus/recensus classification artifacts, not receiver-surface members — same class of finding as #5643 `call:lookup` (left unclaimed by #5920).

Also fixes a pre-existing brittle exact-equality assertion in #5918's own test (`test_kit_manifest_5913_receiver_surface.py::test_manifest_declares_the_two_claimed_members`), which already failed on current main after #5920 extended the same shared manifest file with `pandas.Index`. Narrowed to a subset check so later truthful additions to the same manifest file don't regress it.

## Twins

11 new tests (2 truthful, 6 lying, 3 manifest/sanity). Lying twins: lookalike receiver of a different vendor type (`pd.Series.to_html` — Series is a real receiver-surface type but doesn't have `to_html` in the manifest), shadowed parameter, late rebind, aliased lookalike import (`import json as pd`), bare unauthenticated receiver.

Fails-before verified by stashing the three production files (manifest JSON, `callee_universe.py`, `native_shape.py`): 4 manifest-dependent tests failed (`KitManifestError` / `AttributeError` on the new enum members), while the other 7 refutation/lying-twin tests still passed unchanged — confirming they are not accidentally coupled to the new code. 11/11 pass restored.

`R_vendor_special_case` unaffected (0), with an explicit test asserting the new FQNs are absent from `_CALL_SHAPES`/`_NATIVE_INSTANCE_CALLS`.

Not merging — leaving for coordinator soundness read.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsavo/sugar/pull/5923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add receiver-surface manifest entries for `DataFrame.to_html` and `Categorical._categories_match_up_to_permutation`
> - Adds `PANDAS_CATEGORICAL` to the `NativeShape` enum and two new callee universe entries (`PANDAS_DATAFRAME_TO_HTML`, `PANDAS_CATEGORICAL_MATCH_UP_TO_PERMUTATION`) as the third increment of the #5913 pandas member drain.
> - Updates [pandas_receiver_surface_5913.json](https://github.com/TSavo/sugar/pull/5923/files#diff-51ab40aafd19c17fd266590f9de08fb8a5dee88c17aa0798b6296af246f1deb3) with `call_shape`, `instance_call`, and `imported_callee` mappings for these two methods.
> - Adds a new test module covering manifest recognition, coverage-gap checks, lying-twin scenarios, and manifest unload behavior for this increment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13c51da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->