### PR TITLE
sugar-source-tree: text enters only through the SourceOracle; fragments and mementos exchange through it (#5940, #5954)

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
@@ -128,6 +128,79 @@ installed_module_source.cache_clear = (  # type: ignore[attr-defined]
 )
 
 
+def path_source(path: str) -> tuple[str, str, str]:
+    """Path-addressed minting door — ORACLE-CONTRACT EXTENSION (#5940 tree).
+
+    Second address form beside `installed_module_source`: the module door
+    serves *installed-module* source; a `SourceTree` enumerates *paths*.
+    Identity is the same `(source, filename, content CID)` triple, minted
+    HERE so no parser ever reads or hashes a file itself.
+
+    Minting only: read + decode + CID. No parse gate — which parses is the
+    backend's question, and refusing here would decide it for every backend.
+    Unreadable/undecodable is a LOUD `SourceOracleRefusal`, never `None`:
+    callers record it as a refusal, not an absence.
+    """
+    try:
+        source = Path(path).read_text(encoding="utf-8")
+    except (OSError, UnicodeError, ValueError) as exc:
+        raise SourceOracleRefusal(f"cannot read source `{path}`: {exc}") from exc
+    return (source, str(path), blake3_512_of(source.encode("utf-8")))
+
+
+def resolve_span_memento(
+    memento: dict[str, Any], project_root: str | None = None
+) -> dict[str, Any]:
+    """Resolve a span-addressed SourceMemento by RECOMPUTE — exact or refuse.
+
+    ORACLE-CONTRACT EXTENSION (#5940 tree), the resolution half of
+    `path_source`. Memento shape: `{file, span: {start, end}, source_cid,
+    cid}` — file plus a half-open codepoint span into it, pinned twice:
+    the whole file (`source_cid`) and the sliced segment (`cid`). Reads the
+    on-disk file through `path_source`, re-slices, and returns the identity
+    plus segment IFF both CIDs recompute; else raises `SourceOracleRefusal`.
+    """
+    file = memento.get("file")
+    if not isinstance(file, str) or not file:
+        raise SourceOracleRefusal("span memento missing `file`")
+    span = memento.get("span")
+    if not isinstance(span, dict):
+        raise SourceOracleRefusal("span memento missing `span`")
+    start, end = span.get("start"), span.get("end")
+    if not isinstance(start, int) or not isinstance(end, int) or not (0 <= start <= end):
+        raise SourceOracleRefusal(f"span memento has degenerate span {span!r}")
+
+    path = str(Path(project_root) / file) if project_root else file
+    source, filename, source_cid = path_source(path)
+
+    pinned_source_cid = memento.get("source_cid")
+    if pinned_source_cid is not None and source_cid != pinned_source_cid:
+        raise SourceOracleRefusal(
+            f"source CID misaligned for `{file}`: pinned {pinned_source_cid}, "
+            f"on-disk {source_cid} -- the source drifted from the memento"
+        )
+    if end > len(source):
+        raise SourceOracleRefusal(
+            f"span [{start}, {end}) exceeds `{file}` length {len(source)}"
+        )
+    segment = source[start:end]
+    segment_cid = blake3_512_of(segment.encode("utf-8"))
+    pinned_cid = memento.get("cid")
+    if pinned_cid is not None and segment_cid != pinned_cid:
+        raise SourceOracleRefusal(
+            f"segment CID misaligned for `{file}` [{start}, {end}): pinned "
+            f"{pinned_cid}, on-disk {segment_cid} -- the segment drifted"
+        )
+    return {
+        "source": source,
+        "filename": filename,
+        "source_cid": source_cid,
+        "segment": segment,
+        "cid": segment_cid,
+        "span": {"start": start, "end": end},
+    }
+
+
 def resolve_source_memento(
     project_root: str, memento: dict[str, Any]
 ) -> dict[str, Any]:

--- a/implementations/python/sugar-lift-python-source/tests/test_source_oracle.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_oracle.py
@@ -217,3 +217,54 @@ def test_lean_lift_omits_inline_source_but_keeps_cids(tmp_path: Path) -> None:
     bs = entry["body_source"]
     assert "body_text" not in bs and "ast_template" not in bs  # signs the real code
     assert bs["source_cid"] and bs["template_cid"] and bs["span"]  # by CID + locus
+
+
+# ---------------------------------------------------------------------------
+# Path-addressed doors (#5940 tree): path_source / resolve_span_memento
+# ---------------------------------------------------------------------------
+
+
+def test_path_source_mints_the_identity_triple(tmp_path: Path) -> None:
+    from sugar_lift_python_source.source_oracle import path_source
+
+    p = tmp_path / "m.py"
+    p.write_text("x = 1\n", encoding="utf-8")
+    source, filename, cid = path_source(str(p))
+    assert source == "x = 1\n"
+    assert filename == str(p)
+    assert cid == blake3_512_of(b"x = 1\n")
+
+
+def test_path_source_refuses_loudly_never_none(tmp_path: Path) -> None:
+    from sugar_lift_python_source.source_oracle import path_source
+
+    with pytest.raises(SourceOracleRefusal):
+        path_source(str(tmp_path / "absent.py"))
+    bad = tmp_path / "bad.py"
+    bad.write_bytes(b"\xff\xfe\x00x")
+    with pytest.raises(SourceOracleRefusal):
+        path_source(str(bad))
+
+
+def test_resolve_span_memento_recomputes_or_refuses(tmp_path: Path) -> None:
+    from sugar_lift_python_source.source_oracle import (
+        path_source,
+        resolve_span_memento,
+    )
+
+    p = tmp_path / "m.py"
+    p.write_text("a = 1\nb = 2\n", encoding="utf-8")
+    source, filename, cid = path_source(str(p))
+    memento = {
+        "file": filename,
+        "span": {"start": 6, "end": 11},
+        "source_cid": cid,
+        "cid": blake3_512_of(b"b = 2"),
+    }
+    resolved = resolve_span_memento(memento)
+    assert resolved["segment"] == "b = 2"
+    assert resolved["source_cid"] == cid
+
+    p.write_text("a = 1\nc = 3\n", encoding="utf-8")
+    with pytest.raises(SourceOracleRefusal):
+        resolve_span_memento(memento)

--- a/implementations/python/sugar-source-tree/pyproject.toml
+++ b/implementations/python/sugar-source-tree/pyproject.toml
@@ -5,9 +5,12 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "sugar-source-tree"
 version = "0.1.0"
-description = "A parser and a source tree (#5940): SourceTree enumerates SourceFile enumerates nodes, over a swappable backend. Standalone; stdlib-only core."
+description = "A parser and a source tree (#5940): SourceTree enumerates SourceFile enumerates nodes, over a swappable backend. Built on top of the SourceOracle: text enters only as the oracle's (source, filename, CID) identity."
 requires-python = ">=3.12"
-dependencies = []
+# The oracle (sugar-lift-python-source) is the ONE text/address authority;
+# this parser is built on top of it. It is a sibling package in this repo:
+#   pip install -e ../sugar-lift-python-source -e .
+dependencies = ["sugar-lift-python-source"]
 
 # The core membrane stays stdlib-only. A PROVIDER is an optional extra:
 # installing one must never be a condition of the membrane working, and the

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/__init__.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/__init__.py
@@ -12,9 +12,16 @@ behind a read-only adapter; every node is Typed at construction. Nothing
 above an adapter names a backend library or receives a backend-native
 object. No caching anywhere: a ``SourceFile`` holding its parsed tree IS
 the file.
+
+Built on top of the SourceOracle: text enters only as the oracle's
+``(source, filename, content CID)`` identity, and the two currencies —
+live ``SourceFragment``, sealed ``SourceMemento`` — exchange only through
+it (``fragment.seal()`` / ``resolve_memento``). Every enumerated object
+answers ``.fragment``.
 """
 
 from .backend import Backend, BackendRefused
+from .fragment import SourceFragment, SourceMemento, resolve_memento
 from .nodes import KIND_REGISTRY, Node, SourceUnit, Typeable, Typed
 from .panic import BackendDefect, SourceTreePanic, VocabularyMissing
 from .spans import LineColSpan, LineTable, Span
@@ -29,6 +36,8 @@ __all__ = [
     "LineTable",
     "Node",
     "SourceFile",
+    "SourceFragment",
+    "SourceMemento",
     "SourceTree",
     "SourceTreePanic",
     "SourceUnit",
@@ -36,4 +45,5 @@ __all__ = [
     "Typeable",
     "Typed",
     "VocabularyMissing",
+    "resolve_memento",
 ]

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/bench_backends.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/bench_backends.py
@@ -32,6 +32,8 @@ import time
 from pathlib import Path
 from typing import Optional
 
+from sugar_lift_python_source.source_oracle import SourceOracleRefusal, path_source
+
 from .backend import BackendRefused
 from .corpus import make_backend
 from .panic import SourceTreePanic
@@ -65,12 +67,12 @@ def run_correctness(backend_name: str, root: Path, rss: bool = False) -> int:
         total += 1
         rel = str(path)
         try:
-            source = path.read_text(encoding="utf-8")
-        except UnicodeDecodeError as err:
-            refused.append((rel, f"undecodable: {err}"))
+            identity = path_source(rel)
+        except SourceOracleRefusal as err:
+            refused.append((rel, f"oracle refused: {err}"))
             continue
         try:
-            file = SourceFile(filename=rel, source=source, backend=tree.backend)
+            file = SourceFile(identity, backend=tree.backend)
             for _node in file.nodes():
                 node_count += 1
             parsed += 1
@@ -120,20 +122,20 @@ def run_throughput(backend_name: str, root: Path, limit: Optional[int]) -> None:
     paths = list(tree.paths())
     if limit is not None:
         paths = paths[:limit]
-    sources: list[tuple[str, str]] = []
+    identities: list[tuple[str, str, str]] = []
     for path in paths:
         try:
-            sources.append((str(path), path.read_text(encoding="utf-8")))
-        except UnicodeDecodeError:
+            identities.append(path_source(str(path)))
+        except SourceOracleRefusal:
             continue
 
     load_start = _load1()
     t0 = time.perf_counter()
     constructed = 0
     nodes = 0
-    for rel, source in sources:
+    for identity in identities:
         try:
-            file = SourceFile(filename=rel, source=source, backend=tree.backend)
+            file = SourceFile(identity, backend=tree.backend)
             for _n in file.nodes():
                 nodes += 1
             constructed += 1
@@ -142,7 +144,7 @@ def run_throughput(backend_name: str, root: Path, limit: Optional[int]) -> None:
     dt = time.perf_counter() - t0
     load_end = _load1()
 
-    n = len(sources)
+    n = len(identities)
     print(f"backend:                {backend_name}")
     print(f"files timed:            {n}")
     print(f"host load (1min) start: {load_start}")

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/corpus.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/corpus.py
@@ -48,6 +48,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, Optional
 
+from sugar_lift_python_source.source_oracle import SourceOracleRefusal, path_source
+
 from .backend import Backend, BackendRefused
 from .nodes import Node
 from .panic import BackendDefect, VocabularyMissing
@@ -67,7 +69,13 @@ def node_paths(root: Node) -> Iterator[tuple[str, Node]]:
         stack.extend(reversed(entries))
 
 
-def records_for_file(file: SourceFile) -> list[dict[str, object]]:
+def records_for_file(
+    file: SourceFile, display: Optional[str] = None
+) -> list[dict[str, object]]:
+    """``display`` is the record's ``file`` label (root-relative in a corpus
+    run); the unit's own filename is the oracle's address and stays on the
+    unit."""
+    file_label = display if display is not None else file.filename
     table = file.unit.line_table
     out: list[dict[str, object]] = []
     for path, node in node_paths(file.root):
@@ -75,7 +83,7 @@ def records_for_file(file: SourceFile) -> list[dict[str, object]]:
         segment_cid = hashlib.sha256(node.segment().encode("utf-8")).hexdigest()
         out.append(
             {
-                "file": file.filename,
+                "file": file_label,
                 "path": path,
                 "kind": node.kind,
                 "start": node.span.start,
@@ -129,13 +137,17 @@ def emit_corpus(
         for path in files:
             rel = str(path.relative_to(base)) if base is not None else str(path)
             try:
-                source = path.read_text(encoding="utf-8")
-            except UnicodeDecodeError as err:
-                failures.append((rel, "undecodable", str(err)))
+                identity = path_source(str(path))
+            except SourceOracleRefusal as err:
+                # The ORACLE refused to mint an identity (unreadable or
+                # undecodable). Text enters only through the oracle, so
+                # this is where a bad file surfaces — recorded, never
+                # swallowed.
+                failures.append((rel, "oracle_refused", str(err)))
                 continue
             try:
-                file = SourceFile(filename=rel, source=source, backend=backend)
-                recs = records_for_file(file)
+                file = SourceFile(identity, backend=backend)
+                recs = records_for_file(file, display=rel)
             except BackendRefused as err:
                 # The BACKEND refused the file (not valid input for it).
                 # Recorded loudly; distinct from a vocabulary MISSING. Never

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/fragment.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/fragment.py
@@ -1,0 +1,163 @@
+"""The two currencies: SourceFragment (live) and SourceMemento (sealed).
+
+Sugar deals in exactly two: a ``SourceFragment`` is the LIVE, CAPABLE
+object — oracle-pinned text, a span into it, and (when it was minted by
+enumeration) the typed node it views. It points at actual source on disk
+and answers whatever operations the work needs. A ``SourceMemento`` is
+the sealed minimal address — file, span, two CIDs — inert, never grows.
+
+They are interchangeable through the SourceOracle, and ONLY through it:
+
+    fragment.seal()            -> SourceMemento   (pin)
+    resolve_memento(memento)   -> SourceFragment  (recompute, exact-or-refuse)
+
+Resolution goes back through the oracle's ``resolve_span_memento``: the
+on-disk file must recompute to the pinned file CID and the sliced segment
+to the pinned segment CID, or the oracle refuses loudly. Nothing here
+opens a file or mints a hash outside the oracle.
+
+Enumeration is the only fragment constructor: ``SourceFile.fragment``
+answers the whole file, ``Node.fragment`` answers that node's slice of
+the same pinned text. A fragment that exists is correct because there is
+no other way to make one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional
+
+from sugar_lift_python_source.source_oracle import (
+    SourceOracleRefusal,
+    resolve_span_memento,
+)
+
+from .spans import LineColSpan, Span
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .backend import Backend
+    from .nodes import Node, SourceUnit
+    from .tree import SourceFile
+
+
+@dataclass(frozen=True)
+class SourceMemento:
+    """The sealed currency: file, span, content CIDs. Minimal, inert.
+
+    ``source_cid`` pins the whole file; ``cid`` pins the sliced segment.
+    Both are the oracle's addresses, carried verbatim from sealing.
+    """
+
+    file: str
+    start: int
+    end: int
+    source_cid: str
+    cid: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "file": self.file,
+            "span": {"start": self.start, "end": self.end},
+            "source_cid": self.source_cid,
+            "cid": self.cid,
+        }
+
+
+class SourceFragment:
+    """The live currency: oracle-pinned text + span + (optionally) the node.
+
+    Rich on purpose: it holds the unit (text, CID, line table), the span,
+    and the typed node when enumeration minted it — the working handle,
+    not a value triple. Equality is content identity: same file, same
+    pinned source CID, same span. The node is capability, not identity.
+    """
+
+    __slots__ = ("unit", "span", "node")
+
+    def __init__(self, unit: "SourceUnit", span: Span, node: Optional["Node"]) -> None:
+        self.unit = unit
+        self.span = span
+        self.node = node
+
+    @property
+    def filename(self) -> str:
+        return self.unit.filename
+
+    @property
+    def source_cid(self) -> str:
+        return self.unit.source_cid
+
+    @property
+    def text(self) -> str:
+        return self.span.slice(self.unit.source)
+
+    @property
+    def line_col_span(self) -> LineColSpan:
+        return self.unit.line_table.project(self.span)
+
+    def seal(self) -> SourceMemento:
+        """Fragment -> memento. The segment CID is minted by the oracle's
+        hash over the oracle-pinned text — this layer computes a slice of
+        text the oracle already addressed; it never invents an address."""
+        from sugar_lift_python_source.canonical import blake3_512_of
+
+        return SourceMemento(
+            file=self.unit.filename,
+            start=self.span.start,
+            end=self.span.end,
+            source_cid=self.unit.source_cid,
+            cid=blake3_512_of(self.text.encode("utf-8")),
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SourceFragment):
+            return NotImplemented
+        return (
+            self.unit.filename == other.unit.filename
+            and self.unit.source_cid == other.unit.source_cid
+            and self.span == other.span
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.unit.filename, self.unit.source_cid, self.span))
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return (
+            f"<SourceFragment {self.unit.filename!r} "
+            f"[{self.span.start}, {self.span.end}) "
+            f"node={type(self.node).__name__ if self.node is not None else None}>"
+        )
+
+
+def resolve_memento(
+    memento: SourceMemento,
+    backend: Optional["Backend"] = None,
+    project_root: Optional[str] = None,
+) -> SourceFragment:
+    """Memento -> fragment, through the oracle. Exact or refuse.
+
+    The oracle re-reads the file, recomputes both CIDs, and refuses on any
+    drift. On success the file is re-parsed through a backend and the
+    fragment is re-bound to the node whose span equals the pinned span, so
+    the resolved fragment is as live as the one that sealed. A pinned span
+    that matches no node when the CIDs aligned is a loud refusal — the
+    backend disagreed with itself, and that never becomes silence.
+    """
+    from .tree import SourceFile
+
+    resolved = resolve_span_memento(memento.to_dict(), project_root)
+    file = SourceFile(
+        (resolved["source"], resolved["filename"], resolved["source_cid"]),
+        backend=backend,
+    )
+    span = Span(memento.start, memento.end)
+    if span == Span(0, len(file.unit.source)):
+        return file.fragment
+    for node in file.nodes():
+        if node.span == span:
+            return node.fragment
+    raise SourceOracleRefusal(
+        f"span [{span.start}, {span.end}) recomputed to the pinned CIDs in "
+        f"`{memento.file}` but no enumerated node answers it -- the backend "
+        "disagreed with the enumeration that sealed"
+    )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -32,9 +32,11 @@ the backend contract stays read-only.
 
 from __future__ import annotations
 
