### PR TITLE
drain: AugAssign/AnnAssign build bindings (pandas)

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1206,14 +1206,31 @@ class AugAssign(Statement):
         bound yet, so there is no shape where a Name target both fails to
         thread and stays loud). The rebind rode into the tail as the fold
         binding; the statement itself states nothing more. Attribute/subscript
-        targets are the shapes substitution_binding leaves as a gap (returns None --
-        they are never threaded), so they stay loud gaps here too, mirrored
-        exactly against that same isinstance check."""
-        if not isinstance(self.target, Name):
-            return super()._construct_sugar()
-        from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+        targets are runtime stores rather than lexical bindings, so they reuse
+        Assign's typed attribute/subscript store effects."""
+        if isinstance(self.target, Name):
+            from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
 
-        return InertSugar(site=self.fragment)
+            return InertSugar(site=self.fragment)
+        if isinstance(self.target, Attribute):
+            from sugar_lift_py_tests.sugar.store_effect_sugar import (
+                AttributeStoreEffectSugar,
+            )
+
+            return AttributeStoreEffectSugar(
+                attr=self.target.attr,
+                site=self.fragment,
+            )
+        if isinstance(self.target, Subscript):
+            from sugar_lift_py_tests.sugar.store_effect_sugar import (
+                SubscriptStoreEffectSugar,
+            )
+
+            return SubscriptStoreEffectSugar(
+                index_text=self.target.slice_.fragment.text,
+                site=self.fragment,
+            )
+        return super()._construct_sugar()
 
 
 class AnnAssign(Statement):
@@ -1253,13 +1270,32 @@ class AnnAssign(Statement):
         The annotation itself is NEVER a fact the meaning layer states either
         way: Python does not check it at runtime (no TypeError on mismatch),
         so an annotation asserts nothing -- it is documentation the tree
-        passes through, never a stated post. Non-Name targets (attribute,
-        subscript) stay loud gaps -- no partial binding, no partial sugar."""
-        if not isinstance(self.target, Name):
-            return super()._construct_sugar()
-        from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+        passes through, never a stated post. A valued attribute/subscript target
+        is the same runtime store owned by Assign. A bare non-Name annotation
+        stays loud: evaluating that target is not an inert name declaration."""
+        if isinstance(self.target, Name):
+            from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
 
-        return InertSugar(site=self.fragment)
+            return InertSugar(site=self.fragment)
+        if self.value is not None and isinstance(self.target, Attribute):
+            from sugar_lift_py_tests.sugar.store_effect_sugar import (
+                AttributeStoreEffectSugar,
+            )
+
+            return AttributeStoreEffectSugar(
+                attr=self.target.attr,
+                site=self.fragment,
+            )
+        if self.value is not None and isinstance(self.target, Subscript):
+            from sugar_lift_py_tests.sugar.store_effect_sugar import (
+                SubscriptStoreEffectSugar,
+            )
+
+            return SubscriptStoreEffectSugar(
+                index_text=self.target.slice_.fragment.text,
+                site=self.fragment,
+            )
+        return super()._construct_sugar()
 
 
 class TypeAlias(Statement):

