### PR TITLE
fix borrowed-helper crash: For's readers class-explicit (census-surfaced)

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1142,11 +1142,11 @@ class For(Statement):
         ):
             ints = []
             for arg in iterable.args:
-                v = self._concrete_int(arg)
+                v = For._concrete_int(self, arg)
                 if v is None:
                     return None
                 ints.append(v)
-            return [self._int_constant(i) for i in range(*ints)]
+            return [For._int_constant(self, i) for i in range(*ints)]
         return None
 
     def _concrete_int(self, arg: "Expression") -> "Optional[int]":

--- a/implementations/python/sugar-source-tree/tests/test_listcomp_dissolves.py
+++ b/implementations/python/sugar-source-tree/tests/test_listcomp_dissolves.py
@@ -61,4 +61,14 @@ if __name__ == "__main__":
     test_composes_with_len()
     test_filtered_comprehension_stays_loud()
     test_symbolic_comprehension_stays_loud()
+    test_comprehension_over_range_dissolves()
     print("ok: the concrete comprehension dissolves to its display")
+
+
+def test_comprehension_over_range_dissolves():
+    # [x + 1 for x in range(3)] -> array(1, 2, 3). Also the regression for the
+    # borrowed-helper crash: ListComp borrows For's readers, and every internal
+    # call must be class-explicit (an unbound self._helper AttributeError'd on
+    # real pandas code, arrow/accessors.py).
+    t = _out("def A():\n    return [x + 1 for x in range(3)]\n")
+    assert t.name == "array" and [a.value for a in t.args] == [1, 2, 3]


### PR DESCRIPTION
The pandas census surfaced a **crash escaping the door** (AttributeError, not a panic) on `arrow/accessors.py`: ListComp borrows `For._concrete_elements`, whose range arm still called bare `self._concrete_int`/`self._int_constant` — unresolvable when self isn't a For. Second instance of the bug class (While hit it first); every internal call in the borrowed readers is now `For.`-explicit.

Also unlocks comprehensions over range: `[x + 1 for x in range(3)]` → `array(1, 2, 3)` (pinned as regression). `accessors.py` audits clean (14 honest gaps, 0 crashes).

`sugar-source-tree`: **138 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `For.substitute` crash by using class-qualified helper calls for `range()` unrolling
> In [`nodes.py`](https://github.com/TSavo/sugar/pull/5985/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0), `self._concrete_int` and `self._int_constant` are replaced with `For._concrete_int(self, ...)` and `For._int_constant(self, ...)` inside `For.substitute`. This avoids an `AttributeError` that occurs when these helpers are accessed via instance lookup in borrowed contexts. A new test in [`test_listcomp_dissolves.py`](https://github.com/TSavo/sugar/pull/5985/files#diff-aa074e419b5cc81bd1a7479f8862c87dd2069256439bdacfefc6b473b9414d21) verifies that a list comprehension over `range(3)` dissolves correctly to `[1, 2, 3]`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4564c9a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->