### PR TITLE
substitute drain: the grammar rewrites (73/75 nodes)

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -303,6 +303,24 @@ class Node(Typed):
         under-substitutes rather than captures -- safe)."""
         return {n.id for n in target.walk() if n.kind == "Name"}
 
+    def _substitute_generators(self, generators, scope):
+        """Substitute comprehension generators, threading each target as a
+        binding for the FOLLOWING generators and the result expression. Returns
+        (new_generators, result_scope, changed) -- result_scope has every
+        generator target masked."""
+        bound = set()
+        inner = scope
+        new_gens = []
+        changed = False
+        for gen in generators:
+            new_gen = gen.substitute(inner)
+            if new_gen is not gen:
+                changed = True
+            new_gens.append(new_gen)
+            bound |= self._bound_names_in(gen.target)
+            inner = {k: v for k, v in scope.items() if k not in bound}
+        return (tuple(new_gens) if changed else generators), inner, changed
+
     def sugar(self) -> object:
         """This node's sugar, constructed by the node itself.
 
@@ -465,6 +483,22 @@ class Comprehension(Node):
     ifs: Tuple[Expression, ...]
     is_async: bool
     _child_fields = ("target", "iter", "ifs")
+
+    def substitute(self, scope):
+        """One `for <target> in <iter> [if ...]` clause: iter in the given
+        scope; the target binds for its own ifs. Threading across clauses is the
+        enclosing comprehension's job (_substitute_generators)."""
+        from .shadow import rewrite
+        new_iter, di = self._substitute_field(self.iter, scope)
+        bound = self._bound_names_in(self.target)
+        ifs_scope = {k: v for k, v in scope.items() if k not in bound} if bound else scope
+        new_ifs, df = self._substitute_field(self.ifs, ifs_scope)
+        changed = {}
+        if di:
+            changed["iter"] = new_iter
+        if df:
+            changed["ifs"] = new_ifs
+        return self if not changed else rewrite(self, **changed)
 
 
 class ExceptHandler(Node):
@@ -813,6 +847,10 @@ class Try(Statement):
     finalbody: Tuple[Statement, ...]
     _child_fields = ("body", "handlers", "orelse", "finalbody")
 
+    def substitute(self, scope):
+        """Binds nothing itself (its handlers mask): recurse."""
+        return self._substitute_children(scope)
+
 
 class TryStar(Statement):
     body: Tuple[Statement, ...]
@@ -820,6 +858,10 @@ class TryStar(Statement):
     orelse: Tuple[Statement, ...]
     finalbody: Tuple[Statement, ...]
     _child_fields = ("body", "handlers", "orelse", "finalbody")
+
+    def substitute(self, scope):
+        """Binds nothing itself (its handlers mask): recurse."""
+        return self._substitute_children(scope)
 
 
 class Assert(Statement):
@@ -1039,11 +1081,37 @@ class ListComp(Expression):
     generators: Tuple[Comprehension, ...]
     _child_fields = ("elt", "generators")
 
+    def substitute(self, scope):
+        """A comprehension: thread each generator's target, then substitute the
+        element against the scope with every target masked."""
+        from .shadow import rewrite
+        new_gens, inner, gc = self._substitute_generators(self.generators, scope)
+        new_elt, de = self._substitute_field(self.elt, inner)
+        changed = {}
+        if gc:
+            changed["generators"] = new_gens
+        if de:
+            changed["elt"] = new_elt
+        return self if not changed else rewrite(self, **changed)
+
 
 class SetComp(Expression):
     elt: Expression
     generators: Tuple[Comprehension, ...]
     _child_fields = ("elt", "generators")
+
+    def substitute(self, scope):
+        """A comprehension: thread each generator's target, then substitute the
+        element against the scope with every target masked."""
+        from .shadow import rewrite
+        new_gens, inner, gc = self._substitute_generators(self.generators, scope)
+        new_elt, de = self._substitute_field(self.elt, inner)
+        changed = {}
+        if gc:
+            changed["generators"] = new_gens
+        if de:
+            changed["elt"] = new_elt
+        return self if not changed else rewrite(self, **changed)
 
 
 class DictComp(Expression):
