### PR TITLE
Python enumeration: rewrite temporal scope before Sugar

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -1867,8 +1867,10 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     return
                 sf = _tree.source_file(full_path)
                 span = at.get("span") if isinstance(at, dict) else None
-                assert_node = _tree.find_assert(sf, span)
-                if assert_node is None:
+                source_assert, assert_node = _tree.temporally_rewritten_assert(
+                    sf, span
+                )
+                if source_assert is None or assert_node is None:
                     _send_enumerate_result(
                         msg_id,
                         [],
@@ -1882,7 +1884,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     return
 
                 term_table = TermTableBuilder()
-                caller_memento = _tree.assert_memento(assert_node, file_rel)
+                caller_memento = _tree.assert_memento(source_assert, file_rel)
                 caller_cid = caller_memento["source_cid"]
                 caller_post = None
                 caller_outcome = assert_node.sugar().desugar(None)
@@ -2114,10 +2116,10 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     return
 
                 # facts: at is an assertion memento — desugar THAT assert.
-                node = _tree.find_assert(
+                source_node, node = _tree.temporally_rewritten_assert(
                     sf, at.get("span") if isinstance(at, dict) else None
                 )
-                if node is None:
+                if source_node is None or node is None:
                     _send_enumerate_result(
                         msg_id, [], [{"memento": at, "reason": "no assertion here"}]
                     )
@@ -2129,7 +2131,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                         [],
                         [
                             {
-                                "memento": _tree.assert_memento(node, file_rel),
+                                "memento": _tree.assert_memento(source_node, file_rel),
                                 "reason": "assertion emits no fact",
                             }
                         ],
@@ -2139,7 +2141,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     msg_id,
                     [
                         {
-                            "memento": _tree.assert_memento(node, file_rel),
+                            "memento": _tree.assert_memento(source_node, file_rel),
                             "audit": None,
                             "payload": formula,
                         }

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
@@ -62,7 +62,7 @@ def call_target_names(sf: SourceFile, span: Optional[dict]) -> list:
     (the tree kept the names the factory had to reconstruct)."""
     from sugar_source_tree.nodes import Call, Name
 
-    node = find_assert(sf, span)
+    _source, node = temporally_rewritten_assert(sf, span)
     if node is None:
         return []
     names = []
@@ -80,11 +80,58 @@ def find_assert(sf: SourceFile, span: Optional[dict]):
     return None
 
 
+def temporally_rewritten_assert(sf: SourceFile, span: Optional[dict]):
+    """Return ``(source_assert, rewritten_assert)`` for an exact locus.
+
+    An assertion is not a construction root.  Its meaning depends on every
+    binding before it in the enclosing function (or module), so constructing
+    its Sugar directly from the parser-backed tree is a temporal side door.
+    Find the narrowest enclosing function, rewrite that scope as a block, and
+    only then return the assertion on which callers may invoke ``sugar()``.
+
+    The source node is returned separately because its fragment/memento is the
+    durable address.  Shadow rewrites deliberately borrow that address, but
+    keeping the two roles explicit prevents a future caller from mistaking
+    source lookup for construction readiness.
+    """
+    source_assert = find_assert(sf, span)
+    if source_assert is None:
+        return None, None
+
+    target = source_assert.line_col_span()
+
+    def contains(node) -> bool:
+        locus = node.line_col_span()
+        return (
+            locus.start_line <= target.start_line and locus.end_line >= target.end_line
+        )
+
+    owners = [fn for fn in sf.functions() if contains(fn)]
+    if owners:
+        # Nested functions are also yielded by SourceFile.functions(); temporal
+        # ownership belongs to the narrowest one, never its enclosing function.
+        owner = min(
+            owners,
+            key=lambda fn: (
+                fn.line_col_span().end_line - fn.line_col_span().start_line,
+                fn.line_col_span().end_col - fn.line_col_span().start_col,
+            ),
+        )
+        rewritten_owner = owner.substitute({})
+    else:
+        # Module assertions are temporally owned by the module block.
+        rewritten_owner = sf.root.substitute({})
+
+    for node in rewritten_owner.walk():
+        if isinstance(node, Assert) and _span_matches(node, span or {}):
+            return source_assert, node
+    return source_assert, None
+
+
 def _span_matches(node, span: dict) -> bool:
     lc = node.line_col_span()
-    return (
-        lc.start_line == span.get("start_line")
-        and lc.start_col == span.get("start_col")
+    return lc.start_line == span.get("start_line") and lc.start_col == span.get(
+        "start_col"
     )
 
 
@@ -110,8 +157,10 @@ def assert_memento(node, file_rel: str) -> dict:
 def fact_of(node) -> Optional[Any]:
     """Desugar the assertion; its InvValue's formula is the fact, on the wire.
 
-    None when the assertion emits no fact (e.g. inert support). No factory,
-    no context: a self-contained assertion desugars context-free.
+    ``node`` must be the result of ``temporally_rewritten_assert``, never the
+    parser-backed lookup node.  None when the assertion emits no fact (e.g.
+    inert support). No factory and no ambient context: the enclosing tree has
+    already expressed the temporal state.
     """
     import json
 
@@ -218,7 +267,7 @@ def call_nodes_in_assert(sf: SourceFile, span: Optional[dict]) -> list:
     nodes -- the pre this call fills."""
     from sugar_source_tree.nodes import Call, Name
 
-    node = find_assert(sf, span)
+    _source, node = temporally_rewritten_assert(sf, span)
     if node is None:
         return []
     return [

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
@@ -487,6 +487,61 @@ def test_assertions_and_facts_carry_the_fol(project: Path) -> None:
         assert cid == blake3_512_of(canonical)
 
 
+def test_fact_construction_rewrites_enclosing_temporal_scope(tmp_path: Path) -> None:
+    """A fact is constructed from the rewritten function, not its raw Assert.
+
+    This is the bad twin for the old caller-side bypass: direct
+    ``assert_node.sugar()`` left ``x`` symbolic even though the preceding
+    assignment had already fixed it to 2.
+    """
+    (tmp_path / "temporal.py").write_text(
+        "def add(a):\n    return a\n\n"
+        "def test_bound():\n    x = 2\n    assert add(x) == 2\n",
+        encoding="utf-8",
+    )
+    file_key = _enumerate("source_files", tmp_path)["nodes"][0]["memento"]
+    functions = {
+        n["memento"]["function_name"]: n["memento"]
+        for n in _enumerate("functions", tmp_path, at=file_key)["nodes"]
+    }
+    assertion = _enumerate("call_sites", tmp_path, at=functions["test_bound"])["nodes"][
+        0
+    ]["memento"]
+    result = _enumerate("facts", tmp_path, at=assertion, seek=True)
+    formula = result["nodes"][0]["payload"]
+    call = formula["args"][0]
+    argument = call["args"][0]
+    assert call["name"] == "call:add"
+    assert argument["kind"] == "const"
+    assert argument["value"] == 2
+
+
+def test_universe_cue_rewrites_temporal_callee_alias(tmp_path: Path) -> None:
+    """Callee discovery and argument application see the same rewritten tree."""
+    (tmp_path / "temporal_alias.py").write_text(
+        "def target(a):\n    return a\n\n"
+        "def test_alias():\n    callee = target\n    assert callee(1) == 1\n",
+        encoding="utf-8",
+    )
+    file_key = _enumerate("source_files", tmp_path)["nodes"][0]["memento"]
+    functions = {
+        n["memento"]["function_name"]: n["memento"]
+        for n in _enumerate("functions", tmp_path, at=file_key)["nodes"]
+    }
+    call_site = _enumerate("call_sites", tmp_path, at=functions["test_alias"])["nodes"][
+        0
+    ]["memento"]
+
+    universe = _enumerate("universe", tmp_path, at=call_site, seek=True)
+    assert universe["gaps"] == []
+    assert len(universe["nodes"]) == 1
+    assert universe["nodes"][0]["memento"]["source_function_name"] == "target"
+
+    implication = _enumerate("implications", tmp_path, at=call_site, seek=True)
+    assert implication["gaps"] == []
+    assert implication["nodes"][0]["audit"]["targetSymbol"] == "call:target"
+
+
 def test_every_formula_bearing_enumerate_level_is_closed(project: Path) -> None:
     def refs(value):
         found = set()


### PR DESCRIPTION
Fixes the live caller-side phase bypass: facts, implication callers, and universe call cues now resolve the exact assertion from its temporally rewritten enclosing function/module before constructing Sugar. The source-backed assertion remains the durable memento address. Adds bad twins for a preceding value binding and a preceding callee alias. No factory compatibility door and no panic/refusal weakening.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rewrite temporal scope before Sugar in Python enumeration
> - Adds `temporally_rewritten_assert` in [tree_enumerate.py](https://github.com/TSavo/sugar/pull/5993/files#diff-1a883a4eea1b53f1ee91261df4ca5f694dfda233c883ddab24f920fd9610931e), which locates the source assertion, finds its narrowest temporal owner, substitutes that owner to produce a rewritten tree, and returns both the source and rewritten assertion nodes.
> - Updates `_handle_enumerate` in [lift_rpc.py](https://github.com/TSavo/sugar/pull/5993/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) to use the rewritten assertion for `sugar()`/`desugar()` calls while deriving mementos from the original source assertion, so facts and implications reflect resolved pre-bindings (e.g., constants instead of symbolic names) with correct source spans.
> - Updates `call_target_names` and `call_nodes_in_assert` to also use the rewritten assertion, so callee names and call nodes reflect aliasing present at the assertion point.
> - Adds tests covering fact construction with bound variables and callee alias resolution via universe/implications enumeration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 316cb4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->