### PR TITLE
revert fabricated as-witness: except-as / with-raises-as stay loud

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_contract_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_contract_sugar.py
@@ -12,13 +12,13 @@ outcome to the ONE effect router shared with Try. The contract decides:
 - ``Suppresses(matcher)``: permission -- a matching halt is consumed silently;
   absence is fine; a non-matching effect propagates.
 
-``as <Name>`` (Expects only) is a TEMPORAL bind for the enclosing block's
-tail: ``With.substitution_binding`` exports the matched-effect witness
-(``E()`` stand-in from ``raises(E)``). This sugar records ``as_name`` for
-provenance; substitute already rewrote uses of the name in the tail.
+``as <Name>`` stays LOUD at the node: the honest binding is the routed
+observed-effect witness (the payload of the matched Halted exit), produced at
+route time, never a substitute-time ``E()`` stand-in. It lands with the shared
+exit-set witness mechanism, not here.
 
-Loud at the node: unauthenticated managers, non-Name as-targets, Suppresses+as,
-multiple managers, resource expansion (step 4).
+Loud at the node: unauthenticated managers, any as-target, multiple managers,
+resource expansion (step 4).
 """
 
 from __future__ import annotations
@@ -35,7 +35,6 @@ class WithContractSugar(Sugar):
     contract: object  # Expects | Suppresses (the node guards kind)
     body: tuple  # the body statements' sugars, in source order
     site: object = dataclass_field(compare=False, default=None)
-    as_name: str | None = None  # Expects as-witness; bound temporally for the tail
 
     @classmethod
     def witnesses(cls):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1671,9 +1671,13 @@ class With(Statement):
         if len(self.items) != 1:
             return super().sugar()
         item = self.items[0]
-        as_target = item.optional_vars
-        if as_target is not None and not isinstance(as_target, Name):
-            return super().sugar()  # only plain Name as for step 5
+        if item.optional_vars is not None:
+            # ``as <name>`` stays LOUD: the honest binding is the ROUTED
+            # observed-effect witness (the payload of the Halted exit the
+            # router matches), NOT a manufactured ``E()``. That witness is
+            # produced at route time, so it needs the shared exit-set witness
+            # mechanism -- unwritten here until it lands.
+            return super().sugar()
         from sugar_lift_py_tests.context_manager_contract import (
             Expects,
             RuntimeSelected,
@@ -1691,14 +1695,10 @@ class With(Statement):
         if isinstance(contract, (Expects, Suppresses)):
             if contract.matcher.kind not in ("raise", "warning"):
                 return super().sugar()
-            # Suppresses+as is not a community effect-witness shape; Expects+as is.
-            if as_target is not None and not isinstance(contract, Expects):
-                return super().sugar()
             return WithContractSugar(
                 contract=contract,
                 body=tuple(stmt.sugar() for stmt in self.body),
                 site=self.fragment,
-                as_name=as_target.id if as_target is not None else None,
             )
         # None from the membrane OR an explicit RuntimeSelected enrollment:
         # exit suppression is undecidable statically. Named residual — not a
@@ -1735,8 +1735,10 @@ class With(Statement):
     def substitute(self, scope):
         """with ... as <vars>: masks as-targets for the body (binding sites).
 
-        Expects ``as <Name>`` also EXPORTS a matched-effect witness for the
-        rest of the enclosing block via ``substitution_binding`` (step 5).
+        No witness is EXPORTED for the tail: the honest ``as`` binding is the
+        routed observed-effect witness produced at route time (the payload of
+        the matched Halted exit), not a substitute-time stand-in -- so `as`
+        stays loud in sugar() until the shared exit-set witness lands.
         """
         from .shadow import rewrite
 
@@ -1753,44 +1755,6 @@ class With(Statement):
         if d:
             changed["body"] = new_body
         return self if not changed else rewrite(self, **changed)
-
-    def substitution_binding(self, scope):
-        """Expects ``as <Name>``: bind the name for the TAIL to the matched-
-        effect witness (expected type/category constructed as ``E()``).
-
-        Only on the Expects membrane path; resource ``as`` is step 4.
-        Witness identity is the enrolled expected type expression -- the same
-        name the router discharges against the observed halt.
-        """
-        if len(self.items) != 1:
-            return None
-        ov = self.items[0].optional_vars
-        if not isinstance(ov, Name):
-            return None
-        from sugar_lift_py_tests.context_manager_contract import Expects
-        from sugar_lift_py_tests.manifest_membrane import (
-            contract_for_manager,
-            default_community_manifest,
-        )
-
-        contract = contract_for_manager(
-            default_community_manifest(), self.items[0].context_expr
-        )
-        if not isinstance(contract, Expects):
-            return None
-        if contract.matcher.kind not in ("raise", "warning"):
-            return None
-        witness = self._expects_effect_as_witness(self.items[0].context_expr)
-        if witness is None:
-            return None
-        return {ov.id: witness}
-
-    def _expects_effect_as_witness(self, context_expr: "Expression"):
-        """Temporal stand-in for the matched effect payload: ``E()`` from
-        ``raises(E, ...)`` / ``assert_produces_warning(E, ...)``."""
-        if context_expr.kind != "Call" or not context_expr.args:
-            return None
-        return self._make_call(context_expr.args[0], ())
 
 
 class AsyncWith(Statement):
@@ -1896,16 +1860,25 @@ class Try(Statement):
         """`try: body (except E: handler)+ [else] [finally]` -- the STRUCTURAL
         sibling of with-raises. A typed clause contributes one exact router
         matcher per bare/dotted type (including each element of a tuple); a
