### PR TITLE
drain: Call authenticated call-shape arm, non-lambda (pandas R)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import builtins
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
@@ -79,11 +78,10 @@ class CallSiteSugar(Sugar):
         term = ctor(
             f"call:{self.target_name}",
             [value.to_term(owner=owner) for value in positional] + kwarg_terms,
-            symbol_kind=(
-                "builtin"
-                if hasattr(builtins, self.target_name)
-                else "coordinate"
-            ),
+            # Spelling is never builtin authority.  An authenticated builtin
+            # recognizer may refine its own coordinate later; a plain Name
+            # call (including a shadowed ``len``/``sum`` twin) stays generic.
+            symbol_kind="coordinate",
         )
         return Complete(
             CallSiteValue(

--- a/implementations/python/sugar-source-tree/tests/test_call_authenticated_shapes.py
+++ b/implementations/python/sugar-source-tree/tests/test_call_authenticated_shapes.py
@@ -1,0 +1,102 @@
+"""Authenticated non-lambda call-shape discrimination for the pandas Call lane."""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from sugar_lift_py_tests.ir import constructor_symbol_kinds, term_intern_scope
+from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+from sugar_lift_py_tests.tree_enumerate import (
+    find_function_by_name,
+    function_contract_rows,
+)
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _function(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(source)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _source_file(source: str) -> SourceFile:
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(source)
+        path = f.name
+    return SourceFile(path_source(path))
+
+
+def _returned_term(source: str):
+    return _function(source).sugar().desugar().value.post().args[1]
+
+
+def test_shadowed_builtin_name_does_not_acquire_builtin_semantics() -> None:
+    with term_intern_scope():
+        function = _function("def A(len, x):\n    return len(x)\n")
+        function.sugar().desugar()
+
+        assert constructor_symbol_kinds()["call:len"] == "coordinate"
+
+
+def test_same_spelled_callees_keep_distinct_source_contract_coordinates() -> None:
+    left = _source_file("def enrolled(x):\n    return x\n")
+    right = _source_file("def enrolled(x):\n    return x + 1\n")
+
+    left_fn = find_function_by_name(left, "enrolled")
+    right_fn = find_function_by_name(right, "enrolled")
+    left_memento, _ = function_contract_rows(left_fn, "left.py")
+    right_memento, _ = function_contract_rows(right_fn, "right.py")
+
+    assert left_memento.source_cid != right_memento.source_cid
+
+
+def test_keyword_names_and_source_order_are_preserved() -> None:
+    term = _returned_term(
+        "def A(x):\n    return f(x, second=2, first=1)\n"
+    )
+
+    assert term.name == "call:f"
+    assert [arg.name for arg in term.args[1:]] == ["py.kwarg", "py.kwarg"]
+    assert [arg.args[0].value for arg in term.args[1:]] == ["second", "first"]
+    assert [arg.args[1].value for arg in term.args[1:]] == [2, 1]
+
+
+def test_keyword_spread_is_not_silently_dropped() -> None:
+    with pytest.raises(SugarNotWritten):
+        _function("def A(x, d):\n    return f(x, **d)\n").sugar()
+
+
+def test_computed_callee_preserves_its_own_constructed_term() -> None:
+    term = _returned_term("def A(fs, i, x):\n    return fs[i](x)\n")
+
+    assert term.name == "py.call"
+    assert term.args[0].name == "py.subscript"
+    assert [arg.name for arg in term.args[0].args] == ["fs", "i"]
+
+
+def test_computed_callee_with_keyword_remains_loud() -> None:
+    with pytest.raises(SugarNotWritten):
+        _function("def A(fs, i, x):\n    return fs[i](value=x)\n").sugar()
+
+
+def test_inline_lambda_call_remains_deferred_to_lambda_lane() -> None:
+    with pytest.raises(SugarNotWritten):
+        _function("def A(x):\n    return (lambda value: value)(x)\n").sugar()
+
+
+def test_named_call_is_a_dig_cue_with_truthful_and_lying_contract_twins() -> None:
+    function = _function("def A(x):\n    return enrolled(x)\n")
+    call_value = function.body[0].value.sugar().desugar().value
+    witness = CallSiteSugar.witnesses()
+
+    assert call_value.term.name == "call:enrolled"
+    assert call_value.body is None
+    assert witness.truthful.expected == "sat"
+    assert witness.lying.expected == "unsat"
+    assert "assert A(5) == 5" in witness.truthful.source
+    assert "assert A(5) == 6" in witness.lying.source


### PR DESCRIPTION
## What changed

- Keeps plain Name calls on generic call coordinates unless an authenticated recognizer supplies stronger meaning; familiar builtin spelling alone no longer grants builtin identity.
- Adds Call discrimination twins for source-coordinate separation, shadowed builtins, keyword name/order, spread refusal, computed callees, computed keywords, lambda deferral, and the non-inlined dig cue.
- Reuses the existing CallSiteSugar / MethodCallSugar / ComputedCallSugar arm; no lambda-consuming behavior was added.

## Classification

Admitted: Name and Attribute callees with positional plus exact named arguments; computed callees with positional arguments only. Loud/deferred: keyword spread, computed-callee keywords, starred positional arguments through their child role, and inline/returned/argument-position lambdas.

The plan-pinned pandas source workspace was not present locally, so no local corpus census was run. Predicted Epsilon direct_gap_R = 0 and predicted Epsilon blocked_descendant_R = 0 for this authentication-only delta; battleaxe remains the authority for observed Delta R.

## Floors

Preserves no fabricated values, no silent elision, no name/vendor dispatch, no weakened provenance, and no call-body inlining.

## Focused receipts

- 21 passed: Call source-tree shape and bad-twin tests
- 3 passed: dig-with-args tests with --noconftest
- Python only; no Rust build and no pandas census


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tag all call-site terms as `coordinate` and add authenticated call-shape tests
> - Removes the builtin-detection heuristic in [`call_site_sugar.py`](https://github.com/TSavo/sugar/pull/6048/files#diff-d7d594636ed207e69db76dd7b89c48760b0d3de93da23981143b3c45da88a3c7): `symbol_kind` is now always `'coordinate'` rather than conditionally `'builtin'` when the callee name matches a Python builtin.
> - Adds a new test module [`test_call_authenticated_shapes.py`](https://github.com/TSavo/sugar/pull/6048/files#diff-2c49a8770c400fd310f23c7c8969775a8c1902a2c10ff91eec9a30deb0638fc4) covering shadowed builtins, keyword ordering, keyword spread errors, computed callees, inline lambda deferral, and dig cue witness construction.
> - Behavioral Change: calls whose names happen to match Python builtins (e.g. `len`) are no longer tagged `builtin`; they receive `coordinate` semantics like any other named call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1322b3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->