### PR TITLE
drain: comprehensions build (pandas)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
@@ -554,6 +554,33 @@ def str_const(s: str) -> Term:
     return _intern_term(_ConstStr(s, String()))
 
 
+def bound_transform(name: str, templates: List[Term]) -> Term:
+    """A transform template whose ``name`` is bound only inside its templates.
+
+    The iterable remains outside this coordinate, so an outer variable with the
+    same spelling stays free there.  This denotes an operation to apply later;
+    constructing it does not claim that any template call executed.
+    """
+    if not templates:
+        raise ValueError("a bound transform needs at least one template term")
+    return ctor(
+        "py.bound_transform",
+        [str_const(name), *templates],
+        symbol_kind="coordinate",
+    )
+
+
+def bound_transform_parts(term: Term) -> tuple[str, tuple[Term, ...]] | None:
+    if (
+        isinstance(term, _Ctor)
+        and term.name == "py.bound_transform"
+        and len(term.args) >= 2
+        and isinstance(term.args[0], _ConstStr)
+    ):
+        return term.args[0].value, term.args[1:]
+    return None
+
+
 def real_lit(decimal_string: str) -> Term:
     """A real literal carried as a canonical decimal string (e.g. "0.0000015").
 
@@ -1360,6 +1387,14 @@ def subst_var_in_term(t: Term, formal: str, actual: Term) -> Term:
     if isinstance(t, _Var):
         return actual if t.name == formal else t
     if isinstance(t, _Ctor):
+        bound = bound_transform_parts(t)
+        if bound is not None:
+            name, templates = bound
+            if name == formal:
+                return t
+            return bound_transform(
+                name, [subst_var_in_term(item, formal, actual) for item in templates]
+            )
         return ctor(t.name, [subst_var_in_term(a, formal, actual) for a in t.args])
     return t  # const variants are inert
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
@@ -138,7 +138,14 @@ class _Ctor:
     args: Tuple["Term", ...]
 
 
-Term = Union[_Var, _ConstInt, _ConstStr, _ConstBool, _ConstReal, _Ctor]
+@dataclass(frozen=True)
+class _Lambda:
+    param_name: str
+    param_sort: Sort
+    body: "Term"
+
+
+Term = Union[_Var, _ConstInt, _ConstStr, _ConstBool, _ConstReal, _Ctor, _Lambda]
 
 # Intern tables are keyed by finite structural tuples, never by Term objects:
 # frozen-dataclass ``__hash__`` walks ctor spines recursively and SEGVs on
@@ -242,6 +249,17 @@ def _commit_interned_term(
             term.name,
             tuple(id(arg) for arg in interned_args),
         )
+    elif isinstance(term, _Lambda):
+        if len(interned_args) != 1:
+            raise AssertionError("lambda intern requires exactly one body")
+        if interned_args[0] is not term.body:
+            term = _Lambda(term.param_name, term.param_sort, interned_args[0])
+        key = (
+            "lambda",
+            term.param_name,
+            repr(term.param_sort),
+            id(interned_args[0]),
+        )
     else:
         key = _term_leaf_intern_key(term)
     existing = by_key.get(key)
@@ -290,12 +308,19 @@ def _intern_term(term: Term) -> Term:
         if phase == 0:
             if node_id in visiting:
                 _panic_cyclic_term(node)
-            if not isinstance(node, _Ctor) or not node.args:
+            children = (
+                node.args
+                if isinstance(node, _Ctor)
+                else (node.body,)
+                if isinstance(node, _Lambda)
+                else ()
+            )
+            if not children:
                 done[node_id] = _commit_interned_term(by_key, by_id, node, ())
                 continue
             visiting.add(node_id)
             stack.append((node, 1))
-            for child in reversed(node.args):
+            for child in reversed(children):
                 child_id = id(child)
                 if child_id in done:
                     continue
@@ -309,7 +334,8 @@ def _intern_term(term: Term) -> Term:
         # phase == 1: every child is interned (or the graph was cyclic).
         visiting.discard(node_id)
         interned_args_list: list[Term] = []
-        for child in node.args:
+        children = node.args if isinstance(node, _Ctor) else (node.body,)
+        for child in children:
             child_id = id(child)
             mapped = done.get(child_id)
             if mapped is None:
@@ -552,33 +578,6 @@ def num(n: int) -> Term:
 
 def str_const(s: str) -> Term:
     return _intern_term(_ConstStr(s, String()))
-
-
-def bound_transform(name: str, templates: List[Term]) -> Term:
-    """A transform template whose ``name`` is bound only inside its templates.
-
-    The iterable remains outside this coordinate, so an outer variable with the
-    same spelling stays free there.  This denotes an operation to apply later;
-    constructing it does not claim that any template call executed.
-    """
-    if not templates:
-        raise ValueError("a bound transform needs at least one template term")
-    return ctor(
-        "py.bound_transform",
-        [str_const(name), *templates],
-        symbol_kind="coordinate",
-    )
-
-
-def bound_transform_parts(term: Term) -> tuple[str, tuple[Term, ...]] | None:
-    if (
-        isinstance(term, _Ctor)
-        and term.name == "py.bound_transform"
-        and len(term.args) >= 2
-        and isinstance(term.args[0], _ConstStr)
-    ):
-        return term.args[0].value, term.args[1:]
-    return None
 
 
 def real_lit(decimal_string: str) -> Term:
@@ -1004,6 +1003,15 @@ def term_to_value(t: Term) -> Value:
                 ("args", varr([term_to_value(a) for a in t.args])),
             ]
         )
+    if isinstance(t, _Lambda):
+        return vobj(
+            [
+                ("kind", vstr("lambda")),
+                ("paramName", vstr(t.param_name)),
+                ("paramSort", sort_to_value(t.param_sort)),
+                ("body", term_to_value(t.body)),
+            ]
+        )
     raise TypeError(f"unknown Term: {type(t)!r}")
 
 
@@ -1119,15 +1127,22 @@ class TermTableBuilder:
                     "fix=source-lifter terms are JSON objects only"
                 )
             seen.add(identity)
-            if term.get("kind") == "ctor":
-                for child in term.get("args", []) or []:
-                    if not isinstance(child, dict):
-                        raise TypeError(
-                            f"RPC ctor arg must be a dict, got {type(child)!r}"
-                        )
-                    child_id = id(child)
-                    inbound[child_id] = inbound.get(child_id, 0) + 1
-                    pending.append(child)
+            kind = term.get("kind")
+            children = (
+                term.get("args", []) or []
+                if kind == "ctor"
+                else [term["body"]]
+                if kind == "lambda"
+                else []
+            )
+            for child in children:
+                if not isinstance(child, dict):
+                    raise TypeError(
+                        f"RPC term child must be a dict, got {type(child)!r}"
+                    )
+                child_id = id(child)
+                inbound[child_id] = inbound.get(child_id, 0) + 1
+                pending.append(child)
 
         shared_canonical: dict[int, str] = {}
         cid_by_id: dict[int, str] = {}
@@ -1140,10 +1155,15 @@ class TermTableBuilder:
             if not finishing and cached_value is not None:
                 values.append(cached_value)
                 continue
-            if term.get("kind") == "ctor" and not finishing:
+            kind = term.get("kind")
+            if kind in {"ctor", "lambda"} and not finishing:
                 work.append((term, True))
-                args = term.get("args", []) or []
-                work.extend((child, False) for child in reversed(args))
+                children = (
+                    term.get("args", []) or []
+                    if kind == "ctor"
+                    else [term["body"]]
+                )
+                work.extend((child, False) for child in reversed(children))
                 continue
 
             if term.get("kind") == "ctor":
@@ -1169,6 +1189,26 @@ class TermTableBuilder:
                         }
                         for child in children
                     ],
+                }
+            elif term.get("kind") == "lambda":
+                body = values.pop()
+                canonical = (
+                    '{"body":'
+                    + body
+                    + ',"kind":"lambda","paramName":'
+                    + encode_jcs(vstr(term["paramName"]))
+                    + ',"paramSort":'
+                    + encode_jcs(_json_like_to_value(term["paramSort"]))
+                    + "}"
+                )
+                node_payload = {
+                    "kind": "lambda",
+                    "paramName": term["paramName"],
+                    "paramSort": term["paramSort"],
+                    "body": {
+                        "kind": "term-ref",
+                        "cid": blake3_512_of(_rpc_canonical_bytes(body)),
+                    },
                 }
             else:
                 # Leaves are shallow JSON objects — encode_jcs over the value
@@ -1220,6 +1260,16 @@ class TermTableBuilder:
                     for arg in term.args
                 ],
             }
+        if isinstance(term, _Lambda):
+            return {
+                "kind": "lambda",
+                "paramName": term.param_name,
+                "paramSort": json.loads(encode_jcs(sort_to_value(term.param_sort))),
+                "body": {
+                    "kind": "term-ref",
+                    "cid": self._require_cached_cid(term.body),
+                },
+            }
         return json.loads(encode_jcs(term_to_value(term)))
 
     def _materialize(self, root: Term) -> None:
@@ -1233,11 +1283,17 @@ class TermTableBuilder:
             if identity in seen:
                 continue
             seen.add(identity)
-            if isinstance(term, _Ctor):
-                for child in term.args:
-                    child_id = id(child)
-                    inbound[child_id] = inbound.get(child_id, 0) + 1
-                    pending.append(child)
+            children = (
+                term.args
+                if isinstance(term, _Ctor)
+                else (term.body,)
+                if isinstance(term, _Lambda)
+                else ()
+            )
+            for child in children:
+                child_id = id(child)
+                inbound[child_id] = inbound.get(child_id, 0) + 1
+                pending.append(child)
 
         # Canonical strings are retained only for shared nodes. A linear spine
         # therefore uses O(depth + root-bytes) memory instead of retaining every
@@ -1252,9 +1308,10 @@ class TermTableBuilder:
             if not finishing and cached_value is not None:
                 values.append(cached_value)
                 continue
-            if isinstance(term, _Ctor) and not finishing:
+            if isinstance(term, (_Ctor, _Lambda)) and not finishing:
                 work.append((term, True))
-                work.extend((child, False) for child in reversed(term.args))
+                children = term.args if isinstance(term, _Ctor) else (term.body,)
+                work.extend((child, False) for child in reversed(children))
                 continue
 
             if isinstance(term, _Ctor):
@@ -1267,6 +1324,17 @@ class TermTableBuilder:
                     + ",".join(children)
                     + '],"kind":"ctor","name":'
                     + encode_jcs(vstr(term.name))
+                    + "}"
+                )
+            elif isinstance(term, _Lambda):
+                body = values.pop()
+                canonical = (
+                    '{"body":'
+                    + body
+                    + ',"kind":"lambda","paramName":'
+                    + encode_jcs(vstr(term.param_name))
+                    + ',"paramSort":'
+                    + encode_jcs(sort_to_value(term.param_sort))
                     + "}"
                 )
             else:
@@ -1387,16 +1455,40 @@ def subst_var_in_term(t: Term, formal: str, actual: Term) -> Term:
     if isinstance(t, _Var):
         return actual if t.name == formal else t
     if isinstance(t, _Ctor):
-        bound = bound_transform_parts(t)
-        if bound is not None:
-            name, templates = bound
-            if name == formal:
-                return t
-            return bound_transform(
-                name, [subst_var_in_term(item, formal, actual) for item in templates]
-            )
         return ctor(t.name, [subst_var_in_term(a, formal, actual) for a in t.args])
+    if isinstance(t, _Lambda):
+        if t.param_name == formal:
+            return t
+        replacement_free = _free_vars_in_term(actual)
+        param_name = t.param_name
+        body = t.body
+        if param_name in replacement_free:
+            taken = replacement_free | _free_vars_in_term(body) | {formal, param_name}
+            suffix = 1
+            fresh = f"{param_name}#{suffix}"
+            while fresh in taken:
+                suffix += 1
+                fresh = f"{param_name}#{suffix}"
+            body = subst_var_in_term(body, param_name, make_var(fresh))
+            param_name = fresh
+        return _intern_term(
+            _Lambda(
+                param_name,
+                t.param_sort,
+                subst_var_in_term(body, formal, actual),
+            )
+        )
     return t  # const variants are inert
+
+
+def _free_vars_in_term(t: Term) -> set[str]:
+    if isinstance(t, _Var):
+        return {t.name}
+    if isinstance(t, _Ctor):
+        return set().union(*(_free_vars_in_term(arg) for arg in t.args))
+    if isinstance(t, _Lambda):
+        return _free_vars_in_term(t.body) - {t.param_name}
+    return set()
 
 
 def subst_var_in_formula(f: Formula, formal: str, actual: Term) -> Formula:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/formulas/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/formulas/__init__.py
@@ -9,6 +9,7 @@ from sugar_lift_py_tests.ir import Formula as IrFormula
 from sugar_lift_py_tests.ir import Term as IrTerm
 from sugar_lift_py_tests.ir import _Atomic, _Connective, _Ctor, _Quantifier, _Var
 from sugar_lift_py_tests.ir import and_ as ir_and
+from sugar_lift_py_tests.ir import bound_transform_parts
 from sugar_lift_py_tests.ir import eq as ir_eq
 from sugar_lift_py_tests.ir import formula_to_value
 from sugar_lift_py_tests.proofir._errors import proofir_construction_gap
@@ -170,9 +171,16 @@ def _free_vars_in_ir_term(
     if isinstance(ir_term, _Var):
         result = frozenset({ir_term.name})
     elif isinstance(ir_term, _Ctor):
-        result = frozenset().union(
-            *(_free_vars_in_ir_term(arg, memo) for arg in ir_term.args)
-        )
+        bound = bound_transform_parts(ir_term)
+        if bound is None:
+            result = frozenset().union(
+                *(_free_vars_in_ir_term(arg, memo) for arg in ir_term.args)
+            )
+        else:
+            name, templates = bound
+            result = frozenset().union(
+                *(_free_vars_in_ir_term(arg, memo) for arg in templates)
+            ) - {name}
     else:
         result = frozenset()
     memo[id(ir_term)] = result

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/formulas/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/formulas/__init__.py
@@ -7,9 +7,15 @@ from typing import Any, Generic, Mapping, TypeVar
 from sugar_lift_py_tests.canonicalizer import encode_jcs
 from sugar_lift_py_tests.ir import Formula as IrFormula
 from sugar_lift_py_tests.ir import Term as IrTerm
-from sugar_lift_py_tests.ir import _Atomic, _Connective, _Ctor, _Quantifier, _Var
+from sugar_lift_py_tests.ir import (
+    _Atomic,
+    _Connective,
+    _Ctor,
+    _Lambda,
+    _Quantifier,
+    _Var,
+)
 from sugar_lift_py_tests.ir import and_ as ir_and
-from sugar_lift_py_tests.ir import bound_transform_parts
 from sugar_lift_py_tests.ir import eq as ir_eq
 from sugar_lift_py_tests.ir import formula_to_value
 from sugar_lift_py_tests.proofir._errors import proofir_construction_gap
@@ -171,16 +177,11 @@ def _free_vars_in_ir_term(
     if isinstance(ir_term, _Var):
         result = frozenset({ir_term.name})
     elif isinstance(ir_term, _Ctor):
-        bound = bound_transform_parts(ir_term)
-        if bound is None:
-            result = frozenset().union(
-                *(_free_vars_in_ir_term(arg, memo) for arg in ir_term.args)
-            )
-        else:
-            name, templates = bound
-            result = frozenset().union(
-                *(_free_vars_in_ir_term(arg, memo) for arg in templates)
-            ) - {name}
+        result = frozenset().union(
+            *(_free_vars_in_ir_term(arg, memo) for arg in ir_term.args)
+        )
+    elif isinstance(ir_term, _Lambda):
+        result = _free_vars_in_ir_term(ir_term.body, memo) - {ir_term.param_name}
     else:
         result = frozenset()
     memo[id(ir_term)] = result

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/terms/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/terms/__init__.py
@@ -10,10 +10,10 @@ from sugar_lift_py_tests.ir import (
     _ConstReal,
     _ConstStr,
     _Ctor,
+    _Lambda,
     _Var,
     PrimitiveSort,
     bool_const,
-    bound_transform_parts,
     ctor,
     num,
     real_lit,
@@ -169,6 +169,22 @@ def term_from_ir(ir_term: IrTerm, *, sort: Sort | None = None) -> Term[Any]:
                 *(_free_vars_in_ir_term(arg) for arg in ir_term.args)
             ),
         )
+    if isinstance(ir_term, _Lambda):
+        if sort is None:
+            sort = Sort(
+                name="LegacyLambda",
+                ir_sort=PrimitiveSort("LegacyLambda"),
+            )
+        body_free_vars = _free_vars_in_ir_term(ir_term.body)
+        free_vars = body_free_vars - {ir_term.param_name}
+        free_var_sorts = {name: sort for name in body_free_vars}
+        free_var_sorts.pop(ir_term.param_name, None)
+        return WrappedTerm(
+            ir_term,
+            sort=sort,
+            free_vars=free_vars,
+            free_var_sorts=free_var_sorts,
+        )
     proofir_construction_gap(
         owner="proofir.terms.term_from_ir",
         observed=type(ir_term).__name__,
@@ -215,13 +231,9 @@ def _free_vars_in_ir_term(ir_term: IrTerm) -> frozenset[str]:
     if isinstance(ir_term, _Var):
         return frozenset({ir_term.name})
     if isinstance(ir_term, _Ctor):
-        bound = bound_transform_parts(ir_term)
-        if bound is not None:
-            name, templates = bound
-            return frozenset().union(
-                *(_free_vars_in_ir_term(arg) for arg in templates)
-            ) - {name}
         return frozenset().union(*(_free_vars_in_ir_term(arg) for arg in ir_term.args))
+    if isinstance(ir_term, _Lambda):
+        return _free_vars_in_ir_term(ir_term.body) - {ir_term.param_name}
     return frozenset()
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/terms/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/terms/__init__.py
@@ -13,6 +13,7 @@ from sugar_lift_py_tests.ir import (
     _Var,
     PrimitiveSort,
     bool_const,
+    bound_transform_parts,
     ctor,
     num,
     real_lit,
@@ -214,6 +215,12 @@ def _free_vars_in_ir_term(ir_term: IrTerm) -> frozenset[str]:
     if isinstance(ir_term, _Var):
         return frozenset({ir_term.name})
     if isinstance(ir_term, _Ctor):
+        bound = bound_transform_parts(ir_term)
+        if bound is not None:
+            name, templates = bound
+            return frozenset().union(
+                *(_free_vars_in_ir_term(arg) for arg in templates)
+            ) - {name}
         return frozenset().union(*(_free_vars_in_ir_term(arg) for arg in ir_term.args))
     return frozenset()
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
@@ -52,16 +52,17 @@ class ComprehensionSugar(Sugar):
 
     def _complete(self, iterable, element, key=None) -> Outcome:
         from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
-        from sugar_lift_py_tests.ir import ctor, str_const
+        from sugar_lift_py_tests.ir import bound_transform, ctor
 
         owner = str(self.site)
+        templates = []
+        if key is not None:
+            templates.append(key.to_term(owner=owner))
+        templates.append(element.to_term(owner=owner))
         args = [
             iterable.to_term(owner=owner),
-            str_const(self.target),
+            bound_transform(self.target, templates),
         ]
-        if key is not None:
-            args.append(key.to_term(owner=owner))
-        args.append(element.to_term(owner=owner))
         return Complete(
             ComprehensionValue(ctor(self.kind, args, symbol_kind="coordinate"))
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
@@ -52,16 +52,20 @@ class ComprehensionSugar(Sugar):
 
     def _complete(self, iterable, element, key=None) -> Outcome:
         from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
-        from sugar_lift_py_tests.ir import bound_transform, ctor
+        from sugar_lift_py_tests.ir import PrimitiveSort, _Lambda, _intern_term, ctor
 
         owner = str(self.site)
-        templates = []
         if key is not None:
-            templates.append(key.to_term(owner=owner))
-        templates.append(element.to_term(owner=owner))
+            body = ctor(
+                "python:dict_entry",
+                [key.to_term(owner=owner), element.to_term(owner=owner)],
+                symbol_kind="coordinate",
+            )
+        else:
+            body = element.to_term(owner=owner)
         args = [
             iterable.to_term(owner=owner),
-            bound_transform(self.target, templates),
+            _intern_term(_Lambda(self.target, PrimitiveSort("Value"), body)),
         ]
         return Complete(
             ComprehensionValue(ctor(self.kind, args, symbol_kind="coordinate"))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
@@ -1,0 +1,67 @@
+"""Simple symbolic comprehensions as non-hunting transform coordinates.
+
+Concrete comprehensions dissolve to displays in the source tree.  When the
+single iterable is symbolic, the comprehension instead retains the iterable,
+binding name, and transform term.  A call such as ``f(x)`` therefore remains
+the ordinary ``call:f(x)`` dig cue; this sugar never opens or copies ``f``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_pair
+
+
+@dataclass(frozen=True)
+class ComprehensionSugar(Sugar):
+    kind: str
+    target: str
+    iterable: Sugar
+    element: Sugar
+    key: Sugar | None = None
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        prefix = "def A(xs):\n    return [x for x in xs]\n\n"
+        return _call_pair(
+            name="symbolic_list_comprehension",
+            owner_sugar="ComprehensionSugar",
+            truthful=prefix + "def test_a():\n    assert A([1]) == [1]\n",
+            lying=prefix + "def test_a():\n    assert A([1]) == [2]\n",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        return self.iterable.desugar(ctx).and_then(
+            lambda iterable: self._with_iterable(iterable, ctx)
+        )
+
+    def _with_iterable(self, iterable, ctx: object) -> Outcome:
+        if self.key is not None:
+            return self.key.desugar(ctx).and_then(
+                lambda key: self.element.desugar(ctx).and_then(
+                    lambda element: self._complete(iterable, element, key)
+                )
+            )
+        return self.element.desugar(ctx).and_then(
+            lambda element: self._complete(iterable, element)
+        )
+
+    def _complete(self, iterable, element, key=None) -> Outcome:
+        from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        owner = str(self.site)
+        args = [
+            iterable.to_term(owner=owner),
+            str_const(self.target),
+        ]
+        if key is not None:
+            args.append(key.to_term(owner=owner))
+        args.append(element.to_term(owner=owner))
+        return Complete(
+            ComprehensionValue(ctor(self.kind, args, symbol_kind="coordinate"))
+        )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -84,6 +84,7 @@ class _ConditionalRaiseRoute:
     test: "Node"
     raised_on_true: bool
     exception_name: str
+_NESTED_COMPREHENSION_TEMPLATE = object()
 
 
 @dataclass(frozen=True)
@@ -3078,15 +3079,20 @@ class ListComp(Expression):
         `[e for x in [1, 2, 3]]` is three substitutions of x into e, and the
         comprehension rewrites to the List DISPLAY of those elements. The
         comprehension was never a meaning; it was a count of rewrites."""
-        if ListComp._contains_forbidden_shape(self, (self.elt,)):
-            return self
-        unrolled = self._try_unroll_to_display(scope)
+        unrolled = (
+            None
+            if scope.get(_NESTED_COMPREHENSION_TEMPLATE)
+            else self._try_unroll_to_display(scope)
+        )
         if unrolled is not None:
             return unrolled
         from .shadow import rewrite
 
         new_gens, inner, gc = self._substitute_generators(self.generators, scope)
-        new_elt, de = self._substitute_field(self.elt, inner)
+        template_scope = inner
+        if ListComp._contains_forbidden_shape(self, (self.elt,)):
+            template_scope = {**inner, _NESTED_COMPREHENSION_TEMPLATE: True}
+        new_elt, de = self._substitute_field(self.elt, template_scope)
         changed = {}
         if gc:
             changed["generators"] = new_gens
@@ -3228,15 +3234,20 @@ class SetComp(Expression):
     def substitute(self, scope):
         """A comprehension: thread each generator's target, then substitute the
         element against the scope with every target masked."""
-        if ListComp._contains_forbidden_shape(self, (self.elt,)):
-            return self
-        display = self._try_unroll_to_display(scope)
+        display = (
+            None
+            if scope.get(_NESTED_COMPREHENSION_TEMPLATE)
+            else self._try_unroll_to_display(scope)
+        )
         if display is not None:
             return display
         from .shadow import rewrite
 
         new_gens, inner, gc = self._substitute_generators(self.generators, scope)
-        new_elt, de = self._substitute_field(self.elt, inner)
+        template_scope = inner
+        if ListComp._contains_forbidden_shape(self, (self.elt,)):
+            template_scope = {**inner, _NESTED_COMPREHENSION_TEMPLATE: True}
+        new_elt, de = self._substitute_field(self.elt, template_scope)
         changed = {}
         if gc:
             changed["generators"] = new_gens
@@ -3312,19 +3323,24 @@ class DictComp(Expression):
     def substitute(self, scope):
         """A dict comprehension: thread the generators, then key and value
         against the scope with every target masked."""
-        if ListComp._contains_forbidden_shape(self, (self.key, self.value)):
-            return self
-        display = self._try_unroll_to_display(scope)
+        display = (
+            None
+            if scope.get(_NESTED_COMPREHENSION_TEMPLATE)
+            else self._try_unroll_to_display(scope)
+        )
         if display is not None:
             return display
         from .shadow import rewrite
 
         new_gens, inner, gc = self._substitute_generators(self.generators, scope)
+        template_scope = inner
+        if ListComp._contains_forbidden_shape(self, (self.key, self.value)):
+            template_scope = {**inner, _NESTED_COMPREHENSION_TEMPLATE: True}
         changed = {}
         if gc:
             changed["generators"] = new_gens
         for fld in ("key", "value"):
-            new, d = self._substitute_field(getattr(self, fld), inner)
+            new, d = self._substitute_field(getattr(self, fld), template_scope)
             if d:
                 changed[fld] = new
         return self if not changed else rewrite(self, **changed)
@@ -3415,12 +3431,13 @@ class GeneratorExp(Expression):
     def substitute(self, scope):
         """A comprehension: thread each generator's target, then substitute the
         element against the scope with every target masked."""
-        if ListComp._contains_forbidden_shape(self, (self.elt,)):
-            return self
         from .shadow import rewrite
 
         new_gens, inner, gc = self._substitute_generators(self.generators, scope)
-        new_elt, de = self._substitute_field(self.elt, inner)
+        template_scope = inner
+        if ListComp._contains_forbidden_shape(self, (self.elt,)):
+            template_scope = {**inner, _NESTED_COMPREHENSION_TEMPLATE: True}
+        new_elt, de = self._substitute_field(self.elt, template_scope)
         changed = {}
         if gc:
             changed["generators"] = new_gens

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3078,6 +3078,8 @@ class ListComp(Expression):
         `[e for x in [1, 2, 3]]` is three substitutions of x into e, and the
         comprehension rewrites to the List DISPLAY of those elements. The
         comprehension was never a meaning; it was a count of rewrites."""
+        if ListComp._contains_forbidden_shape(self, (self.elt,)):
+            return self
         unrolled = self._try_unroll_to_display(scope)
         if unrolled is not None:
             return unrolled
@@ -3190,6 +3192,33 @@ class ListComp(Expression):
             self.unit, ShadowNode("List", self.span, slots), self.reporter
         )
 
