### PR TITLE
fleet batch 1: six census families drained by parallel workers

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -45,6 +45,9 @@ from .list_value import ListValue
 from .loop_control_value import LoopControlValue
 from .loop_else_value import LoopElseValue
 from .inv_value import InvValue
+from .bytes_value import BytesValue
+from .complex_value import ComplexValue
+from .ellipsis_value import EllipsisValue
 from .none_value import NoneValue
 from .object_field import ObjectField
 from .object_method_value import ObjectMethodValue
@@ -174,6 +177,9 @@ __all__ = [
     "LoopControlValue",
     "LoopElseValue",
     "InvValue",
+    "BytesValue",
+    "ComplexValue",
+    "EllipsisValue",
     "NoneValue",
     "ObjectField",
     "ObjectMethodValue",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bytes_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bytes_value.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class BytesValue(FloorValue):
+    """The floor for a Python `bytes` literal. Carries the raw bytes; stands as
+    the vendor-canonical ``python:bytes(<hex String const>)`` ctor already
+    consumed by the SMT emitter (``literal_encoding.rs``: "python:bytes(<String
+    const>) is the Python kit's ASCII-gated bytes literal"), the verifier's
+    structural ground-ctor whitelist (``consistency.rs``), and the isinstance
+    fold table (``symbolic_value.py``: ``"python:bytes": "bytes"``). This is
+    the ONE representation -- never a second bytes encoding."""
+
+    value: bytes
+
+    def python_isinstance(self, type_name: str, type_term, site):
+        del type_term
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        return Complete(
+            TrueBoolLiteralSugar(site=site)
+            if type_name == "bytes"
+            else FalseBoolLiteralSugar(site=site)
+        )
+
+    def equals(self, other, site):
+        if type(other) is BytesValue:
+            from sugar_lift_py_tests.outcome import Complete
+            from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+                FalseBoolLiteralSugar,
+            )
+            from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+                TrueBoolLiteralSugar,
+            )
+
+            return Complete(
+                TrueBoolLiteralSugar(site=site)
+                if self.value == other.value
+                else FalseBoolLiteralSugar(site=site)
+            )
+        return super().equals(other, site)
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor("python:bytes", [str_const(self.value.hex())])

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class ComplexValue(FloorValue):
+    """The floor for a Python `complex` literal. Carries the real/imaginary
+    parts (both Python floats). Stands as the vendor-canonical
+    ``py.complex(<real>, <imag>)`` ctor: already in the verifier's structural
+    ground-ctor whitelist (``consistency.rs`` #4398 -- "py.complex is a data
+    value, dual complex literals refuse"), the kit's own ground-ctor list
+    (``call_site_value.py._GROUND_DATA_CTOR_NAMES``), and the isinstance fold
+    table (``symbolic_value.py``: ``"py.complex": "complex"``). This is the
+    ONE representation -- never a second complex encoding."""
+
+    real: float
+    imag: float
+
+    def python_isinstance(self, type_name: str, type_term, site):
+        del type_term
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        return Complete(
+            TrueBoolLiteralSugar(site=site)
+            if type_name == "complex"
+            else FalseBoolLiteralSugar(site=site)
+        )
+
+    def equals(self, other, site):
+        if type(other) is ComplexValue:
+            from sugar_lift_py_tests.outcome import Complete
+            from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+                FalseBoolLiteralSugar,
+            )
+            from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+                TrueBoolLiteralSugar,
+            )
+
+            matches = self.real == other.real and self.imag == other.imag
+            return Complete(
+                TrueBoolLiteralSugar(site=site)
+                if matches
+                else FalseBoolLiteralSugar(site=site)
+            )
+        return super().equals(other, site)
+
+    def to_term(self, *, owner: str):
+        del owner
+        from decimal import Decimal
+
+        from sugar_lift_py_tests.ir import ctor, real_lit
+
+        # Same canonical-decimal-string discipline as TermValue.to_term: never
+        # hash a Python float's non-deterministic text form into the CID.
+        real_term = real_lit(format(Decimal(str(self.real)), "f"))
+        imag_term = real_lit(format(Decimal(str(self.imag)), "f"))
+        return ctor("py.complex", [real_term, imag_term])

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ellipsis_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ellipsis_value.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class EllipsisValue(FloorValue):
+    """The floor for the `...` literal. No fields -- the Ellipsis-ness IS the
+    type, mirroring NoneValue. Stands as the vendor-canonical ``py.ellipsis``
+    ctor: already in the verifier's structural ground-ctor whitelist
+    (``consistency.rs`` #4387/#4398 residue), the kit's own ground-ctor list
+    (``call_site_value.py._GROUND_DATA_CTOR_NAMES``), and the isinstance fold
+    table (``symbolic_value.py``: ``"py.ellipsis": "ellipsis"``)."""
+
+    def python_isinstance(self, type_name: str, type_term, site):
+        del type_term
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        return Complete(
+            TrueBoolLiteralSugar(site=site)
+            if type_name == "ellipsis"
+            else FalseBoolLiteralSugar(site=site)
+        )
+
+    def truth(self, site):
+        # Ellipsis is truthy in Python (bool(...) is True) -- unlike None.
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        return Complete(TrueBoolLiteralSugar(site=site))
+
+    def equals(self, other, site):
+        if type(other) is EllipsisValue:
+            from sugar_lift_py_tests.outcome import Complete
+            from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+                TrueBoolLiteralSugar,
+            )
+
+            return Complete(TrueBoolLiteralSugar(site=site))
+        return super().equals(other, site)
+
+    def is_identical(self, other, site):
+        # Ellipsis is a singleton: `... is ...` folds True.
+        if type(other) is EllipsisValue:
+            from sugar_lift_py_tests.outcome import Complete
+            from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+                TrueBoolLiteralSugar,
+            )
+
+            return Complete(TrueBoolLiteralSugar(site=site))
+        return super().is_identical(other, site)
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor
+
+        return ctor("py.ellipsis", [])

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
@@ -45,3 +45,40 @@ class AssignSugar(Sugar):
         from sugar_lift_py_tests.floor.block_value import BlockValue
 
         return Complete(BlockValue((), can_fall_through=True))