@@ -1052,11 +1120,38 @@ class DictComp(Expression):
     generators: Tuple[Comprehension, ...]
     _child_fields = ("key", "value", "generators")
 
+    def substitute(self, scope):
+        """A dict comprehension: thread the generators, then key and value
+        against the scope with every target masked."""
+        from .shadow import rewrite
+        new_gens, inner, gc = self._substitute_generators(self.generators, scope)
+        changed = {}
+        if gc:
+            changed["generators"] = new_gens
+        for fld in ("key", "value"):
+            new, d = self._substitute_field(getattr(self, fld), inner)
+            if d:
+                changed[fld] = new
+        return self if not changed else rewrite(self, **changed)
+
 
 class GeneratorExp(Expression):
     elt: Expression
     generators: Tuple[Comprehension, ...]
     _child_fields = ("elt", "generators")
+
+    def substitute(self, scope):
+        """A comprehension: thread each generator's target, then substitute the
+        element against the scope with every target masked."""
+        from .shadow import rewrite
+        new_gens, inner, gc = self._substitute_generators(self.generators, scope)
+        new_elt, de = self._substitute_field(self.elt, inner)
+        changed = {}
+        if gc:
+            changed["generators"] = new_gens
+        if de:
+            changed["elt"] = new_elt
+        return self if not changed else rewrite(self, **changed)
 
 
 class Await(Expression):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -296,6 +296,13 @@ class Node(Typed):
                 scope = {**scope, **binding}
         return (tuple(new_items) if changed else statements), changed
 
+    def _bound_names_in(self, target: "Node") -> set:
+        """The names an assignment/for/with/lambda target binds. A Name binds;
+        a Tuple/List/Starred target nests them. Walking for Names is
+        conservative on attribute/subscript targets (over-masking a load
+        under-substitutes rather than captures -- safe)."""
+        return {n.id for n in target.walk() if n.kind == "Name"}
+
     def sugar(self) -> object:
         """This node's sugar, constructed by the node itself.
 
@@ -432,6 +439,10 @@ class Keyword(Node):
     value: Expression
     _child_fields = ("value",)
 
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class DictItem(Node):
     """One ``key: value`` entry of a Dict display. ``key is None`` means
@@ -440,6 +451,10 @@ class DictItem(Node):
     key: Optional[Expression]
     value: Expression
     _child_fields = ("key", "value")
+
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
 
 
 class Comprehension(Node):
@@ -458,16 +473,40 @@ class ExceptHandler(Node):
     body: Tuple[Statement, ...]
     _child_fields = ("type_", "body")
 
+    def substitute(self, scope):
+        """except <type> as <name>: binds the exception name for the body."""
+        from .shadow import rewrite
+        bound = {self.name} if self.name else set()
+        bs = {k: v for k, v in scope.items() if k not in bound} if bound else scope
+        changed = {}
+        new_type, d = self._substitute_field(self.type_, scope)
+        if d:
+            changed["type_"] = new_type
+        new_body, d = self._substitute_body(self.body, bs)
+        if d:
+            changed["body"] = new_body
+        return self if not changed else rewrite(self, **changed)
+
 
 class WithItem(Node):
     context_expr: Expression
     optional_vars: Optional[Expression]
     _child_fields = ("context_expr", "optional_vars")
 
+    def substitute(self, scope):
+        """Substitute the context expr; optional_vars is a binding site."""
+        from .shadow import rewrite
+        new_ctx, d = self._substitute_field(self.context_expr, scope)
+        return self if not d else rewrite(self, context_expr=new_ctx)
+
 
 class ImportAlias(Node):
     name: str
     asname: Optional[str]
+
+    def substitute(self, scope):
+        """Binds nothing, no hole: substitutes to itself."""
+        return self
 
 
 class MatchCase(Node):