+    def _construct_sugar(self):
+        gen = ListComp._simple_generator(self)
+        if gen is None or ListComp._contains_forbidden_shape(self, (self.elt,)):
+            return super()._construct_sugar()
+        from sugar_lift_py_tests.sugar.comprehension_sugar import ComprehensionSugar
+
+        return ComprehensionSugar(
+            kind="py.listcomp",
+            target=gen.target.id,
+            iterable=gen.iter.sugar(),
+            element=self.elt.sugar(),
+            site=self.fragment,
+        )
+
+    def _simple_generator(self):
+        if len(self.generators) != 1:
+            return None
+        gen = self.generators[0]
+        if (
+            gen.is_async
+            or gen.ifs
+            or gen.target.kind != "Name"
+            or ListComp._contains_forbidden_shape(self, (gen.iter,))
+        ):
+            return None
+        return gen
+
 
 class SetComp(Expression):
     elt: Expression
@@ -3199,6 +3228,8 @@ class SetComp(Expression):
     def substitute(self, scope):
         """A comprehension: thread each generator's target, then substitute the
         element against the scope with every target masked."""
+        if ListComp._contains_forbidden_shape(self, (self.elt,)):
+            return self
         display = self._try_unroll_to_display(scope)
         if display is not None:
             return display
@@ -3257,6 +3288,20 @@ class SetComp(Expression):
             self.unit, ShadowNode("Set", self.span, slots), self.reporter
         )
 
