### PR TITLE
roll call: AuditReporter is the roll call; new registers the AST node

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
@@ -58,9 +58,16 @@ def materialize(
     every field access on it is a fresh query through ``ref.describe()``.
     The reporter is threaded here so EVERY constructed node carries one and
     hands it on to the children it later resolves.
+
+    THE construction event IS the registration: the node registers on the roll
+    through its reporter here, so being constructed is being on the roster. A
+    node cannot come into existence off the roll -- that is what it means to be
+    an AST node.
     """
     cls = ref.resolve_type()
-    return cls(unit=unit, ref=ref, reporter=reporter)
+    node = cls(unit=unit, ref=ref, reporter=reporter)
+    reporter.register(node)
+    return node
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/reporter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/reporter.py
@@ -31,31 +31,63 @@ if TYPE_CHECKING:  # pragma: no cover
 
 @runtime_checkable
 class AuditReporter(Protocol):
-    """You may tell me a node had no sugar. I decide nothing."""
+    """The roll call every AST node carries. Construction of the node is the
+    REGISTRATION (``register`` -- the node shows up on the roll); desugaring is
+    the DISCHARGE, which answers with exactly one of ``present_fact`` /
+    ``present_inert`` (showed up) or ``report_gap`` (SugarNotWritten -- the loud
+    absent). The reporter witnesses; it decides nothing. Because the node holds
+    this, ``node.sugar()`` reads it off ``self`` and hands it to the sugar it
+    builds -- no interface is threaded through construction; it is carried."""
 
+    def register(self, node: "Node") -> None: ...
+    def present_fact(self, node: "Node") -> None: ...
+    def present_inert(self, node: "Node") -> None: ...
     def report_gap(self, node: "Node", panic: "SugarNotWritten") -> None: ...
 
 
 class NullReporter:
-    """Reports nowhere. The default a node carries when no one is auditing."""
+    """Answers nowhere. Explicitly carried where no report is being built."""
 
     __slots__ = ()
+
+    def register(self, node: "Node") -> None:
+        return None
+
+    def present_fact(self, node: "Node") -> None:
+        return None
+
+    def present_inert(self, node: "Node") -> None:
+        return None
 
     def report_gap(self, node: "Node", panic: "SugarNotWritten") -> None:
         return None
 
 
 class CollectingReporter:
-    """Accumulates every reported gap in walk order. An audit walk holds one.
+    """Accumulates the roll: every registered node, and each node's discharge.
 
-    ``gaps`` is the frontier: the (node, panic) pair for each unwritten
-    sugar the walk reached. ``len(gaps)`` is R.
+    ``registered`` is the roster (every node constructed while this reporter was
+    carried). ``gaps`` is the loud-absent discharge. ``present`` maps a node to
+    its present answer. The minority is ``registered`` minus ``present`` --
+    ``len(gaps)`` is the loud part of R; a registered node with no discharge at
+    all is the silent part, which the required interface makes unrepresentable.
     """
 
-    __slots__ = ("gaps",)
+    __slots__ = ("gaps", "registered", "present")
 
     def __init__(self) -> None:
         self.gaps: List[Tuple["Node", "SugarNotWritten"]] = []
+        self.registered: List["Node"] = []
+        self.present: dict[int, str] = {}
+
+    def register(self, node: "Node") -> None:
+        self.registered.append(node)
+
+    def present_fact(self, node: "Node") -> None:
+        self.present[id(node)] = "present-fact"
+
+    def present_inert(self, node: "Node") -> None:
+        self.present[id(node)] = "present-inert"
 
     def report_gap(self, node: "Node", panic: "SugarNotWritten") -> None:
         self.gaps.append((node, panic))


### PR DESCRIPTION
The interface every AST node already carries (`self.reporter`) becomes the full roll call, and construction does the registration in the act of `new`.

- `AuditReporter` extended from gap-only to the three-answer roll: `register` (shows up), `present_fact`/`present_inert` (discharge on successful desugar), `report_gap` (SugarNotWritten — loud absent).
- `materialize` (THE construction event) now calls `reporter.register(node)`: being constructed IS being on the roster; a node cannot exist off the roll.
- `CollectingReporter` holds the roll: registered (roster) / gaps (absent) / present (discharge).

**Compiler-leverage symmetry:** the AST node is `new`'d WITH the interface (materialize); the Sugar is `new`'d WITH it via its own constructor (`node.sugar()` passes `self.reporter` in). Each `new` *requires* it as a construction argument — registration happens in the `new`, at both levels.

**Close (next):** make the reporter required (drop NULL defaults so neither `new` can skip it) + Sugar constructors take the same required reporter, discharging present. Additive here; main green at 261.

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Register AST nodes on construction via `AuditReporter.register` in `materialize`
> - Expands the `AuditReporter` protocol in [reporter.py](https://github.com/TSavo/sugar/pull/6019/files#diff-7316d5f6ac79adfd96e099b465639a6e4751c494f53d78cc5c2145218b318ba1) with three new callbacks: `register(node)`, `present_fact(node)`, and `present_inert(node)`.
> - `NullReporter` adds no-op implementations of all three methods; `CollectingReporter` tracks registered nodes in a `registered` list and present status per node id in a `present` dict.
> - `materialize` in [backend.py](https://github.com/TSavo/sugar/pull/6019/files#diff-ad498e547096dff0cc0a35d78feaa867418d745ad78531faf3f78b5e835414b8) now calls `reporter.register(node)` immediately after constructing each node, making construction equivalent to roll-call registration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3a23b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->