### PR TITLE
loop reasoning: the carried fold is a coordinate the dig resolves (the recurrence)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/inert_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/inert_sugar.py
@@ -1,0 +1,26 @@
+"""A statement that states nothing -- an inert contribution to the block.
+
+A pure-fold `for` (only carried assignments) has no fact of its own: its meaning
+rode into the tail as the fold binding (substitution_binding), consumed where the
+carried name is read. So the loop node itself contributes an empty record."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class InertSugar(Sugar):
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+
+        return Complete(BlockValue((), can_fall_through=True))

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -965,10 +965,17 @@ class For(Statement):
                 carried = {k: v for k, v in iter_scope.items() if k != target_name}
             return _Splice(tuple(unrolled))
 
-        # Symbolic (or unsupported) loop: keep the node, mask the target, recurse.
-        # It stays a `for` and reaches `For.sugar` -- a symbolic loop is not a
-        # dead unroll, it is the universal / fold over the hole.
+        # Symbolic (or unsupported) loop: keep the node, mask the target AND every
+        # loop-carried variable (a name the body rebinds), recurse. Masking the
+        # carried names keeps the update SYMBOLIC in the body (`total = total + x`
+        # stays, not `total = 0 + x`) so substitution_binding can read the fold;
+        # the pre-loop value seeds it from the outer scope. A symbolic loop is not
+        # a dead unroll -- it is the universal / fold over the hole.
         bound = self._bound_names_in(self.target)
+        for stmt in self.body:
+            b = stmt.substitution_binding({})
+            if b:
+                bound = bound | set(b)
         bs = {k: v for k, v in scope.items() if k not in bound} if bound else scope
         changed = {}
         if iter_changed:
@@ -979,18 +986,90 @@ class For(Statement):
                 changed[f] = new
         return self if not changed else rewrite(self, **changed)
 
+    def _carried_and_facts(self):
+        """Split the body into carried assignments (statements that bind a name
+        for the tail -- the fold's update) and fact statements (asserts, the rest
+        -- the universal's body). A pure-fold loop is all carried; an assert-only
+        loop is all facts; a loop with BOTH is the accumulator-referencing case
+        (point 3), left loud."""
+        carried, facts = [], []
+        for stmt in self.body:
+            (carried if stmt.substitution_binding({}) else facts).append(stmt)
+        return carried, facts
+
+    def substitution_binding(self, scope):
+        """The carried fold's binding for the rest of the block. A symbolic loop
+        `total = total OP x` over `xs` rebinds `total`, for the tail, to the fold
+        coordinate `py.fold.<op>(init, xs)` -- a REFERENCE the dig resolves, the
+        same shape as a recursion's `call:f(...)`, not an opaque dead-end. So
+        `return total` after the loop becomes `return py.fold.add(0, xs)`. A
+        concrete iterable never reaches here (it unrolled via _Splice); only the
+        symbolic single-accumulator `var = var OP x` shape is a fold today."""
+        if self._concrete_elements(self.iter) is not None:
+            return None  # concrete unrolled in substitute
+        if self.orelse or self.target.kind != "Name":
+            return None
+        carried, facts = self._carried_and_facts()
+        if facts or len(carried) != 1:
+            return None  # accumulator+assert, or multi/zero carried -- not a fold
+        assign = carried[0]
+        if assign.kind != "Assign" or len(assign.targets) != 1:
+            return None
+        name = assign.targets[0]
+        if name.kind != "Name":
+            return None
+        value = assign.value
+        # value must be `<name> OP <expr involving the loop target>`.
+        if value.kind != "BinOp" or value.left.kind != "Name" or value.left.id != name.id:
+            return None
+        init = scope.get(name.id)
+        if init is None:
+            return None  # no pre-loop value to seed the fold
+        op = value.op.kind
+        fold = self._make_call(self._make_name(f"py.fold.{op}"), (init, self.iter))
+        return {name.id: fold}
+
+    def _make_name(self, identifier: str) -> "Node":
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        return materialize(
+            self.unit, ShadowNode("Name", self.span, (("id", Leaf(identifier)),)), self.reporter
+        )
+
+    def _make_call(self, func: "Node", args: tuple) -> "Node":
+        from .backend import Child, Children, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        slots = (
+            ("func", Child(_handle_of(func))),
+            ("args", Children(tuple(_handle_of(a) for a in args))),
+            ("keywords", Children(())),
+        )
+        return materialize(self.unit, ShadowNode("Call", self.span, slots), self.reporter)
+
     def sugar(self):
-        """A loop that did NOT dissolve in substitute is symbolic: its iterable
-        is a hole (a formal), so it cannot unroll. Its meaning is the FOL that was
-        always there. An assert-only body is the degenerate fold -- a universal
-        `forall x in xs: P(x)` (ForUniversalSugar). A carried accumulator (the
-        non-degenerate fold) and a tuple target / else stay loud until written."""
+        """A loop that did NOT dissolve in substitute is symbolic: its iterable is
+        a hole (a formal), so it cannot unroll. Its meaning is the FOL that was
+        always there. An assert-only body is the degenerate fold -- the universal
+        `forall x in xs: P(x)` (ForUniversalSugar). A PURE-fold body (only carried
+        assignments) states no fact of its own: the fold rides its
+        substitution_binding into the tail, so the loop itself is inert here. A
+        body with BOTH a carried accumulator and asserts (the accumulator-
+        referencing case) and a tuple target / else stay loud until written."""
         from sugar_lift_py_tests.sugar.for_universal_sugar import ForUniversalSugar
 
         if self.orelse or self.target.kind != "Name":
             return super().sugar()
-        if any(stmt.substitution_binding({}) for stmt in self.body):
-            return super().sugar()  # carried accumulator -- the fold, not yet
+        carried, facts = self._carried_and_facts()
+        if carried and facts:
+            return super().sugar()  # accumulator-referencing assert -- point 3
+        if carried:
+            # Pure fold: the loop states nothing; its meaning is the fold binding
+            # (substitution_binding), consumed where the carried name is read.
+            from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+
+            return InertSugar(site=self.fragment)
         return ForUniversalSugar(
             target=self.target.id,
             iterable=self.iter.sugar(),

--- a/implementations/python/sugar-source-tree/tests/test_for_unroll.py
+++ b/implementations/python/sugar-source-tree/tests/test_for_unroll.py
@@ -47,11 +47,27 @@ def test_symbolic_assert_only_loop_is_a_universal():
     assert body.operands[1].name == "py.eq"  # x == z
 
 
-def test_symbolic_carried_accumulator_stays_loud():
-    # A carried accumulator over a symbolic iterable is the non-degenerate fold,
-    # not written yet -- still loud.
+def test_symbolic_carried_accumulator_is_a_fold_coordinate():
+    # t = 0; for x in xs: t = t + x; return t  over a symbolic xs is the fold:
+    # the carried t rebinds to the coordinate py.fold.Add(0, xs) -- a reference
+    # the dig resolves (the recurrence), the same shape as a recursion's call:f.
+    post = _fn(
+        "def A(xs):\n    total = 0\n    for x in xs:\n        total = total + x\n    return total\n"
+    ).sugar().desugar().value.post()
+    fold = post.args[1]
+    assert fold.name == "call:py.fold.Add"
+    assert fold.args[0].value == 0  # init
+    assert fold.args[1].name == "xs"  # iterable
+
+
+def test_accumulator_referencing_assert_stays_loud():
+    # for x in xs: assert total > 0; total = total + x  -- the assert references
+    # the RUNNING accumulator (point 3, a real loop invariant), still loud.
     with pytest.raises(SugarNotWritten):
-        _fn("def A(xs):\n    t = 0\n    for x in xs:\n        t = t + x\n    return t\n").sugar()
+        _fn(
+            "def A(xs):\n    total = 0\n    for x in xs:\n        assert total == 0\n"
+            "        total = total + x\n    return total\n"
+        ).sugar()
 
 
 def test_loop_carried_accumulator_folds_over_a_concrete_iterable():
@@ -73,7 +89,8 @@ if __name__ == "__main__":
     test_concrete_for_unrolls_the_body_per_element()
     test_empty_concrete_for_states_nothing()
     test_symbolic_assert_only_loop_is_a_universal()
-    test_symbolic_carried_accumulator_stays_loud()
+    test_symbolic_carried_accumulator_is_a_fold_coordinate()
+    test_accumulator_referencing_assert_stays_loud()
     test_loop_carried_accumulator_folds_over_a_concrete_iterable()
     test_tuple_target_stays_loud()
     print("ok: concrete for unrolls; symbolic/carried/tuple-target loud")


### PR DESCRIPTION
A carried accumulator over a symbolic iterable — `total = 0; for x in xs: total = total + x; return total` — is the non-degenerate fold, and it rides the **same mechanism as recursion**: recursion emits `out == call:f(n-1)` (a coordinate the dig resolves as a cycle), the fold emits `out == call:py.fold.Add(0, xs)` (a coordinate the dig resolves the same way). A **reference**, not an opaque dead-end — not `define-fun-rec` in the lift; the recurrence is the coordinate + the dig, exactly as a self-call is.

All substitution:
- `For.substitute` (symbolic) now masks the loop-carried variables too, so the update stays symbolic (`total = total + x`, not `total = 0 + x`).
- `For.substitution_binding` rebinds the carried name to `py.fold.<op>(init, xs)` (a synthesized `Call`, seeded by the pre-loop value). So `return total` → `return py.fold.Add(0, xs)`.
- `For.sugar`: a pure-fold body states no fact of its own (`InertSugar`); its meaning rode into the tail as the binding.

The `sum(xs)` helper now yields a contract where it used to sink. Concrete loops still unroll to the literal (→ 6).

Still loud (point 3, a real invariant): an assert referencing the **running** accumulator; tuple target / for-else.

`sugar-source-tree`: **121 passed, 5 skipped**. Real pipeline green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)