### PR TITLE
Finally over ExitSet: restore, supersede, try/finally-only

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -161,6 +161,46 @@ class ExitSet(Generic[T]):
                     exits.append(Halted(guard, following.effect))
         return ExitSet(tuple(exits)).normalize()
 
+    def and_finally(
+        self,
+        cleanup: Callable[[], "ExitSet[object]"],
+        *,
+        cleanup_restores: Callable[[object], bool] | None = None,
+    ) -> "ExitSet[object]":
+        """Run cleanup over every completed and halted exit (try/finally).
+
+        Laws:
+        - Cleanup **completion that restores** keeps the incoming exit
+          (completed value or halted effect).
+        - Cleanup **halt** supersedes the incoming exit.
+        - Cleanup **terminal completion** (e.g. return in finally) supersedes
+          with that completed value — ``cleanup_restores`` is False.
+
+        Default: every completed cleanup restores (``cleanup_restores`` always
+        True). Callers that model return-in-finally pass a predicate on the
+        cleanup completed value.
+        """
+        restores = cleanup_restores or (lambda _value: True)
+        # Construct cleanup ExitSet once; fan the same exits across every
+        # incoming exit (cleanup runs on every path, not once per path).
+        cleanup_exits = cleanup().exits
+        exits: list[Exit[object]] = []
+        for incoming in self.exits:
+            for clean in cleanup_exits:
+                guard = _and_guards(incoming.guard, clean.guard)
+                if isinstance(clean, Halted):
+                    exits.append(Halted(guard, clean.effect))
+                    continue
+                if restores(clean.value):
+                    if isinstance(incoming, Completed):
+                        exits.append(Completed(guard, incoming.value))
+                    else:
+                        exits.append(Halted(guard, incoming.effect))
+                else:
+                    # Terminal cleanup completion supersedes (return in finally).
+                    exits.append(Completed(guard, clean.value))
+        return ExitSet(tuple(exits)).normalize()
+
     def collapse(self):
         """Return the old linear Outcome only for one unconditional exit."""
         normalized = self.normalize()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
@@ -1,8 +1,11 @@
-"""`try` effect routing: match once via route_except; binding facts in the record.
+"""`try` effect routing + finally over ExitSet.
 
