### PR TITLE
Resource with: ExitSet.and_exit + WithResourceSugar

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -201,6 +201,56 @@ class ExitSet(Generic[T]):
                     exits.append(Completed(guard, clean.value))
         return ExitSet(tuple(exits)).normalize()
 
+    def and_exit(
+        self,
+        exit_call: Callable[[], "ExitSet[object]"],
+        *,
+        suppresses: Callable[[object, object], bool] | None = None,
+        open_suppression: Callable[[object], object] | None = None,
+    ) -> "ExitSet[object]":
+        """Run ``__exit__`` over every body exit (resource ``with``).
+
+        ``exit_call`` is constructed **once** and fanned across faces (same
+        posture as ``and_finally``). Laws:
+
+        - Exit **halt** supersedes the incoming exit.
+        - Exit **completion** on a **Completed** incoming keeps the body value.
+        - Exit **completion** on a **Halted** incoming:
+          - ``suppresses(effect, exit_value)`` is True → consume the halt
+            (Completed with empty residue).
+          - False → restore/rethrow the incoming halt.
+          - ``open_suppression(effect)`` set → leave that residual halt under
+            the guard (runtime-selected / unproved — never guessed True/False).
+
+        ``NeverSuppresses`` is disposition, not purity: the exit call still
+        runs and can itself halt (supersede). Disposition only answers the
+        completed-exit question: never suppress the body halt.
+        """
+        decide = suppresses or (lambda _effect, _exit_value: False)
+        exit_exits = exit_call().exits
+        exits: list[Exit[object]] = []
+        for incoming in self.exits:
+            for ex in exit_exits:
+                guard = _and_guards(incoming.guard, ex.guard)
+                if isinstance(ex, Halted):
+                    exits.append(Halted(guard, ex.effect))
+                    continue
+                if isinstance(incoming, Completed):
+                    exits.append(Completed(guard, incoming.value))
+                    continue
+                # Incoming Halted + exit completed.
+                if open_suppression is not None:
+                    residual = open_suppression(incoming.effect)
+                    if residual is not None:
+                        exits.append(Halted(guard, residual))
+                        continue
+                if decide(incoming.effect, ex.value):
+                    # Suppress: body halt is consumed; face completes.
+                    exits.append(Completed(guard, None))
+                else:
+                    exits.append(Halted(guard, incoming.effect))
+        return ExitSet(tuple(exits)).normalize()
+
     def collapse(self):
         """Return the old linear Outcome only for one unconditional exit."""
         normalized = self.normalize()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
