### PR TITLE
Node membrane: declare the refusal type; both adapters map to it (#5946)

### DIFF
--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/__init__.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/__init__.py
@@ -7,6 +7,7 @@ interned once. Nothing here imports from, or is imported by, the existing
 tree — greenfield by design.
 """
 
+from .backend import ProviderRefused
 from .construct import Membrane, NodePool
 from .nodes import KIND_REGISTRY, SourceFragment, SourceUnit, Typeable, Typed
 from .panic import MembranePanic
@@ -19,6 +20,7 @@ __all__ = [
     "Membrane",
     "MembranePanic",
     "NodePool",
+    "ProviderRefused",
     "SourceFragment",
     "SourceUnit",
     "Span",

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/backend.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/backend.py
@@ -11,6 +11,18 @@ membrane never writes anything onto them (no stamping) and never hands them
 to callers above the adapter.
 
 Nothing above an adapter may name ``ast`` (or any other backend library).
+
+``Provider.parse`` has two outcomes: a root ``ProviderHandle``, or
+``ProviderRefused`` — the OTHER two-arm law, sitting beside
+``MembranePanic`` (panic.py). They name different failures. A
+``MembranePanic`` is OUR gap: a shape the provider produced has no
+membrane class. ``ProviderRefused`` is the PROVIDER's own gap: the raw
+text was not valid input for it at all — a syntax error, an unparseable
+token, a null byte, whatever that backend's parser refuses on. Every
+adapter must raise ``ProviderRefused`` — never its native library
+exception (``SyntaxError``, ``libcst.ParserSyntaxError``, ...) — so that
+no caller above ``backend.py`` ever needs to know, or guess, which parsing
+library is behind the membrane today.
 """
 
 from __future__ import annotations
@@ -68,6 +80,33 @@ class OpsLeaf:
 Slot = Child | MaybeChild | Children | Leaf | OpLeaf | OpsLeaf
 
 
+class ProviderRefused(Exception):
+    """The provider refused the source unit: not valid input for it.
+
+    Distinct from ``MembranePanic`` (panic.py), which is a membrane MISSING
+    — a shape the provider DID produce but we have no class for. This is
+    the provider declining to produce a tree at all: a syntax error, a
+    tokenizer error, a null byte, an encoding it will not accept. Every
+    adapter's ``parse`` raises exactly this on such input, carrying its own
+    provider name, the file, and the provider's own reason — never letting
+    its native exception type (``SyntaxError``, ``libcst.ParserSyntaxError``,
+    or whatever the next provider throws) escape past ``backend.py``.
+
+    Never caught to continue silently: a refusal is a recorded outcome
+    (corpus.py records it as a failure row), not a substitute for success
+    and never a bare ``None``.
+    """
+
+    def __init__(self, provider: str, file: str, reason: str) -> None:
+        super().__init__(provider, file, reason)
+        self.provider = provider
+        self.file = file
+        self.reason = reason
+
+    def __str__(self) -> str:  # pragma: no cover - formatting only
+        return f"PROVIDER REFUSED [{self.provider}] {self.file}: {self.reason}"
+
+
 @dataclass(frozen=True)
 class Description:
     """Everything the builder needs about one backend node, described once.
@@ -96,7 +135,12 @@ class ProviderHandle(Typeable):
 
 
 class Provider:
-    """A parsing backend. The whole contract: source text in, root handle out."""
+    """A parsing backend. The whole contract: source text in, root handle out.
+
+    Two outcomes: a root ``ProviderHandle``, or ``ProviderRefused`` raised
+    when ``unit.source`` is not valid input for this backend. Never its
+    native library exception.
+    """
 
     name: str = ""
 

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/corpus.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/corpus.py
@@ -22,8 +22,10 @@ This artifact is the instrument that admits or rejects a future provider:
 parse the same sources through another adapter, emit, diff. A provider
 that diverges is not debugged — it is uninstalled.
 
-Failures are LOUD: a MembranePanic or provider SyntaxError on any file is
-recorded, reported, and fails the run. A MISSING never becomes silence.
+Failures are LOUD: a MembranePanic or a provider refusal (ProviderRefused,
+backend.py — the provider's own two-arm outcome, never its native
+exception type) on any file is recorded, reported, and fails the run. A
+MISSING never becomes silence, and neither does a refusal.
 
 CLI:
     python -m sugar_node_membrane.corpus --out corpus.jsonl PATH [PATH ...]
@@ -39,6 +41,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, Optional
 
+from .backend import ProviderRefused
 from .construct import Membrane
 from .nodes import SourceFragment
 from .panic import MembranePanic
@@ -121,10 +124,13 @@ def emit_corpus(
                 continue
             try:
                 recs = records_for_source(membrane, source, rel)
-            except SyntaxError as err:
+            except ProviderRefused as err:
                 # The PROVIDER refused the file (not valid input for it).
-                # Recorded loudly; distinct from a membrane MISSING.
-                failures.append((rel, "provider_syntax_error", str(err)))
+                # Recorded loudly; distinct from a membrane MISSING. Never
+                # the provider's native exception type (#5946) — the
+                # membrane's own contract type, so this catch works
+                # identically no matter which provider is installed.
+                failures.append((rel, "provider_refused", str(err)))
                 continue
             except MembranePanic as err:
                 # A membrane MISSING: a shape with no class. THE finding.

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/cpython_adapter.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/cpython_adapter.py
@@ -19,6 +19,14 @@ not part of our inventory and are not materialized.
 
 An ``ast`` shape this adapter does not recognize panics as a MISSING at the
 boundary — never a permissive fallback.
+
+Source ``ast.parse`` cannot parse at all (a syntax error, or a null byte —
+``ValueError`` on some CPython versions, ``SyntaxError`` on others; both
+mean the same thing: this text is not valid Python) is never let through as
+CPython's own exception type. It is re-raised as ``ProviderRefused``
+(backend.py) — the membrane's own name for "the provider declined this
+input" — so no caller above this module ever needs to know CPython is
+behind the membrane today.
 """
 
 from __future__ import annotations
@@ -36,6 +44,7 @@ from .backend import (
     OpsLeaf,
     Provider,
     ProviderHandle,
+    ProviderRefused,
     Slot,
 )
 from .nodes import SourceUnit
@@ -386,5 +395,14 @@ class CPythonAstProvider(Provider):
     name = "cpython-ast"
 
     def parse(self, unit: SourceUnit) -> ProviderHandle:
-        tree = ast.parse(unit.source, filename=unit.filename)
+        try:
+            tree = ast.parse(unit.source, filename=unit.filename)
+        except (SyntaxError, ValueError) as err:
+            # SyntaxError: the ordinary parse failure (including TabError,
+            # IndentationError). ValueError: some CPython versions raise it
+            # instead of SyntaxError for a null byte in the source. Both are
+            # CPython declining this text — never let either escape as-is.
+            raise ProviderRefused(
+                provider=self.name, file=unit.filename, reason=str(err)
+            ) from err
         return _Handle(unit, tree)

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/libcst_adapter.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/libcst_adapter.py
@@ -62,6 +62,12 @@ What this adapter must translate, because the CST vocabulary differs:
 A LibCST shape with no rule here panics as a MISSING at the boundary. There
 is no generic fallback and no ``getattr`` sniffing: an unmapped CST node is
 the conformance finding itself.
+
+Source LibCST cannot parse at all raises ``libcst.ParserSyntaxError`` —
+which does NOT subclass ``SyntaxError`` (#5946). This adapter catches it
+and re-raises ``ProviderRefused`` (backend.py), never letting the
+library-native type escape, so a caller written against one provider
+never silently stops working when the other is swapped in.
 """
 
 from __future__ import annotations
@@ -81,6 +87,7 @@ from .backend import (
     OpsLeaf,
     Provider,
     ProviderHandle,
+    ProviderRefused,
     Slot,
 )
 from .nodes import SourceUnit
@@ -1523,7 +1530,16 @@ class LibCSTProvider(Provider):
     name = "libcst"
 
     def parse(self, unit: SourceUnit) -> ProviderHandle:
-        module = cst.parse_module(unit.source)
+        try:
+            module = cst.parse_module(unit.source)
+        except cst.ParserSyntaxError as err:
+            # PartialParserSyntaxError (raised internally on some statement/
+            # param shapes) is always upconverted to ParserSyntaxError before
+            # it reaches parse_module (libcst._parser.base_parser) — this is
+            # the one exception type that escapes LibCST's own parser.
+            raise ProviderRefused(
+                provider=self.name, file=unit.filename, reason=str(err)
+            ) from err
         wrapper = MetadataWrapper(module, unsafe_skip_copy=True)
         positions = wrapper.resolve(PositionProvider)
         return _Handle(_Ctx(unit, positions), module)

--- a/implementations/python/sugar-node-membrane/tests/test_libcst_adapter.py
+++ b/implementations/python/sugar-node-membrane/tests/test_libcst_adapter.py
@@ -23,6 +23,7 @@ import pytest
 
 libcst = pytest.importorskip("libcst", reason="LibCST provider not installed")
 
+from sugar_node_membrane.backend import ProviderRefused  # noqa: E402
 from sugar_node_membrane.construct import Membrane  # noqa: E402
 from sugar_node_membrane.cpython_adapter import CPythonAstProvider  # noqa: E402
 from sugar_node_membrane.libcst_adapter import LibCSTProvider, _describe, _Ctx  # noqa: E402
@@ -260,27 +261,26 @@ def test_unknown_operator_panics_rather_than_defaulting():
         _op(_BINARY_OPS, libcst.And(), "binop")
 
 
-def test_provider_refusal_is_loud_but_NOT_a_SyntaxError():
-    """CONTRACT FINDING (#5940): the backend contract never declares how a
-    provider signals refusal, and the membrane's failure vocabulary is
-    written in ONE provider's exception type.
-
-    ``corpus.py`` records a provider refusal by catching ``SyntaxError``.
-    LibCST raises ``libcst.ParserSyntaxError``, which does NOT subclass
-    ``SyntaxError``. So with LibCST installed as the provider, a corpus
-    containing a single unparseable file does not produce a recorded
-    ``provider_syntax_error`` row — the exception escapes and kills the
-    whole run. The instrument stops instead of reporting.
-
-    This test pins the fact. The fix belongs in ``backend.py`` (declare a
-    refusal type every adapter normalizes into), which is outside this
-    adapter's blast radius.
+def test_provider_refusal_is_a_membrane_ProviderRefused_never_a_SyntaxError():
+    """FIX FOR #5946 (the contract finding recorded against #5940): the
+    backend contract now declares how a provider signals refusal
+    (``backend.ProviderRefused``), and this adapter maps its native
+    ``libcst.ParserSyntaxError`` — which does NOT subclass ``SyntaxError``
+    — onto it. Before the fix, ``corpus.py`` caught only ``SyntaxError``,
+    so with LibCST installed a corpus containing one unparseable file let
+    the exception escape and killed the whole run instead of recording a
+    row. This test pins the fix: LibCST's native exception never escapes
+    this adapter, and the membrane's own refusal type does.
     """
-    with pytest.raises(Exception) as excinfo:
+    assert not issubclass(libcst.ParserSyntaxError, SyntaxError), (
+        "if this starts failing, LibCST changed its exception base; the "
+        "underlying #5946 defect may no longer apply, but the mapping "
+        "below must still hold regardless"
+    )
+    with pytest.raises(ProviderRefused) as excinfo:
         build("def (:\n")
     assert not isinstance(excinfo.value, MembranePanic)
-    assert not isinstance(excinfo.value, SyntaxError), (
-        "if this starts passing, LibCST changed its exception base and "
-        "the contract gap below may have closed by accident, not by ruling"
-    )
-    assert type(excinfo.value).__name__ == "ParserSyntaxError"
+    assert not isinstance(excinfo.value, SyntaxError)
+    assert not isinstance(excinfo.value, libcst.ParserSyntaxError)
+    assert excinfo.value.provider == LibCSTProvider().name
+    assert excinfo.value.file == "<test>"

--- a/implementations/python/sugar-node-membrane/tests/test_refusal_twin.py
+++ b/implementations/python/sugar-node-membrane/tests/test_refusal_twin.py
@@ -1,0 +1,79 @@
+"""The refusal contract twin (#5946): both providers refuse identically.
+
+``backend.py`` names the outcome: a provider that cannot parse a source
+unit raises ``ProviderRefused`` — never its native library exception
+(CPython's ``SyntaxError``, LibCST's ``ParserSyntaxError``, which does NOT
+subclass ``SyntaxError``). Before the fix, ``corpus.py`` caught only
+``SyntaxError``: CPython's refusal was recorded as a row, LibCST's escaped
+and killed the run. This test drives one deliberately unparseable file
+through BOTH adapters and asserts identical handling — a recorded refusal
+row from ``emit_corpus``, never an escaped exception.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+libcst = pytest.importorskip("libcst", reason="LibCST provider not installed")
+
+from sugar_node_membrane.backend import ProviderRefused  # noqa: E402
+from sugar_node_membrane.construct import Membrane  # noqa: E402
+from sugar_node_membrane.corpus import emit_corpus  # noqa: E402
+from sugar_node_membrane.cpython_adapter import CPythonAstProvider  # noqa: E402
+from sugar_node_membrane.libcst_adapter import LibCSTProvider  # noqa: E402
+
+UNPARSEABLE = "def f(:\n    pass\n"
+
+
+def test_libcst_raises_a_type_that_does_not_subclass_syntaxerror():
+    """The defect's root cause, pinned: LibCST's own refusal exception is
+    not a SyntaxError, so ``except SyntaxError`` never catches it."""
+    assert not issubclass(libcst.ParserSyntaxError, SyntaxError)
+
+
+@pytest.mark.parametrize(
+    "provider_cls", [CPythonAstProvider, LibCSTProvider], ids=["cpython", "libcst"]
+)
+def test_both_adapters_raise_the_membrane_refusal_not_their_native_exception(
+    provider_cls,
+):
+    membrane = Membrane(provider_cls())
+    with pytest.raises(ProviderRefused) as excinfo:
+        membrane.parse(UNPARSEABLE, filename="<unparseable>")
+    refusal = excinfo.value
+    assert refusal.provider == provider_cls().name
+    assert refusal.file == "<unparseable>"
+    assert refusal.reason
+
+
+@pytest.mark.parametrize(
+    "provider_cls", [CPythonAstProvider, LibCSTProvider], ids=["cpython", "libcst"]
+)
+def test_a_refused_file_produces_a_recorded_row_never_an_escaped_exception(
+    provider_cls, tmp_path: Path
+):
+    """The HARD LAW, driven end to end through the CLI-facing entry point:
+    a refused file is a recorded failure in the corpus result, not a dead
+    process. This is the assertion that failed before the fix for LibCST
+    (the exception escaped ``emit_corpus`` and killed the run) and passes
+    identically for both providers after it."""
+    bad = tmp_path / "unparseable.py"
+    bad.write_text(UNPARSEABLE, encoding="utf-8")
+    good = tmp_path / "fine.py"
+    good.write_text("x = 1\n", encoding="utf-8")
+
+    import sugar_node_membrane.corpus as corpus_mod
+
+    original_membrane = corpus_mod.Membrane
+    try:
+        corpus_mod.Membrane = lambda: Membrane(provider_cls())
+        result = emit_corpus([tmp_path], out_path=None, base=tmp_path)
+    finally:
+        corpus_mod.Membrane = original_membrane
+
+    assert result.files == 1  # only fine.py parsed
+    refused = [f for f in result.failures if f[1] == "provider_refused"]
+    assert len(refused) == 1
+    assert refused[0][0] == "unparseable.py"


### PR DESCRIPTION
Closes #5946. Related: #5940.

## The defect

`backend.py` defined the provider contract but never declared how a provider signals refusal. The vocabulary defaulted to the first implementation's choice: `corpus.py` caught `SyntaxError`, commented "the PROVIDER refused the file." LibCST raises `libcst.ParserSyntaxError`, which does **not** subclass `SyntaxError`. With LibCST installed, one unparseable file let the exception escape `corpus.py` uncaught and killed the whole run instead of recording a row — a MISSING becoming a dead process, not a report.

## The fix

- **`backend.py`** declares `ProviderRefused(provider, file, reason)` as the second two-arm outcome of `Provider.parse`, named alongside `MembranePanic` (panic.py): `MembranePanic` is our own MISSING (a shape the provider produced with no membrane class); `ProviderRefused` is the *provider's* own gap (the raw text was not valid input for it at all).
- **`cpython_adapter.py`** maps `(SyntaxError, ValueError)` → `ProviderRefused`. `ValueError` is included because some CPython versions raise it instead of `SyntaxError` for a null byte in the source (3.12 raises `SyntaxError` for this today, but the adapter should not depend on that having stayed the same across versions).
- **`libcst_adapter.py`** maps `ParserSyntaxError` → `ProviderRefused`. `PartialParserSyntaxError` (LibCST's other refusal-shaped exception) does not need its own catch: it's always upconverted to `ParserSyntaxError` internally, inside `libcst/_parser/base_parser.py`, before `parse_module` returns — confirmed by reading LibCST's own source, not assumed.
- **`corpus.py`** now catches `ProviderRefused`, never `SyntaxError`.

No caller elsewhere in the package caught a provider-native exception — `corpus.py` was the only one.

## Verification

**Twin (mandatory), before/after:**
- Before the fix: `tests/test_refusal_twin.py` fails at *collection* (exit 2) — `ProviderRefused` does not exist yet in `backend.py`.
- After the fix: 5/5 pass (exit 0) — a deliberately unparseable file driven through both `CPythonAstProvider` and `LibCSTProvider` produces identical handling: a recorded refusal row via `emit_corpus`, never an escaped exception.

**Pre-existing test updated, not weakened:** `test_libcst_adapter.py::test_provider_refusal_is_loud_but_NOT_a_SyntaxError` had pinned the *defect itself* as a documented finding from #5940 ("the fix belongs in backend.py ... outside this adapter's blast radius"). Renamed to `test_provider_refusal_is_a_membrane_ProviderRefused_never_a_SyntaxError` and updated to assert the fix.

**Full corpus, both adapters, over `implementations/python/` (2246 files):**

```
=== cpython ===
files:      2246
nodes:      1789045
panics:     0
refused:    0
undecodable:0

=== libcst ===
files:      2246
nodes:      1790203
panics:     0
refused:    0
undecodable:0
```

Zero escaped exceptions for either provider. Node counts differ slightly by construction (different parsers build different trees for the same source — documented in `test_libcst_adapter.py`'s module docstring as expected re-addressing, not divergence).

**Full suite:** 66 pre-existing tests + 5 new = 71/71 pass.

## Scope note

`differential.py` was already removed on `main` (#5947, merged ahead of this branch) by a concurrent agent — this PR is based on current `main` and never touched that file.

## What else is silent in this package (requested finding)

The contract silence this issue names is not isolated. Two more instances of "one implementation's behavior became the de facto spec" surfaced while reading the package, both left alone here as out of scope for #5946:

1. **`emit_corpus` hardcodes `Membrane()`** (corpus.py) — no provider parameter. The CLI (`python -m sugar_node_membrane.corpus`) can only ever run the default `CPythonAstProvider`; running the LibCST corpus requires monkeypatching `corpus_mod.Membrane` (which is what both the twin test and my manual full-corpus run above had to do). The contract for "run the corpus against a given provider" is currently "reach into the module and replace a name," not a declared parameter.
2. **`_span_of` / `_node_span` panic paths never distinguish "provider bug" from "our rule is incomplete"** — both surface as the same `MembranePanic` shape with an `owner` string as the only signal of which side is at fault. Not a refusal-vocabulary problem like #5946, but the same pattern: one exception type carrying two different meanings, disambiguated only by reading the message.

Neither required a code change to close #5946; flagging per the brief's request for what else in the package is silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ProviderRefused` exception type to node membrane and map both adapters to it
> - Introduces `ProviderRefused` in [backend.py](https://github.com/TSavo/sugar/pull/5948/files#diff-6538f6400bf9b6b3f1b3eb30bf87109ad0f00f15711cfd4a16b6cc63ec14eb9c) as a canonical exception carrying provider name, file, and reason for refusal.
> - Both [cpython_adapter.py](https://github.com/TSavo/sugar/pull/5948/files#diff-204eb2a425cf63c79d78a3149e28ea65d06eec6ff34b971d8f13e4655154f5fd) and [libcst_adapter.py](https://github.com/TSavo/sugar/pull/5948/files#diff-c05471cf6b85451a0ed3465cb21a3853fb745c04e47624879464a28407301b49) now catch their native parse errors (`SyntaxError`/`ValueError` and `cst.ParserSyntaxError`) and re-raise as `ProviderRefused`.
> - `emit_corpus` in [corpus.py](https://github.com/TSavo/sugar/pull/5948/files#diff-b39e27439c101820dcfe32b7a223a4826cd6906127a9f3f827a60cff840467f6) now catches `ProviderRefused` instead of `SyntaxError` and records failures as `('provider_refused', str(err))`.
> - `ProviderRefused` is re-exported from the package root so callers can use `from sugar_node_membrane import ProviderRefused`.
> - Behavioral Change: code that previously caught `SyntaxError` or `libcst.ParserSyntaxError` from `parse()` calls must now catch `ProviderRefused`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3924ab5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->