### PR TITLE
constraint drain: match OR-patterns (case a | b | c)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/match_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/match_sugar.py
@@ -26,10 +26,14 @@ from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
 @dataclass(frozen=True)
 class MatchCaseSpec:
-    """One case: its value pattern's sugar (None for the wildcard `case _:`) and
-    its body statement sugars."""
+    """One case: the value-pattern alternatives it matches and its body sugars.
 
-    value: object  # the pattern literal's sugar, or None for the wildcard
+    ``alternatives`` is the tuple of literal sugars the subject may equal --
+    ``(1,)`` for `case 1:`, ``(1, 2)`` for the OR-pattern `case 1 | 2:`, and the
+    EMPTY tuple for a catch-all (`case _:` or a capture `case x:`, both of which
+    always match)."""
+
+    alternatives: tuple  # literal sugars; empty = catch-all
     body: tuple
 
 
@@ -51,7 +55,7 @@ class MatchSugar(Sugar):
 
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.floor.block_value import BlockValue
-        from sugar_lift_py_tests.ir import and_, not_
+        from sugar_lift_py_tests.ir import and_, not_, or_
         from sugar_lift_py_tests.outcome import Incomplete
         from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_statements
 
@@ -65,26 +69,33 @@ class MatchSugar(Sugar):
         for case in self.cases:
             body_entries, _falls, _ft = reduce_statements(case.body)
 
-            if case.value is None:  # wildcard `case _:` -- the catch-all
+            if not case.alternatives:  # catch-all (`case _:` / capture)
+                match_formula = None
+            else:
+                # `case a | b:` matches iff the subject equals ANY alternative.
+                alts = []
+                for alt in case.alternatives:
+                    alt_out = alt.desugar(ctx)
+                    if isinstance(alt_out, Incomplete):
+                        return alt_out
+                    eq_out = subject.equals(alt_out.value, self.site)
+                    formula = getattr(getattr(eq_out, "value", None), "formula", None)
+                    if formula is None:
+                        raise NotImplementedError(
+                            "match value pattern whose equality is not a predicate "
+                            "is not lifted yet (ground fold): symbolic sides only"
+                        )
+                    alts.append(formula)
+                match_formula = or_(tuple(alts)) if len(alts) > 1 else alts[0]
+
+            if match_formula is None:
                 guard = and_(tuple(not_(f) for f in earlier)) if earlier else None
             else:
-                value_out = case.value.desugar(ctx)
-                if isinstance(value_out, Incomplete):
-                    return value_out
-                match_out = subject.equals(value_out.value, self.site)
-                match_formula = getattr(
-                    getattr(match_out, "value", None), "formula", None
-                )
-                if match_formula is None:
-                    raise NotImplementedError(
-                        "match value pattern whose equality is not a predicate is "
-                        "not lifted yet (ground fold): symbolic subject/value only"
-                    )
                 clause = tuple(not_(f) for f in earlier) + (match_formula,)
                 guard = and_(clause) if len(clause) > 1 else match_formula
                 earlier.append(match_formula)
 
-            if guard is None:  # a wildcard with no earlier cases: unconditional
+            if guard is None:  # a catch-all with no earlier cases: unconditional
                 entries.extend(body_entries)
             else:
                 entries.extend(entry.guarded(guard) for entry in body_entries)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1276,6 +1276,30 @@ class Match(Statement):
             changed["cases"] = tuple(new_cases)
         return self if not changed else rewrite(self, **changed)
 
+    def _pattern_alternatives(self, pattern):
+        """The value-pattern alternatives a case matches, as literal sugars:
+        ``()`` for a catch-all (`case _:` / capture `case x:`), ``(sugar,)`` for a
+        value or singleton, the concatenation for an OR-pattern `a | b`. Returns
+        None for a pattern this cut does not own (structural: sequence / mapping /
+        class / star, or a nested capture inside an OR)."""
+        if pattern.kind == "MatchValue":
+            return (pattern.value.sugar(),)
+        if pattern.kind == "MatchSingleton":
+            return (self._singleton_sugar(pattern.value),)
+        if pattern.kind == "MatchAs" and pattern.pattern is None:
+            return ()  # wildcard or capture -- always matches
+        if pattern.kind == "MatchOr":
+            alts: list = []
+            for sub in pattern.patterns:
+                sub_alts = self._pattern_alternatives(sub)
+                # An OR of value/singleton patterns only; a catch-all or
+                # structural arm inside an OR is not a value alternative.
+                if not sub_alts:
+                    return None
+                alts.extend(sub_alts)
+            return tuple(alts)
+        return None
+
     def _singleton_sugar(self, value):
         """The literal sugar for a MatchSingleton value (None / True / False)."""
         if value is None:
