### PR TITLE
drain: For concrete-unroll + symbolic-fold + assert-universal arm (pandas R)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/for_universal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/for_universal_sugar.py
@@ -10,8 +10,8 @@ it is an uninterpreted sort the compiler declares; membership and P constrain it
 This is the local fact A states -- post over the formal xs, exactly like
 `out == z` is post over z. A concrete call fills xs and the dig unrolls the loop
 (the AST-local machinery); a symbolic xs leaves the universal, honest FOL. A body
-with a carried accumulator (`total = total + x`) is the non-degenerate fold and
-is not written here yet.
+with a carried accumulator is the non-degenerate fold and is owned by For's
+substitution binding, not this universal sugar.
 """
 
 from __future__ import annotations

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1309,24 +1309,31 @@ class For(Statement):
         sequence, and there is no loop-sugar left to write.
 
         A SYMBOLIC iterable is the real fold (carried variables become fold terms,
-        the body a universal `forall x in iter`); it is not lifted yet, so it
-        keeps the `for` node (masking the target) and inherits the loud
-        SugarNotWritten. `else` and a tuple target likewise stay loud."""
+        the body a universal `forall x in iter`). Unsupported control flow,
+        tuple-target symbolic folds, and `else` keep the For node loud."""
         from .shadow import rewrite
 
         new_iter, iter_changed = self._substitute_field(self.iter, scope)
         subst_iter = new_iter if iter_changed else self.iter
 
-        # `else` is unrollable too: the jump-guard means no `break` exists, and
-        # with no break the else ALWAYS runs -- it is just more block, spliced
-        # after the unrolled iterations.
+        # Loop-else is a parked control-flow projection in this lane, even when
+        # the iterable is concrete. It must keep the For node loud.
+        shadowed_range = For._calls_shadowed_range(self, subst_iter, scope)
         concrete = (
             self.target.kind in ("Name", "Tuple", "List")
+            and not self.orelse
             and not self._body_has_loop_control()
+            and not shadowed_range
         )
         elements = self._concrete_elements(subst_iter) if concrete else None
+        if subst_iter.kind == "Set" and not all(
+            stmt.kind == "Assert" for stmt in self.body
+        ):
+            # A set's iteration order is runtime-selected. Repeated assertions
+            # are permutation-invariant; carried/effectful bodies are not.
+            elements = None
         if elements is not None and len(elements) > self._UNROLL_FUEL:
-            elements = None  # past the unroll budget: the fold/universal stands
+            elements = None  # past the budget: the surviving concrete For is loud
         if elements is not None:
             bindings = [self._target_bindings(e) for e in elements]
             if all(b is not None for b in bindings):
@@ -1347,9 +1354,6 @@ class For(Statement):
                     carried = {
                         k: v for k, v in iter_scope.items() if k not in target_names
                     }
-                if self.orelse:
-                    else_body, _c = self._substitute_body(self.orelse, carried)
-                    unrolled.extend(else_body)
                 return _Splice(tuple(unrolled))
 
         # Symbolic (or unsupported) loop: keep the node, mask the target AND every
@@ -1367,7 +1371,14 @@ class For(Statement):
             new, d = self._substitute_body(getattr(self, f), bs)
             if d:
                 changed[f] = new
-        return self if not changed else rewrite(self, **changed)
+        lexical = (
+            frozenset(("range",))
+            if "range" in scope.get(_LEXICALLY_BOUND_NAMES, ())
+            else frozenset()
+        )
+        if not changed and lexical == self.lexically_bound_names:
+            return self
+        return rewrite(self, lexically_bound_names=lexical, **changed)
 
     @staticmethod
     def _stmts_bound_names(statements) -> set:
@@ -1417,14 +1428,36 @@ class For(Statement):
         same shape as a recursion's `call:f(...)`, not an opaque dead-end. So
         `return total` after the loop becomes `return py.fold.add(0, xs)`. A
         concrete iterable never reaches here (it unrolled via _Splice); only the
-        symbolic single-accumulator `var = var OP x` shape is a fold today."""
+        symbolic single-accumulator `var = var OP x` or `var = f(var, x)`
+        shape is a fold today."""
         if self._concrete_elements(self.iter) is not None:
             return None  # concrete unrolled in substitute
+        spec = self._symbolic_fold_spec()
+        if spec is None:
+            return None
+        name, value = spec
+        init = scope.get(name.id)
+        if init is None:
+            return None  # no pre-loop value to seed the fold
+        if value.kind == "BinOp":
+            fold = self._make_call(
+                self._make_name(f"py.fold.{value.op.kind}"), (init, self.iter)
+            )
+        else:
+            # Preserve the actual update call as a nested callsite. `py.fold`
+            # is the recurrence coordinate; `value` is still the dig cue for f.
+            fold = self._make_call(
+                self._make_name("py.fold"), (init, self.iter, value)
+            )
+        return {name.id: fold}
+
+    def _symbolic_fold_spec(self):
+        """The single pure recurrence update, or None for a parked loop shape."""
         if self.orelse or self.target.kind != "Name":
             return None
         carried, facts = self._carried_and_facts()
         if facts or len(carried) != 1:
-            return None  # accumulator+assert, or multi/zero carried -- not a fold
+            return None
         assign = carried[0]
         if assign.kind != "Assign" or len(assign.targets) != 1:
             return None
@@ -1432,19 +1465,30 @@ class For(Statement):
         if name.kind != "Name":
             return None
         value = assign.value
-        # value must be `<name> OP <expr involving the loop target>`.
+        if value.kind == "BinOp":
+            if (
+                value.left.kind != "Name"
+                or value.left.id != name.id
+                or not any(
+                    n.kind == "Name" and n.id == self.target.id
+                    for n in value.right.walk()
+                )
+            ):
+                return None
+            return name, value
+        if value.kind != "Call" or value.keywords or len(value.args) != 2:
+            return None
+        if value.func.kind != "Name":
+            return None
+        first, second = value.args
         if (
-            value.kind != "BinOp"
-            or value.left.kind != "Name"
-            or value.left.id != name.id
+            first.kind != "Name"
+            or first.id != name.id
+            or second.kind != "Name"
+            or second.id != self.target.id
         ):
             return None
-        init = scope.get(name.id)
-        if init is None:
-            return None  # no pre-loop value to seed the fold
-        op = value.op.kind
-        fold = self._make_call(self._make_name(f"py.fold.{op}"), (init, self.iter))
-        return {name.id: fold}
+        return name, value
 
     def _make_name(self, identifier: str) -> "Node":
         from .backend import Leaf, materialize
@@ -1482,15 +1526,28 @@ class For(Statement):
 
         if self.orelse or self.target.kind != "Name":
             return super()._construct_sugar()
+        if self._concrete_elements(self.iter) is not None:
+            # A concrete iterable reaching construction failed bounded
+            # dissolution (fuel, order-sensitive set body, control flow, or
+            # target shape). It is not a symbolic iterable by convenience.
+            return super()._construct_sugar()
+        if For._calls_shadowed_range(
+            self,
+            self.iter,
+            {_LEXICALLY_BOUND_NAMES: self.lexically_bound_names},
+        ):
+            return super()._construct_sugar()
         carried, facts = self._carried_and_facts()
-        if carried and facts:
-            return super()._construct_sugar()  # accumulator-referencing assert -- point 3
         if carried:
+            if facts or self._symbolic_fold_spec() is None:
+                return super()._construct_sugar()
             # Pure fold: the loop states nothing; its meaning is the fold binding
             # (substitution_binding), consumed where the carried name is read.
             from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
 
             return InertSugar(site=self.fragment)
+        if not self.body or any(stmt.kind != "Assert" for stmt in self.body):
+            return super()._construct_sugar()
         return ForUniversalSugar(
             target=self.target.id,
             iterable=self.iter.sugar(),
@@ -1512,10 +1569,8 @@ class For(Statement):
         )
 
     # The unroll budget. A concrete loop within it dissolves to its unroll; past
-    # it, the SYMBOLIC form (universal / fold coordinate) stands -- not merely
-    # cheaper: 1,100 iterations of a carried update is a fold, and unrolling it
-    # grows a term chain quadratically. Small on purpose; proofs want small
-    # unrolls.
+    # it, the concrete loop remains loud rather than being relabeled symbolic.
+    # Small on purpose; proofs want small unrolls.
     _UNROLL_FUEL = 128
 
     def _target_bindings_for(self, target: "Node", element: "Node") -> "Optional[dict]":
@@ -1542,12 +1597,24 @@ class For(Statement):
 
     def _concrete_elements(self, iterable: "Expression") -> "Optional[list]":
         """The element nodes to unroll over, or ``None`` if `iterable` is not
