### PR TITLE
Classify native-extension bases as RuntimeEffect; fix star-reexport naming

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/class_decorator.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/class_decorator.py
@@ -142,6 +142,7 @@ def _fixture_parameter_native_shape(statement, parameter: str) -> NativeShape | 
         node.name: node for node in tree.body if isinstance(node, ast.ClassDef)
     }
     from sugar_lift_py_tests.sugar.install_source_dig import (
+        NOT_DEFINED_HERE,
         resolve_install_source_class_method,
     )
 
@@ -149,7 +150,10 @@ def _fixture_parameter_native_shape(statement, parameter: str) -> NativeShape | 
         owner, imports, local_classes, frozenset()
     ):
         provider = resolve_install_source_class_method(qualified_base, parameter)
-        if provider is None:
+        # NOT_DEFINED_HERE: this base doesn't provide the fixture parameter
+        # directly -- a decidable negative, try the next candidate base
+        # exactly as before (#5930).
+        if provider is None or provider is NOT_DEFINED_HERE:
             continue
         shape = _fixture_provider_native_shape(provider)
         if shape is not None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructor_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructor_call_sugar.py
@@ -913,6 +913,46 @@ def _inherited_strategy(site, ctx, target: str, class_site, methods=()):
     if inherited_bytesio is not None:
         return inherited_bytesio
     base_name = base_coordinate
+    # RULING (#5930, T, 2026-07-20): `io` is categorically a RuntimeEffect.
+    # A base whose module artifact is a native extension (e.g. `io.BytesIO`,
+    # backed by `_io`) has no Python source to walk for its MRO -- that is
+    # not a gap in our knowledge, it is I/O, a genuine construction whose
+    # initialization must execute at runtime. Classifying it as unresolved
+    # and panicking would mislabel a KNOWN thing as unknown.
+    #
+    # This check MUST run before `_static_constructor_mro`, not after: MRO
+    # resolution for a native base reaches `_facade_class_source`, which
+    # panics (#5934) rather than returning None, so a check placed after
+    # `mro is None` is unreachable dead code -- the panic already unwound
+    # the stack past it.
+    #
+    # Gated on `site.call_arg_count() == 1`, the same arity
+    # `_inherited_bytesio_strategy` above already required to construct the
+    # exact happy path: that is the only native constructor signature this
+    # file has any concrete knowledge of. An arity outside that is not
+    # evidence the base is unconstructible AS an effect -- it is evidence of
+    # a genuine arity mismatch, which must stay a loud, arity-specific
+    # panic (unaffected by this change), not be smuggled into a coarse
+    # "must execute" classification.
+    if site.call_arg_count() == 1 and base.observed == "Name":
+        native_target = _import_target_for_name(ctx, base.name_id())
+        if native_target is not None:
+            from sugar_lift_py_tests.sugar.install_source_dig import (
+                native_extension_class_origin,
+            )
+
+            native_origin = native_extension_class_origin(native_target)
+            if native_origin is not None:
+                return _runtime_strategy(
+                    site,
+                    ctx,
+                    target,
+                    "native inherited constructor runtime boundary: "
+                    f"{target} extends {native_target}, whose terminal "
+                    f"defining module {native_origin!r} is a native "
+                    "extension; the constructor result depends on runtime "
+                    "execution of that extension's initializer",
+                )
     mro = _static_constructor_mro(target, class_site, ctx)
     if mro is not None:
         return _strategy_from_static_mro(site, ctx, target, class_site, methods, mro)
