### PR TITLE
instrument construction + the census as a committed tool

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
@@ -1,0 +1,101 @@
+"""The corpus census: construct every function once, rank the frontier.
+
+    python -m sugar_lift_py_tests.census <package-root> [--engine-log PATH]
+
+One construction per function; the reporter witnesses every gap DURING that
+construction (linear -- never a per-node re-ask). Per-file progress on stdout;
+the ranked gap-family table at the end. The engine log (configure_live_log) is
+the bisection instrument: every function construction enters a reduction_span,
+so the heartbeat names the exact function a slow lift is inside -- macro
+progress tells you THAT it is slow, the span log tells you WHERE to cut next.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+
+def census(root: Path) -> int:
+    from sugar_source_tree.panic import SugarNotWritten
+    from sugar_source_tree.reporter import CollectingReporter
+    from sugar_source_tree.tree import SourceFile
+
+    files = sorted(root.rglob("*.py"))
+    families: Counter = Counter()
+    crashes: Counter = Counter()
+    clean_files = 0
+    total_fns = 0
+    clean_fns = 0
+    t0 = time.time()
+    for i, f in enumerate(files):
+        ft = time.time()
+        rel = f.relative_to(root)
+        try:
+            reporter = CollectingReporter()
+            sf = SourceFile.from_path(str(f), reporter=reporter)
+            for fn in sf.functions():
+                total_fns += 1
+                try:
+                    fn.sugar()  # ONE construction; nested gaps self-report
+                    clean_fns += 1
+                except SugarNotWritten:
+                    pass
+            seen = set()
+            for node, _p in reporter.gaps:
+                lc = node.line_col_span()
+                key = (node.kind, lc.start_line, lc.start_col)
+                if key not in seen:
+                    seen.add(key)
+                    families[node.kind] += 1
+            if not reporter.gaps:
+                clean_files += 1
+            print(
+                f"[{i + 1}/{len(files)}] {time.time() - ft:5.1f}s "
+                f"gaps={len(reporter.gaps):5d} {rel}",
+                flush=True,
+            )
+        except Exception as e:  # a crash is a DEFECT row, never silence
+            crashes[type(e).__name__] += 1
+            print(
+                f"[{i + 1}/{len(files)}]  CRASH {type(e).__name__} {rel}",
+                flush=True,
+            )
+
+    print(
+        f"\n=== census: {len(files)} files ({clean_files} clean), "
+        f"{total_fns} functions ({clean_fns} construct clean), "
+        f"{time.time() - t0:.0f}s ===",
+        flush=True,
+    )
+    print("--- gap families (top 40, deduped by source site) ---")
+    for kind, n in families.most_common(40):
+        print(f"{n:8d}  {kind}")
+    print("--- crashes (defects, not gaps) ---")
+    for k, n in crashes.most_common():
+        print(f"{n:8d}  {k}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", type=Path, help="package root to census")
+    parser.add_argument(
+        "--engine-log",
+        default=None,
+        help="JSONL span/heartbeat sink (or set SUGAR_ENGINE_LOG)",
+    )
+    args = parser.parse_args()
+
+    from sugar_lift_py_tests.engine_log import configure_live_log
+
+    configure_live_log(args.engine_log)
+    sys.setrecursionlimit(100000)
+    return census(args.root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1099,9 +1099,9 @@ class For(Statement):
         purpose (a nested loop's own jumps also block): over-blocking falls to
         the symbolic branch (loud), never to a wrong unroll."""
         return any(
-            n.kind in ("Break", "Continue")
+            ("break" in stmt.segment() or "continue" in stmt.segment())
+            and any(n.kind in ("Break", "Continue") for n in stmt.walk())
             for stmt in self.body
-            for n in stmt.walk()
         )
 
     def _target_bindings_for(self, target: "Node", element: "Node") -> "Optional[dict]":

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1340,19 +1340,21 @@ class If(Statement):
         return self if not changed else rewrite(self, **changed)
 
     def _branch_bindings(self, statements, scope):
