### PR TITLE
loop reasoning: the symbolic assert-only loop is a universal (not a panic)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/for_universal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/for_universal_sugar.py
@@ -1,0 +1,70 @@
+"""`for x in xs: <asserts>` over a SYMBOLIC iterable -- the degenerate fold.
+
+When xs is a hole (a formal), the loop cannot unroll (unknown length), so its
+meaning is the FOL that was always there: a universal. An assert-only body has
+no carried accumulator, so the fold collapses to `forall x in xs: P(x)` -- each
+body fact P (reduced with the loop target x free, so a symbolic Var) rides under
+membership: `forall x. member(x, xs) -> P(x)`. The element sort is unknown, so
+it is an uninterpreted sort the compiler declares; membership and P constrain it.
+
+This is the local fact A states -- post over the formal xs, exactly like
+`out == z` is post over z. A concrete call fills xs and the dig unrolls the loop
+(the AST-local machinery); a symbolic xs leaves the universal, honest FOL. A body
+with a carried accumulator (`total = total + x`) is the non-degenerate fold and
+is not written here yet.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_pair
+
+
+@dataclass(frozen=True)
+class ForUniversalSugar(Sugar):
+    target: str
+    iterable: Sugar
+    body: tuple  # the body statement sugars (assert-only, no carried binding)
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        prefix = "def A(xs):\n    for x in xs:\n        assert x == x\n    return xs\n\n"
+        return _call_pair(
+            name="for_universal",
+            owner_sugar="ForUniversalSugar",
+            truthful=prefix + "def test_a():\n    assert A([1]) == [1]\n",
+            lying=prefix + "def test_a():\n    assert A([1]) == [2]\n",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.floor.inv_value import InvValue
+        from sugar_lift_py_tests.ir import PrimitiveSort, atomic, forall, implies, make_var
+        from sugar_lift_py_tests.outcome import Incomplete
+        from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_statements
+
+        it = self.iterable.desugar(ctx)
+        if isinstance(it, Incomplete):
+            return it  # the iterable is itself an effect -> the loop is that effect
+        xs_term = it.value.to_term(owner=str(self.site))
+
+        entries, _falls, _ft = reduce_statements(self.body)
+        x = make_var(self.target)
+        member = atomic("py.in", [x, xs_term])
+        element_sort = PrimitiveSort("py.element")  # unknown -> uninterpreted sort
+
+        wrapped: list = []
+        for entry in entries:
+            site = getattr(entry, "site", None) or self.site
+            for formula in entry.inv_contribution():
+                wrapped.append(
+                    InvValue(
+                        forall(self.target, element_sort, implies(member, formula)),
+                        site,
+                    )
+                )
+        return Complete(BlockValue(tuple(wrapped), can_fall_through=True))

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -966,6 +966,8 @@ class For(Statement):
             return _Splice(tuple(unrolled))
 
         # Symbolic (or unsupported) loop: keep the node, mask the target, recurse.
+        # It stays a `for` and reaches `For.sugar` -- a symbolic loop is not a
+        # dead unroll, it is the universal / fold over the hole.
         bound = self._bound_names_in(self.target)
         bs = {k: v for k, v in scope.items() if k not in bound} if bound else scope
         changed = {}
@@ -976,6 +978,25 @@ class For(Statement):
             if d:
                 changed[f] = new
         return self if not changed else rewrite(self, **changed)
+
+    def sugar(self):
+        """A loop that did NOT dissolve in substitute is symbolic: its iterable
+        is a hole (a formal), so it cannot unroll. Its meaning is the FOL that was
+        always there. An assert-only body is the degenerate fold -- a universal
+        `forall x in xs: P(x)` (ForUniversalSugar). A carried accumulator (the
+        non-degenerate fold) and a tuple target / else stay loud until written."""
+        from sugar_lift_py_tests.sugar.for_universal_sugar import ForUniversalSugar
+
+        if self.orelse or self.target.kind != "Name":
+            return super().sugar()
+        if any(stmt.substitution_binding({}) for stmt in self.body):
+            return super().sugar()  # carried accumulator -- the fold, not yet
+        return ForUniversalSugar(
+            target=self.target.id,
+            iterable=self.iter.sugar(),
+            body=tuple(s.sugar() for s in self.body),
+            site=self.fragment,
+        )
 
     def _concrete_elements(self, iterable: "Expression") -> "Optional[list]":
         """The element nodes to unroll over, or ``None`` if `iterable` is not

--- a/implementations/python/sugar-source-tree/tests/test_for_unroll.py
+++ b/implementations/python/sugar-source-tree/tests/test_for_unroll.py
@@ -35,9 +35,23 @@ def test_empty_concrete_for_states_nothing():
     assert invs == ()
 
 
-def test_symbolic_iterable_stays_loud():
+def test_symbolic_assert_only_loop_is_a_universal():
+    # for x in xs: assert P(x)  over a symbolic (formal) xs is the degenerate
+    # fold -- forall x. member(x, xs) -> P(x). The loop no longer sinks the
+    # function; it emits its FOL universal.
+    inv = _invs("def A(z, xs):\n    for x in xs:\n        assert x == z\n    return z\n")[0]
+    assert inv.kind == "forall"
+    body = inv.body  # member(x, xs) -> (x == z)
+    assert body.kind == "implies"
+    assert body.operands[0].name == "py.in"  # member(x, xs)
+    assert body.operands[1].name == "py.eq"  # x == z
+
+
+def test_symbolic_carried_accumulator_stays_loud():
+    # A carried accumulator over a symbolic iterable is the non-degenerate fold,
+    # not written yet -- still loud.
     with pytest.raises(SugarNotWritten):
