### PR TITLE
with (#5994): the match= conjunction -- per-obligation honesty, 96% admitted

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
@@ -31,11 +31,26 @@ from typing import Optional
 
 
 @dataclass(frozen=True)
+class MessagePattern:
+    """A payload obligation: the observed effect's message must match this
+    regex. Independently dischargeable -- undischarged (not passed, not failed)
+    until the effect witness carries authenticated message content."""
+
+    pattern: str
+
+
+@dataclass(frozen=True)
 class EffectMatcher:
-    """Matches an effect by kind and exception/warning name (exact)."""
+    """A CONJUNCTION of independently dischargeable obligations (T's ruling:
+    the unit of honesty is the individual obligation, never the surface
+    construct). The type obligation is decidable against the observed halt;
+    each payload obligation (e.g. MessagePattern from `match=`) carries its own
+    closed verdict -- discharged / refuted / undischarged -- sharing the same
+    observed-effect witness identity."""
 
     kind: str  # "raise" | "warning"
     name: str  # e.g. "ValueError", "FutureWarning"
+    payload_obligations: tuple = ()  # e.g. (MessagePattern(pat),)
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
@@ -123,28 +123,51 @@ def _route_expects(entries: tuple, matcher: EffectMatcher) -> RoutedOutcome:
     if matching is not None:
         index, incomplete = matching
         observed = str_const(incomplete.effect.exception_name)
-        fact = InvValue(eq(str_const(matcher.name), observed))
+        # The TYPE obligation: discharged (ground-true equality; the halt is
+        # the evidence, consumed). Each PAYLOAD obligation (T's conjunction
+        # ruling) is its own row with its own verdict: a MessagePattern stays
+        # UNDISCHARGED -- an opaque py.effect.message_matches over the SAME
+        # observed witness -- until the effect carries authenticated message
+        # content. Never one aggregate boolean; the unobservable message
+        # neither silences the type testimony nor pretends the pattern held.
+        facts = [InvValue(eq(str_const(matcher.name), observed))]
+        for obligation in matcher.payload_obligations:
+            facts.append(
+                InvValue(
+                    atomic(
+                        "py.effect.message_matches",
+                        [observed, str_const(obligation.pattern)],
+                    )
+                )
+            )
         remaining = entries[:index] + entries[index + 1 :]
-        return RoutedOutcome(entries=(*remaining, fact), stated_facts=(fact,))
+        return RoutedOutcome(
+            entries=(*remaining, *facts), stated_facts=tuple(facts)
+        )
 
     wrong = _first_incomplete_raise(entries)
     if wrong is not None:
         _, incomplete = wrong
-        # Wrong effect: name the ground-false equality, but the Incomplete
-        # itself is NOT consumed -- F must not disappear.
+        # Wrong effect: the type obligation is REFUTED (ground-false equality)
+        # and the Incomplete is NOT consumed -- F must not disappear. Payload
+        # obligations are INAPPLICABLE (their witness is the matching halt,
+        # which does not exist), never independently emitted or passed.
         fact = InvValue(eq(str_const(matcher.name), str_const(incomplete.effect.exception_name)))
         return RoutedOutcome(entries=(*entries, fact), stated_facts=(fact,))
 
     if _has_unresolved_call_coordinates(entries):
         # Honest red: a dig may still produce the expected effect. Do not
-        # claim absence -- emit an opaque obligation instead of a fact.
-        obligation = InvValue(
-            atomic(_EFFECT_EXPECTED_OBLIGATION, [str_const(matcher.name)])
-        )
+        # claim absence -- emit an opaque obligation carrying the WHOLE
+        # conjunction (type name + any payload patterns), all undischarged.
+        operands = [str_const(matcher.name)] + [
+            str_const(o.pattern) for o in matcher.payload_obligations
+        ]
+        obligation = InvValue(atomic(_EFFECT_EXPECTED_OBLIGATION, operands))
         return RoutedOutcome(entries=(*entries, obligation), stated_facts=(obligation,))
 
-    # Completion with no hiding coordinates: the lying twin. The expected
-    # effect is asserted absent, ground-false.
+    # Completion with no hiding coordinates: the required-effect obligation is
+    # REFUTED (asserted absent, ground-false). Payload obligations are
+    # inapplicable -- no effect witness exists -- not independently "passed".
     fact = InvValue(eq(str_const(matcher.name), str_const(_EFFECT_ABSENT_NAME)))
     return RoutedOutcome(entries=(*entries, fact), stated_facts=(fact,))
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/manifest_membrane.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/manifest_membrane.py
@@ -188,6 +188,46 @@ def contract_for_manager(manifest: Manifest, manager_node) -> Optional[Contract]
             return None
         return builder(matcher)
 
+    if row.arity == "exception-arg-optional-match":
+        # `raises(E)` or `raises(E, match=<str literal>)`. ONLY the enrolled
+        # kwarg is admitted; the pattern becomes an independently dischargeable
+        # MessagePattern payload obligation (T's ruling: the conjunction). All
+        # of these stay unauthenticated (None -> loud): unknown kwargs,
+        # duplicate match, match=None (community semantics unpinned), a
+        # non-literal pattern (nothing to state), an invalid regex (its own
+        # effect, never folded into non-match).
+        if len(manager_node.args) != 1:
+            return None
+        name = _dotted_name_of(manager_node.args[0])
+        if name is None:
+            return None
+        payload: tuple = ()
+        if manager_node.keywords:
+            if len(manager_node.keywords) != 1:
+                return None
+            kw = manager_node.keywords[0]
+            if kw.arg != "match":
+                return None
+            value = kw.value
+            if value.kind != "Constant" or not isinstance(value.value, str):
+                return None  # match=None / non-literal: unpinned or unstateable
+            import re as _re
+
+            try:
+                _re.compile(value.value)
+            except _re.error:
+                return None  # invalid regex: its own effect, not a non-match
+            from sugar_lift_py_tests.context_manager_contract import MessagePattern
+
+            payload = (MessagePattern(value.value),)
+        matcher = EffectMatcher(
+            kind=row.effect_kind, name=name, payload_obligations=payload
+        )
+        builder = _CONTRACT_BUILDERS.get(row.contract)
+        if builder is None:
+            return None
+        return builder(matcher)
+
     # Unknown arity discipline: refuse rather than guess.
     return None
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/manifests/community_context_managers.json
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/manifests/community_context_managers.json
@@ -2,7 +2,7 @@
   "rows": [
     {
       "spelling": "pytest.raises",
-      "arity": "one-exception-arg",
+      "arity": "exception-arg-optional-match",
       "contract": "expects",
       "effect_kind": "raise"
     },
@@ -19,5 +19,5 @@
       "effect_kind": "warning"
     }
   ],
