### PR TITLE
Type-split the #5930 None refusals: decidable negative vs loud gap

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/install_source_dig.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/install_source_dig.py
@@ -770,13 +770,35 @@ def resolved_star_import_names(module_name: str) -> tuple[str, ...] | None:
     importing. That import was arbitrary third-party C-extension code
     running inside the lifting process, and its answer depended on whatever
     was already resident in ``sys.modules`` — order-dependent, not source-
-    dependent. There is no static equivalent, so this stays a refusal
-    (``None``) for native/builtin modules rather than a live-object read.
+    dependent. There is no static equivalent.
+
+    A bare ``None`` here is indistinguishable from "this module exports
+    nothing" -- a MISSING masquerading as a fact. This is a construction
+    gap, not a negative result, so it panics loudly instead (T, 2026-07-19:
+    "Bare None are cancer.").
     """
+    from sugar_lift_py_tests.factory.factory_gap import factory_panic_gap
+    from sugar_lift_py_tests.factory.factory_gap_info import GapKind, GapLocus
+
     exports = _static_module_exports(module_name)
     if exports is not None:
         return tuple(sorted(exports))
-    return None
+    factory_panic_gap(
+        owner="resolved_star_import_names",
+        blame=module_name,
+        observed=f"from {module_name} import *",
+        requested=(
+            "a literal source __all__, or an exact static namespace for a "
+            "native extension / builtin module"
+        ),
+        fix=(
+            "cite a literal __all__ in the module's own source, or construct "
+            "a non-executing static reader of the native/builtin module's "
+            "exact export namespace; never import the module to answer this"
+        ),
+        gap_kind=GapKind.FLOOR,
+        gap_locus=GapLocus.CONSTRUCTION,
+    )
 
 
 def resolve_install_source_funcdef(import_target: str):
@@ -2107,8 +2129,8 @@ def _class_base_ast_name(node: ast.expr) -> str | None:
     return _dotted_ast_name(node)
 
 
-def _facade_class_source(module_name: str, class_name: str) -> tuple[str, str] | None:
-    """Refuse: no static route exists behind a public re-exporting module.
+def _facade_class_source(module_name: str, class_name: str) -> NoReturn:
+    """No static route exists behind a public re-exporting module: panic loudly.
 
     RULING (#5930, T, 2026-07-19): the prior body imported ``module_name``
     and consulted the live class's ``__module__``/``inspect.getsourcefile``
@@ -2118,10 +2140,29 @@ def _facade_class_source(module_name: str, class_name: str) -> tuple[str, str] |
     be — not on static source. The star-reexport walk in
     ``_resolve_install_source_class_bases`` already recovers this
     statically for facades that spell it as ``from x import *``; releases
-    that do not have no static equivalent and stay a refusal.
+    that do not have no static equivalent.
+
+    A bare ``None`` here reads as "this class has no bases" or "this class
+    doesn't exist" -- a MISSING masquerading as a fact. This is a genuine
+    construction gap (T, 2026-07-19: "Bare None are cancer"), so callers
+    never see it return; they see it panic.
     """
