### PR TITLE
fix the kit: self-bootstrap sibling src trees so the enumeration protocol spawns

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -18,6 +18,18 @@ from typing import Any, Dict, List, Literal, Optional
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+# Self-bootstrap the sibling package src trees onto sys.path. The kit imports
+# sugar_lift_python_source (source_tables, at load via source_fragment) and
+# sugar_source_tree (the tree lift / enumeration). When the lift-plugin resolver
+# spawns this as a bare `python3 lift_rpc.py --rpc` -- dropping the manifest's
+# PYTHONPATH -- those siblings are otherwise unreachable and initialize dies
+# before the handshake. Add them here so the kit is spawnable however invoked.
+_python_root = Path(__file__).resolve().parents[3]  # implementations/python
+for _sibling in ("sugar-lift-python-source", "sugar-source-tree"):
+    _src = _python_root / _sibling / "src"
+    if _src.is_dir() and str(_src) not in sys.path:
+        sys.path.insert(0, str(_src))
+
 from sugar_lift_py_tests.audit_only import AuditOnlyGap, gap_from_factory_panic
 from sugar_lift_py_tests.effect import SourceOracleEffect, effect_reason, effect_status
 from sugar_lift_py_tests.factory.factory_gap import FactoryPanic


### PR DESCRIPTION
`sugar lift --report --visual` died before the kit handshook: the lift-plugin resolver spawns the kit as a bare `python3 lift_rpc.py --rpc`, dropping the manifest's PYTHONPATH, so the kit couldn't import its siblings (`sugar_lift_python_source.source_tables` at load, `sugar_source_tree` for the tree lift). `lift_rpc.py` already self-bootstrapped its own package src; extended to add the sibling src trees.

**Verified end to end** (stripped env): initialize answers, and `sugar.enumerate level=facts auditFrontier=true` serves the minority — `status=failed, gaps=['Delete']` — the frontier over the enumeration protocol now actually reachable.

Full `--report --visual` render additionally needs the release binary rebuilt at HEAD (it correctly refuses `binary @34caec10f != kit @current`) — a cargo build on battleaxe/CI. Tree 260.

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bootstrap sibling `src` trees in `lift_rpc` so the enumeration protocol spawns
> [lift_rpc.py](https://github.com/TSavo/sugar/pull/6024/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) now mutates `sys.path` on import to include the `src` directories of sibling projects `sugar-lift-python-source` and `sugar-source-tree`, resolving them relative to the repository's `implementations/python` root. Paths are only prepended if they exist and are not already present, avoiding duplicates. This replaces the need for an external `PYTHONPATH` when running the enumeration protocol.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db09d09.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->