@@ -607,6 +646,10 @@ class Delete(Statement):
     targets: Tuple[Expression, ...]
     _child_fields = ("targets",)
 
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class Assign(Statement):
     targets: Tuple[Expression, ...]
@@ -678,6 +721,21 @@ class For(Statement):
     orelse: Tuple[Statement, ...]
     _child_fields = ("target", "iter", "body", "orelse")
 
+    def substitute(self, scope):
+        """for <target> in <iter>: binds the loop target for body/orelse."""
+        from .shadow import rewrite
+        bound = self._bound_names_in(self.target)
+        bs = {k: v for k, v in scope.items() if k not in bound} if bound else scope
+        changed = {}
+        new_iter, d = self._substitute_field(self.iter, scope)
+        if d:
+            changed["iter"] = new_iter
+        for f in ("body", "orelse"):
+            new, d = self._substitute_body(getattr(self, f), bs)
+            if d:
+                changed[f] = new
+        return self if not changed else rewrite(self, **changed)
+
 
 class AsyncFor(Statement):
     target: Expression
@@ -693,6 +751,10 @@ class While(Statement):
     orelse: Tuple[Statement, ...]
     _child_fields = ("test", "body", "orelse")
 
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class If(Statement):
     test: Expression
@@ -700,11 +762,32 @@ class If(Statement):
     orelse: Tuple[Statement, ...]
     _child_fields = ("test", "body", "orelse")
 
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class With(Statement):
     items: Tuple[WithItem, ...]
     body: Tuple[Statement, ...]
     _child_fields = ("items", "body")
+
+    def substitute(self, scope):
+        """with ... as <vars>: binds the as-targets for the body."""
+        from .shadow import rewrite
+        bound = set()
+        for item in self.items:
+            if item.optional_vars is not None:
+                bound |= self._bound_names_in(item.optional_vars)
+        bs = {k: v for k, v in scope.items() if k not in bound} if bound else scope
+        changed = {}
+        new_items, d = self._substitute_field(self.items, scope)
+        if d:
+            changed["items"] = new_items
+        new_body, d = self._substitute_body(self.body, bs)
+        if d:
+            changed["body"] = new_body
+        return self if not changed else rewrite(self, **changed)
 
 
 class AsyncWith(Statement):
@@ -717,6 +800,10 @@ class Raise(Statement):
     exc: Optional[Expression]
     cause: Optional[Expression]
     _child_fields = ("exc", "cause")
+
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
 
 
 class Try(Statement):
@@ -766,6 +853,10 @@ class Import(Statement):
     names: Tuple[ImportAlias, ...]
     _child_fields = ("names",)
 
+    def substitute(self, scope):
+        """Binds nothing, no hole: substitutes to itself."""
+        return self
+
 
 class ImportFrom(Statement):
     module: Optional[str]
@@ -773,13 +864,25 @@ class ImportFrom(Statement):
     level: int
     _child_fields = ("names",)
 
+    def substitute(self, scope):
+        """Binds nothing, no hole: substitutes to itself."""
+        return self
+
 
 class Global(Statement):
     names: Tuple[str, ...]
 
+    def substitute(self, scope):
+        """Binds nothing, no hole: substitutes to itself."""
+        return self
+
 
 class Nonlocal(Statement):
     names: Tuple[str, ...]
+
+    def substitute(self, scope):
+        """Binds nothing, no hole: substitutes to itself."""
+        return self
 
 
 class Expr(Statement):
@@ -788,17 +891,33 @@ class Expr(Statement):
     value: Expression
     _child_fields = ("value",)
 
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class Pass(Statement):
     pass
+
+    def substitute(self, scope):
+        """Binds nothing, no hole: substitutes to itself."""
+        return self
 
 
 class Break(Statement):
     pass
 
+    def substitute(self, scope):
+        """Binds nothing, no hole: substitutes to itself."""
+        return self
+
 
 class Continue(Statement):
     pass
+
+    def substitute(self, scope):
+        """Binds nothing, no hole: substitutes to itself."""
+        return self
 
 
 class Match(Statement):