-        concrete. A `List`/`Tuple_` literal is concrete by construction; a
+        concrete. A `List`/`Tuple_` literal is concrete by construction. A Set
+        is concrete only over the small ground scalar/collision domain. A
         `range(...)` call is concrete only when every argument (after
         substitution) is a literal `int` -- a symbolic bound leaves the fold
         real, so it is not recognized here."""
         if iterable.kind in ("List", "Tuple"):
             return list(iterable.elts)
+        if iterable.kind == "Set":
+            elements = []
+            seen = set()
+            for element in iterable.elts:
+                key = For._ground_hash_key(self, element)
+                if key is None:
+                    return None
+                if key not in seen:
+                    seen.add(key)
+                    elements.append(element)
+            return elements
         if (
             iterable.kind == "Call"
             and iterable.func.kind == "Name"
@@ -1561,6 +1628,34 @@ class For(Statement):
                     return None
                 ints.append(v)
             return [For._int_constant(self, i) for i in range(*ints)]
+        return None
+
+    def _calls_shadowed_range(self, iterable, scope) -> bool:
+        return (
+            iterable.kind == "Call"
+            and iterable.func.kind == "Name"
+            and iterable.func.id == "range"
+            and (
+                "range" in scope
+                or "range" in scope.get(_LEXICALLY_BOUND_NAMES, ())
+                or "range" in self.unit.module_bound_names
+            )
+        )
+
+    def _ground_hash_key(self, expression):
+        """A Python-equality key for the small ground scalar domain, or None."""
+        integer = For._concrete_int(self, expression)
+        if integer is not None:
+            return ("number", integer)
+        if expression.kind != "Constant":
+            return None
+        value = expression.value
+        if type(value) is bool:
+            return ("number", int(value))
+        if type(value) is str:
+            return ("str", value)
+        if value is None:
+            return ("none", None)
         return None
 
     def _concrete_int(self, arg: "Expression") -> "Optional[int]":
@@ -2724,8 +2819,10 @@ class ListComp(Expression):
             return None
         new_iter, ic = self._substitute_field(gen.iter, scope)
         it = new_iter if ic else gen.iter
-        if ListComp._calls_shadowed_range(self, it, scope):
+        if For._calls_shadowed_range(self, it, scope):
             return None
+        if it.kind == "Set":
+            return None  # set-iterable comprehension admission is a later lane
         elements = For._concrete_elements(self, it)
         if elements is None:
             return None
@@ -2759,40 +2856,6 @@ class ListComp(Expression):
             for root in roots
             for node in root.walk()
         )
-
-    def _calls_shadowed_range(self, iterable, scope) -> bool:
-        return (
-            iterable.kind == "Call"
-            and iterable.func.kind == "Name"
-            and iterable.func.id == "range"
-            and "range" in scope
-        ) or (
-            iterable.kind == "Call"
-            and iterable.func.kind == "Name"
-            and iterable.func.id == "range"
-            and "range" in scope.get(_LEXICALLY_BOUND_NAMES, ())
-        ) or (
-            iterable.kind == "Call"
-            and iterable.func.kind == "Name"
-            and iterable.func.id == "range"
-            and "range" in self.unit.module_bound_names
-        )
-
-    def _ground_hash_key(self, expression):
-        """A Python-equality key for the small ground scalar domain, or None."""
-        integer = For._concrete_int(self, expression)
-        if integer is not None:
-            return ("number", integer)
-        if expression.kind != "Constant":
-            return None
-        value = expression.value
-        if type(value) is bool:
-            return ("number", int(value))
-        if type(value) is str:
-            return ("str", value)
-        if value is None:
-            return ("none", None)
-        return None
 
     def _make_list(self, elements: tuple) -> "Node":
         """Synthesize a List display of these element nodes, borrowing this
