### PR TITLE
composition: the dig-with-args -- a call IS substitution, drained at the cue

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2022,13 +2022,42 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                         msg_id, direct, [], term_tables=[term_table.nodes]
                     )
                     return
-                targets = _tree.call_target_names(
+                calls = _tree.call_nodes_in_assert(
                     sf, at.get("span") if isinstance(at, dict) else None
                 )
+                targets = []
                 by_name = {name: (m, d) for name, m, d in universes}
-                cued = [
-                    _node(*by_name[t]) for t in targets if t in by_name
-                ]
+                cued = []
+                seen = set()
+                for call in calls:
+                    t = call.func.id
+                    if t in seen:
+                        continue
+                    seen.add(t)
+                    targets.append(t)
+                    if t not in by_name:
+                        continue
+                    fn = _tree.find_function_by_name(sf, t)
+                    # A call IS substitution: ground args fill the pre, so the
+                    # dig serves the contract AS APPLIED at this call (a concrete
+                    # iterable unrolls the callee's loop here; the fold
+                    # coordinate collapses). An arg still carrying a hole leaves
+                    # the abstract contract standing -- the callable floor.
+                    if (
+                        fn is not None
+                        and len(call.args) == len(fn.params)
+                        and _tree._args_are_ground(call)
+                    ):
+                        try:
+                            memento, rows = _tree.applied_contract_rows(
+                                fn, tuple(call.args), file_rel
+                            )
+                        except SugarNotWritten:
+                            rows = None
+                        if rows:
+                            cued.append(_node(memento.to_rpc(), rows[0]))
+                            continue
+                    cued.append(_node(*by_name[t]))
                 _send_enumerate_result(
                     msg_id,
                     cued,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
@@ -210,6 +210,65 @@ def function_contract_rows(fn, file_rel: str):
     return def_memento, outcome.value.payload_rows(def_memento)
 
 
+def call_nodes_in_assert(sf: SourceFile, span: Optional[dict]) -> list:
+    """The plain named Call nodes inside the assertion at `span`, in walk order.
+    The cue's own AST: each carries the callee name AND the actual argument
+    nodes -- the pre this call fills."""
+    from sugar_source_tree.nodes import Call, Name
+
+    node = find_assert(sf, span)
+    if node is None:
+        return []
+    return [
+        call
+        for call in node.walk()
+        if isinstance(call, Call) and isinstance(call.func, Name)
+    ]
+
+
+def _args_are_ground(call) -> bool:
+    """True when every argument fills its pre with no remaining hole: no free
+    Name inside any arg. A hole-bearing arg leaves the callee's contract
+    curried (the abstract contract IS the callable floor); a ground arg set is
+    a fill, and the dig applies it."""
+    for arg in call.args:
+        for n in arg.walk():
+            if n.kind == "Name":
+                return False
+    return True
+
+
+def applied_contract_rows(fn, arg_nodes: tuple, file_rel: str):
+    """The callee's contract AS APPLIED at a call: a call IS substitution.
+
+    Substitute the actual argument nodes for the formals into the body -- the
+    same `_substitute_body` that threads a block; a concrete iterable arg makes
+    a symbolic loop unroll here (`_Splice`), a filled name inlines. Then lift
+    the applied body. `A(xs): total=0; for x in xs: total=total+x` dug at
+    `A([1,2,3])` yields post `out == 6` -- the fold coordinate collapsed by the
+    dig, exactly as `c[post]=5` collapses `b[post]`. The DTO keeps the callee's
+    memento and formals (same wire shape; the post simply no longer mentions
+    them). Incomplete -> (memento, None), an effect, as the abstract path."""
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.sugar.function_universe_sugar import (
+        FunctionUniverseSugar,
+    )
+
+    def_memento = function_def_memento(fn, file_rel)
+    scope = {p.name: a for p, a in zip(fn.params, arg_nodes)}
+    applied_body, _changed = fn._substitute_body(fn.body, scope)
+    sugar = FunctionUniverseSugar(
+        name=fn.name,
+        formals=tuple(p.name for p in fn.params),
+        statements=tuple(stmt.sugar() for stmt in applied_body),
+        site=fn.fragment,
+    )
+    outcome = sugar.desugar(None)
+    if not isinstance(outcome, Complete):
+        return def_memento, None
+    return def_memento, outcome.value.payload_rows(def_memento)
+
+
 def module_definition_memento(sf: SourceFile, file_rel: str, file_cid: str) -> dict:
     """The whole-file body the audit frontier demands one leaf for."""
     lc = sf.root.line_col_span()

--- a/implementations/python/sugar-lift-py-tests/tests/test_dig_with_args.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dig_with_args.py
@@ -1,0 +1,95 @@
+"""The dig-with-args: a call IS substitution, drained at the universe cue.
+
+The caller's fact is a REFERENCE (`call:A(array(1,2,3)) == 6`); the dig at that
+call site serves A's contract AS APPLIED -- ground args substitute into the
+callee body, the loop unrolls there, and the fold coordinate collapses to the
+literal: post `out == 6`. An arg still carrying a hole (a free name) leaves the
+abstract contract standing -- the callable floor.
+"""
+
+import tempfile
+from pathlib import Path
+
+from sugar_lift_py_tests import lift_rpc
+
+
+def _enumerate(src):
+    captured = {}
+    orig = lift_rpc._send_enumerate_result
+    lift_rpc._send_enumerate_result = lambda mid, nodes, gaps, **kw: captured.update(
+        nodes=nodes, gaps=gaps, kw=kw
+    )
+    try:
+        root = tempfile.mkdtemp()
+        Path(root, "t.py").write_text(src)
+
+        def enum(level, at=None, seek=False):
+            lift_rpc._handle_enumerate(
+                1, {"level": level, "workspace_root": root, "at": at, "seek": seek}
+            )
+            return captured["nodes"], captured["gaps"], captured["kw"]
+
+        files, _, _ = enum("source_files")
+        fns, _, _ = enum("functions", files[0]["memento"])
+        caller = [n for n in fns if "test_a" in str(n["memento"])][0]
+        cs, _, _ = enum("call_sites", caller["memento"])
+        uni, gaps, kw = enum("universe", cs[0]["memento"], seek=True)
+        return uni, gaps, kw
+    finally:
+        lift_rpc._send_enumerate_result = orig
+
+
+def _resolved_post(uni, kw):
+    table = kw["term_tables"][0]  # cid -> value
+
+    def resolve(v):
+        if isinstance(v, dict):
+            if v.get("kind") == "term-ref":
+                return resolve(table[v["cid"]])
+            return {k: resolve(x) for k, x in v.items()}
+        if isinstance(v, list):
+            return [resolve(x) for x in v]
+        return v
+
+    return resolve(uni[0]["audit"]["post"])
+
+
+SUM_HELPER = (
+    "def A(xs):\n"
+    "    total = 0\n"
+    "    for x in xs:\n"
+    "        total = total + x\n"
+    "    return total\n\n"
+)
+
+
+def test_ground_args_serve_the_applied_contract():
+    # A([1, 2, 3]) dug -> the fold collapses: post out == 6.
+    uni, gaps, kw = _enumerate(
+        SUM_HELPER + "def test_a():\n    assert A([1, 2, 3]) == 6\n"
+    )
+    assert len(uni) == 1 and not gaps
+    post = _resolved_post(uni, kw)
+    assert post["name"] == "="
+    assert post["args"][0] == {"kind": "var", "name": "out"}
+    assert post["args"][1]["value"] == 6
+
+
+def test_hole_args_serve_the_abstract_contract():
+    # A(ys) where ys is the caller's own formal: the pre is still a hole, so
+    # the curried (abstract) contract stands -- post over the fold coordinate,
+    # not a literal.
+    uni, gaps, kw = _enumerate(
+        SUM_HELPER + "def test_a(ys):\n    assert A(ys) == 6\n"
+    )
+    assert len(uni) == 1
+    post = _resolved_post(uni, kw)
+    assert post["name"] == "="
+    right = post["args"][1]
+    assert right.get("kind") == "ctor" and right["name"] == "call:py.fold.Add"
+
+
+if __name__ == "__main__":
+    test_ground_args_serve_the_applied_contract()
+    test_hole_args_serve_the_abstract_contract()
+    print("ok: dig-with-args -- ground fills and collapses, a hole stays curried")


### PR DESCRIPTION
The emission half was built (references: `call:A(...)`, the fold coordinate, the universal); this is the **composition half actually draining one**. The universe level's call-site cue used to serve only the callee's abstract contract, so `A([1,2,3])` against the sum-helper composed to an EUF coordinate nothing equated to 6 — the lying twin stayed SAT.

Now the dig **applies the call**: `applied_contract_rows` substitutes the actual argument nodes for the formals into the callee body (the same `_substitute_body` that threads a block), so a concrete iterable arg unrolls the callee's loop right there and the fold coordinate collapses. The cue serves post `out == 6` — the lying twin (`== 7`) now contradicts a ground post.

The fill/hole split is the callable floor: ground args (no free Name in any arg) fill the pre → applied contract; a hole-bearing arg leaves the curried abstract contract standing, composed further out where the hole fills. Same wire shape either way.

This is `a[post] = b[post] = c[post] = 5` collapsing for real — the reference chain drained by substitution at the dig, no inlining machinery.

`sugar-source-tree`: **121 passed, 5 skipped**. Real pipeline green. New test pins both arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Substitute ground call arguments into callee contracts when enumerating call-site universe nodes
> - When enumerating a call-site's universe with `seek=true`, [`_handle_enumerate`](https://github.com/TSavo/sugar/pull/5977/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) now resolves each named call's callee contract with actual ground arguments substituted in, instead of returning the abstract function universe.
> - Three new utilities in [`tree_enumerate.py`](https://github.com/TSavo/sugar/pull/5977/files#diff-1a883a4eea1b53f1ee91261df4ca5f694dfda233c883ddab24f920fd9610931e) support this: `call_nodes_in_assert` finds call AST nodes inside an assertion, `_args_are_ground` checks that no argument contains a `Name` node (a hole), and `applied_contract_rows` performs the substitution and desugaring.
> - Duplicate callees at a call-site are de-duplicated by name via a `seen` set; calls with non-ground args or missing/mismatched functions fall back to the abstract universe node.
> - A new test module [`test_dig_with_args.py`](https://github.com/TSavo/sugar/pull/5977/files#diff-2946bd0c448a6724aa7a95198a61ff8ee7445de5fe21ea31f5aaf446d2438f7a) verifies that ground-arg calls yield a collapsed literal in the post-condition, while hole-arg calls retain an abstract fold constructor.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f469d77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Universe exploration now provides applied contract results when function calls use concrete, fully specified arguments.
  * Calls with incomplete or variable arguments continue to show abstract contract information.
  * Call-site results are more precise and reflect the specific values supplied.

* **Bug Fixes**
  * Improved handling of multiple call sites and duplicate function references during universe enumeration.

* **Tests**
  * Added coverage for concrete arguments producing resolved results and variable arguments preserving abstract contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->