### PR TITLE
constraint drain: match (value patterns) -- the n-way guarded split

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/match_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/match_sugar.py
@@ -1,0 +1,92 @@
+"""`match subject: case P: body ...` -- structural pattern matching.
+
+A match is sequential, first-case-wins: case i runs exactly when the subject
+matches P_i AND matched no earlier case. So it is an n-way guarded split, the
+same shape as `if`/`elif`/`else`: each case's body facts ride under
+`matches(subject, P_i) AND NOT matches(subject, P_<i)`, and a guarded fact IS an
+implication (the GuardedValue.guarded / entry.guarded vocabulary).
+
+This first cut owns the VALUE-pattern subset: `case <literal>:` (the subject
+equals that value) and the wildcard `case _:` (the catch-all, guarded only by
+the negation of every earlier case). Captures (`case x:`), pattern guards
+(`case P if g:`), OR-patterns, singletons, and structural patterns (sequence /
+mapping / class / star) stay LOUD -- each is real matching semantics, and
+guessing one would invent a constraint the source never stated. The subject is
+reduced ONCE (Python evaluates it once); every case compares against it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
+
+
+@dataclass(frozen=True)
+class MatchCaseSpec:
+    """One case: its value pattern's sugar (None for the wildcard `case _:`) and
+    its body statement sugars."""
+
+    value: object  # the pattern literal's sugar, or None for the wildcard
+    body: tuple
+
+
+@dataclass(frozen=True)
+class MatchSugar(Sugar):
+    subject: Sugar
+    cases: tuple  # MatchCaseSpec, in source order
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return _call_return_pair(
+            name="match_value_return",
+            owner_sugar="MatchSugar",
+            body="1 if z == 1 else 0",  # a match on z is an if-chain in spirit
+            truthful="1",
+            lying="2",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.ir import and_, not_
+        from sugar_lift_py_tests.outcome import Incomplete
+        from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_statements
+
+        subject_out = self.subject.desugar(ctx)
+        if isinstance(subject_out, Incomplete):
+            return subject_out
+        subject = subject_out.value
+
+        entries: list = []
+        earlier: list = []  # match formulas of the cases before this one
+        for case in self.cases:
+            body_entries, _falls, _ft = reduce_statements(case.body)
+
+            if case.value is None:  # wildcard `case _:` -- the catch-all
+                guard = and_(tuple(not_(f) for f in earlier)) if earlier else None
+            else:
+                value_out = case.value.desugar(ctx)
+                if isinstance(value_out, Incomplete):
+                    return value_out
+                match_out = subject.equals(value_out.value, self.site)
+                match_formula = getattr(
+                    getattr(match_out, "value", None), "formula", None
+                )
+                if match_formula is None:
+                    raise NotImplementedError(
+                        "match value pattern whose equality is not a predicate is "
+                        "not lifted yet (ground fold): symbolic subject/value only"
+                    )
+                clause = tuple(not_(f) for f in earlier) + (match_formula,)
+                guard = and_(clause) if len(clause) > 1 else match_formula
+                earlier.append(match_formula)
+
+            if guard is None:  # a wildcard with no earlier cases: unconditional
+                entries.extend(body_entries)
+            else:
+                entries.extend(entry.guarded(guard) for entry in body_entries)
+
+        return Complete(BlockValue(tuple(entries), can_fall_through=True))

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1246,6 +1246,36 @@ class Match(Statement):
         """Binds nothing itself: recurse into children and reassemble."""
         return self._substitute_children(scope)
 
+    def sugar(self):
+        """`match <subject>: case P: body ...` constructs MatchSugar -- an n-way
+        guarded split. This first cut owns VALUE patterns (`case <literal>:`) and
+        the wildcard (`case _:`), with no pattern guard and no capture. Any other
+        pattern, a `case P if g:` guard, or a capture inherits the loud throw --
+        each is real matching semantics, never guessed.
+        """
+        from sugar_lift_py_tests.sugar.match_sugar import MatchCaseSpec, MatchSugar
+
+        specs = []
+        for case in self.cases:
+            if case.guard is not None:
+                return super().sugar()  # `case P if g:` not written
+            pattern = case.pattern
+            if pattern.kind == "MatchValue":
+                value_sugar = pattern.value.sugar()
+            elif pattern.kind == "MatchAs" and pattern.pattern is None and pattern.name is None:
+                value_sugar = None  # the wildcard `case _:`
+            else:
+                return super().sugar()  # capture / singleton / or / structural
+            specs.append(
+                MatchCaseSpec(
+                    value=value_sugar,
+                    body=tuple(s.sugar() for s in case.body),
+                )
+            )
+        return MatchSugar(
+            subject=self.subject.sugar(), cases=tuple(specs), site=self.fragment
+        )
+
 
 # --------------------------------------------------------------------------
 # Expressions

--- a/implementations/python/sugar-source-tree/tests/test_match_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_match_sugar.py
@@ -1,0 +1,86 @@
+"""`match` -- the value-pattern subset: sequential, first-case-wins guards.
+
+case i runs when the subject matches P_i AND no earlier case matched, so its
+body facts ride under `match_i AND NOT match_<i`. Captures, pattern guards,
+and structural patterns stay loud.
+"""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+_MATCH = (
+    "def A(z):\n"
+    "    match z:\n"
+    "        case 1:\n"
+    "            assert z == 10\n"
+    "        case 2:\n"
+    "            assert z == 20\n"
+    "        case _:\n"
+    "            assert z == 30\n"
+    "    return z\n"
+)
+
+
+def _fn(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _invs(src):
+    return _fn(src).sugar().desugar().value.invs()
+
+
+def test_first_case_guarded_by_its_match():
+    invs = _invs(_MATCH)
+    first = invs[0]
+    assert first.kind == "implies"
+    assert first.operands[0].name == "py.eq"  # z == 1
+    assert first.operands[1].name == "py.eq"  # consequent z == 10
+    assert first.operands[1].args[1].value == 10  # body fact z == 10
+
+
+def test_later_case_excludes_earlier():
+    invs = _invs(_MATCH)
+    second = invs[1]  # case 2: (not(z==1) and (z==2)) -> z == 20
+    assert second.operands[0].kind == "and"
+    assert second.operands[0].operands[0].kind == "not"  # not (z == 1)
+
+
+def test_wildcard_guarded_by_all_negations():
+    invs = _invs(_MATCH)
+    wild = invs[2]  # case _: (not(z==1) and not(z==2)) -> z == 30
+    ante = wild.operands[0]
+    assert ante.kind == "and"
+    assert all(op.kind == "not" for op in ante.operands)
+
+
+def test_capture_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(z):\n    match z:\n        case x:\n            return x\n").sugar()
+
+
+def test_structural_pattern_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(z):\n    match z:\n        case [a, b]:\n            return a\n").sugar()
+
+
+def test_pattern_guard_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(z):\n    match z:\n        case 1 if z > 0:\n            return z\n").sugar()
+
+
+if __name__ == "__main__":
+    test_first_case_guarded_by_its_match()
+    test_later_case_excludes_earlier()
+    test_wildcard_guarded_by_all_negations()
+    test_capture_stays_loud()
+    test_structural_pattern_stays_loud()
+    test_pattern_guard_stays_loud()
+    print("ok: match value patterns -- sequential guarded split; the rest loud")


### PR DESCRIPTION
A `match` is sequential, first-case-wins: case i runs when the subject matches P_i AND no earlier case matched. So it's an n-way guarded split (if/elif/else shape) — each case's body facts ride under `matches(subject, P_i) AND NOT matches(subject, P_<i)`, and a guarded fact is an implication (same `entry.guarded` vocabulary as `If`). The subject is reduced once.

**This cut owns the value-pattern subset**: `case <literal>:` and the wildcard `case _:`. Captures (`case x:`), pattern guards (`case P if g:`), OR-patterns, singletons, and structural patterns (sequence/mapping/class/star) stay **loud** — each is real matching semantics, never guessed. Captures in particular need substitute (a capture binds `name = subject`, temporal — the same second verb `If`'s phi uses) — the natural next slice.

`match z: case 1: assert z==10; case 2: …; case _: …` → `(z==1 → z==10) ∧ (¬(z==1)∧z==2 → …) ∧ (¬(z==1)∧¬(z==2) → …)`.

`sugar-source-tree`: **106 passed, 5 skipped**. Real pipeline green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MatchSugar` desugaring for value-pattern and wildcard match cases
> - Introduces `MatchSugar` and `MatchCaseSpec` dataclasses in [`match_sugar.py`](https://github.com/TSavo/sugar/pull/5968/files#diff-116e9af80dc298a15c5b36f0ceaaa8c644e5455d5a08a10bf6600925bb01e31c) to represent and desugar `match` statements with literal value patterns and wildcards.
> - Desugaring iterates cases in order: each value-pattern case is guarded by its equality predicate ANDed with negations of all earlier match formulae; wildcard cases are guarded by negations of all earlier matches (or unguarded if first).
> - `Match.sugar()` in [`nodes.py`](https://github.com/TSavo/sugar/pull/5968/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) routes only `MatchValue` and wildcard `MatchAs` cases to `MatchSugar`; guarded cases and unsupported pattern kinds (captures, structural, OR, singletons) fall through to the superclass.
> - Tests in [`test_match_sugar.py`](https://github.com/TSavo/sugar/pull/5968/files#diff-c906d720dd9e49c746aab0711d3f12bec622fa7430754040dabb22884e351e84) verify guard ordering and confirm that unsupported patterns raise `SugarNotWritten`.
> - Risk: raises `NotImplementedError` at desugar time if an equality expression does not yield a predicate formula.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff4106f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->