+    def _construct_sugar(self):
+        gen = ListComp._simple_generator(self)
+        if gen is None or ListComp._contains_forbidden_shape(self, (self.elt,)):
+            return super()._construct_sugar()
+        from sugar_lift_py_tests.sugar.comprehension_sugar import ComprehensionSugar
+
+        return ComprehensionSugar(
+            kind="py.setcomp",
+            target=gen.target.id,
+            iterable=gen.iter.sugar(),
+            element=self.elt.sugar(),
+            site=self.fragment,
+        )
+
 
 class DictComp(Expression):
     key: Expression
@@ -3267,6 +3312,8 @@ class DictComp(Expression):
     def substitute(self, scope):
         """A dict comprehension: thread the generators, then key and value
         against the scope with every target masked."""
+        if ListComp._contains_forbidden_shape(self, (self.key, self.value)):
+            return self
         display = self._try_unroll_to_display(scope)
         if display is not None:
             return display
@@ -3342,6 +3389,23 @@ class DictComp(Expression):
             self.reporter,
         )
 
+    def _construct_sugar(self):
+        gen = ListComp._simple_generator(self)
+        if gen is None or ListComp._contains_forbidden_shape(
+            self, (self.key, self.value)
+        ):
+            return super()._construct_sugar()
+        from sugar_lift_py_tests.sugar.comprehension_sugar import ComprehensionSugar
+
+        return ComprehensionSugar(
+            kind="py.dictcomp",
+            target=gen.target.id,
+            iterable=gen.iter.sugar(),
+            key=self.key.sugar(),
+            element=self.value.sugar(),
+            site=self.fragment,
+        )
+
 
 class GeneratorExp(Expression):
     elt: Expression
