### PR TITLE
try: deepen — except-as, multi-type, bare policy

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
@@ -14,8 +14,9 @@ Arms (T's ruling, restated as reduction):
 - A body with no observed raise reduces ``else`` (when present).
 - ``finally`` always reduces and splices; its effects ride on every path.
 
-Loud residuals stay at the node (bare ``except:``, tuple types, ``as`` binding,
-``except*`` on TryStar) -- never silently dropped here.
+Typed tuples are flattened into ordered exact-match arms. A bare ``except:``
+uses the router's widest existing raise query and consumes whichever raise it
+finds. ``except*`` and structurally exotic types stay loud at the node.
 """
 
 from __future__ import annotations
@@ -31,8 +32,9 @@ from sugar_lift_py_tests.sugar.witnesses import _call_pair
 class TrySugar(Sugar):
     """`try` with typed except handlers, constructed by ``Try.sugar``.
 
-    ``handlers`` is an ordered tuple of ``(EffectMatcher, body_sugars)`` --
-    one per ``except E:`` clause, already structure-checked by the node.
+    ``handlers`` is an ordered tuple of ``(EffectMatcher | None, body_sugars)``.
+    ``None`` is the widest bare-except matcher; typed tuple clauses contribute
+    one arm per structurally admitted type.
     """
 
     body: tuple  # body statement sugars, source order
@@ -79,7 +81,11 @@ class TrySugar(Sugar):
         # handler body's entries in its place.
         routed = None
         for matcher, handler_body in self.handlers:
-            matching = _matching_effect(body_entries, matcher)
+            matching = (
+                _first_effect_of_kind(body_entries, "raise")
+                if matcher is None
+                else _matching_effect(body_entries, matcher)
+            )
             if matching is None:
                 continue
             index, _entry, _observation = matching

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1867,40 +1867,49 @@ class Try(Statement):
 
     def sugar(self):
         """`try: body (except E: handler)+ [else] [finally]` -- the STRUCTURAL
-        sibling of with-raises. Each ``except E`` is an EffectMatcher built
-        from the clause's type (native syntax, no membrane). The shared effect
-        router's exact kind+name match decides which handler consumes the
-        body's Incomplete(RaiseEffect). Loud residuals: bare ``except:``,
-        tuple types ``except (A, B):``, ``except E as name:`` (as-binding is a
-        parallel worker), and try with no typed handlers. ``except*`` lives on
-        TryStar and stays loud there."""
+        sibling of with-raises. A typed clause contributes one exact router
+        matcher per bare/dotted type (including each element of a tuple); a
+        bare clause contributes the widest raise matcher. ``as <name>`` is
+        substituted with the selected type's ``E()`` witness only in that
+        matching handler arm. Exotic type expressions and empty tuples stay
+        loud. ``except*`` lives on TryStar and stays loud there."""
         if not self.handlers:
             return super().sugar()  # try/finally-only: not the except-routing core
+        from sugar_lift_py_tests.context_manager_contract import EffectMatcher
+
         handler_specs = []
         for handler in self.handlers:
-            if handler.name is not None:
-                return super().sugar()  # `as` witness -- parallel worker; stay loud
             if handler.type_ is None:
-                return super().sugar()  # bare except:
-            if handler.type_.kind == "Tuple":
-                return super().sugar()  # except (A, B):
-            type_name = self._except_type_name(handler.type_)
-            if type_name is None:
-                return super().sugar()  # exotic except type -- never invent a name
-            handler_specs.append((type_name, handler.body))
+                handler_specs.append(
+                    (None, tuple(stmt.sugar() for stmt in handler.body))
+                )
+                continue
 
-        from sugar_lift_py_tests.context_manager_contract import EffectMatcher
+            type_nodes = (
+                handler.type_.elts if handler.type_.kind == "Tuple" else (handler.type_,)
+            )
+            if not type_nodes:
+                return super().sugar()  # empty tuple: no honest matcher
+            for type_node in type_nodes:
+                type_name = self._except_type_name(type_node)
+                if type_name is None:
+                    return super().sugar()  # exotic tuple elt/type -- stay loud
+                body = handler.body
+                if handler.name is not None:
+                    witness = self._make_call(type_node, ())
+                    body, _ = self._substitute_body(body, {handler.name: witness})
+                handler_specs.append(
+                    (
+                        EffectMatcher(kind="raise", name=type_name),
+                        tuple(stmt.sugar() for stmt in body),
+                    )
+                )
+
         from sugar_lift_py_tests.sugar.try_sugar import TrySugar
 
         return TrySugar(
             body=tuple(stmt.sugar() for stmt in self.body),
-            handlers=tuple(
-                (
-                    EffectMatcher(kind="raise", name=type_name),
-                    tuple(stmt.sugar() for stmt in body),
-                )
-                for type_name, body in handler_specs
-            ),
+            handlers=tuple(handler_specs),
             orelse=tuple(stmt.sugar() for stmt in self.orelse),
             finalbody=tuple(stmt.sugar() for stmt in self.finalbody),
             site=self.fragment,

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -169,39 +169,109 @@ def test_finally_reduces_on_uncaught_path():
     assert "RuntimeError" in names  # finally reduced and spliced
 
 
-def test_bare_except_stays_loud():
+def test_except_as_binds_matching_raise_witness_in_handler():
+    v = _val(
+        "def A():\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError as error:\n"
+        "        return error\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "call:ValueError"
+
+
+def test_except_as_does_not_bind_on_uncaught_path():
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    v = _val(
+        "def A():\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except KeyError as error:\n"
+        "        return error\n"
+        "    return 0\n"
+    )
+    reds = _incompletes(v)
+    assert len(reds) == 1
+    assert isinstance(reds[0].effect, RaiseEffect)
+    assert reds[0].effect.exception_name == "ValueError"
+
+
+def test_tuple_except_catches_any_exactly_listed_type():
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except (KeyError, ValueError):\n"
+        "        pass\n"
+        "    return z\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+def test_tuple_except_does_not_catch_unlisted_type():
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except (KeyError, IndexError):\n"
+        "        pass\n"
+        "    return z\n"
+    )
+    reds = _incompletes(v)
+    assert len(reds) == 1
+    assert isinstance(reds[0].effect, RaiseEffect)
+    assert reds[0].effect.exception_name == "ValueError"
+
+
+def test_tuple_except_as_binds_the_matched_type_witness():
+    v = _val(
+        "def A():\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except (KeyError, ValueError) as error:\n"
+        "        return error\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "call:ValueError"
+
+
+def test_bare_except_catches_arbitrary_raise():
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ArbitraryProjectHalt\n"
+        "    except:\n"
+        "        pass\n"
+        "    return z\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+def test_except_star_stays_loud():
     with pytest.raises(SugarNotWritten):
         _fn(
             "def A(z):\n"
             "    try:\n"
             "        raise ValueError\n"
-            "    except:\n"
+            "    except* ValueError:\n"
             "        pass\n"
             "    return z\n"
         ).sugar()
 
 
-def test_tuple_except_types_stay_loud():
+def test_non_name_except_type_stays_loud():
     with pytest.raises(SugarNotWritten):
         _fn(
             "def A(z):\n"
             "    try:\n"
             "        raise ValueError\n"
-            "    except (ValueError, KeyError):\n"
-            "        pass\n"
-            "    return z\n"
-        ).sugar()
-
-
-def test_as_binding_stays_loud():
-    # `except E as name:` is a parallel worker's lane -- leave loud so we do
-    # not collide on the as-witness binding.
-    with pytest.raises(SugarNotWritten):
-        _fn(
-            "def A(z):\n"
-            "    try:\n"
-            "        raise ValueError\n"
-            "    except ValueError as e:\n"
+            "    except exception_type():\n"
             "        pass\n"
             "    return z\n"
         ).sugar()
@@ -231,8 +301,13 @@ if __name__ == "__main__":
     test_else_does_not_run_when_raise_is_caught()
     test_finally_reduces_on_caught_path()
     test_finally_reduces_on_uncaught_path()
-    test_bare_except_stays_loud()
-    test_tuple_except_types_stay_loud()
-    test_as_binding_stays_loud()
+    test_except_as_binds_matching_raise_witness_in_handler()
+    test_except_as_does_not_bind_on_uncaught_path()
+    test_tuple_except_catches_any_exactly_listed_type()
+    test_tuple_except_does_not_catch_unlisted_type()
+    test_tuple_except_as_binds_the_matched_type_witness()
+    test_bare_except_catches_arbitrary_raise()
+    test_except_star_stays_loud()
+    test_non_name_except_type_stays_loud()
     test_dotted_except_type_matches()
     print("ok: try sugar -- structural effect routing")


### PR DESCRIPTION
## What changed

- Admit `except E as name:` for structurally supported bare and dotted exception types. The matching handler arm substitutes `name` with the matched exception witness `E()`; an uncaught arm is never reduced.
- Admit `except (A, B):` and `except (A, B) as name` by flattening structurally supported tuple elements into ordered handler arms. Every typed arm delegates matching to the shared router exact kind+name rule; there is no subclass matching.
- Admit bare `except:` as the widest raise matcher. It uses the shared router's first-effect-of-kind query, consumes the observed `RaiseEffect`, and reduces the handler. This is honest at the current IR boundary: all Python raises, including BaseException-family raises, share the `RaiseEffect` kind, so no narrower subclass claim is invented.
- Keep `except*`, call-expression/non-name exception types, exotic tuple elements, and empty tuples loud through `SugarNotWritten`.

## Validation

`python3 -m pytest sugar-source-tree/tests/test_try_sugar.py -q`

17 passed in 1.03s

`python3 -m pytest sugar-source-tree/tests/ -q`

227 passed, 5 skipped in 2.82s

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend `Try.sugar` to handle bare `except:`, multi-type tuples, and `except E as name` binding
> - [`Try.sugar`](https://github.com/TSavo/sugar/pull/6007/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now lowers three previously-loud except forms: bare `except:` (matched via the widest raise query), tuple types (flattened into one exact-match arm per element), and `except E as name` (binds an `E()` witness scoped to that arm's handler body).
> - [`TrySugar`](https://github.com/TSavo/sugar/pull/6007/files#diff-f5d956a5de18664d828d314bf5537a359cc1f2f40c5a42b52f03bbe5ecaac0ff) routing updated so a `None` matcher selects the first observed `raise` effect via `_first_effect_of_kind` instead of being ignored.
> - Tests in [`test_try_sugar.py`](https://github.com/TSavo/sugar/pull/6007/files#diff-e08e75c8aa18050f22f6a4f3eab47a900f9605097a7ac8dc38f92f9c906a7e07) replace the old loudness assertions for these forms with correctness checks; loudness is retained for `except*` and non-Name type expressions.
> - Behavioral Change: bare `except:`, tuple except types, and `as`-binding clauses are no longer delegated to `super().sugar()` — they now produce lowered sugar output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65fab9b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->