### PR TITLE
Tests: run opened warning With twin directly

### DIFF
--- a/implementations/python/sugar-source-tree/tests/test_with_contract.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_contract.py
@@ -125,7 +125,7 @@ if __name__ == "__main__":
     test_suppress_non_match_propagates()
     test_unauthenticated_manager_stays_loud()
     test_as_witness_stays_loud()
-    test_warning_kind_stays_loud()
+    test_warning_kind_with_unresolved_call_retains_obligation()
     test_multiple_managers_stay_loud()
     print("ok: with under typed contracts -- ten twins")
 


### PR DESCRIPTION
Fix-forward the direct-execution footer after #6001 opened Expects(warning). Pytest already passed; the script footer still named the retired stays-loud twin. Focused With contract suite: 13 passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run `test_warning_kind_with_unresolved_call_retains_obligation` in test script entrypoint
> Updates the `__main__` block in [test_with_contract.py](https://github.com/TSavo/sugar/pull/6002/files#diff-c52d5be339caa9e038fa2620f6775041499142c9675b24d2b7b5a5c982cf3723) to call `test_warning_kind_with_unresolved_call_retains_obligation()` instead of `test_warning_kind_stays_loud()` when the module is run directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5be3e15.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->