### PR TITLE
constraint drain: match singleton patterns (case None/True/False)

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1276,6 +1276,24 @@ class Match(Statement):
             changed["cases"] = tuple(new_cases)
         return self if not changed else rewrite(self, **changed)
 
+    def _singleton_sugar(self, value):
+        """The literal sugar for a MatchSingleton value (None / True / False)."""
+        if value is None:
+            from sugar_lift_py_tests.sugar.none_literal_sugar import NoneLiteralSugar
+
+            return NoneLiteralSugar(site=self.fragment)
+        if value:
+            from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+                TrueBoolLiteralSugar,
+            )
+
+            return TrueBoolLiteralSugar(site=self.fragment)
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+
+        return FalseBoolLiteralSugar(site=self.fragment)
+
     @staticmethod
     def _capture_name(pattern):
         """The name a bare capture pattern (`case x:`) binds, or None. A capture
@@ -1301,6 +1319,10 @@ class Match(Statement):
             pattern = case.pattern
             if pattern.kind == "MatchValue":
                 value_sugar = pattern.value.sugar()
+            elif pattern.kind == "MatchSingleton":
+                # `case None:` / `case True:` / `case False:` -- the singleton as a
+                # value comparison (subject equals the singleton).
+                value_sugar = self._singleton_sugar(pattern.value)
             elif pattern.kind == "MatchAs" and pattern.pattern is None:
                 # `case _:` (wildcard) or `case x:` (capture) -- both always match,
                 # so both are the catch-all guard. A capture's body already has

--- a/implementations/python/sugar-source-tree/tests/test_match_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_match_sugar.py
@@ -83,6 +83,17 @@ def test_pattern_guard_stays_loud():
         _fn("def A(z):\n    match z:\n        case 1 if z > 0:\n            return z\n").sugar()
 
 
+def test_singleton_pattern_none_and_bool():
+    invs = _invs(
+        "def A(z):\n    match z:\n        case None:\n            assert z == 0\n"
+        "        case True:\n            assert z == 1\n"
+        "        case _:\n            assert z == 2\n    return z\n"
+    )
+    assert invs[0].operands[0].name == "py.eq"  # z == None
+    assert invs[0].operands[0].args[1].name == "None"
+    assert invs[1].operands[0].kind == "and"  # excluded by not(z==None), then z==True
+
+
 if __name__ == "__main__":
     test_first_case_guarded_by_its_match()
     test_later_case_excludes_earlier()
@@ -90,4 +101,5 @@ if __name__ == "__main__":
     test_capture_binds_the_subject()
     test_structural_pattern_stays_loud()
     test_pattern_guard_stays_loud()
+    test_singleton_pattern_none_and_bool()
     print("ok: match value patterns -- sequential guarded split; the rest loud")


### PR DESCRIPTION
A singleton pattern is a value comparison: `case None:`/`case True:`/`case False:` matches when the subject equals that singleton. Reuses the value-pattern guard — the singleton becomes its literal sugar and the case guards on `subject == singleton AND NOT earlier`.

Match now owns: value patterns, singletons, captures (`case x` → x=subject via substitute), wildcard. Still loud: pattern guards, OR-patterns, structural patterns.

`sugar-source-tree`: **107 passed, 5 skipped**. Real pipeline green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add singleton pattern support (None/True/False) to `Match.sugar`
> Extends the `Match.sugar` method in [nodes.py](https://github.com/TSavo/sugar/pull/5970/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to handle `MatchSingleton` patterns, producing structured `MatchSugar` output instead of falling back to the loud form. A new `_singleton_sugar` helper maps Python singleton values (`None`, `True`, `False`) to their corresponding literal sugar classes. A new test in [test_match_sugar.py](https://github.com/TSavo/sugar/pull/5970/files#diff-c906d720dd9e49c746aab0711d3f12bec622fa7430754040dabb22884e351e84) asserts correct sequential guard generation for mixed `None`/`True` cases with a wildcard catch-all.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9b15c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->