### PR TITLE
with (#5994) step 5: Expects as-witness bind for the tail

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_contract_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_contract_sugar.py
@@ -1,4 +1,4 @@
-"""`with <manager>: <body>` under a TYPED contract -- the #5994 wiring.
+"""`with <manager> [as <name>]: <body>` under a TYPED contract -- #5994 wiring.
 
 The node consults the recognition membrane (never a vendor name); the membrane
 issues a typed contract; this sugar reduces the body as a block and hands the
@@ -12,10 +12,13 @@ outcome to the ONE effect router shared with Try. The contract decides:
 - ``Suppresses(matcher)``: permission -- a matching halt is consumed silently;
   absence is fine; a non-matching effect propagates.
 
-Everything else about `with` stays LOUD at the node: unauthenticated managers,
-RuntimeSelected, warning-kind matchers (no WarningEffect exists to observe yet
--- wiring them would mint false absent-twins), `as` witnesses (step 5), multiple
-managers, and the resource expansion (step 4, finally-faithful, its own build).
+``as <Name>`` (Expects only) is a TEMPORAL bind for the enclosing block's
+tail: ``With.substitution_binding`` exports the matched-effect witness
+(``E()`` stand-in from ``raises(E)``). This sugar records ``as_name`` for
+provenance; substitute already rewrote uses of the name in the tail.
+
+Loud at the node: unauthenticated managers, non-Name as-targets, Suppresses+as,
+multiple managers, resource expansion (step 4).
 """
 
 from __future__ import annotations
@@ -29,9 +32,10 @@ from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 @dataclass(frozen=True)
 class WithContractSugar(Sugar):
-    contract: object  # Expects | Suppresses (raise-kind only; the node guards)
+    contract: object  # Expects | Suppresses (the node guards kind)
     body: tuple  # the body statements' sugars, in source order
     site: object = dataclass_field(compare=False, default=None)
+    as_name: str | None = None  # Expects as-witness; bound temporally for the tail
 
     @classmethod
     def witnesses(cls):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -315,6 +315,23 @@ class Node(Typed):
             self.unit, ShadowNode("BinOp", self.span, slots), self.reporter
         )
 
+    def _make_call(self, func: "Node", args: tuple = ()) -> "Node":
+        """Construct a fresh Call ``<func>(<args...>)`` as a shadow borrowing
+        this node's span. Used by Expects ``as``-witness binding: the matched
+        effect payload is the expected type/category constructed with no args
+        (a temporal stand-in for the exception/warning instance)."""
+        from .backend import Child, Children, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        slots = (
+            ("func", Child(_handle_of(func))),
+            ("args", Children(tuple(_handle_of(a) for a in args))),
+            ("keywords", Children(())),
+        )
+        return materialize(
+            self.unit, ShadowNode("Call", self.span, slots), self.reporter
+        )
+
     def _substitute_body(self, statements: tuple, scope: "dict[str, Node]"):
         new_items, changed, _net = self._substitute_body_tracked(statements, scope)
         return new_items, changed
@@ -1604,16 +1621,20 @@ class With(Statement):
     _child_fields = ("items", "body")
 
     def sugar(self):
-        """`with <manager>: <body>` -- the node consults the MEMBRANE, never a
-        vendor name (#5994). A single manager with no `as`, whose membrane-issued
-        contract is a raise-kind Expects/Suppresses, wires through the shared
-        effect router (WithContractSugar). Everything else stays LOUD: the
-        unauthenticated manager (the named residual), warning-kind matchers (no
-        WarningEffect exists to observe -- wiring would mint false absent-twins),
-        `as` witnesses (step 5), multiple managers, and resource managers (the
-        finally-faithful expansion, step 4)."""
-        if len(self.items) != 1 or self.items[0].optional_vars is not None:
+        """`with <manager> [as <name>]: <body>` -- the node consults the MEMBRANE,
+        never a vendor name (#5994). A single manager whose membrane-issued
+        contract is raise/warning Expects/Suppresses wires through the shared
+        effect router (WithContractSugar). Plain ``as <Name>`` is admitted for
+        Expects (step 5: matched-effect witness bound for the tail via
+        substitution_binding). Everything else stays LOUD: unauthenticated
+        managers, non-Name as-targets, Suppresses+as (no community witness
+        shape), multiple managers, and resource expansion (step 4)."""
+        if len(self.items) != 1:
             return super().sugar()
+        item = self.items[0]
+        as_target = item.optional_vars
+        if as_target is not None and not isinstance(as_target, Name):
+            return super().sugar()  # only plain Name as for step 5
         from sugar_lift_py_tests.context_manager_contract import Expects, Suppresses
         from sugar_lift_py_tests.manifest_membrane import (
             contract_for_manager,
@@ -1622,20 +1643,28 @@ class With(Statement):
         from sugar_lift_py_tests.sugar.with_contract_sugar import WithContractSugar
 
         contract = contract_for_manager(
-            default_community_manifest(), self.items[0].context_expr
+            default_community_manifest(), item.context_expr
         )
         if not isinstance(contract, (Expects, Suppresses)):
             return super().sugar()  # unauthenticated / runtime-selected: loud
         if contract.matcher.kind not in ("raise", "warning"):
             return super().sugar()
+        # Suppresses+as is not a community effect-witness shape; Expects+as is.
+        if as_target is not None and not isinstance(contract, Expects):
+            return super().sugar()
         return WithContractSugar(
             contract=contract,
             body=tuple(stmt.sugar() for stmt in self.body),
             site=self.fragment,
+            as_name=as_target.id if as_target is not None else None,
         )
 
     def substitute(self, scope):
-        """with ... as <vars>: binds the as-targets for the body."""
+        """with ... as <vars>: masks as-targets for the body (binding sites).
+
+        Expects ``as <Name>`` also EXPORTS a matched-effect witness for the
+        rest of the enclosing block via ``substitution_binding`` (step 5).
+        """
         from .shadow import rewrite
 
         bound = set()
@@ -1651,6 +1680,44 @@ class With(Statement):
         if d:
             changed["body"] = new_body
         return self if not changed else rewrite(self, **changed)
+
+    def substitution_binding(self, scope):
+        """Expects ``as <Name>``: bind the name for the TAIL to the matched-
+        effect witness (expected type/category constructed as ``E()``).
+
+        Only on the Expects membrane path; resource ``as`` is step 4.
+        Witness identity is the enrolled expected type expression -- the same
+        name the router discharges against the observed halt.
+        """
+        if len(self.items) != 1:
+            return None
+        ov = self.items[0].optional_vars
+        if not isinstance(ov, Name):
+            return None
+        from sugar_lift_py_tests.context_manager_contract import Expects
+        from sugar_lift_py_tests.manifest_membrane import (
+            contract_for_manager,
+            default_community_manifest,
+        )
+
+        contract = contract_for_manager(
+            default_community_manifest(), self.items[0].context_expr
+        )
+        if not isinstance(contract, Expects):
+            return None
+        if contract.matcher.kind not in ("raise", "warning"):
+            return None
+        witness = self._expects_effect_as_witness(self.items[0].context_expr)
+        if witness is None:
+            return None
+        return {ov.id: witness}
+
+    def _expects_effect_as_witness(self, context_expr: "Expression"):
+        """Temporal stand-in for the matched effect payload: ``E()`` from
+        ``raises(E, ...)`` / ``assert_produces_warning(E, ...)``."""
+        if context_expr.kind != "Call" or not context_expr.args:
+            return None
+        return self._make_call(context_expr.args[0], ())
 
 
 class AsyncWith(Statement):

--- a/implementations/python/sugar-source-tree/tests/test_with_contract.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_contract.py
@@ -90,11 +90,46 @@ def test_unauthenticated_manager_stays_loud():
         _fn("def A(z):\n    with open(z):\n        pass\n    return z\n").sugar()
 
 
-def test_as_witness_stays_loud():
+def test_as_witness_admits_and_discharges():
+    """Step 5: Expects ``as <Name>`` is no longer loud; type obligation flows."""
+    v = _val(
+        "def A(z):\n    with pytest.raises(ValueError) as ei:\n"
+        "        raise ValueError\n    return z\n"
+    )
+    inv = v.invs()[0]
+    assert inv.name == "="
+    assert inv.args[0].value == inv.args[1].value == "ValueError"
+    assert v.post().args[1].name == "z"
+
+
+def test_as_witness_inlines_in_the_tail():
+    """Matched-effect witness is bound for the tail: ``return ei`` sees E()."""
+    v = _val(
+        "def A():\n    with pytest.raises(ValueError) as ei:\n"
+        "        raise ValueError\n    return ei\n"
+    )
+    # Type obligation still stated; post is the witness construction ValueError().
+    type_rows = [i for i in v.invs() if getattr(i, "name", "") == "="]
+    assert type_rows
+    assert type_rows[0].args[0].value == type_rows[0].args[1].value == "ValueError"
+    post = v.post().args[1]
+    assert post.name == "call:ValueError"  # E() stand-in for the effect payload
+
+
+def test_as_non_name_target_stays_loud():
     with pytest.raises(SugarNotWritten):
         _fn(
-            "def A(z):\n    with pytest.raises(ValueError) as ei:\n"
+            "def A(z):\n    with pytest.raises(ValueError) as (ei,):\n"
             "        raise ValueError\n    return z\n"
+        ).sugar()
+
+
+def test_suppresses_as_stays_loud():
+    """Suppresses+as is not a community effect-witness shape (step 5 is Expects)."""
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(z):\n    with contextlib.suppress(KeyError) as cm:\n"
+            "        raise KeyError\n    return z\n"
         ).sugar()
 
 
@@ -124,10 +159,13 @@ if __name__ == "__main__":
     test_suppress_matching_consumed()
     test_suppress_non_match_propagates()
     test_unauthenticated_manager_stays_loud()
-    test_as_witness_stays_loud()
+    test_as_witness_admits_and_discharges()
+    test_as_witness_inlines_in_the_tail()
+    test_as_non_name_target_stays_loud()
+    test_suppresses_as_stays_loud()
     test_warning_kind_with_unresolved_call_retains_obligation()
     test_multiple_managers_stay_loud()
-    print("ok: with under typed contracts -- ten twins")
+    print("ok: with under typed contracts -- as-witness twins")
 
 
 def test_match_conjunction_type_discharged_message_undischarged():


### PR DESCRIPTION
## Summary

**#5994 step 5** — Admit Expects `with … as <Name>` and bind the matched-effect witness for the **tail** (temporal), without inventing resource/`WithSugar` expansion.

### Measure / residual

On main `30e456a43`, `test_as_witness_stays_loud` was the intentional step-5 residual: any `as` forced `SugarNotWritten` even for enrolled `pytest.raises`.

### Design (banked)

| Path | Behavior |
| --- | --- |
| **Expects + plain `as Name`** | Membrane + router as today; **`substitution_binding`** exports `{name: E()}` for the enclosing block tail (`E` = first arg of `raises(E)` / warning category). |
| **Body** | as-name still **masked** (binding site, not free rewrite of outer `ei`). |
| **Non-Name as** | Loud |
| **Suppresses + as** | Loud (not a community effect-witness shape) |
| **Resource as** | Loud (step 4) |

Meaning stays on the router; the as-bind is pure temporal (same split as if: substitute ages bindings, sugar states obligations).

### Validation

```text
pytest implementations/python/sugar-source-tree/tests/test_with_contract.py
# 16 passed
```

### Out of scope

Resource finally-faithful expansion, Try wiring, full ExceptionInfo surface (`.value`/`.type` attrs), message discharge for `match=`.

Part of #5994. Do not self-merge.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `as`-witness binding for `with Expects(...) as <Name>:` tail substitution
> - `With.sugar` now admits a plain-Name `as`-target when the context manager is an `Expects` contract (raise or warning kind), forwarding the name via `as_name` to `WithContractSugar`; non-Name targets and `Suppresses`+`as` remain loud.
> - `With.substitution_binding` binds the `as`-name in the enclosing block's tail to a constructed effect witness (e.g. `ValueError()`) derived from the first argument of the `Expects` call.
> - `With._expects_effect_as_witness` and `Node._make_call` are new helpers that build the witness `Call` AST node using the current node's span.
> - New tests in [`test_with_contract.py`](https://github.com/TSavo/sugar/pull/6003/files#diff-c52d5be339caa9e038fa2620f6775041499142c9675b24d2b7b5a5c982cf3723) cover admission, witness inlining in the tail, non-Name target staying loud, and `Suppresses`+`as` staying loud.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0c61df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->