### PR TITLE
the fragment-type seam: one structural site protocol; store targets attach witnesses

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/runtime_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/runtime_effect.py
@@ -2,38 +2,59 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, TypedDict, cast
+from typing import Protocol, TypedDict, cast, runtime_checkable
 
 from sugar_lift_py_tests.ir import Term
 
-if TYPE_CHECKING:
-    from sugar_lift_py_tests.factory.source_fragment import SourceFragment
+
+@runtime_checkable
+class RuntimeEffectSite(Protocol):
+    """The structural contract a witness address must satisfy: a filename, a
+    1-based line, a 0-based column.
+
+    This is the ONE seam every fragment currency threads through. The tree's
+    live fragment (``sugar_source_tree.fragment.SourceFragment``) and the
+    kit's own factory-era fragment (``sugar_lift_py_tests.source_fragment
+    .SourceFragment``, re-exported for compatibility as
+    ``sugar_lift_py_tests.factory.source_fragment.SourceFragment``) both
+    already answer these three attributes — so admission here is structural,
+    never a name check against one concrete class over the other. The tree
+    fragment is the primary, hot-path address; the factory fragment remains
+    admitted through this SAME structural door for the kit's own floor
+    evaluators (list/dict/string/symbolic value dispatch, opaque call sites,
+    …) that still mint their evidence from a factory-owned operation node —
+    there is no separate legacy branch to fall back to, because both
+    fragments are the one shape this protocol names.
+    """
+
+    filename: str
+    line: int
+    col: int
 
 
-def resolve_runtime_effect_site(site) -> "SourceFragment":
-    """Admit only a genuine SourceFragment as the witness address.
+def resolve_runtime_effect_site(site) -> RuntimeEffectSite:
+    """Admit only a genuine fragment (any currency) as the witness address.
 
     The fragment may arrive directly, or as the ``site`` / ``blame`` field of an
     operation object that still carries the fragment (not a locus string). A
     stringly locus cannot mint evidence — reconstruct from the owning fragment
     instead of projecting blame prose into a fake address.
     """
-    from sugar_lift_py_tests.factory.source_fragment import SourceFragment
-
-    if isinstance(site, SourceFragment):
+    if isinstance(site, RuntimeEffectSite):
         return site
     nested = getattr(site, "site", None)
-    if isinstance(nested, SourceFragment):
+    if isinstance(nested, RuntimeEffectSite):
         return nested
     blame = getattr(site, "blame", None)
-    if isinstance(blame, SourceFragment):
+    if isinstance(blame, RuntimeEffectSite):
         return blame
     raise TypeError(
-        "RuntimeEffectWitness.site must be a SourceFragment (genuine runtime "
-        f"locus). Got {type(site).__name__}={site!r}. Thread the fragment that "
-        "owns the boundary; do not reconstruct evidence from blame prose or "
-        "string loci. replacement=pass the SourceFragment (or an operation "
-        "whose .site/.blame still holds that fragment)."
+        "RuntimeEffectWitness.site must be a fragment answering filename/"
+        f"line/col (genuine runtime locus). Got {type(site).__name__}={site!r}."
+        " Thread the fragment that owns the boundary; do not reconstruct "
+        "evidence from blame prose or string loci. replacement=pass the "
+        "fragment (or an operation whose .site/.blame still holds that "
+        "fragment)."
     )
 
 
@@ -165,18 +186,18 @@ def is_lift_time_decidable(term: Term) -> bool:
 class RuntimeEffectWitness:
     """Evidence that perfect lift-time machinery still meets a runtime operand.
 
