### PR TITLE
drain: Lambda expression-bodied callable arm (pandas R)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/lambda_callable.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/lambda_callable.py
@@ -11,10 +11,9 @@ from .term_value import TermValue
 class LambdaCallable(FloorValue):
     """In-source lambda floor: parameters + body SugarBody for dig/apply.
 
-    ``to_term`` is a *callable identity* coordinate
-    ``python:lambda(<param>, ..., <body>)``. The source tree has already masked
-    formals and substituted authenticated lexical captures before constructing
-    the body sugar, so its term is a faithful callable body, not reconstruction.
+    ``to_term`` is an opaque callable identity coordinate containing parameter
+    names only.  ``python:lambda`` is an ordinary ctor in ProofIR, not a binder;
+    placing the body beneath it would leak formal variables into global scope.
     """
 
     parameters: tuple[str, ...]
@@ -39,9 +38,6 @@ class LambdaCallable(FloorValue):
         del owner
         from sugar_lift_py_tests.ir import ctor, str_const
 
-        from sugar_lift_py_tests.outcome import complete_value
-
-        body_value = complete_value(self.body.desugar(), owner="LambdaCallable")
         default_offset = len(self.parameters) - len(self.default_values)
         encoded_parameters = []
         for index, parameter in enumerate(self.parameters):
@@ -78,17 +74,10 @@ class LambdaCallable(FloorValue):
                 )
         if self.kwarg_parameter is not None:
             encoded_parameters.append(str_const(f"**{self.kwarg_parameter}"))
-        return ctor(
-            "python:lambda",
-            [
-                *encoded_parameters,
-                body_value.to_term(owner="LambdaCallable.body"),
-            ],
-        )
+        return ctor("python:lambda", encoded_parameters)
 
     def apply(self, value: TermValue, ctx):
         from sugar_lift_py_tests.outcome import Incomplete, complete_value
-        from sugar_lift_py_tests.temporal import bind_temporal
 
         if (
             len(self.parameters) != 1
@@ -102,17 +91,17 @@ class LambdaCallable(FloorValue):
                 f"vararg={self.vararg_parameter!r}, "
                 f"kwarg={self.kwarg_parameter!r}"
             )
-        next_ctx = bind_temporal(
-            ctx,
-            self.parameters[0],
-            value,
-            owner="LambdaCallable",
-            blame="<lambda>",
-        )
-        outcome = self.body.desugar(next_ctx)
+        outcome = self.body.desugar(ctx)
         if isinstance(outcome, Incomplete):
             return outcome
         result = complete_value(outcome, owner="LambdaCallable")
