### PR TITLE
ExitDispositionProof: static class-__exit__ resolution; generator CM deferred

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/exit_disposition_proof.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/exit_disposition_proof.py
@@ -1,12 +1,20 @@
 """Source-visible ``__exit__`` → authenticated ``ExitDispositionProof``.
 
-Wording (exact): every reachable **completed** return of ``__exit__`` must be
-proven exactly ``None`` or ``False``, including implicit ``None`` fallthrough.
-It is not enough that no ``return True`` was observed.
+Pipeline (required)::
 
-Unknown, symbolic, delegated, or dynamically dispatched returns remain
-unproven → caller keeps ``RuntimeSelected``. Exit **halts** (raise inside
-``__exit__``) do not decide suppression; the proof covers suppression only.
+    source import binding (local AST)
+    → static re-export follow (module source via SourceOracle only)
+    → definition memento (module, class, cid, file, line)
+    → prove every completed return is exact None/False (+ implicit fallthrough)
+
+Wording: every reachable **completed** return must be proven exactly ``None``
+or ``False``, including implicit ``None`` fallthrough — not merely “no
+``return True`` observed.”
+
+**Forbidden** in the manager→definition path: ``importlib.import_module``,
+``getattr`` on live objects, MRO walks, ``inspect.getsource*``, and
+vendor-specific alias tables (``np``/``pd``). Those recreate recognition
+authority through Python execution.
 
 This cut covers class ``__exit__`` methods only. Generator
 ``@contextmanager`` (e.g. ``util.switchdir``) is a separate proof.
@@ -15,7 +23,6 @@ This cut covers class ``__exit__`` methods only. Generator
 from __future__ import annotations
 
 import ast
-import importlib
 from dataclasses import dataclass
 from typing import Iterator, Literal
 
@@ -38,6 +45,17 @@ class ExitDispositionProof:
         return NeverSuppresses()
 
 
+@dataclass(frozen=True)
+class DefinitionMemento:
+    """Authenticated definition coordinate before return analysis."""
+
+    module: str
+    class_name: str
+    source_cid: str
+    filename: str
+    exit_fn: ast.FunctionDef | ast.AsyncFunctionDef
+
+
 class ExitDispositionUnproven(Exception):
     """Internal reason; callers map this to RuntimeSelected."""
 
@@ -46,21 +64,20 @@ class ExitDispositionUnproven(Exception):
         self.reason = reason
 
 
+# ---------------------------------------------------------------------------
+# Return-value exactness (subject-independent theorem)
+# ---------------------------------------------------------------------------
+
+
 def _is_exact_none_or_false(node: ast.AST | None) -> bool:
-    """True only for bare return / literal ``None`` / literal ``False``."""
     if node is None:
-        return True  # bare ``return`` → None
+        return True
     if isinstance(node, ast.Constant):
         return node.value is None or node.value is False
     return False
 
 
 def _iter_direct_stmts(stmt: ast.stmt) -> Iterator[ast.stmt]:
-    """Yield stmt and nested stmts, skipping nested function/class bodies.
-
-    ``Try`` handlers are not ``ast.stmt`` children under generic walk — visit
-    them explicitly so ``except: return True`` is not invisible.
-    """
     yield stmt
     if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
         return
@@ -93,8 +110,6 @@ def _iter_returns(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> Iterator[ast.Re
 
 
 def _body_contains_yield(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
-    """True if ``fn`` body yields (skipping nested defs/classes/lambdas)."""
-
     class _V(ast.NodeVisitor):
         def __init__(self) -> None:
             self.found = False
@@ -134,10 +149,8 @@ def prove_exit_function_ast(
     """Prove every completed return of ``fn`` is exact None/False (+ fallthrough)."""
     if fn.name != "__exit__":
         raise ExitDispositionUnproven(f"expected __exit__, got {fn.name!r}")
-
     if _body_contains_yield(fn):
         raise ExitDispositionUnproven("yield in __exit__ is unproven")
-
     for ret in _iter_returns(fn):
         if not _is_exact_none_or_false(ret.value):
             kind = type(ret.value).__name__ if ret.value is not None else "bare"
@@ -146,9 +159,6 @@ def prove_exit_function_ast(
             raise ExitDispositionUnproven(
                 f"completed return is not exact None/False (got {kind})"
             )
-
-    # Implicit None fallthrough at end of __exit__ is a completed exit and is
-    # proven (Python: missing return → None). No extra observation required.
     return ExitDispositionProof(
         kind="never_suppresses",
         module=module,
@@ -160,16 +170,63 @@ def prove_exit_function_ast(
     )
 
 
-def _defining_class_and_exit(cls: type) -> tuple[type, object] | None:
-    for c in cls.__mro__:
-        if c is object:
-            continue
-        if "__exit__" in getattr(c, "__dict__", {}):
-            return c, c.__dict__["__exit__"]
-    return None
+def prove_from_definition_memento(memento: DefinitionMemento) -> ExitDispositionProof:
+    """Apply the return theorem to an already-authenticated definition."""
+    return prove_exit_function_ast(
+        memento.exit_fn,
+        module=memento.module,
+        class_name=memento.class_name,
+        source_cid=memento.source_cid,
+        filename=memento.filename,
+    )
 
 
-def _find_class_exit_ast(
+# ---------------------------------------------------------------------------
+# SourceOracle: module text only (no package execution)
+# ---------------------------------------------------------------------------
+
+
+def _oracle_module(module_name: str) -> tuple[str, str, str] | None:
+    """``(source, filename, content_cid)`` via SourceOracle — read, do not import."""
+    from sugar_lift_python_source.source_oracle import installed_module_source
+
+    return installed_module_source(module_name)
+
+
+def _parse_module(module_name: str) -> tuple[ast.Module, str, str, str] | None:
+    resolved = _oracle_module(module_name)
+    if resolved is None:
+        return None
+    source, filename, source_cid = resolved
+    from sugar_lift_python_source.source_tables import parsed_tree
+
+    try:
+        tree = parsed_tree(source, filename)
+    except SyntaxError:
+        return None
+    if not isinstance(tree, ast.Module):
+        return None
+    return tree, source, filename, source_cid
+
+
+def _resolve_relative(
+    current_module: str, filename: str, level: int, module: str | None
+) -> str | None:
+    """Absolute module name for a relative import (static)."""
+    if level == 0:
+        return module
+    parts = current_module.split(".")
+    is_pkg = filename.endswith("__init__.py")
+    pkg_parts = parts if is_pkg else parts[:-1]
+    if level - 1 > len(pkg_parts):
+        return None
+    base = pkg_parts[: len(pkg_parts) - (level - 1)] if level >= 1 else pkg_parts
+    if module:
+        return ".".join([*base, *module.split(".")]) if base else module
+    return ".".join(base) if base else None
+
+
+def _find_class_exit(
     tree: ast.Module, class_name: str
 ) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
     for node in ast.walk(tree):
@@ -183,192 +240,253 @@ def _find_class_exit_ast(
     return None
 
 
-def prove_never_suppresses_for_class(cls: type) -> ExitDispositionProof | None:
-    """SourceOracle-backed proof for a concrete class's defining ``__exit__``.
+# ---------------------------------------------------------------------------
+# Static name resolution in a module (re-exports, class defs)
+# ---------------------------------------------------------------------------
 
