### PR TITLE
with (#5994) steps 1+2+3+6: hashed manifest membrane + shared effect router

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
@@ -1,0 +1,175 @@
+"""The one effect router shared by ``Try`` and ``With`` (issue #5994, step 2/3).
+
+T's ruling (verbatim intent, restated as code): the router takes a reduced
+block's contribution entries and a typed ``context_manager_contract.Contract``
+and decides what the contract's arm does to those entries -- never a vendor
+spelling, never a manufactured green.
+
+Arms:
+
+- ``Expects(matcher)`` -- an OBLIGATION. The emitted fact is the FOL equality
+  ``eq(str_const(expected_name), observed_term)``, wrapped in an ``InvValue``:
+    * a matching-kind ``Incomplete(RaiseEffect)`` present -> ground-true
+      (``observed_term = str_const(raised_name)``); the effect is CONSUMED --
+      it was evidence, now discharged.
+    * body completed with NO unresolved call coordinates -> ground-false
+      (``observed_term = str_const("py.effect.none")``) -- the lying twin:
+      the expected effect is asserted absent.
+    * body carries unresolved call coordinates (the halt may be hiding behind
+      a dig) -> do NOT claim absence; emit an opaque obligation
+      ``atomic("py.effect.expected", [str_const(name), ...])`` instead of the
+      InvValue (honest red until composition resolves the dig).
+    * a non-matching Incomplete(RaiseEffect) (wrong effect) -> emit the
+      ground-false equality AND KEEP the Incomplete: the wrong effect must not
+      disappear.
+- ``Suppresses(matcher)`` -- permission. A matching Incomplete is consumed
+  (removed, nothing stated). Absence is fine (no fact). A non-matching effect
+  propagates untouched.
+- ``NeverSuppresses`` -- entries pass through unchanged. The router asserts
+  nothing; it exists so resource expansion can name its policy.
+- ``RuntimeSelected`` -- the router REFUSES: a loud, named error. Reaching the
+  router with a runtime-selected contract is a defect in the caller (it must
+  have stayed loud before reaching the router), not a policy the router picks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sugar_lift_py_tests.context_manager_contract import (
+    Contract,
+    EffectMatcher,
+    Expects,
+    NeverSuppresses,
+    RuntimeSelected,
+    Suppresses,
+)
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+from sugar_lift_py_tests.floor.inv_value import InvValue
+from sugar_lift_py_tests.ir import atomic, eq, str_const
+from sugar_lift_py_tests.outcome.incomplete import Incomplete
+
+_EFFECT_ABSENT_NAME = "py.effect.none"
+_EFFECT_EXPECTED_OBLIGATION = "py.effect.expected"
+
+
+class RuntimeSelectedReachedRouter(RuntimeError):
+    """Raised when a ``RuntimeSelected`` contract reaches ``route``.
+
+    A runtime-selected exit must remain loud before it ever reaches this
+    router (the caller's job); arriving here with one is a defect, never a
+    policy this router is entitled to guess at.
+    """
+
+
+@dataclass(frozen=True)
+class RoutedOutcome:
+    """What the router hands back to its caller (Try or With).
+
+    ``entries`` is the surviving contribution tuple -- what the caller splices
+    into its own ``BlockValue.statements`` (or equivalent). ``stated_facts``
+    is the subset of ``entries`` that are freshly-minted ``InvValue`` facts
+    the router added (already included in ``entries`` too, since the caller
+    needs both "here is the full record" and "here is what I just asserted"
+    views without re-scanning for identity).
+    """
+
+    entries: tuple
+    stated_facts: tuple = ()
+
+
+def _matching_incomplete_raise(entries: tuple, matcher: EffectMatcher):
+    """Return the (index, Incomplete) of the first Incomplete(RaiseEffect)
+    whose effect matches ``matcher`` by EXACT kind+name (pinned rule -- a
+    subclass raise is the mismatch twin, never silently matched), or None."""
+    if matcher.kind != "raise":
+        return None
+    for index, entry in enumerate(entries):
+        if isinstance(entry, Incomplete) and isinstance(entry.effect, RaiseEffect):
+            if entry.effect.exception_name == matcher.name:
+                return index, entry
+    return None
+
+
+def _first_incomplete_raise(entries: tuple):
+    """Any Incomplete(RaiseEffect) at all, matching or not (for the wrong-effect
+    twin: some raise happened, just not the one that was expected)."""
+    for index, entry in enumerate(entries):
+        if isinstance(entry, Incomplete) and isinstance(entry.effect, RaiseEffect):
+            return index, entry
+    return None
+
+
+def _has_unresolved_call_coordinates(entries: tuple) -> bool:
+    """True when the entries carry a call coordinate that has not yet been
+    reduced -- the halt this router is asked to classify may be hiding behind
+    that dig, so absence of a matching effect is NOT yet a fact.
+
+    A callsite is "unresolved" when a ``CallSiteValue`` rides among the entries
+    directly, or is cited by an ``InvValue.operand_callsites`` -- the one
+    documented shape the ruling names. Both are inspected by this single
+    helper; no other code in this module walks entries for callsites."""
+    for entry in entries:
+        if isinstance(entry, CallSiteValue):
+            return True
+        if isinstance(entry, InvValue) and entry.operand_callsites:
+            return True
+    return False
+
+
+def _route_expects(entries: tuple, matcher: EffectMatcher) -> RoutedOutcome:
+    matching = _matching_incomplete_raise(entries, matcher)
+    if matching is not None:
+        index, incomplete = matching
+        observed = str_const(incomplete.effect.exception_name)
+        fact = InvValue(eq(str_const(matcher.name), observed))
+        remaining = entries[:index] + entries[index + 1 :]
+        return RoutedOutcome(entries=(*remaining, fact), stated_facts=(fact,))
+
+    wrong = _first_incomplete_raise(entries)
+    if wrong is not None:
+        _, incomplete = wrong
+        # Wrong effect: name the ground-false equality, but the Incomplete
+        # itself is NOT consumed -- F must not disappear.
+        fact = InvValue(eq(str_const(matcher.name), str_const(incomplete.effect.exception_name)))
+        return RoutedOutcome(entries=(*entries, fact), stated_facts=(fact,))
+
+    if _has_unresolved_call_coordinates(entries):
+        # Honest red: a dig may still produce the expected effect. Do not
+        # claim absence -- emit an opaque obligation instead of a fact.
+        obligation = atomic(_EFFECT_EXPECTED_OBLIGATION, [str_const(matcher.name)])
+        return RoutedOutcome(entries=(*entries, obligation))
+
+    # Completion with no hiding coordinates: the lying twin. The expected
+    # effect is asserted absent, ground-false.
+    fact = InvValue(eq(str_const(matcher.name), str_const(_EFFECT_ABSENT_NAME)))
+    return RoutedOutcome(entries=(*entries, fact), stated_facts=(fact,))
+
+
+def _route_suppresses(entries: tuple, matcher: EffectMatcher) -> RoutedOutcome:
+    matching = _matching_incomplete_raise(entries, matcher)
+    if matching is None:
+        # Absence is fine; non-matching effects (if any) propagate untouched.
+        return RoutedOutcome(entries=entries)
+    index, _incomplete = matching
+    remaining = entries[:index] + entries[index + 1 :]
+    return RoutedOutcome(entries=remaining)
+
+
+def route(entries: tuple, contract: Contract) -> RoutedOutcome:
+    """Route a reduced block's contribution ``entries`` per the typed
+    ``contract``. See module docstring for the per-arm semantics ruling."""
+    if isinstance(contract, Expects):
+        return _route_expects(entries, contract.matcher)
+    if isinstance(contract, Suppresses):
+        return _route_suppresses(entries, contract.matcher)
+    if isinstance(contract, NeverSuppresses):
+        return RoutedOutcome(entries=entries)
+    if isinstance(contract, RuntimeSelected):
+        raise RuntimeSelectedReachedRouter(
+            "effect_router.route reached with RuntimeSelected: the caller "
+            "must keep a runtime-selected exit loud before routing, never "
+            "let it arrive here for the router to guess a policy"
+        )
+    raise TypeError(f"unknown context-manager contract: {type(contract).__name__}")

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/manifest_membrane.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/manifest_membrane.py
@@ -1,0 +1,207 @@
+"""The hashed kit-manifest enrollment membrane (issue #5994, implementation
+order items 1 and 6).
+
+Community coordinates (`pytest.raises`, `contextlib.suppress`,
+`tm.assert_produces_warning`, ...) enter the typed context-manager contract
+(`sugar_lift_py_tests.context_manager_contract`) ONLY through an explicitly
+loaded, hashed manifest. No vendor spelling may appear in this file, or in
+any other `.py` file that consumes it — spellings live exclusively in the
+manifest JSON data loaded at runtime.
+
+Manifest format (JCS-canonicalized JSON)::
+
+    {
+      "rows": [
+        {"spelling": "pytest.raises", "arity": "one-exception-arg",
+         "contract": "expects", "effect_kind": "raise"},
+        ...
+      ],
+      "cid": "blake3-512:<128 lowercase hex>"
+    }
+
+The `cid` is the BLAKE3-512 JCS hash (see `canonicalizer.jcs_hash`) of the
+`rows` array alone. `load_manifest` recomputes that hash from the bytes on
+disk and REFUSES (raises `ManifestIntegrityError`) on any mismatch — never a
+warning. A manifest carries its own integrity; nothing loads implicitly, and
+nothing loads silently-wrong.
+
+The membrane's other half, `contract_for_manager`, inspects a `with`-item's
+manager expression STRUCTURALLY: a `Call` whose callee is a dotted
+`Name`/`Attribute` chain, matched against enrolled spellings; the single
+positional argument must itself be a dotted `Name`/`Attribute` chain, whose
+dotted string becomes the matcher's exception/warning name. Keyword
+arguments, extra positional arguments, or a non-dotted argument all yield
+`None` — unauthenticated, loud, never guessed.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Tuple
+
+from sugar_lift_py_tests.canonicalizer import Value, jcs_hash, varr, vobj, vstr
+from sugar_lift_py_tests.context_manager_contract import (
+    Contract,
+    EffectMatcher,
+    Expects,
+    Suppresses,
+)
+
+_CONTRACT_BUILDERS = {
+    "expects": Expects,
+    "suppresses": Suppresses,
+}
+
+
+class ManifestIntegrityError(Exception):
+    """Raised, loudly, when a manifest's `cid` does not match its `rows`."""
+
+
+@dataclass(frozen=True)
+class ManifestRow:
+    spelling: str
+    arity: str
+    contract: str
+    effect_kind: str
+
+
+@dataclass(frozen=True)
+class Manifest:
+    rows: Tuple[ManifestRow, ...]
+    cid: str
+    path: Path
+
+    def row_for_spelling(self, spelling: str) -> Optional[ManifestRow]:
+        for row in self.rows:
+            if row.spelling == spelling:
+                return row
+        return None
+
+
+def _row_to_value(row: dict) -> Value:
+    return vobj(
+        [
+            ("spelling", vstr(row["spelling"])),
+            ("arity", vstr(row["arity"])),
+            ("contract", vstr(row["contract"])),
+            ("effect_kind", vstr(row["effect_kind"])),
+        ]
+    )
+
+
+def _rows_hash(rows: list) -> str:
+    return jcs_hash(varr([_row_to_value(row) for row in rows]))
+
+
+def load_manifest(path: str | Path) -> Manifest:
+    """Load a hashed kit manifest, verifying its integrity.
+
+    Recomputes the JCS/BLAKE3-512 hash of the `rows` array and compares it
+    against the manifest's own `cid` field. A mismatch REFUSES to load: it
+    raises `ManifestIntegrityError` rather than loading with a warning. This
+    is the only lawful path by which community spellings enter the
+    provider-neutral contract types.
+    """
+    manifest_path = Path(path)
+    raw = manifest_path.read_text(encoding="utf-8")
+    data = json.loads(raw)
+
+    if "rows" not in data or "cid" not in data:
+        raise ManifestIntegrityError(
+            f"manifest at {manifest_path} is missing required 'rows' or 'cid' field"
+        )
+
+    rows_data = data["rows"]
+    declared_cid = data["cid"]
+    computed_cid = _rows_hash(rows_data)
+
+    if computed_cid != declared_cid:
+        raise ManifestIntegrityError(
+            f"manifest at {manifest_path} FAILED integrity check: "
+            f"declared cid {declared_cid!r} does not match computed cid "
+            f"{computed_cid!r} over its rows. Refusing to load."
+        )
+
+    rows = tuple(
+        ManifestRow(
+            spelling=row["spelling"],
+            arity=row["arity"],
+            contract=row["contract"],
+            effect_kind=row["effect_kind"],
+        )
+        for row in rows_data
+    )
+    return Manifest(rows=rows, cid=declared_cid, path=manifest_path)
+
+
+def _dotted_name_of(node) -> Optional[str]:
+    """Return the dotted-name string of a Name/Attribute chain, or None if
+    the node is not structurally a pure dotted-name chain (e.g. a call
+    result, subscript, or literal)."""
+    # Local import: this module must not import sugar_source_tree.nodes at
+    # module scope to stay decoupled from a specific tree revision, but the
+    # membrane still needs the concrete classes to do structural isinstance
+    # checks.
+    from sugar_source_tree.nodes import Attribute, Name
+
+    if isinstance(node, Name):
+        return node.id
+    if isinstance(node, Attribute):
+        base = _dotted_name_of(node.value)
+        if base is None:
+            return None
+        return f"{base}.{node.attr}"
+    return None
+
+
+def contract_for_manager(manifest: Manifest, manager_node) -> Optional[Contract]:
+    """Issue the typed contract for a `with`-item's manager expression, or
+    `None` if the manager is not an authenticated, structurally-matching
+    enrollment. `None` means unauthenticated: the caller stays loud.
+    """
+    from sugar_source_tree.nodes import Call
+
+    if not isinstance(manager_node, Call):
+        return None
+
+    spelling = _dotted_name_of(manager_node.func)
+    if spelling is None:
+        return None
+
+    row = manifest.row_for_spelling(spelling)
+    if row is None:
+        return None
+
+    if row.arity == "one-exception-arg":
+        if manager_node.keywords:
+            return None
+        if len(manager_node.args) != 1:
+            return None
+        name = _dotted_name_of(manager_node.args[0])
+        if name is None:
+            return None
+        matcher = EffectMatcher(kind=row.effect_kind, name=name)
+        builder = _CONTRACT_BUILDERS.get(row.contract)
+        if builder is None:
+            return None
+        return builder(matcher)
+
+    # Unknown arity discipline: refuse rather than guess.
+    return None
+
+
+def default_community_manifest() -> Manifest:
+    """Explicitly load the committed community manifest by its known path.
+
+    This accessor performs the load when CALLED — never at import time. No
+    module-level side effect enrolls community coordinates merely by
+    importing this module.
+    """
+    path = (
+        Path(__file__).resolve().parent
+        / "manifests"
+        / "community_context_managers.json"
+    )
+    return load_manifest(path)

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_router.py
@@ -1,0 +1,154 @@
+"""Pure-unit tests for the shared effect router (issue #5994, step 2/3).
+
+Entries are constructed directly -- no tree lifting. Every arm is exercised
+both directions per T's ruling in context_manager_contract.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_contract import (
+    EffectMatcher,
+    Expects,
+    NeverSuppresses,
+    RuntimeSelected,
+    Suppresses,
+)
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.effect_router import (
+    RoutedOutcome,
+    RuntimeSelectedReachedRouter,
+    route,
+)
+from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+from sugar_lift_py_tests.floor.inv_value import InvValue
+from sugar_lift_py_tests.ir import atomic, eq, make_var, str_const
+from sugar_lift_py_tests.outcome.incomplete import Incomplete
+
+
+def _raise_incomplete(name: str) -> Incomplete:
+    return Incomplete(RaiseEffect(exception_name=name))
+
+
+def _some_fact() -> InvValue:
+    return InvValue(atomic("py.truthy", [make_var("x")]))
+
+
+def _callsite(name: str = "f") -> CallSiteValue:
+    return CallSiteValue(
+        target_name=name,
+        arg_values=(),
+        parameters=(),
+        term=make_var(f"__callsite_{name}"),
+        body=None,
+    )
+
+
+# --- Expects -----------------------------------------------------------
+
+
+def test_expects_matching_raise_ground_true_and_consumes_effect():
+    incomplete = _raise_incomplete("ValueError")
+    other = _some_fact()
+    outcome = route(
+        (other, incomplete), Expects(EffectMatcher(kind="raise", name="ValueError"))
+    )
+    assert isinstance(outcome, RoutedOutcome)
+    assert incomplete not in outcome.entries
+    assert other in outcome.entries
+    fact = outcome.stated_facts[0]
+    assert isinstance(fact, InvValue)
+    assert fact.formula == eq(str_const("ValueError"), str_const("ValueError"))
+
+
+def test_expects_completion_no_coordinates_ground_false_lying_twin():
+    other = _some_fact()
+    outcome = route((other,), Expects(EffectMatcher(kind="raise", name="ValueError")))
+    assert other in outcome.entries
+    fact = outcome.stated_facts[0]
+    assert fact.formula == eq(str_const("ValueError"), str_const("py.effect.none"))
+
+
+def test_expects_wrong_effect_ground_false_and_incomplete_survives():
+    incomplete = _raise_incomplete("KeyError")
+    outcome = route((incomplete,), Expects(EffectMatcher(kind="raise", name="ValueError")))
+    assert incomplete in outcome.entries  # F must not disappear
+    fact = outcome.stated_facts[0]
+    assert fact.formula == eq(str_const("ValueError"), str_const("KeyError"))
+
+
+def test_expects_unresolved_callsite_value_emits_opaque_obligation_no_absence_claim():
+    site = _callsite()
+    outcome = route((site,), Expects(EffectMatcher(kind="raise", name="ValueError")))
+    assert outcome.stated_facts == ()  # no InvValue fact -- no absence claimed
+    assert site in outcome.entries
+    obligation = [e for e in outcome.entries if e is not site]
+    assert len(obligation) == 1
+    assert obligation[0] == atomic("py.effect.expected", [str_const("ValueError")])
+
+
+def test_expects_unresolved_operand_callsites_on_inv_also_defers():
+    site = _callsite()
+    inv_with_callsite = InvValue(
+        atomic("py.truthy", [make_var("y")]), operand_callsites=(site,)
+    )
+    outcome = route(
+        (inv_with_callsite,), Expects(EffectMatcher(kind="raise", name="ValueError"))
+    )
+    assert outcome.stated_facts == ()
+    assert inv_with_callsite in outcome.entries
+
+
+# --- Suppresses ----------------------------------------------------------
+
+
+def test_suppresses_matching_consumed_silently():
+    incomplete = _raise_incomplete("ValueError")
+    outcome = route((incomplete,), Suppresses(EffectMatcher(kind="raise", name="ValueError")))
+    assert outcome.entries == ()
+    assert outcome.stated_facts == ()
+
+
+def test_suppresses_absence_nothing_happens():
+    other = _some_fact()
+    outcome = route((other,), Suppresses(EffectMatcher(kind="raise", name="ValueError")))
+    assert outcome.entries == (other,)
+    assert outcome.stated_facts == ()
+
+
+def test_suppresses_non_match_propagates_untouched():
+    incomplete = _raise_incomplete("KeyError")
+    outcome = route((incomplete,), Suppresses(EffectMatcher(kind="raise", name="ValueError")))
+    assert outcome.entries == (incomplete,)
+    assert outcome.stated_facts == ()
+
+
+# --- NeverSuppresses -------------------------------------------------------
+
+
+def test_never_suppresses_identity_with_effect_present():
+    incomplete = _raise_incomplete("ValueError")
+    outcome = route((incomplete,), NeverSuppresses())
+    assert outcome.entries == (incomplete,)
+    assert outcome.stated_facts == ()
+
+
+def test_never_suppresses_identity_without_effect():
+    other = _some_fact()
+    outcome = route((other,), NeverSuppresses())
+    assert outcome.entries == (other,)
+    assert outcome.stated_facts == ()
+
+
+# --- RuntimeSelected -------------------------------------------------------
+
+
+def test_runtime_selected_refuses_loudly():
+    with pytest.raises(RuntimeSelectedReachedRouter):
+        route((_raise_incomplete("ValueError"),), RuntimeSelected())
+
+
+def test_runtime_selected_refuses_loudly_empty_entries_too():
+    with pytest.raises(RuntimeSelectedReachedRouter):
+        route((), RuntimeSelected())

--- a/implementations/python/sugar-lift-py-tests/tests/test_manifest_membrane.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_manifest_membrane.py
@@ -1,0 +1,133 @@
+"""Tests for the hashed kit-manifest enrollment membrane (#5994, items 1/6).
+
+No vendor spelling appears anywhere in this file's assertions about the
+membrane's mechanics; the enrolled spellings are exercised only as literal
+source text fed through the oracle, exactly as any other lift test does.
+"""
+
+import json
+import tempfile
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_contract import Expects, Suppresses
+from sugar_lift_py_tests.manifest_membrane import (
+    ManifestIntegrityError,
+    contract_for_manager,
+    default_community_manifest,
+    load_manifest,
+)
+
+
+def _oracle_source_file(source: str):
+    """Test door that honors the law: text enters only through the oracle
+    (mirrors `sugar_source_tree`'s own `tests/conftest.py::oracle_source_file`
+    — that fixture lives in a sibling package's test tree and is not
+    importable here, so this is a narrow local mirror, not a new door)."""
+    from sugar_source_tree.tree import SourceFile
+
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", suffix=".py", delete=False
+    ) as handle:
+        handle.write(source)
+        path = handle.name
+    return SourceFile.from_path(path)
+
+
+def _with_manager_node(source: str):
+    """Lift `source` (one function containing a single `with` statement) and
+    return the with-item's manager (context_expr) node."""
+    sf = _oracle_source_file(source)
+    fn = next(sf.functions())
+    with_stmt = fn.body[0]
+    return with_stmt.items[0].context_expr
+
+
+def test_committed_manifest_loads_and_hash_verifies():
+    manifest = default_community_manifest()
+    assert manifest.cid.startswith("blake3-512:")
+    spellings = {row.spelling for row in manifest.rows}
+    assert spellings == {
+        "pytest.raises",
+        "contextlib.suppress",
+        "tm.assert_produces_warning",
+    }
+
+
+def test_tampered_manifest_refuses_loudly(tmp_path):
+    committed = default_community_manifest()
+    data = json.loads(committed.path.read_text(encoding="utf-8"))
+    # Tamper with a row without recomputing the cid.
+    data["rows"][0]["spelling"] = "not.the.real.spelling"
+    tampered_path = tmp_path / "tampered.json"
+    tampered_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(ManifestIntegrityError):
+        load_manifest(tampered_path)
+
+
+def test_missing_fields_refuse_loudly(tmp_path):
+    bad_path = tmp_path / "bad.json"
+    bad_path.write_text(json.dumps({"rows": []}), encoding="utf-8")
+    with pytest.raises(ManifestIntegrityError):
+        load_manifest(bad_path)
+
+
+def test_membrane_issues_expects_for_enrolled_raises():
+    manifest = default_community_manifest()
+    source = (
+        "def f():\n"
+        "    with pytest.raises(ValueError):\n"
+        "        pass\n"
+    )
+    node = _with_manager_node(source)
+    contract = contract_for_manager(manifest, node)
+    assert isinstance(contract, Expects)
+    assert contract.matcher.kind == "raise"
+    assert contract.matcher.name == "ValueError"
+
+
+def test_membrane_issues_suppresses_for_enrolled_suppress():
+    manifest = default_community_manifest()
+    source = (
+        "def f():\n"
+        "    with contextlib.suppress(KeyError):\n"
+        "        pass\n"
+    )
+    node = _with_manager_node(source)
+    contract = contract_for_manager(manifest, node)
+    assert isinstance(contract, Suppresses)
+    assert contract.matcher.kind == "raise"
+    assert contract.matcher.name == "KeyError"
+
+
+def test_unenrolled_manager_returns_none():
+    manifest = default_community_manifest()
+    source = (
+        "def f():\n"
+        "    with some_unenrolled_manager(ValueError):\n"
+        "        pass\n"
+    )
+    node = _with_manager_node(source)
+    assert contract_for_manager(manifest, node) is None
+
+
+def test_bare_name_spelling_not_enrolled_returns_none():
+    """A bare-Name callee spelling (`raises(...)`, not `pytest.raises(...)`)
+    is a different dotted-path string and must not tail-match the enrolled
+    `pytest.raises` row."""
+    manifest = default_community_manifest()
+    source = "def f():\n    with raises(ValueError):\n        pass\n"
+    node = _with_manager_node(source)
+    assert contract_for_manager(manifest, node) is None
+
+
+def test_keyword_argument_manager_returns_none():
+    manifest = default_community_manifest()
+    source = (
+        "def f():\n"
+        "    with pytest.raises(ValueError, match='x'):\n"
+        "        pass\n"
+    )
+    node = _with_manager_node(source)
+    assert contract_for_manager(manifest, node) is None


### PR DESCRIPTION
Two fleet lanes, coordinator-verified. Part of #5994.

**manifest_membrane** — rows→contract enrollment, blake3-512 JCS hash verified on load (tamper/missing-field → loud refusal); structural membrane; `default_community_manifest()` explicit load; three exact spellings enrolled **as data**; zero vendor strings in code; tail-matching disproven by test.

**effect_router** — one router for Try and With. `Expects` = obligation with the RaiseEffect as **evidence**: match → ground-true `eq(name, raised)` + effect consumed; completion (no coordinates) → ground-false `eq(name, py.effect.none)` (lying twin); wrong effect → ground-false **and F survives**; unresolved coordinates → opaque `py.effect.expected` obligation, no absence claimed. `Suppresses` = permission; `NeverSuppresses` = identity; `RuntimeSelected` **raises**.

Wiring deliberately absent — gated on this handoff per the issue's order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hashed manifest membrane and shared effect router for with-statement contract lifting
> - Adds [`effect_router.py`](https://github.com/TSavo/sugar/pull/5996/files#diff-4cf76c9fa93d9f06a5ca7d708a3f6f034186b90e4d615a242ff211d0af3652a0) with a `route` entrypoint that dispatches on contract type (`Expects`, `Suppresses`, `NeverSuppresses`, `RuntimeSelected`) and transforms a tuple of entries into a `RoutedOutcome` containing updated entries and asserted facts.
> - Adds [`manifest_membrane.py`](https://github.com/TSavo/sugar/pull/5996/files#diff-38a7443c57e89958d14963311463ee18ac2439702490eaf2c378256d3f571583) with `load_manifest` (blake3-512 JCS integrity check) and `contract_for_manager` that maps a with-statement AST `Call` node to a typed contract via the manifest.
> - Provides `default_community_manifest()` to load the bundled `community_context_managers.json` with integrity verification.
> - Adds pytest suites for both modules covering routing semantics, manifest hash validation, and AST membrane mapping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c1f999.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->