-        if not isinstance(result, TermValue):
-            raise TypeError("LambdaCallable body must reduce to TermValue")
-        return result
+        from sugar_lift_py_tests.floor import SymbolicValue
+        from sugar_lift_py_tests.ir import subst_var_in_term
+
+        return SymbolicValue(
+            subst_var_in_term(
+                result.to_term(owner="LambdaCallable.body"),
+                self.parameters[0],
+                value.to_term(owner="LambdaCallable.argument"),
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/lambda_callable.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/lambda_callable.py
@@ -18,6 +18,7 @@ class LambdaCallable(FloorValue):
 
     parameters: tuple[str, ...]
     body: Any
+    construction_identity: str
     default_values: tuple[Any, ...] = ()
     keyword_only_parameters: tuple[str, ...] = ()
     keyword_only_default_values: tuple[Any | None, ...] = ()
@@ -74,7 +75,10 @@ class LambdaCallable(FloorValue):
                 )
         if self.kwarg_parameter is not None:
             encoded_parameters.append(str_const(f"**{self.kwarg_parameter}"))
-        return ctor("python:lambda", encoded_parameters)
+        return ctor(
+            "python:lambda",
+            [str_const(self.construction_identity), *encoded_parameters],
+        )
 
     def apply(self, value: TermValue, ctx):
         from sugar_lift_py_tests.outcome import Incomplete, complete_value

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/lambda_callable.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/lambda_callable.py
@@ -12,11 +12,9 @@ class LambdaCallable(FloorValue):
     """In-source lambda floor: parameters + body SugarBody for dig/apply.
 
     ``to_term`` is a *callable identity* coordinate
-    ``python:lambda(<param>, ...)`` -- parameter names only. Body FOL under a
-    free-var binding needs a reduction context ``to_term`` does not receive;
-    fabricating a body term from a synthetic empty ctx would lie about free-
-    variable capture. Apply remains the path that lowers the body under a
-    real binding. Never invent a computed value.
+    ``python:lambda(<param>, ..., <body>)``. The source tree has already masked
+    formals and substituted authenticated lexical captures before constructing
+    the body sugar, so its term is a faithful callable body, not reconstruction.
     """
 
     parameters: tuple[str, ...]
@@ -41,9 +39,9 @@ class LambdaCallable(FloorValue):
         del owner
         from sugar_lift_py_tests.ir import ctor, str_const
 
-        # Source IR uses python:lambda(params…). Factory projection of a
-        # first-class callable value without a reduction ctx carries identity
-        # only (parameter names) -- honest opaque coordinate, not body FOL.
+        from sugar_lift_py_tests.outcome import complete_value
+
+        body_value = complete_value(self.body.desugar(), owner="LambdaCallable")
         default_offset = len(self.parameters) - len(self.default_values)
         encoded_parameters = []
         for index, parameter in enumerate(self.parameters):
@@ -80,7 +78,13 @@ class LambdaCallable(FloorValue):
                 )
         if self.kwarg_parameter is not None:
             encoded_parameters.append(str_const(f"**{self.kwarg_parameter}"))
-        return ctor("python:lambda", encoded_parameters)
+        return ctor(
+            "python:lambda",
+            [
+                *encoded_parameters,
+                body_value.to_term(owner="LambdaCallable.body"),
+            ],
+        )
 
     def apply(self, value: TermValue, ctx):
         from sugar_lift_py_tests.outcome import Incomplete, complete_value
@@ -105,7 +109,7 @@ class LambdaCallable(FloorValue):
             owner="LambdaCallable",
             blame="<lambda>",
         )
-        outcome = self.body.reduce(next_ctx)
+        outcome = self.body.desugar(next_ctx)
         if isinstance(outcome, Incomplete):
             return outcome
         result = complete_value(outcome, owner="LambdaCallable")

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/lambda_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/lambda_sugar.py
@@ -31,4 +31,14 @@ class LambdaSugar(Sugar):
         del ctx
         from sugar_lift_py_tests.floor import LambdaCallable
 
