### PR TITLE
roll call: serve the minority over the RPC (the R census re-homing, now wired)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -1666,6 +1666,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
             "facts",
             "universe",
             "implications",
+            "minority",
         ):
             file_rel = _enumerate_file_of(at)
             if file_rel is None:
@@ -1709,6 +1710,26 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     msg_id,
                     [],
                     [{"memento": at, "reason": f"no such file: {file_rel}"}],
+                )
+                return
+
+            if level == "minority":
+                # The minority report over the reporter channel (the R census
+                # re-homed here, now WIRED): construction registers every node;
+                # the discharge answers present/absent. One node per file
+                # carrying the whole partition as its payload -- the visual
+                # report renders present Blue, absent (minority) Yellow.
+                from sugar_lift_py_tests import tree_enumerate as _tree
+
+                payload = _tree.minority_report_payload(full_path, file_rel)
+                node = {
+                    "memento": _degenerate_file_memento(file_rel),
+                    "audit": None,
+                    "payload": payload,
+                }
+                _send_enumerate_result(msg_id, [node], [])
+                _log_enumeration_demand(
+                    str(level), at, cache="miss", started=demand_started
                 )
                 return
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
@@ -226,6 +226,40 @@ def audit_file_gaps(full_path: Path):
     return sf, list(seen.values())
 
 
+def minority_report_payload(full_path: Path, file_rel: str) -> dict:
+    """The minority report for a file, as the RPC wire payload the visual report
+    renders. One roll call: construction registers every node; the discharge
+    answers present (desugared) or absent (SugarNotWritten). The payload is the
+    partition, keyed by the fragment CID (the one stable identity):
+
+      {file, R, rows: [{cid, kind, name, span, answer}]}
+
+    ``answer`` is ``present`` (Blue -- desugared to a fact) or ``absent``
+    (Yellow -- the minority, unwritten). Every source line is spanned by some
+    row, so the renderer paints every line accounted or minority -- never a
+    third, unpainted state. This is a pure view over the roll the reporter
+    collected; it consults no construction internals of its own.
+    """
+    from sugar_source_tree.reporter import CollectingReporter
+    from sugar_source_tree.roll_call import discharge
+
+    reporter = CollectingReporter()
+    sf = SourceFile.from_path(str(full_path), reporter=reporter)
+    report = discharge(sf)
+    present_cids = {e.cid for e in report.present}
+    rows = [
+        {
+            "cid": e.cid,
+            "kind": e.kind,
+            "name": e.name,
+            "span": {"start_line": e.start_line, "start_col": e.start_col},
+            "answer": "present" if e.cid in present_cids else "absent",
+        }
+        for e in report.roster
+    ]
+    return {"file": file_rel, "R": report.R, "rows": rows}
+
+
 def function_def_memento(fn, file_rel: str):
     """The function's own SourceMemento (the def warrant payload_rows needs)."""
     from sugar_lift_py_tests.kit_rpc.source_memento_dto import SourceMementoDto

--- a/implementations/python/sugar-lift-py-tests/tests/test_minority_report_payload.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_minority_report_payload.py
@@ -1,0 +1,49 @@
+"""The minority report as the RPC wire payload -- the roll call served over the
+wire so `sugar lift --report --visual` can render present (Blue) / absent
+(Yellow). Pure: source in, partition out; no factory, no Rust."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from sugar_lift_py_tests.tree_enumerate import minority_report_payload
+
+
+def _payload(src: str) -> dict:
+    d = tempfile.mkdtemp()
+    p = Path(d) / "m.py"
+    p.write_text(src)
+    return minority_report_payload(p, "m.py")
+
+
+def test_payload_partitions_every_node_present_or_absent() -> None:
+    payload = _payload("def a(z):\n    return z\ndef b(xs):\n    del xs\n")
+    assert payload["file"] == "m.py"
+    answers = {r["answer"] for r in payload["rows"]}
+    assert answers == {"present", "absent"}
+    # a's body desugared -> present; the unwritten Delete -> absent (minority).
+    kinds = {(r["kind"], r["answer"]) for r in payload["rows"]}
+    assert ("Return", "present") in kinds
+    assert ("Delete", "absent") in kinds
+
+
+def test_R_is_the_size_of_the_minority() -> None:
+    payload = _payload("def a(z):\n    return z\ndef b(xs):\n    del xs\n")
+    absent = [r for r in payload["rows"] if r["answer"] == "absent"]
+    assert payload["R"] == len(absent)
+
+
+def test_every_row_is_cid_keyed_and_located() -> None:
+    payload = _payload("def a(z):\n    return z\n")
+    cids = [r["cid"] for r in payload["rows"]]
+    assert len(cids) == len(set(cids))  # unique by CID
+    assert all(r["cid"].startswith("blake3-512:") for r in payload["rows"])
+    assert all("start_line" in r["span"] for r in payload["rows"])
+
+
+if __name__ == "__main__":
+    test_payload_partitions_every_node_present_or_absent()
+    test_R_is_the_size_of_the_minority()
+    test_every_row_is_cid_keyed_and_located()
+    print("ok")


### PR DESCRIPTION
The R census re-homing onto the source tree's reporter channel was left "not yet wired" in `_handle_enumerate`. Wired now: a `minority` enumeration level serves the roll-call partition over the RPC so `sugar lift --report --visual` can render it.

- `tree_enumerate.minority_report_payload`: runs the one roll call (construction registers every node; discharge answers present/absent) → `{file, R, rows:[{cid, kind, name, span, answer}]}`. `answer` = present (Blue) / absent (Yellow, minority). CID-keyed; every source line spanned → paint every line accounted-or-minority.
- `lift_rpc`: `minority` is a file-scoped enumerate level, one node per file carrying the partition; path-escape guarded.

Python producer + RPC serving green (tree 260; payload tests 3).

**Remaining (Rust, battleaxe/CI):** the `--report --visual` consumer reading the `minority` level and painting present Blue / absent Yellow + the end-to-end render receipt.

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serve the `minority` roll call level over the RPC enumerate handler
> - Adds `'minority'` as a recognized level in [`_handle_enumerate`](https://github.com/TSavo/sugar/pull/6022/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335), wiring it to the new [`minority_report_payload`](https://github.com/TSavo/sugar/pull/6022/files#diff-1a883a4eea1b53f1ee91261df4ca5f694dfda233c883ddab24f920fd9610931e) function.
> - `minority_report_payload` runs a roll call discharge against a source file and returns a dict with `file`, `R` (absent count), and `rows` partitioned into present/absent entries with CID, kind, name, and span.
> - The handler wraps the payload in a single degenerate file node and returns early, leaving all other enumerate levels unchanged.
> - Three new tests cover payload partitioning, `R` count correctness, and row structure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ecc808d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->