### PR TITLE
cascade batch 2: deepen Try + NeverSuppresses proof-path finding

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/manifest_membrane.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/manifest_membrane.py
@@ -49,6 +49,14 @@ from sugar_lift_py_tests.context_manager_contract import (
     Suppresses,
 )
 
+# Manifest schema vocabulary. ``never-suppresses`` is deliberately reserved
+# without an issuer below or an enrolled row in the committed manifest: the
+# tree cannot yet represent its finally-faithful exceptional exit. Naming the
+# future proof kind is not permission to infer it from a manager call.
+MANIFEST_CONTRACT_KINDS = frozenset(
+    {"expects", "suppresses", "never-suppresses"}
+)
+
 _CONTRACT_BUILDERS = {
     "expects": Expects,
     "suppresses": Suppresses,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
@@ -14,8 +14,9 @@ Arms (T's ruling, restated as reduction):
 - A body with no observed raise reduces ``else`` (when present).
 - ``finally`` always reduces and splices; its effects ride on every path.
 
-Loud residuals stay at the node (bare ``except:``, tuple types, ``as`` binding,
-``except*`` on TryStar) -- never silently dropped here.
+Typed tuples are flattened into ordered exact-match arms. A bare ``except:``
+uses the router's widest existing raise query and consumes whichever raise it
+finds. ``except*`` and structurally exotic types stay loud at the node.
 """
 
 from __future__ import annotations
@@ -31,8 +32,9 @@ from sugar_lift_py_tests.sugar.witnesses import _call_pair
 class TrySugar(Sugar):
     """`try` with typed except handlers, constructed by ``Try.sugar``.
 
-    ``handlers`` is an ordered tuple of ``(EffectMatcher, body_sugars)`` --
-    one per ``except E:`` clause, already structure-checked by the node.
+    ``handlers`` is an ordered tuple of ``(EffectMatcher | None, body_sugars)``.
+    ``None`` is the widest bare-except matcher; typed tuple clauses contribute
+    one arm per structurally admitted type.
     """
 
     body: tuple  # body statement sugars, source order
@@ -79,7 +81,11 @@ class TrySugar(Sugar):
         # handler body's entries in its place.
         routed = None
         for matcher, handler_body in self.handlers:
-            matching = _matching_effect(body_entries, matcher)
+            matching = (
+                _first_effect_of_kind(body_entries, "raise")
+                if matcher is None
+                else _matching_effect(body_entries, matcher)
+            )
             if matching is None:
                 continue
             index, _entry, _observation = matching

--- a/implementations/python/sugar-lift-py-tests/tests/test_manifest_membrane.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_manifest_membrane.py
@@ -12,6 +12,7 @@ import pytest
 
 from sugar_lift_py_tests.context_manager_contract import Expects, Suppresses
 from sugar_lift_py_tests.manifest_membrane import (
+    MANIFEST_CONTRACT_KINDS,
     ManifestIntegrityError,
     contract_for_manager,
     default_community_manifest,
@@ -52,6 +53,16 @@ def test_committed_manifest_loads_and_hash_verifies():
         "contextlib.suppress",
         "tm.assert_produces_warning",
     }
+
+
+def test_manifest_schema_reserves_never_suppresses_without_enrollment():
+    """Investigation-only step 4: name the future proof kind as schema,
+    without authenticating any manager or licensing an expansion."""
+    assert MANIFEST_CONTRACT_KINDS == frozenset(
+        {"expects", "suppresses", "never-suppresses"}
+    )
+    manifest = default_community_manifest()
+    assert all(row.contract != "never-suppresses" for row in manifest.rows)
 
 
 def test_tampered_manifest_refuses_loudly(tmp_path):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1867,40 +1867,49 @@ class Try(Statement):
 
     def sugar(self):
         """`try: body (except E: handler)+ [else] [finally]` -- the STRUCTURAL
-        sibling of with-raises. Each ``except E`` is an EffectMatcher built
-        from the clause's type (native syntax, no membrane). The shared effect
-        router's exact kind+name match decides which handler consumes the
-        body's Incomplete(RaiseEffect). Loud residuals: bare ``except:``,
-        tuple types ``except (A, B):``, ``except E as name:`` (as-binding is a
-        parallel worker), and try with no typed handlers. ``except*`` lives on
-        TryStar and stays loud there."""
+        sibling of with-raises. A typed clause contributes one exact router
+        matcher per bare/dotted type (including each element of a tuple); a
+        bare clause contributes the widest raise matcher. ``as <name>`` is
+        substituted with the selected type's ``E()`` witness only in that
+        matching handler arm. Exotic type expressions and empty tuples stay
+        loud. ``except*`` lives on TryStar and stays loud there."""
         if not self.handlers:
             return super().sugar()  # try/finally-only: not the except-routing core
+        from sugar_lift_py_tests.context_manager_contract import EffectMatcher
+
         handler_specs = []
         for handler in self.handlers:
-            if handler.name is not None:
-                return super().sugar()  # `as` witness -- parallel worker; stay loud
             if handler.type_ is None:
-                return super().sugar()  # bare except:
-            if handler.type_.kind == "Tuple":
-                return super().sugar()  # except (A, B):
-            type_name = self._except_type_name(handler.type_)
-            if type_name is None:
-                return super().sugar()  # exotic except type -- never invent a name
-            handler_specs.append((type_name, handler.body))
+                handler_specs.append(
+                    (None, tuple(stmt.sugar() for stmt in handler.body))
+                )
+                continue
 
-        from sugar_lift_py_tests.context_manager_contract import EffectMatcher
+            type_nodes = (
+                handler.type_.elts if handler.type_.kind == "Tuple" else (handler.type_,)
+            )
+            if not type_nodes:
+                return super().sugar()  # empty tuple: no honest matcher
+            for type_node in type_nodes:
+                type_name = self._except_type_name(type_node)
+                if type_name is None:
+                    return super().sugar()  # exotic tuple elt/type -- stay loud
+                body = handler.body
+                if handler.name is not None:
+                    witness = self._make_call(type_node, ())
+                    body, _ = self._substitute_body(body, {handler.name: witness})
+                handler_specs.append(
+                    (
+                        EffectMatcher(kind="raise", name=type_name),
+                        tuple(stmt.sugar() for stmt in body),
+                    )
+                )
+
         from sugar_lift_py_tests.sugar.try_sugar import TrySugar
 
         return TrySugar(
             body=tuple(stmt.sugar() for stmt in self.body),
-            handlers=tuple(
-                (
-                    EffectMatcher(kind="raise", name=type_name),
-                    tuple(stmt.sugar() for stmt in body),
-                )
-                for type_name, body in handler_specs
-            ),
+            handlers=tuple(handler_specs),
             orelse=tuple(stmt.sugar() for stmt in self.orelse),
             finalbody=tuple(stmt.sugar() for stmt in self.finalbody),
             site=self.fragment,

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -169,39 +169,109 @@ def test_finally_reduces_on_uncaught_path():
     assert "RuntimeError" in names  # finally reduced and spliced
 
 
-def test_bare_except_stays_loud():
+def test_except_as_binds_matching_raise_witness_in_handler():
+    v = _val(
+        "def A():\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError as error:\n"
+        "        return error\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "call:ValueError"
+
+
+def test_except_as_does_not_bind_on_uncaught_path():
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    v = _val(
+        "def A():\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except KeyError as error:\n"
+        "        return error\n"
+        "    return 0\n"
+    )
+    reds = _incompletes(v)
+    assert len(reds) == 1
+    assert isinstance(reds[0].effect, RaiseEffect)
+    assert reds[0].effect.exception_name == "ValueError"
+
+
+def test_tuple_except_catches_any_exactly_listed_type():
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except (KeyError, ValueError):\n"
+        "        pass\n"
+        "    return z\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+def test_tuple_except_does_not_catch_unlisted_type():
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except (KeyError, IndexError):\n"
+        "        pass\n"
+        "    return z\n"
+    )
+    reds = _incompletes(v)
+    assert len(reds) == 1
+    assert isinstance(reds[0].effect, RaiseEffect)
+    assert reds[0].effect.exception_name == "ValueError"
+
+
+def test_tuple_except_as_binds_the_matched_type_witness():
+    v = _val(
+        "def A():\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except (KeyError, ValueError) as error:\n"
+        "        return error\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "call:ValueError"
+
+
+def test_bare_except_catches_arbitrary_raise():
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ArbitraryProjectHalt\n"
+        "    except:\n"
+        "        pass\n"
+        "    return z\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+def test_except_star_stays_loud():
     with pytest.raises(SugarNotWritten):
         _fn(
             "def A(z):\n"
             "    try:\n"
             "        raise ValueError\n"
-            "    except:\n"
+            "    except* ValueError:\n"
             "        pass\n"
             "    return z\n"
         ).sugar()
 
 
-def test_tuple_except_types_stay_loud():
+def test_non_name_except_type_stays_loud():
     with pytest.raises(SugarNotWritten):
         _fn(
             "def A(z):\n"
             "    try:\n"
             "        raise ValueError\n"
-            "    except (ValueError, KeyError):\n"
-            "        pass\n"
-            "    return z\n"
-        ).sugar()
-
-
-def test_as_binding_stays_loud():
-    # `except E as name:` is a parallel worker's lane -- leave loud so we do
-    # not collide on the as-witness binding.
-    with pytest.raises(SugarNotWritten):
-        _fn(
-            "def A(z):\n"
-            "    try:\n"
-            "        raise ValueError\n"
-            "    except ValueError as e:\n"
+            "    except exception_type():\n"
             "        pass\n"
             "    return z\n"
         ).sugar()
@@ -231,8 +301,13 @@ if __name__ == "__main__":
     test_else_does_not_run_when_raise_is_caught()
     test_finally_reduces_on_caught_path()
     test_finally_reduces_on_uncaught_path()
-    test_bare_except_stays_loud()
-    test_tuple_except_types_stay_loud()
-    test_as_binding_stays_loud()
+    test_except_as_binds_matching_raise_witness_in_handler()
+    test_except_as_does_not_bind_on_uncaught_path()
+    test_tuple_except_catches_any_exactly_listed_type()
+    test_tuple_except_does_not_catch_unlisted_type()
+    test_tuple_except_as_binds_the_matched_type_witness()
+    test_bare_except_catches_arbitrary_raise()
+    test_except_star_stays_loud()
+    test_non_name_except_type_stays_loud()
     test_dotted_except_type_matches()
     print("ok: try sugar -- structural effect routing")


### PR DESCRIPTION
Two codex lanes (worktree-isolated), coordinator-verified and merged. Mechanisms checked personally (multi-type discrimination + except-as binding run by hand). Supersedes #6007/#6008.

- **Try deepened** (#6007) — `except E as name` binds the exception witness on the caught path only; `except (A, B)` matches ANY listed type by the same exact-name rule (no subclass widening); bare `except:` catches any body raise. except*, non-Name types stay loud. Verified: except (KeyError,ValueError) catches ValueError; except (KeyError,IndexError) lets it propagate; except E as e binds+completes. Tree 227 passed.
- **NeverSuppresses proof-path** (#6008) — INVESTIGATION result: manifest-enrollment is the only honest NeverSuppresses source (we don't lift __enter__/__exit__), but the tree/router cannot yet represent the control-flow EDGES the ruling requires (enter-failure-bypasses-exit, exceptional __exit__(type,value,tb), exit-result-selects-suppression, exit-failure-propagates) — method coordinates alone don't encode them, so any expansion would fake the exceptional edge. Enrolls NOTHING; reserves the `never-suppresses` schema kind + a regression proving no enrollment. Architectural finding: resource-with is blocked on the same control-flow-edge representation Try's finally needs. Membrane 10 passed.

Part of #5994. Does not close it.

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deepen Try sugar to handle bare except, tuple types, and as-binding proof paths
> - `Try.sugar()` in [`nodes.py`](https://github.com/TSavo/sugar/pull/6010/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now produces handler arms for bare `except:` (matches first raise effect), tuple exception types (one arm per element), and `except E as name` (substitutes the bound name with a call witness).
> - `TrySugar` in [`try_sugar.py`](https://github.com/TSavo/sugar/pull/6010/files#diff-f5d956a5de18664d828d314bf5537a359cc1f2f40c5a42b52f03bbe5ecaac0ff) accepts `None` as a matcher to represent a bare except arm, selecting the first `raise` effect via `_first_effect_of_kind`.
> - [`manifest_membrane.py`](https://github.com/TSavo/sugar/pull/6010/files#diff-38a7443c57e89958d14963311463ee18ac2439702490eaf2c378256d3f571583) adds `MANIFEST_CONTRACT_KINDS` frozenset, reserving `'never-suppresses'` in the manifest schema vocabulary.
> - Behavioral Change: bare except, tuple types, and as-bindings previously remained loud (unsugared); they now produce proof paths and consume raise effects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe82347.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded `try/except` support to handle bare handlers, tuples of exception types, and bound exceptions.
  * Bound exceptions now provide the matched exception value within the handler.
  * Added manifest contract vocabulary for expected, suppressed, and reserved contract kinds.

* **Bug Fixes**
  * Corrected routing for bare `except:` handlers.

* **Tests**
  * Added coverage for supported exception-handling forms and retained clear errors for unsupported forms such as `except*`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->