-        return Complete(LambdaCallable(parameters=self.formals, body=self.body))
+        sealed = self.site.seal()
+        construction_identity = (
+            f"{sealed.source_cid}@{sealed.start}:{sealed.end}#{sealed.cid}"
+        )
+        return Complete(
+            LambdaCallable(
+                parameters=self.formals,
+                body=self.body,
+                construction_identity=construction_identity,
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/lambda_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/lambda_sugar.py
@@ -1,0 +1,34 @@
+"""A narrow expression-bodied lambda callable."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_pair
+
+
+@dataclass(frozen=True)
+class LambdaSugar(Sugar):
+    """Plain positional formals plus one already-constructed body expression."""
+
+    formals: tuple[str, ...]
+    body: Sugar
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        prefix = "def A(v):\n    return (lambda x: x)(v)\n\n"
+        return _call_pair(
+            name="lambda_identity_call",
+            owner_sugar="LambdaSugar",
+            truthful=prefix + "def test_a():\n    assert A(5) == 5\n",
+            lying=prefix + "def test_a():\n    assert A(5) == 6\n",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        from sugar_lift_py_tests.floor import LambdaCallable
+
+        return Complete(LambdaCallable(parameters=self.formals, body=self.body))

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2575,19 +2575,18 @@ class Lambda(Expression):
     _child_fields = ("params", "body")
 
     def substitute(self, scope):
-        """lambda <params>: masks its parameters for the body expression."""
+        """Mask formals and mark the result as substitution-authenticated."""
         from .shadow import rewrite
 
         bound = {p.name for p in self.params}
         bs = {k: v for k, v in scope.items() if k not in bound} if bound else scope
-        changed = {}
         new_params, d = self._substitute_field(self.params, scope)
-        if d:
-            changed["params"] = new_params
+        del d
         new_body, d = self._substitute_field(self.body, bs)
-        if d:
-            changed["body"] = new_body
-        return self if not changed else rewrite(self, **changed)
+        del d
+        # Always rewrite, even when the children are identical.  A ShadowNode
+        # is the construction-time testimony that capture substitution ran.
+        return rewrite(self, params=new_params, body=new_body)
 
     def _construct_sugar(self):
         """Construct only plain positional-or-keyword expression lambdas.
@@ -2595,7 +2594,9 @@ class Lambda(Expression):
         Every other binding role remains loud.  The body constructs through its
         own node so an unsupported child preserves that child's exact panic.
         """
-        if len(self.params) != 1 or any(
+        from .shadow import ShadowNode
+
+        if not isinstance(self.ref, ShadowNode) or len(self.params) != 1 or any(
             param.param_kind != "positional_or_keyword"
             or param.default is not None
             or param.annotation is not None

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2589,6 +2589,28 @@ class Lambda(Expression):
             changed["body"] = new_body
         return self if not changed else rewrite(self, **changed)
 
+    def _construct_sugar(self):
+        """Construct only plain positional-or-keyword expression lambdas.
+
+        Every other binding role remains loud.  The body constructs through its
+        own node so an unsupported child preserves that child's exact panic.
+        """
+        if len(self.params) != 1 or any(
+            param.param_kind != "positional_or_keyword"
+            or param.default is not None
+            or param.annotation is not None
+            for param in self.params
+        ):
+            return super()._construct_sugar()
+
+        from sugar_lift_py_tests.sugar.lambda_sugar import LambdaSugar
+
+        return LambdaSugar(
+            formals=tuple(param.name for param in self.params),
+            body=self.body.sugar(),
+            site=self.fragment,
+        )
+
 
 class IfExp(Expression):
     test: Expression

--- a/implementations/python/sugar-source-tree/tests/test_computed_call.py
+++ b/implementations/python/sugar-source-tree/tests/test_computed_call.py
@@ -8,10 +8,7 @@ that gap."""
 
 import tempfile
 
-import pytest
-
 from sugar_lift_python_source.source_oracle import path_source
-from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
 
@@ -54,14 +51,18 @@ def test_discrimination_differs_by_callee_operand():
     assert t0 != t1
 
 
-def test_lambda_callee_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A(x):\n    return (lambda z: z)(x)\n").sugar()
+def test_lambda_callee_uses_the_computed_call_path():
+    sugar = _fn("def A(x):\n    return (lambda z: z)(x)\n").sugar()
+    call = sugar.statements[0].value
+
+    assert type(call).__name__ == "ComputedCallSugar"
+    assert type(call.callee).__name__ == "LambdaSugar"
+    assert call.callee.formals == ("z",)
 
 
 if __name__ == "__main__":
     test_computed_call_is_the_py_call_coordinate()
     test_assert_consumes_the_coordinate()
     test_discrimination_differs_by_callee_operand()
-    test_lambda_callee_stays_loud()
-    print("ok: computed callee calls -- coordinate, assert, discrimination, lambda loud")
+    test_lambda_callee_uses_the_computed_call_path()
+    print("ok: computed callee calls -- coordinate, assert, discrimination, lambda")

--- a/implementations/python/sugar-source-tree/tests/test_lambda_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_lambda_sugar.py
@@ -2,6 +2,9 @@
 
 import pytest
 
+from sugar_lift_py_tests.floor import SymbolicValue, TermValue
+from sugar_lift_py_tests.ir import ctor, num, str_const
+from sugar_lift_py_tests.proofir.formulas import _free_vars_in_ir_term
 from sugar_source_tree.panic import SugarNotWritten
 
 from conftest import oracle_source_file
@@ -97,3 +100,36 @@ def test_inline_lambda_call_constructs_callable_then_ordinary_computed_call():
     assert type(sugar.callee).__name__ == "LambdaSugar"
     assert sugar.callee.formals == ("x",)
     assert sugar.args[0].name == "v"
+
+
+def test_lambda_coordinate_is_opaque_and_does_not_leak_nested_same_named_formals():
+    expression = _return_expression(
+        "def A(x):\n    return lambda x: lambda x: x\n"
+    )
+    outer = expression.sugar().desugar().value
+
+    assert outer.to_term(owner="test") == ctor("python:lambda", [str_const("x")])
+    assert _free_vars_in_ir_term(outer.to_term(owner="test")) == frozenset()
+    assert outer.body.formals == ("x",)
+    assert outer.body.body.name == "x"
+
+
+def test_parser_backed_lambda_with_unresolved_capture_stays_loud():
+    function = _function(
+        "def A():\n    z = 7\n    f = lambda x: x + z\n    return f\n"
+    )
+    parser_backed_lambda = function.body[1].value
+
+    with pytest.raises(SugarNotWritten, match="Lambda.sugar"):
+        parser_backed_lambda.sugar()
+
+
+def test_lambda_application_substitutes_the_formal_in_the_body_term():
+    callable_value = _return_expression(
+        "def A():\n    return lambda x: x + 1\n"
+    ).sugar().desugar().value
+
+    applied = callable_value.apply(TermValue(7), None)
+
+    assert isinstance(applied, SymbolicValue)
+    assert applied.term == ctor("+", [num(7), num(1)])

--- a/implementations/python/sugar-source-tree/tests/test_lambda_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_lambda_sugar.py
@@ -34,6 +34,15 @@ def test_lambda_identity_truthful_and_lying_terms_discriminate():
     assert lying != truthful
 
 
+def test_lambda_body_changes_content_addressed_callable_identity():
+    identity = _post_term("def A(v):\n    return (lambda x: x)(v)\n")
+    increment = _post_term("def A(v):\n    return (lambda x: x + 1)(v)\n")
+
+    assert identity.name == increment.name == "py.call"
+    assert identity.args[1] == increment.args[1]
+    assert identity.args[0] != increment.args[0]
+
+
 def test_lambda_parameter_masks_same_spelled_outer_binding():
     expression = _return_expression(
         "def A():\n    x = 7\n    return lambda x: x\n"
@@ -64,6 +73,18 @@ def test_lambda_rebinding_changes_constructed_capture():
     ).sugar()
 
     assert first.body != second.body
+
+
+def test_nested_lambda_capture_rebinding_changes_opaque_coordinate():
+    first = _return_expression(
+        "def A():\n    z = 7\n    return lambda x: lambda x: x + z\n"
+    ).sugar().desugar().value
+    second = _return_expression(
+        "def A():\n    z = 8\n    return lambda x: lambda x: x + z\n"
+    ).sugar().desugar().value
+
+    assert first.parameters == second.parameters == ("x",)
+    assert first.to_term(owner="test") != second.to_term(owner="test")
 
 
 @pytest.mark.parametrize(
@@ -108,8 +129,10 @@ def test_lambda_coordinate_is_opaque_and_does_not_leak_nested_same_named_formals
     )
     outer = expression.sugar().desugar().value
 
-    assert outer.to_term(owner="test") == ctor("python:lambda", [str_const("x")])
-    assert _free_vars_in_ir_term(outer.to_term(owner="test")) == frozenset()
+    coordinate = outer.to_term(owner="test")
+    assert coordinate.name == "python:lambda"
+    assert coordinate.args[1] == str_const("x")
+    assert _free_vars_in_ir_term(coordinate) == frozenset()
     assert outer.body.formals == ("x",)
     assert outer.body.body.name == "x"
 

--- a/implementations/python/sugar-source-tree/tests/test_lambda_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_lambda_sugar.py
@@ -1,0 +1,99 @@
+"""Expression-bodied lambdas construct callables; calls never inline them."""
+
+import pytest
+
+from sugar_source_tree.panic import SugarNotWritten
+
+from conftest import oracle_source_file
+
+
+def _function(source: str):
+    return next(oracle_source_file(source).functions())
+
+
+def _return_expression(source: str):
+    function = _function(source)
+    substituted = function.substitute({})
+    return substituted.body[-1].value
+
+
+def _post_term(source: str):
+    return _function(source).sugar().desugar().value.post().args[1]
+
+
+def test_lambda_identity_truthful_and_lying_terms_discriminate():
+    truthful = _post_term("def A(v):\n    return (lambda x: x)(v)\n")
+    lying = _post_term("def A(v):\n    return (lambda x: x)(v + 1)\n")
+
+    assert truthful.name == "py.call"
+    assert truthful.args[0].name == "python:lambda"
+    assert truthful.args[1].name == "v"
+    assert lying != truthful
+
+
+def test_lambda_parameter_masks_same_spelled_outer_binding():
+    expression = _return_expression(
+        "def A():\n    x = 7\n    return lambda x: x\n"
+    )
+    sugar = expression.sugar()
+
+    assert sugar.formals == ("x",)
+    assert sugar.body.name == "x"
+
+
+def test_lambda_captures_authenticated_outer_binding_while_masking_parameter():
+    expression = _return_expression(
+        "def A():\n    z = 7\n    return lambda x: x + z\n"
+    )
+    sugar = expression.sugar()
+
+    assert sugar.formals == ("x",)
+    assert sugar.body.left.name == "x"
+    assert sugar.body.right.value == 7
+
+
+def test_lambda_rebinding_changes_constructed_capture():
+    first = _return_expression(
+        "def A():\n    z = 7\n    return lambda x: x + z\n"
+    ).sugar()
+    second = _return_expression(
+        "def A():\n    z = 8\n    return lambda x: x + z\n"
+    ).sugar()
+
+    assert first.body != second.body
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "def A():\n    return lambda *args: args\n",
+        "def A():\n    return lambda **kwargs: kwargs\n",
+        "def A():\n    return lambda *, x: x\n",
+        "def A():\n    return lambda x=1: x\n",
+        "def A():\n    return lambda x, /: x\n",
+        "def A():\n    return lambda: 1\n",
+        "def A():\n    return lambda x, y: x\n",
+    ],
+)
+def test_unsupported_lambda_parameter_roles_stay_sugar_not_written(source):
+    with pytest.raises(SugarNotWritten, match="Lambda.sugar"):
+        _return_expression(source).sugar()
+
+
+def test_lambda_preserves_child_panic_role():
+    expression = _return_expression("def A():\n    return lambda x: (yield x)\n")
+
+    with pytest.raises(SugarNotWritten) as caught:
+        expression.sugar()
+
+    assert caught.value.owner == "Yield.sugar"
+
+
+def test_inline_lambda_call_constructs_callable_then_ordinary_computed_call():
+    call = _return_expression("def A(v):\n    return (lambda x: x)(v)\n")
+    sugar = call.sugar()
+
+    assert type(sugar).__name__ == "ComputedCallSugar"
+    assert type(sugar.callee).__name__ == "LambdaSugar"
+    assert sugar.callee.formals == ("x",)
+    assert sugar.args[0].name == "v"