+
+
+@dataclass(frozen=True)
+class MultiAssignSugar(Sugar):
+    """More than one name bound by a single Assign statement -- either a
+    destructured display (`a, b = <tuple/list display>`) or a chained
+    assignment (`x = y = e`). Just like AssignSugar, substitute has already
+    threaded every binding into the rest of the block by the time this sugar
+    reduces: an assignment states no fact of its own, so this too is inert
+    meaning. `bindings` holds each bound name with its own rhs sugar --
+    provenance only, never re-stated.
+
+    Meaning-only, node-constructed: no owns/new/role. Only shapes the tree
+    node has already proven destructure (or chain) reach here; anything else
+    stays a loud gap on the node.
+    """
+
+    bindings: tuple  # tuple of (name, value_sugar) pairs, in target order
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        # A destructuring bind that discriminates ON THE PAIRING: swap the
+        # two names' rhs and the sum through both flips.
+        prefix = "def A(p, q):\n    a, b = p, q\n    return a + b\n\n"
+        return _call_pair(
+            name="multi_assign_destructure",
+            owner_sugar="MultiAssignSugar",
+            truthful=prefix + "def test_a():\n    assert A(2, 3) == 5\n",
+            lying=prefix + "def test_a():\n    assert A(2, 3) == 6\n",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        # Inert: every binding was consumed by substitute. Contribute nothing.
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+
+        return Complete(BlockValue((), can_fall_through=True))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bytes_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bytes_literal_sugar.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.floor.bytes_value import BytesValue
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
+
+
+@dataclass(frozen=True)
+class BytesLiteralSugar(Sugar):
+    """A `bytes` literal (`b"..."`). A leaf: it holds its value and no child
+    sugars, and it desugars to the BytesValue floor -- which stands as the
+    vendor-canonical ``python:bytes(<hex String const>)`` term already
+    consumed downstream (SMT emitter, verifier structural ground-ctor
+    whitelist, isinstance fold table)."""
+
+    value: bytes
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return _call_return_pair(
+            name="bytes_literal_return",
+            owner_sugar="BytesLiteralSugar",
+            body='b"ab"',
+            truthful='b"ab"',
+            lying='b"ac"',
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx  # the bytes stand as a floor value
+        return Complete(BytesValue(self.value))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -30,6 +30,7 @@ class CallSiteSugar(Sugar):
     target_name: str
     args: tuple  # the argument sugars, in source order
     site: object = dataclass_field(compare=False)
+    keywords: tuple = ()  # (name, sugar) pairs, in source order
 
     @classmethod
     def witnesses(cls):
@@ -55,12 +56,29 @@ class CallSiteSugar(Sugar):
                     tuple(rest), accumulated + (value,), ctx
                 )
             )
-        from sugar_lift_py_tests.floor import CallSiteValue
-        from sugar_lift_py_tests.ir import ctor
+        return self._collect_kwargs(self.keywords, (), accumulated, ctx)
 
