### PR TITLE
cascade batch: Try router surface + with-as-witness + resource RuntimeSelected residual

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
@@ -1,0 +1,108 @@
+"""`try: body (except E: handler)+ [else] [finally]` -- structural effect routing.
+
+The structural sibling of ``with``-raises (#5994). ``WithContractSugar`` routes
+via a membrane-issued contract; this sugar routes via the ``except E`` clauses
+themselves -- native syntax, no vendor names. Matching reuses the ONE effect
+router's exact kind+name rule (``_matching_effect``): a subclass raise is the
+mismatch twin, never silently matched.
+
+Arms (T's ruling, restated as reduction):
+
+- A matching ``except E`` CONSUMES the body's ``Incomplete(RaiseEffect)`` and
+  reduces the handler body; the handler's own effects propagate.
+- A non-matching raise propagates past all handlers.
+- A body with no observed raise reduces ``else`` (when present).
+- ``finally`` always reduces and splices; its effects ride on every path.
+
+Loud residuals stay at the node (bare ``except:``, tuple types, ``as`` binding,
+``except*`` on TryStar) -- never silently dropped here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_pair
+
+
+@dataclass(frozen=True)
+class TrySugar(Sugar):
+    """`try` with typed except handlers, constructed by ``Try.sugar``.
+
+    ``handlers`` is an ordered tuple of ``(EffectMatcher, body_sugars)`` --
+    one per ``except E:`` clause, already structure-checked by the node.
+    """
+
+    body: tuple  # body statement sugars, source order
+    handlers: tuple  # ((EffectMatcher, handler_body_sugars), ...)
+    orelse: tuple = ()  # else-branch statement sugars
+    finalbody: tuple = ()  # finally statement sugars
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        # Matching except consumes the raise so the function completes past the
+        # try; a lift that left the raise unconsumed would fail the post.
+        prefix = (
+            "def A(z):\n"
+            "    try:\n"
+            "        raise ValueError\n"
+            "    except ValueError:\n"
+            "        pass\n"
+            "    return z\n\n"
+        )
+        return _call_pair(
+            name="try_matching_except_consumes",
+            owner_sugar="TrySugar",
+            truthful=prefix + "def test_a():\n    assert A(5) == 5\n",
+            lying=prefix + "def test_a():\n    assert A(5) == 6\n",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.effect_router import (
+            _first_effect_of_kind,
+            _matching_effect,
+        )
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.outcome import Incomplete
+        from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_statements
+
+        del ctx
+
+        body_entries, _body_falls, _ = reduce_statements(self.body)
+        body_entries = tuple(body_entries)
+
+        # Route among handlers by the shared exact-match rule. First match wins
+        # (Python order); a match CONSUMES the Incomplete and splices the
+        # handler body's entries in its place.
+        routed = None
+        for matcher, handler_body in self.handlers:
+            matching = _matching_effect(body_entries, matcher)
+            if matching is None:
+                continue
+            index, _entry, _observation = matching
+            remaining = body_entries[:index] + body_entries[index + 1 :]
+            handler_entries, _hf, _ = reduce_statements(handler_body)
+            routed = (*remaining, *handler_entries)
+            break
+
+        if routed is None:
+            # No handler matched. A body with no observed raise runs else; a
+            # non-matching raise propagates (kept in the entries).
+            if _first_effect_of_kind(body_entries, "raise") is None:
+                else_entries, _ef, _ = reduce_statements(self.orelse)
+                routed = (*body_entries, *else_entries)
+            else:
+                routed = body_entries
+
+        # finally runs on every path; its statements reduce and their effects
+        # propagate on all exits (caught, uncaught, else, fall-through).
+        finally_entries, _ff, _ = reduce_statements(self.finalbody)
+        entries = (*routed, *finally_entries)
+
+        # Mirror WithContractSugar: fall-through restored exactly when no red
+        # testimony survives the routing.
+        can_fall_through = not any(isinstance(e, Incomplete) for e in entries)
+        return Complete(BlockValue(entries, can_fall_through=can_fall_through))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_contract_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_contract_sugar.py
@@ -1,4 +1,4 @@
-"""`with <manager>: <body>` under a TYPED contract -- the #5994 wiring.
+"""`with <manager> [as <name>]: <body>` under a TYPED contract -- #5994 wiring.
 
 The node consults the recognition membrane (never a vendor name); the membrane
 issues a typed contract; this sugar reduces the body as a block and hands the
@@ -12,10 +12,13 @@ outcome to the ONE effect router shared with Try. The contract decides:
 - ``Suppresses(matcher)``: permission -- a matching halt is consumed silently;
   absence is fine; a non-matching effect propagates.
 
-Everything else about `with` stays LOUD at the node: unauthenticated managers,
-RuntimeSelected, warning-kind matchers (no WarningEffect exists to observe yet
--- wiring them would mint false absent-twins), `as` witnesses (step 5), multiple
-managers, and the resource expansion (step 4, finally-faithful, its own build).
+``as <Name>`` (Expects only) is a TEMPORAL bind for the enclosing block's
+tail: ``With.substitution_binding`` exports the matched-effect witness
+(``E()`` stand-in from ``raises(E)``). This sugar records ``as_name`` for
+provenance; substitute already rewrote uses of the name in the tail.
+
+Loud at the node: unauthenticated managers, non-Name as-targets, Suppresses+as,
+multiple managers, resource expansion (step 4).
 """
 
 from __future__ import annotations
