### PR TITLE
with (#5994 step 4): resource managers stay RuntimeSelected named residual

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -45,6 +45,7 @@ from .operators import (
     UnaryOperator,
 )
 from .panic import (
+    RuntimeSelectedContextManager,
     SourceTreePanic,
     SubstituteNotWritten,
     SugarNotWritten,
@@ -1607,14 +1608,27 @@ class With(Statement):
         """`with <manager>: <body>` -- the node consults the MEMBRANE, never a
         vendor name (#5994). A single manager with no `as`, whose membrane-issued
         contract is a raise-kind Expects/Suppresses, wires through the shared
-        effect router (WithContractSugar). Everything else stays LOUD: the
-        unauthenticated manager (the named residual), warning-kind matchers (no
-        WarningEffect exists to observe -- wiring would mint false absent-twins),
-        `as` witnesses (step 5), multiple managers, and resource managers (the
-        finally-faithful expansion, step 4)."""
+        effect router (WithContractSugar).
+
+        Unauthenticated / RuntimeSelected managers (resource managers:
+        ``open(...)``, ``tm.ensure_clean(...)``, …) stay LOUD as the *named*
+        residual ``RuntimeSelectedContextManager`` — distinct from bare
+        ``SugarNotWritten`` so the census can count them. Temporal dissolution
+        is licensed only under a typed exit contract; we have no proof any
+        resource manager is ``NeverSuppresses`` (that requires reading
+        ``__exit__``, which we do not lift), so every unenrolled manager is
+        honestly RuntimeSelected. A normal-path-only enter/exit splice that
+        drops the exceptional edge is a different language — never written
+        here. ``NeverSuppresses`` enrollment (none yet) would gate the real
+        finally-faithful expansion; until then that arm stays unwritten loud.
+        `as` witnesses (step 5) and multiple managers remain bare unwritten."""
         if len(self.items) != 1 or self.items[0].optional_vars is not None:
             return super().sugar()
-        from sugar_lift_py_tests.context_manager_contract import Expects, Suppresses
+        from sugar_lift_py_tests.context_manager_contract import (
+            Expects,
+            RuntimeSelected,
+            Suppresses,
+        )
         from sugar_lift_py_tests.manifest_membrane import (
             contract_for_manager,
             default_community_manifest,
@@ -1624,15 +1638,45 @@ class With(Statement):
         contract = contract_for_manager(
             default_community_manifest(), self.items[0].context_expr
         )
-        if not isinstance(contract, (Expects, Suppresses)):
-            return super().sugar()  # unauthenticated / runtime-selected: loud
-        if contract.matcher.kind not in ("raise", "warning"):
-            return super().sugar()
-        return WithContractSugar(
-            contract=contract,
-            body=tuple(stmt.sugar() for stmt in self.body),
-            site=self.fragment,
-        )
+        if isinstance(contract, (Expects, Suppresses)):
+            if contract.matcher.kind not in ("raise", "warning"):
+                return super().sugar()
+            return WithContractSugar(
+                contract=contract,
+                body=tuple(stmt.sugar() for stmt in self.body),
+                site=self.fragment,
+            )
+        # None from the membrane OR an explicit RuntimeSelected enrollment:
+        # exit suppression is undecidable statically. Named residual — not a
+        # bare SugarNotWritten, not a false-green dissolve.
+        if contract is None or isinstance(contract, RuntimeSelected):
+            where = f"{self.unit.filename}"
+            try:
+                lc = self.line_col_span()
+                where = f"{self.unit.filename}:{lc.start_line}:{lc.start_col}"
+            except SourceTreePanic:
+                pass
+            panic = RuntimeSelectedContextManager(
+                owner="With.sugar",
+                observed=(
+                    "unauthenticated context manager — exit suppression "
+                    f"runtime-selected at {where}"
+                ),
+                requested=(
+                    "a typed exit contract (NeverSuppresses with "
+                    "finally-faithful expansion, or Expects/Suppresses via "
+                    "the membrane)"
+                ),
+                fix=(
+                    "enroll a manager only with proof of its __exit__ "
+                    "disposition; never invent a normal-path-only expansion"
+                ),
+            )
+            self.reporter.report_gap(self, panic)
+            raise panic
+        # NeverSuppresses (nothing enrolls yet): finally-faithful expansion
+        # unwritten — bare SugarNotWritten until that slice lands.
+        return super().sugar()
 
     def substitute(self, scope):
         """with ... as <vars>: binds the as-targets for the body."""

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -86,6 +86,25 @@ class SugarNotWritten(SourceTreePanic):
     _LABEL = "SUGAR NOT WRITTEN"
 
 
+class RuntimeSelectedContextManager(SugarNotWritten):
+    """A `with` whose manager has no authenticated exit-suppression contract.
+
+    Resource managers (`open(...)`, `tm.ensure_clean(...)`, …) are not
+    enrolled as ``NeverSuppresses`` / ``Expects`` / ``Suppresses``: the lift
+    never reads ``__enter__`` / ``__exit__``, so suppression is
+    ``RuntimeSelected`` and must stay LOUD. This residual is deliberately a
+    *named* subclass of ``SugarNotWritten`` so the frontier census can count
+    unauthenticated context managers separately from shapes that simply have
+    no ``.sugar()`` override yet.
+
+    Never a normal-path-only ``__enter__``/``__exit__(None,None,None)``
+    rewrite — that drops the exceptional edge and is a different language
+    (issue #5994 step 4).
+    """
+
+    _LABEL = "RUNTIME-SELECTED CONTEXT MANAGER"
+
+
 class SubstituteNotWritten(SourceTreePanic):
     """Nobody has written this node's substitution yet. Raised by the abstract
     ``Node.substitute()``; every concrete class either OVERRIDES it (a leaf

--- a/implementations/python/sugar-source-tree/tests/test_panic_taxonomy.py
+++ b/implementations/python/sugar-source-tree/tests/test_panic_taxonomy.py
@@ -19,6 +19,8 @@ from sugar_source_tree.panic import (
     VocabularyMissing,
     SourceTreePanic,
     BackendDefect,
+    RuntimeSelectedContextManager,
+    SugarNotWritten,
 )
 from sugar_source_tree.spans import LineTable, Span
 
@@ -78,3 +80,21 @@ def test_catching_the_common_base_catches_both():
         resolve_kind("NoSuchKind", observed_at="test")
     with pytest.raises(SourceTreePanic):
         Span(5, 2)
+
+
+def test_runtime_selected_context_manager_is_named_sugar_gap():
+    """Resource-with residual (#5994 step 4): subclass of SugarNotWritten so
+    report_gap / census still see a gap, but isinstance distinguishes it from
+    a bare unwritten shape."""
+    assert issubclass(RuntimeSelectedContextManager, SugarNotWritten)
+    assert issubclass(RuntimeSelectedContextManager, SourceTreePanic)
+    assert RuntimeSelectedContextManager is not SugarNotWritten
+    panic = RuntimeSelectedContextManager(
+        owner="With.sugar",
+        observed="unauthenticated context manager — exit suppression runtime-selected",
+        requested="typed exit contract",
+        fix="enroll with proof of __exit__ disposition",
+    )
+    assert isinstance(panic, SugarNotWritten)
+    assert type(panic) is RuntimeSelectedContextManager
+    assert "RUNTIME-SELECTED CONTEXT MANAGER" in str(panic)

--- a/implementations/python/sugar-source-tree/tests/test_with_contract.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_contract.py
@@ -8,7 +8,7 @@ import tempfile
 import pytest
 
 from sugar_lift_python_source.source_oracle import path_source
-from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.panic import RuntimeSelectedContextManager, SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
 
@@ -86,8 +86,15 @@ def test_suppress_non_match_propagates():
 
 
 def test_unauthenticated_manager_stays_loud():
-    with pytest.raises(SugarNotWritten):
+    # Named residual (step 4): RuntimeSelectedContextManager, not bare
+    # SugarNotWritten — census can count resource managers separately.
+    with pytest.raises(RuntimeSelectedContextManager) as ei:
         _fn("def A(z):\n    with open(z):\n        pass\n    return z\n").sugar()
+    assert isinstance(ei.value, SugarNotWritten)
+    assert (
+        "unauthenticated context manager — exit suppression runtime-selected"
+        in ei.value.observed
+    )
 
 
 def test_as_witness_stays_loud():

--- a/implementations/python/sugar-source-tree/tests/test_with_resource.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_resource.py
@@ -1,0 +1,93 @@
+"""Resource `with` under RuntimeSelected (#5994 step 4).
+
+Honest v1: we never lift ``__enter__``/``__exit__``, so no resource manager
+is proven ``NeverSuppresses``. Every unenrolled resource manager is therefore
+``RuntimeSelected`` and stays LOUD as the named residual
+``RuntimeSelectedContextManager`` — not a silent dissolve, not a bare
+``SugarNotWritten``, not a false green. Assertion managers (Expects/Suppresses
+via the membrane) keep their wired path.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import (
+    RuntimeSelectedContextManager,
+    SugarNotWritten,
+)
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn(src: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _val(src: str):
+    return _fn(src).sugar().desugar().value
+
+
+def test_resource_open_is_runtime_selected_named_residual():
+    """`with open(f): ...` is loud, distinctly named — not dissolved."""
+    with pytest.raises(RuntimeSelectedContextManager) as ei:
+        _fn("def A(f):\n    with open(f):\n        pass\n    return f\n").sugar()
+    panic = ei.value
+    assert isinstance(panic, SugarNotWritten)  # still a gap for census
+    assert type(panic) is RuntimeSelectedContextManager  # not bare
+    assert "unauthenticated context manager — exit suppression runtime-selected" in (
+        panic.observed
+    )
+    assert panic.owner == "With.sugar"
+
+
+def test_resource_open_is_not_silent_dissolve():
+    """No sugar object, no enter/exit splice: the throw is the residual."""
+    with pytest.raises(RuntimeSelectedContextManager):
+        sugar = _fn(
+            "def A(f):\n    with open(f):\n        x = 1\n    return f\n"
+        ).sugar()
+        # If sugar() ever returned instead of raising, that would be a dissolve.
+        sugar.desugar()
+
+
+def test_resource_named_residual_distinct_from_bare_sugar_not_written():
+    """Census discrimination: resource managers are a typed subclass."""
+    with pytest.raises(RuntimeSelectedContextManager) as ei:
+        _fn("def A(z):\n    with open(z):\n        pass\n    return z\n").sugar()
+    assert type(ei.value) is not SugarNotWritten
+    assert issubclass(type(ei.value), SugarNotWritten)
+
+
+def test_assertion_manager_pytest_raises_still_lifts():
+    """Step-4 residual must not disturb the Expects path."""
+    v = _val(
+        "def A(z):\n    with pytest.raises(ValueError):\n        raise ValueError\n"
+        "    return z\n"
+    )
+    inv = v.invs()[0]
+    assert inv.name == "="
+    assert inv.args[0].value == inv.args[1].value == "ValueError"
+    assert v.post().args[1].name == "z"
+
+
+def test_suppress_manager_still_lifts():
+    v = _val(
+        "def A(z):\n    with contextlib.suppress(KeyError):\n        raise KeyError\n"
+        "    return z\n"
+    )
+    assert v.invs() == () and v.post().args[1].name == "z"
+
+
+if __name__ == "__main__":
+    test_resource_open_is_runtime_selected_named_residual()
+    test_resource_open_is_not_silent_dissolve()
+    test_resource_named_residual_distinct_from_bare_sugar_not_written()
+    test_assertion_manager_pytest_raises_still_lifts()
+    test_suppress_manager_still_lifts()
+    print("ok: resource with is RuntimeSelected named residual; Expects undisturbed")


### PR DESCRIPTION
## Summary

Honest v1 for #5994 step 4 (finally-faithful resource-`with` expansion):

- We do **not** lift `__enter__`/`__exit__`, so no resource manager is proven `NeverSuppresses`.
- Every unenrolled manager is therefore **`RuntimeSelected`** and stays **loud**.
- Named residual: `RuntimeSelectedContextManager` (subclass of `SugarNotWritten`) with observed text `unauthenticated context manager — exit suppression runtime-selected`.
- Census can count resource managers separately from bare unwritten shapes.
- **No** normal-path-only `__enter__`/`__exit__(None,None,None)` splice (ruled out: drops exceptional edge).
- Expects/Suppresses membrane path (`pytest.raises`, `contextlib.suppress`) undisturbed.
- `NeverSuppresses` finally-faithful expansion gated and unwritten (nothing enrolls yet).

## Test plan

- [x] `python3 -m pytest sugar-source-tree/tests/test_with_resource.py sugar-source-tree/tests/test_with_contract.py sugar-source-tree/tests/test_panic_taxonomy.py -q` → 27 passed
- [x] `python3 -m pytest sugar-source-tree/tests/ -q` → 219 passed, 5 skipped

Advances #5994 step 4 instrument.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `RuntimeSelectedContextManager` panic for runtime-selected resource managers in `With.sugar`
> - Introduces `RuntimeSelectedContextManager`, a named `SugarNotWritten` subclass with label `RUNTIME-SELECTED CONTEXT MANAGER`, in [`panic.py`](https://github.com/TSavo/sugar/pull/6005/files#diff-c49325db55e61059b852041e925bbb2e6a4c203e8a6b41d793822760d14148cb).
> - Updates `With.sugar` in [`nodes.py`](https://github.com/TSavo/sugar/pull/6005/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to raise this typed panic for unauthenticated or `RuntimeSelected` context managers (e.g. `open(...)`) instead of falling through to `super().sugar()`.
> - `Expects`/`Suppresses` contracts with `raise`/`warning` matchers continue to sugar via `WithContractSugar`; all other contracts still fall back to `super().sugar()`.
> - New tests in [`test_with_resource.py`](https://github.com/TSavo/sugar/pull/6005/files#diff-cd482094142f2d930f31855ea2564aec9239aa6a3c795f171f2664fcd9c1dc2a) and [`test_panic_taxonomy.py`](https://github.com/TSavo/sugar/pull/6005/files#diff-026ea168b03c062dcdc7011a2a8fc32a604d501708d011246331f26910abdc58) verify the panic type, label, and that known-good paths are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61e818e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->