### PR TITLE
fix-forward: the committed community manifest JSON

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/manifests/community_context_managers.json
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/manifests/community_context_managers.json
@@ -1,0 +1,23 @@
+{
+  "rows": [
+    {
+      "spelling": "pytest.raises",
+      "arity": "one-exception-arg",
+      "contract": "expects",
+      "effect_kind": "raise"
+    },
+    {
+      "spelling": "contextlib.suppress",
+      "arity": "one-exception-arg",
+      "contract": "suppresses",
+      "effect_kind": "raise"
+    },
+    {
+      "spelling": "tm.assert_produces_warning",
+      "arity": "one-exception-arg",
+      "contract": "expects",
+      "effect_kind": "warning"
+    }
+  ],
+  "cid": "blake3-512:977d6d4341008a65eb71a6a54e072fb676749dde2a50b563e0f0153890754115de1a952b0830a750c7bfadb015ec4a970620807681fd04d96d76fb16b1c250e7"
+}


### PR DESCRIPTION
The membrane merged without its data — a non-recursive `cp` dropped the manifests directory during lane reconciliation; caught immediately, before any consumer. Part of #5994.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add community context manager manifest for pytest, contextlib, and tm warning assertions
> Adds [community_context_managers.json](https://github.com/TSavo/sugar/pull/5997/files#diff-29b277ce12f460a608ba01b7b225c40a6709297c2b69c7448b0c8415386a5e77) defining three context manager rows: `pytest.raises`, `contextlib.suppress`, and `tm.assert_produces_warning`. Each entry specifies arity (`one-exception-arg`), a contract (`expects` or `suppresses`), and an effect kind (`raise` or `warning`), along with a blake3-512 `cid` hash.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2aeade0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->