### PR TITLE
rebuild the True/False literal sugars (deleted in the factory nuke)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/false_bool_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/false_bool_literal_sugar.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.floor.block_value import BlockValue
+from sugar_lift_py_tests.floor.floor_value import FloorValue
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
+
+@dataclass(frozen=True)
+class FalseBoolLiteralSugar(Sugar, FloorValue):
+    """The literal `False`. It holds no value -- the boolean IS the type. It is its own
+    floor value and it dispatches the emit to the else-face; with no else it emits
+    nothing (an empty block adds no constraint). No fork.
+
+    Inherits FloorValue so unimplemented floor verbs (unary_minus, etc.) and
+    as_expression_statement panic or discard cleanly -- never AttributeError.
+    """
+
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return _call_return_pair(
+            name="false_bool_literal_return",
+            owner_sugar="FalseBoolLiteralSugar",
+            body="False",
+            truthful="False",
+            lying="True",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx  # the literal is its own floor value
+        return Complete(self)
+
+    def contribution(self):
+        # Its own floor value: contributes itself to the block record.
+        return (self,)
+
+    def truth(self, site):
+        # A bool's truth is itself.
+        del site
+        return Complete(self)
+
+    def stated(self, site):
+        # Ground False is decided at lift time and Python raises AssertionError.
+        # This is exact control flow, never RuntimeEffect authority.
+        from sugar_lift_py_tests.floor.ground_assertion_error import (
+            ground_assertion_error,
+        )
+
+        return ground_assertion_error(site=site)
+
+    def negate(self) -> Outcome:
+        # False negates to True -- the literal knows its opposite, no fork.
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        return Complete(TrueBoolLiteralSugar(site=self.site))
+
+    def add(self, other, site):
+        # Python bool is a closed integer subtype: False contributes exactly
+        # zero, then the ordinary numeric floor decides the peer.
+        from sugar_lift_py_tests.floor.term_value import TermValue
+
+        return TermValue(0).add(other, site)
+
+    def subtract(self, other, site):
+        from sugar_lift_py_tests.floor.term_value import TermValue
+
+        return TermValue(0).subtract(other, site)
+
+    def unary_minus(self, site):
+        del site
+        from sugar_lift_py_tests.floor.term_value import TermValue
+
+        return Complete(TermValue(0))
+
+    def bitwise_and(self, other, site):
+        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        if type(other) in (
+            PredicateValue,
+            TrueBoolLiteralSugar,
+            FalseBoolLiteralSugar,
+        ):
+            return Complete(FalseBoolLiteralSugar(site=site))
+        return super().bitwise_and(other, site)
+
+    def bitwise_invert(self, site):
+        del site
+        from sugar_lift_py_tests.floor.term_value import TermValue
+
+        return Complete(TermValue(-1))
+
+    def bitwise_xor(self, other, site):
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        if type(other) is FalseBoolLiteralSugar:
+            return Complete(FalseBoolLiteralSugar(site=site))
+        if type(other) is TrueBoolLiteralSugar:
+            return Complete(TrueBoolLiteralSugar(site=site))
+        return super().bitwise_xor(other, site)
+
+    def is_identical(self, other, site):
+        # False is a singleton: False is False folds True; False is True folds
+        # False. Anything else emits identity (the general case).
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        if type(other) is FalseBoolLiteralSugar:
+            return Complete(TrueBoolLiteralSugar(site=site))
+        if type(other) is TrueBoolLiteralSugar:
+            return Complete(FalseBoolLiteralSugar(site=site))
+        from sugar_lift_py_tests.floor.floor_value import FloorValue
+
+        return FloorValue.is_identical(self, other, site)
+
+    def callsites(self):
+        return ()
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import bool_const
+
+        return bool_const(False)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/true_bool_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/true_bool_literal_sugar.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.floor.floor_value import FloorValue
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
+
+@dataclass(frozen=True)
+class TrueBoolLiteralSugar(Sugar, FloorValue):
+    """The literal `True`. It holds no value -- the boolean IS the type. It is its own
+    floor value and it stands on the bool floor as True: it emits the then-face,
+    always, with no fork.
+
+    Inherits FloorValue so unimplemented floor verbs (unary_minus, etc.) and
+    as_expression_statement panic or discard cleanly -- never AttributeError.
+    """
+
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return _call_return_pair(
+            name="true_bool_literal_return",
+            owner_sugar="TrueBoolLiteralSugar",
+            body="True",
+            truthful="True",
+            lying="False",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx  # the literal is its own floor value
+        return Complete(self)
+
+    def contribution(self):
+        # Its own floor value: contributes itself to the block record.
+        return (self,)
+
+    def truth(self, site):
+        # A bool's truth is itself.
+        del site
+        return Complete(self)
+
+    def stated(self, site):
+        # Ground True states nothing: the assert is support, absorbed.
+        del site
+        from sugar_lift_py_tests.floor.support_value import SupportValue
+
+        return Complete(SupportValue())
+
+    def negate(self) -> Outcome:
+        # True negates to False -- the literal knows its opposite, no fork.
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+
+        return Complete(FalseBoolLiteralSugar(site=self.site))
+
+    def add(self, other, site):
+        # Python bool is a closed integer subtype: True contributes exactly
+        # one, then the ordinary numeric floor decides the peer.
+        from sugar_lift_py_tests.floor.term_value import TermValue
+
+        return TermValue(1).add(other, site)
+
+    def subtract(self, other, site):
+        from sugar_lift_py_tests.floor.term_value import TermValue
+
+        return TermValue(1).subtract(other, site)
+
+    def unary_minus(self, site):
+        del site
+        from sugar_lift_py_tests.floor.term_value import TermValue
+
+        return Complete(TermValue(-1))
+
+    def bitwise_and(self, other, site):
+        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+
+        if type(other) is PredicateValue:
+            return Complete(other)
+        if type(other) is TrueBoolLiteralSugar:
+            return Complete(TrueBoolLiteralSugar(site=site))
+        if type(other) is FalseBoolLiteralSugar:
+            return Complete(FalseBoolLiteralSugar(site=site))
+        return super().bitwise_and(other, site)
+
+    def bitwise_invert(self, site):
+        del site
+        from sugar_lift_py_tests.floor.term_value import TermValue
+
+        return Complete(TermValue(-2))
+
+    def bitwise_xor(self, other, site):
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+
+        if type(other) is TrueBoolLiteralSugar:
+            return Complete(FalseBoolLiteralSugar(site=site))
+        if type(other) is FalseBoolLiteralSugar:
+            return Complete(TrueBoolLiteralSugar(site=site))
+        return super().bitwise_xor(other, site)
+
+    def is_identical(self, other, site):
+        # True is a singleton: True is True folds True; True is False folds False.
+        # Anything else emits identity (the general case).
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+
+        if type(other) is TrueBoolLiteralSugar:
+            return Complete(TrueBoolLiteralSugar(site=site))
+        if type(other) is FalseBoolLiteralSugar:
+            return Complete(FalseBoolLiteralSugar(site=site))
+        from sugar_lift_py_tests.floor.floor_value import FloorValue
+
+        return FloorValue.is_identical(self, other, site)
+
+    def callsites(self):
+        return ()
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import bool_const
+
+        return bool_const(True)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1692,7 +1692,17 @@ class Constant(Expression):
 
             return NoneLiteralSugar(site=self.fragment)
         if isinstance(v, bool):
-            return super().sugar()  # bool is its own sugar, not yet written
+            if v:
+                from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+                    TrueBoolLiteralSugar,
+                )
+
+                return TrueBoolLiteralSugar(site=self.fragment)
+            from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+                FalseBoolLiteralSugar,
+            )
+
+            return FalseBoolLiteralSugar(site=self.fragment)
         if isinstance(v, int):
             from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
 

