### PR TITLE
drain: Return/Raise build their exits (pandas)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/raise_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/raise_effect.py
@@ -15,6 +15,10 @@ class RaiseEffect:
     # type name: two raise ValueError at different loci have different
     # occurrences. Never used as a fabricated "instance identity" from type alone.
     occurrence: str | None = None
+    # The value built from ``raise <exc>``.  A Name is a coordinate pointing
+    # at the existing binding; a constructor call is its ordinary callsite.
+    # Bare re-raise has no child and therefore leaves this absent.
+    raised_value: object | None = None
 
     @property
     def occurrence_id(self) -> str | None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/raise_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/raise_sugar.py
@@ -20,15 +20,12 @@ class RaiseSugar(Sugar):
     not a store effect, so the rest of the block stays unreduced); a matching
     ``TrySugar`` handler may later route it, and unrouted it is the block's exit.
 
-    The exception's NAME is provenance, read structurally off the raised
-    expression and carried onto the effect -- exactly as ``AssertSugar`` treats
-    its message. We do NOT desugar the exception expression as a child sugar:
-    the lift does not construct the exception object, it records that control
-    leaves here and under what name. An exotic raised expression whose name we
-    cannot read is still a raise -- ``exception_name`` is ``None`` and the halt
-    is no less real (the effect is the fact, the name is only its label).
+    The exception child is built normally and carried on the effect.  Its
+    structural name remains routing provenance only; spelling never creates
+    or authenticates an exception value.
     """
 
+    exception: object | None
     exception_name: str | None
     site: object = dataclass_field(compare=False)
 
@@ -55,12 +52,19 @@ class RaiseSugar(Sugar):
             hashlib.sha256(source.encode()).hexdigest() if source is not None else None
         )
         blame = f"{self.site.filename}:{self.site.line}:{self.site.col}"
-        return Incomplete(
-            RaiseEffect(
-                exception_name=self.exception_name,
-                blame=blame,
-                source_sha256=source_sha256,
-                # Occurrence is the raise site — not a type-level identity.
-                occurrence=blame,
+
+        def halt(raised_value=None):
+            return Incomplete(
+                RaiseEffect(
+                    exception_name=self.exception_name,
+                    blame=blame,
+                    source_sha256=source_sha256,
+                    # Occurrence is the raise site — not a type-level identity.
+                    occurrence=blame,
+                    raised_value=raised_value,
+                )
             )
-        )
+
+        if self.exception is None:
+            return halt()
+        return self.exception.desugar(ctx).and_then(halt)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/return_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/return_sugar.py
@@ -14,11 +14,11 @@ class ReturnSugar(Sugar):
     ReturnValue carrying that reduced floor. The block carries it as an exit,
     and the universe's post projects `out == <return term>` from it.
 
-    Meaning-only, node-constructed. Bare `return` (no value) is not this sugar
-    -- the tree node keeps it a gap rather than inventing a None return.
+    Meaning-only, node-constructed.  ``value=None`` is the syntax-owned bare
+    return arm and constructs Python's existing ``NoneValue`` floor.
     """
 
-    value: object  # the returned expression's sugar
+    value: object | None  # expression sugar, or syntactic empty return
     site: object = dataclass_field(compare=False)
 
     @classmethod
@@ -32,6 +32,10 @@ class ReturnSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
+        if self.value is None:
+            from sugar_lift_py_tests.floor import NoneValue
+
+            return Complete(ReturnValue(NoneValue()))
         return self.value.desugar(ctx).and_then(
             lambda value: Complete(ReturnValue(value))
         )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1052,13 +1052,13 @@ class Return(Statement):
         return self._substitute_children(scope)
 
     def _construct_sugar(self):
-        """`return <expr>` constructs ReturnSugar WITH the value's sugar. A bare
-        `return` (no value) stays a loud gap -- no invented None return."""
-        if self.value is None:
-            return super()._construct_sugar()
+        """Construct the function exit, including Python's real empty return."""
         from sugar_lift_py_tests.sugar.return_sugar import ReturnSugar
 
-        return ReturnSugar(value=self.value.sugar(), site=self.fragment)
+        return ReturnSugar(
+            value=self.value.sugar() if self.value is not None else None,
+            site=self.fragment,
+        )
 
 
 class Delete(Statement):
@@ -2163,9 +2163,7 @@ class Raise(Statement):
         return ".".join(reversed(parts))
 
     def _construct_sugar(self):
-        """`raise <exc>[ from <cause>]` constructs RaiseSugar -- the halt arm.
-        The exception name is provenance, read structurally; the expression is
-        never desugared as a child (we do not construct the exception)."""
+        """Build the raised child and carry it on the function's halt exit."""
         if self.cause is not None:
             # `raise X from Y` -- the cause is exception-chaining provenance, not
             # part of the halt. Carrying it is not written yet, so rather than
@@ -2174,7 +2172,11 @@ class Raise(Statement):
             return super()._construct_sugar()
         from sugar_lift_py_tests.sugar.raise_sugar import RaiseSugar
 
-        return RaiseSugar(exception_name=self._exception_name(), site=self.fragment)
+        return RaiseSugar(
+            exception=self.exc.sugar() if self.exc is not None else None,
+            exception_name=self._exception_name(),
+            site=self.fragment,
+        )
 
 
 class Try(Statement):