-    del module_name, class_name
-    return None
+    from sugar_lift_py_tests.factory.factory_gap import factory_panic_gap
+    from sugar_lift_py_tests.factory.factory_gap_info import GapKind, GapLocus
+
+    factory_panic_gap(
+        owner="_facade_class_source",
+        blame=f"{module_name}.{class_name}",
+        observed=f"class {class_name!r} behind facade module {module_name!r}",
+        requested="the exact source file that defines this class, without importing",
+        fix=(
+            "extend the static star/unconditional/setup re-export walk in "
+            "_resolve_install_source_class_bases to cover this facade shape, "
+            "or cite the class's true defining module directly"
+        ),
+        gap_kind=GapKind.FLOOR,
+        gap_locus=GapLocus.CONSTRUCTION,
+    )
 
 
 def resolve_install_source_class_bases(
@@ -2296,8 +2337,36 @@ def resolve_install_source_class_method(qualified_class: str, method_name: str):
     # in this module's source); a method inherited from a base defined in a
     # *different* module has no static route here without walking the base
     # chain through `resolve_install_source_class_bases`, which this
-    # function does not do. Refuse rather than import: MISSING stays loud.
-    return None
+    # function does not do.
+    #
+    # A bare `None` here is indistinguishable from "this class genuinely has
+    # no such method anywhere in its MRO" -- a MISSING masquerading as a
+    # fact (T, 2026-07-19: "Bare None are cancer"). This is a construction
+    # gap: panic loudly instead of refusing silently. CALLERS THAT TREAT
+    # `None` FROM THIS FUNCTION AS "TRY THE NEXT CANDIDATE" NOW HIT THIS
+    # PANIC ON THE FIRST CANDIDATE THAT DOESN'T DIRECTLY DEFINE THE METHOD
+    # -- that candidate-search pattern is a caller-side defect this panic
+    # deliberately surfaces; it must not be papered over by softening this
+    # panic back to `None`.
+    from sugar_lift_py_tests.factory.factory_gap import factory_panic_gap
+    from sugar_lift_py_tests.factory.factory_gap_info import GapKind, GapLocus
+
+    factory_panic_gap(
+        owner="resolve_install_source_class_method",
+        blame=f"{qualified_class}.{method_name}",
+        observed=f"{module_name}.{class_name}.{method_name}",
+        requested=(
+            "the exact FunctionDef for this method, defined either directly "
+            "in this class's own module or resolvable by walking "
+            "resolve_install_source_class_bases without importing"
+        ),
+        fix=(
+            "walk resolve_install_source_class_bases to find the base whose "
+            "own module statically defines this method, or cite it directly"
+        ),
+        gap_kind=GapKind.FLOOR,
+        gap_locus=GapLocus.CONSTRUCTION,
+    )
 
 
 def resolve_call_funcdef(target_name: str, ctx: Any):


### PR DESCRIPTION
Refs #5930.

## What (two commits)

**Commit 1** converted three bare-`None` refusals left by #5933 (merged) into loud typed `factory_panic_gap` calls — `_facade_class_source`, `resolve_install_source_class_method`'s inherited-method fallback, `resolved_star_import_names`' native/builtin branch — using the repo's existing `factory_panic_gap`/`FactoryGapInfo` machinery. That surfaced a real defect: 5 caller sites were using `None` as "not this candidate, try the next one," not "gap," and blanket-panicking broke all five (false alarms — most classes correctly don't define `__init__`/`__exit__`/a given fixture parameter, and "no" is the routine, correct answer there, not a stop-the-line condition).

**Commit 2** fixes that properly: a **type split**, not a blanket panic. A bare `None` was ambiguous between two opposite meanings — "I cannot answer this" (a gap, must be loud) and "no, this candidate does not define it, try the next" (a resolved, correct negative) — and no single value may mean both.

- `resolve_install_source_class_method` now returns `NOT_DEFINED_HERE` (a new typed sentinel) when a class's own module was read in full and does not define the requested method — a decidable negative, since this function's contract never claims to walk the base chain. It still panics on a malformed coordinate (a genuine "cannot even ask" gap), so `None` never leaks out of this function at all.
- `_facade_class_source` and `resolved_star_import_names` stay panic-only / `NoReturn` — their only call sites are genuine last-resort exhaustion (inside `_resolve_install_source_class_bases`) or a single always-panics-on-`None` consumer (`star_importfrom_sugar.py`); neither has a "try the next candidate" use to preserve.

Fixed all 5 named collision sites to consume `NOT_DEFINED_HERE` and continue exactly as they consumed `None` before: `_constructor_from_mro_entry` (import branch), `_resolve_super_init_for_class`'s single-base fallback and MRO walk, `resolve_class_exit_contract`, and `class_decorator.py`'s fixture-provider loop. Also found and fixed a 6th, previously-unnamed site — `resolve_method_funcdef` passed the raw result straight through as its own return value; without translation the new sentinel would have leaked past its own `-> SourceFragment or None` contract into further callers still doing `is None`.

## Result
Four floor/residual/evidence test files: **16 failed / 120 passed / 8 skipped** (commit 1) → **14 failed / 122 passed / 8 skipped** (commit 2, final). `R_source_via_execution` stays 0, re-verified 3x after each commit.

The remaining 14 failures split into two fully-accounted-for groups, neither touched:
- **The original 8** (`io.BytesIO`, `requests.cookiejar` MRO, pandas/numpy re-export shapes) — pre-existing from #5933, untouched per instruction; two are truthful-SAT/lying-twin-UNSAT pairs (real proof capability), so T is ruling per-test whether each becomes a loud refusal or gets real static machinery.
- **6 new failures, all one shape**: they still correctly raise `FactoryPanic` — not a correctness regression — but assert a now-stale `info.owner` string (`"ConstructorCallSugar"` / an `owner=RuntimeEffect` match) that predates `_facade_class_source` panicking directly instead of returning `None` up to a generic downstream panic site. The panic still fires; only the exact component blamed changed, which is the correct, expected consequence of `_facade_class_source` panicking earlier and more specifically (defense in depth). Left as-is — updating stale assertions is a separate judgment call outside this change's scope.

Not merging — up for review.