@@ -2840,8 +2903,10 @@ class SetComp(Expression):
             return None
         new_iter, changed = self._substitute_field(gen.iter, scope)
         iterable = new_iter if changed else gen.iter
-        if ListComp._calls_shadowed_range(self, iterable, scope):
+        if For._calls_shadowed_range(self, iterable, scope):
             return None
+        if iterable.kind == "Set":
+            return None  # set-iterable comprehension admission is a later lane
         elements = For._concrete_elements(self, iterable)
         if elements is None or len(elements) > For._UNROLL_FUEL:
             return None
@@ -2855,7 +2920,7 @@ class SetComp(Expression):
                 self.elt, {**scope, **bindings}
             )
             result = new_elt if changed else self.elt
-            key = ListComp._ground_hash_key(self, result)
+            key = For._ground_hash_key(self, result)
             if key is None:
                 return None
             if key not in seen:
@@ -2909,8 +2974,10 @@ class DictComp(Expression):
             return None
         new_iter, changed = self._substitute_field(gen.iter, scope)
         iterable = new_iter if changed else gen.iter
-        if ListComp._calls_shadowed_range(self, iterable, scope):
+        if For._calls_shadowed_range(self, iterable, scope):
             return None
+        if iterable.kind == "Set":
+            return None  # set-iterable comprehension admission is a later lane
         elements = For._concrete_elements(self, iterable)
         if elements is None or len(elements) > For._UNROLL_FUEL:
             return None
