### PR TITLE
comprehensions: dissolve filtered listcomp + dict/set over concrete iterables

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -32,6 +32,7 @@ the backend contract stays read-only.
 
 from __future__ import annotations
 
+import symtable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, ClassVar, Iterator, Optional, Tuple
 
@@ -55,6 +56,12 @@ from .reporter import NULL_REPORTER, AuditReporter
 from .spans import LineColSpan, LineTable, Span
 
 
+# Scope metadata travels beside temporal bindings under an unforgeable key.
+# It lets recognition distinguish a builtin spelling from a lexically bound
+# formal without substituting a fake value for that formal.
+_LEXICALLY_BOUND_NAMES = object()
+
+
 @dataclass(frozen=True)
 class SourceUnit:
     """One parsed source: oracle-pinned text, its content address, its line table.
@@ -71,9 +78,24 @@ class SourceUnit:
 
     # populated in __post_init__, never by callers
     line_table: LineTable = field(init=False, default=None)  # type: ignore[assignment]
+    module_bound_names: frozenset[str] = field(
+        init=False, default_factory=frozenset
+    )
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "line_table", LineTable(self.source))
+        symbols = symtable.symtable(self.source, self.filename, "exec").get_symbols()
+        object.__setattr__(
+            self,
+            "module_bound_names",
+            frozenset(
+                symbol.get_name()
+                for symbol in symbols
+                if symbol.is_assigned()
+                or symbol.is_imported()
+                or symbol.is_namespace()
+            ),
+        )
 
 
 class Typeable:
@@ -733,6 +755,11 @@ class FunctionDef(Statement):
         body_scope = (
             {k: v for k, v in scope.items() if k not in bound} if bound else scope
         )
+        inherited_bound = scope.get(_LEXICALLY_BOUND_NAMES, frozenset())
+        body_scope = {
+            **body_scope,
+            _LEXICALLY_BOUND_NAMES: frozenset(inherited_bound) | bound,
+        }
 
         changed: dict[str, object] = {}
         # signature: the enclosing scope, unmasked (evaluated before the body).
@@ -2410,33 +2437,90 @@ class ListComp(Expression):
 
     def _try_unroll_to_display(self, scope):
         """The List display this comprehension dissolves to, or None. One
-        synchronous generator, no ifs (the filtered form is a later segment),
+        synchronous generator with ground-decidable filters,
         over a CONCRETE iterable whose elements destructure into the target:
         each element substitutes into `elt`, and the results are the display's
         elements. Reuses For's readers (same structural recognition)."""
-        if len(self.generators) != 1:
+        if len(self.generators) != 1 or ListComp._contains_forbidden_shape(
+            self, (self.elt,)
+        ):
             return None
         gen = self.generators[0]
-        if gen.is_async or gen.ifs:
+        if gen.is_async or ListComp._contains_forbidden_shape(
+            self, (gen.iter, *gen.ifs)
+        ):
             return None
         new_iter, ic = self._substitute_field(gen.iter, scope)
         it = new_iter if ic else gen.iter
+        if ListComp._calls_shadowed_range(self, it, scope):
+            return None
         elements = For._concrete_elements(self, it)
         if elements is None:
+            return None
+        if len(elements) > For._UNROLL_FUEL:
             return None
         target = gen.target
         results = []
         for element in elements:
-            if target.kind == "Name":
-                bindings = {target.id: element}
-            else:
-                bindings = For._target_bindings_for(self, target, element)
-                if bindings is None:
-                    return None
+            bindings = For._target_bindings_for(self, target, element)
+            if bindings is None:
+                return None
             inner = {**scope, **bindings}
+            verdicts = []
+            for guard in gen.ifs:
+                new_guard, changed = self._substitute_field(guard, inner)
+                verdict = While._ground_truth(self, new_guard if changed else guard)
+                if verdict is None:
+                    return None
+                verdicts.append(verdict)
+            if not all(verdicts):
+                continue
             new_elt, _d = self._substitute_field(self.elt, inner)
             results.append(new_elt if _d else self.elt)
