### PR TITLE
Observed-effect coordinates: EffectRef + route authentication

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
@@ -53,6 +53,14 @@ class EffectMatcher:
     payload_obligations: tuple = ()  # e.g. (MessagePattern(pat),)
 
 
+# Binding projections for `with … as name` — declared by the membrane, never
+# by matching vendor spellings in the tree. Syntax rewrites the name to an
+# ObservationRef(slot, projection=…); routing authenticates the slot.
+EXCEPTION_INFO = "exception_info"
+WARNING_OBSERVATION = "warning_observation"
+EFFECT = "effect"
+
+
 @dataclass(frozen=True)
 class NeverSuppresses:
     pass
@@ -66,6 +74,8 @@ class Suppresses:
 @dataclass(frozen=True)
 class Expects:
     matcher: EffectMatcher
+    # What `as name` denotes when this contract is issued (None → no as-export).
+    binding: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_auth.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_auth.py
@@ -1,0 +1,54 @@
+"""Route-time authentication of preallocated effect coordinates.
+
+Syntax (the tree) creates stable slots and rewrites names to EffectRef /
+ObservationRef before sugar. Routing later associates a matched Halted
+payload with a slot. This module holds that association for the duration of
+one function-body reduction — it is not a lexical name map and not a second
+construction door.
+
+  syntax creates the coordinate;
+  routing supplies its testimony.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator
+
+from sugar_lift_py_tests.effect import Effect, require_effect
+
+# Mutable map for the active reduction wave. Never a name→value scope.
+_AUTH: ContextVar[dict[str, Effect] | None] = ContextVar(
+    "effect_slot_auth", default=None
+)
+
+
+@contextmanager
+def effect_auth_wave() -> Iterator[dict[str, Effect]]:
+    """Open an empty authentication table for one function-body reduction."""
+    table: dict[str, Effect] = {}
+    token = _AUTH.set(table)
+    try:
+        yield table
+    finally:
+        _AUTH.reset(token)
+
+
+def authenticate_slot(slot_id: str, effect: Effect) -> None:
+    """Record that routing matched this slot to this effect payload."""
+    table = _AUTH.get()
+    if table is None:
+        raise RuntimeError(
+            "authenticate_slot outside effect_auth_wave: routing must only "
+            "authenticate coordinates during a function-body reduction"
+        )
+    table[slot_id] = require_effect(effect)
+
+
+def lookup_slot(slot_id: str) -> Effect | None:
+    """The authenticated effect for this slot, or None if still open."""
+    table = _AUTH.get()
+    if table is None:
+        return None
+    return table.get(slot_id)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -57,6 +57,7 @@ from .predicate_value import PredicateValue
 from .raise_value import RaiseValue
 from .raises_with_value import RaisesWithValue
 from .warning_observation_value import WarningObservationValue
+from .effect_coordinate import EffectCoordinate, ExceptionInfoCoordinate
 from .return_value import ReturnValue
 from .scope_rebind import GuardedScopeRebind, ScopeRebind
 from .sequence_constructor import SequenceConstructor
@@ -129,6 +130,8 @@ REGISTERED_FLOOR_TYPES: tuple[type[FloorDispatchSurface], ...] = (
     TupleLiteralValue,
     TupleValue,
     UniverseValue,
+    EffectCoordinate,
+    ExceptionInfoCoordinate,
 )
 
 for _floor_type in REGISTERED_FLOOR_TYPES:
@@ -190,6 +193,8 @@ __all__ = [
     "RaiseValue",
     "RaisesWithValue",
     "WarningObservationValue",
+    "EffectCoordinate",
+    "ExceptionInfoCoordinate",
     "ReturnValue",
     "ScopeRebind",
     "SequenceConstructor",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/effect_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/effect_coordinate.py
@@ -1,0 +1,76 @@
+"""Floor projection of a tree-native effect coordinate.
+
+Syntax creates EffectRef(slot). Routing authenticates the slot during desugar
+of the matching try/with arm. This value **seals** that testimony at desugar
+time (open → authenticated payload) so later post/inv projection does not
+depend on ambient auth tables after the reduction wave ends.
+
+Never a constructed E().
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.effect import Effect
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.effect.warning_effect import WarningEffect
+
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class EffectCoordinate(FloorValue):
+    """Coordinate from syntax; ``effect`` is sealed when routing authenticated it."""
+
+    slot_id: str
+    effect: Effect | None = None
+    site: object = dataclass_field(compare=False, default=None)
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        if self.effect is None:
+            return ctor("python:effect_slot", [str_const(self.slot_id)])
+        if isinstance(self.effect, RaiseEffect):
+            name = self.effect.exception_name or "unknown"
+            return ctor(
+                "python:observed_exception",
+                [str_const(name), str_const(self.slot_id)],
+            )
+        if isinstance(self.effect, WarningEffect):
+            return ctor(
+                "python:observed_warning",
+                [str_const(self.effect.category_name), str_const(self.slot_id)],
+            )
+        return ctor(
+            "python:observed_effect",
+            [str_const(type(self.effect).__name__), str_const(self.slot_id)],
+        )
+
+
+@dataclass(frozen=True)
+class ExceptionInfoCoordinate(FloorValue):
+    """Observation wrapper: ``.value`` projects the same sealed effect slot."""
+
+    slot_id: str
+    effect: Effect | None = None
+    site: object = dataclass_field(compare=False, default=None)
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor("python:exception_info", [str_const(self.slot_id)])
+
+    def attribute(self, name, site):
+        if name == "value":
+            from sugar_lift_py_tests.outcome import Complete
+
+            return Complete(
+                EffectCoordinate(
+                    slot_id=self.slot_id, effect=self.effect, site=site
+                )
+            )
+        return super().attribute(name, site)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/manifest_membrane.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/manifest_membrane.py
@@ -57,8 +57,28 @@ MANIFEST_CONTRACT_KINDS = frozenset(
     {"expects", "suppresses", "never-suppresses"}
 )
 