--- a/implementations/python/sugar-source-tree/tests/test_exit_builds.py
+++ b/implementations/python/sugar-source-tree/tests/test_exit_builds.py
@@ -1,0 +1,78 @@
+"""Plain Return/Raise nodes build the values carried by their exits."""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from sugar_lift_py_tests.floor import NoneValue, ReturnValue
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _function(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(source)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _statement(source: str, kind: str):
+    function = _function(source).substitute({})
+    return next(node for node in function.walk() if node.kind == kind)
+
+
+def test_bare_return_builds_the_language_none_exit() -> None:
+    outcome = _statement("def A():\n    return\n", "Return").sugar().desugar()
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, ReturnValue)
+    assert isinstance(outcome.value.value, NoneValue)
+
+
+def test_valued_return_carries_its_built_child() -> None:
+    outcome = _statement("def A():\n    return 7\n", "Return").sugar().desugar()
+
+    assert isinstance(outcome, Complete)
+    assert outcome.value.value.value == 7
+
+
+def test_implicit_falloff_builds_the_same_none_post() -> None:
+    universe = _function("def A():\n    pass\n").sugar().desugar().value
+
+    assert universe.post().args[1].name == "None"
+
+
+def test_raise_name_points_at_the_built_value() -> None:
+    outcome = _statement("def A(exc):\n    raise exc\n", "Raise").sugar().desugar()
+
+    assert isinstance(outcome, Incomplete)
+    assert outcome.effect.exception_name == "exc"
+    assert outcome.effect.raised_value.to_term(owner="test").name == "exc"
+
+
+def test_raise_constructor_carries_its_built_call_coordinate() -> None:
+    outcome = _statement(
+        "def A():\n    raise ValueError(7)\n", "Raise"
+    ).sugar().desugar()
+
+    assert isinstance(outcome, Incomplete)
+    raised = outcome.effect.raised_value
+    assert raised.term.name == "call:ValueError"
+    assert raised.term.args[0].value == 7
+    assert raised.body is None
+
+
+def test_unwritten_raised_child_stays_loud() -> None:
+    with pytest.raises(SugarNotWritten):
+        _statement("def A():\n    raise (lambda: 1)\n", "Raise").sugar()
+
+
+def test_raise_from_stays_loud() -> None:
+    with pytest.raises(SugarNotWritten):
+        _statement(
+            "def A():\n    raise ValueError from KeyError\n", "Raise"
+        ).sugar()

--- a/implementations/python/sugar-source-tree/tests/test_raise_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_raise_sugar.py
@@ -3,8 +3,8 @@
 A raise never states a fact and never returns a value -- it exits. So its
 `.sugar().desugar()` is an `Incomplete(RaiseEffect)`, the halt arm of
 `match(Sugar) { Some => cite_or_effect, None => panic }`, not a `Complete`
-floor value. The exception name is provenance read structurally off `exc`;
-the expression is never desugared as a child. `raise X from Y` is loud until
+floor value. The exception child builds normally and rides on the effect; its
+structural name is routing provenance only. `raise X from Y` is loud until
 cause-carrying is written -- a MISSING never becomes a silent success.
 """
 
@@ -44,7 +44,7 @@ def test_raise_is_the_halt_arm_not_a_value():
 
 def test_exception_name_is_read_structurally():
     # raise E, raise E(...), raise mod.E, raise mod.E(...) all name E / mod.E,
-    # read off the expression WITHOUT desugaring it (we never construct E).
+    # independently of the normally built child carried by the exit.
     assert _effect("def A():\n    raise ValueError\n").exception_name == "ValueError"
     assert _effect("def A():\n    raise ValueError('x')\n").exception_name == "ValueError"
     assert _effect("def A():\n    raise os.error\n").exception_name == "os.error"


### PR DESCRIPTION
## What changed

- Bare return constructs the existing NoneValue floor and carries it in ReturnValue; valued returns continue to carry their normally built child.
- Implicit function fall-off continues to use the same existing NoneValue post construction.
- Explicit raise now builds its exception child normally and carries that floor on RaiseEffect. A raised Name is only its existing binding coordinate; a constructor remains an ordinary non-inlined call coordinate.
- Bare re-raise remains a source-cited halt. Chained raise-from and genuinely unwritten child shapes remain loud.

## Predicted node gain

A syntax-only scan of cached pandas 3.0.3 source found 328 bare returns. Predicted parent-node build gain: Return +328, Raise +0 (Raise already built on current main). Raise gains value carriage and can unblock child construction, but no descendant delta is claimed without the census.

## Floors

No fabricated exception instances, no source hunting, no name/vendor dispatch, no body inlining, and no silent cause elision.

## Focused receipt

58 passed across exit-build, Raise, Try, and ExitSet tests with the requested Python PYTHONPATH. Python only; no Rust build and no full pandas census.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Build and carry exit values for `Return` and `Raise` sugar nodes (pandas)
> - `ReturnSugar` now handles bare `return` by carrying `value=None`, which desugars to `Complete(ReturnValue(NoneValue()))` instead of leaving an unwritten gap.
> - `RaiseSugar` now carries the raised expression's sugar as `exception`, desugars the child, and attaches the built value to `RaiseEffect` as `raised_value`; bare re-raise produces an effect without `raised_value`.
> - `Return._construct_sugar` and `Raise._construct_sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/6051/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) are updated to pass child sugar (or `None`) into their respective sugar types rather than delegating to `super()` or ignoring the child.
> - New tests in [test_exit_builds.py](https://github.com/TSavo/sugar/pull/6051/files#diff-eed10a9c50f6906a99a8710ccc18650bb717ef4563f7f25d22de317f89e016ba) assert correct behavior for bare return, valued return, implicit falloff, named raise, constructor raise, and error cases.
> - Behavioral Change: if a raised expression's sugar is unwritten, constructing sugar for the `raise` node now fails loudly instead of silently succeeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5bf404a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->