-  "cid": "blake3-512:977d6d4341008a65eb71a6a54e072fb676749dde2a50b563e0f0153890754115de1a952b0830a750c7bfadb015ec4a970620807681fd04d96d76fb16b1c250e7"
+  "cid": "blake3-512:f68630ce0039444f5d370fc4aadc635c0ba497615908e877cf66a82382c54344b2db03f4be7c50745c34e823d32c88c174999135289c4dcc108027f3f438448c"
 }

--- a/implementations/python/sugar-lift-py-tests/tests/test_manifest_membrane.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_manifest_membrane.py
@@ -122,11 +122,28 @@ def test_bare_name_spelling_not_enrolled_returns_none():
     assert contract_for_manager(manifest, node) is None
 
 
-def test_keyword_argument_manager_returns_none():
+def test_enrolled_match_kwarg_issues_the_conjunction():
+    # The 96% shape: the enrolled `match=` kwarg is ADMITTED and becomes an
+    # independently dischargeable MessagePattern payload obligation.
     manifest = default_community_manifest()
     source = (
         "def f():\n"
         "    with pytest.raises(ValueError, match='x'):\n"
+        "        pass\n"
+    )
+    node = _with_manager_node(source)
+    contract = contract_for_manager(manifest, node)
+    assert contract is not None
+    assert contract.matcher.name == "ValueError"
+    assert contract.matcher.payload_obligations[0].pattern == "x"
+
+
+def test_unknown_keyword_argument_returns_none():
+    # Only explicitly enrolled kwargs are admitted; anything else stays loud.
+    manifest = default_community_manifest()
+    source = (
+        "def f():\n"
+        "    with pytest.raises(ValueError, check=1):\n"
         "        pass\n"
     )
     node = _with_manager_node(source)