-        """The net bindings a branch leaves for the rest of ITS block, threaded
-        exactly as ``_substitute_body`` threads a block: each statement's
-        ``substitution_binding`` plus any nested walrus. Returns the map of names
-        this branch bound to their final substituted values."""
+        """The net bindings an ALREADY-SUBSTITUTED branch leaves for the rest of
+        its block. The statements were substituted (threaded) by
+        ``If.substitute``; re-substituting them here would redo every subtree
+        once per enclosing if -- 2^nesting, the second computation. So this only
+        READS: each statement's ``substitution_binding`` (whose values are the
+        already-threaded nodes) plus any nested walrus, threading the local map
+        so an AugAssign-style binding sees its predecessor."""
         local = dict(scope)
         touched: "dict[str, Node]" = {}
         for stmt in statements:
-            new_stmt = stmt.substitute(local)
-            binding = new_stmt.substitution_binding(local)
+            binding = stmt.substitution_binding(local)
             if binding:
                 local = {**local, **binding}
                 touched.update(binding)
-            for node in new_stmt.walk():
+            for node in stmt.walk():
                 if node.kind == "NamedExpr":
                     wb = node.substitution_binding(local)
                     if wb:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -715,19 +715,32 @@ class FunctionDef(Statement):
         it. A body statement whose sugar is not written yet raises
         SugarNotWritten from its own `.sugar()`, which propagates out here.
         """
+        from sugar_lift_py_tests.engine_log import reduction_span
         from sugar_lift_py_tests.sugar.function_universe_sugar import (
             FunctionUniverseSugar,
         )
 
-        # Substitute the body against an empty scope: formals are masked (they
-        # stay free -> symbolic), locals thread and inline, phis land as IfExps.
-        substituted = self.substitute({})
-        return FunctionUniverseSugar(
-            name=self.name,
-            formals=tuple(p.name for p in self.params),
-            statements=tuple(stmt.sugar() for stmt in substituted.body),
-            site=self.fragment,
-        )
+        # CONSTRUCTION IS THE INSTRUMENTED BOUNDARY: the span names this
+        # function while it substitutes+constructs, so the engine log's
+        # heartbeat testifies exactly which function a slow lift is inside --
+        # the bisection instrument (macro says nothing; the active frame says
+        # where to cut next). The factory had this on SugarBody.reduce; the
+        # tree construction path re-enters it here.
+        lc = self.line_col_span()
+        with reduction_span(
+            sugar="FunctionUniverse",
+            role="construction",
+            site=f"{self.unit.filename}:{lc.start_line} {self.name}",
+        ):
+            # Substitute the body against an empty scope: formals are masked
+            # (stay free -> symbolic), locals thread and inline, phis -> IfExps.
+            substituted = self.substitute({})
+            return FunctionUniverseSugar(
+                name=self.name,
+                formals=tuple(p.name for p in self.params),
+                statements=tuple(stmt.sugar() for stmt in substituted.body),
+                site=self.fragment,
+            )
 
 
 class AsyncFunctionDef(Statement):


### PR DESCRIPTION
Logging is the bisection instrument: boundary spans name the hot frame; the frame tells you where to cut next.

- `FunctionDef.sugar` enters `reduction_span` — the factory had this boundary on `SugarBody.reduce`; the tree migration dropped it, which is why 'what is it stuck on' was unanswerable from any log. Now the watchdog heartbeats the exact function a slow lift is inside, and every `SugarNotWritten` is logged as itself (full panic + site + elapsed_ms).
- `sugar_lift_py_tests/census.py`: the corpus census as a real module (`python -m sugar_lift_py_tests.census <root> [--engine-log PATH]`) — linear, reporter-witnessed, per-file progress, ranked families, crashes as defect rows. Replaces the ad-hoc /tmp scripts.

Also on this branch: the 2^nesting `_branch_bindings` fix and the byte-scan gates (walrus `:=`, break/continue).

`sugar-source-tree`: **138 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add census tool for one-pass sugar construction across a Python package
> - Adds a [`census`](https://github.com/TSavo/sugar/pull/5986/files#diff-33e0e08a2acade24345dc0b94e0f322c8825c67008eeb014b004a5d09f3f2669) CLI tool that walks a package root, attempts sugar construction for every function, and prints per-file progress with timing, gap counts, and a final summary of gap families and crashes.
> - Wraps `FunctionDef.sugar` construction in a reduction span (labeled with file, line, and function name) for engine log tracing.
> - Fixes `For._body_has_loop_control` to require both a textual match of `break`/`continue` and a corresponding AST node, preventing false positives.
> - Removes redundant substitution passes in `If._branch_bindings`, which now reads already-substituted statements directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 148ef65.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->