### PR TITLE
Typed recognition layer, standalone: accepts is the shape, owns is the operand types (#5940)

### DIFF
--- a/implementations/python/sugar-typed-recognition/pyproject.toml
+++ b/implementations/python/sugar-typed-recognition/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sugar-typed-recognition"
+version = "0.1.0"
+description = "The typed recognition layer (#5940): accepts narrows the shape, owns interrogates the operand types. Standalone; depends only on sugar-node-membrane."
+requires-python = ">=3.12"
+dependencies = []
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/implementations/python/sugar-typed-recognition/src/sugar_typed_recognition/__init__.py
+++ b/implementations/python/sugar-typed-recognition/src/sugar_typed_recognition/__init__.py
@@ -1,0 +1,33 @@
+"""sugar-typed-recognition: the typed recognition layer (#5940).
+
+``accepts`` narrows the node shape, by type. ``owns`` interrogates the
+operand types, which arrive already ``Typed`` from their own construction.
+The catalog resolves the two together — registry-based multiple dispatch —
+to exactly one claim, or it panics. Two arms, never three.
+
+Built against ``sugar-node-membrane`` and nothing else in the tree;
+greenfield beside the legacy ``claim/sugar_catalog.py`` +
+``factory/build.py``, which are untouched.
+"""
+
+from .catalog import TypedCatalog
+from .claim import TypedClaim, operand_types
+from .claims import PORTED_CLAIMS
+from .panic import RecognitionArm, RecognitionPanic
+from .role import Role
+
+__all__ = [
+    "PORTED_CLAIMS",
+    "RecognitionArm",
+    "RecognitionPanic",
+    "Role",
+    "TypedCatalog",
+    "TypedClaim",
+    "operand_types",
+    "default_catalog",
+]
+
+
+def default_catalog() -> TypedCatalog:
+    """The ported demonstration set. Not the full ~80 — proof of mechanism."""
+    return TypedCatalog(PORTED_CLAIMS)

--- a/implementations/python/sugar-typed-recognition/src/sugar_typed_recognition/catalog.py
+++ b/implementations/python/sugar-typed-recognition/src/sugar_typed_recognition/catalog.py
@@ -1,0 +1,235 @@
+"""TypedCatalog: registry-based multiple dispatch over membrane types.
+
+The shape
+---------
+
+::
+
+    resolve(role, site)  ->  exactly one TypedClaim   |   RecognitionPanic
+
+Two arms. Never three. ``resolve`` is the only entry point a builder should
+call; ``candidates_for`` is exposed for tests and diagnostics and is not a
+resolution.
+
+The dispatch key
+----------------
+
+Recognition is where more than one type meets. The key is::
+
+    (role, type(site), *operand_types(site))
+     ^^^^  ^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^
+     |     |            coordinates 1..n: interrogated by owns(), and
+     |     |            available only because operands are already Typed
+     |     coordinate 0: matched against claim.accepts by isinstance,
+     |     BEFORE owns() is called
+     which question is being asked
+
+Each coordinate enters at a different place, and the places are not
+interchangeable:
+
+* **role** is matched on the claim's declaration. A cheap equality on an
+  enum, not a string.
+* **``type(site)``** is matched by ``isinstance(site, claim.accepts)`` in the
+  pre-filter below. This is the coordinate that used to be spelled
+  ``site.observed == "Call"`` inside every predicate, 403 times.
+* **operand types** are interrogated by ``owns``, by ``isinstance`` on
+  membrane classes. This is the coordinate a plain type switch cannot
+  express, and therefore the reason the catalog exists rather than a
+  ``match`` statement on the node class.
+
+Why a type switch is not enough (the load-bearing argument)
+-----------------------------------------------------------
+
+If ``accepts`` were the whole key, this could all be a dict from node class
+to claim, and the catalog would be a needless indirection. It is not the
+whole key. ``AddOpClaim`` and ``MultiplyOpClaim`` and ``AnnotationUnionClaim``
+all declare ``accepts = BinOp`` and are distinguished only by the type of
+``site.op``; ``MethodCallClaim`` and ``PlainCallClaim`` both declare
+``accepts = Call`` and are distinguished only by the type of ``site.func``.
+Dispatch on more than one type at once, resolved by a registry rather than
+by a receiver's vtable, is multiple dispatch. The catalog IS the dispatch
+table.
+
+Why recognition is bottom-up, and why that is forced rather than agreed
+-----------------------------------------------------------------------
+
+``owns`` may interrogate operand types only because operands arrive already
+``Typed``. The membrane constructs bottom-up (``construct.py``: children
+first, every parent built FROM finished children), so the ordering is a
+consequence of the type discipline, not a rule recognition asks anyone to
+follow. There is no phase to schedule and no traversal order to get wrong:
+if you are holding a ``BinOp``, its ``left``, ``right`` and ``op`` are
+already resolved, because you could not have been handed the ``BinOp``
+otherwise.
+
+``operand_types(site)`` is called before any ``owns``, so a child that
+cannot answer its type panics as a MISSING rather than reaching a claim that
+would have no vocabulary but ``False``.
+
+No precedence, on purpose
+-------------------------
+
+Today's factory resolves overlap with a ``comes_before`` precedence walk
+(``factory/build.py:_select_candidate``) and panics only when the walk fails
+to produce a unique winner. This layer has no precedence walk. Overlap is
+the defect itself: if two claims own the same (role, node type, operand
+types) key, the catalog is not a function, and precedence would be a rule
+for picking one of two answers to a question that should have had one.
+Disjointness is achieved by making ``owns`` predicates disjoint — which the
+typed layer makes cheap, because the operand type IS the discriminator.
+``PlainCallClaim`` in ``claims.py`` is the worked example: it excludes the
+builtin coordinate that ``LenCallClaim`` owns, rather than losing a
+precedence contest to it.
+
+See ``REPORT`` notes in the PR: this is the largest behavioral difference
+from the design in #5940, and it is a deliberate narrowing.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence, Tuple
+
+from sugar_node_membrane.nodes import SourceFragment, Typed
+
+from .claim import TypedClaim, operand_types
+from .panic import RecognitionArm, recognition_panic
+from .role import Role
+
+
+class TypedCatalog:
+    """An immutable set of claims plus the dispatch over them."""
+
+    def __init__(self, claims: Iterable[type[TypedClaim]] = ()) -> None:
+        self._claims: Tuple[type[TypedClaim], ...] = tuple(claims)
+        for claim in self._claims:
+            if not (isinstance(claim, type) and issubclass(claim, TypedClaim)):
+                recognition_panic(
+                    RecognitionArm.GAP,
+                    owner="catalog.TypedCatalog",
+                    observed=f"registered {claim!r}",
+                    requested="a TypedClaim subclass",
+                    fix="a claim is a class, registered by class, never an instance",
+                )
+            if getattr(claim, "accepts", None) is None:
+                recognition_panic(
+                    RecognitionArm.GAP,
+                    owner="catalog.TypedCatalog",
+                    observed=f"claim {claim.__name__} declares no accepts",
+                    requested="accepts: type[SourceFragment]",
+                    fix="every registered claim declares the node class it recognizes",
+                )
+
+    @property
+    def claims(self) -> Tuple[type[TypedClaim], ...]:
+        return self._claims
+
+    # -- dispatch ---------------------------------------------------------
+
+    def candidates_for(
+        self, role: Role, site: SourceFragment
+    ) -> Tuple[type[TypedClaim], ...]:
+        """Every claim owning this site under this role. Diagnostics only.
+
+        Not a resolution: a caller that acts on this tuple without going
+        through ``resolve`` has reintroduced "pick the first".
+        """
+        self._require_typed_site(site)
+
+        # Interrogating the operands is also the check that they CAN be
+        # interrogated. Panics on a MISSING operand type before any owns().
+        operand_types(site)
+
+        return tuple(
+            claim
+            for claim in self._claims
+            if claim.role is role
+            # coordinate 0, by type, never by string
+            and isinstance(site, claim.accepts)
+            # coordinates 1..n, inside the claim, on already-Typed operands
+            and claim.owns(site)
+        )
+
+    def resolve(self, role: Role, site: SourceFragment) -> type[TypedClaim]:
+        """THE two-arm match: exactly one claim, or panic.
+
+        ::
+
+            match candidates:
+                [one]  => one
+                _      => panic
+        """
+        candidates = self.candidates_for(role, site)
+        if len(candidates) == 1:
+            return candidates[0]
+        if not candidates:
+            self._panic_gap(role, site)
+        self._panic_ambiguous(role, site, candidates)
+
+    # -- the two loud arms ------------------------------------------------
+
+    def _panic_gap(self, role: Role, site: SourceFragment) -> None:
+        recognition_panic(
+            RecognitionArm.GAP,
+            owner="catalog.TypedCatalog.resolve",
+            observed=(
+                f"{_key_description(role, site)} — no claim owns this combination"
+            ),
+            requested=f"exactly one {role.value} claim",
+            fix=(
+                f"add a claim with accepts = {type(site).__name__} whose owns() "
+                f"answers True for these operand types, or extend an existing "
+                f"claim's owns() to cover them. Never widen a claim to swallow "
+                f"a shape it does not mean."
+            ),
+        )
+
+    def _panic_ambiguous(
+        self,
+        role: Role,
+        site: SourceFragment,
+        candidates: Sequence[type[TypedClaim]],
+    ) -> None:
+        names = ", ".join(claim.name() for claim in candidates)
+        recognition_panic(
+            RecognitionArm.AMBIGUOUS,
+            owner="catalog.TypedCatalog.resolve",
+            observed=(
+                f"{_key_description(role, site)} — {len(candidates)} claims own "
+                f"this combination: [{names}]"
+            ),
+            requested=f"exactly one {role.value} claim",
+            fix=(
+                "two claims own one dispatch key, so the catalog is not a "
+                "function and no answer it gives is defensible. Make the owns() "
+                "predicates disjoint — typically by having one of them exclude "
+                "the operand type the other exists for. There is no precedence "
+                "mechanism here and picking the first is not available: that "
+                "would be a third arm."
+            ),
+        )
+
+    # -- guards -----------------------------------------------------------
+
+    @staticmethod
+    def _require_typed_site(site: SourceFragment) -> None:
+        if isinstance(site, SourceFragment) and isinstance(site, Typed):
+            site.resolve_type()  # panics if abstract; two arms all the way down
+            return
+        recognition_panic(
+            RecognitionArm.MISSING_OPERAND_TYPE,
+            owner="catalog.TypedCatalog",
+            observed=f"site is {type(site).__name__}",
+            requested="a Typed membrane node",
+            fix=(
+                "recognition dispatches on membrane classes. A site that is not "
+                "a constructed membrane node never had a type to dispatch on."
+            ),
+        )
+
+
+def _key_description(role: Role, site: SourceFragment) -> str:
+    operands = ", ".join(t.__name__ for t in operand_types(site))
+    return (
+        f"role={role.value} site={type(site).__name__} "
+        f"operands=({operands}) at [{site.span.start},{site.span.end})"
+    )

--- a/implementations/python/sugar-typed-recognition/src/sugar_typed_recognition/claim.py
+++ b/implementations/python/sugar-typed-recognition/src/sugar_typed_recognition/claim.py
@@ -1,0 +1,247 @@
+"""TypedClaim: ``accepts`` is the shape, ``owns`` is the semantics.
+
+The defect this replaces
+------------------------
+
+Today's claim carries ``owns: Callable[[object], bool]``. That ``object`` is
+the root defect: an untyped parameter forces every predicate to re-derive
+what it is holding before it can ask its real question. Measured on the tree
+this package sits beside: **403 ``.observed ==`` string compares** and 105
+``.node`` reads, most of them shape re-derivation. ``MethodCallSugar.owns``
+is four conjuncts and the first one is ``site.observed == "Call"``.
+
+The replacement is two declarations instead of one predicate:
+
+``accepts: type[SourceFragment]``
+    The syntactic shape, checked **by type**, by the catalog, before ``owns``
+    is ever called. ``accepts = Call`` is the whole of ``observed == "Call"``,
+    and it cannot disagree with the node the way a string compare can.
+
+``owns(cls, site: <accepts>) -> bool``
+    The ONE semantic question that distinguishes this claim from other claims
+    of the same shape. The parameter is typed as the class ``accepts`` names,
+    so the body may reach for that class's fields directly — no ``_require``
+    preamble, no defensive re-check.
+
+isinstance on membrane classes is LEGAL and ENCOURAGED
+------------------------------------------------------
+
+Stated here, in the code, because if the design does not say it out loud
+workers invent kind strings to dodge an imagined ban (#5940 design review,
+section 6).
+
+* ``isinstance(site.func, Attribute)`` — **legal.** "Is this callee an
+  attribute access" is exactly the question the class hierarchy exists to
+  answer. Interior questions about operands are isinstance questions.
+* ``isinstance(site.op, Add)`` — **legal.** Operators are membrane classes
+  too (singletons), so operator dispatch is the same act.
+* ``site.kind == "Call"`` — **banned.** ``kind`` is the wire/CID projection,
+  a frozen serialization word. It is not a dispatch mechanism. Any string
+  compare against it is the disease coming back.
+
+The rule in one line: **isinstance on OUR classes, never a tag compare on
+strings.**
+
+Where multiple dispatch lives
+-----------------------------
+
+``accepts`` narrows ONE type: the node's own class. But recognition is
+where more than one type meets — a claim for ``Int + Int`` and a claim for
+``str + str`` both ``accepts = BinOp`` and disagree about the operands.
+``owns`` is where the operand types enter, and that is why a plain type
+switch on the node class cannot replace the catalog: the node class is only
+the first coordinate of the dispatch key.
+
+The operands can be interrogated at all only because they arrive **already
+``Typed``** from their own construction. That is not a convention this layer
+asks callers to honor; it is forced by the membrane's construction order
+(bottom-up, children before parents, ``construct.py``). Recognition inherits
+that order: by the time a claim is asked about a ``BinOp``, its ``left``,
+``right`` and ``op`` are finished objects with resolved types. So recognition
+is bottom-up because construction is, and the ordering is forced by the
+types rather than by documentation.
+
+A child that cannot answer its type is a MISSING and panics. It is NEVER a
+quiet ``False`` from ``owns`` — see ``operand_types`` below and
+``panic.RecognitionArm.MISSING_OPERAND_TYPE``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields as dataclass_fields, is_dataclass
+from typing import ClassVar, Tuple
+
+from sugar_node_membrane.nodes import SourceFragment, Typeable, Typed
+from sugar_node_membrane.operators import Operator
+
+from .panic import RecognitionArm, recognition_panic
+from .role import Role
+
+
+class TypedClaim:
+    """One claim. Subclass, declare ``accepts`` + ``role``, implement ``owns``.
+
+    Subclasses are plain classes, not instances: a claim is a singleton
+    identified by its class, exactly as today's ``Sugar`` subclasses are.
+    """
+
+    #: Dispatch coordinate 0: the syntactic shape, checked by the catalog.
+    accepts: ClassVar[type[SourceFragment]]
+    #: Dispatch coordinate -1: which question is being asked of the site.
+    role: ClassVar[Role]
+
+    def __init_subclass__(cls, **kw: object) -> None:
+        super().__init_subclass__(**kw)
+        accepts = cls.__dict__.get("accepts", getattr(cls, "accepts", None))
+        if accepts is None:
+            return  # an intermediate abstract claim; concrete ones declare it
+        if not (isinstance(accepts, type) and issubclass(accepts, SourceFragment)):
+            recognition_panic(
+                RecognitionArm.GAP,
+                owner=f"claim.{cls.__name__}",
+                observed=f"accepts = {accepts!r}",
+                requested="a membrane SourceFragment subclass",
+                fix=(
+                    "accepts names the node CLASS this claim recognizes "
+                    "(e.g. accepts = Call). It is never a kind string."
+                ),
+            )
+
+    @classmethod
+    def name(cls) -> str:
+        return cls.__name__
+
+    @classmethod
+    def owns(cls, site: SourceFragment) -> bool:
+        """The ONE semantic question. ``site`` is an instance of ``accepts``.
+
+        Returning ``True``/``False`` is an ANSWER, and only an answer. If this
+        method cannot answer, it does not return ``False`` — nothing here may
+        encode a MISSING as a negative. Operand types are guaranteed resolved
+        before this is called, so "I could not tell" is not a reachable state.
+        """
+        raise NotImplementedError
+
+
+# --------------------------------------------------------------------------
+# operand typing: the guarantee that owns() is only ever asked answerable
+# questions
+# --------------------------------------------------------------------------
+
+
+def _operator_field_names(cls: type) -> Tuple[str, ...]:
+    """Dataclass fields of a membrane class that hold operators.
+
+    Derived from the declared annotations. The membrane writes operator
+    annotations as ``BinaryOperator`` / ``UnaryOperator`` / ``BooleanOperator``
+    / ``Tuple[ComparisonOperator, ...]`` — every one of them contains the
+    substring ``Operator``, and no child or leaf annotation does. This is a
+    read of the membrane's own declarations, not a heuristic over arbitrary
+    text; if the membrane ever names an operator type without that substring,
+    the ``test_operator_fields_cover_every_operator_carrier`` test goes red
+    rather than this silently under-reporting.
+    """
+    cached = _OPERATOR_FIELDS.get(cls)
+    if cached is not None:
+        return cached
+    names: list[str] = []
+    if is_dataclass(cls):
+        for f in dataclass_fields(cls):
+            annotation = f.type if isinstance(f.type, str) else getattr(f.type, "__name__", "")
+            if "Operator" in annotation:
+                names.append(f.name)
+    result = tuple(names)
+    _OPERATOR_FIELDS[cls] = result
+    return result
+
+
+_OPERATOR_FIELDS: dict[type, Tuple[str, ...]] = {}
+
+
+def operand_types(site: SourceFragment) -> Tuple[type, ...]:
+    """The resolved types of every operand of ``site``, in grammar order.
+
+    This is the rest of the dispatch key — the coordinates after ``accepts``.
+    Computing it is also the enforcement point: every operand must be able to
+    answer its own type, and one that cannot panics HERE, before any claim's
+    ``owns`` is called. That ordering is the whole point. If the check lived
+    inside ``owns``, a claim that could not interrogate an operand would have
+    only ``False`` to return, and a hole in the membrane would be
+    indistinguishable from a correct negative answer.
+
+    Structural absence is not a MISSING: an ``Optional`` child that is ``None``
+    (a bare ``return``, a ``Call`` with no receiver) is an answered question
+    whose answer is "nothing is there". It contributes ``type(None)`` to the
+    key. A refusal would be a MISSING; a declared-absent field is a fact.
+    """
+    key: list[type] = []
+    cls = type(site)
+
+    for name in getattr(cls, "_child_fields", ()):
+        value = getattr(site, name)
+        if value is None:
+            key.append(type(None))
+            continue
+        if isinstance(value, tuple):
+            for index, item in enumerate(value):
+                key.append(_resolved_child_type(site, f"{name}[{index}]", item))
+            continue
+        key.append(_resolved_child_type(site, name, value))
+
+    for name in _operator_field_names(cls):
+        value = getattr(site, name)
+        if isinstance(value, tuple):
+            for index, item in enumerate(value):
+                key.append(_resolved_operator_type(site, f"{name}[{index}]", item))
+            continue
+        key.append(_resolved_operator_type(site, name, value))
+
+    return tuple(key)
+
+
+def _resolved_child_type(site: SourceFragment, where: str, value: object) -> type:
+    if isinstance(value, SourceFragment) and isinstance(value, Typed):
+        # Typed.resolve_type() itself panics on an abstract class; a membrane
+        # node that is not an instance of a concrete grammar class never
+        # reaches a claim.
+        return value.resolve_type()
+    recognition_panic(
+        RecognitionArm.MISSING_OPERAND_TYPE,
+        owner="claim.operand_types",
+        observed=(
+            f"{type(site).__name__}.{where} holds "
+            f"{type(value).__name__}"
+            + (
+                " (Typeable but not Typed: it was never constructed)"
+                if isinstance(value, Typeable)
+                else " (not a membrane node)"
+            )
+        ),
+        requested="an already-Typed membrane node",
+        fix=(
+            "operands are Typed by their own construction, bottom-up, before "
+            "the parent is recognized. An operand that cannot answer its type "
+            "is a hole in the membrane, not a False from owns(). Fix the "
+            "construction that produced this child; never make a claim "
+            "tolerate it."
+        ),
+    )
+
+
+def _resolved_operator_type(site: SourceFragment, where: str, value: object) -> type:
+    if isinstance(value, Operator) and type(value).kind:
+        return type(value)
+    recognition_panic(
+        RecognitionArm.MISSING_OPERAND_TYPE,
+        owner="claim.operand_types",
+        observed=(
+            f"{type(site).__name__}.{where} holds {value!r} "
+            f"({type(value).__name__})"
+        ),
+        requested="a concrete membrane Operator singleton",
+        fix=(
+            "operators are membrane classes, not strings. The operator arrives "
+            "from operators.operator_for(), which itself has two arms. A "
+            "non-Operator here means something bypassed that door."
+        ),
+    )

--- a/implementations/python/sugar-typed-recognition/src/sugar_typed_recognition/claims.py
+++ b/implementations/python/sugar-typed-recognition/src/sugar_typed_recognition/claims.py
@@ -1,0 +1,314 @@
+"""A representative handful of claims, ported onto the typed layer.
+
+This is proof of the mechanism, not a migration: ~80 concrete grammar
+classes and a comparable number of sugars exist, and porting them all would
+demonstrate nothing that these nine do not. The set is chosen to cover every
+shape the mechanism has to handle:
+
++-----------------------------+------------------------------------------------+
+| claim                       | what its old ``owns`` collapsed to             |
++=============================+================================================+
+| ``AssertClaim``             | ENTIRELY to ``accepts``. Old body was          |
+|                             | ``site.observed == "Assert"`` — pure shape     |
+|                             | re-derivation, nothing else. ``owns`` is now   |
+|                             | a constant ``True``.                           |
++-----------------------------+------------------------------------------------+
+| ``NameClaim``               | ENTIRELY to ``accepts``. Same story.           |
++-----------------------------+------------------------------------------------+
+| ``ReturnClaim``             | Half. ``observed == "Return"`` -> ``accepts``; |
+|                             | ``return_value() is not None`` survives as a   |
+|                             | real question about a structurally optional    |
+|                             | field.                                         |
++-----------------------------+------------------------------------------------+
+| ``MethodCallClaim`` /       | One of four conjuncts. The shape leg went to   |
+| ``PlainCallClaim`` /        | ``accepts``; the rest were never shape         |
+| ``LenCallClaim`` /          | re-derivation but **claim-ordering facts**,    |
+| ``KeywordCallClaim``        | and they survive as explicit disjointness.     |
++-----------------------------+------------------------------------------------+
+| ``AddOpClaim`` /            | Half, and the surviving half is the point:     |
+| ``MultiplyOpClaim`` /       | genuine operand-type dispatch. Three claims,   |
+| ``AnnotationUnionClaim``    | one ``accepts``, distinguished only by the     |
+|                             | TYPE of ``site.op``.                           |
++-----------------------------+------------------------------------------------+
+
+Two things worth reading closely
+--------------------------------
+
+**The call family is where the no-precedence rule shows its teeth.** Today
+``MethodCallSugar.owns`` reads::
+
+    site.observed == "Call"
+    and site.call_receiver() is not None
+    and site.call_qualified_target_name() != "os.exit"
+    and not site.call_has_keywords()
+
+Four conjuncts, and it is tempting to say typing deletes three. It deletes
+one. The first is shape re-derivation and becomes ``accepts = Call``. The
+other two are facts about OTHER claims — ``OsSugar`` owns ``os.exit``,
+``KeywordCallSugar`` owns keyword-bearing calls — and today they are
+belt-and-braces alongside a ``comes_before`` precedence edge that would have
+resolved the overlap anyway. Here there is no precedence edge, so those
+conjuncts are not redundant defensiveness: they are the disjointness itself,
+and every claim in the call family carries its share of it. That is a real
+cost of removing precedence, and it is priced in below rather than hidden.
+
+**The BinOp family is the multiple dispatch.** ``accepts = BinOp`` narrows
+nothing between them; ``isinstance(site.op, Add)`` is the entire
+discrimination, and ``site.op`` is a membrane ``Operator`` singleton rather
+than the string ``"Add"`` that ``site.operator_kind() == "Add"`` compares
+against today. Both the node type and the operator type participate in one
+dispatch decision. No receiver's vtable can express that; a registry can.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from sugar_node_membrane.nodes import (
+    Assert,
+    Attribute,
+    BinOp,
+    Call,
+    Name,
+    Return,
+    SourceFragment,
+)
+from sugar_node_membrane.operators import Add, BitOr, Mult
+
+from .claim import TypedClaim
+from .role import Role
+
+#: Builtin callees carved out of ``PlainCallClaim`` because a dedicated claim
+#: owns them. Under the no-precedence rule this exclusion is load-bearing, not
+#: cosmetic: without it ``PlainCallClaim`` and ``LenCallClaim`` both own
+#: ``len(xs)`` and resolution panics AMBIGUOUS.
+_DEDICATED_BUILTIN_CALLEES = frozenset({"len"})
+
+
+# --------------------------------------------------------------------------
+# collapsed entirely to accepts — owns asks nothing, because there is nothing
+# left to ask
+# --------------------------------------------------------------------------
+
+
+class AssertClaim(TypedClaim):
+    """``assert <condition>[, <message>]``.
+
+    Ported from ``AssertSugar.owns``, whose entire body was
+    ``site.observed == "Assert"``. There was never a semantic question here:
+    the claim owns a shape, and the shape is now the declaration. ``owns``
+    returning a constant is the honest outcome, not a stub — the alternative
+    would be re-asking by string what ``accepts`` already established by type.
+    """
+
+    accepts: ClassVar[type[SourceFragment]] = Assert
+    role: ClassVar[Role] = Role.STATEMENT
+
+    @classmethod
+    def owns(cls, site: Assert) -> bool:
+        return True
+
+
+class NameClaim(TypedClaim):
+    """A bare name. Ported from ``NameSugar.owns`` (``observed == "Name"``)."""
+
+    accepts: ClassVar[type[SourceFragment]] = Name
+    role: ClassVar[Role] = Role.TERM
+
+    @classmethod
+    def owns(cls, site: Name) -> bool:
+        return True
+
+
+# --------------------------------------------------------------------------
+# structural absence: a real question, and NOT a refusal
+# --------------------------------------------------------------------------
+
+
+class ReturnClaim(TypedClaim):
+    """``return <expr>``. Bare ``return`` is deliberately not owned.
+
+    Ported from ``ReturnSugar.owns``::
+
+        site.observed == "Return" and site.return_value() is not None
+
+    The first conjunct became ``accepts``. The second is a genuine semantic
+    question and survives: ``Return.value`` is ``Optional[Expression]``, and
+    the two cases mean different things. ``value is None`` here is a
+    STRUCTURAL absence being read, which is a fact — not a bare ``None``
+    being used as a refusal. Bare ``return`` then reaches ``resolve`` with no
+    owner and panics GAP, exactly as the original comment intended ("bare
+    return stays a loud factory gap"), and now it is the resolver that makes
+    it loud rather than each claim remembering to.
+    """
+
+    accepts: ClassVar[type[SourceFragment]] = Return
+    role: ClassVar[Role] = Role.STATEMENT
+
+    @classmethod
+    def owns(cls, site: Return) -> bool:
+        return site.value is not None
+
+
+# --------------------------------------------------------------------------
+# the call family: one accepts, four claims, disjoint by construction
+# --------------------------------------------------------------------------
+
+
+class KeywordCallClaim(TypedClaim):
+    """Any call carrying keywords. Ported from ``KeywordCallSugar``'s territory.
+
+    Listed first because the other three define themselves partly by
+    excluding it. Keyword-bearing calls bind differently, so the distinction
+    is real; what changed is that it is now stated once here and once in each
+    peer, instead of being implied by a ``comes_before`` edge.
+    """
+
+    accepts: ClassVar[type[SourceFragment]] = Call
+    role: ClassVar[Role] = Role.TERM
+
+    @classmethod
+    def owns(cls, site: Call) -> bool:
+        return bool(site.keywords)
+
+
+class MethodCallClaim(TypedClaim):
+    """``recv.method(<args>)`` — a call whose callee is an attribute access.
+
+    ``isinstance(site.func, Attribute)`` is the ONE real question, and it is
+    an isinstance on a membrane class: the blessed form. Today the same
+    question is ``site.call_receiver() is not None``, which walks to the
+    callee, checks its ast type, and projects the answer through an Optional
+    so the caller can compare it to ``None`` — three steps to ask what the
+    type system answers in one.
+    """
+
+    accepts: ClassVar[type[SourceFragment]] = Call
+    role: ClassVar[Role] = Role.TERM
+
+    @classmethod
+    def owns(cls, site: Call) -> bool:
+        return isinstance(site.func, Attribute) and not site.keywords
+
+
+class PlainCallClaim(TypedClaim):
+    """``f(<args>)`` — a call on a plain name, excluding dedicated builtins.
+
+    The exclusion is the worked example of disjointness replacing precedence.
+    Today ``CallSugar`` owns every plain call and ``LenCallSugar`` declares
+    ``comes_before=("CallSugar",)`` to win the overlap. Here the overlap is
+    not permitted to exist: ``PlainCallClaim`` says what it does NOT own.
+    Deleting the exclusion does not silently change which sugar fires — it
+    makes ``len(xs)`` panic AMBIGUOUS, which is the test below.
+    """
+
+    accepts: ClassVar[type[SourceFragment]] = Call
+    role: ClassVar[Role] = Role.TERM
+
+    @classmethod
+    def owns(cls, site: Call) -> bool:
+        func = site.func
+        return (
+            isinstance(func, Name)
+            and func.id not in _DEDICATED_BUILTIN_CALLEES
+            and not site.keywords
+        )
+
+
+class LenCallClaim(TypedClaim):
+    """``len(x)``. Ported from ``LenCallSugar``, minus its precedence edge."""
+
+    accepts: ClassVar[type[SourceFragment]] = Call
+    role: ClassVar[Role] = Role.TERM
+
+    @classmethod
+    def owns(cls, site: Call) -> bool:
+        func = site.func
+        return isinstance(func, Name) and func.id == "len" and not site.keywords
+
+
+# --------------------------------------------------------------------------
+# the BinOp family: genuine operand-type dispatch
+# --------------------------------------------------------------------------
+
+
+class AddOpClaim(TypedClaim):
+    """``a + b``. Ported from ``AddOpSugar.owns``::
+
+        site.observed == "BinOp" and site.operator_kind() == "Add"
+
+    Two string compares become one isinstance on a node class and one
+    isinstance on an operator class. ``operator_kind()`` returning ``"Add"``
+    is the tag dispatch the membrane's operator classes exist to delete: the
+    string could disagree with the node, the type cannot.
+    """
+
+    accepts: ClassVar[type[SourceFragment]] = BinOp
+    role: ClassVar[Role] = Role.TERM
+
+    @classmethod
+    def owns(cls, site: BinOp) -> bool:
+        return isinstance(site.op, Add)
+
+
+class MultiplyOpClaim(TypedClaim):
+    """``a * b``. Ported from ``MultiplyOpSugar.owns``."""
+
+    accepts: ClassVar[type[SourceFragment]] = BinOp
+    role: ClassVar[Role] = Role.TERM
+
+    @classmethod
+    def owns(cls, site: BinOp) -> bool:
+        return isinstance(site.op, Mult)
+
+
+class AnnotationUnionClaim(TypedClaim):
+    """``A | B``. Ported from ``AnnotationUnionSugar.owns``, with a caveat.
+
+    The original is three conjuncts::
+
+        site.observed == "BinOp"
+        and site.operator_kind() == "BitOr"
+        and site.is_within_annotation()
+
+    The first two port exactly. **The third does not port, and that is a
+    finding rather than an omission.** ``is_within_annotation()`` is an
+    ANCESTOR question — is this node underneath an annotation — and the
+    membrane's nodes carry children, not parents. So it is not an operand
+    type and ``owns`` cannot ask it here.
+
+    That is not a defect in the typed layer; it is the typed layer surfacing
+    something the string-compare version hid. An ancestor fact is a function
+    of (module source, node span), exactly like a subtree fact, and #5940's
+    design review says so explicitly (part 2 §3: parent links minted at
+    interning time make ancestor facts field reads). The membrane as merged
+    has no parent links, so this claim is ported as the BitOr shape only, and
+    a claim distinguishing union-in-annotation from ordinary bitwise-or on
+    the same operator type is blocked on that vocabulary landing.
+
+    Concretely: with parent links, this becomes a fourth dispatch coordinate
+    of the same kind as the others — ``isinstance(site.parent_chain_head,
+    AnnAssign)`` — and needs no new mechanism. Without them, ``a | b`` in an
+    annotation and ``a | b`` in an expression are one dispatch key here.
+    """
+
+    accepts: ClassVar[type[SourceFragment]] = BinOp
+    role: ClassVar[Role] = Role.TERM
+
+    @classmethod
+    def owns(cls, site: BinOp) -> bool:
+        return isinstance(site.op, BitOr)
+
+
+PORTED_CLAIMS: tuple[type[TypedClaim], ...] = (
+    AssertClaim,
+    NameClaim,
+    ReturnClaim,
+    KeywordCallClaim,
+    MethodCallClaim,
+    PlainCallClaim,
+    LenCallClaim,
+    AddOpClaim,
+    MultiplyOpClaim,
+    AnnotationUnionClaim,
+)

--- a/implementations/python/sugar-typed-recognition/src/sugar_typed_recognition/panic.py
+++ b/implementations/python/sugar-typed-recognition/src/sugar_typed_recognition/panic.py
@@ -1,0 +1,76 @@
+"""RecognitionPanic: the loud arm of recognition's two-arm match.
+
+Resolution has exactly two outcomes: ONE claim, or this panic. There is no
+third arm — no "pick the first candidate", no permissive fallback, no
+default claim, no quiet ``False``, no bare ``None`` refusal.
+
+Three MISSING shapes, all panics, all loud:
+
+* ``GAP`` — no claim owns this (node type, operand types) combination.
+* ``AMBIGUOUS`` — two or more claims own it. This is the SOUNDNESS
+  guarantee, not an incidental error path: if two claims both own a
+  combination, the catalog does not describe a function, and any answer it
+  returns is arbitrary. Picking the first would make the arbitrariness
+  silent. (Today's ``factory/build.py:_raise_ambiguous_candidates`` is the
+  same event, reached only after a ``comes_before`` precedence walk failed
+  to break the tie; here there is no precedence walk to fail — overlap IS
+  the defect. See the module docstring of ``catalog.py``.)
+* ``MISSING_OPERAND_TYPE`` — a child arrived that cannot answer its own
+  type. ``owns`` is never asked in this case, because a claim returning
+  ``False`` because it could not interrogate an operand is indistinguishable
+  from a claim returning ``False`` because the operand did not match. The
+  first is a hole in the membrane; the second is a correct answer. They must
+  never share an encoding.
+
+Modeled on the membrane's ``MembranePanic`` (same four-field shape: owner,
+observed, requested, fix) but a distinct type, because a recognition MISSING
+and a construction MISSING have different owners and different fixes.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import NoReturn
+
+
+class RecognitionArm(Enum):
+    """The named MISSING shapes. Not a severity — every arm halts."""
+
+    GAP = "gap"
+    AMBIGUOUS = "ambiguous"
+    MISSING_OPERAND_TYPE = "missing-operand-type"
+
+
+class RecognitionPanic(Exception):
+    """A recognition MISSING surfacing loudly. Never caught to continue."""
+
+    def __init__(
+        self,
+        arm: RecognitionArm,
+        owner: str,
+        observed: str,
+        requested: str,
+        fix: str,
+    ) -> None:
+        super().__init__(arm, owner, observed, requested, fix)
+        self.arm = arm
+        self.owner = owner
+        self.observed = observed
+        self.requested = requested
+        self.fix = fix
+
+    def __str__(self) -> str:  # pragma: no cover - formatting only
+        return (
+            f"RECOGNITION PANIC [{self.arm.value}] ({self.owner})\n"
+            f"  observed:  {self.observed}\n"
+            f"  requested: {self.requested}\n"
+            f"  fix:       {self.fix}"
+        )
+
+
+def recognition_panic(
+    arm: RecognitionArm, owner: str, observed: str, requested: str, fix: str
+) -> NoReturn:
+    raise RecognitionPanic(
+        arm=arm, owner=owner, observed=observed, requested=requested, fix=fix
+    )

--- a/implementations/python/sugar-typed-recognition/src/sugar_typed_recognition/role.py
+++ b/implementations/python/sugar-typed-recognition/src/sugar_typed_recognition/role.py
@@ -1,0 +1,22 @@
+"""The role a claim answers for. The FIRST dispatch axis.
+
+Roles mirror the existing ``sugar_lift_py_tests.claim.SugarRole`` vocabulary
+by name so a later migration is a rename, not a re-derivation. Declared here
+rather than imported because this package is greenfield: it imports the
+membrane and nothing else from the tree (#5940).
+
+A role is not a node shape. ``Call`` appears as a TERM; ``Assert`` appears as
+a STATEMENT; the same node class could legitimately be claimed under two
+roles by two different claims, and that is not ambiguity — the caller asks
+for one role at a time.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Role(Enum):
+    TERM = "term"
+    STATEMENT = "statement"
+    DEFINITION = "definition"

--- a/implementations/python/sugar-typed-recognition/tests/conftest.py
+++ b/implementations/python/sugar-typed-recognition/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+_here = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_here / "src"))
+sys.path.insert(0, str(_here.parent / "sugar-node-membrane" / "src"))

--- a/implementations/python/sugar-typed-recognition/tests/test_dispatch.py
+++ b/implementations/python/sugar-typed-recognition/tests/test_dispatch.py
@@ -1,0 +1,181 @@
+"""Multiple dispatch: accepts narrows the shape, owns interrogates operands."""
+
+import pytest
+
+from sugar_node_membrane import Membrane
+from sugar_node_membrane.nodes import Assert, BinOp, Call, Name, Return
+
+from sugar_typed_recognition import Role, TypedCatalog, default_catalog, operand_types
+from sugar_typed_recognition.claims import (
+    AddOpClaim,
+    AnnotationUnionClaim,
+    AssertClaim,
+    KeywordCallClaim,
+    LenCallClaim,
+    MethodCallClaim,
+    MultiplyOpClaim,
+    MultiplyOpClaim as _Mult,
+    NameClaim,
+    PlainCallClaim,
+    ReturnClaim,
+)
+
+
+def parse(source: str):
+    return Membrane().parse(source)
+
+
+def only(root, cls):
+    """The single node of that class in the tree. Ambiguity in a fixture is a
+    test defect, so this asserts uniqueness rather than taking the first."""
+    found = [n for n in root.walk() if type(n) is cls]
+    assert len(found) == 1, f"fixture holds {len(found)} {cls.__name__} nodes"
+    return found[0]
+
+
+# -- coordinate 0: accepts, by type -----------------------------------------
+
+
+def test_accepts_prefilters_by_type_before_owns_is_called():
+    """A claim's owns() is never invoked for a shape it does not accept."""
+    calls: list[str] = []
+
+    class Watcher(AssertClaim):
+        accepts = Assert
+        role = Role.STATEMENT
+
+        @classmethod
+        def owns(cls, site):
+            calls.append(type(site).__name__)
+            return True
+
+    catalog = TypedCatalog((Watcher,))
+    root = parse("x = 1 + 2\nassert x\n")
+    for node in root.walk():
+        catalog.candidates_for(Role.STATEMENT, node)
+
+    # Assert is the only shape that ever reached owns(), though the walk
+    # offered it Module, Assign, BinOp, Name, Constant, Expr...
+    assert calls == ["Assert"]
+
+
+def test_accepts_is_a_class_not_a_kind_string():
+    for claim in default_catalog().claims:
+        assert isinstance(claim.accepts, type)
+        assert not isinstance(claim.accepts, str)
+
+
+# -- coordinates 1..n: operand types, inside owns ---------------------------
+
+
+@pytest.mark.parametrize(
+    "source, expected",
+    [
+        ("y = a + b\n", AddOpClaim),
+        ("y = a * b\n", MultiplyOpClaim),
+        ("y = a | b\n", AnnotationUnionClaim),
+    ],
+)
+def test_one_accepts_three_claims_dispatched_by_operator_type(source, expected):
+    """The whole argument for a registry: same node class, different operand.
+
+    All three claims declare accepts = BinOp. accepts narrows nothing between
+    them; the TYPE of site.op decides. This is dispatch on two types at once.
+    """
+    root = parse(source)
+    site = only(root, BinOp)
+    assert default_catalog().resolve(Role.TERM, site) is expected
+
+
+@pytest.mark.parametrize(
+    "source, expected",
+    [
+        ("recv.method(1)\n", MethodCallClaim),
+        ("f(1)\n", PlainCallClaim),
+        ("len(xs)\n", LenCallClaim),
+        ("f(k=1)\n", KeywordCallClaim),
+    ],
+)
+def test_one_accepts_four_claims_dispatched_by_callee_type(source, expected):
+    """accepts = Call for all four; the type of site.func discriminates."""
+    root = parse(source)
+    site = only(root, Call)
+    assert default_catalog().resolve(Role.TERM, site) is expected
+
+
+def test_operand_types_are_the_dispatch_key_tail():
+    root = parse("y = a + b\n")
+    site = only(root, BinOp)
+    # left, right (children, in grammar order), then the operator.
+    assert operand_types(site) == (Name, Name, type(site.op))
+
+
+def test_a_plain_type_switch_could_not_express_this():
+    """Receipt for the load-bearing claim in catalog.py's docstring.
+
+    If accepts were the whole dispatch key, a dict from node class to claim
+    would suffice. It does not: three claims share BinOp, four share Call.
+    """
+    by_accepts: dict[type, list[str]] = {}
+    for claim in default_catalog().claims:
+        by_accepts.setdefault(claim.accepts, []).append(claim.name())
+    assert len(by_accepts[BinOp]) == 3
+    assert len(by_accepts[Call]) == 4
+
+
+# -- ordering is forced by the types, not by convention ---------------------
+
+
+def test_operands_are_already_typed_when_the_parent_is_recognized():
+    """Recognition is bottom-up because construction is.
+
+    Every operand of every node in a real tree answers its own type. Nothing
+    schedules this; it is a consequence of construct.py building parents FROM
+    finished children.
+    """
+    root = parse(
+        "def f(a, b):\n"
+        "    assert len(a) + b * 2\n"
+        "    return a.join(b)\n"
+    )
+    seen = 0
+    for node in root.walk():
+        for t in operand_types(node):
+            assert isinstance(t, type)
+            seen += 1
+    assert seen > 0
+
+
+def test_nested_dispatch_resolves_at_every_level():
+    root = parse("assert len(xs) + n * 2\n")
+    catalog = default_catalog()
+    resolved = {
+        type(n).__name__: catalog.resolve(
+            Role.STATEMENT if isinstance(n, (Assert, Return)) else Role.TERM, n
+        ).name()
+        for n in root.walk()
+        if isinstance(n, (Assert, BinOp, Call, Name))
+    }
+    assert resolved["Assert"] == "AssertClaim"
+    assert resolved["Call"] == "LenCallClaim"
+    assert resolved["Name"] == "NameClaim"
+
+
+# -- collapsed claims -------------------------------------------------------
+
+
+def test_claims_that_collapsed_entirely_to_accepts():
+    """AssertClaim and NameClaim ask nothing: owns is True for every accepted
+    site, because their old predicate was pure shape re-derivation."""
+    root = parse("assert x\n")
+    assert AssertClaim.owns(only(root, Assert)) is True
+    assert NameClaim.owns(only(root, Name)) is True
+
+
+def test_return_claim_reads_a_structural_absence_not_a_refusal():
+    with_value = parse("def f():\n    return 1\n")
+    bare = parse("def f():\n    return\n")
+    assert ReturnClaim.owns(only(with_value, Return)) is True
+    assert ReturnClaim.owns(only(bare, Return)) is False
+    # ...and the bare one is then a GAP at resolve, not a silent skip.
+    # (asserted in test_failure_arms.py)

--- a/implementations/python/sugar-typed-recognition/tests/test_failure_arms.py
+++ b/implementations/python/sugar-typed-recognition/tests/test_failure_arms.py
@@ -1,0 +1,323 @@
+"""Both failure arms, and the MISSING that must never become a False.
+
+Resolution has two arms: exactly one claim, or panic. These tests hold that
+line by driving each panic from a real parsed site wherever one exists, and
+by construction only where a real site cannot produce the shape.
+"""
+
+import pytest
+
+from sugar_node_membrane import Membrane, SourceUnit, Typeable
+from sugar_node_membrane.nodes import BinOp, Call, Name, Return, SourceFragment
+from sugar_node_membrane.operators import Add
+from sugar_node_membrane.spans import Span
+
+from sugar_typed_recognition import (
+    RecognitionArm,
+    RecognitionPanic,
+    Role,
+    TypedCatalog,
+    TypedClaim,
+    default_catalog,
+    operand_types,
+)
+from sugar_typed_recognition.claims import PORTED_CLAIMS, LenCallClaim, PlainCallClaim
+
+
+def parse(source: str):
+    return Membrane().parse(source)
+
+
+def only(root, cls):
+    found = [n for n in root.walk() if type(n) is cls]
+    assert len(found) == 1
+    return found[0]
+
+
+# --------------------------------------------------------------------------
+# ARM 1: no claim owns the combination -> GAP -> panic
+# --------------------------------------------------------------------------
+
+
+def test_gap_when_no_claim_owns_the_operand_types():
+    """`a - b` is a BinOp, so accepts matches three claims — and every one of
+    them says no, because Sub is not Add, Mult or BitOr. Shape alone is not
+    ownership."""
+    site = only(parse("y = a - b\n"), BinOp)
+    with pytest.raises(RecognitionPanic) as exc:
+        default_catalog().resolve(Role.TERM, site)
+    assert exc.value.arm is RecognitionArm.GAP
+    assert "BinOp" in exc.value.observed
+    assert "Sub" in exc.value.observed  # the operand type that found no owner
+
+
+def test_gap_when_no_claim_accepts_the_shape_at_all():
+    site = only(parse("y = [1]\n"), __import__(
+        "sugar_node_membrane.nodes", fromlist=["List"]
+    ).List)
+    with pytest.raises(RecognitionPanic) as exc:
+        default_catalog().resolve(Role.TERM, site)
+    assert exc.value.arm is RecognitionArm.GAP
+
+
+def test_bare_return_is_a_loud_gap_not_a_silent_skip():
+    """ReturnClaim.owns is False for bare `return` — and False from the ONLY
+    candidate means nobody owns it, which panics. The claim declining is not
+    the same event as the site being unowned, and only resolve() decides."""
+    site = only(parse("def f():\n    return\n"), Return)
+    with pytest.raises(RecognitionPanic) as exc:
+        default_catalog().resolve(Role.TERM, site)
+    assert exc.value.arm is RecognitionArm.GAP
+
+
+def test_gap_when_the_callee_is_neither_a_name_nor_an_attribute():
+    """`(lambda: g)()()`-style callees: a real parsed shape no ported claim
+    owns. The call family covers Name and Attribute callees; a Call callee is
+    outside it and says so."""
+    root = parse("h()()\n")
+    outer = [n for n in root.walk() if isinstance(n, Call) and isinstance(n.func, Call)]
+    assert len(outer) == 1
+    with pytest.raises(RecognitionPanic) as exc:
+        default_catalog().resolve(Role.TERM, outer[0])
+    assert exc.value.arm is RecognitionArm.GAP
+
+
+def test_gap_names_the_key_and_the_fix():
+    site = only(parse("y = a - b\n"), BinOp)
+    with pytest.raises(RecognitionPanic) as exc:
+        default_catalog().resolve(Role.TERM, site)
+    assert "accepts = BinOp" in exc.value.fix
+    assert exc.value.requested == "exactly one term claim"
+
+
+# --------------------------------------------------------------------------
+# ARM 2: two claims own the combination -> AMBIGUOUS -> panic
+# --------------------------------------------------------------------------
+
+
+def test_ambiguity_panics_and_never_picks_the_first():
+    """Two claims accepting BinOp and both answering True for Add.
+
+    The catalog does not rank them, does not consult a declaration order, and
+    does not return candidates[0]. Registration order is varied below to show
+    the outcome does not depend on it.
+    """
+
+    class FirstAdd(TypedClaim):
+        accepts = BinOp
+        role = Role.TERM
+
+        @classmethod
+        def owns(cls, site):
+            return isinstance(site.op, Add)
+
+    class SecondAdd(TypedClaim):
+        accepts = BinOp
+        role = Role.TERM
+
+        @classmethod
+        def owns(cls, site):
+            return isinstance(site.op, Add)
+
+    site = only(parse("y = a + b\n"), BinOp)
+
+    for order in ((FirstAdd, SecondAdd), (SecondAdd, FirstAdd)):
+        with pytest.raises(RecognitionPanic) as exc:
+            TypedCatalog(order).resolve(Role.TERM, site)
+        assert exc.value.arm is RecognitionArm.AMBIGUOUS
+        assert "FirstAdd" in exc.value.observed
+        assert "SecondAdd" in exc.value.observed
+
+
+def test_ambiguity_is_the_soundness_guarantee_of_the_ported_disjointness():
+    """Remove PlainCallClaim's builtin exclusion and `len(xs)` goes ambiguous.
+
+    This is the receipt that the exclusion is load-bearing rather than
+    cosmetic. Today's tree resolves the same overlap with a `comes_before`
+    edge; here it is not permitted to exist.
+    """
+
+    class PlainCallWithoutExclusion(TypedClaim):
+        accepts = Call
+        role = Role.TERM
+
+        @classmethod
+        def owns(cls, site):
+            return isinstance(site.func, Name) and not site.keywords
+
+    site = only(parse("len(xs)\n"), Call)
+
+    with pytest.raises(RecognitionPanic) as exc:
+        TypedCatalog((PlainCallWithoutExclusion, LenCallClaim)).resolve(Role.TERM, site)
+    assert exc.value.arm is RecognitionArm.AMBIGUOUS
+
+    # With the exclusion as ported, the same site resolves to exactly one.
+    assert TypedCatalog((PlainCallClaim, LenCallClaim)).resolve(
+        Role.TERM, site
+    ) is LenCallClaim
+
+
+def test_the_ported_catalog_is_unambiguous_over_a_real_corpus():
+    """No site in this source resolves to more than one claim. A catalog that
+    is ambiguous anywhere is not a function anywhere."""
+    catalog = default_catalog()
+    root = parse(
+        "def f(a, b):\n"
+        "    assert len(a) + b * 2\n"
+        "    c = a.join(b)\n"
+        "    d = g(c, k=1)\n"
+        "    return d | c\n"
+    )
+    checked = 0
+    for node in root.walk():
+        for role in Role:
+            candidates = catalog.candidates_for(role, node)
+            assert len(candidates) <= 1, (
+                f"{type(node).__name__} under {role.value} has "
+                f"{[c.name() for c in candidates]}"
+            )
+            checked += 1
+    assert checked > 0
+
+
+# --------------------------------------------------------------------------
+# THE THIRD THING THAT IS NOT AN ARM: a child that cannot answer its type
+# --------------------------------------------------------------------------
+
+
+class _UnconstructedChild(Typeable):
+    """Typeable but never constructed: it can be ASKED for a type and cannot
+    give one. Exactly the shape that must not reach owns()."""
+
+    def resolve_type(self):
+        raise AssertionError("this child has no type; it was never constructed")
+
+
+def _unit():
+    return SourceUnit(filename="<t>", source="a + b\n")
+
+
+def test_untyped_child_panics_and_never_reaches_owns():
+    """If this were allowed through, a claim would have only False to return,
+    and a hole in the membrane would be encoded identically to a correct
+    negative answer."""
+    asked: list[object] = []
+
+    class Nosy(TypedClaim):
+        accepts = BinOp
+        role = Role.TERM
+
+        @classmethod
+        def owns(cls, site):
+            asked.append(site)
+            return True
+
+    unit = _unit()
+    broken = BinOp(
+        unit=unit,
+        span=Span(0, 5),
+        left=_UnconstructedChild(),  # type: ignore[arg-type]
+        op=Add.instance(),
+        right=_UnconstructedChild(),  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(RecognitionPanic) as exc:
+        TypedCatalog((Nosy,)).resolve(Role.TERM, broken)
+    assert exc.value.arm is RecognitionArm.MISSING_OPERAND_TYPE
+    assert "Typeable but not Typed" in exc.value.observed
+    assert asked == [], "owns() must not be called with an uninterrogable operand"
+
+
+def test_string_operator_panics_rather_than_dispatching():
+    """Guarding the regression the operator classes exist to prevent: an
+    operator arriving as the tag `"Add"` instead of the singleton."""
+    unit = _unit()
+    name = Name(unit=unit, span=Span(0, 1), id="a")
+    broken = BinOp(
+        unit=unit,
+        span=Span(0, 5),
+        left=name,
+        op="Add",  # type: ignore[arg-type]
+        right=name,
+    )
+    with pytest.raises(RecognitionPanic) as exc:
+        operand_types(broken)
+    assert exc.value.arm is RecognitionArm.MISSING_OPERAND_TYPE
+    assert "Operator" in exc.value.requested
+
+
+def test_non_membrane_site_panics():
+    with pytest.raises(RecognitionPanic) as exc:
+        default_catalog().resolve(Role.TERM, object())  # type: ignore[arg-type]
+    assert exc.value.arm is RecognitionArm.MISSING_OPERAND_TYPE
+
+
+def test_structural_absence_is_a_fact_not_a_missing():
+    """Optional-and-None is an answered question. `return` with no value and
+    a Call with no keywords both key cleanly; neither panics."""
+    bare = only(parse("def f():\n    return\n"), Return)
+    assert operand_types(bare) == (type(None),)
+
+
+# --------------------------------------------------------------------------
+# declaration-time guards
+# --------------------------------------------------------------------------
+
+
+def test_a_kind_string_as_accepts_is_refused_at_class_creation():
+    with pytest.raises(RecognitionPanic) as exc:
+        class Stringly(TypedClaim):
+            accepts = "Call"  # type: ignore[assignment]
+            role = Role.TERM
+
+            @classmethod
+            def owns(cls, site):
+                return True
+
+    assert "SourceFragment subclass" in exc.value.requested
+
+
+def test_registering_an_instance_rather_than_a_class_is_refused():
+    with pytest.raises(RecognitionPanic):
+        TypedCatalog((LenCallClaim(),))  # type: ignore[list-item]
+
+
+def test_operator_fields_cover_every_operator_carrier():
+    """The annotation read in claim._operator_field_names must see every
+    membrane field that holds an operator. If the membrane ever names an
+    operator type without 'Operator' in it, this goes red rather than the
+    census silently under-reporting."""
+    from dataclasses import fields as dataclass_fields, is_dataclass
+
+    from sugar_node_membrane.nodes import KIND_REGISTRY
+    from sugar_node_membrane.operators import Operator
+
+    from sugar_typed_recognition.claim import _operator_field_names
+
+    for cls in KIND_REGISTRY.values():
+        if not is_dataclass(cls):
+            continue
+        declared = set(_operator_field_names(cls))
+        for f in dataclass_fields(cls):
+            annotation = f.type if isinstance(f.type, str) else ""
+            mentions_operator_class = any(
+                sub.__name__ in annotation
+                for sub in _all_subclasses(Operator)
+            )
+            if mentions_operator_class:
+                assert f.name in declared, (
+                    f"{cls.__name__}.{f.name}: {annotation} holds an operator "
+                    "but the field census does not see it"
+                )
+
+
+def _all_subclasses(cls):
+    for sub in cls.__subclasses__():
+        yield sub
+        yield from _all_subclasses(sub)
+
+
+def test_every_ported_claim_declares_a_membrane_class():
+    for claim in PORTED_CLAIMS:
+        assert issubclass(claim.accepts, SourceFragment)
+        assert isinstance(claim.role, Role)


### PR DESCRIPTION
Greenfield beside the legacy `claim/sugar_catalog.py` + `factory/build.py`, exactly as the node membrane (#5943) was built beside `source_fragment.py`. **Zero existing files changed**; nothing imports this yet. Design context: #5940.

## The shape of the typed catalog

Today's claim carries `owns: Callable[[object], bool]`. That `object` is the root defect: an untyped parameter forces every predicate to re-derive what it holds before it can ask its real question — measured on this tree, **403 `.observed ==` string compares** and 105 `.node` reads.

One predicate becomes two declarations:

```python
class AddOpClaim(TypedClaim):
    accepts: ClassVar[type[SourceFragment]] = BinOp   # shape, by TYPE
    role: ClassVar[Role] = Role.TERM

    @classmethod
    def owns(cls, site: BinOp) -> bool:              # typed parameter
        return isinstance(site.op, Add)              # the ONE real question
```

`isinstance` on membrane classes is **legal and encouraged**, and `claim.py` says so in the code, at length. Interior questions ("is this callee an `Attribute`") are exactly what the hierarchy is for. What stays banned is `site.kind == "Call"` — `kind` is the wire/CID projection, never a dispatch mechanism. The rule in one line: **isinstance on OUR classes, never a tag compare on strings.** Stated explicitly because without it workers invent kind strings to dodge an imagined ban (#5940 design review §6).

## How multiple dispatch resolves, and where each type enters

```
(role, type(site), *operand_types(site))
 ^^^^  ^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^
 |     |            coords 1..n: interrogated INSIDE owns, by isinstance
 |     coord 0: isinstance(site, claim.accepts), in the catalog,
 |              BEFORE owns is ever called
 which question is being asked
```

Each coordinate enters at a different place and they are not interchangeable. Coordinate 0 is what used to be spelled `site.observed == "Call"` inside every predicate. Coordinates 1..n are what a plain type switch cannot express — and that is the load-bearing argument for keeping a registry:

- `AddOpClaim`, `MultiplyOpClaim`, `AnnotationUnionClaim` — all `accepts = BinOp`, separated **only** by the type of `site.op`.
- `MethodCallClaim`, `PlainCallClaim`, `LenCallClaim`, `KeywordCallClaim` — all `accepts = Call`, separated **only** by the type of `site.func` and the presence of keywords.

Dispatch on more than one type at once, resolved by a registry rather than a receiver's vtable, is multiple dispatch. The catalog **is** the dispatch table. (`test_a_plain_type_switch_could_not_express_this` is the receipt.)

**Recognition is bottom-up because construction is.** `owns` may interrogate operand types only because operands arrive already `Typed` from their own construction — `construct.py` builds every parent FROM finished children. There is no phase to schedule and no traversal order to get wrong: if you are holding a `BinOp`, its `left`, `right` and `op` are resolved, because you could not have been handed the `BinOp` otherwise. The ordering is forced by the types, not agreed by convention.

## Claims ported, and what each collapsed to

| claim | old `owns` | collapsed to |
|---|---|---|
| `AssertClaim` | `observed == "Assert"` | **entirely to `accepts`** — `owns` is now constant `True` |
| `NameClaim` | `observed == "Name"` | **entirely to `accepts`** |
| `ReturnClaim` | `observed == "Return" and return_value() is not None` | half: shape to `accepts`, the `Optional` read survives as a real question |
| `MethodCallClaim` | 4 conjuncts | **one** of four; see below |
| `PlainCallClaim` / `LenCallClaim` / `KeywordCallClaim` | + `comes_before` edges | shape to `accepts`; precedence became explicit disjointness |
| `AddOpClaim` / `MultiplyOpClaim` / `AnnotationUnionClaim` | `observed == "BinOp" and operator_kind() == "Add"` | half — and the surviving half is **genuine operand-type dispatch** |

Ten claims, not ~80. Proof of mechanism.

## Both failure arms, with tests

- **GAP** — `a - b` matches three claims by `accepts` and every one says no, because `Sub` is not `Add`/`Mult`/`BitOr`. Shape alone is not ownership. Also: bare `return`, a `Call` whose callee is a `Call`, a `List`.
- **AMBIGUOUS** — two claims owning one key panic. Registration order is varied in the test to show the outcome does not depend on it. Never "pick the first": that would be a third arm.
- **MISSING_OPERAND_TYPE** (not an arm — a hole) — a child that cannot answer its type panics *before* any `owns` is called. If it reached `owns`, a claim would have only `False` to return, and a hole in the membrane would be encoded identically to a correct negative answer. The test asserts `owns` was never invoked.

31 tests, green on battleaxe (python 3.12.3). **Mutation-checked** — every guard was deliberately broken and the suite went red:

| mutant | tests that caught it |
|---|---|
| `resolve` returns `candidates[0]` on overlap | 2 |
| drop the pre-`owns` operand-type guard | 1 |
| drop `PlainCallClaim`'s builtin exclusion | 3 |

## What in the #5940 design turned out wrong

**1. Precedence and "exactly one owner" cannot both be law. I dropped precedence, and it is not free.** The design keeps `comes_before` while making `_raise_ambiguous_candidates` the soundness guarantee. Those are in tension: today `MethodCallSugar` excludes `os.exit` *and* `KeywordCallSugar` shapes *and* there are precedence edges that would have resolved the same overlaps — belt and braces, so the exclusions read as redundant defensiveness. With no precedence walk, they are not redundant; they *are* the disjointness, and every claim in a family carries its share. The design's claim that typing leaves "the ONE real question" for `MethodCallSugar` is right for one conjunct only; the other two survive as ordering facts, which the review already half-corrected. The cost is priced in `claims.py` rather than hidden: `PlainCallClaim` must name what it does not own, and `test_ambiguity_is_the_soundness_guarantee_of_the_ported_disjointness` fails loudly if that exclusion is deleted.

**2. `AnnotationUnionSugar` does not fully port, and the reason is a real gap in the merged membrane.** Its third conjunct is `site.is_within_annotation()` — an **ancestor** question. The membrane's nodes carry children, not parents, so it is not an operand type and `owns` cannot ask it. This is not a defect in the typed layer; it is the typed layer surfacing what the string-compare version hid. The design review already calls for parent links minted at interning time (part 2 §3); with them this becomes a fourth dispatch coordinate *of the same kind as the others* and needs no new mechanism. Without them, `a | b` in an annotation and `a | b` in an expression are one dispatch key. **The typed layer needs parent links before ancestor-conditioned claims can port — that is a prerequisite the design sequences after this step.**

**3. `accepts` alone is a weaker filter than the design implies.** "The factory pre-filters on `accepts` and the first level is free" undersells how much stays in `owns` for the crowded shapes: `BinOp` and `Call` are the two highest-traffic node classes and `accepts` separates *nothing* within them. The 403-site win is real but concentrated in the long tail of one-claim-per-shape sugars (`Assert`, `Name`, `Return`), not in the families that actually cost.

**4. Structural absence needed an explicit ruling the design does not give.** `Optional[Expression]` being `None` is a *fact* (an answered question — "nothing is there"), while a claim that cannot interrogate an operand is a *MISSING*. Both would be spelled `None`-ish in an untyped world. `operand_types` keys structural absence as `type(None)` and panics on the MISSING, so the two can never share an encoding.

Not merged. Not measured against the corpus — this layer has no callers yet by design.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add typed recognition layer with `TypedCatalog`, `TypedClaim`, and `operand_types` dispatch
> - Introduces a new `sugar-typed-recognition` Python package that dispatches AST nodes to sugar claims using typed operands rather than string tags.
> - `TypedClaim` subclasses declare `accepts` (the node shape) and implement `owns()` (a predicate over operand types); `TypedCatalog` resolves exactly one claim per role/site or raises `RecognitionPanic` on gaps or ambiguities.
> - `operand_types(site)` computes a tuple of membrane types and `Operator` singleton classes by inspecting child and operator fields, raising `MISSING_OPERAND_TYPE` if any operand is unresolved.
> - Ships a set of ported claim classes (`PORTED_CLAIMS`) covering `Assert`, `Name`, `Return`, `Call` variants, and `BinOp` operators, plus a `default_catalog()` helper seeded with those claims.
> - Behavioral Change: dispatch now requires all child nodes to be fully typed before `owns()` is called; untyped children raise `RecognitionPanic` rather than falling through silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea52cb5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Python package for typed recognition of syntax elements.
  * Added dispatch support for statements, names, calls, arithmetic operators, and annotation unions.
  * Added configurable catalogs for resolving the appropriate recognition rule.
  * Added default recognition rules for common constructs, including method calls, keyword calls, plain calls, and `len(...)`.
  * Added clear diagnostics for unsupported, ambiguous, or incomplete recognition cases.

* **Tests**
  * Added comprehensive coverage for dispatch behavior, nested expressions, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->