--- a/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
+++ b/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
@@ -1,16 +1,18 @@
 """AnnAssign (`x: T = v` / bare `x: T`) and AugAssign (`x OP= e`) -- both are
 INERT at the meaning layer for a plain Name target, because their binding (if
 any) already threaded via substitute/substitution_binding before sugar runs;
-an annotation states nothing at runtime either way. Non-Name targets (and
-attribute/subscript augmented targets, the shape substitution_binding refuses)
-stay loud gaps."""
+an annotation states nothing at runtime either way. Attribute/subscript
+augmented targets and valued annotations build one typed runtime-store effect;
+bare non-Name annotations remain loud gaps."""
 
 import tempfile
 
-import pytest
-
 from sugar_lift_python_source.source_oracle import path_source
-from sugar_source_tree.panic import SugarNotWritten
+from sugar_lift_py_tests.effect import (
+    AttributeStoreRuntimeEffect,
+    SubscriptStoreRuntimeEffect,
+)
+from sugar_lift_py_tests.outcome import Incomplete
 from sugar_source_tree.tree import SourceFile
 
 
@@ -39,13 +41,37 @@ def test_aug_assign_rebinds_and_is_inert():
     assert v.post().args[1].value == 2
 
 
-def test_attribute_aug_assign_stays_loud():
-    # obj.a += 1 -- the target is not a plain Name, so substitution_binding
-    # refuses it (returns None, never threads); sugar() mirrors that refusal
-    # exactly and stays a loud gap rather than a silent/partial binding.
-    fn = _fn("def A(obj):\n    obj.a += 1\n    return obj\n")
-    with pytest.raises(SugarNotWritten):
-        fn.sugar()
+def _red_effects(source):
+    entries = _fn(source).sugar().desugar().value.record.statements
+    return [entry.effect for entry in entries if isinstance(entry, Incomplete)]
+
+
+def test_attribute_aug_assign_builds_store_effect():
+    effects = _red_effects("def A(obj, y):\n    obj.a += y\n    return y\n")
+
+    assert len(effects) == 1
+    assert isinstance(effects[0], AttributeStoreRuntimeEffect)
+
+
+def test_subscript_aug_assign_builds_store_effect():
+    effects = _red_effects("def A(d, k, y):\n    d[k] += y\n    return y\n")
+
+    assert len(effects) == 1
+    assert isinstance(effects[0], SubscriptStoreRuntimeEffect)
+
+
+def test_annotated_attribute_with_value_builds_store_effect():
+    effects = _red_effects("def A(obj, y):\n    obj.a: int = y\n    return y\n")
+
+    assert len(effects) == 1
+    assert isinstance(effects[0], AttributeStoreRuntimeEffect)
+
+
+def test_annotated_subscript_with_value_builds_store_effect():
+    effects = _red_effects("def A(d, k, y):\n    d[k]: int = y\n    return y\n")
+
+    assert len(effects) == 1
+    assert isinstance(effects[0], SubscriptStoreRuntimeEffect)
 
 
 def test_aug_assign_with_no_prior_binding_is_sound():
@@ -76,7 +102,10 @@ if __name__ == "__main__":
     test_annotated_assign_with_value_is_inert_and_threads()
     test_bare_annotation_lifts_and_states_nothing()
     test_aug_assign_rebinds_and_is_inert()
-    test_attribute_aug_assign_stays_loud()
+    test_attribute_aug_assign_builds_store_effect()
+    test_subscript_aug_assign_builds_store_effect()
+    test_annotated_attribute_with_value_builds_store_effect()
+    test_annotated_subscript_with_value_builds_store_effect()
     test_aug_assign_with_no_prior_binding_is_sound()
     test_discrimination_annassign_value_changes_the_post()
-    print("ok: AnnAssign/AugAssign inert for Name targets, loud otherwise")
+    print("ok: AnnAssign/AugAssign target roles build or stay loud by shape")


### PR DESCRIPTION
## What builds

- plain-name `x OP= y` continues to build the existing shadow `x OP y` BinOp and thread it as the new lexical binding; the statement is inert after substitution consumes the binding
- plain-name `x: T = y` continues to thread the same value binding as Assign; the annotation contributes no fabricated runtime fact
- bare plain-name `x: T` continues to build as an inert declaration with no binding
- attribute AugAssign now builds the existing typed attribute-store effect
- subscript AugAssign now builds the existing typed subscript-store effect
- valued attribute AnnAssign now builds the existing typed attribute-store effect
- valued subscript AnnAssign now builds the existing typed subscript-store effect

Bare non-name annotations remain loud because target evaluation is not the inert plain-name declaration modeled by this lane.

## Instrumentation

- plain AugAssign binding and unbound-formal rebinding tests remain
- valued and bare plain AnnAssign tests remain
- new attribute/subscript AugAssign tests require one correctly typed store effect
- new valued attribute/subscript AnnAssign tests require one correctly typed store effect

## Focused receipt

`PYTHONPATH=implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src:implementations/python/sugar-lift-py-tests/src python3 -m pytest implementations/python/sugar-source-tree/tests -q`

323 passed, 5 skipped, 1 xfailed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Build `AttributeStoreEffectSugar` and `SubscriptStoreEffectSugar` for `AugAssign`/`AnnAssign` targets
> - `AugAssign._construct_sugar` now returns `AttributeStoreEffectSugar` or `SubscriptStoreEffectSugar` for Attribute and Subscript targets respectively, replacing the prior superclass delegation that left these as loud gaps.
> - `AnnAssign._construct_sugar` applies the same typed sugar for valued Attribute/Subscript targets; bare annotations (no value) on non-Name targets still delegate to the superclass.
> - Tests in [`test_annassign_augassign.py`](https://github.com/TSavo/sugar/pull/6053/files#diff-30ccfa310e23bca737065f9008a2cc5abfe0aa5c4cc93f778912a95faa683c35) are updated to assert `AttributeStoreRuntimeEffect` and `SubscriptStoreRuntimeEffect` are produced, replacing prior loud-gap expectations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 033be9b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->