### PR TITLE
roll call: one node roster + discharge interface (construction=registration, desugar=discharge)

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/roll_call.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/roll_call.py
@@ -65,6 +65,54 @@ class RosterEntry:
 
 
 @runtime_checkable
+class RollCall(Protocol):
+    """The WRITE side -- the discharge answers. Registration already happened
+    when the node was CONSTRUCTED (materialized from the source oracle = showing
+    up on the roll); DISCHARGE is desugaring (sugar -> fact). These three
+    methods are the three discharge outcomes: a node desugars to a fact
+    (present_fact), desugars inert (present_inert), or does not discharge --
+    SugarNotWritten, the loud gap (absent). "Registered but not discharged and
+    not loud" is unrepresentable: desugar is never a fallback, never None."""
+
+    def present_fact(self, entry: RosterEntry) -> None: ...
+    def present_inert(self, entry: RosterEntry) -> None: ...
+    def absent(self, entry: RosterEntry, gap: object) -> None: ...
+
+
+class NullRollCall:
+    """Answers nowhere. The default so construction never fails for lack of a
+    roll call; a real recorder is threaded in when the report is being built."""
+
+    def present_fact(self, entry: RosterEntry) -> None: ...
+    def present_inert(self, entry: RosterEntry) -> None: ...
+    def absent(self, entry: RosterEntry, gap: object) -> None: ...
+
+
+NULL_ROLL_CALL = NullRollCall()
+
+
+class RecordingRollCall:
+    """Collects answers into an Attendance. The write side and the read side of
+    the same data: construction fills this during the roll; the report reads the
+    resulting ``attendance()``."""
+
+    def __init__(self) -> None:
+        self._answers: dict[str, Answer] = {}
+
+    def present_fact(self, entry: RosterEntry) -> None:
+        self._answers[entry.cid] = Answer.PRESENT_FACT
+
+    def present_inert(self, entry: RosterEntry) -> None:
+        self._answers[entry.cid] = Answer.PRESENT_INERT
+
+    def absent(self, entry: RosterEntry, gap: object) -> None:
+        self._answers[entry.cid] = Answer.ABSENT
+
+    def attendance(self) -> "Attendance":
+        return MappingAttendance(dict(self._answers))
+
+
+@runtime_checkable
 class Attendance(Protocol):
     """The report INTERFACE. The one seam between the source-side report and the
     construction side. It answers for a roster entry; ``None`` means the entry
@@ -108,19 +156,20 @@ def roster_entry_for(node, kind: str, name: str) -> RosterEntry:
     )
 
 
-def function_roster(source_file) -> tuple[RosterEntry, ...]:
-    """The roster at the function accounting level: every FunctionDef /
-    AsyncFunctionDef in the file, in source order. Pure source enumeration --
-    no ``sugar()``, no reporter. This is the ``functions`` census unit: a clean
-    (present) count against this roster is exactly 'functions construct clean'.
-    """
-    from .nodes import AsyncFunctionDef, FunctionDef
+def roster(source_file) -> tuple[RosterEntry, ...]:
+    """THE roster: every node of the file, in source order, keyed by its
+    fragment CID. One construction, one roster -- every node has a fragment, so
+    every node is on the roll. Pure source enumeration: no ``sugar()``, no
+    reporter. "Functions construct clean" is a QUERY over this one roster (the
+    function nodes whose subtree is all present), never a second roster."""
+    return tuple(
+        roster_entry_for(node, node.kind, _roll_name(node))
+        for node in source_file.nodes()
+    )
 
-    entries: list[RosterEntry] = []
-    for node in source_file.nodes():
-        if isinstance(node, (FunctionDef, AsyncFunctionDef)):
-            entries.append(roster_entry_for(node, node.kind, node.name))
-    return tuple(entries)
+
+def _roll_name(node) -> str:
+    return getattr(node, "name", None) or node.kind
 
 
 @dataclass(frozen=True)
@@ -168,7 +217,7 @@ def minority_report(
     the minority is the whole function roster -- total and honest, zero
     reporters, zero construction."""
     return MinorityReport(
-        roster=function_roster(source_file),
+        roster=roster(source_file),
         attendance=attendance if attendance is not None else EmptyAttendance(),
     )
 

--- a/implementations/python/sugar-source-tree/tests/test_roll_call.py
+++ b/implementations/python/sugar-source-tree/tests/test_roll_call.py
@@ -5,6 +5,9 @@ dict). No reporter, no ``sugar()``, no construction is stood up anywhere. That
 triviality IS the point: reporting is decoupled from constructs except by the
 ``Attendance`` interface, so the accounting mechanism is testable in total
 isolation.
