### PR TITLE
ExitSet: block reduction as an effect-dimension phi (foundation)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/__init__.py
@@ -2,7 +2,16 @@ from __future__ import annotations
 
 from .complete import Complete
 from .complete_value import complete_value
+from .exit_set import Completed, ExitSet, Halted
 from .incomplete import Incomplete
 from .outcome import Outcome
 
-__all__ = ["Complete", "Incomplete", "Outcome", "complete_value"]
+__all__ = [
+    "Complete",
+    "Completed",
+    "ExitSet",
+    "Halted",
+    "Incomplete",
+    "Outcome",
+    "complete_value",
+]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -1,0 +1,181 @@
+"""Guarded block exits: the effect-dimension phi for statement sequencing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Generic, TypeVar
+
+from sugar_lift_py_tests.effect import Effect, require_effect
+from sugar_lift_py_tests.ir import Formula, and_, not_, or_
+
+from .complete import Complete
+from .incomplete import Incomplete
+
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+def true_guard() -> Formula:
+    """The existing FOL encoding of truth: an empty conjunction."""
+    return and_([])
+
+
+def false_guard() -> Formula:
+    return not_(true_guard())
+
+
+def _is_true(guard: Formula) -> bool:
+    return guard == true_guard()
+
+
+def _is_false(guard: Formula) -> bool:
+    return guard == false_guard()
+
+
+def _is_negation(left: Formula, right: Formula) -> bool:
+    return (
+        getattr(left, "kind", None) == "not"
+        and getattr(left, "operands", ()) == (right,)
+    ) or (
+        getattr(right, "kind", None) == "not"
+        and getattr(right, "operands", ()) == (left,)
+    )
+
+
+def _and_guards(left: Formula, right: Formula) -> Formula:
+    if _is_false(left) or _is_false(right) or _is_negation(left, right):
+        return false_guard()
+    if _is_true(left):
+        return right
+    if _is_true(right) or left == right:
+        return left
+    return and_([left, right])
+
+
+def _or_guards(left: Formula, right: Formula) -> Formula:
+    if _is_true(left) or _is_true(right) or _is_negation(left, right):
+        return true_guard()
+    if _is_false(left):
+        return right
+    if _is_false(right) or left == right:
+        return left
+    return or_([left, right])
+
+
+@dataclass(frozen=True)
+class Completed(Generic[T]):
+    guard: Formula
+    value: T
+
+
+@dataclass(frozen=True)
+class Halted:
+    guard: Formula
+    effect: Effect
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "effect", require_effect(self.effect))
+
+
+Exit = Completed[T] | Halted
+
+
+@dataclass(frozen=True)
+class ExitSet(Generic[T]):
+    """A partition of reachable execution into completed and halted exits."""
+
+    exits: tuple[Exit[T], ...]
+
+    @classmethod
+    def completed(cls, value: T, guard: Formula | None = None) -> "ExitSet[T]":
+        return cls((Completed(guard or true_guard(), value),)).normalize()
+
+    @classmethod
+    def halted(cls, effect: Effect, guard: Formula | None = None) -> "ExitSet[T]":
+        return cls((Halted(guard or true_guard(), effect),)).normalize()
+
+    @classmethod
+    def conditional_halt(
+        cls, guard: Formula, effect: Effect, state: T
+    ) -> "ExitSet[T]":
+        return cls((Halted(guard, effect), Completed(not_(guard), state))).normalize()
+
+    def union(self, other: "ExitSet[T]") -> "ExitSet[T]":
+        return ExitSet((*self.exits, *other.exits)).normalize()
+
+    def guarded(self, guard: Formula) -> "ExitSet[T]":
+        """Restrict every exit to one branch of an enclosing partition."""
+        exits: list[Exit[T]] = []
+        for exit_ in self.exits:
+            combined = _and_guards(guard, exit_.guard)
+            if isinstance(exit_, Completed):
+                exits.append(Completed(combined, exit_.value))
+            else:
+                exits.append(Halted(combined, exit_.effect))
+        return ExitSet(tuple(exits)).normalize()
+
+    def normalize(self) -> "ExitSet[T]":
+        """Drop false exits and merge equal destinations by disjoining guards."""
+        merged: list[Exit[T]] = []
+        for exit_ in self.exits:
+            if _is_false(exit_.guard):
+                continue
+            for index, prior in enumerate(merged):
+                same_completed = (
+                    isinstance(exit_, Completed)
+                    and isinstance(prior, Completed)
+                    and exit_.value == prior.value
+                )
+                same_halted = (
+                    isinstance(exit_, Halted)
+                    and isinstance(prior, Halted)
+                    and exit_.effect == prior.effect
+                )
+                if same_completed:
+                    merged[index] = Completed(
+                        _or_guards(prior.guard, exit_.guard), prior.value
+                    )
+                    break
+                if same_halted:
+                    merged[index] = Halted(
+                        _or_guards(prior.guard, exit_.guard), prior.effect
+                    )
+                    break
+            else:
+                merged.append(exit_)
+        return ExitSet(tuple(merged))
+
+    def sequence(self, step: Callable[[T], "ExitSet[U]"]) -> "ExitSet[U]":
+        """Map ``step`` over completed exits; halted exits bypass the tail."""
+        exits: list[Exit[U]] = []
+        for exit_ in self.exits:
+            if isinstance(exit_, Halted):
+                exits.append(exit_)
+                continue
+            for following in step(exit_.value).exits:
+                guard = _and_guards(exit_.guard, following.guard)
+                if isinstance(following, Completed):
+                    exits.append(Completed(guard, following.value))
+                else:
+                    exits.append(Halted(guard, following.effect))
+        return ExitSet(tuple(exits)).normalize()
+
+    def collapse(self):
+        """Return the old linear Outcome only for one unconditional exit."""
+        normalized = self.normalize()
+        if len(normalized.exits) != 1 or not _is_true(normalized.exits[0].guard):
+            return self if normalized == self else normalized
+        exit_ = normalized.exits[0]
+        if isinstance(exit_, Completed):
+            return Complete(exit_.value)
+        return Incomplete(exit_.effect)
+
+
+__all__ = [
+    "Completed",
+    "ExitSet",
+    "Halted",
+    "false_guard",
+    "true_guard",
+]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -21,60 +21,84 @@ from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.floor import BlockValue
 from sugar_lift_py_tests.floor.universe_value import UniverseValue
-from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.outcome import Complete, ExitSet, Incomplete, Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 
-def reduce_statements(statements: tuple):
-    """Reduce a block's statement sugars in order.
+@dataclass(frozen=True)
+class _ReducedBlock:
+    entries: tuple[object, ...]
+    can_fall_through: bool
+    fall_through: tuple
+    transforms: tuple = ()
 
