### PR TITLE
substitute becomes the sole binder: delete ctx.temporal from the hot path + IfExp value

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field as dataclass_field
 
-from sugar_lift_py_tests.floor import BoundVar, ModuleBoundVar
 from sugar_lift_py_tests.outcome import Complete, Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
@@ -10,26 +9,29 @@ from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 @dataclass(frozen=True)
 class AssignSugar(Sugar):
-    """A `name = <rhs>` statement. The rhs is held as SUGAR (the SOURCE), never
-    reduced here -- desugar yields a BoundVar aliasing the name to that source
-    under the DEFINITION scope. The block threads the BoundVar as a let (a scope
-    effect that contributes nothing to the record); a later reference to the
-    name recomposes the source against the captured scope.
+    """A `name = <rhs>` statement -- SPENT by the time it reaches the meaning layer.
 
-    Meaning-only, node-constructed: no owns/new/role, no SugarBody wrapper --
-    the rhs is a tree sugar and the BoundVar reduces it through the Sugar.reduce
-    alias. Single Name target only; the tree node keeps other target shapes as
-    gaps.
+    substitute runs before sugar (FunctionDef.sugar), and an assignment IS a
+    temporal binding: substitute threads it, inlining the rhs into every later
+    reference of the name. So by the time this sugar reduces, the binding has
+    already done its work in the tree -- there is nothing left to state. An
+    assignment contributes no fact, no post, no effect; it is inert meaning.
+
+    (The rhs is not re-stated either: wherever the name was used, the rhs node
+    was substituted in and sugared THERE, in the position that consumes it.)
+
+    Meaning-only, node-constructed: no owns/new/role. Single Name target only;
+    other target shapes stay gaps on the tree node.
     """
 
     name: str
-    value: object  # the rhs sugar (the source), reduced only on reference
+    value: object  # the rhs sugar -- provenance only; substitute already inlined it
     site: object = dataclass_field(compare=False)
 
     @classmethod
     def witnesses(cls):
-        # `x = z; return x` aliases through the source: the truthful twin rides
-        # the identity, the lying twin asserts another -- the pair discriminates.
+        # `x = z; return x` inlines to `return z` via substitute: the truthful
+        # twin rides the identity, the lying twin asserts another.
         prefix = "def A(z):\n    x = z\n    return x\n\n"
         return _call_pair(
             name="assign_return",
@@ -39,9 +41,7 @@ class AssignSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        # Capture the DEFINITION scope: ctx still holds the OLD binding for the
-        # name (the block threads the new one AFTER this), so a self-referential
-        # rebind (`x = x + 1`) reads the old value and terminates. The rhs stays
-        # as source -- not reduced here.
-        binding = ModuleBoundVar if self.name in ctx.global_names else BoundVar
-        return Complete(binding(self.name, self.value, scope=ctx))
+        # Inert: the binding was consumed by substitute. Contribute nothing.
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+
+        return Complete(BlockValue((), can_fall_through=True))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -137,31 +137,24 @@ class FunctionUniverseSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        # A function body is the root of a reduction: if no context is threaded
-        # in, establish a fresh one (empty temporal scope) so statements can bind
-        # names and thread refinements down the body.
-        from dataclasses import replace
-
-        from sugar_lift_py_tests.floor import SymbolicValue
-        from sugar_lift_py_tests.ir import make_var
-
+        # The body was already SUBSTITUTED (FunctionDef.sugar), so there are no
+        # temporal bindings left to thread: a formal reaches its NameSugar as a
+        # free name and becomes its own symbolic Var, a local assignment is inert
+        # (spent by substitute), a conditional binding is an IfExp phi. There is
+        # nothing to bind_value here. A root context is still established because
+        # a few not-yet-converted floor values (GuardedFaces, BlockValue with a
+        # `with` as-binding) call extend_scope during block reduction -- that is
+        # the next slice of the temporal cut, not this one.
         if ctx is None:
             from sugar_lift_py_tests.context.reduce_context import ReduceContext
 
             ctx = ReduceContext.root(owner="FunctionUniverseSugar")
 
-        # Bind each formal to its universe variable, so a body that reads a
-        # parameter reduces against a symbolic value, not an unbound name.
-        temporal = ctx.temporal
-        for formal in self.formals:
-            temporal = temporal.bind_value(formal, SymbolicValue(make_var(formal)))
-        scoped = replace(ctx, temporal=temporal)
-
         # `.and_then` is the Complete/Incomplete distinction: a Complete body
         # (a BlockValue record) becomes the universe; an Incomplete body (an
         # effect) propagates untouched -- an effect is never wrapped into a
         # false contract.
-        return reduce_body(self.statements, scoped).and_then(
+        return reduce_body(self.statements, ctx).and_then(
             lambda record: Complete(
                 UniverseValue(name=self.name, formals=self.formals, record=record)
             )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
@@ -1,0 +1,76 @@
+"""`<body> if <test> else <orelse>` -- a conditional EXPRESSION (a value).
+
+This is the value the phi produces: `If.substitution_binding` rewrites a
+conditionally-bound name to an `IfExp`, so an `IfExp` lands anywhere a value can
+(`return (5 if c else 6)`, `assert (5 if c else 6) == x`, `(5 if c else 6) + 1`).
+
+The value is a `GuardedValue(guard, when_true, when_false)` -- the SAME conditional
+floor value the predicate join bindings already produce. It is not an ite term:
+operations DISTRIBUTE into both arms (`GuardedValue._map`) and a return/equality
+splits into `(c -> out == then) AND (not c -> out == else)` via `post_formula` /
+`equals`, each arm's equality resolved PER ATOM by `resolve_equality_atom`. So the
+"what one sort is the conditional" question never forms -- the value resolves
+itself, and a mixed Int/Real conditional is two per-atom equalities each carrying
+its own `to_real` bridge, never a single mixed-sort term. (Only a genuinely
+opaque collapse -- the conditional as an argument to an EUF function -- folds to
+a `py.conditional` term; there an integer arm promotes to Real, since 5 == 5.0.)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
+
+
+@dataclass(frozen=True)
+class IfExpSugar(Sugar):
+    """`<body> if <test> else <orelse>`, constructed by `IfExp.sugar()` with the
+    test's and both arms' sugars already built."""
+
+    test: Sugar
+    body: Sugar  # the then-value
+    orelse: Sugar  # the else-value
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        # A conditional return: the post distributes to z == 1 -> out == 10, so
+        # the caller's A(1) == 10 discharges and A(1) == 11 contradicts.
+        return _call_return_pair(
+            name="ifexp_conditional_return",
+            owner_sugar="IfExpSugar",
+            body="10 if z == 1 else 20",
+            truthful="10",
+            lying="11",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.guarded_value import GuardedValue
+        from sugar_lift_py_tests.outcome import Incomplete
+
+        cond = self.test.desugar(ctx)
+        # The guard is the test's TRUTHINESS as a predicate -- uniform via
+        # `.truth`: a predicate test (`5 if a == b else 6`) stands as its formula,
+        # a bare value (`5 if c else 6`) emits `py.truthy(c)`. A ground-bool test
+        # folds to a literal with no formula and is not lifted yet -- LOUD.
+        formula = getattr(getattr(cond.value.truth(self.site), "value", None), "formula", None)
+        if formula is None:
+            raise NotImplementedError(
+                "conditional-expression test that folds to a ground boolean is "
+                f"not lifted yet (got {type(getattr(cond, 'value', cond)).__name__})"
+            )
+
+        then_out = self.body.desugar(ctx)
+        else_out = self.orelse.desugar(ctx)
+        # An arm that is itself an effect (an unresolvable call, a halt) is not a
+        # value to guard-join yet: be loud rather than fold an effect into a value.
+        if isinstance(then_out, Incomplete) or isinstance(else_out, Incomplete):
+            raise NotImplementedError(
+                "a conditional-expression arm that reduces to an effect is not "
+                "lifted yet: both arms must be values to form the guarded value"
+            )
+
+        return Complete(GuardedValue(formula, then_out.value, else_out.value))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
@@ -53,24 +53,35 @@ class IfSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.block_value import BlockValue
         from sugar_lift_py_tests.floor.guarded_faces import GuardedFaces
         from sugar_lift_py_tests.ir import not_
         from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_statements
 
-        # The condition states a predicate; its formula is the guard. A condition
-        # whose value carries no formula (a ground bool, a bare truthiness) is not
-        # handled yet -- be LOUD rather than silently guard by nothing.
-        cond = self.test.desugar(ctx)
-        formula = getattr(getattr(cond, "value", None), "formula", None)
-        if formula is None:
-            raise NotImplementedError(
-                "if-condition without a predicate formula is not lifted yet "
-                "(ground bool / bare truthiness): only `if <predicate>:` guards "
-                f"today; got {type(getattr(cond, 'value', cond)).__name__}"
-            )
-
         then_entries, _c1, then_falls, _f1 = reduce_statements(self.then_body, ctx)
         else_entries, _c2, else_falls, _f2 = reduce_statements(self.else_body, ctx)
+
+        # A purely TEMPORAL if -- branches that only bind -- is spent by
+        # substitute (its binding became an IfExp phi threaded past the if), so
+        # both branches reduce to nothing. It contributes no meaning and needs no
+        # guard: the condition is not even consulted (an inert if states nothing,
+        # whatever its test). This is the common residue of the phi rewrite.
+        if not then_entries and not else_entries:
+            return Complete(BlockValue((), can_fall_through=True))
+
+        # Branches carry facts/effects: the guard is the condition's TRUTHINESS
+        # as a predicate. `.truth` is uniform -- a predicate condition (`if a ==
+        # b`) stands as its own formula, a bare value (`if c`) emits the Python
+        # `py.truthy(c)` relation. A ground bool (`if True:`) folds to a literal
+        # with no formula and is not lifted yet -- LOUD, never guard by nothing.
+        cond = self.test.desugar(ctx)
+        formula = getattr(getattr(cond.value.truth(self.site), "value", None), "formula", None)
+        if formula is None:
+            raise NotImplementedError(
+                "if-condition that folds to a ground boolean is not lifted yet "
+                f"(got {type(getattr(cond, 'value', cond)).__name__}); a symbolic "
+                "predicate or bare-truthiness condition guards, a constant does not"
+            )
 
         # Each branch's facts ride under its polarity: then under c, else under ¬c.
         not_formula = not_(formula)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/name_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/name_sugar.py
@@ -9,15 +9,17 @@ from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 @dataclass(frozen=True)
 class NameSugar(Sugar):
-    """A name is nothing on its own: it asks the temporal context what stands
-    at this name, and the binding answers. A concrete binding folds like any
-    value; a symbolic binding (a parameter's SymbolicValue) stands as the term
-    it projects. An unbound name panics loudly at reduce time -- exactly where
-    Python would raise NameError.
+    """A name that survives to the meaning layer is a free FORMAL.
 
-    Meaning-only, node-constructed: no owns/new/role. The tree's Name node
-    constructs this WITH its identifier; there is nothing to build eagerly (a
-    name is a leaf), only to look up when the body reduces.
+    substitute runs before sugar (FunctionDef.sugar), so every temporal binding
+    -- a local assignment, a conditional phi -- is already rewritten into the
+    tree: a bound name has been replaced by its value node and never reaches
+    here. The only Name left standing is a function parameter, which is masked
+    by substitute and therefore free. So a name IS its symbolic universe
+    variable -- the term a parameter projects. There is no context to consult
+    (ctx.temporal is gone): the name resolves to its own Var, always.
+
+    Meaning-only, node-constructed: no owns/new/role. A name is a leaf.
     """
 
     name: str
@@ -37,9 +39,9 @@ class NameSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        # Ask the context what stands at this name; the binding answers.
-        binding = ctx.temporal.value_for(
-            self.name,
-            blame=f"{self.site.filename}:{self.site.line}:{self.site.col}",
-        )
-        return binding.answer(ctx)
+        # A surviving name is a free formal: it IS its symbolic universe variable.
+        from sugar_lift_py_tests.floor import SymbolicValue
+        from sugar_lift_py_tests.ir import make_var
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(SymbolicValue(make_var(self.name)))

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -681,19 +681,26 @@ class FunctionDef(Statement):
         """`def <name>(<formals>): <body>` constructs FunctionUniverseSugar WITH
         each body statement's own sugar — the recursion, child-before-parent.
 
-        A body statement whose sugar is not written yet raises SugarNotWritten
-        from its own `.sugar()`, which propagates out here: the whole function
-        is a frontier gap until every statement it holds can be constructed.
-        That is the honest 99% — no fallback, no partial universe.
+        The body is SUBSTITUTED first: every temporal binding (a local
+        assignment, a conditional phi) is rewritten into the tree before any
+        sugar runs, so by the time a statement is sugared its names are already
+        resolved — a `Name` that survives is only ever a free formal (the
+        parameters are masked by ``substitute``, so they stand as symbolic
+        Vars). This is why the meaning layer holds NO temporal: substitute did
+        it. A body statement whose sugar is not written yet raises
+        SugarNotWritten from its own `.sugar()`, which propagates out here.
         """
         from sugar_lift_py_tests.sugar.function_universe_sugar import (
             FunctionUniverseSugar,
         )
 
+        # Substitute the body against an empty scope: formals are masked (they
+        # stay free -> symbolic), locals thread and inline, phis land as IfExps.
+        substituted = self.substitute({})
         return FunctionUniverseSugar(
             name=self.name,
             formals=tuple(p.name for p in self.params),
-            statements=tuple(stmt.sugar() for stmt in self.body),
+            statements=tuple(stmt.sugar() for stmt in substituted.body),
             site=self.fragment,
         )
 
@@ -1347,6 +1354,21 @@ class IfExp(Expression):
     def substitute(self, scope):
         """Binds nothing: recurse into children and reassemble."""
         return self._substitute_children(scope)
+
+    def sugar(self):
+        """`<body> if <test> else <orelse>` constructs IfExpSugar -- the
+        conditional VALUE the phi produces. It desugars to a GuardedValue that
+        DISTRIBUTES (a return/equality splits into per-arm implications, each arm
+        resolved per-atom), so the conditional never becomes a single mixed-sort
+        term; the compiler stays Python-ignorant and only ever sees ir.eq."""
+        from sugar_lift_py_tests.sugar.if_exp_sugar import IfExpSugar
+
+        return IfExpSugar(
+            test=self.test.sugar(),
+            body=self.body.sugar(),
+            orelse=self.orelse.sugar(),
+            site=self.fragment,
+        )
 
 
 class Dict(Expression):

--- a/implementations/python/sugar-source-tree/tests/test_if_exp_and_phi_lift.py
+++ b/implementations/python/sugar-source-tree/tests/test_if_exp_and_phi_lift.py
@@ -1,0 +1,90 @@
+"""The conditional expression (`IfExp`) and the phi lift, end to end.
+
+`If.substitution_binding` rewrites a conditionally-bound name to an `IfExp`, so
+the phi only lifts if `IfExp` has a value. That value is a `GuardedValue`, which
+DISTRIBUTES: a return/equality splits into per-arm implications, each arm's
+equality resolved per-atom. So the conditional never collapses to a single
+mixed-sort term, and `py.conditional` never reaches the (Python-agnostic)
+compiler -- the lift resolves it into `ir.eq`/`py.eq` atoms.
+
+This also exercises the finished temporal cut: substitute is the sole binder
+(FunctionDef.sugar substitutes first), so `x = z; return x` inlines with no
+`ctx.temporal`, and a conditional binding lands as a phi that lifts here.
+"""
+
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _post(src: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).sugar().desugar().value.post()
+
+
+def _no_py_conditional(post):
+    # The tripwire: py.conditional is the OPAQUE conditional term. If it reaches
+    # the compiler, the lift failed to distribute -- the compiler is Python-
+    # agnostic and must never have to interpret what py.conditional means.
+    assert "py.conditional" not in repr(post), "py.conditional leaked to the compiler"
+
+
+def test_substitute_is_the_sole_binder_straight_line():
+    # x = z; return x  inlines to  out == z  via substitute (no ctx.temporal).
+    post = _post("def A(z):\n    x = z\n    return x\n")
+    assert post.name == "=" and post.args[0].name == "out" and post.args[1].name == "z"
+
+
+def test_single_assignment_fold_reads_the_old_binding():
+    # x = z + 1; x = x + 1; return x  ->  out == (z + 1) + 1 : the rebind reads
+    # the OLD x, the loop-as-repeated-substitute shape.
+    post = _post("def A(z):\n    x = z + 1\n    x = x + 1\n    return x\n")
+    assert post.name == "="
+    outer = post.args[1]
+    assert outer.name == "+" and outer.args[0].name == "+"  # (z+1)+1
+
+
+def test_direct_ifexp_predicate_distributes():
+    # return 10 if z == 1 else 20  ->  (z==1 -> out==10) AND (not(z==1) -> out==20)
+    post = _post("def A(z):\n    return 10 if z == 1 else 20\n")
+    _no_py_conditional(post)
+    assert post.kind == "and"
+    then_imp, else_imp = post.operands
+    assert then_imp.operands[1].args[1].value == 10
+    assert else_imp.operands[0].kind == "not"
+    assert else_imp.operands[1].args[1].value == 20
+
+
+def test_direct_ifexp_bare_truthiness_distributes():
+    # return 5 if c else 6  ->  (py.truthy(c) -> out==5) AND (not truthy -> out==6)
+    post = _post("def A(c):\n    return 5 if c else 6\n")
+    _no_py_conditional(post)
+    then_imp, else_imp = post.operands
+    assert then_imp.operands[0].name == "py.truthy"
+    assert then_imp.operands[1].args[1].value == 5
+    assert else_imp.operands[1].args[1].value == 6
+
+
+def test_phi_conditional_binding_lifts_end_to_end():
+    # if c: x = 5 else: x = 6 ; return x
+    # substitute rewrites `return x` to `return (5 if c else 6)`; the IfExp value
+    # distributes to the same guarded post -- the phi is liftable, not a gap.
+    post = _post("def A(c):\n    if c:\n        x = 5\n    else:\n        x = 6\n    return x\n")
+    _no_py_conditional(post)
+    assert post.kind == "and"
+    then_imp, else_imp = post.operands
+    assert then_imp.operands[0].name == "py.truthy"  # guard is truthiness of c
+    assert then_imp.operands[1].args[1].value == 5
+    assert else_imp.operands[1].args[1].value == 6
+
+
+if __name__ == "__main__":
+    test_substitute_is_the_sole_binder_straight_line()
+    test_single_assignment_fold_reads_the_old_binding()
+    test_direct_ifexp_predicate_distributes()
+    test_direct_ifexp_bare_truthiness_distributes()
+    test_phi_conditional_binding_lifts_end_to_end()
+    print("ok: IfExp value distributes; phi lifts end-to-end; substitute is sole binder")


### PR DESCRIPTION
The substitute migration had built the new binding engine (`node.substitute`) but never unbolted the old one: the sugar path still threaded bindings through `ctx.temporal`. Two temporal mechanisms ran in parallel, and the conditional phi collided with the survivor. This deletes the old one from the three hot sugars and stands the lift on substitute.

## The cut

- **`FunctionDef.sugar()`** now **substitutes the body before sugaring**. Formals are masked (stay free → symbolic), locals thread and inline, a conditional binding lands as an `IfExp` phi. By the time a statement is sugared, its names are already resolved.
- **`NameSugar`**: no more `ctx.temporal.value_for`. A surviving `Name` is only ever a free formal, so it IS its symbolic `Var`, directly.
- **`AssignSugar`**: no more `BoundVar`/ctx. An assignment is a temporal binding substitute already consumed — it is inert, contributes nothing.
- **`FunctionUniverseSugar`**: no more `bind_value` formal loop. (A root `ReduceContext` is kept only to feed `GuardedFaces`/`BlockValue.extend_scope` — the `with`/nonlocal as-binding path, the next slice of the cut.)

Proven: `x = z; return x` → `out == z`; `x = z+1; x = x+1; return x` → `out == (z+1)+1` (the rebind reads the OLD `x` — loop-as-repeated-substitute).

## `IfExp` value (closes the phi loop)

The phi produces `IfExp` nodes, so it only lifts if `IfExp` has a value. `IfExpSugar` → a `GuardedValue`, the existing conditional floor value, which **distributes**: a return/equality splits into per-arm implications, each arm resolved **per-atom** by `resolve_equality_atom` (with its own `to_real` bridge when Int/Real mix). So the conditional never collapses to a single mixed-sort term — the number tower is handled per-atom, no supersort — and **`py.conditional` never reaches the Python-agnostic compiler**. A test enforces that tripwire: `py.conditional` in the compiler would mean the lift failed to distribute.

## Bare-truthiness guard

`if`/`ifexp` now take the guard from the condition's **truthiness** via `.truth` (uniform): a predicate condition (`if a == b`) stands as its formula, a bare value (`if c`) emits `py.truthy(c)`. So `if c: x=5 else: x=6; return x` lifts to `(py.truthy(c) → out==5) ∧ (¬truthy → out==6)`. A ground-bool condition (`if True:`) still folds to a literal and stays **loud** (deferred).

## Tests
`sugar-source-tree`: **72 passed, 5 skipped**. Real pipeline (enumerate RPC) green. Pre-existing Mac-3.14 pandas/numpy frontier RPC failures unchanged (need battleaxe 3.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `substitute` the sole binder by removing `ctx.temporal` from the hot path and adding `IfExp` desugaring
> - Substitution now handles all binding before sugaring, so `NameSugar.desugar` always returns a symbolic variable directly and `AssignSugar.desugar` emits an inert empty `BlockValue` instead of a binding.
> - `FunctionUniverseSugar.desugar` no longer pre-binds formals into `ctx.temporal`; `FunctionDef.sugar` calls `substitute({})` first so the body is already inlined before sugar runs.
> - `IfExpSugar` is added to desugar conditional expressions into a `GuardedValue` guarded by the test's truthiness predicate; constant-boolean tests and effectful arms raise `NotImplementedError`.
> - `IfSugar.desugar` now uses `cond.value.truth(site)` for guard extraction and short-circuits with an empty fall-through `BlockValue` when both branches are purely temporal.
> - Behavioral Change: names that survive to `NameSugar` are always treated as free formals; context-based scope lookup is gone.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cab07a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->