--- a/implementations/python/sugar-source-tree/tests/test_substitute_int_literal.py
+++ b/implementations/python/sugar-source-tree/tests/test_substitute_int_literal.py
@@ -102,7 +102,10 @@ def test_binders_mask_their_bound_names():
     assert forfn.substitute({"x": _bind_target()}) is forfn
     # lambda z: z + 1 -- the parameter z is masked for the body.
     lam = next(n for n in _tree("g = lambda z: z + z\n").root.walk() if n.kind == "Lambda")
-    assert lam.substitute({"z": _bind_target()}) is lam
+    substituted_lambda = lam.substitute({"z": _bind_target()})
+    assert substituted_lambda is not lam  # shadow proves substitution ran
+    assert substituted_lambda.body.left.id == "z"
+    assert substituted_lambda.body.right.id == "z"
     # [i for i in xs] -- the comprehension loop var i is masked (no capture);
     # a free var in the element substitutes.
     c1 = next(n for n in _tree("a = [i for i in xs]\n").root.walk() if n.kind == "ListComp")


### PR DESCRIPTION
## What changed

- construct the exact one-plain-formal expression-bodied Lambda partition
- mask the formal while substituting authenticated outer lexical captures
- require substitution-authenticated shadow construction; raw parser-backed lambdas remain loud
- keep body FOL out of LambdaCallable coordinates, preventing free-variable leakage
- content-address each opaque callable with its sealed source identity: source CID, exact span, and lambda-segment CID
- explicitly substitute the actual argument into the body term in LambdaCallable.apply
- preserve the ordinary computed-call path for inline invocation
- keep defaults, positional-only, keyword-only, zero/multiple formals, variadics, and unsupported child sugar loud