-        bare clause contributes the widest raise matcher. ``as <name>`` is
-        substituted with the selected type's ``E()`` witness only in that
-        matching handler arm. Exotic type expressions and empty tuples stay
-        loud. ``except*`` lives on TryStar and stays loud there."""
+        bare clause contributes the widest raise matcher. Exotic type
+        expressions and empty tuples stay loud. ``except*`` lives on TryStar
+        and stays loud there.
+
+        ``except <type> as <name>`` stays LOUD: the honest binding is the
+        ROUTED observed-effect witness (the exception the router matched and
+        consumed), NOT a manufactured ``<type>()`` -- constructing the type
+        invents a constructor call that never ran and conflates the caught
+        object with the type. That witness is produced at route time, not at
+        substitute time, so it needs the shared observed-effect-witness
+        mechanism (a marker the router fills), unwritten here until it lands."""
         if not self.handlers:
             return super().sugar()  # try/finally-only: not the except-routing core
         from sugar_lift_py_tests.context_manager_contract import EffectMatcher
 
         handler_specs = []
         for handler in self.handlers:
+            if handler.name is not None:
+                return super().sugar()  # except-as: needs the routed witness, loud
             if handler.type_ is None:
                 handler_specs.append(
                     (None, tuple(stmt.sugar() for stmt in handler.body))
@@ -1921,14 +1894,10 @@ class Try(Statement):
                 type_name = self._except_type_name(type_node)
                 if type_name is None:
                     return super().sugar()  # exotic tuple elt/type -- stay loud
-                body = handler.body
-                if handler.name is not None:
-                    witness = self._make_call(type_node, ())
-                    body, _ = self._substitute_body(body, {handler.name: witness})
                 handler_specs.append(
                     (
                         EffectMatcher(kind="raise", name=type_name),
-                        tuple(stmt.sugar() for stmt in body),
+                        tuple(stmt.sugar() for stmt in handler.body),
                     )
                 )
 

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -169,33 +169,31 @@ def test_finally_reduces_on_uncaught_path():
     assert "RuntimeError" in names  # finally reduced and spliced
 
 
-def test_except_as_binds_matching_raise_witness_in_handler():
-    v = _val(
-        "def A():\n"
-        "    try:\n"
-        "        raise ValueError\n"
-        "    except ValueError as error:\n"
-        "        return error\n"
-    )
-    assert _incompletes(v) == []
-    assert v.post().args[1].name == "call:ValueError"
+def test_except_as_stays_loud_until_the_routed_witness_exists():
+    # ``except E as name`` must bind the ROUTED observed-effect witness (the
+    # payload of the matched Halted exit), never a manufactured ``E()``. That
+    # witness is produced at route time, so the honest state is LOUD until the
+    # shared exit-set witness mechanism lands -- never a fabricated binding.
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A():\n"
+            "    try:\n"
+            "        raise ValueError\n"
+            "    except ValueError as error:\n"
+            "        return error\n"
+        ).sugar()
 
 
-def test_except_as_does_not_bind_on_uncaught_path():
-    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
-
-    v = _val(
-        "def A():\n"
-        "    try:\n"
-        "        raise ValueError\n"
-        "    except KeyError as error:\n"
-        "        return error\n"
-        "    return 0\n"
-    )
-    reds = _incompletes(v)
-    assert len(reds) == 1
-    assert isinstance(reds[0].effect, RaiseEffect)
-    assert reds[0].effect.exception_name == "ValueError"
+def test_except_as_stays_loud_even_when_uncaught():
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A():\n"
+            "    try:\n"
+            "        raise ValueError\n"
+            "    except KeyError as error:\n"
+            "        return error\n"
+            "    return 0\n"
+        ).sugar()
 
 
 def test_tuple_except_catches_any_exactly_listed_type():
@@ -228,16 +226,17 @@ def test_tuple_except_does_not_catch_unlisted_type():
     assert reds[0].effect.exception_name == "ValueError"
 
 