-    Each substituted statement's sugar answers `desugar()` with an Outcome that
-    owns its own contribution and whether the run continues -- the loop never
-    branches on a value's kind, and it threads NO scope: substitute already did
-    the binding, so a statement's meaning is a pure function of the (already
-    resolved) tree, not of any accumulated context.
-    """
-    entries: list[object] = []
-    transforms: list = []
-    fall_through: list = []
-    can_fall_through = True
+
+def reduce_block_to_exitset(statements: tuple) -> ExitSet[_ReducedBlock]:
+    """Reduce a suite to guarded exits before the linear compatibility view."""
+    exits = ExitSet.completed(
+        _ReducedBlock(entries=(), can_fall_through=True, fall_through=())
+    )
 
     for index, head in enumerate(statements):
-        outcome = head.desugar()
 
-        contribution = outcome.contribution()
-        for transform in reversed(transforms):
-            contribution = transform(contribution)
-        entries.extend(contribution)
+        def reduce_next(state: _ReducedBlock) -> ExitSet[_ReducedBlock]:
+            outcome = head.desugar()
+            contribution = outcome.contribution()
+            for transform in reversed(state.transforms):
+                contribution = transform(contribution)
+            entries = (*state.entries, *contribution)
 
-        follow = outcome.follow()
-        if not follow.continues:
-            # An early exit (return/raise) makes the tail unreachable. Handling
-            # the kept-but-unreduced tail entries (they must answer
-            # inv_contribution/post_contribution as "raw states nothing") is the
-            # SugarBody-wrapper job the factory did; it is not ported yet. No
-            # WRITTEN tree sugar halts a block today (assert continues), so this
-            # is unreachable now -- and it panics loudly rather than silently
-            # dropping the tail if a newly-written halting sugar reaches it.
-            if follow.keeps_rest and index + 1 < len(statements):
-                raise NotImplementedError(
-                    "block early-exit with a kept tail is not ported to the tree "
-                    "reduction yet: port the SugarBody raw-tail wrapper when the "
-                    f"first halting statement sugar lands (halted at index {index})"
+            follow = outcome.follow()
+            if not follow.continues:
+                if follow.keeps_rest and index + 1 < len(statements):
+                    raise NotImplementedError(
+                        "block early-exit with a kept tail is not ported to the "
+                        "tree reduction yet: port the SugarBody raw-tail wrapper "
+                        "when the first halting statement sugar lands "
+                        f"(halted at index {index})"
+                    )
+                if isinstance(outcome, Incomplete):
+                    if outcome.branch_conditions:
+                        from sugar_lift_py_tests.ir import and_
+
+                        condition = (
+                            outcome.branch_conditions[0]
+                            if len(outcome.branch_conditions) == 1
+                            else and_(list(outcome.branch_conditions))
+                        )
+                        return ExitSet.conditional_halt(
+                            condition, outcome.effect, state
+                        )
+                    return ExitSet.halted(outcome.effect)
+                return ExitSet.completed(
+                    _ReducedBlock(entries, can_fall_through=False, fall_through=())
                 )
-            can_fall_through = False
-            break
-        if follow.transform is not None:
-            transforms.append(follow.transform)
-        if follow.continuation_guard is not None:
-            fall_through.append(follow.continuation_guard)
 
-    return (
-        tuple(entries),
-        can_fall_through,
-        tuple(fall_through) if can_fall_through else (),
-    )
+            transforms = state.transforms
+            if follow.transform is not None:
+                transforms = (*transforms, follow.transform)
+            fall_through = state.fall_through
+            if follow.continuation_guard is not None:
+                fall_through = (*fall_through, follow.continuation_guard)
+            return ExitSet.completed(
+                _ReducedBlock(entries, True, fall_through, transforms)
+            )
+
+        exits = exits.sequence(reduce_next)
+
+    return exits
+
+
+def reduce_statements(statements: tuple):
+    """Return the legacy tuple only after ExitSet proves one unconditional exit."""
+    collapsed = reduce_block_to_exitset(statements).collapse()
+    if isinstance(collapsed, Incomplete):
+        return ((collapsed,), False, ())
+    if not isinstance(collapsed, Complete):
+        return collapsed
+    state = collapsed.value
+    return state.entries, state.can_fall_through, state.fall_through
 
 
 def reduce_body(statements: tuple):
@@ -89,9 +113,14 @@ def reduce_body(statements: tuple):
     always Complete -- the distinction is carried structurally for the sugars
     (calls, unsupported statements) that will.
     """
