### PR TITLE
loop soundness: a jump-bearing body never unrolls

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -946,7 +946,11 @@ class For(Statement):
         new_iter, iter_changed = self._substitute_field(self.iter, scope)
         subst_iter = new_iter if iter_changed else self.iter
 
-        concrete = not self.orelse and self.target.kind in ("Name", "Tuple", "List")
+        concrete = (
+            not self.orelse
+            and self.target.kind in ("Name", "Tuple", "List")
+            and not self._body_has_loop_control()
+        )
         elements = self._concrete_elements(subst_iter) if concrete else None
         if elements is not None:
             bindings = [self._target_bindings(e) for e in elements]
@@ -1080,6 +1084,19 @@ class For(Statement):
             iterable=self.iter.sugar(),
             body=tuple(s.sugar() for s in self.body),
             site=self.fragment,
+        )
+
+    def _body_has_loop_control(self) -> bool:
+        """True when any `break`/`continue` appears anywhere in the body. The
+        plain unroll repeats the body verbatim, which would duplicate the jump
+        and silently mis-thread the carried state -- a break is the last hole
+        being filled, and the unroll must not fake past it. Conservative on
+        purpose (a nested loop's own jumps also block): over-blocking falls to
+        the symbolic branch (loud), never to a wrong unroll."""
+        return any(
+            n.kind in ("Break", "Continue")
+            for stmt in self.body
+            for n in stmt.walk()
         )
 
     def _target_bindings(self, element: "Node") -> "Optional[dict]":
@@ -1239,6 +1256,8 @@ class While(Statement):
     def _try_unroll(self, scope):
         """The unrolled statement tuple, or None if the loop is not concrete
         (condition undecidable against the carried state, or fuel exhausted)."""
+        if For._body_has_loop_control(self):
+            return None  # a jump-bearing body is not a plain unroll
         carried = dict(scope)
         unrolled: list = []
         for _ in range(self._FUEL):

--- a/implementations/python/sugar-source-tree/tests/test_for_unroll.py
+++ b/implementations/python/sugar-source-tree/tests/test_for_unroll.py
@@ -112,4 +112,17 @@ if __name__ == "__main__":
     test_tuple_target_destructures_the_concrete_element()
     test_starred_target_stays_loud()
     test_arity_mismatch_stays_loud()
+    test_jump_bearing_body_never_unrolls()
     print("ok: concrete for unrolls; symbolic/carried/tuple-target loud")
+
+
+def test_jump_bearing_body_never_unrolls():
+    # A break/continue in the body would be duplicated verbatim by the plain
+    # unroll, silently mis-threading the carried state (Python says t == 1 here;
+    # a naive unroll would say 6). The loop itself refuses to unroll -- the
+    # panic is at For.sugar (the loop), never a wrong construction saved late
+    # by Break's own panic.
+    src = "def A():\n    t = 0\n    for x in [1, 2, 3]:\n        t = t + x\n        break\n    return t\n"
+    with pytest.raises(SugarNotWritten) as e:
+        _fn(src).sugar()
+    assert "For.sugar" in str(e.value)


### PR DESCRIPTION
A `break`/`continue` in a concrete loop body landed loud only **indirectly**: the unroll had already spliced the jump N times, and the panic fired later at `Break.sugar`. If Break ever gains a sugar for another context, that unroll goes silently wrong (Python says `t == 1` after `t = t + x; break` over `[1,2,3]`; the verbatim splice would say 6). A break is the last hole being filled — the unroll must not fake past it.

Now the loop itself refuses: `_body_has_loop_control` gates both For's concrete branch and `While._try_unroll` (conservative — a nested loop's own jumps also block, which over-blocks to **loud**, never to a wrong unroll). The panic is at the loop; the wrong construction is never built.

`sugar-source-tree`: **129 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent loop unrolling when body contains `Break` or `Continue` nodes
> For-loops and while-loops with `break` or `continue` in their bodies were previously unrolled even though doing so is unsound. The new `_body_has_loop_control()` helper walks the loop body's subtree; if any `Break` or `Continue` nodes are found, `For.substitute` skips unrolling and retains the node as symbolic, and `While._try_unroll` returns `None` early.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29318c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->