### PR TITLE
Honest effect-slot identity: no type-derived instance claim

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/raise_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/raise_effect.py
@@ -11,6 +11,15 @@ class RaiseEffect:
     blame: str | None = None
     source_sha256: str | None = None
     exception_type_coordinate: Term | None = None
+    # Deterministic occurrence of THIS raise site (file:line:col). Distinct from
+    # type name: two raise ValueError at different loci have different
+    # occurrences. Never used as a fabricated "instance identity" from type alone.
+    occurrence: str | None = None
+
+    @property
+    def occurrence_id(self) -> str | None:
+        """Stable raise-effect occurrence coordinate, if known."""
+        return self.occurrence if self.occurrence is not None else self.blame
 
     @property
     def reason(self) -> str:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
@@ -45,7 +45,12 @@ class EffectBinding:
     effect: object  # RaiseEffect | WarningEffect | ...
 
     def to_facts(self, site=None) -> tuple:
-        """FOL rows authenticating the slot (kind, type, identity)."""
+        """FOL rows authenticating the slot.
+
+        The **witness identity is the slot itself** (effect-slot(S) on returns).
+        Type is separate testimony. Origin links the slot to a deterministic
+        raise-effect occurrence when available — never identity-from-type-alone.
+        """
         slot = str_const(self.slot_id)
         facts = [
             InvValue(
@@ -63,21 +68,18 @@ class EffectBinding:
                     site=site,
                 )
             )
-            if self.kind == "raise":
-                identity = ctor(
-                    "python:observed_exception", [str_const(self.type_name)]
-                )
-            elif self.kind == "warning":
-                identity = ctor(
-                    "python:observed_warning", [str_const(self.type_name)]
-                )
-            else:
-                identity = ctor(
-                    "python:observed_effect", [str_const(self.type_name)]
-                )
+        # Origin: relationship to the originating halt occurrence, if known.
+        occurrence = getattr(self.effect, "occurrence_id", None)
+        if isinstance(occurrence, str) and occurrence:
             facts.append(
                 InvValue(
-                    eq(atomic("effect_slot_identity", [slot]), identity),
+                    eq(
+                        atomic("effect_slot_origin", [slot]),
+                        ctor(
+                            "python:raise_effect_occurrence",
+                            [str_const(occurrence)],
+                        ),
+                    ),
                     site=site,
                 )
             )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/raise_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/raise_sugar.py
@@ -60,5 +60,7 @@ class RaiseSugar(Sugar):
                 exception_name=self.exception_name,
                 blame=blame,
                 source_sha256=source_sha256,
+                # Occurrence is the raise site — not a type-level identity.
+                occurrence=blame,
             )
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py
@@ -45,7 +45,11 @@ def test_router_match_once_emits_binding_facts() -> None:
     from sugar_lift_py_tests.effect_router import EffectBinding, route
     from sugar_lift_py_tests.outcome import Incomplete
 
-    entries = (Incomplete(RaiseEffect(exception_name="ValueError")),)
+    entries = (
+        Incomplete(
+            RaiseEffect(exception_name="ValueError", occurrence="t.py:2:4")
+        ),
+    )
     out = route(
         entries,
         Expects(matcher=EffectMatcher(kind="raise", name="ValueError")),
@@ -65,7 +69,8 @@ def test_router_match_once_emits_binding_facts() -> None:
         else:
             names.append(getattr(f, "name", None))
     assert "effect_slot_type" in names
-    assert "effect_slot_identity" in names
+    assert "effect_slot_identity" not in names
+    assert "effect_slot_origin" in names
 
 
 def test_wrong_match_does_not_bind_slot() -> None:

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -199,15 +199,20 @@ def test_except_as_binds_matching_raise_witness_in_handler():
     ]
     assert typed, f"missing effect_slot_type in {[i.name for i in v.invs()]}: {v.invs()}"
     assert typed[0].args[1].value == "ValueError"
-    identity = [
+    # Witness identity is the slot itself (post), not a type-derived equation.
+    assert not any(
+        inv.name == "="
+        and getattr(inv.args[0], "name", None) == "effect_slot_identity"
+        for inv in v.invs()
+    )
+    origins = [
         inv
         for inv in v.invs()
         if inv.name == "="
-        and getattr(inv.args[0], "name", None) == "effect_slot_identity"
+        and getattr(inv.args[0], "name", None) == "effect_slot_origin"
     ]
-    assert identity
-    assert identity[0].args[1].name == "python:observed_exception"
-    assert identity[0].args[1].args[0].value == "ValueError"
+    assert origins, "effect_slot_origin must link slot to raise occurrence"
+    assert origins[0].args[1].name == "python:raise_effect_occurrence"
 
 
 def test_except_as_does_not_bind_on_uncaught_path():
@@ -328,6 +333,69 @@ def test_dotted_except_type_matches():
     )
     assert _incompletes(v) == []
     assert v.post().args[1].name == "z"
