### PR TITLE
constraint drain: slices (xs[1:2], xs[::2], xs[1:])

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/slice_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/slice_sugar.py
@@ -1,0 +1,43 @@
+"""A slice `lower:upper:step` (as it appears in `xs[1:2]`, `xs[::2]`, ...).
+
+A slice is a value: `slice(lower, upper, step)`. It reduces each present bound
+and stands as the `py.slice` coordinate over their terms; an omitted bound is
+`None` (its NoneValue term), exactly as Python fills it. The container's
+subscript floor consumes this coordinate -- this only constructs it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class SliceSugar(Sugar):
+    lower: object  # sugar or None (omitted bound)
+    upper: object
+    step: object
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.none_value import NoneValue
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+        from sugar_lift_py_tests.ir import ctor
+        from sugar_lift_py_tests.outcome import Incomplete
+
+        terms = []
+        for bound in (self.lower, self.upper, self.step):
+            if bound is None:
+                terms.append(NoneValue().to_term(owner="slice"))
+                continue
+            out = bound.desugar(ctx)
+            if isinstance(out, Incomplete):
+                return out
+            terms.append(out.value.to_term(owner="slice"))
+        return Complete(SymbolicValue(ctor("py.slice", terms)))

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1844,6 +1844,18 @@ class Slice(Expression):
         """Binds nothing: recurse into children and reassemble."""
         return self._substitute_children(scope)
 
+    def sugar(self):
+        """`lower:upper:step` constructs SliceSugar; an omitted bound stays None
+        (its NoneValue), as Python fills it."""
+        from sugar_lift_py_tests.sugar.slice_sugar import SliceSugar
+
+        return SliceSugar(
+            lower=None if self.lower is None else self.lower.sugar(),
+            upper=None if self.upper is None else self.upper.sugar(),
+            step=None if self.step is None else self.step.sugar(),
+            site=self.fragment,
+        )
+
 
 # --------------------------------------------------------------------------
 # match patterns

--- a/implementations/python/sugar-source-tree/tests/test_slice_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_slice_sugar.py
@@ -1,0 +1,34 @@
+"""A slice `lower:upper:step` is the py.slice coordinate; omitted bounds are None."""
+
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sub(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).sugar().desugar().value.post().args[1]
+
+
+def test_full_slice():
+    sub = _sub("def A(xs):\n    return xs[1:2]\n")
+    assert sub.name == "py.subscript"
+    sl = sub.args[1]
+    assert sl.name == "py.slice"
+    assert sl.args[0].value == 1 and sl.args[1].value == 2
+
+
+def test_omitted_bounds_are_none():
+    sl = _sub("def A(xs):\n    return xs[::2]\n").args[1]
+    assert sl.name == "py.slice"
+    assert sl.args[0].name == "None" and sl.args[1].name == "None"
+    assert sl.args[2].value == 2  # step
+
+
+if __name__ == "__main__":
+    test_full_slice()
+    test_omitted_bounds_are_none()
+    print("ok: slice -> py.slice coordinate")


### PR DESCRIPTION
A slice is a value `slice(lower, upper, step)`. `SliceSugar` reduces each present bound and stands as the `py.slice` coordinate; an omitted bound is `None` (its NoneValue term). The container's subscript floor consumes it: `xs[1:2]` → `py.subscript(xs, py.slice(1, 2, None))`.

`sugar-source-tree`: **100 passed, 5 skipped**. Real pipeline green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add slice constraint drain support for `xs[1:2]`, `xs[::2]`, and `xs[1:]` syntax
> - Adds `SliceSugar` dataclass in [`slice_sugar.py`](https://github.com/TSavo/sugar/pull/5967/files#diff-08eabbce095d4b39634073e53c0dedc4ec4b414c3421ed45c56e88c8e3b7e632) representing a Python slice with `lower`, `upper`, and `step` fields, where omitted bounds are `None`.
> - `SliceSugar.desugar()` produces a `py.slice` IR node with three terms, substituting `NoneValue` for omitted bounds and propagating `Incomplete` from child desugaring.
> - Adds `Slice.sugar()` in [`nodes.py`](https://github.com/TSavo/sugar/pull/5967/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to convert source-tree slice nodes into `SliceSugar`, preserving omitted bounds as `None`.
> - Tests in [`test_slice_sugar.py`](https://github.com/TSavo/sugar/pull/5967/files#diff-0caa3969d9a6bc1fb1af9335097f9fa7f90b2bebd7fe76fe931e1632100adaaa) verify that subscript slices desugar into `py.subscript` containing a `py.slice` coordinate for both full and omitted bound cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dba52b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->