-        return self._make_list(tuple(results))
+        return ListComp._make_list(self, tuple(results))
+
+    def _contains_forbidden_shape(self, roots: tuple) -> bool:
+        """True for a nested comprehension or walrus in this comprehension."""
+        return any(
+            node.kind
+            in ("ListComp", "SetComp", "DictComp", "GeneratorExp", "NamedExpr")
+            for root in roots
+            for node in root.walk()
+        )
+
+    def _calls_shadowed_range(self, iterable, scope) -> bool:
+        return (
+            iterable.kind == "Call"
+            and iterable.func.kind == "Name"
+            and iterable.func.id == "range"
+            and "range" in scope
+        ) or (
+            iterable.kind == "Call"
+            and iterable.func.kind == "Name"
+            and iterable.func.id == "range"
+            and "range" in scope.get(_LEXICALLY_BOUND_NAMES, ())
+        ) or (
+            iterable.kind == "Call"
+            and iterable.func.kind == "Name"
+            and iterable.func.id == "range"
+            and "range" in self.unit.module_bound_names
+        )
+
+    def _ground_hash_key(self, expression):
+        """A Python-equality key for the small ground scalar domain, or None."""
+        integer = For._concrete_int(self, expression)
+        if integer is not None:
+            return ("number", integer)
+        if expression.kind != "Constant":
+            return None
+        value = expression.value
+        if type(value) is bool:
+            return ("number", int(value))
+        if type(value) is str:
+            return ("str", value)
+        if value is None:
+            return ("none", None)
+        return None
 
     def _make_list(self, elements: tuple) -> "Node":
         """Synthesize a List display of these element nodes, borrowing this
@@ -2458,6 +2542,9 @@ class SetComp(Expression):
     def substitute(self, scope):
         """A comprehension: thread each generator's target, then substitute the
         element against the scope with every target masked."""
+        display = self._try_unroll_to_display(scope)
+        if display is not None:
+            return display
         from .shadow import rewrite
 
         new_gens, inner, gc = self._substitute_generators(self.generators, scope)
@@ -2469,6 +2556,50 @@ class SetComp(Expression):
             changed["elt"] = new_elt
         return self if not changed else rewrite(self, **changed)
 
+    def _try_unroll_to_display(self, scope):
+        if len(self.generators) != 1 or ListComp._contains_forbidden_shape(
+            self, (self.elt,)
+        ):
+            return None
+        gen = self.generators[0]
+        if gen.is_async or gen.ifs or ListComp._contains_forbidden_shape(
+            self, (gen.iter,)
+        ):
+            return None
+        new_iter, changed = self._substitute_field(gen.iter, scope)
+        iterable = new_iter if changed else gen.iter
+        if ListComp._calls_shadowed_range(self, iterable, scope):
+            return None
+        elements = For._concrete_elements(self, iterable)
+        if elements is None or len(elements) > For._UNROLL_FUEL:
+            return None
+        results = []
+        seen = set()
+        for element in elements:
+            bindings = For._target_bindings_for(self, gen.target, element)
+            if bindings is None:
+                return None
+            new_elt, changed = self._substitute_field(
+                self.elt, {**scope, **bindings}
+            )
+            result = new_elt if changed else self.elt
+            key = ListComp._ground_hash_key(self, result)
+            if key is None:
+                return None
+            if key not in seen:
+                seen.add(key)
+                results.append(result)
+        return SetComp._make_set(self, tuple(results))
+
+    def _make_set(self, elements: tuple) -> "Node":
+        from .backend import Children, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        slots = (("elts", Children(tuple(_handle_of(e) for e in elements))),)
+        return materialize(
+            self.unit, ShadowNode("Set", self.span, slots), self.reporter
+        )
+
 
 class DictComp(Expression):
     key: Expression
@@ -2479,6 +2610,9 @@ class DictComp(Expression):
     def substitute(self, scope):
         """A dict comprehension: thread the generators, then key and value
         against the scope with every target masked."""
+        display = self._try_unroll_to_display(scope)
+        if display is not None:
+            return display
         from .shadow import rewrite
 
         new_gens, inner, gc = self._substitute_generators(self.generators, scope)
@@ -2490,6 +2624,66 @@ class DictComp(Expression):
             if d:
                 changed[fld] = new
         return self if not changed else rewrite(self, **changed)
+
+    def _try_unroll_to_display(self, scope):
+        if len(self.generators) != 1 or ListComp._contains_forbidden_shape(
+            self, (self.key, self.value)
+        ):
+            return None
+        gen = self.generators[0]
+        if gen.is_async or gen.ifs or ListComp._contains_forbidden_shape(
+            self, (gen.iter,)
+        ):
+            return None
+        new_iter, changed = self._substitute_field(gen.iter, scope)
+        iterable = new_iter if changed else gen.iter
+        if ListComp._calls_shadowed_range(self, iterable, scope):
+            return None
+        elements = For._concrete_elements(self, iterable)
+        if elements is None or len(elements) > For._UNROLL_FUEL:
+            return None
+        pairs = []
+        key_indexes = {}
+        for element in elements:
+            bindings = For._target_bindings_for(self, gen.target, element)
+            if bindings is None:
+                return None
+            inner = {**scope, **bindings}
+            key, key_changed = self._substitute_field(self.key, inner)
+            value, value_changed = self._substitute_field(self.value, inner)
+            result_key = key if key_changed else self.key
+            result_value = value if value_changed else self.value
+            hash_key = ListComp._ground_hash_key(self, result_key)
+            if hash_key is None:
+                return None
+            pair = (result_key, result_value)
+            prior = key_indexes.get(hash_key)
+            if prior is None:
+                key_indexes[hash_key] = len(pairs)
+                pairs.append(pair)
+            else:
+                pairs[prior] = pair
+        return DictComp._make_dict(self, tuple(pairs))
+
+    def _make_dict(self, pairs: tuple) -> "Node":
+        from .backend import Child, Children, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        items = []
+        for key, value in pairs:
+            slots = (
+                ("key", Child(_handle_of(key))),
+                ("value", Child(_handle_of(value))),
+            )
+            item = materialize(
+                self.unit, ShadowNode("DictItem", self.span, slots), self.reporter
+            )
+            items.append(_handle_of(item))
+        return materialize(
+            self.unit,
+            ShadowNode("Dict", self.span, (("items", Children(tuple(items))),)),
+            self.reporter,
+        )
 
 
 class GeneratorExp(Expression):
@@ -2510,7 +2704,6 @@ class GeneratorExp(Expression):
         if de:
             changed["elt"] = new_elt
         return self if not changed else rewrite(self, **changed)
-
 
 class Await(Expression):
     value: Expression

--- a/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
+++ b/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
@@ -1,0 +1,146 @@
+"""Concrete comprehensions dissolve to displays; symbolic/lazy shapes stay loud."""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _out(src):
+    return _fn(src).sugar().desugar().value.post().args[1]
+
+
+def test_filtered_listcomp_keeps_ground_true_elements():
+    term = _out("def A():\n    return [x for x in [1, 2, 3, 4] if x > 2]\n")
+    assert term.name == "array"
+    assert [arg.value for arg in term.args] == [3, 4]
+
+
+def test_undecidable_filtered_listcomp_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(limit):\n    return [x for x in [1, 2] if x > limit]\n").sugar()
+
+
+def test_dictcomp_over_concrete_range_dissolves():
+    term = _out("def A():\n    return {x: x + 10 for x in range(2)}\n")
+    assert term.name == "python:dict"
+    assert [(item.args[0].value, item.args[1].value) for item in term.args] == [
+        (0, 10),
+        (1, 11),
+    ]
+
+
+def test_setcomp_over_concrete_range_dissolves():
+    term = _out("def A():\n    return {x + 1 for x in range(3)}\n")
+    assert term.name == "python:set"
+    assert [arg.value for arg in term.args] == [1, 2, 3]
+
+
+def test_setcomp_preserves_duplicate_elimination():
+    term = _out("def A():\n    return {x % 2 for x in range(4)}\n")
+    assert [arg.value for arg in term.args] == [0, 1]
+
+
+def test_dictcomp_preserves_last_value_for_duplicate_key():
+    term = _out("def A():\n    return {0: x for x in range(3)}\n")
+    assert len(term.args) == 1
+    assert (term.args[0].args[0].value, term.args[0].args[1].value) == (0, 2)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "[x for x in xs]",
+        "{x for x in xs}",
+        "{x: x for x in xs}",
+    ],
+)
+def test_symbolic_iterable_comprehensions_stay_loud(source):
+    with pytest.raises(SugarNotWritten):
+        _fn(f"def A(xs):\n    return {source}\n").sugar()
+
+
+def test_generator_directly_consumed_by_sum_stays_loud_without_builtin_identity():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A():\n    return sum(x + 1 for x in range(3))\n").sugar()
+
+
+def test_generator_directly_consumed_by_list_stays_loud_without_builtin_identity():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A():\n    return list(x + 1 for x in range(3))\n").sugar()
+
+
+def test_bare_generator_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A():\n    return (x for x in range(3))\n").sugar()
+
+
+def test_generator_passed_to_unknown_call_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A():\n    return consume(x for x in range(3))\n").sugar()
+
+
+def test_shadowed_range_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(range):\n    return [x for x in range(3)]\n").sugar()
+
+
+def test_shadowed_materializer_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn("def A(sum):\n    return sum(x for x in [1, 2])\n").sugar()
+
+
+def test_locally_rebound_materializer_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(consume):\n"
+            "    sum = consume\n"
+            "    return sum(x for x in [1, 2])\n"
+        ).sugar()
+
+
+def test_module_rebound_materializer_stays_loud():
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "sum = consume\n"
+            "def A():\n"
+            "    return sum(x for x in [1, 2])\n"
+        ).sugar()
+
+
+@pytest.mark.parametrize("consumer", ["any", "all"])
+def test_short_circuit_generator_consumer_stays_loud(consumer):
+    with pytest.raises(SugarNotWritten):
+        _fn(f"def A():\n    return {consumer}(x for x in [0, 1])\n").sugar()
+
+
+def test_every_filter_must_be_ground_decidable():
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(limit):\n"
+            "    return [x for x in [0] if x > 0 if x > limit]\n"
+        ).sugar()
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "[y for x in [[1]] for y in x]",
+        "[[y for y in [1]] for x in [1]]",
+        "[(y := x) for x in [1]]",
+        "[x for x in range(129)]",
+    ],
+)
+def test_unsupported_comprehension_structures_stay_loud(source):
+    with pytest.raises(SugarNotWritten):
+        _fn(f"def A():\n    return {source}\n").sugar()

--- a/implementations/python/sugar-source-tree/tests/test_listcomp_dissolves.py
+++ b/implementations/python/sugar-source-tree/tests/test_listcomp_dissolves.py
@@ -1,8 +1,8 @@
 """`[e for x in <concrete>]` DISSOLVES in substitute -- map disappearing for
 real: N substitutions of x into e, rewritten to the List display of the
 results. The comprehension was never a meaning; it was a count of rewrites.