-    Constructed FROM the SourceFragment that owns the runtime boundary: the
-    site IS the address, so an absolute or empty locus is unrepresentable by
-    construction (SourceFragment.from_node normalizes filenames at the door).
-    Fabricated string sites and non-term operands are refused at the door.
+    Constructed FROM the fragment that owns the runtime boundary: the site IS
+    the address, so an absolute or empty locus is unrepresentable by
+    construction (both fragment currencies normalize filenames at their own
+    construction doors). Fabricated string sites and non-term operands are
+    refused here.
     """
 
     operation: Term
     runtime_operand: RuntimeOperand
-    site: "SourceFragment"
+    site: RuntimeEffectSite
 
     def __post_init__(self) -> None:
-        from sugar_lift_py_tests.factory.source_fragment import SourceFragment
         from sugar_lift_py_tests.ir import Term as TermType
 
         if not isinstance(self.operation, TermType):
@@ -194,17 +215,22 @@ class RuntimeEffectWitness:
                 "RuntimeEffectWitness.runtime_operand.term must be a Term; got "
                 f"{type(self.runtime_operand.term).__name__}"
             )
-        if not isinstance(self.site, SourceFragment):
+        if not isinstance(self.site, RuntimeEffectSite):
             raise TypeError(
-                "RuntimeEffectWitness.site must be a SourceFragment; got "
-                f"{type(self.site).__name__}={self.site!r}. Thread the fragment "
-                "that owns the boundary — string loci are unrepresentable."
+                "RuntimeEffectWitness.site must be a fragment answering "
+                f"filename/line/col; got {type(self.site).__name__}={self.site!r}."
+                " Thread the fragment that owns the boundary — string loci are "
+                "unrepresentable."
             )
 
     @property
     def locus(self) -> str:
-        """The witness address, projected for display: ``file:line:col``."""
-        return str(self.site)
+        """The witness address, projected for display: ``file:line:col``.
+
+        Built directly from the site's structural fields rather than
+        ``str(self.site)`` — the two fragment currencies are not required to
+        share a ``__str__`` rendering, only the filename/line/col contract."""
+        return f"{self.site.filename}:{self.site.line}:{self.site.col}"
 
     @property
     def operand(self) -> Term:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Incomplete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import typed_red_effect_witness
+
+
+@dataclass(frozen=True)
+class AttributeStoreEffectSugar(Sugar):
+    """`<receiver>.<attr> = <value>` -- an attribute store whose receiver
+    identity belongs to the runtime: Python attribute assignment can invoke
+    descriptors and ``__setattr__`` at runtime, so the exact post-state is not
+    lift-time decidable.
+
+    Unlike ``AssignSugar`` (a plain-Name target, spent by substitute), a
+    store target is never bound -- it is read AND written, so it carries no
+    inert-meaning arm. This desugars straight to typed red: ``Incomplete``
+    wrapping an ``AttributeStoreRuntimeEffect``, witnessed at the TREE
+    fragment site (``site``, the statement's own fragment -- the sole site
+    type on this hot path; see ``effect/runtime_effect.py``'s
+    ``RuntimeEffectSite`` protocol). The store completed (Python continues
+    to the next statement), so ``Incomplete.follow()`` treats this effect as
+    continue-with-red, not halt (outcome/incomplete.py::
+    _effect_continues_control_flow) -- the block keeps reducing past it.
+    """
+
+    attr: str
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return typed_red_effect_witness(
+            name="attribute_store_runtime_effect",
+            owner_sugar="AttributeStoreEffectSugar",
+            source="def A(o, v):\n    o.a = v\n    return v\n",
+            effect_class="AttributeStoreRuntimeEffect",
+            reason_needle="attribute store",
+            blame_needle="attr=a",
+            wrong_reason_needle="attribute store target `.b`",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.effect import (
+            AttributeStoreRuntimeEffect,
+            runtime_effect_evidence,
+        )
+        from sugar_lift_py_tests.ir import make_var
+
+        operand = make_var(f"store_target.{self.attr}")
+        return Incomplete(
+            AttributeStoreRuntimeEffect(
+                "attribute assignment runtime boundary: attribute store "
+                f"target `.{self.attr}` -- receiver identity belongs to "
+                "Python's runtime __setattr__/descriptor dispatch; "
+                f"attr={self.attr} site={self.site}",
+                **runtime_effect_evidence("py.setattr", operand, self.site),
+            )
+        )
+
+
+@dataclass(frozen=True)
+class SubscriptStoreEffectSugar(Sugar):
+    """`<receiver>[<index>] = <value>` -- a subscript store whose dispatch
+    (``__setitem__``) belongs to the runtime.
+
+    Same shape as ``AttributeStoreEffectSugar``: a store target is read and
+    written, never bound, so it desugars straight to typed red --
+    ``Incomplete`` wrapping a ``SubscriptStoreRuntimeEffect``, witnessed at
+    the TREE fragment site. The store completed, so the block continues past
+    it (outcome/incomplete.py::_effect_continues_control_flow).
+    """
+
+    index_text: str
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return typed_red_effect_witness(
+            name="subscript_store_runtime_effect",
+            owner_sugar="SubscriptStoreEffectSugar",
+            source="def A(xs, i, v):\n    xs[i] = v\n    return v\n",
+            effect_class="SubscriptStoreRuntimeEffect",
+            reason_needle="subscript store",
+            blame_needle="index=i",
+            wrong_reason_needle="subscript store target `[j]`",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.effect import (
+            SubscriptStoreRuntimeEffect,
+            runtime_effect_evidence,
+        )
+        from sugar_lift_py_tests.ir import make_var
+
+        operand = make_var(f"store_target[{self.index_text}]")
+        return Incomplete(
+            SubscriptStoreRuntimeEffect(
+                "subscript assignment runtime boundary: subscript store "
+                f"target `[{self.index_text}]` -- receiver dispatch belongs "
+                "to Python's runtime __setitem__; "
+                f"index={self.index_text} site={self.site}",
+                **runtime_effect_evidence("py.setitem", operand, self.site),
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/tests/test_fragment_type_seam.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_fragment_type_seam.py
@@ -1,0 +1,91 @@
+"""The fragment-type seam: `resolve_runtime_effect_site` admits a fragment
+structurally (RuntimeEffectSite: filename/line/col), not by isinstance-ing
+one concrete class. The tree's own SourceFragment (the hot-path currency for
+statement-level effect attachment) and the kit's factory-era SourceFragment
+(still the currency the floor evaluators mint their evidence from) are both
+admitted through the SAME predicate -- there is no separate isinstance arm
+naming either class, so neither is a silently-preferred dual citizen and
+neither is a name-checked legacy branch. An object that does NOT answer
+filename/line/col is unrepresentable as a witness address."""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_py_tests.effect.runtime_effect import (
+    RuntimeEffectSite,
+    resolve_runtime_effect_site,
+    runtime_effect_evidence,
+)
+from sugar_lift_py_tests.factory.source_fragment import SourceFragment as FactoryFragment
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.fragment import SourceFragment as TreeFragment
+from sugar_source_tree.tree import SourceFile
+
+
+def _tree_fragment(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    fn = next(SourceFile(path_source(path)).functions())
+    return fn.fragment
+
+
+def test_tree_fragment_satisfies_the_site_protocol_structurally():
+    frag = _tree_fragment("def A(z):\n    return z\n")
+    assert isinstance(frag, RuntimeEffectSite)
+    assert resolve_runtime_effect_site(frag) is frag
+
+
+def test_factory_fragment_satisfies_the_same_site_protocol():
+    frag = FactoryFragment.from_source("x = 1", "t.py").statements()[0]
+    assert isinstance(frag, RuntimeEffectSite)
+    assert resolve_runtime_effect_site(frag) is frag
+
+
+def test_tree_fragment_mints_full_runtime_effect_evidence():
+    """No adapter, no shim: the tree fragment builds a real witness through
+    the same door the factory fragment uses."""
+    from sugar_lift_py_tests.ir import make_var
+
+    frag = _tree_fragment("def A(z):\n    return z\n")
+    evidence = runtime_effect_evidence("py.setattr", make_var("runtime_v"), frag)
+    witness = evidence["witness"]
+    assert witness.site is frag
+    assert witness.locus == f"{frag.filename}:{frag.line}:{frag.col}"
+
+
+def test_an_object_missing_line_col_is_unrepresentable_as_a_site():
+    """The negative space: nothing that fails the structural contract can
+    mint evidence, regardless of which fragment "family" a caller intended."""
+
+    class NotAFragment:
+        filename = "x.py"
+        # no line, no col
+
+    with pytest.raises(TypeError, match="filename/"):
+        resolve_runtime_effect_site(NotAFragment())
+
+
+def test_no_isinstance_of_a_named_fragment_class_gates_the_door():
+    """Structural discipline check: the seam's admission predicate is the
+    protocol, not either concrete fragment class -- so a duck-typed
+    stand-in with the right shape is admitted too, proving there is no
+    hidden isinstance(..., SomeConcreteFragment) arm left in the door."""
+
+    class DuckFragment:
+        filename = "duck.py"
+        line = 3
+        col = 4
+
+    duck = DuckFragment()
+    assert resolve_runtime_effect_site(duck) is duck
+
+
+if __name__ == "__main__":
+    test_tree_fragment_satisfies_the_site_protocol_structurally()
+    test_factory_fragment_satisfies_the_same_site_protocol()
+    test_tree_fragment_mints_full_runtime_effect_evidence()
+    test_an_object_missing_line_col_is_unrepresentable_as_a_site()
+    test_no_isinstance_of_a_named_fragment_class_gates_the_door()
+    print("ok: fragment-type seam unified on the structural site protocol")

--- a/implementations/python/sugar-lift-py-tests/tests/test_runtime_effect_witness.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_runtime_effect_witness.py
@@ -78,7 +78,7 @@ def test_source_fragment_passes_pseudo_filenames_untouched() -> None:
 def test_string_locus_cannot_mint_a_runtime_effect_witness() -> None:
     from sugar_lift_py_tests.effect import runtime_effect_witness
 
-    with pytest.raises(TypeError, match="SourceFragment"):
+    with pytest.raises(TypeError, match="filename/"):
         runtime_effect_witness(
             "py.divide",
             genuine_runtime_operand("py.divide", make_var("x")),

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -924,6 +924,26 @@ class Assign(Statement):
                 site=self.fragment,
             )
 
+        if len(self.targets) == 1 and isinstance(self.targets[0], Attribute):
+            from sugar_lift_py_tests.sugar.store_effect_sugar import (
+                AttributeStoreEffectSugar,
+            )
+
+            return AttributeStoreEffectSugar(
+                attr=self.targets[0].attr,
+                site=self.fragment,
+            )
+
+        if len(self.targets) == 1 and isinstance(self.targets[0], Subscript):
+            from sugar_lift_py_tests.sugar.store_effect_sugar import (
+                SubscriptStoreEffectSugar,
+            )
+
+            return SubscriptStoreEffectSugar(
+                index_text=self.targets[0].slice_.fragment.text,
+                site=self.fragment,
+            )
+
         return super().sugar()
 
 

--- a/implementations/python/sugar-source-tree/tests/test_assign_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_targets.py
@@ -1,13 +1,21 @@
 """`a, b = <display>` destructures against a matching Tuple/List rhs, and
 `x = y = e` chains a single rhs to several names -- both are threaded by
 substitute exactly like the single-Name case, so both go inert at the