+def _expects_with_binding(matcher: EffectMatcher) -> Expects:
+    """Issue Expects with the membrane-declared as-binding projection.
+
+    raise → exception_info (pytest.raises as ei; ei.value is the effect slot)
+    warning → warning_observation
+    Tree never names pytest; it only sees the typed projection string.
+    """
+    from sugar_lift_py_tests.context_manager_contract import (
+        EXCEPTION_INFO,
+        WARNING_OBSERVATION,
+    )
+
+    binding = None
+    if matcher.kind == "raise":
+        binding = EXCEPTION_INFO
+    elif matcher.kind == "warning":
+        binding = WARNING_OBSERVATION
+    return Expects(matcher=matcher, binding=binding)
+
+
 _CONTRACT_BUILDERS = {
-    "expects": Expects,
+    "expects": _expects_with_binding,
     "suppresses": Suppresses,
 }
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/effect_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/effect_ref_sugar.py
@@ -1,0 +1,81 @@
+"""Sugar for tree-native EffectRef / ObservationRef coordinates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class EffectRefSugar(Sugar):
+    """Meaning of EffectRef(slot): a coordinate, open until routing authenticates."""
+
+    slot_id: str
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        # Coordinate sugars are testified by try/with twins, not a free pair.
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        from sugar_lift_py_tests.effect_auth import lookup_slot
+        from sugar_lift_py_tests.floor.effect_coordinate import EffectCoordinate
+
+        # Seal route-time testimony now — post/inv may run after the auth wave.
+        return Complete(
+            EffectCoordinate(
+                slot_id=self.slot_id,
+                effect=lookup_slot(self.slot_id),
+                site=self.site,
+            )
+        )
+
+
+@dataclass(frozen=True)
+class ObservationRefSugar(Sugar):
+    """Meaning of ObservationRef(slot, projection): contract-declared observation."""
+
+    slot_id: str
+    projection: str  # "exception_info" | "warning_observation" | "effect"
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        from sugar_lift_py_tests.effect_auth import lookup_slot
+        from sugar_lift_py_tests.effect.warning_effect import WarningEffect
+        from sugar_lift_py_tests.floor.effect_coordinate import (
+            EffectCoordinate,
+            ExceptionInfoCoordinate,
+        )
+        from sugar_lift_py_tests.floor.warning_observation_value import (
+            WarningObservationValue,
+        )
+
+        effect = lookup_slot(self.slot_id)
+        if self.projection == "exception_info":
+            return Complete(
+                ExceptionInfoCoordinate(
+                    slot_id=self.slot_id, effect=effect, site=self.site
+                )
+            )
+        if self.projection == "warning_observation":
+            if isinstance(effect, WarningEffect):
+                return Complete(WarningObservationValue(effect=effect))
+            return Complete(
+                EffectCoordinate(
+                    slot_id=self.slot_id, effect=effect, site=self.site
+                )
+            )
+        return Complete(
+            EffectCoordinate(
+                slot_id=self.slot_id, effect=effect, site=self.site
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -163,21 +163,17 @@ class FunctionUniverseSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        # No context. The body was already SUBSTITUTED (FunctionDef.sugar), so
-        # there is nothing temporal to thread: a formal reaches its NameSugar as
-        # a free name and becomes its own symbolic Var, a local assignment is
-        # inert (spent by substitute), a conditional binding is an IfExp phi. The
-        # block reduction consults no scope -- ctx.temporal is gone, and the
-        # `with`/nonlocal as-binding paths that once needed extend_scope are not
-        # lifted on the tree (they panic SugarNotWritten), so nothing calls it.
+        # No temporal name map. The body was already SUBSTITUTED
+        # (FunctionDef.sugar): formals stay free Vars, locals/phis are rewritten
+        # tree coordinates (including EffectRef / ObservationRef for as-bindings).
+        # effect_auth_wave holds route-time slot→effect testimony for those
+        # coordinates — not a second construction door.
         del ctx
+        from sugar_lift_py_tests.effect_auth import effect_auth_wave
 
-        # `.and_then` is the Complete/Incomplete distinction: a Complete body
-        # (a BlockValue record) becomes the universe; an Incomplete body (an
-        # effect) propagates untouched -- an effect is never wrapped into a
-        # false contract.
-        return reduce_body(self.statements).and_then(
-            lambda record: Complete(
-                UniverseValue(name=self.name, formals=self.formals, record=record)
+        with effect_auth_wave():
+            return reduce_body(self.statements).and_then(
+                lambda record: Complete(
+                    UniverseValue(name=self.name, formals=self.formals, record=record)
+                )
             )
-        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
@@ -1,22 +1,8 @@
-"""`try: body (except E: handler)+ [else] [finally]` -- structural effect routing.
+"""`try: body (except E [as e]: handler)+ [else] [finally]` -- effect routing.
 
-The structural sibling of ``with``-raises (#5994). ``WithContractSugar`` routes
-via a membrane-issued contract; this sugar routes via the ``except E`` clauses
-themselves -- native syntax, no vendor names. Matching reuses the ONE effect
-router's exact kind+name rule (``_matching_effect``): a subclass raise is the
-mismatch twin, never silently matched.
-
-Arms (T's ruling, restated as reduction):
-
-- A matching ``except E`` CONSUMES the body's ``Incomplete(RaiseEffect)`` and
-  reduces the handler body; the handler's own effects propagate.
-- A non-matching raise propagates past all handlers.
-- A body with no observed raise reduces ``else`` (when present).
-- ``finally`` always reduces and splices; its effects ride on every path.
-
-Typed tuples are flattened into ordered exact-match arms. A bare ``except:``
-uses the router's widest existing raise query and consumes whichever raise it
-finds. ``except*`` and structurally exotic types stay loud at the node.
+``except E as e`` is rewritten by the tree to ``EffectRef(slot)`` before sugar.
+This sugar matches the raise and authenticates the slot with the Halted
+payload — never re-desugars the handler with a name map, never E().
 """
 
 from __future__ import annotations
