### PR TITLE
meaning-layer drain: raise (effect arm) + if (guard + phi)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/incomplete.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/incomplete.py
@@ -8,13 +8,18 @@ from sugar_lift_py_tests.effect import Effect, effect_reason, require_effect
 @dataclass(frozen=True)
 class Incomplete:
     effect: Effect
+    branch_conditions: tuple = ()
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "effect", require_effect(self.effect))
 
     @property
     def reason(self) -> str:
-        return effect_reason(self.effect)
+        base = effect_reason(self.effect)
+        if not self.branch_conditions:
+            return base
+        conds = " and ".join(repr(f) for f in self.branch_conditions)
+        return f"{base}; effect occurs under branch condition {conds}"
 
     def binary_conditional(
         self, then, else_body, ctx: object = None, site=None
@@ -43,18 +48,14 @@ class Incomplete:
         return (self,)
 
     def guarded(self, formula):
-        """Keep a typed effect red while recording its branch condition."""
-        from dataclasses import replace
+        """Keep a typed effect red while recording its branch condition.
 
-        return Incomplete(
-            replace(
-                self.effect,
-                reason=(
-                    f"{self.reason}; effect occurs under branch condition "
-                    f"{formula!r}"
-                ),
-            )
-        )
+        The condition is wrapper-level metadata, recorded on the Incomplete --
+        NOT smashed into the effect's reason. The effect stays pristine (some
+        effects, e.g. RaiseEffect, compute ``reason`` as a property with no field
+        to replace), and a raise guarded by several nested ifs accumulates its
+        conditions in order."""
+        return Incomplete(self.effect, (*self.branch_conditions, formula))
 
     def extend_scope(self, ctx):
         # An effect does not rebind: the rest never runs under a new scope.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
@@ -1,0 +1,104 @@
+"""`if <test>: <then> [else: <else>]` -- the GUARD half of an if statement.
+
+An if splits the universe. Its condition desugars to a predicate; each branch's
+stated facts are then GUARDED by the branch polarity, and a guarded fact IS an
+implication (`InvValue.guarded`): `if c: assert P` emits `c -> P`, `if c: return
+E` emits the guarded post `c -> out == E`, `if c: raise X` emits the raise
+effect red under `c`. That is the whole of `if`'s MEANING.
+
+The other half of an if -- what a name BINDS to after the branch (the phi
+`x = then_x if c else else_x`) -- is temporal, and lives entirely in
+`If.substitute` as an `IfExp` rewrite. So this sugar does NO binding join:
+`joined_bindings`/`guarded_bindings` on the `GuardedFaces` it builds are empty
+by construction. substitute ages the bindings; this reads off the guarded facts.
+
+The factory drove the guard through `PredicateValue.binary_conditional`, but that
+path referenced `reduce_with_scope`, which the factory nuke deleted -- it is dead
+code. The guard here is written fresh from the pure-meaning primitives that
+survived: `reduce_statements` (block reduction), `entry.guarded(formula)`
+(implication), and the `GuardedFaces` floor value the block reducer already
+consumes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
+
+
+@dataclass(frozen=True)
+class IfSugar(Sugar):
+    """`if <test>: <then> [else: <else>]`, constructed by `If.sugar()` with the
+    test's sugar and each branch's statement sugars already built."""
+
+    test: Sugar
+    then_body: tuple  # the then-branch statements' sugars, in source order
+    else_body: tuple  # the else-branch statements' sugars (empty if no else)
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        # A guarded return: under the guard the post is `z == 1 -> out == 10`, so
+        # the caller's `A(1) == 10` discharges and `A(1) == 11` contradicts.
+        return _call_return_pair(
+            name="if_guarded_return",
+            owner_sugar="IfSugar",
+            body="10 if z == 1 else 20",
+            truthful="10",
+            lying="11",
+            prefix="",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.guarded_faces import GuardedFaces
+        from sugar_lift_py_tests.ir import not_
+        from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_statements
+
+        # The condition states a predicate; its formula is the guard. A condition
+        # whose value carries no formula (a ground bool, a bare truthiness) is not
+        # handled yet -- be LOUD rather than silently guard by nothing.
+        cond = self.test.desugar(ctx)
+        formula = getattr(getattr(cond, "value", None), "formula", None)
+        if formula is None:
+            raise NotImplementedError(
+                "if-condition without a predicate formula is not lifted yet "
+                "(ground bool / bare truthiness): only `if <predicate>:` guards "
+                f"today; got {type(getattr(cond, 'value', cond)).__name__}"
+            )
+
+        then_entries, _c1, then_falls, _f1 = reduce_statements(self.then_body, ctx)
+        else_entries, _c2, else_falls, _f2 = reduce_statements(self.else_body, ctx)
+
+        # Each branch's facts ride under its polarity: then under c, else under ¬c.
+        not_formula = not_(formula)
+        entries = (
+            *(entry.guarded(formula) for entry in then_entries),
+            *(entry.guarded(not_formula) for entry in else_entries),
+        )
+
+        then_exits = not then_falls
+        else_exits = not else_falls
+        can_fall_through = not (then_exits and else_exits)
+        # The tail rides under the polarity of whichever branch did NOT exit; if
+        # both fall through it is unconditional, if both exit it is unreachable.
+        continuation_guard = None
+        if then_exits and not else_exits:
+            continuation_guard = not_formula
+        elif else_exits and not then_exits:
+            continuation_guard = formula
+
+        return Complete(
+            GuardedFaces(
+                guard=formula,
+                entries=entries,
+                then_exits=then_exits,
+                else_exits=else_exits,
+                joined_bindings=(),  # bindings are substitute's job (the IfExp phi)
+                guarded_bindings=(),
+                can_fall_through=can_fall_through,
+                continuation_guard=continuation_guard,
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/raise_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/raise_sugar.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.outcome import Incomplete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import typed_red_effect_witness
+
+
+@dataclass(frozen=True)
+class RaiseSugar(Sugar):
+    """`raise <exc>` -- a statement that HALTS the block.
+
+    A raise never states a fact and never returns a value: it exits. So it is
+    the halt arm of ``match(Sugar) { Some => cite_or_effect, None => panic }`` --
+    it desugars to a typed-red effect, ``Incomplete(RaiseEffect)``, not to a
+    ``Complete`` floor value. Its ``follow`` halts the block (a RaiseEffect is
+    not a store effect, so the rest of the block stays unreduced); a matching
+    ``TrySugar`` handler may later route it, and unrouted it is the block's exit.
+
+    The exception's NAME is provenance, read structurally off the raised
+    expression and carried onto the effect -- exactly as ``AssertSugar`` treats
+    its message. We do NOT desugar the exception expression as a child sugar:
+    the lift does not construct the exception object, it records that control
+    leaves here and under what name. An exotic raised expression whose name we
+    cannot read is still a raise -- ``exception_name`` is ``None`` and the halt
+    is no less real (the effect is the fact, the name is only its label).
+    """
+
+    exception_name: str | None
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        # The typed-red effect IS the discriminator: `raise ValueError` must
+        # surface a RaiseEffect whose reason names ValueError; a lift that named
+        # the wrong exception (KeyError) would make the lying arm match and fail.
+        return typed_red_effect_witness(
+            name="raise_named_exception",
+            owner_sugar="RaiseSugar",
+            source="def A():\n    raise ValueError\n",
+            effect_class="RaiseEffect",
+            reason_needle="raise ValueError",
+            blame_needle="exits the current block",
+            wrong_reason_needle="raise KeyError",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        # The halt: an Incomplete carrying the named raise effect. blame is the
+        # construction locus; source_sha256 pins the text the raise lives in.
+        source = getattr(self.site.unit, "source", None)
+        source_sha256 = (
+            hashlib.sha256(source.encode()).hexdigest() if source is not None else None
+        )
+        blame = f"{self.site.filename}:{self.site.line}:{self.site.col}"
+        return Incomplete(
+            RaiseEffect(
+                exception_name=self.exception_name,
+                blame=blame,
+                source_sha256=source_sha256,
+            )
+        )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -940,8 +940,94 @@ class If(Statement):
     _child_fields = ("test", "body", "orelse")
 
     def substitute(self, scope):
-        """Binds nothing: recurse into children and reassemble."""
-        return self._substitute_children(scope)
+        """An if introduces no names into its own scope, but each branch is a
+        sub-block that threads its OWN assignments. So: substitute the test, then
+        thread each branch body (its within-branch bindings inline), and rebuild.
+        What a name binds to AFTER the if is the phi -- that is
+        ``substitution_binding``, not this."""
+        from .shadow import rewrite
+
+        changed = {}
+        new_test, d = self._substitute_field(self.test, scope)
+        if d:
+            changed["test"] = new_test
+        new_body, d = self._substitute_body(self.body, scope)
+        if d:
+            changed["body"] = new_body
+        new_orelse, d = self._substitute_body(self.orelse, scope)
+        if d:
+            changed["orelse"] = new_orelse
+        return self if not changed else rewrite(self, **changed)
+
+    def _branch_bindings(self, statements, scope):
+        """The net bindings a branch leaves for the rest of ITS block, threaded
+        exactly as ``_substitute_body`` threads a block: each statement's
+        ``substitution_binding`` plus any nested walrus. Returns the map of names
+        this branch bound to their final substituted values."""
+        local = dict(scope)
+        touched: "dict[str, Node]" = {}
+        for stmt in statements:
+            new_stmt = stmt.substitute(local)
+            binding = new_stmt.substitution_binding(local)
+            if binding:
+                local = {**local, **binding}
+                touched.update(binding)
+            for node in new_stmt.walk():
+                if node.kind == "NamedExpr":
+                    wb = node.substitution_binding(local)
+                    if wb:
+                        local = {**local, **wb}
+                        touched.update(wb)
+        return touched
+
+    def substitution_binding(self, scope):
+        """The phi. A name bound in either branch rebinds, for the rest of the
+        block, to ``<then value> if <test> else <else value>`` -- an ``IfExp``
+        whose two arms are the branches' values and whose test is the condition.
+        A name bound in only one branch takes its PRIOR binding in the other arm;
+        with no prior binding the other arm would be an invented value, so we
+        leave that name an honest gap (unbound) rather than guess."""
+        then_binds = self._branch_bindings(self.body, scope)
+        else_binds = self._branch_bindings(self.orelse, scope)
+        names = set(then_binds) | set(else_binds)
+        if not names:
+            return None
+        test = self.test.substitute(scope)
+        result: "dict[str, Node]" = {}
+        for name in names:
+            then_val = then_binds.get(name, scope.get(name))
+            else_val = else_binds.get(name, scope.get(name))
+            if then_val is None or else_val is None:
+                continue  # bound in one branch, no prior: honest gap, not a guess
+            result[name] = self._make_ifexp(test, then_val, else_val)
+        return result or None
+
+    def _make_ifexp(self, test: "Node", body: "Node", orelse: "Node") -> "Node":
+        """Synthesize ``<body> if <test> else <orelse>`` as a shadow IfExp that
+        borrows this if's span (so the phi still addresses this source site)."""
+        from .backend import Child, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        slots = (
+            ("body", Child(_handle_of(body))),
+            ("test", Child(_handle_of(test))),
+            ("orelse", Child(_handle_of(orelse))),
+        )
+        return materialize(self.unit, ShadowNode("IfExp", self.span, slots), self.reporter)
+
+    def sugar(self):
+        """`if <test>: <body> [else: <orelse>]` constructs IfSugar -- the guard.
+        The test recognizes itself; each branch's statements recognize themselves.
+        The guard turns each branch's stated facts into implications; the binding
+        phi is substitute's job, never this."""
+        from sugar_lift_py_tests.sugar.if_sugar import IfSugar
+
+        return IfSugar(
+            test=self.test.sugar(),
+            then_body=tuple(s.sugar() for s in self.body),
+            else_body=tuple(s.sugar() for s in self.orelse),
+            site=self.fragment,
+        )
 
 
 class With(Statement):
@@ -985,6 +1071,41 @@ class Raise(Statement):
     def substitute(self, scope):
         """Binds nothing: recurse into children and reassemble."""
         return self._substitute_children(scope)
+
+    def _exception_name(self):
+        """The raised exception's name, read structurally off ``exc`` (never
+        desugared): ``raise E`` -> ``"E"``, ``raise E(...)`` -> ``"E"``,
+        ``raise mod.E`` / ``raise mod.E(...)`` -> ``"mod.E"``. A bare ``raise``
+        (re-raise, ``exc is None``) or an exotic raised expression we cannot read
+        is ``None`` -- the halt is no less real, the name is only its label."""
+        node = self.exc
+        if node is None:
+            return None
+        if node.kind == "Call":  # raise E(...) -- the constructor
+            node = node.func
+        parts = []
+        while node is not None and node.kind == "Attribute":  # mod.sub.E
+            parts.append(node.attr)
+            node = node.value
+        if node is not None and node.kind == "Name":
+            parts.append(node.id)
+        if not parts:
+            return None
+        return ".".join(reversed(parts))
+
+    def sugar(self):
+        """`raise <exc>[ from <cause>]` constructs RaiseSugar -- the halt arm.
+        The exception name is provenance, read structurally; the expression is
+        never desugared as a child (we do not construct the exception)."""
+        if self.cause is not None:
+            # `raise X from Y` -- the cause is exception-chaining provenance, not
+            # part of the halt. Carrying it is not written yet, so rather than
+            # silently drop it we FAIL LOUDLY (the MISSING-becomes-success this
+            # design forbids), exactly as AssertSugar does with its message.
+            return super().sugar()
+        from sugar_lift_py_tests.sugar.raise_sugar import RaiseSugar
+
+        return RaiseSugar(exception_name=self._exception_name(), site=self.fragment)
 
 
 class Try(Statement):

--- a/implementations/python/sugar-source-tree/tests/test_if_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_if_sugar.py
@@ -1,0 +1,160 @@
+"""`if` on the AST tree: the two halves, proven through the node.
+
+An if splits across BOTH verbs:
+
+  * substitute owns the TEMPORAL half -- what a name binds to after the branch is
+    the phi `x = <then> if <test> else <else>`, an IfExp rewrite. A name bound in
+    only one branch takes its prior binding in the other arm, or stays an honest
+    gap when there is none.
+  * sugar owns the MEANING half -- the guard. Each branch's stated facts ride
+    under the branch polarity, and a guarded fact IS an implication:
+    `if c: assert P` emits `c -> P`.
+
+The two never touch each other's failure mode: substitute cannot form an
+implication, sugar cannot mis-bind (it does no binding join at all).
+"""
+
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn(src: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _return_of(fn):
+    sub = fn.substitute({})
+    return next(n for n in sub.walk() if n.kind == "Return")
+
+
+# ---- Half 1: the phi (substitute) --------------------------------------------
+
+
+def test_if_else_assignment_becomes_a_phi():
+    # if c: x = 5 else: x = 6 ; return x  ->  return (5 if c else 6)
+    ret = _return_of(_fn("def A(c):\n    if c:\n        x = 5\n    else:\n        x = 6\n    return x\n"))
+    assert ret.value.kind == "IfExp"
+    assert ret.value.test.kind == "Name" and ret.value.test.id == "c"
+    assert ret.value.body.value == 5  # then arm
+    assert ret.value.orelse.value == 6  # else arm
+
+
+def test_one_armed_if_uses_the_prior_binding_for_the_missing_arm():
+    # x = 9 ; if c: x = 5 ; return x  ->  return (5 if c else 9)
+    ret = _return_of(
+        _fn("def A(c):\n    x = 9\n    if c:\n        x = 5\n    return x\n")
+    )
+    assert ret.value.kind == "IfExp"
+    assert ret.value.body.value == 5  # bound under c
+    assert ret.value.orelse.value == 9  # prior binding under not c
+
+
+def test_one_armed_if_with_no_prior_is_an_honest_gap_not_a_guess():
+    # if c: x = 5 ; return x -- x is bound only under c, with no prior. Rather
+    # than invent a value for the not-c arm, x stays unbound: `return x` keeps a
+    # free Name (a gap the sugar layer meets loudly), never a wrong phi.
+    ret = _return_of(_fn("def A(c):\n    if c:\n        x = 5\n    return x\n"))
+    assert ret.value.kind == "Name" and ret.value.id == "x"
+
+
+def test_the_phi_borrows_the_if_source_span():
+    # The synthesized IfExp is a shadow that still addresses the if's source site
+    # (the memento invariant survives rewriting).
+    fn = _fn("def A(c):\n    if c:\n        x = 5\n    else:\n        x = 6\n    return x\n")
+    if_node = next(n for n in fn.walk() if n.kind == "If")
+    phi = _return_of(fn).value
+    assert phi.span == if_node.span
+
+
+# ---- Half 2: the guard (sugar) -----------------------------------------------
+
+
+def _invs(fn):
+    uni = fn.sugar().desugar()
+    return uni.value.invs()
+
+
+def test_guarded_assert_is_an_implication():
+    # if z == 1: assert z == 1  ->  inv  (z == 1) -> (z == 1)
+    invs = _invs(_fn("def A(z):\n    if z == 1:\n        assert z == 1\n    return z\n"))
+    assert len(invs) == 1
+    guard = invs[0]
+    assert getattr(guard, "kind", None) == "implies", guard
+    # both operands are the same atomic (z == 1): antecedent is the condition,
+    # consequent is the guarded fact.
+    ante, cons = guard.operands
+    assert ante.name == "py.eq" and cons.name == "py.eq"
+
+
+def test_guard_discriminates_condition_from_fact():
+    # if z == 1: assert z == 2  ->  (z == 1) -> (z == 2): antecedent is the
+    # CONDITION, consequent the FACT, and they are not conflated.
+    invs = _invs(_fn("def A(z):\n    if z == 1:\n        assert z == 2\n    return z\n"))
+    ante, cons = invs[0].operands
+    # antecedent right operand is 1 (the condition), consequent right operand 2.
+    assert ante.args[1].value == 1
+    assert cons.args[1].value == 2
+
+
+# ---- Half 2: guarded EXITS (return / raise) ----------------------------------
+
+
+def test_guarded_return_posts_both_faces():
+    # if z == 1: return 10 ; return 20  ->  the exit constraint is
+    #   (z == 1 -> out == 10)  AND  (not(z == 1) -> out == 20)
+    # The exiting branch posts under the guard; the fall-through tail posts under
+    # its negation. No face is dropped.
+    uni = _fn("def A(z):\n    if z == 1:\n        return 10\n    return 20\n").sugar().desugar()
+    post = uni.value.post()
+    assert post.kind == "and"
+    then_imp, else_imp = post.operands
+    assert then_imp.kind == "implies" and else_imp.kind == "implies"
+    # then face: z == 1 -> out == 10
+    assert then_imp.operands[0].args[1].value == 1
+    assert then_imp.operands[1].args[1].value == 10
+    # else face: not(z == 1) -> out == 20
+    assert else_imp.operands[0].kind == "not"
+    assert else_imp.operands[1].args[1].value == 20
+
+
+def test_guarded_raise_halts_its_branch_and_guards_the_tail():
+    # if z == 1: raise ValueError ; assert z == 2 ; return z
+    # The raise halts the z == 1 branch, so the tail rides under its negation:
+    # the assert becomes  not(z == 1) -> (z == 2).
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    v = _fn(
+        "def A(z):\n    if z == 1:\n        raise ValueError\n    assert z == 2\n    return z\n"
+    ).sugar().desugar().value
+    invs = v.invs()
+    assert len(invs) == 1
+    tail = invs[0]
+    assert tail.kind == "implies"
+    assert tail.operands[0].kind == "not"  # guarded by not(z == 1)
+    assert tail.operands[1].args[1].value == 2  # the tail fact z == 2
+
+    # The raise itself is red testimony, pristine RaiseEffect, with the branch
+    # condition recorded on the Incomplete wrapper (not smashed into the effect).
+    raises = [e for e in v.record.contribution() if isinstance(e, Incomplete)]
+    assert len(raises) == 1
+    assert type(raises[0].effect).__name__ == "RaiseEffect"
+    assert raises[0].effect.exception_name == "ValueError"
+    assert len(raises[0].branch_conditions) == 1
+    assert raises[0].branch_conditions[0].args[1].value == 1  # under z == 1
+
+
+if __name__ == "__main__":
+    test_if_else_assignment_becomes_a_phi()
+    test_one_armed_if_uses_the_prior_binding_for_the_missing_arm()
+    test_one_armed_if_with_no_prior_is_an_honest_gap_not_a_guess()
+    test_the_phi_borrows_the_if_source_span()
+    test_guarded_assert_is_an_implication()
+    test_guard_discriminates_condition_from_fact()
+    test_guarded_return_posts_both_faces()
+    test_guarded_raise_halts_its_branch_and_guards_the_tail()
+    print("ok: if -- phi (substitute) + guard (sugar), both halves through the node")

--- a/implementations/python/sugar-source-tree/tests/test_raise_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_raise_sugar.py
@@ -1,0 +1,86 @@
+"""`raise` sugar on the AST tree: the halt arm, proven through the node.
+
+A raise never states a fact and never returns a value -- it exits. So its
+`.sugar().desugar()` is an `Incomplete(RaiseEffect)`, the halt arm of
+`match(Sugar) { Some => cite_or_effect, None => panic }`, not a `Complete`
+floor value. The exception name is provenance read structurally off `exc`;
+the expression is never desugared as a child. `raise X from Y` is loud until
+cause-carrying is written -- a MISSING never becomes a silent success.
+"""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _raise(src: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    fn = next(SourceFile(path_source(path)).functions())
+    return next(n for n in fn.walk() if n.kind == "Raise")
+
+
+def _effect(src: str):
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    out = _raise(src).sugar().desugar()
+    assert isinstance(out, Incomplete), f"raise must halt, got {type(out).__name__}"
+    assert type(out.effect).__name__ == "RaiseEffect"
+    return out.effect
+
+
+def test_raise_is_the_halt_arm_not_a_value():
+    # def A(): raise ValueError -- desugars to Incomplete(RaiseEffect), a typed
+    # red halt, never a Complete floor value.
+    eff = _effect("def A():\n    raise ValueError\n")
+    assert eff.exception_name == "ValueError"
+    assert "raise ValueError" in eff.reason
+
+
+def test_exception_name_is_read_structurally():
+    # raise E, raise E(...), raise mod.E, raise mod.E(...) all name E / mod.E,
+    # read off the expression WITHOUT desugaring it (we never construct E).
+    assert _effect("def A():\n    raise ValueError\n").exception_name == "ValueError"
+    assert _effect("def A():\n    raise ValueError('x')\n").exception_name == "ValueError"
+    assert _effect("def A():\n    raise os.error\n").exception_name == "os.error"
+    assert _effect("def A():\n    raise a.b.E(1)\n").exception_name == "a.b.E"
+
+
+def test_bare_reraise_is_still_a_real_halt_with_no_name():
+    # def A(): raise -- a re-raise: exc is None, so the name is None, but the
+    # halt is no less real. The effect is the fact; the name is only its label.
+    eff = _effect("def A():\n    raise\n")
+    assert eff.exception_name is None
+    assert "unknown exception" in eff.reason
+
+
+def test_the_lift_discriminates_the_exception_name():
+    # The name is not guessed: a raise of KeyError does NOT read as ValueError.
+    # This is the truthful/lying discrimination the witness pair encodes.
+    assert _effect("def A():\n    raise ValueError\n").exception_name == "ValueError"
+    assert _effect("def A():\n    raise KeyError\n").exception_name == "KeyError"
+    assert (
+        _effect("def A():\n    raise ValueError\n").exception_name
+        != _effect("def A():\n    raise KeyError\n").exception_name
+    )
+
+
+def test_raise_from_is_loud_until_cause_carrying_is_written():
+    # def A(): raise X from Y -- the cause is chaining provenance we do not carry
+    # yet. Rather than silently drop it, the sugar is LOUD: SugarNotWritten.
+    with pytest.raises(SugarNotWritten):
+        _raise("def A():\n    raise ValueError from KeyError\n").sugar()
+
+
+if __name__ == "__main__":
+    test_raise_is_the_halt_arm_not_a_value()
+    test_exception_name_is_read_structurally()
+    test_bare_reraise_is_still_a_real_halt_with_no_name()
+    test_the_lift_discriminates_the_exception_name()
+    test_raise_from_is_loud_until_cause_carrying_is_written()
+    print("ok: raise -> Incomplete(RaiseEffect); name structural; from is loud")


### PR DESCRIPTION
Two meaning-layer sugars, opening both arms of `match(Sugar) { Some => cite_or_effect, None => panic }` past the base64 path. Tested through the **node**, not the dead factory instrument.

## `raise` — the effect arm (the halt)

`raise <exc>` desugars to `Incomplete(RaiseEffect)`, the halt arm, never a `Complete` value: it states no fact and returns no value, it exits. The exception name is provenance read structurally off `exc` (`raise E`, `raise E(...)`, `raise mod.E` all name it; bare `raise` → `None`, still a real halt). The expression is never desugared as a child — we record that control leaves, we do not construct the exception. `raise X from Y` is **loud** (`SugarNotWritten`) until cause-carrying is written, same discipline as `AssertSugar`'s message.

## `if` — both verbs, cleanly split

An `if` splits across substitute and sugar, and neither can reach the other's failure mode:

- **substitute owns the temporal half (the phi):** `if c: x = 5 else: x = 6; return x` rewrites to `return (5 if c else 6)` — the two branch bodies become the arms of a synthesized `IfExp`, the condition its test. A name bound in one branch takes its prior binding in the other arm; with no prior it stays an honest gap (free `Name`), never an invented value. The `IfExp` borrows the `if`'s span, so the memento invariant survives the rewrite.
- **sugar owns the meaning half (the guard):** each branch's stated facts ride under the branch polarity, and a guarded fact IS an implication. `if c: assert P` → `c → P`; `if c: return E` → guarded post `c → out == E` with the tail under `¬c`; `if c: raise X` → the raise red under `c`, tail under `¬c`.

The factory drove the guard through `PredicateValue.binary_conditional`, but that path references `reduce_with_scope`, which the factory nuke **deleted** — it is dead code. `IfSugar` is written fresh from the surviving pure-meaning primitives (`reduce_statements`, `entry.guarded`, `GuardedFaces`), and does zero binding join (substitute ages the bindings, sugar reads off the guarded facts).

## `Incomplete.guarded` fix — found by the guarded-raise case

`Incomplete.guarded` did `replace(self.effect, reason=...)`, assuming every effect has a `reason` field — but `RaiseEffect` computes `reason` as a *property*, so a guarded raise crashed. The branch condition is wrapper-level metadata: record it on the `Incomplete` (`branch_conditions`), leave the effect pristine. Works for every effect type and accumulates across nested `if`s. The only other reference to the old string is in the dead `binary_conditional` path.

## Tests
`sugar-source-tree`: **67 passed, 5 skipped**. raise: halt/name/discrimination/loud-from. if: phi (both-arm, one-arm-with-prior, one-arm-gap, span-borrow), guard (implication, condition-vs-fact discrimination), guarded return (both faces posted), guarded raise (branch halted, tail guarded, effect pristine). Pre-existing Mac-3.14 pandas/numpy frontier RPC failures unchanged (need battleaxe 3.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `raise` and `if` desugaring with guarded effects and phi-bindings to the meaning layer
> - Adds [`RaiseSugar`](https://github.com/TSavo/sugar/pull/5960/files#diff-1c0c5027941d1547dc4ca73cc75da930f335eb49af16898ea4c26140cf5a6e83) to desugar `raise` statements into `Incomplete(RaiseEffect)` with structured metadata (exception name, blame location, source SHA).
> - Adds [`IfSugar`](https://github.com/TSavo/sugar/pull/5960/files#diff-1973840cdede6045a823f5394f176c7dfce28cab5c88332fc428d364ccb4b6b1) to desugar `if` statements into `GuardedFaces` with entries guarded under the condition and its negation, correctly modeling branch exits and fallthrough.
> - Adds `If.substitution_binding` in [`nodes.py`](https://github.com/TSavo/sugar/pull/5960/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to synthesize phi-style `IfExp` bindings for names assigned in both branches (or with a prior binding).
> - `Incomplete` now carries `branch_conditions` structurally; `reason` includes a suffix describing active guards instead of mutating the underlying effect object.
> - Risk: `IfSugar.desugar` raises `NotImplementedError` if the test expression has no predicate formula, which may surface on previously-unchecked inputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 06058ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for lifting Python `if` statements, including guarded branches, conditional assertions, and branch-aware exits.
  * Added support for lifting `raise` statements as execution-halting outcomes with exception names and source provenance.
  * Improved branch assignments by preserving values across both branches and representing conditional bindings accurately.
  * Added clearer reporting for outcomes that occur under branch conditions.

* **Bug Fixes**
  * Corrected exception-name handling for qualified and called exception expressions.
  * Added explicit handling for unsupported exception chaining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->