## Instrumentation

- truthful/lying identity call pair
- identical-formal and identical-actual bad twin varies only lambda body and requires distinct py.call coordinates
- nested same-spelled formal twin proves the opaque coordinate has no leaked free variables
- identical nested lambda text under different authenticated captures requires distinct callable coordinates
- parameter-shadow, capture, and rebinding twins
- direct parser-backed unresolved-capture twin stays SugarNotWritten
- application test proves the actual replaces the formal in the body term
- role-specific unsupported parameter twins
- child-panic preservation test
- inline-call test rejects direct body copying at the callsite

## Predicted pandas R impact

- Epsilon direct_gap_R = -N_supported, where N_supported is the next census count of direct Lambda gaps matching the admitted single-formal partition
- Epsilon blocked_descendant_R = 0
- floors preserved: no fabricated value, no silent elision, no RuntimeEffect fallback, no eager inlining, no free-variable leakage, no shared callable identity hubs

## Focused receipt

PYTHONPATH=implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src:implementations/python/sugar-lift-py-tests/src python3 -m pytest implementations/python/sugar-source-tree/tests -q

294 passed, 5 skipped, 1 xfailed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add expression-bodied lambda sugar with content-addressed construction identity
> - Introduces `LambdaSugar` in [`lambda_sugar.py`](https://github.com/TSavo/sugar/pull/6046/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) as a new sugar form for simple single-parameter positional lambdas, desugaring to a `LambdaCallable` with a content-addressed `construction_identity` derived from the call site.
> - Updates `Lambda._construct_sugar` to emit `LambdaSugar` for supported lambda forms (exactly one unannotated, default-free positional parameter on a shadow-authenticated node), falling back to the superclass path otherwise.
> - Changes `LambdaCallable.apply` to return a `SymbolicValue` via term substitution (`subst_var_in_term`) instead of reducing with a bound temporal context.
> - Updates `LambdaCallable.to_term` to prepend `construction_identity` as the first argument to the `python:lambda` IR constructor, altering how callables are discriminated in IR.
> - Behavioral Change: `Lambda.substitute` now always returns a rewritten shadow-authenticated node even when no structural changes occur.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 34749a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->