@@ -816,6 +935,10 @@ class BoolOp(Expression):
     op: BooleanOperator
     values: Tuple[Expression, ...]
     _child_fields = ("values",)
+
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
 
 
 class NamedExpr(Expression):
@@ -857,11 +980,29 @@ class UnaryOp(Expression):
     operand: Expression
     _child_fields = ("operand",)
 
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class Lambda(Expression):
     params: Tuple[Param, ...]
     body: Expression
     _child_fields = ("params", "body")
+
+    def substitute(self, scope):
+        """lambda <params>: masks its parameters for the body expression."""
+        from .shadow import rewrite
+        bound = {p.name for p in self.params}
+        bs = {k: v for k, v in scope.items() if k not in bound} if bound else scope
+        changed = {}
+        new_params, d = self._substitute_field(self.params, scope)
+        if d:
+            changed["params"] = new_params
+        new_body, d = self._substitute_field(self.body, bs)
+        if d:
+            changed["body"] = new_body
+        return self if not changed else rewrite(self, **changed)
 
 
 class IfExp(Expression):
@@ -870,15 +1011,27 @@ class IfExp(Expression):
     orelse: Expression
     _child_fields = ("body", "test", "orelse")
 
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class Dict(Expression):
     items: Tuple[DictItem, ...]
     _child_fields = ("items",)
 
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class Set(Expression):
     elts: Tuple[Expression, ...]
     _child_fields = ("elts",)
+
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
 
 
 class ListComp(Expression):
@@ -910,15 +1063,27 @@ class Await(Expression):
     value: Expression
     _child_fields = ("value",)
 
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class Yield(Expression):
     value: Optional[Expression]
     _child_fields = ("value",)
 
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class YieldFrom(Expression):
     value: Expression
     _child_fields = ("value",)
+
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
 
 
 class Compare(Expression):
@@ -996,10 +1161,18 @@ class FormattedValue(Expression):
     format_spec: Optional["JoinedStr"]
     _child_fields = ("value", "format_spec")
 
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class JoinedStr(Expression):
     values: Tuple[Expression, ...]
     _child_fields = ("values",)
+
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
 
 
 class Constant(Expression):
@@ -1038,6 +1211,10 @@ class Attribute(Expression):
     attr: str
     _child_fields = ("value",)
 
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class Subscript(Expression):
     value: Expression
@@ -1065,6 +1242,10 @@ class Starred(Expression):
     value: Expression
     _child_fields = ("value",)
 
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class Name(Expression):
     id: str
@@ -1089,10 +1270,18 @@ class List(Expression):
     elts: Tuple[Expression, ...]
     _child_fields = ("elts",)
 
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class Tuple_(Expression):
     elts: Tuple[Expression, ...]
     _child_fields = ("elts",)
+
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
 
 
 # Wire word for tuples is "Tuple"; the class name carries a trailing
@@ -1106,6 +1295,10 @@ class Slice(Expression):
     upper: Optional[Expression]
     step: Optional[Expression]
     _child_fields = ("lower", "upper", "step")
+
+    def substitute(self, scope):
+        """Binds nothing: recurse into children and reassemble."""
+        return self._substitute_children(scope)
 
 
 # --------------------------------------------------------------------------

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -321,6 +321,23 @@ class Node(Typed):
             inner = {k: v for k, v in scope.items() if k not in bound}
         return (tuple(new_gens) if changed else generators), inner, changed
 