@@ -30,23 +16,16 @@ from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 @dataclass(frozen=True)
 class TrySugar(Sugar):
-    """`try` with typed except handlers, constructed by ``Try.sugar``.
+    """handlers: ((EffectMatcher|None, body_sugars, slot_id|None), ...)"""
 
-    ``handlers`` is an ordered tuple of ``(EffectMatcher | None, body_sugars)``.
-    ``None`` is the widest bare-except matcher; typed tuple clauses contribute
-    one arm per structurally admitted type.
-    """
-
-    body: tuple  # body statement sugars, source order
-    handlers: tuple  # ((EffectMatcher, handler_body_sugars), ...)
-    orelse: tuple = ()  # else-branch statement sugars
-    finalbody: tuple = ()  # finally statement sugars
+    body: tuple
+    handlers: tuple
+    orelse: tuple = ()
+    finalbody: tuple = ()
     site: object = dataclass_field(compare=False, default=None)
 
     @classmethod
     def witnesses(cls):
-        # Matching except consumes the raise so the function completes past the
-        # try; a lift that left the raise unconsumed would fail the post.
         prefix = (
             "def A(z):\n"
             "    try:\n"
@@ -63,6 +42,7 @@ class TrySugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.effect_auth import authenticate_slot
         from sugar_lift_py_tests.effect_router import (
             _first_effect_of_kind,
             _matching_effect,
@@ -76,11 +56,8 @@ class TrySugar(Sugar):
         body_entries, _body_falls, _ = reduce_statements(self.body)
         body_entries = tuple(body_entries)
 
-        # Route among handlers by the shared exact-match rule. First match wins
-        # (Python order); a match CONSUMES the Incomplete and splices the
-        # handler body's entries in its place.
         routed = None
-        for matcher, handler_body in self.handlers:
+        for matcher, handler_body, slot_id in self.handlers:
             matching = (
                 _first_effect_of_kind(body_entries, "raise")
                 if matcher is None
@@ -88,27 +65,24 @@ class TrySugar(Sugar):
             )
             if matching is None:
                 continue
-            index, _entry, _observation = matching
+            index, entry, _observation = matching
             remaining = body_entries[:index] + body_entries[index + 1 :]
+            # Syntax created the coordinate; routing supplies testimony.
+            if slot_id is not None and isinstance(entry, Incomplete):
+                authenticate_slot(slot_id, entry.effect)
             handler_entries, _hf, _ = reduce_statements(handler_body)
             routed = (*remaining, *handler_entries)
             break
 
         if routed is None:
-            # No handler matched. A body with no observed raise runs else; a
-            # non-matching raise propagates (kept in the entries).
             if _first_effect_of_kind(body_entries, "raise") is None:
                 else_entries, _ef, _ = reduce_statements(self.orelse)
                 routed = (*body_entries, *else_entries)
             else:
                 routed = body_entries
 
-        # finally runs on every path; its statements reduce and their effects
-        # propagate on all exits (caught, uncaught, else, fall-through).
         finally_entries, _ff, _ = reduce_statements(self.finalbody)
         entries = (*routed, *finally_entries)
 
-        # Mirror WithContractSugar: fall-through restored exactly when no red
-        # testimony survives the routing.
         can_fall_through = not any(isinstance(e, Incomplete) for e in entries)
         return Complete(BlockValue(entries, can_fall_through=can_fall_through))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_contract_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_contract_sugar.py
@@ -35,6 +35,8 @@ class WithContractSugar(Sugar):
     contract: object  # Expects | Suppresses (the node guards kind)
     body: tuple  # the body statements' sugars, in source order
     site: object = dataclass_field(compare=False, default=None)
+    # Preallocated by tree substitute for `as` (ObservationRef slot); None if no as.
+    slot_id: str | None = None
 
     @classmethod
     def witnesses(cls):
@@ -59,8 +61,26 @@ class WithContractSugar(Sugar):
         from sugar_lift_py_tests.floor.inv_value import InvValue
         from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_statements
 
+        from sugar_lift_py_tests.effect_auth import authenticate_slot
+        from sugar_lift_py_tests.effect_router import _matching_effect
+        from sugar_lift_py_tests.outcome import Incomplete
+
         entries, _falls, _ft = reduce_statements(self.body)
-        routed = route(tuple(entries), self.contract)
+        body_entries = tuple(entries)
+
+        # Authenticate the preallocated as-slot with the matched halt payload
+        # before/as we route (body already sugared with ObservationRef).
+        if self.slot_id is not None:
+            from sugar_lift_py_tests.context_manager_contract import Expects
+
+            if isinstance(self.contract, Expects):
+                matching = _matching_effect(body_entries, self.contract.matcher)
+                if matching is not None:
+                    _index, entry, _obs = matching
+                    if isinstance(entry, Incomplete):
+                        authenticate_slot(self.slot_id, entry.effect)
+
+        routed = route(body_entries, self.contract)
 
         # The router's facts carry no site; the mint demands one. Re-seat each
         # stated fact on this with's fragment (the locus that stated it).
@@ -70,7 +90,6 @@ class WithContractSugar(Sugar):
             else e
             for e in routed.entries
         )
-        from sugar_lift_py_tests.outcome import Incomplete
 
         # A consumed halt completes the with: fall-through is restored exactly
         # when no red testimony survives the routing.

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -349,9 +349,7 @@ class Node(Typed):
 
     def _make_call(self, func: "Node", args: tuple = ()) -> "Node":
         """Construct a fresh Call ``<func>(<args...>)`` as a shadow borrowing
-        this node's span. Used by Expects ``as``-witness binding: the matched
-        effect payload is the expected type/category constructed with no args
-        (a temporal stand-in for the exception/warning instance)."""
+        this node's span."""
         from .backend import Child, Children, materialize
         from .shadow import ShadowNode, _handle_of
 
@@ -362,6 +360,42 @@ class Node(Typed):
         )
         return materialize(
             self.unit, ShadowNode("Call", self.span, slots), self.reporter
+        )
+
+    def _effect_slot_id(self) -> str:
+        """Stable slot identity from this binding site's source extent."""
+        try:
+            lc = self.line_col_span()
+            return (
+                f"{self.unit.filename}:{lc.start_line}:{lc.start_col}:"
+                f"{lc.end_line}:{lc.end_col}"
+            )
+        except SourceTreePanic:
+            return f"{self.unit.filename}:{self.kind}:{id(self)}"
+
+    def _make_effect_ref(self, slot_id: str) -> "Node":
+        """Synthesize EffectRef(slot) — tree coordinate, not a floor object."""
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        slots = (("slot_id", Leaf(slot_id)),)
+        return materialize(
+            self.unit, ShadowNode("EffectRef", self.span, slots), self.reporter
+        )
+
+    def _make_observation_ref(self, slot_id: str, projection: str) -> "Node":
+        """Synthesize ObservationRef(slot, projection) for with-as bindings."""
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        slots = (
+            ("slot_id", Leaf(slot_id)),
+            ("projection", Leaf(projection)),
+        )
+        return materialize(
+            self.unit,
+            ShadowNode("ObservationRef", self.span, slots),
+            self.reporter,
         )
 
     def _substitute_body(self, statements: tuple, scope: "dict[str, Node]"):
