### PR TITLE
with (#5994): wire Expects/Suppresses through the membrane + router

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
@@ -138,8 +138,10 @@ def _route_expects(entries: tuple, matcher: EffectMatcher) -> RoutedOutcome:
     if _has_unresolved_call_coordinates(entries):
         # Honest red: a dig may still produce the expected effect. Do not
         # claim absence -- emit an opaque obligation instead of a fact.
-        obligation = atomic(_EFFECT_EXPECTED_OBLIGATION, [str_const(matcher.name)])
-        return RoutedOutcome(entries=(*entries, obligation))
+        obligation = InvValue(
+            atomic(_EFFECT_EXPECTED_OBLIGATION, [str_const(matcher.name)])
+        )
+        return RoutedOutcome(entries=(*entries, obligation), stated_facts=(obligation,))
 
     # Completion with no hiding coordinates: the lying twin. The expected
     # effect is asserted absent, ground-false.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/expr_statement_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/expr_statement_sugar.py
@@ -32,8 +32,13 @@ class ExprStatementSugar(Sugar):
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.floor.block_value import BlockValue
 
-        # Reduce the value (effects propagate via and_then); a completed value
-        # in statement position states nothing -- inert contribution.
+        # Reduce the value (effects propagate via and_then). A completed value
+        # in statement position STATES nothing -- but it is not erased: it rides
+        # as a record entry, contributing only what its own floor defaults give
+        # (a docstring: nothing; a call coordinate: its callEdge cue, and its
+        # visibility to the effect router -- dropping it made `with raises(E):
+        # do_thing()` claim a FALSE absence, since the router could no longer
+        # see that a halt might hide behind the unresolved call).
         return self.value.desugar(ctx).and_then(
-            lambda _value: Complete(BlockValue((), can_fall_through=True))
+            lambda value: Complete(BlockValue((value,), can_fall_through=True))
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_contract_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_contract_sugar.py
@@ -1,0 +1,75 @@
+"""`with <manager>: <body>` under a TYPED contract -- the #5994 wiring.
+
+The node consults the recognition membrane (never a vendor name); the membrane
+issues a typed contract; this sugar reduces the body as a block and hands the
+outcome to the ONE effect router shared with Try. The contract decides:
+
+- ``Expects(matcher)``: the obligation `observed_effect matches expected` --
+  a matching halt is EVIDENCE, consumed into a ground-true fact; a completed
+  body (no hiding coordinates) is the lying twin; a wrong effect states the
+  mismatch AND keeps the effect; unresolved call coordinates retain an opaque
+  obligation, never an absence claim.
+- ``Suppresses(matcher)``: permission -- a matching halt is consumed silently;
+  absence is fine; a non-matching effect propagates.
+
+Everything else about `with` stays LOUD at the node: unauthenticated managers,
+RuntimeSelected, warning-kind matchers (no WarningEffect exists to observe yet
+-- wiring them would mint false absent-twins), `as` witnesses (step 5), multiple
+managers, and the resource expansion (step 4, finally-faithful, its own build).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field, replace
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_pair
+
+
+@dataclass(frozen=True)
+class WithContractSugar(Sugar):
+    contract: object  # Expects | Suppresses (raise-kind only; the node guards)
+    body: tuple  # the body statements' sugars, in source order
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        # The obligation discriminates: a body that halts with the expected
+        # exception discharges; asserting the wrong function outcome lies.
+        prefix = (
+            "def A(z):\n"
+            "    with pytest.raises(ValueError):\n"
+            "        raise ValueError\n"
+            "    return z\n\n"
+        )
+        return _call_pair(
+            name="with_expects_raise",
+            owner_sugar="WithContractSugar",
+            truthful=prefix + "def test_a():\n    assert A(5) == 5\n",
+            lying=prefix + "def test_a():\n    assert A(5) == 6\n",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.effect_router import route
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.floor.inv_value import InvValue
+        from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_statements
+
+        entries, _falls, _ft = reduce_statements(self.body)
+        routed = route(tuple(entries), self.contract)
+
+        # The router's facts carry no site; the mint demands one. Re-seat each
+        # stated fact on this with's fragment (the locus that stated it).
+        sited = tuple(
+            replace(e, site=self.site)
+            if isinstance(e, InvValue) and e.site is None
+            else e
+            for e in routed.entries
+        )
+        from sugar_lift_py_tests.outcome import Incomplete
+
+        # A consumed halt completes the with: fall-through is restored exactly
+        # when no red testimony survives the routing.
+        can_fall_through = not any(isinstance(e, Incomplete) for e in sited)
+        return Complete(BlockValue(sited, can_fall_through=can_fall_through))

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_router.py
@@ -81,11 +81,19 @@ def test_expects_wrong_effect_ground_false_and_incomplete_survives():
 def test_expects_unresolved_callsite_value_emits_opaque_obligation_no_absence_claim():
     site = _callsite()
     outcome = route((site,), Expects(EffectMatcher(kind="raise", name="ValueError")))
-    assert outcome.stated_facts == ()  # no InvValue fact -- no absence claimed
+    # The obligation IS a stated inv row (an InvValue -- a raw formula would
+    # crash the record); what is NOT stated is ABSENCE: the fact is the opaque
+    # py.effect.expected, never the ground-false equality.
+    assert len(outcome.stated_facts) == 1
+    assert outcome.stated_facts[0].formula == atomic(
+        "py.effect.expected", [str_const("ValueError")]
+    )
     assert site in outcome.entries
     obligation = [e for e in outcome.entries if e is not site]
     assert len(obligation) == 1
-    assert obligation[0] == atomic("py.effect.expected", [str_const("ValueError")])
+    assert obligation[0].formula == atomic(
+        "py.effect.expected", [str_const("ValueError")]
+    )
 
 
 def test_expects_unresolved_operand_callsites_on_inv_also_defers():
@@ -96,7 +104,8 @@ def test_expects_unresolved_operand_callsites_on_inv_also_defers():
     outcome = route(
         (inv_with_callsite,), Expects(EffectMatcher(kind="raise", name="ValueError"))
     )
-    assert outcome.stated_facts == ()
+    assert len(outcome.stated_facts) == 1
+    assert outcome.stated_facts[0].formula.name == "py.effect.expected"
     assert inv_with_callsite in outcome.entries
 
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1549,6 +1549,37 @@ class With(Statement):
     body: Tuple[Statement, ...]
     _child_fields = ("items", "body")
 
+    def sugar(self):
+        """`with <manager>: <body>` -- the node consults the MEMBRANE, never a
+        vendor name (#5994). A single manager with no `as`, whose membrane-issued
+        contract is a raise-kind Expects/Suppresses, wires through the shared
+        effect router (WithContractSugar). Everything else stays LOUD: the
+        unauthenticated manager (the named residual), warning-kind matchers (no
+        WarningEffect exists to observe -- wiring would mint false absent-twins),
+        `as` witnesses (step 5), multiple managers, and resource managers (the
+        finally-faithful expansion, step 4)."""
+        if len(self.items) != 1 or self.items[0].optional_vars is not None:
+            return super().sugar()
+        from sugar_lift_py_tests.context_manager_contract import Expects, Suppresses
+        from sugar_lift_py_tests.manifest_membrane import (
+            contract_for_manager,
+            default_community_manifest,
+        )
+        from sugar_lift_py_tests.sugar.with_contract_sugar import WithContractSugar
+
+        contract = contract_for_manager(
+            default_community_manifest(), self.items[0].context_expr
+        )
+        if not isinstance(contract, (Expects, Suppresses)):
+            return super().sugar()  # unauthenticated / runtime-selected: loud
+        if contract.matcher.kind != "raise":
+            return super().sugar()  # no WarningEffect to observe yet: loud
+        return WithContractSugar(
+            contract=contract,
+            body=tuple(stmt.sugar() for stmt in self.body),
+            site=self.fragment,
+        )
+
     def substitute(self, scope):
         """with ... as <vars>: binds the as-targets for the body."""
         from .shadow import rewrite

--- a/implementations/python/sugar-source-tree/tests/test_with_contract.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_contract.py
@@ -1,0 +1,128 @@
+"""`with` under a typed contract (#5994 wiring): the membrane issues, the shared
+router routes, the node stays loud for everything unowned. The twin subset that
+is wireable today (resource expansion, `as` witnesses, warning-kind are later
+steps and stay loud)."""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _val(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).sugar().desugar().value
+
+
+def _fn(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def test_expected_matching_raise_discharges_and_consumes():
+    v = _val(
+        "def A(z):\n    with pytest.raises(ValueError):\n        raise ValueError\n"
+        "    return z\n"
+    )
+    inv = v.invs()[0]
+    assert inv.name == "="  # ground-true eq(ValueError, ValueError)
+    assert inv.args[0].value == inv.args[1].value == "ValueError"
+    assert v.post().args[1].name == "z"  # the function completes past the with
+
+
+def test_expected_effect_absent_is_the_lying_twin():
+    v = _val(
+        "def A(z):\n    with pytest.raises(ValueError):\n        z = 1\n    return z\n"
+    )
+    inv = v.invs()[0]
+    assert inv.args[0].value == "ValueError" and inv.args[1].value == "py.effect.none"
+
+
+def test_wrong_effect_states_mismatch_and_survives():
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    v = _val(
+        "def A(z):\n    with pytest.raises(ValueError):\n        raise KeyError\n"
+        "    return z\n"
+    )
+    inv = v.invs()[0]
+    assert inv.args[1].value == "KeyError"  # the mismatch fact
+    reds = [e for e in v.record.contribution() if isinstance(e, Incomplete)]
+    assert len(reds) == 1  # KeyError did not disappear
+
+
+def test_unresolved_call_keeps_the_obligation_open():
+    v = _val(
+        "def A(z):\n    with pytest.raises(ValueError):\n        do_thing(z)\n"
+        "    return z\n"
+    )
+    assert v.invs()[0].name == "py.effect.expected"  # never an absence claim
+
+
+def test_suppress_matching_consumed():
+    v = _val(
+        "def A(z):\n    with contextlib.suppress(KeyError):\n        raise KeyError\n"
+        "    return z\n"
+    )
+    assert v.invs() == () and v.post().args[1].name == "z"
+
+
+def test_suppress_non_match_propagates():
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    v = _val(
+        "def A(z):\n    with contextlib.suppress(KeyError):\n        raise ValueError\n"
+        "    return z\n"
+    )
+    reds = [e for e in v.record.contribution() if isinstance(e, Incomplete)]
+    assert len(reds) == 1  # ValueError rides through the permission
+
+
+def test_unauthenticated_manager_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(z):\n    with open(z):\n        pass\n    return z\n").sugar()
+
+
+def test_as_witness_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(z):\n    with pytest.raises(ValueError) as ei:\n"
+            "        raise ValueError\n    return z\n"
+        ).sugar()
+
+
+def test_warning_kind_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(z):\n    with tm.assert_produces_warning(FutureWarning):\n"
+            "        pass\n    return z\n"
+        ).sugar()
+
+
+def test_multiple_managers_stay_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(z):\n    with pytest.raises(ValueError), contextlib.suppress(KeyError):\n"
+            "        pass\n    return z\n"
+        ).sugar()
+
+
+if __name__ == "__main__":
+    test_expected_matching_raise_discharges_and_consumes()
+    test_expected_effect_absent_is_the_lying_twin()
+    test_wrong_effect_states_mismatch_and_survives()
+    test_unresolved_call_keeps_the_obligation_open()
+    test_suppress_matching_consumed()
+    test_suppress_non_match_propagates()
+    test_unauthenticated_manager_stays_loud()
+    test_as_witness_stays_loud()
+    test_warning_kind_stays_loud()
+    test_multiple_managers_stay_loud()
+    print("ok: with under typed contracts -- ten twins")


### PR DESCRIPTION
With.sugar consults the membrane (never a vendor name): one manager, no as, raise-kind Expects/Suppresses -> WithContractSugar routes the reduced body through the shared effect router; a consumed halt restores fall-through. Loud named residuals: unauthenticated, warning-kind, as (step 5), multiple managers, resource expansion (step 4).

Two intersection defects found while wiring: ExprStatementSugar erased the bare call's coordinate, making with-raises over a bare call claim a false absence (the most common pandas shape) -- expression statements now carry their value as a record entry, which also makes bare statement calls project their callEdge cue; and the router's opaque obligation was a raw formula (record crash) -- now an InvValue stated fact.

Ten twins from the issue's instrument list. sugar-source-tree: 191 passed, 5 skipped. Part of #5994.

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire Expects/Suppresses contracts through the membrane and effect router for `with` blocks
> - `With` nodes with a single manager and no `as` now desugar to `WithContractSugar` when the membrane issues an `Expects` or `Suppresses` raise-kind contract via `contract_for_manager`; other cases fall back to the default loud behavior.
> - `WithContractSugar.desugar` routes accumulated block entries through the effect router: matching raises are consumed, wrong effects persist with a mismatch fact, and unresolved callsites yield an `InvValue` obligation fact. Fall-through is restored only when no `Incomplete` entries remain.
> - `_route_expects` in [effect_router.py](https://github.com/TSavo/sugar/pull/5998/files#diff-4cf76c9fa93d9f06a5ca7d708a3f6f034186b90e4d615a242ff211d0af3652a0) now wraps unresolved-callsite obligations in `InvValue` and includes them in `stated_facts` instead of appending a bare atomic term.
> - Expression statements in [expr_statement_sugar.py](https://github.com/TSavo/sugar/pull/5998/files#diff-f31e170a6e37295ad5e3460626d1a509629d633d94a364bbf01ebf6938b97737) now retain their reduced value as a record entry rather than discarding it, which affects call-coordinate visibility during effect routing.
> - Behavioral Change: `_route_expects` for unresolved callsites now emits an `InvValue` in both `entries` and `stated_facts`; callers expecting a raw atomic term will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a538ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->