### PR TITLE
cut 2: audit-status vocabulary off factory onto construction outcome (by role, not renamed enum)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/audit_only/audit_only_gap.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/audit_only/audit_only_gap.py
@@ -3,14 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from sugar_lift_py_tests.factory import FactoryAuditRow
-
-
 @dataclass(frozen=True)
 class AuditOnlyGap:
     label: str
     info: dict[str, str]
-    audit_row: FactoryAuditRow
     message: str
 
     def to_json(self) -> dict[str, Any]:
@@ -19,5 +15,4 @@ class AuditOnlyGap:
             "label": self.label,
             "message": self.message,
             "gap": dict(self.info),
-            "auditRow": self.audit_row.to_json(),
         }

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/audit_only/collect_construction_gaps.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/audit_only/collect_construction_gaps.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import re
 from typing import Callable, Iterable, TypeAlias, TypeVar
 
-from sugar_lift_py_tests.factory import FactoryAuditRow, GapKind
+from sugar_lift_py_tests.factory import GapKind
 from sugar_lift_py_tests.factory.factory_gap import FactoryPanic
-from sugar_lift_py_tests.factory.factory_gap_info import gap_kind_status
 
 from .audit_only_gap import AuditOnlyGap
 
@@ -56,24 +55,11 @@ def collect_factory_panic(
 
 
 def gap_from_factory_panic(label: str, panic: FactoryPanic) -> AuditOnlyGap:
-    """Structure the panic's FactoryGapInfo as an audit-only gap row."""
+    """Carry the panic's own construction testimony across the audit membrane."""
     info = panic.info.to_json()
-    audit_row = panic.audit_row
-    if audit_row is None:
-        status = gap_kind_status(panic.info.gap_kind)
-        audit_row = FactoryAuditRow(
-            role=info["requested"],
-            status=status,
-            observed=info["observed"],
-            blame=info["blame"],
-            selected=None,
-            candidates=[],
-            message=panic.info.message,
-        )
     return AuditOnlyGap(
         label=label,
         info=info,
-        audit_row=audit_row,
         message=panic.info.message,
     )
 
@@ -83,19 +69,9 @@ def _gap_from_loud_type_error(label: str, message: str) -> AuditOnlyGap | None:
     if gap_kind is None:
         return None
     info = _info_from_loud_message(label, message, gap_kind=gap_kind)
-    status = gap_kind_status(gap_kind)
     return AuditOnlyGap(
         label=label,
         info=info,
-        audit_row=FactoryAuditRow(
-            role=info["requested"],
-            status=status,
-            observed=info["observed"],
-            blame=info["blame"],
-            selected=None,
-            candidates=[],
-            message=message,
-        ),
         message=message,
     )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/array_literal.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/array_literal.py
@@ -11,7 +11,6 @@ from .string_value import StringValue
 from .symbolic_value import SymbolicValue
 from .term_value import TermValue
 from .tuple_literal_value import TupleLiteralValue
-from sugar_lift_py_tests.factory.factory_audit_row import FactoryAuditStatus
 
 
 @dataclass(frozen=True)
@@ -136,7 +135,6 @@ def _call_method_gap(
     fix: str,
 ):
     from sugar_lift_py_tests.factory import (
-        FactoryAuditRow,
         factory_panic,
         FactoryGapInfo,
         GapKind,
@@ -152,15 +150,4 @@ def _call_method_gap(
         gap_kind=GapKind.FLOOR,
         gap_locus=GapLocus.CONSTRUCTION,
     )
-    factory_panic(
-        info,
-        FactoryAuditRow(
-            role=requested,
-            status=FactoryAuditStatus.FLOOR_GAP,
-            observed=observed,
-            blame=blame,
-            selected=None,
-            candidates=[],
-            message=info.message,
-        ),
-    )
+    factory_panic(info)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -10,7 +10,6 @@ from sugar_lift_py_tests.sugar_body import SugarBody
 from sugar_lift_py_tests.recognition.native_shape import NativeShape
 
 from .floor_value import FloorValue
-from sugar_lift_py_tests.factory.factory_audit_row import FactoryAuditStatus
 
 _FORCE_FLOOR_BUDGET = 64
 _NESTED_DIG_DEMAND_BUDGET = 8
@@ -1214,7 +1213,6 @@ def _force_floor_gap(
     fix: str,
 ) -> NoReturn:
     from sugar_lift_py_tests.factory import (
-        FactoryAuditRow,
         factory_panic,
         FactoryGapInfo,
         GapKind,
@@ -1230,18 +1228,7 @@ def _force_floor_gap(
         gap_kind=GapKind.FLOOR,
         gap_locus=GapLocus.PROJECTION,
     )
-    factory_panic(
-        info,
-        FactoryAuditRow(
-            role="force_floor",
-            status=FactoryAuditStatus.FLOOR_GAP,
-            observed=observed,
-            blame=target_name,
-            selected=None,
-            candidates=[],
-            message=info.message,
-        ),
-    )
+    factory_panic(info)
 
 
 def _ctx_with_curried_args(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, NoReturn
 
 from .floor_dispatch_surface import FLOOR_OPERATION_METHOD_NAMES
-from sugar_lift_py_tests.factory.factory_audit_row import FactoryAuditStatus
 
 if TYPE_CHECKING:
     from sugar_lift_py_tests.context import FactoryBuildContext
@@ -115,7 +114,6 @@ class FloorValue:
         here, at the FactoryGapInfo boundary, and nowhere earlier.
         """
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -135,18 +133,7 @@ class FloorValue:
             ),
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role=requested,
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(blame),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     non_fol_support = False
 
@@ -181,7 +168,6 @@ class FloorValue:
         # rebinds through py.list_append). Absence here is the honest "no".
         del value
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -198,18 +184,7 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="append_with",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def mint_contribution(self, name, formals):
         # Default: a record entry mints no row of its own.
@@ -237,7 +212,6 @@ class FloorValue:
         # that CAN override: a return becomes a GuardedReturn, an inv becomes
         # an implication. Absence is the honest no.
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -255,18 +229,7 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="guarded",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=observed,
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def inv_contribution(self):
         # Default: a record entry states no inv. InvValue overrides.
@@ -501,7 +464,6 @@ class FloorValue:
         # condition. Values that CAN answer implement truth (concrete folds,
         # symbolic emits py.truthy); absence here is the honest "no".
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -518,25 +480,13 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="truth",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def length(self, site):
         # Default: this value does not stand on the length floor -- it cannot
         # answer len(...). Values that CAN implement length (concrete folds,
         # symbolic stays the call:len coordinate); absence here is the honest "no".
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -553,18 +503,7 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="length",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def subscript(self, index, site):
         # Default: this value does not stand on the subscript floor -- it cannot
@@ -573,7 +512,6 @@ class FloorValue:
         # here is the honest "no".
         del index
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -590,18 +528,7 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="subscript",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def attribute(self, name, site):
         # Default: this value does not stand on the attribute floor -- it cannot
@@ -610,7 +537,6 @@ class FloorValue:
         # the honest "no".
         del name
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -627,18 +553,7 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="attribute",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def contains(self, item, site):
         # Default: this value does not stand on the membership floor -- it cannot
@@ -646,7 +561,6 @@ class FloorValue:
         # coordinate; a concrete container folds; absence here is the honest "no".
         del item
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -663,23 +577,11 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="contains",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def setitem(self, index, value, site):
         del index, value
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -696,23 +598,11 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="setitem",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def delitem(self, index, site):
         del index
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -729,22 +619,10 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="delitem",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def absolute(self, site):
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -761,18 +639,7 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="absolute",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def py_subscript_coordinate(self, index, site):
         # The legacy symbolic spelling: ctor("py.subscript", [recv, index]).
@@ -815,7 +682,6 @@ class FloorValue:
         # The None arm: a value that CAN implements negate (the bool literals); absence
         # here is the honest "no". No blame arg -- mirror binary_conditional.
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -832,24 +698,12 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="negate",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=observed,
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def unary_minus(self, site):
         # Default: no arithmetic negation floor. TermValue folds; SymbolicValue
         # emits py.neg; absence is the honest "no".
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -866,23 +720,11 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="unary_minus",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def unary_plus(self, site):
         # Default: no unary-plus floor. TermValue / SymbolicValue implement.
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -899,24 +741,12 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="unary_plus",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def bitwise_invert(self, site):
         # Default: no bitwise-not floor. TermValue folds ints; SymbolicValue
         # emits py.invert; absence is the honest "no".
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -933,18 +763,7 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="bitwise_invert",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def equals(self, other, site):
         # Equality vocabulary is resolved here, once, from construction-time
@@ -1056,7 +875,6 @@ class FloorValue:
         # add and gives back the sum (or concat); absence here is the honest "no".
         del other
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -1073,18 +891,7 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="add",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def subtract(self, other, site):
         # Default: this value does not stand on the subtraction floor -- it cannot
@@ -1092,7 +899,6 @@ class FloorValue:
         # implements subtract and gives back a term; absence here is the honest "no".
         del other
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -1109,18 +915,7 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="subtract",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def multiply(self, other, site):
         # Default: this value does not stand on the multiplication floor -- it cannot
@@ -1128,7 +923,6 @@ class FloorValue:
         # implements multiply and gives back a product; absence here is the honest "no".
         del other
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -1145,18 +939,7 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="multiply",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def power(self, other, site):
         del other
@@ -1177,7 +960,6 @@ class FloorValue:
         # implements divide and gives back a quotient; absence here is the honest "no".
         del other
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -1194,18 +976,7 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="divide",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def modulo(self, other, site):
         # Default: this value does not stand on the modulo floor -- it cannot answer
@@ -1213,7 +984,6 @@ class FloorValue:
         # implements modulo and gives back a remainder; absence here is the honest "no".
         del other
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -1230,23 +1000,11 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="modulo",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def floor_divide(self, other, site):
         del other
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -1263,23 +1021,11 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="floor_divide",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def right_shift(self, other, site):
         del other
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             FactoryGapInfo,
             GapKind,
             GapLocus,
@@ -1296,18 +1042,7 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="right_shift",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(site),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def bitwise_and(self, other, site):
         return self._runtime_bitwise_gap(other, site, "bitwise_and", "and")
@@ -1349,7 +1084,6 @@ class FloorValue:
 
     def to_term(self, *, owner: str) -> "Term":
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             factory_panic,
             FactoryGapInfo,
             GapKind,
@@ -1366,22 +1100,10 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.PROJECTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role="to_term",
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=observed,
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def _operation_construction_gap(self, operation: Any, method_name: str) -> NoReturn:
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             factory_panic,
             FactoryGapInfo,
             GapKind,
@@ -1400,18 +1122,7 @@ class FloorValue:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role=method_name,
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(blame),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
     def test_python_type(self, value, site):
         """Only a ``python:type`` coordinate may dispatch a vendor type test."""

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, NoReturn
 from .floor_value import FloorValue
 from .object_field import ObjectField
 from .object_method_value import ObjectMethodValue
-from sugar_lift_py_tests.factory.factory_audit_row import FactoryAuditStatus
 
 if TYPE_CHECKING:
     from sugar_lift_py_tests.context import FactoryBuildContext
@@ -439,7 +438,6 @@ class ObjectValue(FloorValue):
         fix: str,
     ) -> NoReturn:
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             factory_panic,
             FactoryGapInfo,
             GapKind,
@@ -459,18 +457,7 @@ class ObjectValue(FloorValue):
             ),
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role=requested,
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=str(blame),
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
 
 
 _BINARY_DUNDER_METHODS = {

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -5,7 +5,6 @@ import math
 from typing import TYPE_CHECKING, NoReturn, cast
 
 from .floor_value import FloorValue
-from sugar_lift_py_tests.factory.factory_audit_row import FactoryAuditStatus
 
 if TYPE_CHECKING:
     from sugar_lift_py_tests.context import FactoryBuildContext
@@ -692,7 +691,6 @@ def _call_method_gap(
     fix: str,
 ) -> NoReturn:
     from sugar_lift_py_tests.factory import (
-        FactoryAuditRow,
         factory_panic,
         FactoryGapInfo,
         GapKind,
@@ -708,15 +706,4 @@ def _call_method_gap(
         gap_kind=GapKind.FLOOR,
         gap_locus=GapLocus.CONSTRUCTION,
     )
-    factory_panic(
-        info,
-        FactoryAuditRow(
-            role=requested,
-            status=FactoryAuditStatus.FLOOR_GAP,
-            observed=observed,
-            blame=blame,
-            selected=None,
-            candidates=[],
-            message=info.message,
-        ),
-    )
+    factory_panic(info)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import Any
 
 from .floor_value import FloorValue
-from sugar_lift_py_tests.factory.factory_audit_row import FactoryAuditStatus
 
 
 @dataclass(frozen=True)
@@ -641,7 +640,6 @@ def _call_method_gap(
     fix: str,
 ):
     from sugar_lift_py_tests.factory import (
-        FactoryAuditRow,
         factory_panic,
         FactoryGapInfo,
         GapKind,
@@ -657,15 +655,4 @@ def _call_method_gap(
         gap_kind=GapKind.FLOOR,
         gap_locus=GapLocus.CONSTRUCTION,
     )
-    factory_panic(
-        info,
-        FactoryAuditRow(
-            role=requested,
-            status=FactoryAuditStatus.FLOOR_GAP,
-            observed=observed,
-            blame=blame,
-            selected=None,
-            candidates=[],
-            message=info.message,
-        ),
-    )
+    factory_panic(info)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_literal_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_literal_value.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import Any
 
 from .floor_value import FloorValue
-from sugar_lift_py_tests.factory.factory_audit_row import FactoryAuditStatus
 
 
 @dataclass(frozen=True)
@@ -69,7 +68,6 @@ def _call_method_gap(
     fix: str,
 ):
     from sugar_lift_py_tests.factory import (
-        FactoryAuditRow,
         factory_panic,
         FactoryGapInfo,
         GapKind,
@@ -85,15 +83,4 @@ def _call_method_gap(
         gap_kind=GapKind.FLOOR,
         gap_locus=GapLocus.CONSTRUCTION,
     )
-    factory_panic(
-        info,
-        FactoryAuditRow(
-            role=requested,
-            status=FactoryAuditStatus.FLOOR_GAP,
-            observed=observed,
-            blame=blame,
-            selected=None,
-            candidates=[],
-            message=info.message,
-        ),
-    )
+    factory_panic(info)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/_errors.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/_errors.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
-from sugar_lift_py_tests.factory.factory_audit_row import FactoryAuditStatus
 
 from typing import NoReturn
 
 from sugar_lift_py_tests.factory import (
-    FactoryAuditRow,
     factory_panic,
     FactoryGapInfo,
     GapKind,
@@ -28,15 +26,4 @@ def proofir_construction_gap(
         gap_kind=GapKind.PROOFIR,
         gap_locus=GapLocus.CONSTRUCTION_LAW,
     )
-    factory_panic(
-        info,
-        FactoryAuditRow(
-            role="proofir-construction-law",
-            status=FactoryAuditStatus.PROOFIR_GAP,
-            observed=observed,
-            blame="proofir-construction-law",
-            selected=None,
-            candidates=[requested],
-            message=info.message,
-        ),
-    )
+    factory_panic(info)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/nodes/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/nodes/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from sugar_lift_py_tests.factory.factory_audit_row import FactoryAuditStatus
 
 import json
 from abc import ABC, abstractmethod
@@ -8,7 +7,6 @@ from typing import Any, Callable, ClassVar, Iterable, Literal, Mapping, NoReturn
 
 from sugar_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs
 from sugar_lift_py_tests.factory import (
-    FactoryAuditRow,
     factory_panic,
     FactoryGapInfo,
     GapKind,
@@ -305,18 +303,7 @@ def _proofir_gap(
         gap_kind=GapKind.PROOFIR,
         gap_locus=GapLocus.VOCABULARY,
     )
-    factory_panic(
-        info,
-        FactoryAuditRow(
-            role="proofir-vocabulary",
-            status=FactoryAuditStatus.PROOFIR_GAP,
-            observed=observed,
-            blame="proofir-vocabulary",
-            selected=None,
-            candidates=[],
-            message=info.message,
-        ),
-    )
+    factory_panic(info)
 
 
 from .equality_fact import (  # noqa: E402

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/perform_temporal_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/perform_temporal_operation.py
@@ -3,14 +3,12 @@ from __future__ import annotations
 from typing import Any
 
 from .temporal_context import TemporalContext
-from sugar_lift_py_tests.factory.factory_audit_row import FactoryAuditStatus
 
 _DECLARED_OPERATION_MODULE = "sugar_lift_py_tests.temporal."
 
 
 def _operation_method_name(*, owner: str, blame: str, operation: object) -> str:
     from sugar_lift_py_tests.factory import (
-        FactoryAuditRow,
         factory_panic,
         FactoryGapInfo,
         GapKind,
@@ -33,18 +31,7 @@ def _operation_method_name(*, owner: str, blame: str, operation: object) -> str:
         gap_kind=GapKind.OPERATION,
         gap_locus=GapLocus.METHOD_NAME,
     )
-    factory_panic(
-        info,
-        FactoryAuditRow(
-            role="method_name",
-            status=FactoryAuditStatus.OPERATION_GAP,
-            observed=operation_name,
-            blame=blame,
-            selected=None,
-            candidates=[],
-            message=info.message,
-        ),
-    )
+    factory_panic(info)
 
 
 def _is_declared_operation(operation: object) -> bool:
@@ -59,7 +46,6 @@ def _missing_temporal_floor_gap(
     method_name: str,
 ):
     from sugar_lift_py_tests.factory import (
-        FactoryAuditRow,
         factory_panic,
         FactoryGapInfo,
         GapKind,
@@ -79,18 +65,7 @@ def _missing_temporal_floor_gap(
         gap_kind=GapKind.FLOOR,
         gap_locus=GapLocus.CONSTRUCTION,
     )
-    factory_panic(
-        info,
-        FactoryAuditRow(
-            role=method_name,
-            status=FactoryAuditStatus.FLOOR_GAP,
-            observed=observed,
-            blame=blame,
-            selected=None,
-            candidates=[],
-            message=info.message,
-        ),
-    )
+    factory_panic(info)
 
 
 def perform_temporal_operation(
@@ -112,7 +87,6 @@ def perform_temporal_operation(
                 method_name=method_name,
             )
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             factory_panic,
             FactoryGapInfo,
             GapKind,
@@ -132,18 +106,7 @@ def perform_temporal_operation(
             gap_kind=GapKind.OPERATION,
             gap_locus=GapLocus.METHOD_NAME,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role=method_name,
-                status=FactoryAuditStatus.OPERATION_GAP,
-                observed=operation_name,
-                blame=blame,
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)
     recorder = None if ctx is None else ctx.record_operation
     if recorder is not None:
         recorder(owner=owner, method_name=method_name, operation=operation)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/temporal_context.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/temporal_context.py
@@ -9,7 +9,6 @@ from sugar_lift_py_tests.floor import FloorValue
 from sugar_lift_py_tests.outcome import Complete, Incomplete, Outcome
 
 from .temporal_binding import GuardedTemporalBinding, TemporalBinding
-from sugar_lift_py_tests.factory.factory_audit_row import FactoryAuditStatus
 
 
 @dataclass(frozen=True)
@@ -144,7 +143,6 @@ class TemporalContext:
         fix: str,
     ) -> NoReturn:
         from sugar_lift_py_tests.factory import (
-            FactoryAuditRow,
             factory_panic,
             FactoryGapInfo,
             GapKind,
@@ -160,15 +158,4 @@ class TemporalContext:
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
-        factory_panic(
-            info,
-            FactoryAuditRow(
-                role=requested,
-                status=FactoryAuditStatus.FLOOR_GAP,
-                observed=observed,
-                blame=blame,
-                selected=None,
-                candidates=[],
-                message=info.message,
-            ),
-        )
+        factory_panic(info)

--- a/implementations/python/sugar-lift-py-tests/tests/test_audit_status_construction_authority.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_audit_status_construction_authority.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_SEMANTIC_ROOTS = ("floor", "temporal", "proofir", "audit_only")
+_FACTORY_AUDIT_NAMES = ("FactoryAuditStatus", "FactoryAuditRow")
+
+
+def test_construction_semantics_do_not_import_or_reconstruct_factory_audit_objects():
+    """R_semantic_factory_audit_authority stays red until the clean slice is zero."""
+    package = Path(__file__).parents[1] / "src" / "sugar_lift_py_tests"
+    offenders: list[str] = []
+    for root_name in _SEMANTIC_ROOTS:
+        for path in sorted((package / root_name).rglob("*.py")):
+            source = path.read_text(encoding="utf-8")
+            for name in _FACTORY_AUDIT_NAMES:
+                if name in source:
+                    offenders.append(f"{path.relative_to(package)}: {name}")
+
+    assert not offenders, (
+        f"R_semantic_factory_audit_authority={len(offenders)}:\n"
+        + "\n".join(offenders)
+        + "\nreplacement=floor construction outcome or specific loud panic role"
+    )


### PR DESCRIPTION
## What changed

- Removed factory audit-status and audit-row authority from floor/value, temporal, ProofIR, and audit-only construction sites.
- Kept each floor/value gap loud through its existing construction panic and `FactoryGapInfo`; no replacement status enum was introduced.
- Made audit-only enumeration carry the panic construction testimony directly instead of reconstructing a `FactoryAuditRow`.
- Added a stable-zero semantic-authority instrument for the cleanly separable importer slice.

## Measured delta

- Raw Python source files referencing `FactoryAuditStatus` or `FactoryAuditRow`: 21 -> 8.
- Import declarations in production source: 16 -> 3.
- `R_semantic_factory_audit_authority`: 24 name occurrences -> 0 for floor, temporal, ProofIR, and audit-only modules.

Residual factory internals and the `SugarBody` build-result carrier remain loud because they are entangled with concept 1 gap provenance and concept 3 source provenance; this cut does not force those seams.

## Validation

- `python3 -m pytest --noconftest sugar-lift-py-tests/tests/test_audit_status_construction_authority.py sugar-lift-py-tests/tests/test_callsite_ground_residue.py sugar-lift-py-tests/tests/test_callsite_left_shift_floor.py sugar-lift-py-tests/tests/test_datetime_construction_floors.py sugar-lift-py-tests/tests/test_factory_panic_fronts.py sugar-lift-py-tests/tests/test_live_factory_panic_isolation.py -q` (25 passed)
- `python3 -m pytest sugar-lift-py-tests/tests/test_enumerate_rpc.py -k "roll_call or rpc_entry or truthful or lying or minority or silent or panic" -q` (11 passed, 31 deselected)
- `python3 -m pytest sugar-source-tree/tests/ -q` (260 passed, 5 skipped)

Do not merge from this worker.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `FactoryAuditRow` from construction gap panics across floor, temporal, proofir, and audit-only modules
> - Strips `FactoryAuditRow` and `FactoryAuditStatus` construction from all gap/panic call sites; `factory_panic` is now called with only `info` throughout.
> - Removes `audit_row` from the `AuditOnlyGap` dataclass and its JSON output, so `auditRow` no longer appears in construction gap responses.
> - Adds a test in [test_audit_status_construction_authority.py](https://github.com/TSavo/sugar/pull/6029/files#diff-3c91ae33ff31c1c2022eab42d7a9188ba4366f5d724ca9bd63e52a362eba4c51) that scans the affected packages and fails if `FactoryAuditRow` or `FactoryAuditStatus` are referenced, enforcing the new boundary.
> - Behavioral Change: any consumer reading `auditRow` from construction gap JSON will no longer find that field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19cc4d3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->