-    Uses the defining method's on-disk module (not a re-export module such as
-    ``numpy.__init__`` that only aliases the class).
+
+def _module_level_nodes(tree: ast.Module) -> Iterator[ast.AST]:
+    """Yield module-level statements, descending only into If/Try/With at top.
+
+    Package ``__init__`` re-exports often live under ``if not SETUP:`` guards.
+    Nested function/class bodies are not visited.
     """
-    import inspect
+    stack: list[ast.AST] = list(tree.body)
+    while stack:
+        node = stack.pop()
+        yield node
+        if isinstance(node, ast.If):
+            stack.extend(node.orelse)
+            stack.extend(node.body)
+        elif isinstance(node, ast.Try):
+            stack.extend(node.finalbody)
+            stack.extend(node.orelse)
+            for h in node.handlers:
+                stack.extend(h.body)
+            stack.extend(node.body)
+        elif isinstance(node, (ast.With, ast.AsyncWith)):
+            stack.extend(node.body)
 
-    found = _defining_class_and_exit(cls)
-    if found is None:
+
+def _lookup_name_in_module(
+    module_name: str, name: str, *, depth: int = 0
+) -> DefinitionMemento | None:
+    """Find class ``name`` or follow static import re-exports (depth-capped)."""
+    if depth > 12 or not name or not module_name:
         return None