@@ -29,9 +32,10 @@ from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 @dataclass(frozen=True)
 class WithContractSugar(Sugar):
-    contract: object  # Expects | Suppresses (raise-kind only; the node guards)
+    contract: object  # Expects | Suppresses (the node guards kind)
     body: tuple  # the body statements' sugars, in source order
     site: object = dataclass_field(compare=False, default=None)
+    as_name: str | None = None  # Expects as-witness; bound temporally for the tail
 
     @classmethod
     def witnesses(cls):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1732,6 +1732,67 @@ class Try(Statement):
                 changed[f] = new
         return self if not changed else rewrite(self, **changed)
 
+    @staticmethod
+    def _except_type_name(type_node):
+        """Structural exception type name off an ``except E`` clause: bare
+        ``Name`` -> ``"E"``, dotted ``Attribute`` chain -> ``"mod.E"``. Same
+        walk as ``Raise._exception_name`` (no desugar, no factory). Tuple types,
+        bare ``except:``, and exotic expressions return ``None`` so the sugar
+        stays LOUD rather than inventing a matcher."""
+        if type_node is None:
+            return None
+        node = type_node
+        parts = []
+        while node is not None and node.kind == "Attribute":
+            parts.append(node.attr)
+            node = node.value
+        if node is not None and node.kind == "Name":
+            parts.append(node.id)
+        if not parts:
+            return None
+        return ".".join(reversed(parts))
+
+    def sugar(self):
+        """`try: body (except E: handler)+ [else] [finally]` -- the STRUCTURAL
+        sibling of with-raises. Each ``except E`` is an EffectMatcher built
+        from the clause's type (native syntax, no membrane). The shared effect
+        router's exact kind+name match decides which handler consumes the
+        body's Incomplete(RaiseEffect). Loud residuals: bare ``except:``,
+        tuple types ``except (A, B):``, ``except E as name:`` (as-binding is a
+        parallel worker), and try with no typed handlers. ``except*`` lives on
+        TryStar and stays loud there."""
+        if not self.handlers:
+            return super().sugar()  # try/finally-only: not the except-routing core
+        handler_specs = []
+        for handler in self.handlers:
+            if handler.name is not None:
+                return super().sugar()  # `as` witness -- parallel worker; stay loud
+            if handler.type_ is None:
+                return super().sugar()  # bare except:
+            if handler.type_.kind == "Tuple":
+                return super().sugar()  # except (A, B):
+            type_name = self._except_type_name(handler.type_)
+            if type_name is None:
+                return super().sugar()  # exotic except type -- never invent a name
+            handler_specs.append((type_name, handler.body))
+
+        from sugar_lift_py_tests.context_manager_contract import EffectMatcher
+        from sugar_lift_py_tests.sugar.try_sugar import TrySugar
+
+        return TrySugar(
+            body=tuple(stmt.sugar() for stmt in self.body),
+            handlers=tuple(
+                (
+                    EffectMatcher(kind="raise", name=type_name),
+                    tuple(stmt.sugar() for stmt in body),
+                )
+                for type_name, body in handler_specs
+            ),
+            orelse=tuple(stmt.sugar() for stmt in self.orelse),
+            finalbody=tuple(stmt.sugar() for stmt in self.finalbody),
+            site=self.fragment,
+        )
+
 
 class TryStar(Statement):
     body: Tuple[Statement, ...]

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -45,6 +45,7 @@ from .operators import (
     UnaryOperator,
 )
 from .panic import (
+    RuntimeSelectedContextManager,
     SourceTreePanic,
     SubstituteNotWritten,
     SugarNotWritten,
@@ -1607,14 +1608,27 @@ class With(Statement):
         """`with <manager>: <body>` -- the node consults the MEMBRANE, never a
         vendor name (#5994). A single manager with no `as`, whose membrane-issued
         contract is a raise-kind Expects/Suppresses, wires through the shared
-        effect router (WithContractSugar). Everything else stays LOUD: the
-        unauthenticated manager (the named residual), warning-kind matchers (no
-        WarningEffect exists to observe -- wiring would mint false absent-twins),
-        `as` witnesses (step 5), multiple managers, and resource managers (the
-        finally-faithful expansion, step 4)."""
+        effect router (WithContractSugar).
+
+        Unauthenticated / RuntimeSelected managers (resource managers:
+        ``open(...)``, ``tm.ensure_clean(...)``, …) stay LOUD as the *named*
+        residual ``RuntimeSelectedContextManager`` — distinct from bare
+        ``SugarNotWritten`` so the census can count them. Temporal dissolution
+        is licensed only under a typed exit contract; we have no proof any
+        resource manager is ``NeverSuppresses`` (that requires reading
+        ``__exit__``, which we do not lift), so every unenrolled manager is
+        honestly RuntimeSelected. A normal-path-only enter/exit splice that
+        drops the exceptional edge is a different language — never written
+        here. ``NeverSuppresses`` enrollment (none yet) would gate the real
+        finally-faithful expansion; until then that arm stays unwritten loud.
+        `as` witnesses (step 5) and multiple managers remain bare unwritten."""
         if len(self.items) != 1 or self.items[0].optional_vars is not None:
             return super().sugar()
-        from sugar_lift_py_tests.context_manager_contract import Expects, Suppresses
+        from sugar_lift_py_tests.context_manager_contract import (
+            Expects,
+            RuntimeSelected,
+            Suppresses,
+        )
         from sugar_lift_py_tests.manifest_membrane import (
             contract_for_manager,
             default_community_manifest,
@@ -1624,15 +1638,45 @@ class With(Statement):
         contract = contract_for_manager(
             default_community_manifest(), self.items[0].context_expr
         )
-        if not isinstance(contract, (Expects, Suppresses)):
-            return super().sugar()  # unauthenticated / runtime-selected: loud
-        if contract.matcher.kind not in ("raise", "warning"):
-            return super().sugar()
-        return WithContractSugar(
-            contract=contract,
-            body=tuple(stmt.sugar() for stmt in self.body),
-            site=self.fragment,
-        )
+        if isinstance(contract, (Expects, Suppresses)):
+            if contract.matcher.kind not in ("raise", "warning"):
+                return super().sugar()
+            return WithContractSugar(
+                contract=contract,
+                body=tuple(stmt.sugar() for stmt in self.body),
+                site=self.fragment,
+            )
+        # None from the membrane OR an explicit RuntimeSelected enrollment:
+        # exit suppression is undecidable statically. Named residual — not a
+        # bare SugarNotWritten, not a false-green dissolve.
+        if contract is None or isinstance(contract, RuntimeSelected):
+            where = f"{self.unit.filename}"
+            try:
+                lc = self.line_col_span()
+                where = f"{self.unit.filename}:{lc.start_line}:{lc.start_col}"
+            except SourceTreePanic:
+                pass
+            panic = RuntimeSelectedContextManager(
+                owner="With.sugar",
+                observed=(
+                    "unauthenticated context manager — exit suppression "
+                    f"runtime-selected at {where}"
+                ),
+                requested=(
+                    "a typed exit contract (NeverSuppresses with "
+                    "finally-faithful expansion, or Expects/Suppresses via "
+                    "the membrane)"
+                ),
+                fix=(
+                    "enroll a manager only with proof of its __exit__ "
+                    "disposition; never invent a normal-path-only expansion"
+                ),
+            )
+            self.reporter.report_gap(self, panic)
+            raise panic
+        # NeverSuppresses (nothing enrolls yet): finally-faithful expansion
+        # unwritten — bare SugarNotWritten until that slice lands.
+        return super().sugar()
 
     def substitute(self, scope):
         """with ... as <vars>: binds the as-targets for the body."""

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -315,6 +315,23 @@ class Node(Typed):
             self.unit, ShadowNode("BinOp", self.span, slots), self.reporter
         )
 
+    def _make_call(self, func: "Node", args: tuple = ()) -> "Node":
+        """Construct a fresh Call ``<func>(<args...>)`` as a shadow borrowing
+        this node's span. Used by Expects ``as``-witness binding: the matched
+        effect payload is the expected type/category constructed with no args
+        (a temporal stand-in for the exception/warning instance)."""
+        from .backend import Child, Children, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        slots = (
+            ("func", Child(_handle_of(func))),
+            ("args", Children(tuple(_handle_of(a) for a in args))),
+            ("keywords", Children(())),
+        )
+        return materialize(
+            self.unit, ShadowNode("Call", self.span, slots), self.reporter
+        )
+
     def _substitute_body(self, statements: tuple, scope: "dict[str, Node]"):
         new_items, changed, _net = self._substitute_body_tracked(statements, scope)
         return new_items, changed
@@ -1604,16 +1621,20 @@ class With(Statement):
     _child_fields = ("items", "body")
 
     def sugar(self):
-        """`with <manager>: <body>` -- the node consults the MEMBRANE, never a
-        vendor name (#5994). A single manager with no `as`, whose membrane-issued
-        contract is a raise-kind Expects/Suppresses, wires through the shared
-        effect router (WithContractSugar). Everything else stays LOUD: the
-        unauthenticated manager (the named residual), warning-kind matchers (no
-        WarningEffect exists to observe -- wiring would mint false absent-twins),
-        `as` witnesses (step 5), multiple managers, and resource managers (the
-        finally-faithful expansion, step 4)."""
-        if len(self.items) != 1 or self.items[0].optional_vars is not None:
+        """`with <manager> [as <name>]: <body>` -- the node consults the MEMBRANE,
+        never a vendor name (#5994). A single manager whose membrane-issued
+        contract is raise/warning Expects/Suppresses wires through the shared
+        effect router (WithContractSugar). Plain ``as <Name>`` is admitted for
+        Expects (step 5: matched-effect witness bound for the tail via
+        substitution_binding). Everything else stays LOUD: unauthenticated
+        managers, non-Name as-targets, Suppresses+as (no community witness
+        shape), multiple managers, and resource expansion (step 4)."""
+        if len(self.items) != 1:
             return super().sugar()
+        item = self.items[0]
+        as_target = item.optional_vars
+        if as_target is not None and not isinstance(as_target, Name):
+            return super().sugar()  # only plain Name as for step 5
         from sugar_lift_py_tests.context_manager_contract import Expects, Suppresses
         from sugar_lift_py_tests.manifest_membrane import (
             contract_for_manager,
@@ -1622,20 +1643,28 @@ class With(Statement):
         from sugar_lift_py_tests.sugar.with_contract_sugar import WithContractSugar
 
         contract = contract_for_manager(
-            default_community_manifest(), self.items[0].context_expr
+            default_community_manifest(), item.context_expr
         )
         if not isinstance(contract, (Expects, Suppresses)):
             return super().sugar()  # unauthenticated / runtime-selected: loud
         if contract.matcher.kind not in ("raise", "warning"):
             return super().sugar()
+        # Suppresses+as is not a community effect-witness shape; Expects+as is.
+        if as_target is not None and not isinstance(contract, Expects):
+            return super().sugar()
         return WithContractSugar(
             contract=contract,
             body=tuple(stmt.sugar() for stmt in self.body),
             site=self.fragment,
+            as_name=as_target.id if as_target is not None else None,
         )
 
     def substitute(self, scope):
-        """with ... as <vars>: binds the as-targets for the body."""
+        """with ... as <vars>: masks as-targets for the body (binding sites).
+
+        Expects ``as <Name>`` also EXPORTS a matched-effect witness for the
+        rest of the enclosing block via ``substitution_binding`` (step 5).
+        """
         from .shadow import rewrite
 
         bound = set()
@@ -1651,6 +1680,44 @@ class With(Statement):
         if d:
             changed["body"] = new_body
         return self if not changed else rewrite(self, **changed)
+
+    def substitution_binding(self, scope):
+        """Expects ``as <Name>``: bind the name for the TAIL to the matched-
+        effect witness (expected type/category constructed as ``E()``).
+
+        Only on the Expects membrane path; resource ``as`` is step 4.
+        Witness identity is the enrolled expected type expression -- the same
+        name the router discharges against the observed halt.
+        """
+        if len(self.items) != 1:
+            return None
+        ov = self.items[0].optional_vars
+        if not isinstance(ov, Name):
+            return None
+        from sugar_lift_py_tests.context_manager_contract import Expects
+        from sugar_lift_py_tests.manifest_membrane import (
+            contract_for_manager,
+            default_community_manifest,
+        )
+
+        contract = contract_for_manager(
+            default_community_manifest(), self.items[0].context_expr
+        )
+        if not isinstance(contract, Expects):
+            return None
+        if contract.matcher.kind not in ("raise", "warning"):
+            return None
+        witness = self._expects_effect_as_witness(self.items[0].context_expr)
+        if witness is None:
+            return None
+        return {ov.id: witness}
+
+    def _expects_effect_as_witness(self, context_expr: "Expression"):
+        """Temporal stand-in for the matched effect payload: ``E()`` from
+        ``raises(E, ...)`` / ``assert_produces_warning(E, ...)``."""
+        if context_expr.kind != "Call" or not context_expr.args:
+            return None
+        return self._make_call(context_expr.args[0], ())
 
 
 class AsyncWith(Statement):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -86,6 +86,25 @@ class SugarNotWritten(SourceTreePanic):
     _LABEL = "SUGAR NOT WRITTEN"
 
 
+class RuntimeSelectedContextManager(SugarNotWritten):
+    """A `with` whose manager has no authenticated exit-suppression contract.
+
+    Resource managers (`open(...)`, `tm.ensure_clean(...)`, …) are not
+    enrolled as ``NeverSuppresses`` / ``Expects`` / ``Suppresses``: the lift
+    never reads ``__enter__`` / ``__exit__``, so suppression is
+    ``RuntimeSelected`` and must stay LOUD. This residual is deliberately a
+    *named* subclass of ``SugarNotWritten`` so the frontier census can count
+    unauthenticated context managers separately from shapes that simply have
+    no ``.sugar()`` override yet.
+
+    Never a normal-path-only ``__enter__``/``__exit__(None,None,None)``
+    rewrite — that drops the exceptional edge and is a different language
+    (issue #5994 step 4).
+    """
+
+    _LABEL = "RUNTIME-SELECTED CONTEXT MANAGER"
+
+
 class SubstituteNotWritten(SourceTreePanic):
     """Nobody has written this node's substitution yet. Raised by the abstract
     ``Node.substitute()``; every concrete class either OVERRIDES it (a leaf

--- a/implementations/python/sugar-source-tree/tests/test_panic_taxonomy.py
+++ b/implementations/python/sugar-source-tree/tests/test_panic_taxonomy.py
@@ -19,6 +19,8 @@ from sugar_source_tree.panic import (
     VocabularyMissing,
     SourceTreePanic,
     BackendDefect,
+    RuntimeSelectedContextManager,
+    SugarNotWritten,
 )
 from sugar_source_tree.spans import LineTable, Span
 
@@ -78,3 +80,21 @@ def test_catching_the_common_base_catches_both():
         resolve_kind("NoSuchKind", observed_at="test")
     with pytest.raises(SourceTreePanic):
         Span(5, 2)
+
+
+def test_runtime_selected_context_manager_is_named_sugar_gap():
+    """Resource-with residual (#5994 step 4): subclass of SugarNotWritten so
+    report_gap / census still see a gap, but isinstance distinguishes it from
+    a bare unwritten shape."""
+    assert issubclass(RuntimeSelectedContextManager, SugarNotWritten)
+    assert issubclass(RuntimeSelectedContextManager, SourceTreePanic)
+    assert RuntimeSelectedContextManager is not SugarNotWritten
+    panic = RuntimeSelectedContextManager(
+        owner="With.sugar",
+        observed="unauthenticated context manager — exit suppression runtime-selected",
+        requested="typed exit contract",
+        fix="enroll with proof of __exit__ disposition",
+    )
+    assert isinstance(panic, SugarNotWritten)
+    assert type(panic) is RuntimeSelectedContextManager
+    assert "RUNTIME-SELECTED CONTEXT MANAGER" in str(panic)

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -1,0 +1,238 @@
+"""`try` as the STRUCTURAL surface of the effect router: except clauses match
+by exact kind+name (the same rule with-contracts ride), matching handlers
+consume the Incomplete, non-matches propagate, else/finally splice, and the
+loud residuals stay loud. Mirror of test_with_contract.py for the native-syntax
+twin."""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _val(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).sugar().desugar().value
+
+
+def _fn(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _incompletes(v):
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    return [e for e in v.record.contribution() if isinstance(e, Incomplete)]
+
+
+def test_matching_except_consumes_raise_and_try_completes():
+    # Matching except ValueError consumes the body's raise; the function
+    # completes past the try (post out == z), same discharge shape as
+    # with-raises under Suppresses/Expects consume.
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError:\n"
+        "        pass\n"
+        "    return z\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+def test_handler_own_raise_propagates():
+    # A matching handler that itself raises: the body's raise is consumed, the
+    # handler's raise rides out as red testimony (does not disappear).
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError:\n"
+        "        raise KeyError\n"
+        "    return z\n"
+    )
+    reds = _incompletes(v)
+    assert len(reds) == 1
+    assert isinstance(reds[0].effect, RaiseEffect)
+    assert reds[0].effect.exception_name == "KeyError"
+
+
+def test_except_keyerror_does_not_catch_valueerror():
+    # Exact-match discrimination (the mismatch twin): except KeyError does NOT
+    # silently catch a ValueError body -- the Incomplete survives.
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except KeyError:\n"
+        "        pass\n"
+        "    return z\n"
+    )
+    reds = _incompletes(v)
+    assert len(reds) == 1
+    assert isinstance(reds[0].effect, RaiseEffect)
+    assert reds[0].effect.exception_name == "ValueError"
+
+
+def test_except_valueerror_does_catch_valueerror():
+    # Positive twin of the discrimination: except ValueError consumes a
+    # ValueError body raise -- zero red raises survive.
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError:\n"
+        "        pass\n"
+        "    return z\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+def test_else_runs_when_body_is_raise_free():
+    # Body with no observed raise reduces else; the else return is the exit.
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        pass\n"
+        "    except ValueError:\n"
+        "        pass\n"
+        "    else:\n"
+        "        return z\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+def test_else_does_not_run_when_raise_is_caught():
+    # Caught raise takes the handler path, not else: handler return wins.
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError:\n"
+        "        return z\n"
+        "    else:\n"
+        "        return 0\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+def test_finally_reduces_on_caught_path():
+    # finally always runs: after a matching except, finally's return is the
+    # exit (Python: finally return is the function exit).
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError:\n"
+        "        pass\n"
+        "    finally:\n"
+        "        return z\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+def test_finally_reduces_on_uncaught_path():
+    # finally still reduces when the raise is NOT caught: the body's
+    # Incomplete survives AND finally's raise is spliced (both effects ride).
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except KeyError:\n"
+        "        pass\n"
+        "    finally:\n"
+        "        raise RuntimeError\n"
+        "    return z\n"
+    )
+    reds = _incompletes(v)
+    names = {r.effect.exception_name for r in reds if isinstance(r.effect, RaiseEffect)}
+    assert "ValueError" in names  # uncaught body raise survives
+    assert "RuntimeError" in names  # finally reduced and spliced
+
+
+def test_bare_except_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(z):\n"
+            "    try:\n"
+            "        raise ValueError\n"
+            "    except:\n"
+            "        pass\n"
+            "    return z\n"
+        ).sugar()
+
+
+def test_tuple_except_types_stay_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(z):\n"
+            "    try:\n"
+            "        raise ValueError\n"
+            "    except (ValueError, KeyError):\n"
+            "        pass\n"
+            "    return z\n"
+        ).sugar()
+
+
+def test_as_binding_stays_loud():
+    # `except E as name:` is a parallel worker's lane -- leave loud so we do
+    # not collide on the as-witness binding.
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(z):\n"
+            "    try:\n"
+            "        raise ValueError\n"
+            "    except ValueError as e:\n"
+            "        pass\n"
+            "    return z\n"
+        ).sugar()
+
+
+def test_dotted_except_type_matches():
+    # Dotted Name exception types are in the tractable core (same structural
+    # walk as raise's exception_name).
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise os.error\n"
+        "    except os.error:\n"
+        "        pass\n"
+        "    return z\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+if __name__ == "__main__":
+    test_matching_except_consumes_raise_and_try_completes()
+    test_handler_own_raise_propagates()
+    test_except_keyerror_does_not_catch_valueerror()
+    test_except_valueerror_does_catch_valueerror()
+    test_else_runs_when_body_is_raise_free()
+    test_else_does_not_run_when_raise_is_caught()
+    test_finally_reduces_on_caught_path()
+    test_finally_reduces_on_uncaught_path()
+    test_bare_except_stays_loud()
+    test_tuple_except_types_stay_loud()
+    test_as_binding_stays_loud()
+    test_dotted_except_type_matches()
+    print("ok: try sugar -- structural effect routing")