@@ -3351,6 +3415,8 @@ class GeneratorExp(Expression):
     def substitute(self, scope):
         """A comprehension: thread each generator's target, then substitute the
         element against the scope with every target masked."""
+        if ListComp._contains_forbidden_shape(self, (self.elt,)):
+            return self
         from .shadow import rewrite
 
         new_gens, inner, gc = self._substitute_generators(self.generators, scope)
@@ -3361,6 +3427,20 @@ class GeneratorExp(Expression):
         if de:
             changed["elt"] = new_elt
         return self if not changed else rewrite(self, **changed)
+
+    def _construct_sugar(self):
+        gen = ListComp._simple_generator(self)
+        if gen is None or ListComp._contains_forbidden_shape(self, (self.elt,)):
+            return super()._construct_sugar()
+        from sugar_lift_py_tests.sugar.comprehension_sugar import ComprehensionSugar
+
+        return ComprehensionSugar(
+            kind="py.generatorexp",
+            target=gen.target.id,
+            iterable=gen.iter.sugar(),
+            element=self.elt.sugar(),
+            site=self.fragment,
+        )
 
 class Await(Expression):
     value: Expression

--- a/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
+++ b/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
@@ -1,12 +1,23 @@
 """Concrete comprehensions dissolve; simple symbolic forms retain coordinates."""
 