+
+ONE roster: every node, keyed by its fragment CID. "Functions construct clean"
+is a query over it, never a second roster.
 """
 
 import tempfile
@@ -16,8 +19,8 @@ from sugar_source_tree.roll_call import (
     EmptyAttendance,
     MappingAttendance,
     MinorityReport,
-    function_roster,
     minority_report,
+    roster,
     total_R,
 )
 
@@ -32,89 +35,112 @@ def _sf(src: str) -> SourceFile:
 _THREE = "def a(z):\n    return z\ndef b():\n    return 1\ndef c():\n    pass\n"
 
 
-def test_roster_is_pure_source_enumeration() -> None:
-    # Who SHOULD show up: every function, from the oracle, keyed by CID. No
-    # construction consulted.
-    roster = function_roster(_sf(_THREE))
-    assert [e.name for e in roster] == ["a", "b", "c"]
-    assert all(e.cid.startswith("blake3-512:") for e in roster)
+def _fn_names(entries):
+    return [e.name for e in entries if e.kind in ("FunctionDef", "AsyncFunctionDef")]
+
+
+def test_roster_is_pure_source_enumeration_of_every_node() -> None:
+    # ONE roster: every node, keyed by CID. The functions are a query over it.
+    r = roster(_sf(_THREE))
+    assert len(r) > 3  # far more than three: every node, not just functions
+    assert _fn_names(r) == ["a", "b", "c"]
+    assert all(e.cid.startswith("blake3-512:") for e in r)
 
 
 def test_moment_zero_minority_is_the_whole_roster() -> None:
-    # With nobody having answered, the minority is everyone: the honest
-    # "accounted for nothing yet" -- total and truthful before any reporter.
+    # Nobody answered -> the minority is everyone: the honest "accounted for
+    # nothing yet," total and truthful before any reporter.
     report = minority_report(_sf(_THREE))  # EmptyAttendance by default
     assert isinstance(report.attendance, EmptyAttendance)
-    assert report.R == 3
+    r = roster(_sf(_THREE))
+    assert report.R == len(r)
     assert not report.is_clean
-    assert {e.name for e in report.minority} == {"a", "b", "c"}
     assert report.present == ()
 
 
 def test_threading_attendance_only_shrinks_the_minority() -> None:
     sf = _sf(_THREE)
-    roster = function_roster(sf)
+    r = roster(sf)
     att = MappingAttendance(
-        {roster[0].cid: Answer.PRESENT_FACT, roster[2].cid: Answer.PRESENT_INERT}
+        {r[0].cid: Answer.PRESENT_FACT, r[1].cid: Answer.PRESENT_INERT}
     )
     report = minority_report(sf, att)
     # present-fact and present-inert both count as SHOWED UP.
-    assert {e.name for e in report.present} == {"a", "c"}
-    # b never answered -> absent, by difference (b never reported itself).
-    assert [e.name for e in report.minority] == ["b"]
-    assert report.R == 1
+    assert set(report.present) == {r[0], r[1]}
+    # everyone else never answered -> absent, by difference.
+    assert report.R == len(r) - 2
+    assert r[0] not in report.minority and r[1] not in report.minority
 
 
 def test_present_inert_is_showing_up_not_absence() -> None:
-    # A unit that states nothing still ANSWERED: it is accounted, not minority.
     sf = _sf(_THREE)
-    roster = function_roster(sf)
-    inert = MappingAttendance({e.cid: Answer.PRESENT_INERT for e in roster})
+    inert = MappingAttendance({e.cid: Answer.PRESENT_INERT for e in roster(sf)})
     assert minority_report(sf, inert).R == 0
 
 
 def test_explicit_absent_answer_stays_in_the_minority() -> None:
-    # An entry that loudly answered ABSENT is still minority (Yellow) -- present
-    # is only fact/inert.
+    # A loud ABSENT answer is still minority (Yellow) -- present is only
+    # fact/inert.
     sf = _sf(_THREE)
-    roster = function_roster(sf)
-    att = MappingAttendance({roster[0].cid: Answer.ABSENT})
+    r = roster(sf)
+    att = MappingAttendance({r[0].cid: Answer.ABSENT})
     report = minority_report(sf, att)
-    assert roster[0] in report.minority
-    assert report.R == 3
+    assert r[0] in report.minority
+    assert report.R == len(r)
 
 
 def test_R_zero_iff_no_minority() -> None:
     sf = _sf(_THREE)
-    roster = function_roster(sf)
-    full = MappingAttendance({e.cid: Answer.PRESENT_FACT for e in roster})
+    full = MappingAttendance({e.cid: Answer.PRESENT_FACT for e in roster(sf)})
     report = minority_report(sf, full)
     assert report.R == 0
     assert report.is_clean
 
 
 def test_roster_is_deterministic_and_content_addressed() -> None:
-    # Same source -> same roster CIDs (the oracle's hash), every time.
-    a = [e.cid for e in function_roster(_sf(_THREE))]
-    b = [e.cid for e in function_roster(_sf(_THREE))]
+    a = [e.cid for e in roster(_sf(_THREE))]
+    b = [e.cid for e in roster(_sf(_THREE))]
     assert a == b
 
 
 def test_total_R_sums_the_whole_minority() -> None:
-    reports = [minority_report(_sf(_THREE)), minority_report(_sf("def x():\n    return 0\n"))]
-    assert total_R(reports) == 4  # 3 + 1, all moment-zero minority
+    reports = [minority_report(_sf(_THREE)), minority_report(_sf("x = 1\n"))]
+    assert total_R(reports) == len(roster(_sf(_THREE))) + len(roster(_sf("x = 1\n")))
 
 
 def test_report_depends_only_on_the_attendance_interface() -> None:
-    # A hand-rolled Attendance (anything implementing answer_for) works -- the
-    # report never reaches past the interface into construction.
+    # A hand-rolled Attendance (anything with answer_for) works -- the report
+    # never reaches past the interface into construction.
     sf = _sf(_THREE)
-    roster = function_roster(sf)
+    r = roster(sf)
+    first = r[0]
 
-    class OnlyA:
+    class OnlyFirst:
         def answer_for(self, entry):
-            return Answer.PRESENT_FACT if entry.name == "a" else None
+            return Answer.PRESENT_FACT if entry.cid == first.cid else None
 
-    report = MinorityReport(roster=roster, attendance=OnlyA())
-    assert [e.name for e in report.present] == ["a"]
-    assert report.R == 2
+    report = MinorityReport(roster=r, attendance=OnlyFirst())
+    assert report.present == (first,)
+    assert report.R == len(r) - 1
+
+
+def test_the_roster_covers_every_source_line() -> None:
+    # The totality law: every line of source is spanned by some roster node, so
+    # every line is accounted (present) or in the minority (absent) -- never a
+    # third, unpainted state. Coverage is a property of the roster, not a check.
+    src = (
+        "def a(z):\n"
+        "    x = z + 1\n"
+        "    return x\n"
+        "\n"
+        "def b():\n"
+        "    with open('p'):\n"
+        "        pass\n"
+    )
+    sf = _sf(src)
+    code_lines = {i for i, ln in enumerate(src.splitlines(), 1) if ln.strip()}
+    covered: set[int] = set()
+    for node in sf.nodes():
+        lc = node.line_col_span()
+        covered |= set(range(lc.start_line, lc.end_line + 1))
+    assert not (code_lines - covered)  # zero unaccounted lines


### PR DESCRIPTION
Sharpen the roll call to its true shape.

- **ONE roster**: every node, keyed by fragment CID. Every node has a fragment, so every node is on the roll; "functions construct clean" is a query over the one roster, not a second one.
- **Totality law is coverage**: every source line is spanned by a roster node → every line accounted (present) or minority (absent), never unpainted (`test_the_roster_covers_every_source_line`).
- **The two roles are two acts that already exist**: **construction of the AST node IS the registration** (materialize from the source oracle = show up on the roll — the roster is the constructed tree, free and total); **desugaring IS the discharge** (sugar → fact answers the roll). The three `RollCall` methods are the three discharge outcomes: present_fact / present_inert / absent (SugarNotWritten).
- **Silence impossible at the root**: registration total (construction materializes every node) ∧ discharge total (desugar never None, always fact/inert or raise) ⇒ minority = registered \ discharged, no third state.

Phase 2 = a **discharge pass**: desugar the roster, record each outcome; attendance falls out; served over RPC to the shipped `--report --visual`. Tree 260.

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expand roll call roster to cover all source nodes and add a discharge interface
> - Replaces `function_roster` with a new `roster` function in [roll_call.py](https://github.com/TSavo/sugar/pull/6018/files#diff-cb5c5b83dfefe242a4d48f9a545ff4e5a51819ec9fbde4249736248a8c27b251) that enumerates every node in a source file (not only function definitions), keyed by content-addressed CID.
> - Adds a `RollCall` protocol with `present_fact`, `present_inert`, and `absent` methods as the write/discharge interface, along with `NullRollCall` and `RecordingRollCall` implementations.
> - `RecordingRollCall.attendance()` returns a `MappingAttendance` snapshot of recorded answers for use in reporting.
> - `minority_report` now computes presence/absence over all nodes instead of functions only, changing R, present, and minority contents.
> - Behavioral Change: any code relying on roster size or minority report contents based on function-only enumeration will see different counts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7d707d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->