### PR TITLE
Thread the callee-recognition outcome into resolution_kind (#5252/#5913 audit)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/audit_only/universe_coverage.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/audit_only/universe_coverage.py
@@ -75,6 +75,7 @@ def universe_coverage_gaps(
             # Co-located floor/callsite edge sharing the Call's col_offset.
             continue
         from sugar_lift_py_tests.recognition.callee_universe import (
+            classify_callee_resolution,
             recognize_callee_universe,
         )
 
@@ -85,6 +86,9 @@ def universe_coverage_gaps(
         ):
             continue
         blame = f"{file}:{line}:{col}"
+        # Recognition already computed why this callee did not resolve
+        # (#5252/#5913 audit); record that outcome instead of discarding it.
+        resolution_kind = classify_callee_resolution(target, site=node).value
         gaps.append(
             FactoryGapInfo(
                 owner="python.factory",
@@ -97,6 +101,7 @@ def universe_coverage_gaps(
                 ),
                 gap_kind=GapKind.SUGAR,
                 gap_locus=GapLocus.CONSTRUCTION,
+                resolution_kind=resolution_kind,
             )
         )
     return gaps

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/factory/factory_gap_info.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/factory/factory_gap_info.py
@@ -37,6 +37,11 @@ class FactoryGapInfo:
     fix: str
     gap_kind: GapKind = GapKind.SUGAR
     gap_locus: GapLocus = GapLocus.AST
+    # Recognition outcome already computed for this gap's callee, when the
+    # producer has one (#5252/#5913 audit — recognize_callee_universe threw
+    # this away once it decided pass/fail). Empty string when the producer
+    # does not (yet) compute a callee resolution — never invented downstream.
+    resolution_kind: str = ""
 
     def __post_init__(self) -> None:
         if not isinstance(self.gap_kind, GapKind):
@@ -67,6 +72,7 @@ class FactoryGapInfo:
             "observed": self.observed,
             "requested": self.requested,
             "fix": self.fix,
+            "resolution_kind": self.resolution_kind,
             "gap_kind": gap_kind_label(self.gap_kind),
             "gap_locus": gap_locus_label(self.gap_locus),
         }

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/factory_walk_unclassified_locus.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/factory_walk_unclassified_locus.py
@@ -15,10 +15,20 @@ Every unclassified / unresolved walk row MUST retain a locus object:
       "role": "<requested factory role: statement|term|...>",
       "reason": "<why walk left the row unclassified>",
       "file": "<repo-relative path>",
-      "line": 1234
+      "line": 1234,
+      "resolution_kind": "<recognizer's own resolution outcome, or '' when the producer computes none>"
     }
 
 Canonical print form: ``file:line`` (e.g. ``pandas/core/frame.py:1234``).
+
+``resolution_kind`` (#5252/#5913 audit) carries the recognition outcome
+``recognize_callee_universe`` already computed and previously discarded once
+it decided pass/fail — e.g. ``imported_unresolved`` (resolves to an imported/
+assigned definition but no recognizer family covers it — the genuine drain
+frontier), ``local_binding``, ``builtin``, ``chained_receiver``, or
+``unresolved_other``. It is additive: empty when a producer (e.g. a
+conservation-violation gap) computes no callee resolution. Its presence
+never changes ``factory_walk_statuses.unclassified`` or the locus count.
 
 Acceptance for next recensus producer:
 1. ``factory_walk_statuses.unclassified`` equals the count of locus rows.
@@ -52,6 +62,11 @@ LOCUS_FIELD_NAMES = (
     "reason",
     "file",
     "line",
+    # Recognition outcome for this row's callee, when a producer computes one
+    # (#5252/#5913 audit). Additive only: empty string when a producer does
+    # not carry it, never required for addressability (locus_is_addressable
+    # does not gate on it), so its presence never changes any count.
+    "resolution_kind",
 )
 
 
@@ -98,6 +113,10 @@ def project_unclassified_locus(row: Any) -> dict[str, Any] | None:
             or ""
         )
         reason = row.get("reason") or ""
