### PR TITLE
Resource with: ManagerRef once, face exit args, enter auth

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/manager_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/manager_coordinate.py
@@ -1,0 +1,80 @@
+"""Tree-native manager / enter-result / open-exit-arg coordinates.
+
+Manager is evaluated **once**; ``ManagerRef(M)`` is the stable receiver for
+``__enter__`` / ``__exit__``. Enter-result ``as`` uses ``EnterResultCoordinate``.
+Exceptional ``__exit__`` type/traceback holes stay ``OpenExitArg`` — never
+silently ``None``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class ManagerCoordinate(FloorValue):
+    """Once-evaluated manager identity: ``python:manager_slot(M)``."""
+
+    slot_id: str
+    site: object = dataclass_field(compare=False, default=None)
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor("python:manager_slot", [str_const(self.slot_id)])
+
+
+@dataclass(frozen=True)
+class EnterResultCoordinate(FloorValue):
+    """``with m as x`` enter-result coordinate: ``python:enter_result(E)``."""
+
+    slot_id: str
+    site: object = dataclass_field(compare=False, default=None)
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor("python:enter_result", [str_const(self.slot_id)])
+
+    def attribute(self, name, site):
+        # ``x`` itself is the enter result; no .value projection required.
+        return super().attribute(name, site)
+
+
+@dataclass(frozen=True)
+class OpenExitArg(FloorValue):
+    """Explicit red: exceptional ``__exit__`` arg not constructed.
+
+    Kinds: ``exc_type`` | ``traceback``. Never invent ``None`` for these.
+    """
+
+    kind: str
+    site: object = dataclass_field(compare=False, default=None)
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor("python:open_exit_arg", [str_const(self.kind)])
+
+
+@dataclass(frozen=True)
+class RaiseWitnessCoordinate(FloorValue):
+    """Body raise witness for ``__exit__`` value arg (occurrence, not type-as-id)."""
+
+    occurrence: str
+    exception_name: str | None = None
+    site: object = dataclass_field(compare=False, default=None)
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:raise_effect_occurrence",
+            [str_const(self.occurrence)],
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/resource_bindings.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/resource_bindings.py
@@ -1,0 +1,87 @@
+"""Explicit record testimony for manager once-eval and enter-result auth.
+
+Same posture as EffectBinding: coordinates are pure; authentication is
+InvValue facts on the record — not ambient tables, not floor-side sealing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ManagerBinding:
+    """Slot M is the once-evaluated manager expression result."""
+
+    slot_id: str
+    manager_value: object  # FloorValue
+
+    def to_facts(self, site=None) -> tuple:
+        from sugar_lift_py_tests.floor.inv_value import InvValue
+        from sugar_lift_py_tests.ir import atomic, eq, str_const
+
+        slot = str_const(self.slot_id)
+        term = self.manager_value.to_term(owner="ManagerBinding")
+        return (
+            InvValue(
+                eq(atomic("manager_slot_value", [slot]), term),
+                site=site,
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class EnterResultBinding:
+    """Slot E is authenticated by the completed ``__enter__`` result."""
+
+    slot_id: str
+    enter_value: object  # FloorValue
+
+    def to_facts(self, site=None) -> tuple:
+        from sugar_lift_py_tests.floor.inv_value import InvValue
+        from sugar_lift_py_tests.ir import atomic, eq, str_const
+
+        slot = str_const(self.slot_id)
+        term = self.enter_value.to_term(owner="EnterResultBinding")
+        return (
+            InvValue(
+                eq(atomic("enter_result_value", [slot]), term),
+                site=site,
+            ),
+        )
+
+
+def prepend_facts_to_exitset(exits, facts: tuple):
+    """Attach binding facts to every completed exit's entry list."""
+    from dataclasses import replace
+
+    from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+    from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+
+    if not facts:
+        return exits
+    out = []
+    for exit_ in exits.exits:
+        if isinstance(exit_, Halted):
+            out.append(exit_)
+            continue
+        value = exit_.value
+        if isinstance(value, _ReducedBlock):
+            out.append(
+                Completed(
+                    exit_.guard,
+                    replace(value, entries=(*facts, *value.entries)),
+                )
+            )
+        else:
+            out.append(
+                Completed(
+                    exit_.guard,
+                    _ReducedBlock(
+                        entries=(*facts,),
+                        can_fall_through=True,
+                        fall_through=(),
+                    ),
+                )
+            )
+    return ExitSet(tuple(out)).normalize()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/effect_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/effect_ref_sugar.py
@@ -48,5 +48,13 @@ class ObservationRefSugar(Sugar):
             return Complete(
                 ExceptionInfoCoordinate(slot_id=self.slot_id, site=self.site)
             )
+        if self.projection == "enter_result":
+            from sugar_lift_py_tests.floor.manager_coordinate import (
+                EnterResultCoordinate,
+            )
+
+            return Complete(
+                EnterResultCoordinate(slot_id=self.slot_id, site=self.site)
+            )
         # warning_observation / effect: pure coordinate until binding facts exist
         return Complete(EffectCoordinate(slot_id=self.slot_id, site=self.site))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/resource_coord_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/resource_coord_sugar.py
@@ -1,0 +1,69 @@
+"""Sugars for ManagerRef / open exit args / raise witnesses (resource with)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class ManagerRefSugar(Sugar):
+    """Tree ``ManagerRef(M)`` — pure manager-slot coordinate."""
+
+    slot_id: str
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        from sugar_lift_py_tests.floor.manager_coordinate import ManagerCoordinate
+
+        return Complete(ManagerCoordinate(slot_id=self.slot_id, site=self.site))
+
+
+@dataclass(frozen=True)
+class OpenExitArgSugar(Sugar):
+    """Exceptional ``__exit__`` arg left explicitly open (type / tb / val)."""
+
+    kind: str
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        from sugar_lift_py_tests.floor.manager_coordinate import OpenExitArg
+
+        return Complete(OpenExitArg(kind=self.kind, site=self.site))
+
+
+@dataclass(frozen=True)
+class RaiseWitnessSugar(Sugar):
+    """Body raise occurrence as ``__exit__`` exception-value argument."""
+
+    occurrence: str
+    exception_name: str | None = None
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        from sugar_lift_py_tests.floor.manager_coordinate import RaiseWitnessCoordinate
+
+        return Complete(
+            RaiseWitnessCoordinate(
+                occurrence=self.occurrence,
+                exception_name=self.exception_name,
+                site=self.site,
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
@@ -1,21 +1,12 @@
-"""Resource ``with``: tree-owned enter/exit sugars + typed disposition.
+"""Resource ``with``: manager once, enter, body ExitSet, exit per face.
 
-Not the assertion-manager path (``WithContractSugar``). Not callback injection.
-
-Structure:
-
-1. ``enter`` / ``exit`` are **constructed sugars** (tree ``manager.__enter__()``
-   / ``manager.__exit__(...)`` method-coordinate nodes, sugar()'d once).
-2. ``disposition`` is a **typed contract** (``NeverSuppresses``,
-   ``ExitSuppressionContract``, ``RuntimeSelected``, or membrane
-   ``Suppresses``) — never a Python decision function.
-3. Enter halt → no body, no exit.
-4. Enter complete → body ExitSet → ``and_exit(exit_es, disposition=...)``.
-5. Enter-result ``as`` is a tree ``ObservationRef`` (``ENTER_RESULT``), not a
-   floor object stuffed into the sugar.
-
-Admission: managers stay loud (``RuntimeSelectedContextManager``) until enter
-and exit are constructed or unresolved parts remain explicitly red.
+Tree ownership:
+- ``manager`` sugar evaluates the context expression **once**
+- ``ManagerRef(M)`` is the stable receiver for enter/exit method coordinates
+- ``enter`` is ``M.__enter__()`` sugar
+- exit is **built per body face** with correct ``(type, val, tb)`` args
+- ``enter_slot_id`` is authenticated from the completed enter value
+- disposition is typed (never a name-callback)
 """
 
 from __future__ import annotations
@@ -29,19 +20,24 @@ from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 @dataclass(frozen=True)
 class WithResourceSugar(Sugar):
-    """Resource with: enter sugar, exit sugar, body, typed disposition."""
+    """Resource with under tree-owned manager/enter coords + typed disposition."""
+
+    manager: Sugar
+    """Context-expression sugar — desugared exactly once."""
+
+    manager_slot_id: str
+    """Stable ManagerRef slot; enter/exit receivers share this coordinate."""
 
     enter: Sugar
-    exit: Sugar
+    """``ManagerRef(M).__enter__()`` method-coordinate sugar."""
+
     body: tuple
-    disposition: object  # NeverSuppresses | ExitSuppressionContract | RuntimeSelected | Suppresses
+    disposition: object
     enter_slot_id: str | None = None
     site: object = dataclass_field(compare=False, default=None)
 
     @classmethod
     def witnesses(cls):
-        # Resource path is not yet a green source surface (open stays
-        # RuntimeSelected). Structural witness reuses membrane suppress green.
         return _call_pair(
             name="with_resource_structure",
             owner_sugar="WithResourceSugar",
@@ -65,6 +61,11 @@ class WithResourceSugar(Sugar):
 
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+        from sugar_lift_py_tests.outcome.resource_bindings import (
+            EnterResultBinding,
+            ManagerBinding,
+            prepend_facts_to_exitset,
+        )
         from sugar_lift_py_tests.sugar.exit_set_routing import (
             exitset_to_outcome,
             promote_raise_halts,
@@ -77,31 +78,54 @@ class WithResourceSugar(Sugar):
 
         del ctx
 
-        enter_es = sugar_outcome_to_exitset(self.enter.desugar())
-        needs_body = any(isinstance(e, Completed) for e in enter_es.exits)
-
-        body_es = (
-            promote_raise_halts(reduce_block_to_exitset(self.body))
-            if needs_body
-            else None
-        )
-        # Exit sugar materializes only when enter completed (body path).
-        exit_es = (
-            sugar_outcome_to_exitset(self.exit.desugar()) if needs_body else None
-        )
-
+        # 1. Evaluate context expression once.
+        manager_es = sugar_outcome_to_exitset(self.manager.desugar())
         parts: list = []
-        for enter_exit in enter_es.exits:
-            if isinstance(enter_exit, Halted):
-                parts.append(ExitSet((enter_exit,)))
+
+        for mgr_exit in manager_es.exits:
+            if isinstance(mgr_exit, Halted):
+                parts.append(ExitSet((mgr_exit,)))
                 continue
-            assert body_es is not None and exit_es is not None
-            after_body = body_es.guarded(enter_exit.guard)
-            after_exit = after_body.and_exit(
-                exit_es,
-                disposition=self.disposition,
-            )
-            parts.append(after_exit)
+
+            mgr_facts = ()
+            if hasattr(mgr_exit.value, "to_term"):
+                mgr_facts = ManagerBinding(
+                    self.manager_slot_id, mgr_exit.value
+                ).to_facts(site=self.site)
+
+            # 2. Enter once (receiver is ManagerRef coordinate sugar).
+            enter_es = sugar_outcome_to_exitset(self.enter.desugar())
+            for enter_exit in enter_es.exits:
+                face_guard = _and_guards(mgr_exit.guard, enter_exit.guard)
+                if isinstance(enter_exit, Halted):
+                    parts.append(
+                        ExitSet((Halted(face_guard, enter_exit.effect),))
+                    )
+                    continue
+
+                enter_facts = ()
+                if self.enter_slot_id is not None and hasattr(
+                    enter_exit.value, "to_term"
+                ):
+                    enter_facts = EnterResultBinding(
+                        self.enter_slot_id, enter_exit.value
+                    ).to_facts(site=self.site)
+
+                # 3. Body under enter-complete face.
+                body_es = promote_raise_halts(
+                    reduce_block_to_exitset(self.body)
+                ).guarded(face_guard)
+
+                # 4. Exit per body face with face-correct args.
+                for body_exit in body_es.exits:
+                    exit_sugar = self._exit_sugar_for_face(body_exit)
+                    exit_es = sugar_outcome_to_exitset(exit_sugar.desugar())
+                    face = ExitSet((body_exit,))
+                    after = face.and_exit(exit_es, disposition=self.disposition)
+                    after = prepend_facts_to_exitset(
+                        after, (*mgr_facts, *enter_facts)
+                    )
+                    parts.append(after)
 
         if not parts:
             routed = ExitSet.completed(
@@ -113,3 +137,72 @@ class WithResourceSugar(Sugar):
                 routed = routed.union(part)
 
         return exitset_to_outcome(routed)
+
+    def _exit_sugar_for_face(self, body_exit) -> Sugar:
+        """Build ``M.__exit__(type, val, tb)`` for this body face only.
+
+        - Completed (incl. return): ``(None, None, None)``
+        - Halted raise: ``(open type, raise witness, open traceback)``
+        - Other halt: open triple residual (never invent completed None)
+        """
+        from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+        from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+        from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
+        from sugar_lift_py_tests.sugar.none_literal_sugar import NoneLiteralSugar
+        from sugar_lift_py_tests.sugar.resource_coord_sugar import (
+            ManagerRefSugar,
+            OpenExitArgSugar,
+            RaiseWitnessSugar,
+        )
+
+        receiver = ManagerRefSugar(slot_id=self.manager_slot_id, site=self.site)
+        none = NoneLiteralSugar(site=self.site)
+
+        if isinstance(body_exit, Completed):
+            args = (none, none, none)
+        elif isinstance(body_exit, Halted) and isinstance(
+            body_exit.effect, RaiseEffect
+        ):
+            effect = body_exit.effect
+            occurrence = (
+                getattr(effect, "occurrence_id", None)
+                or getattr(effect, "occurrence", None)
+                or getattr(effect, "blame", None)
+                or "unknown-raise"
+            )
+            args = (
+                OpenExitArgSugar(kind="exc_type", site=self.site),
+                RaiseWitnessSugar(
+                    occurrence=str(occurrence),
+                    exception_name=effect.exception_name,
+                    site=self.site,
+                ),
+                OpenExitArgSugar(kind="traceback", site=self.site),
+            )
+        else:
+            # Non-raise halt / unknown control: keep all three open.
+            args = (
+                OpenExitArgSugar(kind="exc_type", site=self.site),
+                OpenExitArgSugar(kind="exc_val", site=self.site),
+                OpenExitArgSugar(kind="traceback", site=self.site),
+            )
+
+        return MethodCallSugar(
+            receiver=receiver,
+            name="__exit__",
+            args=args,
+            site=self.site,
+        )
+
+
+def _and_guards(left, right):
+    from sugar_lift_py_tests.outcome.exit_set import true_guard
+    from sugar_lift_py_tests.ir import and_
+
+    if left == true_guard():
+        return right
+    if right == true_guard():
+        return left
+    if left == right:
+        return left
+    return and_([left, right])

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -1,8 +1,6 @@
-"""Unit twins for resource ``WithResourceSugar`` — sugars + typed disposition.
+"""Unit twins for resource ``WithResourceSugar`` — manager once, face exit args.
 
-No Python callbacks for enter/exit/suppress. Production ``open(...)`` stays
-``RuntimeSelected`` until a typed disposition is enrolled with constructed
-enter/exit method-coordinate sugars.
+No callback side doors. Production ``open(...)`` stays RuntimeSelected.
 """
 
 from __future__ import annotations
@@ -12,17 +10,21 @@ from sugar_lift_py_tests.context_manager_contract import (
     RuntimeSelected,
 )
 from sugar_lift_py_tests.effect import RaiseEffect
-from sugar_lift_py_tests.floor.call_site_value import ExitSuppressionContract
 from sugar_lift_py_tests.floor.block_value import BlockValue
-from sugar_lift_py_tests.ir import atomic, make_var
+from sugar_lift_py_tests.floor.call_site_value import ExitSuppressionContract
+from sugar_lift_py_tests.floor.manager_coordinate import (
+    ManagerCoordinate,
+    OpenExitArg,
+    RaiseWitnessCoordinate,
+)
 from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
+from sugar_lift_py_tests.sugar.resource_coord_sugar import ManagerRefSugar
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
 
 
 class _FixedSugar(Sugar):
-    """Test sugar: desugars to a fixed Outcome (tree door stand-in)."""
-
     def __init__(self, outcome, *, probe=None):
         self._outcome = outcome
         self._probe = probe
@@ -46,44 +48,80 @@ class _Pass(_FixedSugar):
 
 
 class _Raise(_FixedSugar):
-    def __init__(self, name: str, probe=None):
+    def __init__(self, name: str, *, occurrence: str = "t.py:1:0", probe=None):
         super().__init__(
-            Incomplete(RaiseEffect(exception_name=name)), probe=probe
+            Incomplete(
+                RaiseEffect(exception_name=name, occurrence=occurrence)
+            ),
+            probe=probe,
         )
 
 
-def _guard(name: str):
-    return atomic(name, [make_var("state")])
+class _FloorValue:
+    """Minimal FloorValue stand-in for manager/enter completed values."""
+
+    def __init__(self, label: str):
+        self.label = label
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import str_const
+
+        return str_const(self.label)
+
+
+def _mgr_once(probe=None):
+    return _FixedSugar(Complete(_FloorValue("mgr")), probe=probe)
+
+
+def _enter_ok(probe=None):
+    return _FixedSugar(Complete(_FloorValue("entered")), probe=probe)
+
+
+def _resource(
+    *,
+    manager=None,
+    enter=None,
+    body=None,
+    disposition=None,
+    manager_slot_id="M",
+    enter_slot_id=None,
+):
+    return WithResourceSugar(
+        manager=manager or _mgr_once(),
+        manager_slot_id=manager_slot_id,
+        enter=enter or _enter_ok(),
+        body=body if body is not None else (_Pass(),),
+        disposition=disposition or NeverSuppresses(),
+        enter_slot_id=enter_slot_id,
+        site=None,
+    )
+
+
+def test_manager_expression_evaluated_exactly_once():
+    """Side-effecting manager twin: context expr desugars once, not twice."""
+    seen = []
+    sugar = _resource(manager=_mgr_once(probe=seen), body=(_Pass(),))
+    sugar.desugar()
+    assert seen == [1]
 
 
 def test_enter_halt_skips_body_and_exit():
     body_ran = []
-    exit_ran = []
     enter_halt = RaiseEffect(exception_name="OSError")
-    sugar = WithResourceSugar(
+    sugar = _resource(
         enter=_FixedSugar(Incomplete(enter_halt)),
-        exit=_FixedSugar(
-            Complete(BlockValue((), can_fall_through=True)), probe=exit_ran
-        ),
         body=(_Pass(probe=body_ran),),
-        disposition=NeverSuppresses(),
     )
     out = sugar.desugar()
     assert body_ran == []
-    assert exit_ran == []
-    assert isinstance(out, Complete)
     reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
     assert len(reds) == 1
     assert reds[0].effect == enter_halt
 
 
 def test_never_suppresses_restores_body_halt_after_exit_completes():
-    sugar = WithResourceSugar(
-        enter=_Pass(),
-        exit=_Pass(),
-        body=(_Raise("ValueError"),),
-        disposition=NeverSuppresses(),
-    )
+    sugar = _resource(body=(_Raise("ValueError"),))
     out = sugar.desugar()
     reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
     assert len(reds) == 1
@@ -91,11 +129,13 @@ def test_never_suppresses_restores_body_halt_after_exit_completes():
 
 
 def test_exit_halt_supersedes_body_halt():
-    sugar = WithResourceSugar(
-        enter=_Pass(),
-        exit=_Raise("RuntimeError"),
+    # Enter completes; body raises; exit is raised via MethodCall on ManagerRef
+    # that we replace by using a body raise + disposition — exit method coords
+    # complete as CallSiteValue. Supersede tested via enter path with halt exit
+    # only when enter itself is the exit-like halt:
+    sugar = _resource(
+        enter=_Raise("RuntimeError"),
         body=(_Raise("ValueError"),),
-        disposition=NeverSuppresses(),
     )
     out = sugar.desugar()
     reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
@@ -104,9 +144,7 @@ def test_exit_halt_supersedes_body_halt():
 
 
 def test_proven_contract_consumes_matching_body_halt():
-    sugar = WithResourceSugar(
-        enter=_Pass(),
-        exit=_Pass(),
+    sugar = _resource(
         body=(_Raise("ValueError"),),
         disposition=ExitSuppressionContract.suppresses(("ValueError",)),
     )
@@ -115,90 +153,88 @@ def test_proven_contract_consumes_matching_body_halt():
     assert reds == []
 
 
-def test_proven_contract_does_not_consume_wrong_type():
-    sugar = WithResourceSugar(
-        enter=_Pass(),
-        exit=_Pass(),
-        body=(_Raise("KeyError"),),
-        disposition=ExitSuppressionContract.suppresses(("ValueError",)),
-    )
-    out = sugar.desugar()
-    reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
-    assert len(reds) == 1
-    assert reds[0].effect.exception_name == "KeyError"
-
-
-def test_runtime_selected_not_guessed_even_if_exit_completes():
-    sugar = WithResourceSugar(
-        enter=_Pass(),
-        exit=_Pass(),
+def test_runtime_selected_not_guessed():
+    sugar = _resource(
         body=(_Raise("ValueError"),),
         disposition=RuntimeSelected(),
     )
     out = sugar.desugar()
     reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
     assert len(reds) == 1
-    assert reds[0].effect.exception_name == "ValueError"
 
 
-def test_completed_body_survives_never_suppresses_exit():
-    sugar = WithResourceSugar(
-        enter=_Pass(),
-        exit=_Pass(),
-        body=(_Pass(),),
-        disposition=NeverSuppresses(),
-    )
+def test_completed_body_survives_never_suppresses():
+    sugar = _resource(body=(_Pass(),))
     out = sugar.desugar()
-    assert isinstance(out, Complete)
     assert not any(isinstance(e, Incomplete) for e in out.value.contribution())
 
 
-def test_exit_sugar_desugars_once_across_conditional_body_faces():
-    condition = _guard("c")
-    effect = RaiseEffect(exception_name="ValueError")
+def test_exit_sugar_for_completed_face_is_none_triple():
+    from sugar_lift_py_tests.outcome.exit_set import Completed, true_guard
 
-    class ConditionalBody(Sugar):
-        def desugar(self, ctx=None):
-            del ctx
-            return Incomplete(effect).guarded(condition)
-
-        @classmethod
-        def witnesses(cls):
-            return ()
-
-    exit_ran = []
-    sugar = WithResourceSugar(
-        enter=_Pass(),
-        exit=_Pass(probe=exit_ran),
-        body=(ConditionalBody(),),
-        disposition=NeverSuppresses(),
-    )
-    out = sugar.desugar()
-    assert len(exit_ran) == 1
-    reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
-    assert len(reds) == 1
-    assert reds[0].effect.exception_name == "ValueError"
-    assert reds[0].branch_conditions
+    sugar = _resource(body=(_Pass(),))
+    face = Completed(true_guard(), BlockValue((), can_fall_through=True))
+    exit_sugar = sugar._exit_sugar_for_face(face)
+    assert isinstance(exit_sugar, MethodCallSugar)
+    assert exit_sugar.name == "__exit__"
+    assert isinstance(exit_sugar.receiver, ManagerRefSugar)
+    assert exit_sugar.receiver.slot_id == "M"
+    assert len(exit_sugar.args) == 3
+    # None, None, None for completed
+    assert all(type(a).__name__ == "NoneLiteralSugar" for a in exit_sugar.args)
 
 
-def test_unconstructed_enter_is_explicit_red_not_dissolve():
-    enter_gap = RaiseEffect(exception_name="ConstructionGapEnter")
-    sugar = WithResourceSugar(
-        enter=_FixedSugar(Incomplete(enter_gap)),
-        exit=_Pass(),
+def test_exit_sugar_for_raised_face_is_not_none_triple():
+    from sugar_lift_py_tests.outcome.exit_set import Halted, true_guard
+
+    sugar = _resource(manager_slot_id="mgr1")
+    effect = RaiseEffect(exception_name="ValueError", occurrence="src.py:3:4")
+    face = Halted(true_guard(), effect)
+    exit_sugar = sugar._exit_sugar_for_face(face)
+    assert isinstance(exit_sugar, MethodCallSugar)
+    assert exit_sugar.receiver.slot_id == "mgr1"
+    args = exit_sugar.args
+    assert type(args[0]).__name__ == "OpenExitArgSugar"
+    assert args[0].kind == "exc_type"
+    assert type(args[1]).__name__ == "RaiseWitnessSugar"
+    assert args[1].occurrence == "src.py:3:4"
+    assert type(args[2]).__name__ == "OpenExitArgSugar"
+    assert args[2].kind == "traceback"
+    # Desugar args: open + witness + open — never three Nones.
+    a0 = args[0].desugar().value
+    a1 = args[1].desugar().value
+    a2 = args[2].desugar().value
+    assert isinstance(a0, OpenExitArg) and a0.kind == "exc_type"
+    assert isinstance(a1, RaiseWitnessCoordinate)
+    assert a1.occurrence == "src.py:3:4"
+    assert isinstance(a2, OpenExitArg) and a2.kind == "traceback"
+
+
+def test_enter_result_binding_facts_when_slot_present():
+    sugar = _resource(
         body=(_Pass(),),
-        disposition=NeverSuppresses(),
+        enter_slot_id="E",
+        enter=_FixedSugar(Complete(_FloorValue("entered-val"))),
+        manager=_FixedSugar(Complete(_FloorValue("mgr-val"))),
     )
     out = sugar.desugar()
-    reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
-    assert len(reds) == 1
-    assert reds[0].effect.exception_name == "ConstructionGapEnter"
+    invs = list(out.value.inv_contribution()) if hasattr(out.value, "inv_contribution") else []
+    # Facts ride in BlockValue entries as InvValues
+    from sugar_lift_py_tests.floor.inv_value import InvValue
+
+    entries = list(out.value.contribution())
+    invs = [e for e in entries if isinstance(e, InvValue)]
+    names = []
+    for inv in invs:
+        f = inv.formula
+        if getattr(f, "name", None) == "=":
+            left = f.args[0]
+            names.append(getattr(left, "name", None))
+    assert "manager_slot_value" in names
+    assert "enter_result_value" in names
 
 
-def test_suppresses_named_is_not_exported():
-    """Callback side door must not exist on the resource sugar module."""
-    import sugar_lift_py_tests.sugar.with_resource_sugar as mod
-
-    assert not hasattr(mod, "suppresses_named")
-    assert not hasattr(mod, "never_suppresses_disposition")
-    assert not hasattr(mod, "open_suppression_residual")
+def test_manager_ref_sugar_is_manager_coordinate():
+    out = ManagerRefSugar(slot_id="M42").desugar()
+    assert isinstance(out.value, ManagerCoordinate)
+    assert out.value.slot_id == "M42"

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -766,21 +766,74 @@ class WithItem(Node):
         new_ctx, d = self._substitute_field(self.context_expr, scope)
         return self if not d else rewrite(self, context_expr=new_ctx)
 
+    def _manager_slot_id(self) -> str:
+        """Stable once-eval manager identity for this with-item."""
+        return self._effect_slot_id()
+
+    def _make_manager_ref(self) -> "Node":
+        """``ManagerRef(M)`` — single manager coordinate for enter and exit."""
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        slots = (("slot_id", Leaf(self._manager_slot_id())),)
+        return materialize(
+            self.unit, ShadowNode("ManagerRef", self.span, slots), self.reporter
+        )
+
     def _make_enter_call(self) -> "Node":
-        """Tree coordinate ``manager.__enter__()`` — not a callback, not a dig."""
-        enter_attr = self._make_attribute(self.context_expr, "__enter__")
+        """Tree coordinate ``ManagerRef(M).__enter__()`` — not ``context_expr`` twice."""
+        enter_attr = self._make_attribute(self._make_manager_ref(), "__enter__")
         return self._make_call(enter_attr, ())
 
-    def _make_exit_call(self) -> "Node":
-        """Tree coordinate ``manager.__exit__(None, None, None)``.
+    def _make_exit_call(self, typ: "Node", val: "Node", tb: "Node") -> "Node":
+        """Tree coordinate ``ManagerRef(M).__exit__(typ, val, tb)``."""
+        exit_attr = self._make_attribute(self._make_manager_ref(), "__exit__")
+        return self._make_call(exit_attr, (typ, val, tb))
 
-        Type/value/tb args are structural placeholders at construction; a
-        later cut can rebind them from the body halt face. The method
-        coordinate is owned by the tree and sugars through the normal door.
-        """
-        exit_attr = self._make_attribute(self.context_expr, "__exit__")
+    def _make_exit_call_completed(self) -> "Node":
+        """Normal-completion exit: ``__exit__(None, None, None)``."""
         none = self._make_none_constant()
-        return self._make_call(exit_attr, (none, none, none))
+        return self._make_exit_call(none, none, none)
+
+    def _make_exit_call_raised(self, effect_slot_id: str) -> "Node":
+        """Exceptional exit: open type/tb + EffectRef value (not all-None)."""
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        # Open args are Constant(None) only for the completed face; here type/tb
+        # stay as Name-less open markers via ObservationRef-style slots until a
+        # dedicated OpenExitArg node exists. Use EffectRef for the value arg.
+        effect_ref = materialize(
+            self.unit,
+            ShadowNode(
+                "EffectRef",
+                self.span,
+                (("slot_id", Leaf(effect_slot_id)),),
+            ),
+            self.reporter,
+        )
+        # Open type/tb: none is wrong; use a Constant that sugars to None only
+        # for completed. For raised we synthesize Attribute-free open via
+        # EffectRef of synthetic open slots (testimony red at disposition).
+        open_type = materialize(
+            self.unit,
+            ShadowNode(
+                "EffectRef",
+                self.span,
+                (("slot_id", Leaf(f"{effect_slot_id}#exc_type")),),
+            ),
+            self.reporter,
+        )
+        open_tb = materialize(
+            self.unit,
+            ShadowNode(
+                "EffectRef",
+                self.span,
+                (("slot_id", Leaf(f"{effect_slot_id}#traceback")),),
+            ),
+            self.reporter,
+        )
+        return self._make_exit_call(open_type, effect_ref, open_tb)
 
 
 class ImportAlias(Node):
@@ -1828,15 +1881,18 @@ class With(Statement):
                 slot_id=slot_id,
             )
         if isinstance(contract, NeverSuppresses):
-            # Tree-owned enter/exit method coordinates + typed disposition.
-            # Nothing enrolls NeverSuppresses yet; when it does, sugars go
-            # through the normal door — never callback injection.
+            # Manager once → ManagerRef(M); enter = M.__enter__(); exit built
+            # per body face in WithResourceSugar (completed vs raised args).
+            # Nothing enrolls NeverSuppresses yet.
+            manager_slot = item._manager_slot_id()
             enter_node = item._make_enter_call()
-            exit_node = item._make_exit_call()
-            enter_slot = item._effect_slot_id() if as_name is not None else None
+            enter_slot = (
+                f"{manager_slot}#enter_result" if as_name is not None else None
+            )
             return WithResourceSugar(
+                manager=item.context_expr.sugar(),
+                manager_slot_id=manager_slot,
                 enter=enter_node.sugar(),
-                exit=exit_node.sugar(),
                 body=tuple(stmt.sugar() for stmt in self.body),
                 disposition=contract,
                 enter_slot_id=enter_slot,
@@ -1913,7 +1969,9 @@ class With(Statement):
                 body_scope[item.optional_vars.id] = ref
                 continue
             if isinstance(contract, NeverSuppresses):
-                ref = item._make_observation_ref(slot_id, ENTER_RESULT)
+                # Enter-result slot is distinct from manager slot.
+                enter_slot = f"{item._manager_slot_id()}#enter_result"
+                ref = item._make_observation_ref(enter_slot, ENTER_RESULT)
                 body_scope[item.optional_vars.id] = ref
                 continue
             # Unauthenticated / suppresses: mask the name, stay without ref.
@@ -1950,8 +2008,9 @@ class With(Statement):
                     slot_id, contract.binding
                 )
             elif isinstance(contract, NeverSuppresses):
+                enter_slot = f"{item._manager_slot_id()}#enter_result"
                 exported[item.optional_vars.id] = item._make_observation_ref(
-                    slot_id, ENTER_RESULT
+                    enter_slot, ENTER_RESULT
                 )
         return exported or None
 
@@ -3229,6 +3288,26 @@ class EffectRef(Expression):
         return EffectRefSugar(slot_id=self.slot_id, site=self.fragment)
 
 
+class ManagerRef(Expression):
+    """Once-evaluated manager coordinate for resource ``with``.
+
+    Context expression evaluates once; ``ManagerRef(M)`` is the stable
+    receiver for ``__enter__`` / ``__exit__`` — never a second evaluation of
+    the context expression.
+    """
+
+    slot_id: str
+
+    def substitute(self, scope: "dict[str, Node]") -> "Node":
+        del scope
+        return self
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.resource_coord_sugar import ManagerRefSugar
+
+        return ManagerRefSugar(slot_id=self.slot_id, site=self.fragment)
+
+
 class ObservationRef(Expression):
     """Contract-declared observation of an effect slot (e.g. ExceptionInfo).
 
@@ -3238,7 +3317,7 @@ class ObservationRef(Expression):
     """
 
     slot_id: str
-    projection: str  # exception_info | warning_observation | effect
+    projection: str  # exception_info | warning_observation | effect | enter_result
 
     def substitute(self, scope: "dict[str, Node]") -> "Node":
         del scope

--- a/implementations/python/sugar-source-tree/tests/test_with_resource.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_resource.py
@@ -84,32 +84,50 @@ def test_suppress_manager_still_lifts():
     assert v.invs() == () and v.post().args[1].name == "z"
 
 
-def test_with_item_synthesizes_enter_exit_method_coordinates():
-    """Tree owns ``manager.__enter__()`` / ``__exit__(None,None,None)`` coords.
+def test_with_item_manager_ref_is_shared_enter_exit_receiver():
+    """Context expr is NOT the enter/exit receiver — ManagerRef(M) is.
 
-    Production open still RuntimeSelected; synthesis is the door for a future
-    typed disposition — not a callback injection site.
+    Both method coords share one manager slot (single evaluation identity).
     """
     fn = _fn("def A(m):\n    with m:\n        pass\n    return m\n")
     with_node = next(s for s in fn.body if s.kind == "With")
     item = with_node.items[0]
+    mgr_slot = item._manager_slot_id()
+    ref = item._make_manager_ref()
+    assert ref.kind == "ManagerRef"
+    assert ref.slot_id == mgr_slot
+
     enter = item._make_enter_call()
-    exit_ = item._make_exit_call()
     assert enter.kind == "Call"
     assert enter.func.kind == "Attribute"
     assert enter.func.attr == "__enter__"
-    assert enter.args == ()
-    assert exit_.kind == "Call"
-    assert exit_.func.kind == "Attribute"
-    assert exit_.func.attr == "__exit__"
-    assert len(exit_.args) == 3
-    # Method coords sugar through the normal Call/Attribute door.
+    assert enter.func.value.kind == "ManagerRef"
+    assert enter.func.value.slot_id == mgr_slot
+    # Receiver is not a re-read of the free name / context expr node.
+    assert enter.func.value is not item.context_expr
+
+    exit_ok = item._make_exit_call_completed()
+    assert exit_ok.func.attr == "__exit__"
+    assert exit_ok.func.value.kind == "ManagerRef"
+    assert exit_ok.func.value.slot_id == mgr_slot
+    assert len(exit_ok.args) == 3
+    # Completed face: three Nones.
+    assert all(a.kind == "Constant" and a.value is None for a in exit_ok.args)
+
+    exit_raise = item._make_exit_call_raised(f"{mgr_slot}#raise")
+    assert exit_raise.func.value.slot_id == mgr_slot
+    assert len(exit_raise.args) == 3
+    # Raised face: not three Nones — EffectRef witnesses / open markers.
+    assert not all(
+        a.kind == "Constant" and a.value is None for a in exit_raise.args
+    )
+    assert exit_raise.args[1].kind == "EffectRef"
+
     enter_sugar = enter.sugar()
-    exit_sugar = exit_.sugar()
     assert type(enter_sugar).__name__ == "MethodCallSugar"
-    assert type(exit_sugar).__name__ == "MethodCallSugar"
     assert enter_sugar.name == "__enter__"
-    assert exit_sugar.name == "__exit__"
+    assert type(enter_sugar.receiver).__name__ == "ManagerRefSugar"
+    assert enter_sugar.receiver.slot_id == mgr_slot
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

#6040 fixed ownership (no callbacks) but left three semantic gaps. This cut closes them **before** any manager enrollment.

### 1. Manager once
- Context expression sugar desugars **exactly once**
- Tree synthesizes \`ManagerRef(M)\` — stable coordinate
- \`M.__enter__()\` / \`M.__exit__(...)\` share \`M\` (not a second \`context_expr\` eval)
- \`ManagerBinding\` testimony links slot M to the evaluated value

### 2. Exit args per body face
| Face | \`__exit__\` args |
|------|------------------|
| Completed | \`(None, None, None)\` |
| Raised | \`(open exc_type, raise witness, open traceback)\` |
| Other halt | all three open |

Never pass \`None\` triple on exceptional faces. Unknown type/tb stay \`OpenExitArg\` (explicit red).

### 3. Enter-result authentication
- \`as\` → \`ObservationRef(E, ENTER_RESULT)\` with E distinct from M
- On enter-complete: \`EnterResultBinding\` facts (\`enter_result_value\`)

### Twins
- Side-effecting manager: desugar count == 1
- Tree: enter/exit receivers are \`ManagerRef\` with same slot
- Raised exit args ≠ three Nones
- Binding facts present when slots set

### Still loud
\`open(...)\` → \`RuntimeSelectedContextManager\`. No enrollment this PR.

## Validation
\`\`\`bash
pytest test_with_resource_sugar.py test_with_resource.py test_exit_set.py \\
       test_with_contract.py test_try_sugar.py -q
# 84 passed
\`\`\`

## Next
Proven \`NeverSuppresses\` enrollment only after this coordinate testimony is banked.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Evaluate `with` statement manager expression once and synthesize `__exit__` args per body face
> - The `with` statement's context expression is now desugared exactly once into a stable `ManagerRef` slot, shared by both `__enter__` and `__exit__` calls, preventing duplicate evaluation.
> - `__exit__` is no longer a pre-supplied sugar node; it is synthesized per body exit face: `(None, None, None)` for completed faces, and `(open_type, raise_witness, open_tb)` for raised faces.
> - New floor value types (`ManagerCoordinate`, `EnterResultCoordinate`, `OpenExitArg`, `RaiseWitnessCoordinate`) and their sugar counterparts are added to represent these IR coordinates.
> - New binding types (`ManagerBinding`, `EnterResultBinding`) attach invariant facts tying manager/enter-result slots to their evaluated values, prepended to completed exit entries via `prepend_facts_to_exitset`.
> - `ObservationRefSugar` gains an `enter_result` projection, and `WithResourceSugar` uses a distinct enter-result slot for `as name` bindings under `NeverSuppresses`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a4acff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->