### PR TITLE
PROBE: owns migrates off the sugar onto the node — node.sugar() answers its own completion (#5940)

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/completion.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/completion.py
@@ -1,0 +1,178 @@
+"""PROBE (#5940): completion — ask the NODE for its sugar.
+
+The inversion under test
+------------------------
+
+Today recognition is an open-world search: a factory holds a catalog of
+claims, scans every one, and asks each ``owns(site)``. This module probes
+T's inversion: possibility is a property of the grammar class, so the
+question is closed-world and the NODE should answer it. ``node.sugar()``
+dispatches on ``type(node)``; refinement inside a closed family reads the
+node's own typed fields.
+
+What ``owns`` becomes here
+--------------------------
+
+* For a node class with ONE completion (``If``), ``owns`` is DELETED.
+  The declaration ``completes = If`` is the whole of the old predicate,
+  and a second sole completion for the same class is a REGISTRATION-TIME
+  panic — the ambiguity arm dies at import, before any site exists.
+* For a closed family (``Call``), ``owns`` shrinks to ``refines``: the
+  family's discrimination over the node's own typed fields. Members of
+  one family must be disjoint; two refining at once is still a panic,
+  but it can now arise ONLY inside a declared family — never between
+  strangers — and the panic names the family.
+
+Registration stays pluggable: a language kit declares completion classes
+(``completes = <NodeClass>``) and ``__init_subclass__`` registers them.
+No central dispatcher is ever edited.
+
+Two arms, as everywhere: a completion class, or a loud panic. A node
+whose class has no completion, or whose family does not cover its field
+shape, panics ``CompletionGap`` — "I know what I am and nothing
+completes me." Never silence, never a bare ``None``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar, Dict, List, Tuple, Type
+
+from .panic import SourceTreePanic
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .nodes import Node
+
+
+class CompletionGap(SourceTreePanic):
+    """The node knows what it is and nothing completes it. The gap arm,
+    relocated from the factory scan onto the ask itself."""
+
+    _LABEL = "COMPLETION GAP"
+
+
+class CompletionAmbiguous(SourceTreePanic):
+    """More than one completion answered. Between sole completions this is
+    impossible by construction (registration panics first); inside a family
+    it means the family's refinement is not a partition of the node's field
+    shapes — a defect in the family, named as such."""
+
+    _LABEL = "COMPLETION AMBIGUOUS"
+
+
+#: node class -> registered completion classes, in registration order.
+#: Registration order is NOT precedence: resolution requires exactly one
+#: refining member, so order never picks a winner.
+_REGISTRY: Dict[type, List[Type["Completion"]]] = {}
+
+
+class Completion:
+    """One completion of a node class. Subclass and declare ``completes``.
+
+    ``sole = True`` (default): this class is the ONLY completion of its
+    node class. ``refines`` is never consulted; a second registration for
+    the same node class panics at import.
+
+    ``sole = False``: this class is a member of a closed family sharing
+    one node class. ``refines(node)`` reads the node's own typed fields
+    to claim its partition cell. Family members must be pairwise
+    disjoint and should jointly cover the class — a cell nobody claims
+    is the gap arm, at the ask.
+    """
+
+    completes: ClassVar[type]
+    sole: ClassVar[bool] = True
+
+    def __init_subclass__(cls, **kw: object) -> None:
+        super().__init_subclass__(**kw)
+        completes = cls.__dict__.get("completes")
+        if completes is None:
+            return  # abstract intermediate; concrete classes declare it
+        existing = _REGISTRY.setdefault(completes, [])
+        if existing and (cls.sole or any(e.sole for e in existing)):
+            raise CompletionAmbiguous(
+                owner="completion.Completion.__init_subclass__",
+                observed=(
+                    f"{cls.__name__} registers for {completes.__name__}, "
+                    f"already completed by "
+                    f"[{', '.join(e.__name__ for e in existing)}] with a "
+                    f"sole completion involved"
+                ),
+                requested="one sole completion, or an all-family set",
+                fix=(
+                    "a node class has either exactly one completion or one "
+                    "closed family (every member sole = False). Two sole "
+                    "completions cannot coexist — this panic fires at import, "
+                    "before any site exists: the ambiguity arm dies at "
+                    "registration, not at resolution."
+                ),
+            )
+        existing.append(cls)
+
+    @classmethod
+    def refines(cls, node: "Node") -> bool:
+        """Family discrimination over the node's own typed fields. Sole
+        completions never reach here. Returning True/False is an ANSWER;
+        a member that cannot answer must panic, never return False."""
+        raise NotImplementedError(f"{cls.__name__} is sole; refines is never asked")
+
+
+def resolve_completion(node: "Node") -> Type[Completion]:
+    """THE two-arm match, from the node's side: exactly one completion,
+    or a loud panic. Called as ``node.sugar()``."""
+    cls = type(node)
+    entries = _REGISTRY.get(cls, [])
+    if not entries:
+        raise CompletionGap(
+            owner="completion.resolve_completion",
+            observed=(
+                f"{cls.__name__} at [{node.span.start},{node.span.end}) in "
+                f"{node.unit.filename} — I know what I am and nothing "
+                f"completes me"
+            ),
+            requested="a Completion declaring completes = " + cls.__name__,
+            fix=(
+                "declare the completion (sole, or a family member) for this "
+                "grammar class. Never widen a neighbor to swallow it."
+            ),
+        )
+    if len(entries) == 1 and entries[0].sole:
+        return entries[0]
+    matches = [c for c in entries if c.refines(node)]
+    if len(matches) == 1:
+        return matches[0]
+    family = ", ".join(e.__name__ for e in entries)
+    if not matches:
+        raise CompletionGap(
+            owner="completion.resolve_completion",
+            observed=(
+                f"{cls.__name__} at [{node.span.start},{node.span.end}) in "
+                f"{node.unit.filename} — family [{family}] covers no cell "
+                f"for this field shape"
+            ),
+            requested="exactly one refining family member",
+            fix=(
+                "extend the family with the member for this field shape, or "
+                "extend an existing member's cell — deliberately, never by "
+                "default."
+            ),
+        )
+    raise CompletionAmbiguous(
+        owner="completion.resolve_completion",
+        observed=(
+            f"{cls.__name__} at [{node.span.start},{node.span.end}) in "
+            f"{node.unit.filename} — "
+            f"[{', '.join(m.__name__ for m in matches)}] all refine within "
+            f"family [{family}]"
+        ),
+        requested="a partition: exactly one refining member",
+        fix=(
+            "the family's refinement is not disjoint over this node's field "
+            "shape. Make the cells disjoint; there is no precedence and "
+            "picking the first is not available — that would be a third arm."
+        ),
+    )
+
+
+def registered() -> Dict[type, Tuple[Type[Completion], ...]]:
+    """Read-only view for tests and diagnostics. Not a resolution."""
+    return {k: tuple(v) for k, v in _REGISTRY.items()}

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/completion_probe.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/completion_probe.py
@@ -79,9 +79,33 @@ from .tree import SourceFile
 class IfCompletion(Completion):
     """``if``/``elif``/``else``. Sole: an If can only complete as if-shaped
     sugar. The old ``owns`` body (``site.observed == "If"``) is the
-    declaration below; nothing else survived because nothing else existed."""
+    declaration below; nothing else survived because nothing else existed.
+
+    OUTCOME 1 RECEIPT: this class carries NO state — no fields, no
+    ``new()`` construction work, nothing ``__init__``-shaped. The meaning
+    side (IfSugar.desugar: reduce the test, then binary_conditional over
+    the two bodies) is expressible entirely over node fields, shown by
+    ``reduction`` below. A stateless all-classmethod class keyed to one
+    node class is definitionally a method suite OF that node class:
+    the collapse is ``If`` gaining these methods and this class ceasing
+    to exist. IfSugar's fields (condition/then/else_body as SugarBody)
+    are the node's test/body/orelse wrapped with a role — and the role
+    is a function of grammar position the node class already states."""
 
     completes: ClassVar[type] = If
+
+    @classmethod
+    def reduction(cls, node: If) -> tuple:
+        """The desugar plan, from node fields ALONE — the emptied-class
+        demonstration. Roles are grammar positions: test is a TERM ask,
+        the bodies are STATEMENT asks. Nothing here reads sugar-held
+        state, because there is none to read."""
+        return (
+            "binary_conditional",
+            ("term", node.test),
+            ("statements", node.body),
+            ("statements", node.orelse) if node.orelse else None,
+        )
 
 
 # -- While: a closed 2-family over one typed field --------------------------

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/completion_probe.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/completion_probe.py
@@ -1,0 +1,253 @@
+"""PROBE (#5940): the probe subjects — If, While, the Call family, one BinOp.
+
+These stand in for the kit's real sugars (``sugar_lift_py_tests.sugar.*``)
+so the inversion can be measured in isolation. Each class documents what
+the corresponding sugar's ``owns`` was, and what of it survived here.
+
+Before / after, per subject
+---------------------------
+
+``IfSugar.owns``::
+
+    return site.observed == "If"
+
+becomes ``completes = If`` — the whole predicate was shape re-derivation,
+and it is now the declaration. ``owns`` is DELETED, not stubbed.
+
+``WhileSugar.owns``::
+
+    if site.observed != "While": return False
+    if site.while_orelse_count() != 0: return False
+    return True
+
+The shape leg becomes ``completes = While``. The orelse leg was never a
+semantic question about THIS sugar — it was the boundary with
+``WhileElseSugar``. Here the two are one closed family over ``While``,
+partitioned by the node's own typed field: ``bool(node.orelse)``. The
+partition is exhaustive by inspection (a tuple is empty or it is not),
+so the gap arm is unreachable for While — measured below, not assumed.
+
+``MethodCallSugar.owns``::
+
+    site.observed == "Call"
+    and site.call_receiver() is not None
+    and site.call_qualified_target_name() != "os.exit"
+    and not site.call_has_keywords()
+
+Shape leg -> ``completes = Call``. Receiver leg -> ``isinstance(node.func,
+Attribute)`` — the node already holds the answer as a typed field; the
+three-step projection through call_receiver() is gone. The keyword leg is
+the family boundary with KeywordCall, stated as the partition. The
+``os.exit`` leg is deliberately NOT ported: it is a fact about ANOTHER
+sugar's territory expressed as a name string, not a fact this node's
+fields hold — the probe keeps it out and reports it as residue that would
+have to live as one more family cell (an OsCall member refining on
+``func.value.id == "os"``), exactly like len below.
+
+Measurement CLI
+---------------
+
+::
+
+    python -m sugar_source_tree.completion_probe PATH [PATH ...]
+
+Walks every file, asks ``node.sugar()`` on every If/While/Call/BinOp
+node, and reports resolved / gap counts per class and per completion.
+Ambiguity and silence are both structural zeros: an ambiguous family
+panics the RUN (it is a defect in the probe, not a row in the report),
+and every subject node lands in exactly one bucket or the run dies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import ClassVar, Optional
+
+from .completion import Completion, CompletionAmbiguous, CompletionGap
+from .nodes import Attribute, BinOp, Call, If, Name, Node, While
+from .operators import Add
+from .panic import SourceTreePanic
+from .tree import SourceFile
+
+
+# -- If: one completion, owns deleted ---------------------------------------
+
+
+class IfCompletion(Completion):
+    """``if``/``elif``/``else``. Sole: an If can only complete as if-shaped
+    sugar. The old ``owns`` body (``site.observed == "If"``) is the
+    declaration below; nothing else survived because nothing else existed."""
+
+    completes: ClassVar[type] = If
+
+
+# -- While: a closed 2-family over one typed field --------------------------
+
+
+class WhileCompletion(Completion):
+    """``while`` with empty ``orelse`` — WhileSugar's territory."""
+
+    completes: ClassVar[type] = While
+    sole: ClassVar[bool] = False
+
+    @classmethod
+    def refines(cls, node: While) -> bool:
+        return not node.orelse
+
+
+class WhileElseCompletion(Completion):
+    """``while ... else:`` — WhileElseSugar's territory. The other cell of
+    the partition; together the two are exhaustive over While."""
+
+    completes: ClassVar[type] = While
+    sole: ClassVar[bool] = False
+
+    @classmethod
+    def refines(cls, node: While) -> bool:
+        return bool(node.orelse)
+
+
+# -- Call: the closed family, partitioned by the node's own fields ----------
+#
+# Partition coordinates, all fields the Call already holds:
+#   keywords nonempty?            -> KeywordCall
+#   func isinstance Attribute?    -> MethodCall
+#   func isinstance Name, "len"?  -> LenCall
+#   func isinstance Name, other?  -> PlainCall
+#   func anything else, no kw     -> NOBODY: the gap arm, measured below
+#     (computed callables: subscripted, called-result, lambda callees —
+#      today's factory has ComputedCallableSugar etc.; the probe leaves
+#      the cell open on purpose to exercise the gap arm on real corpus)
+
+
+class KeywordCallCompletion(Completion):
+    completes: ClassVar[type] = Call
+    sole: ClassVar[bool] = False
+
+    @classmethod
+    def refines(cls, node: Call) -> bool:
+        return bool(node.keywords)
+
+
+class MethodCallCompletion(Completion):
+    completes: ClassVar[type] = Call
+    sole: ClassVar[bool] = False
+
+    @classmethod
+    def refines(cls, node: Call) -> bool:
+        return not node.keywords and isinstance(node.func, Attribute)
+
+
+class LenCallCompletion(Completion):
+    completes: ClassVar[type] = Call
+    sole: ClassVar[bool] = False
+
+    @classmethod
+    def refines(cls, node: Call) -> bool:
+        func = node.func
+        return not node.keywords and isinstance(func, Name) and func.id == "len"
+
+
+class PlainCallCompletion(Completion):
+    completes: ClassVar[type] = Call
+    sole: ClassVar[bool] = False
+
+    @classmethod
+    def refines(cls, node: Call) -> bool:
+        func = node.func
+        return not node.keywords and isinstance(func, Name) and func.id != "len"
+
+
+# -- BinOp: operand-type refinement via the node's typed op field -----------
+#
+# One member on purpose: every non-Add BinOp exercises the gap arm, which
+# is the honest state of a probe that ported one of the operator sugars.
+
+
+class AddOpCompletion(Completion):
+    """``a + b``. Old owns: ``site.observed == "BinOp" and
+    site.operator_kind() == "Add"`` — two string compares become the
+    declaration plus one isinstance on the operator class the node holds."""
+
+    completes: ClassVar[type] = BinOp
+    sole: ClassVar[bool] = False
+
+    @classmethod
+    def refines(cls, node: BinOp) -> bool:
+        return isinstance(node.op, Add)
+
+
+PROBE_SUBJECTS: tuple[type, ...] = (If, While, Call, BinOp)
+
+
+# -- measurement ------------------------------------------------------------
+
+
+def measure(paths: list[Path], backend=None) -> int:
+    files: list[Path] = []
+    for p in paths:
+        if p.is_dir():
+            files.extend(
+                f for f in sorted(p.rglob("*.py")) if "__pycache__" not in f.parts
+            )
+        else:
+            files.append(p)
+    files.sort()
+
+    resolved: Counter[str] = Counter()  # completion name -> count
+    gaps: Counter[str] = Counter()  # node class -> gap count
+    subject_totals: Counter[str] = Counter()
+    parse_failures = 0
+    parsed = 0
+
+    for path in files:
+        try:
+            file = SourceFile.from_path(path, backend=backend)
+        except (SourceTreePanic, Exception) as err:  # parse-side, recorded loudly
+            parse_failures += 1
+            print(f"PARSE-FAIL {path}: {str(err).splitlines()[0]}", file=sys.stderr)
+            continue
+        parsed += 1
+        for node in file.nodes():
+            if not isinstance(node, PROBE_SUBJECTS):
+                continue
+            cls_name = type(node).__name__
+            subject_totals[cls_name] += 1
+            try:
+                completion = node.sugar()
+            except CompletionGap:
+                gaps[cls_name] += 1  # the loud arm, counted — never silence
+                continue
+            # CompletionAmbiguous deliberately NOT caught: an ambiguous
+            # family is a probe defect and must kill the run.
+            resolved[completion.__name__] += 1
+
+    total = sum(subject_totals.values())
+    accounted = sum(resolved.values()) + sum(gaps.values())
+    print(f"files parsed:   {parsed}  (parse failures: {parse_failures})")
+    print(f"subject nodes:  {total}")
+    for name, count in sorted(subject_totals.items()):
+        print(f"  {name}: {count}")
+    print(f"resolved:       {sum(resolved.values())}")
+    for name, count in sorted(resolved.items()):
+        print(f"  {name}: {count}")
+    print(f"gap arm:        {sum(gaps.values())}")
+    for name, count in sorted(gaps.items()):
+        print(f"  {name}: {count}")
+    print(f"ambiguous:      0 (an ambiguous family kills the run; it did not)")
+    print(f"silent:         {total - accounted} (must be 0)")
+    return 0 if total == accounted else 1
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", type=Path)
+    args = parser.parse_args(argv)
+    return measure(args.paths)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -211,6 +211,19 @@ class Node(Typed):
     def line_col_span(self) -> LineColSpan:
         return self.unit.line_table.project(self.span)
 
+    def sugar(self) -> type:
+        """PROBE (#5940): the node answers for its own completion.
+
+        Two arms: the one Completion class registered for this node's
+        grammar class (refined within a closed family by this node's own
+        typed fields), or a loud CompletionGap / CompletionAmbiguous.
+        Never a scan over a catalog of strangers — possibility is a
+        property of the grammar class, and the class is what you are
+        holding. See completion.py."""
+        from .completion import resolve_completion
+
+        return resolve_completion(self)
+
     def children(self) -> Iterator[tuple[str, Optional[int], "Node"]]:
         """Yield (field_name, index-or-None, child) in declared grammar order."""
         for name in type(self)._child_fields:

--- a/implementations/python/sugar-source-tree/tests/test_completion_probe.py
+++ b/implementations/python/sugar-source-tree/tests/test_completion_probe.py
@@ -1,0 +1,147 @@
+"""PROBE (#5940): both arms of node.sugar(), exercised on real parsed nodes.
+
+Every subject case runs both sides where a discriminator exists: the
+resolving side names the completion, the non-resolving side shows the
+loud arm (CompletionGap), and the ambiguity arm is shown to die at
+registration for sole completions and at resolve for a broken family.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_source_tree.completion import (
+    Completion,
+    CompletionAmbiguous,
+    CompletionGap,
+    registered,
+)
+from sugar_source_tree.completion_probe import (
+    AddOpCompletion,
+    IfCompletion,
+    KeywordCallCompletion,
+    LenCallCompletion,
+    MethodCallCompletion,
+    PlainCallCompletion,
+    WhileCompletion,
+    WhileElseCompletion,
+)
+from sugar_source_tree.nodes import BinOp, Call, If, Node, While
+from sugar_source_tree.tree import SourceFile
+
+
+def _nodes_of(source: str, cls: type, tmp_path) -> list:
+    path = tmp_path / "probe_case.py"
+    path.write_text(source, encoding="utf-8")
+    file = SourceFile.from_path(path)
+    return [n for n in file.nodes() if isinstance(n, cls)]
+
+
+# -- If: sole; owns deleted --------------------------------------------------
+
+
+def test_if_resolves_sole_completion(tmp_path):
+    (node,) = _nodes_of("if x:\n    pass\n", If, tmp_path)
+    assert node.sugar() is IfCompletion
+
+
+def test_elif_is_a_nested_if_and_resolves(tmp_path):
+    nodes = _nodes_of("if x:\n    pass\nelif y:\n    pass\n", If, tmp_path)
+    assert len(nodes) == 2
+    assert all(n.sugar() is IfCompletion for n in nodes)
+
+
+# -- While: closed 2-family over node.orelse --------------------------------
+
+
+def test_while_partition_both_cells(tmp_path):
+    (plain,) = _nodes_of("while x:\n    pass\n", While, tmp_path)
+    (with_else,) = _nodes_of(
+        "while x:\n    pass\nelse:\n    pass\n", While, tmp_path
+    )
+    assert plain.sugar() is WhileCompletion
+    assert with_else.sugar() is WhileElseCompletion
+
+
+# -- Call: the closed family ------------------------------------------------
+
+
+def test_call_family_each_cell(tmp_path):
+    (kw,) = _nodes_of("f(a, k=1)\n", Call, tmp_path)
+    (method,) = _nodes_of("obj.m(a)\n", Call, tmp_path)
+    (length,) = _nodes_of("len(xs)\n", Call, tmp_path)
+    (plain,) = _nodes_of("f(a)\n", Call, tmp_path)
+    assert kw.sugar() is KeywordCallCompletion
+    assert method.sugar() is MethodCallCompletion
+    assert length.sugar() is LenCallCompletion
+    assert plain.sugar() is PlainCallCompletion
+
+
+def test_call_computed_callable_hits_gap_arm(tmp_path):
+    (node,) = _nodes_of("fs[0](a)\n", Call, tmp_path)
+    with pytest.raises(CompletionGap) as err:
+        node.sugar()
+    assert "covers no cell" in str(err.value)
+
+
+# -- BinOp: operand refinement; non-Add is the gap arm ----------------------
+
+
+def test_binop_add_resolves_and_sub_gaps(tmp_path):
+    (add,) = _nodes_of("a + b\n", BinOp, tmp_path)
+    (sub,) = _nodes_of("a - b\n", BinOp, tmp_path)
+    assert add.sugar() is AddOpCompletion
+    with pytest.raises(CompletionGap):
+        sub.sugar()
+
+
+# -- the gap arm for a class with no completion at all ----------------------
+
+
+def test_unregistered_class_gaps_loudly(tmp_path):
+    from sugar_source_tree.nodes import Assert
+
+    (node,) = _nodes_of("assert x\n", Assert, tmp_path)
+    with pytest.raises(CompletionGap) as err:
+        node.sugar()
+    assert "nothing completes me" in str(err.value)
+
+
+# -- the ambiguity arm ------------------------------------------------------
+
+
+def test_second_sole_completion_dies_at_registration():
+    with pytest.raises(CompletionAmbiguous):
+
+        class SecondIfCompletion(Completion):
+            completes = If
+
+    # the failed registration left no residue
+    assert registered()[If] == (IfCompletion,)
+
+
+def test_broken_family_panics_ambiguous_at_resolve(tmp_path):
+    class _ProbeNode2(Node):
+        pass
+
+    class _Cell1(Completion):
+        completes = _ProbeNode2
+        sole = False
+
+        @classmethod
+        def refines(cls, node):
+            return True
+
+    class _Cell2(Completion):
+        completes = _ProbeNode2
+        sole = False
+
+        @classmethod
+        def refines(cls, node):
+            return True
+
+    donor = _nodes_of("pass\n", Node, tmp_path)[0]
+    fake = _ProbeNode2(unit=donor.unit, ref=donor.ref)
+    with pytest.raises(CompletionAmbiguous) as err:
+        fake.sugar()
+    assert "not disjoint" in str(err.value) or "refine within family" in str(err.value)

--- a/implementations/python/sugar-source-tree/tests/test_completion_probe.py
+++ b/implementations/python/sugar-source-tree/tests/test_completion_probe.py
@@ -107,6 +107,29 @@ def test_unregistered_class_gaps_loudly(tmp_path):
     assert "nothing completes me" in str(err.value)
 
 
+# -- outcome 1 receipts: the emptied class, demonstrated --------------------
+
+
+def test_if_completion_is_stateless_and_reduces_from_node_fields(tmp_path):
+    # No fields, no construction: nothing __init__-shaped beyond object's.
+    assert IfCompletion.__init__ is Completion.__init__ is object.__init__
+    assert not [
+        k
+        for k, v in vars(IfCompletion).items()
+        if not k.startswith("__")
+        and not isinstance(v, (classmethod, staticmethod))
+        and k not in ("completes", "sole")
+    ]
+    (plain,) = _nodes_of("if x:\n    a()\n", If, tmp_path)
+    (with_else,) = _nodes_of("if x:\n    a()\nelse:\n    b()\n", If, tmp_path)
+    kind, test, then, orelse = IfCompletion.reduction(plain)
+    assert kind == "binary_conditional"
+    # Accessors are queries (a fresh node per access), so sameness is the
+    # span, not object identity.
+    assert test[1].span == plain.test.span and orelse is None
+    assert IfCompletion.reduction(with_else)[3] is not None
+
+
 # -- the ambiguity arm ------------------------------------------------------
 
 


### PR DESCRIPTION
**DESIGN INVESTIGATION APPENDIX.** T's reframe: well thought out design answers, not tested solutions. This PR is the sketch-grade evidence carrier for the design report — the arguments below are the deliverable, the code is how they were checked against real shapes. Not a landing candidate.

**PROBE, not a landing.** Experiment record for #5940 (does not close #5940, and this sentence is not permission for GitHub to close it — no closing keyword appears here). T's question: migrate the idea of `owns` off the sugar and onto the AST tree, so you just ask the tree for its sugar. Subjects: `If`, `While`, the `Call` family, one `BinOp`. Do NOT merge.

## What the probe built

- `sugar_source_tree/completion.py` — the mechanism: `Completion` classes declare `completes = <NodeClass>` and self-register at class definition (`__init_subclass__`, same registration spirit as `KIND_REGISTRY`; no central dispatcher is ever edited, per-language pluggability holds). `Node.sugar()` (added in `nodes.py`) resolves through the registry: two arms, a completion class or a loud panic (`CompletionGap` / `CompletionAmbiguous`, both `SourceTreePanic`).
- `sugar_source_tree/completion_probe.py` — the probe subjects plus the measurement CLI (`python -m sugar_source_tree.completion_probe PATH...`).
- `tests/test_completion_probe.py` — both arms per subject: resolving side, gap side, ambiguity-at-registration, ambiguity-at-resolve for a deliberately broken family.

## The six questions

### 1. What does `owns` become?

Two different fates, split by whether the node class has one completion or a closed family.

**Deleted** (sole completion). `IfSugar.owns` was `site.observed == "If"` — pure shape re-derivation. After:

```python
class IfCompletion(Completion):
    completes = If          # the whole of the old predicate
```

No `owns`, no `refines`, nothing. The declaration IS the predicate.

**Shrunk to a partition cell** (closed family). `WhileSugar.owns` was shape + `while_orelse_count() != 0` boundary with WhileElseSugar. After: two family members over `While`, partitioned by the node's own typed field:

```python
class WhileCompletion(Completion):
    completes, sole = While, False
    @classmethod
    def refines(cls, node): return not node.orelse
```

`MethodCallSugar.owns` was four conjuncts. Shape leg → `completes = Call`. Receiver leg → `isinstance(node.func, Attribute)` (the node holds the answer as a typed field; the `call_receiver()` three-step projection is gone). Keyword leg → the family boundary with KeywordCall, stated as the partition. The `os.exit` leg did **not** port and is reported as residue: it is a name-string fact about another sugar's territory, expressible as one more family cell (`func.value.id == "os"` when `func.value` is a `Name`) but not a typed-field partition.

### 2. What does the sugar class still hold that the node does not?

- **IfSugar: nothing.** Fields are `condition/then/else_body` — the node's `test/body/orelse` wrapped as `SugarBody(child, role)`, and the role (TERM for test, STATEMENT for bodies) is a function of grammar position, which the node class already states. `new()` is a per-field `ctx.build_body` — the same recursion `node.sugar()` performs. `desugar` reads only those fields plus a reduce-time ctx. The class is the node wearing a second name.
- **AddOpSugar: nothing.** `left/right/site` — the node's own fields verbatim.
- **WhileSugar: real construction work, all subtree-derived.** `carried / deferred_outputs / curried / unclassified_mutation` come from `LoopControlScopeSugar.classify(site, ...)` — a walk of the loop body. Genuine cached state the bare node does not hold, but computable from the node alone at construction.
- **MethodCallSugar: one field the node cannot mint alone.** `import_target = site.call_import_target_name(ctx.import_aliases, ctx.from_imports)` — the module's import environment, today threaded through the factory ctx into `new()`. Everything else (`method_name = func.attr`, receiver, args, keyword names) is node fields.

### 3. Where does the closed-family refinement live, and is it exhaustive-checkable?

In the family members' `refines`, each reading only the node's typed fields. Checkability splits by the shape of the discriminating coordinate:

- **While: yes, mechanically.** The coordinate is `orelse: Tuple[Statement, ...]` — empty or not. Two cells, exhaustive by the field's type. Measured: zero While gaps on the corpus.
- **Call: exhaustive over a *type* coordinate, open over a *string* coordinate.** `(keywords empty?, type(func))` is checkable — `Attribute`/`Name`/other is a closed enumeration of grammar classes. But `len` vs not-`len` (and the unported `os.exit`) discriminate on a string, and no registration-time check can prove a string partition covers anything. The probe leaves the `type(func) ∉ {Attribute, Name}` cell open on purpose; the corpus measures it as the gap arm (computed callables — `fs[0](x)`, `f(x)(y)`, lambda callees).
- **BinOp: yes.** The coordinate is the operator singleton class — a closed set in `operators.py`; a family covering it is enumerable against that set. Probe registers only Add, so every other operator measures the gap arm.

### 4. What happens to `comes_before` and the ambiguity panic?

`comes_before` is dead with nothing replacing it — registration order is explicitly not precedence, resolution demands exactly one answer. The ambiguity arm splits in two:

- **Between sole completions it dies at import.** A second `completes = If` raises `CompletionAmbiguous` at class-definition time, before any site exists (test: `test_second_sole_completion_dies_at_registration`).
- **Inside a family it survives as a runtime panic, but scoped.** Two members refining the same node is still possible if a family's `refines` are not a partition (test: `test_broken_family_panics_ambiguous_at_resolve`). This is the promised major-finding check: ambiguity CAN still arise, but only between siblings of one declared family — never between strangers — and the panic names the family. Zero occurred on the corpus.

### 5. What breaks or fights — what the node genuinely cannot know

Named per mechanism, with where the fact lives today:

- **Import environment** (`MethodCallSugar.import_target`, alias/from-import resolution): a Module-scope fact, today `ctx.import_aliases`/`ctx.from_imports` built by the factory and passed into `new()`. The node cannot mint it — but the `SourceFile` can: imports are statements of the same tree. This is a **construction prerequisite** (SourceFile carries its import table; nodes reach it through their unit), not outcome 3.
- **Ancestor facts** (`AnnotationUnionSugar.is_within_annotation()`): the tree carries children, not parents. Same finding as #5944; #5940's design review already names the fix (parent links minted at construction). Construction prerequisite, not outcome 3.
- **Dedicated-name carve-outs** (`len`, `os.exit`): expressible from node fields but string-typed, so disjointness is by discipline, not by type. This is the one place the old `comes_before` was doing honest work that types cannot absorb.
- **Desugar-time context** (`ctx.temporal`, `resolve_method_funcdef`, install-source dig, cross-file facts): never recognition's problem — `desugar(ctx)` keeps its ctx either way. The inversion moves *recognition and construction*, not reduction.

Nothing surfaced where recognition itself needs a fact that cannot be carried into construction.

### 6. Measured (battleaxe, bench-venv, numpy + pandas installed sources, cpython-ast backend)

```
files parsed:   1828  (parse failures: 0)
subject nodes:  362070
  BinOp: 30378   Call: 307127   If: 24413   While: 152
resolved:       339649
  IfCompletion: 24413        WhileCompletion: 152   WhileElseCompletion: 0
  KeywordCallCompletion: 79189   MethodCallCompletion: 122850
  PlainCallCompletion: 98599     LenCallCompletion: 5658
  AddOpCompletion: 8788
gap arm:        22421
  BinOp: 21590  (every non-Add operator — only Add was ported, by design)
  Call: 831     (computed callables: the family cell left open on purpose)
ambiguous:      0  (an ambiguous family kills the run; it did not)
silent:         0
```

Every one of the 24,413 If nodes and all 152 While nodes resolved — the While partition's gap arm is unreachable, as the field type predicts. The 831 Call gaps are the open computed-callable cell; the 21,590 BinOp gaps are the 13 unported operators exercising the gap arm loudly.

Zero ambiguous (an ambiguous family kills the run; it did not). Zero silent: every If/While/Call/BinOp node resolved or panicked GAP, and the totals reconcile exactly. Full suite: 98 passed on battleaxe (the one local-Mac golden failure is a pre-existing Python-3.14 parse difference, untouched by this branch).

## Per-subject verdict, against T's three outcomes

Judged against T's rubric — reach for 1 where cleanly reachable, without turning the node into a ball of mud; 2 where the seam carries real separation; 3 only where a fact cannot be carried into construction.

| Subject | Verdict | Evidence |
|---|---|---|
| `If` | **Outcome 1 — taken, with both receipts** | Emptied-sugar receipt: `IfCompletion` is stateless — no fields, no `new()`, `__init__` is `object.__init__` (asserted in `test_if_completion_is_stateless_and_reduces_from_node_fields`). `IfSugar`'s fields were the node's `test/body/orelse` wrapped with a role, and role is a function of grammar position the node class already states. Node-after receipt: absorption costs `If` ONE five-line method (`reduction`: the binary-conditional plan over its own fields, roles as grammar positions) — no new conditionals, no mixed concerns, the grammar class stays a grammar class. Witnesses are corpus fixtures, not per-node state; they attach to the language kit either way. |
| `BinOp`/Add | **Outcome 1 by the same receipt, not separately demonstrated** | `AddOpSugar` holds `left/right/site` — verbatim node fields; discrimination is one isinstance on the operator class the node holds. The absorbed method would be one line (`add(left, right)` on the addition floor). Same shape as If; the demonstration was not duplicated. |
| `While` | **Outcome 2 — the seam is carrying real separation** | `LoopControlScopeSugar.classify` output (`carried`, `deferred_outputs`, `curried`, `unclassified_mutation`) is genuine construction work and cached state. It is all subtree-derived (`classify(site, ...)` takes the site alone), so `node.sugar()` builds it and the factory still dies — but absorbing scope classification, currying, and the deferred-output protocol onto the `While` grammar class is the mud signal named exactly: the node would grow beyond its grammar role. A While that knows what it is + a WhileSugar that knows what loop-carried state means is the right factoring. Cleanly collapsible: no. Constructible by the node: yes. |
| `Call` family | **Outcome 2 + one construction prerequisite** | Family discrimination is pure node fields. `import_target` needs the module's import environment — a fact the *tree* holds even though the node does not: enrich construction (SourceFile-scope import table reachable through the unit), do not keep the factory. `MethodCallSugar.desugar` is 140 lines of contract minting, native-shape recognition, and body dig — mud by definition if moved onto `Call`. Not outcome 3: nothing here is unknowable at construction. |

No probe subject landed in outcome 3. The two candidate context-dependencies (imports, ancestors) both classify as carriable-into-construction by enriching the tree — the same move Typed operands already made for operand dispatch. Net: the factory's introduction service (catalog scan, `owns`, `comes_before`, resolve-time ambiguity between strangers) has no remaining territory among these subjects; sugar survives where it demonstrably carries meaning-side weight (While's scope state, Call's contract minting), and collapses where it demonstrably carries none (If, Add).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `node.sugar()` completion resolution with registration, gap, and ambiguity handling
> - Introduces a `Completion` base class in [`completion.py`](https://github.com/TSavo/sugar/pull/5956/files#diff-d01e225576823e2ec3e8e08019400709f436137c55b683c7fc263f48e1db162d) that auto-registers subclasses against target node types at import time, enforcing sole/family exclusivity constraints.
> - Adds `resolve_completion(node)` to look up the registered `Completion` for a node, raising `CompletionGap` when no match exists or `CompletionAmbiguous` when multiple family members match.
> - Adds `Node.sugar()` in [`nodes.py`](https://github.com/TSavo/sugar/pull/5956/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) as a thin wrapper delegating to `resolve_completion(self)`.
> - Adds a probe module [`completion_probe.py`](https://github.com/TSavo/sugar/pull/5956/files#diff-22e81bb71e11805e9cdc9120d470838b620ee804d6028f79bd8ef1b3c0677b3a) with concrete completions for `If`, `While`, `Call`, and `BinOp` nodes, plus a CLI that walks source trees, resolves completions, and exits non-zero if any subject nodes are unaccounted for.
> - Risk: misconfigurations in `Completion` subclasses (e.g. duplicate sole completions) raise `CompletionAmbiguous` at import time, failing loudly on module load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e26c76.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->