### PR TITLE
Resource with: tree enter/exit coords, typed disposition

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
@@ -59,6 +59,9 @@ class EffectMatcher:
 EXCEPTION_INFO = "exception_info"
 WARNING_OBSERVATION = "warning_observation"
 EFFECT = "effect"
+# Resource enter-result: tree coordinate for ``with m as x`` under a resource
+# disposition (NeverSuppresses / proven exit). Not an exception witness.
+ENTER_RESULT = "enter_result"
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -203,31 +203,32 @@ class ExitSet(Generic[T]):
 
     def and_exit(
         self,
-        exit_call: Callable[[], "ExitSet[object]"],
+        exit_es: "ExitSet[object]",
         *,
-        suppresses: Callable[[object, object], bool] | None = None,
-        open_suppression: Callable[[object], object] | None = None,
+        disposition: object,
     ) -> "ExitSet[object]":
-        """Run ``__exit__`` over every body exit (resource ``with``).
+        """Run constructed ``__exit__`` over every body exit (resource ``with``).
 
-        ``exit_call`` is constructed **once** and fanned across faces (same
-        posture as ``and_finally``). Laws:
+        ``exit_es`` is the already-reduced exit ExitSet (built once from tree
+        sugar, not a callback). ``disposition`` is a **typed** exit contract:
+
+        - ``NeverSuppresses`` — restore body halt (exit still ran; may supersede)
+        - ``ExitSuppressionContract`` — proven named suppress / restore
+        - ``RuntimeSelected`` — open residual under the guard (never guessed)
+        - ``Suppresses(matcher)`` — membrane matcher authority only
+
+        Laws:
 
         - Exit **halt** supersedes the incoming exit.
         - Exit **completion** on a **Completed** incoming keeps the body value.
-        - Exit **completion** on a **Halted** incoming:
-          - ``suppresses(effect, exit_value)`` is True → consume the halt
-            (Completed with empty residue).
-          - False → restore/rethrow the incoming halt.
-          - ``open_suppression(effect)`` set → leave that residual halt under
-            the guard (runtime-selected / unproved — never guessed True/False).
-
-        ``NeverSuppresses`` is disposition, not purity: the exit call still
-        runs and can itself halt (supersede). Disposition only answers the
-        completed-exit question: never suppress the body halt.
+        - Exit **completion** on a **Halted** incoming applies ``disposition``:
+          suppress → consume; restore → rethrow; open → residual halt.
         """
-        decide = suppresses or (lambda _effect, _exit_value: False)
-        exit_exits = exit_call().exits
+        from sugar_lift_py_tests.outcome.resource_exit_disposition import (
+            disposition_verdict,
+        )
+
+        exit_exits = exit_es.exits
         exits: list[Exit[object]] = []
         for incoming in self.exits:
             for ex in exit_exits:
@@ -238,16 +239,14 @@ class ExitSet(Generic[T]):
                 if isinstance(incoming, Completed):
                     exits.append(Completed(guard, incoming.value))
                     continue
-                # Incoming Halted + exit completed.
-                if open_suppression is not None:
-                    residual = open_suppression(incoming.effect)
-                    if residual is not None:
-                        exits.append(Halted(guard, residual))
-                        continue
-                if decide(incoming.effect, ex.value):
-                    # Suppress: body halt is consumed; face completes.
+                # Incoming Halted + exit completed → typed disposition.
+                verdict = disposition_verdict(disposition, incoming.effect)
+                if verdict == "suppress":
                     exits.append(Completed(guard, None))
+                elif verdict == "open":
+                    exits.append(Halted(guard, incoming.effect))
                 else:
+                    # restore
                     exits.append(Halted(guard, incoming.effect))
         return ExitSet(tuple(exits)).normalize()
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/resource_exit_disposition.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/resource_exit_disposition.py
@@ -1,0 +1,58 @@
+"""Typed exit disposition for resource ``with`` — not Python decision callbacks.
+
+Authority lives only in:
+
+- ``NeverSuppresses`` — membrane/contract: never consume body halt
+- ``ExitSuppressionContract`` — source-proven named suppress set (or empty)
+- ``RuntimeSelected`` — undecidable; leave open residual under the guard
+- ``Suppresses(matcher)`` — membrane matcher (exact kind+name)
+
+No free-floating exception-name helpers. Production must not select semantics
+by ad-hoc name checks outside these types.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+Verdict = Literal["suppress", "restore", "open"]
+
+
+def disposition_verdict(disposition: object, effect: object) -> Verdict:
+    """Decide suppress / restore / open for a body halt after exit completed.
+
+    Never invents True/False for runtime-selected faces.
+    """
+    from sugar_lift_py_tests.context_manager_contract import (
+        NeverSuppresses,
+        RuntimeSelected,
+        Suppresses,
+    )
+    from sugar_lift_py_tests.floor.call_site_value import ExitSuppressionContract
+
+    if disposition is None or isinstance(disposition, RuntimeSelected):
+        return "open"
+
+    if isinstance(disposition, NeverSuppresses):
+        return "restore"
+
+    if isinstance(disposition, ExitSuppressionContract):
+        name = getattr(effect, "exception_name", None)
+        if not isinstance(name, str) or not name:
+            return "open"
+        return "suppress" if disposition.suppresses_exception(name) else "restore"
+
+    if isinstance(disposition, Suppresses):
+        matcher = disposition.matcher
+        if getattr(matcher, "kind", None) != "raise":
+            return "open"
+        name = getattr(effect, "exception_name", None)
+        if name == matcher.name:
+            return "suppress"
+        return "restore"
+
+    raise TypeError(
+        "resource exit disposition must be NeverSuppresses, "
+        "ExitSuppressionContract, RuntimeSelected, or Suppresses; "
+        f"got {type(disposition).__name__}"
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/exit_set_routing.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/exit_set_routing.py
@@ -193,3 +193,30 @@ def site_inv_values(entries: tuple, site) -> tuple:
         else e
         for e in entries
     )
