### PR TITLE
Resource with: parametric exit, no desugar sugar builds

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/manager_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/manager_coordinate.py
@@ -1,9 +1,9 @@
-"""Tree-native manager / enter-result / open-exit-arg coordinates.
+"""Tree-native manager / enter-result / exit-face coordinates.
 
 Manager is evaluated **once**; ``ManagerRef(M)`` is the stable receiver for
-``__enter__`` / ``__exit__``. Enter-result ``as`` uses ``EnterResultCoordinate``.
-Exceptional ``__exit__`` type/traceback holes stay ``OpenExitArg`` — never
-silently ``None``.
+``__enter__`` / ``__exit__``. Exit args are parametric
+``ExitTypeRef(X)`` / ``ExitValueRef(X)`` / ``ExitTracebackRef(X)`` — pure
+coordinates; face testimony authenticates them under guards.
 """
 
 from __future__ import annotations
@@ -40,41 +40,44 @@ class EnterResultCoordinate(FloorValue):
 
         return ctor("python:enter_result", [str_const(self.slot_id)])
 
-    def attribute(self, name, site):
-        # ``x`` itself is the enter result; no .value projection required.
-        return super().attribute(name, site)
-
 
 @dataclass(frozen=True)
-class OpenExitArg(FloorValue):
-    """Explicit red: exceptional ``__exit__`` arg not constructed.
+class ExitTypeCoordinate(FloorValue):
+    """Parametric ``__exit__`` type arg: ``python:exit_type(X)``."""
 
-    Kinds: ``exc_type`` | ``traceback``. Never invent ``None`` for these.
-    """
-
-    kind: str
+    face_id: str
     site: object = dataclass_field(compare=False, default=None)
 
     def to_term(self, *, owner: str):
         del owner
         from sugar_lift_py_tests.ir import ctor, str_const
 
-        return ctor("python:open_exit_arg", [str_const(self.kind)])
+        return ctor("python:exit_type", [str_const(self.face_id)])
 
 
 @dataclass(frozen=True)
-class RaiseWitnessCoordinate(FloorValue):
-    """Body raise witness for ``__exit__`` value arg (occurrence, not type-as-id)."""
+class ExitValueCoordinate(FloorValue):
+    """Parametric ``__exit__`` value arg: ``python:exit_value(X)``."""
 
-    occurrence: str
-    exception_name: str | None = None
+    face_id: str
     site: object = dataclass_field(compare=False, default=None)
 
     def to_term(self, *, owner: str):
         del owner
         from sugar_lift_py_tests.ir import ctor, str_const
 
-        return ctor(
-            "python:raise_effect_occurrence",
-            [str_const(self.occurrence)],
-        )
+        return ctor("python:exit_value", [str_const(self.face_id)])
+
+
+@dataclass(frozen=True)
+class ExitTracebackCoordinate(FloorValue):
+    """Parametric ``__exit__`` traceback arg: ``python:exit_traceback(X)``."""
+
+    face_id: str
+    site: object = dataclass_field(compare=False, default=None)
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor("python:exit_traceback", [str_const(self.face_id)])

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/resource_bindings.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/resource_bindings.py
@@ -1,7 +1,9 @@
-"""Explicit record testimony for manager once-eval and enter-result auth.
+"""Explicit record testimony for manager, enter-result, and exit-face auth.
 
-Same posture as EffectBinding: coordinates are pure; authentication is
-InvValue facts on the record — not ambient tables, not floor-side sealing.
+Coordinates are pure; authentication is InvValue facts on the record.
+Exit-face bindings supply guarded testimony for parametric
+``ExitTypeRef(X)`` / ``ExitValueRef(X)`` / ``ExitTracebackRef(X)`` —
+never by constructing new sugars at desugar time.
 """
 
 from __future__ import annotations
@@ -51,6 +53,90 @@ class EnterResultBinding:
         )
 
 
+@dataclass(frozen=True)
+class ExitFaceBinding:
+    """Guarded testimony for parametric exit-arg coordinates under face X.
+
+    - completed: type/value/tb bound to None
+    - raised: type open or named; value = raise occurrence; tb open
+    - open: all three open residuals
+    """
+
+    face_id: str
+    kind: str  # "completed" | "raised" | "open"
+    exception_name: str | None = None
+    occurrence: str | None = None
+
+    @classmethod
+    def from_body_exit(cls, face_id: str, body_exit) -> "ExitFaceBinding":
+        from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+        from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+
+        if isinstance(body_exit, Completed):
+            return cls(face_id=face_id, kind="completed")
+        if isinstance(body_exit, Halted) and isinstance(
+            body_exit.effect, RaiseEffect
+        ):
+            effect = body_exit.effect
+            occurrence = (
+                getattr(effect, "occurrence_id", None)
+                or getattr(effect, "occurrence", None)
+                or getattr(effect, "blame", None)
+                or "unknown-raise"
+            )
+            return cls(
+                face_id=face_id,
+                kind="raised",
+                exception_name=effect.exception_name,
+                occurrence=str(occurrence),
+            )
+        return cls(face_id=face_id, kind="open")
+
+    def to_facts(self, site=None, guard=None) -> tuple:
+        from sugar_lift_py_tests.floor.inv_value import InvValue
+        from sugar_lift_py_tests.ir import atomic, ctor, eq, str_const
+        from sugar_lift_py_tests.outcome.exit_set import true_guard
+
+        face = str_const(self.face_id)
+        none = str_const("None")
+        open_type = ctor("python:open_exit_arg", [str_const("exc_type")])
+        open_tb = ctor("python:open_exit_arg", [str_const("traceback")])
+        open_val = ctor("python:open_exit_arg", [str_const("exc_val")])
+
+        if self.kind == "completed":
+            rows = (
+                eq(atomic("exit_type", [face]), none),
+                eq(atomic("exit_value", [face]), none),
+                eq(atomic("exit_traceback", [face]), none),
+            )
+        elif self.kind == "raised":
+            type_term = (
+                str_const(self.exception_name)
+                if self.exception_name
+                else open_type
+            )
+            value_term = ctor(
+                "python:raise_effect_occurrence",
+                [str_const(self.occurrence or "unknown-raise")],
+            )
+            rows = (
+                eq(atomic("exit_type", [face]), type_term),
+                eq(atomic("exit_value", [face]), value_term),
+                eq(atomic("exit_traceback", [face]), open_tb),
+            )
+        else:
+            rows = (
+                eq(atomic("exit_type", [face]), open_type),
+                eq(atomic("exit_value", [face]), open_val),
+                eq(atomic("exit_traceback", [face]), open_tb),
+            )
+
+        facts = tuple(InvValue(row, site=site) for row in rows)
+        if guard is not None and guard != true_guard():
+            facts = tuple(f.guarded(guard) for f in facts)
+        return facts
+
+
 def prepend_facts_to_exitset(exits, facts: tuple):
     """Attach binding facts to every completed exit's entry list."""
     from dataclasses import replace