@@ -661,16 +695,25 @@ class ExceptHandler(Node):
     _child_fields = ("type_", "body")
 
     def substitute(self, scope):
-        """except <type> as <name>: binds the exception name for the body."""
+        """except <type> as <name>: rewrite name → EffectRef(slot) in the body.
+
+        Syntax creates the coordinate; routing authenticates it. The name is
+        NOT exported after the handler (Python clears the exception target).
+        Never E() — EffectRef is not an exception object.
+        """
         from .shadow import rewrite
 
-        bound = {self.name} if self.name else set()
-        bs = {k: v for k, v in scope.items() if k not in bound} if bound else scope
         changed = {}
         new_type, d = self._substitute_field(self.type_, scope)
         if d:
             changed["type_"] = new_type
-        new_body, d = self._substitute_body(self.body, bs)
+        if self.name:
+            slot_id = self._effect_slot_id()
+            ref = self._make_effect_ref(slot_id)
+            body_scope = {**scope, self.name: ref}
+        else:
+            body_scope = scope
+        new_body, d = self._substitute_body(self.body, body_scope)
         if d:
             changed["body"] = new_body
         return self if not changed else rewrite(self, **changed)
@@ -1695,13 +1738,13 @@ class With(Statement):
         if len(self.items) != 1:
             return super()._construct_sugar()
         item = self.items[0]
