### PR TITLE
roll call Phase 1: minority report from the source oracle, zero reporters

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/roll_call.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/roll_call.py
@@ -1,0 +1,179 @@
+"""The roll call: the minority report built from the SOURCE side, zero reporters.
+
+Construction is a roll call with two roles and one interface:
+
+- **Roster** -- who SHOULD show up. A pure function of the source oracle and the
+  enumeration protocol: enumerate every accountable unit of a file. It calls no
+  ``sugar()``, threads no reporter, constructs nothing. Deterministic and
+  content-addressed (each entry keyed by its oracle-minted CID).
+- **Attendance** -- who DID show up. An INTERFACE (``Attendance``) that answers,
+  per roster entry, one of three things: ``present-fact``, ``present-inert``
+  (showed up, states nothing -- a docstring / pass / import), or nothing at all
+  (absent). "Returned without answering" is not expressible: absence is the
+  default, computed by difference, so a unit that crashes or vanishes mid-answer
+  is still on the roster and still counts absent.
+
+The **minority report is ``roster \\ attended``** -- the entries no present
+answer covered. ``R`` is its size. ``R == 0`` iff every roster entry showed up.
+
+This module is the ACCOUNTING mechanism and depends on NOTHING downstream: given
+source it yields a total, honest report before a single reporter exists (with an
+empty attendance the minority is the whole roster -- the honest "accounted for
+nothing yet"). Threading real attendance (Phase 2) is a separate, monotonic pass
+that can only move entries absent -> present; it can never fake a presence or
+hide an absence, because it cannot remove anyone from a roster it did not build.
+That decoupling -- report over (roster, Attendance-interface), never over
+construction -- is what makes testing trivial: a stub attendance, no lift.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable, Iterator, Mapping, Protocol, runtime_checkable
+
+
+class Answer(Enum):
+    """A roll-call answer. PRESENT_FACT and PRESENT_INERT both mean 'showed up'
+    (accounted, Blue); an entry with no Answer is ABSENT (the minority, Yellow).
+    ABSENT is a valid explicit answer too (a construction that loudly reported
+    its own gap), but the roster never needs it stated -- absence is the default.
+    """
+
+    PRESENT_FACT = "present-fact"
+    PRESENT_INERT = "present-inert"
+    ABSENT = "absent"
+
+    @property
+    def is_present(self) -> bool:
+        return self in (Answer.PRESENT_FACT, Answer.PRESENT_INERT)
+
+
+@dataclass(frozen=True)
+class RosterEntry:
+    """One accountable unit, content-addressed. Identity is the CID."""
+
+    cid: str
+    kind: str
+    name: str
+    file: str
+    start_line: int
+    start_col: int
+
+    def __hash__(self) -> int:  # keyed by CID alone
+        return hash(self.cid)
+
+
+@runtime_checkable
+class Attendance(Protocol):
+    """The report INTERFACE. The one seam between the source-side report and the
+    construction side. It answers for a roster entry; ``None`` means the entry
+    never answered (absent). Construction knows nothing of the report except
+    that it implements this."""
+
+    def answer_for(self, entry: RosterEntry) -> Answer | None: ...
+
+
+class EmptyAttendance:
+    """Nobody has answered. The honest moment-zero state: the minority is the
+    entire roster."""
+
+    def answer_for(self, entry: RosterEntry) -> Answer | None:  # noqa: D102
+        return None
+
+
+@dataclass(frozen=True)
+class MappingAttendance:
+    """Attendance from a plain ``{cid: Answer}`` mapping -- for tests and for any
+    caller that has already collected answers out of band. No construction."""
+
+    answers: Mapping[str, Answer]
+
+    def answer_for(self, entry: RosterEntry) -> Answer | None:
+        return self.answers.get(entry.cid)
+
+
+def roster_entry_for(node, kind: str, name: str) -> RosterEntry:
+    """A roster entry for one node -- its CID, kind, name, and locus. Reads the
+    node's oracle-pinned fragment; constructs nothing."""
+    lc = node.line_col_span()
+    cid = node.fragment.seal().cid
+    return RosterEntry(
+        cid=cid,
+        kind=kind,
+        name=name,
+        file=node.unit.filename,
+        start_line=lc.start_line,
+        start_col=lc.start_col,
+    )
+
+
+def function_roster(source_file) -> tuple[RosterEntry, ...]:
+    """The roster at the function accounting level: every FunctionDef /
+    AsyncFunctionDef in the file, in source order. Pure source enumeration --
+    no ``sugar()``, no reporter. This is the ``functions`` census unit: a clean
+    (present) count against this roster is exactly 'functions construct clean'.
+    """
+    from .nodes import AsyncFunctionDef, FunctionDef
+
+    entries: list[RosterEntry] = []
+    for node in source_file.nodes():
+        if isinstance(node, (FunctionDef, AsyncFunctionDef)):
+            entries.append(roster_entry_for(node, node.kind, node.name))
+    return tuple(entries)
+
+
+@dataclass(frozen=True)
+class MinorityReport:
+    """The report over a roster and an attendance interface. Honest by
+    construction: the minority is exactly the roster entries no present answer
+    covered. Nothing here consults construction."""
+
+    roster: tuple[RosterEntry, ...]
+    attendance: Attendance
+
+    def _answer(self, entry: RosterEntry) -> Answer | None:
+        return self.attendance.answer_for(entry)
+
+    @property
+    def present(self) -> tuple[RosterEntry, ...]:
+        return tuple(
+            e for e in self.roster
+            if (a := self._answer(e)) is not None and a.is_present
+        )
+
+    @property
+    def minority(self) -> tuple[RosterEntry, ...]:
+        """roster \\ attended -- entries with no present answer. The absent
+        never report themselves; the roster computes them by difference."""
+        return tuple(
+            e for e in self.roster
+            if (a := self._answer(e)) is None or not a.is_present
+        )
+
+    @property
+    def R(self) -> int:
+        return len(self.minority)
+
+    @property
+    def is_clean(self) -> bool:
+        """R == 0: there is no minority report -- every roster entry showed up."""
+        return self.R == 0
+
+
+def minority_report(
+    source_file, attendance: Attendance | None = None
+) -> MinorityReport:
+    """Build the report for a file. With no attendance (Phase 1 / moment zero)
+    the minority is the whole function roster -- total and honest, zero
+    reporters, zero construction."""
+    return MinorityReport(
+        roster=function_roster(source_file),
+        attendance=attendance if attendance is not None else EmptyAttendance(),
+    )
+
+
+def total_R(reports: Iterable[MinorityReport]) -> int:
+    """R across many files: the size of the whole minority. R == 0 iff there is
+    no minority report anywhere."""
+    return sum(report.R for report in reports)

