### PR TITLE
drain: Delete builds its unbinding/effect (pandas)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py
@@ -5,6 +5,7 @@ from .append_runtime_effect import AppendRuntimeEffect
 from .async_context_manager_runtime_effect import AsyncContextManagerRuntimeEffect
 from .async_iteration_runtime_effect import AsyncIterationRuntimeEffect
 from .attribute_store_runtime_effect import AttributeStoreRuntimeEffect
+from .attribute_delete_runtime_effect import AttributeDeleteRuntimeEffect
 from .attribute_augassign_runtime_effect import AttributeAugAssignRuntimeEffect
 from .await_runtime_effect import AwaitRuntimeEffect
 from .block_operator_runtime_effect import BlockOperatorRuntimeEffect
@@ -67,6 +68,7 @@ from .sequence_concatenation_runtime_effect import SequenceConcatenationRuntimeE
 from .source_oracle_effect import SourceOracleEffect
 from .starred_positional_runtime_effect import StarredPositionalRuntimeEffect
 from .subscript_store_runtime_effect import SubscriptStoreRuntimeEffect
+from .subscript_delete_runtime_effect import SubscriptDeleteRuntimeEffect
 from .subscript_result_runtime_effect import SubscriptResultRuntimeEffect
 from .subtract_runtime_effect import SubtractRuntimeEffect, runtime_subtract
 from .type_error_runtime_effect import TypeErrorRuntimeEffect
