### PR TITLE
the unroll budget: past 128, the fold/universal stands

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -985,6 +985,8 @@ class For(Statement):
             and not self._body_has_loop_control()
         )
         elements = self._concrete_elements(subst_iter) if concrete else None
+        if elements is not None and len(elements) > self._UNROLL_FUEL:
+            elements = None  # past the unroll budget: the fold/universal stands
         if elements is not None:
             bindings = [self._target_bindings(e) for e in elements]
             if all(b is not None for b in bindings):
@@ -1161,6 +1163,13 @@ class For(Statement):
             for stmt in self.body
         )
 
+    # The unroll budget. A concrete loop within it dissolves to its unroll; past
+    # it, the SYMBOLIC form (universal / fold coordinate) stands -- not merely
+    # cheaper: 1,100 iterations of a carried update is a fold, and unrolling it
+    # grows a term chain quadratically. Small on purpose; proofs want small
+    # unrolls.
+    _UNROLL_FUEL = 128
+
     def _target_bindings_for(self, target: "Node", element: "Node") -> "Optional[dict]":
         """`_target_bindings` for an explicit target (shared with comprehensions)."""
         if target.kind == "Name":
@@ -1278,7 +1287,7 @@ class While(Statement):
     # branch, which is loud) -- `while True:` lands there honestly rather than
     # spinning substitute forever. Not a semantic limit: a real concrete loop
     # that long is beyond what an unroll should dissolve anyway.
-    _FUEL = 1000
+    _FUEL = 128  # the shared unroll budget (see For._UNROLL_FUEL)
 
     def substitute(self, scope):
         """`while <test>: <body>` -- the unbounded loop, and over CONCRETE state


### PR DESCRIPTION
The heartbeat named it live: a faithful 1,100-iteration concrete unroll with a carried `d += 3*sec` growing a quadratic term chain. Past the budget the symbolic form is not merely cheaper — 1,100 iterations of a carried update **is** a fold. For and While share the budget (128).

`sugar-source-tree`: 138 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cap unroll budget at 128 iterations for `For` and `While` loops
> - Sets a shared unroll budget of 128 iterations: `For._UNROLL_FUEL = 128` and `While._FUEL` reduced from 1000 to 128.
> - `For.substitute` now checks the element count against `_UNROLL_FUEL`; loops exceeding the limit are treated as symbolic `For` nodes instead of being unrolled.
> - Behavioral Change: concrete `For` loops with >128 iterations and `While` loops that previously ran up to 1000 steps will no longer be fully unrolled, falling back to symbolic nodes earlier.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a802287.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->