-    from sugar_lift_py_tests.outcome import Incomplete
-
-    entries, can_fall_through, fall_through = reduce_statements(statements)
+    exits = reduce_block_to_exitset(statements)
+    collapsed = exits.collapse()
+    if isinstance(collapsed, Incomplete):
+        return collapsed
+    if not isinstance(collapsed, Complete):
+        return collapsed
+    state = collapsed.value
+    entries = state.entries
     # A body that is nothing but a single propagating effect IS that effect --
     # there is no value, no fact, no exit to make a contract from. Propagate it
     # so the def surfaces as an effect (a halt), never a None-returning contract.
@@ -99,7 +128,9 @@ def reduce_body(statements: tuple):
         return entries[0]
     return Complete(
         BlockValue(
-            entries, fall_through=fall_through, can_fall_through=can_fall_through
+            entries,
+            fall_through=state.fall_through,
+            can_fall_through=state.can_fall_through,
         )
     )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
@@ -56,17 +56,26 @@ class IfSugar(Sugar):
         from sugar_lift_py_tests.floor.block_value import BlockValue
         from sugar_lift_py_tests.floor.guarded_faces import GuardedFaces
         from sugar_lift_py_tests.ir import not_
-        from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_statements
+        from sugar_lift_py_tests.outcome import Completed, Halted, Incomplete
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            reduce_block_to_exitset,
+        )
 
