### PR TITLE
drain: Call sites build bridges (pandas)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/computed_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/computed_call_sugar.py
@@ -10,7 +10,9 @@ unlike MethodCallSugar's attribute-callee case.
 A callee whose own node has no `.sugar()` (a Lambda called inline, for example)
 stays loud through the ordinary recursion: this sugar never masks that gap.
 
-Keyword arguments stay loud (the tree node guards them), as on plain calls.
+Keyword arguments and ``**`` spreads ride as explicit ``py.kwarg`` operands,
+the same bridge vocabulary used by named and method calls. They are pointed at,
+not interpreted or silently expanded here.
 """
 
 from __future__ import annotations
@@ -27,6 +29,7 @@ class ComputedCallSugar(Sugar):
     callee: Sugar
     args: tuple  # the argument sugars, in source order
     site: object = dataclass_field(compare=False)
+    keywords: tuple = ()  # (name or explicit "**", sugar), source order
 
     @classmethod
     def witnesses(cls):
@@ -53,20 +56,41 @@ class ComputedCallSugar(Sugar):
                     callee, tuple(rest), accumulated + (value,), ctx
                 )
             )
+        return self._collect_kwargs(callee, self.keywords, (), accumulated, ctx)
+
+    def _collect_kwargs(
+        self, callee, remaining: tuple, kw_values: tuple, positional: tuple, ctx
+    ) -> Outcome:
+        if remaining:
+            (name, sugar), *rest = remaining
+            return sugar.desugar(ctx).and_then(
+                lambda value: self._collect_kwargs(
+                    callee,
+                    tuple(rest),
+                    kw_values + ((name, value),),
+                    positional,
+                    ctx,
+                )
+            )
         from sugar_lift_py_tests.floor import CallSiteValue
-        from sugar_lift_py_tests.ir import ctor
+        from sugar_lift_py_tests.ir import ctor, str_const
 
         owner = str(self.site)
+        keyword_terms = [
+            ctor("py.kwarg", [str_const(name), value.to_term(owner=owner)])
+            for name, value in kw_values
+        ]
         term = ctor(
             "py.call",
             [callee.to_term(owner=owner)]
-            + [value.to_term(owner=owner) for value in accumulated],
+            + [value.to_term(owner=owner) for value in positional]
+            + keyword_terms,
             symbol_kind="coordinate",
         )
         return Complete(
             CallSiteValue(
                 target_name="py.call",
-                arg_values=(callee, *accumulated),
+                arg_values=(callee, *positional, *(value for _, value in kw_values)),
                 parameters=(),
                 term=term,
                 body=None,  # the dig is CUED, not inlined here

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3160,11 +3160,12 @@ class Call(Expression):
         `d["k"](x)`) -> ComputedCallSugar, the `py.call(callee, args)`
         coordinate -- the callee reduces through whatever sugar its own node
         built, so a callee with no sugar (a Lambda called inline) still stays
-        loud through the ordinary recursion. Keyword arguments stay loud gaps
-        until written."""
-        if any(kw.arg is None for kw in self.keywords):
-            return super()._construct_sugar()  # **spread -- not one keyword, never guess
-        keyword_sugars = tuple((kw.arg, kw.value.sugar()) for kw in self.keywords)
+        loud through the ordinary recursion. Named keywords and ``**`` spreads
+        ride explicitly on every coordinate; none is dropped or interpreted."""
+        keyword_sugars = tuple(
+            (kw.arg if kw.arg is not None else "**", kw.value.sugar())
+            for kw in self.keywords
+        )
         if isinstance(self.func, Name):
             from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
 
@@ -3184,14 +3185,13 @@ class Call(Expression):
                 site=self.fragment,
                 keywords=keyword_sugars,
             )
-        if keyword_sugars:
-            return super()._construct_sugar()  # kwargs on a computed callee -- not written
         from sugar_lift_py_tests.sugar.computed_call_sugar import ComputedCallSugar
 
         return ComputedCallSugar(
             callee=self.func.sugar(),
             args=tuple(a.sugar() for a in self.args),
             site=self.fragment,
+            keywords=keyword_sugars,
         )
 
 

--- a/implementations/python/sugar-source-tree/tests/test_call_kwargs.py
+++ b/implementations/python/sugar-source-tree/tests/test_call_kwargs.py
@@ -1,13 +1,8 @@
-"""Keyword arguments on calls ride the coordinate FAITHFULLY: each `name=expr`
-appends a `py.kwarg(name, expr)` operand after the positionals. A `**spread`
-is not one keyword and stays loud (the tree node guards it)."""
+"""Keyword arguments and spreads ride the call bridge coordinate faithfully."""
 
 import tempfile
 
-import pytest
-
 from sugar_lift_python_source.source_oracle import path_source
-from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
 
@@ -47,6 +42,11 @@ def test_kwarg_value_discriminates():
     assert t1 != t2
 
 
-def test_spread_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A(x, d):\n    return f(x, **d)\n").sugar()
+def test_named_call_spread_builds_explicit_bridge_operand():
+    t = _out("def A(x, d):\n    return f(x, **d)\n")
+
+    assert t.name == "call:f"
+    spread = t.args[-1]
+    assert spread.name == "py.kwarg"
+    assert spread.args[0].value == "**"
+    assert spread.args[1].name == "d"

--- a/implementations/python/sugar-source-tree/tests/test_computed_call.py
+++ b/implementations/python/sugar-source-tree/tests/test_computed_call.py
@@ -51,6 +51,19 @@ def test_discrimination_differs_by_callee_operand():
     assert t0 != t1
 
 
+def test_computed_call_keywords_build_on_the_py_call_bridge():
+    t = _out("def A(fs, x, d):\n    return fs[0](x, key=1, **d)\n")
+
+    assert t.name == "py.call"
+    assert t.args[0].name == "py.subscript"
+    named, spread = t.args[-2:]
+    assert named.name == spread.name == "py.kwarg"
+    assert named.args[0].value == "key"
+    assert named.args[1].value == 1
+    assert spread.args[0].value == "**"
+    assert spread.args[1].name == "d"
+
+
 def test_lambda_callee_uses_the_computed_call_path():
     sugar = _fn("def A(x):\n    return (lambda z: z)(x)\n").sugar()
     call = sugar.statements[0].value

--- a/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
@@ -5,10 +5,7 @@ receiver rides as runtime_dispatch_receiver for a future type-aware dig."""
 
 import tempfile
 