+        as_name = None
         if item.optional_vars is not None:
-            # ``as <name>`` stays LOUD: the honest binding is the ROUTED
-            # observed-effect witness (the payload of the Halted exit the
-            # router matches), NOT a manufactured ``E()``. That witness is
-            # produced at route time, so it needs the shared exit-set witness
-            # mechanism -- unwritten here until it lands.
-            return super()._construct_sugar()
+            # ``as <Name>`` only: substitute already rewrote loads to
+            # ObservationRef(slot). Non-Name targets stay loud.
+            if item.optional_vars.kind != "Name":
+                return super()._construct_sugar()
+            as_name = item.optional_vars.id
         from sugar_lift_py_tests.context_manager_contract import (
             Expects,
             RuntimeSelected,
@@ -1719,10 +1762,17 @@ class With(Statement):
         if isinstance(contract, (Expects, Suppresses)):
             if contract.matcher.kind not in ("raise", "warning"):
                 return super()._construct_sugar()
+            # Suppresses+as is not a routed observation surface — stay loud.
+            if as_name is not None and not isinstance(contract, Expects):
+                return super()._construct_sugar()
+            slot_id = None
+            if as_name is not None and isinstance(contract, Expects):
+                slot_id = item._effect_slot_id()
             return WithContractSugar(
                 contract=contract,
                 body=tuple(stmt.sugar() for stmt in self.body),
                 site=self.fragment,
+                slot_id=slot_id,
             )
         # None from the membrane OR an explicit RuntimeSelected enrollment:
         # exit suppression is undecidable statically. Named residual — not a
@@ -1757,28 +1807,72 @@ class With(Statement):
         return super()._construct_sugar()
 
     def substitute(self, scope):
-        """with ... as <vars>: masks as-targets for the body (binding sites).
+        """with ... as <Name>: rewrite name → ObservationRef(slot, projection).
 
-        No witness is EXPORTED for the tail: the honest ``as`` binding is the
-        routed observed-effect witness produced at route time (the payload of
-        the matched Halted exit), not a substitute-time stand-in -- so `as`
-        stays loud in sugar() until the shared exit-set witness lands.
+        Projection comes from the membrane-issued Expects.binding. Syntax
+        creates the coordinate; routing authenticates the slot. Body sees the
+        ref; substitution_binding exports it for subsequent statements.
         """
         from .shadow import rewrite
+        from sugar_lift_py_tests.context_manager_contract import Expects
+        from sugar_lift_py_tests.manifest_membrane import (
+            contract_for_manager,
+            default_community_manifest,
+        )
 
-        bound = set()
-        for item in self.items:
-            if item.optional_vars is not None:
-                bound |= self._bound_names_in(item.optional_vars)
-        bs = {k: v for k, v in scope.items() if k not in bound} if bound else scope
         changed = {}
         new_items, d = self._substitute_field(self.items, scope)
         if d:
             changed["items"] = new_items
-        new_body, d = self._substitute_body(self.body, bs)
+        items = new_items if d else self.items
+
+        body_scope = dict(scope)
+        for item in items:
+            if item.optional_vars is None or item.optional_vars.kind != "Name":
+                # Non-Name as-targets: mask only (no coordinate invented).
+                if item.optional_vars is not None:
+                    for n in self._bound_names_in(item.optional_vars):
+                        body_scope.pop(n, None)
+                continue
+            contract = contract_for_manager(
+                default_community_manifest(), item.context_expr
+            )
+            if not isinstance(contract, Expects) or not contract.binding:
+                # Unauthenticated / suppresses: mask the name, stay without ref.
+                body_scope.pop(item.optional_vars.id, None)
+                continue
+            slot_id = item._effect_slot_id()
+            ref = item._make_observation_ref(slot_id, contract.binding)
+            body_scope[item.optional_vars.id] = ref
+
+        new_body, d = self._substitute_body(self.body, body_scope)
         if d:
             changed["body"] = new_body
         return self if not changed else rewrite(self, **changed)
+
+    def substitution_binding(self, scope):
+        """Export ObservationRef for Expects as-names to the rest of the block."""
+        from sugar_lift_py_tests.context_manager_contract import Expects
+        from sugar_lift_py_tests.manifest_membrane import (
+            contract_for_manager,
+            default_community_manifest,
+        )
+
+        del scope
+        exported: dict[str, Node] = {}
+        for item in self.items:
+            if item.optional_vars is None or item.optional_vars.kind != "Name":
+                continue
+            contract = contract_for_manager(
+                default_community_manifest(), item.context_expr
+            )
+            if not isinstance(contract, Expects) or not contract.binding:
+                continue
+            slot_id = item._effect_slot_id()
+            exported[item.optional_vars.id] = item._make_observation_ref(
+                slot_id, contract.binding
+            )
+        return exported or None
 
 
 class AsyncWith(Statement):
@@ -1888,25 +1982,21 @@ class Try(Statement):
         expressions and empty tuples stay loud. ``except*`` lives on TryStar
         and stays loud there.
 
-        ``except <type> as <name>`` stays LOUD: the honest binding is the
-        ROUTED observed-effect witness (the exception the router matched and
-        consumed), NOT a manufactured ``<type>()`` -- constructing the type
-        invents a constructor call that never ran and conflates the caught
-        object with the type. That witness is produced at route time, not at
-        substitute time, so it needs the shared observed-effect-witness
-        mechanism (a marker the router fills), unwritten here until it lands."""
+        ``except <type> as <name>``: substitute already rewrote loads of
+        ``name`` to ``EffectRef(slot)`` inside the handler. Routing
+        authenticates that slot with the matched Halted raise — never E().
+        """
         if not self.handlers:
             return super()._construct_sugar()  # try/finally-only: not the except-routing core
         from sugar_lift_py_tests.context_manager_contract import EffectMatcher
 
         handler_specs = []
         for handler in self.handlers:
-            if handler.name is not None:
-                return super()._construct_sugar()  # except-as: needs the routed witness, loud
+            # slot_id for authentication when this arm has `as` (substitute site).
+            slot_id = handler._effect_slot_id() if handler.name else None
+            body_sugars = tuple(stmt.sugar() for stmt in handler.body)
             if handler.type_ is None:
-                handler_specs.append(
-                    (None, tuple(stmt.sugar() for stmt in handler.body))
-                )
+                handler_specs.append((None, body_sugars, slot_id))
                 continue
 
             type_nodes = (
@@ -1921,7 +2011,8 @@ class Try(Statement):
                 handler_specs.append(
                     (
                         EffectMatcher(kind="raise", name=type_name),
-                        tuple(stmt.sugar() for stmt in handler.body),
+                        body_sugars,
+                        slot_id,
                     )
                 )
 
@@ -3023,6 +3114,52 @@ class Name(Expression):
         from sugar_lift_py_tests.sugar.name_sugar import NameSugar
 
         return NameSugar(name=self.id, site=self.fragment)
+
+
+class EffectRef(Expression):
+    """Preallocated effect coordinate: syntax creates it; routing authenticates.
+
+    Not an exception object and not a floor witness. ``except E as e`` rewrites
+    ``e`` to ``EffectRef(slot)`` in the handler only. Routing later associates
+    the matched Halted raise payload with that slot — never E().
+    """
+
+    slot_id: str
+
+    def substitute(self, scope: "dict[str, Node]") -> "Node":
+        # Already a coordinate — never re-captured as a free name.
+        del scope
+        return self
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.effect_ref_sugar import EffectRefSugar
+
+        return EffectRefSugar(slot_id=self.slot_id, site=self.fragment)
+
+
+class ObservationRef(Expression):
+    """Contract-declared observation of an effect slot (e.g. ExceptionInfo).
+
+    ``with Expects(...) as ei`` rewrites ``ei`` to ``ObservationRef(slot,
+    projection)``. ``.value`` projects the same slot as EffectRef. Projection
+    comes from the membrane contract, not from vendor names in the tree.
+    """
+
+    slot_id: str
+    projection: str  # exception_info | warning_observation | effect
+
+    def substitute(self, scope: "dict[str, Node]") -> "Node":
+        del scope
+        return self
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.effect_ref_sugar import ObservationRefSugar
+
+        return ObservationRefSugar(
+            slot_id=self.slot_id,
+            projection=self.projection,
+            site=self.fragment,
+        )
 
 
 class List(Expression):

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -169,31 +169,45 @@ def test_finally_reduces_on_uncaught_path():
     assert "RuntimeError" in names  # finally reduced and spliced
 
 
-def test_except_as_stays_loud_until_the_routed_witness_exists():
-    # ``except E as name`` must bind the ROUTED observed-effect witness (the
-    # payload of the matched Halted exit), never a manufactured ``E()``. That
-    # witness is produced at route time, so the honest state is LOUD until the
-    # shared exit-set witness mechanism lands -- never a fabricated binding.
-    with pytest.raises(SugarNotWritten):
-        _fn(
-            "def A():\n"
-            "    try:\n"
-            "        raise ValueError\n"
-            "    except ValueError as error:\n"
-            "        return error\n"
-        ).sugar()
+def test_except_as_binds_matching_raise_witness_in_handler():
+    # Tree rewrites `error` → EffectRef(slot); routing authenticates the slot
+    # with the matched Halted raise. Identity is the payload — never E().
+    from sugar_lift_py_tests.floor.effect_coordinate import EffectCoordinate
+    from sugar_lift_py_tests.ir import ctor
+
+    v = _val(
+        "def A():\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError as error:\n"
+        "        return error\n"
+    )
+    assert _incompletes(v) == []
+    # post is out == observed exception identity for the authenticated slot
+    post = v.post()
+    assert post.args[0].name == "out"
+    term = post.args[1]
+    assert term.name == "python:observed_exception"
+    assert term.args[0].value == "ValueError"
 
 
-def test_except_as_stays_loud_even_when_uncaught():
-    with pytest.raises(SugarNotWritten):
-        _fn(
-            "def A():\n"
-            "    try:\n"
-            "        raise ValueError\n"
-            "    except KeyError as error:\n"
-            "        return error\n"
-            "    return 0\n"
-        ).sugar()
+def test_except_as_does_not_bind_on_uncaught_path():
+    # Wrong-type handler is unreachable; its EffectRef is never authenticated.
+    # Body raise propagates (mismatch twin).
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    v = _val(
+        "def A():\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except KeyError as error:\n"
+        "        return error\n"
+        "    return 0\n"
+    )
+    reds = _incompletes(v)
+    assert len(reds) == 1
+    assert isinstance(reds[0].effect, RaiseEffect)
+    assert reds[0].effect.exception_name == "ValueError"
 
 
 def test_tuple_except_catches_any_exactly_listed_type():
@@ -226,17 +240,18 @@ def test_tuple_except_does_not_catch_unlisted_type():
     assert reds[0].effect.exception_name == "ValueError"
 
 
-def test_tuple_except_as_stays_loud():
-    # A tuple handler with ``as`` is loud for the same reason: the witness is
-    # the routed exception payload, not a constructed type.
-    with pytest.raises(SugarNotWritten):
-        _fn(
-            "def A():\n"
-            "    try:\n"
-            "        raise ValueError\n"
-            "    except (KeyError, ValueError) as error:\n"
-            "        return error\n"
-        ).sugar()
+def test_tuple_except_as_binds_the_matched_type_witness():
+    v = _val(
+        "def A():\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except (KeyError, ValueError) as error:\n"
+        "        return error\n"
+    )
+    assert _incompletes(v) == []
+    term = v.post().args[1]
+    assert term.name == "python:observed_exception"
+    assert term.args[0].value == "ValueError"
 
 
 def test_bare_except_catches_arbitrary_raise():

--- a/implementations/python/sugar-source-tree/tests/test_with_contract.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_contract.py
@@ -97,26 +97,29 @@ def test_unauthenticated_manager_stays_loud():
     )
 
 
-def test_as_witness_stays_loud_until_the_routed_witness_exists():
-    # ``with raises(E) as ei`` must bind an ExceptionInfo observation whose
-    # ``.value`` projects the ROUTED exception witness -- never a manufactured
-    # ``E()``. That witness is produced at route time (the payload of the
-    # matched Halted exit), so ``as`` is honestly LOUD until the shared
-    # exit-set witness mechanism lands. A fabricated ``ei = ValueError()`` is
-    # the cardinal sin (a constructor call that never ran).
-    with pytest.raises(SugarNotWritten):
-        _fn(
-            "def A(z):\n    with pytest.raises(ValueError) as ei:\n"
-            "        raise ValueError\n    return z\n"
-        ).sugar()
+def test_as_exception_info_completes_when_effect_matches():
+    # Tree rewrites `ei` → ObservationRef(slot, exception_info); routing
+    # authenticates the slot. Body completes past the with (return z).
+    v = _val(
+        "def A(z):\n    with pytest.raises(ValueError) as ei:\n"
+        "        raise ValueError\n    return z\n"
+    )
+    inv = v.invs()[0]
+    assert inv.name == "="
+    assert inv.args[0].value == inv.args[1].value == "ValueError"
+    assert v.post().args[1].name == "z"
 
 
-def test_as_witness_loud_even_when_referenced_in_tail():
-    with pytest.raises(SugarNotWritten):
-        _fn(
-            "def A():\n    with pytest.raises(ValueError) as ei:\n"
-            "        raise ValueError\n    return ei\n"
-        ).sugar()
+def test_as_exception_info_value_projects_effect_slot():
+    # ei.value is the same effect slot (ExceptionInfoCoordinate.attribute).
+    v = _val(
+        "def A():\n    with pytest.raises(ValueError) as ei:\n"
+        "        raise ValueError\n    return ei.value\n"
+    )
+    assert v.invs()[0].args[0].value == "ValueError"
+    term = v.post().args[1]
+    assert term.name == "python:observed_exception"
+    assert term.args[0].value == "ValueError"
 
 
 def test_as_non_name_target_stays_loud():


### PR DESCRIPTION
## Summary

Implements the **observed-effect witness** cut with the architecture you ruled:

> Syntax creates the coordinate; routing supplies its testimony.

**Not** the discarded approach (route → name map → re-desugar / reducer scope).

### Tree
- \`EffectRef(slot_id)\` / \`ObservationRef(slot_id, projection)\` synthetic expressions
- \`except E as e\`: substitute rewrites loads of \`e\` to \`EffectRef(slot)\` **inside the handler only** (not exported)
- \`with Expects(...) as ei\`: rewrite to \`ObservationRef(slot, exception_info)\`; \`substitution_binding\` exports for the rest of the block
- Non-Name \`as\` / Suppresses+\`as\` stay loud

### Membrane / contract
- \`Expects.binding\` = \`exception_info\` | \`warning_observation\` (from effect kind)
- Tree never matches \`pytest\` spellings for binding shape

### Sugar / floor / auth
- \`EffectRefSugar\` / \`ObservationRefSugar\` → \`EffectCoordinate\` / \`ExceptionInfoCoordinate\`
- \`authenticate_slot\` during try/with match; seal effect into the coordinate at desugar
- \`ei.value\` projects the same sealed effect slot
- **No \`E()\`**

### Twins
- Matching \`except … as\` returns observed exception identity
- Wrong-type handler does not authenticate; raise propagates
- Tuple except-as binds matched type identity
- \`pytest.raises as ei\` completes; \`return ei.value\` projects observed exception

## Validation
- sugar-source-tree tests: **260 passed**, 5 skipped
- try + with contract: **33 passed** (includes new binding twins)

## Separately
Protocol wire debt tracked in https://github.com/TSavo/sugar/issues/6032 (dual-read; does not block this sequence).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `EffectRef`/`ObservationRef` coordinates with route authentication for try/with as-bindings
> - Introduces `EffectRef` and `ObservationRef` as first-class AST nodes that represent effect-slot coordinates for `except E as name` and `with pytest.raises(E) as name` bindings.
> - Adds a `ContextVar`-backed authentication wave in [effect_auth.py](https://github.com/TSavo/sugar/pull/6033/files#diff-1d16365161eb63fe32098445532b8b4f705924d2694faca958b97ef17510cb41): during desugaring, `TrySugar` and `WithContractSugar` call `authenticate_slot` when a handler matches, sealing the coordinate to the observed effect.
> - New floor values `EffectCoordinate` and `ExceptionInfoCoordinate` emit IR distinguishing unresolved slots, observed exceptions, observed warnings, and other effects.
> - `FunctionUniverseSugar.desugar` wraps body reduction in an `effect_auth_wave` so slot authentication is scoped to a single function reduction.
> - Behavioral Change: references to `name` inside `except E as name` and `with … as name` blocks now resolve to `EffectRef`/`ObservationRef` coordinates rather than ordinary variable bindings; unmatched arms leave slots unauthenticated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e72b383.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->