### PR TITLE
kill the quadratic audit: one construction, the reporter witnesses

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
@@ -143,30 +143,32 @@ def fact_of(node) -> Optional[Any]:
 
 
 def audit_file_gaps(full_path: Path):
-    """Every node in the file whose own sugar() reaches the base throw.
+    """The file's frontier: ONE construction per top-level statement; the
+    reporter witnesses every gap underneath it as it is built.
 
-    Returns ``(sf, [(node, panic), ...])`` deduped by node identity. Each node
-    is asked directly, so it self-reports even when no ancestor's sugar() call
-    reached it first; a gap reported while an ANCESTOR was under construction is
-    the same node object, collapsed by identity here. Only ``SugarNotWritten``
-    is caught: a VocabularyMissing/BackendDefect during the walk is a different,
-    louder failure and is left to propagate, never swallowed into the census.
+    Construction is correctness -- there is no other path, so there is nothing
+    to re-ask. Each top-level statement's sugar() is called once; a gap anywhere
+    in its subtree self-reports through the reporter DURING that construction.
+    Linear in the file, never quadratic: asking every node separately would
+    re-construct every subtree once per ancestor -- a second computation, the
+    side door this replaces. Only ``SugarNotWritten`` is caught: a
+    VocabularyMissing/BackendDefect is a different, louder failure and is left
+    to propagate, never swallowed into the census.
+
+    Returns ``(sf, [(node, panic), ...])`` deduped by SOURCE identity (kind +
+    span): the tree materializes nodes fresh per access, so the same source gap
+    reached twice is still one gap.
     """
     from sugar_source_tree.panic import SugarNotWritten
     from sugar_source_tree.reporter import CollectingReporter
 
     reporter = CollectingReporter()
     sf = SourceFile.from_path(str(full_path), reporter=reporter)
-    for node in sf.root.walk():
+    for stmt in sf.root.body:
         try:
-            node.sugar()
+            stmt.sugar()
         except SugarNotWritten:
             pass  # reported through the channel already; keep counting
-    # Dedup by SOURCE identity, never object id: the tree materializes a node
-    # fresh on every access, so the same source node reached by the walk and
-    # again by a parent's sugar() (e.g. FunctionDef resolving its body) are two
-    # distinct objects. Their identity is the memento (kind + span), so a gap is
-    # one gap however many times it was materialized.
     seen: dict[tuple, Any] = {}
     for node, panic in reporter.gaps:
         lc = node.line_col_span()


### PR DESCRIPTION
`audit_file_gaps` asked **every node** for its sugar — each ask re-constructing that node's whole subtree, so each subtree rebuilt once per ancestor: quadratic in file size (50s on pandas' `core/algorithms.py`). A second computation — the exact side door construction-is-correctness forbids.

The fix is the doctrine itself: construct each top-level statement **once**; every gap underneath self-reports through the reporter during that one construction. Linear. The frontier returned is the outermost unwritten segment per subtree — the honest frontier, since nothing behind an unwritten segment is reachable until it's written.

nodes.py (2,528 lines): **0.28s** where the quadratic walk took ~50s.

`sugar-source-tree`: **137 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reduce `audit_file_gaps` from a full tree walk to a single top-level statement pass
> Previously, `audit_file_gaps` in [tree_enumerate.py](https://github.com/TSavo/sugar/pull/5984/files#diff-1a883a4eea1b53f1ee91261df4ca5f694dfda233c883ddab24f920fd9610931e) walked every node in the tree via `sf.root.walk()` and called `sugar()` on each, resulting in quadratic work. It now iterates only over `sf.root.body` (top-level statements) and calls `sugar()` once per statement, relying on the reporter to witness gaps during construction. Deduplication by source identity (kind + span) is preserved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c773ed8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gap auditing during sugar construction to ensure missing sugar is detected across complete top-level statements.
  * Preserved existing handling for expected sugar-generation exceptions.
* **Performance**
  * Reduced redundant construction work by avoiding repeated processing of every individual node.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->