-        _fn("def A(z, xs):\n    for x in xs:\n        assert x == z\n    return z\n").sugar()
+        _fn("def A(xs):\n    t = 0\n    for x in xs:\n        t = t + x\n    return t\n").sugar()
 
 
 def test_loop_carried_accumulator_folds_over_a_concrete_iterable():
@@ -58,7 +72,8 @@ def test_tuple_target_stays_loud():
 if __name__ == "__main__":
     test_concrete_for_unrolls_the_body_per_element()
     test_empty_concrete_for_states_nothing()
-    test_symbolic_iterable_stays_loud()
+    test_symbolic_assert_only_loop_is_a_universal()
+    test_symbolic_carried_accumulator_stays_loud()
     test_loop_carried_accumulator_folds_over_a_concrete_iterable()
     test_tuple_target_stays_loud()
     print("ok: concrete for unrolls; symbolic/carried/tuple-target loud")

--- a/implementations/python/sugar-source-tree/tests/test_range_unroll.py
+++ b/implementations/python/sugar-source-tree/tests/test_range_unroll.py
@@ -54,11 +54,13 @@ def test_loop_carried_accumulator_folds_over_a_concrete_range():
     assert post.args[1].value == 6
 
 
-def test_symbolic_range_bound_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn(
-            "def A(z, n):\n    for i in range(n):\n        assert i == z\n    return z\n"
-        ).sugar()
+def test_symbolic_range_bound_is_a_universal():
+    # range(n) with symbolic n is not concrete, so the assert-only loop emits
+    # its universal forall i. member(i, range(n)) -> P(i) -- not loud.
+    inv = _fn(
+        "def A(z, n):\n    for i in range(n):\n        assert i == z\n    return z\n"
+    ).sugar().desugar().value.invs()[0]
+    assert inv.kind == "forall"
 
 
 if __name__ == "__main__":
@@ -67,5 +69,5 @@ if __name__ == "__main__":
     test_range_start_stop_step_unrolls_the_body_per_element()
     test_empty_range_states_nothing()
     test_loop_carried_accumulator_folds_over_a_concrete_range()
-    test_symbolic_range_bound_stays_loud()
+    test_symbolic_range_bound_is_a_universal()
     print("ok: concrete range unrolls; symbolic range stays loud")


### PR DESCRIPTION
A `for x in xs` over a symbolic (formal) iterable can't unroll — `xs` is a hole. That was an **unwritten segment** of the one path, so it hit the base `SugarNotWritten` and *sank the whole function*: a helper that iterates its argument had no contract. Now it's written and emits the FOL that was always there.

An assert-only body is the degenerate fold: `∀x. member(x, xs) ⟹ P(x)` (`ForUniversalSugar`). Each body fact reduces with the loop target free (a symbolic Var); the element sort is unknown → an uninterpreted sort the compiler declares. This is A's local fact — post over the formal, exactly like `out == z`; a concrete call fills `xs` and the dig unrolls, a symbolic `xs` leaves the honest universal.

`def A(xs): for x in xs: assert x == 0` now yields a contract where it used to sink. **Construction is total for that segment** — the panic was 'not written,' never 'constructed wrong.'

Still loud (unwritten, not errors): a carried accumulator over a symbolic iterable (the non-degenerate fold — the recurrence), tuple target, for-else. Concrete loops still dissolve in substitute.

`sugar-source-tree`: **120 passed, 5 skipped**. Real pipeline green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Treat symbolic assert-only for-loops as universal quantification instead of a panic
> - Adds `ForUniversalSugar` in [for_universal_sugar.py](https://github.com/TSavo/sugar/pull/5975/files#diff-a73f6e30c420695fd0e6930a5f7f4c6784928b7ebb7b9225f538b14b6b77c245) to desugar assert-only `for` loops over symbolic iterables into `forall x: py.element. member(x, xs) -> P(x)` invariants wrapped in a `Complete(BlockValue(...))`.
> - Updates `For.sugar()` in [nodes.py](https://github.com/TSavo/sugar/pull/5975/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to detect assert-only loops with a simple `Name` target and no `orelse`, routing them to `ForUniversalSugar`; loops with carried accumulators, tuple targets, or `orelse` still defer to base behavior.
> - Updates tests in [test_for_unroll.py](https://github.com/TSavo/sugar/pull/5975/files#diff-d9084484fddde632051cbf7c36d5ee137d9c04f77b28893bd542c434c92c80a8) and [test_range_unroll.py](https://github.com/TSavo/sugar/pull/5975/files#diff-5217b157f874b5590e1a2f9c0ba267d8db65e79fc401abbe926ecc0a4149b940) to expect universal invariants rather than a loud/panic result for assert-only symbolic loops.
> - Behavioral Change: symbolic assert-only `for` loops no longer remain loud (unimplemented); they now produce forall invariants. Loops with accumulators or complex targets are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 404e69b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for symbolic `for` loops containing assertions, translating them into universal conditions over all iterable elements.
  * Symbolic `range` loops with assertion-only bodies now produce universal assertions instead of failing.

* **Bug Fixes**
  * Loops with carried accumulators continue to report that they are unsupported rather than being incorrectly transformed.

* **Tests**
  * Added coverage for universal symbolic-loop behavior and accumulator handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->