### PR TITLE
drain: While builds (pandas)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/while_invariant_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/while_invariant_sugar.py
@@ -1,0 +1,47 @@
+"""The invariant stated by an assert-only symbolic ``while`` body."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class WhileInvariantSugar(Sugar):
+    test: Sugar
+    body: tuple
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.floor.inv_value import InvValue
+        from sugar_lift_py_tests.ir import implies
+        from sugar_lift_py_tests.outcome import Incomplete
+        from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_statements
+
+        condition = self.test.desugar(ctx)
+        if isinstance(condition, Incomplete):
+            return condition
+        formula = getattr(
+            getattr(condition.value.truth(self.site), "value", None), "formula", None
+        )
+        if formula is None:
+            raise NotImplementedError(
+                "symbolic while invariant requires a predicate condition"
+            )
+
+        entries, _falls, _ft = reduce_statements(self.body)
+        wrapped = []
+        for entry in entries:
+            site = getattr(entry, "site", None) or self.site
+            wrapped.extend(
+                InvValue(implies(formula, fact), site)
+                for fact in entry.inv_contribution()
+            )
+        return Complete(BlockValue(tuple(wrapped), can_fall_through=True))

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1651,10 +1651,10 @@ class While(Statement):
         i = i + 1` unrolls to three rebinds of i; `return i` reads 3.
 
         A condition that is NOT ground-decidable against the carried state (a
-        formal in the state, an effect) keeps the node -- the symbolic while is
-        the recurrence-with-exit-condition, an unwritten segment that stays
-        loud. `while True:` exhausts the fuel and lands there too: an infinite
-        concrete loop is a non-termination the unroll must not fake."""
+        formal in the state, an effect) keeps the node for the symbolic fold or
+        assert-invariant construction arm. `while True:` exhausts the fuel and
+        stays loud: an infinite concrete loop is a non-termination the unroll
+        must not fake."""
         from .shadow import rewrite
 
         unrolled = self._try_unroll(scope)
@@ -1674,6 +1674,89 @@ class While(Statement):
             if d:
                 changed[f] = new
         return self if not changed else rewrite(self, **changed)
+
+    def substitution_binding(self, scope):
+        """Bind a clean symbolic recurrence into the tail as one dig coordinate."""
+        spec = self._symbolic_fold_spec()
+        if spec is None or self._has_literal_test_bound():
+            return None
+        name, update = spec
+        init = scope.get(name.id)
+        if init is None:
+            return None
+        fold = For._make_call(
+            self,
+            For._make_name(self, "py.while.fold"),
+            (init, self.test, update),
+        )
+        return {name.id: fold}
+
+    def _symbolic_fold_spec(self):
+        """The single condition-driven recurrence update, or None."""
+        if self.orelse or For._body_has_loop_control(self):
+            return None
+        carried, facts = For._carried_and_facts(self)
+        if facts or len(carried) != 1:
+            return None
+        assign = carried[0]
+        if assign.kind != "Assign" or len(assign.targets) != 1:
+            return None
+        name = assign.targets[0]
+        if name.kind != "Name" or not any(
+            node.kind == "Name" and node.id == name.id for node in self.test.walk()
+        ):
+            return None
+        update = assign.value
+        if update.kind == "BinOp":
+            if update.left.kind != "Name" or update.left.id != name.id:
+                return None
+            return name, update
+        if (
+            update.kind == "Call"
+            and update.func.kind == "Name"
+            and not update.keywords
+            and len(update.args) == 1
+            and update.args[0].kind == "Name"
+            and update.args[0].id == name.id
+        ):
+            return name, update
+        return None
+
+    def _has_literal_test_bound(self) -> bool:
+        """A surviving literal-bounded test is a failed concrete unroll."""
+        if self.test.kind == "Constant":
+            return True
+        if self.test.kind != "Compare":
+            return False
+        operands = (self.test.left, *self.test.comparators)
+        return any(
+            For._concrete_int(self, operand) is not None for operand in operands
+        )
+
+    def _construct_sugar(self):
+        """Construct only the symbolic fold and assert-invariant While roles."""
+        if (
+            self.orelse
+            or self._has_literal_test_bound()
+            or For._body_has_loop_control(self)
+        ):
+            return super()._construct_sugar()
+        carried, facts = For._carried_and_facts(self)
+        if carried:
+            if facts or self._symbolic_fold_spec() is None:
+                return super()._construct_sugar()
+            from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+
+            return InertSugar(site=self.fragment)
+        if not self.body or any(stmt.kind != "Assert" for stmt in self.body):
+            return super()._construct_sugar()
+        from sugar_lift_py_tests.sugar.while_invariant_sugar import WhileInvariantSugar
+
+        return WhileInvariantSugar(
+            test=self.test.sugar(),
+            body=tuple(stmt.sugar() for stmt in self.body),
+            site=self.fragment,
+        )
 
     def _try_unroll(self, scope):
         """The unrolled statement tuple, or None if the loop is not concrete