+    def _pattern_bound_names(self, pattern) -> set:
+        """The names a match pattern captures -- MatchAs/MatchStar `name` and a
+        MatchMapping `rest`. Captures are str fields, not Name references, so
+        the patterns themselves substitute structurally; the MatchCase masks
+        these for its guard and body."""
+        names = set()
+        for n in pattern.walk():
+            if n.kind in ("MatchAs", "MatchStar"):
+                nm = getattr(n, "name", None)
+                if isinstance(nm, str):
+                    names.add(nm)
+            elif n.kind == "MatchMapping":
+                r = getattr(n, "rest", None)
+                if isinstance(r, str):
+                    names.add(r)
+        return names
+
     def sugar(self) -> object:
         """This node's sugar, constructed by the node itself.
 
@@ -549,6 +566,25 @@ class MatchCase(Node):
     body: Tuple[Statement, ...]
     _child_fields = ("pattern", "guard", "body")
 
+    def substitute(self, scope):
+        """`case <pattern> [if <guard>]: <body>` -- the pattern captures bind for
+        the guard and body. Pattern value-exprs evaluate in the enclosing scope;
+        guard and body are masked by the captures (body threaded)."""
+        from .shadow import rewrite
+        bound = self._pattern_bound_names(self.pattern)
+        inner = {k: v for k, v in scope.items() if k not in bound} if bound else scope
+        changed = {}
+        new_pat, d = self._substitute_field(self.pattern, scope)
+        if d:
+            changed["pattern"] = new_pat
+        new_guard, d = self._substitute_field(self.guard, inner)
+        if d:
+            changed["guard"] = new_guard
+        new_body, d = self._substitute_body(self.body, inner)
+        if d:
+            changed["body"] = new_body
+        return self if not changed else rewrite(self, **changed)
+
 
 # --------------------------------------------------------------------------
 # Module and statements
@@ -647,6 +683,11 @@ class AsyncFunctionDef(Statement):
     type_params: Tuple[TypeParam, ...]
     _child_fields = ("decorators", "type_params", "params", "returns", "body")
 
+    def substitute(self, scope):
+        """Same scope shape as FunctionDef (identical fields): masks its
+        parameters for the threaded body."""
+        return FunctionDef.substitute(self, scope)
+
 
 class ClassDef(Statement):
     name: str
@@ -656,6 +697,28 @@ class ClassDef(Statement):
     decorators: Tuple[Expression, ...]
     type_params: Tuple[TypeParam, ...]
     _child_fields = ("decorators", "type_params", "bases", "keywords", "body")
+
+    def substitute(self, scope):
+        """A class: decorators and type params evaluate in the enclosing scope;
+        the type params then bind for the bases, keywords, and body. The body is
+        threaded (a class body reads the enclosing scope; it opens no closure)."""
+        from .shadow import rewrite
+        tnames = {n for tp in self.type_params
+                  for n in [getattr(tp, "name", None)] if isinstance(n, str)}
+        inner = {k: v for k, v in scope.items() if k not in tnames} if tnames else scope
+        changed = {}
+        for fld in ("decorators", "type_params"):
+            new, d = self._substitute_field(getattr(self, fld), scope)
+            if d:
+                changed[fld] = new
+        for fld in ("bases", "keywords"):
+            new, d = self._substitute_field(getattr(self, fld), inner)
+            if d:
+                changed[fld] = new
+        new_body, d = self._substitute_body(self.body, inner)
+        if d:
+            changed["body"] = new_body
+        return self if not changed else rewrite(self, **changed)
 
 
 class Return(Statement):
@@ -740,12 +803,46 @@ class AnnAssign(Statement):
     simple: bool
     _child_fields = ("target", "annotation", "value")
 
+    def substitute(self, scope):
+        """`<target>: <ann> = <value>` -- substitute the annotation and value;
+        the target is a binding site, never substituted."""
+        from .shadow import rewrite
+        changed = {}
+        for fld in ("annotation", "value"):
+            new, d = self._substitute_field(getattr(self, fld), scope)
+            if d:
+                changed[fld] = new
+        return self if not changed else rewrite(self, **changed)
+
+    def substitution_binding(self):
+        # Only an annotated assignment WITH a value and a plain Name target
+        # binds; a bare `x: int` is a declaration and binds nothing.
+        if self.value is not None and isinstance(self.target, Name):
+            return {self.target.id: self.value}
+        return None
+
 
 class TypeAlias(Statement):
     name: Expression
     type_params: Tuple[TypeParam, ...]
     value: Expression
     _child_fields = ("name", "type_params", "value")
+
+    def substitute(self, scope):
+        """`type <name>[<params>] = <value>` -- the type params bind for the
+        value; the name is a binding site."""
+        from .shadow import rewrite
+        tnames = {n for tp in self.type_params
+                  for n in [getattr(tp, "name", None)] if isinstance(n, str)}
+        inner = {k: v for k, v in scope.items() if k not in tnames} if tnames else scope
+        changed = {}
+        new_tp, d = self._substitute_field(self.type_params, scope)
+        if d:
+            changed["type_params"] = new_tp
+        new_val, d = self._substitute_field(self.value, inner)
+        if d:
+            changed["value"] = new_val
+        return self if not changed else rewrite(self, **changed)
 
 
 class For(Statement):
@@ -777,6 +874,10 @@ class AsyncFor(Statement):
     body: Tuple[Statement, ...]
     orelse: Tuple[Statement, ...]
     _child_fields = ("target", "iter", "body", "orelse")
+
+    def substitute(self, scope):
+        """Same as For: masks the loop target for body/orelse."""
+        return For.substitute(self, scope)
 
 
 class While(Statement):
@@ -828,6 +929,10 @@ class AsyncWith(Statement):
     items: Tuple[WithItem, ...]
     body: Tuple[Statement, ...]
     _child_fields = ("items", "body")
+
+    def substitute(self, scope):
+        """Same as With: masks the as-targets for the body."""
+        return With.substitute(self, scope)
 
 
 class Raise(Statement):
@@ -966,6 +1071,10 @@ class Match(Statement):
     subject: Expression
     cases: Tuple[MatchCase, ...]
     _child_fields = ("subject", "cases")
+
+    def substitute(self, scope):
+        """Binds nothing itself: recurse into children and reassemble."""
+        return self._substitute_children(scope)
 
 
 # --------------------------------------------------------------------------
@@ -1405,14 +1514,26 @@ class MatchValue(Pattern):
     value: Expression
     _child_fields = ("value",)
 
+    def substitute(self, scope):
+        """Binds nothing itself: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class MatchSingleton(Pattern):
     value: object
