### PR TITLE
Split MembranePanic into MembraneMissing/MembraneProviderDefect; thread provider through emit_corpus

### DIFF
--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/__init__.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/__init__.py
@@ -10,7 +10,7 @@ tree — greenfield by design.
 from .backend import ProviderRefused
 from .construct import Membrane, NodePool
 from .nodes import KIND_REGISTRY, SourceFragment, SourceUnit, Typeable, Typed
-from .panic import MembranePanic
+from .panic import MembraneMissing, MembranePanic, MembraneProviderDefect
 from .spans import LineColSpan, LineTable, Span
 
 __all__ = [
@@ -18,7 +18,9 @@ __all__ = [
     "LineColSpan",
     "LineTable",
     "Membrane",
+    "MembraneMissing",
     "MembranePanic",
+    "MembraneProviderDefect",
     "NodePool",
     "ProviderRefused",
     "SourceFragment",

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/construct.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/construct.py
@@ -34,7 +34,7 @@ from .backend import (
     ProviderHandle,
 )
 from .nodes import Module, SourceFragment, SourceUnit
-from .panic import membrane_panic
+from .panic import membrane_missing, membrane_provider_defect
 from .spans import Span
 
 
@@ -67,7 +67,7 @@ class NodePool:
         if type(existing) is not type(node) or any(
             getattr(existing, name) != value for name, value in kwargs.items()
         ):
-            membrane_panic(
+            membrane_provider_defect(
                 owner="construct.NodePool.intern",
                 observed=(
                     f"two distinct {node.kind} constructions at "
@@ -98,7 +98,7 @@ class Membrane:
         root_handle = self.provider.parse(unit)
         root = _build(unit, root_handle, self.pool)
         if not isinstance(root, Module):
-            membrane_panic(
+            membrane_provider_defect(
                 owner="construct.Membrane.parse",
                 observed=f"provider root constructed as {type(root).__name__}",
                 requested="a Module at the root",
@@ -155,7 +155,7 @@ def _build(unit: SourceUnit, root: ProviderHandle, pool: NodePool) -> SourceFrag
             elif isinstance(slot, OpsLeaf):
                 kwargs[name] = slot.ops
             else:  # pragma: no cover - Slot union is closed
-                membrane_panic(
+                membrane_provider_defect(
                     owner="construct._build",
                     observed=f"unknown slot type {type(slot).__name__}",
                     requested="a Slot from backend.py",
@@ -201,7 +201,11 @@ def _span_of(desc: Description, child_spans: list[Span]) -> Span:
         return desc.raw_span
     spans = list(desc.anchors) + child_spans
     if not spans:
-        membrane_panic(
+        # Not a structurally-invalid production — this is our own adapter's
+        # anchor-rule vocabulary being incomplete for a kind it has not seen
+        # positioned before (same shape as cpython_adapter._node_span and
+        # spans.py's envelope rule commentary): a MISSING, not a defect.
+        membrane_missing(
             owner="construct._span_of",
             observed=f"{desc.kind} with neither a provider position nor any spanned child",
             requested="every node has a source extent",

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/corpus.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/corpus.py
@@ -22,13 +22,23 @@ This artifact is the instrument that admits or rejects a future provider:
 parse the same sources through another adapter, emit, diff. A provider
 that diverges is not debugged — it is uninstalled.
 
-Failures are LOUD: a MembranePanic or a provider refusal (ProviderRefused,
-backend.py — the provider's own two-arm outcome, never its native
-exception type) on any file is recorded, reported, and fails the run. A
-MISSING never becomes silence, and neither does a refusal.
+Failures are LOUD: a MembraneMissing (our vocabulary is incomplete for a
+shape the provider legitimately produced), a MembraneProviderDefect (the
+provider or its adapter produced something structurally invalid), or a
+provider refusal (ProviderRefused, backend.py — the provider's own
+two-arm outcome, never its native exception type) on any file is
+recorded, reported, and fails the run. None of the three ever becomes
+silence.
+
+The provider is a parameter, not a source edit: default is today's
+behaviour (CPythonAstProvider), but any Provider — including LibCST's
+— can be threaded through from the CLI (--provider) or from code,
+so a benchmark can run the same corpus through more than one adapter
+without monkeypatching this module.
 
 CLI:
     python -m sugar_node_membrane.corpus --out corpus.jsonl PATH [PATH ...]
+    python -m sugar_node_membrane.corpus --provider libcst PATH [PATH ...]
 """
 
 from __future__ import annotations
@@ -41,10 +51,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, Optional
 
-from .backend import ProviderRefused
+from .backend import Provider, ProviderRefused
 from .construct import Membrane
 from .nodes import SourceFragment
-from .panic import MembranePanic
+from .panic import MembraneMissing, MembraneProviderDefect
 
 
 def node_paths(root: SourceFragment) -> Iterator[tuple[str, SourceFragment]]:
@@ -96,8 +106,16 @@ class CorpusResult:
 
 
 def emit_corpus(
-    paths: list[Path], out_path: Optional[Path], base: Optional[Path] = None
+    paths: list[Path],
+    out_path: Optional[Path],
+    base: Optional[Path] = None,
+    provider: Optional[Provider] = None,
 ) -> CorpusResult:
+    """provider defaults to Membrane()'s own default
+    (CPythonAstProvider) — today's behaviour, unchanged. Pass any other
+    Provider (e.g. LibCSTProvider() from libcst_adapter.py) to
+    run the same corpus through it; this is the ONLY thing that should ever
+    change which provider a corpus run measures — never a monkeypatch."""
     files: list[Path] = []
     for p in paths:
         if p.is_dir():
@@ -106,7 +124,7 @@ def emit_corpus(
             files.append(p)
     files.sort()
 
-    membrane = Membrane()
+    membrane = Membrane(provider)
     manifest = hashlib.sha256()
     kind_counts: dict[str, int] = {}
     failures: list[tuple[str, str, str]] = []
@@ -132,9 +150,17 @@ def emit_corpus(
                 # identically no matter which provider is installed.
                 failures.append((rel, "provider_refused", str(err)))
                 continue
-            except MembranePanic as err:
-                # A membrane MISSING: a shape with no class. THE finding.
-                failures.append((rel, "membrane_panic", str(err)))
+            except MembraneMissing as err:
+                # OUR vocabulary is incomplete for a shape the provider
+                # legitimately produced. THE finding this instrument exists
+                # to surface.
+                failures.append((rel, "membrane_missing", str(err)))
+                continue
+            except MembraneProviderDefect as err:
+                # The provider (or its adapter) produced something
+                # structurally invalid. Distinct from membrane_missing:
+                # this is never fixed by adding vocabulary.
+                failures.append((rel, "membrane_provider_defect", str(err)))
                 continue
             parsed += 1
             for rec in recs:
@@ -159,23 +185,64 @@ def emit_corpus(
     )
 
 
+_PROVIDERS: dict[str, str] = {
+    "cpython": "CPythonAstProvider",
+    "libcst": "LibCSTProvider",
+}
+
+
+def _make_provider(name: Optional[str]) -> Optional[Provider]:
+    """None -> Membrane()'s own default (today's behaviour,
+    unchanged). Otherwise construct the named provider by importing its
+    adapter module lazily, so installing libcst is never a condition of
+    running the corpus with the default provider."""
+    if name is None or name == "cpython":
+        return None
+    if name == "libcst":
+        from .libcst_adapter import LibCSTProvider
+
+        return LibCSTProvider()
+    raise SystemExit(
+        f"unknown --provider {name!r}; choices: {sorted(_PROVIDERS)}"
+    )
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("paths", nargs="+", type=Path)
     parser.add_argument("--out", type=Path, default=None)
     parser.add_argument("--base", type=Path, default=None)
+    parser.add_argument(
+        "--provider",
+        choices=sorted(_PROVIDERS),
+        default="cpython",
+        help="which Provider to run the corpus through (default: cpython, "
+        "today's unchanged behaviour). 'libcst' requires the libcst "
+        "extra installed.",
+    )
     args = parser.parse_args(argv)
 
-    result = emit_corpus(args.paths, args.out, args.base)
+    result = emit_corpus(
+        args.paths, args.out, args.base, provider=_make_provider(args.provider)
+    )
+    print(f"provider: {args.provider}")
     print(f"files:    {result.files}")
     print(f"nodes:    {result.nodes}")
     print(f"kinds:    {len(result.kind_counts)}")
     print(f"manifest: {result.manifest_cid}")
-    membrane_missing = [f for f in result.failures if f[1] == "membrane_panic"]
-    other = [f for f in result.failures if f[1] != "membrane_panic"]
+    membrane_missing = [f for f in result.failures if f[1] == "membrane_missing"]
+    provider_defects = [
+        f for f in result.failures if f[1] == "membrane_provider_defect"
+    ]
+    other = [
+        f
+        for f in result.failures
+        if f[1] not in ("membrane_missing", "membrane_provider_defect")
+    ]
     for rel, failure_class, message in result.failures:
         print(f"FAIL[{failure_class}] {rel}: {message.splitlines()[0]}")
-    print(f"membrane panics: {len(membrane_missing)}")
+    print(f"membrane missing (vocabulary gaps): {len(membrane_missing)}")
+    print(f"membrane provider defects: {len(provider_defects)}")
     print(f"provider refusals / undecodable: {len(other)}")
     return 1 if result.failures else 0
 

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/cpython_adapter.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/cpython_adapter.py
@@ -49,7 +49,7 @@ from .backend import (
 )
 from .nodes import SourceUnit
 from .operators import Operator, operator_for
-from .panic import membrane_panic
+from .panic import membrane_missing
 from .spans import Span
 
 
@@ -191,7 +191,7 @@ def _node_span(unit: SourceUnit, node: ast.AST) -> Span:
     lineno = getattr(node, "lineno", None)
     end_lineno = getattr(node, "end_lineno", None)
     if lineno is None or end_lineno is None:
-        membrane_panic(
+        membrane_missing(
             owner="cpython_adapter._node_span",
             observed=f"ast.{type(node).__name__} without a position",
             requested="a positioned node, or a describe() rule marking it envelope-spanned",
@@ -267,7 +267,7 @@ def _comprehension_for_anchor(unit: SourceUnit, comp: ast.comprehension) -> Span
     while j > 0 and src[j - 1].isspace():
         j -= 1
     if src[max(0, j - 3) : j] != "for":
-        membrane_panic(
+        membrane_missing(
             owner="cpython_adapter._comprehension_for_anchor",
             observed=f"no 'for' keyword immediately before comprehension target at {target_start}",
             requested="'for' (optionally 'async for') preceding the target",
@@ -362,7 +362,7 @@ def _describe(unit: SourceUnit, node: ast.AST) -> Description:
                     )
                 )
                 continue
-            membrane_panic(
+            membrane_missing(
                 owner="cpython_adapter._describe",
                 observed=(
                     f"ast.{ast_kind}.{field_name} list with unhandled item "

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/libcst_adapter.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/libcst_adapter.py
@@ -92,7 +92,7 @@ from .backend import (
 )
 from .nodes import SourceUnit
 from .operators import Operator, operator_for
-from .panic import membrane_panic
+from .panic import membrane_missing, membrane_provider_defect
 from .spans import Span
 
 
@@ -116,7 +116,7 @@ class _Ctx:
         try:
             rng = self.positions[node]  # type: ignore[index]
         except KeyError:
-            membrane_panic(
+            membrane_missing(
                 owner="libcst_adapter._Ctx.span",
                 observed=f"libcst {type(node).__name__} carries no position",
                 requested="a positioned node, or a rule marking it envelope-spanned",
@@ -217,7 +217,7 @@ def _asname_str(node: Optional[cst.AsName]) -> Optional[str]:
     target = node.name
     if isinstance(target, cst.Name):
         return target.value
-    membrane_panic(
+    membrane_missing(
         owner="libcst_adapter._asname_str",
         observed=f"AsName over {type(target).__name__}, not a Name",
         requested="a simple name binding",
@@ -234,7 +234,7 @@ def _dotted(node: cst.BaseExpression) -> str:
         parts.append(cur.attr.value)
         cur = cur.value
     if not isinstance(cur, cst.Name):
-        membrane_panic(
+        membrane_missing(
             owner="libcst_adapter._dotted",
             observed=f"import target head is {type(cur).__name__}, not a Name",
             requested="a Name or a chain of Attribute over a Name",
@@ -273,7 +273,7 @@ def _statements(ctx: _Ctx, body: object) -> Tuple[ProviderHandle, ...]:
         if isinstance(item, cst.CSTNode):
             out.append(_Handle(ctx, item))
             continue
-        membrane_panic(
+        membrane_missing(
             owner="libcst_adapter._statements",
             observed=f"{type(item).__name__} in statement position",
             requested="a CST statement, suite, or block",
@@ -290,7 +290,7 @@ def _orelse(ctx: _Ctx, node: object) -> Tuple[ProviderHandle, ...]:
         return _statements(ctx, node.body)
     if isinstance(node, cst.If):
         return (_Handle(ctx, node),)
-    membrane_panic(
+    membrane_missing(
         owner="libcst_adapter._orelse",
         observed=f"{type(node).__name__} in orelse position",
         requested="an Else or a nested If",
@@ -356,7 +356,7 @@ _COMPARE_OPS = {
 def _op(table: dict[str, str], node: cst.CSTNode, where: str) -> Operator:
     kind = table.get(type(node).__name__)
     if kind is None:
-        membrane_panic(
+        membrane_missing(
             owner=f"libcst_adapter._op[{where}]",
             observed=f"libcst operator {type(node).__name__} has no membrane operator",
             requested="a mapping into the frozen operator vocabulary",
@@ -406,7 +406,7 @@ def _comp_for_anchor(ctx: _Ctx, node: cst.CompFor) -> Span:
             continue
         break
     if not (src.startswith("for", j) or src.startswith("async", j)):
-        membrane_panic(
+        membrane_missing(
             owner="libcst_adapter._comp_for_anchor",
             observed=f"no 'for'/'async' keyword at comprehension clause start {j}",
             requested="'for' (optionally 'async for') opening the clause",
@@ -501,7 +501,7 @@ def _params(ctx: _Ctx, params: cst.Parameters) -> Children:
     elif isinstance(star_arg, cst.ParamStar):
         pass  # bare ``*`` separator: a marker, not a parameter
     elif star_arg is not None and not isinstance(star_arg, cst.MaybeSentinel):
-        membrane_panic(
+        membrane_missing(
             owner="libcst_adapter._params",
             observed=f"star_arg is {type(star_arg).__name__}",
             requested="a Param, a ParamStar, or absent",
@@ -584,7 +584,7 @@ def _elements(ctx: _Ctx, elements: Sequence[cst.BaseElement]) -> Children:
         elif isinstance(el, cst.Element):
             out.append(_Handle(ctx, el.value))
         else:
-            membrane_panic(
+            membrane_missing(
                 owner="libcst_adapter._elements",
                 observed=f"{type(el).__name__} in element position",
                 requested="an Element or a StarredElement",
@@ -621,7 +621,7 @@ def _dict_items(ctx: _Ctx, elements: Sequence[cst.BaseDictElement]) -> Children:
                 )
             )
         else:
-            membrane_panic(
+            membrane_missing(
                 owner="libcst_adapter._dict_items",
                 observed=f"{type(el).__name__} in dict element position",
                 requested="a DictElement or a StarredDictElement",
@@ -670,7 +670,7 @@ def _slice_element(ctx: _Ctx, element: cst.SubscriptElement) -> ProviderHandle:
         return _Handle(ctx, inner.value)
     if isinstance(inner, cst.Slice):
         return _Handle(ctx, inner)
-    membrane_panic(
+    membrane_missing(
         owner="libcst_adapter._slice_element",
         observed=f"{type(inner).__name__} in subscript position",
         requested="an Index or a Slice",
@@ -694,7 +694,7 @@ def _format_spec(
         return MaybeChild(None)
     parts = list(spec)
     if not parts:
-        membrane_panic(
+        membrane_missing(
             owner="libcst_adapter._format_spec",
             observed="an empty format spec with no content to span",
             requested="a spec with at least one content node, or no spec at all",
@@ -719,7 +719,7 @@ _CONVERSIONS = {None: -1, "s": 115, "r": 114, "a": 97}
 def _conversion(value: Optional[str]) -> int:
     code = _CONVERSIONS.get(value)
     if code is None:
-        membrane_panic(
+        membrane_missing(
             owner="libcst_adapter._conversion",
             observed=f"f-string conversion {value!r}",
             requested="one of !s, !r, !a, or none",
@@ -1097,7 +1097,7 @@ def _r_matchsingleton(ctx: _Ctx, n: cst.MatchSingleton) -> Description:
 def _singleton(text: str) -> object:
     table: dict[str, object] = {"True": True, "False": False, "None": None}
     if text not in table:
-        membrane_panic(
+        membrane_missing(
             owner="libcst_adapter._singleton",
             observed=f"match singleton {text!r}",
             requested="True, False, or None",
@@ -1123,7 +1123,7 @@ def _match_patterns(ctx: _Ctx, elements: Sequence[cst.CSTNode]) -> Children:
         elif isinstance(el, cst.MatchStar):
             out.append(_Handle(ctx, el))
         else:
-            membrane_panic(
+            membrane_missing(
                 owner="libcst_adapter._match_patterns",
                 observed=f"{type(el).__name__} in match sequence position",
                 requested="a MatchSequenceElement or a MatchStar",
@@ -1249,7 +1249,10 @@ def _r_concatstring(ctx: _Ctx, n: cst.ConcatenatedString) -> Description:
     elif all(isinstance(v, str) for v in values):
         joined = "".join(values)
     else:
-        membrane_panic(
+        # LibCST parsed source CPython itself would reject at compile time
+        # (mixed str/bytes implicit concatenation): the provider's own
+        # output is structurally invalid, not a vocabulary gap.
+        membrane_provider_defect(
             owner="libcst_adapter._r_concatstring",
             observed="implicit concatenation mixing str and bytes pieces",
             requested="pieces of one literal type",
@@ -1510,7 +1513,7 @@ def _r_compfor(ctx: _Ctx, n: cst.CompFor) -> Description:
 def _describe(ctx: _Ctx, node: cst.CSTNode) -> Description:
     rule = _RULES.get(type(node).__name__)
     if rule is None:
-        membrane_panic(
+        membrane_missing(
             owner="libcst_adapter._describe",
             observed=f"libcst {type(node).__name__} has no adapter rule",
             requested="an explicit rule mapping this CST shape into membrane terms",

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/nodes.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/nodes.py
@@ -41,7 +41,7 @@ from .operators import (
     ComparisonOperator,
     UnaryOperator,
 )
-from .panic import membrane_panic
+from .panic import MembranePanic, membrane_missing
 from .spans import LineColSpan, LineTable, Span
 
 
@@ -87,7 +87,16 @@ class Typed(Typeable):
     def resolve_type(self) -> type["SourceFragment"]:
         tp = type(self)
         if tp in _ABSTRACT or not issubclass(tp, SourceFragment):
-            membrane_panic(
+            # Neither of the two panics fits: this is not a provider-facing
+            # question at all (no ProviderHandle, no adapter, no vocabulary
+            # gap) and not a structural-defect-in-provider-output question
+            # either. It is an internal invariant on OUR OWN construction
+            # code: only concrete classes are ever instantiated (construct.py
+            # resolves through resolve_kind, which already excludes
+            # _ABSTRACT). Reaching here means our own code, not a provider,
+            # built an abstract instance. Raised as the common base directly
+            # — deliberately, not a guess at which subclass fits.
+            raise MembranePanic(
                 owner="nodes.Typed.resolve_type",
                 observed=f"instance of abstract membrane class {tp.__name__}",
                 requested="a concrete grammar class",
@@ -776,7 +785,7 @@ def resolve_kind(kind: str, observed_at: str) -> type[SourceFragment]:
     """
     cls = KIND_REGISTRY.get(kind)
     if cls is None or cls in _ABSTRACT:
-        membrane_panic(
+        membrane_missing(
             owner="nodes.resolve_kind",
             observed=f"backend kind {kind!r} at {observed_at} has no membrane class",
             requested="a concrete SourceFragment subclass for every constructible shape",

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/operators.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/operators.py
@@ -12,7 +12,7 @@ Operators carry no children and no span; each concrete class is a singleton
 
 from __future__ import annotations
 
-from .panic import membrane_panic
+from .panic import MembranePanic, membrane_missing
 
 
 class Operator:
@@ -29,7 +29,12 @@ class Operator:
     @classmethod
     def instance(cls) -> "Operator":
         if cls is Operator or not cls.kind:
-            membrane_panic(
+            # Internal invariant, not a provider question: operator_for
+            # (below) only ever resolves to a concrete registered class, so
+            # reaching here means OUR OWN code called .instance() on an
+            # abstract class directly. Not a vocabulary gap, not a provider
+            # defect — raised as the common base deliberately.
+            raise MembranePanic(
                 owner="operators.Operator.instance",
                 observed=f"instance() on abstract {cls.__name__}",
                 requested="a concrete operator class",
@@ -164,7 +169,7 @@ def operator_for(kind: str) -> Operator:
     """Frozen-vocabulary lookup: two arms — resolved, or panic."""
     cls = _OPERATORS.get(kind)
     if cls is None:
-        membrane_panic(
+        membrane_missing(
             owner="operators.operator_for",
             observed=f"operator kind {kind!r} not in the frozen vocabulary",
             requested="one of the declared Operator classes",

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/panic.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/panic.py
@@ -1,11 +1,36 @@
 """MembranePanic: the loud arm of the membrane's two-arm match.
 
 Every question the membrane answers has exactly two outcomes: a resolved,
-Typed answer, or this panic. There is no third arm — no permissive fallback,
-no default case, no quiet ``False``, no bare ``None`` refusal. A MISSING
-(a backend shape with no membrane class, a node the provider cannot
-position, an intern collision) becomes a ``MembranePanic`` that names the
-owner, what was observed, what was requested, and how to fix it.
+Typed answer, or a panic. There is no third arm — no permissive fallback,
+no default case, no quiet ``False``, no bare ``None`` refusal.
+
+Two panics were one before, and the merge was itself a bug: an ``owner``
+string a caller had to read and interpret to tell apart two entirely
+different failures. Now they are two classes, so no caller can conflate
+them by reaching for a string:
+
+``MembraneMissing``
+    OUR vocabulary is incomplete. The provider handed up a shape it
+    legitimately produces (a node kind, an operator, an import target
+    shape, a slot value) and we have no membrane class, adapter rule, or
+    frozen-vocabulary entry for it yet. The fix always adds vocabulary:
+    a class, a rule, a mapping entry — never a fallback.
+
+``MembraneProviderDefect``
+    The provider (or its adapter's translation of it) produced something
+    structurally invalid: a position outside the source, a degenerate
+    span, a coordinate collision, a root of the wrong shape, output that
+    is not even valid Python. The fix is never "add vocabulary" — it is
+    "the provider or the adapter is buggy; fix or uninstall it."
+
+Both are ``MembranePanic`` (this is the common base — kept so that a
+caller that genuinely needs to treat every membrane failure the same way,
+such as the corpus's "record and keep going" loop in ``corpus.py``, has one
+name for "any membrane panic happened." Catching the base is NEVER the
+easy default for anything that needs to react differently to the two —
+there is no code path in this package that catches ``MembranePanic``
+and then re-derives which of the two arms it was by reading ``owner``;
+if a caller needs that distinction it must catch the concrete subclass).
 
 Modeled on ``factory_panic_gap`` (sugar_lift_py_tests.factory.factory_gap),
 but standalone: this package deliberately imports nothing from the existing
@@ -16,7 +41,7 @@ from __future__ import annotations
 
 
 class MembranePanic(Exception):
-    """A membrane MISSING surfacing loudly. Never caught to continue."""
+    """Common base. Never raised directly — always one of the two below."""
 
     def __init__(self, owner: str, observed: str, requested: str, fix: str) -> None:
         super().__init__(owner, observed, requested, fix)
@@ -25,14 +50,41 @@ class MembranePanic(Exception):
         self.requested = requested
         self.fix = fix
 
+    _LABEL = "MEMBRANE PANIC"
+
     def __str__(self) -> str:  # pragma: no cover - formatting only
         return (
-            f"MEMBRANE PANIC [{self.owner}]\n"
+            f"{self._LABEL} [{self.owner}]\n"
             f"  observed:  {self.observed}\n"
             f"  requested: {self.requested}\n"
             f"  fix:       {self.fix}"
         )
 
 
-def membrane_panic(owner: str, observed: str, requested: str, fix: str) -> "MembranePanic":
-    raise MembranePanic(owner=owner, observed=observed, requested=requested, fix=fix)
+class MembraneMissing(MembranePanic):
+    """OUR vocabulary has no class/rule for a shape the provider legitimately
+    produced. The fix is always to add vocabulary — a class, a rule, a
+    mapping entry — deliberately, never a permissive fallback."""
+
+    _LABEL = "MEMBRANE MISSING"
+
+
+class MembraneProviderDefect(MembranePanic):
+    """The provider, or its adapter's translation of it, produced something
+    structurally invalid: an out-of-range position, a degenerate span, a
+    coordinate collision, a malformed root, output that is not even valid
+    for the language it claims to parse. The fix is on the provider/adapter
+    side, never "add vocabulary".
+    """
+
+    _LABEL = "MEMBRANE PROVIDER DEFECT"
+
+
+def membrane_missing(owner: str, observed: str, requested: str, fix: str) -> "MembraneMissing":
+    raise MembraneMissing(owner=owner, observed=observed, requested=requested, fix=fix)
+
+
+def membrane_provider_defect(
+    owner: str, observed: str, requested: str, fix: str
+) -> "MembraneProviderDefect":
+    raise MembraneProviderDefect(owner=owner, observed=observed, requested=requested, fix=fix)

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/spans.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/spans.py
@@ -84,7 +84,7 @@ from __future__ import annotations
 import bisect
 from dataclasses import dataclass
 
-from .panic import membrane_panic
+from .panic import membrane_provider_defect
 
 
 @dataclass(frozen=True, order=True)
@@ -96,7 +96,7 @@ class Span:
 
     def __post_init__(self) -> None:
         if self.start < 0 or self.end < self.start:
-            membrane_panic(
+            membrane_provider_defect(
                 owner="spans.Span",
                 observed=f"degenerate span [{self.start}, {self.end})",
                 requested="0 <= start <= end",
@@ -142,7 +142,7 @@ class LineTable:
     def offset(self, line: int, col: int) -> int:
         """1-based line + 0-based codepoint column -> absolute offset."""
         if line < 1 or line > len(self._line_starts):
-            membrane_panic(
+            membrane_provider_defect(
                 owner="spans.LineTable.offset",
                 observed=f"line {line} outside 1..{len(self._line_starts)}",
                 requested="a position inside the source",
@@ -153,7 +153,7 @@ class LineTable:
     def line_col(self, offset: int) -> tuple[int, int]:
         """Absolute codepoint offset -> (1-based line, 0-based codepoint col)."""
         if offset < 0 or offset > len(self.source):
-            membrane_panic(
+            membrane_provider_defect(
                 owner="spans.LineTable.line_col",
                 observed=f"offset {offset} outside 0..{len(self.source)}",
                 requested="an offset inside the source",
@@ -170,7 +170,7 @@ class LineTable:
         """
         cp_col = self._byte_map(line).get(byte_col)
         if cp_col is None:
-            membrane_panic(
+            membrane_provider_defect(
                 owner="spans.LineTable.offset_from_byte_col",
                 observed=f"byte col {byte_col} is not a codepoint boundary on line {line}",
                 requested="a byte column landing on a codepoint boundary",

--- a/implementations/python/sugar-node-membrane/tests/test_panic_taxonomy.py
+++ b/implementations/python/sugar-node-membrane/tests/test_panic_taxonomy.py
@@ -1,0 +1,80 @@
+"""Two panics, two circumstances: MembraneMissing vs MembraneProviderDefect.
+
+Before this split, a single ``MembranePanic`` conflated "our vocabulary is
+incomplete" with "the provider/adapter is buggy," resolved only by a caller
+reading the ``owner`` string. These tests pin the split: each concrete class
+fires in its own circumstance, and — the load-bearing assertion — catching
+one does NOT catch the other. Both still subclass the common ``MembranePanic``
+base, for callers (like ``corpus.py``) that genuinely need "any membrane
+panic happened."
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_node_membrane.nodes import resolve_kind
+from sugar_node_membrane.operators import operator_for
+from sugar_node_membrane.panic import (
+    MembraneMissing,
+    MembranePanic,
+    MembraneProviderDefect,
+)
+from sugar_node_membrane.spans import LineTable, Span
+
+
+def test_both_are_membrane_panic_but_distinct_from_each_other():
+    assert issubclass(MembraneMissing, MembranePanic)
+    assert issubclass(MembraneProviderDefect, MembranePanic)
+    assert not issubclass(MembraneMissing, MembraneProviderDefect)
+    assert not issubclass(MembraneProviderDefect, MembraneMissing)
+
+
+def test_unknown_backend_kind_is_a_missing_not_a_provider_defect():
+    """resolve_kind: a shape the provider legitimately produced, but our
+    vocabulary has no membrane class for it — the MISSING case."""
+    with pytest.raises(MembraneMissing):
+        resolve_kind("NoSuchKind", observed_at="test")
+
+
+def test_unknown_operator_kind_is_a_missing_not_a_provider_defect():
+    with pytest.raises(MembraneMissing):
+        operator_for("NoSuchOperator")
+
+
+def test_degenerate_span_is_a_provider_defect_not_a_missing():
+    """spans.Span: a structurally invalid position (end before start) —
+    always the adapter/provider's own defect, never a vocabulary gap."""
+    with pytest.raises(MembraneProviderDefect):
+        Span(5, 2)
+
+
+def test_out_of_range_line_is_a_provider_defect_not_a_missing():
+    table = LineTable("x = 1\n")
+    with pytest.raises(MembraneProviderDefect):
+        table.offset(99, 0)
+
+
+def test_catching_missing_does_not_catch_provider_defect():
+    with pytest.raises(MembraneProviderDefect):
+        try:
+            Span(5, 2)
+        except MembraneMissing:
+            pytest.fail("MembraneMissing must not catch a provider defect")
+
+
+def test_catching_provider_defect_does_not_catch_missing():
+    with pytest.raises(MembraneMissing):
+        try:
+            resolve_kind("NoSuchKind", observed_at="test")
+        except MembraneProviderDefect:
+            pytest.fail("MembraneProviderDefect must not catch a missing")
+
+
+def test_catching_the_common_base_catches_both():
+    """The base exists for callers (corpus.py) that need 'any membrane
+    panic happened' — never as the easy default that re-conflates them."""
+    with pytest.raises(MembranePanic):
+        resolve_kind("NoSuchKind", observed_at="test")
+    with pytest.raises(MembranePanic):
+        Span(5, 2)

--- a/implementations/python/sugar-node-membrane/tests/test_refusal_twin.py
+++ b/implementations/python/sugar-node-membrane/tests/test_refusal_twin.py
@@ -64,14 +64,12 @@ def test_a_refused_file_produces_a_recorded_row_never_an_escaped_exception(
     good = tmp_path / "fine.py"
     good.write_text("x = 1\n", encoding="utf-8")
 
-    import sugar_node_membrane.corpus as corpus_mod
-
-    original_membrane = corpus_mod.Membrane
-    try:
-        corpus_mod.Membrane = lambda: Membrane(provider_cls())
-        result = emit_corpus([tmp_path], out_path=None, base=tmp_path)
-    finally:
-        corpus_mod.Membrane = original_membrane
+    # The provider is a parameter of emit_corpus, not a source edit or a
+    # monkeypatch of the Membrane class (#5946/#5948's own workaround) —
+    # this is the fix the corpus.emit_corpus provider parameter exists for.
+    result = emit_corpus(
+        [tmp_path], out_path=None, base=tmp_path, provider=provider_cls()
+    )
 
     assert result.files == 1  # only fine.py parsed
     refused = [f for f in result.failures if f[1] == "provider_refused"]


### PR DESCRIPTION
Two defects surfaced by #5948, refs #5946 and #5940.

## 1. MembranePanic.owner conflated two meanings

Every raise site across `construct.py`, `cpython_adapter.py`, `libcst_adapter.py`, `nodes.py`, `operators.py`, `spans.py` used a bare `owner` string a caller had to read and interpret to tell apart:

- **our vocabulary is incomplete** for a shape the provider legitimately produced (a node kind, an operator, an import/element/parameter shape our adapter's rule table doesn't cover yet)
- **the provider/adapter produced something structurally invalid** (an out-of-range position, a degenerate span, a coordinate collision, a malformed root, LibCST accepting text CPython would reject)

Split into two exception classes:

- `MembraneMissing` — the fix is always "add vocabulary": a class, an adapter rule, a mapping entry. Never a fallback.
- `MembraneProviderDefect` — the fix is on the provider/adapter side, never "add vocabulary."

Both subclass a common `MembranePanic` base, kept for callers (`corpus.py`'s "record and keep going" loop) that genuinely need "any membrane panic happened" — never as an easy default that re-conflates the two; no code path catches the base and then re-derives which arm it was by reading `owner`.

Every raise site classified and migrated. Two sites don't cleanly fit either bucket: `nodes.Typed.resolve_type`'s "instance of abstract membrane class" guard and `operators.Operator.instance`'s equivalent guard are internal invariants on our own construction code (unreachable given current call sites — construct.py only ever resolves through `resolve_kind`, which already excludes abstract classes) — not a provider question at all. Both raise the common `MembranePanic` base directly, documented in place, rather than guessing which subtype fits.

## 2. corpus.emit_corpus hardcoded Membrane() with no provider parameter

`provider` is now a parameter of `emit_corpus` and a `--provider` CLI flag (`cpython` / `libcst`), defaulting to today's behaviour (unchanged). `test_refusal_twin.py`'s `corpus_mod.Membrane = lambda: ...` monkeypatch — the workaround #5948's author needed — is replaced by passing the real parameter.

## Verification

- **71 -> 79 passed** (baseline 71 unchanged; +8 new tests in `test_panic_taxonomy.py` proving each class fires in its own circumstance and that catching one does not catch the other).
- Full corpus (this package's own `src/`, `tests/`, `goldens/` — 20 files) through both providers via `--provider`, no monkeypatching:
  - `cpython`: 15188 nodes, 75 kinds, 0 missing, 0 provider defects, 0 refusals
  - `libcst`: 15191 nodes, 75 kinds, 0 missing, 0 provider defects, 0 refusals
  - (node-count divergence is expected — different parsers build different trees, per corpus.py's own docstring)

Scope: `implementations/python/sugar-node-membrane/` only, per dispatch instructions. Not merging — for review.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split `MembranePanic` into `MembraneMissing` and `MembraneProviderDefect` and thread provider through `emit_corpus`
> - Refactors [panic.py](https://github.com/TSavo/sugar/pull/5949/files#diff-f534f17d1d30a36942402c6cb3607b1ddb26e2d731b79a52e1aa9a8c6138d79a) so `MembranePanic` is a base class with two concrete subclasses: `MembraneMissing` (vocabulary gaps) and `MembraneProviderDefect` (structurally invalid provider output).
> - Updates all raise sites across the adapters, construct, spans, nodes, and operators modules to raise the appropriate subclass instead of the generic panic.
> - Adds an optional `provider` parameter to `emit_corpus` and a `--provider` CLI flag so callers can select `cpython` (default) or `libcst` without monkeypatching.
> - Failure reporting in the corpus CLI now tracks `membrane_missing` and `membrane_provider_defect` as separate counters.
> - Behavioral Change: code that previously caught `MembranePanic` will still catch both subclasses, but code catching the new subclasses will only see the matching category of failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8496446.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->