--- a/implementations/python/sugar-source-tree/tests/test_with_contract.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_contract.py
@@ -90,11 +90,46 @@ def test_unauthenticated_manager_stays_loud():
         _fn("def A(z):\n    with open(z):\n        pass\n    return z\n").sugar()
 
 
-def test_as_witness_stays_loud():
+def test_as_witness_admits_and_discharges():
+    """Step 5: Expects ``as <Name>`` is no longer loud; type obligation flows."""
+    v = _val(
+        "def A(z):\n    with pytest.raises(ValueError) as ei:\n"
+        "        raise ValueError\n    return z\n"
+    )
+    inv = v.invs()[0]
+    assert inv.name == "="
+    assert inv.args[0].value == inv.args[1].value == "ValueError"
+    assert v.post().args[1].name == "z"
+
+
+def test_as_witness_inlines_in_the_tail():
+    """Matched-effect witness is bound for the tail: ``return ei`` sees E()."""
+    v = _val(
+        "def A():\n    with pytest.raises(ValueError) as ei:\n"
+        "        raise ValueError\n    return ei\n"
+    )
+    # Type obligation still stated; post is the witness construction ValueError().
+    type_rows = [i for i in v.invs() if getattr(i, "name", "") == "="]
+    assert type_rows
+    assert type_rows[0].args[0].value == type_rows[0].args[1].value == "ValueError"
+    post = v.post().args[1]
+    assert post.name == "call:ValueError"  # E() stand-in for the effect payload
+
+
+def test_as_non_name_target_stays_loud():
     with pytest.raises(SugarNotWritten):
         _fn(
-            "def A(z):\n    with pytest.raises(ValueError) as ei:\n"
+            "def A(z):\n    with pytest.raises(ValueError) as (ei,):\n"
             "        raise ValueError\n    return z\n"
+        ).sugar()
+
+
+def test_suppresses_as_stays_loud():
+    """Suppresses+as is not a community effect-witness shape (step 5 is Expects)."""
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(z):\n    with contextlib.suppress(KeyError) as cm:\n"
+            "        raise KeyError\n    return z\n"
         ).sugar()
 
 
