### PR TITLE
Resource-with re-census before NeverSuppresses enrollment

### DIFF
--- a/docs/resource-with-recensus-2026-07-22.md
+++ b/docs/resource-with-recensus-2026-07-22.md
@@ -1,0 +1,142 @@
+# Resource-`with` re-census (2026-07-22)
+
+**Snapshot:** `c11e5f647` (post #6042 parametric exit / construction boundary closed)  
+**Packages:** installed `numpy` + `pandas` under the local venv  
+**Instrument:** `implementations/python/sugar-lift-py-tests/scripts/resource_with_recensus.py`  
+**Artifacts:** `docs/resource-with-recensus.json`, `docs/resource-with-recensus-grouped.json`
+
+No manager was enrolled. Production unauthenticated resource managers remain
+`RuntimeSelectedContextManager`. `open` is **not** a special case.
+
+## Boundary
+
+| Axis | Count |
+|------|------:|
+| Python files scanned | **1,818** |
+| `with` items (ast) | **11,535** |
+| Shape `call_dotted` | **11,417** |
+| Shape `name` (bound manager) | **104** |
+| Other shapes | **14** |
+
+Classification of manager **identity** (structural dotted call spelling as
+written in source) against the committed community membrane spellings
+(`pytest.raises`, `tm.assert_produces_warning`, `contextlib.suppress`):
+
+| Bucket | Approx. mass (top-identity rollup) | Meaning |
+|--------|-----------------------------------:|---------|
+| **Assertion wired** | **8,189** | Membrane Expects/Suppresses already on production path |
+| **Resource loud** | **~2,862+** (rest of identity mass) | Unauthenticated → RuntimeSelected residual |
+
+Assertion mass is dominated by `pytest.raises` (6,353) and
+`tm.assert_produces_warning` (1,836). Those are **not** resource-enrollment
+work.
+
+## Resource-loud groups (by manager identity)
+
+Top unauthenticated call_dotted identities (not on the membrane):
+
+| Count | Identity | Notes |
+|------:|----------|--------|
+| 348 | `tm.ensure_clean` | IO resource / temp path |
+| 292 | `np.errstate` | Source-visible class; `__exit__` resets only (implicit None) |
+| 273 | `open` | Builtin — **defer** to attested semantic manifest later; do not name-enroll |
+| 252 | `option_context` | Pandas config CM; `__exit__` restores options, no True return |
+| 194 | `warnings.catch_warnings` | Warning surface (not raise Expects) |
+| 167 | `pytest.warns` | Warning Expects-shaped; not membrane-enrolled spelling |
+| 148 | `assert_raises` | NumPy unittest alias — not `pytest.raises` |
+| 142 | `ensure_clean_store` | HDF5 temp store |
+| 135 | `pd.option_context` | Same family as `option_context` |
+| 133 | `tm.assert_cow_warning` | Warning family |
+| 74 | `assert_raises_regex` | Raises alias |
+| 69 | `tm.raises_chained_assignment_error` | Raises-like |
+| 54 | `temppath` | Temp path |
+| 40 | `monkeypatch.context` | Pytest fixture CM |
+| 37 | `util.switchdir` | `@contextmanager` try/yield/finally (known design representative) |
+| 33 | `ExcelFile` | IO |
+| 30 | `ExcelWriter` / `sql.SQLDatabase` | IO |
+| 28 | `HDFStore` | IO |
+
+## Grouping by exit-disposition **evidence** (not enrollment)
+
+These buckets are for choosing the next **general proof rule**, not for
+name-based admits:
+
+| Evidence bucket | ~Mass | Role in next cut |
+|-----------------|------:|------------------|
+| **config_context_manager** (`errstate`, `option_context`, `config_prefix`, …) | **748** | Strong source-visible NeverSuppresses candidates: exit restores config and does not return True |
+| **io_resource_manager** (`ensure_clean`, stores, Excel, temppath, …) | **654** | Need enter/exit construction; often suppress-never but bodies vary |
+| **warning_observation_like** (`catch_warnings`, `pytest.warns`, cow warning, …) | **529** | Parallel to Expects(warning) — membrane spelling expansion, not NeverSuppresses |
+| **raises_alias_not_on_manifest** (`assert_raises*`, chained assignment error) | **291** | Membrane spelling / alias expansion for Expects(raise) |
+| **builtin_or_open_defer_manifest** (`open`) | **273** | **Do not** special-case by name; later attested builtin manifest |
+| **source_visible_cm_candidate** (`util.switchdir`) | **37** | `@contextmanager` try/yield/finally → never-suppress (existing design) |
+| **bound_name_manager** (`i`, `it`, …) | **47** | Manager is a bound name — identity is temporal, not a call spelling |
+| **other_resource** | **~283** | Monkeypatch, SQL builders, get_handle, `contextlib.closing`, … |
+
+## Source-visible `__exit__` that only returns None/False
+
+Conservative linear-body scan found **13** methods (sample):
+
+- `numpy/_core/_ufunc_config.py` — `errstate.__exit__` (reset only; **implicit None**)
+- `numpy/lib/_npyio_impl.py`, `numpy/testing/...`
+- `pandas/io/common.py`, excel, json, parsers, pytables, sas, sql, pickle tests
+
+**Note:** `option_context.__exit__` has a simple `if` + loop and **no** `return True`,
+but the conservative scanner rejected branching. The next proof rule must
+allow branch-only restore bodies that never return a suppressing truth value.
+
+`util.switchdir` is a generator CM (`try: yield finally: chdir`) — disposition
+evidence is the existing try/yield/finally rule, not a class `__exit__` method.
+
+## Recommended next proof rule (general path first)
+
+**Name:** `source_visible_exit_returns_none_or_false`  
+**Disposition issued:** `NeverSuppresses`  
+**Rule (intent):**
+
+1. Resolve the manager expression to a **source-visible** context-manager
+   definition (class with `__exit__`, or `@contextmanager` generator).
+2. Prove that exceptional exit **never** suppresses:
+   - class `__exit__`: every return is `None` or `False` (or implicit None);
+     no `return True`; branches allowed only if they share that property;
+   - `@contextmanager`: `try: yield; finally: …` with no `except` that
+     swallows (existing design).
+3. Admit only through **`WithResourceSugar`** with constructed
+   `ManagerRef` / enter / parametric exit — never a normal-path-only dissolve.
+4. Leave unproved disposition as **RuntimeSelected** (explicit red).
+
+### Explicitly not next
+
+- Enrolling `open` by spelling.
+- Guessing subclass exception matching for Suppresses.
+- Treating membrane Expects/Suppresses residual mass as resource work
+  (already wired for `pytest.raises` / `tm.assert_produces_warning` /
+  `contextlib.suppress`; aliases like `assert_raises` are membrane spelling
+  work, not NeverSuppresses).
+
+### Suggested first general admits (after the rule exists)
+
+Ordered by evidence + mass, **not** by name special-case:
+
+1. **`np.errstate` / `errstate`** — class `__exit__` is restore-only; **~315** sites.
+2. **`option_context` / `pd.option_context` / `cf.option_context`** — restore-only
+   exit with branches; **~407** sites once branch-safe proof lands.
+3. **`util.switchdir`** — try/yield/finally representative; **37** sites; already
+   named in prior design docs.
+
+IO managers (`ensure_clean`, Excel, HDFStore) and builtins (`open`) come after
+the general rule is green and measured, not before.
+
+## How to re-run
+
+```bash
+export PYTHONPATH=implementations/python/sugar-lift-py-tests/src:\
+implementations/python/sugar-source-tree/src:\
+implementations/python/sugar-lift-python-source/src
+
+python implementations/python/sugar-lift-py-tests/scripts/resource_with_recensus.py \
+  --packages numpy,pandas \
+  --json docs/resource-with-recensus.json
+```
+
+Then re-group with the post-process in session notes / extend the script to
+emit `resource-with-recensus-grouped.json` from the raw JSON + membrane spellings.

--- a/docs/resource-with-recensus-grouped.json
+++ b/docs/resource-with-recensus-grouped.json
@@ -1,0 +1,918 @@
+{
+  "snapshot": "c11e5f647",
+  "packages": [
+    "numpy",
+    "pandas"
+  ],
+  "files_scanned": 1818,
+  "with_items_total": 11535,
+  "by_shape": {
+    "attribute": 1,
+    "call_dotted": 11417,
+    "call_other": 11,
+    "name": 104,
+    "other": 2
+  },
+  "manifest_spellings": {
+    "pytest.raises": {
+      "contract": "expects",
+      "effect_kind": "raise",
+      "arity": "exception-arg-optional-match"
+    },
+    "contextlib.suppress": {
+      "contract": "suppresses",
+      "effect_kind": "raise",
+      "arity": "one-exception-arg"
+    },
+    "tm.assert_produces_warning": {
+      "contract": "expects",
+      "effect_kind": "warning",
+      "arity": "one-exception-arg"
+    }
+  },
+  "assertion_wired": [
+    {
+      "identity": "pytest.raises",
+      "count": 6353,
+      "classification": "assertion_wired",
+      "manifest": true,
+      "manifest_row": {
+        "contract": "expects",
+        "effect_kind": "raise",
+        "arity": "exception-arg-optional-match"
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_api.py:188",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_api.py:450",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_api.py:461",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_api.py:464",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_api.py:472"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "tm.assert_produces_warning",
+      "count": 1836,
+      "classification": "assertion_wired",
+      "manifest": true,
+      "manifest_row": {
+        "contract": "expects",
+        "effect_kind": "warning",
+        "arity": "one-exception-arg"
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/api/test_api.py:380",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/api/test_api.py:242",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/api/test_types.py:61",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/apply/test_frame_apply.py:1611",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/apply/test_frame_apply.py:1696"
+      ],
+      "shape": "call_dotted"
+    }
+  ],
+  "resource_loud_top": [
+    {
+      "identity": "tm.ensure_clean",
+      "count": 348,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/frame/methods/test_to_csv.py:37",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/frame/methods/test_to_csv.py:75",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/frame/methods/test_to_csv.py:111",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/frame/methods/test_to_csv.py:124",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/frame/methods/test_to_csv.py:141"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "np.errstate",
+      "count": 292,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_array_coercion.py:939",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_array_coercion.py:943",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_array_coercion.py:389",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_casting_floatingpoint_errors.py:45",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_casting_floatingpoint_errors.py:152"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "open",
+      "count": 273,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_cpu_features.py:24",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_cpu_features.py:103",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_cython.py:60",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_limited_api.py:58",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_longdouble.py:145"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "option_context",
+      "count": 252,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/apply.py:1078",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/frame.py:1375",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/groupby/groupby.py:1822",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/clipboards.py:193",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/formats/html.py:411"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "warnings.catch_warnings",
+      "count": 194,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/__init__.py:827",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_casting_unittests.py:867",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_casting_unittests.py:888",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_casting_unittests.py:894",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_datetime.py:1645"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "pytest.warns",
+      "count": 167,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_api.py:475",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_array_coercion.py:443",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_array_coercion.py:940",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_casting_floatingpoint_errors.py:149",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_casting_unittests.py:466"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "assert_raises",
+      "count": 148,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_api.py:201",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_conversion_utils.py:26",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_datetime.py:204",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_dtype.py:138",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_dtype.py:1647"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "ensure_clean_store",
+      "count": 142,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_append.py:33",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_append.py:105",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_append.py:152",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_append.py:200",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_append.py:286"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "pd.option_context",
+      "count": 135,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arrays/categorical/test_missing.py:142",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arrays/categorical/test_missing.py:171",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arrays/string_/test_string.py:521",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arrays/string_/test_string.py:553",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arrays/string_/test_string.py:602"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "tm.assert_cow_warning",
+      "count": 133,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/apply/test_frame_apply.py:1504",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/computation/test_eval.py:1983",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/copy_view/index/test_index.py:26",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/copy_view/index/test_index.py:48",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/copy_view/index/test_index.py:61"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "assert_raises_regex",
+      "count": 74,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_arrayprint.py:234",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_datetime.py:1746",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_datetime.py:2446",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_datetime.py:2466",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_defchararray.py:744"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "tm.raises_chained_assignment_error",
+      "count": 69,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/copy_view/test_chained_assignment_deprecation.py:76",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/copy_view/test_chained_assignment_deprecation.py:85",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/copy_view/test_chained_assignment_deprecation.py:124",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/copy_view/test_chained_assignment_deprecation.py:133",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/copy_view/test_chained_assignment_deprecation.py:173"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "temppath",
+      "count": 54,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_longdouble.py:144",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_longdouble.py:228",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_longdouble.py:237",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_longdouble.py:246",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_longdouble.py:255"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "monkeypatch.context",
+      "count": 40,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arithmetic/test_numeric.py:35",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arithmetic/test_numeric.py:150",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arithmetic/test_numeric.py:158",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arrays/categorical/test_indexing.py:379",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/config/test_config.py:13"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "util.switchdir",
+      "count": 37,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/f2py/tests/test_f2py2e.py:146",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/f2py/tests/test_f2py2e.py:162",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/f2py/tests/test_f2py2e.py:174",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/f2py/tests/test_f2py2e.py:188",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/f2py/tests/test_f2py2e.py:201"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "ExcelFile",
+      "count": 33,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_writers.py:397",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_writers.py:413",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_writers.py:474",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_writers.py:494",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_writers.py:515"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "ExcelWriter",
+      "count": 30,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_odswriter.py:58",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_odswriter.py:51",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_openpyxl.py:103",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_openpyxl.py:134",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_openpyxl.py:181"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "sql.SQLDatabase",
+      "count": 30,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:1372",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:1449",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:2465",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:2496",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:2509"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "i",
+      "count": 28,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:921",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:959",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:1018",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:1206",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:1219"
+      ],
+      "shape": "name"
+    },
+    {
+      "identity": "HDFStore",
+      "count": 28,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/pytables.py:308",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/common.py:32",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_file_handling.py:54",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_file_handling.py:65",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_file_handling.py:494"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "tm.external_error_raised",
+      "count": 28,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/dtypes/test_inference.py:220",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/indexes/categorical/test_category.py:79",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/indexes/test_numpy_compat.py:68",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/indexes/test_numpy_compat.py:120",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/indexes/test_numpy_compat.py:124"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "cf.config_prefix",
+      "count": 26,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/_config/dates.py:18",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/_config/display.py:59",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/config_init.py:73",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/config_init.py:313",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/config_init.py:406"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "parser.read_csv",
+      "count": 24,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/common/test_chunksize.py:56",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/common/test_chunksize.py:104",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/common/test_chunksize.py:127",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/common/test_chunksize.py:150",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/common/test_chunksize.py:178"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "errstate",
+      "count": 23,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/__init__.py:859",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/arrayprint.py:1027",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/arrayprint.py:1106",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/numeric.py:2440",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_errstate.py:78"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "pandasSQL_builder",
+      "count": 22,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sql.py:264",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sql.py:384",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sql.py:525",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sql.py:704",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sql.py:841"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "get_handle",
+      "count": 21,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/_testing/contexts.py:52",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/frame.py:2988",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/excel/_base.py:1402",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/feather_format.py:63",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/feather_format.py:120"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "StataReader",
+      "count": 21,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:1976",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:2110",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:302",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:663",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:746"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "tm.maybe_produces_warning",
+      "count": 20,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arithmetic/test_timedelta64.py:1766",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arithmetic/test_timedelta64.py:1774",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/computation/test_eval.py:728",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/frame/indexing/test_indexing.py:1548",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/strings/test_find_replace.py:394"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "cf.option_context",
+      "count": 20,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/config/test_config.py:363",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/config/test_config.py:391",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/config/test_config.py:365",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/dtypes/test_missing.py:59",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/dtypes/test_missing.py:68"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "it",
+      "count": 19,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:933",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:939",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:2920",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:2935",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:2953"
+      ],
+      "shape": "name"
+    },
+    {
+      "identity": "pd.ExcelFile",
+      "count": 19,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_odswriter.py:95",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_readers.py:1503",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_readers.py:1513",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_readers.py:1522",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_readers.py:1532"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "contextlib.closing",
+      "count": 19,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_openpyxl.py:161",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_openpyxl.py:302",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_openpyxl.py:184",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_openpyxl.py:212",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_openpyxl.py:337"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "pandasSQL.run_transaction",
+      "count": 18,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:2726",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:1559",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:1579",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:1594",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:2703"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "np.printoptions",
+      "count": 17,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_arrayprint.py:1240",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_arrayprint.py:1263",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_arrayprint.py:715",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_arrayprint.py:958",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_arrayprint.py:964"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "conn.begin",
+      "count": 16,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:3834",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:198",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:323",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:357",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:1268"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "suppress_warnings",
+      "count": 15,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/_private/utils.py:1992",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:1828",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:1853",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:1872",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:1888"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "BytesIO",
+      "count": 14,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_regression.py:54",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_regression.py:104",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_regression.py:366",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/ma/tests/test_core.py:5619",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_writers.py:1225"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "identity": "exc_iter",
+      "count": 13,
+      "classification": "resource_loud",
+      "manifest": false,
+      "manifest_row": null,
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_extint128.py:73",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_extint128.py:88",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_extint128.py:96",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_extint128.py:107",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_extint128.py:116"
+      ],
+      "shape": "call_dotted"
+    }
+  ],
+  "resource_buckets": {
+    "io_resource_manager": [
+      {
+        "identity": "tm.ensure_clean",
+        "count": 348
+      },
+      {
+        "identity": "ensure_clean_store",
+        "count": 142
+      },
+      {
+        "identity": "temppath",
+        "count": 54
+      },
+      {
+        "identity": "ExcelFile",
+        "count": 33
+      },
+      {
+        "identity": "ExcelWriter",
+        "count": 30
+      },
+      {
+        "identity": "HDFStore",
+        "count": 28
+      },
+      {
+        "identity": "pd.ExcelFile",
+        "count": 19
+      }
+    ],
+    "config_context_manager": [
+      {
+        "identity": "np.errstate",
+        "count": 292
+      },
+      {
+        "identity": "option_context",
+        "count": 252
+      },
+      {
+        "identity": "pd.option_context",
+        "count": 135
+      },
+      {
+        "identity": "cf.config_prefix",
+        "count": 26
+      },
+      {
+        "identity": "errstate",
+        "count": 23
+      },
+      {
+        "identity": "cf.option_context",
+        "count": 20
+      }
+    ],
+    "builtin_or_open_defer_manifest": [
+      {
+        "identity": "open",
+        "count": 273
+      }
+    ],
+    "warning_observation_like": [
+      {
+        "identity": "warnings.catch_warnings",
+        "count": 194
+      },
+      {
+        "identity": "pytest.warns",
+        "count": 167
+      },
+      {
+        "identity": "tm.assert_cow_warning",
+        "count": 133
+      },
+      {
+        "identity": "tm.maybe_produces_warning",
+        "count": 20
+      },
+      {
+        "identity": "suppress_warnings",
+        "count": 15
+      }
+    ],
+    "raises_alias_not_on_manifest": [
+      {
+        "identity": "assert_raises",
+        "count": 148
+      },
+      {
+        "identity": "assert_raises_regex",
+        "count": 74
+      },
+      {
+        "identity": "tm.raises_chained_assignment_error",
+        "count": 69
+      }
+    ],
+    "other_resource": [
+      {
+        "identity": "monkeypatch.context",
+        "count": 40
+      },
+      {
+        "identity": "sql.SQLDatabase",
+        "count": 30
+      },
+      {
+        "identity": "tm.external_error_raised",
+        "count": 28
+      },
+      {
+        "identity": "parser.read_csv",
+        "count": 24
+      },
+      {
+        "identity": "pandasSQL_builder",
+        "count": 22
+      },
+      {
+        "identity": "get_handle",
+        "count": 21
+      },
+      {
+        "identity": "StataReader",
+        "count": 21
+      },
+      {
+        "identity": "contextlib.closing",
+        "count": 19
+      },
+      {
+        "identity": "pandasSQL.run_transaction",
+        "count": 18
+      },
+      {
+        "identity": "np.printoptions",
+        "count": 17
+      },
+      {
+        "identity": "conn.begin",
+        "count": 16
+      },
+      {
+        "identity": "BytesIO",
+        "count": 14
+      },
+      {
+        "identity": "exc_iter",
+        "count": 13
+      }
+    ],
+    "source_visible_cm_candidate": [
+      {
+        "identity": "util.switchdir",
+        "count": 37
+      }
+    ],
+    "bound_name_manager": [
+      {
+        "identity": "i",
+        "count": 28
+      },
+      {
+        "identity": "it",
+        "count": 19
+      }
+    ]
+  },
+  "bucket_totals": {
+    "io_resource_manager": 654,
+    "config_context_manager": 748,
+    "builtin_or_open_defer_manifest": 273,
+    "warning_observation_like": 529,
+    "raises_alias_not_on_manifest": 291,
+    "other_resource": 283,
+    "source_visible_cm_candidate": 37,
+    "bound_name_manager": 47
+  },
+  "exit_never_suppress_candidates": {
+    "count": 13,
+    "sample": [
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/_ufunc_config.py",
+        "line": 488,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/_locales.py",
+        "line": 71,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/lib/_npyio_impl.py",
+        "line": 213,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/_private/utils.py",
+        "line": 2508,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/common.py",
+        "line": 151,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/excel/_base.py",
+        "line": 1347,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/excel/_base.py",
+        "line": 1653,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/json/_json.py",
+        "line": 1116,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/parsers/readers.py",
+        "line": 1990,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/pytables.py",
+        "line": 642,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sas/sasreader.py",
+        "line": 51,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sql.py",
+        "line": 1451,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_pickle.py",
+        "line": 476,
+        "qualname": "__exit__"
+      }
+    ]
+  },
+  "recommended_next_proof_rule": {
+    "disposition": "NeverSuppresses",
+    "do_not": [
+      "enroll open by spelling",
+      "guess subclass exception matching",
+      "admit RuntimeSelected as green"
+    ],
+    "name": "source_visible_exit_returns_none_or_false",
+    "rule": "When a manager's __exit__ is source-visible and every return is provably None or False (no raise/yield, no branching body without the same property), issue NeverSuppresses. Admit via WithResourceSugar only with constructed enter/exit coords. Do not special-case open by name; built-ins need an attested semantic manifest later."
+  }
+}