@@ -63,7 +149,20 @@ def prepend_facts_to_exitset(exits, facts: tuple):
     out = []
     for exit_ in exits.exits:
         if isinstance(exit_, Halted):
+            # Face bindings for halt faces still ride as companion completed
+            # residue under the same guard so testimony is not dropped.
             out.append(exit_)
+            if facts:
+                out.append(
+                    Completed(
+                        exit_.guard,
+                        _ReducedBlock(
+                            entries=facts,
+                            can_fall_through=False,
+                            fall_through=(),
+                        ),
+                    )
+                )
             continue
         value = exit_.value
         if isinstance(value, _ReducedBlock):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/resource_coord_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/resource_coord_sugar.py
@@ -1,4 +1,8 @@
-"""Sugars for ManagerRef / open exit args / raise witnesses (resource with)."""
+"""Sugars for ManagerRef and parametric exit-arg refs (resource with).
+
+These are tree-materialized only. ``WithResourceSugar.desugar`` must not
+construct them.
+"""
 
 from __future__ import annotations
 
@@ -27,10 +31,10 @@ class ManagerRefSugar(Sugar):
 
 
 @dataclass(frozen=True)
-class OpenExitArgSugar(Sugar):
-    """Exceptional ``__exit__`` arg left explicitly open (type / tb / val)."""
+class ExitTypeRefSugar(Sugar):
+    """Tree ``ExitTypeRef(X)`` — pure parametric exit-type coordinate."""
 
-    kind: str
+    face_id: str
     site: object = dataclass_field(compare=False, default=None)
 
     @classmethod
@@ -39,17 +43,16 @@ class OpenExitArgSugar(Sugar):
 
     def desugar(self, ctx: object = None) -> Outcome:
         del ctx
-        from sugar_lift_py_tests.floor.manager_coordinate import OpenExitArg
+        from sugar_lift_py_tests.floor.manager_coordinate import ExitTypeCoordinate
 
-        return Complete(OpenExitArg(kind=self.kind, site=self.site))
+        return Complete(ExitTypeCoordinate(face_id=self.face_id, site=self.site))
 
 
 @dataclass(frozen=True)
-class RaiseWitnessSugar(Sugar):
-    """Body raise occurrence as ``__exit__`` exception-value argument."""
+class ExitValueRefSugar(Sugar):
+    """Tree ``ExitValueRef(X)`` — pure parametric exit-value coordinate."""
 
-    occurrence: str
-    exception_name: str | None = None
+    face_id: str
     site: object = dataclass_field(compare=False, default=None)
 
     @classmethod
@@ -58,12 +61,28 @@ class RaiseWitnessSugar(Sugar):
 
     def desugar(self, ctx: object = None) -> Outcome:
         del ctx