@@ -1922,20 +1962,28 @@ def _multi_base_inherited_strategy(site, ctx, target: str, class_site, methods=(
 
     Undecidable bases (runtime-selected, unresolved, symbolic) stay a loud
     construction panic — never a RuntimeEffect weakening of the gap.
+
+    RULING (#5930, T, 2026-07-20): `io` is categorically a RuntimeEffect, a
+    positive terminal classification, not an absence -- so the native-base
+    check below MUST run before `_static_constructor_mro`, not after: MRO
+    resolution for a native base reaches `_facade_class_source`, which
+    panics (#5934) rather than returning None, so a check placed after
+    `mro is None` is unreachable dead code -- the panic already unwound the
+    stack past it.
     """
+    native_bases = _native_imported_base_targets(class_site, ctx)
+    if native_bases is not None:
+        return _runtime_strategy(
+            site,
+            ctx,
+            target,
+            "native inherited constructor runtime boundary: "
+            f"{target} has statically resolved extension bases "
+            f"{native_bases}; the constructor result depends on its "
+            "runtime arguments",
+        )
     mro = _static_constructor_mro(target, class_site, ctx)
     if mro is None:
-        native_bases = _native_imported_base_targets(class_site, ctx)
-        if native_bases is not None:
-            return _runtime_strategy(
-                site,
-                ctx,
-                target,
-                "native inherited constructor runtime boundary: "
-                f"{target} has statically resolved extension bases "
-                f"{native_bases}; the constructor result depends on its "
-                "runtime arguments",
-            )
         _panic(
             site,
             f"{target} bases={class_site.class_base_names()}",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructor_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructor_call_sugar.py
@@ -934,11 +934,16 @@ def _inherited_strategy(site, ctx, target: str, class_site, methods=()):
             )
         if isinstance(bound, ImportAliasValue) and bound.import_target is not None:
             from sugar_lift_py_tests.sugar.install_source_dig import (
+                NOT_DEFINED_HERE,
                 resolve_install_source_class_method,
             )
 
             init = resolve_install_source_class_method(bound.import_target, "__init__")
-            if init is not None:
+            # NOT_DEFINED_HERE is a decidable negative (`base_name`'s own
+            # module doesn't define __init__ directly); there is no further
+            # candidate here, so fall through to the loud panic below same
+            # as a genuine miss did before (#5930).
+            if init is not None and init is not NOT_DEFINED_HERE:
                 return _strategy_from_init(
                     site,
                     ctx,
@@ -1189,12 +1194,17 @@ def _constructor_from_mro_entry(site, ctx, target: str, class_site, methods, ent
         )
     if entry[0] == "import":
         from sugar_lift_py_tests.sugar.install_source_dig import (
+            NOT_DEFINED_HERE,
             resolve_install_source_class_method,
         )
 
         _kind, import_target = entry
         init = resolve_install_source_class_method(import_target, "__init__")
-        if init is None:
+        # NOT_DEFINED_HERE: this MRO entry doesn't define __init__ directly
+        # -- a decidable negative, not a gap. `None` (the caller's own "no
+        # strategy for this entry" signal) is the correct way to say
+        # "continue to the next MRO entry" here, same as before (#5930).
+        if init is None or init is NOT_DEFINED_HERE:
             return None
         class_fields = _class_fields(class_site, ctx)
         strategy = _strategy_from_init(
@@ -1662,13 +1672,20 @@ def _resolve_super_init_for_class(class_site, target: str, ctx):
             bound = ctx.temporal.value_if_bound(base.name_id())
             if isinstance(bound, ImportAliasValue) and bound.import_target is not None:
                 from sugar_lift_py_tests.sugar.install_source_dig import (
+                    NOT_DEFINED_HERE,
                     resolve_install_source_class_method,
                 )
 
                 init = resolve_install_source_class_method(
                     bound.import_target, "__init__"
                 )
-                return init if init is not None else None
+                # NOT_DEFINED_HERE: the sole base doesn't define __init__
+                # directly -- a decidable negative, collapses to this
+                # function's own "cannot resolve super statically" None,
+                # same as before (#5930).
+                if init is None or init is NOT_DEFINED_HERE:
+                    return None
+                return init
             return None
         resolved_site = SourceFragment.from_node(resolved, ctx.filename)
         if resolved_site.observed != "ClassDef":
@@ -1704,11 +1721,15 @@ def _resolve_super_init_for_class(class_site, target: str, ctx):
             if import_target in {"builtins.object", "object"}:
                 return "object"
             from sugar_lift_py_tests.sugar.install_source_dig import (
+                NOT_DEFINED_HERE,
                 resolve_install_source_class_method,
             )
 
             init = resolve_install_source_class_method(import_target, "__init__")
-            if init is not None:
+            # NOT_DEFINED_HERE: this MRO entry doesn't define __init__
+            # directly -- a decidable negative, continue walking up the MRO
+            # exactly as a normal miss did before (#5930).
+            if init is not None and init is not NOT_DEFINED_HERE:
                 return init
             continue
     return "object"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/install_source_dig.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/install_source_dig.py
@@ -2348,13 +2348,55 @@ def _resolve_install_source_class_bases(
         None,
     )
     if class_node is None:
+        unconditional_reexport = _definite_unconditional_reexport_target(
+            module_name, class_name, parsed
+        )
+        star_reexport = (
+            None
+            if unconditional_reexport is not None
+            else _definite_star_reexport_target(module_name, class_name, parsed)
+        )
         reexport = (
-            _definite_unconditional_reexport_target(module_name, class_name, parsed)
-            or _definite_star_reexport_target(module_name, class_name, parsed)
+            unconditional_reexport
+            or star_reexport
             or _definite_setup_reexport_target(module_name, class_name, parsed)
         )
         if reexport is not None:
-            return _resolve_install_source_class_bases(reexport, resolving, ctx)
+            reexported_bases = _resolve_install_source_class_bases(
+                reexport, resolving, ctx
+            )
+            if reexported_bases is None:
+                return None
+            # RULING (#5930, T, 2026-07-20): ordinary Python with real
+            # source gets walked, not refused. Rewrite only applies to a
+            # STAR reexport (``from _collections_abc import *``): that
+            # aliases the reexported module's ENTIRE namespace through the
+            # facade, so a transitively-resolved base genuinely IS reachable
+            # under the facade's own name too (e.g. ``_collections_abc.Mapping``
+            # is also ``collections.abc.Mapping``) -- without rewriting it,
+            # the private defining module's name leaks into a coordinate the
+            # caller asked about via its public alias.
+            #
+            # An UNCONDITIONAL (named) or setup reexport only aliases the ONE
+            # requested name, not the reexported module's namespace as a
+            # whole: rewriting there would fabricate coordinates that were
+            # never actually reexported (verified: ``base_facade.py`` doing
+            # ``from base_impl import Base`` does NOT also expose
+            # ``base_facade.Root`` just because ``Base``'s own base happens
+            # to be ``base_impl.Root`` -- that would be a MISSING pretending
+            # to be a real coordinate).
+            if star_reexport is None:
+                return reexported_bases
+            reexport_module = reexport.rsplit(".", 1)[0]
+            reexport_prefix = f"{reexport_module}."
+            return tuple(
+                (
+                    f"{module_name}.{base.removeprefix(reexport_prefix)}"
+                    if base.startswith(reexport_prefix)
+                    else base
+                )
+                for base in reexported_bases
+            )
         # Resolve public source facades without consulting runtime ``__mro__``.
         # Python 3.11's ``collections.abc`` is literally a star re-export of
         # ``_collections_abc``; later releases point inspection at the defining

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/install_source_dig.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/install_source_dig.py
@@ -2165,6 +2165,91 @@ def _class_base_ast_name(node: ast.expr) -> str | None:
     return _dotted_ast_name(node)
 
 
+def native_extension_class_origin(
+    qualified_class: str, _resolving: frozenset[str] = frozenset()
+) -> str | None:
+    """The true native-extension module a class terminally resolves to, or None.
+
+    RULING (#5930, T, 2026-07-20): `io` is categorically a `RuntimeEffect` --
+    a positive, terminal classification, not an absence. A class like
+    `io.BytesIO` has no Python source anywhere (`io.py` is a thin re-export
+    of `_io`, a compiled extension), so a caller needs to know THAT before
+    attempting static MRO/method resolution, not after: by the time
+    `_facade_class_source` would panic, the panic has already unwound past
+    any caller trying to classify the result.
+
+    Walks the exact same reexport resolution order
+    `_resolve_install_source_class_bases` uses (unconditional reexport, star
+    reexport, setup reexport, star-import facade loop) WITHOUT ever calling
+    `_facade_class_source` and WITHOUT panicking:
+
+    - real Python source found anywhere along the walk -> ``None`` (not
+      native; the ordinary static path should run and can construct it).
+    - the walk terminates at a module with no Python source that
+      `_installed_native_extension` confirms is a compiled extension or a
+      built-in -> that module's dotted name (native; the caller should
+      classify this as a RuntimeEffect, never construct it).
+    - the walk cannot determine either way -> ``None``. This is the case
+      that must still panic downstream: a "cannot tell" answer here is
+      NEVER treated as "not native," it is left to fall through to the
+      existing gap machinery exactly as before this function existed.
+
+    Unlike `_native_imported_base_targets`, a built-in origin counts as
+    native here: `_io` (which backs `io.BytesIO`) is compiled into the
+    interpreter rather than loaded from a `.so`, but it is still I/O with
+    no Python source -- the CPython build detail is not what makes
+    something an effect.
+    """
+    if not qualified_class or "." not in qualified_class:
+        return None
+    if qualified_class in _resolving:
+        return None
+    _resolving = _resolving | {qualified_class}
+    module_name, class_name = qualified_class.rsplit(".", 1)
+    installed = _installed_source(module_name)
+    if installed is None:
+        origin = _installed_native_extension(module_name)
+        return module_name if origin is not None else None
+    source, sourcefile = installed
+    try:
+        parsed = parsed_tree(source, sourcefile)
+    except SyntaxError:
+        return None
+    class_node = next(
+        (
+            statement
+            for statement in parsed.body
+            if isinstance(statement, ast.ClassDef) and statement.name == class_name
+        ),
+        None,
+    )
+    if class_node is not None:
+        return None
+    reexport = (
+        _definite_unconditional_reexport_target(module_name, class_name, parsed)
+        or _definite_star_reexport_target(module_name, class_name, parsed)
+        or _definite_setup_reexport_target(module_name, class_name, parsed)
+    )
+    if reexport is not None:
+        return native_extension_class_origin(reexport, _resolving)
+    for statement in parsed.body:
+        if not isinstance(statement, ast.ImportFrom) or not any(
+            alias.name == "*" for alias in statement.names
+        ):
+            continue
+        target_module = _absolute_import_from_module(
+            module_name, statement.module, statement.level
+        )
+        if target_module is None:
+            continue
+        origin = native_extension_class_origin(
+            f"{target_module}.{class_name}", _resolving
+        )
+        if origin is not None:
+            return origin
+    return None
+
+
 def _facade_class_source(module_name: str, class_name: str) -> NoReturn:
     """No static route exists behind a public re-exporting module: panic loudly.
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/install_source_dig.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/install_source_dig.py
@@ -45,6 +45,36 @@ _MISSING = object()
 _CLASS_BASES_CACHE: OrderedDict[tuple[Any, ...], tuple[str, ...]] = OrderedDict()
 
 
+class _NotDefinedHereType:
+    """A decidable negative: this exact coordinate was resolved, and it does
+    not define the requested member.
+
+    RULING (#5930, T, 2026-07-19): a bare ``None`` is ambiguous between two
+    opposite meanings -- "I cannot answer this" (a gap, must be loud) and
+    "no, this candidate does not define it, try the next" (a resolved,
+    correct negative). Conflating them either turns a real gap into silence,
+    or turns a routine "no" into a false-alarm panic. ``NOT_DEFINED_HERE``
+    is the second meaning ONLY: a candidate search may consume it and
+    continue exactly as it would a normal negative result. It is never
+    returned when the answer is actually unknown -- that case panics with a
+    typed ``FactoryGapInfo`` instead. No caller may treat this value and an
+    unresolved gap as the same thing; there is no third bare-``None`` case
+    left to check for.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "NOT_DEFINED_HERE"
+
+    def __bool__(self) -> bool:
+        # Never let this be mistaken for a truthy "found" value.
+        return False
+
+
+NOT_DEFINED_HERE = _NotDefinedHereType()
+
+
 @dataclass(frozen=True)
 class _ContextIdentity:
     """Strong, O(1) identity token for one factory-recognition input."""
@@ -965,7 +995,13 @@ def resolve_local_source_exit_contract(filename: str | None, local_name: str):
 def resolve_class_exit_contract(qualified_class: str):
     """Prove exit disposition from an installed class's exact ``__exit__`` body."""
     exit_fn = resolve_install_source_class_method(qualified_class, "__exit__")
-    if exit_fn is None or not isinstance(exit_fn.node, ast.FunctionDef):
+    # NOT_DEFINED_HERE is a decidable negative: this class's own module does
+    # not define __exit__, i.e. it is not a context manager. That is the
+    # correct answer for most classes asked this question -- consume it and
+    # answer "no exit contract" exactly as before, never a gap (#5930).
+    if exit_fn is NOT_DEFINED_HERE:
+        return None
+    if not isinstance(exit_fn.node, ast.FunctionDef):
         return None
     return _exit_method_suppression_contract(exit_fn.node)
 
@@ -2311,9 +2347,41 @@ def _resolve_install_source_class_bases(
 
 
 def resolve_install_source_class_method(qualified_class: str, method_name: str):
-    """Resolve ``module.Class.method`` to a FunctionDef SourceFragment, or None."""
+    """Resolve ``module.Class.method`` to a FunctionDef SourceFragment.
+
+    Returns exactly one of two kinds of answer, never a bare ``None``:
+
+    - a ``SourceFragment`` when ``qualified_class``'s own module statically
+      defines ``method_name`` directly on that class.
+    - ``NOT_DEFINED_HERE`` -- a decidable negative -- when that module was
+      read and does NOT define the method there. This function never walks
+      the base chain (see ``resolve_install_source_class_bases`` for that),
+      so "not defined here" is a complete, resolved answer, not a gap: most
+      classes in an MRO walk correctly don't define most methods, and a
+      context-manager discriminator asking "does this implement __exit__"
+      correctly says no far more often than yes. A candidate search may
+      consume ``NOT_DEFINED_HERE`` and try the next candidate exactly as it
+      would any other negative result.
+
+    A malformed ``qualified_class``/``method_name`` coordinate -- one this
+    function cannot even attempt to resolve -- is a different kind of
+    failure: a genuine construction gap. It panics loudly with a typed
+    ``FactoryGapInfo`` instead of returning anything, so it can never be
+    silently mistaken for either of the two answers above.
+    """
+    from sugar_lift_py_tests.factory.factory_gap import factory_panic_gap
+    from sugar_lift_py_tests.factory.factory_gap_info import GapKind, GapLocus
+
     if not qualified_class or not method_name or "." not in qualified_class:
-        return None
+        factory_panic_gap(
+            owner="resolve_install_source_class_method",
+            blame=qualified_class or "<empty>",
+            observed=f"qualified_class={qualified_class!r} method_name={method_name!r}",
+            requested="a dotted module.Class coordinate and a method name",
+            fix="construct a well-formed qualified_class before calling this resolver",
+            gap_kind=GapKind.FLOOR,
+            gap_locus=GapLocus.CONSTRUCTION,
+        )
     from sugar_lift_py_tests.factory.source_fragment import SourceFragment
 
     module_name, class_name = qualified_class.rsplit(".", 1)
@@ -2333,40 +2401,10 @@ def resolve_install_source_class_method(qualified_class: str, method_name: str):
     # inherited method, then read its source via `inspect.getsource`. That
     # both executed third-party code and depended on the live MRO rather
     # than on this module's own static source. `_module_sibling_function_node`
-    # above already answers the static question (a method defined directly
-    # in this module's source); a method inherited from a base defined in a
-    # *different* module has no static route here without walking the base
-    # chain through `resolve_install_source_class_bases`, which this
-    # function does not do.
-    #
-    # A bare `None` here is indistinguishable from "this class genuinely has
-    # no such method anywhere in its MRO" -- a MISSING masquerading as a
-    # fact (T, 2026-07-19: "Bare None are cancer"). This is a construction
-    # gap: panic loudly instead of refusing silently. CALLERS THAT TREAT
-    # `None` FROM THIS FUNCTION AS "TRY THE NEXT CANDIDATE" NOW HIT THIS
-    # PANIC ON THE FIRST CANDIDATE THAT DOESN'T DIRECTLY DEFINE THE METHOD
-    # -- that candidate-search pattern is a caller-side defect this panic
-    # deliberately surfaces; it must not be papered over by softening this
-    # panic back to `None`.
-    from sugar_lift_py_tests.factory.factory_gap import factory_panic_gap
-    from sugar_lift_py_tests.factory.factory_gap_info import GapKind, GapLocus
-
-    factory_panic_gap(
-        owner="resolve_install_source_class_method",
-        blame=f"{qualified_class}.{method_name}",
-        observed=f"{module_name}.{class_name}.{method_name}",
-        requested=(
-            "the exact FunctionDef for this method, defined either directly "
-            "in this class's own module or resolvable by walking "
-            "resolve_install_source_class_bases without importing"
-        ),
-        fix=(
-            "walk resolve_install_source_class_bases to find the base whose "
-            "own module statically defines this method, or cite it directly"
-        ),
-        gap_kind=GapKind.FLOOR,
-        gap_locus=GapLocus.CONSTRUCTION,
-    )
+    # above already answers the static question completely -- this class's
+    # own module was read in full and does not define the method there.
+    # That is a decidable negative, not a gap: return it as such.
+    return NOT_DEFINED_HERE
 
 
 def resolve_call_funcdef(target_name: str, ctx: Any):
@@ -2465,7 +2503,12 @@ def resolve_method_funcdef(method_name: str, receiver_floor: Any, ctx: Any):
         if class_name in from_imports:
             mod, attr = from_imports[class_name]
             qualified = f"{mod}.{attr}" if mod else attr
-            return resolve_install_source_class_method(qualified, method_name)
+            provider = resolve_install_source_class_method(qualified, method_name)
+            # This function's own contract is "SourceFragment or None"; there
+            # is no further candidate to try here, so a decidable negative
+            # (this class doesn't define the method) collapses to this
+            # function's own "not found" answer, same as before (#5930).
+            return None if provider is NOT_DEFINED_HERE else provider
 
     return None
 


### PR DESCRIPTION
Refs #5930. Follow-up to #5934/#5935 (merged).

## Commit 1 — RuntimeEffect wiring for native-extension inherited bases

RULING (T, 2026-07-20): **`io` is categorically a `RuntimeEffect`.** A native class whose initialization must execute at runtime — e.g. `io.BytesIO`, backed by the compiled `_io` module — is a positive, terminal classification, not an absence. It has no Python source to construct a static MRO/method from, but that is not a gap in our knowledge: it is I/O. Panicking there mislabels a KNOWN thing as unknown.

The multi-base constructor path (`_multi_base_inherited_strategy`) already classified this correctly via `_native_imported_base_targets` + `_runtime_strategy(...)` → `RuntimeConstructorStrategy` → the existing `ConstructorRuntimeEffect`. The single-base path (`_inherited_strategy`) had no equivalent check, so it fell through to `_static_constructor_mro` → `_facade_class_source`, which panics (#5934). Same question, two different answers, depending only on how many bases the class happens to have — that asymmetry was the bug.

Two fixes, no new type:

1. **Ordering, both paths.** The native check ran AFTER `mro is None` in both places, which assumed `_static_constructor_mro` returns `None` cleanly on a native base. Since #5934 that call panics via `_facade_class_source` before ever returning — the check was unreachable dead code. Moved before `_static_constructor_mro` in both functions. Verified directly: without this reordering, the multi-base witness for `pandas._libs.index.BaseMultiIndexCodesEngine` panics before the existing check ever runs.

2. **New non-panicking native-origin walk (`native_extension_class_origin`) for the single-base bare-name-import shape.** `_native_imported_base_targets` only handles a dotted attribute-access base (`class X(mod.Y):`). `from io import BytesIO; class RandomReader(BytesIO):` binds the class name directly — no dotted attribute to split, and even `io.BytesIO` isn't itself the native module: `io.py` is real Python source that re-exports `BytesIO` from `_io`. Answering "is this native" for that shape requires walking the same reexport chain `_resolve_install_source_class_bases` already walks, stopping before it would reach `_facade_class_source`. Verified standalone: `io.BytesIO → _io` (native), `pandas._libs.index.BaseMultiIndexCodesEngine → pandas._libs.index` (native), `http.cookiejar.CookieJar → None`, `collections.abc.MutableMapping → None` (both have real source, correctly not classified as effects).

Gated on `site.call_arg_count() == 1` — the only native constructor arity this file has concrete knowledge of (same arity `_inherited_bytesio_strategy` already requires). An arity mismatch is not evidence a base needs runtime execution to classify; it's evidence of a genuine arity error, which stays a loud, arity-specific panic. `test_inherited_bytesio_constructor_wrong_arity_stays_loud` (0 args, 2 args) still panics after this change, verified directly — guarding against widening the effect arm into a dumping ground.

**Result:** two of the six stale-`info.owner` failures reported against #5935 are genuinely fixed (not relabeled): `test_native_imported_multiple_inheritance_uses_runtime_call_operand` and `test_native_imported_multiple_inheritance_ground_wrong_twin_stays_loud` now pass.

## Commit 2 — fix star-reexport naming, don't refuse

RULING (T): ordinary Python with real source gets walked, not refused. `requests.cookiejar.RequestsCookieJar`'s exact C3 MRO already resolved statically — the only defect was a naming bug: bases inherited transitively past the first star-reexport hop came back named after the private defining module (`_collections_abc.Mapping`) instead of the public facade (`collections.abc.Mapping`).

`_resolve_install_source_class_bases` has two code paths that resolve through a `from x import *` reexport; only one rewrote the result back into the facade's namespace. Fixed the other (the early-return `unconditional or star or setup` reexport branch) — but **only when the match came from `_definite_star_reexport_target` specifically**, never for an unconditional/setup reexport of a single name. A star reexport aliases the reexported module's *entire* namespace; a named reexport only aliases that one name.

**Caught by discrimination, not assumption:** the first version of this fix rewrote unconditionally, and `test_dotted_imported_reexport_base_constructs_exact_inherited_object` immediately failed — a facade doing `from base_impl import Base` does NOT also expose `facade.Root` just because `Base`'s own base happens to be `base_impl.Root`. That would have fabricated a coordinate that was never actually reexported — a MISSING pretending to be real. Distinguishing which reexport function matched before rewriting fixed both tests together.

## Result

Four floor/residual/evidence test files: **14 failed / 122 passed → 11 failed / 125 passed.** `R_source_via_execution` stays 0, re-verified 3x after each commit — neither change adds a new import/find_spec call.

The remaining 11 are the original 8 minus `cookiejar` (now fixed) plus 4 of the 6 stale-`info.owner` failures not addressed here (2 arity-gated BytesIO cases, 2 genuinely-missing-module cases — `missing_facade`, `missing_parent.child` were never native to begin with). Filing a tracking issue for these plus the 5 unrelated pre-existing gaps found while sorting the original 8, per direction — not fixed here.

Not merging — up for review.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Classify native-extension base classes as RuntimeEffect and fix star-reexport naming
> - Adds `native_extension_class_origin` in [`install_source_dig.py`](https://github.com/TSavo/sugar/pull/5936/files#diff-ba8ea78128d6f8f6e443d4085b0b1175dc538cf3a9dde6c1878bc127e44d59dc) to detect native extension origins (e.g., `io.BytesIO`) without importing the live object, allowing constructor calls on such bases to be classified as runtime boundaries instead of triggering a panic.
> - Introduces a `NOT_DEFINED_HERE` sentinel (falsy, but identity-distinguishable from `None`) so callers of `resolve_install_source_class_method` can tell "not in this module" from a hard gap; the function no longer panics for inherited methods.
> - Fixes star-reexport base resolution to rewrite class coordinates to the public facade module name, preventing private module names from leaking to callers.
> - Fixes MRO and `super()` resolution to skip bases where `__init__` is not directly defined in the base's module, rather than treating them as found or panicking.
> - Behavioral Change: `resolve_install_source_class_method` now returns `NOT_DEFINED_HERE` instead of calling `factory_panic_gap` when a method is absent from the class's own module; callers that previously relied on the panic to catch bugs must now handle this return value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 45115b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inherited constructor resolution across complex class hierarchies and multiple inheritance.
  * Fixed handling of classes provided by native extensions, including more reliable runtime fallback behavior.
  * Improved resolution through re-exported modules and star re-exports.
  * Corrected cases where missing class methods or constructors could be misinterpreted, producing more consistent results.
  * Added clearer failure handling for malformed class and method references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->