### PR TITLE
with (#5994) step 1a: provider-neutral typed manager contracts

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
@@ -1,0 +1,63 @@
+"""The typed context-manager contract, and the recognition membrane that issues it.
+
+T's ruling: three contracts wear the one `with` syntax, and production tree code
+sees a TYPED CONTRACT, never a vendor spelling. `pytest` is a vendor: the
+membrane authenticates community spellings (`pytest.raises(E)`,
+`contextlib.suppress(E)`, `tm.assert_produces_warning(W)`) and issues the
+general contract; the language implementation (nodes.py) consults the membrane
+and never matches names itself.
+
+The exit contracts (the only licenses for temporal dissolution):
+- ``NeverSuppresses`` -- exceptional body effect passes through after __exit__.
+- ``Suppresses(matcher)`` -- matching effects are consumed (permission).
+- ``Expects(matcher)`` -- matching effect is REQUIRED and consumed (obligation).
+- ``RuntimeSelected`` -- suppression undecidable statically; stays loud.
+
+Matching rule (pinned): EXACT exception-name match. Subclass matching needs a
+static type hierarchy the lift does not hold; a subclass raise therefore lands
+as the mismatch twin (loud, never silently matched) until that rule is widened
+deliberately.
+
+Enrollment (issue #5994): community coordinates enter ONLY through an
+explicitly loaded, hashed kit manifest that maps authenticated spellings to
+these contracts. This module holds the provider-neutral TYPES only; no vendor
+spelling may appear in code, tree-side or kit-side.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class EffectMatcher:
+    """Matches an effect by kind and exception/warning name (exact)."""
+
+    kind: str  # "raise" | "warning"
+    name: str  # e.g. "ValueError", "FutureWarning"
+
+
+@dataclass(frozen=True)
+class NeverSuppresses:
+    pass
+
+
+@dataclass(frozen=True)
+class Suppresses:
+    matcher: EffectMatcher
+
+
+@dataclass(frozen=True)
+class Expects:
+    matcher: EffectMatcher
+
+
+@dataclass(frozen=True)
+class RuntimeSelected:
+    pass
+
+
+Contract = NeverSuppresses | Suppresses | Expects | RuntimeSelected
+
+


### PR DESCRIPTION
The shared types (EffectMatcher, NeverSuppresses/Suppresses/Expects/RuntimeSelected) both the manifest membrane and the effect router build on. No vendor spellings anywhere — enrollment only via the hashed kit manifest (next lane). Part of #5994; does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add provider-neutral typed context-manager contract definitions in Python
> Adds a new module [`context_manager_contract.py`](https://github.com/TSavo/sugar/pull/5995/files#diff-9c4ddf76cadbdc0e8ff4c2d72b4153508fbc55b2163fc112b3a6fd2c9434973a) defining frozen dataclasses and a `Contract` union type alias for expressing context-manager suppression contracts in a provider-neutral way.
>
> - `EffectMatcher(kind, name)` describes an effect by category and name
> - `NeverSuppresses`, `Suppresses(matcher)`, `Expects(matcher)`, and `RuntimeSelected` cover the four contract variants
> - `Contract` is a union type alias over all four variants for use in type annotations
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8ed383.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->