-import hashlib
 from dataclasses import dataclass, field
-from typing import ClassVar, Iterator, Optional, Tuple
+from typing import TYPE_CHECKING, ClassVar, Iterator, Optional, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .fragment import SourceFragment
 
 from .operators import (
     BinaryOperator,
@@ -48,22 +50,22 @@ from .spans import LineColSpan, LineTable, Span
 
 @dataclass(frozen=True)
 class SourceUnit:
-    """One parsed source: text, its content address, and its line table.
+    """One parsed source: oracle-pinned text, its content address, its line table.
 
-    ``source_cid`` is sha256 over the UTF-8 encoding of the source string —
-    a pure function of the text, never of the parser.
+    The identity ``(source, filename, source_cid)`` is the SourceOracle's
+    triple, carried verbatim. This type never opens a file and never hashes
+    text — minting an address is the oracle's job, and a unit that minted
+    its own would be a second, unpinned identity for the same bytes.
     """
 
     filename: str
     source: str
+    source_cid: str
 
     # populated in __post_init__, never by callers
-    source_cid: str = field(init=False, default="")
     line_table: LineTable = field(init=False, default=None)  # type: ignore[assignment]
 
     def __post_init__(self) -> None:
-        digest = hashlib.sha256(self.source.encode("utf-8")).hexdigest()
-        object.__setattr__(self, "source_cid", f"sha256:{digest}")
         object.__setattr__(self, "line_table", LineTable(self.source))
 
 
@@ -196,6 +198,15 @@ class Node(Typed):
 
     def segment(self) -> str:
         return self.span.slice(self.unit.source)
+
+    @property
+    def fragment(self) -> "SourceFragment":
+        """This node as a SourceFragment: its slice of the same oracle-pinned
+        text the whole file answers. One accessor, one typed answer — never
+        assembled by the caller from span + segment + cid."""
+        from .fragment import SourceFragment
+
+        return SourceFragment(unit=self.unit, span=self.span, node=self)
 
     def line_col_span(self) -> LineColSpan:
         return self.unit.line_table.project(self.span)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
@@ -7,6 +7,12 @@ to a swappable backend:
     SourceFile   enumerates ->  its nodes
     Node         enumerates ->  its children
 
+TEXT ENTERS ONLY THROUGH THE ORACLE. A ``SourceFile`` is constructed from
+the SourceOracle's identity triple ``(source, filename, content CID)``
+(``path_source`` / ``installed_module_source``); this layer never opens a
+file, never hashes text, never owns an address. There is no raw-string
+door and no ``read_text`` anywhere in the parser.
+
 A ``SourceFile`` parses at construction and holds its own tree. That is
 not a cache — it IS the file. There is no pool, no keyed store, no
 registry, no memo: enumerate a ``SourceTree`` and each ``SourceFile`` is
@@ -22,11 +28,19 @@ retains between queries is its own affair, below our line.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterator, Optional
+from typing import Iterator, Optional, Tuple
+
+from sugar_lift_python_source.source_oracle import (
+    SourceOracleRefusal,
+    installed_module_source,
+    path_source,
+)
 
 from .backend import Backend, materialize
+from .fragment import SourceFragment
 from .nodes import Module, Node, SourceUnit
 from .panic import backend_defect
+from .spans import Span
 
 
 def _default_backend() -> Backend:
@@ -37,6 +51,12 @@ def _default_backend() -> Backend:
 
 class SourceFile:
     """One source file, parsed through a backend into a typed tree.
+
+    Constructed from the SourceOracle's identity triple ``(source,
+    filename, content CID)`` — the ONE currency exchange. Use
+    ``SourceFile.from_path`` / ``SourceFile.from_module`` to go through
+    the oracle's doors; there is no raw-string constructor and no
+    filesystem read here.
 
     Parsing happens at construction: a ``SourceFile`` you hold is always
     a parsed file, never a promise of one. ``root`` is the ``Module``;