@@ -1,0 +1,161 @@
+"""Resource ``with``: enter once, body ExitSet, exit on every outgoing face.
+
+Not the assertion-manager path (``WithContractSugar`` / membrane Expects and
+Suppresses). This sugar is the enter/exit transformation:
+
+1. Evaluate enter once.
+2. Enter halt exits before the body and never invokes exit.
+3. Bind ``as`` from the enter-result coordinate (when constructed).
+4. Reduce the body to a guarded ExitSet.
+5. Run exit over every body exit (``ExitSet.and_exit``).
+6. Exit halt supersedes; exit false restores; exit true consumes;
+   unproved suppression stays open residual under its guard.
+
+Admission rule: a manager is admitted only when enter and exit are
+constructed, or unresolved parts remain explicitly red. ``NeverSuppresses``
+is disposition (never consume body halt), not permission to skip the exit
+call — exit can itself halt and must be constructed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+from typing import Callable
+
+from sugar_lift_py_tests.outcome import Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_pair
+
+
+@dataclass(frozen=True)
+class WithResourceSugar(Sugar):
+    """Resource with under a constructed enter/exit pair + exit disposition.
+
+    ``enter`` / ``exit_call`` are zero-arg callables producing ExitSet — the
+    constructed enter/exit behaviours (or explicit red Incomplete residuals).
+    ``suppresses`` decides completed-exit disposition for a body halt; default
+    never suppresses (``NeverSuppresses``). ``open_suppression`` when set marks
+    runtime-selected / unproved halt faces instead of guessing.
+    """
+
+    body: tuple
+    enter: Callable[[], object]  # () -> ExitSet
+    exit_call: Callable[[], object]  # () -> ExitSet
+    suppresses: Callable[[object, object], bool] | None = None
+    open_suppression: Callable[[object], object] | None = None
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        # Resource path is not yet a green source surface (open stays
+        # RuntimeSelected). Witness is structural via unit twins.
+        return _call_pair(
+            name="with_resource_never_suppresses_structure",
+            owner_sugar="WithResourceSugar",
+            truthful=(
+                "def A(z):\n"
+                "    with contextlib.suppress(KeyError):\n"
+                "        raise KeyError\n"
+                "    return z\n\n"
+                "def test_a():\n"
+                "    assert A(5) == 5\n"
+            ),
+            lying=(
+                "def A(z):\n"
+                "    with contextlib.suppress(KeyError):\n"
+                "        raise KeyError\n"
+                "    return z\n\n"
+                "def test_a():\n"
+                "    assert A(5) == 6\n"
+            ),
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+        from sugar_lift_py_tests.sugar.exit_set_routing import (
+            exitset_to_outcome,
+            promote_raise_halts,
+        )
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            _ReducedBlock,
+            reduce_block_to_exitset,
+        )
+
+        del ctx
+
+        enter_es = self.enter()
+        if not isinstance(enter_es, ExitSet):
+            raise TypeError(
+                f"WithResourceSugar.enter must return ExitSet, got {type(enter_es).__name__}"
+            )
+
+        def _exit() -> ExitSet:
+            result = self.exit_call()
+            if not isinstance(result, ExitSet):
+                raise TypeError(
+                    "WithResourceSugar.exit_call must return ExitSet, "
+                    f"got {type(result).__name__}"
+                )
+            return result
+
+        # Body/exit only when enter completes. Reduce body once if any face
+        # completes; never construct body or exit under pure enter-halt.
+        needs_body = any(isinstance(e, Completed) for e in enter_es.exits)
+        body_es = (
+            promote_raise_halts(reduce_block_to_exitset(self.body))
+            if needs_body
+            else None
+        )
+
+        parts: list = []
+        for enter_exit in enter_es.exits:
+            if isinstance(enter_exit, Halted):
+                # Enter halt: no body, no exit.
+                parts.append(ExitSet((enter_exit,)))
+                continue
+            # Enter completed: body under enter guard, then exit on every face.
+            assert body_es is not None
+            after_body = body_es.guarded(enter_exit.guard)
+            after_exit = after_body.and_exit(
+                _exit,
+                suppresses=self.suppresses,
+                open_suppression=self.open_suppression,
+            )
+            parts.append(after_exit)
+
+        if not parts:
+            routed = ExitSet.completed(
+                _ReducedBlock(entries=(), can_fall_through=True, fall_through=())
+            )
+        else:
+            routed = parts[0]
+            for part in parts[1:]:
+                routed = routed.union(part)
+
+        return exitset_to_outcome(routed)
+
+
+def never_suppresses_disposition(_effect: object, _exit_value: object) -> bool:
+    """``NeverSuppresses``: completed exit never consumes the body halt."""
+    return False
+
+
+def suppresses_named(*exception_names: str) -> Callable[[object, object], bool]:
+    """Completed exit suppresses only named raise effects (proven subset)."""
+
+    names = frozenset(exception_names)
+
+    def _decide(effect: object, _exit_value: object) -> bool:
+        name = getattr(effect, "exception_name", None)
+        return name in names
+
+    return _decide
+
+
+def open_suppression_residual(effect: object) -> object:
+    """Keep the body effect as open residual — do not invent suppress/restore.
+
+    Used when exit disposition is runtime-selected. The residual is the same
+    effect under the face guard; callers that need a distinct marker can wrap.
+    """
+    return effect

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
@@ -135,3 +135,88 @@ def test_and_finally_runs_cleanup_on_every_conditional_exit():
     assert len(after.exits) == 2
     assert any(isinstance(e, Halted) and e.effect == effect for e in after.exits)
     assert any(isinstance(e, Completed) and e.value == "state" for e in after.exits)
+
+
+# --- resource with: and_exit -------------------------------------------------
+
+
+def test_and_exit_completion_keeps_body_completed():
+    incoming = ExitSet.completed("body")
+    after = incoming.and_exit(lambda: ExitSet.completed(False))
+    assert after.collapse() == Complete("body")
+
+
+def test_and_exit_halt_supersedes_body_completed():
+    exit_halt = RaiseEffect(exception_name="RuntimeError")
+    incoming = ExitSet.completed("body")
+    after = incoming.and_exit(lambda: ExitSet.halted(exit_halt))
+    assert after.collapse() == Incomplete(exit_halt)
+
+
+def test_and_exit_halt_supersedes_body_halted():
+    body = RaiseEffect(exception_name="ValueError")
+    exit_halt = RaiseEffect(exception_name="RuntimeError")
+    incoming = ExitSet.halted(body)
+    after = incoming.and_exit(lambda: ExitSet.halted(exit_halt))
+    assert after.collapse() == Incomplete(exit_halt)
+
+
+def test_and_exit_false_restores_body_halt():
+    body = RaiseEffect(exception_name="ValueError")
+    incoming = ExitSet.halted(body)
+    after = incoming.and_exit(
+        lambda: ExitSet.completed(False),
+        suppresses=lambda _e, _v: False,
+    )
+    assert after.collapse() == Incomplete(body)
+
+
+def test_and_exit_true_consumes_body_halt():
+    body = RaiseEffect(exception_name="ValueError")
+    incoming = ExitSet.halted(body)
+    after = incoming.and_exit(
+        lambda: ExitSet.completed(True),
+        suppresses=lambda _e, _v: True,
+    )
+    assert after.collapse() == Complete(None)
+
+
+def test_and_exit_open_suppression_leaves_residual_not_guessed():
+    body = RaiseEffect(exception_name="ValueError")
+    incoming = ExitSet.halted(body)
+    after = incoming.and_exit(
+        lambda: ExitSet.completed("runtime"),
+        suppresses=lambda _e, _v: True,  # would suppress if decided
+        open_suppression=lambda effect: effect,  # open wins — never guess
+    )
+    assert after.collapse() == Incomplete(body)
+
+
+def test_and_exit_fans_once_across_conditional_faces():
+    condition = _guard("condition")
+    effect = RaiseEffect(exception_name="ValueError")
+    incoming = ExitSet.conditional_halt(condition, effect, "state")
+    seen = []
+
+    def exit_call():
+        seen.append(1)
+        return ExitSet.completed(False)
+
+    after = incoming.and_exit(exit_call, suppresses=lambda _e, _v: False)
+    assert len(seen) == 1
+    assert any(isinstance(e, Halted) and e.effect == effect for e in after.exits)
+    assert any(isinstance(e, Completed) and e.value == "state" for e in after.exits)
+
+
+def test_and_exit_suppresses_only_matching_face_of_conditional():
+    condition = _guard("condition")
+    effect = RaiseEffect(exception_name="ValueError")
+    incoming = ExitSet.conditional_halt(condition, effect, "state")
+    after = incoming.and_exit(
+        lambda: ExitSet.completed(True),
+        suppresses=lambda e, _v: getattr(e, "exception_name", None) == "ValueError",
+    )
+    # Halted face consumed; completed face kept.
+    assert all(isinstance(e, Completed) for e in after.exits)
+    assert any(e.value == "state" for e in after.exits if isinstance(e, Completed))
+    assert any(e.value is None for e in after.exits if isinstance(e, Completed))

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -1,0 +1,194 @@
+"""Unit twins for resource ``WithResourceSugar`` enter/exit ExitSet laws.
+
+Production ``open(...)`` stays ``RuntimeSelected`` until enter/exit are
+constructed. These twins drive the transformation with explicit ExitSets —
+constructed green faces or explicit red residuals — never invented suppress.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.ir import atomic, make_var, not_
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+from sugar_lift_py_tests.sugar.with_resource_sugar import (
+    WithResourceSugar,
+    never_suppresses_disposition,
+    open_suppression_residual,
+    suppresses_named,
+)
+
+
+class _Pass:
+    def desugar(self, ctx=None):
+        del ctx
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.outcome import Complete as C
+
+        return C(BlockValue((), can_fall_through=True))
+
+
+class _Raise:
+    def __init__(self, name: str):
+        self.name = name
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Incomplete(RaiseEffect(exception_name=self.name))
+
+
+def _guard(name: str):
+    return atomic(name, [make_var("state")])
+
+
+def test_enter_halt_skips_body_and_exit():
+    body_ran = []
+    exit_ran = []
+
+    class BodyProbe:
+        def desugar(self, ctx=None):
+            del ctx
+            body_ran.append(1)
+            return _Pass().desugar()
+
+    enter_halt = RaiseEffect(exception_name="OSError")
+    sugar = WithResourceSugar(
+        body=(BodyProbe(),),
+        enter=lambda: ExitSet.halted(enter_halt),
+        exit_call=lambda: (exit_ran.append(1) or ExitSet.completed(False)),
+        suppresses=never_suppresses_disposition,
+    )
+    out = sugar.desugar()
+    assert body_ran == []
+    assert exit_ran == []
+    assert isinstance(out, Complete)
+    reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
+    assert len(reds) == 1
+    assert reds[0].effect == enter_halt
+
+
+def test_never_suppresses_restores_body_halt_after_exit_completes():
+    body_halt = RaiseEffect(exception_name="ValueError")
+    sugar = WithResourceSugar(
+        body=(_Raise("ValueError"),),
+        enter=lambda: ExitSet.completed("resource"),
+        exit_call=lambda: ExitSet.completed(False),
+        suppresses=never_suppresses_disposition,
+    )
+    out = sugar.desugar()
+    reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
+    assert len(reds) == 1
+    assert reds[0].effect.exception_name == "ValueError"
+
+
+def test_exit_halt_supersedes_body_halt():
+    sugar = WithResourceSugar(
+        body=(_Raise("ValueError"),),
+        enter=lambda: ExitSet.completed("resource"),
+        exit_call=lambda: ExitSet.halted(RaiseEffect(exception_name="RuntimeError")),
+        suppresses=never_suppresses_disposition,
+    )
+    out = sugar.desugar()
+    reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
+    assert len(reds) == 1
+    assert reds[0].effect.exception_name == "RuntimeError"
+
+
+def test_exit_true_consumes_matching_body_halt():
+    sugar = WithResourceSugar(
+        body=(_Raise("ValueError"),),
+        enter=lambda: ExitSet.completed("resource"),
+        exit_call=lambda: ExitSet.completed(True),
+        suppresses=suppresses_named("ValueError"),
+    )
+    out = sugar.desugar()
+    reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
+    assert reds == []
+
+
+def test_exit_true_does_not_consume_wrong_type():
+    sugar = WithResourceSugar(
+        body=(_Raise("KeyError"),),
+        enter=lambda: ExitSet.completed("resource"),
+        exit_call=lambda: ExitSet.completed(True),
+        suppresses=suppresses_named("ValueError"),
+    )
+    out = sugar.desugar()
+    reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
+    assert len(reds) == 1
+    assert reds[0].effect.exception_name == "KeyError"
+
+
+def test_open_suppression_not_guessed_even_if_exit_returns_true():
+    sugar = WithResourceSugar(
+        body=(_Raise("ValueError"),),
+        enter=lambda: ExitSet.completed("resource"),
+        exit_call=lambda: ExitSet.completed(True),
+        suppresses=suppresses_named("ValueError"),
+        open_suppression=open_suppression_residual,
+    )
+    out = sugar.desugar()
+    reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
+    assert len(reds) == 1
+    assert reds[0].effect.exception_name == "ValueError"
+
+
+def test_completed_body_survives_never_suppresses_exit():
+    sugar = WithResourceSugar(
+        body=(_Pass(),),
+        enter=lambda: ExitSet.completed("resource"),
+        exit_call=lambda: ExitSet.completed(False),
+        suppresses=never_suppresses_disposition,
+    )
+    out = sugar.desugar()
+    assert isinstance(out, Complete)
+    assert not any(isinstance(e, Incomplete) for e in out.value.contribution())
+
+
+def test_exit_runs_on_every_conditional_body_face():
+    """Conditional body halt + completion: exit fans once; both faces decided."""
+    condition = _guard("c")
+    effect = RaiseEffect(exception_name="ValueError")
+
+    class ConditionalBody:
+        def desugar(self, ctx=None):
+            del ctx
+            # Multi-exit via Incomplete under guard is produced by if-sugar;
+            # here inject the dual ExitSet by wrapping in a statement that
+            # reduce_block would not dualize — use promote path via Incomplete.
+            return Incomplete(effect).guarded(condition)
+
+    seen = []
+
+    def exit_call():
+        seen.append(1)
+        return ExitSet.completed(False)
+
+    sugar = WithResourceSugar(
+        body=(ConditionalBody(),),
+        enter=lambda: ExitSet.completed("resource"),
+        exit_call=exit_call,
+        suppresses=never_suppresses_disposition,
+    )
+    out = sugar.desugar()
+    assert len(seen) == 1
+    # Guarded halt restored under c (never suppress).
+    reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
+    assert len(reds) == 1
+    assert reds[0].effect.exception_name == "ValueError"
+    assert reds[0].branch_conditions
+
+
+def test_unconstructed_enter_is_explicit_red_not_dissolve():
+    """Admission: missing enter stays Incomplete residual, never silent pass."""
+    enter_gap = RaiseEffect(exception_name="ConstructionGapEnter")
+    sugar = WithResourceSugar(
+        body=(_Pass(),),
+        enter=lambda: ExitSet.halted(enter_gap),
+        exit_call=lambda: ExitSet.completed(False),
+        suppresses=never_suppresses_disposition,
+    )
+    out = sugar.desugar()
+    reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
+    assert len(reds) == 1
+    assert reds[0].effect.exception_name == "ConstructionGapEnter"

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1811,8 +1811,11 @@ class With(Statement):
             )
             self.reporter.report_gap(self, panic)
             raise panic
