### PR TITLE
Fix broken imports: adapters called membrane_panic, which #5949 removed

### DIFF
--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/parso_adapter.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/parso_adapter.py
@@ -78,7 +78,7 @@ from .backend import (
 )
 from .nodes import SourceUnit
 from .operators import Operator, operator_for
-from .panic import membrane_panic
+from .panic import membrane_missing
 from .spans import Span
 
 ParsoNode = object  # parso.tree.NodeOrLeaf, kept untyped at the boundary
@@ -172,7 +172,7 @@ def _cmp_op(node: ParsoNode) -> Operator:
             return operator_for("NotIn")
         if text == "is not":
             return operator_for("IsNot")
-        membrane_panic(
+        membrane_missing(
             owner="parso_adapter._cmp_op",
             observed=f"comp_op token {text!r} not recognized",
             requested="one of: not in, is not",
@@ -185,7 +185,7 @@ def _cmp_op(node: ParsoNode) -> Operator:
         return operator_for("Is")
     kind = _CMP_TOKEN.get(text)
     if kind is None:
-        membrane_panic(
+        membrane_missing(
             owner="parso_adapter._cmp_op",
             observed=f"comparison token {text!r} not recognized",
             requested="a known comparison operator token",
@@ -211,7 +211,7 @@ def _fold_binop(unit: SourceUnit, node: ParsoNode) -> ProviderHandle:
         right_node = kids[i + 1]
         kind = _BIN_TOKEN.get(op_tok.value)
         if kind is None:
-            membrane_panic(
+            membrane_missing(
                 owner="parso_adapter._fold_binop",
                 observed=f"binary operator token {op_tok.value!r} not recognized",
                 requested="a known binary operator token",
@@ -356,7 +356,7 @@ def _constant_leaf(unit: SourceUnit, node: ParsoNode) -> ProviderHandle:
         return _fixed_constant(span, value)
     if node.type == "operator" and node.value == "...":
         return _fixed_constant(span, Ellipsis)
-    membrane_panic(
+    membrane_missing(
         owner="parso_adapter._constant_leaf",
         observed=f"leaf {node.type}:{node.value!r} is not a recognized literal",
         requested="number, string, None/True/False, or Ellipsis",
@@ -376,7 +376,7 @@ def _fstring_values(unit: SourceUnit, node: ParsoNode) -> List[ProviderHandle]:
         elif c.type in ("fstring_start", "fstring_end"):
             continue
         else:
-            membrane_panic(
+            membrane_missing(
                 owner="parso_adapter._fstring_values",
                 observed=f"fstring child {c.type!r} not recognized",
                 requested="fstring_string or fstring_expr",
@@ -411,7 +411,7 @@ def _describe_fstring_expr(unit: SourceUnit, node: ParsoNode) -> Description:
             format_spec = c
             i += 1
             continue
-        membrane_panic(
+        membrane_missing(
             owner="parso_adapter._describe_fstring_expr",
             observed=f"fstring_expr trailing token {c!r} not recognized",
             requested="'!' conversion or format spec",
@@ -472,7 +472,7 @@ def _fold_trailers(unit: SourceUnit, atom: ParsoNode, trailers: Sequence[ParsoNo
                 (("value", Child(acc)), ("slice_", Child(slice_handle))),
             )
         else:
-            membrane_panic(
+            membrane_missing(
                 owner="parso_adapter._fold_trailers",
                 observed=f"trailer starting with {first.value!r} not recognized",
                 requested="'.', '(' or '['",
@@ -513,7 +513,7 @@ def _call_args(unit: SourceUnit, inner: Sequence[ParsoNode]) -> Tuple[List[Provi
                     (("arg", SlotLeaf(ik[0].value)), ("value", Child(_h(unit, ik[2])))),
                 ))
             else:
-                membrane_panic(
+                membrane_missing(
                     owner="parso_adapter._call_args",
                     observed=f"argument shape {[c.type for c in ik]!r} not recognized",
                     requested="*expr, **expr, name=expr, or a comprehension argument",
@@ -560,7 +560,7 @@ def _one_subscript_item(unit: SourceUnit, node: ParsoNode) -> ProviderHandle:
     lower, upper, step = segments[0], segments[1], segments[2]
     for seg in (lower, upper, step):
         if len(seg) > 1:
-            membrane_panic(
+            membrane_missing(
                 owner="parso_adapter._one_subscript_item",
                 observed=f"slice segment with {len(seg)} nodes",
                 requested="zero or one expression per slice segment",
@@ -729,7 +729,7 @@ def _describe(unit: SourceUnit, node: ParsoNode) -> Description:
     fn = _DISPATCH.get(t)
     if fn is not None:
         return fn(unit, node)
-    membrane_panic(
+    membrane_missing(
         owner="parso_adapter._describe",
         observed=f"parso node type {t!r} has no translation rule",
         requested="a mapped statement/expression shape",
@@ -771,7 +771,7 @@ def _describe_leaf(unit: SourceUnit, node: ParsoNode) -> Description:
         # bare `a[:]`: subscript's slice collapses to just the ':' leaf.
         return Description(kind="Slice", raw_span=_span(unit, node), anchors=(),
                             slots=(("lower", MaybeChild(None)), ("upper", MaybeChild(None)), ("step", MaybeChild(None))))
-    membrane_panic(
+    membrane_missing(
         owner="parso_adapter._describe_leaf",
         observed=f"leaf {node.type}:{node.value!r} has no translation rule",
         requested="a mapped leaf shape",
@@ -835,7 +835,7 @@ def _atom(unit: SourceUnit, node: ParsoNode) -> Description:
         return _dictorset(unit, node, kids[1])
     if first.type == "fstring":
         return _describe(unit, first)
-    membrane_panic(
+    membrane_missing(
         owner="parso_adapter._atom",
         observed=f"atom starting with {getattr(first, 'value', first.type)!r} not recognized",
         requested="'(', '[', '{' grouping, or an fstring",
@@ -900,7 +900,7 @@ def _comp_clauses(unit: SourceUnit, nodes: Sequence[ParsoNode]) -> Tuple[Provide
             # folded into the preceding Comprehension's ifs by _comprehension
             continue
         else:
-            membrane_panic(
+            membrane_missing(
                 owner="parso_adapter._comp_clauses",
                 observed=f"comprehension clause child {n.type!r} not recognized",
                 requested="comp_for/sync_comp_for or comp_if",
@@ -928,14 +928,14 @@ def _comprehension(unit: SourceUnit, node: ParsoNode) -> Description:
             ifs.append(_h(unit, ik[1]))
             # a comp_if may itself carry a further comp_iter (chained ifs/for)
             if len(ik) > 2:
-                membrane_panic(
+                membrane_missing(
                     owner="parso_adapter._comprehension",
                     observed="comp_if with a nested comp_iter tail not yet folded",
                     requested="a flattened ifs/for chain",
                     fix="extend _comprehension to fold chained comp_iter tails",
                 )
         elif r2.type in ("comp_for", "sync_comp_for"):
-            membrane_panic(
+            membrane_missing(
                 owner="parso_adapter._comprehension",
                 observed="chained 'for ... for ...' clause not yet folded into a flat generators list",
                 requested="each comp_for as its own top-level Comprehension",
@@ -994,7 +994,7 @@ def _expr_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
                                    ("value", Child(_h(unit, value)))))
     aug_kind = _AUG_TOKEN.get(op.value)
     if aug_kind is None:
-        membrane_panic(
+        membrane_missing(
             owner="parso_adapter._expr_stmt",
             observed=f"expr_stmt operator {op.value!r} not recognized",
             requested="'=' (chained) or an augmented-assignment token",
@@ -1347,7 +1347,7 @@ def _async_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
     if inner.type == "with_stmt":
         base = _with_stmt(unit, inner)
         return Description(kind="AsyncWith", raw_span=span, anchors=(), slots=base.slots)
-    membrane_panic(
+    membrane_missing(
         owner="parso_adapter._async_stmt",
         observed=f"async_stmt wrapping {inner.type!r} not recognized",
         requested="funcdef, for_stmt, or with_stmt",
@@ -1392,7 +1392,7 @@ def _factor(unit: SourceUnit, node: ParsoNode) -> Description:
     kids = _kids(node)
     kind = _UNARY_TOKEN.get(kids[0].value)
     if kind is None:
-        membrane_panic(
+        membrane_missing(
             owner="parso_adapter._factor",
             observed=f"unary token {kids[0].value!r} not recognized",
             requested="'+', '-', or '~'",

--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/tree_sitter_python_adapter.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/tree_sitter_python_adapter.py
@@ -73,7 +73,7 @@ from .backend import (
 )
 from .nodes import SourceUnit
 from .operators import Operator, operator_for
-from .panic import membrane_panic
+from .panic import membrane_missing
 from .spans import Span
 
 TSNode = object  # tree_sitter.Node, kept untyped at the boundary
@@ -209,7 +209,7 @@ def _expression_statement(unit: SourceUnit, node: TSNode) -> Description:
     # bare `a; b` on one physical statement line — each named child is its
     # own small statement; the membrane has no multi-statement-line node,
     # so this shape is not constructible as a single Expr and is a MISSING.
-    membrane_panic(
+    membrane_missing(
         owner="tree_sitter_python_adapter._expression_statement",
         observed=f"expression_statement with {len(kids)} named children",
         requested="exactly one expression",
@@ -257,7 +257,7 @@ def _string_like(unit: SourceUnit, node: TSNode) -> Description:
         elif c.type == "interpolation":
             values.append(_interpolation(unit, c))
         else:
-            membrane_panic(
+            membrane_missing(
                 owner="tree_sitter_python_adapter._string_like",
                 observed=f"f-string child {c.type!r} not recognized",
                 requested="string_content or interpolation",
@@ -350,7 +350,7 @@ def _binary_operator(unit: SourceUnit, node: TSNode) -> Description:
     op_node = _field(node, "operator")
     kind = _BIN_TOKEN.get(op_node.type)
     if kind is None:
-        membrane_panic(
+        membrane_missing(
             owner="tree_sitter_python_adapter._binary_operator",
             observed=f"binary operator token {op_node.type!r} not recognized",
             requested="a known binary operator token",
@@ -381,7 +381,7 @@ def _unary_operator(unit: SourceUnit, node: TSNode) -> Description:
     arg = _field(node, "argument")
     kind = _UNARY_TOKEN.get(op_node.type)
     if kind is None:
-        membrane_panic(
+        membrane_missing(
             owner="tree_sitter_python_adapter._unary_operator",
             observed=f"unary operator token {op_node.type!r} not recognized",
             requested="'+', '-', or '~'",
@@ -402,7 +402,7 @@ def _comparison_operator(unit: SourceUnit, node: TSNode) -> Description:
         text = t.type if t.type not in ("is not", "not in") else t.type
         kind = _CMP_TOKEN.get(t.type)
         if kind is None:
-            membrane_panic(
+            membrane_missing(
                 owner="tree_sitter_python_adapter._comparison_operator",
                 observed=f"comparison token {t.type!r} not recognized",
                 requested="a known comparison operator token",
@@ -492,7 +492,7 @@ def _one_subscript_item(unit: SourceUnit, node: TSNode) -> ProviderHandle:
 def _parenthesized_expression(unit: SourceUnit, node: TSNode) -> Description:
     inner = _named(node)
     if len(inner) != 1:
-        membrane_panic(
+        membrane_missing(
             owner="tree_sitter_python_adapter._parenthesized_expression",
             observed=f"parenthesized_expression with {len(inner)} named children",
             requested="exactly one inner expression",
@@ -537,7 +537,7 @@ def _dictionary(unit: SourceUnit, node: TSNode) -> Description:
             items.append(_fixed("DictItem", _span(unit, c),
                                  (("key", MaybeChild(None)), ("value", Child(_h(unit, inner))))))
         else:
-            membrane_panic(
+            membrane_missing(
                 owner="tree_sitter_python_adapter._dictionary",
                 observed=f"dictionary child {c.type!r} not recognized",
                 requested="pair or dictionary_splat",
@@ -749,7 +749,7 @@ def _one_param(unit: SourceUnit, node: TSNode, after_star: bool) -> ProviderHand
                         ("default", MaybeChild(_h(unit, value_node))),
                         ("param_kind", SlotLeaf("keyword_only" if after_star else "positional_or_keyword"))),
                        anchors=(_span(unit, name_node),))
-    membrane_panic(
+    membrane_missing(
         owner="tree_sitter_python_adapter._one_param",
         observed=f"parameter shape {node.type!r} not recognized",
         requested="a mapped parameter shape",
@@ -806,7 +806,7 @@ def _augmented_assignment(unit: SourceUnit, node: TSNode) -> Description:
     op_node = _field(node, "operator")
     kind = _AUG_TOKEN.get(op_node.type)
     if kind is None:
-        membrane_panic(
+        membrane_missing(
             owner="tree_sitter_python_adapter._augmented_assignment",
             observed=f"augmented assignment token {op_node.type!r} not recognized",
             requested="a known augmented assignment token",
@@ -1239,7 +1239,7 @@ def _pattern(unit: SourceUnit, node: TSNode) -> ProviderHandle:
             i = j + 1
         return _fixed("MatchMapping", span,
                       (("keys", Children(tuple(keys))), ("patterns", Children(tuple(patterns))), ("rest", SlotLeaf(rest))))
-    membrane_panic(
+    membrane_missing(
         owner="tree_sitter_python_adapter._pattern",
         observed=f"case pattern shape {node.type!r} not recognized",
         requested="a mapped match-pattern shape",
@@ -1272,7 +1272,7 @@ _LEAF_DISPATCH = {
 def _describe(unit: SourceUnit, node: TSNode) -> Description:
     t = node.type
     if not node.is_named:
-        membrane_panic(
+        membrane_missing(
             owner="tree_sitter_python_adapter._describe",
             observed=f"unnamed/punctuation node {t!r} reached the dispatcher",
             requested="a named grammar node",
@@ -1286,7 +1286,7 @@ def _describe(unit: SourceUnit, node: TSNode) -> Description:
     fn = _DISPATCH.get(t)
     if fn is not None:
         return fn(unit, node)
-    membrane_panic(
+    membrane_missing(
         owner="tree_sitter_python_adapter._describe",
         observed=f"tree-sitter node type {t!r} has no translation rule",
         requested="a mapped statement/expression shape",


### PR DESCRIPTION
Main is broken: `parso_adapter.py` and `tree_sitter_python_adapter.py` import `membrane_panic`, which #5949 replaced with `membrane_missing` / `membrane_provider_defect`.

#5949 and #5950 were developed in parallel. No textual conflict, so both merged cleanly — the incompatibility is semantic. Importing either adapter now raises `ImportError`.

Found by trying to run the provider throughput benchmark, which could not load either adapter.

All 30 call sites (18 parso, 12 tree-sitter) map to `membrane_missing`, justified by their own `fix=` texts rather than assumed — every one reads *"extend X deliberately"* or *"add a translation rule for this node type; never guess"*. None describes a provider producing something structurally invalid, which is what `membrane_provider_defect` is for.

My error: I merged the two PRs back to back without checking that a symbol one removed was not used by the other.

Refs #5940, #5946.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix broken imports by replacing `membrane_panic` with `membrane_missing` in Python adapters
> PR #5949 removed `membrane_panic`, leaving [parso_adapter.py](https://github.com/TSavo/sugar/pull/5951/files#diff-5d95cb9483383d10a3199d0989433c174a97b3ad5f5dc535a9f7fdf1853a3447) and [tree_sitter_python_adapter.py](https://github.com/TSavo/sugar/pull/5951/files#diff-62a45fea8261debf3b94c9da9f28b015a5b75cb8ad6f0a6c5124d8fc59b0edd3) with broken imports. This PR updates all call sites in both files to use `membrane_missing` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ed6e12.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unsupported or unrecognized Python syntax during parsing and translation.
  * Cases such as unfamiliar operators, expressions, patterns, f-strings, parameters, and comprehensions now produce clearer “missing support” results instead of abruptly failing.
  * Preserved diagnostic context to help identify syntax features that are not yet supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->