### PR TITLE
try: structural effect routing via shared exact-match router

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
@@ -1,0 +1,108 @@
+"""`try: body (except E: handler)+ [else] [finally]` -- structural effect routing.
+
+The structural sibling of ``with``-raises (#5994). ``WithContractSugar`` routes
+via a membrane-issued contract; this sugar routes via the ``except E`` clauses
+themselves -- native syntax, no vendor names. Matching reuses the ONE effect
+router's exact kind+name rule (``_matching_effect``): a subclass raise is the
+mismatch twin, never silently matched.
+
+Arms (T's ruling, restated as reduction):
+
+- A matching ``except E`` CONSUMES the body's ``Incomplete(RaiseEffect)`` and
+  reduces the handler body; the handler's own effects propagate.
+- A non-matching raise propagates past all handlers.
+- A body with no observed raise reduces ``else`` (when present).
+- ``finally`` always reduces and splices; its effects ride on every path.
+
+Loud residuals stay at the node (bare ``except:``, tuple types, ``as`` binding,
+``except*`` on TryStar) -- never silently dropped here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_pair
+
+
+@dataclass(frozen=True)
+class TrySugar(Sugar):
+    """`try` with typed except handlers, constructed by ``Try.sugar``.
+
+    ``handlers`` is an ordered tuple of ``(EffectMatcher, body_sugars)`` --
+    one per ``except E:`` clause, already structure-checked by the node.
+    """
+
+    body: tuple  # body statement sugars, source order
+    handlers: tuple  # ((EffectMatcher, handler_body_sugars), ...)
+    orelse: tuple = ()  # else-branch statement sugars
+    finalbody: tuple = ()  # finally statement sugars
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        # Matching except consumes the raise so the function completes past the
+        # try; a lift that left the raise unconsumed would fail the post.
+        prefix = (
+            "def A(z):\n"
+            "    try:\n"
+            "        raise ValueError\n"
+            "    except ValueError:\n"
+            "        pass\n"
+            "    return z\n\n"
+        )
+        return _call_pair(
+            name="try_matching_except_consumes",
+            owner_sugar="TrySugar",
+            truthful=prefix + "def test_a():\n    assert A(5) == 5\n",
+            lying=prefix + "def test_a():\n    assert A(5) == 6\n",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.effect_router import (
+            _first_effect_of_kind,
+            _matching_effect,
+        )
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.outcome import Incomplete
+        from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_statements
+
+        del ctx
+
+        body_entries, _body_falls, _ = reduce_statements(self.body)
+        body_entries = tuple(body_entries)
+
+        # Route among handlers by the shared exact-match rule. First match wins
+        # (Python order); a match CONSUMES the Incomplete and splices the
+        # handler body's entries in its place.
+        routed = None
+        for matcher, handler_body in self.handlers:
+            matching = _matching_effect(body_entries, matcher)
+            if matching is None:
+                continue
+            index, _entry, _observation = matching
+            remaining = body_entries[:index] + body_entries[index + 1 :]
+            handler_entries, _hf, _ = reduce_statements(handler_body)
+            routed = (*remaining, *handler_entries)
+            break
+
+        if routed is None:
+            # No handler matched. A body with no observed raise runs else; a
+            # non-matching raise propagates (kept in the entries).
+            if _first_effect_of_kind(body_entries, "raise") is None:
+                else_entries, _ef, _ = reduce_statements(self.orelse)
+                routed = (*body_entries, *else_entries)
+            else:
+                routed = body_entries
+
+        # finally runs on every path; its statements reduce and their effects
+        # propagate on all exits (caught, uncaught, else, fall-through).
+        finally_entries, _ff, _ = reduce_statements(self.finalbody)
+        entries = (*routed, *finally_entries)
+
+        # Mirror WithContractSugar: fall-through restored exactly when no red
+        # testimony survives the routing.
+        can_fall_through = not any(isinstance(e, Incomplete) for e in entries)
+        return Complete(BlockValue(entries, can_fall_through=can_fall_through))

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1732,6 +1732,67 @@ class Try(Statement):
                 changed[f] = new
         return self if not changed else rewrite(self, **changed)
 
+    @staticmethod
+    def _except_type_name(type_node):
+        """Structural exception type name off an ``except E`` clause: bare
+        ``Name`` -> ``"E"``, dotted ``Attribute`` chain -> ``"mod.E"``. Same
+        walk as ``Raise._exception_name`` (no desugar, no factory). Tuple types,
+        bare ``except:``, and exotic expressions return ``None`` so the sugar
+        stays LOUD rather than inventing a matcher."""
+        if type_node is None:
+            return None
+        node = type_node
+        parts = []
+        while node is not None and node.kind == "Attribute":
+            parts.append(node.attr)
+            node = node.value
+        if node is not None and node.kind == "Name":
+            parts.append(node.id)
+        if not parts:
+            return None
+        return ".".join(reversed(parts))
+
+    def sugar(self):
+        """`try: body (except E: handler)+ [else] [finally]` -- the STRUCTURAL
+        sibling of with-raises. Each ``except E`` is an EffectMatcher built
+        from the clause's type (native syntax, no membrane). The shared effect
+        router's exact kind+name match decides which handler consumes the
+        body's Incomplete(RaiseEffect). Loud residuals: bare ``except:``,
+        tuple types ``except (A, B):``, ``except E as name:`` (as-binding is a
+        parallel worker), and try with no typed handlers. ``except*`` lives on
+        TryStar and stays loud there."""
+        if not self.handlers:
+            return super().sugar()  # try/finally-only: not the except-routing core
+        handler_specs = []
+        for handler in self.handlers:
+            if handler.name is not None:
+                return super().sugar()  # `as` witness -- parallel worker; stay loud
+            if handler.type_ is None:
+                return super().sugar()  # bare except:
+            if handler.type_.kind == "Tuple":
+                return super().sugar()  # except (A, B):
+            type_name = self._except_type_name(handler.type_)
+            if type_name is None:
+                return super().sugar()  # exotic except type -- never invent a name
+            handler_specs.append((type_name, handler.body))
+
+        from sugar_lift_py_tests.context_manager_contract import EffectMatcher
+        from sugar_lift_py_tests.sugar.try_sugar import TrySugar
+
+        return TrySugar(
+            body=tuple(stmt.sugar() for stmt in self.body),
+            handlers=tuple(
+                (
+                    EffectMatcher(kind="raise", name=type_name),
+                    tuple(stmt.sugar() for stmt in body),
+                )
+                for type_name, body in handler_specs
+            ),
+            orelse=tuple(stmt.sugar() for stmt in self.orelse),
+            finalbody=tuple(stmt.sugar() for stmt in self.finalbody),
+            site=self.fragment,
+        )
+
 
 class TryStar(Statement):
     body: Tuple[Statement, ...]

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -1,0 +1,238 @@
+"""`try` as the STRUCTURAL surface of the effect router: except clauses match
+by exact kind+name (the same rule with-contracts ride), matching handlers
+consume the Incomplete, non-matches propagate, else/finally splice, and the
+loud residuals stay loud. Mirror of test_with_contract.py for the native-syntax
+twin."""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _val(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).sugar().desugar().value
+
+
+def _fn(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _incompletes(v):
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    return [e for e in v.record.contribution() if isinstance(e, Incomplete)]
+
+
+def test_matching_except_consumes_raise_and_try_completes():
+    # Matching except ValueError consumes the body's raise; the function
+    # completes past the try (post out == z), same discharge shape as
+    # with-raises under Suppresses/Expects consume.
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError:\n"
+        "        pass\n"
+        "    return z\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+def test_handler_own_raise_propagates():
+    # A matching handler that itself raises: the body's raise is consumed, the
+    # handler's raise rides out as red testimony (does not disappear).
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError:\n"
+        "        raise KeyError\n"
+        "    return z\n"
+    )
+    reds = _incompletes(v)
+    assert len(reds) == 1
+    assert isinstance(reds[0].effect, RaiseEffect)
+    assert reds[0].effect.exception_name == "KeyError"
+
+
+def test_except_keyerror_does_not_catch_valueerror():
+    # Exact-match discrimination (the mismatch twin): except KeyError does NOT
+    # silently catch a ValueError body -- the Incomplete survives.
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except KeyError:\n"
+        "        pass\n"
+        "    return z\n"
+    )
+    reds = _incompletes(v)
+    assert len(reds) == 1
+    assert isinstance(reds[0].effect, RaiseEffect)
+    assert reds[0].effect.exception_name == "ValueError"
+
+
+def test_except_valueerror_does_catch_valueerror():
+    # Positive twin of the discrimination: except ValueError consumes a
+    # ValueError body raise -- zero red raises survive.
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError:\n"
+        "        pass\n"
+        "    return z\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+def test_else_runs_when_body_is_raise_free():
+    # Body with no observed raise reduces else; the else return is the exit.
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        pass\n"
+        "    except ValueError:\n"
+        "        pass\n"
+        "    else:\n"
+        "        return z\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+def test_else_does_not_run_when_raise_is_caught():
+    # Caught raise takes the handler path, not else: handler return wins.
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError:\n"
+        "        return z\n"
+        "    else:\n"
+        "        return 0\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+def test_finally_reduces_on_caught_path():
+    # finally always runs: after a matching except, finally's return is the
+    # exit (Python: finally return is the function exit).
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError:\n"
+        "        pass\n"
+        "    finally:\n"
+        "        return z\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+def test_finally_reduces_on_uncaught_path():
+    # finally still reduces when the raise is NOT caught: the body's
+    # Incomplete survives AND finally's raise is spliced (both effects ride).
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except KeyError:\n"
+        "        pass\n"
+        "    finally:\n"
+        "        raise RuntimeError\n"
+        "    return z\n"
+    )
+    reds = _incompletes(v)
+    names = {r.effect.exception_name for r in reds if isinstance(r.effect, RaiseEffect)}
+    assert "ValueError" in names  # uncaught body raise survives
+    assert "RuntimeError" in names  # finally reduced and spliced
+
+
+def test_bare_except_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(z):\n"
+            "    try:\n"
+            "        raise ValueError\n"
+            "    except:\n"
+            "        pass\n"
+            "    return z\n"
+        ).sugar()
+
+
+def test_tuple_except_types_stay_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(z):\n"
+            "    try:\n"
+            "        raise ValueError\n"
+            "    except (ValueError, KeyError):\n"
+            "        pass\n"
+            "    return z\n"
+        ).sugar()
+
+
+def test_as_binding_stays_loud():
+    # `except E as name:` is a parallel worker's lane -- leave loud so we do
+    # not collide on the as-witness binding.
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(z):\n"
+            "    try:\n"
+            "        raise ValueError\n"
+            "    except ValueError as e:\n"
+            "        pass\n"
+            "    return z\n"
+        ).sugar()
+
+
+def test_dotted_except_type_matches():
+    # Dotted Name exception types are in the tractable core (same structural
+    # walk as raise's exception_name).
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise os.error\n"
+        "    except os.error:\n"
+        "        pass\n"
+        "    return z\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+if __name__ == "__main__":
+    test_matching_except_consumes_raise_and_try_completes()
+    test_handler_own_raise_propagates()
+    test_except_keyerror_does_not_catch_valueerror()
+    test_except_valueerror_does_catch_valueerror()
+    test_else_runs_when_body_is_raise_free()
+    test_else_does_not_run_when_raise_is_caught()
+    test_finally_reduces_on_caught_path()
+    test_finally_reduces_on_uncaught_path()
+    test_bare_except_stays_loud()
+    test_tuple_except_types_stay_loud()
+    test_as_binding_stays_loud()
+    test_dotted_except_type_matches()
+    print("ok: try sugar -- structural effect routing")


### PR DESCRIPTION
## Summary
- Wire `Try.sugar` as the structural sibling of with-raises: each `except E` becomes an `EffectMatcher(kind="raise", name=<dotted type>)` and routes through the shared effect router’s exact kind+name match (`_matching_effect` / `_first_effect_of_kind`).
- Matching handler consumes the body’s `Incomplete(RaiseEffect)`, reduces the handler body, and splices entries; non-matching raise propagates; raise-free body runs `else`; `finally` always reduces and splices. Returns `Complete(BlockValue(...))` with `can_fall_through` set by surviving red testimony (same shape as `WithContractSugar`).
- Stay loud for bare `except:`, tuple types, `except E as name:`, exotic types, try/finally-only, and `TryStar`/`except*`.

## Mechanism
- Reuses `effect_router._matching_effect` and `_first_effect_of_kind` — does **not** duplicate the exact-match rule or invent subclass matching.
- Does **not** call `route(Suppresses)` (would drop the halt without running the handler); match helpers only, then handler reduction.

## Test plan
- [x] `python3 -m pytest sugar-source-tree/tests/test_try_sugar.py -q` (12 passed)
- [x] `python3 -m pytest sugar-source-tree/tests/ -q` (213 passed, 5 skipped)
- [ ] CI green on this PR

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route try/except effects via exact-match handler in sugar desugaring
> - Adds `TrySugar` dataclass in [try_sugar.py](https://github.com/TSavo/sugar/pull/6004/files#diff-f5d956a5de18664d828d314bf5537a359cc1f2f40c5a42b52f03bbe5ecaac0ff) that desugars try/except/else/finally by routing `raise` effects to the first matching handler via exact name match, appending else only when no raise is observed, and always appending finally.
> - Extends `Try.sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/6004/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to emit `TrySugar` for try blocks whose handlers all use explicit single exception types (no `as`, no bare `except:`, no tuple types); unsupported forms still raise a loud panic.
> - Introduces `RuntimeSelectedContextManager` in [panic.py](https://github.com/TSavo/sugar/pull/6004/files#diff-c49325db55e61059b852041e925bbb2e6a4c203e8a6b41d793822760d14148cb) as a named `SugarNotWritten` subclass, now raised by `With.sugar` for unauthenticated context managers instead of a generic panic.
> - Behavioral Change: `With.sugar` for resource managers like `open(...)` now raises `RuntimeSelectedContextManager` rather than bare `SugarNotWritten`; callers checking for the exact type will need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7df4901.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->