### PR TITLE
constraint grammar drain: comparison family, collections, is/None/float

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
@@ -1,0 +1,115 @@
+"""Collection displays: `[..]` list, `(..)` tuple, `{..}` set, `{k: v}` dict.
+
+Each reduces its element sugars in source order and holds the reduced floor
+values -- ListValue / TupleValue / SetValue / DictValue. The floor owns what the
+collection then DOES (len, subscript, membership); this only constructs it. An
+element that is itself an effect propagates -- a collection with an unresolvable
+element is not a value. Star/double-star spreads (`*xs`, `**d`) stay loud until
+their own sugar lands: a spread is not one element, and guessing would invent
+membership the source never stated.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
+
+
+def _reduce_all(element_sugars, ctx):
+    """Reduce each element sugar to its floor value, in order. Returns
+    ``(values, None)`` or ``(None, effect)`` if an element reduced to an effect."""
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    values = []
+    for element in element_sugars:
+        out = element.desugar(ctx)
+        if isinstance(out, Incomplete):
+            return None, out
+        values.append(out.value)
+    return tuple(values), None
+
+
+@dataclass(frozen=True)
+class ListSugar(Sugar):
+    elements: tuple
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return _call_return_pair(
+            name="list_len", owner_sugar="ListSugar", body="len([z, z, z])",
+            truthful="3", lying="2",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.list_value import ListValue
+
+        values, effect = _reduce_all(self.elements, ctx)
+        return effect if effect is not None else Complete(ListValue(values))
+
+
+@dataclass(frozen=True)
+class TupleSugar(Sugar):
+    elements: tuple
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return _call_return_pair(
+            name="tuple_len", owner_sugar="TupleSugar", body="len((z, z))",
+            truthful="2", lying="3",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.tuple_value import TupleValue
+
+        values, effect = _reduce_all(self.elements, ctx)
+        return effect if effect is not None else Complete(TupleValue(values))
+
+
+@dataclass(frozen=True)
+class SetSugar(Sugar):
+    elements: tuple
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return _call_return_pair(
+            name="set_len", owner_sugar="SetSugar", body="len({1, 2, 3})",
+            truthful="3", lying="2",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.set_value import SetValue
+
+        values, effect = _reduce_all(self.elements, ctx)
+        return effect if effect is not None else Complete(SetValue(values))
+
+
+@dataclass(frozen=True)
+class DictSugar(Sugar):
+    keys: tuple  # key sugars, in source order
+    values: tuple  # value sugars, in source order
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return _call_return_pair(
+            name="dict_len", owner_sugar="DictSugar", body="len({1: z, 2: z})",
+            truthful="2", lying="3",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.dict_value import DictValue
+
+        key_values, effect = _reduce_all(self.keys, ctx)
+        if effect is not None:
+            return effect
+        val_values, effect = _reduce_all(self.values, ctx)
+        if effect is not None:
+            return effect
+        entries = tuple(zip(key_values, val_values))
+        return Complete(DictValue(entries))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
@@ -1,0 +1,60 @@
+"""A comparison `<left> <op> <right>` for the ordering family and `!=`.
+
+`==` keeps its own sugar (EqualityOpSugar, which also refines); this owns the
+rest: the node carries the operator, and this routes the reduced left value to
+the floor method that operator names (`less_than`, `greater_equal`, ...). Each
+is `py.lt` / `py.le` / ... -- vendor comparison, not SMT `<`, so the sort
+universe adjudicates (same NaN/reflexivity split as py.eq). `!=` is `==` negated:
+Python `a != b` is `not (a == b)`, so it stands on the equals floor and negates
+that predicate -- never a bespoke inequality atom.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _boolop_wrapped_pair
+
+# Comparison operator kind -> the floor method that owns its meaning. `Eq` is
+# absent (EqualityOpSugar owns it); `NotEq` is absent (equals + negate, below).
+COMPARE_METHODS: dict[str, str] = {
+    "Lt": "less_than",
+    "LtE": "less_equal",
+    "Gt": "greater_than",
+    "GtE": "greater_equal",
+}
+
+
+@dataclass(frozen=True)
+class ComparisonOpSugar(Sugar):
+    op_kind: str
+    left: Sugar
+    right: Sugar
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return _boolop_wrapped_pair(
+            name="comparison_lt",
+            owner_sugar="ComparisonOpSugar",
+            truthful="1 < 2",
+            lying="2 < 1",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        left = self.left.desugar(ctx)
+        right = lambda l: self.right.desugar(ctx).and_then(  # noqa: E731
+            lambda r: self._apply(l, r)
+        )
+        return left.and_then(right)
+
+    def _apply(self, left, right):
+        if self.op_kind == "NotEq":
+            # a != b is not (a == b): stand on the equals floor, negate.
+            return left.equals(right, self.site).and_then(
+                lambda predicate: predicate.negate()
+            )
+        method = COMPARE_METHODS[self.op_kind]
+        return getattr(left, method)(right, self.site)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
@@ -26,6 +26,11 @@ COMPARE_METHODS: dict[str, str] = {
     "GtE": "greater_equal",
 }
 
+# Every comparison kind this sugar owns (Eq is EqualityOpSugar's, not here).
+# `NotEq`/`IsNot` are their positive form negated; `Is` stands on the identity
+# floor; `In`/`NotIn` (membership) are not owned yet -- they stay loud.
+COMPARISON_KINDS = frozenset(COMPARE_METHODS) | {"NotEq", "Is", "IsNot"}
+
 
 @dataclass(frozen=True)
 class ComparisonOpSugar(Sugar):
@@ -54,6 +59,14 @@ class ComparisonOpSugar(Sugar):
         if self.op_kind == "NotEq":
             # a != b is not (a == b): stand on the equals floor, negate.
             return left.equals(right, self.site).and_then(
+                lambda predicate: predicate.negate()
+            )
+        if self.op_kind == "Is":
+            # a is b: object identity, stands on the is_identical floor.
+            return left.is_identical(right, self.site)
+        if self.op_kind == "IsNot":
+            # a is not b is not (a is b): identity floor, negated.
+            return left.is_identical(right, self.site).and_then(
                 lambda predicate: predicate.negate()
             )
         method = COMPARE_METHODS[self.op_kind]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/none_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/none_literal_sugar.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.floor.none_value import NoneValue
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_pair
+
+
+@dataclass(frozen=True)
+class NoneLiteralSugar(Sugar):
+    """The `None` literal. A leaf: it stands as the NoneValue floor -- the
+    None-ness IS the type, there is no value to carry."""
+
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        prefix = "def A(z):\n    if z is None:\n        return 0\n    return z\n\n"
+        return _call_pair(
+            name="none_is_return",
+            owner_sugar="NoneLiteralSugar",
+            truthful=prefix + "def test_a():\n    assert A(5) == 5\n",
+            lying=prefix + "def test_a():\n    assert A(5) == 0\n",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        return Complete(NoneValue())

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/real_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/real_literal_sugar.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.floor import TermValue
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
+
+
+@dataclass(frozen=True)
+class RealLiteralSugar(Sugar):
+    """A float literal. Like IntLiteralSugar, it stands as a TermValue -- but a
+    float carries the Real sort (int -> Int, float -> Real; there is no Number
+    sort). A leaf: no child sugars."""
+
+    value: float
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return _call_return_pair(
+            name="real_literal_return", owner_sugar="RealLiteralSugar",
+            body="2.5", truthful="2.5", lying="2.6",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        return Complete(TermValue(self.value))

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1405,6 +1405,19 @@ class Dict(Expression):
         """Binds nothing: recurse into children and reassemble."""
         return self._substitute_children(scope)
 
+    def sugar(self):
+        """`{k: v, ...}` constructs DictSugar WITH each key and value sugar. A
+        `**d` spread (a DictItem with key None) stays loud until its own sugar."""
+        from sugar_lift_py_tests.sugar.collection_sugar import DictSugar
+
+        if any(item.key is None for item in self.items):
+            return super().sugar()
+        return DictSugar(
+            keys=tuple(item.key.sugar() for item in self.items),
+            values=tuple(item.value.sugar() for item in self.items),
+            site=self.fragment,
+        )
+
 
 class Set(Expression):
     elts: Tuple[Expression, ...]
@@ -1413,6 +1426,16 @@ class Set(Expression):
     def substitute(self, scope):
         """Binds nothing: recurse into children and reassemble."""
         return self._substitute_children(scope)
+
+    def sugar(self):
+        """`{e, ...}` constructs SetSugar WITH each element's sugar; `*xs` is loud."""
+        from sugar_lift_py_tests.sugar.collection_sugar import SetSugar
+
+        if any(e.kind == "Starred" for e in self.elts):
+            return super().sugar()
+        return SetSugar(
+            elements=tuple(e.sugar() for e in self.elts), site=self.fragment
+        )
 
 
 class ListComp(Expression):
@@ -1738,6 +1761,17 @@ class List(Expression):
         """Binds nothing: recurse into children and reassemble."""
         return self._substitute_children(scope)
 
+    def sugar(self):
+        """`[e, ...]` constructs ListSugar WITH each element's sugar. A `*xs`
+        spread is not one element -- it stays loud until its own sugar lands."""
+        from sugar_lift_py_tests.sugar.collection_sugar import ListSugar
+
+        if any(e.kind == "Starred" for e in self.elts):
+            return super().sugar()
+        return ListSugar(
+            elements=tuple(e.sugar() for e in self.elts), site=self.fragment
+        )
+
 
 class Tuple_(Expression):
     elts: Tuple[Expression, ...]
@@ -1746,6 +1780,16 @@ class Tuple_(Expression):
     def substitute(self, scope):
         """Binds nothing: recurse into children and reassemble."""
         return self._substitute_children(scope)
+
+    def sugar(self):
+        """`(e, ...)` constructs TupleSugar WITH each element's sugar; `*xs` is loud."""
+        from sugar_lift_py_tests.sugar.collection_sugar import TupleSugar
+
+        if any(e.kind == "Starred" for e in self.elts):
+            return super().sugar()
+        return TupleSugar(
+            elements=tuple(e.sugar() for e in self.elts), site=self.fragment
+        )
 
 
 # Wire word for tuples is "Tuple"; the class name carries a trailing

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1565,13 +1565,13 @@ class Compare(Expression):
         """
         from .operators import Eq
         from sugar_lift_py_tests.sugar.comparison_op_sugar import (
-            COMPARE_METHODS,
+            COMPARISON_KINDS,
             ComparisonOpSugar,
         )
         from sugar_lift_py_tests.sugar.equality_op_sugar import EqualityOpSugar
 
         def supported(op):
-            return isinstance(op, Eq) or op.kind == "NotEq" or op.kind in COMPARE_METHODS
+            return isinstance(op, Eq) or op.kind in COMPARISON_KINDS
 
         if not all(supported(op) for op in self.ops):
             return super().sugar()
@@ -1669,19 +1669,27 @@ class Constant(Expression):
         literal kind not yet converted inherits the loud SugarNotWritten throw.
         """
         v = self.value
+        if v is None:
+            from sugar_lift_py_tests.sugar.none_literal_sugar import NoneLiteralSugar
+
+            return NoneLiteralSugar(site=self.fragment)
         if isinstance(v, bool):
             return super().sugar()  # bool is its own sugar, not yet written
         if isinstance(v, int):
             from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
 
             return IntLiteralSugar(value=v, site=self.fragment)
+        if type(v) is float:
+            from sugar_lift_py_tests.sugar.real_literal_sugar import RealLiteralSugar
+
+            return RealLiteralSugar(value=v, site=self.fragment)
         if type(v) is str:
             from sugar_lift_py_tests.sugar.string_literal_sugar import (
                 StringLiteralSugar,
             )
 
             return StringLiteralSugar(value=v, site=self.fragment)
-        return super().sugar()  # float / bytes / None / ... not yet written
+        return super().sugar()  # bool / bytes / ... not yet written
 
 
 class Attribute(Expression):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1533,23 +1533,44 @@ class Compare(Expression):
 
     def sugar(self):
         """A comparison constructs its operator's sugar, built WITH its
-        children's sugar. Each comparison operator is its own sugar type
-        (no operator field to switch on downstream) — dispatch here on the
-        operator class and on arity. A single `==` is EqualityOpSugar; every
-        other operator and chained comparisons inherit the loud throw until
-        written.
+        children's sugar. `==` is EqualityOpSugar (it also refines); the ordering
+        family and `!=` are ComparisonOpSugar. A CHAINED comparison `a < b < c`
+        is `(a < b) and (b < c)` -- each adjacent pair becomes its own comparison
+        sugar and they conjoin (b is the same reduced term in both, as Python
+        evaluates it once). Identity/membership operators (is/in/...) inherit the
+        loud throw until written.
         """
         from .operators import Eq
+        from sugar_lift_py_tests.sugar.comparison_op_sugar import (
+            COMPARE_METHODS,
+            ComparisonOpSugar,
+        )
+        from sugar_lift_py_tests.sugar.equality_op_sugar import EqualityOpSugar
 
-        if len(self.ops) == 1 and isinstance(self.ops[0], Eq):
-            from sugar_lift_py_tests.sugar.equality_op_sugar import EqualityOpSugar
+        def supported(op):
+            return isinstance(op, Eq) or op.kind == "NotEq" or op.kind in COMPARE_METHODS
 
-            return EqualityOpSugar(
-                left=self.left.sugar(),
-                right=self.comparators[0].sugar(),
-                site=self.fragment,
+        if not all(supported(op) for op in self.ops):
+            return super().sugar()
+
+        operands = (self.left, *self.comparators)
+
+        def pair(index):
+            op = self.ops[index]
+            left_s = operands[index].sugar()
+            right_s = operands[index + 1].sugar()
+            if isinstance(op, Eq):
+                return EqualityOpSugar(left=left_s, right=right_s, site=self.fragment)
+            return ComparisonOpSugar(
+                op_kind=op.kind, left=left_s, right=right_s, site=self.fragment
             )
-        return super().sugar()
+
+        pairs = tuple(pair(i) for i in range(len(self.ops)))
+        if len(pairs) == 1:
+            return pairs[0]
+        from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
+
+        return BoolOpSugar(op_kind="And", values=pairs, site=self.fragment)
 
 
 class Call(Expression):

--- a/implementations/python/sugar-source-tree/tests/test_collection_literals.py
+++ b/implementations/python/sugar-source-tree/tests/test_collection_literals.py
@@ -1,0 +1,56 @@
+"""Collection displays: list, tuple, set, dict -- through the node.
+
+Each reduces its elements and holds them as the collection floor value; the
+value owns len/subscript/membership. Star / double-star spreads stay loud.
+"""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn(src: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _post_term(src):
+    return _fn(src).sugar().desugar().value.post().args[1]
+
+
+def test_list_tuple_set_dict_construct_their_terms():
+    assert _post_term("def A(z):\n    return [1, 2, z]\n").name == "array"
+    assert _post_term("def A(z):\n    return (z, 2)\n").name == "tuple"
+    assert _post_term("def A(z):\n    return {1, 2, 3}\n").name == "python:set"
+    assert _post_term("def A(z):\n    return {1: z, 2: 3}\n").name == "python:dict"
+
+
+def test_collection_composes_with_a_call():
+    # len([z, z, z]) -- the list is a real term inside the call
+    term = _post_term("def A(z):\n    return len([z, z, z])\n")
+    assert term.name == "call:len"
+    assert term.args[0].name == "array" and len(term.args[0].args) == 3
+
+
+def test_star_spread_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(xs):\n    return [1, *xs]\n").sugar()
+
+
+def test_double_star_spread_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(d):\n    return {1: 2, **d}\n").sugar()
+
+
+if __name__ == "__main__":
+    test_list_tuple_set_dict_construct_their_terms()
+    test_collection_composes_with_a_call()
+    test_star_spread_stays_loud()
+    test_double_star_spread_stays_loud()
+    print("ok: list/tuple/set/dict literals drained; spreads loud")

--- a/implementations/python/sugar-source-tree/tests/test_comparison_operators.py
+++ b/implementations/python/sugar-source-tree/tests/test_comparison_operators.py
@@ -1,0 +1,56 @@
+"""The comparison family beyond `==`: `!=`, `<`, `<=`, `>`, `>=`, and chains.
+
+`==` stays EqualityOpSugar; the ordering family routes to the value's floor
+method (py.lt/py.le/py.gt/py.ge); `!=` is `==` negated; a chained comparison
+`a < b < c` conjoins its adjacent pairs.
+"""
+
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _inv(src: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).sugar().desugar().value.invs()[0]
+
+
+def test_not_equal_is_equals_negated():
+    inv = _inv("def A(z):\n    assert z != 2\n    return z\n")
+    assert inv.kind == "not"
+    assert inv.operands[0].name == "py.eq"
+
+
+def test_ordering_operators_emit_their_atoms():
+    assert _inv("def A(z):\n    assert z < 10\n    return z\n").name == "py.lt"
+    assert _inv("def A(z):\n    assert z <= 10\n    return z\n").name == "py.le"
+    assert _inv("def A(z):\n    assert z > 0\n    return z\n").name == "py.gt"
+    assert _inv("def A(z):\n    assert z >= 0\n    return z\n").name == "py.ge"
+
+
+def test_chained_comparison_conjoins_adjacent_pairs():
+    # 0 < z < 10  ->  (0 < z) and (z < 10)
+    inv = _inv("def A(z):\n    assert 0 < z < 10\n    return z\n")
+    assert inv.kind == "and"
+    left, right = inv.operands
+    assert left.name == "py.lt" and left.args[0].value == 0 and left.args[1].name == "z"
+    assert right.name == "py.lt" and right.args[0].name == "z" and right.args[1].value == 10
+
+
+def test_comparison_composes_inside_boolop():
+    # the case that was blocked before: (z == 1) and (z != 2)
+    inv = _inv("def A(z):\n    assert (z == 1) and (z != 2)\n    return z\n")
+    assert inv.kind == "and"
+    assert inv.operands[0].name == "py.eq"
+    assert inv.operands[1].kind == "not"  # z != 2
+
+
+if __name__ == "__main__":
+    test_not_equal_is_equals_negated()
+    test_ordering_operators_emit_their_atoms()
+    test_chained_comparison_conjoins_adjacent_pairs()
+    test_comparison_composes_inside_boolop()
+    print("ok: comparison family drained -- !=, <, <=, >, >=, chains, boolop-composed")

--- a/implementations/python/sugar-source-tree/tests/test_identity_and_literals.py
+++ b/implementations/python/sugar-source-tree/tests/test_identity_and_literals.py
@@ -1,0 +1,54 @@
+"""`is` / `is not` identity comparisons, and the None / float literals they need.
+
+`is`/`is not` stand on the is_identical floor (`is not` negated); `in`/`not in`
+(membership) are not owned yet and stay loud. None -> NoneValue, a float -> a
+Real-sorted TermValue (int -> Int, float -> Real, no Number sort).
+"""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _inv(src):
+    return _fn(src).sugar().desugar().value.invs()[0]
+
+
+def test_is_is_identity():
+    inv = _inv("def A(z):\n    assert z is None\n    return z\n")
+    assert inv.name == "identity"
+    assert inv.args[1].name == "None"
+
+
+def test_is_not_is_identity_negated():
+    inv = _inv("def A(z):\n    assert z is not None\n    return z\n")
+    assert inv.kind == "not" and inv.operands[0].name == "identity"
+
+
+def test_float_literal_is_real_sorted():
+    post = _fn("def A():\n    return 2.5\n").sugar().desugar().value.post()
+    assert type(post.args[1]).__name__ == "_ConstReal"
+
+
+def test_membership_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(z):\n    assert z in [1, 2]\n    return z\n").sugar()
+
+
+if __name__ == "__main__":
+    test_is_is_identity()
+    test_is_not_is_identity_negated()
+    test_float_literal_is_real_sorted()
+    test_membership_stays_loud()
+    print("ok: is/is not identity, None + float literals, membership loud")


### PR DESCRIPTION
Three commits draining the expression grammar the meaning layer can lift. Each mirrors an existing dispatch; the node carries the operator/kind, the value owns the meaning.

## Comparison family — `!=`, `<`, `<=`, `>`, `>=`, chains
`ComparisonOpSugar` routes to the value's floor method (`py.lt`/`py.le`/`py.gt`/`py.ge`); `!=` is `==` negated. Chained `a < b < c` = `(a < b) and (b < c)`. This unblocked real expressions (e.g. `z != 2` inside a BoolOp).

## Collection literals — list, tuple, set, dict
Each reduces its elements and holds them as the collection floor value (`ListValue`/`TupleValue`/`SetValue`/`DictValue`); the value owns len/subscript/membership. `[1,2,z]` → `array(1,2,z)`, and they compose: `len([z,z,z])` → `call:len(array(z,z,z))`. Star/`**` spreads stay loud.

## is/is not identity + None and float literals
`is`/`is not` stand on the `is_identical` floor (`is not` negated); `in`/`not in` stay loud (operation-based floor, not yet owned). `Constant.sugar` gains None → `NoneValue` and float → Real-sorted `TermValue` (int→Int, float→Real, no Number sort). bool stays loud — its literal-sugar source was deleted (only a `.pyc` remains), a separate rebuild.

## Tests
`sugar-source-tree`: **91 passed, 5 skipped**. Real pipeline (enumerate RPC) green. Pre-existing Mac-3.14 pandas/numpy frontier RPC failures unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add desugaring for comparison operators, collection literals, `None`, and float literals
> - Implements `desugar` for comparison operators (`!=`, `is`, `is not`, `<`, `<=`, `>`, `>=`) in `ComparisonOpSugar`, chaining adjacent pairs into conjunctions for chained comparisons via `BoolOpSugar`.
> - Adds `desugar` for `ListSugar`, `TupleSugar`, `SetSugar`, and `DictSugar`, reducing child element sugars into their respective `*Value` types or propagating the first incomplete effect.
> - Extends `Constant.sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/5963/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to produce `NoneLiteralSugar` for `None` and `RealLiteralSugar` for floats; extends `Compare.sugar` to produce predicate sugars for supported operators, falling back to `super().sugar()` for unsupported ones.
> - Collection literals with spread elements (`*`, `**`) remain loud and fall back to `super().sugar()`.
> - Adds test coverage for comparison semantics, collection literal sugar/desugar, identity operations, and float/None literal handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a72059a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for list, tuple, set, and dictionary literals.
  * Added support for `None` and floating-point literals.
  * Expanded comparison support for equality, ordering, identity, inequality, and chained comparisons.
  * Collection literals can now be used within function calls.

* **Bug Fixes**
  * Unsupported starred collection elements and membership expressions remain clearly reported as unsupported.

* **Tests**
  * Added coverage for collection literals, comparisons, identity checks, and literal handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->