@@ -124,10 +159,13 @@ if __name__ == "__main__":
     test_suppress_matching_consumed()
     test_suppress_non_match_propagates()
     test_unauthenticated_manager_stays_loud()
-    test_as_witness_stays_loud()
+    test_as_witness_admits_and_discharges()
+    test_as_witness_inlines_in_the_tail()
+    test_as_non_name_target_stays_loud()
+    test_suppresses_as_stays_loud()
     test_warning_kind_with_unresolved_call_retains_obligation()
     test_multiple_managers_stay_loud()
-    print("ok: with under typed contracts -- ten twins")
+    print("ok: with under typed contracts -- as-witness twins")
 
 
 def test_match_conjunction_type_discharged_message_undischarged():

--- a/implementations/python/sugar-source-tree/tests/test_with_contract.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_contract.py
@@ -8,7 +8,7 @@ import tempfile
 import pytest
 
 from sugar_lift_python_source.source_oracle import path_source
-from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.panic import RuntimeSelectedContextManager, SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
 
@@ -86,8 +86,15 @@ def test_suppress_non_match_propagates():
 
 
 def test_unauthenticated_manager_stays_loud():
-    with pytest.raises(SugarNotWritten):
+    # Named residual (step 4): RuntimeSelectedContextManager, not bare
+    # SugarNotWritten — census can count resource managers separately.
+    with pytest.raises(RuntimeSelectedContextManager) as ei:
         _fn("def A(z):\n    with open(z):\n        pass\n    return z\n").sugar()