--- a/implementations/python/sugar-source-tree/tests/test_while_unroll.py
+++ b/implementations/python/sugar-source-tree/tests/test_while_unroll.py
@@ -1,14 +1,11 @@
-"""A `while` over CONCRETE state dissolves: each iteration is one more
-substitution, the condition ground-decided structurally against the carried
-state. `while True:` exhausts the fuel (an infinite concrete loop is a
-non-termination the unroll must not fake) and a symbolic condition keeps the
-node -- both land loud, honest unwritten segments."""
+"""Concrete While dissolves; clean symbolic While constructs fold/invariant."""
 
 import tempfile
 
 import pytest
 
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.tree_enumerate import audit_file_gaps
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
@@ -22,6 +19,18 @@ def _fn(src):
 
 def _out(src):
     return _fn(src).sugar().desugar().value.post().args[1]
+
+
+def _invs(src):
+    return _fn(src).sugar().desugar().value.invs()
+
+
+def _while_gaps(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    _sf, gaps = audit_file_gaps(path)
+    return [(node, panic) for node, panic in gaps if node.kind == "While"]
 
 
 def test_concrete_counter_unrolls():
@@ -46,9 +55,36 @@ def test_while_true_stays_loud():
         _fn("def A():\n    i = 0\n    while True:\n        i = i + 1\n    return i\n").sugar()
 
 
-def test_symbolic_condition_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A(n):\n    i = 0\n    while i < n:\n        i = i + 1\n    return i\n").sugar()
+def test_symbolic_single_accumulator_is_a_conditioned_fold_coordinate():
+    post = _fn(
+        "def A(n):\n    i = 0\n    while i < n:\n        i = i + 1\n    return i\n"
+    ).sugar().desugar().value.post()
+    fold = post.args[1]
+    assert fold.name == "call:py.while.fold"
+    assert fold.args[0].value == 0
+    assert fold.args[1].name == "py.lt"
+    assert fold.args[2].name == "+"
+
+
+def test_symbolic_call_update_remains_a_nested_dig_coordinate():
+    post = _fn(
+        "def A(limit):\n    state = seed\n    while state != limit:\n"
+        "        state = step(state)\n    return state\n"
+    ).sugar().desugar().value.post()
+    fold = post.args[1]
+    assert fold.name == "call:py.while.fold"
+    assert fold.args[1].name == "py.not"
+    assert fold.args[2].name == "call:step"
+
+
+def test_symbolic_assert_only_while_is_a_guarded_invariant():
+    inv = _invs(
+        "def A(active, value):\n    while active:\n"
+        "        assert value == value\n    return value\n"
+    )[0]
+    assert inv.kind == "implies"
+    assert inv.operands[0].name == "py.truthy"
+    assert inv.operands[1].name == "py.eq"
 
 
 if __name__ == "__main__":
@@ -56,9 +92,10 @@ if __name__ == "__main__":
     test_concrete_accumulator_unrolls()
     test_false_condition_skips_the_body()
     test_while_true_stays_loud()
-    test_symbolic_condition_stays_loud()
+    test_symbolic_single_accumulator_is_a_conditioned_fold_coordinate()
+    test_symbolic_assert_only_while_is_a_guarded_invariant()
     test_while_else_splices_after_the_exit()
-    print("ok: concrete while unrolls; True/symbolic loud")
+    print("ok: concrete While unrolls; clean symbolic While builds")
 
 
 def test_while_else_splices_after_the_exit():
@@ -68,3 +105,49 @@ def test_while_else_splices_after_the_exit():
         "    else:\n        i = i + 100\n    return i\n"
     )
     assert _out(src).value == 102