-        then_entries, then_falls, _f1 = reduce_statements(self.then_body)
-        else_entries, else_falls, _f2 = reduce_statements(self.else_body)
+        then_exits = reduce_block_to_exitset(self.then_body)
+        else_exits = reduce_block_to_exitset(self.else_body)
+
+        def entries_are_empty(exits):
+            return all(
+                isinstance(exit_, Completed) and not exit_.value.entries
+                for exit_ in exits.exits
+            )
 
         # A purely TEMPORAL if -- branches that only bind -- is spent by
         # substitute (its binding became an IfExp phi threaded past the if), so
         # both branches reduce to nothing. It contributes no meaning and needs no
         # guard: the condition is not even consulted (an inert if states nothing,
         # whatever its test). This is the common residue of the phi rewrite.
-        if not then_entries and not else_entries:
+        if entries_are_empty(then_exits) and entries_are_empty(else_exits):
             return Complete(BlockValue((), can_fall_through=True))
 
         # Branches carry facts/effects: the guard is the condition's TRUTHINESS
@@ -83,30 +92,43 @@ class IfSugar(Sugar):
                 "predicate or bare-truthiness condition guards, a constant does not"
             )
 
-        # Each branch's facts ride under its polarity: then under c, else under ¬c.
+        # If is union in the exit algebra: each branch is restricted to its
+        # polarity, then the partitions normalize together. In particular, a
+        # halt on one face coexists with the complementary Completed exit.
         not_formula = not_(formula)
-        entries = (
-            *(entry.guarded(formula) for entry in then_entries),
-            *(entry.guarded(not_formula) for entry in else_entries),
-        )
+        exits = then_exits.guarded(formula).union(else_exits.guarded(not_formula))
+        entries = []
+        for exit_ in exits.exits:
+            if isinstance(exit_, Halted):
+                entries.append(Incomplete(exit_.effect).guarded(exit_.guard))
+            else:
+                entries.extend(
+                    entry.guarded(exit_.guard) for entry in exit_.value.entries
+                )
 
-        then_exits = not then_falls
-        else_exits = not else_falls
-        can_fall_through = not (then_exits and else_exits)
+        def can_fall_through(branch_exits):
+            return any(
+                isinstance(exit_, Completed) and exit_.value.can_fall_through
+                for exit_ in branch_exits.exits
+            )
+
+        then_branch_exits = not can_fall_through(then_exits)
+        else_branch_exits = not can_fall_through(else_exits)
+        can_fall_through = not (then_branch_exits and else_branch_exits)
         # The tail rides under the polarity of whichever branch did NOT exit; if
         # both fall through it is unconditional, if both exit it is unreachable.
         continuation_guard = None
-        if then_exits and not else_exits:
+        if then_branch_exits and not else_branch_exits:
             continuation_guard = not_formula