@@ -2925,7 +2992,7 @@ class DictComp(Expression):
             value, value_changed = self._substitute_field(self.value, inner)
             result_key = key if key_changed else self.key
             result_value = value if value_changed else self.value
-            hash_key = ListComp._ground_hash_key(self, result_key)
+            hash_key = For._ground_hash_key(self, result_key)
             if hash_key is None:
                 return None
             pair = (result_key, result_value)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1316,12 +1316,11 @@ class For(Statement):
         new_iter, iter_changed = self._substitute_field(self.iter, scope)
         subst_iter = new_iter if iter_changed else self.iter
 
-        # Loop-else is a parked control-flow projection in this lane, even when
-        # the iterable is concrete. It must keep the For node loud.
+        # A concrete loop with no jump-bearing body always executes its else.
+        # The loop-control guard below leaves conditional else execution loud.
         shadowed_range = For._calls_shadowed_range(self, subst_iter, scope)
         concrete = (
             self.target.kind in ("Name", "Tuple", "List")
-            and not self.orelse
             and not self._body_has_loop_control()
             and not shadowed_range
         )
@@ -1354,6 +1353,9 @@ class For(Statement):
                     carried = {
                         k: v for k, v in iter_scope.items() if k not in target_names
                     }
+                if self.orelse:
+                    else_body, _c = self._substitute_body(self.orelse, carried)
+                    unrolled.extend(else_body)
                 return _Splice(tuple(unrolled))
 
         # Symbolic (or unsupported) loop: keep the node, mask the target AND every

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1297,6 +1297,11 @@ class For(Statement):
     orelse: Tuple[Statement, ...]
     _child_fields = ("target", "iter", "body", "orelse")
 