+
+
+@pytest.mark.parametrize(
+    "src",
+    (
+        "def A():\n    i = 0\n    while i < 2:\n        i = i + 1\n    return i\n",
+        "def A(n):\n    i = 0\n    while i < n:\n        i = i + 1\n    return i\n",
+        "def A(active, value):\n    while active:\n"
+        "        assert value == value\n    return value\n",
+        "def A(limit):\n    state = seed\n    while state != limit:\n"
+        "        state = step(state)\n    return state\n",
+    ),
+    ids=("concrete", "symbolic-fold", "assert-invariant", "call-fold"),
+)
+def test_admitted_while_shapes_leave_no_production_gap(src):
+    assert _while_gaps(src) == []
+
+
+@pytest.mark.parametrize(
+    "src",
+    (
+        "def A(n):\n    i = 0\n    while i < n:\n        break\n    return i\n",
+        "def A(n):\n    i = 0\n    while i < n:\n        continue\n    return i\n",
+        "def A(n):\n    i = 0\n    total = 0\n    while i < n:\n"
+        "        total = total + i\n        i = i + 1\n    return total\n",
+        "def A(n):\n    i = 0\n    while i < n:\n"
+        "        assert i == i\n        i = i + 1\n    return i\n",
+        "def A(n):\n    i = 0\n    while i < n:\n        i = i + 1\n"
+        "    else:\n        i = 100\n    return i\n",
+        "def A(active):\n    while active:\n        consume(active)\n    return active\n",
+        "def A():\n    i = 0\n    while i < 129:\n        i = i + 1\n    return i\n",
+    ),
+    ids=(
+        "break",
+        "continue",
+        "multi-carried",
+        "mixed",
+        "symbolic-else",
+        "effect",
+        "over-fuel",
+    ),
+)
+def test_hard_while_shapes_report_exact_production_gap(src):
+    gaps = _while_gaps(src)
+    assert len(gaps) == 1
+    assert type(gaps[0][1]) is SugarNotWritten


### PR DESCRIPTION
## Scope

- preserve the existing bounded concrete While substitution, including no-break else splicing
- construct one clean symbolic accumulator as `py.while.fold(init, condition, update)` so both condition and recurrence remain dig-visible
- construct assert-only symbolic While as condition-guarded invariant facts
- keep break/continue, multi-carried, mixed fact+accumulator, symbolic else, side-effecting, infinite, and over-fuel shapes loud as exact `SugarNotWritten`

## Production discrimination

`audit_file_gaps` proves concrete, arithmetic fold, call-update fold, and assert-invariant shapes have no While gap. Break/continue/multi-carried/mixed/symbolic-else/effect/over-fuel twins each retain exactly one While gap.

## Focused receipt

```text
PYTHONPATH=implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src:implementations/python/sugar-lift-py-tests/src python3 -m pytest --noconftest implementations/python/sugar-source-tree/tests/test_while_unroll.py implementations/python/sugar-source-tree/tests/test_for_unroll.py implementations/python/sugar-source-tree/tests/test_substitute_int_literal.py -q
39 passed in 0.99s
```

Python compilation and `git diff --check origin/main...HEAD` also pass.

Predicted node-count gain: `-N_clean_symbolic_while` direct gaps from the 31-site baseline (`0 <= N <= 31`); blocked-descendant movement predicted zero. The exact pandas value is census-owned and is not fabricated locally.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add symbolic while-loop desugaring for fold coordinates and assert-guarded invariants
> - `While._construct_sugar` now routes clean symbolic while loops into two new paths: single-variable recurrences (no facts) become `InertSugar` plus a `py.while.fold` substitution binding, and assert-only bodies become `WhileInvariantSugar` that emits `implies(test_predicate, fact)` invariants.
> - `While._symbolic_fold_spec` detects single-carried recurrences supporting `name = name <binop> ...` and `name = func(name)` update forms.
> - `While._has_literal_test_bound` excludes constant and concrete-int-bounded tests from the symbolic paths, treating them as failed concrete unrolls.
> - `WhileInvariantSugar.desugar` reduces body assertions and wraps each `inv_contribution` fact as `InvValue(implies(formula, fact))`, returning a `Complete(BlockValue(..., can_fall_through=True))`.
> - Tests in [`test_while_unroll.py`](https://github.com/TSavo/sugar/pull/6054/files#diff-79f1cccdc6c4bec91d81376b1f78de3a6f5b78d7ccb0ccce88ecbfea29b1d85b) are updated to cover fold coordinates, call-based recurrences, guarded invariants, and production gap audits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30bcaa4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->