-import pytest
-
 from sugar_lift_python_source.source_oracle import path_source
-from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
 
@@ -52,9 +49,15 @@ def test_keyword_args_lift():
     assert kwarg.args[0].value == "default"
 
 
-def test_spread_keyword_args_stay_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A(z, d):\n    return z.get(1, **d)\n").sugar()
+def test_spread_keyword_args_build_method_bridge():
+    t = _out("def A(z, d):\n    return z.get(1, **d)\n")
+
+    assert t.name == "call:get"
+    assert t.args[0].name == "z"
+    spread = t.args[-1]
+    assert spread.name == "py.kwarg"
+    assert spread.args[0].value == "**"
+    assert spread.args[1].name == "d"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- removed the remaining Call-owned refusal branches
- named and method calls now carry `**` spreads explicitly as `py.kwarg("**", value)` operands on their existing `call:<target>` bridge coordinates
- computed calls now carry named keywords and `**` spreads on their existing `py.call(callee, ...)` bridge coordinate
- retained all existing name, method, computed positional, and inline-lambda construction paths
- did not resolve imports or inspect callee bodies; calls remain note-like coordinates consumed by the existing call-site and call-edge machinery

## Instrumentation

- named-call spread builds and points at `call:f`
- method spread builds and points at `call:get` with the receiver preserved
- computed named/spread call builds and points at `py.call` with the computed callee preserved
- existing positional, named-keyword, method-chain, and inline-lambda tests remain in the focused suite

## Predicted pandas node-count gain

- `+N_call_owned`, where `N_call_owned` is the next census count of direct `Call.sugar` gaps whose refusal was `**` spread or computed-callee keywords
- the historical 865 Call-family headline includes blocked descendants, so it is a ceiling rather than an honest predicted gain

## Focused receipt

`PYTHONPATH=implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src:implementations/python/sugar-lift-py-tests/src python3 -m pytest implementations/python/sugar-source-tree/tests -q`

313 passed, 5 skipped, 1 xfailed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bridge keyword arguments and `**` spreads as explicit `py.kwarg` operands on `py.call` terms
> - Previously, keyword arguments and `**` spreads on computed calls and method calls were either rejected or left unwritten; they are now forwarded through all call sugar types.
> - [`ComputedCallSugar`](https://github.com/TSavo/sugar/pull/6050/files#diff-a3d120c7639aa3b0ba91d8111b7382ea76711750f38865a71ec2bfbfe42b1750) gains a `keywords` field and a `_collect_kwargs` pass that emits `py.kwarg` terms (using `'**'` as the name for spreads) appended after positional args.
> - [`Call._construct_sugar`](https://github.com/TSavo/sugar/pull/6050/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) no longer early-returns on spreads or computed-callee keywords; it now passes `keywords=keyword_sugars` to all three sugar constructors.
> - Tests in [`test_call_kwargs.py`](https://github.com/TSavo/sugar/pull/6050/files#diff-d233a8e4a4d3770227d2d94e2c4bdf7408675594ee317940260528d3c01a11b7), [`test_computed_call.py`](https://github.com/TSavo/sugar/pull/6050/files#diff-f89220a2bcc8b6e7b5ee6d54fb04aac7eae009e4b25848a4aa0cb4509549d34d), and [`test_method_call_sugar.py`](https://github.com/TSavo/sugar/pull/6050/files#diff-4d5ad4986ba168ced864ccd6ff8210b1f530e17745edc68f392cdc75c2b8dd93) are updated to assert the new `py.kwarg` operand structure.
> - Behavioral Change: call sites that previously silently dropped or rejected keyword/spread args now produce explicit bridge operands.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb7f92e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->