-    defining_cls, method = found
-
-    # Prefer the module that *defines* the function object (not the re-export).
-    method_mod = getattr(method, "__module__", None) or getattr(
-        defining_cls, "__module__", None
-    )
-    if not method_mod:
+    parsed = _parse_module(module_name)
+    if parsed is None:
         return None
+    tree, _source, filename, source_cid = parsed
 
-    from sugar_lift_python_source.canonical import blake3_512_of
-    from sugar_lift_python_source.source_oracle import installed_module_source
-    from sugar_lift_python_source.source_tables import parsed_tree
-
-    resolved = installed_module_source(method_mod)
-    # If re-export module lacks the class body, resolve via source file of method.
-    source: str | None = None
-    filename: str | None = None
-    source_cid: str | None = None
-    if resolved is not None:
-        source, filename, source_cid = resolved
-        tree = None
-        try:
-            tree = parsed_tree(source, filename)
-        except SyntaxError:
-            tree = None
-        fn = (
-            _find_class_exit_ast(tree, defining_cls.__name__)
-            if isinstance(tree, ast.Module)
-            else None
-        )
-        if fn is not None:
-            try:
-                return prove_exit_function_ast(
-                    fn,
-                    module=method_mod,
-                    class_name=defining_cls.__name__,
-                    source_cid=source_cid,
-                    filename=filename,
-                )
-            except ExitDispositionUnproven:
+    # 1. Class definition in this module (any nesting depth for ClassDef name).
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            exit_fn = _find_class_exit(tree, name)
+            if exit_fn is None:
                 return None
+            return DefinitionMemento(
+                module=module_name,
+                class_name=name,
+                source_cid=source_cid,
+                filename=filename,
+                exit_fn=exit_fn,
+            )
+    # Class under module-level If (rare)
+    for node in _module_level_nodes(tree):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            exit_fn = _find_class_exit(tree, name)
+            if exit_fn is None:
+                return None
+            return DefinitionMemento(
+                module=module_name,
+                class_name=name,
+                source_cid=source_cid,
+                filename=filename,
+                exit_fn=exit_fn,
+            )
 
