### PR TITLE
constraint drain: f-strings (JoinedStr + FormattedValue)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/fstring_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/fstring_sugar.py
@@ -1,0 +1,72 @@
+"""f-strings: `f"pre {value} post"`.
+
+A JoinedStr is the CONCATENATION of its parts -- literal chunks (StringLiteral)
+and interpolations (FormattedValue). It folds them left with `add`, the same
+string concatenation `+` uses: ground chunks fold to one string, an interpolated
+symbol becomes a `str.++` coordinate. A FormattedValue is `format(value, spec)`:
+with no conversion and no format spec it is the value's own `__format__`
+coordinate (`call:__format__(value, "")`), decidable without inventing a
+rendered string. A conversion (`!r`/`!s`/`!a`) or a format spec (`{x:>10}`) is
+not lifted yet -- LOUD, never a silently dropped modifier.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_pair
+
+
+@dataclass(frozen=True)
+class FormattedValueSugar(Sugar):
+    """`{value}` inside an f-string -- format(value) with an empty spec."""
+
+    value: Sugar
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.string_value import StringValue
+
+        return self.value.desugar(ctx).and_then(
+            lambda value: value.format_data_model(StringValue(""), self.site, ctx)
+        )
+
+
+@dataclass(frozen=True)
+class JoinedStrSugar(Sugar):
+    """The whole f-string: concatenate its parts left-to-right via `add`."""
+
+    parts: tuple
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        prefix = 'def A(z):\n    return f"n={z}"\n\n'
+        return _call_pair(
+            name="fstring_return",
+            owner_sugar="JoinedStrSugar",
+            truthful=prefix + "def test_a():\n    assert A(5) == '5'\n",
+            lying=prefix + "def test_a():\n    assert A(5) == '6'\n",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.string_value import StringValue
+        from sugar_lift_py_tests.outcome import Incomplete
+
+        if not self.parts:
+            return Complete(StringValue(""))
+        acc = self.parts[0].desugar(ctx)
+        for part in self.parts[1:]:
+            if isinstance(acc, Incomplete):
+                return acc
+            right = part.desugar(ctx)
+            if isinstance(right, Incomplete):
+                return right
+            acc = acc.value.add(right.value, self.site)
+        return acc

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1643,6 +1643,15 @@ class FormattedValue(Expression):
         """Binds nothing: recurse into children and reassemble."""
         return self._substitute_children(scope)
 
+    def sugar(self):
+        """`{value}` in an f-string. A conversion (!r/!s/!a) or a format spec is
+        not lifted yet -- LOUD rather than a silently dropped modifier."""
+        from sugar_lift_py_tests.sugar.fstring_sugar import FormattedValueSugar
+
+        if self.conversion != -1 or self.format_spec is not None:
+            return super().sugar()
+        return FormattedValueSugar(value=self.value.sugar(), site=self.fragment)
+
 
 class JoinedStr(Expression):
     values: Tuple[Expression, ...]
@@ -1651,6 +1660,15 @@ class JoinedStr(Expression):
     def substitute(self, scope):
         """Binds nothing: recurse into children and reassemble."""
         return self._substitute_children(scope)
+
+    def sugar(self):
+        """The f-string: JoinedStrSugar over each part's sugar (literal chunks
+        and {value} interpolations), concatenated."""
+        from sugar_lift_py_tests.sugar.fstring_sugar import JoinedStrSugar
+
+        return JoinedStrSugar(
+            parts=tuple(v.sugar() for v in self.values), site=self.fragment
+        )
 
 
 class Constant(Expression):

--- a/implementations/python/sugar-source-tree/tests/test_fstring_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_fstring_sugar.py
@@ -1,0 +1,54 @@
+"""f-strings: JoinedStr concatenates its parts; FormattedValue is format(value).
+
+Modifiers -- a conversion (!r/!s/!a) or a format spec ({x:>10}) -- stay loud.
+"""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _post_term(src):
+    return _fn(src).sugar().desugar().value.post().args[1]
+
+
+def test_fstring_concatenates_literal_and_interpolation():
+    # f"n={z}" -> "n=" ++ format(z)
+    term = _post_term('def A(z):\n    return f"n={z}"\n')
+    assert term.name == "+"
+    assert term.args[0].value == "n="
+    assert term.args[1].name == "call:__format__"
+
+
+def test_fstring_with_only_a_literal_is_the_string():
+    term = _post_term('def A():\n    return f"hello"\n')
+    assert type(term).__name__ == "_ConstStr" and term.value == "hello"
+
+
+def test_conversion_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn('def A(z):\n    return f"{z!r}"\n').sugar()
+
+
+def test_format_spec_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn('def A(z):\n    return f"{z:>3}"\n').sugar()
+
+
+if __name__ == "__main__":
+    test_fstring_concatenates_literal_and_interpolation()
+    test_fstring_with_only_a_literal_is_the_string()
+    test_conversion_stays_loud()
+    test_format_spec_stays_loud()
+    print("ok: f-strings concatenate; modifiers loud")


### PR DESCRIPTION
A JoinedStr is the concatenation of its parts (literal chunks and `{value}` interpolations), folded left with `add` — the same concatenation `+` uses. A `FormattedValue` with no conversion and no format spec is the value's own `__format__` coordinate (`call:__format__(value, "")`), decidable without inventing a rendered string.

A conversion (`!r`/`!s`/`!a`) or a format spec (`{x:>10}`) is **loud** — never a silently dropped modifier.

`f"n={z}"` → `"n=" ++ call:__format__(z)`; `f"hello"` → `"hello"`.

`sugar-source-tree`: **95 passed, 5 skipped**. Real pipeline green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add f-string desugaring support for `JoinedStr` and `FormattedValue` nodes
> - Adds `JoinedStrSugar` and `FormattedValueSugar` dataclasses in [fstring_sugar.py](https://github.com/TSavo/sugar/pull/5964/files#diff-b9bf9ce9ae16c63aff5f1d7c8263e093b8ead2dbe787bf3d2bb8f5c1ba55cc3f) to represent f-strings in the sugar layer.
> - `JoinedStrSugar.desugar()` folds parts left-to-right using `add`, short-circuiting on `Incomplete` outcomes.
> - `FormattedValueSugar.desugar()` maps interpolated values to the floor model via `format_data_model` with an empty string spec.
> - `JoinedStr.sugar()` and `FormattedValue.sugar()` overrides in [nodes.py](https://github.com/TSavo/sugar/pull/5964/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) route simple f-strings into these new types; nodes with conversion or format spec continue to raise via the base `sugar()` path.
> - Four tests in [test_fstring_sugar.py](https://github.com/TSavo/sugar/pull/5964/files#diff-1debc2069458943d7a2e3023ec44d4ec26aed3b5ae397cdd4901da18c5e87789) cover literal-only, interpolated, and unsupported (conversion/format spec) cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0eb6cbf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->