### PR TITLE
drain: Assert builds its check (pandas)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assert_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assert_sugar.py
@@ -28,6 +28,7 @@ class AssertSugar(Sugar):
 
     test: Sugar
     site: object = dataclass_field(compare=False)
+    message: object | None = dataclass_field(compare=False, default=None)
 
     @classmethod
     def witnesses(cls):
@@ -49,4 +50,3 @@ class AssertSugar(Sugar):
         return self.test.desugar(ctx).and_then(
             lambda value: value.stated(self.site)
         )
-

--- a/implementations/python/sugar-lift-py-tests/tests/test_assert_sugar_from_node.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assert_sugar_from_node.py
@@ -3,8 +3,8 @@
 Source string, parsed, the Assert node asked for its sugar: an AssertSugar
 whose `test` is the EqualityOpSugar the Compare node produced — the whole
 recursion, Assert → Compare → two Constants, all node.sugar() calling
-node.sugar(). No factory in the chain. The message operand is provenance
-only (never a child sugar): AssertSugar never builds or reduces it.
+node.sugar(). No factory in the chain. The message operand is source
+provenance only: AssertSugar carries its pinned fragment but never reduces it.
 """
 from __future__ import annotations
 
@@ -53,16 +53,31 @@ def test_a_bare_assert_holds_its_terms_sugar():
     assert isinstance(sugar.test, IntLiteralSugar) and sugar.test.value == 1
 
 
-def test_an_assert_with_a_message_fails_loudly_until_provenance_is_carried():
-    # `assert cond, "msg"` — the message is provenance (assertMessage on the
-    # memento), never a child sugar. Carrying it is not written yet, so an
-    # assert that HAS a message must throw loudly, not silently drop it.
-    # Silent loss is a MISSING becoming success — forbidden.
+def test_assert_with_message_builds_and_carries_message_provenance():
+    node = _assert_node("assert 1 == 1, 'boom'\n")
+    sugar = node.sugar()
+    outcome = sugar.desugar()
+
+    assert isinstance(sugar, AssertSugar)
+    assert sugar.message.text == "'boom'"
+    assert outcome.value.site.memento().extra["assertMessage"] == "'boom'"
+    assert outcome.value.site.memento().to_rpc()["assertMessage"] == "'boom'"
+
+
+def test_assert_message_is_not_reduced_on_the_success_path():
+    node = _assert_node("assert 1 == 1, (yield 2)\n")
+
+    sugar = node.sugar()
+
+    assert sugar.message.text == "yield 2"
+
+
+def test_unbuilt_condition_child_preserves_its_own_gap():
     from sugar_source_tree.panic import SugarNotWritten
 
-    node = _assert_node("assert 1 == 1, 'boom'\n")
+    node = _assert_node("assert (yield 1)\n")
     try:
         node.sugar()
-        assert False, "an assert with a message must fail loudly, not drop it"
-    except SugarNotWritten:
-        pass
+        assert False, "the Yield child gap must remain loud"
+    except SugarNotWritten as panic:
+        assert panic.owner == "Yield.sugar"

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/fragment.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/fragment.py
@@ -116,10 +116,20 @@ class SourceFragment:
         from sugar_lift_py_tests.kit_rpc.source_span_dto import SourceSpanDto
 
         lc = self.line_col_span
+        extra = {}
+        node = self.node
+        from .nodes import Assert
+
+        if isinstance(node, Assert) and node.msg is not None:
+            # Diagnostic provenance only.  CPython evaluates this expression
+            # on the failing path; the fact membrane carries its exact pinned
+            # spelling without constructing or reducing it (#4593/#4594).
+            extra["assertMessage"] = node.msg.fragment.text
         return SourceMementoDto(
             file=self.filename,
             span=SourceSpanDto(lc.start_line, lc.start_col, lc.end_line, lc.end_col),
             source_cid=self.seal().cid,
+            extra=extra,
         )
 
     def seal(self) -> SourceMemento:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2210,18 +2210,15 @@ class Assert(Statement):
         """`assert <test>[, <msg>]` constructs AssertSugar WITH the test's
         sugar. The test recognizes itself (self.test.sugar()) — the recursion.
         The message is provenance only (#4593/#4594): AssertSugar never builds
-        or reduces it, so it is not passed as a child sugar.
+        or reduces it; its pinned fragment rides separately from the condition.
         """
         from sugar_lift_py_tests.sugar.assert_sugar import AssertSugar
 
-        if self.msg is not None:
-            # The message is provenance (assertMessage on the memento, #4593/
-            # #4594) — never a child sugar, but NOT nothing. Carrying it onto
-            # the memento is not written yet, so an assert that has one FAILS
-            # LOUDLY rather than silently dropping it. Silent loss is the exact
-            # MISSING-becomes-success this design forbids.
-            return super()._construct_sugar()
-        return AssertSugar(test=self.test.sugar(), site=self.fragment)
+        return AssertSugar(
+            test=self.test.sugar(),
+            message=self.msg.fragment if self.msg is not None else None,
+            site=self.fragment,
+        )
 
 
 class Import(Statement):


### PR DESCRIPTION
## What changed

- Every Assert node now constructs AssertSugar from its normally constructed condition.
- Message-bearing asserts carry the message expression as oracle-pinned provenance without reducing or evaluating it.
- Assertion source warrants project the exact message spelling through assertMessage.
- An unbuilt condition remains loud with the child owner; no generic Assert fallback masks it.

## Pandas syntax partition

A syntax-only scan of cached pandas 3.0.3 source found 17,405 message-free asserts and 138 message-bearing asserts. Current main already builds the message-free arm; this lane admits the 138 message-bearing parent nodes when their condition children construct. This is a syntax projection, not an observed census delta.

## Focused receipts

- 7 passed: Assert construction and end-to-end assertion lift
- 16 passed, 1 skipped: source-fragment/memento and roll-call tests
- Python only; no Rust build and no full pandas census


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Build `Assert._construct_sugar` for pandas assert nodes that carry a message
> - `Assert._construct_sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/6055/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now always returns an `AssertSugar`, passing the message's fragment via a new `message` field instead of falling back to a failure path when a message was present.
> - `AssertSugar` gains an optional `message` field (excluded from equality comparisons) to carry the pinned source fragment of the assert message.
> - `SourceFragment.to_rpc()` in [fragment.py](https://github.com/TSavo/sugar/pull/6055/files#diff-9b30966a38ea981a2bb45d5bc8ae6730c4d2c6f2fb8535ed7cf799acd34da03a) now includes an `extra.assertMessage` entry with the pinned text when the fragment belongs to an `Assert` node with a message.
> - The message expression is stored as provenance only and is never reduced on success paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1675e1b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->