-    # Fallback: defining source file from inspect (still CID-pinned).
-    try:
-        path = inspect.getsourcefile(method) or inspect.getfile(defining_cls)
-    except TypeError:
-        return None
-    if not path or not path.endswith((".py", ".pyi")):
-        return None
-    try:
-        from pathlib import Path
-
-        source = Path(path).read_text(encoding="utf-8")
-    except OSError:
-        return None
-    source_cid = blake3_512_of(source.encode("utf-8"))
-    filename = path
-    try:
-        tree = parsed_tree(source, filename)
-    except SyntaxError:
-        return None
-    if not isinstance(tree, ast.Module):
-        return None
-    fn = _find_class_exit_ast(tree, defining_cls.__name__)
-    if fn is None:
-        return None
-    try:
-        return prove_exit_function_ast(
-            fn,
-            module=method_mod,
-            class_name=defining_cls.__name__,
-            source_cid=source_cid,
-            filename=filename,
-        )
-    except ExitDispositionUnproven:
-        return None
-
-
-_IMPORT_ALIASES = {
-    "np": "numpy",
-    "pd": "pandas",
-}
-
-
-def _resolve_callable_from_dotted(dotted: str) -> object | None:
-    if not dotted:
-        return None
-    parts = dotted.split(".")
-    if len(parts) == 1:
-        return None  # bare name needs local scope — unproven
-    candidates = [dotted]
-    if parts[0] in _IMPORT_ALIASES:
-        candidates.append(".".join([_IMPORT_ALIASES[parts[0]], *parts[1:]]))
-    for candidate in candidates:
-        cparts = candidate.split(".")
-        for split in range(len(cparts) - 1, 0, -1):
-            mod_name = ".".join(cparts[:split])
-            rest = cparts[split:]
-            try:
-                mod = importlib.import_module(mod_name)
-            except Exception:
+    # 2. from X import name / from X import Y as name / star-import follow
+    for node in _module_level_nodes(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        for alias in node.names:
+            if alias.name == "*":
+                target = _resolve_relative(
+                    module_name, filename, node.level, node.module
+                )
+                if target is None:
+                    continue
+                hit = _lookup_name_in_module(target, name, depth=depth + 1)
+                if hit is not None:
+                    return hit
                 continue
-            obj: object = mod
-            try:
-                for attr in rest:
-                    obj = getattr(obj, attr)
-                return obj
-            except Exception:
+            bound = alias.asname or alias.name
+            if bound != name:
                 continue
+            target = _resolve_relative(
+                module_name, filename, node.level, node.module
+            )
+            if target is None:
+                return None
+            return _lookup_name_in_module(target, alias.name, depth=depth + 1)
+
+    # 3. Simple alias: name = OtherName (same module)
+    for node in _module_level_nodes(tree):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            t = node.targets[0]
+            if isinstance(t, ast.Name) and t.id == name and isinstance(node.value, ast.Name):
+                return _lookup_name_in_module(
+                    module_name, node.value.id, depth=depth + 1
+                )
+
     return None
 
 
-def _dotted_of_sugar_node(node) -> str | None:
+def _local_import_bindings(source: str) -> dict[str, tuple[str, str]]:
+    """Map local bound name → (kind, payload).
+
+    kind ``module``: payload is absolute module name (``import numpy as np``).
+    kind ``from``: payload is ``module.name`` to look up
+    (``from pandas import option_context``).
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return {}
+    out: dict[str, tuple[str, str]] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.asname:
+                    # import numpy as np → np denotes module numpy
+                    out[alias.asname] = ("module", alias.name)
+                else:
+                    # import a.b.c binds only top-level name `a`
+                    top = alias.name.split(".")[0]
+                    out[top] = ("module", top)
+        if isinstance(node, ast.ImportFrom) and node.module is not None and node.level == 0:
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                bound = alias.asname or alias.name
+                out[bound] = ("from", f"{node.module}.{alias.name}")
+    return out
+
+
+def _dotted_of_sugar_node(node) -> list[str] | None:
+    """Attribute/Name chain as component list, or None if not pure."""
     from sugar_source_tree.nodes import Attribute, Name
 
     if isinstance(node, Name):
-        return node.id
+        return [node.id]
     if isinstance(node, Attribute):
         base = _dotted_of_sugar_node(node.value)
         if base is None:
             return None
-        return f"{base}.{node.attr}"
+        return [*base, node.attr]
     return None
 
 
-def _resolve_from_unit_imports(unit, name: str) -> object | None:
-    """Resolve a bare name via the source file's top-level imports only."""
+def resolve_definition_memento_from_manager_expr(
+    manager_node,
+) -> DefinitionMemento | None:
+    """Static import binding → SourceOracle modules → class ``__exit__`` memento.
+
+    No package execution. No vendor alias table.
+    """
+    from sugar_source_tree.nodes import Call, Name
+
+    if not isinstance(manager_node, Call):
+        return None
+    unit = manager_node.unit
     source = getattr(unit, "source", None)
-    if not source or not name:
+    if not source:
         return None
-    try:
-        tree = ast.parse(source)
-    except SyntaxError:
+    bindings = _local_import_bindings(source)
+    parts = _dotted_of_sugar_node(manager_node.func)
+    if not parts:
         return None
-    for node in tree.body:
-        if isinstance(node, ast.ImportFrom) and node.module:
-            for alias in node.names:
-                bound = alias.asname or alias.name
-                if bound == name:
-                    if alias.name == "*":
-                        return None
-                    return _resolve_callable_from_dotted(f"{node.module}.{alias.name}")
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                bound = alias.asname or alias.name
-                if bound == name:
-                    try:
-                        return importlib.import_module(alias.name)
-                    except Exception:
-                        return None
+
+    head, *rest = parts
+    if head not in bindings:
+        return None
+    kind, payload = bindings[head]
+    if payload is None:
+        return None
+
+    if kind == "module":
+        # head is a module binding; rest are attributes into that package.
+        if not rest:
+            return None  # calling a module is not a class CM
+        module_name = payload
+        # Walk attributes: each step is either a submodule or a name in module
+        for i, attr in enumerate(rest):
+            is_last = i == len(rest) - 1
+            if is_last:
+                return _lookup_name_in_module(module_name, attr)
+            # Non-final: treat as submodule package path
+            module_name = f"{module_name}.{attr}"
+        return None
+
+    if kind == "from":
+        # from mod import name [as head]; rest must be empty for Class() form
+        if rest:
+            # from mod import pkg; pkg.Class — rare; treat payload module.attr
+            # payload is mod.name; if rest, unproven unless name is submodule
+            return None
+        # payload "pandas.option_context" or "numpy.errstate" style
+        if "." not in payload:
+            return None
+        mod, _, name = payload.rpartition(".")
+        return _lookup_name_in_module(mod, name)
+
     return None
 
 
 def prove_exit_disposition_from_manager_expr(
     manager_node,
 ) -> ExitDispositionProof | None:
-    """Prove NeverSuppresses from a sugar-tree manager expression, or None.
-
-    Handles ``Class(...)`` calls where ``Class`` resolves to a type with a
-    source-visible defining ``__exit__``. Bare names resolve only through
-    authenticated top-level imports in the same file (not ambient globals).
-    Functions/generators and ambiguous dispatch → None (RuntimeSelected).
-    """
-    from sugar_source_tree.nodes import Call, Name
-
-    if not isinstance(manager_node, Call):
+    """Static resolve + return proof. None → RuntimeSelected."""
+    memento = resolve_definition_memento_from_manager_expr(manager_node)
+    if memento is None:
         return None
-    func = manager_node.func
-    obj = None
-    if isinstance(func, Name):
-        obj = _resolve_from_unit_imports(manager_node.unit, func.id)
-    else:
-        dotted = _dotted_of_sugar_node(func)
-        if dotted is not None:
-            obj = _resolve_callable_from_dotted(dotted)
-    if obj is None or not isinstance(obj, type):
+    try:
+        return prove_from_definition_memento(memento)
+    except ExitDispositionUnproven:
         return None
-    return prove_never_suppresses_for_class(obj)
+
+
+# ---------------------------------------------------------------------------
+# Executable floor: no reflection authority in this module's resolve path
+# ---------------------------------------------------------------------------
+
+_FORBIDDEN_RESOLVE_TOKENS = (
+    "importlib",
+    "inspect.getsource",
+    "inspect.getfile",
+    "inspect.getmodule",
+    "inspect.getattr_static",
+    "__mro__",
+    "_IMPORT_ALIASES",
+    "prove_never_suppresses_for_class",
+    "import_module",
+)
+
+
+def assert_no_runtime_resolve_authority() -> None:
+    """Floor: manager→definition path must not use runtime reflection tokens."""
+    import inspect as _inspect
+
+    # Only the resolve/lookup source is constrained (not this assert helper).
+    src = _inspect.getsource(resolve_definition_memento_from_manager_expr)
+    src += _inspect.getsource(_lookup_name_in_module)
+    src += _inspect.getsource(_local_import_bindings)
+    src += _inspect.getsource(prove_exit_disposition_from_manager_expr)
+    src += _inspect.getsource(_oracle_module)
+    src += _inspect.getsource(_parse_module)
+    for token in _FORBIDDEN_RESOLVE_TOKENS:
+        if token in src:
+            raise AssertionError(
+                f"exit disposition resolve path must not contain {token!r}"
+            )

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_proof.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_proof.py
@@ -1,7 +1,7 @@
-"""ExitDispositionProof: exact None/False completed returns (incl. fallthrough).
+"""ExitDispositionProof: exact None/False returns + static resolve floor.
 
-Lying twins: True, symbolic, mixed branch, swallowed-but-true, ambiguous
-dispatch, overriding subclass. Truthful: restore-only / implicit None.
+Return theorem and lying twins stay. Manager→definition uses static imports
+and SourceOracle module text only — no importlib/getattr/MRO/inspect.
 """
 
 from __future__ import annotations
@@ -14,20 +14,21 @@ import pytest
 from sugar_lift_py_tests.exit_disposition_proof import (
     ExitDispositionProof,
     ExitDispositionUnproven,
+    assert_no_runtime_resolve_authority,
+    prove_exit_disposition_from_manager_expr,
     prove_exit_function_ast,
-    prove_never_suppresses_for_class,
+    resolve_definition_memento_from_manager_expr,
 )
 
 
 def _exit_fn(src: str) -> ast.FunctionDef:
     mod = ast.parse(textwrap.dedent(src))
     cls = next(n for n in mod.body if isinstance(n, ast.ClassDef))
-    fn = next(
+    return next(
         n
         for n in cls.body
         if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name == "__exit__"
     )
-    return fn
 
 
 def _prove_src(src: str) -> ExitDispositionProof:
@@ -42,18 +43,17 @@ def _prove_src(src: str) -> ExitDispositionProof:
 
 
 def test_truthful_implicit_none_fallthrough():
-    proof = _prove_src(
+    assert _prove_src(
         """
         class M:
             def __exit__(self, *a):
                 self.cleanup()
         """
-    )
-    assert proof.kind == "never_suppresses"
+    ).kind == "never_suppresses"
 
 
 def test_truthful_explicit_none_and_false():
-    proof = _prove_src(
+    assert _prove_src(
         """
         class M:
             def __exit__(self, *a):
@@ -61,21 +61,18 @@ def test_truthful_explicit_none_and_false():
                     return None
                 return False
         """
-    )
-    assert proof.kind == "never_suppresses"
+    ).kind == "never_suppresses"
 
 
 def test_truthful_raise_inside_exit_is_halt_not_suppress():
-    """Exit halt is intact; raise does not invent suppression."""
-    proof = _prove_src(
+    assert _prove_src(
         """
         class M:
             def __exit__(self, *a):
                 if a[0] is not None:
                     raise RuntimeError("exit failed")
         """
-    )
-    assert proof.kind == "never_suppresses"
+    ).kind == "never_suppresses"
 
 
 def test_lying_return_true():
@@ -114,7 +111,6 @@ def test_lying_mixed_branch():
 
 
 def test_lying_swallowed_exception_then_return_true():
-    """Except that swallows is fine only if completed returns stay None/False."""
     with pytest.raises(ExitDispositionUnproven, match="not exact None/False"):
         _prove_src(
             """
@@ -129,7 +125,7 @@ def test_lying_swallowed_exception_then_return_true():
 
 
 def test_truthful_swallowed_exception_then_none():
-    proof = _prove_src(
+    assert _prove_src(
         """
         class M:
             def __exit__(self, *a):
@@ -138,8 +134,7 @@ def test_truthful_swallowed_exception_then_none():
                 except Exception:
                     pass
         """
-    )
-    assert proof.kind == "never_suppresses"
+    ).kind == "never_suppresses"
 
 
 def test_lying_ambiguous_dispatch_return_call():
@@ -153,74 +148,81 @@ def test_lying_ambiguous_dispatch_return_call():
         )
 
 
