### PR TITLE
WithContractSugar routes over ExitSet faces

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/exit_set_routing.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/exit_set_routing.py
@@ -1,0 +1,195 @@
+"""Shared ExitSet helpers for Try and With contract routing.
+
+Promote embedded guarded raises out of Completed blocks, and project an
+ExitSet back to the linear BlockValue Outcome consumers still speak.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+
+
+def is_hard_raise(entry) -> bool:
+    """True when entry is a raise Incomplete that halts control flow."""
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    if not isinstance(entry, Incomplete):
+        return False
+    if not isinstance(entry.effect, RaiseEffect):
+        return False
+    return not entry.follow().continues
+
+
+def guard_from_conditions(exit_guard, branch_conditions):
+    from sugar_lift_py_tests.ir import and_
+    from sugar_lift_py_tests.outcome.exit_set import true_guard
+
+    parts = []
+    if exit_guard is not None and exit_guard != true_guard():
+        parts.append(exit_guard)
+    parts.extend(branch_conditions)
+    if not parts:
+        return true_guard()
+    if len(parts) == 1:
+        return parts[0]
+    return and_(list(parts))
+
+
+def promote_raise_halts(exits):
+    """Lift Incomplete(raise) entries out of Completed blocks into Halted exits.
+
+    ``if c: raise`` flattens through IfSugar into a single Completed whose
+    entries embed ``Incomplete(..., branch_conditions=(c,))``. Without this
+    promotion, contract/handler routing cannot see a Halted face and the
+    complementary completion path is lost under a linear adapter.
+    """
+    from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+    from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+
+    promoted: list = []
+    for exit_ in exits.exits:
+        if isinstance(exit_, Halted):
+            promoted.append(exit_)
+            continue
+        if not isinstance(exit_, Completed):
+            promoted.append(exit_)
+            continue
+        state = exit_.value
+        if not isinstance(state, _ReducedBlock):
+            promoted.append(exit_)
+            continue
+
+        remaining: list = []
+        saw_halt = False
+        for entry in state.entries:
+            if is_hard_raise(entry):
+                saw_halt = True
+                guard = guard_from_conditions(exit_.guard, entry.branch_conditions)
+                promoted.append(Halted(guard, entry.effect))
+            else:
+                remaining.append(entry)
+
+        if not saw_halt:
+            promoted.append(exit_)
+            continue
+
+        if remaining or state.can_fall_through:
+            promoted.append(
+                Completed(
+                    exit_.guard,
+                    replace(state, entries=tuple(remaining)),
+                )
+            )
+    return ExitSet(tuple(promoted)).normalize()
+
+
+def exitset_to_outcome(exits) -> Outcome:
+    """Collapse ExitSet to the linear Complete(BlockValue) / Incomplete view."""
+    from sugar_lift_py_tests.floor.block_value import BlockValue
+    from sugar_lift_py_tests.floor.return_value import ReturnValue
+    from sugar_lift_py_tests.outcome import Incomplete
+    from sugar_lift_py_tests.outcome.exit_set import Completed, Halted, true_guard
+    from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+
+    from sugar_lift_py_tests.outcome import Complete as OutcomeComplete
+
+    collapsed = exits.collapse()
+    if isinstance(collapsed, Incomplete):
+        return Complete(BlockValue((collapsed,), can_fall_through=False))
+    if isinstance(collapsed, OutcomeComplete):
+        value = collapsed.value
+        if isinstance(value, _ReducedBlock):
+            return Complete(
+                BlockValue(
+                    value.entries,
+                    fall_through=value.fall_through,
+                    can_fall_through=value.can_fall_through,
+                )
+            )
+        if isinstance(value, ReturnValue):
+            return Complete(BlockValue((value,), can_fall_through=False))
+        return Complete(BlockValue((), can_fall_through=True))
+
+    entries: list = []
+    can_fall = False
+    for exit_ in exits.normalize().exits:
+        if isinstance(exit_, Halted):
+            inc = Incomplete(exit_.effect)
+            if exit_.guard != true_guard():
+                inc = Incomplete(exit_.effect, branch_conditions=(exit_.guard,))
+            entries.append(inc)
+        elif isinstance(exit_, Completed):
+            value = exit_.value
+            if isinstance(value, _ReducedBlock):
+                if exit_.guard != true_guard():
+                    entries.extend(
+                        entry.guarded(exit_.guard) for entry in value.entries
+                    )
+                else:
+                    entries.extend(value.entries)
+                can_fall = can_fall or value.can_fall_through
+            elif isinstance(value, ReturnValue):
+                if exit_.guard != true_guard():
+                    entries.append(value.guarded(exit_.guard))
+                else:
+                    entries.append(value)
+    return Complete(BlockValue(tuple(entries), can_fall_through=can_fall))
+
+
+def routed_entries_to_exitset(entries: tuple, guard, *, prior_state=None):
+    """Project a linear route result under ``guard`` back into an ExitSet.
+
+    Hard raises become Halted; remaining entries (facts, warnings, body
+    residue) ride as Completed under the same guard.
+    """
+    from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+    from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+
+    remaining: list = []
+    out: list = []
+    for entry in entries:
+        if is_hard_raise(entry):
+            out.append(Halted(guard, entry.effect))
+        else:
+            remaining.append(entry)
+
+    can_fall = not out
+    if prior_state is not None and isinstance(prior_state, _ReducedBlock):
+        fall_through = prior_state.fall_through
+        transforms = prior_state.transforms
+        if not out:
+            can_fall = prior_state.can_fall_through or True
+    else:
+        fall_through = ()
+        transforms = ()
+
+    if remaining or not out:
+        out.append(
+            Completed(
+                guard,
+                _ReducedBlock(
+                    entries=tuple(remaining),
+                    can_fall_through=can_fall,
+                    fall_through=fall_through,
+                    transforms=transforms,
+                ),
+            )
+        )
+    return ExitSet(tuple(out)).normalize()
+
+
+def site_inv_values(entries: tuple, site) -> tuple:
+    """Stamp ``site`` on InvValues that arrived without one."""
+    from dataclasses import replace as dc_replace
+
+    from sugar_lift_py_tests.floor.inv_value import InvValue
+
+    return tuple(
+        dc_replace(e, site=site)
+        if isinstance(e, InvValue) and e.site is None
+        else e
+        for e in entries
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field as dataclass_field, replace
 
-from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.outcome import Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
@@ -50,7 +50,10 @@ class TrySugar(Sugar):
 
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.floor.return_value import ReturnValue
-        from sugar_lift_py_tests.outcome.exit_set import ExitSet
+        from sugar_lift_py_tests.sugar.exit_set_routing import (
+            exitset_to_outcome,
+            promote_raise_halts,
+        )
         from sugar_lift_py_tests.sugar.function_universe_sugar import (
             _ReducedBlock,
             reduce_block_to_exitset,
@@ -58,10 +61,7 @@ class TrySugar(Sugar):
 
         del ctx
 
-        # 1. Body as guarded ExitSet (promote embedded conditional raises).
-        body_es = _promote_raise_halts(reduce_block_to_exitset(self.body))
-
-        # 2. Route handlers over Halted exits; Completed (+ else) pass through.
+        body_es = promote_raise_halts(reduce_block_to_exitset(self.body))
         pre_finally = _route_handlers_over_exits(
             body_es,
             self.handlers,
@@ -69,9 +69,8 @@ class TrySugar(Sugar):
             site=self.site,
         )
 
-        # 3. finally over every exit.
         if not self.finalbody:
-            return _exitset_to_outcome(pre_finally)
+            return exitset_to_outcome(pre_finally)
 
         cleanup_es = reduce_block_to_exitset(self.finalbody)
 
@@ -79,8 +78,6 @@ class TrySugar(Sugar):
             return cleanup_es
 
         def _restores(value: object) -> bool:
-            # Fall-through completed cleanup restores the try exit.
-            # Terminal return in finally supersedes.
             if isinstance(value, _ReducedBlock):
                 if not value.can_fall_through:
                     return False
@@ -90,90 +87,7 @@ class TrySugar(Sugar):
             return True
 
         after = pre_finally.and_finally(_cleanup, cleanup_restores=_restores)
-        return _exitset_to_outcome(after)
-
-
-def _is_hard_raise(entry) -> bool:
-    """True when entry is a raise Incomplete that halts control flow."""
-    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
-    from sugar_lift_py_tests.outcome import Incomplete
-
-    if not isinstance(entry, Incomplete):
-        return False
-    if not isinstance(entry.effect, RaiseEffect):
-        return False
-    # Store-like effects continue; raises halt (follow default).
-    return not entry.follow().continues
-
-
-def _guard_from_conditions(exit_guard, branch_conditions):
-    from sugar_lift_py_tests.ir import and_
-    from sugar_lift_py_tests.outcome.exit_set import true_guard
-
-    parts = []
-    if exit_guard is not None and exit_guard != true_guard():
-        parts.append(exit_guard)
-    parts.extend(branch_conditions)
-    if not parts:
-        return true_guard()
-    if len(parts) == 1:
-        return parts[0]
-    return and_(list(parts))
-
-
-def _promote_raise_halts(exits: "ExitSet") -> "ExitSet":
-    """Lift Incomplete(raise) entries out of Completed blocks into Halted exits.
-
-    ``if c: raise`` flattens through IfSugar into a single Completed whose
-    entries embed ``Incomplete(..., branch_conditions=(c,))``. Without this
-    promotion, handler routing cannot see a Halted face and the complementary
-    completion path is lost when the linear adapter consumes the raise.
-    """
-    from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
-    from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
-
-    promoted: list = []
-    for exit_ in exits.exits:
-        if isinstance(exit_, Halted):
-            promoted.append(exit_)
-            continue
-        if not isinstance(exit_, Completed):
-            promoted.append(exit_)
-            continue
-        state = exit_.value
-        if not isinstance(state, _ReducedBlock):
-            promoted.append(exit_)
-            continue
-
-        remaining: list = []
-        saw_halt = False
-        for entry in state.entries:
-            if _is_hard_raise(entry):
-                saw_halt = True
-                guard = _guard_from_conditions(
-                    exit_.guard, entry.branch_conditions
-                )
-                promoted.append(Halted(guard, entry.effect))
-            else:
-                remaining.append(entry)
-
-        if not saw_halt:
-            promoted.append(exit_)
-            continue
-
-        # Complementary completed face: non-raise entries (already self-guarded
-        # when they came from if-flattening) under the original exit guard.
-        if remaining or state.can_fall_through:
-            promoted.append(
-                Completed(
-                    exit_.guard,
-                    replace(
-                        state,
-                        entries=tuple(remaining),
-                    ),
-                )
-            )
-    return ExitSet(tuple(promoted)).normalize()
+        return exitset_to_outcome(after)
 
 
 def _effect_matches(effect, matcher) -> bool:
@@ -215,7 +129,7 @@ def _route_handlers_over_exits(
     Completed exits take ``else`` when present; unmatched halts propagate.
     Every resulting exit keeps its guard so finally fans across the partition.
     """