+    def _collect_kwargs(
+        self, remaining: tuple, kw_values: tuple, positional: tuple, ctx: object
+    ) -> Outcome:
+        if remaining:
+            (name, sugar), *rest = remaining
+            return sugar.desugar(ctx).and_then(
+                lambda value: self._collect_kwargs(
+                    tuple(rest), kw_values + ((name, value),), positional, ctx
+                )
+            )
+        from sugar_lift_py_tests.floor import CallSiteValue
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        owner = str(self.site)
+        kwarg_terms = [
+            ctor("py.kwarg", [str_const(name), value.to_term(owner=owner)])
+            for name, value in kw_values
+        ]
         term = ctor(
             f"call:{self.target_name}",
-            [value.to_term(owner=str(self.site)) for value in accumulated],
+            [value.to_term(owner=owner) for value in positional] + kwarg_terms,
             symbol_kind=(
                 "builtin"
                 if hasattr(builtins, self.target_name)
@@ -70,7 +88,7 @@ class CallSiteSugar(Sugar):
         return Complete(
             CallSiteValue(
                 target_name=self.target_name,
-                arg_values=accumulated,
+                arg_values=positional + tuple(value for _, value in kw_values),
                 parameters=(),
                 term=term,
                 body=None,  # the dig is CUED, not inlined here

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/complex_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/complex_literal_sugar.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.floor.complex_value import ComplexValue
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
+
+
+@dataclass(frozen=True)
+class ComplexLiteralSugar(Sugar):
+    """A `complex` literal (e.g. `2j`). A leaf: it holds its real/imaginary
+    parts and no child sugars, and it desugars to the ComplexValue floor --
+    which stands as the vendor-canonical ``py.complex(<real>, <imag>)`` term
+    already consumed downstream (verifier structural ground-ctor whitelist
+    #4398, isinstance fold table)."""
+
+    real: float
+    imag: float
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return _call_return_pair(
+            name="complex_literal_return",
+            owner_sugar="ComplexLiteralSugar",
+            body="2j",
+            truthful="2j",
+            lying="3j",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx  # the complex value stands as a floor value
+        return Complete(ComplexValue(self.real, self.imag))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/computed_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/computed_call_sugar.py
@@ -1,0 +1,75 @@
+"""A computed callee call `<callee>(<args>)` -- the callee is an expression,
+not a bare name or attribute (`fs[0](x)`, `d["k"](x)`). A COMPOSITION, not a
+new mechanism: the callee reduces like any value (whatever sugar its own node
+built -- SubscriptSugar for `fs[0]`, and so on), and the call stands as the
+coordinate `py.call(callee, args)` with `symbol_kind="coordinate"`. There is no
+receiver whose runtime type selects a method body here (the callee itself IS
+the thing being invoked), so no `runtime_dispatch_receiver` rides this value --
+unlike MethodCallSugar's attribute-callee case.
+
+A callee whose own node has no `.sugar()` (a Lambda called inline, for example)
+stays loud through the ordinary recursion: this sugar never masks that gap.
+
+Keyword arguments stay loud (the tree node guards them), as on plain calls.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_pair
+
+
+@dataclass(frozen=True)
+class ComputedCallSugar(Sugar):
+    callee: Sugar
+    args: tuple  # the argument sugars, in source order
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        # fs[0] is a real computed callee with a decidable shape: the
+        # coordinate's identity against a contradicting asserted value.
+        prefix = "def A(fs, x):\n    return fs[0](x)\n\n"
+        return _call_pair(
+            name="computed_call_return",
+            owner_sugar="ComputedCallSugar",
+            truthful=prefix + "def test_a():\n    assert A([lambda z: z], 5) == 5\n",
+            lying=prefix + "def test_a():\n    assert A([lambda z: z], 5) == 6\n",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        return self.callee.desugar(ctx).and_then(
+            lambda callee: self._collect(callee, self.args, (), ctx)
+        )
+
+    def _collect(self, callee, remaining: tuple, accumulated: tuple, ctx) -> Outcome:
+        if remaining:
+            head, *rest = remaining
+            return head.desugar(ctx).and_then(
+                lambda value: self._collect(
+                    callee, tuple(rest), accumulated + (value,), ctx
+                )
+            )
+        from sugar_lift_py_tests.floor import CallSiteValue
+        from sugar_lift_py_tests.ir import ctor
+
+        owner = str(self.site)
+        term = ctor(
+            "py.call",
+            [callee.to_term(owner=owner)]
+            + [value.to_term(owner=owner) for value in accumulated],
+            symbol_kind="coordinate",
+        )
+        return Complete(
+            CallSiteValue(
+                target_name="py.call",
+                arg_values=(callee, *accumulated),
+                parameters=(),
+                term=term,
+                body=None,  # the dig is CUED, not inlined here
+                site=self.site,
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/ellipsis_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/ellipsis_literal_sugar.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.floor.ellipsis_value import EllipsisValue
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_pair
+
+
+@dataclass(frozen=True)
+class EllipsisLiteralSugar(Sugar):
+    """The `...` (Ellipsis) literal. A leaf: it stands as the EllipsisValue
+    floor -- the Ellipsis-ness IS the type, there is no value to carry.
+    Mirrors NoneLiteralSugar's shape exactly."""
+
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        prefix = (
+            "def A(z):\n"
+            "    if z is ...:\n"
+            "        return 0\n"
+            "    return z\n\n"
+        )
+        return _call_pair(
+            name="ellipsis_is_return",
+            owner_sugar="EllipsisLiteralSugar",
+            truthful=prefix + "def test_a():\n    assert A(5) == 5\n",
+            lying=prefix + "def test_a():\n    assert A(5) == 0\n",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        return Complete(EllipsisValue())

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
@@ -28,6 +28,7 @@ class MethodCallSugar(Sugar):
     name: str
     args: tuple  # the argument sugars, in source order
     site: object = dataclass_field(compare=False)
+    keywords: tuple = ()  # (name, sugar) pairs, in source order
 
     @classmethod
     def witnesses(cls):
@@ -54,20 +55,37 @@ class MethodCallSugar(Sugar):
                     receiver, tuple(rest), accumulated + (value,), ctx
                 )
             )
+        return self._collect_kwargs(receiver, self.keywords, (), accumulated, ctx)
+
+    def _collect_kwargs(
+        self, receiver, remaining: tuple, kw_values: tuple, positional: tuple, ctx
+    ) -> Outcome:
+        if remaining:
+            (name, sugar), *rest = remaining
+            return sugar.desugar(ctx).and_then(
+                lambda value: self._collect_kwargs(
+                    receiver, tuple(rest), kw_values + ((name, value),), positional, ctx
+                )
+            )
         from sugar_lift_py_tests.floor import CallSiteValue
-        from sugar_lift_py_tests.ir import ctor
+        from sugar_lift_py_tests.ir import ctor, str_const
 
         owner = str(self.site)
+        kwarg_terms = [
+            ctor("py.kwarg", [str_const(name), value.to_term(owner=owner)])
+            for name, value in kw_values
+        ]
         term = ctor(
             f"call:{self.name}",
             [receiver.to_term(owner=owner)]
-            + [value.to_term(owner=owner) for value in accumulated],
+            + [value.to_term(owner=owner) for value in positional]
+            + kwarg_terms,
             symbol_kind="method-coordinate",
         )
         return Complete(
             CallSiteValue(
                 target_name=self.name,
-                arg_values=(receiver, *accumulated),
+                arg_values=(receiver, *positional, *(v for _, v in kw_values)),
                 parameters=(),
                 term=term,
                 body=None,  # the dig is CUED, not inlined here

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1615,6 +1615,16 @@ class Import(Statement):
         """Binds nothing, no hole: substitutes to itself."""
         return self
 
+    def sugar(self):
+        """`import <module>` binds a module name that stays a FREE SYMBOLIC
+        in the meaning layer: nothing about the import itself is stated as
+        a fact. A later `pd.concat(...)` reduces as a method coordinate on
+        the free name `pd` -- correct without the import ever having stated
+        anything. So the import contributes an honestly empty record."""
+        from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+
+        return InertSugar(site=self.fragment)
+
 
 class ImportFrom(Statement):
     module: Optional[str]
@@ -1626,6 +1636,15 @@ class ImportFrom(Statement):
         """Binds nothing, no hole: substitutes to itself."""
         return self
 
+    def sugar(self):
+        """`from <module> import <names>` binds free symbolics the same way
+        plain `import` does: the bound names stay FREE SYMBOLIC in the
+        meaning layer, reduced only where a later expression uses them as a
+        coordinate. The import statement itself states nothing."""
+        from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+
+        return InertSugar(site=self.fragment)
+
 
 class Global(Statement):
     names: Tuple[str, ...]
@@ -1634,6 +1653,16 @@ class Global(Statement):
         """Binds nothing, no hole: substitutes to itself."""
         return self
 
+    def sugar(self):
+        """`global <names>` is a scope DECLARATION, not a fact: it tells
+        substitute which enclosing binding a name resolves against. That
+        binding semantics lives entirely in substitute (see above) -- by
+        the time sugar/meaning runs, the declaration itself has nothing
+        left to state."""
+        from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+
+        return InertSugar(site=self.fragment)
+
 
 class Nonlocal(Statement):
     names: Tuple[str, ...]
@@ -1641,6 +1670,15 @@ class Nonlocal(Statement):
     def substitute(self, scope):
         """Binds nothing, no hole: substitutes to itself."""
         return self
+
+    def sugar(self):
+        """`nonlocal <names>` is a scope DECLARATION like `global`: it
+        routes a name to an enclosing function scope during substitute.
+        Once substitute has resolved the binding, the declaration carries
+        no further meaning-layer content of its own."""
+        from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+
+        return InertSugar(site=self.fragment)
 
 
 class Expr(Statement):
@@ -1669,6 +1707,14 @@ class Pass(Statement):
     def substitute(self, scope):
         """Binds nothing, no hole: substitutes to itself."""
         return self
+
+    def sugar(self):
+        """`pass` states nothing by definition: it is the syntax for an
+        intentionally empty statement body. Its sugar is the honestly
+        empty record, not a placeholder awaiting content."""
+        from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+
+        return InertSugar(site=self.fragment)
 
 
 class Break(Statement):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2470,7 +2470,25 @@ class Constant(Expression):
             )
 
             return StringLiteralSugar(value=v, site=self.fragment)
-        return super().sugar()  # bool / bytes / ... not yet written
+        if type(v) is bytes:
+            from sugar_lift_py_tests.sugar.bytes_literal_sugar import (
+                BytesLiteralSugar,
+            )
+
+            return BytesLiteralSugar(value=v, site=self.fragment)
+        if v is Ellipsis:
+            from sugar_lift_py_tests.sugar.ellipsis_literal_sugar import (
+                EllipsisLiteralSugar,
+            )
+
+            return EllipsisLiteralSugar(site=self.fragment)
+        if type(v) is complex:
+            from sugar_lift_py_tests.sugar.complex_literal_sugar import (
+                ComplexLiteralSugar,
+            )
+
+            return ComplexLiteralSugar(real=v.real, imag=v.imag, site=self.fragment)
+        return super().sugar()  # every literal kind is now converted
 
 
 class Attribute(Expression):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -951,6 +951,22 @@ class AugAssign(Statement):
         old = scope.get(name, self.target)
         return {name: self._make_binop(old, self.op, self.value)}
 
+    def sugar(self):
+        """`<target> OP= <value>` -- a plain Name target is INERT at the
+        meaning layer: substitution_binding ALWAYS threads for a Name target
+        (it falls back to the target itself as the old value when nothing was
+        bound yet, so there is no shape where a Name target both fails to
+        thread and stays loud). The rebind rode into the tail as the fold
+        binding; the statement itself states nothing more. Attribute/subscript
+        targets are the shapes substitution_binding refuses (returns None --
+        they are never threaded), so they stay loud gaps here too, mirrored
+        exactly against that same isinstance check."""
+        if not isinstance(self.target, Name):
+            return super().sugar()
+        from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+
+        return InertSugar(site=self.fragment)
+
 
 class AnnAssign(Statement):
     target: Expression
@@ -976,6 +992,25 @@ class AnnAssign(Statement):
         if self.value is not None and isinstance(self.target, Name):
             return {self.target.id: self.value}
         return None
+
+    def sugar(self):
+        """`<target>: <annotation> [= <value>]` -- a plain Name target is
+        INERT at the meaning layer. If there is a value, its binding already
+        threaded via substitution_binding, exactly as a plain Assign's does;
+        the rebind rode into the tail and this node contributes nothing more.
+        If there is no value, it is a bare declaration: no bytecode runs, no
+        binding is introduced, nothing happens at runtime at all.
+
+        The annotation itself is NEVER a fact the meaning layer states either
+        way: Python does not check it at runtime (no TypeError on mismatch),
+        so an annotation asserts nothing -- it is documentation the tree
+        passes through, never a stated post. Non-Name targets (attribute,
+        subscript) stay loud gaps -- no partial binding, no partial sugar."""
+        if not isinstance(self.target, Name):
+            return super().sugar()
+        from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+
+        return InertSugar(site=self.fragment)
 
 
 class TypeAlias(Statement):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2222,8 +2222,12 @@ class Call(Expression):
         `<name>(<args>)` -> CallSiteSugar, the call-site coordinate (THE DIG
         CUE). `<receiver>.<name>(<args>)` -> MethodCallSugar, the method
         coordinate `call:<name>(receiver, args)` with the receiver riding as
-        runtime_dispatch_receiver. Computed callees (`fs[i](x)`, lambdas called
-        inline) and keyword arguments stay loud gaps until written."""
+        runtime_dispatch_receiver. Any other callee expression (`fs[i](x)`,
+        `d["k"](x)`) -> ComputedCallSugar, the `py.call(callee, args)`
+        coordinate -- the callee reduces through whatever sugar its own node
+        built, so a callee with no sugar (a Lambda called inline) still stays
+        loud through the ordinary recursion. Keyword arguments stay loud gaps
+        until written."""
         if self.keywords:
             return super().sugar()
         if isinstance(self.func, Name):
@@ -2243,7 +2247,13 @@ class Call(Expression):
                 args=tuple(a.sugar() for a in self.args),
                 site=self.fragment,
             )
-        return super().sugar()  # computed callee -- not written
+        from sugar_lift_py_tests.sugar.computed_call_sugar import ComputedCallSugar
+
+        return ComputedCallSugar(
+            callee=self.func.sugar(),
+            args=tuple(a.sugar() for a in self.args),
+            site=self.fragment,
+        )
 
 
 class FormattedValue(Expression):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2228,8 +2228,9 @@ class Call(Expression):
         built, so a callee with no sugar (a Lambda called inline) still stays
         loud through the ordinary recursion. Keyword arguments stay loud gaps
         until written."""
-        if self.keywords:
-            return super().sugar()
+        if any(kw.arg is None for kw in self.keywords):
+            return super().sugar()  # **spread -- not one keyword, never guess
+        keyword_sugars = tuple((kw.arg, kw.value.sugar()) for kw in self.keywords)
         if isinstance(self.func, Name):
             from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
 
@@ -2237,6 +2238,7 @@ class Call(Expression):
                 target_name=self.func.id,
                 args=tuple(a.sugar() for a in self.args),
                 site=self.fragment,
+                keywords=keyword_sugars,
             )
         if isinstance(self.func, Attribute):
             from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
@@ -2246,7 +2248,10 @@ class Call(Expression):
                 name=self.func.attr,
                 args=tuple(a.sugar() for a in self.args),
                 site=self.fragment,
+                keywords=keyword_sugars,
             )
+        if keyword_sugars:
+            return super().sugar()  # kwargs on a computed callee -- not written
         from sugar_lift_py_tests.sugar.computed_call_sugar import ComputedCallSugar
 
         return ComputedCallSugar(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -859,28 +859,72 @@ class Assign(Statement):
             return self
         return rewrite(self, value=new_value)
 
+    def _destructured_binding(self):
+        # `a, b = <display>` -- a single Tuple/List target of plain Names,
+        # destructured against the already-substituted rhs when it is a
+        # Tuple/List display of the same arity. Starred/nested targets, an
+        # arity mismatch, or a non-display rhs return None here (mirrors
+        # For._target_bindings_for -- the shared destructuring reader, called
+        # class-explicitly so it never depends on `self` being a For).
+        target = self.targets[0]
+        if not isinstance(target, (Tuple_, List)):
+            return None
+        return For._target_bindings_for(self, target, self.value)
+
     def substitution_binding(self, scope):
         # A single Name target binds its name to the already-substituted rhs.
-        # Tuple / attribute / subscript targets thread nothing yet -- their
-        # references stay honest gaps rather than a wrong binding.
-        if len(self.targets) == 1 and isinstance(self.targets[0], Name):
-            return {self.targets[0].id: self.value}
+        # A single Tuple/List target of plain Names destructures against a
+        # matching display rhs (see _destructured_binding). A chain of plain
+        # Name targets (`x = y = e`) binds each name to the same rhs.
+        # Attribute / subscript targets, starred/nested tuples, and arity
+        # mismatches thread nothing -- their references stay honest gaps
+        # rather than a wrong binding.
+        if len(self.targets) == 1:
+            target = self.targets[0]
+            if isinstance(target, Name):
+                return {target.id: self.value}
+            return self._destructured_binding()
+        if all(isinstance(t, Name) for t in self.targets):
+            return {t.id: self.value for t in self.targets}
         return None
 
     def sugar(self):
         """`<name> = <rhs>` constructs AssignSugar WITH the rhs's sugar (held as
-        the deferred source). Single Name target only: tuple/attribute/subscript
-        targets and chained `a = b = c` stay loud gaps until their own sugars
-        are written -- never a partial binding."""
-        if len(self.targets) != 1 or not isinstance(self.targets[0], Name):
-            return super().sugar()
-        from sugar_lift_py_tests.sugar.assign_sugar import AssignSugar
+        the deferred source). A destructured tuple/list target or a chained
+        `x = y = e` whose binding threaded constructs MultiAssignSugar -- both
+        are inert once substitute has done its work, exactly like the single
+        Name case. Any shape whose binding did NOT thread (attribute/subscript
+        targets, starred/nested tuples, arity mismatches) stays a loud gap --
+        never a partial binding rendered inert."""
+        if len(self.targets) == 1 and isinstance(self.targets[0], Name):
+            from sugar_lift_py_tests.sugar.assign_sugar import AssignSugar
 
-        return AssignSugar(
-            name=self.targets[0].id,
-            value=self.value.sugar(),
-            site=self.fragment,
-        )
+            return AssignSugar(
+                name=self.targets[0].id,
+                value=self.value.sugar(),
+                site=self.fragment,
+            )
+
+        if len(self.targets) == 1 and isinstance(self.targets[0], (Tuple_, List)):
+            bindings = self._destructured_binding()
+            if bindings is None:
+                return super().sugar()
+            from sugar_lift_py_tests.sugar.assign_sugar import MultiAssignSugar
+
+            return MultiAssignSugar(
+                bindings=tuple((name, val.sugar()) for name, val in bindings.items()),
+                site=self.fragment,
+            )
+
+        if len(self.targets) > 1 and all(isinstance(t, Name) for t in self.targets):
+            from sugar_lift_py_tests.sugar.assign_sugar import MultiAssignSugar
+
+            return MultiAssignSugar(
+                bindings=tuple((t.id, self.value.sugar()) for t in self.targets),
+                site=self.fragment,
+            )
+
+        return super().sugar()
 
 
 class AugAssign(Statement):

--- a/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
+++ b/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
@@ -1,0 +1,82 @@
+"""AnnAssign (`x: T = v` / bare `x: T`) and AugAssign (`x OP= e`) -- both are
+INERT at the meaning layer for a plain Name target, because their binding (if
+any) already threaded via substitute/substitution_binding before sugar runs;
+an annotation states nothing at runtime either way. Non-Name targets (and
+attribute/subscript augmented targets, the shape substitution_binding refuses)
+stay loud gaps."""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def test_annotated_assign_with_value_is_inert_and_threads():
+    v = _fn("def A():\n    x: int = 5\n    return x\n").sugar().desugar().value
+    assert v.invs() == ()
+    assert v.post().args[1].value == 5
+
+
+def test_bare_annotation_lifts_and_states_nothing():
+    v = _fn("def A(z):\n    x: int\n    return z\n").sugar().desugar().value
+    assert v.invs() == ()
+    assert v.post().args[1].name == "z"
+
+
+def test_aug_assign_rebinds_and_is_inert():
+    v = _fn("def A():\n    t = 0\n    t += 2\n    return t\n").sugar().desugar().value
+    assert v.invs() == ()
+    assert v.post().args[1].value == 2
+
+
+def test_attribute_aug_assign_stays_loud():
+    # obj.a += 1 -- the target is not a plain Name, so substitution_binding
+    # refuses it (returns None, never threads); sugar() mirrors that refusal
+    # exactly and stays a loud gap rather than a silent/partial binding.
+    fn = _fn("def A(obj):\n    obj.a += 1\n    return obj\n")
+    with pytest.raises(SugarNotWritten):
+        fn.sugar()
+
+
+def test_aug_assign_with_no_prior_binding_is_sound():
+    # x += 1 as the FIRST statement: substitution_binding cannot see a prior
+    # x in scope, so it falls back to the target itself as the "old" value
+    # (scope.get(name, self.target)) -- the binding still threads, just with
+    # x left free/symbolic. Pinning what actually happens: `return x` inlines
+    # to the BinOp `x + 1` over the still-free x, not a panic and not a
+    # silent drop -- sound, not spent.
+    v = _fn("def A(x):\n    x += 1\n    return x\n").sugar().desugar().value
+    assert v.invs() == ()
+    post = v.post()
+    rhs = post.args[1]
+    assert rhs.name == "+"
+    assert rhs.args[0].name == "x"  # the still-free x, not a panic
+    assert rhs.args[1].value == 1
+
+
+def test_discrimination_annassign_value_changes_the_post():
+    a = _fn("def A():\n    x: int = 5\n    return x\n").sugar().desugar().value.post()
+    b = _fn("def A():\n    x: int = 6\n    return x\n").sugar().desugar().value.post()
+    assert a.args[1].value == 5
+    assert b.args[1].value == 6
+    assert a.args[1].value != b.args[1].value
+
+
+if __name__ == "__main__":
+    test_annotated_assign_with_value_is_inert_and_threads()
+    test_bare_annotation_lifts_and_states_nothing()
+    test_aug_assign_rebinds_and_is_inert()
+    test_attribute_aug_assign_stays_loud()
+    test_aug_assign_with_no_prior_binding_is_sound()
+    test_discrimination_annassign_value_changes_the_post()
+    print("ok: AnnAssign/AugAssign inert for Name targets, loud otherwise")

--- a/implementations/python/sugar-source-tree/tests/test_assign_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_targets.py
@@ -1,0 +1,103 @@
+"""`a, b = <display>` destructures against a matching Tuple/List rhs, and
+`x = y = e` chains a single rhs to several names -- both are threaded by
+substitute exactly like the single-Name case, so both go inert at the
+meaning layer. Starred/nested targets, arity mismatches, and store targets
+(attribute/subscript) do not thread and stay loud gaps."""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _post(src):
+    return _fn(src).sugar().desugar().value.post()
+
+
+def test_tuple_destructure_assign_lifts_through():
+    post = _post("def A():\n    a, b = (1, 2)\n    return a + b\n")
+    assert post.args[1].value == 3
+
+
+def test_tuple_destructure_discriminates_on_pairing():
+    # Swap the pair -- a different sum, a different fact -- proves the
+    # binding actually threads a AND b, not just "some" value.
+    forward = _post("def A():\n    a, b = (1, 2)\n    return a - b\n").args[1].value
+    swapped = _post("def A():\n    a, b = (2, 1)\n    return a - b\n").args[1].value
+    assert forward == -1
+    assert swapped == 1
+    assert forward != swapped
+
+
+def test_list_display_destructure_also_lifts():
+    post = _post("def A():\n    a, b = [10, 20]\n    return a + b\n")
+    assert post.args[1].value == 30
+
+
+def test_chained_assign_binds_every_target():
+    post = _post("def A():\n    x = y = 5\n    return x + y\n")
+    assert post.args[1].value == 10
+
+
+def test_starred_target_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A():\n    a, *b = (1, 2, 3)\n    return a\n").sugar()
+
+
+def test_nested_tuple_target_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A():\n    (a, b), c = (1, 2), 3\n    return c\n").sugar()
+
+
+def test_arity_mismatch_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A():\n    a, b = (1, 2, 3)\n    return a\n").sugar()
+
+
+def test_non_display_rhs_stays_loud():
+    # The rhs is a Name, not a Tuple/List display -- no shape to destructure
+    # against, so the tuple target is not threaded.
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(p):\n    a, b = p\n    return a\n").sugar()
+
+
+def test_mixed_chained_targets_stay_loud():
+    # x is a plain Name but the second target is a tuple -- mixed shapes
+    # never get a partial binding.
+    with pytest.raises(SugarNotWritten):
+        _fn("def A():\n    x = (a, b) = (1, 2)\n    return x\n").sugar()
+
+
+def test_attribute_store_target_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(o):\n    o.a = 1\n    return o\n").sugar()
+
+
+def test_subscript_store_target_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(xs):\n    xs[0] = 1\n    return xs\n").sugar()
+
+
+if __name__ == "__main__":
+    test_tuple_destructure_assign_lifts_through()
+    test_tuple_destructure_discriminates_on_pairing()
+    test_list_display_destructure_also_lifts()
+    test_chained_assign_binds_every_target()
+    test_starred_target_stays_loud()
+    test_nested_tuple_target_stays_loud()
+    test_arity_mismatch_stays_loud()
+    test_non_display_rhs_stays_loud()
+    test_mixed_chained_targets_stay_loud()
+    test_attribute_store_target_stays_loud()
+    test_subscript_store_target_stays_loud()
+    print("ok: tuple/chained assign destructures; starred/nested/store stay loud")

--- a/implementations/python/sugar-source-tree/tests/test_call_kwargs.py
+++ b/implementations/python/sugar-source-tree/tests/test_call_kwargs.py
@@ -1,0 +1,52 @@
+"""Keyword arguments on calls ride the coordinate FAITHFULLY: each `name=expr`
+appends a `py.kwarg(name, expr)` operand after the positionals. A `**spread`
+is not one keyword and stays loud (the tree node guards it)."""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _out(src):
+    return _fn(src).sugar().desugar().value.post().args[1]
+
+
+def test_named_call_kwarg_lifts():
+    t = _out("def A(x):\n    return f(x, k=1)\n")
+    assert t.name == "call:f"
+    kwarg = t.args[-1]
+    assert kwarg.name == "py.kwarg"
+    assert kwarg.args[0].value == "k"
+    assert kwarg.args[1].value == 1
+
+
+def test_method_call_kwarg_lifts():
+    t = _out("def A(z):\n    return z.get(1, default=2)\n")
+    assert t.name == "call:get"
+    kwarg = t.args[-1]
+    assert kwarg.name == "py.kwarg"
+    assert kwarg.args[0].value == "default"
+    assert kwarg.args[1].value == 2
+
+
+def test_kwarg_value_discriminates():
+    t1 = _out("def A(x):\n    return f(x, k=1)\n")
+    t2 = _out("def A(x):\n    return f(x, k=2)\n")
+    assert t1.args[-1].args[1].value != t2.args[-1].args[1].value
+    assert t1 != t2
+
+
+def test_spread_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(x, d):\n    return f(x, **d)\n").sugar()

--- a/implementations/python/sugar-source-tree/tests/test_computed_call.py
+++ b/implementations/python/sugar-source-tree/tests/test_computed_call.py
@@ -1,0 +1,67 @@
+"""The computed callee: `<callee>(<args>)` where the callee is an expression
+rather than a bare name or attribute (`fs[0](x)`, `d["k"](x)`). A COMPOSITION:
+the callee reduces like any value through whatever sugar its own node built
+(SubscriptSugar for `fs[0]`), and the call stands as the coordinate
+`py.call(callee, args)`. A callee whose node has no sugar (a Lambda called
+inline) stays loud through the ordinary recursion -- this sugar never masks
+that gap."""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _out(src):
+    return _fn(src).sugar().desugar().value.post().args[1]
+
+
+def test_computed_call_is_the_py_call_coordinate():
+    t = _out("def A(fs, x):\n    return fs[0](x)\n")
+    assert t.name == "py.call"
+    callee = t.args[0]
+    assert callee.name == "py.subscript"  # fs[0], the callee operand
+    assert t.args[1].name == "x"  # the argument
+
+
+def test_assert_consumes_the_coordinate():
+    inv = (
+        _fn("def A(fs, x):\n    assert fs[0](x) == x\n    return x\n")
+        .sugar()
+        .desugar()
+        .value.invs()[0]
+    )
+    assert inv.name == "py.eq"
+    assert inv.args[0].name == "py.call"
+
+
+def test_discrimination_differs_by_callee_operand():
+    # fs[0](x) vs fs[1](x) -- same shape, different callee coordinate.
+    t0 = _out("def A(fs, x):\n    return fs[0](x)\n")
+    t1 = _out("def A(fs, x):\n    return fs[1](x)\n")
+    assert t0.name == t1.name == "py.call"
+    assert t0.args[0] != t1.args[0]  # the callee subscript differs
+    assert t0 != t1
+
+
+def test_lambda_callee_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(x):\n    return (lambda z: z)(x)\n").sugar()
+
+
+if __name__ == "__main__":
+    test_computed_call_is_the_py_call_coordinate()
+    test_assert_consumes_the_coordinate()
+    test_discrimination_differs_by_callee_operand()
+    test_lambda_callee_stays_loud()
+    print("ok: computed callee calls -- coordinate, assert, discrimination, lambda loud")

--- a/implementations/python/sugar-source-tree/tests/test_constant_kinds.py
+++ b/implementations/python/sugar-source-tree/tests/test_constant_kinds.py
@@ -1,0 +1,66 @@
+"""The remaining Constant literal kinds: bytes, complex, Ellipsis.
+
+bytes and Ellipsis both have a canonical floor representation already
+consumed downstream (SMT emitter / verifier ground-ctor whitelist /
+isinstance fold table), so they lift. complex ALSO has an established
+canonical ``py.complex(<real>, <imag>)`` representation in that same
+whitelist and fold table, so it lifts too -- this is not a new vocabulary
+decision, it mirrors vocabulary already agreed elsewhere in the kit.
+"""
+
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _return_value(src):
+    """desugar `def A(): return <expr>` and return the floor value."""
+    return _fn(src).sugar().desugar().value.post().args[1]
+
+
+def test_bytes_literal_lifts_to_canonical_python_bytes_term():
+    term = _return_value('def A():\n    return b"ab"\n')
+    assert term.name == "python:bytes"
+    assert len(term.args) == 1
+    assert term.args[0].value == b"ab".hex()
+
+
+def test_bytes_literal_discriminates_on_content():
+    ab = _return_value('def A():\n    return b"ab"\n')
+    ac = _return_value('def A():\n    return b"ac"\n')
+    assert ab != ac
+
+
+def test_ellipsis_literal_lifts_to_canonical_py_ellipsis_term():
+    term = _return_value("def A():\n    return ...\n")
+    assert term.name == "py.ellipsis"
+    assert term.args == ()
+
+
+def test_complex_literal_lifts_to_canonical_py_complex_term():
+    term = _return_value("def A():\n    return 2j\n")
+    assert term.name == "py.complex"
+    assert len(term.args) == 2
+
+
+def test_complex_literal_discriminates_on_imaginary_part():
+    two_j = _return_value("def A():\n    return 2j\n")
+    three_j = _return_value("def A():\n    return 3j\n")
+    assert two_j != three_j
+
+
+if __name__ == "__main__":
+    test_bytes_literal_lifts_to_canonical_python_bytes_term()
+    test_bytes_literal_discriminates_on_content()
+    test_ellipsis_literal_lifts_to_canonical_py_ellipsis_term()
+    test_complex_literal_lifts_to_canonical_py_complex_term()
+    test_complex_literal_discriminates_on_imaginary_part()
+    print("ok: bytes / Ellipsis / complex literal kinds")

--- a/implementations/python/sugar-source-tree/tests/test_inert_statements.py
+++ b/implementations/python/sugar-source-tree/tests/test_inert_statements.py
@@ -1,0 +1,75 @@
+"""Import, ImportFrom, Pass, Global, Nonlocal state nothing at function-lift
+level: they are honestly inert, not gaps.
+
+An `import` binds a module name that stays a FREE SYMBOLIC in the meaning
+layer -- a later `pd.concat(...)` reduces as a method coordinate on the free
+name `pd`, correct without the import ever stating anything. `pass` states
+nothing by definition. `global`/`nonlocal` are scope DECLARATIONS whose
+binding semantics live in substitute, not meaning -- by sugar time there is
+nothing left for them to say.
+"""
+
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _val(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).sugar().desugar().value
+
+
+def test_import_is_inert():
+    v = _val("def A(z):\n    import os\n    return z\n")
+    assert v.invs() == ()
+    assert v.post().args[1].name == "z"
+
+
+def test_import_from_is_inert():
+    v = _val("def A(z):\n    from x import y\n    return z\n")
+    assert v.invs() == ()
+    assert v.post().args[1].name == "z"
+
+
+def test_pass_is_inert():
+    v = _val("def A(z):\n    pass\n    return z\n")
+    assert v.invs() == ()
+    assert v.post().args[1].name == "z"
+
+
+def test_global_is_inert():
+    v = _val("def A(z):\n    global g\n    return z\n")
+    assert v.invs() == ()
+    assert v.post().args[1].name == "z"
+
+
+def test_nonlocal_is_inert():
+    v = _val(
+        "def A(z):\n"
+        "    def inner():\n"
+        "        nonlocal z\n"
+        "        return z\n"
+        "    return z\n"
+    )
+    assert v.invs() == ()
+    assert v.post().args[1].name == "z"
+
+
+def test_import_does_not_block_a_later_fact():
+    v = _val("def A(z):\n    import m\n    assert z == 1\n    return z\n")
+    assert len(v.invs()) == 1
+    assert v.invs()[0].name == "py.eq"
+    assert v.post().args[1].name == "z"
+
+
+if __name__ == "__main__":
+    test_import_is_inert()
+    test_import_from_is_inert()
+    test_pass_is_inert()
+    test_global_is_inert()
+    test_nonlocal_is_inert()
+    test_import_does_not_block_a_later_fact()
+    print("ok: import/importfrom/pass/global/nonlocal inert; effects still ride through")

--- a/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
@@ -44,9 +44,17 @@ def test_assert_consumes_the_coordinate():
     assert inv.args[0].name == "call:upper"
 
 
-def test_keyword_args_stay_loud():
+def test_keyword_args_lift():
+    t = _out("def A(z):\n    return z.get(1, default=2)\n")
+    assert t.name == "call:get"
+    kwarg = t.args[-1]
+    assert kwarg.name == "py.kwarg"
+    assert kwarg.args[0].value == "default"
+
+
+def test_spread_keyword_args_stay_loud():
     with pytest.raises(SugarNotWritten):
-        _fn("def A(z):\n    return z.get(1, default=2)\n").sugar()
+        _fn("def A(z, d):\n    return z.get(1, **d)\n").sugar()
 
 
 if __name__ == "__main__":
@@ -54,4 +62,4 @@ if __name__ == "__main__":
     test_method_chains_compose()
     test_assert_consumes_the_coordinate()
     test_keyword_args_stay_loud()
-    print("ok: method calls -- coordinate, chains, assert; kwargs loud")
+    print("ok: method calls -- coordinate, chains, assert; kwargs/computed loud")

--- a/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
@@ -49,15 +49,9 @@ def test_keyword_args_stay_loud():
         _fn("def A(z):\n    return z.get(1, default=2)\n").sugar()
 
 
-def test_computed_callee_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A(fs, x):\n    return fs[0](x)\n").sugar()
-
-
 if __name__ == "__main__":
     test_method_call_is_the_method_coordinate()
     test_method_chains_compose()
     test_assert_consumes_the_coordinate()
     test_keyword_args_stay_loud()
-    test_computed_callee_stays_loud()
-    print("ok: method calls -- coordinate, chains, assert; kwargs/computed loud")
+    print("ok: method calls -- coordinate, chains, assert; kwargs loud")


### PR DESCRIPTION
Six Sonnet workers, one census family each, worktree-isolated, serially verified and reconciled by the coordinator. Suite 145 → **181** (36 new tests).

- **computed callees** → `py.call(callee, args)` coordinate (`fs[0](x)` composes)
- **call kwargs** → `py.kwarg(name, term)` operands; positional coordinates byte-identical; `**spread` loud
- **inert statements** → Import/ImportFrom/Pass/Global/Nonlocal state nothing; imported names stay free symbolics
- **assign targets** → tuple destructure + `x = y = e` chains; starred/nested/mismatch loud; **store targets stay loud with the documented seam** (effect-witness requires the factory fragment type — deliberate fix later, never shimmed)
- **AnnAssign/AugAssign** → inert where the binding threaded; no-prior `x += 1` pinned sound (`x + 1`, free symbolic)
- **bytes/Ellipsis/complex** → existing vendor canon only (`python:bytes(hex)`, `py.ellipsis`, `py.complex` per #4387/#4398); zero new vocabulary

One real conflict (both call lanes editing `Call.sugar`) hand-reconciled: kwargs ride Name+Attribute callees, kwargs-on-computed stays loud. Census receipt to follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add floor types and desugar statement/expression forms for bytes, complex, ellipsis, kwargs, and computed calls
> - Adds `BytesValue`, `ComplexValue`, and `EllipsisValue` floor types with isinstance/equality folding and canonical IR term emission.
> - Extends `CallSiteSugar` and `MethodCallSugar` to represent named keyword arguments as `py.kwarg` IR nodes; calls with `**spread` remain loud.
> - Adds `ComputedCallSugar` for calls with non-name/attribute callees, emitting a `py.call` coordinate IR term.
> - Desugars `bytes`, `complex`, and `Ellipsis` constants to their respective sugar/floor forms instead of staying loud.
> - Makes `import`, `from-import`, `pass`, `global`, `nonlocal`, `AugAssign` (Name target), and `AnnAssign` (Name target) statements desugar as inert; extends `Assign` to thread bindings for single destructuring and chained Name assignments.
> - Adds comprehensive test coverage for all new behaviors across six new test files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d5576ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for bytes, complex-number, and ellipsis literals.
  * Added destructuring and chained assignment handling.
  * Added keyword arguments to regular and method calls.
  * Added support for calls through computed expressions.
* **Bug Fixes**
  * Improved handling of annotated and augmented assignments.
  * Prevented inert statements such as imports and `pass` from affecting captured behavior.
* **Tests**
  * Added coverage for new literal, assignment, call, and statement behaviors, including unsupported cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->