-meaning layer. Starred/nested targets, arity mismatches, and store targets
-(attribute/subscript) do not thread and stay loud gaps."""
+meaning layer. Starred/nested targets and arity mismatches do not thread
+and stay loud gaps. Store targets (attribute/subscript) are never bound --
+they lift straight to a typed red runtime effect instead (the fragment-type
+seam; see test_store_target_effect.py for the full witness/continuation
+discipline)."""
 
 import tempfile
 
 import pytest
 
+from sugar_lift_py_tests.effect import (
+    AttributeStoreRuntimeEffect,
+    SubscriptStoreRuntimeEffect,
+)
+from sugar_lift_py_tests.outcome import Incomplete
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
@@ -78,14 +86,18 @@ def test_mixed_chained_targets_stay_loud():
         _fn("def A():\n    x = (a, b) = (1, 2)\n    return x\n").sugar()
 
 
-def test_attribute_store_target_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A(o):\n    o.a = 1\n    return o\n").sugar()
+def test_attribute_store_target_lifts_a_typed_red_effect():
+    entries = _fn("def A(o):\n    o.a = 1\n    return o\n").sugar().desugar().value.record.statements
+    red = [e for e in entries if isinstance(e, Incomplete)]
+    assert len(red) == 1
+    assert isinstance(red[0].effect, AttributeStoreRuntimeEffect)
 
 
-def test_subscript_store_target_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A(xs):\n    xs[0] = 1\n    return xs\n").sugar()
+def test_subscript_store_target_lifts_a_typed_red_effect():
+    entries = _fn("def A(xs):\n    xs[0] = 1\n    return xs\n").sugar().desugar().value.record.statements
+    red = [e for e in entries if isinstance(e, Incomplete)]
+    assert len(red) == 1
+    assert isinstance(red[0].effect, SubscriptStoreRuntimeEffect)
 
 
 if __name__ == "__main__":