+
+
+def sugar_outcome_to_exitset(outcome) -> "ExitSet":
+    """Project one sugar ``Outcome`` into a (usually single-exit) ExitSet.
+
+    Used for tree-owned enter/exit method-coordinate sugars: Incomplete → Halted,
+    Complete → Completed. Multi-exit Outcomes are not produced by a single
+    method call desugar today.
+    """
+    from sugar_lift_py_tests.ir import and_
+    from sugar_lift_py_tests.outcome import Complete, Incomplete
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
+    if isinstance(outcome, Incomplete):
+        if outcome.branch_conditions:
+            condition = (
+                outcome.branch_conditions[0]
+                if len(outcome.branch_conditions) == 1
+                else and_(list(outcome.branch_conditions))
+            )
+            return ExitSet.halted(outcome.effect, condition)
+        return ExitSet.halted(outcome.effect)
+    if isinstance(outcome, Complete):
+        return ExitSet.completed(outcome.value)
+    raise TypeError(
+        f"sugar_outcome_to_exitset expects Complete|Incomplete, got {type(outcome).__name__}"
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
@@ -1,26 +1,26 @@
-"""Resource ``with``: enter once, body ExitSet, exit on every outgoing face.
+"""Resource ``with``: tree-owned enter/exit sugars + typed disposition.
 
-Not the assertion-manager path (``WithContractSugar`` / membrane Expects and
-Suppresses). This sugar is the enter/exit transformation:
+Not the assertion-manager path (``WithContractSugar``). Not callback injection.
 
-1. Evaluate enter once.
-2. Enter halt exits before the body and never invokes exit.
-3. Bind ``as`` from the enter-result coordinate (when constructed).
-4. Reduce the body to a guarded ExitSet.
-5. Run exit over every body exit (``ExitSet.and_exit``).
-6. Exit halt supersedes; exit false restores; exit true consumes;
-   unproved suppression stays open residual under its guard.
+Structure:
 
-Admission rule: a manager is admitted only when enter and exit are
-constructed, or unresolved parts remain explicitly red. ``NeverSuppresses``
-is disposition (never consume body halt), not permission to skip the exit
-call — exit can itself halt and must be constructed.
+1. ``enter`` / ``exit`` are **constructed sugars** (tree ``manager.__enter__()``
+   / ``manager.__exit__(...)`` method-coordinate nodes, sugar()'d once).
+2. ``disposition`` is a **typed contract** (``NeverSuppresses``,
+   ``ExitSuppressionContract``, ``RuntimeSelected``, or membrane
+   ``Suppresses``) — never a Python decision function.
+3. Enter halt → no body, no exit.
+4. Enter complete → body ExitSet → ``and_exit(exit_es, disposition=...)``.
+5. Enter-result ``as`` is a tree ``ObservationRef`` (``ENTER_RESULT``), not a
+   floor object stuffed into the sugar.
+
+Admission: managers stay loud (``RuntimeSelectedContextManager``) until enter
+and exit are constructed or unresolved parts remain explicitly red.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field as dataclass_field
-from typing import Callable
 
 from sugar_lift_py_tests.outcome import Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
@@ -29,28 +29,21 @@ from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 @dataclass(frozen=True)
 class WithResourceSugar(Sugar):
-    """Resource with under a constructed enter/exit pair + exit disposition.
+    """Resource with: enter sugar, exit sugar, body, typed disposition."""
 
-    ``enter`` / ``exit_call`` are zero-arg callables producing ExitSet — the
-    constructed enter/exit behaviours (or explicit red Incomplete residuals).
-    ``suppresses`` decides completed-exit disposition for a body halt; default
-    never suppresses (``NeverSuppresses``). ``open_suppression`` when set marks
-    runtime-selected / unproved halt faces instead of guessing.
-    """
-
+    enter: Sugar
+    exit: Sugar
     body: tuple
-    enter: Callable[[], object]  # () -> ExitSet
-    exit_call: Callable[[], object]  # () -> ExitSet
-    suppresses: Callable[[object, object], bool] | None = None
-    open_suppression: Callable[[object], object] | None = None
+    disposition: object  # NeverSuppresses | ExitSuppressionContract | RuntimeSelected | Suppresses
+    enter_slot_id: str | None = None
     site: object = dataclass_field(compare=False, default=None)
 
     @classmethod
     def witnesses(cls):
         # Resource path is not yet a green source surface (open stays
-        # RuntimeSelected). Witness is structural via unit twins.
+        # RuntimeSelected). Structural witness reuses membrane suppress green.
         return _call_pair(
-            name="with_resource_never_suppresses_structure",
+            name="with_resource_structure",
             owner_sugar="WithResourceSugar",
             truthful=(
                 "def A(z):\n"
@@ -75,6 +68,7 @@ class WithResourceSugar(Sugar):
         from sugar_lift_py_tests.sugar.exit_set_routing import (
             exitset_to_outcome,
             promote_raise_halts,
+            sugar_outcome_to_exitset,
         )
         from sugar_lift_py_tests.sugar.function_universe_sugar import (
             _ReducedBlock,
@@ -83,43 +77,29 @@ class WithResourceSugar(Sugar):
 
         del ctx
 
-        enter_es = self.enter()
-        if not isinstance(enter_es, ExitSet):
-            raise TypeError(
-                f"WithResourceSugar.enter must return ExitSet, got {type(enter_es).__name__}"
-            )
-
-        def _exit() -> ExitSet:
-            result = self.exit_call()
-            if not isinstance(result, ExitSet):
-                raise TypeError(
-                    "WithResourceSugar.exit_call must return ExitSet, "
-                    f"got {type(result).__name__}"
-                )
-            return result
-
-        # Body/exit only when enter completes. Reduce body once if any face
-        # completes; never construct body or exit under pure enter-halt.
+        enter_es = sugar_outcome_to_exitset(self.enter.desugar())
         needs_body = any(isinstance(e, Completed) for e in enter_es.exits)
+
         body_es = (
             promote_raise_halts(reduce_block_to_exitset(self.body))
             if needs_body
             else None
         )
+        # Exit sugar materializes only when enter completed (body path).
+        exit_es = (
+            sugar_outcome_to_exitset(self.exit.desugar()) if needs_body else None
+        )
 
         parts: list = []
         for enter_exit in enter_es.exits:
             if isinstance(enter_exit, Halted):
-                # Enter halt: no body, no exit.
                 parts.append(ExitSet((enter_exit,)))
                 continue
-            # Enter completed: body under enter guard, then exit on every face.
-            assert body_es is not None
+            assert body_es is not None and exit_es is not None
             after_body = body_es.guarded(enter_exit.guard)
             after_exit = after_body.and_exit(
-                _exit,
-                suppresses=self.suppresses,
-                open_suppression=self.open_suppression,
+                exit_es,
+                disposition=self.disposition,
             )
             parts.append(after_exit)
 
@@ -133,29 +113,3 @@ class WithResourceSugar(Sugar):
                 routed = routed.union(part)
 
         return exitset_to_outcome(routed)
-
-
-def never_suppresses_disposition(_effect: object, _exit_value: object) -> bool:
-    """``NeverSuppresses``: completed exit never consumes the body halt."""
-    return False
-
-
-def suppresses_named(*exception_names: str) -> Callable[[object, object], bool]:
-    """Completed exit suppresses only named raise effects (proven subset)."""
-
-    names = frozenset(exception_names)
-
-    def _decide(effect: object, _exit_value: object) -> bool:
-        name = getattr(effect, "exception_name", None)
-        return name in names
-
-    return _decide
-
-
-def open_suppression_residual(effect: object) -> object:
-    """Keep the body effect as open residual — do not invent suppress/restore.
-
-    Used when exit disposition is runtime-selected. The residual is the same
-    effect under the face guard; callers that need a distinct marker can wrap.
-    """
-    return effect

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
@@ -1,4 +1,11 @@
+from sugar_lift_py_tests.context_manager_contract import (
+    EffectMatcher,
+    NeverSuppresses,
+    RuntimeSelected,
+    Suppresses,
+)
 from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.floor.call_site_value import ExitSuppressionContract
 from sugar_lift_py_tests.ir import atomic, make_var, not_, or_
 from sugar_lift_py_tests.outcome import Complete, Incomplete
 from sugar_lift_py_tests.outcome.exit_set import (
@@ -137,19 +144,23 @@ def test_and_finally_runs_cleanup_on_every_conditional_exit():
     assert any(isinstance(e, Completed) and e.value == "state" for e in after.exits)
 
 
-# --- resource with: and_exit -------------------------------------------------
+# --- resource with: and_exit (typed disposition, ExitSet not callbacks) -----
 
 
 def test_and_exit_completion_keeps_body_completed():
     incoming = ExitSet.completed("body")
-    after = incoming.and_exit(lambda: ExitSet.completed(False))
+    after = incoming.and_exit(
+        ExitSet.completed(False), disposition=NeverSuppresses()
+    )
     assert after.collapse() == Complete("body")
 
 
 def test_and_exit_halt_supersedes_body_completed():
     exit_halt = RaiseEffect(exception_name="RuntimeError")
     incoming = ExitSet.completed("body")
-    after = incoming.and_exit(lambda: ExitSet.halted(exit_halt))
+    after = incoming.and_exit(
+        ExitSet.halted(exit_halt), disposition=NeverSuppresses()
+    )
     assert after.collapse() == Incomplete(exit_halt)
 
 
@@ -157,66 +168,69 @@ def test_and_exit_halt_supersedes_body_halted():
     body = RaiseEffect(exception_name="ValueError")
     exit_halt = RaiseEffect(exception_name="RuntimeError")
     incoming = ExitSet.halted(body)
-    after = incoming.and_exit(lambda: ExitSet.halted(exit_halt))
+    after = incoming.and_exit(
+        ExitSet.halted(exit_halt), disposition=NeverSuppresses()
+    )
     assert after.collapse() == Incomplete(exit_halt)
 
 
-def test_and_exit_false_restores_body_halt():
+def test_and_exit_never_suppresses_restores_body_halt():
     body = RaiseEffect(exception_name="ValueError")
     incoming = ExitSet.halted(body)
     after = incoming.and_exit(
-        lambda: ExitSet.completed(False),
-        suppresses=lambda _e, _v: False,
+        ExitSet.completed(False), disposition=NeverSuppresses()
     )
     assert after.collapse() == Incomplete(body)
 
 
-def test_and_exit_true_consumes_body_halt():
+def test_and_exit_proven_contract_consumes_named_halt():
     body = RaiseEffect(exception_name="ValueError")
     incoming = ExitSet.halted(body)
     after = incoming.and_exit(
-        lambda: ExitSet.completed(True),
-        suppresses=lambda _e, _v: True,
+        ExitSet.completed(True),
+        disposition=ExitSuppressionContract.suppresses(("ValueError",)),
     )
     assert after.collapse() == Complete(None)
 
 
-def test_and_exit_open_suppression_leaves_residual_not_guessed():
+def test_and_exit_runtime_selected_leaves_open_residual_not_guessed():
     body = RaiseEffect(exception_name="ValueError")
     incoming = ExitSet.halted(body)
     after = incoming.and_exit(
-        lambda: ExitSet.completed("runtime"),
-        suppresses=lambda _e, _v: True,  # would suppress if decided
-        open_suppression=lambda effect: effect,  # open wins — never guess
+        ExitSet.completed(True),
+        disposition=RuntimeSelected(),
     )
     assert after.collapse() == Incomplete(body)
 
 
-def test_and_exit_fans_once_across_conditional_faces():
+def test_and_exit_fans_exitset_across_conditional_faces():
     condition = _guard("condition")
     effect = RaiseEffect(exception_name="ValueError")
     incoming = ExitSet.conditional_halt(condition, effect, "state")
-    seen = []
-
-    def exit_call():
-        seen.append(1)
-        return ExitSet.completed(False)
-
-    after = incoming.and_exit(exit_call, suppresses=lambda _e, _v: False)
-    assert len(seen) == 1
+    exit_es = ExitSet.completed(False)
+    after = incoming.and_exit(exit_es, disposition=NeverSuppresses())
     assert any(isinstance(e, Halted) and e.effect == effect for e in after.exits)
     assert any(isinstance(e, Completed) and e.value == "state" for e in after.exits)
 
 
-def test_and_exit_suppresses_only_matching_face_of_conditional():
+def test_and_exit_proven_contract_suppresses_only_matching_face():
     condition = _guard("condition")
     effect = RaiseEffect(exception_name="ValueError")
     incoming = ExitSet.conditional_halt(condition, effect, "state")
     after = incoming.and_exit(
-        lambda: ExitSet.completed(True),
-        suppresses=lambda e, _v: getattr(e, "exception_name", None) == "ValueError",
+        ExitSet.completed(True),
+        disposition=ExitSuppressionContract.suppresses(("ValueError",)),
     )
-    # Halted face consumed; completed face kept.
     assert all(isinstance(e, Completed) for e in after.exits)
     assert any(e.value == "state" for e in after.exits if isinstance(e, Completed))
     assert any(e.value is None for e in after.exits if isinstance(e, Completed))
+
+
+def test_and_exit_membrane_suppresses_matcher_authority():
+    body = RaiseEffect(exception_name="KeyError")
+    incoming = ExitSet.halted(body)
+    after = incoming.and_exit(
+        ExitSet.completed(True),
+        disposition=Suppresses(EffectMatcher(kind="raise", name="KeyError")),
+    )
+    assert after.collapse() == Complete(None)

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -1,40 +1,55 @@
-"""Unit twins for resource ``WithResourceSugar`` enter/exit ExitSet laws.
+"""Unit twins for resource ``WithResourceSugar`` — sugars + typed disposition.
 
-Production ``open(...)`` stays ``RuntimeSelected`` until enter/exit are
-constructed. These twins drive the transformation with explicit ExitSets —
-constructed green faces or explicit red residuals — never invented suppress.
+No Python callbacks for enter/exit/suppress. Production ``open(...)`` stays
+``RuntimeSelected`` until a typed disposition is enrolled with constructed
+enter/exit method-coordinate sugars.
 """
 
 from __future__ import annotations
 
-from sugar_lift_py_tests.effect import RaiseEffect
-from sugar_lift_py_tests.ir import atomic, make_var, not_
-from sugar_lift_py_tests.outcome import Complete, Incomplete
-from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
-from sugar_lift_py_tests.sugar.with_resource_sugar import (
-    WithResourceSugar,
-    never_suppresses_disposition,
-    open_suppression_residual,
-    suppresses_named,
+from sugar_lift_py_tests.context_manager_contract import (
+    NeverSuppresses,
+    RuntimeSelected,
 )
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.floor.call_site_value import ExitSuppressionContract
+from sugar_lift_py_tests.floor.block_value import BlockValue
+from sugar_lift_py_tests.ir import atomic, make_var
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
 
 
-class _Pass:
+class _FixedSugar(Sugar):
+    """Test sugar: desugars to a fixed Outcome (tree door stand-in)."""
+
+    def __init__(self, outcome, *, probe=None):
+        self._outcome = outcome
+        self._probe = probe
+
     def desugar(self, ctx=None):
         del ctx
-        from sugar_lift_py_tests.floor.block_value import BlockValue
-        from sugar_lift_py_tests.outcome import Complete as C
+        if self._probe is not None:
+            self._probe.append(1)
+        return self._outcome
 
-        return C(BlockValue((), can_fall_through=True))
+    @classmethod
+    def witnesses(cls):
+        return ()
 
 
-class _Raise:
-    def __init__(self, name: str):
-        self.name = name
+class _Pass(_FixedSugar):
+    def __init__(self, probe=None):
+        super().__init__(
+            Complete(BlockValue((), can_fall_through=True)), probe=probe
+        )
 
-    def desugar(self, ctx=None):
-        del ctx
-        return Incomplete(RaiseEffect(exception_name=self.name))
+
+class _Raise(_FixedSugar):
+    def __init__(self, name: str, probe=None):
+        super().__init__(
+            Incomplete(RaiseEffect(exception_name=name)), probe=probe
+        )
 
 
 def _guard(name: str):
@@ -44,19 +59,14 @@ def _guard(name: str):
 def test_enter_halt_skips_body_and_exit():
     body_ran = []
     exit_ran = []
-
-    class BodyProbe:
-        def desugar(self, ctx=None):
-            del ctx
-            body_ran.append(1)
-            return _Pass().desugar()
-
     enter_halt = RaiseEffect(exception_name="OSError")
     sugar = WithResourceSugar(
-        body=(BodyProbe(),),
-        enter=lambda: ExitSet.halted(enter_halt),
-        exit_call=lambda: (exit_ran.append(1) or ExitSet.completed(False)),
-        suppresses=never_suppresses_disposition,
+        enter=_FixedSugar(Incomplete(enter_halt)),
+        exit=_FixedSugar(
+            Complete(BlockValue((), can_fall_through=True)), probe=exit_ran
+        ),
+        body=(_Pass(probe=body_ran),),
+        disposition=NeverSuppresses(),
     )
     out = sugar.desugar()
     assert body_ran == []
@@ -68,12 +78,11 @@ def test_enter_halt_skips_body_and_exit():
 
 
 def test_never_suppresses_restores_body_halt_after_exit_completes():
-    body_halt = RaiseEffect(exception_name="ValueError")
     sugar = WithResourceSugar(
+        enter=_Pass(),
+        exit=_Pass(),
         body=(_Raise("ValueError"),),
-        enter=lambda: ExitSet.completed("resource"),
-        exit_call=lambda: ExitSet.completed(False),
-        suppresses=never_suppresses_disposition,
+        disposition=NeverSuppresses(),
     )
     out = sugar.desugar()
     reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
@@ -83,10 +92,10 @@ def test_never_suppresses_restores_body_halt_after_exit_completes():
 
 def test_exit_halt_supersedes_body_halt():
     sugar = WithResourceSugar(
+        enter=_Pass(),
+        exit=_Raise("RuntimeError"),
         body=(_Raise("ValueError"),),
-        enter=lambda: ExitSet.completed("resource"),
-        exit_call=lambda: ExitSet.halted(RaiseEffect(exception_name="RuntimeError")),
-        suppresses=never_suppresses_disposition,
+        disposition=NeverSuppresses(),
     )
     out = sugar.desugar()
     reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
@@ -94,24 +103,24 @@ def test_exit_halt_supersedes_body_halt():
     assert reds[0].effect.exception_name == "RuntimeError"
 
 
-def test_exit_true_consumes_matching_body_halt():
+def test_proven_contract_consumes_matching_body_halt():
     sugar = WithResourceSugar(
+        enter=_Pass(),
+        exit=_Pass(),
         body=(_Raise("ValueError"),),
-        enter=lambda: ExitSet.completed("resource"),
-        exit_call=lambda: ExitSet.completed(True),
-        suppresses=suppresses_named("ValueError"),
+        disposition=ExitSuppressionContract.suppresses(("ValueError",)),
     )
     out = sugar.desugar()
     reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
     assert reds == []
 
 
-def test_exit_true_does_not_consume_wrong_type():
+def test_proven_contract_does_not_consume_wrong_type():
     sugar = WithResourceSugar(
+        enter=_Pass(),
+        exit=_Pass(),
         body=(_Raise("KeyError"),),
-        enter=lambda: ExitSet.completed("resource"),
-        exit_call=lambda: ExitSet.completed(True),
-        suppresses=suppresses_named("ValueError"),
+        disposition=ExitSuppressionContract.suppresses(("ValueError",)),
     )
     out = sugar.desugar()
     reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
@@ -119,13 +128,12 @@ def test_exit_true_does_not_consume_wrong_type():
     assert reds[0].effect.exception_name == "KeyError"
 
 
-def test_open_suppression_not_guessed_even_if_exit_returns_true():
+def test_runtime_selected_not_guessed_even_if_exit_completes():
     sugar = WithResourceSugar(
+        enter=_Pass(),
+        exit=_Pass(),
         body=(_Raise("ValueError"),),
-        enter=lambda: ExitSet.completed("resource"),
-        exit_call=lambda: ExitSet.completed(True),
-        suppresses=suppresses_named("ValueError"),
-        open_suppression=open_suppression_residual,
+        disposition=RuntimeSelected(),
     )
     out = sugar.desugar()
     reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
@@ -135,44 +143,38 @@ def test_open_suppression_not_guessed_even_if_exit_returns_true():
 
 def test_completed_body_survives_never_suppresses_exit():
     sugar = WithResourceSugar(
+        enter=_Pass(),
+        exit=_Pass(),
         body=(_Pass(),),
-        enter=lambda: ExitSet.completed("resource"),
-        exit_call=lambda: ExitSet.completed(False),
-        suppresses=never_suppresses_disposition,
+        disposition=NeverSuppresses(),
     )
     out = sugar.desugar()
     assert isinstance(out, Complete)
     assert not any(isinstance(e, Incomplete) for e in out.value.contribution())
 
 
-def test_exit_runs_on_every_conditional_body_face():
-    """Conditional body halt + completion: exit fans once; both faces decided."""
+def test_exit_sugar_desugars_once_across_conditional_body_faces():
     condition = _guard("c")
     effect = RaiseEffect(exception_name="ValueError")
 
-    class ConditionalBody:
+    class ConditionalBody(Sugar):
         def desugar(self, ctx=None):
             del ctx
-            # Multi-exit via Incomplete under guard is produced by if-sugar;
-            # here inject the dual ExitSet by wrapping in a statement that
-            # reduce_block would not dualize — use promote path via Incomplete.
             return Incomplete(effect).guarded(condition)
 
-    seen = []
+        @classmethod
+        def witnesses(cls):
+            return ()
 
-    def exit_call():
-        seen.append(1)
-        return ExitSet.completed(False)
-
+    exit_ran = []
     sugar = WithResourceSugar(
+        enter=_Pass(),
+        exit=_Pass(probe=exit_ran),
         body=(ConditionalBody(),),
-        enter=lambda: ExitSet.completed("resource"),
-        exit_call=exit_call,
-        suppresses=never_suppresses_disposition,
+        disposition=NeverSuppresses(),
     )
     out = sugar.desugar()
-    assert len(seen) == 1
-    # Guarded halt restored under c (never suppress).
+    assert len(exit_ran) == 1
     reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
     assert len(reds) == 1
     assert reds[0].effect.exception_name == "ValueError"
@@ -180,15 +182,23 @@ def test_exit_runs_on_every_conditional_body_face():
 
 
 def test_unconstructed_enter_is_explicit_red_not_dissolve():
-    """Admission: missing enter stays Incomplete residual, never silent pass."""
     enter_gap = RaiseEffect(exception_name="ConstructionGapEnter")
     sugar = WithResourceSugar(
+        enter=_FixedSugar(Incomplete(enter_gap)),
+        exit=_Pass(),
         body=(_Pass(),),
-        enter=lambda: ExitSet.halted(enter_gap),
-        exit_call=lambda: ExitSet.completed(False),
-        suppresses=never_suppresses_disposition,
+        disposition=NeverSuppresses(),
     )
     out = sugar.desugar()
     reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
     assert len(reds) == 1
     assert reds[0].effect.exception_name == "ConstructionGapEnter"
+
+
+def test_suppresses_named_is_not_exported():
+    """Callback side door must not exist on the resource sugar module."""
+    import sugar_lift_py_tests.sugar.with_resource_sugar as mod
+
+    assert not hasattr(mod, "suppresses_named")
+    assert not hasattr(mod, "never_suppresses_disposition")
+    assert not hasattr(mod, "open_suppression_residual")

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -362,6 +362,32 @@ class Node(Typed):
             self.unit, ShadowNode("Call", self.span, slots), self.reporter
         )
 
+    def _make_attribute(self, value: "Node", attr: str) -> "Node":
+        """Construct ``<value>.<attr>`` as a shadow borrowing this node's span."""
+        from .backend import Child, Leaf, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        slots = (
+            ("value", Child(_handle_of(value))),
+            ("attr", Leaf(attr)),
+        )
+        return materialize(
+            self.unit, ShadowNode("Attribute", self.span, slots), self.reporter
+        )
+
+    def _make_none_constant(self) -> "Node":
+        """Synthesize ``None`` literal at this node's span."""
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        slots = (
+            ("value", Leaf(None)),
+            ("literal_kind", Leaf(None)),
+        )
+        return materialize(
+            self.unit, ShadowNode("Constant", self.span, slots), self.reporter
+        )
+
     def _effect_slot_id(self) -> str:
         """Deterministic slot identity from this binding site's source extent.
 
@@ -739,6 +765,22 @@ class WithItem(Node):
 
         new_ctx, d = self._substitute_field(self.context_expr, scope)
         return self if not d else rewrite(self, context_expr=new_ctx)
+
+    def _make_enter_call(self) -> "Node":
+        """Tree coordinate ``manager.__enter__()`` — not a callback, not a dig."""
+        enter_attr = self._make_attribute(self.context_expr, "__enter__")
+        return self._make_call(enter_attr, ())
+
+    def _make_exit_call(self) -> "Node":
+        """Tree coordinate ``manager.__exit__(None, None, None)``.
+
+        Type/value/tb args are structural placeholders at construction; a
+        later cut can rebind them from the body halt face. The method
+        coordinate is owned by the tree and sugars through the normal door.
+        """
+        exit_attr = self._make_attribute(self.context_expr, "__exit__")
+        none = self._make_none_constant()
+        return self._make_call(exit_attr, (none, none, none))
 
 
 class ImportAlias(Node):
@@ -1756,6 +1798,7 @@ class With(Statement):
             as_name = item.optional_vars.id
         from sugar_lift_py_tests.context_manager_contract import (
             Expects,
+            NeverSuppresses,
             RuntimeSelected,
             Suppresses,
         )
@@ -1764,6 +1807,7 @@ class With(Statement):
             default_community_manifest,
         )
         from sugar_lift_py_tests.sugar.with_contract_sugar import WithContractSugar
+        from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
 
         contract = contract_for_manager(
             default_community_manifest(), item.context_expr
@@ -1782,6 +1826,21 @@ class With(Statement):
                 body=tuple(stmt.sugar() for stmt in self.body),
                 site=self.fragment,
                 slot_id=slot_id,
+            )
+        if isinstance(contract, NeverSuppresses):
+            # Tree-owned enter/exit method coordinates + typed disposition.
+            # Nothing enrolls NeverSuppresses yet; when it does, sugars go
+            # through the normal door — never callback injection.
+            enter_node = item._make_enter_call()
+            exit_node = item._make_exit_call()
+            enter_slot = item._effect_slot_id() if as_name is not None else None
+            return WithResourceSugar(
+                enter=enter_node.sugar(),
+                exit=exit_node.sugar(),
+                body=tuple(stmt.sugar() for stmt in self.body),
+                disposition=contract,
+                enter_slot_id=enter_slot,
+                site=self.fragment,
             )
         # None from the membrane OR an explicit RuntimeSelected enrollment:
         # exit suppression is undecidable statically. Named residual — not a
@@ -1811,22 +1870,21 @@ class With(Statement):
             )
             self.reporter.report_gap(self, panic)
             raise panic
-        # NeverSuppresses: disposition-only license for WithResourceSugar
-        # (enter once, body ExitSet, exit on every face). Nothing enrolls yet;
-        # when it does, enter/exit must be constructed or left explicitly red —
-        # never a normal-path-only dissolve. Until enrollment + construction,
-        # stay loud.
         return super()._construct_sugar()
 
     def substitute(self, scope):
         """with ... as <Name>: rewrite name → ObservationRef(slot, projection).
 
-        Projection comes from the membrane-issued Expects.binding. Syntax
-        creates the coordinate; routing authenticates the slot. Body sees the
-        ref; substitution_binding exports it for subsequent statements.
+        Projection comes from membrane Expects.binding or resource
+        ENTER_RESULT under NeverSuppresses. Syntax creates the coordinate;
+        routing/enter authenticates the slot.
         """
         from .shadow import rewrite
-        from sugar_lift_py_tests.context_manager_contract import Expects
+        from sugar_lift_py_tests.context_manager_contract import (
+            ENTER_RESULT,
+            Expects,
+            NeverSuppresses,
+        )
         from sugar_lift_py_tests.manifest_membrane import (
             contract_for_manager,
             default_community_manifest,
@@ -1849,13 +1907,17 @@ class With(Statement):
             contract = contract_for_manager(
                 default_community_manifest(), item.context_expr
             )
-            if not isinstance(contract, Expects) or not contract.binding:
-                # Unauthenticated / suppresses: mask the name, stay without ref.
-                body_scope.pop(item.optional_vars.id, None)
-                continue
             slot_id = item._effect_slot_id()
-            ref = item._make_observation_ref(slot_id, contract.binding)
-            body_scope[item.optional_vars.id] = ref
+            if isinstance(contract, Expects) and contract.binding:
+                ref = item._make_observation_ref(slot_id, contract.binding)
+                body_scope[item.optional_vars.id] = ref
+                continue
+            if isinstance(contract, NeverSuppresses):
+                ref = item._make_observation_ref(slot_id, ENTER_RESULT)
+                body_scope[item.optional_vars.id] = ref
+                continue
+            # Unauthenticated / suppresses: mask the name, stay without ref.
+            body_scope.pop(item.optional_vars.id, None)
 
         new_body, d = self._substitute_body(self.body, body_scope)
         if d:
@@ -1863,8 +1925,12 @@ class With(Statement):
         return self if not changed else rewrite(self, **changed)
 
     def substitution_binding(self, scope):
-        """Export ObservationRef for Expects as-names to the rest of the block."""
-        from sugar_lift_py_tests.context_manager_contract import Expects
+        """Export ObservationRef for Expects / resource enter-result as-names."""
+        from sugar_lift_py_tests.context_manager_contract import (
+            ENTER_RESULT,
+            Expects,
+            NeverSuppresses,
+        )
         from sugar_lift_py_tests.manifest_membrane import (
             contract_for_manager,
             default_community_manifest,
@@ -1878,12 +1944,15 @@ class With(Statement):
             contract = contract_for_manager(
                 default_community_manifest(), item.context_expr
             )
-            if not isinstance(contract, Expects) or not contract.binding:
-                continue
             slot_id = item._effect_slot_id()
-            exported[item.optional_vars.id] = item._make_observation_ref(
-                slot_id, contract.binding
-            )
+            if isinstance(contract, Expects) and contract.binding:
+                exported[item.optional_vars.id] = item._make_observation_ref(
+                    slot_id, contract.binding
+                )
+            elif isinstance(contract, NeverSuppresses):
+                exported[item.optional_vars.id] = item._make_observation_ref(
+                    slot_id, ENTER_RESULT
+                )
         return exported or None
 
 

--- a/implementations/python/sugar-source-tree/tests/test_with_resource.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_resource.py
@@ -84,10 +84,39 @@ def test_suppress_manager_still_lifts():
     assert v.invs() == () and v.post().args[1].name == "z"
 
 
+def test_with_item_synthesizes_enter_exit_method_coordinates():
+    """Tree owns ``manager.__enter__()`` / ``__exit__(None,None,None)`` coords.
+
+    Production open still RuntimeSelected; synthesis is the door for a future
+    typed disposition — not a callback injection site.
+    """
+    fn = _fn("def A(m):\n    with m:\n        pass\n    return m\n")
+    with_node = next(s for s in fn.body if s.kind == "With")
+    item = with_node.items[0]
+    enter = item._make_enter_call()
+    exit_ = item._make_exit_call()
+    assert enter.kind == "Call"
+    assert enter.func.kind == "Attribute"
+    assert enter.func.attr == "__enter__"
+    assert enter.args == ()
+    assert exit_.kind == "Call"
+    assert exit_.func.kind == "Attribute"
+    assert exit_.func.attr == "__exit__"
+    assert len(exit_.args) == 3
+    # Method coords sugar through the normal Call/Attribute door.
+    enter_sugar = enter.sugar()
+    exit_sugar = exit_.sugar()
+    assert type(enter_sugar).__name__ == "MethodCallSugar"
+    assert type(exit_sugar).__name__ == "MethodCallSugar"
+    assert enter_sugar.name == "__enter__"
+    assert exit_sugar.name == "__exit__"
+
+
 if __name__ == "__main__":
     test_resource_open_is_runtime_selected_named_residual()
     test_resource_open_is_not_silent_dissolve()
     test_resource_named_residual_distinct_from_bare_sugar_not_written()
     test_assertion_manager_pytest_raises_still_lifts()
     test_suppress_manager_still_lifts()
+    test_with_item_synthesizes_enter_exit_method_coordinates()
     print("ok: resource with is RuntimeSelected named residual; Expects undisturbed")


### PR DESCRIPTION
## Summary

#6039 banked \`ExitSet.and_exit\` algebra behind a **callback side door**. This cut closes that door before any manager is admitted green.

### Interface (no injected callables)

| Before | After |
|--------|--------|
| \`enter: Callable[[], ExitSet]\` | \`enter: Sugar\` (tree method-coordinate) |
| \`exit_call: Callable[[], ExitSet]\` | \`exit: Sugar\` |
| \`suppresses: Callable\` | typed \`disposition\` |
| \`open_suppression: Callable\` | \`RuntimeSelected\` disposition → open residual |
| \`suppresses_named(...)\` | **removed** |

### Tree

- \`WithItem._make_enter_call()\` → \`manager.__enter__()\`
- \`WithItem._make_exit_call()\` → \`manager.__exit__(None, None, None)\`
- Both sugar through normal Call/Attribute → \`MethodCallSugar\`
- \`NeverSuppresses\` arm builds \`WithResourceSugar\` with those coords (nothing enrolls yet)
- Resource \`as\` → \`ObservationRef(slot, ENTER_RESULT)\`

### Disposition authority

\`NeverSuppresses\` | \`ExitSuppressionContract\` | \`RuntimeSelected\` | membrane \`Suppresses\` — only these; no free-floating name checks.

### Still loud

Production \`open(...)\` remains **\`RuntimeSelectedContextManager\`**. No manager admitted green without constructed enter/exit or explicit red.

## Validation

\`\`\`bash
pytest test_exit_set.py test_with_resource_sugar.py test_with_resource.py \\
       test_with_contract.py test_try_sugar.py -q
# 83 passed
\`\`\`

## Next

1. Proven NeverSuppresses enrollment (manifest + source exit proof)
2. Enter-slot authentication on completed enter
3. Multi-manager nesting
4. Re-census

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tree enter/exit coordinates and typed disposition to `WithResourceSugar`
> - `WithResourceSugar` now accepts `enter` and `exit` as `Sugar` instances (synthesized `__enter__`/`__exit__` method-coordinate nodes) and a typed disposition object, replacing the previous callback-based suppression hooks.
> - `WithItem` gains `_make_enter_call` and `_make_exit_call` helpers that construct the tree coordinates for `manager.__enter__()` and `manager.__exit__(None, None, None)`.
> - `With._construct_sugar` now lowers `NeverSuppresses`-contracted managers into `WithResourceSugar` with these synthesized nodes rather than falling back to non-resource sugar handling.
> - `With.substitute` and `With.substitution_binding` now bind `as` names under `NeverSuppresses` to an `ObservationRef` tagged with `ENTER_RESULT` instead of masking them.
> - New `disposition_verdict` function in [`resource_exit_disposition.py`](https://github.com/TSavo/sugar/pull/6040/files#diff-20be49d626b2079bf4f8b73c96f929cdac404f9d75d57c1c956e1f74b5f124db) computes a `suppress`/`restore`/`open` verdict for body halts based on the typed disposition.
> - `ExitSet.and_exit` is refactored to accept a precomputed `ExitSet` and typed disposition, dropping per-face callbacks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb3f66f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->