+        extra = row.get("extra") if isinstance(row.get("extra"), Mapping) else {}
+        resolution_kind = row.get("resolution_kind") or extra.get(
+            "resolution_kind"
+        ) or ""
     else:
         file = getattr(row, "file", None) or getattr(row, "path", None) or ""
         line = getattr(row, "line", None)
@@ -112,6 +131,11 @@ def project_unclassified_locus(row: Any) -> dict[str, Any] | None:
             or ""
         )
         reason = getattr(row, "reason", None) or ""
+        row_extra = getattr(row, "extra", None)
+        extra = row_extra if isinstance(row_extra, Mapping) else {}
+        resolution_kind = (
+            getattr(row, "resolution_kind", None) or extra.get("resolution_kind") or ""
+        )
 
     try:
         line_int = int(line) if line is not None and line != "" else 0
@@ -128,6 +152,7 @@ def project_unclassified_locus(row: Any) -> dict[str, Any] | None:
         "reason": str(reason),
         "file": str(file),
         "line": line_int,
+        "resolution_kind": str(resolution_kind),
     }
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2363,6 +2363,10 @@ def _factory_walk_red_from_gap(
         "blame": blame,
         "gap_kind": str(gap.info.get("gap_kind") or ""),
         "gap_locus": str(gap.info.get("gap_locus") or ""),
+        # Recognition outcome already computed for this callee's gap, when
+        # the producer computes one (#5252/#5913 audit). Empty when the
+        # producer (e.g. conservation violations) has no callee to classify.
+        "resolution_kind": str(gap.info.get("resolution_kind") or ""),
     }
     if recovered_owner_span is not None:
         extra.update(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/callee_universe.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import builtins as _builtins_module
 from enum import Enum, auto
 
 from sugar_lift_python_source.source_tables import locate_parsed_node, parsed_parents
@@ -443,6 +444,113 @@ def recognize_callee_universe(
     if not _target_matches_call(target, identity, site):
         return None
     return support
+
+
+class CalleeResolutionKind(str, Enum):
+    """Why a call-site coordinate did or did not resolve (#5252/#5913 audit).
+
+    ``recognize_callee_universe`` already computes local-binding, imported-
+    identity, and receiver-shape testimony on every call before deciding pass
+    or fail; it discarded that testimony once the boolean answer was made.
+    This is the same testimony, kept, as a coarse partition:
+
+    * ``RECOGNIZED`` — ``recognize_callee_universe`` already accepted it; not
+      an unclassified-locus row at all.
+    * ``IMPORTED_UNRESOLVED`` — resolves to an imported/assigned definition
+      (vendor or otherwise) but no recognizer family covers it. This is the
+      genuine drain frontier.
+    * ``LOCAL_BINDING`` — resolves to a local FunctionDef/Lambda/for-unpacked
+      binding, not a vendor method.
+    * ``BUILTIN`` — the call leaf is a Python builtin (``hash``, ``repr``,
+      …), not a vendor method, even when no production recognizer claims it.
+    * ``CHAINED_RECEIVER`` — the receiver is an Attribute/Call expression
+      (``a.b.c.method()``), not a bindable Name; needs a different partition
+      than a name-rooted call.
+    * ``UNRESOLVED_OTHER`` — none of the above testified; named explicitly so
+      it is never silently folded into one of the other classes.
+    """
+
+    RECOGNIZED = "recognized"
+    IMPORTED_UNRESOLVED = "imported_unresolved"
+    LOCAL_BINDING = "local_binding"
+    BUILTIN = "builtin"
+    CHAINED_RECEIVER = "chained_receiver"
+    UNRESOLVED_OTHER = "unresolved_other"
+
+
+def classify_callee_resolution(
+    target: str | None, *, site
+) -> CalleeResolutionKind:
+    """Classify the recognition outcome already computed for ``site``.
+
+    Reuses exactly the structural provenance ``recognize_callee_universe``
+    itself calls (``_local_source_function_identity``, ``_result_call_
+    identity``, ``_bound_source_callable_identity``, ``call_receiver``) —
+    no new predicate, no scan, no vendor-name matching. Never claims
+    ``RECOGNIZED`` unless the recognizer itself accepted the call, and never
+    claims ``IMPORTED_UNRESOLVED``/``BUILTIN``/``LOCAL_BINDING`` for a call
+    the recognizer already resolved.
+    """
+
+    if site is None or getattr(site, "observed", None) != "Call":
+        return CalleeResolutionKind.UNRESOLVED_OTHER
+    if recognize_callee_universe(target, site=site) is not None:
+        return CalleeResolutionKind.RECOGNIZED
+    receiver = site.call_receiver()
+    if receiver is not None and receiver.observed != "Name":
+        # Attribute/Call chain receiver: not a bindable name at all.
+        return CalleeResolutionKind.CHAINED_RECEIVER
+    if receiver is None and (
+        _local_source_function_identity(site) is not None
+        or _bare_call_binds_locally(site)
+    ):
+        return CalleeResolutionKind.LOCAL_BINDING
+    identity = _result_call_identity(site)
+    if identity is None and receiver is None:
+        identity = _bound_source_callable_identity(site)
+    if identity is not None:
+        # Resolved to an imported/assigned definition; no recognizer family
+        # claims it. This is the genuine drain frontier.
+        return CalleeResolutionKind.IMPORTED_UNRESOLVED
+    leaf = site.call_target_name()
+    if leaf is not None and hasattr(_builtins_module, leaf):
+        return CalleeResolutionKind.BUILTIN
+    return CalleeResolutionKind.UNRESOLVED_OTHER
+
+
+def _bare_call_binds_locally(site) -> bool:
+    """True when a bare call's name is bound by a FunctionDef/Lambda-Assign.
+
+    Same declaration testimony ``_local_source_function_identity`` reads
+    (nested ``FunctionDef`` / ``Assign`` of a ``Lambda``), but without that
+    function's stricter "function-local" requirement: a module-level
+    test-file helper (``drepr = lambda x: ...`` at module scope, then used
+    inside a ``test_*`` function) is still a local, non-vendor binding even
+    though it is not lexically local to the enclosing function.
+    """
+
+    if site is None or site.observed != "Call" or site.call_receiver() is not None:
+        return False
+    target = site.call_target_name()
+    if target is None:
+        return False
+    declarations, shadowed_parameters = visible_declarations(site)
+    if target in shadowed_parameters:
+        return False
+    bound = False
+    for declaration in declarations:
+        if declaration.observed in {"FunctionDef", "AsyncFunctionDef"}:
+            if declaration.function_name() == target:
+                bound = True
+            continue
+        if target not in declaration.stored_or_deleted_names():
+            continue
+        bound = (
+            declaration.observed == "Assign"
+            and declaration.stored_or_deleted_names() == frozenset({target})
+            and declaration.assign_value().observed == "Lambda"
+        )
+    return bound
 
 
 def _target_matches_call(target: str | None, coordinate: str | None, site) -> bool:
@@ -1407,8 +1515,10 @@ def _source_path(statement):
 
 
 __all__ = [
+    "CalleeResolutionKind",
     "CalleeUniverseRecognition",
     "CalleeUniverseSupport",
+    "classify_callee_resolution",
     "clear_dtype_result_protocol",
     "clear_imported_callee_protocol",
     "imported_call_identity",

--- a/implementations/python/sugar-lift-py-tests/tests/test_callee_resolution_kind_5252.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_callee_resolution_kind_5252.py
@@ -1,0 +1,213 @@
+"""Prove ``resolution_kind`` carries the recognizer's own discarded testimony.
+
+#5252/#5913 audit: ``recognize_callee_universe`` already computes local-
+binding, imported-identity, and receiver-shape testimony on every call before
+deciding pass/fail, then threw the testimony away once the boolean answer was
+made. ``classify_callee_resolution`` keeps that same testimony as a coarse
+partition; ``FactoryGapInfo``/``universe_coverage_gaps``/the unclassified
+locus schema thread it through instead of discarding it again.
+
+Fixtures are the four confirmed classes from the audit:
+
+- ``pd.DataFrame.lookup`` — removed vendor API: resolves to an imported
+  definition, no recognizer family covers it -> ``imported_unresolved``.
+- a locally-bound test lambda -> ``local_binding``.
+- ``hash(x)`` — a Python builtin, not a vendor method -> ``builtin``.
+- ``a.b.c.method()`` — receiver is a chained attribute expression, not a
+  bindable name -> ``chained_receiver``.
+
+Each test also proves recognize_callee_universe itself returns None for the
+fixture (i.e. it is genuinely an unclassified-locus candidate, not something
+already recognized under a different name).
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from sugar_lift_py_tests.canonicalizer import blake3_512_of
+from sugar_lift_py_tests.factory.factory_gap_info import FactoryGapInfo, GapKind, GapLocus
+from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+from sugar_lift_py_tests.idd.factory_walk_unclassified_locus import (
+    locus_is_addressable,
+    project_unclassified_locus,
+)
+from sugar_lift_py_tests.kit_rpc.factory_walk_row_dto import (
+    FactoryWalkRedRowDto,
+    FactoryWalkStatus,
+)
+from sugar_lift_py_tests.kit_rpc.source_memento_dto import SourceMementoDto
+from sugar_lift_py_tests.kit_rpc.source_span_dto import SourceSpanDto
+from sugar_lift_py_tests.recognition.callee_universe import (
+    CalleeResolutionKind,
+    classify_callee_resolution,
+    recognize_callee_universe,
+)
+
+
+def _call_site(source: str, *, attr: str | None = None, name: str | None = None):
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+        if attr and isinstance(node.func, ast.Attribute) and node.func.attr == attr:
+            return SourceFragment.from_node(node, "t.py", source=source)
+        if name and isinstance(node.func, ast.Name) and node.func.id == name:
+            return SourceFragment.from_node(node, "t.py", source=source)
+    raise AssertionError("no matching Call site in fixture source")
+
+
+IMPORTED_UNRESOLVED_SOURCE = (
+    "import pandas as pd\n"
+    "\n"
+    "def test_lookup(rows, cols):\n"
+    "    df = pd.DataFrame({'a': [1, 2]})\n"
+    "    assert df.lookup(rows, cols) is not None\n"
+)
+
+LOCAL_BINDING_SOURCE = (
+    # Module-level test-file helper lambda (the #5923 corpus shape): assigned
+    # outside any enclosing function, so it is source-bound but not
+    # *function*-local — recognize_callee_universe's BOUND_SOURCE_CALLABLE
+    # path requires the Lambda assign to be function-local and stays loud,
+    # yet the call is still, structurally, a local (non-vendor) binding.
+    "drepr = lambda x: x._repr_base()\n"
+    "\n"
+    "def test_drepr(value):\n"
+    "    assert drepr(value) == value\n"
+)
+
+BUILTIN_SOURCE = "def test_hash(value):\n    assert hash(value) != 0\n"
+
+CHAINED_RECEIVER_SOURCE = (
+    "def test_chained(a):\n    assert a.b.c.method() is not None\n"
+)
+
+
+@pytest.mark.parametrize(
+    ("source", "callee_leaf", "expected"),
+    [
+        (
+            IMPORTED_UNRESOLVED_SOURCE,
+            "lookup",
+            CalleeResolutionKind.IMPORTED_UNRESOLVED,
+        ),
+        (LOCAL_BINDING_SOURCE, "drepr", CalleeResolutionKind.LOCAL_BINDING),
+        (BUILTIN_SOURCE, "hash", CalleeResolutionKind.BUILTIN),
+        (
+            CHAINED_RECEIVER_SOURCE,
+            "method",
+            CalleeResolutionKind.CHAINED_RECEIVER,
+        ),
+    ],
+)
+def test_classify_callee_resolution_per_class(source, callee_leaf, expected) -> None:
+    site = _call_site(source, attr=callee_leaf, name=callee_leaf)
+    target = f"call:{callee_leaf}"
+
+    # Genuinely unclassified: the existing recognizer does not accept it.
+    assert recognize_callee_universe(target, site=site) is None
+
+    assert classify_callee_resolution(target, site=site) is expected
+
+
+def test_recognized_call_never_reclassified_as_unresolved() -> None:
+    """A call the recognizer already accepts must classify as RECOGNIZED.
+
+    ``re.compile('x').search(value)`` is a known-recognized surface method
+    (regex search) — proves classify_callee_resolution never mislabels an
+    accepted call as one of the unresolved classes.
+    """
+    source = (
+        "import re\n"
+        "\n"
+        "def test_search(value):\n"
+        "    pattern = re.compile('x')\n"
+        "    assert pattern.search(value) is not None\n"
+    )
+    site = _call_site(source, attr="search")
+    target = "call:search"
+
+    assert recognize_callee_universe(target, site=site) is not None
+    assert (
+        classify_callee_resolution(target, site=site)
+        is CalleeResolutionKind.RECOGNIZED
+    )
+
+
+def test_factory_gap_info_carries_resolution_kind_in_to_json() -> None:
+    info = FactoryGapInfo(
+        owner="python.factory",
+        blame="t.py:2:0",
+        observed="call:lookup",
+        requested="callee universe coverage",
+        fix="add builtin-universe recognizer",
+        gap_kind=GapKind.SUGAR,
+        gap_locus=GapLocus.CONSTRUCTION,
+        resolution_kind=CalleeResolutionKind.IMPORTED_UNRESOLVED.value,
+    )
+    assert info.to_json()["resolution_kind"] == "imported_unresolved"
+
+
+def test_factory_gap_info_defaults_resolution_kind_empty() -> None:
+    """Producers that never computed a callee resolution stay honestly empty."""
+    info = FactoryGapInfo(
+        owner="python.factory",
+        blame="t.py:2:0",
+        observed="Assign",
+        requested="source→factory classification",
+        fix="remove the pre-factory skip or classify an explicit boundary",
+        gap_kind=GapKind.SUGAR,
+        gap_locus=GapLocus.CONSTRUCTION,
+    )
+    assert info.to_json()["resolution_kind"] == ""
+
+
+def _red_row(*, ast_kind: str, resolution_kind: str) -> FactoryWalkRedRowDto:
+    memento = SourceMementoDto(
+        file="t.py",
+        span=SourceSpanDto(start_line=2, start_col=0, end_line=2, end_col=0),
+        source_cid=blake3_512_of(b""),
+    )
+    return FactoryWalkRedRowDto(
+        file="t.py",
+        line=2,
+        requested_role="callee universe coverage",
+        ast_kind=ast_kind,
+        selected=None,
+        status=FactoryWalkStatus.UNCLASSIFIED,
+        output="SUGAR_GAP",
+        source_memento=memento,
+        reason="no universe sugar for this callee",
+        extra={"resolution_kind": resolution_kind},
+    )
+
+
+def test_unclassified_locus_projects_resolution_kind_from_extra() -> None:
+    row = _red_row(ast_kind="call:lookup", resolution_kind="imported_unresolved")
+    locus = project_unclassified_locus(row)
+    assert locus is not None
+    assert locus["resolution_kind"] == "imported_unresolved"
+    # Addressability is unaffected by the new field — never gates on it.
+    assert locus_is_addressable(locus)
+
+
+def test_unclassified_locus_resolution_kind_empty_when_absent() -> None:
+    row = _red_row(ast_kind="call:whatever", resolution_kind="")
+    row = FactoryWalkRedRowDto(
+        file=row.file,
+        line=row.line,
+        requested_role=row.requested_role,
+        ast_kind=row.ast_kind,
+        selected=row.selected,
+        status=row.status,
+        output=row.output,
+        source_memento=row.source_memento,
+        reason=row.reason,
+        extra={},
+    )
+    locus = project_unclassified_locus(row)
+    assert locus is not None
+    assert locus["resolution_kind"] == ""
+    assert locus_is_addressable(locus)


### PR DESCRIPTION
Part of #5252

`recognize_callee_universe` already computes local-binding, imported-identity, and receiver-shape testimony for every unresolved callee before deciding pass/fail — then discarded that testimony once it had the boolean answer. A removed vendor API, a locally-bound test lambda, a builtin, and a chained-receiver method were indistinguishable on the emitted unclassified locus row: the `reason` field is a fixed template identical for every failure class.

## What this adds

- `CalleeResolutionKind` + `classify_callee_resolution` in `recognition/callee_universe.py`, reusing the exact structural provenance the recognizer itself already reads (`_local_source_function_identity`, `_result_call_identity`, `_bound_source_callable_identity`, `call_receiver`) — no new scan, no vendor-name matching, no invented category.
- `FactoryGapInfo.resolution_kind` (additive, default `""`).
- `universe_coverage_gaps` (`audit_only/universe_coverage.py`) computes it for every gap it emits.
- `lift_rpc.py`'s row projection threads it into the factory-walk red row's `extra` dict.
- `idd/factory_walk_unclassified_locus.py` projects it onto the locus schema (new optional field, not required for `locus_is_addressable`).

## Classes (what the recognizer genuinely supports)

- `imported_unresolved` — resolves to an imported/assigned definition (vendor or otherwise) but no recognizer family covers it. **This is the genuine drain frontier.**
- `local_binding` — resolves to a local FunctionDef/Lambda/for-unpacked binding (including module-level test-file helpers, not just function-local ones), not a vendor method.
- `builtin` — the call leaf is a Python builtin (checked via `builtins` introspection), not a vendor method, even when no production recognizer table claims it.
- `chained_receiver` — receiver is an Attribute/Call expression (`a.b.c.method()`), not a bindable Name.
- `unresolved_other` — named explicitly rather than silently folded into another class.
- `recognized` — guard value; never emitted on a gap row (gaps only exist when `recognize_callee_universe` already returned `None`), proven by a dedicated test so the classifier never mislabels an accepted call.

## Twins

`tests/test_callee_resolution_kind_5252.py`, using the audit's confirmed fixtures:
- `pd.DataFrame.lookup` (removed API) → `imported_unresolved`
- a module-level test-file lambda → `local_binding`
- `hash(x)` → `builtin`
- `a.b.c.method()` → `chained_receiver`
- a recognized call (`re.compile('x').search(...)`) → `recognized`, never one of the unresolved classes
- `FactoryGapInfo.to_json()` carries `resolution_kind`; defaults to `""` when a producer computes none
- locus projection carries `resolution_kind` from the row's `extra` dict, and `locus_is_addressable` is unaffected by its presence/absence

**Fails-before verified**: reverting the change causes `ImportError: cannot import name 'CalleeResolutionKind'` on test collection.

## Counts unchanged

Ran the affected suites (`test_universe_coverage_gap.py`, `test_builtin_callee_universe_sugar.py`, `test_source_path_locus_index.py`) with the change stashed out and restored: identical pre-existing failures both times (36 in the first group, 2 in the second), pass counts differ only by the 9 new tests in this PR. No row is added, removed, or reclassified — the field is purely additive telemetry on gaps the code already emitted.

Not merging — coordinator merges after a soundness read.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Thread callee-recognition outcome into `resolution_kind` for callee-universe gap auditing
> - Adds a `CalleeResolutionKind` enum and `classify_callee_resolution` function in [`callee_universe.py`](https://github.com/TSavo/sugar/pull/5925/files#diff-72e9f915afa350390348a1c277d0c2047b26a0182bb4780c57baf73f30fdcaa8) to classify call sites as recognized, imported-unresolved, local binding, builtin, chained receiver, or other.
> - Adds a `resolution_kind` field to [`FactoryGapInfo`](https://github.com/TSavo/sugar/pull/5925/files#diff-9514f90ab65b3bf3751ed83c7852a96672b4255b935996ca2b3d2bbbcbaa5645), populated via `classify_callee_resolution` in [`universe_coverage.py`](https://github.com/TSavo/sugar/pull/5925/files#diff-7ebc06dd7d5535234c84a3fde5ff86ed07305340e7a60cd9378f765aed76b7b5) and serialized in `to_json`.
> - Propagates `resolution_kind` through [`lift_rpc.py`](https://github.com/TSavo/sugar/pull/5925/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) into `FactoryWalkRedRowDto.extra` and through [`factory_walk_unclassified_locus.py`](https://github.com/TSavo/sugar/pull/5925/files#diff-db8ef8c5a5b27b72879a4464f03f447e6e4ea527b49ad1242ed6bfff844b0e76) into unclassified locus dicts.
> - Adds parametrized unit tests in [`test_callee_resolution_kind_5252.py`](https://github.com/TSavo/sugar/pull/5925/files#diff-67ffb4d39334697a69a583b35d4cd09cfa50824ce637f3589052f6670a56358b) covering classification and end-to-end propagation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64c2095.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->