-        elif else_exits and not then_exits:
+        elif else_branch_exits and not then_branch_exits:
             continuation_guard = formula
 
         return Complete(
             GuardedFaces(
                 guard=formula,
-                entries=entries,
-                then_exits=then_exits,
-                else_exits=else_exits,
+                entries=tuple(entries),
+                then_exits=then_branch_exits,
+                else_exits=else_branch_exits,
                 joined_bindings=(),  # bindings are substitute's job (the IfExp phi)
                 guarded_bindings=(),
                 can_fall_through=can_fall_through,

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
@@ -1,0 +1,81 @@
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.ir import atomic, make_var, not_, or_
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.outcome.exit_set import (
+    Completed,
+    ExitSet,
+    Halted,
+    false_guard,
+)
+from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
+
+
+def _guard(name: str):
+    return atomic(name, [make_var("state")])
+
+
+def test_single_unconditional_completed_collapses_to_complete():
+    assert ExitSet.completed("state").collapse() == Complete("state")
+
+
+def test_single_unconditional_halted_collapses_to_incomplete():
+    effect = RaiseEffect(exception_name="ValueError")
+
+    assert ExitSet.halted(effect).collapse() == Incomplete(effect)
+
+
+def test_conditional_halt_keeps_halted_and_complementary_completed_exits():
+    condition = _guard("condition")
+    effect = RaiseEffect(exception_name="ValueError")
+
+    exits = ExitSet.conditional_halt(condition, effect, "state")
+
+    assert exits.exits == (
+        Halted(condition, effect),
+        Completed(not_(condition), "state"),
+    )
+    assert exits.collapse() is exits
+
+
+def test_union_normalize_merges_equal_exits_by_disjoining_their_guards():
+    left = _guard("left")
+    right = _guard("right")
+
+    exits = ExitSet((Completed(left, "state"),)).union(
+        ExitSet((Completed(right, "state"),))
+    )
+
+    assert exits.exits == (Completed(or_([left, right]), "state"),)
+
+
+def test_normalize_drops_unsatisfiable_exit():
+    assert ExitSet((Completed(false_guard(), "unreachable"),)).normalize().exits == ()
+
+
+def test_sequencing_maps_only_completed_exits():
+    condition = _guard("condition")
+    effect = RaiseEffect(exception_name="ValueError")
+    exits = ExitSet.conditional_halt(condition, effect, 1)
+
+    sequenced = exits.sequence(lambda value: ExitSet.completed(value + 1))
+
+    assert sequenced.exits == (
+        Halted(condition, effect),
+        Completed(not_(condition), 2),
+    )
+
+
+def test_block_reduction_retains_complement_of_guarded_halt():
+    condition = _guard("condition")
+    effect = RaiseEffect(exception_name="ValueError")
+
+    class GuardedHalt:
+        def desugar(self):
+            return Incomplete(effect).guarded(condition)
+
+    exits = reduce_block_to_exitset((GuardedHalt(),))
+
+    assert isinstance(exits.exits[0], Halted)
+    assert exits.exits[0].guard == condition
+    assert isinstance(exits.exits[1], Completed)
+    assert exits.exits[1].guard == not_(condition)


### PR DESCRIPTION
## ExitSet API

Adds `Completed(guard, value/state)`, `Halted(guard, effect)`, and `ExitSet` construction, guarded union/normalization, unsatisfiable-exit removal, sequencing over completed exits only, and collapse for a single unconditional exit. Guards reuse the existing FOL `Formula` algebra.

## Behavior preservation

`reduce_block_to_exitset(...)` is now the block reducer, and `reduce_statements` / `reduce_body` cross back into the legacy `Outcome` representation only through `collapse()`. The exact source-tree gate remains `251 passed, 5 skipped`.

## If as union

`IfSugar` reduces both branches to ExitSets, restricts them by the condition and its negation, and combines them through union/normalize before projecting the existing `GuardedFaces` compatibility value.

## Lost-continuation regression

The direct algebra and block-reducer tests prove that a conditional halt retains both `Halted(C, effect)` and the complementary `Completed(not C, state)` exit, so the ordinary continuation is not discarded.

## Validation

- `python3 -m pytest sugar-lift-py-tests/tests/test_exit_set.py -q` — 7 passed
- `python3 -m pytest sugar-source-tree/tests/ -q` — 251 passed, 5 skipped
- focused `compileall` and `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ExitSet` as a guarded-exit abstraction for block reduction in the effect-dimension phi foundation
> - Introduces `ExitSet[T]` in [exit_set.py](https://github.com/TSavo/sugar/pull/6014/files#diff-40bf423f2f11b7e245b883146f67d6943005b30b1c5a4d74f1aab767272e3716), a partition of reachable execution into `Completed` (with guard + value) and `Halted` (with guard + effect) exits, supporting union, guard restriction, normalization, sequencing, and collapse to legacy `Outcome` forms.
> - Adds `reduce_block_to_exitset` in [function_universe_sugar.py](https://github.com/TSavo/sugar/pull/6014/files#diff-1a034881b3b9f8294d507d8d13e7d0addd04ec63a0ccc585b95ed6ae81f9f21b), which reduces a statement sequence into an `ExitSet` preserving complementary fall-through guards alongside conditional halts instead of collapsing prematurely.
> - Refactors `reduce_statements` and `reduce_body` to delegate to `reduce_block_to_exitset` and collapse to legacy shapes only when a single unconditional exit exists.
> - Rewrites `IfSugar.desugar` in [if_sugar.py](https://github.com/TSavo/sugar/pull/6014/files#diff-1973840cdede6045a823f5394f176c7dfce28cab5c88332fc428d364ccb4b6b1) to operate on `ExitSet` partitions from both branches, restricting exits by branch guards and unioning them before emitting guarded `Incomplete` entries for halts.
> - Behavioral Change: `reduce_statements` and `reduce_body` may now return a non-tuple `ExitSet` to callers when the result is not collapsible to a single unconditional exit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d445872.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->