### PR TITLE
Drain 3 pre-existing Group A gaps from #5937

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/remaining_semantics.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/remaining_semantics.py
@@ -40,7 +40,7 @@ class RemainingSemanticRecognition:
             and zero_arg_super
             and not call.call_has_keywords()
             and len(arguments) == 2
-            and arguments[0].observed == "PrimitiveLiteral"
+            and arguments[0].observed == "Constant"
             and isinstance(arguments[0].literal_value(), str)
         ):
             return InitializerCallSite(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructor_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructor_call_sugar.py
@@ -525,7 +525,9 @@ def _strategy_from_init(
     max_args -= 1
     supplied = site.call_arg_count()
     if not min_args <= supplied <= max_args:
-        return _arity_strategy(site, ctx, target, min_args, max_args)
+        return _arity_strategy(
+            site, ctx, target, min_args, max_args, exact_signature=True
+        )
     bytesio = _source_bytesio_strategy(
         site,
         ctx,
@@ -2025,7 +2027,13 @@ def _strategy_from_static_mro(site, ctx, target, class_site, methods, mro):
 
 
 def _arity_strategy(
-    site, ctx, target: str, minimum: int, maximum: int
+    site,
+    ctx,
+    target: str,
+    minimum: int,
+    maximum: int,
+    *,
+    exact_signature: bool = False,
 ) -> RuntimeConstructorStrategy:
     return RuntimeConstructorStrategy(
         class_name=target,
@@ -2038,6 +2046,7 @@ def _arity_strategy(
             f"{minimum}..{maximum} positional arguments, got {site.call_arg_count()}"
         ),
         arity_error=True,
+        exact_signature=exact_signature,
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructor_strategy.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructor_strategy.py
@@ -235,6 +235,13 @@ class RuntimeConstructorStrategy:
     reason: str
     arity_error: bool = False
     runtime_operand: SugarBody | None = None
+    # Set only when the arity mismatch is against a class's own, statically
+    # authenticated __init__ signature (see _strategy_from_init) -- the
+    # exact expected arity is fully known, so the TypeError is certain
+    # regardless of argument values. Inherited/MRO-derived/generated arity
+    # gaps (base class resolution, dataclass fields, ...) leave this False
+    # and keep panicking loudly until that construction is built out.
+    exact_signature: bool = False
 
     def __post_init__(self) -> None:
         if not all(isinstance(argument, SugarBody) for argument in self.arguments):
@@ -270,6 +277,7 @@ class RuntimeConstructorStrategy:
             TypeErrorRuntimeEffect,
             runtime_effect_evidence,
         )
+        from sugar_lift_py_tests.effect.runtime_effect import genuine_runtime_operand
         from sugar_lift_py_tests.ir import ctor, str_const
         from sugar_lift_py_tests.sugar.floor_terms import floor_to_term
 
@@ -283,12 +291,28 @@ class RuntimeConstructorStrategy:
         effect_type = (
             TypeErrorRuntimeEffect if self.arity_error else ConstructorRuntimeEffect
         )
+        chosen_operand = runtime_operand if runtime_operand is not None else call_term
+        if self.arity_error and runtime_operand is None and self.exact_signature:
+            # An arity TypeError is certain at every call regardless of the
+            # (possibly ground) argument values -- Python decides it before
+            # touching any value. The mismatch itself is only known once the
+            # call executes against the constructor's real signature, so cite
+            # it as a call: coordinate (runtime-by-nature per
+            # is_lift_time_decidable) rather than a bare ground constructor
+            # term, mirroring NoneValue.subtract's ground-operand door.
+            try:
+                genuine_runtime_operand("py.constructor", call_term)
+            except TypeError:
+                chosen_operand = ctor(
+                    f"call:{self.class_name}.__init__",
+                    [call_term],
+                )
         return Incomplete(
             effect_type(
                 self.reason,
                 **runtime_effect_evidence(
                     "py.constructor",
-                    runtime_operand if runtime_operand is not None else call_term,
+                    chosen_operand,
                     self.site,
                 ),
             )


### PR DESCRIPTION
Fixes 3 of the 5 "Group A" pre-existing gaps tracked in #5937.

## Fixed

**#3 + #4 (one root cause, two tests): `super().__setattr__` recognizer never fired**
- `test_source_initializer_super_setattr_constructs_ground_field`
- `test_super_setattr_constructor_truthful_sat_wrong_twin_unsat`

`RemainingSemanticRecognition.initializer_call_site` (the ONE recognizer for constructor-body calls: `super().__init__`, `super().__setattr__`, authenticated base calls, `self.method()`) checked the literal target-name argument against the legacy `observed == "PrimitiveLiteral"` wire member. `SourceFragment.observed` reports the current structural class name `"Constant"` for `ast.Constant` (`PRIMITIVE_LITERAL` is retained only as a legacy wire member per `node_kind.py`'s own docstring). The check never matched, so `super().__setattr__("f", f)` fell through to the generic `Expr` panic in `_strategy_from_init`'s field-only loop instead of routing to the existing `SuperSetAttrApply` construction. One-line fix to the existing recognizer at `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/recognition/remaining_semantics.py:43` — no new predicate, no bespoke matcher.

**#5: statically-impossible constructor arity now constructs `TypeErrorRuntimeEffect`**
- `test_statically_impossible_constructor_arity_is_witnessed_type_error`

`RuntimeConstructorStrategy.emit` routed *every* arity mismatch through `runtime_effect_evidence`, which requires a genuine (non-lift-time-decidable) operand. A `Box()` call against a locally-declared `__init__(self, value)` supplies zero ground arguments, so the constructed `python:constructor_call` term is fully decidable — the door correctly refused to mint `RuntimeEffect` authority from it and panicked instead.

But an arity mismatch against a class's *own* statically authenticated `__init__` signature is a certainty independent of the (possibly ground) argument values — Python decides the `TypeError` before touching them. That's the same shape `NoneValue.subtract` already handles for ground operands: wrap the term as a `call:<Class>.__init__` coordinate, which `is_lift_time_decidable` correctly treats as runtime-by-nature (a call denotes a result that doesn't exist until executed, even with ground args).

Added an `exact_signature` flag on `RuntimeConstructorStrategy`/`_arity_strategy`, set `True` only at the `_strategy_from_init` call site (the one path where the mismatched arity is checked against a locally-declared, statically-parsed `__init__`). Every other `_arity_strategy` call site (inherited/MRO-derived resolution, generated dataclass/namedtuple fields) leaves it `False` and keeps panicking loudly — that construction genuinely isn't built yet, and this PR does not claim it is.

I initially wrote this fix too broadly (no flag) and it silently flipped `test_inherited_bytesio_constructor_shadowed_base_stays_loud` from a correct loud panic to a false success — caught by running the full four-suite tally, not just the target test. The `exact_signature` gate was added specifically to stop that regression; verified all 4 tests (2 new fixes + the discrimination test they could have broken) pass together in one run.

## Not fixed here (left for follow-up)
- `test_pandas_pyarrow_flag_constructs_guarded_predicate` — passed on this branch/run without any change; not reproduced against current `main` in this session. Worth re-checking against #5937's exact repro before closing that sub-item.
- `test_numpy_setup_reexport_getattr_constructs_exact_import_coordinate` — the cycle-guard verification question (real cycle vs constructible coordinate) was not investigated; left untouched per instruction not to touch the two cycle guards another agent owns.

## Verification

Four suites (`test_import_alias_floor_drain.py`, `test_import_alias_fatal_corpus.py`, `test_import_alias_residual_floors.py`, `test_constructor_call_evidence.py`):

- Baseline: 11 failed / 125 passed / 8 skipped
- This branch: **7 failed / 129 passed / 8 skipped**

`R_source_via_execution` law: green, `R_source_via_execution = 0` (unchanged). `construction_cache_context_law` untouched — owned by another agent, currently red on `main` independent of this change.

Discrimination: ran the 2 newly-passing tests plus `test_inherited_bytesio_constructor_shadowed_base_stays_loud` (the wrong twin the broad version of the arity fix broke) together — all 4 pass, exit code 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix constructor arity error evidence and `super().__setattr__` recognition in sugar-lift tests
> - Fixes `RemainingSemanticRecognition.initializer_call_site` to check `observed == "Constant"` instead of `observed == "PrimitiveLiteral"` when recognizing `super().__setattr__(<str>, ...)` calls.
> - Adds an `exact_signature: bool` field to `RuntimeConstructorStrategy` and threads it through `_arity_strategy` and `_strategy_from_init`, so arity mismatches against a class's own `__init__` are flagged accordingly.
> - When `exact_signature=True` and no explicit `runtime_operand` is provided, `RuntimeConstructorStrategy.emit` attempts `genuine_runtime_operand("py.constructor", call_term)` and falls back to a `call:Class.__init__` coordinated operand, so emitted `TypeErrorRuntimeEffect` evidence cites the correct term.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 45b2f81.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->