@@ -98,6 +110,9 @@ if __name__ == "__main__":
     test_arity_mismatch_stays_loud()
     test_non_display_rhs_stays_loud()
     test_mixed_chained_targets_stay_loud()
-    test_attribute_store_target_stays_loud()
-    test_subscript_store_target_stays_loud()
-    print("ok: tuple/chained assign destructures; starred/nested/store stay loud")
+    test_attribute_store_target_lifts_a_typed_red_effect()
+    test_subscript_store_target_lifts_a_typed_red_effect()
+    print(
+        "ok: tuple/chained assign destructures; starred/nested stay loud; "
+        "store targets lift typed red"
+    )

--- a/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
+++ b/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
@@ -1,0 +1,109 @@
+"""Store-target assignments (`obj.a = e`, `xs[i] = e`) attach a typed red
+runtime-effect witness at the TREE fragment site (the fragment-type seam,
+#5994-adjacent). The store completed -- Python continues -- so the block
+keeps reducing past it (see outcome/incomplete.py::
+_effect_continues_control_flow); the returned value is unaffected."""
+
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.effect import (
+    AttributeStoreRuntimeEffect,
+    SubscriptStoreRuntimeEffect,
+)
+from sugar_lift_py_tests.outcome import Incomplete
+from sugar_source_tree.fragment import SourceFragment as TreeSourceFragment
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _entries(src):
+    outcome = _fn(src).sugar().desugar()
+    return outcome.value.record.statements
+
+
+def test_attribute_store_lifts_a_red_effect_and_the_block_continues():
+    entries = _entries("def A(o, v):\n    o.a = v\n    return v\n")
+    red = [e for e in entries if isinstance(e, Incomplete)]
+    assert len(red) == 1
+    assert isinstance(red[0].effect, AttributeStoreRuntimeEffect)
+    # the block kept reducing: a ReturnValue entry rides beside the effect
+    assert any(type(e).__name__ == "ReturnValue" for e in entries)
+
+
+def test_attribute_store_post_out_equals_the_returned_value():
+    v = _fn("def A(o, v):\n    o.a = v\n    return v\n").sugar().desugar().value
+    post = v.post()
+    assert post.name == "="
+    assert post.args[0].name == "out"
+    assert post.args[1].name == "v"
+
+
+def test_subscript_store_lifts_a_red_effect_and_the_block_continues():
+    entries = _entries("def A(xs, i, v):\n    xs[i] = v\n    return v\n")
+    red = [e for e in entries if isinstance(e, Incomplete)]
+    assert len(red) == 1
+    assert isinstance(red[0].effect, SubscriptStoreRuntimeEffect)
+    assert any(type(e).__name__ == "ReturnValue" for e in entries)
+
+
+def test_subscript_store_post_out_equals_the_returned_value():
+    v = (
+        _fn("def A(xs, i, v):\n    xs[i] = v\n    return v\n")
+        .sugar()
+        .desugar()
+        .value
+    )
+    post = v.post()
+    assert post.name == "="
+    assert post.args[0].name == "out"
+    assert post.args[1].name == "v"
+
+
+def test_attribute_store_witness_site_is_the_tree_fragment():
+    """Discrimination: the effect's evidence names the right site AND the
+    right target -- the witness address is the TREE's own fragment
+    currency, not a reconstructed/factory one, and the operand cites the
+    attribute actually stored."""
+    entries = _entries("def A(o, v):\n    o.a = v\n    return v\n")
+    (red,) = [e for e in entries if isinstance(e, Incomplete)]
+    witness = red.effect.witness
+    assert isinstance(witness.site, TreeSourceFragment)
+    assert witness.site.text == "o.a = v"
+    assert "store_target.a" in repr(witness.runtime_operand.term)
+
+
+def test_subscript_store_witness_names_the_index():
+    entries = _entries("def A(xs, i, v):\n    xs[i] = v\n    return v\n")
+    (red,) = [e for e in entries if isinstance(e, Incomplete)]
+    witness = red.effect.witness
+    assert isinstance(witness.site, TreeSourceFragment)
+    assert "store_target[i]" in repr(witness.runtime_operand.term)
+
+
+def test_two_stores_in_one_block_both_lift_and_discriminate_by_target():
+    entries = _entries(
+        "def A(o, v, w):\n    o.a = v\n    o.b = w\n    return v\n"
+    )
+    red = [e for e in entries if isinstance(e, Incomplete)]
+    assert len(red) == 2
+    operands = {repr(e.effect.witness.runtime_operand.term) for e in red}
+    assert any("store_target.a" in o for o in operands)
+    assert any("store_target.b" in o for o in operands)
+
+
+if __name__ == "__main__":
+    test_attribute_store_lifts_a_red_effect_and_the_block_continues()
+    test_attribute_store_post_out_equals_the_returned_value()
+    test_subscript_store_lifts_a_red_effect_and_the_block_continues()
+    test_subscript_store_post_out_equals_the_returned_value()
+    test_attribute_store_witness_site_is_the_tree_fragment()
+    test_subscript_store_witness_names_the_index()
+    test_two_stores_in_one_block_both_lift_and_discriminate_by_target()
+    print("ok: store-target assignments lift typed red witnessed by the tree fragment")


