### PR TITLE
Split resolve_install_source_class_method: decidable negative vs gap (typed)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/class_decorator.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/class_decorator.py
@@ -142,6 +142,7 @@ def _fixture_parameter_native_shape(statement, parameter: str) -> NativeShape | 
         node.name: node for node in tree.body if isinstance(node, ast.ClassDef)
     }
     from sugar_lift_py_tests.sugar.install_source_dig import (
+        NOT_DEFINED_HERE,
         resolve_install_source_class_method,
     )
 
@@ -149,7 +150,10 @@ def _fixture_parameter_native_shape(statement, parameter: str) -> NativeShape | 
         owner, imports, local_classes, frozenset()
     ):
         provider = resolve_install_source_class_method(qualified_base, parameter)
-        if provider is None:
+        # NOT_DEFINED_HERE: this base doesn't provide the fixture parameter
+        # directly -- a decidable negative, try the next candidate base
+        # exactly as before (#5930).
+        if provider is None or provider is NOT_DEFINED_HERE:
             continue
         shape = _fixture_provider_native_shape(provider)
         if shape is not None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructor_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructor_call_sugar.py
@@ -934,11 +934,16 @@ def _inherited_strategy(site, ctx, target: str, class_site, methods=()):
             )
         if isinstance(bound, ImportAliasValue) and bound.import_target is not None:
             from sugar_lift_py_tests.sugar.install_source_dig import (
+                NOT_DEFINED_HERE,
                 resolve_install_source_class_method,
             )
 
             init = resolve_install_source_class_method(bound.import_target, "__init__")
