### PR TITLE
loop reasoning: range(concrete) unrolls like a list literal

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -946,16 +946,13 @@ class For(Statement):
         new_iter, iter_changed = self._substitute_field(self.iter, scope)
         subst_iter = new_iter if iter_changed else self.iter
 
-        concrete = (
-            not self.orelse
-            and self.target.kind == "Name"
-            and subst_iter.kind in ("List", "Tuple_")
-        )
-        if concrete:
+        concrete = not self.orelse and self.target.kind == "Name"
+        elements = self._concrete_elements(subst_iter) if concrete else None
+        if elements is not None:
             target_name = self.target.id
             unrolled: list = []
             carried = dict(scope)  # carries loop variables across iterations
-            for element in subst_iter.elts:
+            for element in elements:
                 iter_scope = {**carried, target_name: element}
                 new_body, _c = self._substitute_body(self.body, iter_scope)
                 unrolled.extend(new_body)
@@ -979,6 +976,56 @@ class For(Statement):
             if d:
                 changed[f] = new
         return self if not changed else rewrite(self, **changed)
+
+    def _concrete_elements(self, iterable: "Expression") -> "Optional[list]":
+        """The element nodes to unroll over, or ``None`` if `iterable` is not
+        concrete. A `List`/`Tuple_` literal is concrete by construction; a
+        `range(...)` call is concrete only when every argument (after
+        substitution) is a literal `int` -- a symbolic bound leaves the fold
+        real, so it is not recognized here."""
+        if iterable.kind in ("List", "Tuple_"):
+            return list(iterable.elts)
+        if (
+            iterable.kind == "Call"
+            and iterable.func.kind == "Name"
+            and iterable.func.id == "range"
+            and not iterable.keywords
+        ):
+            ints = []
+            for arg in iterable.args:
+                v = self._concrete_int(arg)
+                if v is None:
+                    return None
+                ints.append(v)
+            return [self._int_constant(i) for i in range(*ints)]
+        return None
+
+    def _concrete_int(self, arg: "Expression") -> "Optional[int]":
+        """The literal int an arg denotes, or ``None`` if it is not one. A
+        negative bound parses as `UnaryOp(USub, Constant(n))` (cpython does
+        not fold the literal), so both shapes are recognized; `bool` is
+        rejected even though it subclasses `int`."""
+        if arg.kind == "Constant" and isinstance(arg.value, int) and not isinstance(
+            arg.value, bool
+        ):
+            return arg.value
+        if arg.kind == "UnaryOp" and arg.op.kind == "USub":
+            inner = self._concrete_int(arg.operand)
+            return -inner if inner is not None else None
+        return None
+
+    def _int_constant(self, value: int) -> "Node":
+        """Synthesize an int `Constant` node bound to `value`, borrowing this
+        `for`'s span -- the unroll rebinds the loop target to a real node, and
+        `range`'s elements have no source site of their own to borrow."""
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        slots = (
+            ("value", Leaf(value)),
+            ("literal_kind", Leaf(None)),
+        )
+        return materialize(self.unit, ShadowNode("Constant", self.span, slots), self.reporter)
 
 
 class AsyncFor(Statement):

--- a/implementations/python/sugar-source-tree/tests/test_range_unroll.py
+++ b/implementations/python/sugar-source-tree/tests/test_range_unroll.py
@@ -1,0 +1,71 @@
+"""`for i in range(...)` over CONCRETE integer arguments is a concrete
+iterable exactly like a list/tuple literal: it dissolves the same way,
+unrolling the body once per synthesized int. A symbolic bound leaves the
+fold real and it stays loud, same as any other symbolic iterable."""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _invs(src):
+    return _fn(src).sugar().desugar().value.invs()
+
+
+def test_range_stop_unrolls_the_body_per_element():
+    invs = _invs("def A(z):\n    for i in range(3):\n        assert i == z\n    return z\n")
+    assert len(invs) == 3
+    assert [i.args[0].value for i in invs] == [0, 1, 2]
+
+
+def test_range_start_stop_unrolls_the_body_per_element():
+    invs = _invs("def A(z):\n    for i in range(2, 5):\n        assert i == z\n    return z\n")
+    assert [i.args[0].value for i in invs] == [2, 3, 4]
+
+
+def test_range_start_stop_step_unrolls_the_body_per_element():
+    invs = _invs(
+        "def A(z):\n    for i in range(10, 0, -3):\n        assert i == z\n    return z\n"
+    )
+    assert [i.args[0].value for i in invs] == [10, 7, 4, 1]
+
+
+def test_empty_range_states_nothing():
+    invs = _invs("def A(z):\n    for i in range(0):\n        assert i == z\n    return z\n")
+    assert invs == ()
+
+
+def test_loop_carried_accumulator_folds_over_a_concrete_range():
+    # t = 0; for i in range(4): t = t + i; return t  -- folds to 0+1+2+3 = 6.
+    post = _fn(
+        "def A():\n    t = 0\n    for i in range(4):\n        t = t + i\n    return t\n"
+    ).sugar().desugar().value.post()
+    assert post.args[1].value == 6
+
+
+def test_symbolic_range_bound_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(z, n):\n    for i in range(n):\n        assert i == z\n    return z\n"
+        ).sugar()
+
+
+if __name__ == "__main__":
+    test_range_stop_unrolls_the_body_per_element()
+    test_range_start_stop_unrolls_the_body_per_element()
+    test_range_start_stop_step_unrolls_the_body_per_element()
+    test_empty_range_states_nothing()
+    test_loop_carried_accumulator_folds_over_a_concrete_range()
+    test_symbolic_range_bound_stays_loud()
+    print("ok: concrete range unrolls; symbolic range stays loud")


### PR DESCRIPTION
`for i in range(...)` over concrete integer arguments dissolves by unrolling, exactly like `for x in [literals]`. `For.substitute` asks `_concrete_elements(iter)` for the element nodes: `.elts` for a List/Tuple_, or the synthesized Constants of `range(*ints)` when every argument resolves to a literal int. `_concrete_int` recognizes a plain int Constant (rejecting bool) and `UnaryOp(USub, Constant)` (cpython doesn't fold `-3`). A symbolic bound falls through to the symbolic branch and stays loud.

All threading/fold/`_Splice` unchanged: `range(4)` carried-sum → 6, negative steps and empty ranges work, `range(n)` symbolic stays `SugarNotWritten`.

`sugar-source-tree`: **119 passed, 5 skipped**. Verified independently across all cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unroll `range()` calls with literal integer arguments in `For` loop reasoning
> - Extends `For.substitute` in [nodes.py](https://github.com/TSavo/sugar/pull/5974/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to treat `range(...)` with all-literal integer arguments as concrete, unrolling them the same way list/tuple literals are.
> - Adds `_concrete_elements`, `_concrete_int`, and `_int_constant` helpers to detect concrete iterables and synthesize `Constant` nodes for each integer in the range (supporting start/stop/step and negative values).
> - `range()` calls with any symbolic argument are left as-is and keep the `For` node.
> - Adds test coverage in [test_range_unroll.py](https://github.com/TSavo/sugar/pull/5974/files#diff-5217b157f874b5590e1a2f9c0ba267d8db65e79fc401abbe926ecc0a4149b940) for single-arg, two-arg, stepped, negative-step, empty, and loop-carried accumulator cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70e364b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->