### PR TITLE
temporal: the concrete list comprehension dissolves to its display

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1104,6 +1104,19 @@ class For(Statement):
             for n in stmt.walk()
         )
 
+    def _target_bindings_for(self, target: "Node", element: "Node") -> "Optional[dict]":
+        """`_target_bindings` for an explicit target (shared with comprehensions)."""
+        if target.kind == "Name":
+            return {target.id: element}
+        names = []
+        for t in target.elts:
+            if t.kind != "Name":
+                return None
+            names.append(t.id)
+        if element.kind not in ("Tuple", "List") or len(element.elts) != len(names):
+            return None
+        return dict(zip(names, element.elts))
+
     def _target_bindings(self, element: "Node") -> "Optional[dict]":
         """What this loop's target binds when the element is `element`, or None
         when the shapes do not destructure. A Name target binds it whole; a
@@ -1111,16 +1124,7 @@ class For(Statement):
         element of the same arity (`for a, b in [(1, 2)]` binds a=1, b=2). A
         nested or starred target, or an element that is not a matching display,
         is not destructured here -- the loop falls to the symbolic branch."""
-        if self.target.kind == "Name":
-            return {self.target.id: element}
-        names = []
-        for t in self.target.elts:
-            if t.kind != "Name":
-                return None  # nested/starred target -- not written
-            names.append(t.id)
-        if element.kind not in ("Tuple", "List") or len(element.elts) != len(names):
-            return None
-        return dict(zip(names, element.elts))
+        return For._target_bindings_for(self, self.target, element)
 
     def _concrete_elements(self, iterable: "Expression") -> "Optional[list]":
         """The element nodes to unroll over, or ``None`` if `iterable` is not
@@ -1917,7 +1921,15 @@ class ListComp(Expression):
 
     def substitute(self, scope):
         """A comprehension: thread each generator's target, then substitute the
-        element against the scope with every target masked."""
+        element against the scope with every target masked.
+
+        Over a CONCRETE iterable it DISSOLVES -- `map` disappearing for real:
+        `[e for x in [1, 2, 3]]` is three substitutions of x into e, and the
+        comprehension rewrites to the List DISPLAY of those elements. The
+        comprehension was never a meaning; it was a count of rewrites."""
+        unrolled = self._try_unroll_to_display(scope)
+        if unrolled is not None:
+            return unrolled
         from .shadow import rewrite
         new_gens, inner, gc = self._substitute_generators(self.generators, scope)
         new_elt, de = self._substitute_field(self.elt, inner)
@@ -1927,6 +1939,46 @@ class ListComp(Expression):
         if de:
             changed["elt"] = new_elt
         return self if not changed else rewrite(self, **changed)
+
+    def _try_unroll_to_display(self, scope):
+        """The List display this comprehension dissolves to, or None. One
+        synchronous generator, no ifs (the filtered form is a later segment),
+        over a CONCRETE iterable whose elements destructure into the target:
+        each element substitutes into `elt`, and the results are the display's
+        elements. Reuses For's readers (same structural recognition)."""
+        if len(self.generators) != 1:
+            return None
+        gen = self.generators[0]
+        if gen.is_async or gen.ifs:
+            return None
+        new_iter, ic = self._substitute_field(gen.iter, scope)
+        it = new_iter if ic else gen.iter
+        elements = For._concrete_elements(self, it)
+        if elements is None:
+            return None
+        target = gen.target
+        results = []
+        for element in elements:
+            if target.kind == "Name":
+                bindings = {target.id: element}
+            else:
+                bindings = For._target_bindings_for(self, target, element)
+                if bindings is None:
+                    return None
+            inner = {**scope, **bindings}
+            new_elt, _d = self._substitute_field(self.elt, inner)
+            results.append(new_elt if _d else self.elt)
+        return self._make_list(tuple(results))
+
+    def _make_list(self, elements: tuple) -> "Node":
+        """Synthesize a List display of these element nodes, borrowing this
+        comprehension's span -- the dissolved `map`, a display like any other."""
+        from .backend import Children, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        slots = (("elts", Children(tuple(_handle_of(e) for e in elements))),)
+        return materialize(self.unit, ShadowNode("List", self.span, slots), self.reporter)
+
 
 
 class SetComp(Expression):

