### PR TITLE
roll call: ONE interface -- delete the duplicate; the report is a view over it

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
@@ -59,15 +59,14 @@ def materialize(
     The reporter is threaded here so EVERY constructed node carries one and
     hands it on to the children it later resolves.
 
-    THE construction event IS the registration: the node registers on the roll
-    through its reporter here, so being constructed is being on the roster. A
-    node cannot come into existence off the roll -- that is what it means to be
-    an AST node.
+    THE construction event IS the registration: a node registers on the roll in
+    its own constructor (``Node.__post_init__``), so being constructed is being
+    on the roster and there is no way to new a node off the roll -- that is what
+    it means to be an AST node. materialize does not register; the constructor
+    does.
     """
     cls = ref.resolve_type()
-    node = cls(unit=unit, ref=ref, reporter=reporter)
-    reporter.register(node)
-    return node
+    return cls(unit=unit, ref=ref, reporter=reporter)
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -178,16 +178,25 @@ class Node(Typed):
 
     unit: SourceUnit
     ref: object  # the BackendNode reference; duck-typed to avoid a cycle
-    # The audit channel, threaded at construction (backend.materialize) and
-    # handed on to every child this node resolves. Off the audit path this is
-    # the shared do-nothing NULL_REPORTER; nothing allocates, nothing changes.
-    reporter: AuditReporter = NULL_REPORTER
+    # The roll call. REQUIRED -- no default -- so a node cannot be constructed
+    # off the roll: this is what makes construction complete BY CONSTRUCTION,
+    # not by a call someone remembers to make. The constructor registers the
+    # node (``__post_init__``); every child this node resolves is constructed
+    # with the same reporter, so registration flows through the whole tree.
+    reporter: AuditReporter
 
     # Ordered names of fields holding child nodes (Node, optional
     # Node, or tuple of Node). Leaf values (str/int/...)
     # and operators are NOT children. Declared per class, in grammar order.
     # ClassVar on purpose: never a dataclass field, never instance state.
     _child_fields: ClassVar[Tuple[str, ...]] = ()
+
+    def __post_init__(self) -> None:
+        # THE construction event IS the registration. Registering here, in the
+        # constructor, means calling ``cls(...)`` at all is showing up on the
+        # roll -- there is no way to new a node without it. (register only
+        # records the reference; the node's fields stay lazy through ref.)
+        self.reporter.register(self)
 
     def __init_subclass__(cls, **kw: object) -> None:
         super().__init_subclass__(**kw)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/roll_call.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/roll_call.py
@@ -1,57 +1,34 @@
-"""The roll call: the minority report built from the SOURCE side, zero reporters.
+"""The minority report: a view over the ONE roll-call interface.
 
-Construction is a roll call with two roles and one interface:
+There is a single roll-call interface -- ``reporter.AuditReporter`` -- carried by
+every AST node and threaded through construction. This module does NOT define a
+second one; it reads the ``CollectingReporter`` that construction fills:
 
-- **Roster** -- who SHOULD show up. A pure function of the source oracle and the
-  enumeration protocol: enumerate every accountable unit of a file. It calls no
-  ``sugar()``, threads no reporter, constructs nothing. Deterministic and
-  content-addressed (each entry keyed by its oracle-minted CID).
-- **Attendance** -- who DID show up. An INTERFACE (``Attendance``) that answers,
-  per roster entry, one of three things: ``present-fact``, ``present-inert``
-  (showed up, states nothing -- a docstring / pass / import), or nothing at all
-  (absent). "Returned without answering" is not expressible: absence is the
-  default, computed by difference, so a unit that crashes or vanishes mid-answer
-  is still on the roster and still counts absent.
+- ``register`` (in the node's constructor) enrolls the node -> ``registered`` is
+  the roster (who SHOULD show up);
+- ``present_fact`` / ``present_inert`` (the desugar discharge) -> ``present`` is
+  who DID show up;
+- ``report_gap`` (SugarNotWritten) -> ``gaps`` is the loud absent.
 
-The **minority report is ``roster \\ attended``** -- the entries no present
-answer covered. ``R`` is its size. ``R == 0`` iff every roster entry showed up.
+The **minority is ``registered`` minus ``present``**. ``R`` is its size; ``R ==
+0`` iff there is no minority. A registered node that never discharged and never
+gapped is the silent part -- unrepresentable, because the constructor requires
+the interface and desugar is never a fallback: every constructed node discharges
+present or reports absent.
 
-This module is the ACCOUNTING mechanism and depends on NOTHING downstream: given
-source it yields a total, honest report before a single reporter exists (with an
-empty attendance the minority is the whole roster -- the honest "accounted for
-nothing yet"). Threading real attendance (Phase 2) is a separate, monotonic pass
-that can only move entries absent -> present; it can never fake a presence or
-hide an absence, because it cannot remove anyone from a roster it did not build.
-That decoupling -- report over (roster, Attendance-interface), never over
-construction -- is what makes testing trivial: a stub attendance, no lift.
+The report never consults construction internals -- only the collected roll --
+so it is testable from a ``CollectingReporter`` you fill by hand, no lift.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
-from typing import Iterable, Iterator, Mapping, Protocol, runtime_checkable
-
-
-class Answer(Enum):
-    """A roll-call answer. PRESENT_FACT and PRESENT_INERT both mean 'showed up'
-    (accounted, Blue); an entry with no Answer is ABSENT (the minority, Yellow).
-    ABSENT is a valid explicit answer too (a construction that loudly reported
-    its own gap), but the roster never needs it stated -- absence is the default.
-    """
-
-    PRESENT_FACT = "present-fact"
-    PRESENT_INERT = "present-inert"
-    ABSENT = "absent"
-
-    @property
-    def is_present(self) -> bool:
-        return self in (Answer.PRESENT_FACT, Answer.PRESENT_INERT)
+from typing import Iterable
 
 
 @dataclass(frozen=True)
 class RosterEntry:
-    """One accountable unit, content-addressed. Identity is the CID."""
+    """One accountable node, content-addressed. Identity is the CID."""
 
     cid: str
     kind: str
@@ -60,144 +37,53 @@ class RosterEntry:
     start_line: int
     start_col: int
 
-    def __hash__(self) -> int:  # keyed by CID alone
+    def __hash__(self) -> int:
         return hash(self.cid)
 
 
-@runtime_checkable
-class RollCall(Protocol):
-    """The WRITE side -- the discharge answers. Registration already happened
-    when the node was CONSTRUCTED (materialized from the source oracle = showing
-    up on the roll); DISCHARGE is desugaring (sugar -> fact). These three
-    methods are the three discharge outcomes: a node desugars to a fact
-    (present_fact), desugars inert (present_inert), or does not discharge --
-    SugarNotWritten, the loud gap (absent). "Registered but not discharged and
-    not loud" is unrepresentable: desugar is never a fallback, never None."""
-
-    def present_fact(self, entry: RosterEntry) -> None: ...
-    def present_inert(self, entry: RosterEntry) -> None: ...
-    def absent(self, entry: RosterEntry, gap: object) -> None: ...
-
-
-class NullRollCall:
-    """Answers nowhere. The default so construction never fails for lack of a
-    roll call; a real recorder is threaded in when the report is being built."""
-
-    def present_fact(self, entry: RosterEntry) -> None: ...
-    def present_inert(self, entry: RosterEntry) -> None: ...
-    def absent(self, entry: RosterEntry, gap: object) -> None: ...
-
-
-NULL_ROLL_CALL = NullRollCall()
-
-
-class RecordingRollCall:
-    """Collects answers into an Attendance. The write side and the read side of
-    the same data: construction fills this during the roll; the report reads the
-    resulting ``attendance()``."""
-
-    def __init__(self) -> None:
-        self._answers: dict[str, Answer] = {}
-
-    def present_fact(self, entry: RosterEntry) -> None:
-        self._answers[entry.cid] = Answer.PRESENT_FACT
-
-    def present_inert(self, entry: RosterEntry) -> None:
-        self._answers[entry.cid] = Answer.PRESENT_INERT
-
-    def absent(self, entry: RosterEntry, gap: object) -> None:
-        self._answers[entry.cid] = Answer.ABSENT
-
-    def attendance(self) -> "Attendance":
-        return MappingAttendance(dict(self._answers))
-
-
-@runtime_checkable
-class Attendance(Protocol):
-    """The report INTERFACE. The one seam between the source-side report and the
-    construction side. It answers for a roster entry; ``None`` means the entry
-    never answered (absent). Construction knows nothing of the report except
-    that it implements this."""
-
-    def answer_for(self, entry: RosterEntry) -> Answer | None: ...
-
-
-class EmptyAttendance:
-    """Nobody has answered. The honest moment-zero state: the minority is the
-    entire roster."""
-
-    def answer_for(self, entry: RosterEntry) -> Answer | None:  # noqa: D102
-        return None
-
-
-@dataclass(frozen=True)
-class MappingAttendance:
-    """Attendance from a plain ``{cid: Answer}`` mapping -- for tests and for any
-    caller that has already collected answers out of band. No construction."""
-
-    answers: Mapping[str, Answer]
-
-    def answer_for(self, entry: RosterEntry) -> Answer | None:
-        return self.answers.get(entry.cid)
-
-
-def roster_entry_for(node, kind: str, name: str) -> RosterEntry:
-    """A roster entry for one node -- its CID, kind, name, and locus. Reads the
-    node's oracle-pinned fragment; constructs nothing."""
+def roster_entry_for(node) -> RosterEntry:
+    """A roster entry for one node -- its CID, kind, name, and locus, from the
+    node's oracle-pinned fragment. Constructs nothing new."""
     lc = node.line_col_span()
-    cid = node.fragment.seal().cid
     return RosterEntry(
-        cid=cid,
-        kind=kind,
-        name=name,
+        cid=node.fragment.seal().cid,
+        kind=node.kind,
+        name=getattr(node, "name", None) or node.kind,
         file=node.unit.filename,
         start_line=lc.start_line,
         start_col=lc.start_col,
     )
 
 
-def roster(source_file) -> tuple[RosterEntry, ...]:
-    """THE roster: every node of the file, in source order, keyed by its
-    fragment CID. One construction, one roster -- every node has a fragment, so
-    every node is on the roll. Pure source enumeration: no ``sugar()``, no
-    reporter. "Functions construct clean" is a QUERY over this one roster (the
-    function nodes whose subtree is all present), never a second roster."""
-    return tuple(
-        roster_entry_for(node, node.kind, _roll_name(node))
-        for node in source_file.nodes()
-    )
-
-
-def _roll_name(node) -> str:
-    return getattr(node, "name", None) or node.kind
-
-
 @dataclass(frozen=True)
 class MinorityReport:
-    """The report over a roster and an attendance interface. Honest by
-    construction: the minority is exactly the roster entries no present answer
-    covered. Nothing here consults construction."""
+    """A view over the roll a ``CollectingReporter`` collected. The minority is
+    ``registered`` minus ``present`` -- nothing here consults construction, only
+    the collected roll."""
 
-    roster: tuple[RosterEntry, ...]
-    attendance: Attendance
+    reporter: object  # a reporter.CollectingReporter
 
-    def _answer(self, entry: RosterEntry) -> Answer | None:
-        return self.attendance.answer_for(entry)
+    @property
+    def roster(self) -> tuple[RosterEntry, ...]:
+        return tuple(roster_entry_for(n) for n in self.reporter.registered)
 
     @property
     def present(self) -> tuple[RosterEntry, ...]:
         return tuple(
-            e for e in self.roster
-            if (a := self._answer(e)) is not None and a.is_present
+            roster_entry_for(n)
+            for n in self.reporter.registered
+            if id(n) in self.reporter.present
         )
 
     @property
     def minority(self) -> tuple[RosterEntry, ...]:
-        """roster \\ attended -- entries with no present answer. The absent
-        never report themselves; the roster computes them by difference."""
+        """registered \\ present -- registered nodes that never discharged a
+        present answer. The absent never report themselves; the roster (the
+        registered set) computes them by difference."""
         return tuple(
-            e for e in self.roster
-            if (a := self._answer(e)) is None or not a.is_present
+            roster_entry_for(n)
+            for n in self.reporter.registered
+            if id(n) not in self.reporter.present
         )
 
     @property
@@ -206,23 +92,21 @@ class MinorityReport:
 
     @property
     def is_clean(self) -> bool:
-        """R == 0: there is no minority report -- every roster entry showed up."""
+        """R == 0: no minority -- every registered node showed up."""
         return self.R == 0
 
 
-def minority_report(
-    source_file, attendance: Attendance | None = None
-) -> MinorityReport:
-    """Build the report for a file. With no attendance (Phase 1 / moment zero)
-    the minority is the whole function roster -- total and honest, zero
-    reporters, zero construction."""
-    return MinorityReport(
-        roster=roster(source_file),
-        attendance=attendance if attendance is not None else EmptyAttendance(),
-    )
+def minority_report(source_file) -> MinorityReport:
+    """The report for a file, over its construction reporter. The file must have
+    been constructed with a ``CollectingReporter``; materializing the whole tree
+    registers every node (the roster). Before any desugar the minority is the
+    whole roster -- the honest 'accounted for nothing yet.'"""
+    for _ in source_file.nodes():  # materialize the tree -> register every node
+        pass
+    return MinorityReport(reporter=source_file.reporter)
 
 
 def total_R(reports: Iterable[MinorityReport]) -> int:
     """R across many files: the size of the whole minority. R == 0 iff there is
-    no minority report anywhere."""
+    no minority anywhere."""
     return sum(report.R for report in reports)

--- a/implementations/python/sugar-source-tree/tests/test_roll_call.py
+++ b/implementations/python/sugar-source-tree/tests/test_roll_call.py
@@ -1,133 +1,135 @@
-"""The roll call / minority report -- Phase 1, clean room.
+"""The minority report -- a view over the ONE roll-call interface.
 
-Every test here builds the report from source + a STUB attendance (a plain
-dict). No reporter, no ``sugar()``, no construction is stood up anywhere. That
-triviality IS the point: reporting is decoupled from constructs except by the
-``Attendance`` interface, so the accounting mechanism is testable in total
-isolation.
-
-ONE roster: every node, keyed by its fragment CID. "Functions construct clean"
-is a query over it, never a second roster.
+There is one interface: ``reporter.AuditReporter``, threaded through
+construction and collected by ``CollectingReporter``. The report reads it; there
+is no second interface. These tests fill a ``CollectingReporter`` (by
+construction, or by hand through the same interface) and assert the view.
 """
 
 import tempfile
 
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.reporter import CollectingReporter, NullReporter
 from sugar_source_tree.tree import SourceFile
 from sugar_source_tree.roll_call import (
-    Answer,
-    EmptyAttendance,
-    MappingAttendance,
     MinorityReport,
     minority_report,
-    roster,
+    roster_entry_for,
     total_R,
 )
 
 
-def _sf(src: str) -> SourceFile:
+def _sf(src: str, reporter) -> SourceFile:
     f = tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp")
     f.write(src)
     f.close()
-    return SourceFile(path_source(f.name))  # NO reporter -- the clean room
+    return SourceFile(path_source(f.name), reporter=reporter)
 
 
 _THREE = "def a(z):\n    return z\ndef b():\n    return 1\ndef c():\n    pass\n"
 
 
-def _fn_names(entries):
-    return [e.name for e in entries if e.kind in ("FunctionDef", "AsyncFunctionDef")]
-
-
-def test_roster_is_pure_source_enumeration_of_every_node() -> None:
-    # ONE roster: every node, keyed by CID. The functions are a query over it.
-    r = roster(_sf(_THREE))
-    assert len(r) > 3  # far more than three: every node, not just functions
-    assert _fn_names(r) == ["a", "b", "c"]
-    assert all(e.cid.startswith("blake3-512:") for e in r)
+def test_construction_registers_every_node_through_the_one_interface() -> None:
+    # The roster IS what construction registered: no separate enumeration, no
+    # second interface -- the reporter threaded through construction holds it.
+    r = CollectingReporter()
+    report = minority_report(_sf(_THREE, r))
+    assert len(report.roster) == len(r.registered)
+    assert len(report.roster) > 3  # every node, not just the three functions
 
 
 def test_moment_zero_minority_is_the_whole_roster() -> None:
-    # Nobody answered -> the minority is everyone: the honest "accounted for
-    # nothing yet," total and truthful before any reporter.
-    report = minority_report(_sf(_THREE))  # EmptyAttendance by default
-    assert isinstance(report.attendance, EmptyAttendance)
-    r = roster(_sf(_THREE))
-    assert report.R == len(r)
+    # Registered but nothing discharged yet -> the minority is everyone: the
+    # honest "accounted for nothing yet."
+    r = CollectingReporter()
+    report = minority_report(_sf(_THREE, r))
+    assert report.R == len(report.roster)
     assert not report.is_clean
     assert report.present == ()
 
 
-def test_threading_attendance_only_shrinks_the_minority() -> None:
-    sf = _sf(_THREE)
-    r = roster(sf)
-    att = MappingAttendance(
-        {r[0].cid: Answer.PRESENT_FACT, r[1].cid: Answer.PRESENT_INERT}
-    )
-    report = minority_report(sf, att)
-    # present-fact and present-inert both count as SHOWED UP.
-    assert set(report.present) == {r[0], r[1]}
-    # everyone else never answered -> absent, by difference.
-    assert report.R == len(r) - 2
-    assert r[0] not in report.minority and r[1] not in report.minority
-
-
-def test_present_inert_is_showing_up_not_absence() -> None:
-    sf = _sf(_THREE)
-    inert = MappingAttendance({e.cid: Answer.PRESENT_INERT for e in roster(sf)})
-    assert minority_report(sf, inert).R == 0
-
-
-def test_explicit_absent_answer_stays_in_the_minority() -> None:
-    # A loud ABSENT answer is still minority (Yellow) -- present is only
-    # fact/inert.
-    sf = _sf(_THREE)
-    r = roster(sf)
-    att = MappingAttendance({r[0].cid: Answer.ABSENT})
-    report = minority_report(sf, att)
-    assert r[0] in report.minority
-    assert report.R == len(r)
+def test_present_discharge_shrinks_the_minority() -> None:
+    # Answer present through the SAME interface construction uses; the minority
+    # shrinks by exactly those nodes.
+    r = CollectingReporter()
+    report = minority_report(_sf(_THREE, r))
+    a, b = r.registered[0], r.registered[1]
+    r.present_fact(a)
+    r.present_inert(b)  # present-inert also counts as showed up
+    present_cids = {e.cid for e in report.present}
+    assert present_cids == {roster_entry_for(a).cid, roster_entry_for(b).cid}
+    assert report.R == len(report.roster) - 2
 
 
 def test_R_zero_iff_no_minority() -> None:
-    sf = _sf(_THREE)
-    full = MappingAttendance({e.cid: Answer.PRESENT_FACT for e in roster(sf)})
-    report = minority_report(sf, full)
+    r = CollectingReporter()
+    report = minority_report(_sf(_THREE, r))
+    for node in list(r.registered):
+        r.present_fact(node)
     assert report.R == 0
     assert report.is_clean
 
 
-def test_roster_is_deterministic_and_content_addressed() -> None:
-    a = [e.cid for e in roster(_sf(_THREE))]
-    b = [e.cid for e in roster(_sf(_THREE))]
-    assert a == b
+def test_report_is_only_a_view_no_construction_needed() -> None:
+    # Fill a CollectingReporter BY HAND through the one interface -- no lift, no
+    # SourceFile. The report is a pure view over the collected roll.
+    class _FakeNode:
+        def __init__(self, cid):
+            self._cid = cid
+
+        @property
+        def fragment(self):
+            outer = self
+
+            class _Seal:
+                cid = outer._cid
+
+            class _Frag:
+                def seal(self_):
+                    return _Seal()
+
+            return _Frag()
+
+        def line_col_span(self):
+            class _LC:
+                start_line = 1
+                start_col = 0
+
+            return _LC()
+
+        kind = "Name"
+        name = "x"
+
+        class unit:
+            filename = "m.py"
+
+    r = CollectingReporter()
+    n1, n2 = _FakeNode("cid1"), _FakeNode("cid2")
+    r.register(n1)
+    r.register(n2)
+    r.present_fact(n1)
+    report = MinorityReport(reporter=r)
+    assert {e.cid for e in report.present} == {"cid1"}
+    assert {e.cid for e in report.minority} == {"cid2"}
+    assert report.R == 1
+
+
+def test_null_reporter_still_satisfies_construction() -> None:
+    # A NullReporter is a valid roll-call interface (no-op); construction with it
+    # is still complete -- the node is required to carry SOME interface.
+    sf = _sf(_THREE, NullReporter())
+    assert list(sf.nodes())  # constructs fine
 
 
 def test_total_R_sums_the_whole_minority() -> None:
-    reports = [minority_report(_sf(_THREE)), minority_report(_sf("x = 1\n"))]
-    assert total_R(reports) == len(roster(_sf(_THREE))) + len(roster(_sf("x = 1\n")))
-
-
-def test_report_depends_only_on_the_attendance_interface() -> None:
-    # A hand-rolled Attendance (anything with answer_for) works -- the report
-    # never reaches past the interface into construction.
-    sf = _sf(_THREE)
-    r = roster(sf)
-    first = r[0]
-
-    class OnlyFirst:
-        def answer_for(self, entry):
-            return Answer.PRESENT_FACT if entry.cid == first.cid else None
-
-    report = MinorityReport(roster=r, attendance=OnlyFirst())
-    assert report.present == (first,)
-    assert report.R == len(r) - 1
+    r1, r2 = CollectingReporter(), CollectingReporter()
+    reps = [minority_report(_sf(_THREE, r1)), minority_report(_sf("x = 1\n", r2))]
+    assert total_R(reps) == len(r1.registered) + len(r2.registered)
 
 
 def test_the_roster_covers_every_source_line() -> None:
-    # The totality law: every line of source is spanned by some roster node, so
-    # every line is accounted (present) or in the minority (absent) -- never a
-    # third, unpainted state. Coverage is a property of the roster, not a check.
+    # Totality: every source line is spanned by a registered node, so every line
+    # is accounted (present) or in the minority (absent) -- never unpainted.
     src = (
         "def a(z):\n"
         "    x = z + 1\n"
@@ -137,10 +139,12 @@ def test_the_roster_covers_every_source_line() -> None:
         "    with open('p'):\n"
         "        pass\n"
     )
-    sf = _sf(src)
+    r = CollectingReporter()
+    sf = _sf(src, r)
+    list(sf.nodes())
     code_lines = {i for i, ln in enumerate(src.splitlines(), 1) if ln.strip()}
     covered: set[int] = set()
-    for node in sf.nodes():
+    for node in r.registered:
         lc = node.line_col_span()
         covered |= set(range(lc.start_line, lc.end_line + 1))
-    assert not (code_lines - covered)  # zero unaccounted lines
+    assert not (code_lines - covered)


### PR DESCRIPTION
Collapse two interfaces into one. `AuditReporter` (register / present_fact / present_inert / report_gap) is THE roll call — carried by every node, required in the constructor, threaded through construction. Deleted the parallel `RollCall`/`RecordingRollCall`/`Attendance`/`MappingAttendance` from `roll_call.py` — they duplicated the interface construction already threads.

`roll_call.py` now defines **no interface** — only `RosterEntry` (data) and `MinorityReport`, a pure **view** over the `CollectingReporter`: roster = registered, present = discharged, minority = registered \ present. Testable by filling one reporter through the same interface, no second type. Tree suite 259.

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `Attendance` protocol with a single `CollectingReporter` interface for roll-call tracking
> - Removes the `Attendance` protocol and related helpers (`EmptyAttendance`, `MappingAttendance`) from [roll_call.py](https://github.com/TSavo/sugar/pull/6020/files#diff-cb5c5b83dfefe242a4d48f9a545ff4e5a51819ec9fbde4249736248a8c27b251); roll-call state is now held exclusively in a `CollectingReporter`.
> - `Node` construction in [nodes.py](https://github.com/TSavo/sugar/pull/6020/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now requires a `reporter` argument and auto-registers via `__post_init__`, so `materialize` in [backend.py](https://github.com/TSavo/sugar/pull/6020/files#diff-ad498e547096dff0cc0a35d78feaa867418d745ad78531faf3f78b5e835414b8) no longer calls `reporter.register` explicitly.
> - `MinorityReport` now derives `present` and `minority` sets from `CollectingReporter.registered` and discharge events rather than querying an `Attendance` object.
> - Risk: `reporter` is now a required field on `Node`; any construction site omitting it will break at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1db5e92.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->