### PR TITLE
composition: the applied dig fires even when the abstract universe is a gap

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2035,14 +2035,17 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                         continue
                     seen.add(t)
                     targets.append(t)
-                    if t not in by_name:
-                        continue
                     fn = _tree.find_function_by_name(sf, t)
                     # A call IS substitution: ground args fill the pre, so the
                     # dig serves the contract AS APPLIED at this call (a concrete
                     # iterable unrolls the callee's loop here; the fold
-                    # coordinate collapses). An arg still carrying a hole leaves
-                    # the abstract contract standing -- the callable floor.
+                    # coordinate collapses; a symbolic while's condition grounds
+                    # and unrolls). An arg still carrying a hole leaves the
+                    # abstract contract standing -- the callable floor. The
+                    # applied dig is attempted even when the ABSTRACT universe is
+                    # a gap: the applied substitution can succeed exactly where
+                    # the abstract is still a hole (that is the whole point of
+                    # filling the pre).
                     if (
                         fn is not None
                         and len(call.args) == len(fn.params)
@@ -2057,7 +2060,8 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                         if rows:
                             cued.append(_node(memento.to_rpc(), rows[0]))
                             continue
-                    cued.append(_node(*by_name[t]))
+                    if t in by_name:
+                        cued.append(_node(*by_name[t]))
                 _send_enumerate_result(
                     msg_id,
                     cued,

--- a/implementations/python/sugar-lift-py-tests/tests/test_dig_with_args.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dig_with_args.py
@@ -92,4 +92,25 @@ def test_hole_args_serve_the_abstract_contract():
 if __name__ == "__main__":
     test_ground_args_serve_the_applied_contract()
     test_hole_args_serve_the_abstract_contract()
+    test_applied_dig_fires_even_when_the_abstract_universe_is_a_gap()
     print("ok: dig-with-args -- ground fills and collapses, a hole stays curried")
+
+
+WHILE_HELPER = (
+    "def A(n):\n"
+    "    i = 0\n"
+    "    while i < n:\n"
+    "        i = i + 1\n"
+    "    return i\n\n"
+)
+
+
+def test_applied_dig_fires_even_when_the_abstract_universe_is_a_gap():
+    # The symbolic while has NO abstract universe (loud) -- but a ground call
+    # fills n, the condition grounds, and the existing unroll fires: the dig
+    # serves out == 3. A symbolic while needed no coordinate; it was a
+    # substitute all along.
+    uni, gaps, kw = _enumerate(WHILE_HELPER + "def test_a():\n    assert A(3) == 3\n")
+    assert len(uni) == 1
+    post = _resolved_post(uni, kw)
+    assert post["args"][1]["value"] == 3


### PR DESCRIPTION
The symbolic while needed no `py.while` coordinate — **it was a substitute all along**. A while over a formal has no abstract universe (loud), but at a ground call the pre fills, the condition grounds, and the existing concrete unroll fires. The missing wire: the universe cue path skipped callees absent from the abstract list, so a loud-abstract function never got its applied dig attempted — backwards, since the applied substitution succeeds exactly where the abstract is still a hole.

`def A(n): while i < n: i = i+1` at `A(3)` now serves `out == 3`. Same resolution covers the accumulator-referencing assert at ground calls. Abstract emissions stay loud until the corpus demands one.

**Receipt:** battleaxe full-stack witness corpus (3.12 + built fleet + z3) at current main: **10 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fire applied contract dig in enumerate RPC even when abstract universe is a gap
> - In [`lift_rpc.py`](https://github.com/TSavo/sugar/pull/5983/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335), the `_handle_enumerate` handler previously skipped applied-contract dig when a callee had no abstract universe entry. It now always attempts the dig, returning the applied node when arguments are ground and match parameters.
> - The fallback that appends the abstract universe node is now only triggered when the callee exists in `by_name` and the applied dig yields no rows.
> - A new test in [`test_dig_with_args.py`](https://github.com/TSavo/sugar/pull/5983/files#diff-2946bd0c448a6724aa7a95198a61ff8ee7445de5fe21ea31f5aaf446d2438f7a) validates this behavior using a while-loop helper where the abstract universe is a gap.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f04fde.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->