--- a/implementations/python/sugar-source-tree/tests/test_bool_literals.py
+++ b/implementations/python/sugar-source-tree/tests/test_bool_literals.py
@@ -1,0 +1,42 @@
+"""The `True` / `False` literals -- their sugar source was rebuilt (it had been
+deleted in the factory nuke, leaving only a .pyc). Each stands as its own bool
+floor value: `return True` -> out == True; a ground `assert True` states nothing
+(support, absorbed); `x == True` -> py.eq(x, True)."""
+
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _uni(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).sugar().desugar().value
+
+
+def test_return_true_and_false_are_bool_consts():
+    t = _uni("def A():\n    return True\n").post().args[1]
+    assert type(t).__name__ == "_ConstBool" and t.value is True
+    f = _uni("def A():\n    return False\n").post().args[1]
+    assert type(f).__name__ == "_ConstBool" and f.value is False
+
+
+def test_ground_assert_true_states_nothing():
+    # assert True is support -- absorbed, no inv emitted.
+    v = _uni("def A(z):\n    assert True\n    return z\n")
+    assert v.invs() == ()
+
+
+def test_bool_composes_in_equality():
+    v = _uni("def A(x):\n    assert x == True\n    return x\n")
+    assert v.invs()[0].name == "py.eq"
+    assert v.invs()[0].args[1].value is True
+
+
+if __name__ == "__main__":
+    test_return_true_and_false_are_bool_consts()
+    test_ground_assert_true_states_nothing()
+    test_bool_composes_in_equality()
+    print("ok: True/False literals rebuilt and lifting")


### PR DESCRIPTION
`TrueBoolLiteralSugar`/`FalseBoolLiteralSugar` had their **source deleted** in the factory nuke, leaving only a stale `.pyc` — so every floor path that returns a bool literal from `.truth()` (`NoneValue`, `TermValue`, `StringValue`, …) was **latently broken**: the lazy import would `ModuleNotFoundError` the moment a ground truthiness was taken.

Restored from pre-nuke source, with the one dead method removed (`binary_conditional` referenced the deleted `reduce_with_scope`/`ctx.temporal`). Everything else is intact and tree-native: own-floor-value nature, `negate`, bool-as-int arithmetic, `stated` → `SupportValue` for a ground `assert True`, `to_term` → `_ConstBool`.

`Constant.sugar` now dispatches `bool` → the matching literal (before `int`, since bool is an int subclass). `return True` → `out == True`; `assert True` states nothing (absorbed); `x == True` → `py.eq(x, True)`.

A ground-bool *condition* (`if True:`) is still loud (unchanged).

`sugar-source-tree`: **98 passed, 5 skipped**. Real pipeline green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore `TrueBoolLiteralSugar` and `FalseBoolLiteralSugar` floor value implementations
> - Adds `TrueBoolLiteralSugar` and `FalseBoolLiteralSugar` as concrete `Sugar`/`FloorValue` types that fold boolean/logical operations at compile time and emit `ir.bool_const(True/False)` during lowering.
> - Updates `Constant.sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/5966/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) so that `bool`-valued constant nodes return these concrete sugar objects instead of delegating upward.
> - Arithmetic and bitwise ops map to integer semantics (`True == 1`, `False == 0`); `stated()` on `False` raises a ground `AssertionError` while `stated()` on `True` absorbs as support.
> - Adds tests in [test_bool_literals.py](https://github.com/TSavo/sugar/pull/5966/files#diff-51beac488bc202e7ec8d2f1acf6428289f9f46fe0fff3f2a3a2d60aea6c43638) covering lowering, ground assert, and equality composition.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43aa0c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->