### PR TITLE
with (#5994 step 4): NeverSuppresses proof-path investigation

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/manifest_membrane.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/manifest_membrane.py
@@ -49,6 +49,14 @@ from sugar_lift_py_tests.context_manager_contract import (
     Suppresses,
 )
 
+# Manifest schema vocabulary. ``never-suppresses`` is deliberately reserved
+# without an issuer below or an enrolled row in the committed manifest: the
+# tree cannot yet represent its finally-faithful exceptional exit. Naming the
+# future proof kind is not permission to infer it from a manager call.
+MANIFEST_CONTRACT_KINDS = frozenset(
+    {"expects", "suppresses", "never-suppresses"}
+)
+
 _CONTRACT_BUILDERS = {
     "expects": Expects,
     "suppresses": Suppresses,

--- a/implementations/python/sugar-lift-py-tests/tests/test_manifest_membrane.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_manifest_membrane.py
@@ -12,6 +12,7 @@ import pytest
 
 from sugar_lift_py_tests.context_manager_contract import Expects, Suppresses
 from sugar_lift_py_tests.manifest_membrane import (
+    MANIFEST_CONTRACT_KINDS,
     ManifestIntegrityError,
     contract_for_manager,
     default_community_manifest,
@@ -52,6 +53,16 @@ def test_committed_manifest_loads_and_hash_verifies():
         "contextlib.suppress",
         "tm.assert_produces_warning",
     }
+
+
+def test_manifest_schema_reserves_never_suppresses_without_enrollment():
+    """Investigation-only step 4: name the future proof kind as schema,
+    without authenticating any manager or licensing an expansion."""
+    assert MANIFEST_CONTRACT_KINDS == frozenset(
+        {"expects", "suppresses", "never-suppresses"}
+    )
+    manifest = default_community_manifest()
+    assert all(row.contract != "never-suppresses" for row in manifest.rows)
 
 
 def test_tampered_manifest_refuses_loudly(tmp_path):


### PR DESCRIPTION
## Investigation verdict

Confirmed: in this cut, manifest-enrolled `NeverSuppresses` is the only honest possible source of that contract. The lifter does not lift or inspect a manager's `__enter__` or `__exit__`, so it cannot infer exit disposition from the call. An external, content-addressed manifest assertion is therefore the only available proof boundary, exactly like the existing community assertion vocabulary.

That source is necessary but not sufficient for dissolution today. The current tree/router surface can route effect entries after a body has reduced, but it cannot faithfully construct the complete control-flow rewrite required by T's ruling: enter failure bypasses exit; normal completion calls `__exit__(None, None, None)`; exceptional completion calls `__exit__(type, value, traceback)`; the exit result selects suppression; exit failure propagates; and an unsuppressed body effect is re-propagated only after exit. Method coordinates alone do not represent those control-flow edges. Any resource expansion in this cut would therefore fake or omit the exceptional edge, so this PR enrolls no manager and leaves `With.sugar` loud.

## Landed

- Reserved `never-suppresses` in the manifest contract-kind vocabulary.
- Added a regression asserting the kind is schema-only and the committed hashed manifest contains no `NeverSuppresses` enrollment.
- Added no builder, arity rule, manifest row, hash change, manager inference, factory import, or `With.sugar` expansion.
- The existing named `RuntimeSelectedContextManager` floor remains intact.

Measured direction: enrolled NeverSuppresses managers R remains 0; predicted Epsilon R is 0. This investigation does not claim to drain any resource-With locus.

## Validation

`cd implementations/python && PYTHONPATH="sugar-source-tree/src:sugar-lift-python-source/src:sugar-lift-py-tests/src" python3 -m pytest sugar-source-tree/tests/ -q`

222 passed, 5 skipped in 7.06s.

Part of #5994 step 4. Does not close #5994.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reserve 'never-suppresses' in manifest schema vocabulary without enrollment
> Adds `MANIFEST_CONTRACT_KINDS` as a module-level frozenset in [manifest_membrane.py](https://github.com/TSavo/sugar/pull/6008/files#diff-38a7443c57e89958d14963311463ee18ac2439702490eaf2c378256d3f571583) containing `'expects'`, `'suppresses'`, and `'never-suppresses'`. A new test in [test_manifest_membrane.py](https://github.com/TSavo/sugar/pull/6008/files#diff-7ed7aa0ce724c5cc43aee55a8c352aa51cd4aa41f85636fdd87d4896ea872ab9) asserts the constant matches this set and that the default community manifest has no rows with `contract == 'never-suppresses'`, confirming the kind is schema-reserved but not yet backed by a manager or enrolled row.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65d89e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->