### PR TITLE
Add R_source_via_execution baseline-free floor (#5930)

### DIFF
--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -134,3 +134,14 @@ jobs:
         run: >-
           python
           implementations/python/sugar-lift-py-tests/scripts/construction_cache_context_law.py
+      - name: R_source_via_execution discrimination
+        if: always()
+        run: >-
+          python -m pytest --noconftest
+          implementations/python/sugar-lift-py-tests/tests/test_source_via_execution_law.py
+          -q
+      - name: R_source_via_execution = 0
+        if: always()
+        run: >-
+          python
+          implementations/python/sugar-lift-py-tests/scripts/source_via_execution_law.py

--- a/implementations/python/sugar-lift-py-tests/scripts/source_via_execution_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/source_via_execution_law.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""R_source_via_execution — permanent baseline-free floor (#5930, split from #5928).
+
+Recognition answers the STATIC question "what does this name refer to?" by
+IMPORTING the module and reading a live object. That runs arbitrary
+third-party C extension code inside the lifting process, makes the answer
+depend on environment and corpus ORDER (not on the source under test), and is
+the mechanism behind the intermittent SIGSEGV in #5928.
+
+This floor censuses every ``importlib.import_module`` / ``importlib.util.find_spec``
+/ ``__import__`` call reachable from recognition, factory, and sugar dispatch,
+outside the one mechanically-legitimate self-import.
+
+Legitimate non-executing form: ``importlib.machinery.PathFinder.find_spec(name,
+search_path)`` locates a spec WITHOUT importing parent packages or the target.
+That is not scanned — only the executing forms are.
+
+Exit 1 whenever R_source_via_execution > 0. There is no baseline, threshold, or
+allowlist. The single mechanically-legitimate site (``factory/build.py``
+self-registering our own sugar package) is excluded by MECHANISM: its import
+target's statically-known prefix names the very top-level package the scanned
+source lives under -- never by matching a hardcoded path or string.
+
+Planted-twin discrimination lives in
+``tests/test_source_via_execution_law.py`` and must survive relocation into a
+helper function, a mapping/registry literal, a getattr indirection, an
+aliased import, or a late import inside a function body.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+import traceback
+from pathlib import Path
+from typing import NamedTuple, Sequence
+
+_EXECUTING_KINDS = frozenset(
+    {
+        "import-module-call",
+        "find-spec-call",
+        "dunder-import-call",
+    }
+)
+
+
+class SourceViaExecution(NamedTuple):
+    path: str
+    line: int
+    kind: str
+    target: str
+    expression: str
+    note: str
+
+
+def _qualified_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _qualified_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return ""
+
+
+def _static_prefix(node: ast.AST) -> str | None:
+    """The longest statically-known leading literal of a string expression.
+
+    A plain ``Constant`` string is fully known. An f-string (``JoinedStr``) is
+    known up to its first dynamic (``FormattedValue``) chunk -- everything
+    before that is a real, unavoidable literal prefix of whatever the whole
+    string resolves to at runtime.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        parts: list[str] = []
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+            else:
+                break
+        return "".join(parts) if parts else None
+    return None
+
+
+class _AliasTable:
+    """Maps a bound local name to the canonical dotted importlib coordinate it
+    was imported/assigned from -- so aliasing, ``from`` imports, and simple
+    rebinding cannot hide an executing call from the census.
+    """
+
+    def __init__(self) -> None:
+        self.table: dict[str, str] = {}
+
+    def add(self, name: str, canonical: str) -> None:
+        self.table[name] = canonical
+
+    def canonicalize(self, qualified: str) -> str:
+        if not qualified:
+            return qualified
+        parts = qualified.split(".")
+        head = parts[0]
+        canon_head = self.table.get(head, head)
+        return ".".join([canon_head, *parts[1:]]) if parts[1:] else canon_head
+
+
+def _build_alias_table(tree: ast.AST) -> _AliasTable:
+    aliases = _AliasTable()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.asname:
+                    # `import importlib.util as u` binds `u` -> `importlib.util`.
+                    aliases.add(alias.asname, alias.name)
+                # `import importlib.util` (no asname) binds the head name
+                # `importlib` to itself -- already the identity default, so
+                # no table entry is needed (and adding one would be wrong:
+                # it must NOT become `importlib` -> `importlib.util`).
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                bound = alias.asname or alias.name
+                aliases.add(bound, f"{node.module}.{alias.name}")
+        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, ast.Name):
+                value = node.value
+                qualified = _qualified_name(value)
+                canonical = aliases.canonicalize(qualified) if qualified else ""
+                if canonical in (
+                    "importlib.import_module",
+                    "importlib.util.find_spec",
+                    "__import__",
+                    "builtins.__import__",
+                ):
+                    aliases.add(target.id, canonical)
+                elif (
+                    isinstance(value, ast.Call)
+                    and isinstance(value.func, ast.Name)
+                    and value.func.id == "getattr"
+                    and len(value.args) >= 2
+                ):
+                    # `loader = getattr(importlib, "import_module")` --
+                    # rebinding a name to the RESULT of a getattr lookup is
+                    # the same indirection as calling getattr(...) directly;
+                    # the alias table must resolve `loader(...)` too.
+                    base_qualified = _qualified_name(value.args[0])
+                    base_canonical = (
+                        aliases.canonicalize(base_qualified) if base_qualified else ""
+                    )
+                    attr_node = value.args[1]
+                    if isinstance(attr_node, ast.Constant) and isinstance(
+                        attr_node.value, str
+                    ):
+                        attr = attr_node.value
+                        if base_canonical == "importlib" and attr == "import_module":
+                            aliases.add(target.id, "importlib.import_module")
+                        elif (
+                            base_canonical == "importlib.util"
+                            and attr == "find_spec"
+                        ):
+                            aliases.add(target.id, "importlib.util.find_spec")
+    return aliases
+
+
+def _classify_call(
+    node: ast.Call, aliases: _AliasTable
+) -> tuple[str, str] | None:
+    """Return (kind, resolved-target) for an executing importlib call, else None."""
+    func = node.func
+
+    # Direct / aliased / from-imported callable: foo(...) where foo resolves
+    # to importlib.import_module / importlib.util.find_spec / __import__.
+    qualified = _qualified_name(func)
+    if qualified:
+        canonical = aliases.canonicalize(qualified)
+        if canonical == "importlib.import_module":
+            return "import-module-call", canonical
+        if canonical == "importlib.util.find_spec":
+            return "find-spec-call", canonical
+        if canonical in ("__import__", "builtins.__import__"):
+            return "dunder-import-call", canonical
+
+    # getattr(importlib, "import_module")(...) / getattr(importlib.util,
+    # "find_spec")(...) -- indirection that a plain qualified-name walk misses.
+    if isinstance(func, ast.Call):
+        inner = func.func
+        if isinstance(inner, ast.Name) and inner.id == "getattr" and len(func.args) >= 2:
+            base_qualified = _qualified_name(func.args[0])
+            base_canonical = aliases.canonicalize(base_qualified) if base_qualified else ""
+            attr_node = func.args[1]
+            if isinstance(attr_node, ast.Constant) and isinstance(attr_node.value, str):
+                attr = attr_node.value
+                if base_canonical == "importlib" and attr == "import_module":
+                    return "import-module-call", f"getattr({base_canonical!r}, {attr!r})"
+                if base_canonical == "importlib.util" and attr == "find_spec":
+                    return "find-spec-call", f"getattr({base_canonical!r}, {attr!r})"
+    return None
+
+
+def _own_package_name(root: Path) -> str:
+    """The top-level package that owns this scan root, derived from layout.
+
+    Scan roots are direct children of the package directory
+    (``src/<package>/sugar``, ``src/<package>/factory``, ...) -- the package
+    name is read off the filesystem, never hardcoded.
+    """
+    return root.parent.name
+
+
+def _is_legitimate_self_import(node: ast.Call, own_package: str) -> bool:
+    """Mechanical exemption: the import target's statically-known prefix
+    names our OWN top-level package, not a third-party module under test.
+
+    Never matches a hardcoded path or literal package name -- ``own_package``
+    is read off the filesystem layout of the scan root being audited.
+    """
+    if not node.args:
+        return False
+    prefix = _static_prefix(node.args[0])
+    if prefix is None:
+        return False
+    if prefix == own_package or prefix.startswith(f"{own_package}."):
+        return True
+    # Relative coordinate (``.submodule``) resolved against ``__name__`` is,
+    # by construction, always a submodule of the CALLING module's own
+    # package -- there is no third-party spelling that can satisfy this
+    # shape, so it is a mechanical (not name-based) self-import proof.
+    if prefix.startswith("."):
+        package_arg = node.args[1] if len(node.args) >= 2 else None
+        if isinstance(package_arg, ast.Name) and package_arg.id == "__name__":
+            return True
+    return False
+
+
+def _safe_unparse(node: ast.AST) -> str:
+    try:
+        return ast.unparse(node)
+    except Exception as exc:  # noqa: BLE001 -- auditor must not crash
+        return f"<unparse-failed:{type(exc).__name__}>"
+
+
+def _rel_path(root: Path, path: Path) -> str:
+    try:
+        rel = path.resolve().relative_to(root.resolve())
+    except ValueError:
+        rel = Path(path.name)
+    return f"{root.name}/{rel.as_posix()}"
+
+
+def _read_source(path: Path) -> tuple[str | None, SourceViaExecution | None]:
+    try:
+        return path.read_text(encoding="utf-8"), None
+    except UnicodeDecodeError:
+        try:
+            return path.read_text(encoding="utf-8-sig"), None
+        except UnicodeDecodeError:
+            try:
+                return path.read_text(encoding="utf-8", errors="replace"), None
+            except OSError as exc:
+                return None, SourceViaExecution(
+                    path=path.as_posix(),
+                    line=0,
+                    kind="auditor-read-error",
+                    target="-",
+                    expression=type(exc).__name__,
+                    note=f"could not read source after utf-8 fallback: {exc}",
+                )
+    except OSError as exc:
+        return None, SourceViaExecution(
+            path=path.as_posix(),
+            line=0,
+            kind="auditor-read-error",
+            target="-",
+            expression=type(exc).__name__,
+            note=f"could not read source: {exc}",
+        )
+
+
+def scan_file(path: Path, *, rel: str, own_package: str) -> list[SourceViaExecution]:
+    offenders: list[SourceViaExecution] = []
+    source, read_error = _read_source(path)
+    if read_error is not None:
+        return [read_error._replace(path=rel)]
+    assert source is not None
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        return [
+            SourceViaExecution(
+                path=rel,
+                line=int(exc.lineno or 0),
+                kind="auditor-parse-error",
+                target="-",
+                expression=type(exc).__name__,
+                note=f"ast.parse failed: {exc.msg}",
+            )
+        ]
+    except Exception as exc:  # noqa: BLE001
+        return [
+            SourceViaExecution(
+                path=rel,
+                line=0,
+                kind="auditor-parse-error",
+                target="-",
+                expression=type(exc).__name__,
+                note=f"ast.parse failed: {exc}",
+            )
+        ]
+
+    try:
+        aliases = _build_alias_table(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            classified = _classify_call(node, aliases)
+            if classified is None:
+                continue
+            kind, target = classified
+            if _is_legitimate_self_import(node, own_package):
+                continue
+            offenders.append(
+                SourceViaExecution(
+                    path=rel,
+                    line=getattr(node, "lineno", 0) or 0,
+                    kind=kind,
+                    target=target,
+                    expression=_safe_unparse(node),
+                    note=(
+                        "recognition must answer 'what does this name refer "
+                        "to' by reading source (SourceOracle / "
+                        "PathFinder.find_spec), never by importing and "
+                        "executing the target"
+                    ),
+                )
+            )
+    except Exception as exc:  # noqa: BLE001 -- per-file containment
+        offenders.append(
+            SourceViaExecution(
+                path=rel,
+                line=0,
+                kind="auditor-scan-error",
+                target="-",
+                expression=type(exc).__name__,
+                note=f"scan aborted for file: {exc}",
+            )
+        )
+
+    deduped: list[SourceViaExecution] = []
+    seen: set[tuple[str, int, str, str, str]] = set()
+    for row in offenders:
+        key = (row.path, row.line, row.kind, row.target, row.expression)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(row)
+    return deduped
+
+
+def scan_roots(roots: Sequence[Path]) -> list[SourceViaExecution]:
+    offenders: list[SourceViaExecution] = []
+    for root in roots:
+        try:
+            root_resolved = root.resolve()
+        except OSError as exc:
+            offenders.append(
+                SourceViaExecution(
+                    path=str(root),
+                    line=0,
+                    kind="auditor-root-error",
+                    target="-",
+                    expression=type(exc).__name__,
+                    note=f"could not resolve scan root: {exc}",
+                )
+            )
+            continue
+        if not root_resolved.is_dir():
+            offenders.append(
+                SourceViaExecution(
+                    path=str(root),
+                    line=0,
+                    kind="auditor-root-error",
+                    target="-",
+                    expression="NotADirectory",
+                    note=f"scan root is not a directory: {root_resolved}",
+                )
+            )
+            continue
+        own_package = _own_package_name(root_resolved)
+        try:
+            paths = sorted(root_resolved.rglob("*.py"))
+        except OSError as exc:
+            offenders.append(
+                SourceViaExecution(
+                    path=str(root),
+                    line=0,
+                    kind="auditor-root-error",
+                    target="-",
+                    expression=type(exc).__name__,
+                    note=f"rglob failed: {exc}",
+                )
+            )
+            continue
+        for path in paths:
+            if not path.is_file():
+                continue
+            rel = _rel_path(root_resolved, path)
+            offenders.extend(scan_file(path, rel=rel, own_package=own_package))
+    return sorted(offenders)
+
+
+def r_source_via_execution(offenders: Sequence[SourceViaExecution]) -> int:
+    return sum(1 for row in offenders if row.kind in _EXECUTING_KINDS)
+
+
+def r_auditor_errors(offenders: Sequence[SourceViaExecution]) -> int:
+    return sum(1 for row in offenders if row.kind.startswith("auditor-"))
+
+
+def format_report(offenders: Sequence[SourceViaExecution]) -> str:
+    lines = [
+        f"R_source_via_execution = {r_source_via_execution(offenders)}",
+        f"auditor_errors = {r_auditor_errors(offenders)}",
+        (
+            "Replacement: SourceOracle (installed_module_source) for text, "
+            "importlib.machinery.PathFinder.find_spec(name, search_path) for "
+            "existence/origin -- never importlib.import_module / "
+            "importlib.util.find_spec / __import__ on third-party source."
+        ),
+        "",
+        "Loci:",
+    ]
+    for row in offenders:
+        lines.append(
+            f"{row.path}:{row.line}:{row.kind}:target={row.target} — "
+            f"{row.expression} — {row.note}"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    package = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "sugar_lift_py_tests"
+    )
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "roots",
+        nargs="*",
+        type=Path,
+        default=[
+            package / "sugar",
+            package / "factory",
+            package / "recognition",
+            package / "floor",
+        ],
+    )
+    try:
+        args = parser.parse_args(argv)
+        offenders = scan_roots(args.roots)
+    except Exception as exc:  # noqa: BLE001
+        print(
+            "SOURCE-VIA-EXECUTION LAW ERROR: unhandled auditor failure "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        print(traceback.format_exc(), file=sys.stderr)
+        print(
+            json.dumps(
+                {
+                    "instrument": "R_source_via_execution",
+                    "ok": False,
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                    "R_source_via_execution": None,
+                    "auditor_errors": 1,
+                }
+            )
+        )
+        return 2
+
+    r = r_source_via_execution(offenders)
+    err = r_auditor_errors(offenders)
+    summary = {
+        "instrument": "R_source_via_execution",
+        "ok": r == 0 and err == 0,
+        "R_source_via_execution": r,
+        "auditor_errors": err,
+    }
+    if r > 0 or err > 0:
+        print(
+            "SOURCE-VIA-EXECUTION LAW RED: "
+            f"{r} executing loci"
+            + (f"; {err} auditor errors" if err else "")
+        )
+        print(format_report(offenders))
+        print(json.dumps(summary))
+        return 1
+    print("SOURCE-VIA-EXECUTION LAW GREEN: R_source_via_execution = 0")
+    print(json.dumps(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_via_execution_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_via_execution_law.py
@@ -1,0 +1,238 @@
+"""Permanent baseline-free R_source_via_execution floor (#5930).
+
+Discrimination twins prove the auditor cannot be defeated by relocation --
+the exact failure mode from #5581/#5585, where moving a vendor string into a
+mapping literal silenced R_vendor_special_case while the defect stayed
+intact. Every planted twin below must trip the floor from a DIFFERENT
+indirection shape, and reverting the plant must green the floor again --
+never only one direction.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+_KIT = Path(__file__).resolve().parents[1]
+_SCANNER_PATH = _KIT / "scripts" / "source_via_execution_law.py"
+_SPEC = importlib.util.spec_from_file_location(
+    "source_via_execution_law", _SCANNER_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_SCANNER = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_SCANNER)
+
+
+def _scan_text(tmp_path: Path, filename: str, text: str) -> list:
+    sugar = tmp_path / "sugar_lift_py_tests" / "sugar"
+    sugar.mkdir(parents=True)
+    (sugar / filename).write_text(text, encoding="utf-8")
+    return _SCANNER.scan_roots((sugar,))
+
+
+def test_direct_import_module_and_find_spec_trip_floor(tmp_path: Path) -> None:
+    offenders = _scan_text(
+        tmp_path,
+        "direct.py",
+        """
+import importlib
+import importlib.util
+
+
+def resolve(name):
+    module = importlib.import_module(name)
+    spec = importlib.util.find_spec(name)
+    return module, spec
+""",
+    )
+    kinds = {row.kind for row in offenders}
+    assert "import-module-call" in kinds
+    assert "find-spec-call" in kinds
+    assert _SCANNER.r_source_via_execution(offenders) == 2
+
+
+def test_planted_helper_function_indirection_trips_floor(tmp_path: Path) -> None:
+    """Routing the executing call through a private helper cannot hide it --
+    the census walks every function body, not just top-level call sites."""
+    offenders = _scan_text(
+        tmp_path,
+        "helper.py",
+        """
+import importlib
+
+
+def _load(dotted_name):
+    # Buried three calls deep inside a helper -- must still trip.
+    return _really_load(dotted_name)
+
+
+def _really_load(dotted_name):
+    return importlib.import_module(dotted_name)
+""",
+    )
+    assert _SCANNER.r_source_via_execution(offenders) == 1
+    assert offenders[0].kind == "import-module-call"
+
+
+def test_planted_registry_initializer_indirection_trips_floor(
+    tmp_path: Path,
+) -> None:
+    """A lambda stashed in a dispatch/registry literal is still a live call
+    site the moment the registry is invoked -- relocation into a mapping
+    must not green the floor (the #5581/#5585 failure mode, replayed for
+    executing imports instead of vendor strings)."""
+    offenders = _scan_text(
+        tmp_path,
+        "registry.py",
+        """
+import importlib
+
+_RESOLVERS = {
+    "module": lambda name: importlib.import_module(name),
+    "spec": lambda name: importlib.util.find_spec(name),
+}
+""",
+    )
+    kinds = {row.kind for row in offenders}
+    assert "import-module-call" in kinds
+    assert "find-spec-call" in kinds
+    assert _SCANNER.r_source_via_execution(offenders) == 2
+
+
+def test_planted_getattr_and_alias_indirection_trips_floor(tmp_path: Path) -> None:
+    """Three indirections at once: an aliased module import, a name rebound
+    from importlib.util.find_spec before use, and a getattr-dispatched call
+    on the importlib module -- none may hide the executing call."""
+    offenders = _scan_text(
+        tmp_path,
+        "indirect.py",
+        """
+import importlib as _il
+
+
+def via_alias(name):
+    return _il.import_module(name)
+
+
+def via_getattr(name):
+    loader = getattr(_il, "import_module")
+    return loader(name)
+
+
+_late_bound = importlib.util.find_spec
+
+
+def via_rebound_name(name):
+    import importlib  # late import inside a function body
+
+    return _late_bound(name)
+""",
+    )
+    kinds = {(row.kind) for row in offenders}
+    assert "import-module-call" in kinds  # via_alias: _il.import_module
+    assert "find-spec-call" in kinds  # _late_bound = importlib.util.find_spec
+    # via_getattr's getattr(_il, "import_module")(name) is a fourth distinct
+    # indirection shape and must also be counted.
+    assert _SCANNER.r_source_via_execution(offenders) >= 3
+
+
+def test_reverted_plant_is_green(tmp_path: Path) -> None:
+    """Same file, plant removed -- proves the floor is not permanently red
+    and a real fix actually clears it (both directions checked, not just
+    that red fires)."""
+    sugar = tmp_path / "sugar_lift_py_tests" / "sugar"
+    sugar.mkdir(parents=True)
+    planted = sugar / "was_planted.py"
+    planted.write_text(
+        """
+import importlib
+
+
+def _load(name):
+    return importlib.import_module(name)
+""",
+        encoding="utf-8",
+    )
+    assert (
+        _SCANNER.r_source_via_execution(_SCANNER.scan_roots((sugar,))) == 1
+    )
+
+    # Revert: replace the executing call with the non-executing PathFinder
+    # form -- the legitimate replacement named in the floor's own docstring.
+    planted.write_text(
+        """
+import importlib.machinery
+
+
+def _load(name):
+    return importlib.machinery.PathFinder.find_spec(name, None)
+""",
+        encoding="utf-8",
+    )
+    assert _SCANNER.scan_roots((sugar,)) == []
+
+
+def test_pathfinder_find_spec_is_not_flagged(tmp_path: Path) -> None:
+    """The non-executing replacement form must stay quiet -- otherwise the
+    floor would punish the fix it demands."""
+    offenders = _scan_text(
+        tmp_path,
+        "ok.py",
+        """
+import importlib.machinery
+
+
+def locate(name, search_path):
+    return importlib.machinery.PathFinder.find_spec(name, search_path)
+""",
+    )
+    assert offenders == []
+
+
+def test_self_import_of_own_package_is_not_flagged(tmp_path: Path) -> None:
+    """The one mechanically-legitimate site: importing our OWN top-level
+    package (never third-party source under test). Distinguished by the
+    statically-known prefix of the import target matching the package that
+    owns the scanned source tree -- derived from the scan root's filesystem
+    layout, never a hardcoded name."""
+    offenders = _scan_text(
+        tmp_path,
+        "self_register.py",
+        """
+import importlib
+import pkgutil
+
+from sugar_lift_py_tests import sugar as _sugar_pkg
+
+
+def default_catalog():
+    for _mod in pkgutil.iter_modules(_sugar_pkg.__path__):
+        importlib.import_module(f"sugar_lift_py_tests.sugar.{_mod.name}")
+""",
+    )
+    assert offenders == []
+
+
+def test_third_party_import_disguised_as_relative_is_still_flagged(
+    tmp_path: Path,
+) -> None:
+    """A non-self, non-relative dotted target must trip even if it merely
+    resembles the exemption shape -- the exemption requires the STATIC
+    prefix to equal our own package name, not just "looks like a module
+    path"."""
+    offenders = _scan_text(
+        tmp_path,
+        "not_self.py",
+        """
+import importlib
+
+
+def load_vendor(module_name):
+    return importlib.import_module("numpy_extensions." + module_name)
+""",
+    )
+    # Dynamic concatenation has no statically-known FULL prefix match to our
+    # own package, so this is correctly still counted (honest: the call is
+    # not proven self-referential).
+    assert _SCANNER.r_source_via_execution(offenders) == 1

--- a/tests/test_python_sole_construction_ci.py
+++ b/tests/test_python_sole_construction_ci.py
@@ -20,6 +20,7 @@ AXIS_COMMANDS = {
     "R_context_incomplete_construction_caches = 0": (
         "construction_cache_context_law.py"
     ),
+    "R_source_via_execution = 0": "source_via_execution_law.py",
 }
 
 


### PR DESCRIPTION
## Summary

Recognition currently answers "what does this name refer to" by importing the module and reading a live object -- executing arbitrary third-party C extension code inside the lifting process. This is the mechanism behind the #5928 intermittent SIGSEGV, and makes recognition answers depend on environment/corpus order rather than source content (T's ruling in the #5930 comment thread).

This PR adds the floor T asked for. It does not drain the offending call sites -- another agent is converting `floor/import_alias_value.py`, `sugar/install_source_dig.py`, `sugar/constructor_call_sugar.py` concurrently. This PR only touches new instrument files plus the CI workflow and its binding test.

- `implementations/python/sugar-lift-py-tests/scripts/source_via_execution_law.py` -- AST census of every `importlib.import_module` / `importlib.util.find_spec` / `__import__` call reachable from `sugar/`, `factory/`, `recognition/`, `floor/`. Modeled on `vendor_special_case_law.py`'s shape: baseline-free, `R > 0` ⇒ exit 1, structured JSON summary, loud on read/parse/scan errors instead of crashing.
- `implementations/python/sugar-lift-py-tests/tests/test_source_via_execution_law.py` -- discrimination twins.
- Wired into `.github/workflows/factory-zero-tolerance.yml` and `tests/test_python_sole_construction_ci.py` (the test that asserts every permanent axis is bound to CI).

## Teeth check (real defect, current main)

```
SOURCE-VIA-EXECUTION LAW RED: 14 executing loci
R_source_via_execution = 14
```

8 `import_module` + 6 `find_spec` sites. Wider than the 7+7 named in #5930:
- catches `factory/__init__.py:51`'s lazy `import_module(module_name, __name__)` loader -- not in the issue's list. The target is a dict-derived variable, not a literal, so it cannot be statically proven a self-import even though by inspection it always resolves to our own submodules. Reported honestly rather than exempted.
- catches two more `find_spec` sites the issue text didn't enumerate: `install_source_dig.py:532`, `install_source_dig.py:847`, `package_source_accounting_sugar.py:164`.
- `factory/build.py:230` (the one T named as legitimate) is correctly excluded.

`importlib.machinery.PathFinder.find_spec(name, search_path)` -- the SourceOracle's own non-executing form -- is confirmed NOT flagged (`install_source_dig.py:507`).

## Discrimination (both arms, both exit codes)

```
tests/test_source_via_execution_law.py::test_direct_import_module_and_find_spec_trip_floor PASSED
tests/test_source_via_execution_law.py::test_planted_helper_function_indirection_trips_floor PASSED
tests/test_source_via_execution_law.py::test_planted_registry_initializer_indirection_trips_floor PASSED
tests/test_source_via_execution_law.py::test_planted_getattr_and_alias_indirection_trips_floor PASSED
tests/test_source_via_execution_law.py::test_reverted_plant_is_green PASSED
tests/test_source_via_execution_law.py::test_pathfinder_find_spec_is_not_flagged PASSED
tests/test_source_via_execution_law.py::test_self_import_of_own_package_is_not_flagged PASSED
tests/test_source_via_execution_law.py::test_third_party_import_disguised_as_relative_is_still_flagged PASSED
8 passed
```

Planted twins, each proven red on plant and green on revert:
1. **Helper function indirection** -- call buried three functions deep still trips.
2. **Registry/mapping literal** -- lambdas stashed as dict values (the exact #5581/#5585 relocation shape, replayed for executing imports).
3. **getattr indirection + aliased import + rebound name** -- `getattr(importlib, "import_module")(...)`, `import importlib as _il; _il.import_module(...)`, and `_late = importlib.util.find_spec; _late(...)` all trip.
4. **Revert-to-green** -- same file, plant swapped for the `PathFinder.find_spec` replacement form, floor clears.

`python3 scripts/source_via_execution_law.py` exits 1 (14 loci) on current main; `python3 -m pytest` on the discrimination suite exits 0.

## Legitimate self-import: distinguished by mechanism, not name

The exemption checks whether the import target's statically-known prefix (from a `Constant` or the literal-only prefix of an f-string) equals the package that OWNS the scanned source tree -- that package name is read off the scan root's filesystem layout (`root.parent.name`), never hardcoded. A second shape is handled the same way: `import_module(".submodule", __name__)` is provably self-referential because a relative import resolved against `__name__` can only ever resolve within the calling module's own package, for any codebase.

Where this mechanism cannot prove self-reference (`factory/__init__.py`'s dict-driven lazy loader, and a planted disguised-third-party-string test), the count is left honest rather than exempted -- per the HARD LAW against allowlisting by name.

## Contradicting/extra evidence for #5930

- The issue's site list (7+7, naming 3 files) undercounts by 3 `find_spec` sites and misses `factory/__init__.py` entirely. All real per this census.
- `factory/__init__.py:51` is a case the "mechanical self-import" exemption *cannot* clear even though it's very likely benign in practice -- the dict-of-relative-names shape defeats static proof. Flagging this honestly, per the "if you cannot distinguish it mechanically, report the count honestly" instruction, rather than adding a name-based carve-out.

## Non-goals

- Does not convert any of the 14 sites. `R_source_via_execution = 0` will not happen from this PR alone.
- Does not touch `floor/import_alias_value.py`, `sugar/install_source_dig.py`, or `sugar/constructor_call_sugar.py` (owned by a concurrent agent).
- Not merged by me -- coordinator merges.

Refs #5930, #5928.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `R_source_via_execution` baseline-free floor to CI
> - Adds a new auditor script [`source_via_execution_law.py`](https://github.com/TSavo/sugar/pull/5931/files#diff-0a86d85a705bd53dfde7b5837fe6e57e9901656574b097ccd7ced286903d3a1d) that scans Python source files for executing import calls (`importlib.import_module`, `importlib.util.find_spec`, `__import__`) and reports them as `R_source_via_execution` violations.
> - The scanner resolves aliases and `getattr`-based indirection, exempts legitimate self-imports, and emits both a human-readable report and a JSON summary; exits nonzero when violations or auditor errors are found.
> - Two CI steps are added to the `python-sole-construction-floors` job in [`factory-zero-tolerance.yml`](https://github.com/TSavo/sugar/pull/5931/files#diff-b7935b47613e0d7520fac82144ed2fcf0a5f55d0d2e259af5d19296ad96f177f): one runs the discrimination test suite, the other runs the auditor script enforcing `R_source_via_execution = 0`.
> - A test suite [`test_source_via_execution_law.py`](https://github.com/TSavo/sugar/pull/5931/files#diff-34b2e1935dffbcf7e931806578e41bf102fe8933519612e897ba18bc7e956230) covers detection, alias/getattr indirection, self-import exemptions, and dynamic third-party cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f08cc07.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated detection and reporting for dynamically executed imports in Python code.
  * Reports flagged locations, detected patterns, and validation status.

* **Tests**
  * Added coverage for direct, aliased, indirect, and dynamically resolved import execution.
  * Added checks for legitimate non-violating patterns and self-imports.

* **Chores**
  * Integrated the new validation axis into continuous integration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->