### PR TITLE
constraint drain: expression statements are inert

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/expr_statement_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/expr_statement_sugar.py
@@ -1,0 +1,39 @@
+"""An expression in statement position -- `<expr>` on its own line.
+
+The census's #2 family, and mostly docstrings. A bare expression STATES no
+fact: its value reduces (the recursion -- a docstring to its string, a method
+call to its coordinate) and then contributes nothing to the record. What DOES
+ride is an effect: an Incomplete outcome propagates itself through and_then, so
+`raise`-bearing or unresolvable expressions stay red testimony, never dropped.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import inert_statement_return_witness
+
+
+@dataclass(frozen=True)
+class ExprStatementSugar(Sugar):
+    value: Sugar
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return inert_statement_return_witness(
+            name="expr_statement_inert",
+            owner_sugar="ExprStatementSugar",
+            statement='"""a docstring"""',
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+
+        # Reduce the value (effects propagate via and_then); a completed value
+        # in statement position states nothing -- inert contribution.
+        return self.value.desugar(ctx).and_then(
+            lambda _value: Complete(BlockValue((), can_fall_through=True))
+        )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1653,6 +1653,15 @@ class Expr(Statement):
         """Binds nothing: recurse into children and reassemble."""
         return self._substitute_children(scope)
 
+    def sugar(self):
+        """`<expr>` as a statement constructs ExprStatementSugar WITH the
+        value's sugar. States nothing; an effect in the value rides."""
+        from sugar_lift_py_tests.sugar.expr_statement_sugar import (
+            ExprStatementSugar,
+        )
+
+        return ExprStatementSugar(value=self.value.sugar(), site=self.fragment)
+
 
 class Pass(Statement):
     pass

--- a/implementations/python/sugar-source-tree/tests/test_expr_statement.py
+++ b/implementations/python/sugar-source-tree/tests/test_expr_statement.py
@@ -1,0 +1,30 @@
+"""`<expr>` in statement position states nothing; effects ride."""
+
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _val(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).sugar().desugar().value
+
+
+def test_docstring_and_bare_call_are_inert():
+    v = _val('def A(z):\n    """doc."""\n    z.validate()\n    return z\n')
+    assert v.invs() == ()
+    assert v.post().args[1].name == "z"  # the function lifts through them
+
+
+def test_bare_int_is_inert():
+    v = _val("def A(z):\n    42\n    return z\n")
+    assert v.invs() == () and v.post().args[1].name == "z"
+
+
+if __name__ == "__main__":
+    test_docstring_and_bare_call_are_inert()
+    test_bare_int_is_inert()
+    print("ok: expression statements inert; effects ride")


### PR DESCRIPTION
The census's #2 family (6,626 — mostly docstrings). A bare expression states no fact: the value reduces and contributes nothing; an `Incomplete` propagates itself via `and_then`, so effect-bearing expressions stay red testimony. `sugar-source-tree`: **145 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make expression statements inert during constraint drain desugaring
> - Adds `ExprStatementSugar` in [expr_statement_sugar.py](https://github.com/TSavo/sugar/pull/5991/files#diff-f31e170a6e37295ad5e3460626d1a509629d633d94a364bbf01ebf6938b97737), a new `Sugar` type for expression statements in statement position.
> - Desugaring reduces the inner expression value and discards it, returning an empty `BlockValue` with `can_fall_through=True`, meaning expression statements contribute no output and are otherwise inert.
> - Hooks `Expr.sugar()` in [nodes.py](https://github.com/TSavo/sugar/pull/5991/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to produce `ExprStatementSugar` wrapping the sugared inner value.
> - Adds tests in [test_expr_statement.py](https://github.com/TSavo/sugar/pull/5991/files#diff-7c0684cd2bfcce730298e9f62538fd9a2b66676c032a3282b51a5c93c2ba9083) covering docstrings, bare calls, and bare integers as inert expression statements.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c52b766.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->