--- a/implementations/python/sugar-source-tree/tests/test_listcomp_dissolves.py
+++ b/implementations/python/sugar-source-tree/tests/test_listcomp_dissolves.py
@@ -1,0 +1,64 @@
+"""`[e for x in <concrete>]` DISSOLVES in substitute -- map disappearing for
+real: N substitutions of x into e, rewritten to the List display of the
+results. The comprehension was never a meaning; it was a count of rewrites.
+Symbolic iterables, filters (ifs), multi-generator, and async keep the node
+(loud until their segments are written)."""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _out(src):
+    return _fn(src).sugar().desugar().value.post().args[1]
+
+
+def test_identity_comprehension_is_the_display():
+    t = _out("def A():\n    return [x for x in [1, 2, 3]]\n")
+    assert t.name == "array" and [a.value for a in t.args] == [1, 2, 3]
+
+
+def test_mapped_comprehension_folds_per_element():
+    t = _out("def A():\n    return [x + 10 for x in [1, 2]]\n")
+    assert [a.value for a in t.args] == [11, 12]
+
+
+def test_tuple_target_comprehension_destructures():
+    t = _out("def A():\n    return [a + b for a, b in [(1, 2), (3, 4)]]\n")
+    assert [a.value for a in t.args] == [3, 7]
+
+
+def test_composes_with_len():
+    t = _out("def A():\n    return len([x for x in [1, 2, 3]])\n")
+    assert t.name == "call:len"
+
+
+def test_filtered_comprehension_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A():\n    return [x for x in [1, 2] if x == 1]\n").sugar()
+
+
+def test_symbolic_comprehension_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(xs):\n    return [x for x in xs]\n").sugar()
+
+
+if __name__ == "__main__":
+    test_identity_comprehension_is_the_display()
+    test_mapped_comprehension_folds_per_element()
+    test_tuple_target_comprehension_destructures()
+    test_composes_with_len()
+    test_filtered_comprehension_stays_loud()
+    test_symbolic_comprehension_stays_loud()
+    print("ok: the concrete comprehension dissolves to its display")


### PR DESCRIPTION
`[e for x in [1, 2, 3]]` is three substitutions of x into e — **map as a count of rewrites**, the original ruling made literal. `ListComp.substitute`, over one sync generator with no ifs and a concrete iterable, rewrites to the List **display** of the per-element substitutions. Results fold at the meaning layer like any display: `[x + 10 for x in [1, 2]]` → `array(11, 12)`; composes with `len`. Tuple targets destructure via the shared reader.

Filters, multi-generator, async, symbolic iterables keep the node — loud until written.

`sugar-source-tree`: **137 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dissolve list comprehensions into `List` display nodes during substitution
> - `ListComp.substitute` now attempts to unroll a comprehension into a concrete `List` display when there is exactly one synchronous generator without filters and its iterable resolves to concrete elements.
> - A new `_try_unroll_to_display` helper drives this: it substitutes the iterable, retrieves elements via `For._concrete_elements`, computes per-binding substitutions using a new `For._target_bindings_for` helper, and assembles the result with `_make_list`.
> - `For._target_bindings_for` is extracted from the inlined destructuring logic in `For._target_bindings`, centralising Name and tuple/list target handling.
> - Filtered comprehensions and those over symbolic iterables fall back to the previous substitution behavior.
> - Tests covering identity, mapped, and tuple-destructuring cases, plus non-dissolving filtered and symbolic cases, are added in [test_listcomp_dissolves.py](https://github.com/TSavo/sugar/pull/5982/files#diff-aa074e419b5cc81bd1a7479f8862c87dd2069256439bdacfefc6b473b9414d21).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d72dc91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->