-Symbolic iterables, filters (ifs), multi-generator, and async keep the node
-(loud until their segments are written)."""
+Symbolic iterables, undecidable filters, multi-generator, and async keep the
+node loud."""
 
 import tempfile
 
@@ -44,9 +44,9 @@ def test_composes_with_len():
     assert t.name == "call:len"
 
 
-def test_filtered_comprehension_stays_loud():
+def test_undecidable_filtered_comprehension_stays_loud():
     with pytest.raises(SugarNotWritten):
-        _fn("def A():\n    return [x for x in [1, 2] if x == 1]\n").sugar()
+        _fn("def A(limit):\n    return [x for x in [1, 2] if x > limit]\n").sugar()
 
 
 def test_symbolic_comprehension_stays_loud():
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     test_mapped_comprehension_folds_per_element()
     test_tuple_target_comprehension_destructures()
     test_composes_with_len()
-    test_filtered_comprehension_stays_loud()
+    test_undecidable_filtered_comprehension_stays_loud()
     test_symbolic_comprehension_stays_loud()
     test_comprehension_over_range_dissolves()
     print("ok: the concrete comprehension dissolves to its display")


### PR DESCRIPTION
Codex lane (worktree-isolated), coordinator-verified. The false-green refusals checked by hand: symbolic iterable stays loud, non-ground guard over a concrete iterable stays loud (no partial finite list), nested/multi-for stay loud. Filtered concrete listcomp dissolves to the right elements.