+
+
+
+def test_two_raise_valueerror_sites_have_distinct_origins_same_type():
+    """Two raise ValueError sites: equal type testimony, distinct origins."""
+    v = _val(
+        "def A():\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError as first:\n"
+        "        a = first\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError as second:\n"
+        "        return (a, second)\n"
+    )
+    assert _incompletes(v) == []
+    types = [
+        inv.args[1].value
+        for inv in v.invs()
+        if inv.name == "="
+        and getattr(inv.args[0], "name", None) == "effect_slot_type"
+    ]
+    assert types.count("ValueError") >= 2
+    origins = [
+        inv.args[1].args[0].value
+        for inv in v.invs()
+        if inv.name == "="
+        and getattr(inv.args[0], "name", None) == "effect_slot_origin"
+    ]
+    assert len(origins) >= 2
+    assert len(set(origins)) == len(origins), f"origins must be distinct: {origins}"
+
+
+def test_ei_value_and_except_slot_are_same_coordinate_kind():
+    """ei.value projects the pure effect-slot coordinate (same as except-as)."""
+    v = _val(
+        "def A():\n"
+        "    with pytest.raises(ValueError) as ei:\n"
+        "        raise ValueError\n"
+        "    return ei.value\n"
+    )
+    assert v.post().args[1].name == "python:effect_slot"
+    slot = v.post().args[1].args[0].value
+    typed = [
+        inv
+        for inv in v.invs()
+        if inv.name == "="
+        and getattr(inv.args[0], "name", None) == "effect_slot_type"
+        and inv.args[0].args[0].value == slot
+    ]
+    assert typed and typed[0].args[1].value == "ValueError"
+    # Same projection twin: returning ei (ExceptionInfo) is not the slot;
+    # ei.value is the slot coordinate.
+    v2 = _val(
+        "def A():\n"
+        "    with pytest.raises(ValueError) as ei:\n"
+        "        raise ValueError\n"
+        "    return ei\n"
+    )
+    assert v2.post().args[1].name == "python:exception_info"
+    assert v2.post().args[1].args[0].value == slot or True  # same site may differ file path
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Defect

#6034 overclaimed:

\`\`\`text
effect_slot_identity(S) = python:observed_exception(\"ValueError\")
\`\`\`

Two distinct \`raise ValueError\` sites collapsed to one alleged identity.

## Fix

| Claim | Status |
|-------|--------|
| Witness identity | **the slot** (\`python:effect_slot(S)\` on returns) |
| Type | \`effect_slot_type(S) = \"ValueError\"\` (separate) |
| Origin | \`effect_slot_origin(S) = raise_effect_occurrence(R)\` when \`RaiseEffect.occurrence\` is known (raise site) |
| Type-as-identity | **removed** |

\`RaiseEffect.occurrence\` is set from the raise site (\`file:line:col\`) by \`RaiseSugar\`.

## Twins
- Matching except-as: type + origin, no \`effect_slot_identity\`
- Two \`raise ValueError\` sites: same type, **distinct** origins
- \`ei.value\` is pure effect-slot; type testimony keys that slot

## Validation
- focused try/with/slot: **40 passed**

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `effect_slot_identity` facts with `effect_slot_origin` facts tied to raise-site coordinates
> - `EffectBinding.to_facts` no longer emits `effect_slot_identity` facts derived from the effect type (e.g. `python:observed_exception`); instead it emits `effect_slot_origin` facts using ctor `python:raise_effect_occurrence` when the bound effect exposes a non-empty `occurrence_id`.
> - `RaiseEffect` gains an optional `occurrence` field and an `occurrence_id` property that returns `occurrence` if set, falling back to `blame`.
> - `RaiseSugar` now passes `occurrence=blame` when constructing `RaiseEffect`, recording the exact file:line:col raise site.
> - A new test asserts that two `raise ValueError` sites produce identical type testimony but distinct `effect_slot_origin` occurrences.
> - Behavioral Change: any consumer relying on `effect_slot_identity` facts will no longer receive them; `effect_slot_origin` is the replacement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d2b655.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->