+
+    def substitute(self, scope):
+        """Binds nothing itself: recurse into children and reassemble."""
+        return self._substitute_children(scope)
 
 
 class MatchSequence(Pattern):
     patterns: Tuple[Pattern, ...]
     _child_fields = ("patterns",)
+
+    def substitute(self, scope):
+        """Binds nothing itself: recurse into children and reassemble."""
+        return self._substitute_children(scope)
 
 
 class MatchMapping(Pattern):
@@ -1420,6 +1541,10 @@ class MatchMapping(Pattern):
     patterns: Tuple[Pattern, ...]
     rest: Optional[str]
     _child_fields = ("keys", "patterns")
+
+    def substitute(self, scope):
+        """Binds nothing itself: recurse into children and reassemble."""
+        return self._substitute_children(scope)
 
 
 class MatchClass(Pattern):
@@ -1429,9 +1554,17 @@ class MatchClass(Pattern):
     kwd_patterns: Tuple[Pattern, ...]
     _child_fields = ("cls_", "patterns", "kwd_patterns")
 
+    def substitute(self, scope):
+        """Binds nothing itself: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class MatchStar(Pattern):
     name: Optional[str]
+
+    def substitute(self, scope):
+        """Binds nothing itself: recurse into children and reassemble."""
+        return self._substitute_children(scope)
 
 
 class MatchAs(Pattern):
@@ -1439,10 +1572,18 @@ class MatchAs(Pattern):
     name: Optional[str]
     _child_fields = ("pattern",)
 
+    def substitute(self, scope):
+        """Binds nothing itself: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class MatchOr(Pattern):
     patterns: Tuple[Pattern, ...]
     _child_fields = ("patterns",)
+
+    def substitute(self, scope):
+        """Binds nothing itself: recurse into children and reassemble."""
+        return self._substitute_children(scope)
 
 
 # --------------------------------------------------------------------------