-def test_overriding_subclass_uses_defining_class_exit():
-    """Subclass without override inherits base proof; with override is own source."""
+def test_no_runtime_resolve_authority_floor():
+    assert_no_runtime_resolve_authority()
 
-    class Base:
-        def __enter__(self):
-            return self
 
-        def __exit__(self, *a):
-            return None
+def test_static_resolve_np_errstate_via_source_imports():
+    """Local ``import numpy as np`` + static re-export follow — not importlib."""
+    import tempfile
 
-    class GoodChild(Base):
-        pass
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.tree import SourceFile
 
-    class BadChild(Base):
-        def __exit__(self, *a):
-            return True
-
-    # Base-defined exit is never-suppress (if source is available). These live
-    # in this test module — SourceOracle installed_module_source may not pin
-    # test modules. prove_never_suppresses_for_class needs on-disk module source.
-    # Unit proof on AST for BadChild-style body:
-    with pytest.raises(ExitDispositionUnproven):
-        _prove_src(
-            """
-            class BadChild:
-                def __exit__(self, *a):
-                    return True
-            """
-        )
-    proof = _prove_src(
-        """
-        class GoodChild:
-            def __exit__(self, *a):
-                return None
-        """
+    src = (
+        "import numpy as np\n"
+        "def A(z):\n"
+        "    with np.errstate(all='ignore'):\n"
+        "        z = z\n"
+        "    return z\n"
     )
-    assert proof.kind == "never_suppresses"
-
-
-def test_numpy_errstate_source_proof():
-    """Installed numpy.errstate: SourceOracle + exact None fallthrough."""
-    import numpy as np
-
-    proof = prove_never_suppresses_for_class(np.errstate)
-    assert proof is not None
-    assert proof.kind == "never_suppresses"
-    assert proof.class_name == "errstate"
-    assert proof.method_name == "__exit__"
-    assert proof.source_cid
-
-
-def test_pandas_option_context_source_proof():
-    from pandas import option_context
-
-    proof = prove_never_suppresses_for_class(option_context)
-    assert proof is not None
-    assert proof.kind == "never_suppresses"
-    assert proof.class_name == "option_context"
-
-
-def test_switchdir_is_not_class_exit_proof():
-    """Generator CM is a separate proof — class path must not invent NeverSuppresses."""
-    # switchdir is a function, not a type
-    import importlib.util
-    from pathlib import Path
-
-    util_path = Path(
-        "/Users/tsavo/provekit/.venv/lib/python3.14/site-packages/numpy/f2py/tests/util.py"
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    fn = next(SourceFile(path_source(path)).functions())
+    with_node = next(s for s in fn.body if s.kind == "With")
+    mgr = with_node.items[0].context_expr
+    memento = resolve_definition_memento_from_manager_expr(mgr)
+    assert memento is not None, "static resolve must find errstate without importlib"
+    assert memento.class_name == "errstate"
+    assert "ufunc_config" in memento.filename or memento.module.endswith(
+        "_ufunc_config"
     )
-    # Do not import util (side-effect meson). Just assert function form unproven.
-    assert prove_never_suppresses_for_class(type("X", (), {})) is None
+    proof = prove_exit_disposition_from_manager_expr(mgr)
+    assert proof is not None and proof.kind == "never_suppresses"
+
+
+def test_generator_contextmanager_is_deferred_not_falsely_proven():
+    # option_context is `@contextmanager def option_context(...)` -- a GENERATOR
+    # context manager, not a class with __exit__. This cut proves class __exit__
+    # only (see module docstring: generator @contextmanager is a SEPARATE proof).
+    # The static resolver reaches the def but finds no class __exit__, so it
+    # DEFERS (no memento, no proof) -> the caller keeps RuntimeSelected. The
+    # point of the assertion: the cut must NOT falsely prove a generator CM
+    # never-suppresses just because its post-yield cleanup happens to look inert.
+    import tempfile
+
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.tree import SourceFile
+
+    src = (
+        "from pandas import option_context\n"
+        "def A(z):\n"
+        "    with option_context('display.max_rows', 10):\n"
+        "        z = z\n"
+        "    return z\n"
+    )
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    fn = next(SourceFile(path_source(path)).functions())
+    with_node = next(s for s in fn.body if s.kind == "With")
+    mgr = with_node.items[0].context_expr
+    # generator CM -> class __exit__ analysis is N/A -> deferred, not proven.
+    assert resolve_definition_memento_from_manager_expr(mgr) is None
+    assert prove_exit_disposition_from_manager_expr(mgr) is None
+
+
+def test_open_still_unproven_statically():
+    import tempfile
+
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.tree import SourceFile
+
+    src = "def A(f):\n    with open(f):\n        pass\n    return f\n"
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    fn = next(SourceFile(path_source(path)).functions())
+    with_node = next(s for s in fn.body if s.kind == "With")
+    assert prove_exit_disposition_from_manager_expr(with_node.items[0].context_expr) is None

--- a/implementations/python/sugar-source-tree/tests/test_with_resource_disposition.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_resource_disposition.py
@@ -37,6 +37,14 @@ def test_errstate_routes_to_with_resource_sugar():
     assert isinstance(with_s.disposition, NeverSuppresses)
 
 
+@pytest.mark.xfail(
+    reason="option_context is a generator @contextmanager, not a class __exit__. "
+    "This cut proves class __exit__ only (static, no importlib/execution). The "
+    "generator never-suppresses proof is a separate, soundness-sensitive cut: "
+    "proving it wrong would unsoundly dissolve a suppressing manager. Deferred "
+    "to the generator-@contextmanager proof; routed to the architect.",
+    strict=True,
+)
 def test_option_context_routes_to_with_resource_sugar():
     sugar = _fn(
         "from pandas import option_context\n"


### PR DESCRIPTION
Recovers and finishes the static-resolution work on `ExitDispositionProof`.

## What changed
- The manager → `__exit__` definition path is now **static**: source import binding (local AST) → re-export follow via SourceOracle → definition memento → return-exactness proof. No recognition through execution.
- `importlib.import_module`, `getattr` on live objects, MRO walks, `inspect.getsource`, and vendor alias tables are **forbidden**, enforced by a self-policing guard that reads the resolution functions' own source and fails if any forbidden token appears.
- `np.errstate` (a class CM) proves the class path end to end.

## Generator @contextmanager — deferred honestly, not falsely proven
- The kit test asserts a generator CM (`option_context`) resolves to `None` (deferred) — the cut never claims a generator never-suppresses.
- The tree goal-test (`option_context` → `WithResourceSugar`/`NeverSuppresses`) is `xfail(strict)`: the generator never-suppresses proof is a separate, **soundness-sensitive** cut (proving it wrong would unsoundly dissolve a *suppressing* manager). Routed to the architect.

## Architect note
The architect's review flags this proof's approach (standalone AST analyzer) as duplicate control-flow semantics — it should eventually fold into constructed ExitSet/roll-call facts, never broaden by heuristic return scanning. This PR is the conservative, provenance-pinned static increment; that refactor is a separate cut.

Suites: `test_exit_disposition_proof` 13 passed; `sugar-source-tree` 276 passed, 5 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace runtime import/MRO resolution with static SourceOracle-based `__exit__` proof in `exit_disposition_proof`
> - Rewrites `prove_exit_disposition_from_manager_expr` to resolve class `__exit__` purely from source text via `SourceOracle`, eliminating all `importlib`, `getattr`, and MRO-walk code paths.
> - Introduces `resolve_definition_memento_from_manager_expr` and `_lookup_name_in_module` to statically follow import bindings across modules without executing any imports.
> - Adds `DefinitionMemento`, a frozen dataclass carrying authenticated class coordinates (module, class name, source CID, filename, and `__exit__` AST node) used as proof input.
> - Removes `prove_never_suppresses_for_class` and `_resolve_from_unit_imports`; callers that relied on reflection-based proving now receive `None` (deferred) instead.
> - Generator `@contextmanager` cases are explicitly deferred; the `test_option_context_routes_to_with_resource_sugar` test is marked `xfail` until generator proof is implemented.
> - Adds `assert_no_runtime_resolve_authority` floor guard to fail the suite if forbidden reflection tokens appear in the resolve path.
> - Behavioral Change: any manager expression previously proven via runtime import/MRO (e.g. `pandas.option_context`) now returns `None` until static or generator proof is added.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bfcef3f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->