### PR TITLE
Python With: add non-halting WarningEffect routing

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py
@@ -48,6 +48,7 @@ from .modulo_by_zero_runtime_effect import ModuloByZeroRuntimeEffect
 from .os_exit_runtime_effect import OSExitRuntimeEffect
 from .power_runtime_effect import PowerRuntimeEffect
 from .raise_effect import RaiseEffect
+from .warning_effect import WarningEffect
 from .runtime_effect import (
     RuntimeEffect,
     RuntimeOperand,
@@ -117,6 +118,7 @@ __all__ = [
     "OSExitRuntimeEffect",
     "PowerRuntimeEffect",
     "RaiseEffect",
+    "WarningEffect",
     "RuntimeEffect",
     "RuntimeOperand",
     "RuntimeEffectWitness",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/effect.py
@@ -6,13 +6,17 @@ from .coverage_gap_effect import CoverageGapEffect
 from .raise_effect import RaiseEffect
 from .runtime_effect import RuntimeEffect
 from .source_oracle_effect import SourceOracleEffect
+from .warning_effect import WarningEffect
 
 # FactoryGapEffect and DigBoundaryEffect are DELETED.
 # No-recognizer is panic, not a typed Incomplete arm.
-Effect = RaiseEffect | RuntimeEffect | CoverageGapEffect | SourceOracleEffect
+Effect = (
+    RaiseEffect | WarningEffect | RuntimeEffect | CoverageGapEffect | SourceOracleEffect
+)
 
 EffectStatus = Literal[
     "raise-effect",
+    "warning-effect",
     "runtime-effect",
     "coverage-gap",
     "absent",
@@ -25,6 +29,7 @@ def require_effect(effect: object) -> Effect:
         effect,
         (
             RaiseEffect,
+            WarningEffect,
             RuntimeEffect,
             CoverageGapEffect,
             SourceOracleEffect,
@@ -33,7 +38,7 @@ def require_effect(effect: object) -> Effect:
         return effect
     raise TypeError(
         "Incomplete.effect must be a typed Effect "
-        "(RaiseEffect | RuntimeEffect | CoverageGapEffect | SourceOracleEffect); "
+        "(RaiseEffect | WarningEffect | RuntimeEffect | CoverageGapEffect | SourceOracleEffect); "
         "FactoryGap/DigBoundary were deleted — the None arm panics"
     )
 
@@ -41,6 +46,8 @@ def require_effect(effect: object) -> Effect:
 def effect_kind(effect: Effect) -> str:
     if isinstance(effect, RaiseEffect):
         return "RaiseEffect"
+    if isinstance(effect, WarningEffect):
+        return "WarningEffect"
     if isinstance(effect, RuntimeEffect):
         return "RuntimeEffect"
     if isinstance(effect, CoverageGapEffect):
@@ -52,6 +59,8 @@ def effect_kind(effect: Effect) -> str:
 
 def effect_reason(effect: Effect) -> str:
     if isinstance(effect, RaiseEffect):
+        return effect.reason
+    if isinstance(effect, WarningEffect):
         return effect.reason
     if isinstance(effect, RuntimeEffect):
         return effect.reason
@@ -65,6 +74,8 @@ def effect_reason(effect: Effect) -> str:
 def effect_status(effect: Effect) -> EffectStatus:
     if isinstance(effect, RaiseEffect):
         return "raise-effect"
+    if isinstance(effect, WarningEffect):
+        return "warning-effect"
     if isinstance(effect, RuntimeEffect):
         return "runtime-effect"
     if isinstance(effect, CoverageGapEffect):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/warning_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/warning_effect.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class WarningEffect:
+    """A non-halting Python warning observation.
+
+    Category is independently observable from message.  ``message`` remains
+    ``None`` until an authenticated producer carries it; absence is not an
+    empty message and cannot discharge a message-pattern obligation.
+    """
+
+    category_name: str
+    message: str | None = None
+    blame: str | None = None
+
+    @property
+    def reason(self) -> str:
+        locus = f" at {self.blame}" if self.blame is not None else ""
+        return (
+            f"warning {self.category_name}{locus}: a non-halting Python warning effect"
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
@@ -45,6 +45,7 @@ from sugar_lift_py_tests.context_manager_contract import (
     Suppresses,
 )
 from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.floor.warning_observation_value import WarningObservationValue
 from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
 from sugar_lift_py_tests.floor.inv_value import InvValue
 from sugar_lift_py_tests.ir import atomic, eq, str_const
@@ -79,25 +80,36 @@ class RoutedOutcome:
     stated_facts: tuple = ()
 
 
-def _matching_incomplete_raise(entries: tuple, matcher: EffectMatcher):
-    """Return the (index, Incomplete) of the first Incomplete(RaiseEffect)
-    whose effect matches ``matcher`` by EXACT kind+name (pinned rule -- a
-    subclass raise is the mismatch twin, never silently matched), or None."""
-    if matcher.kind != "raise":
-        return None
-    for index, entry in enumerate(entries):
-        if isinstance(entry, Incomplete) and isinstance(entry.effect, RaiseEffect):
-            if entry.effect.exception_name == matcher.name:
-                return index, entry
+def _observed_effect(entry):
+    if isinstance(entry, Incomplete) and isinstance(entry.effect, RaiseEffect):
+        return "raise", entry.effect.exception_name, None, True
+    if isinstance(entry, WarningObservationValue):
+        return "warning", entry.effect.category_name, entry.effect.message, False
     return None
 
 
-def _first_incomplete_raise(entries: tuple):
+def _matching_effect(entries: tuple, matcher: EffectMatcher):
+    """Return the (index, Incomplete) of the first Incomplete(RaiseEffect)
+    whose effect matches ``matcher`` by EXACT kind+name (pinned rule -- a
+    subclass raise is the mismatch twin, never silently matched), or None."""
+    for index, entry in enumerate(entries):
+        observed = _observed_effect(entry)
+        if (
+            observed is not None
+            and observed[0] == matcher.kind
+            and observed[1] == matcher.name
+        ):
+            return index, entry, observed
+    return None
+
+
+def _first_effect_of_kind(entries: tuple, kind: str):
     """Any Incomplete(RaiseEffect) at all, matching or not (for the wrong-effect
     twin: some raise happened, just not the one that was expected)."""
     for index, entry in enumerate(entries):
-        if isinstance(entry, Incomplete) and isinstance(entry.effect, RaiseEffect):
-            return index, entry
+        observed = _observed_effect(entry)
+        if observed is not None and observed[0] == kind:
+            return index, entry, observed
     return None
 
 
@@ -119,10 +131,10 @@ def _has_unresolved_call_coordinates(entries: tuple) -> bool:
 
 
 def _route_expects(entries: tuple, matcher: EffectMatcher) -> RoutedOutcome:
-    matching = _matching_incomplete_raise(entries, matcher)
+    matching = _matching_effect(entries, matcher)
     if matching is not None:
-        index, incomplete = matching
-        observed = str_const(incomplete.effect.exception_name)
+        index, _entry, observation = matching
+        observed = str_const(observation[1])
         # The TYPE obligation: discharged (ground-true equality; the halt is
         # the evidence, consumed). Each PAYLOAD obligation (T's conjunction
         # ruling) is its own row with its own verdict: a MessagePattern stays
@@ -132,27 +144,30 @@ def _route_expects(entries: tuple, matcher: EffectMatcher) -> RoutedOutcome:
         # neither silences the type testimony nor pretends the pattern held.
         facts = [InvValue(eq(str_const(matcher.name), observed))]
         for obligation in matcher.payload_obligations:
+            # Message absence is an explicit open obligation over the SAME
+            # effect witness.  An observed message can now state the concrete
+            # message coordinate; regex discharge remains the solver's job.
+            message = observation[2]
+            message_term = observed if message is None else str_const(message)
             facts.append(
                 InvValue(
                     atomic(
                         "py.effect.message_matches",
-                        [observed, str_const(obligation.pattern)],
+                        [message_term, str_const(obligation.pattern)],
                     )
                 )
             )
         remaining = entries[:index] + entries[index + 1 :]
-        return RoutedOutcome(
-            entries=(*remaining, *facts), stated_facts=tuple(facts)
-        )
+        return RoutedOutcome(entries=(*remaining, *facts), stated_facts=tuple(facts))
 
-    wrong = _first_incomplete_raise(entries)
+    wrong = _first_effect_of_kind(entries, matcher.kind)
     if wrong is not None:
-        _, incomplete = wrong
+        _, _entry, observation = wrong
         # Wrong effect: the type obligation is REFUTED (ground-false equality)
         # and the Incomplete is NOT consumed -- F must not disappear. Payload
         # obligations are INAPPLICABLE (their witness is the matching halt,
         # which does not exist), never independently emitted or passed.
-        fact = InvValue(eq(str_const(matcher.name), str_const(incomplete.effect.exception_name)))
+        fact = InvValue(eq(str_const(matcher.name), str_const(observation[1])))
         return RoutedOutcome(entries=(*entries, fact), stated_facts=(fact,))
 
     if _has_unresolved_call_coordinates(entries):
@@ -173,11 +188,11 @@ def _route_expects(entries: tuple, matcher: EffectMatcher) -> RoutedOutcome:
 
 
 def _route_suppresses(entries: tuple, matcher: EffectMatcher) -> RoutedOutcome:
-    matching = _matching_incomplete_raise(entries, matcher)
+    matching = _matching_effect(entries, matcher)
     if matching is None:
         # Absence is fine; non-matching effects (if any) propagate untouched.
         return RoutedOutcome(entries=entries)
-    index, _incomplete = matching
+    index, _entry, _observation = matching
     remaining = entries[:index] + entries[index + 1 :]
     return RoutedOutcome(entries=remaining)
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -56,6 +56,7 @@ from .opaque_op_callsite import OpaqueOpCallsite
 from .predicate_value import PredicateValue
 from .raise_value import RaiseValue
 from .raises_with_value import RaisesWithValue
+from .warning_observation_value import WarningObservationValue
 from .return_value import ReturnValue
 from .scope_rebind import GuardedScopeRebind, ScopeRebind
 from .sequence_constructor import SequenceConstructor
@@ -188,6 +189,7 @@ __all__ = [
     "PredicateValue",
     "RaiseValue",
     "RaisesWithValue",
+    "WarningObservationValue",
     "ReturnValue",
     "ScopeRebind",
     "SequenceConstructor",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/warning_observation_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/warning_observation_value.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .floor_value import FloorValue
+from sugar_lift_py_tests.effect.warning_effect import WarningEffect
+
+
+@dataclass(frozen=True)
+class WarningObservationValue(FloorValue):
+    """Continuing record entry carrying one observed warning.
+
+    Unlike ``Incomplete(RaiseEffect)``, a warning does not halt the block.
+    The ordinary ``FloorValue.follow_rest`` therefore remains correct while
+    the shared effect router can consume this value as expectation evidence.
+    """
+
+    effect: WarningEffect

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_router.py
@@ -25,6 +25,8 @@ from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
 from sugar_lift_py_tests.floor.inv_value import InvValue
 from sugar_lift_py_tests.ir import atomic, eq, make_var, str_const
 from sugar_lift_py_tests.outcome.incomplete import Incomplete
+from sugar_lift_py_tests.effect.warning_effect import WarningEffect
+from sugar_lift_py_tests.floor.warning_observation_value import WarningObservationValue
 
 
 def _raise_incomplete(name: str) -> Incomplete:
@@ -43,6 +45,10 @@ def _callsite(name: str = "f") -> CallSiteValue:
         term=make_var(f"__callsite_{name}"),
         body=None,
     )
+
+
+def _warning(name: str, message: str | None = None) -> WarningObservationValue:
+    return WarningObservationValue(WarningEffect(name, message=message))
 
 
 # --- Expects -----------------------------------------------------------
@@ -72,7 +78,9 @@ def test_expects_completion_no_coordinates_ground_false_lying_twin():
 
 def test_expects_wrong_effect_ground_false_and_incomplete_survives():
     incomplete = _raise_incomplete("KeyError")
-    outcome = route((incomplete,), Expects(EffectMatcher(kind="raise", name="ValueError")))
+    outcome = route(
+        (incomplete,), Expects(EffectMatcher(kind="raise", name="ValueError"))
+    )
     assert incomplete in outcome.entries  # F must not disappear
     fact = outcome.stated_facts[0]
     assert fact.formula == eq(str_const("ValueError"), str_const("KeyError"))
@@ -109,26 +117,54 @@ def test_expects_unresolved_operand_callsites_on_inv_also_defers():
     assert inv_with_callsite in outcome.entries
 
 
+def test_expects_matching_warning_consumes_non_halting_observation():
+    warning = _warning("FutureWarning")
+    outcome = route(
+        (warning,), Expects(EffectMatcher(kind="warning", name="FutureWarning"))
+    )
+    assert warning not in outcome.entries
+    assert outcome.stated_facts[0].formula == eq(
+        str_const("FutureWarning"), str_const("FutureWarning")
+    )
+
+
+def test_expects_wrong_warning_refutes_and_preserves_observation():
+    warning = _warning("UserWarning")
+    outcome = route(
+        (warning,), Expects(EffectMatcher(kind="warning", name="FutureWarning"))
+    )
+    assert warning in outcome.entries
+    assert outcome.stated_facts[0].formula == eq(
+        str_const("FutureWarning"), str_const("UserWarning")
+    )
+
+
 # --- Suppresses ----------------------------------------------------------
 
 
 def test_suppresses_matching_consumed_silently():
     incomplete = _raise_incomplete("ValueError")
-    outcome = route((incomplete,), Suppresses(EffectMatcher(kind="raise", name="ValueError")))
+    outcome = route(
+        (incomplete,), Suppresses(EffectMatcher(kind="raise", name="ValueError"))
+    )
     assert outcome.entries == ()
     assert outcome.stated_facts == ()
 
 
 def test_suppresses_absence_nothing_happens():
     other = _some_fact()
-    outcome = route((other,), Suppresses(EffectMatcher(kind="raise", name="ValueError")))
+    outcome = route(
+        (other,), Suppresses(EffectMatcher(kind="raise", name="ValueError"))
+    )
     assert outcome.entries == (other,)
     assert outcome.stated_facts == ()
 
 
 def test_suppresses_non_match_propagates_untouched():
     incomplete = _raise_incomplete("KeyError")
-    outcome = route((incomplete,), Suppresses(EffectMatcher(kind="raise", name="ValueError")))
+    outcome = route(
+        (incomplete,), Suppresses(EffectMatcher(kind="raise", name="ValueError"))
+    )
     assert outcome.entries == (incomplete,)
     assert outcome.stated_facts == ()
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -267,8 +267,7 @@ class Node(Typed):
             return new, new is not value
         items = tuple(value)
         new_items = tuple(
-            item.substitute(scope) if isinstance(item, Node) else item
-            for item in items
+            item.substitute(scope) if isinstance(item, Node) else item for item in items
         )
         changed = any(new is not old for new, old in zip(new_items, items))
         return (new_items if changed else value), changed
@@ -290,7 +289,9 @@ class Node(Typed):
             return self
         return rewrite(self, **changed)
 
-    def substitution_binding(self, scope: "dict[str, Node]") -> "Optional[dict[str, Node]]":
+    def substitution_binding(
+        self, scope: "dict[str, Node]"
+    ) -> "Optional[dict[str, Node]]":
         """The binding this STATEMENT introduces for the rest of its block, or
         None. An assignment returns ``{name: its substituted rhs}``; an augmented
         assignment reads the OLD value from ``scope`` to build ``x OP e``;
@@ -310,7 +311,9 @@ class Node(Typed):
             ("op", OpLeaf(op)),
             ("right", Child(_handle_of(right))),
         )
-        return materialize(self.unit, ShadowNode("BinOp", self.span, slots), self.reporter)
+        return materialize(
+            self.unit, ShadowNode("BinOp", self.span, slots), self.reporter
+        )
 
     def _substitute_body(self, statements: tuple, scope: "dict[str, Node]"):
         new_items, changed, _net = self._substitute_body_tracked(statements, scope)
@@ -346,7 +349,9 @@ class Node(Typed):
             # here so the block threads each one -- the loop's carried accumulator
             # is just ordinary block-threading over the unrolled sequence. The
             # expanded statements are already substituted; thread their bindings.
-            produced = new_stmt.statements if isinstance(new_stmt, _Splice) else (new_stmt,)
+            produced = (
+                new_stmt.statements if isinstance(new_stmt, _Splice) else (new_stmt,)
+            )
             for produced_stmt in produced:
                 new_items.append(produced_stmt)
                 binding = produced_stmt.substitution_binding(scope)
@@ -471,9 +476,7 @@ class Node(Typed):
         while stack:
             node = stack.pop()
             yield node
-            stack.extend(
-                child for _, _, child in reversed(list(node.children()))
-            )
+            stack.extend(child for _, _, child in reversed(list(node.children())))
 
     def __repr__(self) -> str:  # pragma: no cover
         return f"<{self.kind} [{self.span.start},{self.span.end})>"
@@ -572,9 +575,12 @@ class Comprehension(Node):
         scope; the target binds for its own ifs. Threading across clauses is the
         enclosing comprehension's job (_substitute_generators)."""
         from .shadow import rewrite
+
         new_iter, di = self._substitute_field(self.iter, scope)
         bound = self._bound_names_in(self.target)
-        ifs_scope = {k: v for k, v in scope.items() if k not in bound} if bound else scope
+        ifs_scope = (
+            {k: v for k, v in scope.items() if k not in bound} if bound else scope
+        )
         new_ifs, df = self._substitute_field(self.ifs, ifs_scope)
         changed = {}
         if di:
@@ -593,6 +599,7 @@ class ExceptHandler(Node):
     def substitute(self, scope):
         """except <type> as <name>: binds the exception name for the body."""
         from .shadow import rewrite
+
         bound = {self.name} if self.name else set()
         bs = {k: v for k, v in scope.items() if k not in bound} if bound else scope
         changed = {}
@@ -613,6 +620,7 @@ class WithItem(Node):
     def substitute(self, scope):
         """Substitute the context expr; optional_vars is a binding site."""
         from .shadow import rewrite
+
         new_ctx, d = self._substitute_field(self.context_expr, scope)
         return self if not d else rewrite(self, context_expr=new_ctx)
 
@@ -639,6 +647,7 @@ class MatchCase(Node):
         (a capture bound to the match SUBJECT, threaded by ``Match.substitute``)
         are re-applied so a `case x:` body sees x = subject, not a free name."""
         from .shadow import rewrite
+
         bound = self._pattern_bound_names(self.pattern)
         inner = {k: v for k, v in scope.items() if k not in bound} if bound else scope
         if extra_bindings:
@@ -749,9 +758,7 @@ class FunctionDef(Statement):
         # tree construction path re-enters it here.
         lc = self.line_col_span()
         where = f"{self.unit.filename}:{lc.start_line} {self.name}"
-        with reduction_span(
-            sugar="FunctionUniverse", role="construction", site=where
-        ):
+        with reduction_span(sugar="FunctionUniverse", role="construction", site=where):
             # Phase spans: the bisection instrument. A slow function names its
             # slow PHASE here; the per-statement spans inside _substitute_body
             # then name the statement. We measure; we do not guess.
@@ -797,8 +804,13 @@ class ClassDef(Statement):
         the type params then bind for the bases, keywords, and body. The body is
         threaded (a class body reads the enclosing scope; it opens no closure)."""
         from .shadow import rewrite
-        tnames = {n for tp in self.type_params
-                  for n in [getattr(tp, "name", None)] if isinstance(n, str)}
+
+        tnames = {
+            n
+            for tp in self.type_params
+            for n in [getattr(tp, "name", None)]
+            if isinstance(n, str)
+        }
         inner = {k: v for k, v in scope.items() if k not in tnames} if tnames else scope
         changed = {}
         for fld in ("decorators", "type_params"):
@@ -999,6 +1011,7 @@ class AnnAssign(Statement):
         """`<target>: <ann> = <value>` -- substitute the annotation and value;
         the target is a binding site, never substituted."""
         from .shadow import rewrite
+
         changed = {}
         for fld in ("annotation", "value"):
             new, d = self._substitute_field(getattr(self, fld), scope)
@@ -1043,8 +1056,13 @@ class TypeAlias(Statement):
         """`type <name>[<params>] = <value>` -- the type params bind for the
         value; the name is a binding site."""
         from .shadow import rewrite
-        tnames = {n for tp in self.type_params
-                  for n in [getattr(tp, "name", None)] if isinstance(n, str)}
+
+        tnames = {
+            n
+            for tp in self.type_params
+            for n in [getattr(tp, "name", None)]
+            if isinstance(n, str)
+        }
         inner = {k: v for k, v in scope.items() if k not in tnames} if tnames else scope
         changed = {}
         new_tp, d = self._substitute_field(self.type_params, scope)
@@ -1199,7 +1217,11 @@ class For(Statement):
             return None
         value = assign.value
         # value must be `<name> OP <expr involving the loop target>`.
-        if value.kind != "BinOp" or value.left.kind != "Name" or value.left.id != name.id:
+        if (
+            value.kind != "BinOp"
+            or value.left.kind != "Name"
+            or value.left.id != name.id
+        ):
             return None
         init = scope.get(name.id)
         if init is None:
@@ -1213,7 +1235,9 @@ class For(Statement):
         from .shadow import ShadowNode
 
         return materialize(
-            self.unit, ShadowNode("Name", self.span, (("id", Leaf(identifier)),)), self.reporter
+            self.unit,
+            ShadowNode("Name", self.span, (("id", Leaf(identifier)),)),
+            self.reporter,
         )
 
     def _make_call(self, func: "Node", args: tuple) -> "Node":
@@ -1225,7 +1249,9 @@ class For(Statement):
             ("args", Children(tuple(_handle_of(a) for a in args))),
             ("keywords", Children(())),
         )
-        return materialize(self.unit, ShadowNode("Call", self.span, slots), self.reporter)
+        return materialize(
+            self.unit, ShadowNode("Call", self.span, slots), self.reporter
+        )
 
     def sugar(self):
         """A loop that did NOT dissolve in substitute is symbolic: its iterable is
@@ -1326,8 +1352,10 @@ class For(Statement):
         negative bound parses as `UnaryOp(USub, Constant(n))` (cpython does
         not fold the literal), so both shapes are recognized; `bool` is
         rejected even though it subclasses `int`."""
-        if arg.kind == "Constant" and isinstance(arg.value, int) and not isinstance(
-            arg.value, bool
+        if (
+            arg.kind == "Constant"
+            and isinstance(arg.value, int)
+            and not isinstance(arg.value, bool)
         ):
             return arg.value
         if arg.kind == "UnaryOp" and arg.op.kind == "USub":
@@ -1367,7 +1395,9 @@ class For(Statement):
             ("value", Leaf(value)),
             ("literal_kind", Leaf(None)),
         )
-        return materialize(self.unit, ShadowNode("Constant", self.span, slots), self.reporter)
+        return materialize(
+            self.unit, ShadowNode("Constant", self.span, slots), self.reporter
+        )
 
 
 class AsyncFor(Statement):
@@ -1534,7 +1564,9 @@ class If(Statement):
             ("targets", Children((_handle_of(target),))),
             ("value", Child(_handle_of(value))),
         )
-        return materialize(self.unit, ShadowNode("Assign", self.span, slots), self.reporter)
+        return materialize(
+            self.unit, ShadowNode("Assign", self.span, slots), self.reporter
+        )
 
     def _make_ifexp(self, test: "Node", body: "Node", orelse: "Node") -> "Node":
         """Synthesize ``<body> if <test> else <orelse>`` as a shadow IfExp that
@@ -1547,7 +1579,9 @@ class If(Statement):
             ("test", Child(_handle_of(test))),
             ("orelse", Child(_handle_of(orelse))),
         )
-        return materialize(self.unit, ShadowNode("IfExp", self.span, slots), self.reporter)
+        return materialize(
+            self.unit, ShadowNode("IfExp", self.span, slots), self.reporter
+        )
 
     def sugar(self):
         """`if <test>: <body> [else: <orelse>]` constructs IfSugar -- the guard.
@@ -1592,8 +1626,8 @@ class With(Statement):
         )
         if not isinstance(contract, (Expects, Suppresses)):
             return super().sugar()  # unauthenticated / runtime-selected: loud
-        if contract.matcher.kind != "raise":
-            return super().sugar()  # no WarningEffect to observe yet: loud
+        if contract.matcher.kind not in ("raise", "warning"):
+            return super().sugar()
         return WithContractSugar(
             contract=contract,
             body=tuple(stmt.sugar() for stmt in self.body),
@@ -1603,6 +1637,7 @@ class With(Statement):
     def substitute(self, scope):
         """with ... as <vars>: binds the as-targets for the body."""
         from .shadow import rewrite
+
         bound = set()
         for item in self.items:
             if item.optional_vars is not None:
@@ -1945,7 +1980,11 @@ class Match(Statement):
         """The name a bare capture pattern (`case x:`) binds, or None. A capture
         is a MatchAs with no sub-pattern and a name; `case _:` (name None) is the
         wildcard and binds nothing."""
-        if pattern.kind == "MatchAs" and pattern.pattern is None and pattern.name is not None:
+        if (
+            pattern.kind == "MatchAs"
+            and pattern.pattern is None
+            and pattern.name is not None
+        ):
             return pattern.name
         return None
 
@@ -2088,6 +2127,7 @@ class Lambda(Expression):
     def substitute(self, scope):
         """lambda <params>: masks its parameters for the body expression."""
         from .shadow import rewrite
+
         bound = {p.name for p in self.params}
         bs = {k: v for k, v in scope.items() if k not in bound} if bound else scope
         changed = {}
@@ -2184,6 +2224,7 @@ class ListComp(Expression):
         if unrolled is not None:
             return unrolled
         from .shadow import rewrite
+
         new_gens, inner, gc = self._substitute_generators(self.generators, scope)
         new_elt, de = self._substitute_field(self.elt, inner)
         changed = {}
@@ -2230,8 +2271,9 @@ class ListComp(Expression):
         from .shadow import ShadowNode, _handle_of
 
         slots = (("elts", Children(tuple(_handle_of(e) for e in elements))),)
-        return materialize(self.unit, ShadowNode("List", self.span, slots), self.reporter)
-
+        return materialize(
+            self.unit, ShadowNode("List", self.span, slots), self.reporter
+        )
 
 
 class SetComp(Expression):
@@ -2243,6 +2285,7 @@ class SetComp(Expression):
         """A comprehension: thread each generator's target, then substitute the
         element against the scope with every target masked."""
         from .shadow import rewrite
+
         new_gens, inner, gc = self._substitute_generators(self.generators, scope)
         new_elt, de = self._substitute_field(self.elt, inner)
         changed = {}
@@ -2263,6 +2306,7 @@ class DictComp(Expression):
         """A dict comprehension: thread the generators, then key and value
         against the scope with every target masked."""
         from .shadow import rewrite
+
         new_gens, inner, gc = self._substitute_generators(self.generators, scope)
         changed = {}
         if gc:
@@ -2283,6 +2327,7 @@ class GeneratorExp(Expression):
         """A comprehension: thread each generator's target, then substitute the
         element against the scope with every target masked."""
         from .shadow import rewrite
+
         new_gens, inner, gc = self._substitute_generators(self.generators, scope)
         new_elt, de = self._substitute_field(self.elt, inner)
         changed = {}

--- a/implementations/python/sugar-source-tree/tests/test_with_contract.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_contract.py
@@ -98,12 +98,14 @@ def test_as_witness_stays_loud():
         ).sugar()
 
 
-def test_warning_kind_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn(
-            "def A(z):\n    with tm.assert_produces_warning(FutureWarning):\n"
-            "        pass\n    return z\n"
-        ).sugar()
+def test_warning_kind_with_unresolved_call_retains_obligation():
+    v = _val(
+        "def A(z):\n    with tm.assert_produces_warning(FutureWarning):\n"
+        "        do_thing(z)\n    return z\n"
+    )
+    inv = v.invs()[0]
+    assert inv.name == "py.effect.expected"
+    assert inv.args[0].value == "FutureWarning"
 
 
 def test_multiple_managers_stay_loud():
@@ -140,7 +142,9 @@ def test_match_conjunction_type_discharged_message_undischarged():
     invs = v.invs()
     assert len(invs) == 2
     type_row = [i for i in invs if getattr(i, "name", "") == "="][0]
-    msg_row = [i for i in invs if getattr(i, "name", "") == "py.effect.message_matches"][0]
+    msg_row = [
+        i for i in invs if getattr(i, "name", "") == "py.effect.message_matches"
+    ][0]
     assert type_row.args[0].value == type_row.args[1].value == "ValueError"
     assert msg_row.args[0].value == "ValueError"  # shared observed witness
     assert msg_row.args[1].value == "bad"
@@ -158,9 +162,9 @@ def test_match_deferred_carries_the_whole_conjunction():
 
 def test_match_rejections_stay_loud():
     for src in (
-        'def A(z):\n    with pytest.raises(ValueError, match=None):\n        pass\n    return z\n',
+        "def A(z):\n    with pytest.raises(ValueError, match=None):\n        pass\n    return z\n",
         'def A(z):\n    with pytest.raises(ValueError, match="["):\n        pass\n    return z\n',
-        'def A(z):\n    with pytest.raises(ValueError, check=1):\n        pass\n    return z\n',
+        "def A(z):\n    with pytest.raises(ValueError, check=1):\n        pass\n    return z\n",
     ):
         with pytest.raises(SugarNotWritten):
             _fn(src).sugar()


### PR DESCRIPTION
First post-seam With cascade slice. Adds a typed non-halting WarningEffect carried by WarningObservationValue, generalizes the shared router across raise/warning kind+name, preserves wrong warning observations, consumes matching observations, and admits warning Expects contracts. Unresolved warning-producing calls retain py.effect.expected rather than minting absence. Message remains an independent obligation. Focused effect-router + With contract suite: 27 passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add non-halting WarningEffect routing to Python With contract sugar
> - Introduces `WarningEffect` (frozen dataclass) and `WarningObservationValue` to represent non-halting warning observations alongside existing raise effects.
> - Extends `effect_router` to detect, match, and consume warning observations: `_route_expects` emits `py.effect.message_matches` obligations for `Expects(kind="warning")`, and `_route_suppresses` silently consumes matching warnings.
> - Updates `nodes.With.sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/6001/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to synthesize `WithContractSugar` for `"warning"`-kind contracts instead of falling back to default sugar.
> - Updates tests in [test_with_contract.py](https://github.com/TSavo/sugar/pull/6001/files#diff-c52d5be339caa9e038fa2620f6775041499142c9675b24d2b7b5a5c982cf3723) to expect obligations rather than errors for warning-kind contracts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42216e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->