--- a/implementations/python/sugar-source-tree/tests/test_roll_call.py
+++ b/implementations/python/sugar-source-tree/tests/test_roll_call.py
@@ -1,0 +1,120 @@
+"""The roll call / minority report -- Phase 1, clean room.
+
+Every test here builds the report from source + a STUB attendance (a plain
+dict). No reporter, no ``sugar()``, no construction is stood up anywhere. That
+triviality IS the point: reporting is decoupled from constructs except by the
+``Attendance`` interface, so the accounting mechanism is testable in total
+isolation.
+"""
+
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+from sugar_source_tree.roll_call import (
+    Answer,
+    EmptyAttendance,
+    MappingAttendance,
+    MinorityReport,
+    function_roster,
+    minority_report,
+    total_R,
+)
+
+
+def _sf(src: str) -> SourceFile:
+    f = tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp")
+    f.write(src)
+    f.close()
+    return SourceFile(path_source(f.name))  # NO reporter -- the clean room
+
+
+_THREE = "def a(z):\n    return z\ndef b():\n    return 1\ndef c():\n    pass\n"
+
+
+def test_roster_is_pure_source_enumeration() -> None:
+    # Who SHOULD show up: every function, from the oracle, keyed by CID. No
+    # construction consulted.
+    roster = function_roster(_sf(_THREE))
+    assert [e.name for e in roster] == ["a", "b", "c"]
+    assert all(e.cid.startswith("blake3-512:") for e in roster)
+
+
+def test_moment_zero_minority_is_the_whole_roster() -> None:
+    # With nobody having answered, the minority is everyone: the honest
+    # "accounted for nothing yet" -- total and truthful before any reporter.
+    report = minority_report(_sf(_THREE))  # EmptyAttendance by default
+    assert isinstance(report.attendance, EmptyAttendance)
+    assert report.R == 3
+    assert not report.is_clean
+    assert {e.name for e in report.minority} == {"a", "b", "c"}
+    assert report.present == ()
+
+
+def test_threading_attendance_only_shrinks_the_minority() -> None:
+    sf = _sf(_THREE)
+    roster = function_roster(sf)
+    att = MappingAttendance(
+        {roster[0].cid: Answer.PRESENT_FACT, roster[2].cid: Answer.PRESENT_INERT}
+    )
+    report = minority_report(sf, att)
+    # present-fact and present-inert both count as SHOWED UP.
+    assert {e.name for e in report.present} == {"a", "c"}
+    # b never answered -> absent, by difference (b never reported itself).
+    assert [e.name for e in report.minority] == ["b"]
+    assert report.R == 1
+
+
+def test_present_inert_is_showing_up_not_absence() -> None:
+    # A unit that states nothing still ANSWERED: it is accounted, not minority.
+    sf = _sf(_THREE)
+    roster = function_roster(sf)
+    inert = MappingAttendance({e.cid: Answer.PRESENT_INERT for e in roster})
+    assert minority_report(sf, inert).R == 0
+
+
+def test_explicit_absent_answer_stays_in_the_minority() -> None:
+    # An entry that loudly answered ABSENT is still minority (Yellow) -- present
+    # is only fact/inert.
+    sf = _sf(_THREE)
+    roster = function_roster(sf)
+    att = MappingAttendance({roster[0].cid: Answer.ABSENT})
+    report = minority_report(sf, att)
+    assert roster[0] in report.minority
+    assert report.R == 3
+
+
+def test_R_zero_iff_no_minority() -> None:
+    sf = _sf(_THREE)
+    roster = function_roster(sf)
+    full = MappingAttendance({e.cid: Answer.PRESENT_FACT for e in roster})
+    report = minority_report(sf, full)
+    assert report.R == 0
+    assert report.is_clean
+
+
+def test_roster_is_deterministic_and_content_addressed() -> None:
+    # Same source -> same roster CIDs (the oracle's hash), every time.
+    a = [e.cid for e in function_roster(_sf(_THREE))]
+    b = [e.cid for e in function_roster(_sf(_THREE))]
+    assert a == b
+
+
+def test_total_R_sums_the_whole_minority() -> None:
+    reports = [minority_report(_sf(_THREE)), minority_report(_sf("def x():\n    return 0\n"))]
+    assert total_R(reports) == 4  # 3 + 1, all moment-zero minority
+
+
+def test_report_depends_only_on_the_attendance_interface() -> None:
+    # A hand-rolled Attendance (anything implementing answer_for) works -- the
+    # report never reaches past the interface into construction.
+    sf = _sf(_THREE)
+    roster = function_roster(sf)
+
+    class OnlyA:
+        def answer_for(self, entry):
+            return Answer.PRESENT_FACT if entry.name == "a" else None
+
+    report = MinorityReport(roster=roster, attendance=OnlyA())
+    assert [e.name for e in report.present] == ["a"]
+    assert report.R == 2


