### PR TITLE
Route cycle-guard None through _install_source_cycle_panic (#5930)

### DIFF
--- a/discriminate.py
+++ b/discriminate.py
@@ -1,0 +1,29 @@
+import sys
+
+sys.path.insert(0, "implementations/python/sugar-lift-py-tests/src")
+
+from sugar_lift_py_tests.floor.import_alias_value import (
+    _resolve_static_module_attribute_chain,
+)
+from sugar_lift_py_tests.sugar.install_source_dig import native_extension_class_origin
+
+arm = sys.argv[1]
+
+if arm == "import_alias_cycle":
+    # Force the guard: pre-seed `resolving` with the cycle_key this exact
+    # call will compute (module_name.name), so the guard fires immediately.
+    _resolve_static_module_attribute_chain(
+        "os", ["path"], resolving=frozenset({"os.path"})
+    )
+elif arm == "import_alias_normal":
+    receiver = _resolve_static_module_attribute_chain("json", ["JSONDecoder"])
+    assert receiver is not None and receiver.kind == "class", receiver
+    print("OK", receiver)
+elif arm == "native_origin_cycle":
+    native_extension_class_origin("io.BytesIO", frozenset({"io.BytesIO"}))
+elif arm == "native_origin_normal":
+    origin = native_extension_class_origin("io.BytesIO")
+    assert origin is not None, origin
+    print("OK", origin)
+else:
+    raise SystemExit(f"unknown arm {arm}")

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_alias_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_alias_value.py
@@ -491,6 +491,7 @@ def _resolve_static_module_attribute_chain(
         _definite_setup_reexport_target,
         _definite_star_reexport_target,
         _definite_unconditional_reexport_target,
+        _install_source_cycle_panic,
         _installed_native_extension,
         installed_module_source,
         parsed_tree,
@@ -500,7 +501,17 @@ def _resolve_static_module_attribute_chain(
     rest = remaining[1:]
     cycle_key = f"{module_name}.{name}"
     if cycle_key in resolving:
-        return None
+        # A cycle here is a genuine construction gap, not a decidable
+        # "try the next candidate" negative: nothing further in this walk
+        # can resolve it, unlike the many other `None` returns below (no
+        # module, syntax error, no reexport found) that ARE decidable
+        # negatives callers already fall through on (#5930 ruling: bare
+        # `None` must never be ambiguous between "no" and "cannot tell").
+        _install_source_cycle_panic(
+            guard="import-alias-attribute-chain",
+            target=cycle_key,
+            active=resolving,
+        )
     resolving = resolving | {cycle_key}
 
     installed = installed_module_source(module_name)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/install_source_dig.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/install_source_dig.py
@@ -2203,7 +2203,19 @@ def native_extension_class_origin(
     if not qualified_class or "." not in qualified_class:
         return None
     if qualified_class in _resolving:
-        return None
+        # Same cycle `_resolve_install_source_class_bases` already panics
+        # on downstream (line ~2322): this earlier check exists so the
+        # decision is loud at first detection, not just when some caller
+        # happens to keep walking into the class-bases resolver. The other
+        # `None` returns in this function are documented decidable
+        # negatives ("not provably native, existing gap machinery decides
+        # downstream") -- this one is not, so it does not get to share
+        # their bare-`None` shape (#5930 ruling).
+        _install_source_cycle_panic(
+            guard="native-extension-class-origin",
+            target=qualified_class,
+            active=_resolving,
+        )
     _resolving = _resolving | {qualified_class}
     module_name, class_name = qualified_class.rsplit(".", 1)
     installed = _installed_source(module_name)


### PR DESCRIPTION
Fixes the CI-red `Python sole-construction floors (R>0 red)` job.

Two cycle guards landed tonight in #5933-#5936 still returned bare `None` instead of a loud typed terminal:

- `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_alias_value.py:502` `_resolve_static_module_attribute_chain`
- `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/install_source_dig.py:2205` `native_extension_class_origin`

## Caller-trace findings

Both cycle checks fire only when the exact key (`cycle_key` / `qualified_class`) is already in the `resolving`/`_resolving` set for *this* walk — i.e. we are already resolving that exact coordinate higher on the same call stack. Traced every caller:

- `_resolve_static_module_attribute_chain` has exactly one non-recursive entry point (`_resolve_qualified_import_object`, line 464) plus one recursive self-call for re-export chains (line 562) — both simply propagate whatever this function returns; there is no "try the next candidate" loop around the cycle check itself.
- `native_extension_class_origin` is called from `constructor_call_sugar.py:944` (single call, no fallback) and recursively from itself for unconditional/star re-exports (`install_source_dig.py:2246`, `2257`). The star-reexport loop at 2257 does iterate multiple *re-export* candidates on ordinary `None`, but that's unrelated to the cycle guard: the cycle guard only fires when the *specific* qualified_class being probed is already mid-resolution, which is a real gap for that coordinate, not a "keep trying other candidates" signal.

Conclusion: both cycles are genuine construction gaps. Routed both through the existing `_install_source_cycle_panic` terminal (`install_source_dig.py:137`), whose docstring already states the ruling: *"A recursion guard is a typed construction terminal, never opacity."* Left every other `None` return in both functions untouched — those remain documented decidable negatives (no module, syntax error, no reexport found, not provably native) that callers already fall through on.

## Verification

`scripts/construction_cache_context_law.py`:
- **Before** (diff stashed): `{"instrument": "R_context_incomplete_construction_caches", "ok": false, "R_context_incomplete_construction_caches": 2, "files_scanned": 463}` — RED, flags both sites above.
- **After**: `{"instrument": "R_context_incomplete_construction_caches", "ok": true, "R_context_incomplete_construction_caches": 0, "files_scanned": 463}` — GREEN.

`scripts/source_via_execution_law.py`: stays `R_source_via_execution = 0`.

Four suites (`test_import_alias_floor_drain`, `test_import_alias_fatal_corpus`, `test_import_alias_residual_floors`, `test_constructor_call_evidence`): **35 failed / 101 passed / 8 skipped**, byte-identical with and without this diff (confirmed by re-running with the diff stashed). This box's sugarbin/cargo build is stale relative to the stated main baseline of 11 failed/125 passed/8 skipped — the delta is pre-existing local build-environment drift, not caused by this change. Zero test-count change from this patch.

Discrimination test (`discriminate.py`, both arms, both exit codes):
- `import_alias_cycle` → `FactoryPanic` raised, loud, exit 1.
- `import_alias_normal` → resolves `json.JSONDecoder` fine, exit 0.
- `native_origin_cycle` → `FactoryPanic` raised, loud, exit 1.
- `native_origin_normal` → resolves `io.BytesIO` origin `_io`, exit 0.

No floor/test was weakened or suppressed to reach green.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route cycle-guard `None` returns through `_install_source_cycle_panic` in cycle detection
> - `_resolve_static_module_attribute_chain` and `native_extension_class_origin` previously returned `None` on detecting a resolution cycle; both now call `_install_source_cycle_panic` instead, with a named guard, target, and active resolving set.
> - The change ensures cycles are loud failures rather than silent `None` returns, which were indistinguishable from decidable negative results.
> - A new test script (`discriminate.py`) exercises both cycle and normal code paths for import-alias and native-origin resolution via `sys.argv`.
> - Behavioral Change: callers that previously received `None` on a cycle will now get a panic instead of a falsy return value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a497c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Circular resolution scenarios now produce explicit failures instead of being silently reported as unresolved.
  - Improved diagnostics distinguish circular dependencies from legitimate cases where a module, attribute, or native class origin cannot be found.
  - Normal import and native extension resolution behavior remains supported.

- **Tests**
  - Added coverage for both circular and successful resolution paths, including aliased imports and native classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->