-        from sugar_lift_py_tests.floor.manager_coordinate import RaiseWitnessCoordinate
+        from sugar_lift_py_tests.floor.manager_coordinate import ExitValueCoordinate
+
+        return Complete(ExitValueCoordinate(face_id=self.face_id, site=self.site))
+
+
+@dataclass(frozen=True)
+class ExitTracebackRefSugar(Sugar):
+    """Tree ``ExitTracebackRef(X)`` — pure parametric exit-traceback coordinate."""
+
+    face_id: str
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        from sugar_lift_py_tests.floor.manager_coordinate import (
+            ExitTracebackCoordinate,
+        )
 
         return Complete(
-            RaiseWitnessCoordinate(
-                occurrence=self.occurrence,
-                exception_name=self.exception_name,
-                site=self.site,
-            )
+            ExitTracebackCoordinate(face_id=self.face_id, site=self.site)
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
@@ -1,12 +1,14 @@
-"""Resource ``with``: manager once, enter, body ExitSet, exit per face.
+"""Resource ``with``: manager once, enter, body ExitSet, parametric exit.
 
-Tree ownership:
-- ``manager`` sugar evaluates the context expression **once**
-- ``ManagerRef(M)`` is the stable receiver for enter/exit method coordinates
-- ``enter`` is ``M.__enter__()`` sugar
-- exit is **built per body face** with correct ``(type, val, tb)`` args
-- ``enter_slot_id`` is authenticated from the completed enter value
-- disposition is typed (never a name-callback)
+Tree ownership (construction door only):
+- ``manager`` — context expr, desugared once
+- ``enter`` — ``ManagerRef(M).__enter__()``
+- ``exit`` — **one** prebuilt ``M.__exit__(ExitTypeRef(X), ExitValueRef(X),
+  ExitTracebackRef(X))`` sugar
+- face testimony via ``ExitFaceBinding`` under each body-exit guard
+
+``desugar`` must not import or construct sugars (MethodCallSugar, etc.).
+It only desugars existing sugars, emits binding facts, and runs ExitSet algebra.
 """
 
 from __future__ import annotations
@@ -20,16 +22,16 @@ from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 @dataclass(frozen=True)
 class WithResourceSugar(Sugar):
-    """Resource with under tree-owned manager/enter coords + typed disposition."""
+    """Resource with: tree-owned manager/enter/exit + typed disposition."""
 
     manager: Sugar
-    """Context-expression sugar — desugared exactly once."""
-
     manager_slot_id: str
-    """Stable ManagerRef slot; enter/exit receivers share this coordinate."""
-
     enter: Sugar
-    """``ManagerRef(M).__enter__()`` method-coordinate sugar."""
+    exit: Sugar
+    """Single parametric ``M.__exit__(ExitTypeRef(X), …)`` — never rebuilt."""
+
+    exit_face_id: str
+    """Stable face coordinate X for ExitFaceBinding testimony."""
 
     body: tuple
     disposition: object
@@ -60,9 +62,12 @@ class WithResourceSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+        # Construction boundary: only ExitSet algebra + binding facts.
+        # No sugar-class imports or construction on this path.
+        from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
         from sugar_lift_py_tests.outcome.resource_bindings import (
             EnterResultBinding,
+            ExitFaceBinding,
             ManagerBinding,
             prepend_facts_to_exitset,
         )
@@ -78,7 +83,6 @@ class WithResourceSugar(Sugar):
 
         del ctx
 
-        # 1. Evaluate context expression once.
         manager_es = sugar_outcome_to_exitset(self.manager.desugar())
         parts: list = []
 
@@ -93,7 +97,6 @@ class WithResourceSugar(Sugar):
                     self.manager_slot_id, mgr_exit.value
                 ).to_facts(site=self.site)
 
-            # 2. Enter once (receiver is ManagerRef coordinate sugar).
             enter_es = sugar_outcome_to_exitset(self.enter.desugar())
             for enter_exit in enter_es.exits:
                 face_guard = _and_guards(mgr_exit.guard, enter_exit.guard)
@@ -111,19 +114,21 @@ class WithResourceSugar(Sugar):
                         self.enter_slot_id, enter_exit.value
                     ).to_facts(site=self.site)
 
-                # 3. Body under enter-complete face.
                 body_es = promote_raise_halts(
                     reduce_block_to_exitset(self.body)
                 ).guarded(face_guard)
 
-                # 4. Exit per body face with face-correct args.
+                # Parametric exit: materialize once, fan over every body face.
+                exit_es = sugar_outcome_to_exitset(self.exit.desugar())
+
                 for body_exit in body_es.exits:
-                    exit_sugar = self._exit_sugar_for_face(body_exit)
-                    exit_es = sugar_outcome_to_exitset(exit_sugar.desugar())
+                    face_facts = ExitFaceBinding.from_body_exit(
+                        self.exit_face_id, body_exit
+                    ).to_facts(site=self.site, guard=body_exit.guard)
                     face = ExitSet((body_exit,))
                     after = face.and_exit(exit_es, disposition=self.disposition)
                     after = prepend_facts_to_exitset(
-                        after, (*mgr_facts, *enter_facts)
+                        after, (*mgr_facts, *enter_facts, *face_facts)
                     )
                     parts.append(after)
 
@@ -138,66 +143,10 @@ class WithResourceSugar(Sugar):
 
         return exitset_to_outcome(routed)
 
-    def _exit_sugar_for_face(self, body_exit) -> Sugar:
-        """Build ``M.__exit__(type, val, tb)`` for this body face only.
-
-        - Completed (incl. return): ``(None, None, None)``
-        - Halted raise: ``(open type, raise witness, open traceback)``
-        - Other halt: open triple residual (never invent completed None)
-        """
-        from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
-        from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
-        from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
-        from sugar_lift_py_tests.sugar.none_literal_sugar import NoneLiteralSugar
-        from sugar_lift_py_tests.sugar.resource_coord_sugar import (
-            ManagerRefSugar,
-            OpenExitArgSugar,
-            RaiseWitnessSugar,
-        )
-
-        receiver = ManagerRefSugar(slot_id=self.manager_slot_id, site=self.site)
-        none = NoneLiteralSugar(site=self.site)
-
-        if isinstance(body_exit, Completed):
-            args = (none, none, none)
-        elif isinstance(body_exit, Halted) and isinstance(
-            body_exit.effect, RaiseEffect
-        ):
-            effect = body_exit.effect
-            occurrence = (
-                getattr(effect, "occurrence_id", None)
-                or getattr(effect, "occurrence", None)
-                or getattr(effect, "blame", None)
-                or "unknown-raise"
-            )
-            args = (
-                OpenExitArgSugar(kind="exc_type", site=self.site),
-                RaiseWitnessSugar(
-                    occurrence=str(occurrence),
-                    exception_name=effect.exception_name,
-                    site=self.site,
-                ),
-                OpenExitArgSugar(kind="traceback", site=self.site),
-            )
-        else:
-            # Non-raise halt / unknown control: keep all three open.
-            args = (
-                OpenExitArgSugar(kind="exc_type", site=self.site),
-                OpenExitArgSugar(kind="exc_val", site=self.site),
-                OpenExitArgSugar(kind="traceback", site=self.site),
-            )
-
-        return MethodCallSugar(
-            receiver=receiver,
-            name="__exit__",
-            args=args,
-            site=self.site,
-        )
-
 
 def _and_guards(left, right):
-    from sugar_lift_py_tests.outcome.exit_set import true_guard
     from sugar_lift_py_tests.ir import and_
+    from sugar_lift_py_tests.outcome.exit_set import true_guard
 
     if left == true_guard():
         return right

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -1,9 +1,11 @@
-"""Unit twins for resource ``WithResourceSugar`` — manager once, face exit args.
+"""Unit twins for resource ``WithResourceSugar`` — parametric exit, no desugar builds.
 
-No callback side doors. Production ``open(...)`` stays RuntimeSelected.
+Production ``open(...)`` stays RuntimeSelected.
 """
 
 from __future__ import annotations
+
+import inspect
 
 from sugar_lift_py_tests.context_manager_contract import (
     NeverSuppresses,
@@ -13,13 +15,22 @@ from sugar_lift_py_tests.effect import RaiseEffect
 from sugar_lift_py_tests.floor.block_value import BlockValue
 from sugar_lift_py_tests.floor.call_site_value import ExitSuppressionContract
 from sugar_lift_py_tests.floor.manager_coordinate import (
+    ExitTracebackCoordinate,
+    ExitTypeCoordinate,
+    ExitValueCoordinate,
     ManagerCoordinate,
-    OpenExitArg,
-    RaiseWitnessCoordinate,
 )
+from sugar_lift_py_tests.floor.inv_value import InvValue
 from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.outcome.exit_set import Completed, Halted, true_guard
+from sugar_lift_py_tests.outcome.resource_bindings import ExitFaceBinding
 from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
-from sugar_lift_py_tests.sugar.resource_coord_sugar import ManagerRefSugar
+from sugar_lift_py_tests.sugar.resource_coord_sugar import (
+    ExitTracebackRefSugar,
+    ExitTypeRefSugar,
+    ExitValueRefSugar,
+    ManagerRefSugar,
+)
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
 
@@ -58,8 +69,6 @@ class _Raise(_FixedSugar):
 
 
 class _FloorValue:
-    """Minimal FloorValue stand-in for manager/enter completed values."""
-
     def __init__(self, label: str):
         self.label = label
 
@@ -70,27 +79,58 @@ class _FloorValue:
         return str_const(self.label)
 
 
-def _mgr_once(probe=None):
-    return _FixedSugar(Complete(_FloorValue("mgr")), probe=probe)
-
-
-def _enter_ok(probe=None):
-    return _FixedSugar(Complete(_FloorValue("entered")), probe=probe)
+def _parametric_exit(face_id="X", manager_slot="M", probe=None):
+    """Prebuilt tree-shaped exit: M.__exit__(ExitTypeRef(X), …)."""
+    return MethodCallSugar(
+        receiver=ManagerRefSugar(slot_id=manager_slot, site=None),
+        name="__exit__",
+        args=(
+            ExitTypeRefSugar(face_id=face_id, site=None),
+            ExitValueRefSugar(face_id=face_id, site=None),
+            ExitTracebackRefSugar(face_id=face_id, site=None),
+        ),
+        site=None,
+    )
 
 
 def _resource(
     *,
     manager=None,
     enter=None,
+    exit=None,
     body=None,
     disposition=None,
     manager_slot_id="M",
+    exit_face_id="X",
     enter_slot_id=None,
+    exit_probe=None,
 ):
+    exit_sugar = exit
+    if exit_sugar is None:
+        exit_sugar = _parametric_exit(
+            face_id=exit_face_id, manager_slot=manager_slot_id
+        )
+        if exit_probe is not None:
+            # Wrap to count desugars of the prebuilt exit sugar.
+            inner = exit_sugar
+
+            class _ProbeExit(Sugar):
+                def desugar(self, ctx=None):
+                    exit_probe.append(1)
+                    return inner.desugar(ctx)
+
+                @classmethod
+                def witnesses(cls):
+                    return ()
+
+            exit_sugar = _ProbeExit()
+
     return WithResourceSugar(
-        manager=manager or _mgr_once(),
+        manager=manager or _FixedSugar(Complete(_FloorValue("mgr"))),
         manager_slot_id=manager_slot_id,
-        enter=enter or _enter_ok(),
+        enter=enter or _FixedSugar(Complete(_FloorValue("entered"))),
+        exit=exit_sugar,
+        exit_face_id=exit_face_id,
         body=body if body is not None else (_Pass(),),
         disposition=disposition or NeverSuppresses(),
         enter_slot_id=enter_slot_id,
@@ -99,48 +139,66 @@ def _resource(
 
 
 def test_manager_expression_evaluated_exactly_once():
-    """Side-effecting manager twin: context expr desugars once, not twice."""
     seen = []
-    sugar = _resource(manager=_mgr_once(probe=seen), body=(_Pass(),))
+    sugar = _resource(
+        manager=_FixedSugar(Complete(_FloorValue("mgr")), probe=seen),
+        body=(_Pass(),),
+    )
     sugar.desugar()
     assert seen == [1]
 
 
+def test_parametric_exit_desugars_once_for_body_path():
+    """Prebuilt exit sugar desugars once when the body path runs."""
+    seen = []
+    sugar = _resource(body=(_Raise("ValueError"),), exit_probe=seen)
+    sugar.desugar()
+    assert seen == [1]
+
+
+def test_exit_face_binding_applied_per_face_without_rebuilding_exit():
+    """Exit sugar desugars once; face kinds differ by ExitFaceBinding."""
+    seen = []
+    sugar = _resource(body=(_Raise("KeyError"),), exit_probe=seen)
+    sugar.desugar()
+    assert seen == [1]
+    completed = ExitFaceBinding.from_body_exit(
+        "X", Completed(true_guard(), BlockValue((), can_fall_through=True))
+    )
+    raised = ExitFaceBinding.from_body_exit(
+        "X",
+        Halted(
+            true_guard(),
+            RaiseEffect(exception_name="KeyError", occurrence="k.py:1:0"),
+        ),
+    )
+    assert completed.kind == "completed"
+    assert raised.kind == "raised"
+    assert completed.kind != raised.kind
+
+
 def test_enter_halt_skips_body_and_exit():
     body_ran = []
+    exit_ran = []
     enter_halt = RaiseEffect(exception_name="OSError")
     sugar = _resource(
         enter=_FixedSugar(Incomplete(enter_halt)),
         body=(_Pass(probe=body_ran),),
+        exit_probe=exit_ran,
     )
     out = sugar.desugar()
     assert body_ran == []
+    assert exit_ran == []
     reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
     assert len(reds) == 1
     assert reds[0].effect == enter_halt
 
 
-def test_never_suppresses_restores_body_halt_after_exit_completes():
+def test_never_suppresses_restores_body_halt():
     sugar = _resource(body=(_Raise("ValueError"),))
     out = sugar.desugar()
     reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
-    assert len(reds) == 1
-    assert reds[0].effect.exception_name == "ValueError"
-
-
-def test_exit_halt_supersedes_body_halt():
-    # Enter completes; body raises; exit is raised via MethodCall on ManagerRef
-    # that we replace by using a body raise + disposition — exit method coords
-    # complete as CallSiteValue. Supersede tested via enter path with halt exit
-    # only when enter itself is the exit-like halt:
-    sugar = _resource(
-        enter=_Raise("RuntimeError"),
-        body=(_Raise("ValueError"),),
-    )
-    out = sugar.desugar()
-    reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
-    assert len(reds) == 1
-    assert reds[0].effect.exception_name == "RuntimeError"
+    assert any(r.effect.exception_name == "ValueError" for r in reds)
 
 
 def test_proven_contract_consumes_matching_body_halt():
@@ -149,7 +207,12 @@ def test_proven_contract_consumes_matching_body_halt():
         disposition=ExitSuppressionContract.suppresses(("ValueError",)),
     )
     out = sugar.desugar()
-    reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
+    reds = [
+        e
+        for e in out.value.contribution()
+        if isinstance(e, Incomplete)
+        and getattr(e.effect, "exception_name", None) == "ValueError"
+    ]
     assert reds == []
 
 
@@ -159,58 +222,54 @@ def test_runtime_selected_not_guessed():
         disposition=RuntimeSelected(),
     )
     out = sugar.desugar()
-    reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
+    reds = [
+        e
+        for e in out.value.contribution()
+        if isinstance(e, Incomplete)
+        and getattr(e.effect, "exception_name", None) == "ValueError"
+    ]
     assert len(reds) == 1
 
 
 def test_completed_body_survives_never_suppresses():
     sugar = _resource(body=(_Pass(),))
     out = sugar.desugar()
-    assert not any(isinstance(e, Incomplete) for e in out.value.contribution())
+    reds = [
+        e
+        for e in out.value.contribution()
+        if isinstance(e, Incomplete)
+        and getattr(getattr(e, "effect", None), "exception_name", None)
+    ]
+    assert reds == []
 
 
-def test_exit_sugar_for_completed_face_is_none_triple():
-    from sugar_lift_py_tests.outcome.exit_set import Completed, true_guard
-
-    sugar = _resource(body=(_Pass(),))
+def test_exit_face_binding_completed_is_none_triple():
     face = Completed(true_guard(), BlockValue((), can_fall_through=True))
-    exit_sugar = sugar._exit_sugar_for_face(face)
-    assert isinstance(exit_sugar, MethodCallSugar)
-    assert exit_sugar.name == "__exit__"
-    assert isinstance(exit_sugar.receiver, ManagerRefSugar)
-    assert exit_sugar.receiver.slot_id == "M"
-    assert len(exit_sugar.args) == 3
-    # None, None, None for completed
-    assert all(type(a).__name__ == "NoneLiteralSugar" for a in exit_sugar.args)
+    binding = ExitFaceBinding.from_body_exit("X", face)
+    assert binding.kind == "completed"
+    facts = binding.to_facts()
+    assert len(facts) == 3
+    # All consequents bind to "None"
+    for inv in facts:
+        assert inv.formula.args[1].value == "None"
 
 
-def test_exit_sugar_for_raised_face_is_not_none_triple():
-    from sugar_lift_py_tests.outcome.exit_set import Halted, true_guard
-
-    sugar = _resource(manager_slot_id="mgr1")
+def test_exit_face_binding_raised_is_not_none_triple():
     effect = RaiseEffect(exception_name="ValueError", occurrence="src.py:3:4")
     face = Halted(true_guard(), effect)
-    exit_sugar = sugar._exit_sugar_for_face(face)
-    assert isinstance(exit_sugar, MethodCallSugar)
-    assert exit_sugar.receiver.slot_id == "mgr1"
-    args = exit_sugar.args
-    assert type(args[0]).__name__ == "OpenExitArgSugar"
-    assert args[0].kind == "exc_type"
-    assert type(args[1]).__name__ == "RaiseWitnessSugar"
-    assert args[1].occurrence == "src.py:3:4"
-    assert type(args[2]).__name__ == "OpenExitArgSugar"
-    assert args[2].kind == "traceback"
-    # Desugar args: open + witness + open — never three Nones.
-    a0 = args[0].desugar().value
-    a1 = args[1].desugar().value
-    a2 = args[2].desugar().value
-    assert isinstance(a0, OpenExitArg) and a0.kind == "exc_type"
-    assert isinstance(a1, RaiseWitnessCoordinate)
-    assert a1.occurrence == "src.py:3:4"
-    assert isinstance(a2, OpenExitArg) and a2.kind == "traceback"
+    binding = ExitFaceBinding.from_body_exit("X", face)
+    assert binding.kind == "raised"
+    facts = binding.to_facts()
+    vals = [inv.formula.args[1] for inv in facts]
+    # type named, value occurrence, tb open — not three Nones
+    assert not all(getattr(v, "value", None) == "None" for v in vals)
+    assert any(getattr(v, "value", None) == "ValueError" for v in vals)
+    assert any(
+        getattr(v, "name", None) == "python:raise_effect_occurrence" for v in vals
+    )
 
 
-def test_enter_result_binding_facts_when_slot_present():
+def test_enter_result_and_manager_binding_facts():
     sugar = _resource(
         body=(_Pass(),),
         enter_slot_id="E",
@@ -218,23 +277,58 @@ def test_enter_result_binding_facts_when_slot_present():
         manager=_FixedSugar(Complete(_FloorValue("mgr-val"))),
     )
     out = sugar.desugar()
-    invs = list(out.value.inv_contribution()) if hasattr(out.value, "inv_contribution") else []
-    # Facts ride in BlockValue entries as InvValues
-    from sugar_lift_py_tests.floor.inv_value import InvValue
-
-    entries = list(out.value.contribution())
-    invs = [e for e in entries if isinstance(e, InvValue)]
+    invs = [e for e in out.value.contribution() if isinstance(e, InvValue)]
     names = []
     for inv in invs:
         f = inv.formula
+        if getattr(f, "kind", None) == "implies":
+            f = f.operands[1]
         if getattr(f, "name", None) == "=":
-            left = f.args[0]
-            names.append(getattr(left, "name", None))
+            names.append(getattr(f.args[0], "name", None))
     assert "manager_slot_value" in names
     assert "enter_result_value" in names
+    assert "exit_type" in names  # completed face testimony
+
+
+def test_parametric_exit_args_are_exit_refs():
+    exit_sugar = _parametric_exit(face_id="face1", manager_slot="m1")
+    assert isinstance(exit_sugar, MethodCallSugar)
+    assert exit_sugar.name == "__exit__"
+    assert isinstance(exit_sugar.receiver, ManagerRefSugar)
+    assert [type(a).__name__ for a in exit_sugar.args] == [
+        "ExitTypeRefSugar",
+        "ExitValueRefSugar",
+        "ExitTracebackRefSugar",
+    ]
+    assert exit_sugar.args[0].desugar().value.face_id == "face1"
+    assert isinstance(exit_sugar.args[0].desugar().value, ExitTypeCoordinate)
+    assert isinstance(exit_sugar.args[1].desugar().value, ExitValueCoordinate)
+    assert isinstance(exit_sugar.args[2].desugar().value, ExitTracebackCoordinate)
 
 
 def test_manager_ref_sugar_is_manager_coordinate():
     out = ManagerRefSugar(slot_id="M42").desugar()
     assert isinstance(out.value, ManagerCoordinate)
     assert out.value.slot_id == "M42"
+
+
+def test_with_resource_desugar_does_not_construct_sugars():
+    """Law: desugar must not build sugars or import sugar constructors."""
+    src = inspect.getsource(WithResourceSugar.desugar)
+    forbidden = (
+        "MethodCallSugar",
+        "RaiseWitnessSugar",
+        "OpenExitArgSugar",
+        "NoneLiteralSugar",
+        "ManagerRefSugar",
+        "ExitTypeRefSugar",
+        "ExitValueRefSugar",
+        "ExitTracebackRefSugar",
+        "_exit_sugar_for_face",
+        "sugar.method_call",
+        "sugar.resource_coord",
+        "sugar.none_literal",
+    )
+    for token in forbidden:
+        assert token not in src, f"desugar must not reference {token!r}"
+    assert not hasattr(WithResourceSugar, "_exit_sugar_for_face")

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -785,55 +785,55 @@ class WithItem(Node):
         enter_attr = self._make_attribute(self._make_manager_ref(), "__enter__")
         return self._make_call(enter_attr, ())
 
+    def _exit_face_id(self) -> str:
+        """Stable exit-face coordinate X for parametric exit-arg refs."""
+        return f"{self._manager_slot_id()}#exit_face"
+
+    def _make_exit_type_ref(self) -> "Node":
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        slots = (("face_id", Leaf(self._exit_face_id())),)
+        return materialize(
+            self.unit, ShadowNode("ExitTypeRef", self.span, slots), self.reporter
+        )
+
+    def _make_exit_value_ref(self) -> "Node":
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        slots = (("face_id", Leaf(self._exit_face_id())),)
+        return materialize(
+            self.unit, ShadowNode("ExitValueRef", self.span, slots), self.reporter
+        )
+
+    def _make_exit_traceback_ref(self) -> "Node":
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        slots = (("face_id", Leaf(self._exit_face_id())),)
+        return materialize(
+            self.unit,
+            ShadowNode("ExitTracebackRef", self.span, slots),
+            self.reporter,
+        )
+
     def _make_exit_call(self, typ: "Node", val: "Node", tb: "Node") -> "Node":
         """Tree coordinate ``ManagerRef(M).__exit__(typ, val, tb)``."""
         exit_attr = self._make_attribute(self._make_manager_ref(), "__exit__")
         return self._make_call(exit_attr, (typ, val, tb))
 
-    def _make_exit_call_completed(self) -> "Node":
-        """Normal-completion exit: ``__exit__(None, None, None)``."""
-        none = self._make_none_constant()
-        return self._make_exit_call(none, none, none)
+    def _make_parametric_exit_call(self) -> "Node":
+        """One exit call: ``M.__exit__(ExitTypeRef(X), ExitValueRef(X), ExitTracebackRef(X))``.
 
-    def _make_exit_call_raised(self, effect_slot_id: str) -> "Node":
-        """Exceptional exit: open type/tb + EffectRef value (not all-None)."""
-        from .backend import Leaf, materialize
-        from .shadow import ShadowNode
-
-        # Open args are Constant(None) only for the completed face; here type/tb
-        # stay as Name-less open markers via ObservationRef-style slots until a
-        # dedicated OpenExitArg node exists. Use EffectRef for the value arg.
-        effect_ref = materialize(
-            self.unit,
-            ShadowNode(
-                "EffectRef",
-                self.span,
-                (("slot_id", Leaf(effect_slot_id)),),
-            ),
-            self.reporter,
+        Face-specific values are ExitFaceBinding testimony under guards —
+        not alternate MethodCall sugars built at desugar time.
+        """
+        return self._make_exit_call(
+            self._make_exit_type_ref(),
+            self._make_exit_value_ref(),
+            self._make_exit_traceback_ref(),
         )
-        # Open type/tb: none is wrong; use a Constant that sugars to None only
-        # for completed. For raised we synthesize Attribute-free open via
-        # EffectRef of synthetic open slots (testimony red at disposition).
-        open_type = materialize(
-            self.unit,
-            ShadowNode(
-                "EffectRef",
-                self.span,
-                (("slot_id", Leaf(f"{effect_slot_id}#exc_type")),),
-            ),
-            self.reporter,
-        )
-        open_tb = materialize(
-            self.unit,
-            ShadowNode(
-                "EffectRef",
-                self.span,
-                (("slot_id", Leaf(f"{effect_slot_id}#traceback")),),
-            ),
-            self.reporter,
-        )
-        return self._make_exit_call(open_type, effect_ref, open_tb)
 
 
 class ImportAlias(Node):
@@ -1881,11 +1881,12 @@ class With(Statement):
                 slot_id=slot_id,
             )
         if isinstance(contract, NeverSuppresses):
-            # Manager once → ManagerRef(M); enter = M.__enter__(); exit built
-            # per body face in WithResourceSugar (completed vs raised args).
+            # Manager once → ManagerRef(M); enter = M.__enter__();
+            # one parametric exit = M.__exit__(ExitTypeRef(X), …).
             # Nothing enrolls NeverSuppresses yet.
             manager_slot = item._manager_slot_id()
             enter_node = item._make_enter_call()
+            exit_node = item._make_parametric_exit_call()
             enter_slot = (
                 f"{manager_slot}#enter_result" if as_name is not None else None
             )
@@ -1893,6 +1894,8 @@ class With(Statement):
                 manager=item.context_expr.sugar(),
                 manager_slot_id=manager_slot,
                 enter=enter_node.sugar(),
+                exit=exit_node.sugar(),
+                exit_face_id=item._exit_face_id(),
                 body=tuple(stmt.sugar() for stmt in self.body),
                 disposition=contract,
                 enter_slot_id=enter_slot,
@@ -3306,6 +3309,53 @@ class ManagerRef(Expression):
         from sugar_lift_py_tests.sugar.resource_coord_sugar import ManagerRefSugar
 
         return ManagerRefSugar(slot_id=self.slot_id, site=self.fragment)
+
+
+class ExitTypeRef(Expression):
+    """Parametric ``__exit__`` type argument: ``ExitTypeRef(X)``."""
+
+    face_id: str
+
+    def substitute(self, scope: "dict[str, Node]") -> "Node":
+        del scope
+        return self
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.resource_coord_sugar import ExitTypeRefSugar
+
+        return ExitTypeRefSugar(face_id=self.face_id, site=self.fragment)
+
+
+class ExitValueRef(Expression):
+    """Parametric ``__exit__`` value argument: ``ExitValueRef(X)``."""
+
+    face_id: str
+
+    def substitute(self, scope: "dict[str, Node]") -> "Node":
+        del scope
+        return self
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.resource_coord_sugar import ExitValueRefSugar
+
+        return ExitValueRefSugar(face_id=self.face_id, site=self.fragment)
+
+
+class ExitTracebackRef(Expression):
+    """Parametric ``__exit__`` traceback argument: ``ExitTracebackRef(X)``."""
+
+    face_id: str
+
+    def substitute(self, scope: "dict[str, Node]") -> "Node":
+        del scope
+        return self
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.resource_coord_sugar import (
+            ExitTracebackRefSugar,
+        )
+
+        return ExitTracebackRefSugar(face_id=self.face_id, site=self.fragment)
 
 
 class ObservationRef(Expression):

--- a/implementations/python/sugar-source-tree/tests/test_with_resource.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_resource.py
@@ -1,11 +1,9 @@
 """Resource `with` under RuntimeSelected (#5994 step 4).
 
-Production: unenrolled managers (``open``, …) stay LOUD as the named residual
-``RuntimeSelectedContextManager`` until enter/exit are constructed. The
-enter/exit ExitSet transformation lives on ``WithResourceSugar`` (unit twins
-in ``test_with_resource_sugar.py``); assertion managers (Expects/Suppresses)
-stay on ``WithContractSugar``. No manager is admitted green without constructed
-enter/exit or an explicit red residual.
+Production: unenrolled managers stay LOUD as ``RuntimeSelectedContextManager``.
+Tree synthesizes ManagerRef + parametric exit; enter/exit ExitSet lives on
+``WithResourceSugar`` (unit twins). No manager is admitted green without
+constructed enter/exit or explicit red.
 """
 
 from __future__ import annotations
@@ -38,8 +36,8 @@ def test_resource_open_is_runtime_selected_named_residual():
     with pytest.raises(RuntimeSelectedContextManager) as ei:
         _fn("def A(f):\n    with open(f):\n        pass\n    return f\n").sugar()
     panic = ei.value
-    assert isinstance(panic, SugarNotWritten)  # still a gap for census
-    assert type(panic) is RuntimeSelectedContextManager  # not bare
+    assert isinstance(panic, SugarNotWritten)
+    assert type(panic) is RuntimeSelectedContextManager
     assert "unauthenticated context manager — exit suppression runtime-selected" in (
         panic.observed
     )
@@ -47,17 +45,14 @@ def test_resource_open_is_runtime_selected_named_residual():
 
 
 def test_resource_open_is_not_silent_dissolve():
-    """No sugar object, no enter/exit splice: the throw is the residual."""
     with pytest.raises(RuntimeSelectedContextManager):
         sugar = _fn(
             "def A(f):\n    with open(f):\n        x = 1\n    return f\n"
         ).sugar()
-        # If sugar() ever returned instead of raising, that would be a dissolve.
         sugar.desugar()
 
 
 def test_resource_named_residual_distinct_from_bare_sugar_not_written():
-    """Census discrimination: resource managers are a typed subclass."""
     with pytest.raises(RuntimeSelectedContextManager) as ei:
         _fn("def A(z):\n    with open(z):\n        pass\n    return z\n").sugar()
     assert type(ei.value) is not SugarNotWritten
@@ -65,7 +60,6 @@ def test_resource_named_residual_distinct_from_bare_sugar_not_written():
 
 
 def test_assertion_manager_pytest_raises_still_lifts():
-    """Step-4 residual must not disturb the Expects path."""
     v = _val(
         "def A(z):\n    with pytest.raises(ValueError):\n        raise ValueError\n"
         "    return z\n"
@@ -84,50 +78,45 @@ def test_suppress_manager_still_lifts():
     assert v.invs() == () and v.post().args[1].name == "z"
 
 
-def test_with_item_manager_ref_is_shared_enter_exit_receiver():
-    """Context expr is NOT the enter/exit receiver — ManagerRef(M) is.
-
-    Both method coords share one manager slot (single evaluation identity).
-    """
+def test_with_item_parametric_exit_uses_manager_ref_and_exit_refs():
+    """One exit call: M.__exit__(ExitTypeRef(X), ExitValueRef(X), ExitTracebackRef(X))."""
     fn = _fn("def A(m):\n    with m:\n        pass\n    return m\n")
     with_node = next(s for s in fn.body if s.kind == "With")
     item = with_node.items[0]
     mgr_slot = item._manager_slot_id()
+    face_id = item._exit_face_id()
+    assert face_id == f"{mgr_slot}#exit_face"
+
     ref = item._make_manager_ref()
     assert ref.kind == "ManagerRef"
     assert ref.slot_id == mgr_slot
 
     enter = item._make_enter_call()
-    assert enter.kind == "Call"
-    assert enter.func.kind == "Attribute"
     assert enter.func.attr == "__enter__"
     assert enter.func.value.kind == "ManagerRef"
     assert enter.func.value.slot_id == mgr_slot
-    # Receiver is not a re-read of the free name / context expr node.
-    assert enter.func.value is not item.context_expr
 
-    exit_ok = item._make_exit_call_completed()
-    assert exit_ok.func.attr == "__exit__"
-    assert exit_ok.func.value.kind == "ManagerRef"
-    assert exit_ok.func.value.slot_id == mgr_slot
-    assert len(exit_ok.args) == 3
-    # Completed face: three Nones.
-    assert all(a.kind == "Constant" and a.value is None for a in exit_ok.args)
+    exit_ = item._make_parametric_exit_call()
+    assert exit_.func.attr == "__exit__"
+    assert exit_.func.value.kind == "ManagerRef"
+    assert exit_.func.value.slot_id == mgr_slot
+    assert len(exit_.args) == 3
+    assert exit_.args[0].kind == "ExitTypeRef"
+    assert exit_.args[1].kind == "ExitValueRef"
+    assert exit_.args[2].kind == "ExitTracebackRef"
+    assert exit_.args[0].face_id == face_id
+    assert exit_.args[1].face_id == face_id
+    assert exit_.args[2].face_id == face_id
 
-    exit_raise = item._make_exit_call_raised(f"{mgr_slot}#raise")
-    assert exit_raise.func.value.slot_id == mgr_slot
-    assert len(exit_raise.args) == 3
-    # Raised face: not three Nones — EffectRef witnesses / open markers.
-    assert not all(
-        a.kind == "Constant" and a.value is None for a in exit_raise.args
-    )
-    assert exit_raise.args[1].kind == "EffectRef"
-
-    enter_sugar = enter.sugar()
-    assert type(enter_sugar).__name__ == "MethodCallSugar"
-    assert enter_sugar.name == "__enter__"
-    assert type(enter_sugar.receiver).__name__ == "ManagerRefSugar"
-    assert enter_sugar.receiver.slot_id == mgr_slot
+    exit_sugar = exit_.sugar()
+    assert type(exit_sugar).__name__ == "MethodCallSugar"
+    assert exit_sugar.name == "__exit__"
+    assert type(exit_sugar.receiver).__name__ == "ManagerRefSugar"
+    assert [type(a).__name__ for a in exit_sugar.args] == [
+        "ExitTypeRefSugar",
+        "ExitValueRefSugar",
+        "ExitTracebackRefSugar",
+    ]
 
 
 if __name__ == "__main__":
@@ -136,5 +125,5 @@ if __name__ == "__main__":
     test_resource_named_residual_distinct_from_bare_sugar_not_written()
     test_assertion_manager_pytest_raises_still_lifts()
     test_suppress_manager_still_lifts()
-    test_with_item_synthesizes_enter_exit_method_coordinates()
-    print("ok: resource with is RuntimeSelected named residual; Expects undisturbed")
+    test_with_item_parametric_exit_uses_manager_ref_and_exit_refs()
+    print("ok: resource with RuntimeSelected; parametric exit tree coords")


### PR DESCRIPTION
## Summary

#6041 still built \`MethodCallSugar\` / arg sugars inside \`WithResourceSugar.desugar\` via \`_exit_sugar_for_face\`. That construction side door is closed.

### Tree-owned parametric exit (once)

\`\`\`text
ManagerRef(M).__exit__(
    ExitTypeRef(X),
    ExitValueRef(X),
    ExitTracebackRef(X),
)
\`\`\`

### Routing supplies guarded testimony (\`ExitFaceBinding\`)

| Face | Testimony |
|------|-----------|
| completed | type/value/tb = None |
| raised | type name or open; value = raise occurrence; tb open |
| open | all three open |

### Construction boundary

- \`desugar\` only: desugar existing sugars, emit bindings, ExitSet algebra
- **No** sugar imports/construction on that path
- Law: source of \`desugar\` must not mention MethodCallSugar / Exit*RefSugar / etc.
- \`_exit_sugar_for_face\` removed

### Still loud

\`open(...)\` → RuntimeSelected. No enrollment.

## Validation

\`\`\`bash
pytest test_with_resource_sugar.py test_with_resource.py test_exit_set.py \\
       test_with_contract.py test_try_sugar.py -q
\`\`\`

## Next

Enroll \`NeverSuppresses\` only after this is banked.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace per-face exit sugar construction with a single parametric exit sugar in `WithResourceSugar`
> - Introduces `ExitTypeRef`, `ExitValueRef`, and `ExitTracebackRef` AST nodes and corresponding sugars/coordinates that serialize to `python:exit_type`, `python:exit_value`, and `python:exit_traceback` terms keyed by a stable face id.
> - `WithResourceSugar` now accepts a prebuilt parametric exit sugar and `exit_face_id`; it desugars the exit sugar once and applies it across all body faces, replacing the previous per-face construction.
> - Exit-face classification (`completed`/`raised`/`open`) and argument binding are now emitted as `InvValue` facts via the new `ExitFaceBinding` dataclass, replacing the `OpenExitArg` and `RaiseWitnessCoordinate` approach.
> - `prepend_facts_to_exitset` now attaches facts to `Halted` exits by appending a companion `Completed` exit, so binding facts are preserved for all exit kinds.
> - Behavioral Change: desugaring no longer constructs `OpenExitArgSugar` or `RaiseWitnessSugar`; open exit arguments and raise occurrences are encoded in facts instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73f4c28.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->