### PR DESCRIPTION
The report mechanism built entirely from the **source oracle + enumeration protocol** — the clean room. `roll_call.py` imports only stdlib + nodes: no reporter, no `sugar()`, no construction.

- **Roster** (who SHOULD show up) = pure function of source → every accountable node, keyed by oracle-minted CID.
- **Attendance** = the one INTERFACE seam to construction (construction implements it; the report never reaches past it). Three answers: present-fact / present-inert (both showed up, Blue) / absent (Yellow).
- **minority = roster \ attended**, **R = |minority|**, **R==0 iff no minority**.

Correct-by-construction: the roster is source-side and prior to construction, so at moment zero (empty attendance) the minority is the whole roster — the honest "accounted for nothing yet." Threading attendance (Phase 2) can only shrink the minority; an unthreaded path is honest-absent, never silent green. Silence is unrepresentable — the absent are computed by difference; they never report themselves.

Testing is trivial *because* reporting is decoupled from constructs except by the interface: 9 tests over source + a stub dict, no lift, **0.12s**. Tree suite 260.

**Phase 2 next:** thread the Attendance interface into construction; the silent floor retires (silently_unaccounted=0 becomes a theorem).

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added source-file roll calls that enumerate functions and track attendance.
  * Added minority reports showing which functions lack an accounted-for response.
  * Added support for fact, inert, and absent attendance statuses.
  * Added cleanliness and aggregate minority metrics across multiple files.

* **Tests**
  * Added coverage for deterministic rosters, attendance handling, minority calculations, and aggregate metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add roll call Phase 1 minority report module with roster enumeration and attendance tracking
> - Adds [roll_call.py](https://github.com/TSavo/sugar/pull/6017/files#diff-cb5c5b83dfefe242a4d48f9a545ff4e5a51819ec9fbde4249736248a8c27b251) with a `function_roster` that enumerates all functions in a `SourceFile` into content-addressed `RosterEntry` objects in source order.
> - Introduces an `Attendance` protocol with `EmptyAttendance` and `MappingAttendance` implementations to answer present/absent queries per roster entry.
> - Adds `MinorityReport`, which computes which roster entries lack a present attendance answer, exposing `R` (minority count) and `is_clean` (R == 0).
> - Adds `total_R` to sum minority counts across multiple reports.
> - Adds [test_roll_call.py](https://github.com/TSavo/sugar/pull/6017/files#diff-8176c245bbd0aa910a85bedd4309ce607f7f6c821ee6d57b87e287a9662a7edc) covering roster determinism, attendance semantics, and aggregate minority computation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5f5855.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->