-        # NeverSuppresses (nothing enrolls yet): finally-faithful expansion
-        # unwritten — bare SugarNotWritten until that slice lands.
+        # NeverSuppresses: disposition-only license for WithResourceSugar
+        # (enter once, body ExitSet, exit on every face). Nothing enrolls yet;
+        # when it does, enter/exit must be constructed or left explicitly red —
+        # never a normal-path-only dissolve. Until enrollment + construction,
+        # stay loud.
         return super()._construct_sugar()
 
     def substitute(self, scope):

--- a/implementations/python/sugar-source-tree/tests/test_with_resource.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_resource.py
@@ -1,11 +1,11 @@
 """Resource `with` under RuntimeSelected (#5994 step 4).
 
-Honest v1: we never lift ``__enter__``/``__exit__``, so no resource manager
-is proven ``NeverSuppresses``. Every unenrolled resource manager is therefore
-``RuntimeSelected`` and stays LOUD as the named residual
-``RuntimeSelectedContextManager`` — not a silent dissolve, not a bare
-``SugarNotWritten``, not a false green. Assertion managers (Expects/Suppresses
-via the membrane) keep their wired path.
+Production: unenrolled managers (``open``, …) stay LOUD as the named residual
+``RuntimeSelectedContextManager`` until enter/exit are constructed. The
+enter/exit ExitSet transformation lives on ``WithResourceSugar`` (unit twins
+in ``test_with_resource_sugar.py``); assertion managers (Expects/Suppresses)
+stay on ``WithContractSugar``. No manager is admitted green without constructed
+enter/exit or an explicit red residual.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

After #6038 closed linear control routing for assertion With, this cut adds the **resource** enter/exit transformation — without admitting unconstructed managers as green.

### Algebra (`ExitSet.and_exit`)

- Exit call constructed **once**, fanned across every body face
- Exit **halt** supersedes incoming
- Exit complete + body complete → keep body value
- Exit complete + body halt → suppress (consume) / restore / **open residual** (runtime-selected — never guessed)

`NeverSuppresses` is disposition (never consume), not purity: exit still runs and can halt.

### `WithResourceSugar`

1. Enter once  
2. Enter halt → no body, no exit  
3. Enter complete → body ExitSet (promoted guarded raises)  
4. `and_exit` over every body face  

### Admission

Production `open(...)` remains **`RuntimeSelectedContextManager`**. No manager is admitted green until enter/exit are constructed or unresolved parts stay explicitly red. Unit twins drive the transformation with explicit ExitSets.

### Validation

```bash
pytest test_exit_set.py test_with_resource_sugar.py test_with_resource.py \
       test_with_contract.py test_try_sugar.py -q
# 80 passed
```

## Next

1. Proven NeverSuppresses enrollment (membrane + constructed enter/exit)
2. Runtime-selected suppression residual wiring into production With
3. Multi-manager nesting (nested transformations, reverse exit order)
4. Re-census

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ExitSet.and_exit` and `WithResourceSugar` for resource-guarded block desugaring
> - Adds `ExitSet.and_exit` to [exit_set.py](https://github.com/TSavo/sugar/pull/6039/files#diff-40bf423f2f11b7e245b883146f67d6943005b30b1c5a4d74f1aab767272e3716), which composes two `ExitSet` instances with guard intersection and configurable suppression of body halts.
> - Adds `WithResourceSugar` to [with_resource_sugar.py](https://github.com/TSavo/sugar/pull/6039/files#diff-e157731c16f82dd84b0fbeeff14ddf0c765c34521ebda25182232c5cd85f670d), a dataclass that desugars a resource-guarded block by validating enter/exit `ExitSet` types, skipping body/exit when enter halts, reducing the body once if any enter face completes, and applying exit semantics via `and_exit`.
> - Adds helper predicates `never_suppresses_disposition`, `suppresses_named`, and `open_suppression_residual` to control whether a completing exit consumes or propagates body halts.
> - Adds test coverage in [test_exit_set.py](https://github.com/TSavo/sugar/pull/6039/files#diff-522e4fef8e66faf7c59f4346f56fc648f832775f363dbfa4e789859e3448b0b9) and [test_with_resource_sugar.py](https://github.com/TSavo/sugar/pull/6039/files#diff-2f3ef62c9f2b0c15b9f9ce067770fa40d6698321025089647c1a4db727f0aac0).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4104f3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->