-    from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
     from sugar_lift_py_tests.sugar.function_universe_sugar import (
         _ReducedBlock,
         reduce_block_to_exitset,
@@ -232,7 +146,6 @@ def _route_handlers_over_exits(
                 facts = _binding_facts_for(slot_id, exit_.effect, site)
                 if facts:
                     handler_es = _prepend_facts(handler_es, facts)
-                # Handler runs only under the halt's guard (c: handler path).
                 parts.append(handler_es.guarded(exit_.guard))
                 matched = True
                 break
@@ -240,7 +153,6 @@ def _route_handlers_over_exits(
                 parts.append(ExitSet((exit_,)))
             continue
 
-        # Completed: optional else under the same guard.
         if orelse:
             else_es = reduce_block_to_exitset(orelse)
 
@@ -257,9 +169,7 @@ def _route_handlers_over_exits(
                 )
 
             if isinstance(exit_.value, _ReducedBlock):
-                parts.append(
-                    ExitSet((exit_,)).sequence(_then_else)
-                )
+                parts.append(ExitSet((exit_,)).sequence(_then_else))
             else:
                 parts.append(ExitSet((exit_,)).sequence(lambda _s: else_es))
         else:
@@ -305,61 +215,3 @@ def _prepend_facts(exits, facts: tuple):
                 )
             )
     return ExitSet(tuple(out)).normalize()
-
-
-def _exitset_to_outcome(exits) -> Outcome:
-    """Collapse ExitSet to the linear Complete(BlockValue) / Incomplete view."""
-    from sugar_lift_py_tests.floor.block_value import BlockValue
-    from sugar_lift_py_tests.floor.return_value import ReturnValue
-    from sugar_lift_py_tests.outcome import Incomplete
-    from sugar_lift_py_tests.outcome.exit_set import Completed, Halted, true_guard
-    from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
-
-    from sugar_lift_py_tests.outcome import Complete as OutcomeComplete
-
-    collapsed = exits.collapse()
-    if isinstance(collapsed, Incomplete):
-        # Pure halt: still expose as BlockValue red testimony so later
-        # statements / invs see the effect entry (and finally supersede is
-        # already applied).
-        return Complete(BlockValue((collapsed,), can_fall_through=False))
-    if isinstance(collapsed, OutcomeComplete):
-        value = collapsed.value
-        if isinstance(value, _ReducedBlock):
-            return Complete(
-                BlockValue(
-                    value.entries,
-                    fall_through=value.fall_through,
-                    can_fall_through=value.can_fall_through,
-                )
-            )
-        # Terminal cleanup completed with raw value (rare)
-        if isinstance(value, ReturnValue):
-            return Complete(BlockValue((value,), can_fall_through=False))
-        return Complete(BlockValue((), can_fall_through=True))
-
-    # Multi-exit: flatten every exit under its guard so dual posts survive.
-    entries: list = []
-    can_fall = False
-    for exit_ in exits.normalize().exits:
-        if isinstance(exit_, Halted):
-            inc = Incomplete(exit_.effect)
-            if exit_.guard != true_guard():
-                inc = Incomplete(exit_.effect, branch_conditions=(exit_.guard,))
-            entries.append(inc)
-        elif isinstance(exit_, Completed):
-            value = exit_.value
-            if isinstance(value, _ReducedBlock):
-                if exit_.guard != true_guard():
-                    entries.extend(
-                        entry.guarded(exit_.guard) for entry in value.entries
-                    )
-                else:
-                    entries.extend(value.entries)
-                can_fall = can_fall or value.can_fall_through
-            elif isinstance(value, ReturnValue):
-                if exit_.guard != true_guard():
-                    entries.append(value.guarded(exit_.guard))
-                else:
-                    entries.append(value)
-    return Complete(BlockValue(tuple(entries), can_fall_through=can_fall))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_contract_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_contract_sugar.py
@@ -1,10 +1,20 @@
-"""`with` under a typed contract: route once; slot binding is router testimony."""
+"""`with` under a typed contract: route over ExitSet faces, not a linear list.
+
+Path:
+
+    body -> reduce_block_to_exitset
+         -> promote guarded raises to Halted
+         -> route contract over each Halted / Completed exit
+         -> preserve unmatched Completed exits
+         -> authenticate slots only on matched guarded exits
+         -> normalize
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field as dataclass_field, replace
+from dataclasses import dataclass, field as dataclass_field
 
-from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.outcome import Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
@@ -33,28 +43,62 @@ class WithContractSugar(Sugar):
 
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.effect_router import route
-        from sugar_lift_py_tests.floor.block_value import BlockValue
-        from sugar_lift_py_tests.floor.inv_value import InvValue
         from sugar_lift_py_tests.outcome import Incomplete
-        from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_statements
+        from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
+        from sugar_lift_py_tests.sugar.exit_set_routing import (
+            exitset_to_outcome,
+            promote_raise_halts,
+            routed_entries_to_exitset,
+            site_inv_values,
+        )
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            _ReducedBlock,
+            reduce_block_to_exitset,
+        )
 
         del ctx
 
-        entries, _falls, _ft = reduce_statements(self.body)
-        # Single match authority — route once, including optional slot binding.
-        routed = route(
-            tuple(entries),
-            self.contract,
-            slot_id=self.slot_id,
-            site=self.site,
-        )
+        body_es = promote_raise_halts(reduce_block_to_exitset(self.body))
+        parts: list = []
+        for exit_ in body_es.exits:
+            if isinstance(exit_, Halted):
+                # One face, one observed halt — route under that guard only.
+                entries = (Incomplete(exit_.effect),)
+                routed = route(
+                    entries,
+                    self.contract,
+                    slot_id=self.slot_id,
+                    site=self.site,
+                )
+                sited = site_inv_values(routed.entries, self.site)
+                parts.append(routed_entries_to_exitset(sited, exit_.guard))
+                continue
 
-        sited = tuple(
-            replace(e, site=self.site)
-            if isinstance(e, InvValue) and e.site is None
-            else e
-            for e in routed.entries
-        )
+            state = exit_.value
+            if isinstance(state, _ReducedBlock):
+                entries = state.entries
+                prior = state
+            else:
+                entries = ()
+                prior = None
+            routed = route(
+                tuple(entries),
+                self.contract,
+                slot_id=self.slot_id,
+                site=self.site,
+            )
+            sited = site_inv_values(routed.entries, self.site)
+            parts.append(
+                routed_entries_to_exitset(sited, exit_.guard, prior_state=prior)
+            )
 
-        can_fall_through = not any(isinstance(e, Incomplete) for e in sited)
-        return Complete(BlockValue(sited, can_fall_through=can_fall_through))
+        if not parts:
+            routed_es = ExitSet.completed(
+                _ReducedBlock(entries=(), can_fall_through=True, fall_through=())
+            )
+        else:
+            routed_es = parts[0]
+            for part in parts[1:]:
+                routed_es = routed_es.union(part)
+
+        return exitset_to_outcome(routed_es)

--- a/implementations/python/sugar-source-tree/tests/test_with_contract.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_contract.py
@@ -222,3 +222,194 @@ def test_match_rejections_stay_loud():
     ):
         with pytest.raises(SugarNotWritten):
             _fn(src).sugar()
+
+
+# ---------------------------------------------------------------------------
+# Guarded ExitSet twins — contract routes per face, not over a linear list.
+# ---------------------------------------------------------------------------
+
+
+def test_conditional_expects_raised_face_and_absent_face():
+    """Expects over if c: raise — match under c; absence under ¬c must survive."""
+    v = _val(
+        "def A(c, z):\n"
+        "    with pytest.raises(ValueError):\n"
+        "        if c:\n"
+        "            raise ValueError\n"
+        "        z = 1\n"
+        "    return z\n"
+    )
+    invs = list(v.invs())
+    # Two obligation faces: discharge ValueError=ValueError and absence.
+    consequents = []
+    for inv in invs:
+        f = inv
+        if getattr(f, "kind", None) == "implies":
+            f = f.operands[1]
+        consequents.append(f)
+    discharges = [
+        c
+        for c in consequents
+        if getattr(c, "name", None) == "="
+        and getattr(c.args[0], "value", None) == "ValueError"
+        and getattr(c.args[1], "value", None) == "ValueError"
+    ]
+    absences = [
+        c
+        for c in consequents
+        if getattr(c, "name", None) == "="
+        and getattr(c.args[0], "value", None) == "ValueError"
+        and getattr(c.args[1], "value", None) == "py.effect.none"
+    ]
+    assert discharges, f"missing matched discharge in {invs}"
+    assert absences, f"missing ¬c absence obligation in {invs}"
+    # Raised face is consumed — no residual ValueError Incomplete.
+    from sugar_lift_py_tests.outcome import Incomplete
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    reds = [
+        e
+        for e in v.record.contribution()
+        if isinstance(e, Incomplete) and isinstance(e.effect, RaiseEffect)
+    ]
+    assert reds == []
+
+
+def test_conditional_expects_wrong_type_keeps_halt_and_completion():
+    """Wrong halt under c + complementary completion under ¬c both survive."""
+    from sugar_lift_py_tests.outcome import Incomplete
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    v = _val(
+        "def A(c, z):\n"
+        "    with pytest.raises(ValueError):\n"
+        "        if c:\n"
+        "            raise KeyError\n"
+        "        z = 1\n"
+        "    return z\n"
+    )
+    reds = [
+        e
+        for e in v.record.contribution()
+        if isinstance(e, Incomplete) and isinstance(e.effect, RaiseEffect)
+    ]
+    assert len(reds) == 1
+    assert reds[0].effect.exception_name == "KeyError"
+    # Guarded under c — not an unconditional residual.
+    assert reds[0].branch_conditions, "wrong halt must keep its guard"
+    # Mismatch fact present (ValueError vs KeyError).
+    assert any(
+        getattr(inv, "name", None) == "="
+        or (
+            getattr(inv, "kind", None) == "implies"
+            and getattr(inv.operands[1], "name", None) == "="
+            and inv.operands[1].args[1].value == "KeyError"
+        )
+        or (
+            getattr(inv, "name", None) == "="
+            and getattr(inv.args[1], "value", None) == "KeyError"
+        )
+        for inv in v.invs()
+    )
+    # ¬c completion is not erased: absence or body residue under the complement.
+    invs = list(v.invs())
+    assert len(invs) >= 1
+
+
+def test_conditional_expects_as_authenticates_slot_only_on_matched_face():
+    """ei.value / effect_slot_type only on the matched raise face."""
+    v = _val(
+        "def A(c):\n"
+        "    with pytest.raises(ValueError) as ei:\n"
+        "        if c:\n"
+        "            raise ValueError\n"
+        "        x = 1\n"
+        "    return ei.value\n"
+    )
+    # Slot type auth must appear, and under a guard when multi-face.
+    typed = []
+    for inv in v.invs():
+        f = inv
+        guard = None
+        if getattr(f, "kind", None) == "implies":
+            guard, f = f.operands[0], f.operands[1]
+        if (
+            getattr(f, "name", None) == "="
+            and getattr(f.args[0], "name", None) == "effect_slot_type"
+        ):
+            typed.append((guard, f.args[1].value))
+    assert typed, f"missing effect_slot_type in {list(v.invs())}"
+    assert all(val == "ValueError" for _, val in typed)
+    # Matched-face only: if guarded, guard is the truthy(c) polarity.
+    if any(g is not None for g, _ in typed):
+        assert any(
+            g is not None and getattr(g, "name", None) == "py.truthy"
+            for g, _ in typed
+        )
+    assert v.post().args[1].name == "python:effect_slot"
+
+
+def test_conditional_suppresses_match_only_on_matching_face():
+    """Suppresses consumes KeyError under c; ¬c completion survives; mismatch rides."""
+    from sugar_lift_py_tests.outcome import Incomplete
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    v = _val(
+        "def A(c, z):\n"
+        "    with contextlib.suppress(KeyError):\n"
+        "        if c:\n"
+        "            raise KeyError\n"
+        "        z = 1\n"
+        "    return z\n"
+    )
+    reds = [
+        e
+        for e in v.record.contribution()
+        if isinstance(e, Incomplete) and isinstance(e.effect, RaiseEffect)
+    ]
+    assert reds == [], "matching KeyError face must be consumed"
+    assert v.post().args[1].name == "z"
+
+    # Mismatch face: wrong raise under c survives guarded.
+    v_bad = _val(
+        "def A(c, z):\n"
+        "    with contextlib.suppress(KeyError):\n"
+        "        if c:\n"
+        "            raise ValueError\n"
+        "        z = 1\n"
+        "    return z\n"
+    )
+    reds_bad = [
+        e
+        for e in v_bad.record.contribution()
+        if isinstance(e, Incomplete) and isinstance(e.effect, RaiseEffect)
+    ]
+    assert len(reds_bad) == 1
+    assert reds_bad[0].effect.exception_name == "ValueError"
+    assert reds_bad[0].branch_conditions
+
+
+def test_warning_kind_routing_non_halting_on_guarded_completed_faces():
+    """Warning Expects is non-halting; dual completed faces each get a verdict.
+
+    Unresolved-call openness stays covered by
+    ``test_warning_kind_with_unresolved_call_retains_obligation``. Conditional
+    bodies that need ``CallSiteValue.guarded`` stay out of this twin until that
+    Floor is written — here both faces complete without a raise halt.
+    """
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    v = _val(
+        "def A(c, z):\n"
+        "    with tm.assert_produces_warning(FutureWarning):\n"
+        "        if c:\n"
+        "            z = 1\n"
+        "        else:\n"
+        "            z = 2\n"
+        "    return z\n"
+    )
+    assert not any(isinstance(e, Incomplete) for e in v.record.contribution())
+    # No observed warning → absence (or open expected) on completed faces.
+    invs = list(v.invs())
+    assert invs, f"warning contract must state a verdict: {invs}"
+    assert v.post().args[1].name == "z"


### PR DESCRIPTION
## Summary

Same linear-router cut as #6037 for Try: assertion-manager `WithContractSugar` no longer does `reduce_statements` → `route(entries)`.

```text
body -> reduce_block_to_exitset
     -> promote guarded raises to Halted
     -> route contract over each Halted / Completed exit
     -> preserve unmatched Completed exits
     -> authenticate slots only on matched guarded exits
     -> normalize
```

Shared `exit_set_routing` helpers used by Try and With.

### Twins

- **Conditional Expects**: raised face consumed + discharged; ¬c absence survives
- **Conditional wrong type**: KeyError halt under guard; completion face survives
- **Conditional `as ei`**: `effect_slot_type` only on matched face
- **Conditional Suppresses**: match consumed under c; mismatch ValueError guarded
- **Warning**: non-halting dual completed faces still state a verdict

## Validation

```bash
python -m pytest test_with_contract.py test_try_sugar.py test_exit_set.py -q
# 58 passed
```

## Next (not this PR)

1. Generic enter/exit resource transformation
2. Proven NeverSuppresses enrollment
3. Runtime-selected suppression
4. Multi-manager nesting
5. Re-census

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route `WithContractSugar.desugar` over `ExitSet` faces instead of linearized entries
> - Refactors `WithContractSugar.desugar` in [with_contract_sugar.py](https://github.com/TSavo/sugar/pull/6038/files#diff-672d341bb64fbfbf08ca08317028247fd83494449bc842b3e118baea34dbbadc) to reduce the body to an `ExitSet`, promote halting raises into `Halted` exits, then route contract handlers per guarded face rather than over a single flat entry list.
> - Halted faces route a synthetic `Incomplete(effect)` tuple under their guard; Completed faces route the state's entries; results are lifted back into `ExitSet` faces and collapsed to an `Outcome` via `exitset_to_outcome`.
> - Extracts shared utilities (`is_hard_raise`, `guard_from_conditions`, `promote_raise_halts`, `exitset_to_outcome`, `routed_entries_to_exitset`, `site_inv_values`) into a new [exit_set_routing.py](https://github.com/TSavo/sugar/pull/6038/files#diff-c44b7c06a673ccf3c76f2b01e5af17b1d0d393b5b38c1021b7f710e4eaf361da) module, removing duplicated helpers from [try_sugar.py](https://github.com/TSavo/sugar/pull/6038/files#diff-f5d956a5de18664d828d314bf5537a359cc1f2f40c5a42b52f03bbe5ecaac0ff).
> - New tests in [test_with_contract.py](https://github.com/TSavo/sugar/pull/6038/files#diff-c52d5be339caa9e038fa2620f6775041499142c9675b24d2b7b5a5c982cf3723) cover conditional expects, wrong-type halt guard preservation, slot authentication on matched faces, and guarded warning-kind routing.
> - Behavioral Change: contract routing now consumes matched halts only under their guard; mismatched halts survive under their own guard; the returned `Outcome` reflects multi-face routing rather than a single linear collapse.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3059899.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->