-            if init is not None:
+            # NOT_DEFINED_HERE is a decidable negative (`base_name`'s own
+            # module doesn't define __init__ directly); there is no further
+            # candidate here, so fall through to the loud panic below same
+            # as a genuine miss did before (#5930).
+            if init is not None and init is not NOT_DEFINED_HERE:
                 return _strategy_from_init(
                     site,
                     ctx,
@@ -1189,12 +1194,17 @@ def _constructor_from_mro_entry(site, ctx, target: str, class_site, methods, ent
         )
     if entry[0] == "import":
         from sugar_lift_py_tests.sugar.install_source_dig import (
+            NOT_DEFINED_HERE,
             resolve_install_source_class_method,
         )
 
         _kind, import_target = entry
         init = resolve_install_source_class_method(import_target, "__init__")
-        if init is None:
+        # NOT_DEFINED_HERE: this MRO entry doesn't define __init__ directly
+        # -- a decidable negative, not a gap. `None` (the caller's own "no
+        # strategy for this entry" signal) is the correct way to say
+        # "continue to the next MRO entry" here, same as before (#5930).
+        if init is None or init is NOT_DEFINED_HERE:
             return None
         class_fields = _class_fields(class_site, ctx)
         strategy = _strategy_from_init(
@@ -1662,13 +1672,20 @@ def _resolve_super_init_for_class(class_site, target: str, ctx):
             bound = ctx.temporal.value_if_bound(base.name_id())
             if isinstance(bound, ImportAliasValue) and bound.import_target is not None:
                 from sugar_lift_py_tests.sugar.install_source_dig import (
+                    NOT_DEFINED_HERE,
                     resolve_install_source_class_method,
                 )
 
                 init = resolve_install_source_class_method(
                     bound.import_target, "__init__"
                 )
-                return init if init is not None else None
+                # NOT_DEFINED_HERE: the sole base doesn't define __init__
+                # directly -- a decidable negative, collapses to this
+                # function's own "cannot resolve super statically" None,
+                # same as before (#5930).
+                if init is None or init is NOT_DEFINED_HERE:
+                    return None
+                return init
             return None
         resolved_site = SourceFragment.from_node(resolved, ctx.filename)
         if resolved_site.observed != "ClassDef":
@@ -1704,11 +1721,15 @@ def _resolve_super_init_for_class(class_site, target: str, ctx):
             if import_target in {"builtins.object", "object"}:
                 return "object"
             from sugar_lift_py_tests.sugar.install_source_dig import (
+                NOT_DEFINED_HERE,
                 resolve_install_source_class_method,
             )
 
             init = resolve_install_source_class_method(import_target, "__init__")
-            if init is not None:
+            # NOT_DEFINED_HERE: this MRO entry doesn't define __init__
+            # directly -- a decidable negative, continue walking up the MRO
+            # exactly as a normal miss did before (#5930).
+            if init is not None and init is not NOT_DEFINED_HERE:
                 return init
             continue
     return "object"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/install_source_dig.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/install_source_dig.py
@@ -45,6 +45,36 @@ _MISSING = object()
 _CLASS_BASES_CACHE: OrderedDict[tuple[Any, ...], tuple[str, ...]] = OrderedDict()
 
 
+class _NotDefinedHereType:
+    """A decidable negative: this exact coordinate was resolved, and it does
+    not define the requested member.
+
+    RULING (#5930, T, 2026-07-19): a bare ``None`` is ambiguous between two
+    opposite meanings -- "I cannot answer this" (a gap, must be loud) and
+    "no, this candidate does not define it, try the next" (a resolved,
+    correct negative). Conflating them either turns a real gap into silence,
+    or turns a routine "no" into a false-alarm panic. ``NOT_DEFINED_HERE``
+    is the second meaning ONLY: a candidate search may consume it and
+    continue exactly as it would a normal negative result. It is never
+    returned when the answer is actually unknown -- that case panics with a
+    typed ``FactoryGapInfo`` instead. No caller may treat this value and an
+    unresolved gap as the same thing; there is no third bare-``None`` case
+    left to check for.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "NOT_DEFINED_HERE"
+
+    def __bool__(self) -> bool:
+        # Never let this be mistaken for a truthy "found" value.
+        return False
+
+
+NOT_DEFINED_HERE = _NotDefinedHereType()
+
+
 @dataclass(frozen=True)
 class _ContextIdentity:
     """Strong, O(1) identity token for one factory-recognition input."""
@@ -965,7 +995,13 @@ def resolve_local_source_exit_contract(filename: str | None, local_name: str):
 def resolve_class_exit_contract(qualified_class: str):
     """Prove exit disposition from an installed class's exact ``__exit__`` body."""
     exit_fn = resolve_install_source_class_method(qualified_class, "__exit__")
-    if exit_fn is None or not isinstance(exit_fn.node, ast.FunctionDef):
+    # NOT_DEFINED_HERE is a decidable negative: this class's own module does
+    # not define __exit__, i.e. it is not a context manager. That is the
+    # correct answer for most classes asked this question -- consume it and
+    # answer "no exit contract" exactly as before, never a gap (#5930).
+    if exit_fn is NOT_DEFINED_HERE:
+        return None
+    if not isinstance(exit_fn.node, ast.FunctionDef):
         return None
     return _exit_method_suppression_contract(exit_fn.node)
 
@@ -2311,9 +2347,41 @@ def _resolve_install_source_class_bases(
 
 
 def resolve_install_source_class_method(qualified_class: str, method_name: str):
-    """Resolve ``module.Class.method`` to a FunctionDef SourceFragment, or None."""
+    """Resolve ``module.Class.method`` to a FunctionDef SourceFragment.
+
+    Returns exactly one of two kinds of answer, never a bare ``None``:
+
+    - a ``SourceFragment`` when ``qualified_class``'s own module statically
+      defines ``method_name`` directly on that class.
+    - ``NOT_DEFINED_HERE`` -- a decidable negative -- when that module was
+      read and does NOT define the method there. This function never walks
+      the base chain (see ``resolve_install_source_class_bases`` for that),
+      so "not defined here" is a complete, resolved answer, not a gap: most
+      classes in an MRO walk correctly don't define most methods, and a
+      context-manager discriminator asking "does this implement __exit__"
+      correctly says no far more often than yes. A candidate search may
+      consume ``NOT_DEFINED_HERE`` and try the next candidate exactly as it
+      would any other negative result.
+
+    A malformed ``qualified_class``/``method_name`` coordinate -- one this
+    function cannot even attempt to resolve -- is a different kind of
+    failure: a genuine construction gap. It panics loudly with a typed
+    ``FactoryGapInfo`` instead of returning anything, so it can never be
+    silently mistaken for either of the two answers above.
+    """
+    from sugar_lift_py_tests.factory.factory_gap import factory_panic_gap
+    from sugar_lift_py_tests.factory.factory_gap_info import GapKind, GapLocus
+
     if not qualified_class or not method_name or "." not in qualified_class:
-        return None
+        factory_panic_gap(
+            owner="resolve_install_source_class_method",
+            blame=qualified_class or "<empty>",
+            observed=f"qualified_class={qualified_class!r} method_name={method_name!r}",
+            requested="a dotted module.Class coordinate and a method name",
+            fix="construct a well-formed qualified_class before calling this resolver",
+            gap_kind=GapKind.FLOOR,
+            gap_locus=GapLocus.CONSTRUCTION,
+        )
     from sugar_lift_py_tests.factory.source_fragment import SourceFragment
 
     module_name, class_name = qualified_class.rsplit(".", 1)
@@ -2333,40 +2401,10 @@ def resolve_install_source_class_method(qualified_class: str, method_name: str):
     # inherited method, then read its source via `inspect.getsource`. That
     # both executed third-party code and depended on the live MRO rather
     # than on this module's own static source. `_module_sibling_function_node`
-    # above already answers the static question (a method defined directly
-    # in this module's source); a method inherited from a base defined in a
-    # *different* module has no static route here without walking the base
-    # chain through `resolve_install_source_class_bases`, which this
-    # function does not do.
-    #
-    # A bare `None` here is indistinguishable from "this class genuinely has
-    # no such method anywhere in its MRO" -- a MISSING masquerading as a
-    # fact (T, 2026-07-19: "Bare None are cancer"). This is a construction
-    # gap: panic loudly instead of refusing silently. CALLERS THAT TREAT
-    # `None` FROM THIS FUNCTION AS "TRY THE NEXT CANDIDATE" NOW HIT THIS
-    # PANIC ON THE FIRST CANDIDATE THAT DOESN'T DIRECTLY DEFINE THE METHOD
-    # -- that candidate-search pattern is a caller-side defect this panic
-    # deliberately surfaces; it must not be papered over by softening this
-    # panic back to `None`.
-    from sugar_lift_py_tests.factory.factory_gap import factory_panic_gap
-    from sugar_lift_py_tests.factory.factory_gap_info import GapKind, GapLocus
-
-    factory_panic_gap(
-        owner="resolve_install_source_class_method",
-        blame=f"{qualified_class}.{method_name}",
-        observed=f"{module_name}.{class_name}.{method_name}",
-        requested=(
-            "the exact FunctionDef for this method, defined either directly "
-            "in this class's own module or resolvable by walking "
-            "resolve_install_source_class_bases without importing"
-        ),
-        fix=(
-            "walk resolve_install_source_class_bases to find the base whose "
-            "own module statically defines this method, or cite it directly"
-        ),
-        gap_kind=GapKind.FLOOR,
-        gap_locus=GapLocus.CONSTRUCTION,
-    )
+    # above already answers the static question completely -- this class's
+    # own module was read in full and does not define the method there.
+    # That is a decidable negative, not a gap: return it as such.
+    return NOT_DEFINED_HERE
 
 
 def resolve_call_funcdef(target_name: str, ctx: Any):
@@ -2465,7 +2503,12 @@ def resolve_method_funcdef(method_name: str, receiver_floor: Any, ctx: Any):
         if class_name in from_imports:
             mod, attr = from_imports[class_name]
             qualified = f"{mod}.{attr}" if mod else attr
-            return resolve_install_source_class_method(qualified, method_name)
+            provider = resolve_install_source_class_method(qualified, method_name)
+            # This function's own contract is "SourceFragment or None"; there
+            # is no further candidate to try here, so a decidable negative
+            # (this class doesn't define the method) collapses to this
+            # function's own "not found" answer, same as before (#5930).
+            return None if provider is NOT_DEFINED_HERE else provider
 
     return None
 


### PR DESCRIPTION
Refs #5930. Follow-up to #5934, which merged before this commit existed — the type split was stranded on the branch after its PR closed. Same branch, new PR. Commit `876560229`.

## What

#5934 converted three `None` refusals to loud typed panics. That was correct for gaps, but it also turned a **decidable negative** into a false alarm at six candidate-search call sites — `None` had been carrying two opposite meanings:

- *"I cannot answer this"* — a gap. Must be loud.
- *"No, this class's own module does not define this member, try the next candidate"* — a correct, resolved answer.

Blanket-panicking picks one meaning and erases the other. The fix is a TYPE, so no single value can mean both.

`resolve_install_source_class_method` now returns exactly one of:
- a `SourceFragment` — found
- `NOT_DEFINED_HERE` — typed sentinel; the class's own module was read in full and genuinely does not define the method
- panics with typed `FactoryGapInfo` — malformed coordinate, a genuine "cannot even ask" gap

The leading guard was converted too, so `None` never leaks out of the function at all. Sentinel follows the file's existing `_MISSING` idiom rather than introducing a new one.

`_facade_class_source` and `resolved_star_import_names` stay panic-only — their only callers (the two last-resort `_resolve_install_source_class_bases` exhaustion sites, and `star_importfrom_sugar.py`) already treated `None` as a gap, so there is no "try next candidate" semantics to preserve.

## Collision sites fixed

All five previously named, plus a sixth found by grepping fresh rather than trusting the earlier list:

`_constructor_from_mro_entry` (import branch), `_resolve_super_init_for_class` single-base fallback, `_resolve_super_init_for_class` MRO walk, `resolve_class_exit_contract`, `class_decorator.py` fixture-provider loop — each now checks `is NOT_DEFINED_HERE` and continues exactly as it consumed `None` before.

**Sixth site, and a live bug caught:** `resolve_method_funcdef` passes the raw result straight through as its own return value. Without translation at that boundary, `NOT_DEFINED_HERE` would have leaked past its `-> SourceFragment | None` contract into callers still testing `is None` — a bug the type split would itself have introduced. Translated at the boundary.

## Result

- **16 failed / 120 passed -> 14 failed / 122 passed**
- `R_source_via_execution` = 0, re-verified 3x
- Two of the failures introduced by #5934 are fixed BY this split (`test_dotted_imported_reexport_base_constructs_exact_inherited_object`, `test_explicit_base_initializer_truthful_sat_wrong_twin_unsat`) — the split is doing real work, not cosmetic

## The remaining 14, fully accounted for — two distinct groups, NEITHER touched

1. **The original 8** — assert success for shapes that only ever resolved by executing (`io.BytesIO`, `requests.cookiejar` MRO, pandas/numpy re-export). Under separate ruling; two are truthful-SAT / lying-twin-UNSAT proof-capability pairs.
2. **6 new, all one shape** — these still correctly raise `FactoryPanic`. Not a correctness regression and not silence. They assert a stale `info.owner` string that predates `_facade_class_source` panicking directly: e.g. `test_unresolved_dotted_imported_base_stays_loud` expects `owner == "ConstructorCallSugar"` and now gets `"_facade_class_source"` — the same panic from an earlier, more specific origin, which is #5934's defense-in-depth working as designed. Fixing these means editing test expectations, deliberately left out of scope.

## Not in scope

Crash-rate reproduction — per #5932 battleaxe has a second, independent host-level crash source; crash rate is not a valid acceptance signal there.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split `resolve_install_source_class_method` to return `NOT_DEFINED_HERE` sentinel for non-local methods
> - Introduces a `NOT_DEFINED_HERE` sentinel in [`install_source_dig.py`](https://github.com/TSavo/sugar/pull/5935/files#diff-ba8ea78128d6f8f6e443d4085b0b1175dc538cf3a9dde6c1878bc127e44d59dc) to distinguish a decidable negative (method not defined in the class's own module) from a gap/error condition.
> - `resolve_install_source_class_method` now returns `NOT_DEFINED_HERE` instead of panicking when the method is defined outside the queried module, and panics (via `factory_panic_gap`) for malformed inputs instead of silently returning `None`.
> - Callers in [`constructor_call_sugar.py`](https://github.com/TSavo/sugar/pull/5935/files#diff-51aabdb59d393d90c4a02bdb08869a15e182a8077b689ff5d52eb3d6d699ab33) and [`class_decorator.py`](https://github.com/TSavo/sugar/pull/5935/files#diff-19211378bbb353bf1c344eaaaf0dc61bdc88f8dc26a8174e873452efd8c121eb) are updated to treat `NOT_DEFINED_HERE` as absence, continuing MRO walks or returning `None` rather than misinterpreting the sentinel as a found method.
> - `resolve_method_funcdef` collapses `NOT_DEFINED_HERE` to `None` to preserve its existing `SourceFragment | None` contract.
> - Behavioral Change: inputs that previously returned `None` silently (malformed `qualified_class` or empty `method_name`) now panic, which may surface previously hidden misuse.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b192f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->