@@ -1456,17 +1597,29 @@ class TypeVar(TypeParam):
     default_value: Optional[Expression] = None  # PEP 696 (3.13+)
     _child_fields = ("bound", "default_value")
 
+    def substitute(self, scope):
+        """Binds nothing itself: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class ParamSpec(TypeParam):
     name: str
     default_value: Optional[Expression] = None  # PEP 696 (3.13+)
     _child_fields = ("default_value",)
 
+    def substitute(self, scope):
+        """Binds nothing itself: recurse into children and reassemble."""
+        return self._substitute_children(scope)
+
 
 class TypeVarTuple(TypeParam):
     name: str
     default_value: Optional[Expression] = None  # PEP 696 (3.13+)
     _child_fields = ("default_value",)
+
+    def substitute(self, scope):
+        """Binds nothing itself: recurse into children and reassemble."""
+        return self._substitute_children(scope)
 
 
 def resolve_kind(kind: str, observed_at: str) -> type[Node]:

--- a/implementations/python/sugar-source-tree/tests/test_substitute_int_literal.py
+++ b/implementations/python/sugar-source-tree/tests/test_substitute_int_literal.py
@@ -103,16 +103,22 @@ def test_binders_mask_their_bound_names():
     # lambda z: z + 1 -- the parameter z is masked for the body.
     lam = next(n for n in _tree("g = lambda z: z + z\n").root.walk() if n.kind == "Lambda")
     assert lam.substitute({"z": _bind_target()}) is lam
+    # [i for i in xs] -- the comprehension loop var i is masked (no capture);
+    # a free var in the element substitutes.
+    c1 = next(n for n in _tree("a = [i for i in xs]\n").root.walk() if n.kind == "ListComp")
+    assert c1.substitute({"i": _bind_target()}) is c1
+    c2 = next(n for n in _tree("a = [y for i in xs]\n").root.walk() if n.kind == "ListComp")
+    assert c2.substitute({"y": _bind_target()}).elt.value == 3
 
 
 def test_an_unwritten_binder_still_panics():
-    # A comprehension binds its loop variable and has no masking substitute yet:
-    # rather than silently capturing, it is loud -- the drain names it next.
-    comp = next(
-        n for n in _tree("y = [i for i in xs]\n").root.walk() if n.kind == "ListComp"
+    # NamedExpr (walrus) binds into the enclosing scope and has no substitute
+    # yet: rather than silently mishandling it, it is loud -- the drain names it.
+    walrus = next(
+        n for n in _tree("a = (x := 5)\n").root.walk() if n.kind == "NamedExpr"
     )
     with pytest.raises(SubstituteNotWritten):
-        comp.substitute({"i": _bind_target()})
+        walrus.substitute({"x": _bind_target()})
 
 
 if __name__ == "__main__":

--- a/implementations/python/sugar-source-tree/tests/test_substitute_int_literal.py
+++ b/implementations/python/sugar-source-tree/tests/test_substitute_int_literal.py
@@ -95,14 +95,24 @@ def test_a_block_threads_its_assignments():
     assert retg.value.value == 2
 
 
+def test_binders_mask_their_bound_names():
+    # for x in xs: return x -- the loop target x is masked for the body, so an
+    # outer x cannot capture it; the loop comes back unchanged.
+    forfn = next(_tree("def f(xs):\n    for x in xs:\n        return x\n").functions())
+    assert forfn.substitute({"x": _bind_target()}) is forfn
+    # lambda z: z + 1 -- the parameter z is masked for the body.
+    lam = next(n for n in _tree("g = lambda z: z + z\n").root.walk() if n.kind == "Lambda")
+    assert lam.substitute({"z": _bind_target()}) is lam
+
+
 def test_an_unwritten_binder_still_panics():
-    # Lambda binds its own parameter and has no masking substitute yet: rather
-    # than silently capturing, it is loud -- coverage visible in the hierarchy.
-    lam = next(
-        n for n in _tree("f = lambda z: z + 1\n").root.walk() if n.kind == "Lambda"
+    # A comprehension binds its loop variable and has no masking substitute yet:
+    # rather than silently capturing, it is loud -- the drain names it next.
+    comp = next(
+        n for n in _tree("y = [i for i in xs]\n").root.walk() if n.kind == "ListComp"
     )
     with pytest.raises(SubstituteNotWritten):
-        lam.substitute({"z": _bind_target()})
+        comp.substitute({"i": _bind_target()})
 
 
 if __name__ == "__main__":
@@ -110,6 +120,7 @@ if __name__ == "__main__":
     test_name_is_the_one_base_case_that_binds()
     test_compound_just_recurses()
     test_function_masks_its_parameter()
+    test_binders_mask_their_bound_names()
     test_an_unwritten_binder_still_panics()
     print(
         "ok: substitute -- literal inert, Name binds, compound recurses, "


### PR DESCRIPTION
## The whole grammar ages itself now

`substitute` — the temporal rewrite — is written for 73 of 75 node classes. Each is deliberate; an unwritten one still panics `SubstituteNotWritten` and names itself.

- **inert** (bind nothing, no hole → self): `Pass`, `Break`, `Continue`, `Global`, `Nonlocal`, `Import`/`ImportFrom`/`ImportAlias`, `MatchSingleton`.
- **structural** (bind nothing → recurse): `Attribute`, `Expr`, `If`, `While`, `BoolOp`, `UnaryOp`, `List`/`Tuple`/`Set`/`Dict`/`DictItem`, `Starred`, `Slice`, `Await`, `Yield`/`YieldFrom`, `Raise`, `Delete`, `JoinedStr`/`FormattedValue`/`Keyword`, `IfExp`, `Try`/`TryStar`, `Match` + all patterns, `TypeVar`/`TypeVarTuple`/`ParamSpec`.
- **binders** (mask bound names for the body): `FunctionDef`/`AsyncFunctionDef`, `For`/`AsyncFor`, `With`/`AsyncWith`/`WithItem`, `Lambda`, `ExceptHandler`, the comprehensions (`ListComp`/`SetComp`/`DictComp`/`GeneratorExp` + `Comprehension`, with nested per-generator threading), `MatchCase` (pattern captures), `TypeAlias`, `ClassDef`, `Assign`/`AnnAssign` (via `substitution_binding` + block threading).

Blocks thread their assignments (`_substitute_body`) — the temporal that used to live in `ctx.temporal`, now the tree rewriting itself in single-assignment form. base64 rewrites end to end, provenance intact (shadow nodes borrow their origin's span).

**Left deliberately loud (2):** `AugAssign` (`x += e` rebinds to `x OP e` — needs synthetic node construction; a half-version would silently give the stale value) and `NamedExpr` (walrus binds into the *enclosing* scope from inside an expression). Both panic honestly until written right.

base64 substitute frontier: 0 gaps. 17 tree tests green. Floors remain honestly red for the ongoing sugar drain — the migration state, deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `substitute` on 73 of 75 AST node types in the Python sugar source tree
> - Adds `substitute` methods to 73 AST node classes in [nodes.py](https://github.com/TSavo/sugar/pull/5958/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0), covering statements, expressions, comprehensions, match patterns, and type parameter nodes.
> - Adds three shared helpers on `Node`: `_bound_names_in` (collect binding identifiers from a target), `_substitute_generators` (thread scope masking across comprehension generator chains), and `_pattern_bound_names` (collect names bound by match patterns).
> - Nodes that are pure binding sites (`Import`, `Pass`, `Break`, `Continue`, etc.) return `self` as no-ops; nodes with mixed binding/expression fields (`For`, `Lambda`, `With`, `ExceptHandler`, `MatchCase`, `ClassDef`, etc.) mask bound names before substituting into their inner scopes.
> - Updates tests to cover masking behavior across for-loops, lambdas, and comprehensions, and adjusts the "unwritten binder" panic test from `Lambda` (now implemented) to `NamedExpr` (still unwritten).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 853315c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->