### PR TITLE
LibCST adapter: the second provider, and what the CID differential found (#5940, #5932)

### DIFF
--- a/implementations/python/sugar-node-membrane/pyproject.toml
+++ b/implementations/python/sugar-node-membrane/pyproject.toml
@@ -9,6 +9,13 @@ description = "The node membrane (#5940): source text in, constructed graph out.
 requires-python = ">=3.12"
 dependencies = []
 
+# The core membrane stays stdlib-only. A PROVIDER is an optional extra:
+# installing one must never be a condition of the membrane working, and the
+# membrane must never depend on any single parser. Install with
+# ``pip install -e '.[libcst]'`` to run the provider differential.
+[project.optional-dependencies]
+libcst = ["libcst>=1.8"]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/differential.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/differential.py
@@ -38,6 +38,13 @@ from .construct import Membrane
 from .corpus import records_for_source
 from .panic import MembranePanic
 
+try:  # the refusal type the contract should have declared but does not
+    from libcst import ParserSyntaxError as _LibCSTRefusal
+
+    _PROVIDER_REFUSALS: tuple[type[BaseException], ...] = (_LibCSTRefusal,)
+except ImportError:  # LibCST not installed: only the CPython provider exists
+    _PROVIDER_REFUSALS = ()
+
 
 @dataclass(frozen=True)
 class Divergence:
@@ -100,6 +107,14 @@ def _emit(
         result.failures.append((rel, side, "membrane_panic", str(err)))
         return None
     except SyntaxError as err:
+        result.failures.append((rel, side, "provider_syntax_error", str(err)))
+        return None
+    except _PROVIDER_REFUSALS as err:
+        # CONTRACT GAP (#5940): backend.py never declares a refusal type, so
+        # the membrane's failure vocabulary is written in CPython's
+        # SyntaxError. LibCST's ParserSyntaxError does not subclass it, so
+        # this differential has to name it explicitly. corpus.py, which only
+        # catches SyntaxError, would let it escape and kill the run.
         result.failures.append((rel, side, "provider_syntax_error", str(err)))
         return None
     except RecursionError as err:

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/differential.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/differential.py
@@ -1,0 +1,237 @@
+"""Provider differential: the instrument that admits or uninstalls a provider.
+
+The governing invariant (#5940): **the memento CID is a function of SOURCE,
+not of the parser.** Two providers parse the same text; every record is
+addressed by ``(file, node_path)``; every CID must match. A divergence is
+reported as ``file:node_path`` with BOTH spans and BOTH CIDs — the divergent
+node path IS the finding. Nothing is normalized away to make the diff clean.
+
+A divergence has exactly two causes, and they are distinguished by hand, not
+by the tool:
+
+1. **The span spec is under-specified** — it did not rule on some shape, so
+   two providers legitimately differ. The SPEC is the defect.
+2. **The adapter is wrong** — the provider can express our spec and the
+   mapping is incorrect. The ADAPTER is the defect.
+
+Three outcomes per record, never two-and-a-shrug:
+``matched``, ``diverged`` (both sides present, CIDs differ), and
+``missing_left`` / ``missing_right`` (a node path one provider materialized
+and the other did not — an inventory divergence, which is a divergence, not
+an absence to be ignored).
+
+CLI::
+
+    python -m sugar_node_membrane.differential PATH [PATH ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from .construct import Membrane
+from .corpus import records_for_source
+from .panic import MembranePanic
+
+
+@dataclass(frozen=True)
+class Divergence:
+    """One node path where two providers disagree. The finding itself."""
+
+    file: str
+    path: str
+    left_kind: Optional[str]
+    right_kind: Optional[str]
+    left_span: Optional[tuple[int, int]]
+    right_span: Optional[tuple[int, int]]
+    left_cid: Optional[str]
+    right_cid: Optional[str]
+
+    @property
+    def category(self) -> str:
+        if self.left_cid is None:
+            return "missing_left"
+        if self.right_cid is None:
+            return "missing_right"
+        if self.left_kind != self.right_kind:
+            return "kind"
+        return "span"
+
+    def render(self) -> str:
+        return (
+            f"{self.file}:{self.path}  [{self.category}]\n"
+            f"    left : kind={self.left_kind} span={self.left_span} cid={self.left_cid}\n"
+            f"    right: kind={self.right_kind} span={self.right_span} cid={self.right_cid}"
+        )
+
+
+@dataclass
+class DiffResult:
+    files_compared: int = 0
+    records_left: int = 0
+    records_right: int = 0
+    matched: int = 0
+    divergences: list[Divergence] = field(default_factory=list)
+    # (file, side, failure_class, message) — a provider refusal or a MISSING.
+    failures: list[tuple[str, str, str, str]] = field(default_factory=list)
+    seconds_left: float = 0.0
+    seconds_right: float = 0.0
+
+    @property
+    def R(self) -> int:
+        """Remaining work: divergent node paths plus per-file failures.
+
+        A failure counts. A MISSING never becomes success OR silence.
+        """
+        return len(self.divergences) + len(self.failures)
+
+
+def _emit(
+    membrane: Membrane, source: str, rel: str, side: str, result: DiffResult
+) -> Optional[list[dict[str, object]]]:
+    try:
+        return records_for_source(membrane, source, rel)
+    except MembranePanic as err:
+        result.failures.append((rel, side, "membrane_panic", str(err)))
+        return None
+    except SyntaxError as err:
+        result.failures.append((rel, side, "provider_syntax_error", str(err)))
+        return None
+    except RecursionError as err:
+        result.failures.append((rel, side, "recursion_error", str(err)))
+        return None
+    except Exception as err:  # noqa: BLE001 - recorded, never swallowed
+        # An adapter bug (not a MISSING and not a provider refusal). Recorded
+        # with its type so a corpus sweep names every one of them, and
+        # counted in R: a crash is never silence.
+        result.failures.append(
+            (rel, side, f"adapter_crash:{type(err).__name__}", str(err))
+        )
+        return None
+
+
+def compare_source(
+    left: Membrane, right: Membrane, source: str, rel: str, result: DiffResult
+) -> None:
+    t0 = time.perf_counter()
+    left_records = _emit(left, source, rel, "left", result)
+    t1 = time.perf_counter()
+    right_records = _emit(right, source, rel, "right", result)
+    t2 = time.perf_counter()
+    result.seconds_left += t1 - t0
+    result.seconds_right += t2 - t1
+
+    if left_records is None or right_records is None:
+        return
+
+    result.files_compared += 1
+    result.records_left += len(left_records)
+    result.records_right += len(right_records)
+
+    by_path_left = {r["path"]: r for r in left_records}
+    by_path_right = {r["path"]: r for r in right_records}
+
+    for path in sorted(set(by_path_left) | set(by_path_right)):
+        a = by_path_left.get(path)
+        b = by_path_right.get(path)
+        if a is not None and b is not None and a["cid"] == b["cid"] and a["kind"] == b["kind"]:
+            result.matched += 1
+            continue
+        result.divergences.append(
+            Divergence(
+                file=rel,
+                path=str(path),
+                left_kind=None if a is None else str(a["kind"]),
+                right_kind=None if b is None else str(b["kind"]),
+                left_span=None if a is None else (int(a["start"]), int(a["end"])),
+                right_span=None if b is None else (int(b["start"]), int(b["end"])),
+                left_cid=None if a is None else str(a["cid"]),
+                right_cid=None if b is None else str(b["cid"]),
+            )
+        )
+
+
+def compare(paths: list[Path], base: Optional[Path] = None, limit: int = 0) -> DiffResult:
+    from .cpython_adapter import CPythonAstProvider
+    from .libcst_adapter import LibCSTProvider
+
+    files: list[Path] = []
+    for p in paths:
+        if p.is_dir():
+            files.extend(sorted(p.rglob("*.py")))
+        else:
+            files.append(p)
+    files.sort()
+    if limit:
+        files = files[:limit]
+
+    result = DiffResult()
+    for path in files:
+        rel = str(path.relative_to(base)) if base is not None else str(path)
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError) as err:
+            result.failures.append((rel, "both", "unreadable", str(err)))
+            continue
+        # Fresh membranes per file: the pool caches by source CID, and a
+        # shared pool across a large corpus would measure memory, not spans.
+        compare_source(
+            Membrane(CPythonAstProvider()),
+            Membrane(LibCSTProvider()),
+            source,
+            rel,
+            result,
+        )
+    return result
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="CPython vs LibCST memento CID differential")
+    parser.add_argument("paths", nargs="+", type=Path)
+    parser.add_argument("--base", type=Path, default=None)
+    parser.add_argument("--limit", type=int, default=0)
+    parser.add_argument("--show", type=int, default=40, help="divergences to print")
+    args = parser.parse_args(argv)
+
+    result = compare(args.paths, args.base, args.limit)
+
+    print(f"files compared : {result.files_compared}")
+    print(f"records (cpython/libcst): {result.records_left}/{result.records_right}")
+    print(f"matched        : {result.matched}")
+    print(f"divergences    : {len(result.divergences)}")
+    print(f"failures       : {len(result.failures)}")
+    print(f"R              : {result.R}")
+    print(f"parse+build s  : cpython={result.seconds_left:.2f} libcst={result.seconds_right:.2f}")
+
+    by_category: dict[str, int] = {}
+    by_kind: dict[str, int] = {}
+    for d in result.divergences:
+        by_category[d.category] = by_category.get(d.category, 0) + 1
+        key = f"{d.category}:{d.left_kind}->{d.right_kind}"
+        by_kind[key] = by_kind.get(key, 0) + 1
+    if by_category:
+        print("\nby category:")
+        for k, v in sorted(by_category.items(), key=lambda kv: -kv[1]):
+            print(f"  {k:16} {v}")
+        print("\nby shape:")
+        for k, v in sorted(by_kind.items(), key=lambda kv: -kv[1])[:30]:
+            print(f"  {k:44} {v}")
+
+    for rel, side, cls, msg in result.failures[:40]:
+        print(f"FAIL[{side}/{cls}] {rel}: {msg.splitlines()[0]}")
+
+    if result.divergences:
+        print(f"\nfirst {args.show} divergent node paths:")
+        for d in result.divergences[: args.show]:
+            print(d.render())
+
+    return 1 if result.R else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/libcst_adapter.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/libcst_adapter.py
@@ -1,0 +1,1507 @@
+"""LibCST provider adapter — the second provider (#5940, #5932).
+
+THE ONLY MODULE IN THIS PACKAGE THAT MAY NAME ``libcst``. Same read-only
+contract as ``cpython_adapter``: ``parse(unit) -> handle``, and per handle a
+single ``describe()`` giving our kind, our codepoint span, and our fields as
+slots. Nothing is ever written onto a LibCST node (they are immutable
+anyway), no provider node is ever constructed, and no handle travels above
+the builder.
+
+Why a second provider exists at all: #5932 isolated an intermittent SIGSEGV
+to CPython's own ``ast.parse`` -> ``compile()``. LibCST is Rust-backed and
+does not call ``compile()``. T's rule — a provider that segfaults, or
+diverges on the golden corpus, is not debugged, it is uninstalled — only has
+teeth when a second provider exists to switch to.
+
+MAPPING NOTES (LibCST is a CONCRETE syntax tree; ours is AST-shaped)
+====================================================================
+
+What LibCST gives us for free, matching spans.py exactly:
+
+- **Columns are codepoints.** ``PositionProvider`` reports character
+  columns, which IS our span definition. CPython's UTF-8 byte columns are
+  the ones needing normalization, not LibCST's. (Measured: ``é = f(ü)``
+  puts the ``Call`` at codepoint [4,8).)
+- **Grouping parens are excluded.** ``(x + y)`` positions the
+  ``BinaryOperation`` at ``x + y``; ``(n := 10)`` positions the
+  ``NamedExpr`` at ``n := 10``. Both are our ruling.
+- **Decorated defs start at ``def``.** ``FunctionDef`` positions from the
+  ``def`` keyword, decorators excluded — our ruling.
+
+What this adapter must translate, because the CST vocabulary differs:
+
+- **Pure-syntax nodes are not in our inventory** and are never materialized:
+  ``SimpleStatementLine``, ``SimpleStatementSuite``, ``IndentedBlock``,
+  ``Else``, ``Finally``, ``Decorator``, ``Annotation``, ``AsName``,
+  ``Element``, ``Arg``, ``AssignTarget``, ``Index``, ``SubscriptElement``,
+  ``ParamStar``, ``Parameters``, ``LeftParen``/``RightParen``, whitespace,
+  commas, and every other trivia node. They are unwrapped or flattened.
+- **Tuple parens.** LibCST excludes them; our spec includes them for a
+  tuple display (spans.py, the one ruled exception). Recovered from the
+  innermost ``lpar``/``rpar`` positions.
+- **Param sigils.** LibCST's ``Param`` for ``*b`` spans ``*b``; our spec
+  excludes the sigil (it is an arity marker of the parameter LIST). The
+  ``Param`` is anchored on its NAME token and enveloped with annotation and
+  default, exactly as the CPython adapter anchors on ``ast.arg``.
+- **Comprehension clauses.** LibCST's ``CompFor`` span starts at the
+  whitespace before ``for``; our spec starts at the keyword. Recovered by a
+  forward scan over whitespace from the clause start — the mirror of the
+  CPython adapter's backscan, and equally pure.
+- **Literals.** LibCST has ``Integer``/``Float``/``Imaginary``/
+  ``SimpleString``/``Ellipsis``, and spells ``True``/``False``/``None`` as
+  ``Name``. All become our ``Constant``.
+- **n-ary flattening.** ``a and b and c`` is left-nested in LibCST and
+  n-ary in our ``BoolOp.values``; same for ``del a, b`` against our
+  ``Delete.targets``. The membrane class declares the arity, so the adapter
+  flattens into it.
+- **Format specs.** LibCST carries a format spec as a bare sequence of
+  content nodes with no wrapper; our ``FormattedValue.format_spec`` is a
+  ``JoinedStr``. One is synthesized, spanning its contents — which is the
+  text after the ``:``, our ruling.
+
+A LibCST shape with no rule here panics as a MISSING at the boundary. There
+is no generic fallback and no ``getattr`` sniffing: an unmapped CST node is
+the conformance finding itself.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional, Sequence, Tuple
+
+import libcst as cst
+from libcst.metadata import MetadataWrapper, PositionProvider
+
+from .backend import (
+    Child,
+    Children,
+    Description,
+    Leaf,
+    MaybeChild,
+    OpLeaf,
+    OpsLeaf,
+    Provider,
+    ProviderHandle,
+    Slot,
+)
+from .nodes import SourceUnit
+from .operators import Operator, operator_for
+from .panic import membrane_panic
+from .spans import Span
+
+
+# --------------------------------------------------------------------------
+# Context: the position map, resolved once per parse
+# --------------------------------------------------------------------------
+
+
+class _Ctx:
+    """Per-parse state: the unit and LibCST's resolved position metadata."""
+
+    __slots__ = ("unit", "positions")
+
+    def __init__(self, unit: SourceUnit, positions: object) -> None:
+        self.unit = unit
+        self.positions = positions
+
+    def span(self, node: cst.CSTNode) -> Span:
+        """LibCST CodeRange -> our codepoint Span. Columns are ALREADY
+        codepoints; there is no byte seam on this provider."""
+        try:
+            rng = self.positions[node]  # type: ignore[index]
+        except KeyError:
+            membrane_panic(
+                owner="libcst_adapter._Ctx.span",
+                observed=f"libcst {type(node).__name__} carries no position",
+                requested="a positioned node, or a rule marking it envelope-spanned",
+                fix="add an explicit rule for this kind; never invent a span",
+            )
+        table = self.unit.line_table
+        return Span(
+            table.offset(rng.start.line, rng.start.column),
+            table.offset(rng.end.line, rng.end.column),
+        )
+
+
+# --------------------------------------------------------------------------
+# Handles
+# --------------------------------------------------------------------------
+
+
+class _Handle(ProviderHandle):
+    """Read-only view of one LibCST node, described by its rule."""
+
+    __slots__ = ("_ctx", "_node", "_desc")
+
+    def __init__(self, ctx: _Ctx, node: cst.CSTNode) -> None:
+        self._ctx = ctx
+        self._node = node
+        self._desc: Optional[Description] = None
+
+    def describe(self) -> Description:
+        if self._desc is None:
+            self._desc = _describe(self._ctx, self._node)
+        return self._desc
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<libcst-handle {type(self._node).__name__} in {self._ctx.unit.filename}>"
+
+
+class _Synth(ProviderHandle):
+    """A membrane constituent LibCST does not materialize as one node.
+
+    Used where the CST vocabulary is coarser or finer than ours: a
+    ``DictItem`` pair, a ``Param``, a format-spec ``JoinedStr``, a
+    multi-element subscript ``Tuple``. It describes membrane fields over
+    LibCST children — it never constructs a provider node.
+    """
+
+    __slots__ = ("_kind", "_raw_span", "_anchors", "_slots", "_label")
+
+    def __init__(
+        self,
+        kind: str,
+        raw_span: Optional[Span],
+        slots: Tuple[Tuple[str, Slot], ...],
+        anchors: Tuple[Span, ...] = (),
+        label: str = "",
+    ) -> None:
+        self._kind = kind
+        self._raw_span = raw_span
+        self._anchors = anchors
+        self._slots = slots
+        self._label = label
+
+    def describe(self) -> Description:
+        return Description(
+            kind=self._kind,
+            raw_span=self._raw_span,
+            anchors=self._anchors,
+            slots=self._slots,
+        )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<libcst-synth {self._kind} {self._label}>"
+
+
+# --------------------------------------------------------------------------
+# Slot helpers
+# --------------------------------------------------------------------------
+
+
+def _child(ctx: _Ctx, node: cst.CSTNode) -> Child:
+    return Child(_Handle(ctx, node))
+
+
+def _maybe(ctx: _Ctx, node: Optional[cst.CSTNode]) -> MaybeChild:
+    return MaybeChild(None if node is None else _Handle(ctx, node))
+
+
+def _children(ctx: _Ctx, nodes: Sequence[cst.CSTNode]) -> Children:
+    return Children(tuple(_Handle(ctx, n) for n in nodes))
+
+
+def _unwrap_annotation(node: Optional[cst.Annotation]) -> Optional[cst.BaseExpression]:
+    return None if node is None else node.annotation
+
+
+def _asname_str(node: Optional[cst.AsName]) -> Optional[str]:
+    if node is None:
+        return None
+    target = node.name
+    if isinstance(target, cst.Name):
+        return target.value
+    membrane_panic(
+        owner="libcst_adapter._asname_str",
+        observed=f"AsName over {type(target).__name__}, not a Name",
+        requested="a simple name binding",
+        fix="add an explicit rule; never guess an identifier",
+    )
+    raise AssertionError("unreachable")
+
+
+def _dotted(node: cst.BaseExpression) -> str:
+    """Dotted module name of an import target. Iterative, never recursive."""
+    parts: list[str] = []
+    cur = node
+    while isinstance(cur, cst.Attribute):
+        parts.append(cur.attr.value)
+        cur = cur.value
+    if not isinstance(cur, cst.Name):
+        membrane_panic(
+            owner="libcst_adapter._dotted",
+            observed=f"import target head is {type(cur).__name__}, not a Name",
+            requested="a Name or a chain of Attribute over a Name",
+            fix="add an explicit rule for this import shape",
+        )
+    parts.append(cur.value)  # type: ignore[union-attr]
+    return ".".join(reversed(parts))
+
+
+# --------------------------------------------------------------------------
+# Statement-body flattening: CST suites are not in our inventory
+# --------------------------------------------------------------------------
+
+
+def _statements(ctx: _Ctx, body: object) -> Tuple[ProviderHandle, ...]:
+    """A CST suite/block/line -> our flat tuple of statement handles."""
+    out: list[ProviderHandle] = []
+    pending: list[object] = [body]
+    while pending:
+        item = pending.pop(0)
+        if item is None:
+            continue
+        if isinstance(item, (list, tuple)):
+            pending = list(item) + pending
+            continue
+        if isinstance(item, (cst.IndentedBlock, cst.SimpleStatementSuite)):
+            pending = list(item.body) + pending
+            continue
+        if isinstance(item, cst.SimpleStatementLine):
+            # ``a = 1; b = 2`` is one CST line and two of our statements.
+            pending = list(item.body) + pending
+            continue
+        if isinstance(item, (cst.Else, cst.Finally)):
+            pending = [item.body] + pending
+            continue
+        if isinstance(item, cst.CSTNode):
+            out.append(_Handle(ctx, item))
+            continue
+        membrane_panic(
+            owner="libcst_adapter._statements",
+            observed=f"{type(item).__name__} in statement position",
+            requested="a CST statement, suite, or block",
+            fix="add an explicit rule for this container",
+        )
+    return tuple(out)
+
+
+def _orelse(ctx: _Ctx, node: object) -> Tuple[ProviderHandle, ...]:
+    """``If.orelse``: an ``Else`` (flattened) or a nested ``If`` (an elif)."""
+    if node is None:
+        return ()
+    if isinstance(node, cst.Else):
+        return _statements(ctx, node.body)
+    if isinstance(node, cst.If):
+        return (_Handle(ctx, node),)
+    membrane_panic(
+        owner="libcst_adapter._orelse",
+        observed=f"{type(node).__name__} in orelse position",
+        requested="an Else or a nested If",
+        fix="add an explicit rule for this shape",
+    )
+    raise AssertionError("unreachable")
+
+
+# --------------------------------------------------------------------------
+# Operators
+# --------------------------------------------------------------------------
+
+_BINARY_OPS = {
+    "Add": "Add",
+    "Subtract": "Sub",
+    "Multiply": "Mult",
+    "Divide": "Div",
+    "Modulo": "Mod",
+    "Power": "Pow",
+    "FloorDivide": "FloorDiv",
+    "MatrixMultiply": "MatMult",
+    "LeftShift": "LShift",
+    "RightShift": "RShift",
+    "BitOr": "BitOr",
+    "BitAnd": "BitAnd",
+    "BitXor": "BitXor",
+}
+
+_AUG_OPS = {
+    "AddAssign": "Add",
+    "SubtractAssign": "Sub",
+    "MultiplyAssign": "Mult",
+    "DivideAssign": "Div",
+    "ModuloAssign": "Mod",
+    "PowerAssign": "Pow",
+    "FloorDivideAssign": "FloorDiv",
+    "MatrixMultiplyAssign": "MatMult",
+    "LeftShiftAssign": "LShift",
+    "RightShiftAssign": "RShift",
+    "BitOrAssign": "BitOr",
+    "BitAndAssign": "BitAnd",
+    "BitXorAssign": "BitXor",
+}
+
+_UNARY_OPS = {"Plus": "UAdd", "Minus": "USub", "Not": "Not", "BitInvert": "Invert"}
+
+_BOOL_OPS = {"And": "And", "Or": "Or"}
+
+_COMPARE_OPS = {
+    "Equal": "Eq",
+    "NotEqual": "NotEq",
+    "LessThan": "Lt",
+    "LessThanEqual": "LtE",
+    "GreaterThan": "Gt",
+    "GreaterThanEqual": "GtE",
+    "In": "In",
+    "NotIn": "NotIn",
+    "Is": "Is",
+    "IsNot": "IsNot",
+}
+
+
+def _op(table: dict[str, str], node: cst.CSTNode, where: str) -> Operator:
+    kind = table.get(type(node).__name__)
+    if kind is None:
+        membrane_panic(
+            owner=f"libcst_adapter._op[{where}]",
+            observed=f"libcst operator {type(node).__name__} has no membrane operator",
+            requested="a mapping into the frozen operator vocabulary",
+            fix="add the operator deliberately in operators.py and here; never guess",
+        )
+        raise AssertionError("unreachable")
+    return operator_for(kind)
+
+
+# --------------------------------------------------------------------------
+# Span recovery for the shapes where LibCST and our spec differ
+# --------------------------------------------------------------------------
+
+
+def _tuple_span(ctx: _Ctx, node: cst.Tuple) -> Span:
+    """Our spec: an enclosed tuple display INCLUDES its parens (the one
+    ruled exception to the grouping rule). LibCST excludes them; the
+    innermost paren pair is the display's delimiter."""
+    inner = ctx.span(node)
+    if node.lpar and node.rpar:
+        return ctx.span(node.lpar[-1]).envelope(ctx.span(node.rpar[0]))
+    return inner
+
+
+def _comp_for_anchor(ctx: _Ctx, node: cst.CompFor) -> Span:
+    """The clause's ``for`` (or ``async``) keyword start.
+
+    LibCST's ``CompFor`` span begins at the whitespace preceding the
+    keyword; our spec begins at the keyword. Pure forward scan over
+    whitespace — the mirror of the CPython adapter's backscan.
+    """
+    start = ctx.span(node).start
+    src = ctx.unit.source
+    j = start
+    while j < len(src) and src[j].isspace():
+        j += 1
+    if not (src.startswith("for", j) or src.startswith("async", j)):
+        membrane_panic(
+            owner="libcst_adapter._comp_for_anchor",
+            observed=f"no 'for'/'async' keyword at comprehension clause start {j}",
+            requested="'for' (optionally 'async for') opening the clause",
+            fix="the forward-scan rule is wrong for this shape; extend it deliberately",
+        )
+    return Span(j, j)
+
+
+def _comp_clauses(ctx: _Ctx, first: cst.CompFor) -> Tuple[ProviderHandle, ...]:
+    """LibCST nests comprehension clauses via ``inner_for_in``; our
+    ``generators`` is a flat tuple. Iterative, never recursive."""
+    out: list[ProviderHandle] = []
+    cur: Optional[cst.CompFor] = first
+    while cur is not None:
+        out.append(_Handle(ctx, cur))
+        cur = cur.inner_for_in
+    return tuple(out)
+
+
+def _flatten_boolop(
+    node: cst.BooleanOperation,
+) -> tuple[cst.CSTNode, list[cst.BaseExpression]]:
+    """``a and b and c`` is left-nested in LibCST and n-ary in our
+    ``BoolOp.values``. Flatten same-operator chains; a parenthesized
+    sub-operation is its own expression and is NOT flattened through."""
+    op_type = type(node.operator)
+    values: list[cst.BaseExpression] = [node.right]
+    cur: cst.BaseExpression = node.left
+    while (
+        isinstance(cur, cst.BooleanOperation)
+        and type(cur.operator) is op_type
+        and not cur.lpar
+    ):
+        values.append(cur.right)
+        cur = cur.left
+    values.append(cur)
+    values.reverse()
+    return node.operator, values
+
+
+def _concat_parts(node: cst.BaseExpression) -> list[cst.BaseExpression]:
+    """Flatten a ``ConcatenatedString`` chain into its literal pieces."""
+    parts: list[cst.BaseExpression] = []
+    pending: list[cst.BaseExpression] = [node]
+    while pending:
+        item = pending.pop(0)
+        if isinstance(item, cst.ConcatenatedString):
+            pending = [item.left, item.right] + pending
+            continue
+        parts.append(item)
+    return parts
+
+
+# --------------------------------------------------------------------------
+# Parameters
+# --------------------------------------------------------------------------
+
+
+def _param_handle(ctx: _Ctx, param: cst.Param, param_kind: str) -> ProviderHandle:
+    """One formal parameter, anchored on its NAME token.
+
+    Our spec excludes the ``*``/``**`` sigil from a ``Param`` span (it is an
+    arity marker of the parameter LIST). LibCST's ``Param`` span includes
+    it, so the name token is the anchor and annotation/default widen it by
+    the envelope rule.
+    """
+    annotation = _unwrap_annotation(param.annotation)
+    default = param.default
+    return _Synth(
+        kind="Param",
+        raw_span=None,
+        anchors=(ctx.span(param.name),),
+        slots=(
+            ("name", Leaf(param.name.value)),
+            ("annotation", _maybe(ctx, annotation)),
+            ("default", _maybe(ctx, default)),
+            ("param_kind", Leaf(param_kind)),
+        ),
+        label=param.name.value,
+    )
+
+
+def _params(ctx: _Ctx, params: cst.Parameters) -> Children:
+    out: list[ProviderHandle] = []
+    for p in params.posonly_params:
+        out.append(_param_handle(ctx, p, "positional_only"))
+    for p in params.params:
+        out.append(_param_handle(ctx, p, "positional_or_keyword"))
+    star_arg = params.star_arg
+    if isinstance(star_arg, cst.Param):
+        out.append(_param_handle(ctx, star_arg, "vararg"))
+    elif isinstance(star_arg, cst.ParamStar):
+        pass  # bare ``*`` separator: a marker, not a parameter
+    elif star_arg is not None and not isinstance(star_arg, cst.MaybeSentinel):
+        membrane_panic(
+            owner="libcst_adapter._params",
+            observed=f"star_arg is {type(star_arg).__name__}",
+            requested="a Param, a ParamStar, or absent",
+            fix="add an explicit rule for this parameter shape",
+        )
+    for p in params.kwonly_params:
+        out.append(_param_handle(ctx, p, "keyword_only"))
+    if params.star_kwarg is not None:
+        out.append(_param_handle(ctx, params.star_kwarg, "kwarg"))
+    return Children(tuple(out))
+
+
+# --------------------------------------------------------------------------
+# Call / class arguments
+# --------------------------------------------------------------------------
+
+
+def _split_args(
+    ctx: _Ctx, args: Sequence[cst.Arg]
+) -> tuple[Tuple[ProviderHandle, ...], Tuple[ProviderHandle, ...]]:
+    """CST ``Arg`` is one node for four shapes. Ours splits positional
+    (including ``*spread``, which becomes ``Starred``) from keywords
+    (including ``**spread``, a ``Keyword`` with ``arg is None``)."""
+    positional: list[ProviderHandle] = []
+    keywords: list[ProviderHandle] = []
+    for arg in args:
+        if arg.star == "*":
+            positional.append(
+                _Synth(
+                    kind="Starred",
+                    raw_span=ctx.span(arg),
+                    slots=(("value", _child(ctx, arg.value)),),
+                    label="*arg",
+                )
+            )
+        elif arg.star == "**":
+            keywords.append(
+                _Synth(
+                    kind="Keyword",
+                    raw_span=ctx.span(arg),
+                    slots=(("arg", Leaf(None)), ("value", _child(ctx, arg.value))),
+                    label="**kwargs",
+                )
+            )
+        elif arg.keyword is not None:
+            keywords.append(
+                _Synth(
+                    kind="Keyword",
+                    raw_span=ctx.span(arg),
+                    slots=(
+                        ("arg", Leaf(arg.keyword.value)),
+                        ("value", _child(ctx, arg.value)),
+                    ),
+                    label=arg.keyword.value,
+                )
+            )
+        else:
+            positional.append(_Handle(ctx, arg.value))
+    return tuple(positional), tuple(keywords)
+
+
+# --------------------------------------------------------------------------
+# Collection elements
+# --------------------------------------------------------------------------
+
+
+def _elements(ctx: _Ctx, elements: Sequence[cst.BaseElement]) -> Children:
+    """``Element``/``StarredElement`` wrappers -> our expressions."""
+    out: list[ProviderHandle] = []
+    for el in elements:
+        if isinstance(el, cst.StarredElement):
+            out.append(
+                _Synth(
+                    kind="Starred",
+                    raw_span=ctx.span(el),
+                    slots=(("value", _child(ctx, el.value)),),
+                    label="*element",
+                )
+            )
+        elif isinstance(el, cst.Element):
+            out.append(_Handle(ctx, el.value))
+        else:
+            membrane_panic(
+                owner="libcst_adapter._elements",
+                observed=f"{type(el).__name__} in element position",
+                requested="an Element or a StarredElement",
+                fix="add an explicit rule for this element shape",
+            )
+    return Children(tuple(out))
+
+
+def _dict_items(ctx: _Ctx, elements: Sequence[cst.BaseDictElement]) -> Children:
+    out: list[ProviderHandle] = []
+    for el in elements:
+        if isinstance(el, cst.DictElement):
+            out.append(
+                _Synth(
+                    kind="DictItem",
+                    raw_span=None,
+                    slots=(
+                        ("key", _maybe(ctx, el.key)),
+                        ("value", _child(ctx, el.value)),
+                    ),
+                    label="item",
+                )
+            )
+        elif isinstance(el, cst.StarredDictElement):
+            out.append(
+                _Synth(
+                    kind="DictItem",
+                    raw_span=None,
+                    slots=(
+                        ("key", MaybeChild(None)),
+                        ("value", _child(ctx, el.value)),
+                    ),
+                    label="**spread",
+                )
+            )
+        else:
+            membrane_panic(
+                owner="libcst_adapter._dict_items",
+                observed=f"{type(el).__name__} in dict element position",
+                requested="a DictElement or a StarredDictElement",
+                fix="add an explicit rule for this dict entry shape",
+            )
+    return Children(tuple(out))
+
+
+# --------------------------------------------------------------------------
+# Subscripts
+# --------------------------------------------------------------------------
+
+
+def _subscript_slice(ctx: _Ctx, node: cst.Subscript) -> Child:
+    parts = list(node.slice)
+    if len(parts) == 1:
+        return Child(_slice_element(ctx, parts[0]))
+    # ``a[1, 2]`` -> one Tuple over the elements, spanning them.
+    handles = tuple(_slice_element(ctx, p) for p in parts)
+    span = ctx.span(parts[0].slice)
+    for p in parts[1:]:
+        span = span.envelope(ctx.span(p.slice))
+    return Child(
+        _Synth(
+            kind="Tuple",
+            raw_span=span,
+            slots=(("elts", Children(handles)),),
+            label="subscript-tuple",
+        )
+    )
+
+
+def _slice_element(ctx: _Ctx, element: cst.SubscriptElement) -> ProviderHandle:
+    inner = element.slice
+    if isinstance(inner, cst.Index):
+        return _Handle(ctx, inner.value)
+    if isinstance(inner, cst.Slice):
+        return _Handle(ctx, inner)
+    membrane_panic(
+        owner="libcst_adapter._slice_element",
+        observed=f"{type(inner).__name__} in subscript position",
+        requested="an Index or a Slice",
+        fix="add an explicit rule for this subscript shape",
+    )
+    raise AssertionError("unreachable")
+
+
+# --------------------------------------------------------------------------
+# f-strings
+# --------------------------------------------------------------------------
+
+
+def _format_spec(
+    ctx: _Ctx, spec: Optional[Sequence[cst.BaseFormattedStringContent]]
+) -> MaybeChild:
+    """Our ``FormattedValue.format_spec`` is a ``JoinedStr``; LibCST carries
+    a bare content sequence with no wrapper node. Synthesize one, spanning
+    its contents — i.e. the text AFTER the ``:``, per our ruling."""
+    if spec is None:
+        return MaybeChild(None)
+    parts = list(spec)
+    if not parts:
+        membrane_panic(
+            owner="libcst_adapter._format_spec",
+            observed="an empty format spec with no content to span",
+            requested="a spec with at least one content node, or no spec at all",
+            fix="rule on the span of an empty format spec; never invent one",
+        )
+    span = ctx.span(parts[0])
+    for p in parts[1:]:
+        span = span.envelope(ctx.span(p))
+    return MaybeChild(
+        _Synth(
+            kind="JoinedStr",
+            raw_span=span,
+            slots=(("values", _children(ctx, parts)),),
+            label="format-spec",
+        )
+    )
+
+
+_CONVERSIONS = {None: -1, "s": 115, "r": 114, "a": 97}
+
+
+def _conversion(value: Optional[str]) -> int:
+    code = _CONVERSIONS.get(value)
+    if code is None:
+        membrane_panic(
+            owner="libcst_adapter._conversion",
+            observed=f"f-string conversion {value!r}",
+            requested="one of !s, !r, !a, or none",
+            fix="add the conversion deliberately; never guess a code",
+        )
+        raise AssertionError("unreachable")
+    return code
+
+
+# --------------------------------------------------------------------------
+# Rules: one per LibCST node type we admit. No fallback.
+# --------------------------------------------------------------------------
+
+_Rule = Callable[[_Ctx, cst.CSTNode], Description]
+_RULES: dict[str, _Rule] = {}
+
+
+def _rule(*names: str) -> Callable[[_Rule], _Rule]:
+    def register(fn: _Rule) -> _Rule:
+        for name in names:
+            _RULES[name] = fn
+        return fn
+
+    return register
+
+
+def _desc(
+    kind: str,
+    span: Optional[Span],
+    *slots: Tuple[str, Slot],
+    anchors: Tuple[Span, ...] = (),
+) -> Description:
+    return Description(kind=kind, raw_span=span, anchors=anchors, slots=tuple(slots))
+
+
+# --- module and statements -------------------------------------------------
+
+
+@_rule("Module")
+def _r_module(ctx: _Ctx, n: cst.Module) -> Description:
+    return _desc(
+        "Module",
+        Span(0, len(ctx.unit.source)),
+        ("body", Children(_statements(ctx, n.body))),
+    )
+
+
+@_rule("FunctionDef")
+def _r_functiondef(ctx: _Ctx, n: cst.FunctionDef) -> Description:
+    kind = "AsyncFunctionDef" if n.asynchronous is not None else "FunctionDef"
+    return _desc(
+        kind,
+        ctx.span(n),
+        ("name", Leaf(n.name.value)),
+        ("params", _params(ctx, n.params)),
+        ("body", Children(_statements(ctx, n.body))),
+        ("decorators", Children(tuple(_Handle(ctx, d.decorator) for d in n.decorators))),
+        ("returns", _maybe(ctx, _unwrap_annotation(n.returns))),
+        ("type_params", _type_params(ctx, n.type_parameters)),
+    )
+
+
+@_rule("ClassDef")
+def _r_classdef(ctx: _Ctx, n: cst.ClassDef) -> Description:
+    bases, keywords = _split_args(ctx, list(n.bases) + list(n.keywords))
+    return _desc(
+        "ClassDef",
+        ctx.span(n),
+        ("name", Leaf(n.name.value)),
+        ("bases", Children(bases)),
+        ("keywords", Children(keywords)),
+        ("body", Children(_statements(ctx, n.body))),
+        ("decorators", Children(tuple(_Handle(ctx, d.decorator) for d in n.decorators))),
+        ("type_params", _type_params(ctx, n.type_parameters)),
+    )
+
+
+def _type_params(ctx: _Ctx, node: Optional[cst.TypeParameters]) -> Children:
+    if node is None:
+        return Children(())
+    return Children(tuple(_Handle(ctx, p.param) for p in node.params))
+
+
+@_rule("TypeVar")
+def _r_typevar(ctx: _Ctx, n: cst.TypeVar) -> Description:
+    return _desc(
+        "TypeVar",
+        ctx.span(n),
+        ("name", Leaf(n.name.value)),
+        ("bound", _maybe(ctx, n.bound)),
+    )
+
+
+@_rule("ParamSpec")
+def _r_paramspec(ctx: _Ctx, n: cst.ParamSpec) -> Description:
+    return _desc("ParamSpec", ctx.span(n), ("name", Leaf(n.name.value)))
+
+
+@_rule("TypeVarTuple")
+def _r_typevartuple(ctx: _Ctx, n: cst.TypeVarTuple) -> Description:
+    return _desc("TypeVarTuple", ctx.span(n), ("name", Leaf(n.name.value)))
+
+
+@_rule("TypeAlias")
+def _r_typealias(ctx: _Ctx, n: cst.TypeAlias) -> Description:
+    return _desc(
+        "TypeAlias",
+        ctx.span(n),
+        ("name", _child(ctx, n.name)),
+        ("type_params", _type_params(ctx, n.type_parameters)),
+        ("value", _child(ctx, n.value)),
+    )
+
+
+@_rule("Return")
+def _r_return(ctx: _Ctx, n: cst.Return) -> Description:
+    return _desc("Return", ctx.span(n), ("value", _maybe(ctx, n.value)))
+
+
+@_rule("Del")
+def _r_del(ctx: _Ctx, n: cst.Del) -> Description:
+    target = n.target
+    # ``del a, b``: our Delete.targets is n-ary; LibCST wraps in a bare Tuple.
+    if isinstance(target, cst.Tuple) and not target.lpar:
+        targets = _elements(ctx, target.elements)
+    else:
+        targets = Children((_Handle(ctx, target),))
+    return _desc("Delete", ctx.span(n), ("targets", targets))
+
+
+@_rule("Assign")
+def _r_assign(ctx: _Ctx, n: cst.Assign) -> Description:
+    return _desc(
+        "Assign",
+        ctx.span(n),
+        ("targets", Children(tuple(_Handle(ctx, t.target) for t in n.targets))),
+        ("value", _child(ctx, n.value)),
+    )
+
+
+@_rule("AugAssign")
+def _r_augassign(ctx: _Ctx, n: cst.AugAssign) -> Description:
+    return _desc(
+        "AugAssign",
+        ctx.span(n),
+        ("target", _child(ctx, n.target)),
+        ("op", OpLeaf(_op(_AUG_OPS, n.operator, "augassign"))),
+        ("value", _child(ctx, n.value)),
+    )
+
+
+@_rule("AnnAssign")
+def _r_annassign(ctx: _Ctx, n: cst.AnnAssign) -> Description:
+    return _desc(
+        "AnnAssign",
+        ctx.span(n),
+        ("target", _child(ctx, n.target)),
+        ("annotation", Child(_Handle(ctx, n.annotation.annotation))),
+        ("value", _maybe(ctx, n.value)),
+        ("simple", Leaf(isinstance(n.target, cst.Name))),
+    )
+
+
+@_rule("For")
+def _r_for(ctx: _Ctx, n: cst.For) -> Description:
+    kind = "AsyncFor" if n.asynchronous is not None else "For"
+    return _desc(
+        kind,
+        ctx.span(n),
+        ("target", _child(ctx, n.target)),
+        ("iter", _child(ctx, n.iter)),
+        ("body", Children(_statements(ctx, n.body))),
+        ("orelse", Children(_statements(ctx, n.orelse))),
+    )
+
+
+@_rule("While")
+def _r_while(ctx: _Ctx, n: cst.While) -> Description:
+    return _desc(
+        "While",
+        ctx.span(n),
+        ("test", _child(ctx, n.test)),
+        ("body", Children(_statements(ctx, n.body))),
+        ("orelse", Children(_statements(ctx, n.orelse))),
+    )
+
+
+@_rule("If")
+def _r_if(ctx: _Ctx, n: cst.If) -> Description:
+    return _desc(
+        "If",
+        ctx.span(n),
+        ("test", _child(ctx, n.test)),
+        ("body", Children(_statements(ctx, n.body))),
+        ("orelse", Children(_orelse(ctx, n.orelse))),
+    )
+
+
+@_rule("With")
+def _r_with(ctx: _Ctx, n: cst.With) -> Description:
+    kind = "AsyncWith" if n.asynchronous is not None else "With"
+    return _desc(
+        kind,
+        ctx.span(n),
+        ("items", _children(ctx, n.items)),
+        ("body", Children(_statements(ctx, n.body))),
+    )
+
+
+@_rule("WithItem")
+def _r_withitem(ctx: _Ctx, n: cst.WithItem) -> Description:
+    asname = n.asname
+    return _desc(
+        "WithItem",
+        None,
+        ("context_expr", _child(ctx, n.item)),
+        ("optional_vars", _maybe(ctx, None if asname is None else asname.name)),
+    )
+
+
+@_rule("Raise")
+def _r_raise(ctx: _Ctx, n: cst.Raise) -> Description:
+    cause = n.cause
+    return _desc(
+        "Raise",
+        ctx.span(n),
+        ("exc", _maybe(ctx, n.exc)),
+        ("cause", _maybe(ctx, None if cause is None else cause.item)),
+    )
+
+
+@_rule("Try", "TryStar")
+def _r_try(ctx: _Ctx, n: cst.CSTNode) -> Description:
+    kind = "TryStar" if isinstance(n, cst.TryStar) else "Try"
+    return _desc(
+        kind,
+        ctx.span(n),
+        ("body", Children(_statements(ctx, n.body))),  # type: ignore[attr-defined]
+        ("handlers", _children(ctx, n.handlers)),  # type: ignore[attr-defined]
+        ("orelse", Children(_statements(ctx, n.orelse))),  # type: ignore[attr-defined]
+        ("finalbody", Children(_statements(ctx, n.finalbody))),  # type: ignore[attr-defined]
+    )
+
+
+@_rule("ExceptHandler", "ExceptStarHandler")
+def _r_excepthandler(ctx: _Ctx, n: cst.CSTNode) -> Description:
+    return _desc(
+        "ExceptHandler",
+        ctx.span(n),
+        ("type_", _maybe(ctx, n.type)),  # type: ignore[attr-defined]
+        ("name", Leaf(_asname_str(n.name))),  # type: ignore[attr-defined]
+        ("body", Children(_statements(ctx, n.body))),  # type: ignore[attr-defined]
+    )
+
+
+@_rule("Assert")
+def _r_assert(ctx: _Ctx, n: cst.Assert) -> Description:
+    return _desc(
+        "Assert",
+        ctx.span(n),
+        ("test", _child(ctx, n.test)),
+        ("msg", _maybe(ctx, n.msg)),
+    )
+
+
+@_rule("Import")
+def _r_import(ctx: _Ctx, n: cst.Import) -> Description:
+    return _desc("Import", ctx.span(n), ("names", _children(ctx, n.names)))
+
+
+@_rule("ImportFrom")
+def _r_importfrom(ctx: _Ctx, n: cst.ImportFrom) -> Description:
+    module = None if n.module is None else _dotted(n.module)
+    names = n.names
+    if isinstance(names, cst.ImportStar):
+        aliases: Tuple[ProviderHandle, ...] = (
+            _Synth(
+                kind="ImportAlias",
+                raw_span=ctx.span(names),
+                slots=(("name", Leaf("*")), ("asname", Leaf(None))),
+                label="import-star",
+            ),
+        )
+    else:
+        aliases = tuple(_Handle(ctx, a) for a in names)
+    return _desc(
+        "ImportFrom",
+        ctx.span(n),
+        ("module", Leaf(module)),
+        ("names", Children(aliases)),
+        ("level", Leaf(len(n.relative))),
+    )
+
+
+@_rule("ImportAlias")
+def _r_importalias(ctx: _Ctx, n: cst.ImportAlias) -> Description:
+    return _desc(
+        "ImportAlias",
+        ctx.span(n),
+        ("name", Leaf(_dotted(n.name))),
+        ("asname", Leaf(_asname_str(n.asname))),
+    )
+
+
+@_rule("Global")
+def _r_global(ctx: _Ctx, n: cst.Global) -> Description:
+    return _desc(
+        "Global", ctx.span(n), ("names", Leaf(tuple(i.name.value for i in n.names)))
+    )
+
+
+@_rule("Nonlocal")
+def _r_nonlocal(ctx: _Ctx, n: cst.Nonlocal) -> Description:
+    return _desc(
+        "Nonlocal", ctx.span(n), ("names", Leaf(tuple(i.name.value for i in n.names)))
+    )
+
+
+@_rule("Expr")
+def _r_expr(ctx: _Ctx, n: cst.Expr) -> Description:
+    return _desc("Expr", ctx.span(n), ("value", _child(ctx, n.value)))
+
+
+@_rule("Pass")
+def _r_pass(ctx: _Ctx, n: cst.Pass) -> Description:
+    return _desc("Pass", ctx.span(n))
+
+
+@_rule("Break")
+def _r_break(ctx: _Ctx, n: cst.Break) -> Description:
+    return _desc("Break", ctx.span(n))
+
+
+@_rule("Continue")
+def _r_continue(ctx: _Ctx, n: cst.Continue) -> Description:
+    return _desc("Continue", ctx.span(n))
+
+
+# --- match -----------------------------------------------------------------
+
+
+@_rule("Match")
+def _r_match(ctx: _Ctx, n: cst.Match) -> Description:
+    return _desc(
+        "Match",
+        ctx.span(n),
+        ("subject", _child(ctx, n.subject)),
+        ("cases", _children(ctx, n.cases)),
+    )
+
+
+@_rule("MatchCase")
+def _r_matchcase(ctx: _Ctx, n: cst.MatchCase) -> Description:
+    return _desc(
+        "MatchCase",
+        None,
+        ("pattern", _child(ctx, n.pattern)),
+        ("guard", _maybe(ctx, n.guard)),
+        ("body", Children(_statements(ctx, n.body))),
+    )
+
+
+@_rule("MatchValue")
+def _r_matchvalue(ctx: _Ctx, n: cst.MatchValue) -> Description:
+    return _desc("MatchValue", ctx.span(n), ("value", _child(ctx, n.value)))
+
+
+@_rule("MatchSingleton")
+def _r_matchsingleton(ctx: _Ctx, n: cst.MatchSingleton) -> Description:
+    return _desc(
+        "MatchSingleton", ctx.span(n), ("value", Leaf(_singleton(n.value.value)))
+    )
+
+
+def _singleton(text: str) -> object:
+    table: dict[str, object] = {"True": True, "False": False, "None": None}
+    if text not in table:
+        membrane_panic(
+            owner="libcst_adapter._singleton",
+            observed=f"match singleton {text!r}",
+            requested="True, False, or None",
+            fix="add the singleton deliberately; never guess a value",
+        )
+    return table[text]
+
+
+@_rule("MatchList", "MatchTuple", "MatchSequence")
+def _r_matchsequence(ctx: _Ctx, n: cst.CSTNode) -> Description:
+    return _desc(
+        "MatchSequence",
+        ctx.span(n),
+        ("patterns", _match_patterns(ctx, n.patterns)),  # type: ignore[attr-defined]
+    )
+
+
+def _match_patterns(ctx: _Ctx, elements: Sequence[cst.CSTNode]) -> Children:
+    out: list[ProviderHandle] = []
+    for el in elements:
+        if isinstance(el, cst.MatchSequenceElement):
+            out.append(_Handle(ctx, el.value))
+        elif isinstance(el, cst.MatchStar):
+            out.append(_Handle(ctx, el))
+        else:
+            membrane_panic(
+                owner="libcst_adapter._match_patterns",
+                observed=f"{type(el).__name__} in match sequence position",
+                requested="a MatchSequenceElement or a MatchStar",
+                fix="add an explicit rule for this pattern element",
+            )
+    return Children(tuple(out))
+
+
+@_rule("MatchStar")
+def _r_matchstar(ctx: _Ctx, n: cst.MatchStar) -> Description:
+    name = n.name
+    return _desc(
+        "MatchStar",
+        ctx.span(n),
+        ("name", Leaf(None if name is None else name.value)),
+    )
+
+
+@_rule("MatchMapping")
+def _r_matchmapping(ctx: _Ctx, n: cst.MatchMapping) -> Description:
+    rest = n.rest
+    return _desc(
+        "MatchMapping",
+        ctx.span(n),
+        ("keys", Children(tuple(_Handle(ctx, e.key) for e in n.elements))),
+        ("patterns", Children(tuple(_Handle(ctx, e.pattern) for e in n.elements))),
+        ("rest", Leaf(None if rest is None else rest.value)),
+    )
+
+
+@_rule("MatchClass")
+def _r_matchclass(ctx: _Ctx, n: cst.MatchClass) -> Description:
+    return _desc(
+        "MatchClass",
+        ctx.span(n),
+        ("cls_", _child(ctx, n.cls)),
+        ("patterns", _match_patterns(ctx, n.patterns)),
+        ("kwd_attrs", Leaf(tuple(k.key.value for k in n.kwds))),
+        ("kwd_patterns", Children(tuple(_Handle(ctx, k.pattern) for k in n.kwds))),
+    )
+
+
+@_rule("MatchAs")
+def _r_matchas(ctx: _Ctx, n: cst.MatchAs) -> Description:
+    name = n.name
+    return _desc(
+        "MatchAs",
+        ctx.span(n),
+        ("pattern", _maybe(ctx, n.pattern)),
+        ("name", Leaf(None if name is None else name.value)),
+    )
+
+
+@_rule("MatchOr")
+def _r_matchor(ctx: _Ctx, n: cst.MatchOr) -> Description:
+    return _desc(
+        "MatchOr",
+        ctx.span(n),
+        ("patterns", Children(tuple(_Handle(ctx, e.pattern) for e in n.patterns))),
+    )
+
+
+# --- expressions -----------------------------------------------------------
+
+
+@_rule("Name")
+def _r_name(ctx: _Ctx, n: cst.Name) -> Description:
+    # LibCST spells True/False/None as Name; ours are Constants.
+    if n.value in ("True", "False", "None"):
+        return _desc(
+            "Constant",
+            ctx.span(n),
+            ("value", Leaf(_singleton(n.value))),
+            ("literal_kind", Leaf(None)),
+        )
+    return _desc("Name", ctx.span(n), ("id", Leaf(n.value)))
+
+
+@_rule("Integer", "Float", "Imaginary")
+def _r_number(ctx: _Ctx, n: cst.CSTNode) -> Description:
+    return _desc(
+        "Constant",
+        ctx.span(n),
+        ("value", Leaf(n.evaluated_value)),  # type: ignore[attr-defined]
+        ("literal_kind", Leaf(None)),
+    )
+
+
+@_rule("Ellipsis")
+def _r_ellipsis(ctx: _Ctx, n: cst.Ellipsis) -> Description:
+    return _desc(
+        "Constant", ctx.span(n), ("value", Leaf(...)), ("literal_kind", Leaf(None))
+    )
+
+
+@_rule("SimpleString")
+def _r_simplestring(ctx: _Ctx, n: cst.SimpleString) -> Description:
+    return _desc(
+        "Constant",
+        ctx.span(n),
+        ("value", Leaf(n.evaluated_value)),
+        ("literal_kind", Leaf("u" if n.prefix.lower() == "u" else None)),
+    )
+
+
+@_rule("ConcatenatedString")
+def _r_concatstring(ctx: _Ctx, n: cst.ConcatenatedString) -> Description:
+    parts = _concat_parts(n)
+    span = ctx.span(n)
+    if any(isinstance(p, cst.FormattedString) for p in parts):
+        # Any f-string piece makes the whole literal a JoinedStr, whose
+        # values are the pieces' contents in order.
+        values: list[ProviderHandle] = []
+        for p in parts:
+            if isinstance(p, cst.FormattedString):
+                values.extend(_Handle(ctx, c) for c in p.parts)
+            else:
+                values.append(_Handle(ctx, p))
+        return _desc("JoinedStr", span, ("values", Children(tuple(values))))
+    values = [piece.evaluated_value for piece in parts]  # type: ignore[attr-defined]
+    if all(isinstance(v, bytes) for v in values):
+        joined: object = b"".join(values)
+    elif all(isinstance(v, str) for v in values):
+        joined = "".join(values)
+    else:
+        membrane_panic(
+            owner="libcst_adapter._r_concatstring",
+            observed="implicit concatenation mixing str and bytes pieces",
+            requested="pieces of one literal type",
+            fix="this is not valid Python; the provider accepted something CPython would refuse",
+        )
+    return _desc(
+        "Constant", span, ("value", Leaf(joined)), ("literal_kind", Leaf(None))
+    )
+
+
+@_rule("FormattedString")
+def _r_formattedstring(ctx: _Ctx, n: cst.FormattedString) -> Description:
+    return _desc("JoinedStr", ctx.span(n), ("values", _children(ctx, n.parts)))
+
+
+@_rule("FormattedStringText")
+def _r_fstringtext(ctx: _Ctx, n: cst.FormattedStringText) -> Description:
+    return _desc(
+        "Constant",
+        ctx.span(n),
+        ("value", Leaf(n.value)),
+        ("literal_kind", Leaf(None)),
+    )
+
+
+@_rule("FormattedStringExpression")
+def _r_fstringexpr(ctx: _Ctx, n: cst.FormattedStringExpression) -> Description:
+    return _desc(
+        "FormattedValue",
+        ctx.span(n),
+        ("value", _child(ctx, n.expression)),
+        ("conversion", Leaf(_conversion(n.conversion))),
+        ("format_spec", _format_spec(ctx, n.format_spec)),
+    )
+
+
+@_rule("Attribute")
+def _r_attribute(ctx: _Ctx, n: cst.Attribute) -> Description:
+    return _desc(
+        "Attribute",
+        ctx.span(n),
+        ("value", _child(ctx, n.value)),
+        ("attr", Leaf(n.attr.value)),
+    )
+
+
+@_rule("Subscript")
+def _r_subscript(ctx: _Ctx, n: cst.Subscript) -> Description:
+    return _desc(
+        "Subscript",
+        ctx.span(n),
+        ("value", _child(ctx, n.value)),
+        ("slice_", _subscript_slice(ctx, n)),
+    )
+
+
+@_rule("Slice")
+def _r_slice(ctx: _Ctx, n: cst.Slice) -> Description:
+    return _desc(
+        "Slice",
+        ctx.span(n),
+        ("lower", _maybe(ctx, n.lower)),
+        ("upper", _maybe(ctx, n.upper)),
+        ("step", _maybe(ctx, n.step)),
+    )
+
+
+@_rule("Call")
+def _r_call(ctx: _Ctx, n: cst.Call) -> Description:
+    args, keywords = _split_args(ctx, n.args)
+    return _desc(
+        "Call",
+        ctx.span(n),
+        ("func", _child(ctx, n.func)),
+        ("args", Children(args)),
+        ("keywords", Children(keywords)),
+    )
+
+
+@_rule("Await")
+def _r_await(ctx: _Ctx, n: cst.Await) -> Description:
+    return _desc("Await", ctx.span(n), ("value", _child(ctx, n.expression)))
+
+
+@_rule("Yield")
+def _r_yield(ctx: _Ctx, n: cst.Yield) -> Description:
+    value = n.value
+    if isinstance(value, cst.From):
+        return _desc("YieldFrom", ctx.span(n), ("value", _child(ctx, value.item)))
+    return _desc("Yield", ctx.span(n), ("value", _maybe(ctx, value)))
+
+
+@_rule("Lambda")
+def _r_lambda(ctx: _Ctx, n: cst.Lambda) -> Description:
+    return _desc(
+        "Lambda",
+        ctx.span(n),
+        ("params", _params(ctx, n.params)),
+        ("body", _child(ctx, n.body)),
+    )
+
+
+@_rule("IfExp")
+def _r_ifexp(ctx: _Ctx, n: cst.IfExp) -> Description:
+    return _desc(
+        "IfExp",
+        ctx.span(n),
+        ("test", _child(ctx, n.test)),
+        ("body", _child(ctx, n.body)),
+        ("orelse", _child(ctx, n.orelse)),
+    )
+
+
+@_rule("BinaryOperation")
+def _r_binop(ctx: _Ctx, n: cst.BinaryOperation) -> Description:
+    return _desc(
+        "BinOp",
+        ctx.span(n),
+        ("left", _child(ctx, n.left)),
+        ("op", OpLeaf(_op(_BINARY_OPS, n.operator, "binop"))),
+        ("right", _child(ctx, n.right)),
+    )
+
+
+@_rule("UnaryOperation")
+def _r_unaryop(ctx: _Ctx, n: cst.UnaryOperation) -> Description:
+    return _desc(
+        "UnaryOp",
+        ctx.span(n),
+        ("op", OpLeaf(_op(_UNARY_OPS, n.operator, "unaryop"))),
+        ("operand", _child(ctx, n.expression)),
+    )
+
+
+@_rule("BooleanOperation")
+def _r_boolop(ctx: _Ctx, n: cst.BooleanOperation) -> Description:
+    operator, values = _flatten_boolop(n)
+    return _desc(
+        "BoolOp",
+        ctx.span(n),
+        ("op", OpLeaf(_op(_BOOL_OPS, operator, "boolop"))),
+        ("values", _children(ctx, values)),
+    )
+
+
+@_rule("Comparison")
+def _r_comparison(ctx: _Ctx, n: cst.Comparison) -> Description:
+    return _desc(
+        "Compare",
+        ctx.span(n),
+        ("left", _child(ctx, n.left)),
+        (
+            "ops",
+            OpsLeaf(
+                tuple(_op(_COMPARE_OPS, t.operator, "compare") for t in n.comparisons)
+            ),
+        ),
+        ("comparators", Children(tuple(_Handle(ctx, t.comparator) for t in n.comparisons))),
+    )
+
+
+@_rule("NamedExpr")
+def _r_namedexpr(ctx: _Ctx, n: cst.NamedExpr) -> Description:
+    return _desc(
+        "NamedExpr",
+        ctx.span(n),
+        ("target", _child(ctx, n.target)),
+        ("value", _child(ctx, n.value)),
+    )
+
+
+@_rule("Tuple")
+def _r_tuple(ctx: _Ctx, n: cst.Tuple) -> Description:
+    return _desc("Tuple", _tuple_span(ctx, n), ("elts", _elements(ctx, n.elements)))
+
+
+@_rule("List")
+def _r_list(ctx: _Ctx, n: cst.List) -> Description:
+    return _desc("List", ctx.span(n), ("elts", _elements(ctx, n.elements)))
+
+
+@_rule("Set")
+def _r_set(ctx: _Ctx, n: cst.Set) -> Description:
+    return _desc("Set", ctx.span(n), ("elts", _elements(ctx, n.elements)))
+
+
+@_rule("Dict")
+def _r_dict(ctx: _Ctx, n: cst.Dict) -> Description:
+    return _desc("Dict", ctx.span(n), ("items", _dict_items(ctx, n.elements)))
+
+
+@_rule("StarredElement")
+def _r_starredelement(ctx: _Ctx, n: cst.StarredElement) -> Description:
+    return _desc("Starred", ctx.span(n), ("value", _child(ctx, n.value)))
+
+
+@_rule("ListComp")
+def _r_listcomp(ctx: _Ctx, n: cst.ListComp) -> Description:
+    return _desc(
+        "ListComp",
+        ctx.span(n),
+        ("elt", _child(ctx, n.elt)),
+        ("generators", Children(_comp_clauses(ctx, n.for_in))),
+    )
+
+
+@_rule("SetComp")
+def _r_setcomp(ctx: _Ctx, n: cst.SetComp) -> Description:
+    return _desc(
+        "SetComp",
+        ctx.span(n),
+        ("elt", _child(ctx, n.elt)),
+        ("generators", Children(_comp_clauses(ctx, n.for_in))),
+    )
+
+
+@_rule("GeneratorExp")
+def _r_genexp(ctx: _Ctx, n: cst.GeneratorExp) -> Description:
+    return _desc(
+        "GeneratorExp",
+        ctx.span(n),
+        ("elt", _child(ctx, n.elt)),
+        ("generators", Children(_comp_clauses(ctx, n.for_in))),
+    )
+
+
+@_rule("DictComp")
+def _r_dictcomp(ctx: _Ctx, n: cst.DictComp) -> Description:
+    return _desc(
+        "DictComp",
+        ctx.span(n),
+        ("key", _child(ctx, n.key)),
+        ("value", _child(ctx, n.value)),
+        ("generators", Children(_comp_clauses(ctx, n.for_in))),
+    )
+
+
+@_rule("CompFor")
+def _r_compfor(ctx: _Ctx, n: cst.CompFor) -> Description:
+    return Description(
+        kind="Comprehension",
+        raw_span=None,
+        anchors=(_comp_for_anchor(ctx, n),),
+        slots=(
+            ("target", _child(ctx, n.target)),
+            ("iter", _child(ctx, n.iter)),
+            ("ifs", Children(tuple(_Handle(ctx, i.test) for i in n.ifs))),
+            ("is_async", Leaf(n.asynchronous is not None)),
+        ),
+    )
+
+
+# --------------------------------------------------------------------------
+# Dispatch
+# --------------------------------------------------------------------------
+
+
+def _describe(ctx: _Ctx, node: cst.CSTNode) -> Description:
+    rule = _RULES.get(type(node).__name__)
+    if rule is None:
+        membrane_panic(
+            owner="libcst_adapter._describe",
+            observed=f"libcst {type(node).__name__} has no adapter rule",
+            requested="an explicit rule mapping this CST shape into membrane terms",
+            fix="add the rule in libcst_adapter.py — never a permissive fallback",
+        )
+        raise AssertionError("unreachable")
+    return rule(ctx, node)
+
+
+class LibCSTProvider(Provider):
+    """The second provider: Instagram's Rust-backed parser, behind the membrane.
+
+    Does not call CPython's ``compile()`` — which is the frame #5932's
+    SIGSEGV lives in.
+    """
+
+    name = "libcst"
+
+    def parse(self, unit: SourceUnit) -> ProviderHandle:
+        module = cst.parse_module(unit.source)
+        wrapper = MetadataWrapper(module, unsafe_skip_copy=True)
+        positions = wrapper.resolve(PositionProvider)
+        return _Handle(_Ctx(unit, positions), module)

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/libcst_adapter.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/libcst_adapter.py
@@ -377,15 +377,27 @@ def _tuple_span(ctx: _Ctx, node: cst.Tuple) -> Span:
 def _comp_for_anchor(ctx: _Ctx, node: cst.CompFor) -> Span:
     """The clause's ``for`` (or ``async``) keyword start.
 
-    LibCST's ``CompFor`` span begins at the whitespace preceding the
-    keyword; our spec begins at the keyword. Pure forward scan over
-    whitespace — the mirror of the CPython adapter's backscan.
+    LibCST's ``CompFor`` span begins at the trivia preceding the keyword;
+    our spec begins at the keyword. Pure forward scan — the mirror of the
+    CPython adapter's backscan.
+
+    Between the element expression and the ``for`` keyword only whitespace
+    and COMMENTS can occur. Comments are common here in real code (a
+    ``# type: ignore`` on the element line), which a whitespace-only scan
+    walks straight into.
     """
     start = ctx.span(node).start
     src = ctx.unit.source
     j = start
-    while j < len(src) and src[j].isspace():
-        j += 1
+    while j < len(src):
+        if src[j].isspace():
+            j += 1
+            continue
+        if src[j] == "#":
+            newline = src.find("\n", j)
+            j = len(src) if newline == -1 else newline + 1
+            continue
+        break
     if not (src.startswith("for", j) or src.startswith("async", j)):
         membrane_panic(
             owner="libcst_adapter._comp_for_anchor",
@@ -616,15 +628,25 @@ def _dict_items(ctx: _Ctx, elements: Sequence[cst.BaseDictElement]) -> Children:
 # --------------------------------------------------------------------------
 
 
+def _has_comma(element: cst.SubscriptElement) -> bool:
+    return isinstance(element.comma, cst.Comma)
+
+
 def _subscript_slice(ctx: _Ctx, node: cst.Subscript) -> Child:
+    """``a[x]`` is an expression subscript; ``a[x, y]`` AND ``a[x,]`` are
+    tuple subscripts. The trailing comma is what makes a single-element
+    subscript a tuple, so it is the discriminator, and it is inside the
+    tuple's span — without it there is no tuple."""
     parts = list(node.slice)
-    if len(parts) == 1:
+    if len(parts) == 1 and not _has_comma(parts[0]):
         return Child(_slice_element(ctx, parts[0]))
-    # ``a[1, 2]`` -> one Tuple over the elements, spanning them.
     handles = tuple(_slice_element(ctx, p) for p in parts)
     span = ctx.span(parts[0].slice)
     for p in parts[1:]:
         span = span.envelope(ctx.span(p.slice))
+    last = parts[-1]
+    if _has_comma(last):
+        span = span.envelope(ctx.span(last.comma))
     return Child(
         _Synth(
             kind="Tuple",

--- a/implementations/python/sugar-node-membrane/tests/test_libcst_adapter.py
+++ b/implementations/python/sugar-node-membrane/tests/test_libcst_adapter.py
@@ -257,10 +257,30 @@ def test_unknown_operator_panics_rather_than_defaulting():
         _op(_BINARY_OPS, libcst.And(), "binop")
 
 
-def test_provider_refusal_is_a_syntax_error_not_a_silent_empty_tree():
+def test_provider_refusal_is_loud_but_NOT_a_SyntaxError():
+    """CONTRACT FINDING (#5940): the backend contract never declares how a
+    provider signals refusal, and the membrane's failure vocabulary is
+    written in ONE provider's exception type.
+
+    ``corpus.py`` records a provider refusal by catching ``SyntaxError``.
+    LibCST raises ``libcst.ParserSyntaxError``, which does NOT subclass
+    ``SyntaxError``. So with LibCST installed as the provider, a corpus
+    containing a single unparseable file does not produce a recorded
+    ``provider_syntax_error`` row — the exception escapes and kills the
+    whole run. The instrument stops instead of reporting.
+
+    This test pins the fact. The fix belongs in ``backend.py`` (declare a
+    refusal type every adapter normalizes into), which is outside this
+    adapter's blast radius.
+    """
     with pytest.raises(Exception) as excinfo:
         build("def (:\n")
     assert not isinstance(excinfo.value, MembranePanic)
+    assert not isinstance(excinfo.value, SyntaxError), (
+        "if this starts passing, LibCST changed its exception base and "
+        "the contract gap below may have closed by accident, not by ruling"
+    )
+    assert type(excinfo.value).__name__ == "ParserSyntaxError"
 
 
 # --------------------------------------------------------------------------
@@ -320,6 +340,110 @@ def test_cid_agreement_on_the_golden_corpus_is_pinned_with_its_open_findings():
         ("$.body[45].body[0].cases[4]", "span"),
         ("$.body[45].body[0].cases[4].pattern", "span"),
     }
+
+
+def _diff(source: str) -> DiffResult:
+    result = DiffResult()
+    compare_source(
+        Membrane(CPythonAstProvider()),
+        Membrane(LibCSTProvider()),
+        source,
+        "<repro>",
+        result,
+    )
+    return result
+
+
+def test_open_finding_parenthesized_genexp_parens(capsys=None):
+    """SPEC/CPYTHON-ADAPTER FINDING, 849 divergences over numpy+pandas.
+
+    spans.py rules: "grouping parentheses are NEVER part of an expression's
+    span", with the enclosed TUPLE display as the one exception. A generator
+    expression is not a tuple, so by the written spec its own parens are
+    excluded. The CPython adapter includes them.
+
+    Minimal reproducer, pinned so the day someone rules on it the pin moves
+    deliberately rather than silently. The same root cause produces the
+    ``Param`` residue below: a parenthesized ANNOTATION (``a: (X | Y)``)
+    puts CPython's ``arg`` end after the ``)`` while the annotation
+    expression itself, per the grouping rule, ends at ``Y``.
+    """
+    result = _diff("g = (x for x in xs)\n")
+    assert len(result.divergences) == 1
+    d = result.divergences[0]
+    assert d.category == "span"
+    assert d.left_kind == d.right_kind == "GeneratorExp"
+    assert d.left_span == (4, 19)  # cpython: '(x for x in xs)'
+    assert d.right_span == (5, 18)  # libcst: 'x for x in xs' — the written spec
+
+
+def test_open_finding_parenthesized_annotation_param_span():
+    """Same grouping-paren root cause, seen through a Param."""
+    result = _diff("def f(a: (int | str)): pass\n")
+    kinds = {d.left_kind for d in result.divergences}
+    assert kinds == {"Param"}
+
+
+def test_open_finding_implicit_concatenated_fstring_segmentation():
+    """SPEC FINDING, 4,869 divergences over numpy+pandas (85% of all of them).
+
+    ``f"a " "b"`` is one literal. spans.py rules what the WHOLE literal
+    spans, but says nothing about the inventory or spans of the literal
+    runs INSIDE the resulting ``JoinedStr``.
+
+    CPython merges the runs across the piece boundary into one ``Constant``
+    whose span crosses the closing quote of one piece and the opening
+    prefix of the next — so its segment contains inter-piece SYNTAX and is
+    not the literal's text. LibCST keeps one content node per piece. Every
+    subsequent index in ``values[]`` then shifts, which is what produces
+    the paired ``missing_left``/``missing_right`` and the
+    ``FormattedValue``<->``Constant`` "kind" swaps in the corpus report:
+    index misalignment, not genuinely different nodes.
+
+    Nothing is normalized here. The spec has to rule on the segmentation.
+    """
+    result = _diff('s = f"a{x} " "b"\n')
+    assert result.divergences, "the concatenation divergence must not vanish silently"
+    cpython_segments = [
+        d.left_span for d in result.divergences if d.left_kind == "Constant"
+    ]
+    assert cpython_segments, "expected a merged CPython Constant run"
+
+
+def test_a_plain_fstring_without_concatenation_agrees():
+    """The discriminator's other arm: without the concatenation boundary the
+    same f-string machinery — literal runs, replacement fields, conversions,
+    nesting — agrees exactly. This is what makes the finding above specific
+    to concatenation rather than to f-strings at large."""
+    result = _diff('s = f"a{x}b{y!r}c"\n')
+    assert result.divergences == []
+
+
+def test_open_finding_zero_width_constant_inside_a_format_spec():
+    """SPEC FINDING, independent of the two above.
+
+    CPython materializes a ZERO-WIDTH empty ``Constant`` at the end of an
+    f-string format spec. Its span is ``[n, n)`` and its CID is the sha256
+    of the empty string — an address that identifies no source text.
+
+    spans.py's own envelope rule already states the principle it violates:
+    "there is no such thing as a node with no source extent". So the node
+    INVENTORY contradicts the span spec, and LibCST — which materializes no
+    such node — is the side consistent with the written rule.
+
+    The contract has no way to express node inventory, so this is only ever
+    visible through a differential. Needs a ruling.
+    """
+    result = _diff('s = f"{x:>{w}}"\n')
+    empty_cid = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    zero_width = [
+        d
+        for d in result.divergences
+        if d.category == "missing_right" and d.left_cid == empty_cid
+    ]
+    assert len(zero_width) == 1
+    d = zero_width[0]
+    assert d.left_span is not None and d.left_span[0] == d.left_span[1]
 
 
 def test_the_vast_majority_of_the_corpus_already_agrees():

--- a/implementations/python/sugar-node-membrane/tests/test_libcst_adapter.py
+++ b/implementations/python/sugar-node-membrane/tests/test_libcst_adapter.py
@@ -1,0 +1,329 @@
+"""The LibCST adapter, and the provider differential it exists to feed.
+
+Two things are under test:
+
+1. **The adapter maps LibCST onto the span spec** (spans.py). Each ruling
+   the spec makes about a shape where providers differ gets a test that
+   asserts OUR span, not LibCST's raw one.
+2. **The two-arm law holds at the boundary.** A CST shape with no rule
+   panics as a MISSING. There is no permissive fallback, so the negative
+   arm is tested alongside the positive one.
+
+The pinned differential test at the bottom is NOT a "clean diff" check.
+It pins the CURRENT divergence set against the golden corpus so that any
+movement — a divergence appearing, disappearing, or changing shape — is
+loud. The divergences it pins are open findings, documented on the test.
+"""
+
+import pytest
+
+libcst = pytest.importorskip("libcst", reason="LibCST provider not installed")
+
+from sugar_node_membrane.construct import Membrane  # noqa: E402
+from sugar_node_membrane.cpython_adapter import CPythonAstProvider  # noqa: E402
+from sugar_node_membrane.differential import compare_source, DiffResult  # noqa: E402
+from sugar_node_membrane.libcst_adapter import LibCSTProvider, _describe, _Ctx  # noqa: E402
+from sugar_node_membrane import nodes  # noqa: E402
+from sugar_node_membrane.panic import MembranePanic  # noqa: E402
+
+
+def build(source: str):
+    return Membrane(LibCSTProvider()).parse(source, filename="<test>")
+
+
+def only(root, cls):
+    found = [n for n in root.walk() if isinstance(n, cls)]
+    assert found, f"no {cls.__name__} in tree"
+    return found[0]
+
+
+def segment_of(source: str, cls) -> str:
+    return only(build(source), cls).segment()
+
+
+# --------------------------------------------------------------------------
+# The rulings LibCST satisfies natively — pinned so a provider upgrade that
+# changes them is caught here rather than in a corpus diff.
+# --------------------------------------------------------------------------
+
+
+def test_columns_are_codepoints_not_bytes():
+    """Our spec is codepoint offsets. A non-ASCII name before the node is
+    the discriminator: byte columns would shift the Call right by one."""
+    source = "é = f(ü)\n"
+    assert segment_of(source, nodes.Call) == "f(ü)"
+
+
+def test_grouping_parens_are_excluded():
+    assert segment_of("(x + y)\n", nodes.BinOp) == "x + y"
+
+
+def test_walrus_grouping_parens_are_excluded():
+    assert segment_of("z = (n := 10)\n", nodes.NamedExpr) == "n := 10"
+
+
+def test_decorated_def_starts_at_the_def_keyword():
+    source = "@deco\ndef f():\n    pass\n"
+    assert segment_of(source, nodes.FunctionDef) == "def f():\n    pass"
+
+
+def test_decorator_expression_is_its_own_node():
+    root = build("@deco\ndef f():\n    pass\n")
+    fn = only(root, nodes.FunctionDef)
+    assert [d.segment() for d in fn.decorators] == ["deco"]
+
+
+# --------------------------------------------------------------------------
+# The rulings the adapter has to translate, because LibCST differs
+# --------------------------------------------------------------------------
+
+
+def test_enclosed_tuple_display_includes_its_parens():
+    """spans.py's one ruled exception to the grouping rule. LibCST's raw
+    Tuple position excludes them; the adapter recovers them from lpar/rpar."""
+    assert segment_of("t = (1, 2)\n", nodes.Tuple_) == "(1, 2)"
+
+
+def test_bare_tuple_spans_its_elements():
+    assert segment_of("u = 1, 2\n", nodes.Tuple_) == "1, 2"
+
+
+def test_doubly_parenthesized_tuple_takes_the_innermost_parens():
+    """The outer pair is grouping; the innermost pair delimits the display."""
+    assert segment_of("t = ((1, 2))\n", nodes.Tuple_) == "(1, 2)"
+
+
+def test_param_span_excludes_the_star_sigil():
+    """Sigils are arity markers of the parameter LIST, not of the parameter
+    (spans.py). LibCST's raw Param position includes them."""
+    root = build("def g(a, *b, c=1, **d): pass\n")
+    fn = only(root, nodes.FunctionDef)
+    assert [p.segment() for p in fn.params] == ["a", "b", "c=1", "d"]
+
+
+def test_param_span_includes_annotation_and_default():
+    root = build("def g(a: int = 1): pass\n")
+    fn = only(root, nodes.FunctionDef)
+    assert [p.segment() for p in fn.params] == ["a: int = 1"]
+
+
+def test_comprehension_clause_starts_at_the_for_keyword():
+    """LibCST's CompFor position starts at the preceding whitespace."""
+    assert segment_of("[i for i in xs if i]\n", nodes.Comprehension) == "for i in xs if i"
+
+
+def test_async_comprehension_clause_starts_at_async():
+    source = "async def f():\n    return [i async for i in xs]\n"
+    assert segment_of(source, nodes.Comprehension) == "async for i in xs"
+
+
+def test_nested_comprehension_clauses_are_flat_generators():
+    root = build("[a for a in xs for b in ys]\n")
+    comp = only(root, nodes.ListComp)
+    assert [g.segment() for g in comp.generators] == ["for a in xs", "for b in ys"]
+
+
+def test_format_spec_spans_the_text_after_the_colon():
+    root = build('x = f"a{b!r:>{w}}c"\n')
+    fmt = only(root, nodes.FormattedValue)
+    assert fmt.segment() == "{b!r:>{w}}"
+    assert fmt.format_spec is not None
+    assert fmt.format_spec.segment() == ">{w}"
+
+
+def test_conversion_is_the_cpython_code():
+    root = build('x = f"{b!r}"\n')
+    assert only(root, nodes.FormattedValue).conversion == 114
+
+
+# --------------------------------------------------------------------------
+# Vocabulary translation: CST shapes that are not in our inventory
+# --------------------------------------------------------------------------
+
+
+def test_true_false_none_become_constants_not_names():
+    """LibCST spells them as Name; ours are Constant."""
+    root = build("x = True\ny = None\n")
+    values = [c.value for c in root.walk() if isinstance(c, nodes.Constant)]
+    assert values == [True, None]
+    assert not [n for n in root.walk() if isinstance(n, nodes.Name) and n.id == "True"]
+
+
+def test_semicolon_separated_statements_flatten_into_the_body():
+    root = build("a = 1; b = 2\n")
+    assert len(root.body) == 2
+    assert [s.segment() for s in root.body] == ["a = 1", "b = 2"]
+
+
+def test_boolop_chain_is_flattened_n_ary():
+    """``BoolOp.values`` is a tuple; LibCST left-nests the operation."""
+    root = build("r = a and b and c\n")
+    ops = [n for n in root.walk() if isinstance(n, nodes.BoolOp)]
+    assert len(ops) == 1
+    assert [v.segment() for v in ops[0].values] == ["a", "b", "c"]
+
+
+def test_parenthesized_boolop_is_not_flattened_through():
+    """A grouped sub-operation is its own expression, so the chain stops."""
+    root = build("r = (a and b) and c\n")
+    ops = [n for n in root.walk() if isinstance(n, nodes.BoolOp)]
+    assert len(ops) == 2
+
+
+def test_del_with_several_targets_is_n_ary():
+    root = build("del a, b\n")
+    delete = only(root, nodes.Delete)
+    assert [t.segment() for t in delete.targets] == ["a", "b"]
+    assert not [n for n in root.walk() if isinstance(n, nodes.Tuple_)]
+
+
+def test_implicit_concatenation_is_one_constant():
+    root = build("s = 'a' 'b'\n")
+    const = only(root, nodes.Constant)
+    assert const.segment() == "'a' 'b'"
+    assert const.value == "ab"
+
+
+def test_multi_element_subscript_becomes_one_tuple():
+    root = build("v = a[1, 2]\n")
+    tup = only(root, nodes.Tuple_)
+    assert tup.segment() == "1, 2"
+
+
+def test_call_arguments_split_into_args_and_keywords():
+    root = build("f(a, *b, c=1, **d)\n")
+    call = only(root, nodes.Call)
+    assert [a.segment() for a in call.args] == ["a", "*b"]
+    assert [(k.arg, k.segment()) for k in call.keywords] == [
+        ("c", "c=1"),
+        (None, "**d"),
+    ]
+
+
+def test_import_star_is_an_alias_named_star():
+    root = build("from m import *\n")
+    imp = only(root, nodes.ImportFrom)
+    assert [(a.name, a.segment()) for a in imp.names] == [("*", "*")]
+
+
+def test_relative_import_level_counts_the_dots():
+    root = build("from ...pkg import a\n")
+    assert only(root, nodes.ImportFrom).level == 3
+
+
+def test_elif_nests_as_an_if_in_orelse():
+    root = build("if a:\n    pass\nelif b:\n    pass\n")
+    outer = only(root, nodes.If)
+    assert len(outer.orelse) == 1
+    assert isinstance(outer.orelse[0], nodes.If)
+
+
+def test_async_shapes_resolve_to_their_own_classes():
+    source = (
+        "async def f():\n"
+        "    async with a as b:\n"
+        "        async for i in c:\n"
+        "            await d\n"
+    )
+    root = build(source)
+    kinds = {type(n).__name__ for n in root.walk()}
+    assert {"AsyncFunctionDef", "AsyncWith", "AsyncFor", "Await"} <= kinds
+
+
+# --------------------------------------------------------------------------
+# The two-arm law at the boundary: resolved, or panic. Both arms run.
+# --------------------------------------------------------------------------
+
+
+def test_unmapped_cst_shape_panics_as_a_missing():
+    """The negative arm. A CST node with no rule must NOT get a fallback."""
+    unit = nodes.SourceUnit(filename="<test>", source="x = 1\n")
+    ctx = _Ctx(unit, {})
+    with pytest.raises(MembranePanic) as excinfo:
+        _describe(ctx, libcst.Semicolon())
+    assert "no adapter rule" in excinfo.value.observed
+
+
+def test_mapped_cst_shape_resolves():
+    """The positive arm of the same discriminator."""
+    root = build("x = 1\n")
+    assert isinstance(root, nodes.Module)
+
+
+def test_unknown_operator_panics_rather_than_defaulting():
+    from sugar_node_membrane.libcst_adapter import _op, _BINARY_OPS
+
+    with pytest.raises(MembranePanic):
+        _op(_BINARY_OPS, libcst.And(), "binop")
+
+
+def test_provider_refusal_is_a_syntax_error_not_a_silent_empty_tree():
+    with pytest.raises(Exception) as excinfo:
+        build("def (:\n")
+    assert not isinstance(excinfo.value, MembranePanic)
+
+
+# --------------------------------------------------------------------------
+# The differential: the instrument itself
+# --------------------------------------------------------------------------
+
+
+def _quirks_diff() -> DiffResult:
+    from pathlib import Path
+
+    goldens = Path(__file__).resolve().parents[1] / "goldens" / "quirks.py"
+    source = goldens.read_text(encoding="utf-8")
+    result = DiffResult()
+    compare_source(
+        Membrane(CPythonAstProvider()),
+        Membrane(LibCSTProvider()),
+        source,
+        "quirks.py",
+        result,
+    )
+    return result
+
+
+def test_differential_runs_both_providers_without_failing_either():
+    result = _quirks_diff()
+    assert result.failures == []
+    assert result.files_compared == 1
+
+
+def test_cid_agreement_on_the_golden_corpus_is_pinned_with_its_open_findings():
+    """The acceptance criterion is ZERO divergence. It is not met yet, and
+    this test pins exactly which node paths are open so movement is loud.
+
+    All four open divergences are findings ABOUT THE SPEC OR THE CPYTHON
+    ADAPTER, not about this adapter (see the module docstring of
+    libcst_adapter.py and the PR body for #5940):
+
+    - ``...format_spec.values[1]``: CPython materializes a ZERO-WIDTH empty
+      ``Constant`` inside an f-string format spec. spans.py's own envelope
+      rule says "there is no such thing as a node with no source extent",
+      so the node inventory contradicts the spec. Needs a ruling.
+    - two ``GeneratorExp`` paths: spans.py rules that grouping parens are
+      excluded from an expression's span; the CPython adapter includes them
+      for a parenthesized generator expression. LibCST follows the written
+      spec. The pinned golden encodes the violation.
+    - ``cases[4]`` / ``cases[4].pattern``: whether a PARENTHESIZED SEQUENCE
+      PATTERN (``case (a_, b_):``) includes its parens the way a tuple
+      DISPLAY does is not ruled anywhere. Genuine spec gap; guessing is
+      forbidden, so nothing is normalized here.
+    """
+    result = _quirks_diff()
+    open_findings = {(d.path, d.category) for d in result.divergences}
+    assert open_findings == {
+        ("$.body[14].value.values[3].format_spec.values[1]", "missing_right"),
+        ("$.body[32].value.body", "span"),
+        ("$.body[32].value.orelse", "span"),
+        ("$.body[45].body[0].cases[4]", "span"),
+        ("$.body[45].body[0].cases[4].pattern", "span"),
+    }
+
+
+def test_the_vast_majority_of_the_corpus_already_agrees():
+    """Not a substitute for zero — a floor under regression while the five
+    open findings above are ruled on."""
+    result = _quirks_diff()
+    assert result.matched >= 537


### PR DESCRIPTION
Second provider behind the `sugar-node-membrane` backend contract (#5940), and the differential that makes T's provider rule enforceable.

> a provider that segfaults, or diverges on the golden corpus, is not debugged — it is uninstalled, and never installed again.

That rule needs somewhere to switch **to**. This is it. **Not for merge until the rulings below land** — three of the four findings are questions for the spec, not code I should have guessed at.

## Headline: #5932 confirmed from an independent harness, and it is CPython

Running the differential over numpy+pandas (1,821 files) **SIGSEGVs**, and faulthandler names the frame:

```
Fatal Python error: Segmentation fault
Current thread 0x00007a30f5ec0640 (most recent call first):
  File "/usr/lib/python3.12/ast.py", line 52 in parse
  File ".../sugar_node_membrane/cpython_adapter.py", line 389 in parse
```

`ast.py:52 in parse` — byte-identical to #5932's frame. **LibCST is nowhere in the stack.**

Measured, not inferred:

| | result |
|---|---|
| SIGSEGVs | **5 in 78 process runs (~6.4%)**, every one in `ast.parse` |
| chunk retries needed to complete a full corpus pass | 5 (each succeeded on retry — intermittent, as #5932 says) |
| LibCST `parse_module` over the same 1,821 files | **0 failures**, across every run |
| CPython `ast.parse` over the same files, isolated single pass | 0 failures (a clean pass does not refute an intermittent crash) |

The instrument could not complete a corpus run at all until I chunked it so a segfault costs one chunk instead of the whole sweep. That is worth stating plainly: **the reference provider currently cannot get through our own corpus in one process.**

## CID divergence: 99.84% agreement, and every divergence is a spec question

Acceptance is zero. It is not met. Here is exactly where it stands, at `(file, node_path)` granularity with both spans and both CIDs.

| | count |
|---|---|
| records compared | 2,919,036 (cpython) / 2,919,978 (libcst) |
| **matched** | **2,915,392 (99.8429%)** |
| divergences | 5,718 |
| hard failures | **0** |
| files fully clean | 1,423 of 1,821 |

Golden corpus (`goldens/quirks.jsonl`, 542 records): **537 matched on the first run**, 5 divergent — all instances of the families below.

### Adapter bugs — found by the instrument, fixed (6 hard failures → 0)

1. `_comp_for_anchor` walked into a **comment** between the element and the `for` keyword (`# type: ignore` on the element line, common in pandas). Scan now skips whitespace *and* comments — still a pure function of source.
2. A single-element subscript with a **trailing comma** (`a[x,]`) is a tuple subscript, not an expression subscript. The comma is the discriminator and is inside the tuple's span — without it there is no tuple.

### Finding 1 — grouping parens: 849 divergences. LibCST follows the written spec; the CPython adapter does not.

`spans.py` rules: *"grouping parentheses are NEVER part of an expression's span"*, with the enclosed tuple display as the one exception. A generator expression is not a tuple.

```
g = (x for x in xs)
   cpython (4, 19): '(x for x in xs)'
   libcst  (5, 18): 'x for x in xs'      <- what spans.py says
```

Same root cause reaches a `Param` through a parenthesized annotation (`percentiles: (np.ndarray | Sequence[float])` — CPython's `arg` ends after the `)`), and a `MatchSequence` through `case (a_, b_):`.

**This is a spec question, not a bug I should fix.** There is a real argument the other way: a genexp's parens are arguably constitutive the way a tuple display's are, since a genexp *requires* enclosing parens except as a sole call argument. If that is the ruling, the spec gets amended and the goldens are correct. **As the spec is written today, LibCST is right and the pinned goldens encode a violation.** Parenthesized sequence *patterns* are ruled nowhere at all.

### Finding 2 — implicit-concatenated f-strings: 4,869 divergences (85% of all of them). Genuine spec gap.

`spans.py` rules what the whole concatenated literal spans. It says nothing about the inventory or spans of the literal runs **inside** the resulting `JoinedStr`.

```python
f"In the future `np.{attr}` will be defined as the "
"corresponding NumPy scalar."
```

- **CPython** merges the runs across the piece boundary into one `Constant` spanning `` ` will be defined as the "\n                "corresponding NumPy scalar." `` — a segment that contains the closing quote, the newline, the indentation, and the opening prefix of the next piece. **Its segment is not the literal's text.**
- **LibCST** keeps one content node per piece: `` ` will be defined as the ``.

Every subsequent index in `values[]` then shifts, which is what produces the paired `missing_left`/`missing_right` counts (Name 686/684, Attribute 222/223, Call 149/150) and the `FormattedValue`↔`Constant` "kind" swaps. Those are **index misalignment, not genuinely different nodes** — worth knowing before anyone reads the raw histogram as 4,869 independent problems.

The discriminator's other arm is in the suite and passes: a plain f-string with no concatenation (`f"a{x}b{y!r}c"`) agrees **exactly**. The finding is specific to concatenation, not to f-strings.

### Finding 3 — zero-width `Constant` in a format spec. The spec contradicts itself.

CPython materializes an empty `Constant` at the end of an f-string format spec, span `[n, n)`, CID = sha256 of the empty string — **an address that identifies no source text.** `spans.py`'s own envelope rule already states the principle: *"there is no such thing as a node with no source extent."* LibCST materializes no such node.

## The contract finding — the most valuable thing here

**`backend.py` never declares how a provider signals refusal, so the membrane's failure vocabulary is written in one provider's exception type.**

`corpus.py:127` records a provider refusal by catching `SyntaxError`. LibCST raises `libcst.ParserSyntaxError`, whose MRO is `(ParserSyntaxError, Exception, BaseException, object)` — **it does not subclass `SyntaxError`.** So the moment LibCST is the installed provider, a corpus containing one unparseable file does not produce a recorded `provider_syntax_error` row. The exception escapes and kills the whole run. **The instrument stops instead of reporting** — a MISSING becoming neither success nor a row.

This is #5940's own thesis reproduced inside the new membrane package: a stated-but-unenforced boundary. The contract's stated purpose is provider-agnosticism, and its error vocabulary is CPython-shaped. Pinned by `test_provider_refusal_is_loud_but_NOT_a_SyntaxError`; the fix belongs in `backend.py`, outside this adapter's blast radius, so I did not make it.

Three smaller contract gaps, in descending order of teeth:

1. **A misfilled shape is not a boundary panic.** The contract's claim is that a backend which cannot express a shape "fails loudly at construction, at the boundary." A backend that fills a shape *wrongly* — misspelled field name, missing slot — surfaces as an unhandled `TypeError` from the dataclass constructor inside `construct._build`, three layers from the adapter that caused it. `nodes.field_names()` exists and nothing calls it. I hit this repeatedly while building; `differential.py` needed an `adapter_crash:` failure class purely to survive it.
2. **`Leaf` vs `MaybeChild` carry no enforced distinction.** `construct._build` assigns `None` for both, so a leaf absence and a structural absence are indistinguishable at the receiving end. The CPython adapter's generic path maps every `None` to `MaybeChild(None)` including for genuine leaf fields (`ExceptHandler.name`, `ImportFrom.module`). It works by accident. The union is wider than the semantics it enforces.
3. **No inventory declaration.** Conformance is defined as "every node class can be constructed by this adapter." The risk actually measured here is the opposite — one provider materialising a node the other does not (Finding 3, and every `missing_*` row). The contract cannot express inventory, so inventory divergence is **only ever detectable by differential**, never by the contract itself.

## Throughput — the cost, measured rather than guessed

Pure parse, 1,821 files / 28.9 MB, battleaxe, CPython 3.12.3, LibCST 1.8.6:

| provider | time | files/s | MB/s |
|---|---|---|---|
| `ast.parse` | 2.66 s | 685 | 10.86 |
| `libcst.parse_module` | 32.22 s | 57 | 0.90 |

**LibCST is ~12.1× slower to parse.** Parse + full membrane construction: cpython 31.9 s vs libcst 120.8 s — **3.8×**, since our construction pass dominates and is shared. Position metadata resolution (`MetadataWrapper` + `PositionProvider`) is a large part of LibCST's cost and is not optional for us — we need positions for every span.

Stating the tradeoff without deciding it: 12× on parse against a parser that does not segfault. Which matters more is a ruling, not a measurement.

## What is in the diff

- `src/sugar_node_membrane/libcst_adapter.py` — the provider. Read-only: no stamping, no provider-node construction, nothing above it names `libcst`. Explicit rule per CST node type; **an unmapped shape panics as a MISSING** — no generic fallback, no `getattr` sniffing.
- `src/sugar_node_membrane/differential.py` — parse the same source through both providers, address every record by `(file, node_path)`, diff every CID, report `file:node_path` with both spans and both CIDs. Inventory divergence counts as divergence, never as an absence to ignore.
- `tests/test_libcst_adapter.py` — 39 tests. Every `spans.py` ruling where the providers differ; both arms of each discriminator (an unmapped `Semicolon` panics, a mapped `Name` resolves); the three findings pinned as minimal reproducers so a ruling moves them deliberately rather than silently.
- `pyproject.toml` — LibCST as an optional extra. The core membrane stays stdlib-only; **installing a provider must never be a condition of the membrane working.**

Nothing outside the membrane package is touched. The CPython adapter, node classes, and `spans.py` are untouched — where the contract proved inadequate I reported it rather than editing.

74 tests pass (`pytest tests/`: 39 new, 35 pre-existing).

Refs #5940, #5932. Do not merge.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add LibCST-backed provider and CID differential tool to sugar-node-membrane
> - Adds [libcst_adapter.py](https://github.com/TSavo/sugar/pull/5945/files#diff-c05471cf6b85451a0ed3465cb21a3853fb745c04e47624879464a28407301b49), a full LibCST-backed `Provider` that maps LibCST CST nodes to the membrane Description/Slot vocabulary; unmapped or out-of-spec shapes raise `MembranePanic` rather than silently accepting them.
> - Adds [differential.py](https://github.com/TSavo/sugar/pull/5945/files#diff-6f0ec553bb7e38ce90ba4e0f8c5d0e22e04dd97365e593d7d5ecc8d1217fffc7), a CLI and programmatic tool that runs `CPythonAstProvider` vs `LibCSTProvider` side-by-side over files or directory trees, reporting matched records, divergences, failures, and timings.
> - Adds a test suite in [test_libcst_adapter.py](https://github.com/TSavo/sugar/pull/5945/files#diff-78e4ef0b0acdb862fc48775566004fc3e50cc72c61daf3d3b3ee422d98f60537) covering span semantics, vocabulary translations, operator mapping panics, and differential golden-corpus assertions against `quirks.py`.
> - `libcst>=1.8` is added as an optional dependency installable via `pip install -e '.[libcst]'`; core installation remains stdlib-only.
> - Risk: the differential exits with code 1 when any divergences or provider failures remain, which may surface known open findings pinned in tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d83349.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->