- Filtered ListComp `[e for x in <concrete> if <cond>]` — per-element ground-true guard evaluation, kept elements only, _UNROLL_FUEL bounded.
- DictComp / SetComp over concrete iterables dissolve to dict/set displays.
- GeneratorExp stays LOUD (honest verdict: bare materializer names like list/sum lack authenticated builtin identity — could be shadowed).

Reuses For._concrete_elements/_concrete_int/_target_bindings_for class-explicitly. Tree 251 passed, 5 skipped. Supersedes #6009. Part of the meaning-layer drain.

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dissolve filtered list, set, and dict comprehensions over concrete iterables into displays
> - List, set, and dict comprehensions now attempt to unroll into concrete displays (`[...]`, `{...}`, `{k: v}`) during substitution when the iterable is ground and finite.
> - Unrolling requires a single non-async generator, no nested comprehensions or walrus expressions, a non-shadowed `range` or other concrete iterable, decidable guards, and ground-hashable keys for sets/dicts — all within an existing fuel limit.
> - `SourceUnit` now exposes `module_bound_names` (via Python's `symtable`) and `FunctionDef.substitute` threads lexically bound names through scopes, so shadowing of `range` and other builtins can be detected without substituting values.
> - Set unrolling deduplicates elements matching Python set semantics; dict unrolling preserves insertion order with last-value-wins on duplicate keys.
> - New tests in [test_comprehension_dissolves.py](https://github.com/TSavo/sugar/pull/6011/files#diff-376ccb1d9ca8fd6e08b3a64879e66aa3f894abbf4619f85d1cec4a7853c83952) cover both dissolution and cases that must remain unevaluated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea762a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->