+import json
 import tempfile
 
 import pytest
 
 from sugar_lift_python_source.source_oracle import path_source
-from sugar_lift_py_tests.ir import ctor, num
+from sugar_lift_py_tests.ir import (
+    ctor,
+    encode_jcs,
+    make_var,
+    num,
+    str_const,
+    subst_var_in_term,
+    term_to_value,
+)
 from sugar_lift_py_tests.proofir.formulas import _free_vars_in_ir_term
+from sugar_lift_py_tests.proofir.sorts import Sort
+from sugar_lift_py_tests.proofir.terms import term_from_ir
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
@@ -72,11 +83,52 @@ def test_simple_symbolic_comprehension_builds_coordinate(source, coordinate, tra
     term = _out(f"def A(xs):\n    return {source}\n")
     assert term.name == coordinate
     assert term.args[0].name == "xs"
-    assert term.args[1].name == "py.bound_transform"
-    assert term.args[1].args[0].value == "x"
-    assert any(
-        getattr(arg, "name", None) == transform for arg in term.args[1].args[1:]
+    assert term.args[1].param_name == "x"
+    assert term.args[1].param_sort.name == "Value"
+    body = term.args[1].body
+    if coordinate == "py.dictcomp":
+        assert body.name == "python:dict_entry"
+        assert body.args[1].name == transform
+    else:
+        assert body.name == transform
+
+
+def test_symbolic_comprehension_serializes_transform_as_real_lambda():
+    term = _out("def A(xs, y):\n    return [f(x, y) for x in xs]\n")
+    wire = json.loads(encode_jcs(term_to_value(term)))
+    transform = wire["args"][1]
+
+    assert transform == {
+        "kind": "lambda",
+        "paramName": "x",
+        "paramSort": {"kind": "primitive", "name": "Value"},
+        "body": {
+            "kind": "ctor",
+            "name": "call:f",
+            "args": [
+                {"kind": "var", "name": "x"},
+                {"kind": "var", "name": "y"},
+            ],
+        },
+    }
+    assert _free_vars_in_ir_term(term.args[1]) == frozenset({"y"})
+    assert _free_vars_in_ir_term(term) == frozenset({"xs", "y"})
+
+    value_sort = Sort(name="Value", ir_sort=term.args[1].param_sort)
+    wrapped = term_from_ir(term.args[1], sort=value_sort)
+    assert wrapped.free_vars == frozenset({"y"})
+    assert wrapped.free_var_sorts == {"y": value_sort}
+
+
+def test_old_bound_transform_ctor_is_nonbinding_lying_twin():
+    lying = ctor(
+        "py.bound_transform",
+        [str_const("x"), ctor("call:f", [make_var("x")])],
     )
+    wire = json.loads(encode_jcs(term_to_value(lying)))
+
+    assert wire["kind"] == "ctor"
+    assert _free_vars_in_ir_term(lying) == frozenset({"x"})
 
 
 def test_bound_target_is_absent_from_coordinate_free_variables():
@@ -88,11 +140,12 @@ def test_same_spelled_outer_iterable_remains_free_while_element_is_bound():
     term = _out("def A(x):\n    return [f(x) for x in x]\n")
     assert _free_vars_in_ir_term(term) == frozenset({"x"})
     transform = term.args[1]
-    assert transform.args[1].name == "call:f"
-    assert transform.args[1].args[0].name == "x"
+    assert _free_vars_in_ir_term(transform) == frozenset()
+    assert transform.body.name == "call:f"
+    assert transform.body.args[0].name == "x"
 
 
-def test_nested_lambda_same_name_does_not_escape_bound_transform():
+def test_nested_lambda_same_name_does_not_escape_comprehension_transform():
     term = _out("def A(xs):\n    return [(lambda x: x) for x in xs]\n")
     assert _free_vars_in_ir_term(term) == frozenset({"xs"})
 
@@ -104,19 +157,17 @@ def test_bound_target_masks_outer_same_spelling_and_keeps_call_coordinate():
         "    return [f(x) for x in xs]\n"
     )
     assert term.name == "py.listcomp"
-    assert term.args[1].name == "py.bound_transform"
-    assert term.args[1].args[0].value == "x"
-    assert term.args[1].args[1].name == "call:f"
-    assert term.args[1].args[1].args[0].name == "x"
+    assert term.args[1].param_name == "x"
+    assert term.args[1].body.name == "call:f"
+    assert term.args[1].body.args[0].name == "x"
 
 
 def test_concrete_generator_builds_lazy_coordinate_without_materializing():
     term = _out("def A():\n    return (f(x) for x in [1, 2])\n")
     assert term.name == "py.generatorexp"
     assert term.args[0].name == "array"
-    assert term.args[1].name == "py.bound_transform"
-    assert term.args[1].args[0].value == "x"
-    assert term.args[1].args[1].name == "call:f"
+    assert term.args[1].param_name == "x"
+    assert term.args[1].body.name == "call:f"
 
 
 @pytest.mark.parametrize("consumer", ["sum", "list", "consume", "any", "all"])
@@ -148,15 +199,27 @@ def test_list_and_generator_keep_distinct_eager_and_lazy_coordinates():
 def test_generator_creation_keeps_call_inside_unexecuted_transform_template():
     term = _out("def A(xs):\n    return (f(x) for x in xs)\n")
     transform = term.args[1]
-    assert transform.name == "py.bound_transform"
-    assert transform.args[1].name == "call:f"
+    assert transform.param_name == "x"
+    assert transform.body.name == "call:f"
     assert _free_vars_in_ir_term(term) == frozenset({"xs"})
 
 
-def test_over_fuel_concrete_comprehension_builds_bound_transform_coordinate():
+def test_over_fuel_concrete_comprehension_builds_lambda_transform_coordinate():
     term = _out("def A():\n    return [f(x) for x in range(129)]\n")
     assert term.name == "py.listcomp"
-    assert term.args[1].name == "py.bound_transform"
+    assert term.args[1].param_name == "x"
+
+
+def test_lambda_substitution_alpha_renames_to_avoid_capture():
+    term = _out("def A(xs, y):\n    return [y for x in xs]\n")
+    transform = term.args[1]
+
+    substituted = subst_var_in_term(transform, "y", make_var("x"))
+
+    assert substituted.param_name != "x"
+    assert substituted.param_sort.name == "Value"
+    assert substituted.body.name == "x"
+    assert _free_vars_in_ir_term(substituted) == frozenset({"x"})
 
 
 def test_shadowed_range_is_not_unrolled_but_builds_symbolic_coordinate():

--- a/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
+++ b/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
@@ -1,4 +1,4 @@
-"""Concrete comprehensions dissolve to displays; symbolic/lazy shapes stay loud."""
+"""Concrete comprehensions dissolve; simple symbolic forms retain coordinates."""
 
 import tempfile
 
@@ -58,77 +58,47 @@ def test_dictcomp_preserves_last_value_for_duplicate_key():
 
 
 @pytest.mark.parametrize(
-    "source",
+    ("source", "coordinate", "transform"),
     [
-        "[x for x in xs]",
-        "{x for x in xs}",
-        "{x: x for x in xs}",
+        ("[f(x) for x in xs]", "py.listcomp", "call:f"),
+        ("{f(x) for x in xs}", "py.setcomp", "call:f"),
+        ("{x: f(x) for x in xs}", "py.dictcomp", "call:f"),
+        ("(f(x) for x in xs)", "py.generatorexp", "call:f"),
     ],
 )
-def test_symbolic_iterable_comprehensions_stay_loud(source):
-    with pytest.raises(SugarNotWritten):
-        _fn(f"def A(xs):\n    return {source}\n").sugar()
+def test_simple_symbolic_comprehension_builds_coordinate(source, coordinate, transform):
+    term = _out(f"def A(xs):\n    return {source}\n")
+    assert term.name == coordinate
+    assert term.args[0].name == "xs"
+    assert term.args[1].value == "x"
+    assert any(getattr(arg, "name", None) == transform for arg in term.args[2:])
 
 
-def test_generator_directly_consumed_by_sum_stays_loud_without_builtin_identity():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A():\n    return sum(x + 1 for x in range(3))\n").sugar()
+def test_concrete_generator_builds_lazy_coordinate_without_materializing():
+    term = _out("def A():\n    return (f(x) for x in [1, 2])\n")
+    assert term.name == "py.generatorexp"
+    assert term.args[0].name == "array"
+    assert term.args[1].value == "x"
+    assert term.args[2].name == "call:f"
 
 
-def test_generator_directly_consumed_by_list_stays_loud_without_builtin_identity():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A():\n    return list(x + 1 for x in range(3))\n").sugar()
+@pytest.mark.parametrize("consumer", ["sum", "list", "consume", "any", "all"])
+def test_generator_consumer_points_at_lazy_coordinate(consumer):
+    term = _out(f"def A():\n    return {consumer}(x for x in [0, 1])\n")
+    assert term.name == f"call:{consumer}"
+    assert term.args[0].name == "py.generatorexp"
 
 
-def test_bare_generator_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A():\n    return (x for x in range(3))\n").sugar()
-
-
-def test_generator_passed_to_unknown_call_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A():\n    return consume(x for x in range(3))\n").sugar()
-
-
-def test_shadowed_range_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A(range):\n    return [x for x in range(3)]\n").sugar()
-
-
-def test_shadowed_materializer_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A(sum):\n    return sum(x for x in [1, 2])\n").sugar()
-
-
-def test_locally_rebound_materializer_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn(
-            "def A(consume):\n"
-            "    sum = consume\n"
-            "    return sum(x for x in [1, 2])\n"
-        ).sugar()
-
-
-def test_module_rebound_materializer_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn(
-            "sum = consume\n"
-            "def A():\n"
-            "    return sum(x for x in [1, 2])\n"
-        ).sugar()
-
-
-@pytest.mark.parametrize("consumer", ["any", "all"])
-def test_short_circuit_generator_consumer_stays_loud(consumer):
-    with pytest.raises(SugarNotWritten):
-        _fn(f"def A():\n    return {consumer}(x for x in [0, 1])\n").sugar()
+def test_shadowed_range_is_not_unrolled_but_builds_symbolic_coordinate():
+    term = _out("def A(range):\n    return [x for x in range(3)]\n")
+    assert term.name == "py.listcomp"
+    assert term.args[0].name == "call:range"
 
 
 def test_every_filter_must_be_ground_decidable():
     with pytest.raises(SugarNotWritten):
         _fn(
-            "def A(limit):\n"
-            "    return [x for x in [0] if x > 0 if x > limit]\n"
+            "def A(limit):\n" "    return [x for x in [0] if x > 0 if x > limit]\n"
         ).sugar()
 
 
@@ -138,7 +108,6 @@ def test_every_filter_must_be_ground_decidable():
         "[y for x in [[1]] for y in x]",
         "[[y for y in [1]] for x in [1]]",
         "[(y := x) for x in [1]]",
-        "[x for x in range(129)]",
     ],
 )
 def test_unsupported_comprehension_structures_stay_loud(source):