@@ -51,11 +71,13 @@ class SourceFile:
 
     def __init__(
         self,
-        filename: str,
-        source: str,
+        identity: Tuple[str, str, str],
         backend: Optional[Backend] = None,
     ) -> None:
-        self.unit = SourceUnit(filename=filename, source=source)
+        source, filename, source_cid = identity
+        self.unit = SourceUnit(
+            filename=filename, source=source, source_cid=source_cid
+        )
         self.backend = backend if backend is not None else _default_backend()
         root = materialize(self.unit, self.backend.root(self.unit))
         if not isinstance(root, Module):
@@ -69,8 +91,24 @@ class SourceFile:
         self.root: Module = root
 
     @classmethod
-    def read(cls, path: Path, filename: str, backend: Optional[Backend] = None) -> "SourceFile":
-        return cls(filename=filename, source=path.read_text(encoding="utf-8"), backend=backend)
+    def from_path(
+        cls, path: Path | str, backend: Optional[Backend] = None
+    ) -> "SourceFile":
+        """Through the oracle's path-addressed door. Unreadable/undecodable
+        is the oracle's loud ``SourceOracleRefusal``, never a swallow."""
+        return cls(path_source(str(path)), backend=backend)
+
+    @classmethod
+    def from_module(
+        cls, module_name: str, backend: Optional[Backend] = None
+    ) -> "SourceFile":
+        """Through the oracle's installed-module door."""
+        identity = installed_module_source(module_name)
+        if identity is None:
+            raise SourceOracleRefusal(
+                f"oracle has no installed source for module `{module_name}`"
+            )
+        return cls(identity, backend=backend)
 
     @property
     def filename(self) -> str:
@@ -79,6 +117,13 @@ class SourceFile:
     @property
     def source(self) -> str:
         return self.unit.source
+
+    @property
+    def fragment(self) -> SourceFragment:
+        """The whole file as a SourceFragment: full span, oracle CID."""
+        return SourceFragment(
+            unit=self.unit, span=Span(0, len(self.unit.source)), node=self.root
+        )
 
     def nodes(self) -> Iterator[Node]:
         """Every node of this file, pre-order, iterative."""
@@ -98,6 +143,10 @@ class SourceTree:
     the way out and retained by nobody but the caller. The tree holds the
     root path and the backend — never the parsed files. That is what
     keeps peak RSS flat across a corpus of any size.
+
+    Enumerating NAMES (globbing) is the tree's job; reading TEXT is the
+    oracle's: every path found here enters as the oracle's path-addressed
+    identity, so the parser itself never opens a file.
     """
 
     def __init__(self, root: Path, backend: Optional[Backend] = None) -> None:
@@ -115,20 +164,16 @@ class SourceTree:
             yield path
 
     def files(self) -> Iterator[SourceFile]:
-        """Enumerate ``SourceFile``s. Parse failures propagate loudly —
-        a caller that wants record-and-continue catches the three
-        contract types per file (see corpus.py); nothing here swallows."""
+        """Enumerate ``SourceFile``s, each through the oracle's identity.
+        Parse failures propagate loudly — a caller that wants
+        record-and-continue catches the three contract types plus
+        ``SourceOracleRefusal`` per file (see corpus.py); nothing here
+        swallows."""
         for path in self.paths():
-            yield SourceFile.read(
-                path,
-                filename=str(path.relative_to(self.root) if self.root.is_dir() else path),
-                backend=self.backend,
-            )
+            yield SourceFile(path_source(str(path)), backend=self.backend)
 
     def __iter__(self) -> Iterator[SourceFile]:
         return self.files()
 
     def __repr__(self) -> str:  # pragma: no cover
         return f"<SourceTree {str(self.root)!r} backend={self.backend.name}>"
-
-

--- a/implementations/python/sugar-source-tree/tests/conftest.py
+++ b/implementations/python/sugar-source-tree/tests/conftest.py
@@ -1,4 +1,25 @@
 import sys
+import tempfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[2] / "sugar-lift-python-source" / "src")
+)
+
+
+def oracle_source_file(source: str, backend=None, suffix: str = ".py"):
+    """Test door that honors the law: text enters only through the oracle.
+
+    Writes the literal to a real file and constructs the SourceFile through
+    the oracle's path-addressed identity — there is no raw-string door to
+    bypass, in tests or anywhere else.
+    """
+    from sugar_source_tree.tree import SourceFile
+
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", suffix=suffix, delete=False
+    ) as handle:
+        handle.write(source)
+        path = handle.name
+    return SourceFile.from_path(path, backend=backend)

--- a/implementations/python/sugar-source-tree/tests/test_corpus.py
+++ b/implementations/python/sugar-source-tree/tests/test_corpus.py
@@ -19,8 +19,9 @@ GOLDENS = Path(__file__).resolve().parents[1] / "goldens"
 
 
 def _generate() -> list[str]:
-    source = (GOLDENS / "quirks.py").read_text(encoding="utf-8")
-    records = records_for_file(SourceFile(filename="quirks.py", source=source))
+    records = records_for_file(
+        SourceFile.from_path(GOLDENS / "quirks.py"), display="quirks.py"
+    )
     return [json.dumps(r, sort_keys=True, ensure_ascii=True) for r in records]
 
 

--- a/implementations/python/sugar-source-tree/tests/test_fragment.py
+++ b/implementations/python/sugar-source-tree/tests/test_fragment.py
@@ -1,0 +1,113 @@
+"""The two currencies exchange through the oracle, both directions.
+
+fragment.seal() -> SourceMemento; resolve_memento(memento) -> an EQUAL
+SourceFragment; sealing the resolved fragment reproduces an EQUAL memento.
+Drift refuses loudly (SourceOracleRefusal) — never silence, never None.
+"""
+
+from pathlib import Path
+
+import pytest
+from conftest import oracle_source_file
+from sugar_lift_python_source.source_oracle import SourceOracleRefusal, path_source
+from sugar_source_tree import (
+    Node,
+    SourceFile,
+    SourceFragment,
+    SourceMemento,
+    resolve_memento,
+)
+
+SOURCE = (
+    "def f(a, b):\n"
+    "    total = a + b\n"
+    "    return total\n"
+    "\n"
+    "x = f(1, 2)\n"
+)
+
+
+def test_every_enumerated_object_answers_fragment():
+    file = oracle_source_file(SOURCE)
+    frag = file.fragment
+    assert isinstance(frag, SourceFragment)
+    assert frag.text == SOURCE
+    assert frag.source_cid == file.unit.source_cid
+    assert frag.node is file.root
+    for node in file.nodes():
+        nf = node.fragment
+        assert isinstance(nf, SourceFragment)
+        assert nf.node is node
+        assert nf.text == node.segment()
+        assert nf.source_cid == file.unit.source_cid  # same pinned text
+
+
+def test_fragment_seals_and_memento_resolves_back_equal():
+    file = oracle_source_file(SOURCE)
+    node = next(n for n in file.nodes() if n.kind == "Return")
+    frag = node.fragment
+
+    memento = frag.seal()
+    assert isinstance(memento, SourceMemento)
+    assert memento.source_cid == file.unit.source_cid
+    assert memento.cid.startswith("blake3-512:")
+
+    resolved = resolve_memento(memento)
+    assert resolved == frag
+    assert resolved.text == frag.text == "return total"
+    assert isinstance(resolved.node, Node)
+    assert resolved.node.kind == "Return"
+
+    # and back again: the resolved fragment seals to an equal memento
+    assert resolved.seal() == memento
+
+
+def test_file_level_fragment_round_trips():
+    file = oracle_source_file(SOURCE)
+    memento = file.fragment.seal()
+    resolved = resolve_memento(memento)
+    assert resolved == file.fragment
+    assert resolved.text == SOURCE
+    assert resolved.node.kind == "Module"
+
+
+def test_round_trip_holds_across_backends():
+    pytest.importorskip("parso")
+    from sugar_source_tree.parso_adapter import ParsoBackend
+
+    file = oracle_source_file(SOURCE)
+    node = next(n for n in file.nodes() if n.kind == "Return")
+    memento = node.fragment.seal()
+    resolved = resolve_memento(memento, backend=ParsoBackend())
+    assert resolved == node.fragment
+    assert resolved.seal() == memento
+
+
+def test_drifted_source_refuses_loudly_never_silence():
+    file = oracle_source_file(SOURCE)
+    node = next(n for n in file.nodes() if n.kind == "Return")
+    memento = node.fragment.seal()
+    Path(file.filename).write_text(SOURCE + "\ny = 3\n", encoding="utf-8")
+    with pytest.raises(SourceOracleRefusal):
+        resolve_memento(memento)
+
+
+def test_missing_file_refuses_loudly_never_silence():
+    file = oracle_source_file(SOURCE)
+    memento = file.fragment.seal()
+    Path(file.filename).unlink()
+    with pytest.raises(SourceOracleRefusal):
+        resolve_memento(memento)
+
+
+def test_source_file_has_no_raw_text_door():
+    with pytest.raises((TypeError, ValueError)):
+        SourceFile(filename="<test>", source="x = 1\n")  # type: ignore[call-arg]
+    assert not hasattr(SourceFile, "read")
+
+
+def test_unit_carries_the_oracle_cid_verbatim():
+    file = oracle_source_file(SOURCE)
+    _, _, cid = path_source(file.filename)
+    assert file.unit.source_cid == cid
+    assert cid.startswith("blake3-512:")

--- a/implementations/python/sugar-source-tree/tests/test_libcst_adapter.py
+++ b/implementations/python/sugar-source-tree/tests/test_libcst_adapter.py
@@ -23,6 +23,7 @@ import pytest
 
 libcst = pytest.importorskip("libcst", reason="LibCST backend not installed")
 
+from conftest import oracle_source_file
 from sugar_source_tree.backend import BackendRefused  # noqa: E402
 from sugar_source_tree.tree import SourceFile  # noqa: E402
 from sugar_source_tree.cpython_adapter import CPythonAstBackend  # noqa: E402
@@ -32,7 +33,7 @@ from sugar_source_tree.panic import SourceTreePanic  # noqa: E402
 
 
 def build(source: str):
-    return SourceFile(filename="<test>", source=source, backend=LibCSTBackend()).root
+    return oracle_source_file(source, backend=LibCSTBackend()).root
 
 
 def only(root, cls):
@@ -241,7 +242,7 @@ def test_async_shapes_resolve_to_their_own_classes():
 
 def test_unmapped_cst_shape_panics_as_a_missing():
     """The negative arm. A CST node with no rule must NOT get a fallback."""
-    unit = nodes.SourceUnit(filename="<test>", source="x = 1\n")
+    unit = oracle_source_file("x = 1\n").unit
     ctx = _Ctx(unit, {})
     with pytest.raises(SourceTreePanic) as excinfo:
         _describe(ctx, libcst.Semicolon())
@@ -283,4 +284,4 @@ def test_provider_refusal_is_a_membrane_BackendRefused_never_a_SyntaxError():
     assert not isinstance(excinfo.value, SyntaxError)
     assert not isinstance(excinfo.value, libcst.ParserSyntaxError)
     assert excinfo.value.backend == LibCSTBackend().name
-    assert excinfo.value.file == "<test>"
+    assert excinfo.value.file.endswith(".py")

--- a/implementations/python/sugar-source-tree/tests/test_no_recursion.py
+++ b/implementations/python/sugar-source-tree/tests/test_no_recursion.py
@@ -7,6 +7,7 @@ Executed proof: run them under a recursion limit far below the tree depth.
 
 import sys
 
+from conftest import oracle_source_file
 from sugar_source_tree import SourceFile
 from sugar_source_tree.corpus import node_paths
 
@@ -26,13 +27,13 @@ def test_deep_binop_chain_builds_without_recursion():
     src = "total = " + " + ".join(["1"] * DEPTH) + "\n"
     # The backend parse runs at the normal limit (its recursion is the
     # backend's own affair, #5932); OUR pass — materialize, walk — runs low.
-    file = SourceFile(filename="<deep>", source=src)
+    file = oracle_source_file(src)
     assert sum(1 for _ in _under_limit(80, lambda: list(file.root.walk()))) > DEPTH
 
 
 def test_corpus_paths_enumerate_without_recursion():
     src = "total = " + " + ".join(["1"] * DEPTH) + "\n"
-    root = SourceFile(filename="<deep>", source=src).root
+    root = oracle_source_file(src).root
     paths = _under_limit(80, lambda: list(node_paths(root)))
     assert len(paths) == len(list(root.walk()))
     assert len({p for p, _ in paths}) == len(paths)  # paths are unique addresses

--- a/implementations/python/sugar-source-tree/tests/test_parso_adapter.py
+++ b/implementations/python/sugar-source-tree/tests/test_parso_adapter.py
@@ -14,6 +14,7 @@ parso = pytest.importorskip("parso")
 
 from pathlib import Path
 
+from conftest import oracle_source_file
 from sugar_source_tree import SourceFile
 from sugar_source_tree.backend import BackendRefused
 from sugar_source_tree.panic import SourceTreePanic
@@ -23,7 +24,7 @@ GOLDENS = Path(__file__).resolve().parents[1] / "goldens"
 
 
 def _root(source: str, filename: str):
-    return SourceFile(filename=filename, source=source, backend=ParsoBackend()).root
+    return oracle_source_file(source, backend=ParsoBackend()).root
 
 
 def test_constructs_a_representative_sample():

--- a/implementations/python/sugar-source-tree/tests/test_refusal_twin.py
+++ b/implementations/python/sugar-source-tree/tests/test_refusal_twin.py
@@ -18,6 +18,7 @@ import pytest
 
 libcst = pytest.importorskip("libcst", reason="LibCST backend not installed")
 
+from conftest import oracle_source_file
 from sugar_source_tree.backend import BackendRefused  # noqa: E402
 from sugar_source_tree.tree import SourceFile  # noqa: E402
 from sugar_source_tree.corpus import emit_corpus  # noqa: E402
@@ -40,10 +41,10 @@ def test_both_adapters_raise_the_membrane_refusal_not_their_native_exception(
     provider_cls,
 ):
     with pytest.raises(BackendRefused) as excinfo:
-        SourceFile(filename="<unparseable>", source=UNPARSEABLE, backend=provider_cls())
+        oracle_source_file(UNPARSEABLE, backend=provider_cls())
     refusal = excinfo.value
     assert refusal.backend == provider_cls().name
-    assert refusal.file == "<unparseable>"
+    assert refusal.file.endswith(".py")
     assert refusal.reason
 
 

--- a/implementations/python/sugar-source-tree/tests/test_spans.py
+++ b/implementations/python/sugar-source-tree/tests/test_spans.py
@@ -6,6 +6,7 @@ on raw numbers, so the tests read as the spec's worked examples.
 
 import pytest
 
+from conftest import oracle_source_file
 from sugar_source_tree import SourceFile
 from sugar_source_tree.nodes import (
     Assign,
@@ -31,7 +32,7 @@ from sugar_source_tree.nodes import (
 
 
 def parse(source: str) -> Module:
-    return SourceFile(filename="<test>", source=source).root
+    return oracle_source_file(source).root
 
 
 def only(root, cls):

--- a/implementations/python/sugar-source-tree/tests/test_tree_sitter_adapter.py
+++ b/implementations/python/sugar-source-tree/tests/test_tree_sitter_adapter.py
@@ -14,6 +14,7 @@ pytest.importorskip("tree_sitter_python")
 
 from pathlib import Path
 
+from conftest import oracle_source_file
 from sugar_source_tree import SourceFile
 from sugar_source_tree.tree_sitter_python_adapter import TreeSitterPythonBackend
 
@@ -21,7 +22,7 @@ GOLDENS = Path(__file__).resolve().parents[1] / "goldens"
 
 
 def _root(source: str, filename: str):
-    return SourceFile(filename=filename, source=source, backend=TreeSitterPythonBackend()).root
+    return oracle_source_file(source, backend=TreeSitterPythonBackend()).root
 
 
 def test_constructs_the_full_quirks_golden():

--- a/implementations/python/sugar-source-tree/tests/test_typed.py
+++ b/implementations/python/sugar-source-tree/tests/test_typed.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from conftest import oracle_source_file
 from sugar_source_tree import SourceFile, SourceTreePanic, Typed
 from sugar_source_tree.backend import Description, Backend, BackendNode
 from sugar_source_tree.nodes import Node, resolve_kind
@@ -10,7 +11,7 @@ from sugar_source_tree.spans import Span
 
 
 def test_every_constructed_node_is_typed():
-    root = SourceFile(filename="<test>", source=(
+    root = oracle_source_file((
         "import os\n"
         "class C:\n"
         "    def m(self, *a, **k):\n"
@@ -40,7 +41,7 @@ class _BogusBackend(Backend):
 
 def test_unresolvable_typeable_panics_never_false_never_none():
     with pytest.raises(SourceTreePanic) as exc:
-        SourceFile(filename="<test>", source="x = 1\n", backend=_BogusBackend())
+        oracle_source_file("x = 1\n", backend=_BogusBackend())
     assert "Bogus" in exc.value.observed
 
 


### PR DESCRIPTION
Part of #5940; preserves the #5954 backend-parameter contract. Fixes the oracle-law violation at the bottom of `sugar-source-tree` (#5953).

## FLAGGED: oracle-contract extension, for T's review

The oracle served only *installed-module* addresses; a `SourceTree` enumerates *paths*. Rather than keep a filesystem read in the parser, the oracle gains ONE path-addressed door pair in `source_oracle.py`:

- **`path_source(path) -> (source, filename, content CID)`** — minting side. Read + decode + CID only; **no parse gate** (deliberate: which backend parses a file is the parser's question, and a CPython-`ast` gate here would decide it for every backend). Unreadable/undecodable raises `SourceOracleRefusal` loudly — never `None`.
- **`resolve_span_memento({file, span:{start,end}, source_cid, cid})`** — resolution side, recompute-or-refuse: whole-file CID and sliced-segment CID must both recompute or it refuses. Sits beside `resolve_source_memento` (function/stmt/expr mementos), same refusal type, same doctrine.

This is a second *address form* on the same oracle, not a parallel implementation; nothing else widened.

## The two currencies

- `SourceFile` is constructed only from the oracle's identity triple (`from_path` / `from_module`). `SourceFile.read` and the bare-string constructor are **deleted**; `SourceUnit` carries the oracle CID verbatim and its homegrown sha256 **dies** (`hashlib` import gone from `nodes.py`).
- Every enumerated object answers **`.fragment`**: `SourceFile.fragment` is the full span over the oracle CID; `Node.fragment` is that node's slice of the same pinned text. One accessor, one typed answer.
- `SourceFragment` (new `fragment.py`) is the LIVE currency: unit (pinned text + CID + line table), span, and the typed node it views — rich on purpose, per T's ruling. `SourceMemento` is the sealed minimal address: `{file, start, end, source_cid, cid}`, inert. `fragment.seal()` and `resolve_memento()` exchange them **only** through the oracle; resolution re-parses through a backend and re-binds the live node, refusing loudly if the pinned span matches no node.
- `SourceTree.files()`, `corpus.py`, and `bench_backends.py` all route text through `path_source`; **zero `read_text`/`open()` of source files remain in the parser** (`/proc/loadavg` and the corpus's *output* sink are the only `open`s).
- Tests enter text the same way: a `conftest.oracle_source_file` helper writes the literal to a real file and goes through the oracle — there is no raw-string door left to bypass, in tests or anywhere else.

## Ruling recommendation (point 5)

Superseded mid-task by T's ruling (fragment = live capable object, memento = sealed minimum); implemented as ruled. Convergence note: an enumerated node already IS a fragment view over oracle-pinned source — `Node.fragment` currently mints the `SourceFragment` wrapper holding the node; folding seal/text/line-col onto `Node` itself (node *is* fragment) is the natural next merge with the kit's `sugar_lift_py_tests.source_fragment`, whose defects were the leaked raw `.node` and open construction, not its richness. No third fragment concept was minted: this one is the typed-tree face of the same currency.

## Evidence (battleaxe, bench-venv Python 3.12, blake3 installed)

Full corpus via the oracle's identities, RSS mode:

| corpus | backend | files | nodes | refusals | panics | crashes | RSS |
|---|---|---|---|---|---|---|---|
| numpy | cpython-ast | 407 | 849,166 | 0 | 0 | 0 | flat 105.0 MiB |
| numpy | tree-sitter-python | 407 | 805,642 | 0 | 0 | 0 | flat 104.3 MiB |
| pandas | cpython-ast | 1,421 | 2,098,053 | 0 | 0 | 0 | flat 72.3 MiB |
| pandas | tree-sitter-python | 1,421 | 2,025,864 | 0 | 0 | 0 | flat 61.6 MiB |

RSS constant from first checkpoint to last in all four runs (no growth across 200-file checkpoints).

Round-trip: `tests/test_fragment.py` — node fragment seals to a memento, `resolve_memento` returns an EQUAL fragment (content identity: file + file CID + span) with a live re-bound node, and re-sealing reproduces an equal memento; file-level round-trip; cross-backend round-trip (sealed under cpython-ast, resolved under parso); drifted-file and deleted-file both refuse with `SourceOracleRefusal`, never silence. `test_source_file_has_no_raw_text_door` pins the deleted doors.

Tests: sugar-source-tree 89 passed; sugar-lift-python-source `test_source_oracle.py` 12 passed (other files in that suite need the full kit installed and did not collect in the bench venv — not touched by this change).

## What fought the design

- **"Standalone; stdlib-only core" died.** The package's own pyproject boasted stdlib-only; being built on the oracle means depending on `sugar-lift-python-source` (and blake3). The boast was the isolation that caused the defect; description updated.
- **The corpus instrument still mints per-record sha256** over each segment (`corpus.py`), pinned by `goldens/quirks.jsonl`. That is a diff-instrument label that never escapes as an address (mementos use the oracle's blake3 CIDs); left as-is to keep the golden byte-identical, called out here rather than changed silently.
- **`seal()` calls the oracle's `blake3_512_of` directly** for the segment CID (hash function from the oracle's canonical module, over oracle-pinned text). If T wants sealing itself to be an oracle door (`seal_span`), it is a five-line move.

Do NOT merge — for T's review, especially the flagged oracle extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route all source text through `SourceOracle` and introduce `SourceFragment`/`SourceMemento` for fragment exchange
> - All text entry into `sugar-source-tree` now goes through the oracle (`path_source`, `installed_module_source`); direct raw-string construction of `SourceFile` is removed and replaced by `SourceFile.from_path` and `SourceFile.from_module` classmethods.
> - `SourceUnit` no longer computes its own SHA-256 content hash; it now accepts a blake3-512 CID verbatim from the oracle, making content identity canonical and externally controlled.
> - Introduces `SourceFragment` (a live view of a node or file span) and `SourceMemento` (a serializable, pinned representation) in [fragment.py](https://github.com/TSavo/sugar/pull/5955/files#diff-9b30966a38ea981a2bb45d5bc8ae6730c4d2c6f2fb8535ed7cf799acd34da03a); `resolve_memento` reconstructs a live fragment from a memento and verifies pinned CIDs against on-disk content.
> - `resolve_span_memento` in [source_oracle.py](https://github.com/TSavo/sugar/pull/5955/files#diff-46c211dd48cf8b40814f36939afc72cfd9d8d750d36f6572af9c9e02ba22ea6f) validates file/span fields, compares source and segment CIDs, and raises `SourceOracleRefusal` on drift or invalid bounds.
> - Risk: any caller constructing `SourceFile(filename, source, backend)` directly will break; construction now requires an identity tuple `(source, filename, source_cid)` from the oracle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7dca00f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->