### PR TITLE
bench: stream a flushed per-file trace so a crash does not lose the run

### DIFF
--- a/implementations/python/sugar-node-membrane/src/sugar_node_membrane/bench_providers.py
+++ b/implementations/python/sugar-node-membrane/src/sugar_node_membrane/bench_providers.py
@@ -28,6 +28,7 @@ CLI::
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 import time
 import traceback
@@ -125,10 +126,29 @@ def _require_quiet(threshold: float) -> None:
     print(f"host 1-min load at start: {load} {tag}")
 
 
-def run_throughput(provider_name: str, files: list[Path], limit: Optional[int]) -> None:
+def _trace(handle, phase: str, path: Path) -> None:
+    """Write one line per file and FLUSH.
+
+    A long timed run that dies mid-way (a provider segfault, an OOM kill)
+    otherwise loses everything it had measured: buffered stdout never
+    reaches the disk, and the log is zero bytes. The last line here names
+    the file the process was on when it died.
+    """
+    if handle is None:
+        return
+    handle.write(f"{phase}\t{path}\n")
+    handle.flush()
+    os.fsync(handle.fileno())
+
+
+def run_throughput(
+    provider_name: str, files: list[Path], limit: Optional[int],
+    trace_path: Optional[Path] = None,
+) -> None:
     if limit is not None:
         files = files[:limit]
     provider = _provider(provider_name)
+    trace = open(trace_path, "w", buffering=1) if trace_path else None
 
     sources: list[tuple[Path, str]] = []
     for path in files:
@@ -145,7 +165,8 @@ def run_throughput(provider_name: str, files: list[Path], limit: Optional[int]) 
             provider.parse.__self__  # no-op; keeps provider warm
         except Exception:
             pass
-    for _, source in sources:
+    for path, source in sources:
+        _trace(trace, "parse", path)
         try:
             from .nodes import SourceUnit
             unit = SourceUnit(filename="<bench>", source=source)
@@ -159,6 +180,7 @@ def run_throughput(provider_name: str, files: list[Path], limit: Optional[int]) 
     t1 = time.perf_counter()
     constructed = 0
     for path, source in sources:
+        _trace(trace, "construct", path)
         try:
             membrane.parse(source, filename=str(path))
             constructed += 1
@@ -173,6 +195,8 @@ def run_throughput(provider_name: str, files: list[Path], limit: Optional[int]) 
     print(f"host load (1min) start: {load_start}")
     print(f"host load (1min) end:   {load_end}")
     print(f"pure parse:            {t_parse:.3f}s  ({n / t_parse if t_parse else float('inf'):.1f} files/s)  [{parsed_handles} ok]")
+    if trace is not None:
+        trace.close()
     print(f"parse+construct:       {t_construct_total:.3f}s  ({n / t_construct_total if t_construct_total else float('inf'):.1f} files/s)  [{constructed} ok]")
 
 
@@ -184,6 +208,8 @@ def main(argv: Optional[list[str]] = None) -> int:
     ap.add_argument("--mode", choices=["correctness", "throughput"], default="correctness")
     ap.add_argument("--require-quiet", type=float, default=None)
     ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--trace", type=Path, default=None,
+                    help="write a flushed per-file trace here; survives a crash")
     args = ap.parse_args(argv)
 
     files = collect_files(args.paths)
@@ -191,7 +217,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         return run_correctness(args.provider, files, args.base)
     if args.require_quiet is not None:
         _require_quiet(args.require_quiet)
-    run_throughput(args.provider, files, args.limit)
+    run_throughput(args.provider, files, args.limit, args.trace)
     return 0
 
 


### PR DESCRIPTION
A timed run over the full corpus buffered all output and printed only at the end. So when a run died mid-way, it left a **zero-byte log** — no way to tell what had been measured or which file it was on. That happened to both a `cpython-ast` and a `libcst` throughput run.

`--trace PATH` now writes one line per file (phase + path), **flushed and fsynced**, during both timed loops. The last line names the file the process was on when it died.

### Context this was found in

Chasing that segfault: run one-at-a-time with a **fresh `Membrane` per file**, LibCST parses all **1,828 corpus files with 0 errors**. The harness reuses **one `Membrane` across the whole corpus**, so the intern pool accumulates every node (~2.9M) — and **both** providers segfault there.

Two independent parsers failing identically points at **shared construction**, not at either parser. That investigation is ongoing; this PR is only about not losing the evidence next time.

Refs #5940.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stream a flushed per-file trace during bench runs to survive crashes
> Adds a `--trace PATH` CLI option to `run_throughput` in [bench_providers.py](https://github.com/TSavo/sugar/pull/5952/files#diff-be39045fde6b9745135c96b280fe8fbac5ef38055a8ce87a5d81f0f89eb17348) that writes a `phase\tpath` line before each parse and construct operation. Each line is immediately flushed and fsynced, so progress is durably recorded even if the process crashes mid-run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1803090.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->