### PR TITLE
loop reasoning: tuple targets destructure + latent Tuple kind fix

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -946,24 +946,29 @@ class For(Statement):
         new_iter, iter_changed = self._substitute_field(self.iter, scope)
         subst_iter = new_iter if iter_changed else self.iter
 
-        concrete = not self.orelse and self.target.kind == "Name"
+        concrete = not self.orelse and self.target.kind in ("Name", "Tuple", "List")
         elements = self._concrete_elements(subst_iter) if concrete else None
         if elements is not None:
-            target_name = self.target.id
-            unrolled: list = []
-            carried = dict(scope)  # carries loop variables across iterations
-            for element in elements:
-                iter_scope = {**carried, target_name: element}
-                new_body, _c = self._substitute_body(self.body, iter_scope)
-                unrolled.extend(new_body)
-                # thread this iteration's bindings forward (the carried fold),
-                # never the loop target itself (rebound next iteration).
-                for stmt in new_body:
-                    b = stmt.substitution_binding(iter_scope)
-                    if b:
-                        iter_scope = {**iter_scope, **b}
-                carried = {k: v for k, v in iter_scope.items() if k != target_name}
-            return _Splice(tuple(unrolled))
+            bindings = [self._target_bindings(e) for e in elements]
+            if all(b is not None for b in bindings):
+                target_names = self._bound_names_in(self.target)
+                unrolled: list = []
+                carried = dict(scope)  # carries loop variables across iterations
+                for element_bindings in bindings:
+                    iter_scope = {**carried, **element_bindings}
+                    new_body, _c = self._substitute_body(self.body, iter_scope)
+                    unrolled.extend(new_body)
+                    # thread this iteration's bindings forward (the carried
+                    # fold), never the loop target's own names (rebound next
+                    # iteration).
+                    for stmt in new_body:
+                        b = stmt.substitution_binding(iter_scope)
+                        if b:
+                            iter_scope = {**iter_scope, **b}
+                    carried = {
+                        k: v for k, v in iter_scope.items() if k not in target_names
+                    }
+                return _Splice(tuple(unrolled))
 
         # Symbolic (or unsupported) loop: keep the node, mask the target AND every
         # loop-carried variable (a name the body rebinds), recurse. Masking the
@@ -1077,13 +1082,31 @@ class For(Statement):
             site=self.fragment,
         )
 
+    def _target_bindings(self, element: "Node") -> "Optional[dict]":
+        """What this loop's target binds when the element is `element`, or None
+        when the shapes do not destructure. A Name target binds it whole; a
+        tuple/list target of plain Names destructures a tuple/list DISPLAY
+        element of the same arity (`for a, b in [(1, 2)]` binds a=1, b=2). A
+        nested or starred target, or an element that is not a matching display,
+        is not destructured here -- the loop falls to the symbolic branch."""
+        if self.target.kind == "Name":
+            return {self.target.id: element}
+        names = []
+        for t in self.target.elts:
+            if t.kind != "Name":
+                return None  # nested/starred target -- not written
+            names.append(t.id)
+        if element.kind not in ("Tuple", "List") or len(element.elts) != len(names):
+            return None
+        return dict(zip(names, element.elts))
+
     def _concrete_elements(self, iterable: "Expression") -> "Optional[list]":
         """The element nodes to unroll over, or ``None`` if `iterable` is not
         concrete. A `List`/`Tuple_` literal is concrete by construction; a
         `range(...)` call is concrete only when every argument (after
         substitution) is a literal `int` -- a symbolic bound leaves the fold
         real, so it is not recognized here."""
-        if iterable.kind in ("List", "Tuple_"):
+        if iterable.kind in ("List", "Tuple"):
             return list(iterable.elts)
         if (
             iterable.kind == "Call"

--- a/implementations/python/sugar-source-tree/tests/test_for_unroll.py
+++ b/implementations/python/sugar-source-tree/tests/test_for_unroll.py
@@ -80,9 +80,26 @@ def test_loop_carried_accumulator_folds_over_a_concrete_iterable():
     assert post.args[1].value == 6  # out == 0+1+2+3
 
 
-def test_tuple_target_stays_loud():
+def test_tuple_target_destructures_the_concrete_element():
+    # for a, b in [(1, 2), (3, 4)]: assert a == b  -- each display element
+    # destructures into the tuple target's names; two invs, 1==2 and 3==4.
+    invs = _invs(
+        "def A(z):\n    for a, b in [(1, 2), (3, 4)]:\n        assert a == b\n    return z\n"
+    )
+    assert [(i.args[0].value, i.args[1].value) for i in invs] == [(1, 2), (3, 4)]
+
+
+def test_starred_target_stays_loud():
+    # for a, *b -- a starred target does not destructure here; still loud.
     with pytest.raises(SugarNotWritten):
-        _fn("def A(z):\n    for a, b in [(1, 2)]:\n        assert a == b\n    return z\n").sugar()
+        _fn("def A(z):\n    for a, *b in [(1, 2)]:\n        assert a == a\n    return z\n").sugar()
+
+
+def test_arity_mismatch_stays_loud():
+    # the target has two names, the element three -- not destructured, loud
+    # (running it would be a ValueError; never bind a wrong shape).
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(z):\n    for a, b in [(1, 2, 3)]:\n        assert a == b\n    return z\n").sugar()
 
 
 if __name__ == "__main__":
@@ -92,5 +109,7 @@ if __name__ == "__main__":
     test_symbolic_carried_accumulator_is_a_fold_coordinate()
     test_accumulator_referencing_assert_stays_loud()
     test_loop_carried_accumulator_folds_over_a_concrete_iterable()
-    test_tuple_target_stays_loud()
+    test_tuple_target_destructures_the_concrete_element()
+    test_starred_target_stays_loud()
+    test_arity_mismatch_stays_loud()
     print("ok: concrete for unrolls; symbolic/carried/tuple-target loud")


### PR DESCRIPTION
`for a, b in [(1, 2), (3, 4)]:` — a tuple/list target of plain Names destructures a tuple/list display element of matching arity per unrolled iteration; the dict-items shape (`for k, v in [...]`) accumulates. Arity mismatch / starred / nested targets don't destructure — loud (a mismatch at runtime is a ValueError; never bind a wrong shape).

Also a latent kind-string bug: the class is `Tuple_` but `.kind` is `"Tuple"`, so a tuple **iterable** never matched — `for x in (1, 2, 3)` never unrolled. Fixed (→ 6).

`sugar-source-tree`: **128 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support tuple/list destructuring targets in concrete `for` loop unrolling
> - Extends `For.substitute` in [nodes.py](https://github.com/TSavo/sugar/pull/5979/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to unroll loops whose target is a `Tuple` or `List` pattern over matching display elements, rather than leaving them symbolic.
> - Adds `For._target_bindings` helper to compute per-variable bindings during destructuring; returns `None` for starred targets, nested patterns, or arity mismatches, falling back to the symbolic path.
> - Fixes `For._concrete_elements` to recognize the `'Tuple'` kind (was `'Tuple_'`) so tuple literals are treated as concrete iterables.
> - New tests cover successful destructuring, starred-target fallback, and arity-mismatch fallback in [test_for_unroll.py](https://github.com/TSavo/sugar/pull/5979/files#diff-d9084484fddde632051cbf7c36d5ee137d9c04f77b28893bd542c434c92c80a8).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa1d636.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->