--- a/docs/resource-with-recensus.json
+++ b/docs/resource-with-recensus.json
@@ -1,0 +1,2259 @@
+{
+  "assertion_wired_groups": [
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 429,
+        "pos=1;kw=match": 5924
+      },
+      "count": 6353,
+      "enrollment_posture": "already_wired_assertion",
+      "identity": "pytest.raises",
+      "membranes": {
+        "expects": 6353
+      },
+      "residuals": {
+        "assertion_wired": 6353
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_api.py:188",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_api.py:450",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_api.py:461",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_api.py:464",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_api.py:472"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 8,
+        "pos=1;kw=-": 349,
+        "pos=1;kw=check_stacklevel": 30,
+        "pos=1;kw=check_stacklevel,match": 74,
+        "pos=1;kw=check_stacklevel,match,raise_on_extra_warnings": 11,
+        "pos=1;kw=check_stacklevel,raise_on_extra_warnings": 1,
+        "pos=1;kw=filter_level": 1,
+        "pos=1;kw=match": 1340,
+        "pos=1;kw=match,raise_on_extra_warnings": 12,
+        "pos=1;kw=raise_on_extra_warnings": 10
+      },
+      "count": 1836,
+      "enrollment_posture": "already_wired_assertion",
+      "identity": "tm.assert_produces_warning",
+      "membranes": {
+        "expects": 1836
+      },
+      "residuals": {
+        "assertion_wired": 1836
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/api/test_api.py:380",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/api/test_api.py:242",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/api/test_types.py:61",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/apply/test_frame_apply.py:1611",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/apply/test_frame_apply.py:1696"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 3
+      },
+      "count": 3,
+      "enrollment_posture": "already_wired_assertion",
+      "identity": "contextlib.suppress",
+      "membranes": {
+        "suppresses": 3
+      },
+      "residuals": {
+        "assertion_wired": 3
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_dtype.py:897",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/lib/_histograms_impl.py:908",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/_private/utils.py:942"
+      ],
+      "shape": "call_dotted"
+    }
+  ],
+  "by_membrane": {
+    "expects": 8189,
+    "suppresses": 3,
+    "unknown": 3343
+  },
+  "by_residual": {
+    "assertion_wired": 8192,
+    "resource_candidate": 3343
+  },
+  "by_shape": {
+    "attribute": 1,
+    "call_dotted": 11417,
+    "call_other": 11,
+    "name": 104,
+    "other": 2
+  },
+  "exit_never_suppress_candidates": {
+    "count": 13,
+    "sample": [
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/_ufunc_config.py",
+        "line": 488,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/_locales.py",
+        "line": 71,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/lib/_npyio_impl.py",
+        "line": 213,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/_private/utils.py",
+        "line": 2508,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/common.py",
+        "line": 151,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/excel/_base.py",
+        "line": 1347,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/excel/_base.py",
+        "line": 1653,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/json/_json.py",
+        "line": 1116,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/parsers/readers.py",
+        "line": 1990,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/pytables.py",
+        "line": 642,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sas/sasreader.py",
+        "line": 51,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sql.py",
+        "line": 1451,
+        "qualname": "__exit__"
+      },
+      {
+        "evidence": "source_visible_exit_returns_none_or_false",
+        "file": "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_pickle.py",
+        "line": 476,
+        "qualname": "__exit__"
+      }
+    ]
+  },
+  "files_parse_error": 0,
+  "files_scanned": 1818,
+  "hits": 11535,
+  "manifest_spellings": {
+    "contextlib.suppress": "suppresses",
+    "pytest.raises": "expects",
+    "tm.assert_produces_warning": "expects"
+  },
+  "recommended_next_proof_rule": {
+    "disposition": "NeverSuppresses",
+    "do_not": [
+      "enroll open by spelling",
+      "guess subclass exception matching",
+      "admit RuntimeSelected as green"
+    ],
+    "first_general_admits_after_rule": [
+      "np.errstate / errstate (~315 sites; restore-only __exit__)",
+      "option_context family (~407 sites; restore-only with branches)",
+      "util.switchdir (37 sites; try/yield/finally)"
+    ],
+    "name": "source_visible_exit_returns_none_or_false",
+    "rule": "When a manager's __exit__ is source-visible and every return is provably None or False (implicit None allowed; branches allowed only if they never return a suppressing truth value), issue NeverSuppresses. Admit via WithResourceSugar only with constructed enter/exit coords. Do not special-case open by name; built-ins need an attested semantic manifest later."
+  },
+  "resource_loud_groups": [
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 175,
+        "pos=0;kw=encoding,mode,return_filelike": 1,
+        "pos=0;kw=filename": 8,
+        "pos=0;kw=mode,return_filelike": 1,
+        "pos=0;kw=return_filelike": 2,
+        "pos=1;kw=-": 161
+      },
+      "count": 348,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "tm.ensure_clean",
+      "membranes": {
+        "unknown": 348
+      },
+      "residuals": {
+        "resource_candidate": 348
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/frame/methods/test_to_csv.py:37",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/frame/methods/test_to_csv.py:75",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/frame/methods/test_to_csv.py:111",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/frame/methods/test_to_csv.py:124",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/frame/methods/test_to_csv.py:141"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 3,
+        "pos=0;kw=all": 103,
+        "pos=0;kw=all,call": 1,
+        "pos=0;kw=all,under": 2,
+        "pos=0;kw=call": 2,
+        "pos=0;kw=call,divide,over": 1,
+        "pos=0;kw=call,invalid": 1,
+        "pos=0;kw=divide": 21,
+        "pos=0;kw=divide,invalid": 49,
+        "pos=0;kw=divide,over": 3,
+        "pos=0;kw=invalid": 78,
+        "pos=0;kw=invalid,over": 5,
+        "pos=0;kw=over": 18,
+        "pos=0;kw=over,under": 2,
+        "pos=0;kw=under": 3
+      },
+      "count": 292,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "np.errstate",
+      "membranes": {
+        "unknown": 292
+      },
+      "residuals": {
+        "resource_candidate": 292
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_array_coercion.py:939",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_array_coercion.py:943",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_array_coercion.py:389",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_casting_floatingpoint_errors.py:45",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_casting_floatingpoint_errors.py:152"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 14,
+        "pos=1;kw=buffering,mode": 1,
+        "pos=1;kw=encoding": 40,
+        "pos=1;kw=encoding,newline": 1,
+        "pos=1;kw=mode": 9,
+        "pos=2;kw=-": 171,
+        "pos=2;kw=buffering": 3,
+        "pos=2;kw=encoding": 30,
+        "pos=2;kw=encoding,newline": 3,
+        "pos=3;kw=-": 1
+      },
+      "count": 273,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "open",
+      "membranes": {
+        "unknown": 273
+      },
+      "residuals": {
+        "resource_candidate": 273
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_cpu_features.py:24",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_cpu_features.py:103",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_cython.py:60",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_limited_api.py:58",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_longdouble.py:145"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=10;kw=-": 4,
+        "pos=2;kw=-": 197,
+        "pos=4;kw=-": 45,
+        "pos=6;kw=-": 5,
+        "pos=8;kw=-": 1
+      },
+      "count": 252,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "option_context",
+      "membranes": {
+        "unknown": 252
+      },
+      "residuals": {
+        "resource_candidate": 252
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/apply.py:1078",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/frame.py:1375",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/groupby/groupby.py:1822",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/clipboards.py:193",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/formats/html.py:411"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 121,
+        "pos=0;kw=record": 73
+      },
+      "count": 194,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "warnings.catch_warnings",
+      "membranes": {
+        "unknown": 194
+      },
+      "residuals": {
+        "resource_candidate": 194
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/__init__.py:827",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_casting_unittests.py:867",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_casting_unittests.py:888",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_casting_unittests.py:894",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_datetime.py:1645"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 1,
+        "pos=0;kw=expected_warning": 1,
+        "pos=0;kw=match": 3,
+        "pos=1;kw=-": 57,
+        "pos=1;kw=match": 105
+      },
+      "count": 167,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "pytest.warns",
+      "membranes": {
+        "unknown": 167
+      },
+      "residuals": {
+        "resource_candidate": 167
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_api.py:475",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_array_coercion.py:443",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_array_coercion.py:940",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_casting_floatingpoint_errors.py:149",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_casting_unittests.py:466"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 146,
+        "pos=1;kw=msg": 2
+      },
+      "count": 148,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "assert_raises",
+      "membranes": {
+        "unknown": 148
+      },
+      "residuals": {
+        "resource_candidate": 148
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_api.py:201",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_conversion_utils.py:26",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_datetime.py:204",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_dtype.py:138",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_dtype.py:1647"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 130,
+        "pos=1;kw=mode": 10,
+        "pos=2;kw=**": 2
+      },
+      "count": 142,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "ensure_clean_store",
+      "membranes": {
+        "unknown": 142
+      },
+      "residuals": {
+        "resource_candidate": 142
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_append.py:33",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_append.py:105",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_append.py:152",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_append.py:200",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_append.py:286"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=2;kw=-": 135
+      },
+      "count": 135,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "pd.option_context",
+      "membranes": {
+        "unknown": 135
+      },
+      "residuals": {
+        "resource_candidate": 135
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arrays/categorical/test_missing.py:142",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arrays/categorical/test_missing.py:171",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arrays/string_/test_string.py:521",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arrays/string_/test_string.py:553",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arrays/string_/test_string.py:602"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 12,
+        "pos=0;kw=match": 6,
+        "pos=0;kw=raise_on_extra_warnings": 1,
+        "pos=1;kw=-": 111,
+        "pos=1;kw=match": 3
+      },
+      "count": 133,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "tm.assert_cow_warning",
+      "membranes": {
+        "unknown": 133
+      },
+      "residuals": {
+        "resource_candidate": 133
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/apply/test_frame_apply.py:1504",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/computation/test_eval.py:1983",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/copy_view/index/test_index.py:26",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/copy_view/index/test_index.py:48",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/copy_view/index/test_index.py:61"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=2;kw=-": 74
+      },
+      "count": 74,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "assert_raises_regex",
+      "membranes": {
+        "unknown": 74
+      },
+      "residuals": {
+        "resource_candidate": 74
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_arrayprint.py:234",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_datetime.py:1746",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_datetime.py:2446",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_datetime.py:2466",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_defchararray.py:744"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 64,
+        "pos=0;kw=extra_warnings": 2,
+        "pos=1;kw=-": 3
+      },
+      "count": 69,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "tm.raises_chained_assignment_error",
+      "membranes": {
+        "unknown": 69
+      },
+      "residuals": {
+        "resource_candidate": 69
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/copy_view/test_chained_assignment_deprecation.py:76",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/copy_view/test_chained_assignment_deprecation.py:85",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/copy_view/test_chained_assignment_deprecation.py:124",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/copy_view/test_chained_assignment_deprecation.py:133",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/copy_view/test_chained_assignment_deprecation.py:173"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 28,
+        "pos=0;kw=prefix,suffix": 3,
+        "pos=0;kw=suffix": 23
+      },
+      "count": 54,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "temppath",
+      "membranes": {
+        "unknown": 54
+      },
+      "residuals": {
+        "resource_candidate": 54
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_longdouble.py:144",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_longdouble.py:228",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_longdouble.py:237",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_longdouble.py:246",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_longdouble.py:255"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 40
+      },
+      "count": 40,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "monkeypatch.context",
+      "membranes": {
+        "unknown": 40
+      },
+      "residuals": {
+        "resource_candidate": 40
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arithmetic/test_numeric.py:35",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arithmetic/test_numeric.py:150",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arithmetic/test_numeric.py:158",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arrays/categorical/test_indexing.py:379",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/config/test_config.py:13"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 37
+      },
+      "count": 37,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "util.switchdir",
+      "membranes": {
+        "unknown": 37
+      },
+      "residuals": {
+        "resource_candidate": 37
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/f2py/tests/test_f2py2e.py:146",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/f2py/tests/test_f2py2e.py:162",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/f2py/tests/test_f2py2e.py:174",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/f2py/tests/test_f2py2e.py:188",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/f2py/tests/test_f2py2e.py:201"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 32,
+        "pos=1;kw=engine": 1
+      },
+      "count": 33,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "ExcelFile",
+      "membranes": {
+        "unknown": 33
+      },
+      "residuals": {
+        "resource_candidate": 33
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_writers.py:397",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_writers.py:413",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_writers.py:474",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_writers.py:494",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_writers.py:515"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 10,
+        "pos=1;kw=date_format,datetime_format": 1,
+        "pos=1;kw=engine": 9,
+        "pos=1;kw=engine,engine_kwargs": 3,
+        "pos=1;kw=engine,engine_kwargs,mode": 2,
+        "pos=1;kw=engine,if_sheet_exists,mode": 4,
+        "pos=1;kw=engine,mode": 1
+      },
+      "count": 30,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "ExcelWriter",
+      "membranes": {
+        "unknown": 30
+      },
+      "residuals": {
+        "resource_candidate": 30
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_odswriter.py:58",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_odswriter.py:51",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_openpyxl.py:103",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_openpyxl.py:134",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_openpyxl.py:181"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 7,
+        "pos=1;kw=need_transaction": 23
+      },
+      "count": 30,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "sql.SQLDatabase",
+      "membranes": {
+        "unknown": 30
+      },
+      "residuals": {
+        "resource_candidate": 30
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:1372",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:1449",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:2465",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:2496",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:2509"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 20,
+        "pos=1;kw=complevel,complib,fletcher32,mode": 1,
+        "pos=1;kw=complevel,complib,mode": 1,
+        "pos=1;kw=mode": 5,
+        "pos=2;kw=-": 1
+      },
+      "count": 28,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "HDFStore",
+      "membranes": {
+        "unknown": 28
+      },
+      "residuals": {
+        "resource_candidate": 28
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/pytables.py:308",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/common.py:32",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_file_handling.py:54",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_file_handling.py:65",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_file_handling.py:494"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {},
+      "count": 28,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "i",
+      "membranes": {
+        "unknown": 28
+      },
+      "residuals": {
+        "resource_candidate": 28
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:921",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:959",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:1018",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:1206",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:1219"
+      ],
+      "shape": "name"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 28
+      },
+      "count": 28,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "tm.external_error_raised",
+      "membranes": {
+        "unknown": 28
+      },
+      "residuals": {
+        "resource_candidate": 28
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/dtypes/test_inference.py:220",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/indexes/categorical/test_category.py:79",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/indexes/test_numpy_compat.py:68",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/indexes/test_numpy_compat.py:120",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/indexes/test_numpy_compat.py:124"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 26
+      },
+      "count": 26,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "cf.config_prefix",
+      "membranes": {
+        "unknown": 26
+      },
+      "residuals": {
+        "resource_candidate": 26
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/_config/dates.py:18",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/_config/display.py:59",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/config_init.py:73",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/config_init.py:313",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/config_init.py:406"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=**,chunksize": 4,
+        "pos=1;kw=**,iterator": 1,
+        "pos=1;kw=**,skipfooter": 1,
+        "pos=1;kw=chunksize": 8,
+        "pos=1;kw=chunksize,comment,header,iterator,skiprows": 1,
+        "pos=1;kw=chunksize,dtype": 2,
+        "pos=1;kw=chunksize,dtype,encoding,header": 1,
+        "pos=1;kw=chunksize,index_col": 2,
+        "pos=1;kw=chunksize,index_col,parse_dates": 1,
+        "pos=1;kw=chunksize,names": 2,
+        "pos=1;kw=iterator": 1
+      },
+      "count": 24,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "parser.read_csv",
+      "membranes": {
+        "unknown": 24
+      },
+      "residuals": {
+        "resource_candidate": 24
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/common/test_chunksize.py:56",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/common/test_chunksize.py:104",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/common/test_chunksize.py:127",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/common/test_chunksize.py:150",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/common/test_chunksize.py:178"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=all": 4,
+        "pos=0;kw=call,divide,invalid,over,under": 12,
+        "pos=0;kw=invalid": 4,
+        "pos=0;kw=over": 1
+      },
+      "count": 23,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "errstate",
+      "membranes": {
+        "unknown": 23
+      },
+      "residuals": {
+        "resource_candidate": 23
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/__init__.py:859",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/arrayprint.py:1027",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/arrayprint.py:1106",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/numeric.py:2440",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_errstate.py:78"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=con": 1,
+        "pos=1;kw=-": 13,
+        "pos=1;kw=need_transaction": 5,
+        "pos=1;kw=need_transaction,schema": 2,
+        "pos=1;kw=schema": 1
+      },
+      "count": 22,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "pandasSQL_builder",
+      "membranes": {
+        "unknown": 22
+      },
+      "residuals": {
+        "resource_candidate": 22
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sql.py:264",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sql.py:384",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sql.py:525",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sql.py:704",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sql.py:841"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 16,
+        "pos=1;kw=chunksize": 3,
+        "pos=1;kw=chunksize,order_categoricals": 1,
+        "pos=1;kw=convert_categoricals": 1
+      },
+      "count": 21,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "StataReader",
+      "membranes": {
+        "unknown": 21
+      },
+      "residuals": {
+        "resource_candidate": 21
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:1976",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:2110",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:302",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:663",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:746"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=2;kw=compression": 3,
+        "pos=2;kw=compression,encoding": 2,
+        "pos=2;kw=compression,encoding,errors,storage_options": 1,
+        "pos=2;kw=compression,encoding,storage_options": 1,
+        "pos=2;kw=compression,is_text": 1,
+        "pos=2;kw=compression,is_text,storage_options": 4,
+        "pos=2;kw=compression,storage_options": 1,
+        "pos=2;kw=encoding,storage_options": 1,
+        "pos=2;kw=is_text": 2,
+        "pos=2;kw=is_text,storage_options": 3,
+        "pos=2;kw=storage_options": 2
+      },
+      "count": 21,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "get_handle",
+      "membranes": {
+        "unknown": 21
+      },
+      "residuals": {
+        "resource_candidate": 21
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/_testing/contexts.py:52",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/frame.py:2988",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/excel/_base.py:1402",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/feather_format.py:63",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/feather_format.py:120"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=2;kw=-": 20
+      },
+      "count": 20,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "cf.option_context",
+      "membranes": {
+        "unknown": 20
+      },
+      "residuals": {
+        "resource_candidate": 20
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/config/test_config.py:363",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/config/test_config.py:391",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/config/test_config.py:365",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/dtypes/test_missing.py:59",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/dtypes/test_missing.py:68"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=2;kw=-": 17,
+        "pos=2;kw=check_stacklevel": 3
+      },
+      "count": 20,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "tm.maybe_produces_warning",
+      "membranes": {
+        "unknown": 20
+      },
+      "residuals": {
+        "resource_candidate": 20
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arithmetic/test_timedelta64.py:1766",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/arithmetic/test_timedelta64.py:1774",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/computation/test_eval.py:728",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/frame/indexing/test_indexing.py:1548",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/strings/test_find_replace.py:394"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 19
+      },
+      "count": 19,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "contextlib.closing",
+      "membranes": {
+        "unknown": 19
+      },
+      "residuals": {
+        "resource_candidate": 19
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_openpyxl.py:161",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_openpyxl.py:302",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_openpyxl.py:184",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_openpyxl.py:212",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_openpyxl.py:337"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {},
+      "count": 19,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "it",
+      "membranes": {
+        "unknown": 19
+      },
+      "residuals": {
+        "resource_candidate": 19
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:933",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:939",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:2920",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:2935",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:2953"
+      ],
+      "shape": "name"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 19
+      },
+      "count": 19,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "pd.ExcelFile",
+      "membranes": {
+        "unknown": 19
+      },
+      "residuals": {
+        "resource_candidate": 19
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_odswriter.py:95",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_readers.py:1503",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_readers.py:1513",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_readers.py:1522",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_readers.py:1532"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 18
+      },
+      "count": 18,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "pandasSQL.run_transaction",
+      "membranes": {
+        "unknown": 18
+      },
+      "residuals": {
+        "resource_candidate": 18
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:2726",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:1559",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:1579",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:1594",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:2703"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=**": 1,
+        "pos=0;kw=-": 1,
+        "pos=0;kw=legacy": 6,
+        "pos=0;kw=legacy,linewidth": 4,
+        "pos=0;kw=linewidth,precision": 2,
+        "pos=0;kw=override_repr": 1,
+        "pos=0;kw=precision": 2
+      },
+      "count": 17,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "np.printoptions",
+      "membranes": {
+        "unknown": 17
+      },
+      "residuals": {
+        "resource_candidate": 17
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_arrayprint.py:1240",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_arrayprint.py:1263",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_arrayprint.py:715",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_arrayprint.py:958",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_arrayprint.py:964"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 16
+      },
+      "count": 16,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "conn.begin",
+      "membranes": {
+        "unknown": 16
+      },
+      "residuals": {
+        "resource_candidate": 16
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:3834",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:198",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:323",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:357",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:1268"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 10,
+        "pos=0;kw=_warn": 1,
+        "pos=1;kw=-": 4
+      },
+      "count": 15,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "suppress_warnings",
+      "membranes": {
+        "unknown": 15
+      },
+      "residuals": {
+        "resource_candidate": 15
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/_private/utils.py:1992",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:1828",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:1853",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:1872",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:1888"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 12,
+        "pos=1;kw=-": 2
+      },
+      "count": 14,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "BytesIO",
+      "membranes": {
+        "unknown": 14
+      },
+      "residuals": {
+        "resource_candidate": 14
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_regression.py:54",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_regression.py:104",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_regression.py:366",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/ma/tests/test_core.py:5619",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/excel/test_writers.py:1225"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 5,
+        "pos=2;kw=-": 7,
+        "pos=3;kw=-": 1
+      },
+      "count": 13,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "exc_iter",
+      "membranes": {
+        "unknown": 13
+      },
+      "residuals": {
+        "resource_candidate": 13
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_extint128.py:73",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_extint128.py:88",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_extint128.py:96",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_extint128.py:107",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_extint128.py:116"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 12
+      },
+      "count": 12,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "conn.connect",
+      "membranes": {
+        "unknown": 12
+      },
+      "residuals": {
+        "resource_candidate": 12
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:3905",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:3941",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:3989",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:317",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:351"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=2;kw=buffersize,casting,op_dtypes,order": 2,
+        "pos=3;kw=-": 5,
+        "pos=3;kw=casting": 1,
+        "pos=3;kw=casting,op_dtypes": 4
+      },
+      "count": 12,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "nditer",
+      "membranes": {
+        "unknown": 12
+      },
+      "residuals": {
+        "resource_candidate": 12
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:55",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:972",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:992",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:1024",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_nditer.py:1050"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=close_fds,stderr,stdout": 2,
+        "pos=1;kw=close_fds,stdin": 5,
+        "pos=1;kw=close_fds,stdout": 3,
+        "pos=1;kw=stderr,stdout": 1
+      },
+      "count": 11,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "subprocess.Popen",
+      "membranes": {
+        "unknown": 11
+      },
+      "residuals": {
+        "resource_candidate": 11
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/clipboard/__init__.py:102",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/clipboard/__init__.py:108",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/clipboard/__init__.py:174",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/clipboard/__init__.py:183",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/clipboard/__init__.py:205"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 10,
+        "pos=2;kw=-": 1
+      },
+      "count": 11,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "suppress",
+      "membranes": {
+        "unknown": 11
+      },
+      "residuals": {
+        "resource_candidate": 11
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/indexing.py:1366",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/indexing.py:1691",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/indexing.py:767",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/indexing.py:772",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/indexing.py:1056"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 3,
+        "pos=1;kw=mode": 3,
+        "pos=2;kw=-": 4,
+        "pos=2;kw=compression": 1
+      },
+      "count": 11,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "zipfile.ZipFile",
+      "membranes": {
+        "unknown": 11
+      },
+      "residuals": {
+        "resource_candidate": 11
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/lib/tests/test_io.py:218",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/excel/_base.py:1419",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/test_compression.py:42",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/test_compression.py:61",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/test_compression.py:73"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=chunksize": 4,
+        "pos=1;kw=convert_categoricals,convert_dates,iterator": 2,
+        "pos=1;kw=iterator": 4
+      },
+      "count": 10,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "read_stata",
+      "membranes": {
+        "unknown": 10
+      },
+      "residuals": {
+        "resource_candidate": 10
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:1183",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:1222",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:1226",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:1230",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:1234"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 8,
+        "pos=1;kw=-": 1
+      },
+      "count": 9,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "Attribute",
+      "membranes": {
+        "unknown": 9
+      },
+      "residuals": {
+        "resource_candidate": 9
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/f2py/tests/test_f2py2e.py:375",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/f2py/tests/test_f2py2e.py:493",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/f2py/tests/test_f2py2e.py:549",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/f2py/tests/test_f2py2e.py:567",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/f2py/tests/test_f2py2e.py:599"
+      ],
+      "shape": "call_other"
+    },
+    {
+      "arity_sketches": {
+        "pos=3;kw=-": 7,
+        "pos=3;kw=condition": 2
+      },
+      "count": 9,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "com.temp_setattr",
+      "membranes": {
+        "unknown": 9
+      },
+      "residuals": {
+        "resource_candidate": 9
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/apply.py:1568",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/apply.py:1605",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/groupby/generic.py:357",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/groupby/groupby.py:2360",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/groupby/groupby.py:3072"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=2;kw=-": 3,
+        "pos=2;kw=compression": 3,
+        "pos=2;kw=is_text": 2,
+        "pos=2;kw=is_text,memory_map": 1
+      },
+      "count": 9,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "icom.get_handle",
+      "membranes": {
+        "unknown": 9
+      },
+      "residuals": {
+        "resource_candidate": 9
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_common.py:138",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_common.py:167",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_common.py:120",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_common.py:126",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_common.py:429"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=chunksize,engine,lines": 6,
+        "pos=1;kw=chunksize,engine,lines,nrows": 2,
+        "pos=1;kw=chunksize,engine,lines,typ": 1
+      },
+      "count": 9,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "read_json",
+      "membranes": {
+        "unknown": 9
+      },
+      "residuals": {
+        "resource_candidate": 9
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/json/test_readlines.py:138",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/json/test_readlines.py:171",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/json/test_readlines.py:190",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/json/test_readlines.py:374",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/json/test_readlines.py:149"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=compression": 3,
+        "pos=2;kw=-": 6
+      },
+      "count": 9,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "tm.decompress_file",
+      "membranes": {
+        "unknown": 9
+      },
+      "residuals": {
+        "resource_candidate": 9
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/frame/methods/test_to_csv.py:1083",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/frame/methods/test_to_csv.py:1088",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/frame/methods/test_to_csv.py:1354",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/json/test_compression.py:26",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_pickle.py:302"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 9
+      },
+      "count": 9,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "tm.set_timezone",
+      "membranes": {
+        "unknown": 9
+      },
+      "residuals": {
+        "resource_candidate": 9
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/indexes/datetimes/methods/test_normalize.py:86",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_timezones.py:304",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_timezones.py:309",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/scalar/timestamp/methods/test_replace.py:118",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/scalar/timestamp/methods/test_replace.py:128"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 7
+      },
+      "count": 7,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "conn.cursor",
+      "membranes": {
+        "unknown": 7
+      },
+      "residuals": {
+        "resource_candidate": 7
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:165",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:285",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:277",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:212",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:391"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 5,
+        "pos=1;kw=allow_pickle": 1,
+        "pos=1;kw=allow_pickle,encoding": 1
+      },
+      "count": 7,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "np.load",
+      "membranes": {
+        "unknown": 7
+      },
+      "residuals": {
+        "resource_candidate": 7
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_custom_dtypes.py:367",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/lib/tests/test_format.py:525",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/lib/tests/test_format.py:552",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/lib/tests/test_format.py:614",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/lib/tests/test_format.py:978"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=chunksize,encoding": 1,
+        "pos=1;kw=encoding,format,iterator": 2,
+        "pos=1;kw=encoding,iterator": 4
+      },
+      "count": 7,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "pd.read_sas",
+      "membranes": {
+        "unknown": 7
+      },
+      "residuals": {
+        "resource_candidate": 7
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/sas/test_sas7bdat.py:141",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/sas/test_sas7bdat.py:146",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/sas/test_sas7bdat.py:102",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/sas/test_sas7bdat.py:111",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/sas/test_sas7bdat.py:116"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=floatmode": 1,
+        "pos=0;kw=floatmode,precision": 1,
+        "pos=0;kw=infstr,nanstr": 1,
+        "pos=0;kw=linewidth": 1,
+        "pos=0;kw=precision": 3
+      },
+      "count": 7,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "printoptions",
+      "membranes": {
+        "unknown": 7
+      },
+      "residuals": {
+        "resource_candidate": 7
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/polynomial/tests/test_printing.py:246",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/polynomial/tests/test_printing.py:522",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/polynomial/tests/test_printing.py:533",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/polynomial/tests/test_printing.py:542",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/polynomial/tests/test_printing.py:545"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=chunksize,format": 2,
+        "pos=1;kw=chunksize,format,index": 1,
+        "pos=1;kw=chunksize,index": 1,
+        "pos=1;kw=format,index,iterator": 1,
+        "pos=1;kw=format,iterator": 2
+      },
+      "count": 7,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "read_sas",
+      "membranes": {
+        "unknown": 7
+      },
+      "residuals": {
+        "resource_candidate": 7
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/sas/test_xport.py:56",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/sas/test_xport.py:61",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/sas/test_xport.py:66",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/sas/test_xport.py:72",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/sas/test_xport.py:94"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=mode": 7
+      },
+      "count": 7,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "tables.open_file",
+      "membranes": {
+        "unknown": 7
+      },
+      "residuals": {
+        "resource_candidate": 7
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_compat.py:32",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_file_handling.py:206",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_file_handling.py:217",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_file_handling.py:228",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_file_handling.py:247"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 6
+      },
+      "count": 6,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "assert_no_warnings",
+      "membranes": {
+        "unknown": 6
+      },
+      "residuals": {
+        "resource_candidate": 6
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_umath.py:5084",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_umath.py:1601",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_umath.py:1947",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_umath.py:1959",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/lib/tests/test_io.py:1563"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 6
+      },
+      "count": 6,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "con.begin",
+      "membranes": {
+        "unknown": 6
+      },
+      "residuals": {
+        "resource_candidate": 6
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:3906",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:3942",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:3990",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:1348",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:1427"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {},
+      "count": 6,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "ctx",
+      "membranes": {
+        "unknown": 6
+      },
+      "residuals": {
+        "resource_candidate": 6
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/_methods.py:243",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/records.py:903",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/config/test_config.py:426",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/formats/style/test_style.py:736",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/plotting/test_converter.py:123"
+      ],
+      "shape": "name"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 2,
+        "pos=0;kw=rc": 4
+      },
+      "count": 6,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "mpl.rc_context",
+      "membranes": {
+        "unknown": 6
+      },
+      "residuals": {
+        "resource_candidate": 6
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/formats/style/test_matplotlib.py:30",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/plotting/conftest.py:22",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/plotting/frame/test_frame_color.py:638",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/plotting/test_style.py:27",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/plotting/test_style.py:48"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {},
+      "count": 6,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "sup",
+      "membranes": {
+        "unknown": 6
+      },
+      "residuals": {
+        "resource_candidate": 6
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:1843",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:1848",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:1878",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:1883",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:1931"
+      ],
+      "shape": "name"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=fileobj": 2,
+        "pos=1;kw=-": 1,
+        "pos=1;kw=mode": 1,
+        "pos=2;kw=-": 2
+      },
+      "count": 6,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "tarfile.open",
+      "membranes": {
+        "unknown": 6
+      },
+      "residuals": {
+        "resource_candidate": 6
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/test_c_parser_only.py:529",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/test_compression.py:207",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_gcs.py:133",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_gcs.py:133",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_pickle.py:270"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 6
+      },
+      "count": 6,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "tempdir",
+      "membranes": {
+        "unknown": 6
+      },
+      "residuals": {
+        "resource_candidate": 6
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/lib/tests/test_io.py:568",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/lib/tests/test_io.py:582",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/lib/tests/test_io.py:1556",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/lib/tests/test_io.py:631",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:2029"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 3,
+        "pos=0;kw=mode": 1,
+        "pos=1;kw=delete,suffix": 1
+      },
+      "count": 5,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "NamedTemporaryFile",
+      "membranes": {
+        "unknown": 5
+      },
+      "residuals": {
+        "resource_candidate": 5
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_custom_dtypes.py:361",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_memmap.py:245",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_memmap.py:257",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_memmap.py:268",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/lib/tests/test_loadtxt.py:652"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=**,chunksize": 2,
+        "pos=1;kw=**,chunksize,skiprows": 1,
+        "pos=1;kw=**,header": 1,
+        "pos=1;kw=**,names": 1
+      },
+      "count": 5,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "TextParser",
+      "membranes": {
+        "unknown": 5
+      },
+      "residuals": {
+        "resource_candidate": 5
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/html.py:875",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/xml.py:747",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/common/test_data_list.py:31",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/common/test_data_list.py:50",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/common/test_data_list.py:73"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=max_workers": 5
+      },
+      "count": 5,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "ThreadPoolExecutor",
+      "membranes": {
+        "unknown": 5
+      },
+      "residuals": {
+        "resource_candidate": 5
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_hashtable.py:49",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_hashtable.py:67",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_hashtable.py:84",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_hashtable.py:110",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_hashtable.py:144"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=encoding,mode": 2,
+        "pos=2;kw=encoding": 3
+      },
+      "count": 5,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "codecs.open",
+      "membranes": {
+        "unknown": 5
+      },
+      "residuals": {
+        "resource_candidate": 5
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/formats/test_to_latex.py:45",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/formats/test_to_latex.py:53",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_common.py:521",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_common.py:523",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/util/_print_versions.py:142"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 3,
+        "pos=2;kw=-": 2
+      },
+      "count": 5,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "gzip.open",
+      "membranes": {
+        "unknown": 5
+      },
+      "residuals": {
+        "resource_candidate": 5
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/random/tests/test_direct.py:579",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/random/tests/test_generator_mt19937.py:2823",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_compression.py:361",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:1860",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:2034"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {},
+      "count": 5,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "reader",
+      "membranes": {
+        "unknown": 5
+      },
+      "residuals": {
+        "resource_candidate": 5
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sas/sasreader.py:177",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/stata.py:2108",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/json/test_readlines.py:237",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/common/test_file_buffer_url.py:426",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/common/test_file_buffer_url.py:447"
+      ],
+      "shape": "name"
+    },
+    {
+      "arity_sketches": {
+        "pos=2;kw=-": 5
+      },
+      "count": 5,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "rewrite_exception",
+      "membranes": {
+        "unknown": 5
+      },
+      "residuals": {
+        "resource_candidate": 5
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/indexes/base.py:1086",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/indexes/interval.py:233",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/indexes/interval.py:273",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/indexes/interval.py:309",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/core/indexes/interval.py:344"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 5
+      },
+      "count": 5,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "self.con.cursor",
+      "membranes": {
+        "unknown": 5
+      },
+      "residuals": {
+        "resource_candidate": 5
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sql.py:2104",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sql.py:2225",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sql.py:2305",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sql.py:2402",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/io/sql.py:2390"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=1;kw=-": 5
+      },
+      "count": 5,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "sql.pandasSQL_builder",
+      "membranes": {
+        "unknown": 5
+      },
+      "residuals": {
+        "resource_candidate": 5
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:1759",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:4156",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:4223",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:4265",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_sql.py:4287"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 3,
+        "pos=0;kw=suffix": 1,
+        "pos=1;kw=delete": 1
+      },
+      "count": 5,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "tempfile.NamedTemporaryFile",
+      "membranes": {
+        "unknown": 5
+      },
+      "residuals": {
+        "resource_candidate": 5
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_regression.py:1589",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_stringdtype.py:537",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/typing/tests/data/pass/ndarray_conversion.py:22",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/test_encoding.py:213",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/pytables/test_store.py:991"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 3,
+        "pos=1;kw=-": 1
+      },
+      "count": 4,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "StringIO",
+      "membranes": {
+        "unknown": 4
+      },
+      "residuals": {
+        "resource_candidate": 4
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/frame/methods/test_info.py:189",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/frame/methods/test_info.py:563",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/parser/test_c_parser_only.py:304",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_common.py:125"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 4
+      },
+      "count": 4,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "activated_tracemalloc",
+      "membranes": {
+        "unknown": 4
+      },
+      "residuals": {
+        "resource_candidate": 4
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/libs/test_hashtable.py:465",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/libs/test_hashtable.py:476",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/libs/test_hashtable.py:222",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/libs/test_hashtable.py:232"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 4
+      },
+      "count": 4,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "assert_no_gc_cycles",
+      "membranes": {
+        "unknown": 4
+      },
+      "residuals": {
+        "resource_candidate": 4
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/lib/tests/test_io.py:2696",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/lib/tests/test_io.py:2701",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:2088",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:2101"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 2,
+        "pos=0;kw=modules": 2
+      },
+      "count": 4,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "clear_and_catch_warnings",
+      "membranes": {
+        "unknown": 4
+      },
+      "residuals": {
+        "resource_candidate": 4
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:1778",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:1784",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:1794",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/tests/test_utils.py:1800"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=-": 1,
+        "pos=0;kw=max_workers": 3
+      },
+      "count": 4,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "concurrent.futures.ThreadPoolExecutor",
+      "membranes": {
+        "unknown": 4
+      },
+      "residuals": {
+        "resource_candidate": 4
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_multithreading.py:338",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/_core/tests/test_multithreading.py:441",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/f2py/tests/util.py:93",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/testing/_private/utils.py:2815"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=2;kw=-": 4
+      },
+      "count": 4,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "ensure_removed",
+      "membranes": {
+        "unknown": 4
+      },
+      "residuals": {
+        "resource_candidate": 4
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/test_register_accessor.py:63",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/test_register_accessor.py:74",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/test_register_accessor.py:95",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/test_register_accessor.py:87"
+      ],
+      "shape": "call_dotted"
+    },
+    {
+      "arity_sketches": {
+        "pos=0;kw=fileobj,mode": 2,
+        "pos=2;kw=-": 2
+      },
+      "count": 4,
+      "enrollment_posture": "resource_loud_candidate",
+      "identity": "gzip.GzipFile",
+      "membranes": {
+        "unknown": 4
+      },
+      "residuals": {
+        "resource_candidate": 4
+      },
+      "sample_loci": [
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/lib/tests/test_io.py:2394",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_http_headers.py:26",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:1747",
+        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/pandas/tests/io/test_stata.py:1749"
+      ],
+      "shape": "call_dotted"
+    }
+  ],
+  "top_identities": [
+    [
+      "pytest.raises",
+      6353
+    ],
+    [
+      "tm.assert_produces_warning",
+      1836
+    ],
+    [
+      "tm.ensure_clean",
+      348
+    ],
+    [
+      "np.errstate",
+      292
+    ],
+    [
+      "open",
+      273
+    ],
+    [
+      "option_context",
+      252
+    ],
+    [
+      "warnings.catch_warnings",
+      194
+    ],
+    [
+      "pytest.warns",
+      167
+    ],
+    [
+      "assert_raises",
+      148
+    ],
+    [
+      "ensure_clean_store",
+      142
+    ],
+    [
+      "pd.option_context",
+      135
+    ],
+    [
+      "tm.assert_cow_warning",
+      133
+    ],
+    [
+      "assert_raises_regex",
+      74
+    ],
+    [
+      "tm.raises_chained_assignment_error",
+      69
+    ],
+    [
+      "temppath",
+      54
+    ],
+    [
+      "monkeypatch.context",
+      40
+    ],
+    [
+      "util.switchdir",
+      37
+    ],
+    [
+      "ExcelFile",
+      33
+    ],
+    [
+      "ExcelWriter",
+      30
+    ],
+    [
+      "sql.SQLDatabase",
+      30
+    ],
+    [
+      "i",
+      28
+    ],
+    [
+      "HDFStore",
+      28
+    ],
+    [
+      "tm.external_error_raised",
+      28
+    ],
+    [
+      "cf.config_prefix",
+      26
+    ],
+    [
+      "parser.read_csv",
+      24
+    ],
+    [
+      "errstate",
+      23
+    ],
+    [
+      "pandasSQL_builder",
+      22
+    ],
+    [
+      "get_handle",
+      21
+    ],
+    [
+      "StataReader",
+      21
+    ],
+    [
+      "tm.maybe_produces_warning",
+      20
+    ],
+    [
+      "cf.option_context",
+      20
+    ],
+    [
+      "it",
+      19
+    ],
+    [
+      "pd.ExcelFile",
+      19
+    ],
+    [
+      "contextlib.closing",
+      19
+    ],
+    [
+      "pandasSQL.run_transaction",
+      18
+    ],
+    [
+      "np.printoptions",
+      17
+    ],
+    [
+      "conn.begin",
+      16
+    ],
+    [
+      "suppress_warnings",
+      15
+    ],
+    [
+      "BytesIO",
+      14
+    ],
+    [
+      "exc_iter",
+      13
+    ]
+  ],
+  "with_items_total": 11535
+}