@@ -1316,24 +1340,12 @@ class Match(Statement):
         for case in self.cases:
             if case.guard is not None:
                 return super().sugar()  # `case P if g:` not written
-            pattern = case.pattern
-            if pattern.kind == "MatchValue":
-                value_sugar = pattern.value.sugar()
-            elif pattern.kind == "MatchSingleton":
-                # `case None:` / `case True:` / `case False:` -- the singleton as a
-                # value comparison (subject equals the singleton).
-                value_sugar = self._singleton_sugar(pattern.value)
-            elif pattern.kind == "MatchAs" and pattern.pattern is None:
-                # `case _:` (wildcard) or `case x:` (capture) -- both always match,
-                # so both are the catch-all guard. A capture's body already has
-                # x = subject substituted in (Match.substitute), so it needs no
-                # special handling here: the binding was the temporal half.
-                value_sugar = None
-            else:
-                return super().sugar()  # singleton / or / structural pattern
+            alternatives = self._pattern_alternatives(case.pattern)
+            if alternatives is None:
+                return super().sugar()  # structural pattern (sequence/class/...)
             specs.append(
                 MatchCaseSpec(
-                    value=value_sugar,
+                    alternatives=alternatives,
                     body=tuple(s.sugar() for s in case.body),
                 )
             )

--- a/implementations/python/sugar-source-tree/tests/test_match_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_match_sugar.py
@@ -94,6 +94,16 @@ def test_singleton_pattern_none_and_bool():
     assert invs[1].operands[0].kind == "and"  # excluded by not(z==None), then z==True
 
 
+def test_or_pattern_disjoins_alternatives():
+    invs = _invs(
+        "def A(z):\n    match z:\n        case 1 | 2 | 3:\n            assert z == 100\n"
+        "        case _:\n            assert z == 200\n    return z\n"
+    )
+    ante = invs[0].operands[0]
+    assert ante.kind == "or" and len(ante.operands) == 3
+    assert all(op.name == "py.eq" for op in ante.operands)
+
+
 if __name__ == "__main__":
     test_first_case_guarded_by_its_match()
     test_later_case_excludes_earlier()
@@ -102,4 +112,5 @@ if __name__ == "__main__":
     test_structural_pattern_stays_loud()
     test_pattern_guard_stays_loud()
     test_singleton_pattern_none_and_bool()
+    test_or_pattern_disjoins_alternatives()
     print("ok: match value patterns -- sequential guarded split; the rest loud")


### PR DESCRIPTION
An OR-pattern matches when the subject equals ANY alternative — its guard is the disjunction of the per-alternative comparisons. `MatchCaseSpec` now holds `alternatives` (tuple of literal sugars; empty = catch-all), and `MatchSugar` builds `or_(subject==a, ...)` then the usual sequential exclusion. Pattern recognition folds to one `_pattern_alternatives` walk.

`case 1 | 2 | 3: … ; case _: …` → `(or(z==1,z==2,z==3) → …) ∧ (¬or(…) → …)`.

Match now owns: value/singleton/OR patterns, captures, wildcard. Still loud: pattern guards, structural patterns (sequence/mapping/class/star).

`sugar-source-tree`: **108 passed, 5 skipped**. Real pipeline green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OR-pattern support to constraint drain match sugar
> - `MatchCaseSpec` replaces its single `value` field with an `alternatives` tuple to represent OR-patterns; empty tuple signals a catch-all.
> - `Match._pattern_alternatives` in [nodes.py](https://github.com/TSavo/sugar/pull/5971/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) computes alternatives for a pattern, handling wildcards, captures, singletons, and OR-patterns of values.
> - `MatchSugar.desugar` in [match_sugar.py](https://github.com/TSavo/sugar/pull/5971/files#diff-116e9af80dc298a15c5b36f0ceaaa8c644e5455d5a08a10bf6600925bb01e31c) combines per-alternative equality predicates with `or_` when multiple alternatives exist.
> - A new test in [test_match_sugar.py](https://github.com/TSavo/sugar/pull/5971/files#diff-c906d720dd9e49c746aab0711d3f12bec622fa7430754040dabb22884e351e84) asserts that `1 | 2 | 3` lowers to a disjunction of three `py.eq` predicates.
> - Behavioral Change: `MatchCaseSpec` constructor signature changes; any code constructing it with a `value` keyword argument will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 79fd9e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for matching multiple literal alternatives in a single `case`, such as `case 1 | 2 | 3`.
  * Preserved catch-all and capture-case behavior alongside alternative matching.

* **Bug Fixes**
  * Improved first-match handling when cases include multiple alternatives.

* **Tests**
  * Added coverage verifying OR-pattern matching and its generated equality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->