--- a/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
+++ b/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
@@ -5,6 +5,8 @@ import tempfile
 import pytest
 
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.ir import ctor, num
+from sugar_lift_py_tests.proofir.formulas import _free_vars_in_ir_term
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
@@ -70,8 +72,29 @@ def test_simple_symbolic_comprehension_builds_coordinate(source, coordinate, tra
     term = _out(f"def A(xs):\n    return {source}\n")
     assert term.name == coordinate
     assert term.args[0].name == "xs"
-    assert term.args[1].value == "x"
-    assert any(getattr(arg, "name", None) == transform for arg in term.args[2:])
+    assert term.args[1].name == "py.bound_transform"
+    assert term.args[1].args[0].value == "x"
+    assert any(
+        getattr(arg, "name", None) == transform for arg in term.args[1].args[1:]
+    )
+
+
+def test_bound_target_is_absent_from_coordinate_free_variables():
+    term = _out("def A(xs):\n    return [f(x) for x in xs]\n")
+    assert _free_vars_in_ir_term(term) == frozenset({"xs"})
+
+
+def test_same_spelled_outer_iterable_remains_free_while_element_is_bound():
+    term = _out("def A(x):\n    return [f(x) for x in x]\n")
+    assert _free_vars_in_ir_term(term) == frozenset({"x"})
+    transform = term.args[1]
+    assert transform.args[1].name == "call:f"
+    assert transform.args[1].args[0].name == "x"
+
+
+def test_nested_lambda_same_name_does_not_escape_bound_transform():
+    term = _out("def A(xs):\n    return [(lambda x: x) for x in xs]\n")
+    assert _free_vars_in_ir_term(term) == frozenset({"xs"})
 
 
 def test_bound_target_masks_outer_same_spelling_and_keeps_call_coordinate():
@@ -81,17 +104,19 @@ def test_bound_target_masks_outer_same_spelling_and_keeps_call_coordinate():
         "    return [f(x) for x in xs]\n"
     )
     assert term.name == "py.listcomp"