-``except E as e`` is already rewritten to EffectRef(slot) by the tree.
-On match, route_except emits EffectBinding facts for that slot — no ContextVar,
-no re-desugar, no dual match.
+except-as is tree-rewritten to EffectRef(slot); route_except matches once and
+emits EffectBinding facts. finally runs on every exit:
+
+- cleanup fall-through restores the incoming exit
+- cleanup halt supersedes
+- cleanup terminal completion (return) supersedes
 """
 
 from __future__ import annotations
@@ -47,35 +50,149 @@ class TrySugar(Sugar):
             route_except,
         )
         from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.floor.return_value import ReturnValue
         from sugar_lift_py_tests.outcome import Incomplete
-        from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_statements
+        from sugar_lift_py_tests.outcome.exit_set import (
+            Completed,
+            ExitSet,
+            Halted,
+        )
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            _ReducedBlock,
+            reduce_block_to_exitset,
+            reduce_statements,
+        )
 
         del ctx
 
-        body_entries, _body_falls, _ = reduce_statements(self.body)
+        body_entries, body_falls, body_ft = reduce_statements(self.body)
         body_entries = tuple(body_entries)
 
-        routed = None
+        routed_entries: tuple | None = None
+        routed_falls = True
         for matcher, handler_body, slot_id in self.handlers:
             arm = route_except(
                 body_entries, matcher, slot_id=slot_id, site=self.site
             )
             if arm is None:
                 continue
-            # Match decided once. Handler already contains EffectRef(slot).
-            handler_entries, _hf, _ = reduce_statements(handler_body)
-            routed = (*arm.entries, *handler_entries)
+            handler_entries, handler_falls, _ = reduce_statements(handler_body)
+            routed_entries = (*arm.entries, *handler_entries)
+            routed_falls = handler_falls
             break
 
-        if routed is None:
+        if routed_entries is None:
             if _first_effect_of_kind(body_entries, "raise") is None:
-                else_entries, _ef, _ = reduce_statements(self.orelse)
-                routed = (*body_entries, *else_entries)
+                else_entries, else_falls, _ = reduce_statements(self.orelse)
+                routed_entries = (*body_entries, *else_entries)
+                routed_falls = else_falls if self.orelse else body_falls
             else:
-                routed = body_entries
+                routed_entries = body_entries
+                routed_falls = body_falls
 
-        finally_entries, _ff, _ = reduce_statements(self.finalbody)
-        entries = (*routed, *finally_entries)
+        pre_finally = _linear_entries_to_exitset(routed_entries, routed_falls)
 
-        can_fall_through = not any(isinstance(e, Incomplete) for e in entries)
-        return Complete(BlockValue(entries, can_fall_through=can_fall_through))
+        if not self.finalbody:
+            return _exitset_to_outcome(pre_finally)
+
+        cleanup_es = reduce_block_to_exitset(self.finalbody)
+
+        def _cleanup():
+            return cleanup_es
+
+        def _restores(value: object) -> bool:
+            # Fall-through completed cleanup restores the try exit.
+            # Terminal return in finally supersedes.
+            if isinstance(value, _ReducedBlock):
+                if not value.can_fall_through:
+                    return False
+                if any(isinstance(e, ReturnValue) for e in value.entries):
+                    return False
+                return True
+            return True
+
+        after = pre_finally.and_finally(_cleanup, cleanup_restores=_restores)
+        return _exitset_to_outcome(after)
+
+
+def _linear_entries_to_exitset(entries: tuple, can_fall_through: bool) -> ExitSet:
+    """Project the linear entry list into a one-or-few-exit ExitSet."""
+    from sugar_lift_py_tests.outcome import Incomplete
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+    from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+
+    state = _ReducedBlock(
+        entries=entries,
+        can_fall_through=can_fall_through,
+        fall_through=(),
+    )
+    # First hard halt Incomplete (raise) becomes Halted; testimony rides on state.
+    for entry in entries:
+        if not isinstance(entry, Incomplete):
+            continue
+        follow = entry.follow()
+        if not follow.continues:
+            return ExitSet.halted(entry.effect)
+    return ExitSet.completed(state)
+
+
+def _exitset_to_outcome(exits: ExitSet) -> Outcome:
+    """Collapse ExitSet to the linear Complete(BlockValue) / Incomplete view."""
+    from sugar_lift_py_tests.floor.block_value import BlockValue
+    from sugar_lift_py_tests.floor.return_value import ReturnValue
+    from sugar_lift_py_tests.outcome import Incomplete
+    from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+    from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+
+    from sugar_lift_py_tests.outcome import Complete as OutcomeComplete
+
+    collapsed = exits.collapse()
+    if isinstance(collapsed, Incomplete):
+        # Pure halt: still expose as BlockValue red testimony so later
+        # statements / invs see the effect entry (and finally supersede is
+        # already applied).
+        return Complete(
+            BlockValue((collapsed,), can_fall_through=False)
+        )
+    if isinstance(collapsed, OutcomeComplete):
+        value = collapsed.value
+        if isinstance(value, _ReducedBlock):
+            return Complete(
+                BlockValue(
+                    value.entries,
+                    fall_through=value.fall_through,
+                    can_fall_through=value.can_fall_through,
+                )
+            )
+        # Terminal cleanup completed with raw value (rare)
+        if isinstance(value, ReturnValue):
+            return Complete(BlockValue((value,), can_fall_through=False))
+        return Complete(BlockValue((), can_fall_through=True))
+
+    # Multi-exit: flatten every exit's contribution under its guard.
+    # For the linear BlockValue consumers, concatenate completed entries and
+    # include each halt as Incomplete (guarded when possible).
+    entries: list = []
+    can_fall = False
+    for exit_ in exits.normalize().exits:
+        if isinstance(exit_, Halted):
+            inc = Incomplete(exit_.effect)
+            if exit_.guard is not None:
+                # Preserve branch condition when non-trivial.
+                from sugar_lift_py_tests.outcome.exit_set import true_guard
+
+                if exit_.guard != true_guard():
+                    inc = Incomplete(
+                        exit_.effect, branch_conditions=(exit_.guard,)
+                    )
+            entries.append(inc)
+        elif isinstance(exit_, Completed):
+            value = exit_.value
+            if isinstance(value, _ReducedBlock):
+                entries.extend(value.entries)
+                can_fall = can_fall or value.can_fall_through
+            elif isinstance(value, ReturnValue):
+                entries.append(value)
+    return Complete(
+        BlockValue(tuple(entries), can_fall_through=can_fall)
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
@@ -79,3 +79,59 @@ def test_block_reduction_retains_complement_of_guarded_halt():
     assert exits.exits[0].guard == condition
     assert isinstance(exits.exits[1], Completed)
     assert exits.exits[1].guard == not_(condition)
+
+
+def test_and_finally_cleanup_completion_restores_incoming_completed():
+    incoming = ExitSet.completed("try-state")
+    after = incoming.and_finally(lambda: ExitSet.completed("cleanup-done"))
+    assert after.collapse() == Complete("try-state")
+
+
+def test_and_finally_cleanup_completion_restores_incoming_halted():
+    effect = RaiseEffect(exception_name="ValueError")
+    incoming = ExitSet.halted(effect)
+    after = incoming.and_finally(lambda: ExitSet.completed("cleanup-done"))
+    assert after.collapse() == Incomplete(effect)
+
+
+def test_and_finally_cleanup_halt_supersedes_incoming():
+    original = RaiseEffect(exception_name="ValueError")
+    cleanup = RaiseEffect(exception_name="RuntimeError")
+    incoming = ExitSet.halted(original)
+    after = incoming.and_finally(lambda: ExitSet.halted(cleanup))
+    assert after.collapse() == Incomplete(cleanup)
+
+
+def test_and_finally_cleanup_halt_supersedes_completed():
+    cleanup = RaiseEffect(exception_name="RuntimeError")
+    incoming = ExitSet.completed("ok")
+    after = incoming.and_finally(lambda: ExitSet.halted(cleanup))
+    assert after.collapse() == Incomplete(cleanup)
+
+
+def test_and_finally_terminal_cleanup_completion_supersedes():
+    incoming = ExitSet.completed("try-state")
+    after = incoming.and_finally(
+        lambda: ExitSet.completed("return-from-finally"),
+        cleanup_restores=lambda value: False,
+    )
+    assert after.collapse() == Complete("return-from-finally")
+
+
+def test_and_finally_runs_cleanup_on_every_conditional_exit():
+    condition = _guard("condition")
+    effect = RaiseEffect(exception_name="ValueError")
+    incoming = ExitSet.conditional_halt(condition, effect, "state")
+    seen = []
+
+    def cleanup():
+        seen.append(1)
+        return ExitSet.completed("done")
+
+    after = incoming.and_finally(cleanup)
+    # cleanup invoked once per construction of cleanup ExitSet — and_finally
+    # calls cleanup() once then fans the resulting exits across incoming.
+    assert len(seen) == 1
+    assert len(after.exits) == 2
+    assert any(isinstance(e, Halted) and e.effect == effect for e in after.exits)
+    assert any(isinstance(e, Completed) and e.value == "state" for e in after.exits)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1995,8 +1995,21 @@ class Try(Statement):
         ``name`` to ``EffectRef(slot)`` inside the handler. Routing
         authenticates that slot with the matched Halted raise — never E().
         """