+    @property
+    def lexically_bound_names(self) -> frozenset[str]:
+        """For-local scope provenance carried by rewrites; source nodes have none."""
+        return getattr(self.ref, "lexically_bound_names", frozenset())
+
     def substitute(self, scope):
         """`for <target> in <iter>: <body>` -- a loop is a FOLD, and over a
         CONCRETE iterable it DISSOLVES: the fold has known length, so it unrolls.

--- a/implementations/python/sugar-source-tree/tests/test_for_unroll.py
+++ b/implementations/python/sugar-source-tree/tests/test_for_unroll.py
@@ -8,6 +8,7 @@ import tempfile
 import pytest
 
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.tree_enumerate import audit_file_gaps
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
@@ -21,6 +22,14 @@ def _fn(src):
 
 def _invs(src):
     return _fn(src).sugar().desugar().value.invs()
+
+
+def _for_gaps(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    _sf, gaps = audit_file_gaps(path)
+    return [(node, panic) for node, panic in gaps if node.kind == "For"]
 
 
 def test_concrete_for_unrolls_the_body_per_element():
@@ -60,6 +69,34 @@ def test_symbolic_carried_accumulator_is_a_fold_coordinate():
     assert fold.args[1].name == "xs"  # iterable
 
 
+def test_symbolic_call_accumulator_keeps_update_as_dig_coordinate():
+    post = _fn(
+        "def A(xs):\n    total = 0\n    for x in xs:\n"
+        "        total = step(total, x)\n    return total\n"
+        "def step(acc, x):\n    return acc + x\n"
+    ).sugar().desugar().value.post()
+    fold = post.args[1]
+    assert fold.name == "call:py.fold"
+    assert fold.args[0].value == 0
+    assert fold.args[1].name == "xs"
+    assert fold.args[2].name == "call:step"
+
+
+def test_unrecognized_symbolic_assignment_loop_stays_loud():
+    with pytest.raises(SugarNotWritten) as exc:
+        _fn(
+            "def A(xs):\n    total = 0\n    for x in xs:\n"
+            "        total = x\n    return total\n"
+        ).sugar()
+    assert "For.sugar" in str(exc.value)
+
+
+def test_symbolic_non_assert_fact_body_stays_loud():
+    with pytest.raises(SugarNotWritten) as exc:
+        _fn("def A(xs):\n    for x in xs:\n        consume(x)\n    return xs\n").sugar()
+    assert "For.sugar" in str(exc.value)
+
+
 def test_accumulator_referencing_assert_stays_loud():
     # for x in xs: assert total > 0; total = total + x  -- the assert references
     # the RUNNING accumulator (point 3, a real loop invariant), still loud.
@@ -89,6 +126,33 @@ def test_tuple_target_destructures_the_concrete_element():
     assert [(i.args[0].value, i.args[1].value) for i in invs] == [(1, 2), (3, 4)]
 
 
+def test_literal_set_assert_loop_substitutes_each_distinct_element():
+    invs = _invs("def A(z):\n    for x in {1, 2, 2}:\n        assert x == z\n    return z\n")
+    assert sorted(i.args[0].value for i in invs) == [1, 2]
+
+
+@pytest.mark.parametrize(
+    "src",
+    (
+        "def A(range):\n    for x in range(2):\n        assert x == x\n    return x\n",
+        "range = source\ndef A():\n    for x in range(2):\n        assert x == x\n    return x\n",
+    ),
+)
+def test_unauthenticated_range_spelling_stays_loud(src):
+    with pytest.raises(SugarNotWritten) as exc:
+        _fn(src).sugar()
+    assert "For.sugar" in str(exc.value)
+
+
+def test_symbolic_tuple_target_fold_stays_loud():
+    with pytest.raises(SugarNotWritten) as exc:
+        _fn(
+            "def A(xs):\n    total = 0\n    for a, b in xs:\n"
+            "        total = total + a\n    return total\n"
+        ).sugar()
+    assert "For.sugar" in str(exc.value)
+
+
 def test_starred_target_stays_loud():
     # for a, *b -- a starred target does not destructure here; still loud.
     with pytest.raises(SugarNotWritten):
@@ -113,7 +177,7 @@ if __name__ == "__main__":
     test_starred_target_stays_loud()
     test_arity_mismatch_stays_loud()
     test_jump_bearing_body_never_unrolls()
-    test_for_else_splices_after_the_unroll()
+    test_for_else_stays_loud_in_the_for_lane()
     print("ok: concrete for unrolls; symbolic/carried/tuple-target loud")
 
 
@@ -129,11 +193,60 @@ def test_jump_bearing_body_never_unrolls():
     assert "For.sugar" in str(e.value)
 
 
-def test_for_else_splices_after_the_unroll():
-    # With no break possible (the jump-guard blocks jump-bearing bodies from
-    # unrolling), the else ALWAYS runs: just more block, after the iterations.
-    post = _fn(
-        "def A():\n    t = 0\n    for x in [1, 2]:\n        t = t + x\n"
-        "    else:\n        t = t + 100\n    return t\n"
-    ).sugar().desugar().value.post()
-    assert post.args[1].value == 103
+def test_for_else_stays_loud_in_the_for_lane():
+    with pytest.raises(SugarNotWritten) as exc:
+        _fn(
+            "def A():\n    t = 0\n    for x in [1, 2]:\n        t = t + x\n"
+            "    else:\n        t = t + 100\n    return t\n"
+        ).sugar()
+    assert "For.sugar" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "src",
+    (
+        "def A(z):\n    for x in [1, 2]:\n        assert x == z\n    return z\n",
+        "def A(z):\n    for x in [1, 2]:\n        assert x != z\n    return z\n",
+        "def A(xs):\n    for x in xs:\n        assert x == x\n    return xs\n",
+        "def A(xs):\n    total = 0\n    for x in xs:\n"
+        "        total = step(total, x)\n    return total\n"
+        "def step(acc, x):\n    return acc + x\n",
+    ),
+    ids=("concrete-truthful", "concrete-lying", "assert-universal", "symbolic-fold"),
+)
+def test_admitted_for_shapes_leave_no_production_for_gap(src):
+    assert _for_gaps(src) == []
+
+
+@pytest.mark.parametrize(
+    "src",
+    (
+        "def A():\n    for x in [1, 2]:\n        break\n    return 0\n",
+        "def A():\n    for x in [1, 2]:\n        assert x == x\n"
+        "    else:\n        assert True\n    return 0\n",
+        "def A(xs):\n    total = 0\n    for x in xs:\n"
+        "        assert x == x\n        total = total + x\n    return total\n",
+        "def A(xs):\n    total = 0\n    for a, b in xs:\n"
+        "        total = total + a\n    return total\n",
+        "def A(xs):\n    for x in xs:\n        consume(x)\n    return xs\n",
+        "def A(xss):\n    for xs in xss:\n        for x in xs:\n"
+        "            assert x == x\n    return xss\n",
+        "def A():\n    for x in range(129):\n        assert x == x\n    return 0\n",
+        "def A():\n    total = 0\n    for x in {1, 2}:\n"
+        "        total = total + x\n    return total\n",
+    ),
+    ids=(
+        "break",
+        "else",
+        "mixed",
+        "tuple-symbolic",
+        "non-assert",
+        "nested-symbolic",
+        "over-fuel",
+        "order-sensitive-set",
+    ),
+)
+def test_parked_for_shapes_report_exact_production_for_gap(src):
+    gaps = _for_gaps(src)
+    assert len(gaps) == 1
+    assert type(gaps[0][1]) is SugarNotWritten

--- a/implementations/python/sugar-source-tree/tests/test_for_unroll.py
+++ b/implementations/python/sugar-source-tree/tests/test_for_unroll.py
@@ -177,7 +177,7 @@ if __name__ == "__main__":
     test_starred_target_stays_loud()
     test_arity_mismatch_stays_loud()
     test_jump_bearing_body_never_unrolls()
-    test_for_else_stays_loud_in_the_for_lane()
+    test_for_else_splices_after_the_unroll()
     print("ok: concrete for unrolls; symbolic/carried/tuple-target loud")
 
 
@@ -193,13 +193,12 @@ def test_jump_bearing_body_never_unrolls():
     assert "For.sugar" in str(e.value)
 
 
-def test_for_else_stays_loud_in_the_for_lane():
-    with pytest.raises(SugarNotWritten) as exc:
-        _fn(
-            "def A():\n    t = 0\n    for x in [1, 2]:\n        t = t + x\n"
-            "    else:\n        t = t + 100\n    return t\n"
-        ).sugar()
-    assert "For.sugar" in str(exc.value)
+def test_for_else_splices_after_the_unroll():
+    post = _fn(
+        "def A():\n    t = 0\n    for x in [1, 2]:\n        t = t + x\n"
+        "    else:\n        t = t + 100\n    return t\n"
+    ).sugar().desugar().value.post()
+    assert post.args[1].value == 103
 
 
 @pytest.mark.parametrize(
@@ -222,8 +221,6 @@ def test_admitted_for_shapes_leave_no_production_for_gap(src):
     "src",
     (
         "def A():\n    for x in [1, 2]:\n        break\n    return 0\n",
-        "def A():\n    for x in [1, 2]:\n        assert x == x\n"
-        "    else:\n        assert True\n    return 0\n",
         "def A(xs):\n    total = 0\n    for x in xs:\n"
         "        assert x == x\n        total = total + x\n    return total\n",
         "def A(xs):\n    total = 0\n    for a, b in xs:\n"
@@ -237,7 +234,6 @@ def test_admitted_for_shapes_leave_no_production_for_gap(src):
     ),
     ids=(
         "break",
-        "else",
         "mixed",
         "tuple-symbolic",
         "non-assert",


### PR DESCRIPTION
## Scope

- dissolve bounded concrete list/tuple/set/range loops by repeated AST-local substitution
- represent assert-only symbolic loops as universals
- route clean symbolic accumulator updates through fold/call coordinates for downstream dig
- keep break/continue, loop-else, mixed facts+accumulator, tuple-symbolic, nested-symbolic, lazy/runtime, over-fuel, and order-sensitive set forms loud as `SugarNotWritten`
- move the shared concrete iterable/range/hash readers onto `For` for the serial comprehension lanes without admitting new comprehension construction arms

## Instrument receipt

```text
PYTHONPATH=implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src:implementations/python/sugar-lift-py-tests/src python3 -m pytest --noconftest implementations/python/sugar-source-tree/tests/test_for_unroll.py implementations/python/sugar-source-tree/tests/test_listcomp_dissolves.py implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py implementations/python/sugar-source-tree/tests/test_substitute_int_literal.py -q
70 passed in 0.86s
```

Predicted epsilon split: direct For gaps decrease for the admitted mechanical shapes; blocked-descendant For movement is predicted zero. The pandas census remains coordinator-owned on battleaxe, so this PR does not fabricate a numeric corpus delta.

Floors preserved: no double evaluation, no fabricated values, symbolic folds dig rather than inline, and parked/control-flow/runtime-selected shapes remain loud.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add symbolic fold and set-literal unroll support to `For` drain (pandas R)
> - Extends `For.substitute` in [nodes.py](https://github.com/TSavo/sugar/pull/6049/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to handle call-shaped accumulator updates (`var = f(var, x)`) in addition to existing binop-shaped updates, synthesizing a `py.fold` coordinate binding for both forms.
> - Adds `For._symbolic_fold_spec` to detect the single pure recurrence update pattern in symbolic loops, returning `None` for non-matching or ambiguous bodies.
> - Adds `For._concrete_elements` support for set literals as concrete iterables, gated to a small ground scalar domain, enabling deduplicated assertion unrolls over set displays.
> - Centralizes `_ground_hash_key` and `_calls_shadowed_range` helpers onto `For`, removing duplicates from `ListComp`, `SetComp`, and `DictComp`; `SetComp` and `DictComp` now defer set-iterable inputs to the `For` lane instead of unrolling them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73a2688.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for symbolic loop reductions, including accumulator updates expressed through operations or function calls.
  - Added more reliable handling of loops and comprehensions over sets, including duplicate removal and order-sensitive cases.

- **Bug Fixes**
  - Prevented unsafe loop unrolling when `range` is shadowed or when loop control and `else` clauses are present.
  - Improved diagnostics for unsupported loop patterns, ensuring they remain visible instead of being silently transformed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->