-    assert term.args[1].value == "x"
-    assert term.args[2].name == "call:f"
-    assert term.args[2].args[0].name == "x"
+    assert term.args[1].name == "py.bound_transform"
+    assert term.args[1].args[0].value == "x"
+    assert term.args[1].args[1].name == "call:f"
+    assert term.args[1].args[1].args[0].name == "x"
 
 
 def test_concrete_generator_builds_lazy_coordinate_without_materializing():
     term = _out("def A():\n    return (f(x) for x in [1, 2])\n")
     assert term.name == "py.generatorexp"
     assert term.args[0].name == "array"
-    assert term.args[1].value == "x"
-    assert term.args[2].name == "call:f"
+    assert term.args[1].name == "py.bound_transform"
+    assert term.args[1].args[0].value == "x"
+    assert term.args[1].args[1].name == "call:f"
 
 
 @pytest.mark.parametrize("consumer", ["sum", "list", "consume", "any", "all"])
@@ -109,6 +134,29 @@ def test_shadowed_consumer_does_not_materialize_generator():
     )
     assert term.name == "call:materialize"
     assert term.args[0].name == "py.generatorexp"
+
+
+def test_list_and_generator_keep_distinct_eager_and_lazy_coordinates():
+    eager = _out("def A(xs):\n    return [f(x) for x in xs]\n")
+    lazy = _out("def A(xs):\n    return (f(x) for x in xs)\n")
+    assert eager.name == "py.listcomp"
+    assert lazy.name == "py.generatorexp"
+    assert eager.args[1] == lazy.args[1]
+    assert eager != lazy
+
+
+def test_generator_creation_keeps_call_inside_unexecuted_transform_template():
+    term = _out("def A(xs):\n    return (f(x) for x in xs)\n")
+    transform = term.args[1]
+    assert transform.name == "py.bound_transform"
+    assert transform.args[1].name == "call:f"
+    assert _free_vars_in_ir_term(term) == frozenset({"xs"})
+
+
+def test_over_fuel_concrete_comprehension_builds_bound_transform_coordinate():
+    term = _out("def A():\n    return [f(x) for x in range(129)]\n")
+    assert term.name == "py.listcomp"
+    assert term.args[1].name == "py.bound_transform"
 
 
 def test_shadowed_range_is_not_unrolled_but_builds_symbolic_coordinate():
@@ -135,3 +183,37 @@ def test_every_filter_must_be_ground_decidable():
 def test_unsupported_comprehension_structures_stay_loud(source):
     with pytest.raises(SugarNotWritten):
         _fn(f"def A():\n    return {source}\n").sugar()
+
+
+def test_nested_comprehension_substitutes_outer_capture_before_own_gap():
+    fn = _fn(
+        "def A():\n"
+        "    values = [1]\n"
+        "    return [[y for y in values] for x in [1]]\n"
+    )
+    expression = fn.substitute({}).body[-1].value
+    nested = expression.elt
+    assert nested.generators[0].iter.kind == "List"
+    with pytest.raises(SugarNotWritten):
+        expression.sugar()
+
+
+def test_walrus_comprehension_substitutes_outer_capture_before_own_gap():
+    fn = _fn(
+        "def A():\n"
+        "    value = 7\n"
+        "    return [(captured := value) for x in [1]]\n"
+    )
+    expression = fn.substitute({}).body[-1].value
+    assert expression.elt.value.value == 7
+    with pytest.raises(SugarNotWritten):
+        expression.sugar()
+
+
+def test_existing_concrete_displays_keep_exact_terms():
+    filtered = _out("def A():\n    return [x for x in [1, 2, 3] if x > 1]\n")
+    destructured = _out(
+        "def A():\n    return [a + b for a, b in [(1, 2), (3, 4)]]\n"
+    )
+    assert filtered == ctor("array", [num(2), num(3)])
+    assert destructured == ctor("array", [num(3), num(7)])

