### PR TITLE
temporal cut slice 2 (context-free reduction) + constraint drain (UnaryOp/BoolOp/Attribute)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -603,6 +603,43 @@ class FloorValue:
             ),
         )
 
+    def attribute(self, name, site):
+        # Default: this value does not stand on the attribute floor -- it cannot
+        # answer what it yields at `.name`. A symbolic receiver stays the
+        # py.getattr coordinate; a value that owns a field folds; absence here is
+        # the honest "no".
+        del name
+        from sugar_lift_py_tests.factory import (
+            FactoryAuditRow,
+            FactoryGapInfo,
+            GapKind,
+            GapLocus,
+            factory_panic,
+        )
+
+        observed = type(self).__name__
+        info = FactoryGapInfo(
+            owner="attribute",
+            blame=str(site),
+            observed=observed,
+            requested="stand on the attribute floor",
+            fix=f"write more Floor: implement {observed}.attribute",
+            gap_kind=GapKind.FLOOR,
+            gap_locus=GapLocus.CONSTRUCTION,
+        )
+        factory_panic(
+            info,
+            FactoryAuditRow(
+                role="attribute",
+                status=FactoryAuditStatus.FLOOR_GAP,
+                observed=observed,
+                blame=str(site),
+                selected=None,
+                candidates=[],
+                message=info.message,
+            ),
+        )
+
     def setitem(self, index, value, site):
         del index, value
         from sugar_lift_py_tests.factory import (

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -417,6 +417,18 @@ class SymbolicValue(FloorValue):
         # A symbolic receiver stays the py.subscript coordinate regardless of index.
         return self.py_subscript_coordinate(index, site)
 
+    def attribute(self, name, site):
+        # A symbolic receiver stays the py.getattr coordinate: an opaque term
+        # `py.getattr(recv, "name")`, the same EUF vocabulary as py.subscript.
+        # The lift does not know the receiver's fields, so `.name` is an
+        # uninterpreted projection -- decidable only where it later meets an
+        # equality, never invented.
+        del site
+        from sugar_lift_py_tests.ir import ctor, str_const
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(SymbolicValue(ctor("py.getattr", [self.term, str_const(name)])))
+
     def format_data_model(self, spec, site, ctx):
         """Construct ``format(symbolic, spec)`` as an exact data-model coordinate.
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
@@ -1,0 +1,41 @@
+"""Attribute access `<receiver>.<name>`.
+
+Reduce the receiver and ask it for the attribute -- the value owns what `.name`
+means, exactly as SubscriptSugar asks the receiver what `[index]` means. A
+symbolic receiver stays the opaque `py.getattr(recv, "name")` coordinate (the
+same EUF vocabulary as `py.subscript`); a value that owns the field folds; a
+value with no attribute floor hits its own loud gap. The attribute NAME is a
+static identifier carried onto the coordinate, never desugared.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_pair
+
+
+@dataclass(frozen=True)
+class AttributeSugar(Sugar):
+    receiver: Sugar
+    name: str
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        # `z.numerator` on an int is z itself; the pair rides the coordinate's
+        # identity vs a contradicting asserted value.
+        prefix = "def A(z):\n    return z.numerator\n\n"
+        return _call_pair(
+            name="attribute_return",
+            owner_sugar="AttributeSugar",
+            truthful=prefix + "def test_a():\n    assert A(5) == 5\n",
+            lying=prefix + "def test_a():\n    assert A(5) == 6\n",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        return self.receiver.desugar(ctx).and_then(
+            lambda receiver: receiver.attribute(self.name, self.site)
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
@@ -1,0 +1,65 @@
+"""A boolean operation `a and b`, `a or b` (n-ary: `a and b and c`).
+
+In a boolean context -- a condition, an assertion -- `a and b` is true exactly
+when both operands are truthy, `a or b` when either is. So the meaning is the
+conjunction / disjunction of the operands' TRUTHINESS: each operand states its
+own `truth` predicate (a comparison stands as itself, a bare value emits
+`py.truthy`), and this combines them with `and_` / `or_`. One predicate results,
+which states as an inv or guards an if exactly like any other predicate.
+
+(Python's `and`/`or` also carry a short-circuit VALUE -- `a and b` evaluates to
+`a` when `a` is falsy, else `b`. That value form is not modeled here; the boolean
+meaning is what a condition or assertion consumes, and it is what this lifts.)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _boolop_wrapped_pair
+
+
+@dataclass(frozen=True)
+class BoolOpSugar(Sugar):
+    op_kind: str  # "And" | "Or"
+    values: tuple  # the operand sugars, in source order (>= 2)
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        # `(z == 1) and (z != 2)` holds at z == 1 and fails when the asserted
+        # value contradicts a conjunct.
+        return _boolop_wrapped_pair(
+            name="boolop_and",
+            owner_sugar="BoolOpSugar",
+            truthful="(1 == 1) and (2 == 2)",
+            lying="(1 == 1) and (2 == 3)",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+        from sugar_lift_py_tests.ir import and_, or_
+        from sugar_lift_py_tests.outcome import Incomplete
+
+        formulas = []
+        for operand in self.values:
+            out = operand.desugar(ctx)
+            if isinstance(out, Incomplete):
+                # An operand that is itself an effect propagates -- the boolean is
+                # not decidable once a conjunct halts.
+                return out
+            truth = out.value.truth(self.site)
+            formula = getattr(getattr(truth, "value", None), "formula", None)
+            if formula is None:
+                # A ground-bool operand (no formula) is not lifted yet -- LOUD,
+                # never drop a conjunct silently.
+                raise NotImplementedError(
+                    "boolean operand that folds to a ground boolean is not lifted "
+                    f"yet (got {type(getattr(out, 'value', out)).__name__})"
+                )
+            formulas.append(formula)
+
+        combine = and_ if self.op_kind == "And" else or_
+        return Complete(PredicateValue(combine(formulas), self.site))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -26,24 +26,22 @@ from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 
-def reduce_statements(statements: tuple, ctx: object):
-    """Reduce a block's statement sugars in order, threading scope.
+def reduce_statements(statements: tuple):
+    """Reduce a block's statement sugars in order.
 
-    The factory's `_collect_iterative`, verbatim in behavior, but calling
-    `stmt.desugar(ctx)` directly (the tree's sugars answer `desugar`, not the
-    SugarBody `reduce` wrapper). Each outcome owns its own contribution, its
-    scope extension, and whether the run continues -- the loop never branches on
-    a value's kind.
+    Each substituted statement's sugar answers `desugar()` with an Outcome that
+    owns its own contribution and whether the run continues -- the loop never
+    branches on a value's kind, and it threads NO scope: substitute already did
+    the binding, so a statement's meaning is a pure function of the (already
+    resolved) tree, not of any accumulated context.
     """
     entries: list[object] = []
     transforms: list = []
     fall_through: list = []
-    final_ctx = ctx
     can_fall_through = True
 
     for index, head in enumerate(statements):
-        outcome = head.desugar(final_ctx)
-        final_ctx = outcome.extend_scope(final_ctx)
+        outcome = head.desugar()
 
         contribution = outcome.contribution()
         for transform in reversed(transforms):
@@ -74,13 +72,12 @@ def reduce_statements(statements: tuple, ctx: object):
 
     return (
         tuple(entries),
-        final_ctx,
         can_fall_through,
         tuple(fall_through) if can_fall_through else (),
     )
 
 
-def reduce_body(statements: tuple, ctx: object):
+def reduce_body(statements: tuple):
     """Reduce a function body to ONE Outcome, preserving Complete/Incomplete.
 
     A body that reduces to a value is `Complete(BlockValue(record))` -- the
@@ -94,9 +91,7 @@ def reduce_body(statements: tuple, ctx: object):
     """
     from sugar_lift_py_tests.outcome import Incomplete
 
-    entries, _final_ctx, can_fall_through, fall_through = reduce_statements(
-        statements, ctx
-    )
+    entries, can_fall_through, fall_through = reduce_statements(statements)
     # A body that is nothing but a single propagating effect IS that effect --
     # there is no value, no fact, no exit to make a contract from. Propagate it
     # so the def surfaces as an effect (a halt), never a None-returning contract.
@@ -137,24 +132,20 @@ class FunctionUniverseSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        # The body was already SUBSTITUTED (FunctionDef.sugar), so there are no
-        # temporal bindings left to thread: a formal reaches its NameSugar as a
-        # free name and becomes its own symbolic Var, a local assignment is inert
-        # (spent by substitute), a conditional binding is an IfExp phi. There is
-        # nothing to bind_value here. A root context is still established because
-        # a few not-yet-converted floor values (GuardedFaces, BlockValue with a
-        # `with` as-binding) call extend_scope during block reduction -- that is
-        # the next slice of the temporal cut, not this one.
-        if ctx is None:
-            from sugar_lift_py_tests.context.reduce_context import ReduceContext
-
-            ctx = ReduceContext.root(owner="FunctionUniverseSugar")
+        # No context. The body was already SUBSTITUTED (FunctionDef.sugar), so
+        # there is nothing temporal to thread: a formal reaches its NameSugar as
+        # a free name and becomes its own symbolic Var, a local assignment is
+        # inert (spent by substitute), a conditional binding is an IfExp phi. The
+        # block reduction consults no scope -- ctx.temporal is gone, and the
+        # `with`/nonlocal as-binding paths that once needed extend_scope are not
+        # lifted on the tree (they panic SugarNotWritten), so nothing calls it.
+        del ctx
 
         # `.and_then` is the Complete/Incomplete distinction: a Complete body
         # (a BlockValue record) becomes the universe; an Incomplete body (an
         # effect) propagates untouched -- an effect is never wrapped into a
         # false contract.
-        return reduce_body(self.statements, ctx).and_then(
+        return reduce_body(self.statements).and_then(
             lambda record: Complete(
                 UniverseValue(name=self.name, formals=self.formals, record=record)
             )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
@@ -58,8 +58,8 @@ class IfSugar(Sugar):
         from sugar_lift_py_tests.ir import not_
         from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_statements
 
-        then_entries, _c1, then_falls, _f1 = reduce_statements(self.then_body, ctx)
-        else_entries, _c2, else_falls, _f2 = reduce_statements(self.else_body, ctx)
+        then_entries, then_falls, _f1 = reduce_statements(self.then_body)
+        else_entries, else_falls, _f2 = reduce_statements(self.else_body)
 
         # A purely TEMPORAL if -- branches that only bind -- is spent by
         # substitute (its binding became an IfExp phi threaded past the if), so

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py
@@ -1,0 +1,54 @@
+"""A unary operation `<op> <operand>` -- `-x`, `+x`, `~x`, `not x`.
+
+Mirrors BinOpSugar: the node carries its operator, so recognition is the node's;
+this routes the reduced operand to the floor method that operator names, and the
+value owns the answer (a number folds, a symbol emits `py.neg`/`py.invert`, a
+type with no such floor hits its own loud gap). `not` is the one that composes
+two floor verbs: Python `not x` is `not bool(x)`, so it takes the operand's
+TRUTHINESS (`truth`) and negates that predicate -- never a bespoke boolean.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_pair
+
+# Unary operator kind -> the floor method that owns its meaning. Every entry is
+# a real FloorValue method; an operator whose value has no such floor reaches
+# that value's own loud gap, never a silent default.
+UNARYOP_METHODS: dict[str, str] = {
+    "USub": "unary_minus",
+    "UAdd": "unary_plus",
+    "Invert": "bitwise_invert",
+}
+
+
+@dataclass(frozen=True)
+class UnaryOpSugar(Sugar):
+    op_kind: str
+    operand: Sugar
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        # `not` composes truth+negate: `if not (z == 1)` holds exactly when z != 1.
+        prefix = "def A(z):\n    if not (z == 1):\n        return z\n    return 0\n\n"
+        return _call_pair(
+            name="unaryop_not_return",
+            owner_sugar="UnaryOpSugar",
+            truthful=prefix + "def test_a():\n    assert A(5) == 5\n",
+            lying=prefix + "def test_a():\n    assert A(5) == 0\n",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        operand = self.operand.desugar(ctx)
+        if self.op_kind == "Not":
+            # `not x` = not bool(x): take the operand's truthiness, negate it.
+            return operand.and_then(lambda v: v.truth(self.site)).and_then(
+                lambda predicate: predicate.negate()
+            )
+        method = UNARYOP_METHODS[self.op_kind]
+        return operand.and_then(lambda v: getattr(v, method)(self.site))

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1261,6 +1261,17 @@ class BoolOp(Expression):
         """Binds nothing: recurse into children and reassemble."""
         return self._substitute_children(scope)
 
+    def sugar(self):
+        """`a and b` / `a or b` constructs BoolOpSugar WITH each operand's sugar.
+        The node knows its connective (And/Or); the operands recognize themselves."""
+        from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
+
+        return BoolOpSugar(
+            op_kind=self.op.kind,
+            values=tuple(v.sugar() for v in self.values),
+            site=self.fragment,
+        )
+
 
 class NamedExpr(Expression):
     target: Expression
@@ -1323,6 +1334,21 @@ class UnaryOp(Expression):
     def substitute(self, scope):
         """Binds nothing: recurse into children and reassemble."""
         return self._substitute_children(scope)
+
+    def sugar(self):
+        """`<op> <operand>` constructs UnaryOpSugar WITH the operand's sugar. The
+        node already knows its operator; an operator with no floor method inherits
+        the base throw, never a silent default."""
+        from sugar_lift_py_tests.sugar.unary_op_sugar import (
+            UNARYOP_METHODS,
+            UnaryOpSugar,
+        )
+
+        if self.op.kind != "Not" and self.op.kind not in UNARYOP_METHODS:
+            return super().sugar()
+        return UnaryOpSugar(
+            op_kind=self.op.kind, operand=self.operand.sugar(), site=self.fragment
+        )
 
 
 class Lambda(Expression):
@@ -1618,6 +1644,15 @@ class Attribute(Expression):
     value: Expression
     attr: str
     _child_fields = ("value",)
+
+    def sugar(self):
+        """`<value>.<attr>` constructs AttributeSugar WITH the receiver's sugar.
+        The attr name is a static identifier carried onto the coordinate."""
+        from sugar_lift_py_tests.sugar.attribute_sugar import AttributeSugar
+
+        return AttributeSugar(
+            receiver=self.value.sugar(), name=self.attr, site=self.fragment
+        )
 
     def substitute(self, scope):
         """Binds nothing: recurse into children and reassemble."""

--- a/implementations/python/sugar-source-tree/tests/test_unary_bool_attribute_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_unary_bool_attribute_sugar.py
@@ -1,0 +1,93 @@
+"""Constraint-grammar drain: UnaryOp, BoolOp, Attribute, through the node.
+
+Each mirrors an existing dispatch: UnaryOp routes to the operand value's floor
+method (`not` composes truth+negate); BoolOp combines the operands' truthiness
+via and_/or_; Attribute asks the receiver for `.name` (a symbolic receiver stays
+the opaque py.getattr coordinate, like py.subscript).
+"""
+
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn(src: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _post(src):
+    return _fn(src).sugar().desugar().value.post()
+
+
+def _invs(src):
+    return _fn(src).sugar().desugar().value.invs()
+
+
+# ---- UnaryOp -----------------------------------------------------------------
+
+
+def test_unary_minus_and_invert_emit_symbolic_ops():
+    assert _post("def A(z):\n    return -z\n").args[1].name == "py.neg"
+    assert _post("def A(z):\n    return ~z\n").args[1].name == "py.invert"
+
+
+def test_not_is_truth_then_negate():
+    # if not (z == 1): the guard is not(z == 1), so the body's fact rides under it.
+    invs = _invs("def A(z):\n    if not (z == 1):\n        assert z == z\n    return z\n")
+    guard = invs[0].operands[0]  # antecedent of the guarded implication
+    assert guard.kind == "not"
+    assert guard.operands[0].name == "py.eq"
+
+
+# ---- BoolOp ------------------------------------------------------------------
+
+
+def test_and_conjoins_operand_truthiness():
+    invs = _invs("def A(z):\n    assert (z == 1) and (z == 3)\n    return z\n")
+    assert invs[0].kind == "and"
+    assert all(op.name == "py.eq" for op in invs[0].operands)
+
+
+def test_or_disjoins_operand_truthiness():
+    invs = _invs("def A(z):\n    assert (z == 1) or (z == 2)\n    return z\n")
+    assert invs[0].kind == "or"
+
+
+def test_bare_operands_use_py_truthy():
+    invs = _invs("def A(a, b):\n    assert a and b\n    return a\n")
+    assert invs[0].kind == "and"
+    assert all(op.name == "py.truthy" for op in invs[0].operands)
+
+
+# ---- Attribute ---------------------------------------------------------------
+
+
+def test_attribute_is_the_py_getattr_coordinate():
+    post = _post("def A(z):\n    return z.numerator\n")
+    getattr_term = post.args[1]
+    assert getattr_term.name == "py.getattr"
+    assert getattr_term.args[0].name == "z"
+    assert getattr_term.args[1].value == "numerator"
+
+
+def test_attribute_chain_nests():
+    # z.a.b -> py.getattr(py.getattr(z, "a"), "b")
+    post = _post("def A(z):\n    return z.a.b\n")
+    outer = post.args[1]
+    assert outer.name == "py.getattr" and outer.args[1].value == "b"
+    assert outer.args[0].name == "py.getattr" and outer.args[0].args[1].value == "a"
+
+
+if __name__ == "__main__":
+    test_unary_minus_and_invert_emit_symbolic_ops()
+    test_not_is_truth_then_negate()
+    test_and_conjoins_operand_truthiness()
+    test_or_disjoins_operand_truthiness()
+    test_bare_operands_use_py_truthy()
+    test_attribute_is_the_py_getattr_coordinate()
+    test_attribute_chain_nests()
+    print("ok: UnaryOp, BoolOp, Attribute drained through the node")


### PR DESCRIPTION
Two commits: finishing the temporal cut, then three more constraint-grammar sugars.

## Slice 2 — block reduction is now context-free

With substitute the sole binder (slice 1, #5961), the block reducer has nothing left to thread:
- `reduce_statements`/`reduce_body` drop the `ctx` parameter and stop calling `outcome.extend_scope(final_ctx)`. A statement's meaning is a pure function of the already-substituted tree. (`final_ctx` was already discarded by the only caller; `extend_scope` threaded bindings substitute now owns — pure residue, proven by the suite passing unchanged with it removed.)
- `FunctionUniverseSugar.desugar` no longer establishes a root `ReduceContext` — the last live `ctx.temporal` object on the tree path is gone. The `with`/nonlocal as-binding paths that once needed `extend_scope` aren't lifted on the tree (they panic `SugarNotWritten`), so nothing calls it.

## Constraint drain — UnaryOp + BoolOp + Attribute

Each mirrors an existing dispatch; the node carries its operator/name, the value owns the meaning.

- **UnaryOp** `-x` `+x` `~x` `not x` — kind→floor-method map (`unary_minus`/`unary_plus`/`bitwise_invert`); `not x` composes `truth`+`negate` (Python `not x` = `not bool(x)`). → `py.neg`, `py.invert`, `not(z==1)`.
- **BoolOp** `a and b` / `a or b` — conjunction/disjunction of the operands' **truthiness** (`.truth` → predicate, combined with `and_`/`or_`). `(z==1) and (z==3)` → `and(z==1, z==3)`; `a and b` → `and(py.truthy(a), py.truthy(b))`. (Short-circuit value form not modeled; the boolean meaning is what a condition consumes.)
- **Attribute** `x.y` — mirrors `SubscriptSugar`: a symbolic receiver stays the opaque `py.getattr(recv, "name")` coordinate (same EUF vocabulary as `py.subscript`), decidable only where it meets an equality. Chains nest: `z.a.b` → `py.getattr(py.getattr(z, "a"), "b")`. Adds `SymbolicValue.attribute` (the term) + base `FloorValue.attribute` (the honest floor gap).

## Tests
`sugar-source-tree`: **79 passed, 5 skipped**. Real pipeline (enumerate RPC) green. Pre-existing Mac-3.14 pandas/numpy frontier RPC failures unchanged (need battleaxe 3.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add context-free desugaring for UnaryOp, BoolOp, and Attribute AST nodes
> - Adds [`UnaryOpSugar`](https://github.com/TSavo/sugar/pull/5962/files#diff-9701dc81d02d5c66bf2d96792b742e8df06dde7a5027b3d5e0c354b49b74d893), [`BoolOpSugar`](https://github.com/TSavo/sugar/pull/5962/files#diff-73c2a5ae1e04df48a3942a0cb20fba48229df0773e79787ec3b8a7f11aae8199), and [`AttributeSugar`](https://github.com/TSavo/sugar/pull/5962/files#diff-dbd736f4cfe3d43f5f03b925994f117b1b962d9a10a2a832805468df2f8b7272) classes that desugar their respective AST node types to floor-level IR.
> - `BoolOpSugar.desugar` combines operand truth predicates using `and_`/`or_` formulas, producing a `PredicateValue`; ground-boolean operands are not supported and raise `NotImplementedError`.
> - `UnaryOpSugar.desugar` handles logical `Not` by negating the operand's truth predicate, and delegates arithmetic/bitwise ops to corresponding floor methods.
> - `AttributeSugar.desugar` delegates to the receiver's `.attribute(name, site)` floor method; `SymbolicValue` models this as `py.getattr(receiver, name)` and `FloorValue` panics with a `FLOOR_GAP`.
> - Removes the `ctx` parameter from `reduce_statements` in [`function_universe_sugar.py`](https://github.com/TSavo/sugar/pull/5962/files#diff-1a034881b3b9f8294d507d8d13e7d0addd04ec63a0ccc585b95ed6ae81f9f21b) and updates callers in [`if_sugar.py`](https://github.com/TSavo/sugar/pull/5962/files#diff-1973840cdede6045a823f5394f176c7dfce28cab5c88332fc428d364ccb4b6b1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 682bdcf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->