--- a/implementations/python/sugar-source-tree/tests/test_with_contract.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_contract.py
@@ -126,3 +126,41 @@ if __name__ == "__main__":
     test_warning_kind_stays_loud()
     test_multiple_managers_stay_loud()
     print("ok: with under typed contracts -- ten twins")
+
+
+def test_match_conjunction_type_discharged_message_undischarged():
+    # The 96% shape: raises(E, match=pat). Two rows, closed verdicts each:
+    # type discharged (ground-true eq), message UNDISCHARGED (opaque
+    # py.effect.message_matches over the SAME observed witness) -- never one
+    # aggregate boolean, never a silent drop of match=.
+    v = _val(
+        'def A(z):\n    with pytest.raises(ValueError, match="bad"):\n'
+        "        raise ValueError\n    return z\n"
+    )
+    invs = v.invs()
+    assert len(invs) == 2
+    type_row = [i for i in invs if getattr(i, "name", "") == "="][0]
+    msg_row = [i for i in invs if getattr(i, "name", "") == "py.effect.message_matches"][0]
+    assert type_row.args[0].value == type_row.args[1].value == "ValueError"
+    assert msg_row.args[0].value == "ValueError"  # shared observed witness
+    assert msg_row.args[1].value == "bad"
+
+
+def test_match_deferred_carries_the_whole_conjunction():
+    v = _val(
+        'def A(z):\n    with pytest.raises(ValueError, match="x"):\n'
+        "        do_thing(z)\n    return z\n"
+    )
+    inv = v.invs()[0]
+    assert inv.name == "py.effect.expected"
+    assert [a.value for a in inv.args] == ["ValueError", "x"]
+
+
+def test_match_rejections_stay_loud():
+    for src in (
+        'def A(z):\n    with pytest.raises(ValueError, match=None):\n        pass\n    return z\n',
+        'def A(z):\n    with pytest.raises(ValueError, match="["):\n        pass\n    return z\n',
+        'def A(z):\n    with pytest.raises(ValueError, check=1):\n        pass\n    return z\n',
+    ):
+        with pytest.raises(SugarNotWritten):
+            _fn(src).sugar()


### PR DESCRIPTION
T's ruling: the unit of honesty is the individual obligation. raises(E, match=pat) is a conjunction — type AND message — each with a closed verdict (discharged/refuted/undischarged) sharing one observed witness. The unobservable message neither silences type testimony nor pretends the pattern held.

EffectMatcher gains payload_obligations (MessagePattern); membrane admits ONLY the enrolled match= kwarg (loud: unknown kwargs, match=None, non-literal, invalid regex — its own effect, never a non-match); router emits the discharged type row + an undischarged py.effect.message_matches row per pattern (same witness); wrong-type/completion make payload obligations inapplicable, never passed; deferral carries the whole conjunction.

96% of pandas' 5,512 raises sites carry match= — now admitted, name-half decidable, message-half honestly open. Part of #5994.

194 tree + 9 membrane + 12 router tests green.

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `match=` keyword support to `pytest.raises` contract with per-obligation honesty
> - Introduces a new `MessagePattern` payload obligation and `exception-arg-optional-match` arity discipline so `pytest.raises(E, match="...")` can be authenticated by the manifest membrane.
> - When a matching raise is observed, `_route_expects` now emits one `py.effect.type_eq` invariant plus one `py.effect.message_matches` invariant per pattern, rather than a single type equality fact.
> - When deferred (unresolved call coordinates), the `py.effect.expected` obligation now carries both the exception name and all pattern strings as operands.
> - Rejects unknown keywords, non-literal or `None` match values, and invalid regex patterns by returning `None` (raising `SugarNotWritten`).
> - The `pytest.raises` entry in [community_context_managers.json](https://github.com/TSavo/sugar/pull/5999/files#diff-29b277ce12f460a608ba01b7b225c40a6709297c2b69c7448b0c8415386a5e77) is updated from `one-exception-arg` to `exception-arg-optional-match`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59e547a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->