--- a/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
+++ b/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
@@ -74,6 +74,18 @@ def test_simple_symbolic_comprehension_builds_coordinate(source, coordinate, tra
     assert any(getattr(arg, "name", None) == transform for arg in term.args[2:])
 
 
+def test_bound_target_masks_outer_same_spelling_and_keeps_call_coordinate():
+    term = _out(
+        "def A(xs):\n"
+        "    x = 999\n"
+        "    return [f(x) for x in xs]\n"
+    )
+    assert term.name == "py.listcomp"
+    assert term.args[1].value == "x"
+    assert term.args[2].name == "call:f"
+    assert term.args[2].args[0].name == "x"
+
+
 def test_concrete_generator_builds_lazy_coordinate_without_materializing():
     term = _out("def A():\n    return (f(x) for x in [1, 2])\n")
     assert term.name == "py.generatorexp"
@@ -86,6 +98,16 @@ def test_concrete_generator_builds_lazy_coordinate_without_materializing():
 def test_generator_consumer_points_at_lazy_coordinate(consumer):
     term = _out(f"def A():\n    return {consumer}(x for x in [0, 1])\n")
     assert term.name == f"call:{consumer}"
+    assert term.args[0].name == "py.generatorexp"
+
+
+def test_shadowed_consumer_does_not_materialize_generator():
+    term = _out(
+        "def A(materialize):\n"
+        "    list = materialize\n"
+        "    return list(x for x in [0, 1])\n"
+    )
+    assert term.name == "call:materialize"
     assert term.args[0].name == "py.generatorexp"
 
 

--- a/implementations/python/sugar-source-tree/tests/test_listcomp_dissolves.py
+++ b/implementations/python/sugar-source-tree/tests/test_listcomp_dissolves.py
@@ -49,9 +49,10 @@ def test_undecidable_filtered_comprehension_stays_loud():
         _fn("def A(limit):\n    return [x for x in [1, 2] if x > limit]\n").sugar()
 
 
-def test_symbolic_comprehension_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A(xs):\n    return [x for x in xs]\n").sugar()
+def test_symbolic_comprehension_builds_coordinate():
+    t = _out("def A(xs):\n    return [x for x in xs]\n")
+    assert t.name == "py.listcomp"
+    assert t.args[0].name == "xs"
 
 
 if __name__ == "__main__":

--- a/implementations/rust/sugar-ir-types/tests/proofir_membership.rs
+++ b/implementations/rust/sugar-ir-types/tests/proofir_membership.rs
@@ -11,7 +11,7 @@ use sugar_ir_types::membership::{
     BoolSort, CallTerm, ClaimFormula, ConstTerm, ConstructionError, EqualityFact,
     FormulaProvenance, IntSort, OpenFormula, ProvenanceKind, ScopedFormula, VarTerm,
 };
-use sugar_ir_types::{Formula, Sort};
+use sugar_ir_types::{Declaration, Document, Formula, Sort, Term};
 
 fn crate_root() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -235,4 +235,151 @@ fn legal_near_miss_scopes_explicit_free_var() {
 
     let scoped: ScopedFormula = open.scope(scope).expect("x is explicitly scoped as Int");
     assert!(scoped.formula().free_vars().contains("x"));
+}
+
+fn python_comprehension_document(expression: &str, parameters: &str) -> Document {
+    let repo = crate_root()
+        .ancestors()
+        .nth(3)
+        .expect("sugar-ir-types lives below the repository root");
+    let python_path = [
+        repo.join("implementations/python/sugar-source-tree/src"),
+        repo.join("implementations/python/sugar-lift-py-tests/src"),
+        repo.join("implementations/python/sugar-lift-python-source/src"),
+    ]
+    .iter()
+    .map(|path| path.display().to_string())
+    .collect::<Vec<_>>()
+    .join(":");
+    let script = r#"
+import json
+import sys
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.ir import ContractDecl, atomic, declarations_to_value, encode_jcs, make_var
+from sugar_source_tree.tree import SourceFile
+
+expression, parameters = sys.argv[1], sys.argv[2]
+with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as source:
+    source.write(f"def A({parameters}):\n    return {expression}\n")
+    path = source.name
+function = next(SourceFile(path_source(path)).functions())
+term = function.sugar().desugar().value.post().args[1]
+post = atomic("=", [make_var("out"), term])
+print(encode_jcs(declarations_to_value([ContractDecl("A", post=post)])))
+"#;
+    let output = Command::new("python3")
+        .arg("-c")
+        .arg(script)
+        .arg(expression)
+        .arg(parameters)
+        .env("PYTHONPATH", python_path)
+        .current_dir(repo)
+        .output()
+        .expect("run Python comprehension construction");
+    assert!(
+        output.status.success(),
+        "Python construction failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("parse complete Python ProofIR document")
+}
+
+fn document_post_term(document: Document) -> Term {
+    let Declaration::Contract {
+        post: Some(Formula::Atomic { mut args, .. }),
+        ..
+    } = document.into_iter().next().expect("one contract")
+    else {
+        panic!("Python document must contain one contract with an atomic post")
+    };
+    assert_eq!(args.len(), 2, "post equality has output and comprehension");
+    args.pop().expect("comprehension term")
+}
+
+fn free_vars(term: Term) -> std::collections::BTreeSet<String> {
+    let formula = Formula::Atomic {
+        name: "=".to_string(),
+        args: vec![term],
+    };
+    let open = OpenFormula::from_ir_formula_with_sorts(formula, BTreeMap::new());
+    open.free_vars()
+}
+
+#[test]
+fn python_comprehension_lambda_survives_rust_parse_and_membership() {
+    let term = document_post_term(python_comprehension_document(
+        "[f(x, y) for x in xs]",
+        "xs, y",
+    ));
+    let Term::Ctor { args, .. } = &term else {
+        panic!("comprehension must remain a constructor coordinate")
+    };
+    let transform = args.get(1).expect("comprehension transform");
+    assert!(matches!(transform, Term::Lambda { .. }));
+    assert_eq!(free_vars(transform.clone()), ["y".to_string()].into());
+    assert_eq!(
+        free_vars(term.clone()),
+        ["xs".to_string(), "y".to_string()].into()
+    );
+
+    let formula = Formula::Atomic {
+        name: "=".to_string(),
+        args: vec![term],
+    };
+    let sorts = BTreeMap::from([
+        (
+            "xs".to_string(),
+            Sort::Primitive {
+                name: "Value".into(),
+            },
+        ),
+        (
+            "y".to_string(),
+            Sort::Primitive {
+                name: "Value".into(),
+            },
+        ),
+    ]);
+    OpenFormula::from_ir_formula_with_sorts(formula, sorts.clone())
+        .scope(sorts)
+        .expect("membership admits xs and y without admitting bound x");
+}
+
+#[test]
+fn bound_transform_spelling_does_not_turn_a_ctor_into_a_binder() {
+    let lying: Term = serde_json::from_value(json!({
+        "kind": "ctor",
+        "name": "py.bound_transform",
+        "args": [
+            {"kind": "const", "value": "x", "sort": {"kind": "primitive", "name": "String"}},
+            {"kind": "ctor", "name": "call:f", "args": [{"kind": "var", "name": "x"}]}
+        ]
+    }))
+    .expect("lying constructor parses as an ordinary term");
+    assert!(matches!(lying, Term::Ctor { .. }));
+    assert_eq!(free_vars(lying.clone()), ["x".to_string()].into());
+
+    let formula = Formula::Atomic {
+        name: "=".to_string(),
+        args: vec![lying],
+    };
+    let err = OpenFormula::from_ir_formula_with_sorts(formula, BTreeMap::new())
+        .scope(BTreeMap::new())
+        .expect_err("x is not admitted");
+    assert!(matches!(err, ConstructionError::IllegalFreeVars { .. }));
+}
+
+#[test]
+fn same_spelling_binds_only_transform_body_after_rust_parse() {
+    let term = document_post_term(python_comprehension_document("[f(x) for x in x]", "x"));
+    let Term::Ctor { args, .. } = &term else {
+        panic!("comprehension must remain a constructor coordinate")
+    };
+    assert_eq!(
+        free_vars(args[1].clone()),
+        std::collections::BTreeSet::new()
+    );
+    assert_eq!(free_vars(term), ["x".to_string()].into());
 }


### PR DESCRIPTION
## What changed

- preserve existing concrete ListComp, SetComp, and DictComp dissolution to displays
- construct simple one-generator symbolic comprehensions as typed coordinates carrying iterable, bound target, and transform
- construct GeneratorExp as a lazy coordinate for both concrete and symbolic iterables
- keep nested, multi-generator, filtered, async, walrus, and unsupported-target shapes loud

The transform remains its ordinary term, such as `call:f(x)`, so the comprehension points at the callee and never opens or copies its body.

## Predicted pandas impact

The family headline is 1,052 nodes (ListComp 639, SetComp 18, DictComp 117, GeneratorExp 278). This change can lower only the simple one-generator unfiltered direct subset, so predicted `Epsilon direct_gap_R` is bounded from 0 through -1,052 pending the next census; it does not claim the blocked-descendant portion.

## Verification

- focused comprehension tests: 28 passed
- full source-tree tests: 310 passed, 5 skipped, 1 xfailed
- `git diff --check`: clean

DO NOT MERGE from this lane.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add lambda terms and capture-avoiding substitution to support comprehension desugaring
> - Introduces `_Lambda` as a new IR term type with a parameter name, sort, and body, enabling comprehensions to desugar into coordinate constructors with a lambda transform instead of immediate evaluation.
> - Adds `_free_vars_in_term` and updates `subst_var_in_term` to be capture-avoiding for lambdas, including alpha-renaming when substitution would capture a bound variable.
> - Extends `TermTableBuilder`, `term_to_value`, and `_intern_term` to serialize, intern, and canonicalize lambda terms through the full IR pipeline.
> - `ComprehensionSugar` in [comprehension_sugar.py](https://github.com/TSavo/sugar/pull/6052/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) lowers Python-style list/dict comprehensions into `py.listcomp`/`py.dictcomp` coordinate constructors wrapping an interned `_Lambda`.
> - Nested comprehensions with forbidden-shape elements no longer prematurely unroll; `ListComp.substitute` propagates a sentinel scope to defer unrolling.
> - New Rust-side tests in [proofir_membership.rs](https://github.com/TSavo/sugar/pull/6052/files#diff-671781e31a5ffa0d8359fab2e3a115c84c904ba4877b7a08cf76d018e3564c09) verify that lambda terms survive round-trip parsing and that binding only covers the transform body.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 635f212.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->