-def test_tuple_except_as_binds_the_matched_type_witness():
-    v = _val(
-        "def A():\n"
-        "    try:\n"
-        "        raise ValueError\n"
-        "    except (KeyError, ValueError) as error:\n"
-        "        return error\n"
-    )
-    assert _incompletes(v) == []
-    assert v.post().args[1].name == "call:ValueError"
+def test_tuple_except_as_stays_loud():
+    # A tuple handler with ``as`` is loud for the same reason: the witness is
+    # the routed exception payload, not a constructed type.
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A():\n"
+            "    try:\n"
+            "        raise ValueError\n"
+            "    except (KeyError, ValueError) as error:\n"
+            "        return error\n"
+        ).sugar()
 
 
 def test_bare_except_catches_arbitrary_raise():

--- a/implementations/python/sugar-source-tree/tests/test_with_contract.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_contract.py
@@ -97,30 +97,26 @@ def test_unauthenticated_manager_stays_loud():
     )
 
 
-def test_as_witness_admits_and_discharges():
-    """Step 5: Expects ``as <Name>`` is no longer loud; type obligation flows."""
-    v = _val(
-        "def A(z):\n    with pytest.raises(ValueError) as ei:\n"
-        "        raise ValueError\n    return z\n"
-    )
-    inv = v.invs()[0]
-    assert inv.name == "="
-    assert inv.args[0].value == inv.args[1].value == "ValueError"
-    assert v.post().args[1].name == "z"
+def test_as_witness_stays_loud_until_the_routed_witness_exists():
+    # ``with raises(E) as ei`` must bind an ExceptionInfo observation whose
+    # ``.value`` projects the ROUTED exception witness -- never a manufactured
+    # ``E()``. That witness is produced at route time (the payload of the
+    # matched Halted exit), so ``as`` is honestly LOUD until the shared
+    # exit-set witness mechanism lands. A fabricated ``ei = ValueError()`` is
+    # the cardinal sin (a constructor call that never ran).
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(z):\n    with pytest.raises(ValueError) as ei:\n"
+            "        raise ValueError\n    return z\n"
+        ).sugar()
 
 
-def test_as_witness_inlines_in_the_tail():
-    """Matched-effect witness is bound for the tail: ``return ei`` sees E()."""
-    v = _val(
-        "def A():\n    with pytest.raises(ValueError) as ei:\n"
-        "        raise ValueError\n    return ei\n"
-    )
-    # Type obligation still stated; post is the witness construction ValueError().
-    type_rows = [i for i in v.invs() if getattr(i, "name", "") == "="]
-    assert type_rows
-    assert type_rows[0].args[0].value == type_rows[0].args[1].value == "ValueError"
-    post = v.post().args[1]
-    assert post.name == "call:ValueError"  # E() stand-in for the effect payload
+def test_as_witness_loud_even_when_referenced_in_tail():
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A():\n    with pytest.raises(ValueError) as ei:\n"
+            "        raise ValueError\n    return ei\n"
+        ).sugar()
 
 
 def test_as_non_name_target_stays_loud():


### PR DESCRIPTION
The `as` binding manufactured `E()` — a constructor call that never ran, conflating the caught exception, pytest's ExceptionInfo, and the warning binding into one invented value (the cardinal sin). Merged unchanged #6003→#6006, duplicated into Try #6010. Both sites reverted to loud; the honest binding is the ROUTED observed-effect witness (payload of the matched Halted exit), which lands with the shared exit-set mechanism, not a substitute-time stand-in. Five fabrication-pinning tests flipped to assert SugarNotWritten. Counterfeit as-site clean-count gains removed. Tree 251 passed.

Note: the `lift_file_payload` scanner ImportError (CI bare-exception false amplification) is a separate PRE-EXISTING issue (removed in 9d3b5c304), handled next.

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert fabricated witness bindings so `except-as` and `with-raises-as` stay loud
> - `with <ctx> as <target>` and `except <Type> as <name>` constructs no longer desugar into contract sugar; any use of `as` now falls back to `super().sugar()`, raising `SugarNotWritten`.
> - Removes the `as_name` field from `WithContractSugar`, the `substitution_binding` method, and the `_expects_effect_as_witness` helper that previously manufactured an `E()` stand-in.
> - Tests in [test_try_sugar.py](https://github.com/TSavo/sugar/pull/6012/files#diff-e08e75c8aa18050f22f6a4f3eab47a900f9605097a7ac8dc38f92f9c906a7e07) and [test_with_contract.py](https://github.com/TSavo/sugar/pull/6012/files#diff-c52d5be339caa9e038fa2620f6775041499142c9675b24d2b7b5a5c982cf3723) are updated to assert `SugarNotWritten` for all `as`-binding cases.
> - Behavioral Change: constructs that previously silently desugared with a synthesized witness now loudly refuse to desugar; callers that relied on the fabricated binding will need to handle `SugarNotWritten`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdd0600.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->