+        from sugar_lift_py_tests.sugar.try_sugar import TrySugar
+
         if not self.handlers:
-            return super()._construct_sugar()  # try/finally-only: not the except-routing core
+            # try/finally-only (no except): same TrySugar with empty handlers;
+            # finally is ExitSet.and_finally over the body exits.
+            if not self.finalbody:
+                return super()._construct_sugar()
+            return TrySugar(
+                body=tuple(stmt.sugar() for stmt in self.body),
+                handlers=(),
+                orelse=tuple(stmt.sugar() for stmt in self.orelse),
+                finalbody=tuple(stmt.sugar() for stmt in self.finalbody),
+                site=self.fragment,
+            )
+
         from sugar_lift_py_tests.context_manager_contract import EffectMatcher
 
         handler_specs = []
@@ -2024,8 +2037,6 @@ class Try(Statement):
                         slot_id,
                     )
                 )
-
-        from sugar_lift_py_tests.sugar.try_sugar import TrySugar
 
         return TrySugar(
             body=tuple(stmt.sugar() for stmt in self.body),

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -149,8 +149,8 @@ def test_finally_reduces_on_caught_path():
 
 
 def test_finally_reduces_on_uncaught_path():
-    # finally still reduces when the raise is NOT caught: the body's
-    # Incomplete survives AND finally's raise is spliced (both effects ride).
+    # Cleanup halt supersedes the incoming uncaught raise (Python: only
+    # RuntimeError propagates; ValueError does not also ride).
     from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
 
     v = _val(
@@ -165,9 +165,58 @@ def test_finally_reduces_on_uncaught_path():
     )
     reds = _incompletes(v)
     names = {r.effect.exception_name for r in reds if isinstance(r.effect, RaiseEffect)}
-    assert "ValueError" in names  # uncaught body raise survives
-    assert "RuntimeError" in names  # finally reduced and spliced
+    assert names == {"RuntimeError"}
 
+
+
+
+def test_finally_pass_restores_uncaught_raise():
+    """Cleanup fall-through restores the incoming halt (ValueError survives)."""
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except KeyError:\n"
+        "        pass\n"
+        "    finally:\n"
+        "        z = z\n"
+        "    return z\n"
+    )
+    reds = _incompletes(v)
+    assert len(reds) == 1
+    assert isinstance(reds[0].effect, RaiseEffect)
+    assert reds[0].effect.exception_name == "ValueError"
+
+
+def test_finally_return_supersedes_caught_path():
+    """Return in finally is the function exit after a matching except."""
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError:\n"
+        "        x = 1\n"
+        "    finally:\n"
+        "        return z\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+def test_finally_on_normal_completion():
+    """finally runs on the no-raise path; fall-through keeps body completion."""
+    v = _val(
+        "def A(z):\n"
+        "    try:\n"
+        "        x = z\n"
+        "    finally:\n"
+        "        y = 1\n"
+        "    return z\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
 
 def test_except_as_binds_matching_raise_witness_in_handler():
     # Tree rewrites `error` → EffectRef(slot); routing emits EffectBinding facts.


### PR DESCRIPTION
## Summary

Banked path after #6034 (EffectBinding) and #6035 (honest slot identity): implement **finally** as ExitSet algebra, not a special case.

- **`ExitSet.and_finally`**: cleanup constructed once; fanned across every incoming exit. Fall-through completion restores; cleanup halt supersedes; terminal cleanup completion (return) supersedes via `cleanup_restores`.
- **`TrySugar`**: reduce body/except to an ExitSet, then `and_finally(finalbody)`.
- **`Try` construction**: try/finally-only (no handlers) builds `TrySugar` with empty handlers instead of staying loud.
- **Laws**: unit tests on restore/supersede/single cleanup invocation; try_sugar twins for uncaught cleanup halt, pass restores, return supersedes, normal path.

## Validation

```bash
PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src \
  python -m pytest \
  implementations/python/sugar-lift-py-tests/tests/test_exit_set.py \
  implementations/python/sugar-source-tree/tests/test_try_sugar.py -q
# 35 passed
```

## Next

Resource `with`, then re-census.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `ExitSet.and_finally` and rewrite try/finally desugaring to use per-exit finally semantics
> - Adds `ExitSet.and_finally(cleanup, *, cleanup_restores)` in [exit_set.py](https://github.com/TSavo/sugar/pull/6036/files#diff-40bf423f2f11b7e245b883146f67d6943005b30b1c5a4d74f1aab767272e3716), which fans a cleanup `ExitSet` across each incoming exit: a halted cleanup supersedes, a fall-through cleanup restores, and a terminal completion supersedes.
> - Rewrites `TrySugar.desugar` in [try_sugar.py](https://github.com/TSavo/sugar/pull/6036/files#diff-f5d956a5de18664d828d314bf5537a359cc1f2f40c5a42b52f03bbe5ecaac0ff) to project try/except results into an `ExitSet`, apply `and_finally` for finally blocks, then collapse back to a linear `BlockValue` — replacing the previous simple linear concatenation.
> - Fixes `Try._construct_sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/6036/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) so that try/finally-only statements (no except handlers) now route through `TrySugar` instead of the superclass, gaining correct finally semantics.
> - Behavioral Change: finally blocks now correctly supersede uncaught raises when they themselves raise, and returns inside finally now supersede prior exits — the prior linear concatenation did not model these cases correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7abe6c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `try/finally` cleanup across all execution paths, including normal completion, raised effects, and conditional exits.
  * Cleanup can preserve the original result or override it with a terminal return.
  * Cleanup failures now supersede prior outcomes.

* **Bug Fixes**
  * Corrected handling of uncaught exceptions when cleanup completes or raises.
  * Added support for `try/finally` blocks without exception handlers.

* **Tests**
  * Expanded coverage for cleanup restoration, overrides, failures, and execution on every exit path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->