@@ -79,6 +81,7 @@ __all__ = [
     "AsyncContextManagerRuntimeEffect",
     "AsyncIterationRuntimeEffect",
     "AttributeStoreRuntimeEffect",
+    "AttributeDeleteRuntimeEffect",
     "AttributeAugAssignRuntimeEffect",
     "AwaitRuntimeEffect",
     "BlockOperatorRuntimeEffect",
@@ -135,6 +138,7 @@ __all__ = [
     "SourceOracleEffect",
     "StarredPositionalRuntimeEffect",
     "SubscriptStoreRuntimeEffect",
+    "SubscriptDeleteRuntimeEffect",
     "SubscriptResultRuntimeEffect",
     "SubtractRuntimeEffect",
     "runtime_subtract",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/attribute_delete_runtime_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/attribute_delete_runtime_effect.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .runtime_effect import RuntimeEffect
+
+
+@dataclass(frozen=True)
+class AttributeDeleteRuntimeEffect(RuntimeEffect):
+    """An attribute deletion whose descriptor dispatch belongs to Python."""
+
+    def kind(self) -> type[RuntimeEffect]:
+        return AttributeDeleteRuntimeEffect

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/subscript_delete_runtime_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/subscript_delete_runtime_effect.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .runtime_effect import RuntimeEffect
+
+
+@dataclass(frozen=True)
+class SubscriptDeleteRuntimeEffect(RuntimeEffect):
+    """A subscript deletion whose __delitem__ dispatch belongs to Python."""
+
+    def kind(self) -> type[RuntimeEffect]:
+        return SubscriptDeleteRuntimeEffect

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -60,6 +60,7 @@ from .warning_observation_value import WarningObservationValue
 from .effect_coordinate import EffectCoordinate, ExceptionInfoCoordinate
 from .return_value import ReturnValue
 from .scope_rebind import GuardedScopeRebind, ScopeRebind
+from .scope_unbind import ScopeUnbind
 from .sequence_constructor import SequenceConstructor
 from .set_literal_value import SetLiteralValue
 from .set_value import SetValue
@@ -118,6 +119,7 @@ REGISTERED_FLOOR_TYPES: tuple[type[FloorDispatchSurface], ...] = (
     RaisesWithValue,
     ReturnValue,
     ScopeRebind,
+    ScopeUnbind,
     SequenceConstructor,
     SetLiteralValue,
     SetValue,
@@ -197,6 +199,7 @@ __all__ = [
     "ExceptionInfoCoordinate",
     "ReturnValue",
     "ScopeRebind",
+    "ScopeUnbind",
     "SequenceConstructor",
     "SetLiteralValue",
     "SetValue",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/scope_unbind.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/scope_unbind.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class ScopeUnbind(FloorValue):
+    """A lexical deletion carried to the remaining statement scope."""
+
+    names: tuple[str, ...]
+
+    def contribution(self):
+        return ()
+
+    def extend_scope(self, ctx):
+        return replace(ctx, temporal=ctx.temporal.unbind_names(self.names))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/incomplete.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/incomplete.py
@@ -95,7 +95,9 @@ def _effect_continues_control_flow(effect) -> bool:
     """
     from sugar_lift_py_tests.effect import (
         AttributeAugAssignRuntimeEffect,
+        AttributeDeleteRuntimeEffect,
         AttributeStoreRuntimeEffect,
+        SubscriptDeleteRuntimeEffect,
         SubscriptStoreRuntimeEffect,
     )
 
@@ -105,5 +107,7 @@ def _effect_continues_control_flow(effect) -> bool:
             SubscriptStoreRuntimeEffect,
             AttributeStoreRuntimeEffect,
             AttributeAugAssignRuntimeEffect,
+            AttributeDeleteRuntimeEffect,
+            SubscriptDeleteRuntimeEffect,
         ),
     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_sugar.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Incomplete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+
+@dataclass(frozen=True)
+class DeleteTarget:
+    kind: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class DeleteSugar(Sugar):
+    """Ordered lexical unbindings and typed Python store-delete effects."""
+
+    targets: tuple[DeleteTarget, ...]
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return NotVerdictBearing(
+            sugar_name="DeleteSugar",
+            floor_name="ScopeUnbind",
+            reason="delete constructs scope/effect state rather than a value verdict",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        from sugar_lift_py_tests.effect import (
+            AttributeDeleteRuntimeEffect,
+            SubscriptDeleteRuntimeEffect,
+            runtime_effect_evidence,
+        )
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.floor.scope_unbind import ScopeUnbind
+        from sugar_lift_py_tests.ir import make_var
+
+        entries = []
+        for target in self.targets:
+            if target.kind == "name":
+                entries.append(ScopeUnbind((target.detail,)))
+                continue
+            if target.kind == "attribute":
+                operand = make_var(f"delete_target.{target.detail}")
+                effect = AttributeDeleteRuntimeEffect(
+                    "attribute deletion runtime boundary: Python must dispatch "
+                    f"__delattr__/descriptor deletion for .{target.detail}; "
+                    f"site={self.site}",
+                    **runtime_effect_evidence("py.delattr", operand, self.site),
+                )
+            else:
+                operand = make_var(f"delete_target[{target.detail}]")
+                effect = SubscriptDeleteRuntimeEffect(
+                    "subscript deletion runtime boundary: Python must dispatch "
+                    f"__delitem__ for [{target.detail}]; site={self.site}",
+                    **runtime_effect_evidence("py.delitem", operand, self.site),
+                )
+            entries.append(Incomplete(effect))
+        return Complete(BlockValue(tuple(entries), can_fall_through=True))

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -331,6 +331,10 @@ class Node(Typed):
         so its value is already rewritten against the scope that stood before it."""
         return None
 
+    def substitution_unbinding(self) -> "tuple[str, ...]":
+        """Names this statement removes before the block tail is rewritten."""
+        return ()
+
     def _make_binop(self, left: "Node", op, right: "Node") -> "Node":
         """Construct a fresh BinOp node ``<left> <op> <right>`` as a shadow that
         borrows this node's span (so it still addresses this source site). Used
@@ -475,6 +479,8 @@ class Node(Typed):
                 binding = produced_stmt.substitution_binding(scope)
                 if binding:
                     scope = {**scope, **binding}
+                for name in produced_stmt.substitution_unbinding():
+                    scope.pop(name, None)
                 # walrus bindings nested in the statement's expressions leak out
                 # to the enclosing block (their scope is the containing function).
                 for node in produced_stmt.walk():
@@ -1066,8 +1072,34 @@ class Delete(Statement):
     _child_fields = ("targets",)
 
     def substitute(self, scope):
-        """Binds nothing: recurse into children and reassemble."""
-        return self._substitute_children(scope)
+        """Names are deletion sites; store-target operands remain ordinary loads."""
+        from .shadow import rewrite
+
+        targets = []
+        changed = False
+        for target in self.targets:
+            new_target = target if isinstance(target, Name) else target.substitute(scope)
+            targets.append(new_target)
+            changed |= new_target is not target
+        return self if not changed else rewrite(self, targets=tuple(targets))
+
+    def substitution_unbinding(self):
+        return tuple(target.id for target in self.targets if isinstance(target, Name))
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.delete_sugar import DeleteSugar, DeleteTarget
+
+        targets = []
+        for target in self.targets:
+            if isinstance(target, Name):
+                targets.append(DeleteTarget("name", target.id))
+            elif isinstance(target, Attribute):
+                targets.append(DeleteTarget("attribute", target.attr))
+            elif isinstance(target, Subscript):
+                targets.append(DeleteTarget("subscript", target.slice_.fragment.text))
+            else:
+                return super()._construct_sugar()
+        return DeleteSugar(targets=tuple(targets), site=self.fragment)
 
 
 class Assign(Statement):

--- a/implementations/python/sugar-source-tree/tests/test_delete_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_delete_targets.py
@@ -1,0 +1,72 @@
+"""Delete constructs lexical unbinding and ordered target effects."""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_py_tests.outcome import Incomplete
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn(src):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _entries(src):
+    return _fn(src).sugar().desugar().value.record.statements
+
+
+def test_name_delete_unbinds_the_old_tree_binding_and_builds():
+    value = (
+        _fn("def A():\n    x = 1\n    del x\n    return x\n").sugar().desugar().value
+    )
+    post = value.post()
+    assert post.args[1].name == "x"
+
+
+@pytest.mark.parametrize(
+    ("source", "effect_name", "operand_text"),
+    [
+        (
+            "def A(o):\n    del o.attr\n    return o\n",
+            "AttributeDeleteRuntimeEffect",
+            "delete_target.attr",
+        ),
+        (
+            "def A(d, k):\n    del d[k]\n    return d\n",
+            "SubscriptDeleteRuntimeEffect",
+            "delete_target[k]",
+        ),
+    ],
+)
+def test_store_delete_builds_typed_continuing_effect(source, effect_name, operand_text):
+    entries = _entries(source)
+    red = [entry for entry in entries if isinstance(entry, Incomplete)]
+    assert len(red) == 1
+    assert type(red[0].effect).__name__ == effect_name
+    assert operand_text in repr(red[0].effect.witness.runtime_operand.term)
+    assert any(type(entry).__name__ == "ReturnValue" for entry in entries)
+
+
+def test_multi_target_delete_builds_each_target_in_source_order():
+    entries = _entries(
+        "def A(o, d, k):\n" "    x = 1\n" "    del x, o.attr, d[k]\n" "    return x\n"
+    )
+    red = [entry for entry in entries if isinstance(entry, Incomplete)]
+    assert [type(entry.effect).__name__ for entry in red] == [
+        "AttributeDeleteRuntimeEffect",
+        "SubscriptDeleteRuntimeEffect",
+    ]
+    returned = [entry for entry in entries if type(entry).__name__ == "ReturnValue"]
+    assert returned[0].value.to_term(owner="test").name == "x"
+
+
+@pytest.mark.parametrize("target", ["(a, b)", "[a, b]"])
+def test_nested_delete_target_grammar_stays_loud(target):
+    with pytest.raises(SugarNotWritten):
+        _fn(f"def A(a, b):\n    del {target}\n    return a\n").sugar()

--- a/implementations/python/sugar-source-tree/tests/test_roll_call.py
+++ b/implementations/python/sugar-source-tree/tests/test_roll_call.py
@@ -156,9 +156,8 @@ def test_the_roster_covers_every_source_line() -> None:
 
 def test_discharge_produces_the_true_minority_written_vs_not() -> None:
     # The whole loop: construction REGISTERS (constructor), discharge ANSWERS
-    # present (template) or absent (abstract). A written function's nodes
-    # discharge present; an unwritten construct (Delete has no sugar) and its
-    # ancestors stay in the minority -- red until written.
+    # present (template) or absent (abstract). Written Return and Delete nodes
+    # discharge present; genuinely unwritten registered nodes stay minority.
     from sugar_source_tree.roll_call import discharge
 
     r = CollectingReporter()
@@ -166,5 +165,6 @@ def test_discharge_produces_the_true_minority_written_vs_not() -> None:
     kinds_present = {e.kind for e in report.present}
     kinds_absent = {e.kind for e in report.minority}
     assert "Return" in kinds_present  # a's body desugared
-    assert "Delete" in kinds_absent  # the unwritten construct is minority
+    assert "Delete" in kinds_present  # lexical unbinding now constructs
+    assert "Delete" not in kinds_absent
     assert not report.is_clean  # R > 0 while anything is unwritten


### PR DESCRIPTION
## What changed

- `del x` removes the AST-local binding before the remaining block is substituted and carries a scope-only unbind outcome
- `del obj.attr` constructs an `AttributeDeleteRuntimeEffect`
- `del d[k]` constructs a `SubscriptDeleteRuntimeEffect`
- comma-separated targets construct in source order
- tuple/list target grammar remains an honest `SugarNotWritten` boundary

Delete store effects are continuing typed-red statements, mirroring assignment store effects, so later statements still construct. No target body or implementation is hunted.

## Verification

- Delete plus adjacent Assign/store tests: 24 passed
- full source-tree tests: 308 passed, 5 skipped, 1 xfailed
- `git diff --check`: clean

DO NOT MERGE from this lane.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add delete desugaring for name unbinding and attribute/subscript deletion effects
> - Introduces `ScopeUnbind` floor value that removes names from the temporal scope when evaluated, used for `del name` targets.
> - Adds `AttributeDeleteRuntimeEffect` and `SubscriptDeleteRuntimeEffect` as new `RuntimeEffect` types representing attribute and subscript deletion boundaries.
> - Implements `DeleteSugar.desugar()` in [delete_sugar.py](https://github.com/TSavo/sugar/pull/6056/files#diff-441493491f890e3165443955aa3781a9ca7c236a63faa6661d676e1ac9be0b87) to emit ordered `BlockValue` entries: `ScopeUnbind` for name targets, `Incomplete` with typed effects for attribute/subscript targets.
> - Extends `nodes.Delete` in [nodes.py](https://github.com/TSavo/sugar/pull/6056/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) with `substitution_unbinding()`, `_construct_sugar()`, and updated `substitute()` so name delete targets are preserved as deletion sites rather than resolved during substitution.
> - During block rewriting, names declared by `substitution_unbinding()` are now popped from the substitution scope for subsequent statements.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9790ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->