### PR TITLE
cut 1: lift_rpc gap/audit off factory onto the roll call (projection, by role)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -30,10 +30,7 @@ for _sibling in ("sugar-lift-python-source", "sugar-source-tree"):
     if _src.is_dir() and str(_src) not in sys.path:
         sys.path.insert(0, str(_src))
 
-from sugar_lift_py_tests.audit_only import AuditOnlyGap, gap_from_factory_panic
 from sugar_lift_py_tests.effect import SourceOracleEffect, effect_reason, effect_status
-from sugar_lift_py_tests.factory.factory_gap import FactoryPanic
-from sugar_lift_py_tests.factory.factory_gap_info import FactoryGapInfo
 from sugar_lift_py_tests.filename import cid_from_proof_stem
 from sugar_lift_py_tests.idd.lift_coverage_accounting import (
     account_lift_coverage,
@@ -43,14 +40,12 @@ from sugar_lift_py_tests.idd.lift_coverage_census import census_paths
 from sugar_lift_py_tests.kit_rpc import (
     EffectDto,
     LiftReportPayloadDto,
-    RecoveredAuditDto,
     RecoveredEffectDto,
-    RecoveredFactoryPanicDto,
     SuppressedAuditLocusDto,
 )
 from sugar_lift_py_tests.kit_rpc.rpc_value import to_rpc_value
-from sugar_lift_py_tests.factory.factory_audit_row import FactoryAuditStatus
 from sugar_lift_py_tests.source_provenance import kit_source_provenance
+from sugar_source_tree.panic import SourceTreePanic
 
 KIT_ID = "python"
 KIT_VERSION = "0.1.0"
@@ -1002,73 +997,6 @@ def _qualify_factory_walk_owner(rows, start: int, qualified_name: str) -> None:
         rows[index] = dataclasses.replace(row, source_memento=memento)
 
 
-def _factory_walk_red_from_gap(
-    gap: AuditOnlyGap,
-    *,
-    recovered_owner_span: tuple[int, int] | None = None,
-):
-    """Project a held FactoryPanic as a factory-walk red row.
-
-    status=unclassified serializes to unresolved/verdict=gap so
-    visual_factory_walk_rows takes the existing RED-with-grounds arm.
-    """
-    from sugar_lift_py_tests.canonicalizer import blake3_512_of
-    from sugar_lift_py_tests.kit_rpc.factory_walk_row_dto import (
-        FactoryWalkRedRowDto,
-        FactoryWalkStatus,
-    )
-    from sugar_lift_py_tests.kit_rpc.source_memento_dto import SourceMementoDto
-    from sugar_lift_py_tests.kit_rpc.source_span_dto import SourceSpanDto
-
-    audit = gap.audit_row
-    blame = str(audit.blame or gap.info.get("blame") or gap.label or "")
-    file, line, col = _parse_blame_locus(blame)
-    if not file:
-        # Fall back to the def label (filename:line:col) when blame is bare.
-        file, line, col = _parse_blame_locus(gap.label)
-    memento = SourceMementoDto(
-        file=file or "<unknown>",
-        span=SourceSpanDto(
-            start_line=line,
-            start_col=col,
-            end_line=line,
-            end_col=col,
-        ),
-        source_cid=blake3_512_of(b""),
-    )
-    reason = gap.message or audit.message or "factory gap"
-    extra = {
-        "candidates": list(audit.candidates),
-        "blame": blame,
-        "gap_kind": str(gap.info.get("gap_kind") or ""),
-        "gap_locus": str(gap.info.get("gap_locus") or ""),
-        # Recognition outcome already computed for this callee's gap, when
-        # the producer computes one (#5252/#5913 audit). Empty when the
-        # producer (e.g. conservation violations) has no callee to classify.
-        "resolution_kind": str(gap.info.get("resolution_kind") or ""),
-    }
-    if recovered_owner_span is not None:
-        extra.update(
-            {
-                "reportRecoveredPanic": True,
-                "recoveredOwnerStartLine": recovered_owner_span[0],
-                "recoveredOwnerEndLine": recovered_owner_span[1],
-            }
-        )
-    return FactoryWalkRedRowDto(
-        file=file or "<unknown>",
-        line=line,
-        requested_role=str(audit.role or gap.info.get("requested") or "statement"),
-        ast_kind=str(audit.observed or gap.info.get("observed") or "unknown"),
-        selected=audit.selected,
-        status=FactoryWalkStatus.UNCLASSIFIED,
-        output=str(audit.status or FactoryAuditStatus.SUGAR_GAP),
-        source_memento=memento,
-        reason=reason,
-        extra=extra,
-    )
-
-
 def _parse_blame_locus(site: str) -> tuple[str, int, int]:
     """Parse 'path:line:col' from the right (paths may contain colons)."""
     if not site:
@@ -1267,6 +1195,111 @@ def _send_enumerate_result(
     )
 
 
+def _roll_call_audit_leaf(full_path: Path, file_rel: str) -> dict:
+    """Project one construction roll call directly onto the legacy audit wire.
+
+    The old wire names remain compatibility spelling only. They are populated
+    at this serialization boundary from the one ``MinorityReport`` and its
+    reporter testimony; no factory gap or audit model is reconstructed.
+    """
+    from sugar_source_tree.reporter import CollectingReporter
+    from sugar_source_tree.roll_call import discharge
+    from sugar_source_tree.tree import SourceFile
+
+    reporter = CollectingReporter()
+    source_file = SourceFile.from_path(str(full_path), reporter=reporter)
+    report = discharge(source_file)
+    present_cids = {entry.cid for entry in report.present}
+    loci = [
+        {
+            "status": "warranted" if entry.cid in present_cids else "unresolved",
+            "kind": entry.kind,
+            "name": entry.name,
+            "source_cid": entry.cid,
+            "locus": {
+                "file": file_rel,
+                "line": entry.start_line,
+                "col": entry.start_col,
+            },
+        }
+        for entry in report.roster
+    ]
+    warranted = sum(row["status"] == "warranted" for row in loci)
+    source_audit = {
+        "role": file_rel,
+        "loci": loci,
+        "totals": {
+            "source_loci": len(loci),
+            "source_warranted": warranted,
+            "source_unresolved": report.R,
+        },
+    }
+
+    demanded_source = f"module:{source_file.unit.source_cid}"
+    panics = []
+    nodes_by_cid = {}
+    for node in reporter.registered:
+        nodes_by_cid.setdefault(node.fragment.seal().cid, node)
+    gaps_by_cid = {}
+    for node, panic in reporter.gaps:
+        cid = node.fragment.seal().cid
+        nodes_by_cid.setdefault(cid, node)
+        gaps_by_cid.setdefault(cid, panic)
+    absent_cids = [entry.cid for entry in report.minority]
+    absent_cids.extend(cid for cid in gaps_by_cid if cid not in absent_cids)
+    for cid in absent_cids:
+        node = nodes_by_cid[cid]
+        panic = gaps_by_cid.get(cid)
+        lc = node.line_col_span()
+        locus = f"{file_rel}:{lc.start_line}:{lc.start_col}"
+        terminal = (
+            f"{file_rel}:{lc.start_line}:{lc.start_col}-"
+            f"{lc.end_line}:{lc.end_col}[{node.kind}]"
+        )
+        panic_kind = (
+            type(panic).__name__
+            if panic is not None
+            else "UnaccountedConstruction"
+        )
+        reason = (
+            panic.observed or str(panic)
+            if panic is not None
+            else f"{node.kind} registered but never answered the roll call"
+        )
+        panics.append(
+            {
+                # Closed-envelope discriminators required by the current Rust
+                # reader. They construct no Python factory object and carry no
+                # role; the direct roll-call answer lives in `gap` below.
+                "kind": "FactoryPanic",
+                "status": "mandatory-panic",
+                "reason": reason,
+                "locus": locus,
+                "demandedSource": demanded_source,
+                "terminalGapLocus": terminal,
+                "gap": {
+                    "blame": terminal,
+                    "kind": panic_kind,
+                    "nodeKind": node.kind,
+                    "reason": reason,
+                },
+            }
+        )
+
+    # `kind` and `recoveryOverride` are closed-envelope discriminators required
+    # by the current Rust reader. No recovery policy is consulted here; every
+    # semantic value is projected from the roll call above.
+    return {
+        "kind": "recovered-construction-audit",
+        "recoveryOverride": True,
+        "status": "failed" if panics else "clean",
+        "panics": panics,
+        "effects": [],
+        "suppressedDescendants": [],
+        "sourceAudit": source_audit,
+    }
+
+
 def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
     """`sugar.enumerate`: the ONE wire method behind the Rust `tree` module's
     lazy accessors (Part 6 Phase 2,
@@ -1428,7 +1461,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     return
 
                 if level == "facts":
-                    leaf = _tree.frontier_leaf_rpc(full_path, file_rel)
+                    leaf = _roll_call_audit_leaf(full_path, file_rel)
                     _send_enumerate_result(
                         msg_id,
                         [{"memento": at, "audit": leaf, "payload": None}],
@@ -1841,6 +1874,11 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 },
             }
         )
+    except SourceTreePanic:
+        # Preserve the concrete tree taxonomy for the resident RPC boundary;
+        # VocabularyMissing, BackendDefect, SugarNotWritten, and its
+        # RuntimeSelected specialization are different repair roles.
+        raise
     except Exception as exc:
         _TRANSPORT_LOG.exception(
             "enumeration_request_failed",
@@ -1997,7 +2035,7 @@ def _serve() -> None:
         request_count += 1
         try:
             keep_serving = _dispatch_request(msg)
-        except FactoryPanic as panic:
+        except SourceTreePanic as panic:
             _send(
                 {
                     "jsonrpc": "2.0",
@@ -2008,7 +2046,12 @@ def _serve() -> None:
                         "data": {
                             "exception_type": type(panic).__name__,
                             "stage": "dispatch",
-                            "diagnostic": panic.info.to_json(),
+                            "diagnostic": {
+                                "owner": panic.owner,
+                                "observed": panic.observed,
+                                "requested": panic.requested,
+                                "fix": panic.fix,
+                            },
                         },
                     },
                 }

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
@@ -10,15 +10,12 @@ handler through the real JSON-RPC membrane end to end).
 from __future__ import annotations
 
 import json
-import os
-import tempfile
 from pathlib import Path
 
 import pytest
 
 from sugar_lift_py_tests import lift_rpc
 from sugar_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs
-from sugar_lift_py_tests.factory import factory_panic_gap
 from sugar_lift_py_tests.ir import _json_like_to_value
 
 FIXTURE_SOURCE = """\
@@ -41,8 +38,7 @@ def project(tmp_path: Path) -> Path:
 def _enumerate(
     level: str, workspace_root: Path, at=None, seek: bool = False, options=None
 ):
-    """Call `_handle_enumerate` directly and capture its `_send` output by
-    monkeypatching the module's `_send` for the duration of one call."""
+    """Dispatch a real ``sugar.enumerate`` request and capture its response."""
     options = dict(options or {})
     if options.get("auditFrontier") is True:
         options.setdefault("allowedBrokenComponents", ["python"])
@@ -50,14 +46,18 @@ def _enumerate(
     original_send = lift_rpc._send
     lift_rpc._send = captured.append
     try:
-        lift_rpc._handle_enumerate(
-            1,
+        lift_rpc._dispatch_request(
             {
-                "level": level,
-                "workspace_root": str(workspace_root),
-                "at": at,
-                "seek": seek,
-                "options": options,
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "sugar.enumerate",
+                "params": {
+                    "level": level,
+                    "workspace_root": str(workspace_root),
+                    "at": at,
+                    "seek": seek,
+                    "options": options,
+                },
             },
         )
     finally:
@@ -70,68 +70,6 @@ def _enumerate(
 
 
 
-
-
-def test_audit_context_is_parsed_once_per_file_cid_and_mutation_misses(
-    project: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    from sugar_lift_py_tests.factory.source_fragment import SourceFragment
-
-    sibling = project / "sibling.py"
-    sibling.write_text("def test_sibling():\n    assert 1 == 1\n", encoding="utf-8")
-    lift_rpc._AUDIT_FILE_CONTEXTS.clear()
-    original = SourceFragment.from_source.__func__
-    parsed: list[str] = []
-
-    def counted(cls, source: str, filename: str):
-        parsed.append(filename)
-        return original(cls, source, filename)
-
-    monkeypatch.setattr(SourceFragment, "from_source", classmethod(counted))
-
-    file_nodes = {
-        node["memento"]["file"]: node["memento"]
-        for node in _enumerate("source_files", project)["nodes"]
-    }
-    mathy_key = file_nodes["mathy.py"]
-    sibling_key = file_nodes["sibling.py"]
-    assert mathy_key["source_cid"]
-    assert sibling_key["source_cid"]
-
-    definitions = _enumerate(
-        "functions", project, at=mathy_key, options={"auditFrontier": True}
-    )["nodes"]
-    for definition in definitions:
-        _enumerate(
-            "facts",
-            project,
-            at=definition["memento"],
-            seek=True,
-            options={"auditFrontier": True},
-        )
-    assert parsed.count("mathy.py") == 1
-
-    _enumerate("functions", project, at=sibling_key, options={"auditFrontier": True})
-    assert parsed.count("sibling.py") == 1
-
-    (project / "mathy.py").write_text(
-        FIXTURE_SOURCE + "\ndef test_changed():\n    assert 2 == 2\n", encoding="utf-8"
-    )
-    changed_nodes = {
-        node["memento"]["file"]: node["memento"]
-        for node in _enumerate("source_files", project)["nodes"]
-    }
-    assert changed_nodes["mathy.py"]["source_cid"] != mathy_key["source_cid"]
-    _enumerate(
-        "functions",
-        project,
-        at=changed_nodes["mathy.py"],
-        options={"auditFrontier": True},
-    )
-    _enumerate("functions", project, at=sibling_key, options={"auditFrontier": True})
-
-    assert parsed.count("mathy.py") == 2, "new file CID must parse once"
-    assert parsed.count("sibling.py") == 1, "untouched sibling CID must stay warm"
 
 
 def test_enumeration_file_context_cache_is_bounded(
@@ -147,29 +85,224 @@ def test_enumeration_file_context_cache_is_bounded(
     assert list(cache) == ["second", "third"]
 
 
-def test_resident_factory_panic_evidence_drops_recovery_frames() -> None:
-    with pytest.raises(lift_rpc.FactoryPanic) as caught:
-        factory_panic_gap(
-            owner="traceback-cycle-fixture",
-            blame="fixture.py:1:0",
-            observed="missing",
-            requested="value",
-            fix="detach recovery frames before caching evidence",
-        )
-
-    assert caught.value.__traceback__ is not None
-    detached = lift_rpc._detached_factory_panic(caught.value)
-    assert detached.__traceback__ is None
-    assert detached.__context__ is None
-    assert detached.__cause__ is None
-
-
-
 def test_source_files_scan_finds_the_fixture_file(project: Path) -> None:
     result = _enumerate("source_files", project)
     assert result["gaps"] == []
     files = [n["memento"]["file"] for n in result["nodes"]]
     assert files == ["mathy.py"]
+
+
+def _audit_leaf(workspace: Path, file: str = "mathy.py") -> dict:
+    file_key = next(
+        node["memento"]
+        for node in _enumerate("source_files", workspace)["nodes"]
+        if node["memento"]["file"] == file
+    )
+    module = _enumerate(
+        "functions", workspace, at=file_key, options={"auditFrontier": True}
+    )["nodes"]
+    assert len(module) == 1
+    return _enumerate(
+        "facts",
+        workspace,
+        at=module[0]["memento"],
+        seek=True,
+        options={"auditFrontier": True},
+    )["nodes"][0]["audit"]
+
+
+def _script_roll_call(monkeypatch: pytest.MonkeyPatch, answer: str) -> None:
+    """Fill the real reporter interface with a controlled roll-call answer."""
+    from sugar_source_tree.panic import SugarNotWritten
+    from sugar_source_tree.roll_call import MinorityReport
+    import sugar_source_tree.roll_call as roll_call
+
+    def scripted_discharge(source_file):
+        list(source_file.nodes())
+        reporter = source_file.reporter
+        by_cid = {}
+        for node in reporter.registered:
+            by_cid.setdefault(node.fragment.seal().cid, node)
+        nodes = list(by_cid.values())
+        assert nodes
+        absent = nodes[-1]
+        present = nodes if answer in {"truthful", "lying"} else nodes[:-1]
+        for node in present:
+            reporter.present_fact(node)
+        if answer in {"lying", "minority"}:
+            reporter.report_gap(
+                absent,
+                SugarNotWritten(
+                    owner="rpc-roll-call-twin",
+                    observed=absent.kind,
+                    requested="written tree sugar",
+                    fix="write the node sugar",
+                ),
+            )
+        return MinorityReport(reporter)
+
+    monkeypatch.setattr(roll_call, "discharge", scripted_discharge)
+
+
+def test_rpc_roll_call_truthful_twin_projects_present_as_warranted(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _script_roll_call(monkeypatch, "truthful")
+    leaf = _audit_leaf(project)
+    assert leaf["status"] == "clean"
+    assert leaf["panics"] == []
+    assert leaf["sourceAudit"]["totals"]["source_unresolved"] == 0
+    assert {row["status"] for row in leaf["sourceAudit"]["loci"]} == {"warranted"}
+
+
+def test_rpc_roll_call_lying_twin_does_not_hide_gap_testimony(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _script_roll_call(monkeypatch, "lying")
+    leaf = _audit_leaf(project)
+    assert leaf["status"] == "failed"
+    assert len(leaf["panics"]) == 1
+    assert leaf["sourceAudit"]["totals"]["source_unresolved"] == 0
+
+
+def test_rpc_roll_call_minority_twin_projects_one_absent_everywhere(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Re-home #6025's seed-panic law: one absent owns one panic row."""
+    _script_roll_call(monkeypatch, "minority")
+    leaf = _audit_leaf(project)
+    unresolved = [
+        row for row in leaf["sourceAudit"]["loci"] if row["status"] == "unresolved"
+    ]
+    assert leaf["status"] == "failed"
+    assert len(leaf["panics"]) == 1
+    assert len(unresolved) == 1
+    assert leaf["sourceAudit"]["totals"]["source_unresolved"] == 1
+    assert leaf["panics"][0]["gap"]["kind"] == "SugarNotWritten"
+    assert leaf["panics"][0]["gap"]["nodeKind"] == unresolved[0]["kind"]
+
+
+def test_rpc_roll_call_silently_unaccounted_twin_stays_loud(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _script_roll_call(monkeypatch, "silent")
+    leaf = _audit_leaf(project)
+    assert leaf["status"] == "failed"
+    assert len(leaf["panics"]) == 1
+    assert leaf["panics"][0]["gap"]["kind"] == "UnaccountedConstruction"
+    assert leaf["sourceAudit"]["totals"]["source_unresolved"] == 1
+
+
+def test_roll_call_audit_uses_one_construction_and_one_discharge(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Re-home monolithic-fold and partial-demand laws onto one module roll."""
+    from sugar_source_tree.tree import SourceFile
+    import sugar_source_tree.roll_call as roll_call
+
+    calls = {"construction": 0, "discharge": 0}
+    original_from_path = SourceFile.from_path.__func__
+    original_discharge = roll_call.discharge
+
+    def counted_from_path(cls, *args, **kwargs):
+        calls["construction"] += 1
+        return original_from_path(cls, *args, **kwargs)
+
+    def counted_discharge(source_file):
+        calls["discharge"] += 1
+        return original_discharge(source_file)
+
+    monkeypatch.setattr(SourceFile, "from_path", classmethod(counted_from_path))
+    monkeypatch.setattr(roll_call, "discharge", counted_discharge)
+    leaf = _audit_leaf(project)
+
+    assert leaf["sourceAudit"]["totals"]["source_loci"] > 0
+    assert calls == {"construction": 1, "discharge": 1}
+
+
+def test_roll_call_law_same_bytes_at_distinct_seats_keep_distinct_loci(
+    tmp_path: Path,
+) -> None:
+    """Re-homed: source identity may match, but each RPC seat stays distinct."""
+    source = "def f():\n    return 1\n"
+    (tmp_path / "first.py").write_text(source, encoding="utf-8")
+    (tmp_path / "second.py").write_text(source, encoding="utf-8")
+
+    first = _audit_leaf(tmp_path, "first.py")["sourceAudit"]
+    second = _audit_leaf(tmp_path, "second.py")["sourceAudit"]
+    assert first["role"] == "first.py"
+    assert second["role"] == "second.py"
+    assert {row["source_cid"] for row in first["loci"]} == {
+        row["source_cid"] for row in second["loci"]
+    }
+    assert {row["locus"]["file"] for row in first["loci"]} == {"first.py"}
+    assert {row["locus"]["file"] for row in second["loci"]} == {"second.py"}
+
+
+def test_roll_call_law_empty_file_has_one_canonical_module_leaf(tmp_path: Path) -> None:
+    """Re-homed: the empty child-set fold is one module roll-call projection."""
+    (tmp_path / "empty.py").write_bytes(b"")
+    leaf = _audit_leaf(tmp_path, "empty.py")
+    assert leaf["sourceAudit"]["role"] == "empty.py"
+    assert leaf["sourceAudit"]["totals"]["source_loci"] >= 1
+
+
+@pytest.mark.parametrize(
+    "panic_type",
+    [
+        pytest.param("VocabularyMissing", id="missing-tree-vocabulary"),
+        pytest.param("BackendDefect", id="invalid-backend-shape"),
+        pytest.param("SugarNotWritten", id="known-construction-missing"),
+        pytest.param(
+            "RuntimeSelectedContextManager", id="runtime-selected-construction"
+        ),
+    ],
+)
+def test_rpc_entry_preserves_tree_panic_role(
+    panic_type: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Re-home the no-recovery law; preserve each panic at the RPC entry."""
+    import sugar_source_tree.panic as tree_panic
+
+    panic = getattr(tree_panic, panic_type)(
+        owner="rpc-role-map",
+        observed="fixture",
+        requested="role-correct answer",
+        fix="preserve the concrete tree taxonomy",
+    )
+    (tmp_path / "role.py").write_text("x = 1\n", encoding="utf-8")
+    request = {
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "sugar.enumerate",
+        "params": {
+            "level": "facts",
+            "workspace_root": str(tmp_path),
+            "at": {"file": "role.py"},
+            "seek": True,
+            "options": {"auditFrontier": True},
+        },
+    }
+    requests = iter([request])
+    sent = []
+    monkeypatch.setattr(lift_rpc, "_recv", lambda: next(requests, None))
+    monkeypatch.setattr(
+        "sugar_source_tree.tree.SourceFile.from_path",
+        classmethod(lambda _cls, *_args, **_kwargs: (_ for _ in ()).throw(panic)),
+    )
+    monkeypatch.setattr(lift_rpc, "_send", sent.append)
+
+    with pytest.raises(SystemExit):
+        lift_rpc._serve()
+
+    diagnostic = sent[0]["error"]["data"]
+    assert diagnostic["exception_type"] == panic_type
+    assert diagnostic["diagnostic"] == {
+        "owner": "rpc-role-map",
+        "observed": "fixture",
+        "requested": "role-correct answer",
+        "fix": "preserve the concrete tree taxonomy",
+    }
 
 
 def test_source_files_seek_matches_by_file(project: Path) -> None:


### PR DESCRIPTION
## What changed
- construct one `CollectingReporter`/`SourceFile` and discharge one roll call for the audit-frontier RPC leaf
- project sourceAudit, minority, gap rows, and visual status directly at the wire boundary; construct no factory gap/audit compatibility objects
- preserve concrete tree panic roles (`VocabularyMissing`, `BackendDefect`, `SugarNotWritten`, `RuntimeSelectedContextManager`) and keep silently unaccounted construction loud as `UnaccountedConstruction`
- re-home the six factory-dead enumerate laws onto roll-call/RPC-entry tests

## Delta-epsilon
- concept 1 gap importer files: R 25 -> 24 (Delta R = -1; Epsilon R after landing = -1)
- concept 2 audit-status importer files: R 13 -> 12 (Delta R = -1; Epsilon R after landing = -1)
- floor: `lift_rpc.py` references to `factory_gap`, `factory_gap_info`, `factory_audit_row`: 0
- floor: silently unaccounted construction remains failed/loud

## Role map
- known node without sugar -> `SugarNotWritten`
- legitimate backend shape missing from tree vocabulary -> `VocabularyMissing`
- structurally invalid backend/adapter output -> `BackendDefect`
- runtime-selected context-manager behavior -> `RuntimeSelectedContextManager`
- registered node with no answer and no gap testimony -> `UnaccountedConstruction` wire row (not falsely relabeled as SugarNotWritten)

## Validation
- `python3 -m pytest sugar-lift-py-tests/tests/test_enumerate_rpc.py -k "rpc_roll_call or roll_call_audit_uses_one or same_bytes_at_distinct or empty_file_has_one or rpc_entry_preserves_tree_panic_role" -q` -> 11 passed, 31 deselected
- `python3 -m pytest sugar-source-tree/tests/ -q` -> 260 passed, 5 skipped
- `python3 -m py_compile .../lift_rpc.py .../test_enumerate_rpc.py`
- `git diff --check`

Not merging in this PR.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace factory-based audit with roll call projection in `lift_rpc` facts enumeration
> - The `facts` branch in [lift_rpc.py](https://github.com/TSavo/sugar/pull/6027/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) now calls a new `_roll_call_audit_leaf` helper instead of `_tree.frontier_leaf_rpc`, deriving the source audit from `sugar_source_tree` roll call results (roster/present sets, per-locus warranted/unresolved totals, and panic envelopes for absent or gapped nodes).
> - Factory/audit imports (`AuditOnlyGap`, `FactoryPanic`, `FactoryGapInfo`, etc.) are replaced with a single `SourceTreePanic` import; `FactoryPanic` handling in the serve loop is replaced with `SourceTreePanic`, and the error payload now emits `owner/observed/requested/fix` fields directly from the exception.
> - Tests in [test_enumerate_rpc.py](https://github.com/TSavo/sugar/pull/6027/files#diff-579080ebef2db8fc5e34d0de0893b2759ef8f3b74aff0570a77e3227de57ef41) are rewritten to drive real JSON-RPC dispatch and cover roll call outcomes (`truthful`, `lying`, `minority`, `silent`) plus panic propagation and LRU cache bounds.
> - Behavioral Change: the `facts` enumeration response schema changes to a `recoveredConstructionAudit` with a closed-envelope panic format; clients consuming the old factory-based response shape will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f116fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->