### PR TITLE
constraint drain: match captures (case x binds x = subject)

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -590,13 +590,17 @@ class MatchCase(Node):
     body: Tuple[Statement, ...]
     _child_fields = ("pattern", "guard", "body")
 
-    def substitute(self, scope):
+    def substitute(self, scope, extra_bindings=None):
         """`case <pattern> [if <guard>]: <body>` -- the pattern captures bind for
         the guard and body. Pattern value-exprs evaluate in the enclosing scope;
-        guard and body are masked by the captures (body threaded)."""
+        guard and body are masked by the captures, then any ``extra_bindings``
+        (a capture bound to the match SUBJECT, threaded by ``Match.substitute``)
+        are re-applied so a `case x:` body sees x = subject, not a free name."""
         from .shadow import rewrite
         bound = self._pattern_bound_names(self.pattern)
         inner = {k: v for k, v in scope.items() if k not in bound} if bound else scope
+        if extra_bindings:
+            inner = {**inner, **extra_bindings}
         changed = {}
         new_pat, d = self._substitute_field(self.pattern, scope)
         if d:
@@ -1243,8 +1247,43 @@ class Match(Statement):
     _child_fields = ("subject", "cases")
 
     def substitute(self, scope):
-        """Binds nothing itself: recurse into children and reassemble."""
-        return self._substitute_children(scope)
+        """The subject evaluates in the enclosing scope; each case's captures
+        bind to that SUBJECT for its body. `case x:` is x = subject, so the
+        subject node is threaded into that case's body substitution as the
+        capture binding -- the temporal half of a capture, exactly as an
+        assignment's rhs threads to the rest of a block."""
+        from .shadow import rewrite
+
+        new_subject, subj_changed = self._substitute_field(self.subject, scope)
+        subject = new_subject if subj_changed else self.subject
+
+        new_cases = []
+        cases_changed = False
+        for case in self.cases:
+            capture = self._capture_name(case.pattern)
+            if capture is not None:
+                new_case = case.substitute(scope, extra_bindings={capture: subject})
+            else:
+                new_case = case.substitute(scope)
+            if new_case is not case:
+                cases_changed = True
+            new_cases.append(new_case)
+
+        changed = {}
+        if subj_changed:
+            changed["subject"] = new_subject
+        if cases_changed:
+            changed["cases"] = tuple(new_cases)
+        return self if not changed else rewrite(self, **changed)
+
+    @staticmethod
+    def _capture_name(pattern):
+        """The name a bare capture pattern (`case x:`) binds, or None. A capture
+        is a MatchAs with no sub-pattern and a name; `case _:` (name None) is the
+        wildcard and binds nothing."""
+        if pattern.kind == "MatchAs" and pattern.pattern is None and pattern.name is not None:
+            return pattern.name
+        return None
 
     def sugar(self):
         """`match <subject>: case P: body ...` constructs MatchSugar -- an n-way
@@ -1262,10 +1301,14 @@ class Match(Statement):
             pattern = case.pattern
             if pattern.kind == "MatchValue":
                 value_sugar = pattern.value.sugar()
-            elif pattern.kind == "MatchAs" and pattern.pattern is None and pattern.name is None:
-                value_sugar = None  # the wildcard `case _:`
+            elif pattern.kind == "MatchAs" and pattern.pattern is None:
+                # `case _:` (wildcard) or `case x:` (capture) -- both always match,
+                # so both are the catch-all guard. A capture's body already has
+                # x = subject substituted in (Match.substitute), so it needs no
+                # special handling here: the binding was the temporal half.
+                value_sugar = None
             else:
-                return super().sugar()  # capture / singleton / or / structural
+                return super().sugar()  # singleton / or / structural pattern
             specs.append(
                 MatchCaseSpec(
                     value=value_sugar,

--- a/implementations/python/sugar-source-tree/tests/test_match_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_match_sugar.py
@@ -61,9 +61,16 @@ def test_wildcard_guarded_by_all_negations():
     assert all(op.kind == "not" for op in ante.operands)
 
 
-def test_capture_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A(z):\n    match z:\n        case x:\n            return x\n").sugar()
+def test_capture_binds_the_subject():
+    # case x: binds x = subject (the temporal half, via substitute). So a
+    # `case 1: return 10; case x: return x` capture arm is `not(z==1) -> out==z`.
+    post = _fn(
+        "def A(z):\n    match z:\n        case 1:\n            return 10\n"
+        "        case x:\n            return x\n"
+    ).sugar().desugar().value.post()
+    capture_arm = post.operands[1]  # the `case x:` implication
+    assert capture_arm.operands[0].operands[0].kind == "not"  # guarded by not(z==1)
+    assert capture_arm.operands[1].args[1].name == "z"  # out == z (x = subject)
 
 
 def test_structural_pattern_stays_loud():
@@ -80,7 +87,7 @@ if __name__ == "__main__":
     test_first_case_guarded_by_its_match()
     test_later_case_excludes_earlier()
     test_wildcard_guarded_by_all_negations()
-    test_capture_stays_loud()
+    test_capture_binds_the_subject()
     test_structural_pattern_stays_loud()
     test_pattern_guard_stays_loud()
     print("ok: match value patterns -- sequential guarded split; the rest loud")


### PR DESCRIPTION
A capture `case x:` binds x to the match subject for its body — the temporal half, so it lives in **substitute**, exactly as `If`'s phi and an assignment's rhs do. `Match.substitute` threads the (substituted) subject node into each capture case's body as `{x: subject}`, overriding `MatchCase`'s capture-mask. By the time `MatchSugar` reduces the body, x is already the subject, not a free name.

The guard half is unchanged: a capture always matches, so it's a catch-all like the wildcard — guarded only by the negation of every earlier case. `match z: case 1: return 10; case x: return x` → `(z==1 → out==10) ∧ (¬(z==1) → out==z)`, x resolved to the subject z.

Still loud: pattern guards, OR-patterns, singletons, structural patterns.

`sugar-source-tree`: **106 passed, 5 skipped**. Real pipeline green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `Match` sugar to bind capture patterns to the match subject
> - Bare capture patterns (`case x:`) now substitute `x = subject` into the guard and body during `Match.substitute`, so the body sees the capture as an alias for the subject.
> - `Match.sugar` now treats capture arms as valid catch-all cases instead of rejecting them as unwritten.
> - A new `Match._capture_name` helper detects bare `MatchAs` patterns (no sub-pattern, non-None name) to distinguish captures from wildcards.
> - `MatchCase.substitute` accepts an optional `extra_bindings` parameter to re-apply capture bindings after masking the pattern's bound names.
> - Behavioral Change: capture cases that previously remained unsugared are now fully sugared and produce an implication with the capture bound to the subject.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d39a79.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->