### PR DESCRIPTION
T's cut. The witness consumes exactly filename/line/col (measured). The factory fragment is not legacy (~30 live floor call sites), so the unification is ONE runtime_checkable RuntimeEffectSite protocol — one predicate, one definition of a site, no dual-citizen isinstance branches; both fragments satisfy it structurally; a shape missing line/col refuses.

Receipt the seam is open: store-target assignments attach their typed red witness from the tree (Attribute/Subscript arms -> Incomplete(store effect) via runtime_effect_evidence; stores continue-with-red, so `o.a = v; return v` lifts red with out == v).

Out of scope, untouched: full store drain, resource expansion, WarningEffect, Try, as-witnesses — the cascade consumes this next. Part of #5994's substrate.

sugar-source-tree 201 passed; seam+witness tests 16 passed.

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `RuntimeEffectSite` protocol and lift attribute/subscript store targets to typed red effects
> - Introduces `RuntimeEffectSite`, a `runtime_checkable` Protocol requiring `filename`, `line`, and `col` attributes, replacing the concrete `SourceFragment` dependency in `RuntimeEffectWitness` and `resolve_runtime_effect_site`.
> - Adds `AttributeStoreEffectSugar` and `SubscriptStoreEffectSugar` in [store_effect_sugar.py](https://github.com/TSavo/sugar/pull/6000/files#diff-6f46518d171fa580b4032690b7812b715f45c1e70297923383aff5601e14128e), each desugaring into a typed red `Incomplete` wrapping the corresponding `AttributeStoreRuntimeEffect` or `SubscriptStoreRuntimeEffect`.
> - Extends `Assign.substitution_binding` in [nodes.py](https://github.com/TSavo/sugar/pull/6000/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to detect single-target attribute and subscript assignments and return the appropriate Sugar, where previously these fell through without effect.
> - `witness.locus` is now formatted as `filename:line:col` directly rather than delegating to the site's `__str__`, making the output independent of site implementation.
> - Behavioral Change: any object with `filename`/`line`/`col` now satisfies the site contract; objects lacking these attributes now raise `TypeError` with updated message text.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc33353.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assignment to object attributes and indexed items now lifts into typed runtime effects.
  * Runtime effect evidence supports compatible source locations across different fragment types.
  * Runtime effect locations now consistently display as `filename:line:column`.

* **Bug Fixes**
  * Store-target assignments continue processing subsequent statements and preserve returned values.

* **Tests**
  * Added coverage for attribute and subscript stores, source locations, witness metadata, and structural fragment compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->