--- a/implementations/python/sugar-lift-py-tests/scripts/resource_with_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/resource_with_recensus.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+"""Re-census resource ``with`` sites before NeverSuppresses enrollment.
+
+Walks installed numpy/pandas (or paths given on the CLI). For each ``with``
+item, classifies the manager by membrane authentication vs RuntimeSelected
+residual shape, and groups by structural manager identity.
+
+Does **not** enroll anything. Does **not** special-case ``open``.
+
+Exit disposition evidence is structural only at this stage:
+- membrane Expects / Suppresses (assertion managers already wired)
+- unauthenticated Call / Name / Attribute / other → resource residual candidates
+- optional scan for source-visible ``__exit__`` bodies that only return
+  None/False (candidate NeverSuppresses proof rule input)
+
+Usage (from repo / worktree root)::
+
+    PYTHONPATH=implementations/python/sugar-lift-py-tests/src:\\
+               implementations/python/sugar-source-tree/src:\\
+               implementations/python/sugar-lift-python-source/src \\
+      python implementations/python/sugar-lift-py-tests/scripts/resource_with_recensus.py \\
+        --packages numpy,pandas --json docs/resource-with-recensus.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib.util
+import json
+import sys
+from collections import Counter, defaultdict
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+
+# ---------------------------------------------------------------------------
+# Structural manager identity (stdlib ast — no sugar construction required)
+# ---------------------------------------------------------------------------
+
+
+def _dotted(node: ast.AST | None) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _dotted(node.value)
+        if base is None:
+            return None
+        return f"{base}.{node.attr}"
+    return None
+
+
+def _manager_shape(node: ast.AST) -> tuple[str, str]:
+    """Return (shape_kind, identity_key).
+
+    shape_kind:
+      call_dotted | call_other | name | attribute | other
+    identity_key is a stable grouping string for that shape.
+    """
+    if isinstance(node, ast.Call):
+        dotted = _dotted(node.func)
+        if dotted is not None:
+            return "call_dotted", dotted
+        return "call_other", type(node.func).__name__
+    if isinstance(node, ast.Name):
+        return "name", node.id
+    if isinstance(node, ast.Attribute):
+        dotted = _dotted(node)
+        if dotted is not None:
+            return "attribute", dotted
+        return "attribute", f"*.{node.attr}"
+    return "other", type(node).__name__
+
+
+def _call_arg_sketch(node: ast.Call) -> str:
+    """Coarse arity sketch for grouping (not a second authority)."""
+    n_pos = len(node.args)
+    kws = sorted(k.arg or "**" for k in node.keywords)
+    return f"pos={n_pos};kw={','.join(kws) if kws else '-'}"
+
+
+# ---------------------------------------------------------------------------
+# Membrane classification (same door production With uses)
+# ---------------------------------------------------------------------------
+
+
+def _membrane_class(manager_node) -> str:
+    """expects | suppresses | never_suppresses | unauthenticated."""
+    from sugar_lift_py_tests.context_manager_contract import (
+        Expects,
+        NeverSuppresses,
+        RuntimeSelected,
+        Suppresses,
+    )
+    from sugar_lift_py_tests.manifest_membrane import (
+        contract_for_manager,
+        default_community_manifest,
+    )
+
+    contract = contract_for_manager(default_community_manifest(), manager_node)
+    if isinstance(contract, Expects):
+        return "expects"
+    if isinstance(contract, Suppresses):
+        return "suppresses"
+    if isinstance(contract, NeverSuppresses):
+        return "never_suppresses"
+    if isinstance(contract, RuntimeSelected):
+        return "runtime_selected"
+    return "unauthenticated"
+
+
+def _sugar_with_nodes(path: Path) -> list[Any]:
+    """Materialize sugar tree With nodes for one file (best-effort)."""
+    from sugar_source_tree.tree import SourceFile
+
+    try:
+        sf = SourceFile.from_path(str(path))
+    except Exception:
+        return []
+    found: list[Any] = []
+
+    def walk(node) -> None:
+        kind = getattr(node, "kind", None)
+        if kind == "With":
+            found.append(node)
+        for name in getattr(node, "_child_fields", ()) or ():
+            child = getattr(node, name, None)
+            if child is None:
+                continue
+            if isinstance(child, tuple):
+                for c in child:
+                    walk(c)
+            else:
+                walk(child)
+
+    try:
+        walk(sf.root)
+    except Exception:
+        return found
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Source-visible __exit__ candidates (general NeverSuppresses rule input)
+# ---------------------------------------------------------------------------
+
+
+def _returns_only_none_or_false(body: list[ast.stmt]) -> bool:
+    """True when every return is literal None/False and no bare return of other.
+
+    Conservative: any non-return control (raise, yield) or non-literal return
+    → False. Empty body / implicit None → True (Python default).
+    """
+    has_explicit = False
+    for stmt in body:
+        if isinstance(stmt, ast.Return):
+            has_explicit = True
+            v = stmt.value
+            if v is None:
+                continue  # bare return → None
+            if isinstance(v, ast.Constant) and v.value in (None, False):
+                continue
+            return False
+        if isinstance(stmt, (ast.Raise, ast.Yield, ast.YieldFrom)):
+            return False
+        # Recurse into simple compound statements conservatively
+        for child in ast.iter_child_nodes(stmt):
+            if isinstance(child, ast.stmt):
+                # Nested function/class: ignore their bodies
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                    continue
+            # Don't deep-walk compounds with branches here — require linear-ish
+        if isinstance(stmt, (ast.If, ast.For, ast.While, ast.Try, ast.With, ast.Match)):
+            # Branching exit bodies need deeper proof; not candidates here
+            return False
+    return True  # all returns None/False, or implicit None
+
+
+def scan_exit_never_suppress_candidates(path: Path) -> list[dict[str, Any]]:
+    """Find methods named __exit__ whose body returns only None/False."""
+    try:
+        src = path.read_text(encoding="utf-8", errors="replace")
+        tree = ast.parse(src, filename=str(path))
+    except (SyntaxError, OSError, UnicodeError):
+        return []
+    out: list[dict[str, Any]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name != "__exit__":
+            continue
+        if not _returns_only_none_or_false(list(node.body)):
+            continue
+        # Qualify with enclosing class if any
+        # (best-effort: walk parents not available on ast — use line only)
+        out.append(
+            {
+                "file": str(path),
+                "line": node.lineno,
+                "qualname": node.name,
+                "evidence": "source_visible_exit_returns_none_or_false",
+            }
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# File walk
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WithHit:
+    file: str
+    line: int
+    shape: str
+    identity: str
+    arity_sketch: str
+    membrane: str  # expects|suppresses|never_suppresses|unauthenticated|unknown
+    residual: str  # assertion_wired | resource_candidate | never_suppresses_enrolled
+
+
+@dataclass
+class FileReport:
+    path: str
+    with_items: int = 0
+    parse_error: str | None = None
+    hits: list[WithHit] = field(default_factory=list)
+
+
+def package_root(name: str) -> Path:
+    spec = importlib.util.find_spec(name)
+    if spec is None or not spec.origin:
+        raise SystemExit(f"package {name!r} not importable")
+    return Path(spec.origin).resolve().parent
+
+
+def iter_py_files(root: Path) -> Iterator[Path]:
+    for p in sorted(root.rglob("*.py")):
+        # skip caches / tests of sugar itself
+        parts = set(p.parts)
+        if "__pycache__" in parts or ".git" in parts:
+            continue
+        yield p
+
+
+def census_file_ast(path: Path) -> FileReport:
+    """Primary census: stdlib ast + membrane on sugar nodes when available."""
+    rel = str(path)
+    report = FileReport(path=rel)
+    try:
+        src = path.read_text(encoding="utf-8", errors="replace")
+        tree = ast.parse(src, filename=rel)
+    except SyntaxError as e:
+        report.parse_error = f"SyntaxError: {e}"
+        return report
+    except OSError as e:
+        report.parse_error = f"OSError: {e}"
+        return report
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.With, ast.AsyncWith)):
+            continue
+        for item in node.items:
+            report.with_items += 1
+            shape, identity = _manager_shape(item.context_expr)
+            arity = ""
+            if isinstance(item.context_expr, ast.Call):
+                arity = _call_arg_sketch(item.context_expr)
+            # Membrane needs sugar tree node — fill later or leave unknown
+            report.hits.append(
+                WithHit(
+                    file=rel,
+                    line=getattr(item.context_expr, "lineno", node.lineno),
+                    shape=shape,
+                    identity=identity,
+                    arity_sketch=arity,
+                    membrane="unknown",
+                    residual="resource_candidate"
+                    if shape != "call_dotted"
+                    else "resource_candidate",
+                )
+            )
+    return report
+
+
+def attach_membrane_classifications(path: Path, report: FileReport) -> None:
+    """Best-effort membrane classify by matching sugar With items to AST hits."""
+    with_nodes = _sugar_with_nodes(path)
+    if not with_nodes:
+        return
+    # Flatten sugar items with line numbers
+    sugar_items: list[tuple[int, Any, str]] = []
+    for w in with_nodes:
+        try:
+            for item in w.items:
+                lc = item.line_col_span()
+                membrane = _membrane_class(item.context_expr)
+                sugar_items.append((lc.start_line, item, membrane))
+        except Exception:
+            continue
+    # Match by line number
+    by_line: dict[int, list[str]] = defaultdict(list)
+    for line, _item, membrane in sugar_items:
+        by_line[line].append(membrane)
+    for hit in report.hits:
+        membranes = by_line.get(hit.line)
+        if not membranes:
+            continue
+        # take first membrane for that line
+        m = membranes.pop(0)
+        hit.membrane = m
+        if m in ("expects", "suppresses"):
+            hit.residual = "assertion_wired"
+        elif m == "never_suppresses":
+            hit.residual = "never_suppresses_enrolled"
+        else:
+            hit.residual = "resource_candidate"
+
+
+def _manifest_spellings() -> dict[str, str]:
+    """spelling → contract kind (expects|suppresses|never-suppresses)."""
+    try:
+        from sugar_lift_py_tests.manifest_membrane import default_community_manifest
+
+        return {
+            row.spelling: row.contract
+            for row in default_community_manifest().rows
+        }
+    except Exception:
+        return {}
+
+
+def _classify_hit(hit: WithHit, spellings: dict[str, str]) -> None:
+    """Fill membrane/residual from community spelling when sugar membrane skipped."""
+    if hit.membrane != "unknown":
+        return
+    contract = spellings.get(hit.identity)
+    if contract == "expects":
+        hit.membrane = "expects"
+        hit.residual = "assertion_wired"
+    elif contract == "suppresses":
+        hit.membrane = "suppresses"
+        hit.residual = "assertion_wired"
+    elif contract == "never-suppresses":
+        hit.membrane = "never_suppresses"
+        hit.residual = "never_suppresses_enrolled"
+    else:
+        hit.residual = "resource_candidate"
+
+
+def summarize(reports: list[FileReport], exit_candidates: list[dict]) -> dict[str, Any]:
+    spellings = _manifest_spellings()
+    hits = [h for r in reports for h in r.hits]
+    for h in hits:
+        _classify_hit(h, spellings)
+
+    by_identity: dict[str, dict[str, Any]] = {}
+    identity_counter: Counter[str] = Counter()
+    residual_counter: Counter[str] = Counter()
+    shape_counter: Counter[str] = Counter()
+    membrane_counter: Counter[str] = Counter()
+
+    for h in hits:
+        identity_counter[h.identity] += 1
+        residual_counter[h.residual] += 1
+        shape_counter[h.shape] += 1
+        membrane_counter[h.membrane] += 1
+        bucket = by_identity.setdefault(
+            h.identity,
+            {
+                "identity": h.identity,
+                "shape": h.shape,
+                "count": 0,
+                "residuals": Counter(),
+                "membranes": Counter(),
+                "arity_sketches": Counter(),
+                "sample_loci": [],
+            },
+        )
+        bucket["count"] += 1
+        bucket["residuals"][h.residual] += 1
+        bucket["membranes"][h.membrane] += 1
+        if h.arity_sketch:
+            bucket["arity_sketches"][h.arity_sketch] += 1
+        if len(bucket["sample_loci"]) < 5:
+            bucket["sample_loci"].append(f"{h.file}:{h.line}")
+
+    groups = []
+    for identity, bucket in sorted(
+        by_identity.items(), key=lambda kv: (-kv[1]["count"], kv[0])
+    ):
+        groups.append(
+            {
+                "identity": identity,
+                "shape": bucket["shape"],
+                "count": bucket["count"],
+                "residuals": dict(bucket["residuals"]),
+                "membranes": dict(bucket["membranes"]),
+                "arity_sketches": dict(bucket["arity_sketches"]),
+                "sample_loci": bucket["sample_loci"],
+                "enrollment_posture": (
+                    "already_wired_assertion"
+                    if bucket["residuals"].get("assertion_wired", 0)
+                    == bucket["count"]
+                    else (
+                        "never_suppresses_enrolled"
+                        if bucket["residuals"].get("never_suppresses_enrolled", 0)
+                        else "resource_loud_candidate"
+                    )
+                ),
+            }
+        )
+
+    resource_groups = [
+        g for g in groups if g["enrollment_posture"] == "resource_loud_candidate"
+    ]
+    assertion_groups = [
+        g for g in groups if g["enrollment_posture"] == "already_wired_assertion"
+    ]
+
+    return {
+        "files_scanned": len(reports),
+        "files_parse_error": sum(1 for r in reports if r.parse_error),
+        "with_items_total": sum(r.with_items for r in reports),
+        "hits": len(hits),
+        "by_residual": dict(residual_counter),
+        "by_shape": dict(shape_counter),
+        "by_membrane": dict(membrane_counter),
+        "manifest_spellings": spellings,
+        "top_identities": identity_counter.most_common(40),
+        "resource_loud_groups": resource_groups[:80],
+        "assertion_wired_groups": assertion_groups[:40],
+        "exit_never_suppress_candidates": {
+            "count": len(exit_candidates),
+            "sample": exit_candidates[:30],
+        },
+        "recommended_next_proof_rule": {
+            "name": "source_visible_exit_returns_none_or_false",
+            "disposition": "NeverSuppresses",
+            "rule": (
+                "When a manager's __exit__ is source-visible and every return "
+                "is provably None or False (implicit None allowed; branches "
+                "allowed only if they never return a suppressing truth value), "
+                "issue NeverSuppresses. Admit via WithResourceSugar only with "
+                "constructed enter/exit coords. Do not special-case open by "
+                "name; built-ins need an attested semantic manifest later."
+            ),
+            "first_general_admits_after_rule": [
+                "np.errstate / errstate (~315 sites; restore-only __exit__)",
+                "option_context family (~407 sites; restore-only with branches)",
+                "util.switchdir (37 sites; try/yield/finally)",
+            ],
+            "do_not": [
+                "enroll open by spelling",
+                "guess subclass exception matching",
+                "admit RuntimeSelected as green",
+            ],
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--packages",
+        default="numpy,pandas",
+        help="Comma-separated importable packages (default: numpy,pandas)",
+    )
+    ap.add_argument(
+        "--roots",
+        default="",
+        help="Optional extra roots (colon-separated paths) instead of/in addition",
+    )
+    ap.add_argument("--json", default="", help="Write full JSON report here")
+    ap.add_argument(
+        "--max-files",
+        type=int,
+        default=0,
+        help="Cap files per root (0 = no cap)",
+    )
+    ap.add_argument(
+        "--membrane",
+        action="store_true",
+        help="Attach membrane classification via sugar tree (slower)",
+    )
+    ap.add_argument(
+        "--scan-exit",
+        action="store_true",
+        default=True,
+        help="Scan for source-visible __exit__ None/False candidates (default on)",
+    )
+    ap.add_argument("--no-scan-exit", action="store_false", dest="scan_exit")
+    args = ap.parse_args(argv)
+
+    roots: list[Path] = []
+    for name in args.packages.split(","):
+        name = name.strip()
+        if not name:
+            continue
+        roots.append(package_root(name))
+    if args.roots:
+        for part in args.roots.split(":"):
+            part = part.strip()
+            if part:
+                roots.append(Path(part).resolve())
+
+    reports: list[FileReport] = []
+    exit_candidates: list[dict[str, Any]] = []
+    for root in roots:
+        files = list(iter_py_files(root))
+        if args.max_files:
+            files = files[: args.max_files]
+        print(f"# root {root} files={len(files)}", flush=True)
+        for i, path in enumerate(files, 1):
+            if i % 200 == 0:
+                print(f"  … {i}/{len(files)}", flush=True)
+            report = census_file_ast(path)
+            if args.membrane and report.with_items:
+                try:
+                    attach_membrane_classifications(path, report)
+                except Exception as e:
+                    report.parse_error = (report.parse_error or "") + f" membrane:{e}"
+            reports.append(report)
+            if args.scan_exit:
+                exit_candidates.extend(scan_exit_never_suppress_candidates(path))
+
+    summary = summarize(reports, exit_candidates)
+    # Human-readable
+    print()
+    print("=== resource-with re-census ===")
+    print(f"files_scanned: {summary['files_scanned']}")
+    print(f"with_items_total: {summary['with_items_total']}")
+    print(f"by_residual: {summary['by_residual']}")
+    print(f"by_shape: {summary['by_shape']}")
+    print(f"by_membrane: {summary['by_membrane']}")
+    print()
+    print("--- top manager identities ---")
+    for identity, count in summary["top_identities"][:25]:
+        print(f"  {count:5d}  {identity}")
+    print()
+    print("--- top resource-loud groups ---")
+    for g in summary["resource_loud_groups"][:25]:
+        print(
+            f"  {g['count']:5d}  {g['identity']!r}  shape={g['shape']}  "
+            f"membranes={g['membranes']}"
+        )
+        for loc in g["sample_loci"][:2]:
+            print(f"           e.g. {loc}")
+    print()
+    print(
+        f"source-visible __exit__ None/False candidates: "
+        f"{summary['exit_never_suppress_candidates']['count']}"
+    )
+    for row in summary["exit_never_suppress_candidates"]["sample"][:10]:
+        print(f"  {row['file']}:{row['line']}")
+    print()
+    print("recommended_next_proof_rule:")
+    print(f"  {summary['recommended_next_proof_rule']['name']}")
+    print(f"  {summary['recommended_next_proof_rule']['rule']}")
+
+    if args.json:
+        out_path = Path(args.json)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        # Convert Counters already done; write summary
+        out_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+        print(f"\n# wrote {out_path}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Post-#6042 measurement cut: re-census resource \`with\` before any enrollment.

- **1,818** numpy/pandas files, **11,535** \`with\` items
- Membrane assertion mass (\`pytest.raises\`, \`tm.assert_produces_warning\`): **~8.2k**
- Resource-loud residual mass: **~2.9k** identities
- Grouped by disposition evidence (config CM, IO, warnings, raises aliases, open, switchdir, …)
- Recommended general rule: source-visible \`__exit__\` never returns suppressing truth → \`NeverSuppresses\`
- First general admits after the rule: \`errstate\`, \`option_context\` family, \`util.switchdir\`
- **Not** enrolling \`open\` by name

## Artifacts

- \`scripts/resource_with_recensus.py\`
- \`docs/resource-with-recensus-2026-07-22.md\`
- \`docs/resource-with-recensus.json\` / \`-grouped.json\`

## Next

Implement the general NeverSuppresses proof rule; then measure Delta R on errstate/option_context before IO/builtins.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add recensus CLI to classify with-statements before NeverSuppresses enrollment
> - Adds [resource_with_recensus.py](https://github.com/TSavo/sugar/pull/6043/files#diff-a74378283e026c37b1d2c9a534d64fc130f2ed5eb758e96a0da9dbff4951898f), a CLI that scans Python files across specified packages, uses stdlib `ast` to census `with`-statements, and classifies each manager against the community manifest into categories like `never_suppresses`, `suppresses`, or `resource_candidate`.
> - Detects source-visible `__exit__` bodies that only return `None`/`False` as NeverSuppresses candidates, using a conservative linear-body analyzer that rejects branching, raising, and yielding.
> - Outputs a human-readable console summary and optional structured JSON report (grouped by identity and residual), with a recommended next proof rule embedded in the output.
> - Adds two generated snapshot artifacts ([resource-with-recensus.json](https://github.com/TSavo/sugar/pull/6043/files#diff-dcea5fc702cf15cd88ca6f9a5ad2d0fc4effebf5fc478330c4d7e3573baecfd4) and [resource-with-recensus-grouped.json](https://github.com/TSavo/sugar/pull/6043/files#diff-f4f1e64c44b03cd5a6a748f01391b39f556cac7f0f60a40ee34d9a41a3e94329)) and a documenting engineering report ([resource-with-recensus-2026-07-22.md](https://github.com/TSavo/sugar/pull/6043/files#diff-5297063db19d0cd760d543120cb0e9bb1cfd390e190af8240676d4eeaab53e14)).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65e1234.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->