### PR TITLE
Add parso and tree-sitter-python provider adapters (#5940, #5932)

### DIFF
--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/bench_providers.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/bench_providers.py
@@ -1,0 +1,199 @@
+"""Provider bench harness (#5940, #5932): correctness first, speed second.
+
+Two independent passes, never conflated:
+
+1. CORRECTNESS — parse + construct every file in the corpus. Record parse
+   failures (provider refused: SyntaxError), membrane panics (a shape with
+   no class: MembranePanic), and any other crash verbatim. Not load
+   sensitive; safe to run on a busy host.
+
+2. THROUGHPUT — pure parse time and parse+construct time, files/second.
+   Load-sensitive: the caller is responsible for only trusting numbers
+   taken with the host quiet (see the ``--require-quiet`` flag, which
+   blocks until 1-minute load average is under the given threshold and
+   prints load before and after the timed run).
+
+No cross-provider CID comparison here — that instrument is
+``differential.py`` and is explicitly out of scope for this harness
+(different parsers build different trees; matching CIDs across providers
+is not a criterion, per #5940/#5932).
+
+CLI::
+
+    python -m sugar_node_membrane.bench_providers PATH [PATH ...] \\
+        --provider cpython-ast|libcst|parso|tree-sitter-python \\
+        [--require-quiet 5] [--limit N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+import traceback
+from pathlib import Path
+from typing import Optional
+
+from .construct import Membrane
+from .panic import MembranePanic
+
+
+def _load1() -> Optional[float]:
+    try:
+        with open("/proc/loadavg") as f:
+            return float(f.read().split()[0])
+    except Exception:
+        return None
+
+
+def _provider(name: str):
+    if name == "cpython-ast":
+        from .cpython_adapter import CPythonAstProvider
+        return CPythonAstProvider()
+    if name == "libcst":
+        from .libcst_adapter import LibCSTProvider
+        return LibCSTProvider()
+    if name == "parso":
+        from .parso_adapter import ParsoProvider
+        return ParsoProvider()
+    if name == "tree-sitter-python":
+        from .tree_sitter_python_adapter import TreeSitterPythonProvider
+        return TreeSitterPythonProvider()
+    raise SystemExit(f"unknown provider {name!r}")
+
+
+def collect_files(paths: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for p in paths:
+        if p.is_dir():
+            files.extend(sorted(p.rglob("*.py")))
+        else:
+            files.append(p)
+    files.sort()
+    return files
+
+
+def run_correctness(provider_name: str, files: list[Path], base: Optional[Path]) -> int:
+    provider = _provider(provider_name)
+    membrane = Membrane(provider)
+    parsed = 0
+    parse_failures: list[tuple[str, str]] = []
+    panics: list[tuple[str, str]] = []
+    crashes: list[tuple[str, str]] = []
+    for path in files:
+        rel = str(path.relative_to(base)) if base is not None else str(path)
+        try:
+            source = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as err:
+            parse_failures.append((rel, f"undecodable: {err}"))
+            continue
+        try:
+            membrane.parse(source, filename=rel)
+            parsed += 1
+        except SyntaxError as err:
+            parse_failures.append((rel, str(err).splitlines()[0]))
+        except MembranePanic as err:
+            panics.append((rel, " | ".join(str(err).splitlines())))
+        except Exception as err:  # noqa: BLE001 - a crash IS a result here
+            crashes.append((rel, f"{type(err).__name__}: {err}"))
+
+    print(f"provider:        {provider_name}")
+    print(f"files:           {len(files)}")
+    print(f"constructed:     {parsed}")
+    print(f"parse failures:  {len(parse_failures)}")
+    for rel, msg in parse_failures:
+        print(f"  PARSE_FAIL  {rel}: {msg}")
+    print(f"membrane panics: {len(panics)}")
+    for rel, msg in panics:
+        print(f"  PANIC       {rel}: {msg}")
+    print(f"other crashes:   {len(crashes)}")
+    for rel, msg in crashes:
+        print(f"  CRASH       {rel}: {msg}")
+    return 1 if crashes else 0
+
+
+def _require_quiet(threshold: float) -> None:
+    load = _load1()
+    if load is None:
+        return
+    waited = False
+    while load is not None and load >= threshold:
+        waited = True
+        time.sleep(30)
+        load = _load1()
+    tag = "(waited)" if waited else "(already quiet)"
+    print(f"host 1-min load at start: {load} {tag}")
+
+
+def run_throughput(provider_name: str, files: list[Path], limit: Optional[int]) -> None:
+    if limit is not None:
+        files = files[:limit]
+    provider = _provider(provider_name)
+
+    sources: list[tuple[Path, str]] = []
+    for path in files:
+        try:
+            sources.append((path, path.read_text(encoding="utf-8")))
+        except UnicodeDecodeError:
+            continue
+
+    load_start = _load1()
+    t0 = time.perf_counter()
+    parsed_handles = 0
+    for _, source in sources:
+        try:
+            provider.parse.__self__  # no-op; keeps provider warm
+        except Exception:
+            pass
+    for _, source in sources:
+        try:
+            from .nodes import SourceUnit
+            unit = SourceUnit(filename="<bench>", source=source)
+            provider.parse(unit)
+            parsed_handles += 1
+        except Exception:
+            continue
+    t_parse = time.perf_counter() - t0
+
+    membrane = Membrane(_provider(provider_name))
+    t1 = time.perf_counter()
+    constructed = 0
+    for path, source in sources:
+        try:
+            membrane.parse(source, filename=str(path))
+            constructed += 1
+        except Exception:
+            continue
+    t_construct_total = time.perf_counter() - t1
+    load_end = _load1()
+
+    n = len(sources)
+    print(f"provider:              {provider_name}")
+    print(f"files timed:           {n}")
+    print(f"host load (1min) start: {load_start}")
+    print(f"host load (1min) end:   {load_end}")
+    print(f"pure parse:            {t_parse:.3f}s  ({n / t_parse if t_parse else float('inf'):.1f} files/s)  [{parsed_handles} ok]")
+    print(f"parse+construct:       {t_construct_total:.3f}s  ({n / t_construct_total if t_construct_total else float('inf'):.1f} files/s)  [{constructed} ok]")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("paths", nargs="+", type=Path)
+    ap.add_argument("--provider", required=True)
+    ap.add_argument("--base", type=Path, default=None)
+    ap.add_argument("--mode", choices=["correctness", "throughput"], default="correctness")
+    ap.add_argument("--require-quiet", type=float, default=None)
+    ap.add_argument("--limit", type=int, default=None)
+    args = ap.parse_args(argv)
+
+    files = collect_files(args.paths)
+    if args.mode == "correctness":
+        return run_correctness(args.provider, files, args.base)
+    if args.require_quiet is not None:
+        _require_quiet(args.require_quiet)
+    run_throughput(args.provider, files, args.limit)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/parso_adapter.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/parso_adapter.py
@@ -1,0 +1,1506 @@
+"""parso provider adapter (#5940, #5932) — candidate #3.
+
+THE ONLY MODULE IN THIS PACKAGE THAT MAY NAME ``parso``. Same read-only
+contract as ``cpython_adapter`` / ``libcst_adapter``: ``parse(unit) ->
+handle``, and per handle a single ``describe()`` giving our kind, our
+codepoint span, and our fields as slots.
+
+Why parso is a credible third candidate: it is pure Python (no C extension,
+no ``compile()``, cannot SIGSEGV the way #5932 isolated CPython's own
+``ast.parse`` doing), has explicit *error recovery* (it is what Jedi and
+``black``'s blib2to3 fork use to parse code with syntax errors), and its
+positions are already codepoint columns — matching our span spec exactly,
+with no byte->codepoint seam to build (see spans.py; same property as
+LibCST, the opposite of CPython's UTF-8 byte columns).
+
+MAPPING NOTES — parso is a raw CST (blib2to3/lib2to3 family grammar), NOT
+AST-shaped. Concretely, versus ``ast``/our membrane:
+
+- parso collapses any grammar node with exactly one child down to that
+  child (no wrapper). This does a lot of our unwrapping for free: a bare
+  name expression is never wrapped in ``test``/``or_test``/... at all.
+- Binary operator chains (``arith_expr``, ``term``, ``expr``, ``xor_expr``,
+  ``and_expr``, ``shift_expr``) are FLAT n-ary nodes (operand, op, operand,
+  op, operand, ...) that we must fold pairwise, left-associative, into
+  nested ``BinOp`` — ast is strictly binary. Each intermediate fold's span
+  is [first-operand-start, this-step's-right-operand-end], never the whole
+  chain's span except at the final fold.
+- ``or_test`` / ``and_test`` are already flat n-ary matching our
+  ``BoolOp.values`` directly — no folding needed, and every operator in one
+  such node is provably the same (mixed precedence is expressed as nesting
+  a different node type, not multiple operators in one flat list).
+- ``comparison`` is flat n-ary matching ``Compare`` directly: alternating
+  operand / ``comp_op``-or-single-token / operand.
+- Grouping parens live inside an ``atom`` node (``'(' testlist_comp ')'``)
+  and are never included in the inner expression's own span — matching our
+  ruling — with the one ruled exception: a parenthesized tuple display's
+  parens ARE part of the ``Tuple`` span, so that one case takes the atom's
+  own span explicitly rather than the envelope of its elements.
+- ``atom_expr`` is ``['await'] atom trailer*`` — we fold trailers
+  (``.NAME``, ``(...)``, ``[...]``) into nested ``Attribute`` / ``Call`` /
+  ``Subscript``, spanning from the atom's start to each trailer's own end
+  (already correct for CPython's multi-line-call ruling, since the
+  trailer's own span already reaches its closing token).
+- A subscript's comma list becomes a synthetic bare ``Tuple`` (no
+  parens/brackets of its own) exactly as CPython's own post-3.9 ``ast``
+  does for ``arr[i, j]`` — envelope-spanned over its elements.
+- f-strings (``fstring`` / ``fstring_expr`` / ``fstring_format_spec``) are
+  parso's own first-class grammar (not a lexer hack); translated to
+  ``JoinedStr`` / ``FormattedValue`` per the same rulings as the other two
+  adapters.
+- ``match_stmt`` / patterns: parso 0.8's grammar supports PEP 634, but this
+  adapter's pattern coverage is intentionally partial — see the panics in
+  ``_pattern`` below. An unhandled pattern shape is a MISSING, not a guess.
+
+A parso shape with no rule here panics as a MISSING at the boundary. There
+is no generic fallback and no ``getattr`` sniffing on children: an unmapped
+CST node/shape is the conformance finding itself.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence, Tuple
+
+import parso
+from parso.tree import BaseNode, Leaf
+
+from .backend import (
+    Child,
+    Children,
+    Description,
+    Leaf as SlotLeaf,
+    MaybeChild,
+    OpLeaf,
+    OpsLeaf,
+    Provider,
+    ProviderHandle,
+    Slot,
+)
+from .nodes import SourceUnit
+from .operators import Operator, operator_for
+from .panic import membrane_panic
+from .spans import Span
+
+ParsoNode = object  # parso.tree.NodeOrLeaf, kept untyped at the boundary
+
+
+def _is_leaf(node: ParsoNode) -> bool:
+    return isinstance(node, Leaf)
+
+
+def _span(unit: SourceUnit, node: ParsoNode) -> Span:
+    table = unit.line_table
+    sl, sc = node.start_pos
+    el, ec = node.end_pos
+    return Span(table.offset(sl, sc), table.offset(el, ec))
+
+
+def _kids(node: ParsoNode) -> List[ParsoNode]:
+    return list(getattr(node, "children", ()))
+
+
+class _Handle(ProviderHandle):
+    """Read-only view of one real parso node."""
+
+    __slots__ = ("_unit", "_node", "_desc")
+
+    def __init__(self, unit: SourceUnit, node: ParsoNode) -> None:
+        self._unit = unit
+        self._node = node
+        self._desc: Optional[Description] = None
+
+    def describe(self) -> Description:
+        if self._desc is None:
+            self._desc = _describe(self._unit, self._node)
+        return self._desc
+
+    def __repr__(self) -> str:  # pragma: no cover
+        t = getattr(self._node, "type", "?")
+        return f"<parso-handle {t} in {self._unit.filename}>"
+
+
+class _Fixed(ProviderHandle):
+    """A synthetic constituent: precomputed Description, no single backing
+    node (a fold step, a flattened tuple, a folded trailer chain, ...)."""
+
+    __slots__ = ("_desc",)
+
+    def __init__(self, desc: Description) -> None:
+        self._desc = desc
+
+    def describe(self) -> Description:
+        return self._desc
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<parso-fixed {self._desc.kind}>"
+
+
+def _fixed(kind: str, raw_span: Optional[Span], slots: Tuple[Tuple[str, Slot], ...],
+           anchors: Tuple[Span, ...] = ()) -> _Fixed:
+    return _Fixed(Description(kind=kind, raw_span=raw_span, anchors=anchors, slots=slots))
+
+
+def _h(unit: SourceUnit, node: ParsoNode) -> ProviderHandle:
+    return _Handle(unit, node)
+
+
+# --------------------------------------------------------------------------
+# Binary operator token -> our Operator kind
+# --------------------------------------------------------------------------
+
+_BIN_TOKEN = {
+    "+": "Add", "-": "Sub", "*": "Mult", "@": "MatMult", "/": "Div",
+    "%": "Mod", "**": "Pow", "<<": "LShift", ">>": "RShift", "|": "BitOr",
+    "^": "BitXor", "&": "BitAnd", "//": "FloorDiv",
+}
+_AUG_TOKEN = {
+    "+=": "Add", "-=": "Sub", "*=": "Mult", "@=": "MatMult", "/=": "Div",
+    "%=": "Mod", "**=": "Pow", "<<=": "LShift", ">>=": "RShift", "|=": "BitOr",
+    "^=": "BitXor", "&=": "BitAnd", "//=": "FloorDiv",
+}
+_UNARY_TOKEN = {"+": "UAdd", "-": "USub", "~": "Invert"}
+_CMP_TOKEN = {
+    "<": "Lt", ">": "Gt", "==": "Eq", ">=": "GtE", "<=": "LtE", "<>": "NotEq",
+    "!=": "NotEq",
+}
+
+
+def _cmp_op(node: ParsoNode) -> Operator:
+    if node.type == "comp_op":
+        text = " ".join(c.value for c in _kids(node))
+        if text == "not in":
+            return operator_for("NotIn")
+        if text == "is not":
+            return operator_for("IsNot")
+        membrane_panic(
+            owner="parso_adapter._cmp_op",
+            observed=f"comp_op token {text!r} not recognized",
+            requested="one of: not in, is not",
+            fix="extend the comp_op mapping deliberately",
+        )
+    text = node.value
+    if text == "in":
+        return operator_for("In")
+    if text == "is":
+        return operator_for("Is")
+    kind = _CMP_TOKEN.get(text)
+    if kind is None:
+        membrane_panic(
+            owner="parso_adapter._cmp_op",
+            observed=f"comparison token {text!r} not recognized",
+            requested="a known comparison operator token",
+            fix="extend _CMP_TOKEN deliberately",
+        )
+    return operator_for(kind)
+
+
+# --------------------------------------------------------------------------
+# Folds
+# --------------------------------------------------------------------------
+
+
+def _fold_binop(unit: SourceUnit, node: ParsoNode) -> ProviderHandle:
+    """Flat n-ary chain (arith_expr/term/expr/xor_expr/and_expr/shift_expr)
+    -> nested left-associative BinOp handles."""
+    kids = _kids(node)
+    first_start = _span(unit, kids[0]).start
+    acc = _h(unit, kids[0])
+    i = 1
+    while i < len(kids):
+        op_tok = kids[i]
+        right_node = kids[i + 1]
+        kind = _BIN_TOKEN.get(op_tok.value)
+        if kind is None:
+            membrane_panic(
+                owner="parso_adapter._fold_binop",
+                observed=f"binary operator token {op_tok.value!r} not recognized",
+                requested="a known binary operator token",
+                fix="extend _BIN_TOKEN deliberately",
+            )
+        right = _h(unit, right_node)
+        end = _span(unit, right_node).end
+        acc = _fixed(
+            "BinOp",
+            Span(first_start, end),
+            (
+                ("left", Child(acc)),
+                ("op", OpLeaf(operator_for(kind))),
+                ("right", Child(right)),
+            ),
+        )
+        i += 2
+    return acc
+
+
+def _boolop(unit: SourceUnit, node: ParsoNode, op_kind: str) -> Description:
+    values = tuple(_h(unit, c) for c in _kids(node) if not _is_leaf(c))
+    return Description(
+        kind="BoolOp",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("op", OpLeaf(operator_for(op_kind))),
+            ("values", Children(values)),
+        ),
+    )
+
+
+def _compare(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    left = _h(unit, kids[0])
+    ops: List[Operator] = []
+    comparators: List[ProviderHandle] = []
+    i = 1
+    while i < len(kids):
+        ops.append(_cmp_op(kids[i]))
+        comparators.append(_h(unit, kids[i + 1]))
+        i += 2
+    return Description(
+        kind="Compare",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("left", Child(left)),
+            ("ops", OpsLeaf(tuple(ops))),
+            ("comparators", Children(tuple(comparators))),
+        ),
+    )
+
+
+def _bare_tuple(unit: SourceUnit, elts: Sequence[ParsoNode], unit_span: Optional[Span] = None) -> ProviderHandle:
+    handles = tuple(_h(unit, e) for e in elts)
+    return _fixed("Tuple", unit_span, (("elts", Children(handles)),))
+
+
+def _strip_commas(kids: Sequence[ParsoNode]) -> List[ParsoNode]:
+    return [c for c in kids if not (_is_leaf(c) and c.value == ",")]
+
+
+# --------------------------------------------------------------------------
+# atom / trailer folding
+# --------------------------------------------------------------------------
+
+
+def _keyword_str(kids: Sequence[ParsoNode], value: str) -> bool:
+    return any(_is_leaf(c) and c.value == value for c in kids)
+
+
+def _string_piece_kind(node: ParsoNode) -> str:
+    # 'string' leaf, or 'fstring' node (first-class in parso >= 0.8)
+    if _is_leaf(node):
+        return "string"
+    if node.type == "fstring":
+        return "fstring"
+    return "other"
+
+
+def _constant_prefix_kind(text: str) -> Optional[str]:
+    lowered = text.lower()
+    i = 0
+    while i < len(lowered) and lowered[i] not in ("'", '"'):
+        i += 1
+    return lowered[:i] if i else ""
+
+
+def _join_string_pieces(unit: SourceUnit, pieces: Sequence[ParsoNode]) -> ProviderHandle:
+    """Implicit string concatenation: one Constant, or JoinedStr if any
+    piece is an f-string. Spans the first piece's start to the last's end
+    (spec: including inter-piece whitespace/newlines)."""
+    start = _span(unit, pieces[0]).start
+    end = _span(unit, pieces[-1]).end
+    span = Span(start, end)
+    if any(_string_piece_kind(p) == "fstring" for p in pieces):
+        values: List[ProviderHandle] = []
+        for p in pieces:
+            if _string_piece_kind(p) == "fstring":
+                values.extend(_fstring_values(unit, p))
+            else:
+                values.append(_constant_leaf(unit, p))
+        return _fixed("JoinedStr", span, (("values", Children(tuple(values))),))
+    # plain string(s): concatenate python-literal values
+    import ast as _pyast  # value decoding only — never structure; see docstring
+
+    text = "".join(unit.source[_span(unit, p).start:_span(unit, p).end] for p in pieces)
+    try:
+        value = _pyast.literal_eval(text)
+    except Exception:
+        value = unit.source[start:end]
+    return _fixed_constant(span, value)
+
+
+# _Fixed has no _replace_value; build Constant directly instead.
+def _fixed_constant(span: Span, value: object, literal_kind: Optional[str] = None) -> ProviderHandle:
+    return _fixed(
+        "Constant",
+        span,
+        (("value", SlotLeaf(value)), ("literal_kind", SlotLeaf(literal_kind))),
+    )
+
+
+def _constant_leaf(unit: SourceUnit, node: ParsoNode) -> ProviderHandle:
+    span = _span(unit, node)
+    text = unit.source[span.start:span.end]
+    if node.type == "number":
+        import ast as _pyast
+        value = _pyast.literal_eval(text)
+        return _fixed_constant(span, value)
+    if node.type == "string":
+        import ast as _pyast
+        try:
+            value = _pyast.literal_eval(text)
+        except Exception:
+            value = text
+        return _fixed_constant(span, value)
+    if node.type == "keyword" and node.value in ("None", "True", "False"):
+        value = {"None": None, "True": True, "False": False}[node.value]
+        return _fixed_constant(span, value)
+    if node.type == "operator" and node.value == "...":
+        return _fixed_constant(span, Ellipsis)
+    membrane_panic(
+        owner="parso_adapter._constant_leaf",
+        observed=f"leaf {node.type}:{node.value!r} is not a recognized literal",
+        requested="number, string, None/True/False, or Ellipsis",
+        fix="extend _constant_leaf deliberately",
+    )
+    raise AssertionError("unreachable")
+
+
+def _fstring_values(unit: SourceUnit, node: ParsoNode) -> List[ProviderHandle]:
+    out: List[ProviderHandle] = []
+    for c in _kids(node):
+        if c.type == "fstring_string":
+            span = _span(unit, c)
+            out.append(_fixed_constant(span, unit.source[span.start:span.end]))
+        elif c.type == "fstring_expr":
+            out.append(_h(unit, c))
+        elif c.type in ("fstring_start", "fstring_end"):
+            continue
+        else:
+            membrane_panic(
+                owner="parso_adapter._fstring_values",
+                observed=f"fstring child {c.type!r} not recognized",
+                requested="fstring_string or fstring_expr",
+                fix="extend _fstring_values deliberately",
+            )
+    return out
+
+
+def _describe_fstring_expr(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = [c for c in _kids(node) if not (_is_leaf(c) and c.value in ("{", "}"))]
+    # kids[0] is the value expression; optional '=' debug spec, '!' conversion,
+    # ':' format_spec follow. Conversion / debug specifiers are rare in numpy
+    # /pandas source; unrecognized trailing tokens panic rather than guess.
+    value = kids[0]
+    conversion = -1
+    format_spec: Optional[ParsoNode] = None
+    i = 1
+    while i < len(kids):
+        c = kids[i]
+        if _is_leaf(c) and c.value == "!":
+            conv_name = kids[i + 1]
+            conversion = ord(conv_name.value)
+            i += 2
+            continue
+        if c.type == "fstring_conversion":
+            conv_kids = _kids(c)
+            conv_name = conv_kids[-1]
+            conversion = ord(conv_name.value)
+            i += 1
+            continue
+        if c.type == "fstring_format_spec":
+            format_spec = c
+            i += 1
+            continue
+        membrane_panic(
+            owner="parso_adapter._describe_fstring_expr",
+            observed=f"fstring_expr trailing token {c!r} not recognized",
+            requested="'!' conversion or format spec",
+            fix="extend _describe_fstring_expr deliberately",
+        )
+    format_spec_slot: Slot
+    if format_spec is not None:
+        spec_span = _span(unit, format_spec)
+        spec_values = _fstring_values(unit, format_spec)
+        format_spec_slot = MaybeChild(
+            _fixed("JoinedStr", spec_span, (("values", Children(tuple(spec_values))),))
+        )
+    else:
+        format_spec_slot = MaybeChild(None)
+    return Description(
+        kind="FormattedValue",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("value", Child(_h(unit, value))),
+            ("conversion", SlotLeaf(conversion)),
+            ("format_spec", format_spec_slot),
+        ),
+    )
+
+
+def _fold_trailers(unit: SourceUnit, atom: ParsoNode, trailers: Sequence[ParsoNode],
+                    has_await: bool, await_start: Optional[int]) -> ProviderHandle:
+    base_start = _span(unit, atom).start
+    acc: ProviderHandle = _h(unit, atom)
+    for tr in trailers:
+        tk = _kids(tr)
+        first = tk[0]
+        end = _span(unit, tr).end
+        if first.value == ".":
+            name_node = tk[1]
+            acc = _fixed(
+                "Attribute",
+                Span(base_start, end),
+                (("value", Child(acc)), ("attr", SlotLeaf(name_node.value))),
+            )
+        elif first.value == "(":
+            args, keywords = _call_args(unit, tk[1:-1])
+            acc = _fixed(
+                "Call",
+                Span(base_start, end),
+                (
+                    ("func", Child(acc)),
+                    ("args", Children(tuple(args))),
+                    ("keywords", Children(tuple(keywords))),
+                ),
+            )
+        elif first.value == "[":
+            slice_handle = _subscript_slice(unit, tk[1:-1])
+            acc = _fixed(
+                "Subscript",
+                Span(base_start, end),
+                (("value", Child(acc)), ("slice_", Child(slice_handle))),
+            )
+        else:
+            membrane_panic(
+                owner="parso_adapter._fold_trailers",
+                observed=f"trailer starting with {first.value!r} not recognized",
+                requested="'.', '(' or '['",
+                fix="extend _fold_trailers deliberately",
+            )
+    if has_await:
+        acc = _fixed("Await", Span(await_start, end if trailers else _span(unit, atom).end),
+                      (("value", Child(acc)),))
+    return acc
+
+
+def _call_args(unit: SourceUnit, inner: Sequence[ParsoNode]) -> Tuple[List[ProviderHandle], List[ProviderHandle]]:
+    if len(inner) == 1 and inner[0].type == "arglist":
+        inner = _kids(inner[0])
+    inner = _strip_commas(inner)
+    if len(inner) == 1 and inner[0].type == "argument" and any(
+        c.type in ("comp_for", "sync_comp_for") for c in _kids(inner[0])
+    ):
+        # bare generator expression as the sole call argument
+        ik = _kids(inner[0])
+        genexp = _genexp(unit, ik[0], ik[1:])
+        return [genexp], []
+    args: List[ProviderHandle] = []
+    keywords: List[ProviderHandle] = []
+    for item in inner:
+        if item.type == "argument":
+            ik = _kids(item)
+            if _is_leaf(ik[0]) and ik[0].value == "**":
+                keywords.append(_fixed("Keyword", None,
+                                        (("arg", SlotLeaf(None)), ("value", Child(_h(unit, ik[1]))))))
+            elif _is_leaf(ik[0]) and ik[0].value == "*":
+                args.append(_fixed("Starred", Span(_span(unit, item).start, _span(unit, item).end),
+                                    (("value", Child(_h(unit, ik[1]))),)))
+            elif len(ik) >= 2 and _is_leaf(ik[1]) and ik[1].value == "=":
+                keywords.append(_fixed(
+                    "Keyword",
+                    Span(_span(unit, item).start, _span(unit, item).end),
+                    (("arg", SlotLeaf(ik[0].value)), ("value", Child(_h(unit, ik[2])))),
+                ))
+            else:
+                membrane_panic(
+                    owner="parso_adapter._call_args",
+                    observed=f"argument shape {[c.type for c in ik]!r} not recognized",
+                    requested="*expr, **expr, name=expr, or a comprehension argument",
+                    fix="extend _call_args deliberately",
+                )
+        elif _is_leaf(item) and item.value == "*":
+            continue  # handled as part of an 'argument' pairing above in real grammars
+        elif item.type == "star_expr":
+            sk = _kids(item)
+            args.append(_fixed("Starred", _span(unit, item), (("value", Child(_h(unit, sk[1]))),)))
+        else:
+            args.append(_h(unit, item))
+    return args, keywords
+
+
+def _subscript_slice(unit: SourceUnit, inner: Sequence[ParsoNode]) -> ProviderHandle:
+    if len(inner) == 1 and inner[0].type == "subscriptlist":
+        inner = _kids(inner[0])
+    items = _strip_commas(inner)
+    if len(items) == 1:
+        return _one_subscript_item(unit, items[0])
+    handles = tuple(_one_subscript_item(unit, it) for it in items)
+    return _fixed("Tuple", None, (("elts", Children(handles)),))
+
+
+def _one_subscript_item(unit: SourceUnit, node: ParsoNode) -> ProviderHandle:
+    if node.type != "subscript":
+        return _h(unit, node)
+    # a slice: split on ':' leaves, flattening one level of 'sliceop'
+    flat: List[ParsoNode] = []
+    for c in _kids(node):
+        if c.type == "sliceop":
+            flat.extend(_kids(c))
+        else:
+            flat.append(c)
+    segments: List[List[ParsoNode]] = [[]]
+    for c in flat:
+        if _is_leaf(c) and c.value == ":":
+            segments.append([])
+        else:
+            segments[-1].append(c)
+    while len(segments) < 3:
+        segments.append([])
+    lower, upper, step = segments[0], segments[1], segments[2]
+    for seg in (lower, upper, step):
+        if len(seg) > 1:
+            membrane_panic(
+                owner="parso_adapter._one_subscript_item",
+                observed=f"slice segment with {len(seg)} nodes",
+                requested="zero or one expression per slice segment",
+                fix="extend the slice segment scan deliberately",
+            )
+
+    def _maybe(seg: List[ParsoNode]) -> Slot:
+        return MaybeChild(_h(unit, seg[0]) if seg else None)
+
+    return _fixed(
+        "Slice",
+        _span(unit, node),
+        (("lower", _maybe(lower)), ("upper", _maybe(upper)), ("step", _maybe(step))),
+    )
+
+
+# --------------------------------------------------------------------------
+# parameters
+# --------------------------------------------------------------------------
+
+
+def _flatten_params(unit: SourceUnit, node: Optional[ParsoNode]) -> Tuple[ProviderHandle, ...]:
+    if node is None:
+        return ()
+    if node.type == "param":
+        return (_one_param(unit, node, "positional_or_keyword"),)
+    if node.type == "tfpdef":
+        # a lone annotated param with no default collapses past 'param' too
+        # when it is the function's ONLY parameter.
+        return (_one_param(unit, node, "positional_or_keyword"),)
+    if node.type == "name":
+        # a single plain (no annotation, no default) parameter collapses all
+        # the way down to a bare Name leaf when it is the only parameter.
+        return (_fixed(
+            "Param", None,
+            (("name", SlotLeaf(node.value)), ("annotation", MaybeChild(None)),
+             ("default", MaybeChild(None)), ("param_kind", SlotLeaf("positional_or_keyword"))),
+            anchors=(_span(unit, node),),
+        ),)
+    kids = _kids(node)
+    if node.type == "parameters":
+        kids = kids[1:-1]  # drop '(' ')'
+    params: List[ProviderHandle] = []
+    mode = "positional_or_keyword"
+    for c in kids:
+        if _is_leaf(c) and c.value == ",":
+            continue
+        if _is_leaf(c) and c.value == "/":
+            for p in params:
+                pass  # positional-only marker: retroactive tagging not needed —
+                # every param before '/' was already emitted; re-tag them.
+            params = [
+                p if p.describe().slots[3][1].value != "positional_or_keyword"
+                else _retag(p, "positional_only")
+                for p in params
+            ]
+            continue
+        if _is_leaf(c) and c.value == "*":
+            mode = "keyword_only"
+            continue
+        if c.type == "param":
+            pk = _kids(c)
+            if _is_leaf(pk[0]) and pk[0].value == "*":
+                params.append(_one_param(unit, c, "vararg"))
+                mode = "keyword_only"
+            elif _is_leaf(pk[0]) and pk[0].value == "**":
+                params.append(_one_param(unit, c, "kwarg"))
+            else:
+                params.append(_one_param(unit, c, mode))
+    return tuple(params)
+
+
+def _retag(handle: ProviderHandle, kind: str) -> ProviderHandle:
+    desc = handle.describe()
+    new_slots = tuple(
+        (name, SlotLeaf(kind)) if name == "param_kind" else (name, slot)
+        for name, slot in desc.slots
+    )
+    return _fixed(desc.kind, desc.raw_span, new_slots, desc.anchors)
+
+
+def _one_param(unit: SourceUnit, node: ParsoNode, kind: str) -> ProviderHandle:
+    kids = _kids(node)
+    if kind in ("vararg", "kwarg"):
+        kids = kids[1:]  # drop '*'/'**'
+    if kids and kids[0].type == "tfpdef":
+        # `NAME ':' annotation` collapses into its own 'tfpdef' node when the
+        # param has no default (e.g. an annotated *args/**kwargs, or a plain
+        # annotated positional param) — splice it back into a flat sequence.
+        kids = _kids(kids[0]) + kids[1:]
+    name_node = kids[0]
+    name_span = _span(unit, name_node)
+    annotation: Optional[ParsoNode] = None
+    default: Optional[ParsoNode] = None
+    i = 1
+    while i < len(kids):
+        c = kids[i]
+        if _is_leaf(c) and c.value == ":":
+            annotation = kids[i + 1]
+            i += 2
+        elif _is_leaf(c) and c.value == "=":
+            default = kids[i + 1]
+            i += 2
+        else:
+            i += 1
+    anchor_end = name_span.end
+    return _fixed(
+        "Param",
+        None,
+        (
+            ("name", SlotLeaf(name_node.value)),
+            ("annotation", MaybeChild(_h(unit, annotation) if annotation is not None else None)),
+            ("default", MaybeChild(_h(unit, default) if default is not None else None)),
+            ("param_kind", SlotLeaf(kind)),
+        ),
+        anchors=(Span(name_span.start, anchor_end),),
+    )
+
+
+# --------------------------------------------------------------------------
+# suite / block flattening
+# --------------------------------------------------------------------------
+
+
+def _stmts(unit: SourceUnit, node: ParsoNode) -> Tuple[ProviderHandle, ...]:
+    """Flatten a 'suite' (or, for one-liners, the bare simple_stmt/compound
+    stmt already sitting where a suite would be) into a tuple of statement
+    handles, dropping NEWLINE/INDENT/DEDENT and unwrapping simple_stmt."""
+    out: List[ProviderHandle] = []
+    if node.type == "suite":
+        for c in _kids(node):
+            if c.type in ("newline", "indent", "dedent"):
+                continue
+            out.extend(_stmt_handles(unit, c))
+    else:
+        out.extend(_stmt_handles(unit, node))
+    return tuple(out)
+
+
+def _stmt_handles(unit: SourceUnit, node: ParsoNode) -> List[ProviderHandle]:
+    if node.type == "simple_stmt":
+        out = []
+        for c in _kids(node):
+            if _is_leaf(c) and c.value in (";", "\n") or c.type == "newline":
+                continue
+            out.append(_h(unit, c))
+        return out
+    return [_h(unit, node)]
+
+
+def _body_of(unit: SourceUnit, node: ParsoNode) -> Tuple[ProviderHandle, ...]:
+    """The ':' suite/simple_stmt trailing a compound statement header."""
+    kids = _kids(node)
+    return _stmts(unit, kids[-1])
+
+
+# --------------------------------------------------------------------------
+# top-level dispatch
+# --------------------------------------------------------------------------
+
+
+def _describe(unit: SourceUnit, node: ParsoNode) -> Description:
+    if _is_leaf(node):
+        return _describe_leaf(unit, node)
+    t = node.type
+    fn = _DISPATCH.get(t)
+    if fn is not None:
+        return fn(unit, node)
+    membrane_panic(
+        owner="parso_adapter._describe",
+        observed=f"parso node type {t!r} has no translation rule",
+        requested="a mapped statement/expression shape",
+        fix="add a translation rule for this parso node type; never guess",
+    )
+    raise AssertionError("unreachable")
+
+
+def _describe_leaf(unit: SourceUnit, node: ParsoNode) -> Description:
+    if node.type == "name":
+        return Description(kind="Name", raw_span=_span(unit, node), anchors=(),
+                             slots=(("id", SlotLeaf(node.value)),))
+    if node.type in ("number", "string"):
+        d = _constant_leaf(unit, node)
+        return d.describe()
+    if node.type == "keyword" and node.value in ("None", "True", "False"):
+        return _constant_leaf(unit, node).describe()
+    if node.type == "operator" and node.value == "...":
+        return _constant_leaf(unit, node).describe()
+    if node.type == "fstring":
+        return _fixed("JoinedStr", _span(unit, node),
+                       (("values", Children(tuple(_fstring_values(unit, node)))),)).describe()
+    if node.type == "keyword" and node.value == "pass":
+        return Description(kind="Pass", raw_span=_span(unit, node), anchors=(), slots=())
+    if node.type == "keyword" and node.value == "break":
+        return Description(kind="Break", raw_span=_span(unit, node), anchors=(), slots=())
+    if node.type == "keyword" and node.value == "continue":
+        return Description(kind="Continue", raw_span=_span(unit, node), anchors=(), slots=())
+    if node.type == "keyword" and node.value == "return":
+        # bare `return` with no value: parso collapses the return_stmt
+        # wrapper down to just this keyword leaf (single-child collapsing).
+        return Description(kind="Return", raw_span=_span(unit, node), anchors=(), slots=(("value", MaybeChild(None)),))
+    if node.type == "keyword" and node.value == "raise":
+        return Description(kind="Raise", raw_span=_span(unit, node), anchors=(),
+                            slots=(("exc", MaybeChild(None)), ("cause", MaybeChild(None))))
+    if node.type == "keyword" and node.value == "yield":
+        return Description(kind="Yield", raw_span=_span(unit, node), anchors=(), slots=(("value", MaybeChild(None)),))
+    if node.type == "operator" and node.value == ":":
+        # bare `a[:]`: subscript's slice collapses to just the ':' leaf.
+        return Description(kind="Slice", raw_span=_span(unit, node), anchors=(),
+                            slots=(("lower", MaybeChild(None)), ("upper", MaybeChild(None)), ("step", MaybeChild(None))))
+    membrane_panic(
+        owner="parso_adapter._describe_leaf",
+        observed=f"leaf {node.type}:{node.value!r} has no translation rule",
+        requested="a mapped leaf shape",
+        fix="add a translation rule for this leaf; never guess",
+    )
+    raise AssertionError("unreachable")
+
+
+def _module(unit: SourceUnit, node: ParsoNode) -> Description:
+    body: List[ProviderHandle] = []
+    for c in _kids(node):
+        if c.type in ("endmarker", "newline"):
+            continue
+        body.extend(_stmt_handles(unit, c))
+    return Description(kind="Module", raw_span=Span(0, len(unit.source)), anchors=(),
+                        slots=(("body", Children(tuple(body))),))
+
+
+def _atom(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    first = kids[0]
+    if _is_leaf(first) and first.value == "(":
+        if len(kids) == 2:  # '()' empty tuple
+            return _bare_tuple(unit, (), _span(unit, node)).describe()
+        inner = kids[1]
+        if inner.type == "yield_expr":
+            return _describe(unit, inner)
+        if inner.type == "testlist_comp":
+            ik = _kids(inner)
+            if len(ik) >= 2 and ik[1].type == "comp_for" or (len(ik) >= 2 and ik[1].type == "sync_comp_for"):
+                return _genexp(unit, ik[0], ik[1:]).describe()
+            elts = _strip_commas(ik)
+            has_trailing_comma = _is_leaf(ik[-1]) and ik[-1].value == ","
+            if len(elts) == 1 and not has_trailing_comma:
+                # a merely-parenthesized single expression: parens excluded
+                return _describe(unit, elts[0])
+            return _bare_tuple(unit, elts, _span(unit, node)).describe()
+        # a single parenthesized expression
+        return _describe(unit, inner)
+    if _is_leaf(first) and first.value == "[":
+        if len(kids) == 2:
+            return Description(kind="List", raw_span=_span(unit, node), anchors=(),
+                                slots=(("elts", Children(())),))
+        inner = kids[1]
+        if inner.type in ("testlist_comp",):
+            ik = _kids(inner)
+            if len(ik) >= 2 and ik[1].type in ("comp_for", "sync_comp_for"):
+                elt = _h(unit, ik[0])
+                gens = _comp_clauses(unit, ik[1:])
+                return Description(kind="ListComp", raw_span=_span(unit, node), anchors=(),
+                                    slots=(("elt", Child(elt)), ("generators", Children(gens))))
+            elts = _strip_commas(ik)
+            return Description(kind="List", raw_span=_span(unit, node), anchors=(),
+                                slots=(("elts", Children(tuple(_h(unit, e) for e in elts))),))
+        return Description(kind="List", raw_span=_span(unit, node), anchors=(),
+                            slots=(("elts", Children((_h(unit, inner),))),))
+    if _is_leaf(first) and first.value == "{":
+        if len(kids) == 2:
+            return Description(kind="Dict", raw_span=_span(unit, node), anchors=(),
+                                slots=(("items", Children(())),))
+        return _dictorset(unit, node, kids[1])
+    if first.type == "fstring":
+        return _describe(unit, first)
+    membrane_panic(
+        owner="parso_adapter._atom",
+        observed=f"atom starting with {getattr(first, 'value', first.type)!r} not recognized",
+        requested="'(', '[', '{' grouping, or an fstring",
+        fix="extend _atom deliberately",
+    )
+    raise AssertionError("unreachable")
+
+
+def _dictorset(unit: SourceUnit, atom_node: ParsoNode, inner: ParsoNode) -> Description:
+    span = _span(unit, atom_node)
+    if inner.type == "dictorsetmaker":
+        ik = _kids(inner)
+        has_colon = any(_is_leaf(c) and c.value == ":" for c in ik)
+        has_comp = any(c.type in ("comp_for", "sync_comp_for") for c in ik)
+        if has_colon and has_comp:
+            colon_i = next(i for i, c in enumerate(ik) if _is_leaf(c) and c.value == ":")
+            key = _h(unit, ik[0])
+            value = _h(unit, ik[colon_i + 1])
+            gens = _comp_clauses(unit, ik[colon_i + 2:])
+            return Description(kind="DictComp", raw_span=span, anchors=(),
+                                slots=(("key", Child(key)), ("value", Child(value)),
+                                       ("generators", Children(gens))))
+        if has_colon:
+            items: List[ProviderHandle] = []
+            i = 0
+            while i < len(ik):
+                c = ik[i]
+                if _is_leaf(c) and c.value == ",":
+                    i += 1
+                    continue
+                if _is_leaf(c) and c.value == "**":
+                    items.append(_fixed("DictItem", None,
+                                         (("key", MaybeChild(None)), ("value", Child(_h(unit, ik[i + 1]))))))
+                    i += 2
+                    continue
+                key_n = c
+                value_n = ik[i + 2]
+                items.append(_fixed("DictItem", None,
+                                     (("key", MaybeChild(_h(unit, key_n))), ("value", Child(_h(unit, value_n))))))
+                i += 3
+            return Description(kind="Dict", raw_span=span, anchors=(),
+                                slots=(("items", Children(tuple(items))),))
+        if has_comp:
+            elt = _h(unit, ik[0])
+            gens = _comp_clauses(unit, ik[1:])
+            return Description(kind="SetComp", raw_span=span, anchors=(),
+                                slots=(("elt", Child(elt)), ("generators", Children(gens))))
+        elts = _strip_commas(ik)
+        return Description(kind="Set", raw_span=span, anchors=(),
+                            slots=(("elts", Children(tuple(_h(unit, e) for e in elts))),))
+    # single element -> a one-item set
+    return Description(kind="Set", raw_span=span, anchors=(),
+                        slots=(("elts", Children((_h(unit, inner),))),))
+
+
+def _comp_clauses(unit: SourceUnit, nodes: Sequence[ParsoNode]) -> Tuple[ProviderHandle, ...]:
+    out: List[ProviderHandle] = []
+    for n in nodes:
+        if n.type in ("comp_for", "sync_comp_for"):
+            out.append(_h(unit, n))
+        elif n.type == "comp_if":
+            # folded into the preceding Comprehension's ifs by _comprehension
+            continue
+        else:
+            membrane_panic(
+                owner="parso_adapter._comp_clauses",
+                observed=f"comprehension clause child {n.type!r} not recognized",
+                requested="comp_for/sync_comp_for or comp_if",
+                fix="extend _comp_clauses deliberately",
+            )
+    return tuple(out)
+
+
+def _comprehension(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    is_async = _is_leaf(kids[0]) and kids[0].value == "async"
+    if is_async:
+        kids = kids[1:]
+    # kids: 'for' exprlist 'in' or_test [comp_iter]
+    target_n = kids[1]
+    iter_n = kids[3]
+    ifs: List[ProviderHandle] = []
+    rest = kids[4:]
+    for r in rest:
+        r2 = r
+        while r2.type == "comp_iter":
+            r2 = _kids(r2)[0]
+        if r2.type == "comp_if":
+            ik = _kids(r2)
+            ifs.append(_h(unit, ik[1]))
+            # a comp_if may itself carry a further comp_iter (chained ifs/for)
+            if len(ik) > 2:
+                membrane_panic(
+                    owner="parso_adapter._comprehension",
+                    observed="comp_if with a nested comp_iter tail not yet folded",
+                    requested="a flattened ifs/for chain",
+                    fix="extend _comprehension to fold chained comp_iter tails",
+                )
+        elif r2.type in ("comp_for", "sync_comp_for"):
+            membrane_panic(
+                owner="parso_adapter._comprehension",
+                observed="chained 'for ... for ...' clause not yet folded into a flat generators list",
+                requested="each comp_for as its own top-level Comprehension",
+                fix="extend the caller to walk comp_iter tails, not just this node",
+            )
+    target = target_n if target_n.type != "exprlist" else None
+    if target is None:
+        elts = _strip_commas(_kids(target_n))
+        target_handle: ProviderHandle = _bare_tuple(unit, elts)
+    else:
+        target_handle = _h(unit, target_n)
+    return Description(
+        kind="Comprehension",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("target", Child(target_handle)),
+            ("iter", Child(_h(unit, iter_n))),
+            ("ifs", Children(tuple(ifs))),
+            ("is_async", SlotLeaf(is_async)),
+        ),
+    )
+
+
+def _genexp(unit: SourceUnit, elt_node: ParsoNode, clause_nodes: Sequence[ParsoNode]) -> ProviderHandle:
+    elt = _h(unit, elt_node)
+    gens = _comp_clauses(unit, clause_nodes)
+    return _fixed("GeneratorExp", None, (("elt", Child(elt)), ("generators", Children(gens))))
+
+
+# ---- statements -----------------------------------------------------------
+
+
+def _expr_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    span = _span(unit, node)
+    # annotated assignment: NAME ':' test ['=' test]
+    colon_idx = next((i for i, c in enumerate(kids) if _is_leaf(c) and c.value == ":"), None)
+    if colon_idx is not None:
+        target = _h(unit, kids[0])
+        annotation = _h(unit, kids[colon_idx + 1])
+        value = None
+        if len(kids) > colon_idx + 2:
+            value = _h(unit, kids[colon_idx + 3])
+        return Description(kind="AnnAssign", raw_span=span, anchors=(),
+                            slots=(("target", Child(target)), ("annotation", Child(annotation)),
+                                   ("value", MaybeChild(value)), ("simple", SlotLeaf(True))))
+    if len(kids) == 1:
+        return _describe(unit, kids[0])
+    op = kids[1]
+    if op.value == "=":
+        targets = [kids[0]] + [kids[i] for i in range(2, len(kids) - 1, 2)]
+        value = kids[-1]
+        return Description(kind="Assign", raw_span=span, anchors=(),
+                            slots=(("targets", Children(tuple(_h(unit, t) for t in targets))),
+                                   ("value", Child(_h(unit, value)))))
+    aug_kind = _AUG_TOKEN.get(op.value)
+    if aug_kind is None:
+        membrane_panic(
+            owner="parso_adapter._expr_stmt",
+            observed=f"expr_stmt operator {op.value!r} not recognized",
+            requested="'=' (chained) or an augmented-assignment token",
+            fix="extend _expr_stmt deliberately",
+        )
+    return Description(kind="AugAssign", raw_span=span, anchors=(),
+                        slots=(("target", Child(_h(unit, kids[0]))),
+                               ("op", OpLeaf(operator_for(aug_kind))),
+                               ("value", Child(_h(unit, kids[2])))))
+
+
+def _return_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    value = _h(unit, kids[1]) if len(kids) > 1 else None
+    return Description(kind="Return", raw_span=_span(unit, node), anchors=(),
+                        slots=(("value", MaybeChild(value)),))
+
+
+def _yield_expr(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    span = _span(unit, node)
+    if len(kids) == 1:
+        return Description(kind="Yield", raw_span=span, anchors=(), slots=(("value", MaybeChild(None)),))
+    arg = kids[1]
+    if arg.type == "yield_arg":
+        ak = _kids(arg)
+        return Description(kind="YieldFrom", raw_span=span, anchors=(),
+                            slots=(("value", Child(_h(unit, ak[1]))),))
+    if arg.type == "testlist_star_expr" or arg.type == "testlist":
+        elts = _strip_commas(_kids(arg))
+        value = _bare_tuple(unit, elts) if len(elts) > 1 else _h(unit, elts[0])
+        return Description(kind="Yield", raw_span=span, anchors=(), slots=(("value", MaybeChild(value)),))
+    return Description(kind="Yield", raw_span=span, anchors=(), slots=(("value", MaybeChild(_h(unit, arg))),))
+
+
+def _raise_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    exc = cause = None
+    if len(kids) > 1:
+        exc = kids[1]
+        if len(kids) > 2:
+            cause = kids[3]
+    return Description(kind="Raise", raw_span=_span(unit, node), anchors=(),
+                        slots=(("exc", MaybeChild(_h(unit, exc) if exc is not None else None)),
+                               ("cause", MaybeChild(_h(unit, cause) if cause is not None else None))))
+
+
+def _del_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    target = kids[1]
+    if target.type == "exprlist":
+        elts = _strip_commas(_kids(target))
+    else:
+        elts = [target]
+    return Description(kind="Delete", raw_span=_span(unit, node), anchors=(),
+                        slots=(("targets", Children(tuple(_h(unit, e) for e in elts))),))
+
+
+def _import_name(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    dotted = kids[1]
+    names = _dotted_as_names(unit, dotted)
+    return Description(kind="Import", raw_span=_span(unit, node), anchors=(),
+                        slots=(("names", Children(names)),))
+
+
+def _dotted_name_str(node: ParsoNode) -> str:
+    if node.type == "dotted_name":
+        return "".join(c.value for c in _kids(node) if not (_is_leaf(c) and c.value == "."))
+    return node.value
+
+
+def _dotted_as_names(unit: SourceUnit, node: ParsoNode) -> Tuple[ProviderHandle, ...]:
+    if node.type == "dotted_as_names":
+        items = _strip_commas(_kids(node))
+    else:
+        items = [node]
+    out = []
+    for it in items:
+        out.append(_dotted_as_name(unit, it))
+    return tuple(out)
+
+
+def _dotted_as_name(unit: SourceUnit, node: ParsoNode) -> ProviderHandle:
+    if node.type == "dotted_as_name":
+        k = _kids(node)
+        name = _dotted_name_str(k[0])
+        asname = k[2].value
+    else:
+        name = _dotted_name_str(node)
+        asname = None
+    return _fixed("ImportAlias", _span(unit, node),
+                  (("name", SlotLeaf(name)), ("asname", SlotLeaf(asname))))
+
+
+def _import_from(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    i = 1
+    level = 0
+    module: Optional[str] = None
+    while i < len(kids) and (_is_leaf(kids[i]) and kids[i].value in (".", "...")):
+        level += len(kids[i].value)
+        i += 1
+    if i < len(kids) and not (_is_leaf(kids[i]) and kids[i].value == "import"):
+        module = _dotted_name_str(kids[i])
+        i += 1
+    assert _is_leaf(kids[i]) and kids[i].value == "import"
+    i += 1
+    if _is_leaf(kids[i]) and kids[i].value == "*":
+        names = (_fixed("ImportAlias", _span(unit, kids[i]), (("name", SlotLeaf("*")), ("asname", SlotLeaf(None)))),)
+    elif _is_leaf(kids[i]) and kids[i].value == "(":
+        names = _import_as_names(unit, kids[i + 1])
+    else:
+        names = _import_as_names(unit, kids[i])
+    return Description(kind="ImportFrom", raw_span=_span(unit, node), anchors=(),
+                        slots=(("module", SlotLeaf(module)), ("names", Children(names)),
+                               ("level", SlotLeaf(level))))
+
+
+def _import_as_names(unit: SourceUnit, node: ParsoNode) -> Tuple[ProviderHandle, ...]:
+    if node.type == "import_as_names":
+        items = _strip_commas(_kids(node))
+    else:
+        items = [node]
+    out = []
+    for it in items:
+        if it.type == "import_as_name":
+            k = _kids(it)
+            out.append(_fixed("ImportAlias", _span(unit, it),
+                               (("name", SlotLeaf(k[0].value)), ("asname", SlotLeaf(k[2].value)))))
+        else:
+            out.append(_fixed("ImportAlias", _span(unit, it),
+                               (("name", SlotLeaf(it.value)), ("asname", SlotLeaf(None)))))
+    return tuple(out)
+
+
+def _global_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _strip_commas(_kids(node)[1:])
+    return Description(kind="Global", raw_span=_span(unit, node), anchors=(),
+                        slots=(("names", SlotLeaf(tuple(k.value for k in kids))),))
+
+
+def _nonlocal_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _strip_commas(_kids(node)[1:])
+    return Description(kind="Nonlocal", raw_span=_span(unit, node), anchors=(),
+                        slots=(("names", SlotLeaf(tuple(k.value for k in kids))),))
+
+
+def _assert_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    test = _h(unit, kids[1])
+    msg = _h(unit, kids[3]) if len(kids) > 3 else None
+    return Description(kind="Assert", raw_span=_span(unit, node), anchors=(),
+                        slots=(("test", Child(test)), ("msg", MaybeChild(msg))))
+
+
+def _if_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    # if TEST ':' suite (elif TEST ':' suite)* (else ':' suite)?
+    return _if_chain(unit, kids, 0, _span(unit, node))
+
+
+def _if_chain(unit: SourceUnit, kids: List[ParsoNode], i: int, outer_span: Span) -> Description:
+    keyword = kids[i]
+    test = _h(unit, kids[i + 1])
+    body = _stmts(unit, kids[i + 3])
+    j = i + 4
+    if j < len(kids) and kids[j].type == "keyword" and kids[j].value == "elif":
+        orelse: Tuple[ProviderHandle, ...] = (_fixed_if_chain(unit, kids, j, outer_span),)
+    elif j < len(kids) and kids[j].type == "keyword" and kids[j].value == "else":
+        orelse = _stmts(unit, kids[j + 2])
+    else:
+        orelse = ()
+    span = Span(_span(unit, keyword).start, outer_span.end) if i > 0 else outer_span
+    return Description(kind="If", raw_span=span, anchors=(),
+                        slots=(("test", Child(test)), ("body", Children(body)), ("orelse", Children(orelse))))
+
+
+def _fixed_if_chain(unit: SourceUnit, kids: List[ParsoNode], i: int, outer_span: Span) -> ProviderHandle:
+    d = _if_chain(unit, kids, i, outer_span)
+    return _fixed(d.kind, d.raw_span, d.slots, d.anchors)
+
+
+def _while_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    test = _h(unit, kids[1])
+    body = _stmts(unit, kids[3])
+    orelse: Tuple[ProviderHandle, ...] = ()
+    if len(kids) > 4:
+        orelse = _stmts(unit, kids[6])
+    return Description(kind="While", raw_span=_span(unit, node), anchors=(),
+                        slots=(("test", Child(test)), ("body", Children(body)), ("orelse", Children(orelse))))
+
+
+def _for_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    target_n = kids[1]
+    if target_n.type == "exprlist":
+        elts = _strip_commas(_kids(target_n))
+        target = _bare_tuple(unit, elts) if len(elts) > 1 else _h(unit, elts[0])
+    else:
+        target = _h(unit, target_n)
+    iter_n = kids[3]
+    if iter_n.type == "testlist":
+        elts = _strip_commas(_kids(iter_n))
+        iter_handle: ProviderHandle = _bare_tuple(unit, elts)
+    else:
+        iter_handle = _h(unit, iter_n)
+    body = _stmts(unit, kids[5])
+    orelse: Tuple[ProviderHandle, ...] = ()
+    if len(kids) > 6:
+        orelse = _stmts(unit, kids[8])
+    return Description(kind="For", raw_span=_span(unit, node), anchors=(),
+                        slots=(("target", Child(target)), ("iter", Child(iter_handle)),
+                               ("body", Children(body)), ("orelse", Children(orelse))))
+
+
+def _try_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    body = _stmts(unit, kids[2])
+    handlers: List[ProviderHandle] = []
+    orelse: Tuple[ProviderHandle, ...] = ()
+    finalbody: Tuple[ProviderHandle, ...] = ()
+    is_star = False
+    i = 3
+    while i < len(kids):
+        c = kids[i]
+        if c.type == "except_clause":
+            ek = _kids(c)
+            j = 1
+            exc_type = None
+            exc_name = None
+            if j < len(ek) and _is_leaf(ek[j]) and ek[j].value == "*":
+                is_star = True
+                j += 1
+            if j < len(ek):
+                exc_type = ek[j]
+                j += 1
+            if j < len(ek) and _is_leaf(ek[j]) and ek[j].value == "as":
+                exc_name = ek[j + 1].value
+            handler_body = _stmts(unit, kids[i + 2])
+            handlers.append(_fixed(
+                "ExceptHandler",
+                _span(unit, c).envelope(_span(unit, kids[i + 2])),
+                (("type_", MaybeChild(_h(unit, exc_type) if exc_type is not None else None)),
+                 ("name", SlotLeaf(exc_name)), ("body", Children(handler_body))),
+            ))
+            i += 3
+        elif c.type == "keyword" and c.value == "else":
+            orelse = _stmts(unit, kids[i + 2])
+            i += 3
+        elif c.type == "keyword" and c.value == "finally":
+            finalbody = _stmts(unit, kids[i + 2])
+            i += 3
+        else:
+            i += 1
+    kind = "TryStar" if is_star else "Try"
+    return Description(kind=kind, raw_span=_span(unit, node), anchors=(),
+                        slots=(("body", Children(body)), ("handlers", Children(tuple(handlers))),
+                               ("orelse", Children(orelse)), ("finalbody", Children(finalbody))))
+
+
+def _with_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    items_nodes = [c for c in kids[1:-2] if not (_is_leaf(c) and c.value == ",")]
+    items: List[ProviderHandle] = []
+    for it in items_nodes:
+        if it.type == "with_item":
+            ik = _kids(it)
+            ctx = _h(unit, ik[0])
+            var = _h(unit, ik[2]) if len(ik) > 2 else None
+            items.append(_fixed("WithItem", _span(unit, it),
+                                 (("context_expr", Child(ctx)), ("optional_vars", MaybeChild(var)))))
+        else:
+            items.append(_fixed("WithItem", _span(unit, it),
+                                 (("context_expr", Child(_h(unit, it))), ("optional_vars", MaybeChild(None)))))
+    body = _stmts(unit, kids[-1])
+    return Description(kind="With", raw_span=_span(unit, node), anchors=(),
+                        slots=(("items", Children(tuple(items))), ("body", Children(body))))
+
+
+def _funcdef(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    name = kids[1].value
+    idx = 2
+    if kids[idx].type in ("typeparams",):
+        idx += 1  # PEP 695 generic params: not further destructured (rare in this corpus)
+    params_node = kids[idx]
+    idx += 1
+    returns = None
+    if _is_leaf(kids[idx]) and kids[idx].value == "->":
+        returns = kids[idx + 1]
+        idx += 2
+    body = _stmts(unit, kids[-1])
+    return Description(kind="FunctionDef", raw_span=_span(unit, node), anchors=(),
+                        slots=(("name", SlotLeaf(name)), ("params", Children(_flatten_params(unit, params_node))),
+                               ("body", Children(body)), ("decorators", Children(())),
+                               ("returns", MaybeChild(_h(unit, returns) if returns is not None else None)),
+                               ("type_params", Children(()))))
+
+
+def _classdef(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    name = kids[1].value
+    bases: Tuple[ProviderHandle, ...] = ()
+    keywords: Tuple[ProviderHandle, ...] = ()
+    idx = 2
+    if idx < len(kids) and _is_leaf(kids[idx]) and kids[idx].value == "(":
+        if not (_is_leaf(kids[idx + 1]) and kids[idx + 1].value == ")"):
+            arglist_kids = _kids(kids[idx + 1]) if kids[idx + 1].type == "arglist" else [kids[idx + 1]]
+            b, kw = _call_args(unit, arglist_kids)
+            bases, keywords = tuple(b), tuple(kw)
+    body = _stmts(unit, kids[-1])
+    return Description(kind="ClassDef", raw_span=_span(unit, node), anchors=(),
+                        slots=(("name", SlotLeaf(name)), ("bases", Children(bases)),
+                               ("keywords", Children(keywords)), ("body", Children(body)),
+                               ("decorators", Children(())), ("type_params", Children(()))))
+
+
+def _decorated(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    decorators = [c for c in kids[:-1] if c.type == "decorator"]
+    dec_handles = tuple(_h(unit, _kids(d)[1]) for d in decorators)
+    target = kids[-1]
+    if target.type == "async_funcdef":
+        base = _funcdef(unit, _kids(target)[1])
+        kind = "AsyncFunctionDef"
+        span = Span(_span(unit, target).start, base.raw_span.end)
+    else:
+        base = _describe(unit, target)
+        kind = base.kind
+        span = base.raw_span
+    new_slots = tuple(
+        (name, Children(dec_handles)) if name == "decorators" else (name, slot)
+        for name, slot in base.slots
+    )
+    return Description(kind=kind, raw_span=span, anchors=(), slots=new_slots)
+
+
+def _async_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    inner = kids[1]
+    span = _span(unit, node)
+    if inner.type == "funcdef":
+        base = _funcdef(unit, inner)
+        return Description(kind="AsyncFunctionDef", raw_span=span, anchors=(), slots=base.slots)
+    if inner.type == "for_stmt":
+        base = _for_stmt(unit, inner)
+        return Description(kind="AsyncFor", raw_span=span, anchors=(), slots=base.slots)
+    if inner.type == "with_stmt":
+        base = _with_stmt(unit, inner)
+        return Description(kind="AsyncWith", raw_span=span, anchors=(), slots=base.slots)
+    membrane_panic(
+        owner="parso_adapter._async_stmt",
+        observed=f"async_stmt wrapping {inner.type!r} not recognized",
+        requested="funcdef, for_stmt, or with_stmt",
+        fix="extend _async_stmt deliberately",
+    )
+    raise AssertionError("unreachable")
+
+
+def _lambdef(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    params_node = None
+    body_node = kids[-1]
+    if len(kids) > 3:
+        params_node = kids[1]
+    return Description(kind="Lambda", raw_span=_span(unit, node), anchors=(),
+                        slots=(("params", Children(_flatten_params(unit, params_node))),
+                               ("body", Child(_h(unit, body_node)))))
+
+
+def _ternary(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    body = _h(unit, kids[0])
+    test = _h(unit, kids[2])
+    orelse = _h(unit, kids[4])
+    return Description(kind="IfExp", raw_span=_span(unit, node), anchors=(),
+                        slots=(("test", Child(test)), ("body", Child(body)), ("orelse", Child(orelse))))
+
+
+def _namedexpr(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    return Description(kind="NamedExpr", raw_span=_span(unit, node), anchors=(),
+                        slots=(("target", Child(_h(unit, kids[0]))), ("value", Child(_h(unit, kids[2])))))
+
+
+def _not_test(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    return Description(kind="UnaryOp", raw_span=_span(unit, node), anchors=(),
+                        slots=(("op", OpLeaf(operator_for("Not"))), ("operand", Child(_h(unit, kids[1])))))
+
+
+def _factor(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    kind = _UNARY_TOKEN.get(kids[0].value)
+    if kind is None:
+        membrane_panic(
+            owner="parso_adapter._factor",
+            observed=f"unary token {kids[0].value!r} not recognized",
+            requested="'+', '-', or '~'",
+            fix="extend _UNARY_TOKEN deliberately",
+        )
+    return Description(kind="UnaryOp", raw_span=_span(unit, node), anchors=(),
+                        slots=(("op", OpLeaf(operator_for(kind))), ("operand", Child(_h(unit, kids[1])))))
+
+
+def _power(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    left = _h(unit, kids[0])
+    right = _h(unit, kids[2])
+    return Description(kind="BinOp", raw_span=_span(unit, node), anchors=(),
+                        slots=(("left", Child(left)), ("op", OpLeaf(operator_for("Pow"))), ("right", Child(right))))
+
+
+def _star_expr(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    return Description(kind="Starred", raw_span=_span(unit, node), anchors=(),
+                        slots=(("value", Child(_h(unit, kids[1]))),))
+
+
+def _atom_expr(unit: SourceUnit, node: ParsoNode) -> Description:
+    kids = _kids(node)
+    has_await = _is_leaf(kids[0]) and kids[0].value == "await"
+    await_start = _span(unit, kids[0]).start if has_await else None
+    atom = kids[1] if has_await else kids[0]
+    trailers = kids[2:] if has_await else kids[1:]
+    handle = _fold_trailers(unit, atom, trailers, has_await, await_start)
+    return handle.describe()
+
+
+def _bare_tuple_node(unit: SourceUnit, node: ParsoNode) -> Description:
+    elts = _strip_commas(_kids(node))
+    return _bare_tuple(unit, elts, _span(unit, node)).describe()  # note: overridden below for envelope
+
+
+_DISPATCH = {
+    "file_input": _module,
+    "atom": _atom,
+    "atom_expr": _atom_expr,
+    "power": _power,
+    "factor": _factor,
+    "not_test": _not_test,
+    "and_test": lambda u, n: _boolop(u, n, "And"),
+    "or_test": lambda u, n: _boolop(u, n, "Or"),
+    "comparison": _compare,
+    "expr": lambda u, n: _fold_binop(u, n).describe(),
+    "xor_expr": lambda u, n: _fold_binop(u, n).describe(),
+    "and_expr": lambda u, n: _fold_binop(u, n).describe(),
+    "shift_expr": lambda u, n: _fold_binop(u, n).describe(),
+    "arith_expr": lambda u, n: _fold_binop(u, n).describe(),
+    "term": lambda u, n: _fold_binop(u, n).describe(),
+    "star_expr": _star_expr,
+    "test": _ternary,
+    "namedexpr_test": _namedexpr,
+    "lambdef": _lambdef,
+    "lambdef_nocond": _lambdef,
+    "comp_for": _comprehension,
+    "sync_comp_for": _comprehension,
+    "fstring_expr": _describe_fstring_expr,
+    "strings": lambda u, n: _join_string_pieces(u, _kids(n)).describe(),
+    "fstring": lambda u, n: _fixed("JoinedStr", _span(u, n),
+                                    (("values", Children(tuple(_fstring_values(u, n)))),)).describe(),
+    "expr_stmt": _expr_stmt,
+    "return_stmt": _return_stmt,
+    "yield_expr": _yield_expr,
+    "raise_stmt": _raise_stmt,
+    "del_stmt": _del_stmt,
+    "import_name": _import_name,
+    "import_from": _import_from,
+    "global_stmt": _global_stmt,
+    "nonlocal_stmt": _nonlocal_stmt,
+    "assert_stmt": _assert_stmt,
+    "if_stmt": _if_stmt,
+    "while_stmt": _while_stmt,
+    "for_stmt": _for_stmt,
+    "try_stmt": _try_stmt,
+    "with_stmt": _with_stmt,
+    "funcdef": _funcdef,
+    "classdef": _classdef,
+    "decorated": _decorated,
+    "async_stmt": _async_stmt,
+    "async_funcdef": lambda u, n: _funcdef(u, _kids(n)[1]),
+    "testlist_star_expr": _bare_tuple_node,
+    "testlist": _bare_tuple_node,
+    "exprlist": _bare_tuple_node,
+}
+
+
+class ParsoProvider(Provider):
+    """parso: pure-Python, error-recovering — the third candidate provider."""
+
+    name = "parso"
+
+    def __init__(self, version: str = "3.12") -> None:
+        self._grammar = parso.load_grammar(version=version)
+
+    def parse(self, unit: SourceUnit) -> ProviderHandle:
+        # error_recovery=False + catching parso's own ParserSyntaxError (which
+        # is NOT a SyntaxError subclass) and re-raising as SyntaxError is the
+        # one place this adapter widens the contract's exception type: the
+        # membrane's corpus/differential harnesses both catch SyntaxError to
+        # mean "the PROVIDER refused this source," and parso's own error type
+        # does not satisfy that without translation.
+        try:
+            module = self._grammar.parse(unit.source, error_recovery=False)
+        except parso.parser.ParserSyntaxError as err:
+            raise SyntaxError(str(err)) from err
+        return _Handle(unit, module)

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/tree_sitter_python_adapter.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/tree_sitter_python_adapter.py
@@ -1,0 +1,1386 @@
+"""tree-sitter-python provider adapter (#5940, #5932) — candidate #4.
+
+THE ONLY MODULE IN THIS PACKAGE THAT MAY NAME ``tree_sitter`` /
+``tree_sitter_python``. Same read-only contract as the other adapters:
+``parse(unit) -> handle``, and per handle a single ``describe()`` giving our
+kind, our codepoint span, and our fields as slots.
+
+Why tree-sitter is a credible fourth candidate: it is a C library with an
+error-tolerant, incremental GLR-style parser (built for editors to re-parse
+on every keystroke) and does not call CPython's ``compile()`` — the same
+property that makes LibCST and parso immune to #5932. Its grammar is also
+the closest structural match to our AST-shaped membrane of any candidate
+examined: binary/boolean/comparison operator chains are ALREADY nested
+left-associatively by the grammar (unlike parso's flat n-ary chains that
+this package's ``parso_adapter`` must fold by hand), and most productions
+expose named fields (``child_by_field_name``) instead of requiring
+positional child-counting.
+
+MAPPING NOTES
+=============
+
+- **Byte columns, like CPython — NOT like parso/LibCST.** tree-sitter's
+  ``start_point``/``end_point`` report ``(row, column)`` where the column
+  is a UTF-8 BYTE offset within the row, not a codepoint offset (verified:
+  a non-ASCII character before a node shifts its byte column but not its
+  codepoint column). This adapter reuses the exact same seam the CPython
+  adapter built — ``LineTable.offset_from_byte_col`` — just fed 0-based
+  rows instead of CPython's 1-based lines.
+- **Grouping parens are excluded** for a ``parenthesized_expression``: the
+  inner expression is unwrapped and keeps its own (narrower) span — our
+  ruling. A parenthesized tuple's parens ARE part of the ``Tuple`` span
+  (the one ruled exception) since a bracketed comma list is its own
+  ``tuple``/``list``/... node whose span already includes the brackets.
+- **Anonymous/punctuation nodes** (``(``, ``)``, ``,``, ``:``, keywords)
+  are unnamed children (``is_named`` False) and are skipped everywhere
+  except where their presence/absence changes meaning (e.g. ``except*``,
+  ``async for``).
+- **Decorators**: ``decorated_definition`` wraps ``decorator*`` plus the
+  ``funcdef``/``classdef`` in a ``definition`` field; the def's span in our
+  membrane starts at ``def``/``class``, excluding decorators — matches
+  ``FunctionDef``/``ClassDef`` spanning from their own keyword, computed
+  here by re-describing the inner definition and only widening the
+  ``decorators`` slot, mirroring the LibCST/parso adapters.
+- **match/case**: tree-sitter-python has first-class ``match_statement`` /
+  ``case_clause`` / ``*_pattern`` grammar (unlike parso 0.8's grammar,
+  which has none at all — see ``parso_adapter``'s docstring finding). This
+  adapter maps the common pattern shapes; an unmapped pattern shape panics
+  as a MISSING rather than a guess.
+
+A tree-sitter shape with no rule here panics as a MISSING at the boundary.
+There is no generic fallback and no attribute sniffing: an unmapped node
+type is the conformance finding itself.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence, Tuple
+
+import tree_sitter
+import tree_sitter_python as tspython
+
+from .backend import (
+    Child,
+    Children,
+    Description,
+    Leaf as SlotLeaf,
+    MaybeChild,
+    OpLeaf,
+    OpsLeaf,
+    Provider,
+    ProviderHandle,
+    Slot,
+)
+from .nodes import SourceUnit
+from .operators import Operator, operator_for
+from .panic import membrane_panic
+from .spans import Span
+
+TSNode = object  # tree_sitter.Node, kept untyped at the boundary
+
+_LANGUAGE = tree_sitter.Language(tspython.language())
+
+
+def _span(unit: SourceUnit, node: TSNode) -> Span:
+    table = unit.line_table
+    sr, sc = node.start_point
+    er, ec = node.end_point
+    return Span(
+        table.offset_from_byte_col(sr + 1, sc),
+        table.offset_from_byte_col(er + 1, ec),
+    )
+
+
+_SKIP_TYPES = frozenset({"comment", "line_continuation"})
+
+
+def _named(node: TSNode) -> List[TSNode]:
+    return [c for c in node.children if c.is_named and c.type not in _SKIP_TYPES]
+
+
+def _field(node: TSNode, name: str) -> Optional[TSNode]:
+    return node.child_by_field_name(name)
+
+
+def _fields(node: TSNode, name: str) -> List[TSNode]:
+    return list(node.children_by_field_name(name))
+
+
+def _text(unit: SourceUnit, node: TSNode) -> str:
+    span = _span(unit, node)
+    return unit.source[span.start:span.end]
+
+
+class _Handle(ProviderHandle):
+    __slots__ = ("_unit", "_node", "_desc")
+
+    def __init__(self, unit: SourceUnit, node: TSNode) -> None:
+        self._unit = unit
+        self._node = node
+        self._desc: Optional[Description] = None
+
+    def describe(self) -> Description:
+        if self._desc is None:
+            self._desc = _describe(self._unit, self._node)
+        return self._desc
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<ts-handle {self._node.type} in {self._unit.filename}>"
+
+
+class _Fixed(ProviderHandle):
+    __slots__ = ("_desc",)
+
+    def __init__(self, desc: Description) -> None:
+        self._desc = desc
+
+    def describe(self) -> Description:
+        return self._desc
+
+
+def _fixed(kind: str, raw_span: Optional[Span], slots: Tuple[Tuple[str, Slot], ...],
+           anchors: Tuple[Span, ...] = ()) -> _Fixed:
+    return _Fixed(Description(kind=kind, raw_span=raw_span, anchors=anchors, slots=slots))
+
+
+def _h(unit: SourceUnit, node: Optional[TSNode]) -> Optional[ProviderHandle]:
+    return _Handle(unit, node) if node is not None else None
+
+
+_BIN_TOKEN = {
+    "+": "Add", "-": "Sub", "*": "Mult", "@": "MatMult", "/": "Div",
+    "%": "Mod", "**": "Pow", "<<": "LShift", ">>": "RShift", "|": "BitOr",
+    "^": "BitXor", "&": "BitAnd", "//": "FloorDiv",
+}
+_AUG_TOKEN = {k + "=": v for k, v in _BIN_TOKEN.items()}
+_UNARY_TOKEN = {"+": "UAdd", "-": "USub", "~": "Invert"}
+_CMP_TOKEN = {
+    "<": "Lt", ">": "Gt", "==": "Eq", ">=": "GtE", "<=": "LtE", "!=": "NotEq",
+    "<>": "NotEq", "in": "In", "not in": "NotIn", "is": "Is", "is not": "IsNot",
+}
+
+
+def _bool_kind(node_type: str) -> str:
+    return {"and": "And", "or": "Or"}[node_type]
+
+
+def _bare_tuple(unit: SourceUnit, elts: Sequence[TSNode], raw_span: Optional[Span]) -> ProviderHandle:
+    return _fixed("Tuple", raw_span, (("elts", Children(tuple(_h(unit, e) for e in elts))),))
+
+
+def _pattern_list_targets(unit: SourceUnit, node: TSNode) -> ProviderHandle:
+    """pattern_list / expression_list / tuple(without parens context) -> a
+    bare-tuple target, or the single element when there is exactly one."""
+    elts = _named(node)
+    if len(elts) == 1:
+        return _h(unit, elts[0])
+    return _bare_tuple(unit, elts, None)
+
+
+# --------------------------------------------------------------------------
+# statement bodies
+# --------------------------------------------------------------------------
+
+
+def _block_stmts(unit: SourceUnit, node: Optional[TSNode]) -> Tuple[ProviderHandle, ...]:
+    if node is None:
+        return ()
+    out = []
+    for c in _named(node):
+        out.append(_h(unit, c))
+    return tuple(out)
+
+
+# --------------------------------------------------------------------------
+# module / leaves
+# --------------------------------------------------------------------------
+
+
+def _module(unit: SourceUnit, node: TSNode) -> Description:
+    body = tuple(_h(unit, c) for c in _named(node) if c.type != "comment")
+    return Description(kind="Module", raw_span=Span(0, len(unit.source)), anchors=(),
+                        slots=(("body", Children(body)),))
+
+
+def _expression_statement(unit: SourceUnit, node: TSNode) -> Description:
+    kids = _named(node)
+    if len(kids) == 1:
+        return _describe(unit, kids[0])
+    # bare `a; b` on one physical statement line — each named child is its
+    # own small statement; the membrane has no multi-statement-line node,
+    # so this shape is not constructible as a single Expr and is a MISSING.
+    membrane_panic(
+        owner="tree_sitter_python_adapter._expression_statement",
+        observed=f"expression_statement with {len(kids)} named children",
+        requested="exactly one expression",
+        fix="extend the caller to flatten semicolon-joined statements before this point",
+    )
+    raise AssertionError("unreachable")
+
+
+def _leaf_identifier(unit: SourceUnit, node: TSNode) -> Description:
+    return Description(kind="Name", raw_span=_span(unit, node), anchors=(),
+                        slots=(("id", SlotLeaf(_text(unit, node))),))
+
+
+def _fixed_constant(span: Span, value: object, literal_kind: Optional[str] = None) -> Description:
+    return Description(kind="Constant", raw_span=span, anchors=(),
+                        slots=(("value", SlotLeaf(value)), ("literal_kind", SlotLeaf(literal_kind))))
+
+
+def _number(unit: SourceUnit, node: TSNode) -> Description:
+    import ast as _pyast
+    text = _text(unit, node)
+    value = _pyast.literal_eval(text)
+    return _fixed_constant(_span(unit, node), value)
+
+
+def _string_like(unit: SourceUnit, node: TSNode) -> Description:
+    """A single `string` node: plain literal, OR an f-string container
+    holding `interpolation` children — dispatch on that."""
+    interpolations = [c for c in node.children if c.type == "interpolation"]
+    span = _span(unit, node)
+    if not interpolations:
+        text = _text(unit, node)
+        import ast as _pyast
+        try:
+            value = _pyast.literal_eval(text)
+        except Exception:
+            value = text
+        return _fixed_constant(span, value)
+    values: List[ProviderHandle] = []
+    for c in node.children:
+        if c.type in ("string_start", "string_end"):
+            continue
+        if c.type == "string_content":
+            values.append(_h(unit, c))
+        elif c.type == "interpolation":
+            values.append(_interpolation(unit, c))
+        else:
+            membrane_panic(
+                owner="tree_sitter_python_adapter._string_like",
+                observed=f"f-string child {c.type!r} not recognized",
+                requested="string_content or interpolation",
+                fix="extend _string_like deliberately",
+            )
+    return Description(kind="JoinedStr", raw_span=span, anchors=(),
+                        slots=(("values", Children(tuple(values))),))
+
+
+def _concatenated_string(unit: SourceUnit, node: TSNode) -> Description:
+    """Implicit adjacent-string-literal concatenation: one Constant, or a
+    JoinedStr if any piece has interpolation — spanning the first piece's
+    start to the last's end (spec: including inter-piece whitespace)."""
+    pieces = _named(node)
+    span = Span(_span(unit, pieces[0]).start, _span(unit, pieces[-1]).end)
+    any_fstring = any(any(c.type == "interpolation" for c in p.children) for p in pieces)
+    if not any_fstring:
+        import ast as _pyast
+        text = "".join(_text(unit, p) for p in pieces)
+        try:
+            value = _pyast.literal_eval(text)
+        except Exception:
+            value = unit.source[span.start:span.end]
+        return _fixed_constant(span, value)
+    values: List[ProviderHandle] = []
+    for p in pieces:
+        for c in p.children:
+            if c.type in ("string_start", "string_end"):
+                continue
+            if c.type == "string_content":
+                values.append(_h(unit, c))
+            elif c.type == "interpolation":
+                values.append(_interpolation(unit, c))
+    return Description(kind="JoinedStr", raw_span=span, anchors=(), slots=(("values", Children(tuple(values))),))
+
+
+def _string_content(unit: SourceUnit, node: TSNode) -> Description:
+    span = _span(unit, node)
+    return _fixed_constant(span, unit.source[span.start:span.end])
+
+
+def _interpolation(unit: SourceUnit, node: TSNode) -> ProviderHandle:
+    value = _field(node, "expression")
+    conv_node = _field(node, "type_conversion")
+    conversion = ord(_text(unit, conv_node)[1]) if conv_node is not None else -1
+    spec_node = _field(node, "format_specifier")
+    format_spec: Optional[ProviderHandle] = None
+    if spec_node is not None:
+        spec_span = _span(unit, spec_node)
+        spec_values: List[ProviderHandle] = []
+        for c in spec_node.children:
+            if not c.is_named:
+                continue
+            if c.type == "format_expression":
+                inner = _field(c, "expression")
+                spec_values.append(_interpolation_like(unit, c, inner))
+            else:
+                spec_values.append(_h(unit, c))
+        format_spec = _fixed("JoinedStr", spec_span, (("values", Children(tuple(spec_values))),))
+    return _fixed(
+        "FormattedValue",
+        _span(unit, node),
+        (("value", Child(_h(unit, value))), ("conversion", SlotLeaf(conversion)),
+         ("format_spec", MaybeChild(format_spec))),
+    )
+
+
+def _interpolation_like(unit: SourceUnit, node: TSNode, inner: TSNode) -> ProviderHandle:
+    return _fixed("FormattedValue", _span(unit, node),
+                  (("value", Child(_h(unit, inner))), ("conversion", SlotLeaf(-1)),
+                   ("format_spec", MaybeChild(None))))
+
+
+_SIMPLE_LEAF = {
+    "true": lambda u, n: _fixed_constant(_span(u, n), True),
+    "false": lambda u, n: _fixed_constant(_span(u, n), False),
+    "none": lambda u, n: _fixed_constant(_span(u, n), None),
+    "ellipsis": lambda u, n: _fixed_constant(_span(u, n), Ellipsis),
+}
+
+
+# --------------------------------------------------------------------------
+# operators
+# --------------------------------------------------------------------------
+
+
+def _binary_operator(unit: SourceUnit, node: TSNode) -> Description:
+    left = _field(node, "left")
+    right = _field(node, "right")
+    op_node = _field(node, "operator")
+    kind = _BIN_TOKEN.get(op_node.type)
+    if kind is None:
+        membrane_panic(
+            owner="tree_sitter_python_adapter._binary_operator",
+            observed=f"binary operator token {op_node.type!r} not recognized",
+            requested="a known binary operator token",
+            fix="extend _BIN_TOKEN deliberately",
+        )
+    return Description(kind="BinOp", raw_span=_span(unit, node), anchors=(),
+                        slots=(("left", Child(_h(unit, left))), ("op", OpLeaf(operator_for(kind))),
+                               ("right", Child(_h(unit, right)))))
+
+
+def _boolean_operator(unit: SourceUnit, node: TSNode) -> Description:
+    kids = node.children
+    op_type = next(c.type for c in kids if not c.is_named)
+    values = _named(node)
+    return Description(kind="BoolOp", raw_span=_span(unit, node), anchors=(),
+                        slots=(("op", OpLeaf(operator_for(_bool_kind(op_type)))),
+                               ("values", Children(tuple(_h(unit, v) for v in values)))))
+
+
+def _not_operator(unit: SourceUnit, node: TSNode) -> Description:
+    arg = _field(node, "argument")
+    return Description(kind="UnaryOp", raw_span=_span(unit, node), anchors=(),
+                        slots=(("op", OpLeaf(operator_for("Not"))), ("operand", Child(_h(unit, arg)))))
+
+
+def _unary_operator(unit: SourceUnit, node: TSNode) -> Description:
+    op_node = _field(node, "operator")
+    arg = _field(node, "argument")
+    kind = _UNARY_TOKEN.get(op_node.type)
+    if kind is None:
+        membrane_panic(
+            owner="tree_sitter_python_adapter._unary_operator",
+            observed=f"unary operator token {op_node.type!r} not recognized",
+            requested="'+', '-', or '~'",
+            fix="extend _UNARY_TOKEN deliberately",
+        )
+    return Description(kind="UnaryOp", raw_span=_span(unit, node), anchors=(),
+                        slots=(("op", OpLeaf(operator_for(kind))), ("operand", Child(_h(unit, arg)))))
+
+
+def _comparison_operator(unit: SourceUnit, node: TSNode) -> Description:
+    kids = list(node.children)
+    named = [c for c in kids if c.is_named]
+    left = named[0]
+    comparators = named[1:]
+    op_tokens = [c for c in kids if not c.is_named]
+    ops: List[Operator] = []
+    for t in op_tokens:
+        text = t.type if t.type not in ("is not", "not in") else t.type
+        kind = _CMP_TOKEN.get(t.type)
+        if kind is None:
+            membrane_panic(
+                owner="tree_sitter_python_adapter._comparison_operator",
+                observed=f"comparison token {t.type!r} not recognized",
+                requested="a known comparison operator token",
+                fix="extend _CMP_TOKEN deliberately",
+            )
+        ops.append(operator_for(kind))
+    return Description(kind="Compare", raw_span=_span(unit, node), anchors=(),
+                        slots=(("left", Child(_h(unit, left))), ("ops", OpsLeaf(tuple(ops))),
+                               ("comparators", Children(tuple(_h(unit, c) for c in comparators)))))
+
+
+# --------------------------------------------------------------------------
+# calls / subscripts / attributes
+# --------------------------------------------------------------------------
+
+
+def _call(unit: SourceUnit, node: TSNode) -> Description:
+    func = _field(node, "function")
+    arglist = _field(node, "arguments")
+    args: List[ProviderHandle] = []
+    keywords: List[ProviderHandle] = []
+    if arglist is not None:
+        if arglist.type == "generator_expression":
+            args.append(_h(unit, arglist))
+        else:
+            for c in _named(arglist):
+                if c.type == "list_splat":
+                    inner = c.children[1]
+                    args.append(_fixed("Starred", _span(unit, c), (("value", Child(_h(unit, inner))),)))
+                elif c.type == "dictionary_splat":
+                    inner = c.children[1]
+                    keywords.append(_fixed("Keyword", None,
+                                            (("arg", SlotLeaf(None)), ("value", Child(_h(unit, inner))))))
+                elif c.type == "keyword_argument":
+                    name_node = _field(c, "name")
+                    value_node = _field(c, "value")
+                    keywords.append(_fixed("Keyword", _span(unit, c),
+                                            (("arg", SlotLeaf(_text(unit, name_node))),
+                                             ("value", Child(_h(unit, value_node))))))
+                else:
+                    args.append(_h(unit, c))
+    return Description(kind="Call", raw_span=_span(unit, node), anchors=(),
+                        slots=(("func", Child(_h(unit, func))), ("args", Children(tuple(args))),
+                               ("keywords", Children(tuple(keywords)))))
+
+
+def _attribute(unit: SourceUnit, node: TSNode) -> Description:
+    value = _field(node, "object")
+    attr = _field(node, "attribute")
+    return Description(kind="Attribute", raw_span=_span(unit, node), anchors=(),
+                        slots=(("value", Child(_h(unit, value))), ("attr", SlotLeaf(_text(unit, attr)))))
+
+
+def _subscript(unit: SourceUnit, node: TSNode) -> Description:
+    value = _field(node, "value")
+    subs = _fields(node, "subscript")
+    if len(subs) == 1:
+        slice_handle = _one_subscript_item(unit, subs[0])
+    else:
+        elts = tuple(_one_subscript_item(unit, s) for s in subs)
+        slice_handle = _fixed("Tuple", None, (("elts", Children(elts)),))
+    return Description(kind="Subscript", raw_span=_span(unit, node), anchors=(),
+                        slots=(("value", Child(_h(unit, value))), ("slice_", Child(slice_handle))))
+
+
+def _one_subscript_item(unit: SourceUnit, node: TSNode) -> ProviderHandle:
+    if node.type != "slice":
+        return _h(unit, node)
+    parts = [c for c in node.children]
+    segments: List[List[TSNode]] = [[]]
+    for c in parts:
+        if not c.is_named and c.type == ":":
+            segments.append([])
+        elif c.is_named:
+            segments[-1].append(c)
+    while len(segments) < 3:
+        segments.append([])
+    lower, upper, step = segments[0], segments[1], segments[2]
+
+    def _maybe(seg: List[TSNode]) -> Slot:
+        return MaybeChild(_h(unit, seg[0]) if seg else None)
+
+    return _fixed("Slice", _span(unit, node),
+                  (("lower", _maybe(lower)), ("upper", _maybe(upper)), ("step", _maybe(step))))
+
+
+def _parenthesized_expression(unit: SourceUnit, node: TSNode) -> Description:
+    inner = _named(node)
+    if len(inner) != 1:
+        membrane_panic(
+            owner="tree_sitter_python_adapter._parenthesized_expression",
+            observed=f"parenthesized_expression with {len(inner)} named children",
+            requested="exactly one inner expression",
+            fix="extend _parenthesized_expression deliberately",
+        )
+    return _describe(unit, inner[0])
+
+
+def _tuple_expr(unit: SourceUnit, node: TSNode) -> Description:
+    elts = [c for c in _named(node) if c.type != "comment"]
+    return Description(kind="Tuple", raw_span=_span(unit, node), anchors=(),
+                        slots=(("elts", Children(tuple(_h(unit, e) for e in elts))),))
+
+
+def _list_expr(unit: SourceUnit, node: TSNode) -> Description:
+    elts: List[ProviderHandle] = []
+    for c in _named(node):
+        if c.type == "list_splat":
+            inner = c.children[1]
+            elts.append(_fixed("Starred", _span(unit, c), (("value", Child(_h(unit, inner))),)))
+        else:
+            elts.append(_h(unit, c))
+    return Description(kind="List", raw_span=_span(unit, node), anchors=(),
+                        slots=(("elts", Children(tuple(elts))),))
+
+
+def _set_expr(unit: SourceUnit, node: TSNode) -> Description:
+    elts = tuple(_h(unit, c) for c in _named(node))
+    return Description(kind="Set", raw_span=_span(unit, node), anchors=(), slots=(("elts", Children(elts)),))
+
+
+def _dictionary(unit: SourceUnit, node: TSNode) -> Description:
+    items: List[ProviderHandle] = []
+    for c in _named(node):
+        if c.type == "pair":
+            key = _field(c, "key")
+            value = _field(c, "value")
+            items.append(_fixed("DictItem", _span(unit, c),
+                                 (("key", MaybeChild(_h(unit, key))), ("value", Child(_h(unit, value))))))
+        elif c.type == "dictionary_splat":
+            inner = c.children[1]
+            items.append(_fixed("DictItem", _span(unit, c),
+                                 (("key", MaybeChild(None)), ("value", Child(_h(unit, inner))))))
+        else:
+            membrane_panic(
+                owner="tree_sitter_python_adapter._dictionary",
+                observed=f"dictionary child {c.type!r} not recognized",
+                requested="pair or dictionary_splat",
+                fix="extend _dictionary deliberately",
+            )
+    return Description(kind="Dict", raw_span=_span(unit, node), anchors=(), slots=(("items", Children(tuple(items))),))
+
+
+def _comprehension_clause(unit: SourceUnit, node: TSNode) -> Description:
+    """`for_in_clause` (comp_for) -> Comprehension; `if_clause` handled by
+    the caller that flattens the parent list of comprehension clauses."""
+    left = _field(node, "left")
+    right = _field(node, "right")
+    is_async = any(not c.is_named and c.type == "async" for c in node.children)
+    target = _pattern_list_targets(unit, left) if left.type in ("pattern_list", "tuple_pattern") else _h(unit, left)
+    return Description(kind="Comprehension", raw_span=_span(unit, node), anchors=(),
+                        slots=(("target", Child(target)), ("iter", Child(_h(unit, right))),
+                               ("ifs", Children(())), ("is_async", SlotLeaf(is_async))))
+
+
+def _comprehension_body(unit: SourceUnit, node: TSNode, elt_field: str) -> Tuple[ProviderHandle, Tuple[ProviderHandle, ...]]:
+    elt = _field(node, elt_field)
+    generators: List[ProviderHandle] = []
+    current_desc: Optional[Description] = None
+    current_ifs: List[ProviderHandle] = []
+    for c in node.children:
+        if c.type == "for_in_clause":
+            if current_desc is not None:
+                generators.append(_finish_clause(current_desc, current_ifs))
+            current_desc = _comprehension_clause(unit, c)
+            current_ifs = []
+        elif c.type == "if_clause":
+            cond = _named(c)[0]
+            current_ifs.append(_h(unit, cond))
+    if current_desc is not None:
+        generators.append(_finish_clause(current_desc, current_ifs))
+    return _h(unit, elt), tuple(generators)
+
+
+def _finish_clause(desc: Description, ifs: List[ProviderHandle]) -> ProviderHandle:
+    new_slots = tuple((n, Children(tuple(ifs))) if n == "ifs" else (n, s) for n, s in desc.slots)
+    return _fixed(desc.kind, desc.raw_span, new_slots, desc.anchors)
+
+
+def _list_comprehension(unit: SourceUnit, node: TSNode) -> Description:
+    elt, gens = _comprehension_body(unit, node, "body")
+    return Description(kind="ListComp", raw_span=_span(unit, node), anchors=(),
+                        slots=(("elt", Child(elt)), ("generators", Children(gens))))
+
+
+def _set_comprehension(unit: SourceUnit, node: TSNode) -> Description:
+    elt, gens = _comprehension_body(unit, node, "body")
+    return Description(kind="SetComp", raw_span=_span(unit, node), anchors=(),
+                        slots=(("elt", Child(elt)), ("generators", Children(gens))))
+
+
+def _generator_expression(unit: SourceUnit, node: TSNode) -> Description:
+    elt, gens = _comprehension_body(unit, node, "body")
+    return Description(kind="GeneratorExp", raw_span=_span(unit, node), anchors=(),
+                        slots=(("elt", Child(elt)), ("generators", Children(gens))))
+
+
+def _dictionary_comprehension(unit: SourceUnit, node: TSNode) -> Description:
+    body = _field(node, "body")
+    key = _field(body, "key")
+    value = _field(body, "value")
+    generators: List[ProviderHandle] = []
+    current_desc: Optional[Description] = None
+    current_ifs: List[ProviderHandle] = []
+    for c in node.children:
+        if c.type == "for_in_clause":
+            if current_desc is not None:
+                generators.append(_finish_clause(current_desc, current_ifs))
+            current_desc = _comprehension_clause(unit, c)
+            current_ifs = []
+        elif c.type == "if_clause":
+            current_ifs.append(_h(unit, _named(c)[0]))
+    if current_desc is not None:
+        generators.append(_finish_clause(current_desc, current_ifs))
+    return Description(kind="DictComp", raw_span=_span(unit, node), anchors=(),
+                        slots=(("key", Child(_h(unit, key))), ("value", Child(_h(unit, value))),
+                               ("generators", Children(tuple(generators)))))
+
+
+def _conditional_expression(unit: SourceUnit, node: TSNode) -> Description:
+    named = _named(node)
+    body, test, orelse = named[0], named[1], named[2]
+    return Description(kind="IfExp", raw_span=_span(unit, node), anchors=(),
+                        slots=(("test", Child(_h(unit, test))), ("body", Child(_h(unit, body))),
+                               ("orelse", Child(_h(unit, orelse)))))
+
+
+def _named_expression(unit: SourceUnit, node: TSNode) -> Description:
+    name = _field(node, "name")
+    value = _field(node, "value")
+    return Description(kind="NamedExpr", raw_span=_span(unit, node), anchors=(),
+                        slots=(("target", Child(_h(unit, name))), ("value", Child(_h(unit, value)))))
+
+
+def _yield_expr(unit: SourceUnit, node: TSNode) -> Description:
+    kids = node.children
+    has_from = any(not c.is_named and c.type == "from" for c in kids)
+    named = _named(node)
+    span = _span(unit, node)
+    if has_from:
+        return Description(kind="YieldFrom", raw_span=span, anchors=(), slots=(("value", Child(_h(unit, named[0]))),))
+    value = named[0] if named else None
+    return Description(kind="Yield", raw_span=span, anchors=(), slots=(("value", MaybeChild(_h(unit, value))),))
+
+
+def _await_expr(unit: SourceUnit, node: TSNode) -> Description:
+    value = _named(node)[0]
+    return Description(kind="Await", raw_span=_span(unit, node), anchors=(), slots=(("value", Child(_h(unit, value))),))
+
+
+def _lambda(unit: SourceUnit, node: TSNode) -> Description:
+    params_node = _field(node, "parameters")
+    body = _field(node, "body")
+    return Description(kind="Lambda", raw_span=_span(unit, node), anchors=(),
+                        slots=(("params", Children(_flatten_params(unit, params_node))), ("body", Child(_h(unit, body)))))
+
+
+# --------------------------------------------------------------------------
+# parameters
+# --------------------------------------------------------------------------
+
+
+def _flatten_params(unit: SourceUnit, node: Optional[TSNode]) -> Tuple[ProviderHandle, ...]:
+    if node is None:
+        return ()
+    params: List[ProviderHandle] = []
+    seen_star = False
+    seen_slash_at: Optional[int] = None
+    for c in node.children:
+        if not c.is_named or c.type in _SKIP_TYPES:
+            continue
+        if c.type == "positional_separator":
+            seen_slash_at = len(params)
+            continue
+        if c.type == "keyword_separator":
+            seen_star = True
+            continue
+        params.append(_one_param(unit, c, seen_star))
+    if seen_slash_at is not None:
+        for i in range(seen_slash_at):
+            params[i] = _retag(params[i], "positional_only")
+    return tuple(params)
+
+
+def _retag(handle: ProviderHandle, kind: str) -> ProviderHandle:
+    desc = handle.describe()
+    new_slots = tuple((n, SlotLeaf(kind)) if n == "param_kind" else (n, s) for n, s in desc.slots)
+    return _fixed(desc.kind, desc.raw_span, new_slots, desc.anchors)
+
+
+def _one_param(unit: SourceUnit, node: TSNode, after_star: bool) -> ProviderHandle:
+    span = _span(unit, node)
+    if node.type == "identifier":
+        return _fixed("Param", None,
+                       (("name", SlotLeaf(_text(unit, node))), ("annotation", MaybeChild(None)),
+                        ("default", MaybeChild(None)),
+                        ("param_kind", SlotLeaf("keyword_only" if after_star else "positional_or_keyword"))),
+                       anchors=(span,))
+    if node.type == "list_splat_pattern":
+        name_node = _named(node)[0]
+        return _fixed("Param", None,
+                       (("name", SlotLeaf(_text(unit, name_node))), ("annotation", MaybeChild(None)),
+                        ("default", MaybeChild(None)), ("param_kind", SlotLeaf("vararg"))),
+                       anchors=(_span(unit, name_node),))
+    if node.type == "dictionary_splat_pattern":
+        name_node = _named(node)[0]
+        return _fixed("Param", None,
+                       (("name", SlotLeaf(_text(unit, name_node))), ("annotation", MaybeChild(None)),
+                        ("default", MaybeChild(None)), ("param_kind", SlotLeaf("kwarg"))),
+                       anchors=(_span(unit, name_node),))
+    if node.type == "default_parameter":
+        name_node = _field(node, "name")
+        value_node = _field(node, "value")
+        return _fixed("Param", None,
+                       (("name", SlotLeaf(_text(unit, name_node))), ("annotation", MaybeChild(None)),
+                        ("default", MaybeChild(_h(unit, value_node))),
+                        ("param_kind", SlotLeaf("keyword_only" if after_star else "positional_or_keyword"))),
+                       anchors=(_span(unit, name_node),))
+    if node.type == "typed_parameter":
+        kids = list(node.children)
+        name_node = kids[0]
+        annotation_node = _field(node, "type")
+        kind = "positional_or_keyword"
+        if name_node.type == "list_splat_pattern":
+            name_node = _named(name_node)[0]
+            kind = "vararg"
+        elif name_node.type == "dictionary_splat_pattern":
+            name_node = _named(name_node)[0]
+            kind = "kwarg"
+        elif after_star:
+            kind = "keyword_only"
+        return _fixed("Param", None,
+                       (("name", SlotLeaf(_text(unit, name_node))),
+                        ("annotation", MaybeChild(_h(unit, annotation_node))),
+                        ("default", MaybeChild(None)), ("param_kind", SlotLeaf(kind))),
+                       anchors=(_span(unit, name_node),))
+    if node.type == "typed_default_parameter":
+        name_node = _field(node, "name")
+        annotation_node = _field(node, "type")
+        value_node = _field(node, "value")
+        return _fixed("Param", None,
+                       (("name", SlotLeaf(_text(unit, name_node))),
+                        ("annotation", MaybeChild(_h(unit, annotation_node))),
+                        ("default", MaybeChild(_h(unit, value_node))),
+                        ("param_kind", SlotLeaf("keyword_only" if after_star else "positional_or_keyword"))),
+                       anchors=(_span(unit, name_node),))
+    membrane_panic(
+        owner="tree_sitter_python_adapter._one_param",
+        observed=f"parameter shape {node.type!r} not recognized",
+        requested="a mapped parameter shape",
+        fix="extend _one_param deliberately",
+    )
+    raise AssertionError("unreachable")
+
+
+# --------------------------------------------------------------------------
+# statements
+# --------------------------------------------------------------------------
+
+
+def _assignment(unit: SourceUnit, node: TSNode) -> Description:
+    left = _field(node, "left")
+    right = _field(node, "right")
+    type_node = _field(node, "type")
+    span = _span(unit, node)
+    if type_node is not None:
+        return Description(kind="AnnAssign", raw_span=span, anchors=(),
+                            slots=(("target", Child(_h(unit, left))), ("annotation", Child(_h(unit, type_node))),
+                                   ("value", MaybeChild(_h(unit, right))), ("simple", SlotLeaf(True))))
+    targets = [left]
+    value_node = right
+    while value_node is not None and value_node.type == "assignment":
+        targets.append(_field(value_node, "left"))
+        value_node = _field(value_node, "right")
+    target_handles = tuple(_target_handle(unit, t) for t in targets)
+    return Description(kind="Assign", raw_span=span, anchors=(),
+                        slots=(("targets", Children(target_handles)), ("value", Child(_h(unit, value_node)))))
+
+
+def _target_handle(unit: SourceUnit, node: TSNode) -> ProviderHandle:
+    if node.type in ("pattern_list", "expression_list"):
+        elts = _named(node)
+        if len(elts) == 1:
+            return _target_handle(unit, elts[0])
+        return _fixed("Tuple", None, (("elts", Children(tuple(_target_handle(unit, e) for e in elts))),))
+    if node.type == "tuple_pattern":
+        elts = _named(node)
+        return _fixed("Tuple", _span(unit, node), (("elts", Children(tuple(_target_handle(unit, e) for e in elts))),))
+    if node.type == "list_pattern":
+        elts = _named(node)
+        return _fixed("List", _span(unit, node), (("elts", Children(tuple(_target_handle(unit, e) for e in elts))),))
+    if node.type == "list_splat_pattern":
+        inner = _named(node)[0]
+        return _fixed("Starred", _span(unit, node), (("value", Child(_target_handle(unit, inner))),))
+    return _h(unit, node)
+
+
+def _augmented_assignment(unit: SourceUnit, node: TSNode) -> Description:
+    left = _field(node, "left")
+    right = _field(node, "right")
+    op_node = _field(node, "operator")
+    kind = _AUG_TOKEN.get(op_node.type)
+    if kind is None:
+        membrane_panic(
+            owner="tree_sitter_python_adapter._augmented_assignment",
+            observed=f"augmented assignment token {op_node.type!r} not recognized",
+            requested="a known augmented assignment token",
+            fix="extend _AUG_TOKEN deliberately",
+        )
+    return Description(kind="AugAssign", raw_span=_span(unit, node), anchors=(),
+                        slots=(("target", Child(_h(unit, left))), ("op", OpLeaf(operator_for(kind))),
+                               ("value", Child(_h(unit, right)))))
+
+
+def _return_statement(unit: SourceUnit, node: TSNode) -> Description:
+    named = _named(node)
+    value: Optional[ProviderHandle] = None
+    if named:
+        if len(named) > 1:
+            value = _bare_tuple(unit, named, None)
+        else:
+            value = _h(unit, named[0])
+    return Description(kind="Return", raw_span=_span(unit, node), anchors=(), slots=(("value", MaybeChild(value)),))
+
+
+def _delete_statement(unit: SourceUnit, node: TSNode) -> Description:
+    named = _named(node)
+    inner = named[0]
+    elts = _named(inner) if inner.type == "expression_list" else [inner]
+    return Description(kind="Delete", raw_span=_span(unit, node), anchors=(),
+                        slots=(("targets", Children(tuple(_h(unit, e) for e in elts))),))
+
+
+def _raise_statement(unit: SourceUnit, node: TSNode) -> Description:
+    exc = _field(node, None) if False else None
+    named = [c for c in node.children if c.is_named]
+    cause = _field(node, "cause")
+    exc_node = named[0] if named and named[0] is not cause else None
+    if named and cause is not None and named[0] is cause:
+        exc_node = None
+    elif named:
+        exc_node = named[0]
+    return Description(kind="Raise", raw_span=_span(unit, node), anchors=(),
+                        slots=(("exc", MaybeChild(_h(unit, exc_node))), ("cause", MaybeChild(_h(unit, cause)))))
+
+
+def _assert_statement(unit: SourceUnit, node: TSNode) -> Description:
+    named = _named(node)
+    test = named[0]
+    msg = named[1] if len(named) > 1 else None
+    return Description(kind="Assert", raw_span=_span(unit, node), anchors=(),
+                        slots=(("test", Child(_h(unit, test))), ("msg", MaybeChild(_h(unit, msg)))))
+
+
+def _global_statement(unit: SourceUnit, node: TSNode) -> Description:
+    names = tuple(_text(unit, c) for c in _named(node))
+    return Description(kind="Global", raw_span=_span(unit, node), anchors=(), slots=(("names", SlotLeaf(names)),))
+
+
+def _nonlocal_statement(unit: SourceUnit, node: TSNode) -> Description:
+    names = tuple(_text(unit, c) for c in _named(node))
+    return Description(kind="Nonlocal", raw_span=_span(unit, node), anchors=(), slots=(("names", SlotLeaf(names)),))
+
+
+def _if_statement(unit: SourceUnit, node: TSNode) -> Description:
+    test = _field(node, "condition")
+    body = _block_stmts(unit, _field(node, "consequence"))
+    alt = _field(node, "alternative")
+    orelse: Tuple[ProviderHandle, ...]
+    if alt is None:
+        orelse = ()
+    elif alt.type == "elif_clause":
+        orelse = (_elif_handle(unit, alt),)
+    else:  # else_clause
+        orelse = _block_stmts(unit, _field(alt, "body"))
+    return Description(kind="If", raw_span=_span(unit, node), anchors=(),
+                        slots=(("test", Child(_h(unit, test))), ("body", Children(body)), ("orelse", Children(orelse))))
+
+
+def _elif_handle(unit: SourceUnit, node: TSNode) -> ProviderHandle:
+    test = _field(node, "condition")
+    body = _block_stmts(unit, _field(node, "consequence"))
+    alt = _field(node, "alternative")
+    if alt is None:
+        orelse: Tuple[ProviderHandle, ...] = ()
+    elif alt.type == "elif_clause":
+        orelse = (_elif_handle(unit, alt),)
+    else:
+        orelse = _block_stmts(unit, _field(alt, "body"))
+    return _fixed("If", _span(unit, node),
+                  (("test", Child(_h(unit, test))), ("body", Children(body)), ("orelse", Children(orelse))))
+
+
+def _while_statement(unit: SourceUnit, node: TSNode) -> Description:
+    test = _field(node, "condition")
+    body = _block_stmts(unit, _field(node, "body"))
+    alt = _field(node, "alternative")
+    orelse = _block_stmts(unit, _field(alt, "body")) if alt is not None else ()
+    return Description(kind="While", raw_span=_span(unit, node), anchors=(),
+                        slots=(("test", Child(_h(unit, test))), ("body", Children(body)), ("orelse", Children(orelse))))
+
+
+def _for_statement(unit: SourceUnit, node: TSNode) -> Description:
+    left = _field(node, "left")
+    right = _field(node, "right")
+    target = _target_handle(unit, left)
+    it = right if right.type != "expression_list" else None
+    iter_handle = _pattern_list_targets(unit, right) if it is None else _h(unit, right)
+    body = _block_stmts(unit, _field(node, "body"))
+    alt = _field(node, "alternative")
+    orelse = _block_stmts(unit, _field(alt, "body")) if alt is not None else ()
+    kind = "AsyncFor" if any(not c.is_named and c.type == "async" for c in node.children) else "For"
+    return Description(kind=kind, raw_span=_span(unit, node), anchors=(),
+                        slots=(("target", Child(target)), ("iter", Child(iter_handle)),
+                               ("body", Children(body)), ("orelse", Children(orelse))))
+
+
+def _with_statement(unit: SourceUnit, node: TSNode) -> Description:
+    clause = _field(node, None) if False else None
+    with_clause = next(c for c in node.children if c.type == "with_clause")
+    items: List[ProviderHandle] = []
+    for it in _named(with_clause):
+        if it.type != "with_item":
+            continue
+        value = _field(it, "value")
+        if value.type == "as_pattern":
+            ctx = _named(value)[0]
+            alias = _field(value, "alias")
+            alias_inner = _named(alias)[0] if alias is not None else None
+            items.append(_fixed("WithItem", _span(unit, it),
+                                 (("context_expr", Child(_h(unit, ctx))),
+                                  ("optional_vars", MaybeChild(_h(unit, alias_inner))))))
+        else:
+            items.append(_fixed("WithItem", _span(unit, it),
+                                 (("context_expr", Child(_h(unit, value))), ("optional_vars", MaybeChild(None)))))
+    body = _block_stmts(unit, _field(node, "body"))
+    kind = "AsyncWith" if any(not c.is_named and c.type == "async" for c in node.children) else "With"
+    return Description(kind=kind, raw_span=_span(unit, node), anchors=(),
+                        slots=(("items", Children(tuple(items))), ("body", Children(body))))
+
+
+def _try_statement(unit: SourceUnit, node: TSNode) -> Description:
+    body = _block_stmts(unit, _field(node, "body"))
+    handlers: List[ProviderHandle] = []
+    orelse: Tuple[ProviderHandle, ...] = ()
+    finalbody: Tuple[ProviderHandle, ...] = ()
+    is_star = False
+    for c in node.children:
+        if c.type == "except_clause":
+            if any(not k.is_named and k.type == "*" for k in c.children):
+                is_star = True
+            value = _field(c, "value")
+            exc_type: Optional[TSNode] = None
+            exc_name: Optional[str] = None
+            if value is not None:
+                if value.type == "as_pattern":
+                    exc_type = _named(value)[0]
+                    alias = _field(value, "alias")
+                    exc_name = _text(unit, _named(alias)[0]) if alias is not None else None
+                else:
+                    exc_type = value
+            handler_body = _block_stmts(unit, next(k for k in c.children if k.type == "block"))
+            handlers.append(_fixed(
+                "ExceptHandler", _span(unit, c),
+                (("type_", MaybeChild(_h(unit, exc_type))), ("name", SlotLeaf(exc_name)),
+                 ("body", Children(handler_body))),
+            ))
+        elif c.type == "else_clause":
+            orelse = _block_stmts(unit, _field(c, "body"))
+        elif c.type == "finally_clause":
+            finalbody = _block_stmts(unit, next(k for k in c.children if k.type == "block"))
+    kind = "TryStar" if is_star else "Try"
+    return Description(kind=kind, raw_span=_span(unit, node), anchors=(),
+                        slots=(("body", Children(body)), ("handlers", Children(tuple(handlers))),
+                               ("orelse", Children(orelse)), ("finalbody", Children(finalbody))))
+
+
+def _function_definition(unit: SourceUnit, node: TSNode) -> Description:
+    name = _text(unit, _field(node, "name"))
+    params = _flatten_params(unit, _field(node, "parameters"))
+    returns = _field(node, "return_type")
+    body = _block_stmts(unit, _field(node, "body"))
+    kind = "AsyncFunctionDef" if any(not c.is_named and c.type == "async" for c in node.children) else "FunctionDef"
+    return Description(kind=kind, raw_span=_span(unit, node), anchors=(),
+                        slots=(("name", SlotLeaf(name)), ("params", Children(params)), ("body", Children(body)),
+                               ("decorators", Children(())),
+                               ("returns", MaybeChild(_h(unit, returns))), ("type_params", Children(()))))
+
+
+def _class_definition(unit: SourceUnit, node: TSNode) -> Description:
+    name = _text(unit, _field(node, "name"))
+    supers = _field(node, "superclasses")
+    bases: List[ProviderHandle] = []
+    keywords: List[ProviderHandle] = []
+    if supers is not None:
+        for c in _named(supers):
+            if c.type == "keyword_argument":
+                name_node = _field(c, "name")
+                value_node = _field(c, "value")
+                keywords.append(_fixed("Keyword", _span(unit, c),
+                                        (("arg", SlotLeaf(_text(unit, name_node))), ("value", Child(_h(unit, value_node))))))
+            elif c.type == "list_splat":
+                inner = c.children[1]
+                bases.append(_fixed("Starred", _span(unit, c), (("value", Child(_h(unit, inner))),)))
+            elif c.type == "dictionary_splat":
+                inner = c.children[1]
+                keywords.append(_fixed("Keyword", None, (("arg", SlotLeaf(None)), ("value", Child(_h(unit, inner))))))
+            else:
+                bases.append(_h(unit, c))
+    body = _block_stmts(unit, _field(node, "body"))
+    return Description(kind="ClassDef", raw_span=_span(unit, node), anchors=(),
+                        slots=(("name", SlotLeaf(name)), ("bases", Children(tuple(bases))),
+                               ("keywords", Children(tuple(keywords))), ("body", Children(body)),
+                               ("decorators", Children(())), ("type_params", Children(()))))
+
+
+def _decorated_definition(unit: SourceUnit, node: TSNode) -> Description:
+    decorators = [c for c in node.children if c.type == "decorator"]
+    dec_handles = tuple(_h(unit, _named(d)[0]) for d in decorators)
+    inner = _field(node, "definition")
+    base = _describe(unit, inner)
+    span = Span(_span(unit, node).start, base.raw_span.end)
+    new_slots = tuple((n, Children(dec_handles)) if n == "decorators" else (n, s) for n, s in base.slots)
+    return Description(kind=base.kind, raw_span=span, anchors=(), slots=new_slots)
+
+
+def _import_statement(unit: SourceUnit, node: TSNode) -> Description:
+    names = []
+    for c in node.children:
+        if not c.is_named or c.type in _SKIP_TYPES:
+            continue
+        names.append(_import_alias(unit, c))
+    return Description(kind="Import", raw_span=_span(unit, node), anchors=(), slots=(("names", Children(tuple(names))),))
+
+
+def _import_alias(unit: SourceUnit, node: TSNode) -> ProviderHandle:
+    if node.type == "aliased_import":
+        name_node = _field(node, "name")
+        alias_node = _field(node, "alias")
+        return _fixed("ImportAlias", _span(unit, node),
+                      (("name", SlotLeaf(_dotted_str(unit, name_node))), ("asname", SlotLeaf(_text(unit, alias_node)))))
+    return _fixed("ImportAlias", _span(unit, node), (("name", SlotLeaf(_dotted_str(unit, node))), ("asname", SlotLeaf(None))))
+
+
+def _dotted_str(unit: SourceUnit, node: TSNode) -> str:
+    return _text(unit, node)
+
+
+def _import_from_statement(unit: SourceUnit, node: TSNode) -> Description:
+    module_node = _field(node, "module_name")
+    level = 0
+    module: Optional[str] = None
+    if module_node is not None:
+        if module_node.type == "relative_import":
+            prefix = _field(module_node, None) if False else next(
+                (c for c in module_node.children if c.type == "import_prefix"), None
+            )
+            if prefix is not None:
+                level = sum(1 for c in prefix.children if c.type == ".")
+            dotted = next((c for c in module_node.children if c.type == "dotted_name"), None)
+            module = _text(unit, dotted) if dotted is not None else None
+        else:
+            module = _dotted_str(unit, module_node)
+    names_nodes = _fields(node, "name")
+    star_node = next((c for c in node.children if not c.is_named and c.type == "*"), None)
+    if star_node is not None:
+        names = (_fixed("ImportAlias", _span(unit, star_node),
+                         (("name", SlotLeaf("*")), ("asname", SlotLeaf(None)))),)
+    else:
+        names = tuple(_import_alias(unit, n) for n in names_nodes)
+    return Description(kind="ImportFrom", raw_span=_span(unit, node), anchors=(),
+                        slots=(("module", SlotLeaf(module)), ("names", Children(names)), ("level", SlotLeaf(level))))
+
+
+def _dotted_name_expr(unit: SourceUnit, node: TSNode) -> ProviderHandle:
+    """`a.b.c` used as an expression (e.g. a match-pattern class name), built
+    as nested Attribute over its identifier parts — only reachable here for
+    a bare dotted_name that never went through the normal atom_expr/trailer
+    fold (match patterns hold it directly, not inside an atom_expr)."""
+    parts = [c for c in node.children if c.type == "identifier"]
+    acc: ProviderHandle = _h(unit, parts[0])
+    start = _span(unit, parts[0]).start
+    for p in parts[1:]:
+        end = _span(unit, p).end
+        acc = _fixed("Attribute", Span(start, end), (("value", Child(acc)), ("attr", SlotLeaf(_text(unit, p)))))
+    return acc
+
+
+def _generic_type(unit: SourceUnit, node: TSNode) -> Description:
+    """`Name[Args]` in annotation position (e.g. ``Generic[T]``, ``list[int]``
+    written where the grammar treats it as a type rather than an expression)
+    — same shape as a subscript, mapped the same way."""
+    kids = _named(node)
+    base = kids[0]
+    type_params = kids[1]
+    items = [c for c in type_params.children if c.is_named and c.type != "comment"]
+    if len(items) == 1:
+        slice_handle = _one_subscript_item(unit, items[0])
+    else:
+        slice_handle = _fixed("Tuple", None, (("elts", Children(tuple(_one_subscript_item(unit, i) for i in items))),))
+    return Description(kind="Subscript", raw_span=_span(unit, node), anchors=(),
+                        slots=(("value", Child(_h(unit, base))), ("slice_", Child(slice_handle))))
+
+
+def _type_alias_statement(unit: SourceUnit, node: TSNode) -> Description:
+    # PEP 695 `type X = int` / `type X[T] = list[T]`. Generic `[T]` type
+    # parameters are not further destructured here (rare in this corpus);
+    # an alias with them still constructs, just with an empty type_params.
+    left = _field(node, "left")
+    right = _field(node, "right")
+    name_expr = _named(left)[0] if left.type not in ("identifier",) else left
+    return Description(kind="TypeAlias", raw_span=_span(unit, node), anchors=(),
+                        slots=(("name", Child(_h(unit, name_expr))), ("type_params", Children(())),
+                               ("value", Child(_h(unit, _named(right)[0] if right.type == "type" else right)))))
+
+
+def _future_import_statement(unit: SourceUnit, node: TSNode) -> Description:
+    names = tuple(_import_alias(unit, n) for n in _fields(node, "name"))
+    return Description(kind="ImportFrom", raw_span=_span(unit, node), anchors=(),
+                        slots=(("module", SlotLeaf("__future__")), ("names", Children(names)), ("level", SlotLeaf(0))))
+
+
+def _match_statement(unit: SourceUnit, node: TSNode) -> Description:
+    subject = _field(node, "subject")
+    block = next(c for c in node.children if c.type == "block")
+    cases = []
+    for c in block.children:
+        if c.type != "case_clause":
+            continue
+        cases.append(_case_clause(unit, c))
+    return Description(kind="Match", raw_span=_span(unit, node), anchors=(),
+                        slots=(("subject", Child(_h(unit, subject))), ("cases", Children(tuple(cases)))))
+
+
+def _case_clause(unit: SourceUnit, node: TSNode) -> ProviderHandle:
+    # tree-sitter-python does not expose a 'pattern' field on case_clause;
+    # the pattern(s) are the case_pattern named children preceding 'if'/':'.
+    pattern_nodes = [c for c in node.children if c.type == "case_pattern"]
+    guard = _field(node, "guard")
+    body_node = _field(node, "consequence")
+    body = _block_stmts(unit, body_node)
+    if len(pattern_nodes) == 1:
+        pattern = _pattern(unit, pattern_nodes[0])
+    else:
+        pat_span = Span(_span(unit, pattern_nodes[0]).start, _span(unit, pattern_nodes[-1]).end)
+        pattern = _fixed("MatchSequence", pat_span,
+                          (("patterns", Children(tuple(_pattern(unit, p) for p in pattern_nodes))),))
+    guard_cond = _named(guard)[0] if guard is not None else None
+    return _fixed("MatchCase", _span(unit, node),
+                  (("pattern", Child(pattern)), ("guard", MaybeChild(_h(unit, guard_cond))),
+                   ("body", Children(body))))
+
+
+def _pattern(unit: SourceUnit, node: TSNode) -> ProviderHandle:
+    if node.type == "case_pattern":
+        inner = _named(node)
+        if len(inner) == 1:
+            return _pattern(unit, inner[0])
+        return _fixed("MatchSequence", _span(unit, node),
+                       (("patterns", Children(tuple(_pattern(unit, p) for p in inner))),))
+    span = _span(unit, node)
+    if node.type == "_":
+        return _fixed("MatchAs", span, (("pattern", MaybeChild(None)), ("name", SlotLeaf(None))))
+    if node.type in ("integer", "float", "true", "false", "none", "string", "complex_pattern", "unary_operator",
+                      "concatenated_string"):
+        return _h(unit, node) if node.type != "true" and node.type != "false" and node.type != "none" else _Fixed(_SIMPLE_LEAF[node.type](unit, node))
+    if node.type == "identifier":
+        return _fixed("MatchAs", span, (("pattern", MaybeChild(None)), ("name", SlotLeaf(_text(unit, node)))))
+    if node.type in ("dotted_name", "attribute"):
+        return _fixed("MatchValue", span, (("value", Child(_h(unit, node))),))
+    if node.type in ("list_pattern", "tuple_pattern"):
+        items = []
+        for c in _named(node):
+            items.append(_pattern_item(unit, c))
+        return _fixed("MatchSequence", span, (("patterns", Children(tuple(items))),))
+    if node.type == "splat_pattern":
+        inner = _named(node)
+        name = _text(unit, inner[0]) if inner else None
+        return _fixed("MatchStar", span, (("name", SlotLeaf(name)),))
+    if node.type == "as_pattern":
+        inner = _named(node)[0]
+        target = _field(node, "alias") or (node.children[-1] if node.children else None)
+        target_name = None
+        tn = _fields(node, "alias")
+        if tn:
+            tgt = tn[0]
+            target_name = _text(unit, _named(tgt)[0] if tgt.type == "as_pattern_target" else tgt)
+        return _fixed("MatchAs", span, (("pattern", MaybeChild(_pattern(unit, inner))), ("name", SlotLeaf(target_name))))
+    if node.type == "union_pattern":
+        items = [_pattern(unit, c) for c in _named(node)]
+        return _fixed("MatchOr", span, (("patterns", Children(tuple(items))),))
+    if node.type == "class_pattern":
+        cls_node = _named(node)[0]
+        positional: List[ProviderHandle] = []
+        kwd_attrs: List[str] = []
+        kwd_patterns: List[ProviderHandle] = []
+        for raw in _named(node)[1:]:
+            # each argument is wrapped in its own case_pattern
+            c = _named(raw)[0] if raw.type == "case_pattern" else raw
+            if c.type == "keyword_pattern":
+                kn = _named(c)[0]
+                kv = _named(c)[1]
+                kwd_attrs.append(_text(unit, kn))
+                kwd_patterns.append(_pattern_item(unit, kv))
+            else:
+                positional.append(_pattern_item(unit, c))
+        return _fixed("MatchClass", span,
+                      (("cls_", Child(_h(unit, cls_node))), ("patterns", Children(tuple(positional))),
+                       ("kwd_attrs", SlotLeaf(tuple(kwd_attrs))), ("kwd_patterns", Children(tuple(kwd_patterns)))))
+    if node.type == "dict_pattern":
+        keys: List[ProviderHandle] = []
+        patterns: List[ProviderHandle] = []
+        rest: Optional[str] = None
+        kids = list(node.children)
+        i = 0
+        while i < len(kids):
+            c = kids[i]
+            if not c.is_named:
+                i += 1
+                continue
+            if c.type == "splat_pattern":
+                inner = _named(c)
+                rest = _text(unit, inner[0]) if inner else None
+                i += 1
+                continue
+            key_node = c
+            # next named child is the value pattern (case_pattern)
+            j = i + 1
+            while j < len(kids) and not kids[j].is_named:
+                j += 1
+            value_node = kids[j]
+            keys.append(_h(unit, key_node))
+            patterns.append(_pattern_item(unit, value_node))
+            i = j + 1
+        return _fixed("MatchMapping", span,
+                      (("keys", Children(tuple(keys))), ("patterns", Children(tuple(patterns))), ("rest", SlotLeaf(rest))))
+    membrane_panic(
+        owner="tree_sitter_python_adapter._pattern",
+        observed=f"case pattern shape {node.type!r} not recognized",
+        requested="a mapped match-pattern shape",
+        fix="extend _pattern deliberately",
+    )
+    raise AssertionError("unreachable")
+
+
+def _pattern_item(unit: SourceUnit, node: TSNode) -> ProviderHandle:
+    if node.type == "case_pattern":
+        return _pattern(unit, node)
+    return _pattern(unit, node)
+
+
+# --------------------------------------------------------------------------
+# top-level dispatch
+# --------------------------------------------------------------------------
+
+
+_LEAF_DISPATCH = {
+    "identifier": _leaf_identifier,
+    "integer": _number,
+    "float": _number,
+    "string": _string_like,
+    "string_content": _string_content,
+    "concatenated_string": _concatenated_string,
+}
+
+
+def _describe(unit: SourceUnit, node: TSNode) -> Description:
+    t = node.type
+    if not node.is_named:
+        membrane_panic(
+            owner="tree_sitter_python_adapter._describe",
+            observed=f"unnamed/punctuation node {t!r} reached the dispatcher",
+            requested="a named grammar node",
+            fix="filter this token out one level up",
+        )
+    if t in _SIMPLE_LEAF:
+        return _SIMPLE_LEAF[t](unit, node)
+    leaf_fn = _LEAF_DISPATCH.get(t)
+    if leaf_fn is not None:
+        return leaf_fn(unit, node)
+    fn = _DISPATCH.get(t)
+    if fn is not None:
+        return fn(unit, node)
+    membrane_panic(
+        owner="tree_sitter_python_adapter._describe",
+        observed=f"tree-sitter node type {t!r} has no translation rule",
+        requested="a mapped statement/expression shape",
+        fix="add a translation rule for this node type; never guess",
+    )
+    raise AssertionError("unreachable")
+
+
+_DISPATCH = {
+    "module": _module,
+    "expression_statement": _expression_statement,
+    "assignment": _assignment,
+    "augmented_assignment": _augmented_assignment,
+    "return_statement": _return_statement,
+    "delete_statement": _delete_statement,
+    "raise_statement": _raise_statement,
+    "assert_statement": _assert_statement,
+    "global_statement": _global_statement,
+    "nonlocal_statement": _nonlocal_statement,
+    "pass_statement": lambda u, n: Description(kind="Pass", raw_span=_span(u, n), anchors=(), slots=()),
+    "break_statement": lambda u, n: Description(kind="Break", raw_span=_span(u, n), anchors=(), slots=()),
+    "continue_statement": lambda u, n: Description(kind="Continue", raw_span=_span(u, n), anchors=(), slots=()),
+    "if_statement": _if_statement,
+    "while_statement": _while_statement,
+    "for_statement": _for_statement,
+    "with_statement": _with_statement,
+    "try_statement": _try_statement,
+    "function_definition": _function_definition,
+    "class_definition": _class_definition,
+    "decorated_definition": _decorated_definition,
+    "import_statement": _import_statement,
+    "import_from_statement": _import_from_statement,
+    "match_statement": _match_statement,
+    "binary_operator": _binary_operator,
+    "boolean_operator": _boolean_operator,
+    "not_operator": _not_operator,
+    "unary_operator": _unary_operator,
+    "comparison_operator": _comparison_operator,
+    "call": _call,
+    "attribute": _attribute,
+    "subscript": _subscript,
+    "parenthesized_expression": _parenthesized_expression,
+    "tuple": _tuple_expr,
+    "list": _list_expr,
+    "set": _set_expr,
+    "dictionary": _dictionary,
+    "list_comprehension": _list_comprehension,
+    "set_comprehension": _set_comprehension,
+    "dictionary_comprehension": _dictionary_comprehension,
+    "generator_expression": _generator_expression,
+    "conditional_expression": _conditional_expression,
+    "named_expression": _named_expression,
+    "yield": _yield_expr,
+    "await": _await_expr,
+    "lambda": _lambda,
+    "pattern_list": lambda u, n: _pattern_list_targets(u, n).describe(),
+    "expression_list": lambda u, n: _pattern_list_targets(u, n).describe(),
+    "type": lambda u, n: _describe(u, _named(n)[0]),
+    "type_alias_statement": _type_alias_statement,
+    "future_import_statement": _future_import_statement,
+    "dotted_name": lambda u, n: _dotted_name_expr(u, n).describe(),
+    "generic_type": _generic_type,
+    "splat_type": lambda u, n: Description(
+        kind="Starred", raw_span=_span(u, n), anchors=(),
+        slots=(("value", Child(_h(u, _named(n)[0]))),),
+    ),
+    "list_splat": lambda u, n: Description(
+        kind="Starred", raw_span=_span(u, n), anchors=(),
+        slots=(("value", Child(_h(u, _named(n)[0]))),),
+    ),
+    # PEP 604 `X | Y` written in annotation position parses as its own
+    # 'union_type' node rather than a binary_operator (the '|' expression
+    # form still goes through binary_operator/BinOp as usual) — same shape.
+    "union_type": lambda u, n: Description(
+        kind="BinOp", raw_span=_span(u, n), anchors=(),
+        slots=(("left", Child(_h(u, _named(n)[0]))), ("op", OpLeaf(operator_for("BitOr"))),
+               ("right", Child(_h(u, _named(n)[1])))),
+    ),
+}
+
+
+class TreeSitterPythonProvider(Provider):
+    """tree-sitter-python: C, incremental — the fourth candidate provider."""
+
+    name = "tree-sitter-python"
+
+    def __init__(self) -> None:
+        self._parser = tree_sitter.Parser(_LANGUAGE)
+
+    def parse(self, unit: SourceUnit) -> ProviderHandle:
+        tree = self._parser.parse(unit.source.encode("utf-8"))
+        root = tree.root_node
+        if root.has_error:
+            raise SyntaxError(
+                f"tree-sitter-python reported a parse error in {unit.filename}"
+            )
+        return _Handle(unit, root)

--- a/implementations/python/sugar-node-membrane/tests/test_parso_adapter.py
+++ b/implementations/python/sugar-node-membrane/tests/test_parso_adapter.py
@@ -1,0 +1,100 @@
+"""parso adapter smoke tests (#5940, #5932).
+
+No cross-provider CID comparison here (out of scope — see differential.py
+and the #5940/#5932 ruling that different parsers are not expected to
+agree on addresses). These tests only establish: the adapter constructs a
+representative sample without crashing, and the one hard, load-bearing
+finding — parso 0.8's shipped grammar has NO match/case support at all — is
+pinned as an explicit, named result rather than an unexplained failure.
+"""
+
+import pytest
+
+parso = pytest.importorskip("parso")
+
+from pathlib import Path
+
+from sugar_node_membrane import Membrane
+from sugar_node_membrane.panic import MembranePanic
+from sugar_node_membrane.parso_adapter import ParsoProvider
+
+GOLDENS = Path(__file__).resolve().parents[1] / "goldens"
+
+
+def _membrane() -> Membrane:
+    return Membrane(ParsoProvider())
+
+
+def test_constructs_a_representative_sample():
+    source = '''
+import os
+from typing import Optional, List
+
+
+class Point:
+    """A point."""
+
+    def __init__(self, x: int, y: int = 0, *args, z: float = 1.0, **kwargs) -> None:
+        self.x = x
+        self.y = y
+
+    def norm(self) -> float:
+        return (self.x ** 2 + self.y ** 2) ** 0.5
+
+    @property
+    def as_tuple(self):
+        return (self.x, self.y)
+
+
+async def fetch(urls: List[str]) -> Optional[dict]:
+    out = {}
+    async with open_session() as session:
+        for i, u in enumerate(urls):
+            try:
+                out[u] = await session.get(u)
+            except (ValueError, KeyError) as e:
+                raise RuntimeError("bad") from e
+            finally:
+                pass
+    return out if out else None
+
+
+def gen():
+    yield from range(10)
+    x = [i * 2 for i in range(5) if i % 2 == 0]
+    y = {k: v for k, v in zip(x, x)}
+    z = (a for a in x)
+    return x, y, z
+
+
+result = f"{gen()!r}"
+'''
+    root = _membrane().parse(source, filename="sample.py")
+    assert len(list(root.walk())) > 20
+
+
+def test_match_statement_is_not_supported_by_parso_080_grammar():
+    """The load-bearing finding: parso's shipped grammar311/312/etc. has no
+    match_stmt/case_block productions at all (verified by grepping the
+    grammar text files directly). This is not an adapter gap — there is no
+    tree to translate. A source using `match` refuses to parse."""
+    source = "match x:\n    case 0:\n        pass\n"
+    with pytest.raises(SyntaxError):
+        _membrane().parse(source, filename="match.py")
+
+
+def test_quirks_golden_fails_on_the_known_match_gap():
+    source = (GOLDENS / "quirks.py").read_text(encoding="utf-8")
+    with pytest.raises(SyntaxError):
+        _membrane().parse(source, filename="quirks.py")
+
+
+def test_fstring_format_spec_is_a_known_adapter_gap():
+    """Documented, not silently worked around: an f-string WITH a format
+    spec (``f"{x!r:>10}"``) panics in this adapter today. parso's own
+    ``fstring_format_spec`` node mixes literal spec characters in with
+    the containing fstring_expr's own children in a shape this adapter's
+    ``_fstring_values``/``_describe_fstring_expr`` do not yet parse
+    correctly — real coverage gap, tracked here rather than guessed at."""
+    with pytest.raises(MembranePanic):
+        _membrane().parse('x = f"{y!r:>10}"\n', filename="fspec.py")

--- a/implementations/python/sugar-node-membrane/tests/test_tree_sitter_adapter.py
+++ b/implementations/python/sugar-node-membrane/tests/test_tree_sitter_adapter.py
@@ -1,0 +1,60 @@
+"""tree-sitter-python adapter smoke tests (#5940, #5932).
+
+No cross-provider CID comparison here (out of scope — see differential.py).
+This adapter reproduces the FULL goldens/quirks.py corpus (including match/
+case, which parso's grammar cannot express at all — see
+test_parso_adapter.py), so the golden file doubles as this adapter's
+broadest single regression fixture.
+"""
+
+import pytest
+
+tree_sitter = pytest.importorskip("tree_sitter")
+pytest.importorskip("tree_sitter_python")
+
+from pathlib import Path
+
+from sugar_node_membrane import Membrane
+from sugar_node_membrane.tree_sitter_python_adapter import TreeSitterPythonProvider
+
+GOLDENS = Path(__file__).resolve().parents[1] / "goldens"
+
+
+def _membrane() -> Membrane:
+    return Membrane(TreeSitterPythonProvider())
+
+
+def test_constructs_the_full_quirks_golden():
+    source = (GOLDENS / "quirks.py").read_text(encoding="utf-8")
+    root = _membrane().parse(source, filename="quirks.py")
+    assert len(list(root.walk())) > 20
+
+
+def test_match_case_constructs():
+    source = (
+        "def matcher(value):\n"
+        "    match value:\n"
+        "        case 0 | 1:\n"
+        "            return 'small'\n"
+        "        case [first, *rest] if rest:\n"
+        "            return first\n"
+        "        case {'key': v, **others}:\n"
+        "            return v\n"
+        "        case Point(x=0, y=0):\n"
+        "            return 'origin'\n"
+        "        case _:\n"
+        "            return None\n"
+    )
+    root = _membrane().parse(source, filename="match.py")
+    assert len(list(root.walk())) > 10
+
+
+def test_byte_vs_codepoint_columns_are_normalized():
+    """tree-sitter reports UTF-8 BYTE columns (like CPython, unlike parso/
+    LibCST) — verify a non-ASCII prefix does not corrupt a later span."""
+    source = 'x = "éü" + f(y)\n'
+    root = _membrane().parse(source, filename="unicode.py")
+    call_positions = [
+        n.segment() for n in root.walk() if type(n).__name__ == "Call"
+    ]
+    assert call_positions == ["f(y)"]


### PR DESCRIPTION
## Summary

Adds two more candidate providers behind the existing membrane contract (`backend.py`), additive only — no edits to `backend.py`, `corpus.py`, `cpython_adapter.py`, `libcst_adapter.py`, or `differential.py`.

Context: #5932 isolated an intermittent CPython `ast.parse` SIGSEGV (5/78 runs, ~6.4%, always `ast.py:52`). #5945 added LibCST as the second provider (0 failures on the 1,821-file numpy+pandas corpus, ~57 files/s vs CPython's ~685 files/s). This PR evaluates two more candidates.

**No cross-provider CID comparison** — different parsers build different trees; matching addresses across providers is not a criterion (settled per #5940/#5932).

## Candidates

**parso** (`parso_adapter.py`) — pure Python, error-recovering (what Jedi/black's blib2to3 use).
- Corpus: 352/406 numpy + 1176/1415 pandas constructed = **83.9%** combined.
- 5 files fail to *parse at all* — all traced to one hard finding: **parso 0.8.7's shipped grammar has NO `match_stmt`/`case_block` productions whatsoever** (verified by grepping `grammar*.txt` directly in the installed package — the productions simply do not exist for any Python version parso ships). Any `match`/`case` source is a hard refusal, not a partial gap.
- Remaining gap files are membrane panics (unmapped CST shapes — parso is a raw lib2to3-family CST, not AST-shaped, so translation is substantial) and a documented f-string format-spec adapter gap (see `test_fstring_format_spec_is_a_known_adapter_gap`).
- No SIGSEGVs observed; pure Python, cannot call `compile()`.

**tree-sitter-python** (`tree_sitter_python_adapter.py`) — C, incremental, does not call `compile()`.
- Corpus: 398/406 numpy + 1410/1415 pandas constructed = **99.3%** combined, **zero** parse failures, **zero** crashes.
- Structurally the closest match to our AST-shaped membrane of any candidate: binary/boolean/comparison operator chains are already left-nested by the grammar (parso's are flat n-ary and must be folded by hand), most productions expose named fields, and match/case has full first-class grammar support.
- Byte-column caveat: like CPython (unlike parso/LibCST), tree-sitter reports UTF-8 *byte* columns, not codepoints — reused the same `LineTable.offset_from_byte_col` seam the CPython adapter built.

## Throughput

**Not included in this PR.** battleaxe was at 1-minute load 40–48 for the entire session (three concurrent agents on one box, per the coordinator). Correctness is not load-sensitive and was measured now; throughput will be measured in a follow-up once the host is quiet (`bench_providers.py --mode throughput --require-quiet 5` blocks and records load at both ends — the harness is ready, the clean measurement is not yet taken).

## What the contract could not express (the requested finding)

- **parso has no match/case grammar at all** — not an adapter gap, a candidate disqualifier for any codebase using structural pattern matching.
- **Positional-only param retagging and vararg/kwarg detection in parso require checking `_is_leaf` before reading `.value`** — parso silently collapses single-child wrapper nodes (including `tfpdef` for an annotated no-default parameter), so the same grammar production surfaces as different node shapes depending on sibling content. Several crashes here were exactly this: code assuming a child was always a leaf.
- **tree-sitter-python's `case_clause` has no `pattern` field** despite exposing field names everywhere else — the pattern(s) had to be found positionally by filtering for `case_pattern`-typed children.
- Neither gap is a limitation of the *contract* (`backend.py`) itself — both parsers can express everything the membrane's `Description`/`Slot` vocabulary needs; the gaps are in how much of each grammar this adapter has mapped so far.

## Delivered

- `implementations/python/sugar-node-membrane/src/sugar_node_membrane/parso_adapter.py`
- `implementations/python/sugar-node-membrane/src/sugar_node_membrane/tree_sitter_python_adapter.py`
- `implementations/python/sugar-node-membrane/src/sugar_node_membrane/bench_providers.py` — correctness + throughput harness (`--mode correctness|throughput`, `--require-quiet`)
- `implementations/python/sugar-node-membrane/tests/test_parso_adapter.py`
- `implementations/python/sugar-node-membrane/tests/test_tree_sitter_adapter.py`

Full existing test suite (42 tests) still green; 7 new tests added, all passing.

**Not merging this myself** — for review.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add parso and tree-sitter-python provider adapters to the membrane
> - Adds [`parso_adapter.py`](https://github.com/TSavo/sugar/pull/5950/files#diff-5d95cb9483383d10a3199d0989433c174a97b3ad5f5dc535a9f7fdf1853a3447) implementing a `ParsoProvider` that parses Python source via parso and exposes the AST as membrane `ProviderHandle`/`Description` trees; syntax errors surface as `SyntaxError`, unsupported nodes trigger `membrane_panic`.
> - Adds [`tree_sitter_python_adapter.py`](https://github.com/TSavo/sugar/pull/5950/files#diff-62a45fea8261debf3b94c9da9f28b015a5b75cb8ad6f0a6c5124d8fc59b0edd3) implementing `TreeSitterPythonProvider` with broad Python grammar coverage including pattern matching, f-strings, comprehensions, async forms, PEP 695 type aliases, and column normalization for non-ASCII source.
> - Adds [`bench_providers.py`](https://github.com/TSavo/sugar/pull/5950/files#diff-be39045fde6b9745135c96b280fe8fbac5ef38055a8ce87a5d81f0f89eb17348) as a CLI tool for benchmarking any registered provider in either correctness mode (parse failures, panics, crashes) or throughput mode (files/s), with optional load-average gating.
> - Test coverage is added for both adapters, including a golden-file round-trip, match-statement support gaps in parso, and byte-vs-codepoint column normalization in the tree-sitter adapter.
> - Risk: the parso adapter does not support `match` statements (raises `SyntaxError`) and panics on f-strings with both a conversion and a format spec.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36efa65.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->