+    assert isinstance(ei.value, SugarNotWritten)
+    assert (
+        "unauthenticated context manager — exit suppression runtime-selected"
+        in ei.value.observed
+    )
 
 
 def test_as_witness_stays_loud():

--- a/implementations/python/sugar-source-tree/tests/test_with_resource.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_resource.py
@@ -1,0 +1,93 @@
+"""Resource `with` under RuntimeSelected (#5994 step 4).
+
+Honest v1: we never lift ``__enter__``/``__exit__``, so no resource manager
+is proven ``NeverSuppresses``. Every unenrolled resource manager is therefore
+``RuntimeSelected`` and stays LOUD as the named residual
+``RuntimeSelectedContextManager`` — not a silent dissolve, not a bare
+``SugarNotWritten``, not a false green. Assertion managers (Expects/Suppresses
+via the membrane) keep their wired path.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import (
+    RuntimeSelectedContextManager,
+    SugarNotWritten,
+)
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn(src: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _val(src: str):
+    return _fn(src).sugar().desugar().value
+
+
+def test_resource_open_is_runtime_selected_named_residual():
+    """`with open(f): ...` is loud, distinctly named — not dissolved."""
+    with pytest.raises(RuntimeSelectedContextManager) as ei:
+        _fn("def A(f):\n    with open(f):\n        pass\n    return f\n").sugar()
+    panic = ei.value
+    assert isinstance(panic, SugarNotWritten)  # still a gap for census
+    assert type(panic) is RuntimeSelectedContextManager  # not bare
+    assert "unauthenticated context manager — exit suppression runtime-selected" in (
+        panic.observed
+    )
+    assert panic.owner == "With.sugar"
+
+
+def test_resource_open_is_not_silent_dissolve():
+    """No sugar object, no enter/exit splice: the throw is the residual."""
+    with pytest.raises(RuntimeSelectedContextManager):
+        sugar = _fn(
+            "def A(f):\n    with open(f):\n        x = 1\n    return f\n"
+        ).sugar()
+        # If sugar() ever returned instead of raising, that would be a dissolve.
+        sugar.desugar()
+
+
+def test_resource_named_residual_distinct_from_bare_sugar_not_written():
+    """Census discrimination: resource managers are a typed subclass."""
+    with pytest.raises(RuntimeSelectedContextManager) as ei:
+        _fn("def A(z):\n    with open(z):\n        pass\n    return z\n").sugar()
+    assert type(ei.value) is not SugarNotWritten
+    assert issubclass(type(ei.value), SugarNotWritten)
+
+
+def test_assertion_manager_pytest_raises_still_lifts():
+    """Step-4 residual must not disturb the Expects path."""
+    v = _val(
+        "def A(z):\n    with pytest.raises(ValueError):\n        raise ValueError\n"
+        "    return z\n"
+    )
+    inv = v.invs()[0]
+    assert inv.name == "="
+    assert inv.args[0].value == inv.args[1].value == "ValueError"
+    assert v.post().args[1].name == "z"
+
+
+def test_suppress_manager_still_lifts():
+    v = _val(
+        "def A(z):\n    with contextlib.suppress(KeyError):\n        raise KeyError\n"
+        "    return z\n"
+    )
+    assert v.invs() == () and v.post().args[1].name == "z"
+
+
+if __name__ == "__main__":
+    test_resource_open_is_runtime_selected_named_residual()
+    test_resource_open_is_not_silent_dissolve()
+    test_resource_named_residual_distinct_from_bare_sugar_not_written()
+    test_assertion_manager_pytest_raises_still_lifts()
+    test_suppress_manager_still_lifts()
+    print("ok: resource with is RuntimeSelected named residual; Expects undisturbed")


### PR DESCRIPTION
Three fleet lanes (self-PR'd as #6003/#6004/#6005), coordinator-verified and merged into one. Each mechanism checked personally; tree suite 222 passed, 5 skipped.

- **Try** (#6004) — structural surface of the shared effect router: `except E` builds the matcher structurally (native syntax, no membrane), reuses the exact-match rule; matching handler consumes the raise, else/finally on the right paths. Bare-except, tuple-types, except*, and `as` stay loud.
- **with-as-witness** (#6003, step 5) — Expects `as <Name>` binds the matched-effect witness for the tail via substitution_binding; non-Name targets and Suppresses+as stay loud.
- **resource RuntimeSelected** (#6005, step 4) — unenrolled resource managers (open/ensure_clean/…) become a NAMED loud residual (RuntimeSelectedContextManager), distinct from bare SugarNotWritten so the census counts them; NO normal-path dissolve (the exceptional-edge-dropping splice is 'a different language', never written). Honest investigation verdict: every unenrolled manager is RuntimeSelected until a NeverSuppresses enrollment proves otherwise.

With.sugar three-way conflict (all three touched it) hand-reconciled: as-handling + RuntimeSelected residual compose. Fix-forward on main per IDD.

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `try/except` and `with ... as` desugaring with `RuntimeSelectedContextManager` residual
> - Adds `TrySugar` to route `raise` effects to matching `except` handlers by name, execute `else` when no raise is observed, and always execute `finally`; implemented in [`try_sugar.py`](https://github.com/TSavo/sugar/pull/6006/files#diff-f5d956a5de18664d828d314bf5537a359cc1f2f40c5a42b52f03bbe5ecaac0ff) and [`nodes.py`](https://github.com/TSavo/sugar/pull/6006/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0).
> - Extends `With.sugar()` to support `with <manager> as <name>:` for `Expects` contracts, recording the as-witness name in `WithContractSugar.as_name` and generating a substitution binding via `With.substitution_binding()`.
> - Introduces `RuntimeSelectedContextManager` panic (a `SugarNotWritten` subclass) raised when a `with` statement's manager contract is `None` or `RuntimeSelected` (e.g. `open(...)`), replacing the previous generic sugar gap.
> - Risk: `with` statements that previously produced a generic sugar gap now raise `RuntimeSelectedContextManager`; callers catching `SugarNotWritten` are unaffected, but callers expecting a silent gap will need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5699ebb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->