### PR TITLE
constraint drain: the attribute callee -- 61% of the pandas frontier

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
@@ -1,0 +1,77 @@
+"""A method call `<receiver>.<name>(<args>)` -- the attribute callee.
+
+The pandas census's largest family (15,638 sites, 61% of the frontier), and it
+is a COMPOSITION, not a new mechanism: the receiver reduces like any value (the
+`py.getattr` discipline), and the call stands as the method coordinate
+`call:<name>(receiver, args)` with `symbol_kind="method-coordinate"` -- the same
+vocabulary `__format__`/`__getitem__` already use. The receiver rides as
+`runtime_dispatch_receiver` on the CallSiteValue: the field that exists for
+exactly this ("the receiver whose runtime type selects a method body"), so a
+future type-aware dig can resolve the body; today the coordinate is honest EUF,
+decidable where an equality consumes it.
+
+Keyword arguments stay loud (the tree node guards them), as on plain calls.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_pair
+
+
+@dataclass(frozen=True)
+class MethodCallSugar(Sugar):
+    receiver: Sugar
+    name: str
+    args: tuple  # the argument sugars, in source order
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        # int.bit_length is a real method with a decidable shape: the pair rides
+        # the coordinate's identity against a contradicting asserted value.
+        prefix = "def A(z):\n    return z.bit_length()\n\n"
+        return _call_pair(
+            name="method_call_return",
+            owner_sugar="MethodCallSugar",
+            truthful=prefix + "def test_a():\n    assert A(5) == 3\n",
+            lying=prefix + "def test_a():\n    assert A(5) == 4\n",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        return self.receiver.desugar(ctx).and_then(
+            lambda receiver: self._collect(receiver, self.args, (), ctx)
+        )
+
+    def _collect(self, receiver, remaining: tuple, accumulated: tuple, ctx) -> Outcome:
+        if remaining:
+            head, *rest = remaining
+            return head.desugar(ctx).and_then(
+                lambda value: self._collect(
+                    receiver, tuple(rest), accumulated + (value,), ctx
+                )
+            )
+        from sugar_lift_py_tests.floor import CallSiteValue
+        from sugar_lift_py_tests.ir import ctor
+
+        owner = str(self.site)
+        term = ctor(
+            f"call:{self.name}",
+            [receiver.to_term(owner=owner)]
+            + [value.to_term(owner=owner) for value in accumulated],
+            symbol_kind="method-coordinate",
+        )
+        return Complete(
+            CallSiteValue(
+                target_name=self.name,
+                arg_values=(receiver, *accumulated),
+                parameters=(),
+                term=term,
+                body=None,  # the dig is CUED, not inlined here
+                site=self.site,
+                runtime_dispatch_receiver=receiver,
+            )
+        )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2209,20 +2209,32 @@ class Call(Expression):
         return None
 
     def sugar(self):
-        """`<name>(<args>)` constructs CallSiteSugar WITH the argument sugars.
-        The result is a call-site coordinate -- the DIG CUE the enclosing assert
-        carries into its InvValue. Plain positional calls to a NAMED callee
-        only; method/attribute/computed callees and keyword arguments stay loud
-        gaps until their own sugars are written."""
-        if not isinstance(self.func, Name) or self.keywords:
+        """A call constructs its callee's sugar WITH the argument sugars.
+        `<name>(<args>)` -> CallSiteSugar, the call-site coordinate (THE DIG
+        CUE). `<receiver>.<name>(<args>)` -> MethodCallSugar, the method
+        coordinate `call:<name>(receiver, args)` with the receiver riding as
+        runtime_dispatch_receiver. Computed callees (`fs[i](x)`, lambdas called
+        inline) and keyword arguments stay loud gaps until written."""
+        if self.keywords:
             return super().sugar()
-        from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+        if isinstance(self.func, Name):
+            from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
 
-        return CallSiteSugar(
-            target_name=self.func.id,
-            args=tuple(a.sugar() for a in self.args),
-            site=self.fragment,
-        )
+            return CallSiteSugar(
+                target_name=self.func.id,
+                args=tuple(a.sugar() for a in self.args),
+                site=self.fragment,
+            )
+        if isinstance(self.func, Attribute):
+            from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
+
+            return MethodCallSugar(
+                receiver=self.func.value.sugar(),
+                name=self.func.attr,
+                args=tuple(a.sugar() for a in self.args),
+                site=self.fragment,
+            )
+        return super().sugar()  # computed callee -- not written
 
 
 class FormattedValue(Expression):

--- a/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
@@ -1,0 +1,63 @@
+"""The attribute callee: `<receiver>.<name>(<args>)` -- the census's largest
+family (61%). A composition: receiver reduces like any value; the call stands as
+the method coordinate `call:<name>(receiver, args)`; chains compose; the
+receiver rides as runtime_dispatch_receiver for a future type-aware dig."""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _out(src):
+    return _fn(src).sugar().desugar().value.post().args[1]
+
+
+def test_method_call_is_the_method_coordinate():
+    t = _out("def A(z):\n    return z.bit_length()\n")
+    assert t.name == "call:bit_length"
+    assert t.args[0].name == "z"  # the receiver is the first coordinate operand
+
+
+def test_method_chains_compose():
+    # z.get(k).strip() -> call:strip(call:get(z, k))
+    t = _out("def A(z, k):\n    return z.get(k).strip()\n")
+    assert t.name == "call:strip"
+    inner = t.args[0]
+    assert inner.name == "call:get"
+    assert inner.args[0].name == "z" and inner.args[1].name == "k"
+
+
+def test_assert_consumes_the_coordinate():
+    inv = _fn("def A(s):\n    assert s.upper() == s\n    return s\n").sugar().desugar().value.invs()[0]
+    assert inv.name == "py.eq"
+    assert inv.args[0].name == "call:upper"
+
+
+def test_keyword_args_stay_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(z):\n    return z.get(1, default=2)\n").sugar()
+
+
+def test_computed_callee_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(fs, x):\n    return fs[0](x)\n").sugar()
+
+
+if __name__ == "__main__":
+    test_method_call_is_the_method_coordinate()
+    test_method_chains_compose()
+    test_assert_consumes_the_coordinate()
+    test_keyword_args_stay_loud()
+    test_computed_callee_stays_loud()
+    print("ok: method calls -- coordinate, chains, assert; kwargs/computed loud")


### PR DESCRIPTION
`<receiver>.<name>(<args>)` was the census's largest family (15,638 sites, 61%). A **composition**: the receiver reduces like any value; the call stands as the method coordinate `call:<name>(receiver, args...)` (`method-coordinate`, the vocabulary `__format__`/`__getitem__` already use). The receiver rides as `runtime_dispatch_receiver` for a future type-aware dig; today the coordinate is honest EUF.

`z.bit_length()` → `call:bit_length(z)`; chains compose: `z.get(k).strip()` → `call:strip(call:get(z, k))`; `assert s.upper() == s` consumes it. Kwargs/computed callees stay loud.

`sugar-source-tree`: **143 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MethodCallSugar` to desugar attribute-based method calls to method-coordinate terms
> - Adds `MethodCallSugar` in [method_call_sugar.py](https://github.com/TSavo/sugar/pull/5990/files#diff-1a6a1e058898693a04db89a8dda185ad15e19277c08fb04e58876c1736c68088), which desugars attribute calls (e.g. `z.bit_length()`) into a `CallSiteValue` whose term is a `call:<name>` method-coordinate with the receiver as the first operand and `runtime_dispatch_receiver` set.
> - Extends `Call.sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/5990/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to branch on callee type: `Name` callees produce `CallSiteSugar`, `Attribute` callees produce `MethodCallSugar`, and calls with keywords or computed callees defer to `SugarNotWritten`.
> - Adds tests in [test_method_call_sugar.py](https://github.com/TSavo/sugar/pull/5990/files#diff-4d5ad4986ba168ced864ccd6ff8210b1f530e17745edc68f392cdc75c2b8dd93) covering method-coordinate naming, chained calls, assertion consumption, keyword args, and computed callees.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07fa7cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->