### PR TITLE
loop reasoning: for-else / while-else drain into the unroll

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -946,9 +946,11 @@ class For(Statement):
         new_iter, iter_changed = self._substitute_field(self.iter, scope)
         subst_iter = new_iter if iter_changed else self.iter
 
+        # `else` is unrollable too: the jump-guard means no `break` exists, and
+        # with no break the else ALWAYS runs -- it is just more block, spliced
+        # after the unrolled iterations.
         concrete = (
-            not self.orelse
-            and self.target.kind in ("Name", "Tuple", "List")
+            self.target.kind in ("Name", "Tuple", "List")
             and not self._body_has_loop_control()
         )
         elements = self._concrete_elements(subst_iter) if concrete else None
@@ -972,6 +974,9 @@ class For(Statement):
                     carried = {
                         k: v for k, v in iter_scope.items() if k not in target_names
                     }
+                if self.orelse:
+                    else_body, _c = self._substitute_body(self.orelse, carried)
+                    unrolled.extend(else_body)
                 return _Splice(tuple(unrolled))
 
         # Symbolic (or unsupported) loop: keep the node, mask the target AND every
@@ -1230,10 +1235,9 @@ class While(Statement):
         concrete loop is a non-termination the unroll must not fake."""
         from .shadow import rewrite
 
-        if not self.orelse:
-            unrolled = self._try_unroll(scope)
-            if unrolled is not None:
-                return _Splice(unrolled)
+        unrolled = self._try_unroll(scope)
+        if unrolled is not None:
+            return _Splice(unrolled)
 
         # Symbolic (or unsupported) while: keep the node; mask the carried
         # names (any name the body rebinds) so the update stays symbolic.
@@ -1266,6 +1270,11 @@ class While(Statement):
             if verdict is None:
                 return None  # not decidable -- not a concrete loop
             if verdict is False:
+                # Exit via the condition: with no break (jump-guard), the
+                # `else` always runs -- spliced after the iterations.
+                if self.orelse:
+                    else_body, _c = self._substitute_body(self.orelse, carried)
+                    unrolled.extend(else_body)
                 return tuple(unrolled)
             new_body, _c = self._substitute_body(self.body, carried)
             unrolled.extend(new_body)

--- a/implementations/python/sugar-source-tree/tests/test_for_unroll.py
+++ b/implementations/python/sugar-source-tree/tests/test_for_unroll.py
@@ -113,6 +113,7 @@ if __name__ == "__main__":
     test_starred_target_stays_loud()
     test_arity_mismatch_stays_loud()
     test_jump_bearing_body_never_unrolls()
+    test_for_else_splices_after_the_unroll()
     print("ok: concrete for unrolls; symbolic/carried/tuple-target loud")
 
 
@@ -126,3 +127,13 @@ def test_jump_bearing_body_never_unrolls():
     with pytest.raises(SugarNotWritten) as e:
         _fn(src).sugar()
     assert "For.sugar" in str(e.value)
+
+
+def test_for_else_splices_after_the_unroll():
+    # With no break possible (the jump-guard blocks jump-bearing bodies from
+    # unrolling), the else ALWAYS runs: just more block, after the iterations.
+    post = _fn(
+        "def A():\n    t = 0\n    for x in [1, 2]:\n        t = t + x\n"
+        "    else:\n        t = t + 100\n    return t\n"
+    ).sugar().desugar().value.post()
+    assert post.args[1].value == 103

--- a/implementations/python/sugar-source-tree/tests/test_while_unroll.py
+++ b/implementations/python/sugar-source-tree/tests/test_while_unroll.py
@@ -57,4 +57,14 @@ if __name__ == "__main__":
     test_false_condition_skips_the_body()
     test_while_true_stays_loud()
     test_symbolic_condition_stays_loud()
+    test_while_else_splices_after_the_exit()
     print("ok: concrete while unrolls; True/symbolic loud")
+
+
+def test_while_else_splices_after_the_exit():
+    # The unroll exits only via condition-false; with no break, else always runs.
+    src = (
+        "def A():\n    i = 0\n    while i < 2:\n        i = i + 1\n"
+        "    else:\n        i = i + 100\n    return i\n"
+    )
+    assert _out(src).value == 102


### PR DESCRIPTION
The jump-guard made `else` trivially sound: an unrollable body has no `break`, and with no break the `else` **always** runs (Python's for-else is 'else unless broken'). So the else is just more block — threaded against the final carried state, spliced after the unroll (for) / after the condition-false exit (while). No new machinery.

`for x in [1,2]: t=t+x else: t=t+100` → 103; `while i<2: i=i+1 else: i=i+100` → 102. A symbolic loop's else still rides the symbolic branch (loud with it).

`sugar-source-tree`: **131 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unroll for-else and while-else loops by splicing the else body after iterations
> - `For.substitute` now unrolls concrete for-loops that have an `else` clause, appending the substituted else body after the unrolled iterations instead of skipping unroll entirely.
> - `While.substitute` and `While._try_unroll` now handle `else` clauses: when the loop exits via a false condition, the else body is substituted in the carried scope and appended after the final iteration.
> - Tests added in [test_for_unroll.py](https://github.com/TSavo/sugar/pull/5981/files#diff-d9084484fddde632051cbf7c36d5ee137d9c04f77b28893bd542c434c92c80a8) and [test_while_unroll.py](https://github.com/TSavo/sugar/pull/5981/files#diff-79f1cccdc6c4bec91d81376b1f78de3a6f5b78d7ccb0ccce88ecbfea29b1d85b) covering both cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1178ecc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->