### PR TITLE
fix: remove dead refusal vocabulary (gap / could-not-parse / source-unavailable / unwitnessed / open)

### DIFF
--- a/implementations/python/sugar-lift-py-pytest-witness/tests/test_witness.py
+++ b/implementations/python/sugar-lift-py-pytest-witness/tests/test_witness.py
@@ -18,7 +18,7 @@ from sugar_pytest_witness import (
 )
 from sugar_pytest_witness.discharge_cli import main as discharge_main
 from sugar_lift_py_tests.witness_oracle import (
-    WitnessOracleRefusal,
+    WitnessOracleUnwitnessed,
     resolve_witness,
 )
 from sugar_lift_py_tests.filename import cid_filename
@@ -139,7 +139,7 @@ def test_oracle_refuses_minted_witness_when_code_drifts(tmp_path):
     def recompute(_m):
         return run_and_witness(proj, w.test_id, list(w.code_files)).cid
 
-    with pytest.raises(WitnessOracleRefusal, match="recompute misaligned"):
+    with pytest.raises(WitnessOracleUnwitnessed, match="recompute misaligned"):
         resolve_witness(m, recompute_fn=recompute)
 
 
@@ -147,7 +147,7 @@ def test_oracle_refuses_minted_witness_with_tampered_signature(tmp_path):
     proj = _project(tmp_path, GOOD)
     m = witness_memento(run_and_witness(proj, "test_add.py", CODE))
     m["signature"] = "00" * 64  # forge the mark
-    with pytest.raises(WitnessOracleRefusal, match="signature invalid"):
+    with pytest.raises(WitnessOracleUnwitnessed, match="signature invalid"):
         resolve_witness(m)
 
 
@@ -183,7 +183,7 @@ def test_package_tamper_is_refused_by_content_address(tmp_path):
     with open(paths[0], "ab") as f:
         f.write(b" tampered")  # swap the body under the same name
     body = read_witness_body(w.cid, str(pkg))
-    with pytest.raises(WitnessOracleRefusal, match="content misaligned"):
+    with pytest.raises(WitnessOracleUnwitnessed, match="content misaligned"):
         resolve_witness(witness_memento(w), witness_content=body)
 
 

--- a/implementations/python/sugar-lift-py-tests/scripts/classify_loud_timeouts.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/classify_loud_timeouts.py
@@ -15,7 +15,7 @@ with escalating bounds (60s → 120s → 300s) and records an explicit verdict:
 
 Hard law:
   - Timeout is NEVER silently reclassified as complete or dropped.
-  - No panic/refusal weakened; no bound raised to invent green without recording slow.
+  - No panic/gap weakened; no bound raised to invent green without recording slow.
   - Single-lane sequential replay only (no host parallelism).
   - Ledger is append-only JSONL so partial progress ships and residual R is measured.
 

--- a/implementations/python/sugar-lift-py-tests/scripts/finite_unfold_compact_projection_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/finite_unfold_compact_projection_law.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """R_finite_unfold_compact_gaps — over-cap finite For/range must project compactly.
 
-Illegal residual: ForSugar / CallSugar still refuse decidable finite over-cap work
+Illegal residual: ForSugar / CallSugar still leave decidable finite over-cap work as gaps
 (or finite for + non-ground while) with ``finite_unfold_cap_panic`` instead of the
 shared compact projection door.
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
@@ -45,7 +45,7 @@ class EffectMatcher:
     the unit of honesty is the individual obligation, never the surface
     construct). The type obligation is decidable against the observed halt;
     each payload obligation (e.g. MessagePattern from `match=`) carries its own
-    closed verdict -- discharged / refuted / undischarged -- sharing the same
+    closed verdict -- discharged / disproven / undischarged -- sharing the same
     observed-effect witness identity."""
 
     kind: str  # "raise" | "warning"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/runtime_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/runtime_effect.py
@@ -180,7 +180,7 @@ class RuntimeEffectWitness:
     the address, so an absolute or empty locus is unrepresentable by
     construction (both fragment currencies normalize filenames at their own
     construction doors). Fabricated string sites and non-term operands are
-    refused here.
+    remains a gap here.
     """
 
     operation: Term

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -534,7 +534,7 @@ class CallSiteValue(FloorValue):
         Concrete containers fold post-state. A callsite receiver (for example
         ``dict_class(...)``) has no element history, but the delete still
         rebinds the name: carry prior coordinate and index on ``py.delitem``.
-        Do not invent members; do not soft-refuse — silence stays illegal.
+        Do not invent members; do not hide the gap — silence stays illegal.
         """
         from sugar_lift_py_tests.ir import ctor
         from sugar_lift_py_tests.outcome import Complete
@@ -569,7 +569,7 @@ class CallSiteValue(FloorValue):
         and the derived value remain independently visible at the EUF join.
         Only a single ``out = ground-value`` post is a derived value pin;
         opaque, effectful, symbolic, and multi-exit bodies stay absent and
-        therefore loud at the existing refusal/gap boundary.
+        therefore loud at the existing construction-gap boundary.
 
         Ground values are primitive consts *and* data constructors the
         verifier treats as structural values (``None``, ``py.ellipsis``,
@@ -1158,7 +1158,7 @@ def _project_callsite_floor(
 
 # Data constructors the verifier treats as structural *values* (not operators /
 # callsites). Must stay aligned with sugar-verifier `is_ground_data_ctor_name`
-# so Derived residue duals refuse the same ground faces structurally.
+# so Derived residue duals leave the same ground faces as gaps structurally.
 _GROUND_DATA_CTOR_NAMES = frozenset(
     {
         "tuple",
@@ -1186,7 +1186,7 @@ def _is_ground_value_term(term) -> bool:
     Mirrors sugar-verifier ``is_const_value``: primitive consts, plus ground
     data constructors whose args are themselves ground. Operator/callsite
     ctors (``+``, ``call:…``, ``py.attr``, …) stay out so dig residue cannot
-    invent a dual that structural consistency would not refuse.
+    invent a dual that structural consistency would not mark as a gap.
     """
     from sugar_lift_py_tests.ir import (
         _ConstBool,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py
@@ -11,7 +11,7 @@ class ComplexValue(FloorValue):
     parts (both Python floats). Stands as the vendor-canonical
     ``py.complex(<real>, <imag>)`` ctor: already in the verifier's structural
     ground-ctor whitelist (``consistency.rs`` #4398 -- "py.complex is a data
-    value, dual complex literals refuse"), the kit's own ground-ctor list
+    value, dual complex literals remain gaps"), the kit's own ground-ctor list
     (``call_site_value.py._GROUND_DATA_CTOR_NAMES``), and the isinstance fold
     table (``symbolic_value.py``: ``"py.complex": "complex"``). This is the
     ONE representation -- never a second complex encoding."""

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -765,7 +765,7 @@ class SymbolicValue(FloorValue):
         Concrete containers fold post-state. A symbolic formal (for example
         ``**kwargs``) has no element history, but the assignment still rebinds
         the name: carry prior coordinate, index, and value on ``py.setitem``.
-        Do not invent members; do not soft-refuse — silence stays illegal.
+        Do not invent members; do not hide the gap — silence stays illegal.
         """
         from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
         from sugar_lift_py_tests.ir import ctor

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/collect_dunder_frontier.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/collect_dunder_frontier.py
@@ -202,5 +202,5 @@ def _owned_dunder_slots() -> dict[str, str]:
 def _fix(axis: str, name: str) -> str:
     return (
         f"write {name} sugar/floor dispatch for the `{axis}` data-model slot; "
-        "the kit must lower by ownership or loudly effect/refuse"
+        "the kit must lower by ownership or leave a loud effect/gap"
     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/collect_panic_audit.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/collect_panic_audit.py
@@ -151,7 +151,7 @@ def _resolve_installed_package_path(package: str) -> Path:
         "path = os.path.abspath(path)\n"
         "base = os.path.basename(path)\n"
         "if base.endswith(('.so', '.pyd', '.dll')) or 'lib-dynload' in path:\n"
-        "    raise SystemExit('refused C-extension path: ' + path)\n"
+        "    raise SystemExit('C-extension path gap: ' + path)\n"
         "if base == '__init__.py':\n"
         "    print(os.path.dirname(path))\n"
         "else:\n"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/lift_coverage_accounting.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/lift_coverage_accounting.py
@@ -5,12 +5,12 @@
 #4019 — assertions are the default report body (no "majority" brand).
 
 Assertions (claim layer, silent-loss detector — the report's default body):
-  stated / lifted+cited / refused-loud / silently-unaccounted
+  stated / lifted+cited / gap / silently-unaccounted
   Gate: silently-unaccounted == 0 (RED if > 0).
 
 Conservation (#4013 — independent AST vs report accounting):
   onDisk = independent ast assert count (shares NO code with the lift path)
-  accounted = report buckets (lifted+cited + refused-loud / AuditOnlyGap)
+  accounted = report buckets (lifted+cited + gap / AuditOnlyGap)
   delta = onDisk - accounted  (silent residue; MUST be 0)
   Emitted first-class on totals + conservation + perFile rows.
 
@@ -36,17 +36,17 @@ from .lift_coverage_census import (
 
 # Report statuses that mean the lifter *spoke* about the assertion.
 _LIFTED = frozenset({"warranted", "support", "inactive", "boundary"})
-_REFUSED = frozenset({"unresolved", "refused", "refuted", "unclassified"})
+_GAP_STATUSES = frozenset({"unresolved", "gap", "disproven", "unclassified"})
 
 
 @dataclass
 class AssertionAxis:
     stated: int = 0
     lifted_cited: int = 0
-    refused_loud: int = 0
+    gap: int = 0
     silently_unaccounted: int = 0
     lifted_loci: list[dict] = field(default_factory=list)
-    refused_loci: list[dict] = field(default_factory=list)
+    gap_loci: list[dict] = field(default_factory=list)
     silent_loci: list[dict] = field(default_factory=list)
     on_disk: list[dict] = field(default_factory=list)
 
@@ -55,12 +55,12 @@ class AssertionAxis:
             "axis": "assertions",
             "stated": self.stated,
             "lifted_cited": self.lifted_cited,
-            "refused_loud": self.refused_loud,
+            "gap": self.gap,
             "silently_unaccounted": self.silently_unaccounted,
             "gate": "silently_unaccounted == 0",
             "is_zero": self.silently_unaccounted == 0,
             "lifted_loci": list(self.lifted_loci),
-            "refused_loci": list(self.refused_loci),
+            "gap_loci": list(self.gap_loci),
             "silent_loci": list(self.silent_loci),
             "on_disk": list(self.on_disk),
         }
@@ -144,8 +144,8 @@ class LiftCoverageReport:
 
     @property
     def accounted(self) -> int:
-        """Report buckets that spoke: lifted+cited + refused-loud (M)."""
-        return self.assertions.lifted_cited + self.assertions.refused_loud
+        """Report buckets that spoke: lifted+cited + gap (M)."""
+        return self.assertions.lifted_cited + self.assertions.gap
 
     @property
     def delta(self) -> int:
@@ -233,8 +233,8 @@ def account_lift_coverage(
 def _per_file_conservation(assertions: AssertionAxis) -> list[dict]:
     """Per-file onDisk / accounted / delta from the on-disk assert partition.
 
-    Each on-disk assert is classified exactly once (lifted / refused / silent).
-    ``lifted_loci`` / ``refused_loci`` / ``silent_loci`` hold the matched on-disk
+    Each on-disk assert is classified exactly once (lifted / gap / silent).
+    ``lifted_loci`` / ``gap_loci`` / ``silent_loci`` hold the matched on-disk
     asserts when ``account_lift_coverage`` ran (they carry ``preview`` from the
     census). Report-side dump loci without preview are ignored for per-file
     accounting so extras cannot inflate ``accounted``.
@@ -260,18 +260,18 @@ def _per_file_conservation(assertions: AssertionAxis) -> list[dict]:
             continue
         file = str(locus.get("file") or "")
         ensure(file)["accounted"] = int(ensure(file)["accounted"]) + 1
-    for locus in assertions.refused_loci:
+    for locus in assertions.gap_loci:
         if not isinstance(locus, Mapping) or not is_on_disk_match(locus):
             continue
         file = str(locus.get("file") or "")
         ensure(file)["accounted"] = int(ensure(file)["accounted"]) + 1
 
     # Single-file fallback: when loci are report dumps without preview, the
-    # axis totals still conserve (lifted+refused+silent == stated).
+    # axis totals still conserve (lifted+gap+silent == stated).
     if assertions.on_disk and all(int(r["accounted"]) == 0 for r in rows.values()):
         if len(rows) == 1:
             only = next(iter(rows.values()))
-            only["accounted"] = assertions.lifted_cited + assertions.refused_loud
+            only["accounted"] = assertions.lifted_cited + assertions.gap
 
     for row in rows.values():
         row["delta"] = int(row["onDisk"]) - int(row["accounted"])
@@ -285,7 +285,7 @@ def _account_assertions(
 
     Doctrine (unambiguous):
       * Lifted+cited — floor implemented; fact row spoke.
-      * Refused-loud — instrument engaged and refused (ConstructionPanic held as gap,
+      * Gap — instrument engaged but construction stopped (ConstructionPanic held as gap,
         factory-walk unresolved/unclassified, auditOnlyGaps). **Panic is correct**
         when the code is not implemented yet; that is not silent.
       * Silently-unaccounted — stated assert and the instrument never engaged.
@@ -294,7 +294,7 @@ def _account_assertions(
 
     Lifted+cited: a kind=contract ::assertion (inv) row whose warrant memento
     covers the census file:line -- the warrant is the assert's sealed memento.
-    Refused-loud: auditOnlyGaps at locus **or** any non-lifted assert when the
+    Gap: auditOnlyGaps at locus **or** any non-lifted assert when the
     factory instrument engaged on this payload (unresolved walk / held panic).
     Silently-unaccounted: neither (Crime-1 gate; RED when positive).
 
@@ -302,9 +302,9 @@ def _account_assertions(
     older report shapes still classify; the collapse fact rows are the primary.
     """
     lifted_keys: set[tuple[str, int, int]] = set()
-    refused_keys: set[tuple[str, int, int]] = set()
+    gap_keys: set[tuple[str, int, int]] = set()
     lifted_loci: list[dict] = []
-    refused_loci: list[dict] = []
+    gap_loci: list[dict] = []
 
     # Primary: ::assertion fact rows the collapse minted (mirror minority join).
     for item in payload.get("ir") or []:
@@ -330,7 +330,7 @@ def _account_assertions(
                 }
             )
 
-    # Refused-loud: audit door gap rows (site = blame file:line:col).
+    # Gap: audit door gap rows (site = blame file:line:col).
     for gap in payload.get("auditOnlyGaps") or payload.get("audit_only_gaps") or []:
         if not isinstance(gap, Mapping):
             continue
@@ -338,13 +338,13 @@ def _account_assertions(
         if not file and not line:
             continue
         key = (file, line, col)
-        refused_keys.add(key)
-        refused_loci.append(
+        gap_keys.add(key)
+        gap_loci.append(
             {
                 "file": file,
                 "line": line,
                 "col": col,
-                "status": "refused",
+                "status": "gap",
                 "source": "audit-only-gap",
                 "label": str(gap.get("label") or ""),
                 "message": str(gap.get("message") or ""),
@@ -364,9 +364,9 @@ def _account_assertions(
         if status in _LIFTED:
             lifted_keys.add(key)
             lifted_loci.append(entry)
-        elif status in _REFUSED:
-            refused_keys.add(key)
-            refused_loci.append(entry)
+        elif status in _GAP_STATUSES:
+            gap_keys.add(key)
+            gap_loci.append(entry)
         else:
             # Unknown status -- treat as spoken (lifted) so we don't invent silent
             # loss from an unmapped vocabulary word; still listed under lifted.
@@ -374,22 +374,22 @@ def _account_assertions(
             lifted_loci.append(entry)
 
     # Doctrine (unambiguous): a stated assert is either lifted+cited or
-    # refused-loud. Silently-unaccounted is illegal — soft-skip is forbidden.
-    # Unimplemented floors → refuse-loud (panic/gap is the correct answer).
-    # Ground folds with no fact row also refuse-loud until a floor speaks them.
+    # gap. Silently-unaccounted is illegal — soft-skip is forbidden.
+    # Unimplemented floors → gap (panic/gap is the correct answer).
+    # Ground folds with no fact row also gap until a floor speaks them.
     instrument_engaged = _factory_instrument_engaged(payload)
     instrument_notes = _factory_instrument_notes(payload)
     recovered_panic_spans = _report_recovered_panic_spans(payload)
 
     silent: list[AssertLocus] = []
     lifted_matched: list[AssertLocus] = []
-    refused_matched: list[AssertLocus] = []
+    gap_matched: list[AssertLocus] = []
     for a in asserts:
         if _matched(a, lifted_keys):
             lifted_matched.append(a)
             continue
-        if _matched(a, refused_keys):
-            refused_matched.append(a)
+        if _matched(a, gap_keys):
+            gap_matched.append(a)
             continue
         if any(
             a.file == file and start_line <= a.line <= end_line
@@ -397,25 +397,25 @@ def _account_assertions(
         ):
             # The report rendered the ConstructionPanic loudly, but no assertion
             # fact exists for this poisoned definition. It therefore cannot
-            # be counted as cited or refused-and-accounted: retain it on the
+            # be counted as cited or gap-and-accounted: retain it on the
             # mandatory silently_unaccounted RED gate until construction
             # completes. "Silent" is the legacy gate name; the paired factory
             # row makes the cause visible and source-cited.
             silent.append(a)
             continue
-        # Not lifted: refuse-loud. Never silent.
-        refused_matched.append(a)
-        refused_loci.append(
+        # Not lifted: gap. Never silent.
+        gap_matched.append(a)
+        gap_loci.append(
             {
                 **a.to_json(),
-                "status": "refused",
+                "status": "gap",
                 "source": (
                     "factory-instrument"
                     if instrument_engaged
                     else "unimplemented-or-unspoken"
                 ),
                 "message": (
-                    "stated assert without ::assertion fact row — refuse-loud "
+                    "stated assert without ::assertion fact row — gap "
                     "(panic/gap or missing floor is correct; silent is illegal)"
                 ),
                 "instrument": instrument_notes[:3],
@@ -427,10 +427,10 @@ def _account_assertions(
         # Counts are over on-disk asserts classified by the report -- not raw
         # report row counts (a report may re-emit the same locus).
         lifted_cited=len(lifted_matched),
-        refused_loud=len(refused_matched),
+        gap=len(gap_matched),
         silently_unaccounted=len(silent),
         lifted_loci=[a.to_json() for a in lifted_matched] or lifted_loci,
-        refused_loci=[a.to_json() for a in refused_matched] or refused_loci,
+        gap_loci=[a.to_json() for a in gap_matched] or gap_loci,
         silent_loci=[
             {
                 **a.to_json(),
@@ -852,7 +852,7 @@ def paint_lines(
 ) -> list[dict]:
     """Per-line bucket paint for visual reports.
 
-    Buckets: lifted+cited | refused-loud | silently-unaccounted |
+    Buckets: lifted+cited | gap | silently-unaccounted |
              minority-dug | minority-un-asserted | non-proof | other
     """
     lines = source.splitlines()
@@ -860,10 +860,10 @@ def paint_lines(
 
     def _mark(line: int, tag: str) -> None:
         if 1 <= line <= len(tags):
-            # Priority: silent > refused > lifted > minority-dug > minority-un
+            # Priority: silent > gap > lifted > minority-dug > minority-un
             order = {
                 "silently-unaccounted": 50,
-                "refused-loud": 40,
+                "gap": 40,
                 "lifted+cited": 30,
                 "minority-dug": 20,
                 "minority-un-asserted": 10,
@@ -877,9 +877,9 @@ def paint_lines(
     for a in coverage.assertions.lifted_loci:
         if Path_basename(str(a.get("file", ""))) in {base, file}:
             _mark(int(a["line"]), "lifted+cited")
-    for a in coverage.assertions.refused_loci:
+    for a in coverage.assertions.gap_loci:
         if Path_basename(str(a.get("file", ""))) in {base, file}:
-            _mark(int(a["line"]), "refused-loud")
+            _mark(int(a["line"]), "gap")
     for a in coverage.assertions.silent_loci:
         if Path_basename(str(a.get("file", ""))) in {base, file}:
             _mark(int(a["line"]), "silently-unaccounted")

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/live_construction_panic_isolation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/live_construction_panic_isolation.py
@@ -43,7 +43,7 @@ def assert_bearing_py_files(root: Path) -> list[Path]:
 
 
 def factory_engaged_empty_report() -> dict[str, Any]:
-    """Factory instrument engaged, no spoken assert rows → refuse-loud partition."""
+    """Factory instrument engaged, no spoken assert rows → gap partition."""
     return {
         "factoryAuditSummary": {"statusCounts": {"unresolved": 1}},
         "auditOnlyGaps": [],
@@ -68,7 +68,7 @@ def live_per_file_isolation_conservation(
     """Production lift path per assert-bearing file; conservation + panic residual.
 
     Completed files feed the real lift payload into ``account_lift_coverage``.
-    ConstructionPanic / other hard fails engage refuse-loud for that file's on-disk
+    ConstructionPanic / other hard fails engage gap for that file's on-disk
     asserts (panic is loud, not silent). Aggregate delta must be 0.
 
     Returns a closed ranking payload including ``R_live_construction_panic_files``,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/numpy_wall.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/numpy_wall.py
@@ -98,7 +98,7 @@ def summarize_numpy_wall(report_json: Mapping[str, Any]) -> NumpyWallSummary:
     red_reasoned  -- lines classified `effect`: a named typed effect with
                       grounds anchored to the line.
     red_bare      -- effect lines with no grounds. `line_accounting`
-                      always attaches grounds (the refusal reason, or the
+                      always attaches grounds (the gap reason, or the
                       callee name as a fallback), so this is 0 by
                       construction; kept as a field so the invariant stays
                       visible and the floor check below still fires if that

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
@@ -206,7 +206,7 @@ def _panic_cyclic_term(term: Term) -> None:
         observed=observed,
         requested="DAG term hash-cons (finite structural intern key)",
         fix=(
-            "IR terms must be finite DAGs; refuse cyclic _Ctor graphs with "
+            "IR terms must be finite DAGs; cyclic _Ctor graphs are gaps with "
             "ConstructionPanic at intern. Never soft-complete, never timeout-launder, "
             "never leave recursive dataclass __hash__ as the intern seat, and "
             "never convert this into RuntimeEffect"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/open_lane_dto.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/open_lane_dto.py
@@ -48,7 +48,7 @@ class VendorConjoinDto(TypedDict, total=False):
 
 
 class DiagnosticDto(TypedDict, total=False):
-    """Ad hoc diagnostic rows (dig refusals, agreement violations, proofir
+    """Ad hoc diagnostic rows (dig gaps, agreement violations, proofir
     provenance notes). Each producer stamps its own `kind`; the payload
     fields vary by kind, so `Any` is the honest membrane for now.
     """

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -689,7 +689,7 @@ def _runtime_lift_command() -> List[str]:
 def _source_oracle_api():
     try:
         from sugar_lift_python_source.source_oracle import (
-            SourceOracleRefusal,
+            SourceUnavailable,
             resolve_source_memento,
         )
     except ModuleNotFoundError:
@@ -699,10 +699,10 @@ def _source_oracle_api():
         if str(sibling_src) not in sys.path:
             sys.path.insert(0, str(sibling_src))
         from sugar_lift_python_source.source_oracle import (
-            SourceOracleRefusal,
+            SourceUnavailable,
             resolve_source_memento,
         )
-    return SourceOracleRefusal, resolve_source_memento
+    return SourceUnavailable, resolve_source_memento
 
 
 def _source_memento_from_params(params: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -807,10 +807,10 @@ def _resolve_source_memento_result(params: Dict[str, Any]) -> Dict[str, Any]:
             "status": "absent",
             "reason": "invalid source memento shape",
         }
-    SourceOracleRefusal, resolve_source_memento = _source_oracle_api()
+    SourceUnavailable, resolve_source_memento = _source_oracle_api()
     try:
         resolved = resolve_source_memento(workspace_root, memento)
-    except SourceOracleRefusal as exc:
+    except SourceUnavailable as exc:
         return _source_oracle_effect_result(
             SourceOracleEffect(reason=str(exc)), memento
         )
@@ -1056,7 +1056,7 @@ def _term_ref_cids(value: Any):
     """Yield every term reference in a response-owned value.
 
     A term-ref is a leaf in the wire graph. Malformed reference objects are
-    refused here, before a JSON-RPC response can be constructed.
+    left as a gap here, before a JSON-RPC response can be constructed.
     """
     if isinstance(value, dict):
         if value.get("kind") == "term-ref":
@@ -1080,7 +1080,7 @@ def _closed_enumerate_result(
     *,
     term_tables: Optional[List[Dict[str, Dict[str, Any]]]] = None,
 ) -> Dict[str, Any]:
-    """Construct one closed enumeration result or refuse it.
+    """Construct one closed enumeration result or leave a gap.
 
     The response is the ownership boundary for its term DAG. Every reachable
     term-ref brings exactly one canonical row with it; omitted/dangling tables,
@@ -1336,9 +1336,9 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
             # fragments minted through the SourceOracle — identity without
             # parsing, no file read or hashed outside the oracle. The handler
             # only formats. An unreadable/undecodable file is a loud oracle
-            # refusal recorded as a protocol gap, never served as a node
+            # source-unavailable result recorded as a protocol gap, never served as a node
             # (previously it was hashed raw and masqueraded as enumerable).
-            from sugar_lift_python_source.source_oracle import SourceOracleRefusal
+            from sugar_lift_python_source.source_oracle import SourceUnavailable
             from sugar_source_tree.tree import SourceTree
 
             nodes = []
@@ -1351,11 +1351,11 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     rel_path = path.name
                 try:
                     fragment = tree.fragment_of(path)
-                except SourceOracleRefusal as refusal:
+                except SourceUnavailable as unavailable:
                     gaps.append(
                         {
                             "memento": _degenerate_file_memento(rel_path),
-                            "reason": str(refusal),
+                            "reason": str(unavailable),
                         }
                     )
                     continue
@@ -1433,16 +1433,16 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 # sugar, `clean` when fully sugared -- no false green.
                 from sugar_lift_py_tests import tree_enumerate as _tree
                 from sugar_lift_python_source.source_oracle import (
-                    SourceOracleRefusal,
+                    SourceUnavailable,
                     path_source,
                 )
 
                 if level == "functions":
                     try:
                         identity = path_source(str(full_path))
-                    except SourceOracleRefusal as refusal:
+                    except SourceUnavailable as unavailable:
                         _send_enumerate_result(
-                            msg_id, [], [{"memento": at, "reason": str(refusal)}]
+                            msg_id, [], [{"memento": at, "reason": str(unavailable)}]
                         )
                         return
                     _src, _fname, file_cid = identity
@@ -1496,16 +1496,16 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 # when FunctionDef.sugar() is written; syntax does not wait
                 # for it.
                 from sugar_lift_python_source.source_oracle import (
-                    SourceOracleRefusal,
+                    SourceUnavailable,
                     path_source,
                 )
                 from sugar_source_tree.tree import SourceFile as _TreeSourceFile
 
                 try:
                     identity = path_source(str(full_path))
-                except SourceOracleRefusal as refusal:
+                except SourceUnavailable as unavailable:
                     _send_enumerate_result(
-                        msg_id, [], [{"memento": at, "reason": str(refusal)}]
+                        msg_id, [], [{"memento": at, "reason": str(unavailable)}]
                     )
                     return
                 _source, _fname, file_cid = identity
@@ -1587,7 +1587,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                         [
                             {
                                 "memento": at,
-                                "reason": "no call site for exact memento; refusing implication substitution",
+                                "reason": "no call site for exact memento; leaving implication substitution open",
                             }
                         ],
                     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/manifest_membrane.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/manifest_membrane.py
@@ -21,7 +21,7 @@ Manifest format (JCS-canonicalized JSON)::
 
 The `cid` is the BLAKE3-512 JCS hash (see `canonicalizer.jcs_hash`) of the
 `rows` array alone. `load_manifest` recomputes that hash from the bytes on
-disk and REFUSES (raises `ManifestIntegrityError`) on any mismatch — never a
+disk and LEAVES A GAP (raises `ManifestIntegrityError`) on any mismatch — never a
 warning. A manifest carries its own integrity; nothing loads implicitly, and
 nothing loads silently-wrong.
 
@@ -127,7 +127,7 @@ def load_manifest(path: str | Path) -> Manifest:
     """Load a hashed kit manifest, verifying its integrity.
 
     Recomputes the JCS/BLAKE3-512 hash of the `rows` array and compares it
-    against the manifest's own `cid` field. A mismatch REFUSES to load: it
+    against the manifest's own `cid` field. A mismatch LEAVES A GAP to load: it
     raises `ManifestIntegrityError` rather than loading with a warning. This
     is the only lawful path by which community spellings enter the
     provider-neutral contract types.
@@ -149,7 +149,7 @@ def load_manifest(path: str | Path) -> Manifest:
         raise ManifestIntegrityError(
             f"manifest at {manifest_path} FAILED integrity check: "
             f"declared cid {declared_cid!r} does not match computed cid "
-            f"{computed_cid!r} over its rows. Refusing to load."
+            f"{computed_cid!r} over its rows. Manifest load gap."
         )
 
     rows = tuple(
@@ -256,7 +256,7 @@ def contract_for_manager(manifest: Manifest, manager_node) -> Optional[Contract]
             return None
         return builder(matcher)
 
-    # Unknown arity discipline: refuse rather than guess.
+    # Unknown arity discipline: leave a gap rather than guess.
     return None
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/nodes/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/nodes/__init__.py
@@ -109,14 +109,14 @@ class Provenance:
 @dataclass(frozen=True)
 class VerdictWitnessCase:
     name: str
-    expected: Literal["sat", "unsat", "construction-refusal"]
+    expected: Literal["sat", "unsat", "construction-open"]
     formulas: tuple[Formula, ...] = ()
     declarations: Mapping[str, Sort] = field(default_factory=dict)
     construct: Callable[[], object] | None = None
     source: str | None = None
     node_class: str | None = None
     expected_sugar: str | None = None
-    refusal_absence: bool = False
+    open_absence: bool = False
 
 
 @dataclass(frozen=True)
@@ -348,7 +348,7 @@ def registered_verdict_witnesses() -> tuple[tuple[str, bool, bool], ...]:
                     and pair.truthful.expected_sugar is not None
                 ),
                 (
-                    pair.lying.expected == "construction-refusal"
+                    pair.lying.expected == "construction-open"
                     or (
                         pair.lying.expected == "unsat"
                         and pair.lying.source is not None

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/nodes/audit_memento.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/nodes/audit_memento.py
@@ -140,8 +140,8 @@ class AuditMemento(ProofIRNode):
                 ),
             ),
             lying=VerdictWitnessCase(
-                name="audit-memento-raw-locus-refuses",
-                expected="construction-refusal",
+                name="audit-memento-raw-locus-open",
+                expected="construction-open",
                 construct=lambda: cls(
                     role="python.literal-call-sugar",
                     contract="module::source::assertion",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/nodes/boundary_record.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/nodes/boundary_record.py
@@ -28,7 +28,7 @@ from . import (
 
 @dataclass(frozen=True, init=False)
 class BoundaryRecord:
-    """A typed-effect record with grounds, not a lift-side refusal."""
+    """A typed-effect record with grounds; no open lift-side boundary."""
 
     node_class: ClassVar[str] = "BoundaryRecord"
 
@@ -124,10 +124,10 @@ class BoundaryRecord:
                 expected="sat",
                 formulas=(),
                 declarations={},
-                source=_effectful_refusal_source(),
+                source=_effectful_open_source(),
                 node_class=cls.node_class,
                 expected_sugar="python.literal-call-sugar",
-                refusal_absence=True,
+                open_absence=True,
                 construct=lambda: cls.from_incomplete(
                     _runtime_effect_incomplete("opaque runtime effect"),
                     provenance=_witness_provenance(
@@ -136,16 +136,16 @@ class BoundaryRecord:
                 ),
             ),
             lying=VerdictWitnessCase(
-                name="boundary-record-fact-and-refusal-refuses",
-                expected="construction-refusal",
+                name="boundary-record-fact-and-open-open",
+                expected="construction-open",
                 formulas=(),
                 declarations={},
-                construct=lambda: _fact_and_refusal_refuses(cls),
+                construct=lambda: _fact_and_open_is_open(cls),
             ),
         )
 
 
-def _effectful_refusal_source() -> str:
+def _effectful_open_source() -> str:
     return (
         "def A(x):\n"
         "    print(x)\n"
@@ -176,7 +176,7 @@ def _runtime_effect_incomplete(reason: str) -> Incomplete:
     )
 
 
-def _fact_and_refusal_refuses(cls: type[BoundaryRecord]) -> BoundaryRecord:
+def _fact_and_open_is_open(cls: type[BoundaryRecord]) -> BoundaryRecord:
     return cast(Any, cls.from_incomplete)(
         _runtime_effect_incomplete("opaque runtime effect"),
         provenance=_witness_provenance(cls.node_class, warrants=("Derived",)),

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/nodes/call_edge_decl.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/nodes/call_edge_decl.py
@@ -142,8 +142,8 @@ class CallEdgeDecl(ProofIRNode):
                 ),
             ),
             lying=VerdictWitnessCase(
-                name="call-edge-decl-raw-json-refuses",
-                expected="construction-refusal",
+                name="call-edge-decl-raw-json-open",
+                expected="construction-open",
                 construct=lambda: cls(
                     bridge={"kind": "call-edge"},
                     provenance=_witness_provenance(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/nodes/universe_mint.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/nodes/universe_mint.py
@@ -134,8 +134,8 @@ class UniverseMint(ProofIRNode):
                 ),
             ),
             lying=VerdictWitnessCase(
-                name="universe-mint-raw-formula-refuses",
-                expected="construction-refusal",
+                name="universe-mint-raw-formula-open",
+                expected="construction-open",
                 construct=lambda: cls(
                     name="module::lying::assertion",
                     slot="inv",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/nodes/vendor_conjoin.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/nodes/vendor_conjoin.py
@@ -43,7 +43,7 @@ class VendorConjoin(ProofIRNode):
 
     fact: FactAtom | None = field(init=False)
     universe: UniverseAtom | None = field(init=False)
-    refusal: BoundaryRecord | None = field(init=False)
+    open: BoundaryRecord | None = field(init=False)
     _provenance: Provenance = field(init=False, repr=False)
 
     def __init__(
@@ -51,18 +51,18 @@ class VendorConjoin(ProofIRNode):
         *,
         fact: FactAtom | None = None,
         universe: UniverseAtom | None = None,
-        refusal: BoundaryRecord | None = None,
+        open: BoundaryRecord | None = None,
         provenance: Provenance,
     ) -> None:
         _require_provenance(provenance, owner=self.node_class)
-        if refusal is not None:
-            if not isinstance(refusal, BoundaryRecord):
-                raise TypeError("VendorConjoin refusal must be BoundaryRecord")
+        if open is not None:
+            if not isinstance(open, BoundaryRecord):
+                raise TypeError("VendorConjoin open must be BoundaryRecord")
             if fact is not None or universe is not None:
                 _proofir_gap(
                     owner=self.node_class,
-                    observed="fact/universe plus refusal",
-                    requested="either typed fact+universe or explicit refusal",
+                    observed="fact/universe plus open",
+                    requested="either typed fact+universe or explicit open",
                     fix="do not let a vendor fact float in the silent third state",
                 )
         else:
@@ -72,7 +72,7 @@ class VendorConjoin(ProofIRNode):
                 raise TypeError("VendorConjoin universe must be UniverseAtom")
         object.__setattr__(self, "fact", fact)
         object.__setattr__(self, "universe", universe)
-        object.__setattr__(self, "refusal", refusal)
+        object.__setattr__(self, "open", open)
         object.__setattr__(self, "_provenance", provenance)
 
     def denotation(self):
@@ -82,10 +82,10 @@ class VendorConjoin(ProofIRNode):
         return self._provenance
 
     def to_declaration(self) -> dict[str, Any]:
-        if self.refusal is not None:
+        if self.open is not None:
             return {
                 "kind": "vendor-conjoin",
-                "refusal": self.refusal.to_declaration(),
+                "open": self.open.to_declaration(),
                 "provenance": self.provenance().to_rpc(),
             }
         assert self.fact is not None and self.universe is not None
@@ -110,8 +110,8 @@ class VendorConjoin(ProofIRNode):
                 construct=lambda: _witness_vendor_conjoin(cls),
             ),
             lying=VerdictWitnessCase(
-                name="vendor-conjoin-raw-formula-refuses",
-                expected="construction-refusal",
+                name="vendor-conjoin-raw-formula-open",
+                expected="construction-open",
                 construct=lambda: cls(
                     fact={"kind": "atomic"},
                     universe=None,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/witnesses.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/witnesses.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-Verdict = Literal["sat", "unsat", "refused"]
+Verdict = Literal["sat", "unsat", "unwitnessed"]
 
 
 @dataclass(frozen=True)
@@ -24,7 +24,7 @@ class SugarWitnessPair:
 
 
 @dataclass(frozen=True)
-class SugarRefusedWitnessPair:
+class SugarUnwitnessedPair:
     """A lawful epistemic-red pair: neither arm may be guessed."""
 
     name: str
@@ -71,13 +71,13 @@ class NotVerdictBearing:
 
 SugarWitnesses = (
     SugarWitnessPair
-    | SugarRefusedWitnessPair
+    | SugarUnwitnessedPair
     | SugarRedEffectWitnessPair
     | tuple[SugarWitnessPair, ...]
     | NotVerdictBearing
     | tuple[
         SugarWitnessPair
-        | SugarRefusedWitnessPair
+        | SugarUnwitnessedPair
         | SugarRedEffectWitnessPair
         | NotVerdictBearing,
         ...,
@@ -121,7 +121,7 @@ def _call_return_pair(
     )
 
 
-def _refused_call_return_pair(
+def _unwitnessed_call_return_pair(
     *,
     name: str,
     owner_sugar: str,
@@ -129,19 +129,19 @@ def _refused_call_return_pair(
     truthful: str,
     lying: str,
     prefix: str = "",
-) -> SugarRefusedWitnessPair:
+) -> SugarUnwitnessedPair:
     base = prefix + f"def A(z):\n    return {body}\n\n"
-    return SugarRefusedWitnessPair(
+    return SugarUnwitnessedPair(
         name=name,
         owner_sugar=owner_sugar,
-        family="opaque-equality-refusal",
+        family="opaque-equality-unwitnessed",
         truthful=WitnessSource(
             source=base + f"def test_a():\n    assert A(5) == {truthful}\n",
-            expected="refused",
+            expected="unwitnessed",
         ),
         lying=WitnessSource(
             source=base + f"def test_a():\n    assert A(5) == {lying}\n",
-            expected="refused",
+            expected="unwitnessed",
         ),
     )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/witness_harness.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/witness_harness.py
@@ -15,7 +15,7 @@ from sugar_lift_py_tests.sugar_binary import (
 )
 
 Verdict = Literal[
-    "sat", "unsat", "refused", "refused-modulo-unavailable-seats", "solver-timeout"
+    "sat", "unsat", "unwitnessed", "unwitnessed-modulo-unavailable-seats", "solver-timeout"
 ]
 
 ROOT = Path(__file__).resolve().parents[5]
@@ -441,7 +441,7 @@ def prove_verdict(prove_doc: dict) -> Verdict:
         return "unsat"
     if statuses and all(status == "discharged" for status in statuses):
         return "sat"
-    if statuses and all(status == "refused" for status in statuses):
+    if statuses and all(status == "unwitnessed" for status in statuses):
         provisional = False
         for row in rows:
             invocations = row.get("verification", {}).get("solverInvocations", [])
@@ -458,7 +458,7 @@ def prove_verdict(prove_doc: dict) -> Verdict:
             ):
                 raise ProofObligationPanic(row)
             provisional = provisional or "unavailable" in states
-        return "refused-modulo-unavailable-seats" if provisional else "refused"
+        return "unwitnessed-modulo-unavailable-seats" if provisional else "unwitnessed"
     terminal = next(
         (
             row

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/witness_oracle.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/witness_oracle.py
@@ -23,7 +23,7 @@
 #   - RECOMPUTE (when re-runnable + deterministic): re-run, re-derive the CID,
 #       confirm it reproduces. Only the substrate's own runnable, deterministic
 #       witnesses (e.g. a unit test via the kit's discharge) take this path.
-# Any mismatch -> REFUSE, loudly. exact-or-refuse, no silent loss.
+# Any mismatch -> UNWITNESSED, loudly. exact-or-unwitnessed, no silent loss.
 
 from __future__ import annotations
 
@@ -33,7 +33,7 @@ from typing import Any, Callable
 from .canonicalizer import blake3_512_of
 
 
-class WitnessOracleRefusal(Exception):
+class WitnessOracleUnwitnessed(Exception):
     """Raised LOUDLY when a witness fails to verify: bad signature, package
     content that does not recompute to the pinned CID, or a re-run that drifts."""
 
@@ -47,16 +47,16 @@ def resolve_witness(
     """Verify a WitnessMemento. SIGNATURE is the universal check (whose sharpie);
     CONTENT-ADDRESS is checked when the witness package is supplied; RECOMPUTE is
     checked when the witness is re-runnable. Returns the strongest verification
-    achieved, or refuses loudly."""
+    achieved, or remains unwitnessed loudly."""
     witness_cid = memento.get("witness_cid")
     if not isinstance(witness_cid, str) or not witness_cid:
-        raise WitnessOracleRefusal("witness memento missing `witness_cid`")
+        raise WitnessOracleUnwitnessed("witness memento missing `witness_cid`")
 
     # 1. SIGNATURE -- the universal path. A witness is a signed mark; verify whose.
     if not _verify_signature(
         witness_cid, memento.get("signature"), memento.get("signer")
     ):
-        raise WitnessOracleRefusal(
+        raise WitnessOracleUnwitnessed(
             f"witness signature invalid for {witness_cid} "
             f"(signer {memento.get('signer')!r}) -- cannot trust the mark"
         )
@@ -67,7 +67,7 @@ def resolve_witness(
     if witness_content is not None:
         recomputed = blake3_512_of(witness_content)
         if recomputed != witness_cid:
-            raise WitnessOracleRefusal(
+            raise WitnessOracleUnwitnessed(
                 f"witness content misaligned: pinned {witness_cid}, "
                 f"package content {recomputed} -- the witness was swapped"
             )
@@ -79,7 +79,7 @@ def resolve_witness(
     if recompute_fn is not None:
         reproduced = recompute_fn(memento)
         if reproduced != witness_cid:
-            raise WitnessOracleRefusal(
+            raise WitnessOracleUnwitnessed(
                 f"witness recompute misaligned: pinned {witness_cid}, "
                 f"reproduced {reproduced} -- the run drifted"
             )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/witness_verify.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/witness_verify.py
@@ -3,7 +3,7 @@
 # The VERIFY dimension over witnesses.
 #
 # verify does NOT trust the Witness Oracle. The oracle RESOLVES a witness body
-# and refuses loudly on drift -- that is its job, the resolution layer. verify
+# and remains unwitnessed loudly on drift -- that is its job, the resolution layer. verify
 # AUDITS: it recomputes the CID itself (blake3 over the body) and re-checks the
 # signature, independently of whatever the oracle reported.
 #
@@ -15,19 +15,19 @@
 #
 # This is the witness axis of the three-axis pin made a first-class attestation:
 # not lazily resolved at materialize time, but enumerated and recomputed as a
-# checked dimension of `verify`. exact-or-refuse, no silent loss.
+# checked dimension of `verify`. exact-or-unwitnessed, no silent loss.
 
 from __future__ import annotations
 
 from typing import Any, Callable
 
 from .canonicalizer import blake3_512_of
-from .witness_oracle import WitnessOracleRefusal, _verify_signature
+from .witness_oracle import WitnessOracleUnwitnessed, _verify_signature
 
 
-class WitnessVerifyRefusal(Exception):
+class WitnessVerifyUnwitnessed(Exception):
     """The witness does not hold: signature invalid, or a body that does not
-    recompute to the pinned witness_cid. verify refuses loudly."""
+    recompute to the pinned witness_cid. Verification remains unwitnessed loudly."""
 
 
 class BrokenOracleError(Exception):
@@ -54,15 +54,15 @@ def verify_witness(
     - RECOMPUTE (when re-runnable): re-derive the CID via ``recompute_fn`` and
       compare.
 
-    Any misalignment -> ``WitnessVerifyRefusal``. A lying/broken oracle ->
+    Any misalignment -> ``WitnessVerifyUnwitnessed``. A lying/broken oracle ->
     ``BrokenOracleError``. Returns the checks performed on success."""
     cid = memento.get("witness_cid")
     if not isinstance(cid, str) or not cid:
-        raise WitnessVerifyRefusal("witness memento missing `witness_cid`")
+        raise WitnessVerifyUnwitnessed("witness memento missing `witness_cid`")
 
     # 1. SIGNATURE -- recomputed here, not taken from the oracle's word.
     if not _verify_signature(cid, memento.get("signature"), memento.get("signer")):
-        raise WitnessVerifyRefusal(
+        raise WitnessVerifyUnwitnessed(
             f"signature invalid for {cid} (signer {memento.get('signer')!r})"
         )
     checks = ["signature"]
@@ -80,16 +80,16 @@ def verify_witness(
             try:
                 verdict = oracle(memento, witness_content=witness_content)
                 oracle_approved = verdict.get("verified_by") == "content-address"
-            except WitnessOracleRefusal:
+            except WitnessOracleUnwitnessed:
                 oracle_approved = False
             if oracle_approved and recomputed != cid:
                 raise BrokenOracleError(
                     f"oracle APPROVED {cid} but its body computes to {recomputed} "
-                    f"-- the oracle is broken; verify recomputed the CID and refused"
+                    f"-- the oracle is broken; verify recomputed the CID and left it unwitnessed"
                 )
 
         if recomputed != cid:
-            raise WitnessVerifyRefusal(
+            raise WitnessVerifyUnwitnessed(
                 f"content misaligned: pinned {cid}, body computes to {recomputed} "
                 f"-- this witness is not the body that was signed for"
             )
@@ -99,7 +99,7 @@ def verify_witness(
     if recompute_fn is not None:
         reproduced = recompute_fn(memento)
         if reproduced != cid:
-            raise WitnessVerifyRefusal(
+            raise WitnessVerifyUnwitnessed(
                 f"recompute misaligned: pinned {cid}, reproduced {reproduced} "
                 f"-- the run drifted"
             )

--- a/implementations/python/sugar-lift-py-tests/tests/test_lift_coverage_harness.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_lift_coverage_harness.py
@@ -148,21 +148,21 @@ def test_independent_census_counts_asserts_and_bodies() -> None:
 
 
 def test_assertions_silent_measured_not_hardcoded() -> None:
-    """Discrimination (a): unaccounted construct → refuse-loud (silent illegal)."""
+    """Discrimination (a): unaccounted construct → gap (silent illegal)."""
     src = (
         "def f():\n"
         "    assert True\n"
         "    assert False  # second assert never cited by empty report\n"
     )
     disk = census_source(src, file="t.py")
-    # Empty report → every assert is refuse-loud; silent counter stays 0.
+    # Empty report → every assert is gap; silent counter stays 0.
     cov = account_lift_coverage(disk, {})
     assert cov.assertions.stated == 2
     assert cov.assertions.lifted_cited == 0
     assert cov.assertions.silently_unaccounted == 0
-    assert cov.assertions.refused_loud == 2
+    assert cov.assertions.gap == 2
     assert cov.assertions.to_json()["is_zero"] is True  # silent gate green
-    lines = {a["line"] for a in cov.assertions.refused_loci}
+    lines = {a["line"] for a in cov.assertions.gap_loci}
     assert lines == {2, 3}
 
 
@@ -250,7 +250,7 @@ def test_statistics_headline_delta_matches_probe(statistics_report: dict) -> Non
     cov = statistics_report["liftCoverage"]
     ax = cov["assertions"]
     assert ax["stated"] == len(disk.asserts) == 4
-    assert ax["lifted_cited"] + ax["refused_loud"] == 4
+    assert ax["lifted_cited"] + ax["gap"] == 4
     assert ax["silently_unaccounted"] == 0, (
         f"expected 0 silent asserts on statistics after #4017; got "
         f"{ax['silently_unaccounted']}: {ax['silent_loci']}"
@@ -329,7 +329,7 @@ def test_statistics_human_report_contains_literal_minority_report_header() -> No
         ok = (
             "Minority Report" in human
             or "silently_unaccounted=0" in human
-            or "refused-loud" in human
+            or "gap" in human
             or "accounted=" in human
         )
         assert (
@@ -397,11 +397,11 @@ def test_discrimination_inject_unaccounted_construct_reds_assertions(
     cov_full = account_lift_coverage(disk, full)
     cov_partial = account_lift_coverage(disk, partial)
     assert cov_full.assertions.silently_unaccounted == 0
-    # Partial cite: one lifted, one refuse-loud (never silent).
+    # Partial cite: one lifted, one gap (never silent).
     assert cov_partial.assertions.silently_unaccounted == 0
     assert cov_partial.assertions.lifted_cited == 1
-    assert cov_partial.assertions.refused_loud == 1
-    assert cov_partial.assertions.refused_loci[0]["line"] == 3
+    assert cov_partial.assertions.gap == 1
+    assert cov_partial.assertions.gap_loci[0]["line"] == 3
 
 
 # ---------------------------------------------------------------------------
@@ -520,7 +520,7 @@ _CONSERVATION_VENDORS = (
 
 # Full installed package trees — residual named after #4721. Live sugar
 # --report on these trees panics (ConstructionPanic floor gaps); the independent
-# AST census + refuse-loud partition is the measurable conservation gate until
+# AST census + gap partition is the measurable conservation gate until
 # production floors make full-tree live report possible.
 _HEAVY_CONSERVATION_VENDORS = (
     "numpy",
@@ -561,7 +561,7 @@ def test_conservation_triple_emitted_and_conserves() -> None:
         "    assert a() is None or True\n"
     )
     disk = census_source(src, file="c.py")
-    # Empty report: every assert is refuse-loud → accounted == onDisk, delta 0.
+    # Empty report: every assert is gap → accounted == onDisk, delta 0.
     cov = account_lift_coverage(disk, {})
     body = cov.to_json()
     totals = body["totals"]
@@ -596,7 +596,7 @@ def test_conservation_per_file_rows_for_multi_file_census() -> None:
         ],
         bodies=[],
     )
-    # Cite only a.py:1 as warranted; rest refuse-loud.
+    # Cite only a.py:1 as warranted; rest gap.
     report = {
         "sourceAudits": [
             {
@@ -616,7 +616,7 @@ def test_conservation_per_file_rows_for_multi_file_census() -> None:
     cov = account_lift_coverage(disk, report)
     body = cov.to_json()
     assert body["totals"]["onDisk"] == 3
-    assert body["totals"]["accounted"] == 3  # 1 lifted + 2 refuse
+    assert body["totals"]["accounted"] == 3  # 1 lifted + 2 gaps
     assert body["totals"]["delta"] == 0
     by_file = {r["file"]: r for r in body["perFile"]}
     assert by_file["a.py"]["onDisk"] == 2
@@ -630,7 +630,7 @@ def test_conservation_per_file_rows_for_multi_file_census() -> None:
 def test_conservation_bad_twin_drop_from_axis_flips_delta() -> None:
     """Discrimination: if accounted under-counts onDisk, delta > 0 and RED.
 
-    The production partition never leaves silent residue (refuse-loud fills
+    The production partition never leaves silent residue (gap fills
     the gap). This unit twin plants a hand-built axis that violates
     conservation so the gate field itself is proven measured, not hardcoded.
     """
@@ -645,7 +645,7 @@ def test_conservation_bad_twin_drop_from_axis_flips_delta() -> None:
     assertions = AssertionAxis(
         stated=2,
         lifted_cited=1,
-        refused_loud=0,
+        gap=0,
         silently_unaccounted=1,
         on_disk=[
             {"file": "t.py", "line": 1, "col": 0, "preview": "assert 1"},
@@ -686,9 +686,9 @@ def test_statistics_report_emits_conservation_triple(
 def _census_conservation_for_paths(
     files: list[Path], *, root: Path, label: str
 ) -> dict:
-    """Independent AST census + refuse-loud partition; returns coverage JSON."""
+    """Independent AST census + gap partition; returns coverage JSON."""
     disk = census_paths(files, root=root)
-    # Factory-instrument-engaged empty report: refuse-loud fills the gap;
+    # Factory-instrument-engaged empty report: gap fills the gap;
     # conservation identity still holds (delta == 0). The independent census
     # is the only onDisk source — no lift code is shared.
     eng_report = {
@@ -711,7 +711,7 @@ def test_stdlib_vendor_conservation_delta_is_zero(package: str) -> None:
 
     Six stdlib modules. The independent AST census (shares NO code with the
     lift path) is the onDisk side. Accounted is the report-bucket partition
-    (lifted+cited + refused-loud). Under the refuse-loud doctrine every
+    (lifted+cited + gap). Under the gap doctrine every
     stated assert is classified, so delta must be 0. Live sugar --report
     emission of the same triple is gated by
     ``test_statistics_report_emits_conservation_triple``.
@@ -742,14 +742,14 @@ def test_heavy_vendor_full_tree_conservation_delta_is_zero(package: str) -> None
     """#4013 residual after #4721: full-tree numpy/pandas conservation.
 
     Walks every ``*.py`` under the installed package (no 40-file cap). The
-    independent AST census is the onDisk side; accounted is refuse-loud
+    independent AST census is the onDisk side; accounted is gap
     partition against a factory-engaged empty report. Live full-tree
     ``sugar lift --report`` still panics on floor gaps (ConstructionPanic) — that
     live residual stays open; this gate measures the census half of
     conservation on the real heavy surface.
 
     Measured R (local instrument): numpy onDisk≈3208, pandas onDisk≈17543,
-    both delta=0 under refuse-loud.
+    both delta=0 under gap.
     """
     path = _resolve_installed_package_path(package)
     if not path.exists():
@@ -791,7 +791,7 @@ def test_heavy_vendor_live_per_file_isolation_conservation_delta_is_zero(
     file on the production file-lift path:
 
     * completed → real payload into conservation accounting
-    * ConstructionPanic → refuse-loud for that file's on-disk asserts
+    * ConstructionPanic → gap for that file's on-disk asserts
 
     Gate: aggregate conservation delta==0 on the live path.
     Residual axis (named, leave #4013 open): ``R_live_construction_panic_files``
@@ -825,7 +825,7 @@ def test_heavy_vendor_live_per_file_isolation_conservation_delta_is_zero(
         f"{package} live isolation must exceed stdlib sample; "
         f"got assert_files={result['assert_files']}"
     )
-    # Every per-file row conserved (completed or refuse-loud after panic).
+    # Every per-file row conserved (completed or gap after panic).
     for row in result["perFile"]:
         assert int(row["delta"]) == 0, row
     # Residual is measured, not hidden. Multi-file live report stays open

--- a/implementations/python/sugar-lift-py-tests/tests/test_witness_oracle.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_witness_oracle.py
@@ -4,7 +4,7 @@ import pytest
 
 from sugar_lift_py_tests.canonicalizer import blake3_512_of
 from sugar_lift_py_tests.witness_oracle import (
-    WitnessOracleRefusal,
+    WitnessOracleUnwitnessed,
     resolve_witness,
 )
 
@@ -40,15 +40,15 @@ def test_poem_witness_is_signature_then_content_verified():
         resolve_witness(memento, witness_content=poem)["verified_by"]
         == "content-address"
     )
-    # Swapped witness -> refuse loudly.
-    with pytest.raises(WitnessOracleRefusal, match="content misaligned"):
+    # Swapped witness -> remains unwitnessed loudly.
+    with pytest.raises(WitnessOracleUnwitnessed, match="content misaligned"):
         resolve_witness(memento, witness_content=b"a different poem")
 
 
 def test_bad_signature_refused():
     cid, _signature, signer = _signed(b"a CI run log")
     memento = {"witness_cid": cid, "signer": signer, "signature": "00" * 64}
-    with pytest.raises(WitnessOracleRefusal, match="signature invalid"):
+    with pytest.raises(WitnessOracleUnwitnessed, match="signature invalid"):
         resolve_witness(memento)
 
 
@@ -65,6 +65,6 @@ def test_runnable_witness_recompute_or_refuse():
         resolve_witness(memento, recompute_fn=lambda _m: cid)["verified_by"]
         == "recompute"
     )
-    # Re-run drifts -> refuse.
-    with pytest.raises(WitnessOracleRefusal, match="recompute misaligned"):
+    # Re-run drifts -> remains unwitnessed.
+    with pytest.raises(WitnessOracleUnwitnessed, match="recompute misaligned"):
         resolve_witness(memento, recompute_fn=lambda _m: "blake3-512:" + "0" * 128)

--- a/implementations/python/sugar-lift-py-tests/tests/test_witness_verify.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_witness_verify.py
@@ -6,7 +6,7 @@ from sugar_lift_py_tests.canonicalizer import blake3_512_of
 from sugar_lift_py_tests.witness_oracle import resolve_witness
 from sugar_lift_py_tests.witness_verify import (
     BrokenOracleError,
-    WitnessVerifyRefusal,
+    WitnessVerifyUnwitnessed,
     verify_witness,
 )
 
@@ -47,8 +47,8 @@ def test_verify_recomputes_and_passes_aligned_witness():
 
 def test_verify_refuses_tampered_body_even_with_real_oracle():
     m = _memento(b"junit: 42 passed")
-    # the real oracle would also refuse -- but verify recomputes regardless.
-    with pytest.raises(WitnessVerifyRefusal, match="content misaligned"):
+    # the real oracle would also leave it unwitnessed -- verify recomputes regardless.
+    with pytest.raises(WitnessVerifyUnwitnessed, match="content misaligned"):
         verify_witness(m, witness_content=b"junit: 0 passed", oracle=resolve_witness)
 
 
@@ -73,14 +73,14 @@ def test_broken_oracle_no_false_alarm_on_aligned_body():
 def test_verify_refuses_tampered_body_with_NO_oracle():
     # No oracle at all -> verify is still the backstop; recompute catches it.
     m = _memento(b"a CI run log")
-    with pytest.raises(WitnessVerifyRefusal, match="content misaligned"):
+    with pytest.raises(WitnessVerifyUnwitnessed, match="content misaligned"):
         verify_witness(m, witness_content=b"a different CI run log")
 
 
 def test_verify_refuses_bad_signature():
     m = _memento(b"a compiler report")
     m["signature"] = "00" * 64
-    with pytest.raises(WitnessVerifyRefusal, match="signature invalid"):
+    with pytest.raises(WitnessVerifyUnwitnessed, match="signature invalid"):
         verify_witness(m)
 
 
@@ -89,5 +89,5 @@ def test_verify_recompute_dimension_for_runnable_witness():
     m = {"witness_cid": cid, "signer": signer, "signature": signature}
     out = verify_witness(m, recompute_fn=lambda _m: cid)
     assert "recompute" in out["checks"]
-    with pytest.raises(WitnessVerifyRefusal, match="recompute misaligned"):
+    with pytest.raises(WitnessVerifyUnwitnessed, match="recompute misaligned"):
         verify_witness(m, recompute_fn=lambda _m: "blake3-512:" + "0" * 128)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
@@ -11,12 +11,12 @@
 # Oracle. Its contract is one line:
 #
 #   given a locus + CID, return the source IFF it recomputes to the CID;
-#   else REFUSE, loudly.
+#   else SOURCE UNAVAILABLE, loudly.
 #
-# That refusal is the BINARY axis of the three-axis pin made operational, checked
+# That source-unavailable result is the BINARY axis of the three-axis pin made operational, checked
 # at every resolution: a tampered or wrong-version package -> CID mismatch ->
-# refuse -> the sugar cannot resolve -> you KNOW the on-disk source is not what was
-# proven. exact-or-refuse, no silent loss (supra omnia, rectum).
+# source unavailable -> the sugar cannot resolve -> you KNOW the on-disk source is not what was
+# proven. exact-or-source-unavailable, no silent loss (supra omnia, rectum).
 
 from __future__ import annotations
 
@@ -37,7 +37,7 @@ from .canonical import blake3_512_of, template_cid_of_json
 from .source_tables import parsed_tree, source_segment, source_splitlines
 
 
-class SourceOracleRefusal(Exception):
+class SourceUnavailable(Exception):
     """Raised LOUDLY when on-disk source does not recompute to the pinned CID:
     the source has drifted from what the `.proof` pins. Never a silent fallback."""
 
@@ -137,57 +137,57 @@ def path_source(path: str) -> tuple[str, str, str]:
     HERE so no parser ever reads or hashes a file itself.
 
     Minting only: read + decode + CID. No parse gate — which parses is the
-    backend's question, and refusing here would decide it for every backend.
-    Unreadable/undecodable is a LOUD `SourceOracleRefusal`, never `None`:
-    callers record it as a refusal, not an absence.
+    backend's question, and marking source unavailable here would decide it for every backend.
+    Unreadable/undecodable is a LOUD `SourceUnavailable`, never `None`:
+    callers record it as a source-unavailable result, not an absence.
     """
     try:
         source = Path(path).read_text(encoding="utf-8")
     except (OSError, UnicodeError, ValueError) as exc:
-        raise SourceOracleRefusal(f"cannot read source `{path}`: {exc}") from exc
+        raise SourceUnavailable(f"cannot read source `{path}`: {exc}") from exc
     return (source, str(path), blake3_512_of(source.encode("utf-8")))
 
 
 def resolve_span_memento(
     memento: dict[str, Any], project_root: str | None = None
 ) -> dict[str, Any]:
-    """Resolve a span-addressed SourceMemento by RECOMPUTE — exact or refuse.
+    """Resolve a span-addressed SourceMemento by RECOMPUTE — exact or source unavailable.
 
     ORACLE-CONTRACT EXTENSION (#5940 tree), the resolution half of
     `path_source`. Memento shape: `{file, span: {start, end}, source_cid,
     cid}` — file plus a half-open codepoint span into it, pinned twice:
     the whole file (`source_cid`) and the sliced segment (`cid`). Reads the
     on-disk file through `path_source`, re-slices, and returns the identity
-    plus segment IFF both CIDs recompute; else raises `SourceOracleRefusal`.
+    plus segment IFF both CIDs recompute; else raises `SourceUnavailable`.
     """
     file = memento.get("file")
     if not isinstance(file, str) or not file:
-        raise SourceOracleRefusal("span memento missing `file`")
+        raise SourceUnavailable("span memento missing `file`")
     span = memento.get("span")
     if not isinstance(span, dict):
-        raise SourceOracleRefusal("span memento missing `span`")
+        raise SourceUnavailable("span memento missing `span`")
     start, end = span.get("start"), span.get("end")
     if not isinstance(start, int) or not isinstance(end, int) or not (0 <= start <= end):
-        raise SourceOracleRefusal(f"span memento has degenerate span {span!r}")
+        raise SourceUnavailable(f"span memento has degenerate span {span!r}")
 
     path = str(Path(project_root) / file) if project_root else file
     source, filename, source_cid = path_source(path)
 
     pinned_source_cid = memento.get("source_cid")
     if pinned_source_cid is not None and source_cid != pinned_source_cid:
-        raise SourceOracleRefusal(
+        raise SourceUnavailable(
             f"source CID misaligned for `{file}`: pinned {pinned_source_cid}, "
             f"on-disk {source_cid} -- the source drifted from the memento"
         )
     if end > len(source):
-        raise SourceOracleRefusal(
+        raise SourceUnavailable(
             f"span [{start}, {end}) exceeds `{file}` length {len(source)}"
         )
     segment = source[start:end]
     segment_cid = blake3_512_of(segment.encode("utf-8"))
     pinned_cid = memento.get("cid")
     if pinned_cid is not None and segment_cid != pinned_cid:
-        raise SourceOracleRefusal(
+        raise SourceUnavailable(
             f"segment CID misaligned for `{file}` [{start}, {end}): pinned "
             f"{pinned_cid}, on-disk {segment_cid} -- the segment drifted"
         )
@@ -209,11 +209,11 @@ def resolve_source_memento(
     Reads the on-disk source at the memento's locus, re-derives the pinned
     function body or source node with the same machinery that minted it, and
     returns the source/AST IFF the recomputed `source_cid`/`template_cid` equal
-    the pinned ones. Otherwise raises `SourceOracleRefusal`.
+    the pinned ones. Otherwise raises `SourceUnavailable`.
     """
     file = memento.get("file")
     if not isinstance(file, str) or not file:
-        raise SourceOracleRefusal("source memento missing `file`")
+        raise SourceUnavailable("source memento missing `file`")
     function_name = memento.get("source_function_name")
     pinned_source_cid = memento.get("source_cid")
     pinned_template_cid = memento.get("template_cid")
@@ -223,15 +223,15 @@ def resolve_source_memento(
     try:
         source = path.read_text(encoding="utf-8")
     except OSError as exc:
-        raise SourceOracleRefusal(f"cannot read source `{path}`: {exc}") from exc
+        raise SourceUnavailable(f"cannot read source `{path}`: {exc}") from exc
     try:
         tree = parsed_tree(source, filename=str(path))
     except SyntaxError as exc:
-        raise SourceOracleRefusal(f"cannot parse source `{path}`: {exc}") from exc
+        raise SourceUnavailable(f"cannot parse source `{path}`: {exc}") from exc
 
     node = _locate_function(tree, function_name, span)
     if node is None:
-        raise SourceOracleRefusal(
+        raise SourceUnavailable(
             f"source function `{function_name}` not found in `{file}` near line "
             f"{span.get('start_line')}"
         )
@@ -255,7 +255,7 @@ def resolve_source_memento(
         pinned_source_cid is not None
         and recomputed.get("source_cid") != pinned_source_cid
     ):
-        raise SourceOracleRefusal(
+        raise SourceUnavailable(
             f"source CID misaligned for `{function_name}` in `{file}`: "
             f"pinned {pinned_source_cid}, on-disk {recomputed.get('source_cid')} "
             "-- the source drifted from the proof"
@@ -264,7 +264,7 @@ def resolve_source_memento(
         pinned_template_cid is not None
         and recomputed.get("template_cid") != pinned_template_cid
     ):
-        raise SourceOracleRefusal(
+        raise SourceUnavailable(
             f"template CID misaligned for `{function_name}` in `{file}`: "
             f"pinned {pinned_template_cid}, on-disk {recomputed.get('template_cid')} "
             "-- the AST drifted from the proof"
@@ -288,13 +288,13 @@ def _node_source_locator(
 ) -> dict[str, Any]:
     node = _locate_spanned_node(fn, span, source_kind)
     if node is None:
-        raise SourceOracleRefusal(
+        raise SourceUnavailable(
             f"{source_kind} source node not found in `{rel_path}` near line "
             f"{span.get('start_line')}"
         )
     body_text = source_segment(source, node)
     if body_text is None:
-        raise SourceOracleRefusal(
+        raise SourceUnavailable(
             f"{source_kind} source node in `{rel_path}` had no source segment"
         )
     params = function_param_names(fn)
@@ -303,7 +303,7 @@ def _node_source_locator(
     elif isinstance(node, ast.expr):
         ast_template = expr_to_template(node, params)
     else:
-        raise SourceOracleRefusal(
+        raise SourceUnavailable(
             f"unsupported source node kind `{type(node).__name__}`"
         )
     return {
@@ -354,17 +354,17 @@ def _span_of(node: ast.AST) -> dict[str, int]:
 def resolve_from_roots(memento: dict[str, Any], roots: list[str]) -> dict[str, Any]:
     """Resolve a SourceMemento against the first root whose on-disk source aligns
     to the pinned CIDs. The source already lives SOMEWHERE on disk (the consumer's
-    project, or the vendor's installed package); try each candidate root, refuse
-    loudly only if none aligns."""
-    last: SourceOracleRefusal | None = None
+    project, or the vendor's installed package); try each candidate root, reporting
+    source unavailable loudly only if none aligns."""
+    last: SourceUnavailable | None = None
     for root in roots:
         if not root:
             continue
         try:
             return resolve_source_memento(root, memento)
-        except SourceOracleRefusal as exc:
+        except SourceUnavailable as exc:
             last = exc
-    raise last or SourceOracleRefusal("no root resolved the source memento")
+    raise last or SourceUnavailable("no root resolved the source memento")
 
 
 def importlib_package_root(file: str) -> str | None:

--- a/implementations/python/sugar-lift-python-source/tests/test_source_oracle.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_oracle.py
@@ -14,7 +14,7 @@ from sugar_lift_python_source.bind_lifter import (
 from sugar_lift_python_source.ast_template import function_param_names, stmt_to_template
 from sugar_lift_python_source.canonical import blake3_512_of, template_cid_of_json
 from sugar_lift_python_source.source_oracle import (
-    SourceOracleRefusal,
+    SourceUnavailable,
     installed_module_source,
     resolve_source_memento,
 )
@@ -197,7 +197,7 @@ def test_oracle_refuses_loudly_when_source_drifts(tmp_path: Path) -> None:
     (tmp_path / "pkg" / "calc.py").write_text(
         "def add(x, y):\n    return x - y\n", encoding="utf-8"
     )
-    with pytest.raises(SourceOracleRefusal) as exc:
+    with pytest.raises(SourceUnavailable) as exc:
         resolve_source_memento(str(tmp_path), memento)
     assert "misaligned" in str(exc.value)
 
@@ -238,11 +238,11 @@ def test_path_source_mints_the_identity_triple(tmp_path: Path) -> None:
 def test_path_source_refuses_loudly_never_none(tmp_path: Path) -> None:
     from sugar_lift_python_source.source_oracle import path_source
 
-    with pytest.raises(SourceOracleRefusal):
+    with pytest.raises(SourceUnavailable):
         path_source(str(tmp_path / "absent.py"))
     bad = tmp_path / "bad.py"
     bad.write_bytes(b"\xff\xfe\x00x")
-    with pytest.raises(SourceOracleRefusal):
+    with pytest.raises(SourceUnavailable):
         path_source(str(bad))
 
 
@@ -266,5 +266,5 @@ def test_resolve_span_memento_recomputes_or_refuses(tmp_path: Path) -> None:
     assert resolved["source_cid"] == cid
 
     p.write_text("a = 1\nc = 3\n", encoding="utf-8")
-    with pytest.raises(SourceOracleRefusal):
+    with pytest.raises(SourceUnavailable):
         resolve_span_memento(memento)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/__init__.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/__init__.py
@@ -20,7 +20,7 @@ it (``fragment.seal()`` / ``resolve_memento``). Every enumerated object
 answers ``.fragment``.
 """
 
-from .backend import Backend, BackendRefused
+from .backend import Backend, BackendCouldNotParse
 from .fragment import SourceFragment, SourceMemento, resolve_memento
 from .nodes import KIND_REGISTRY, Node, SourceUnit, Typeable, Typed
 from .panic import BackendDefect, SourceTreePanic, VocabularyMissing
@@ -30,7 +30,7 @@ from .tree import SourceFile, SourceTree
 __all__ = [
     "Backend",
     "BackendDefect",
-    "BackendRefused",
+    "BackendCouldNotParse",
     "KIND_REGISTRY",
     "LineColSpan",
     "LineTable",

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
@@ -3,7 +3,7 @@
 Two queries, one per level:
 
 - ``Backend.root(unit)`` — give me this file's root. Two outcomes: a
-  ``BackendNode`` reference, or ``BackendRefused`` raised when the source
+  ``BackendNode`` reference, or ``BackendCouldNotParse`` raised when the source
   is not valid input for this backend.
 - ``BackendNode.describe()`` — give me THIS node's children (and its
   kind, its span, its leaf values). Called on demand, per node, when our
@@ -31,7 +31,7 @@ Failure vocabulary, three distinct classes, never a string:
   shape we have no class for.
 - ``BackendDefect`` (panic.py) — the backend produced something
   structurally invalid.
-- ``BackendRefused`` (here) — the backend's own gap: the raw text was
+- ``BackendCouldNotParse`` (here) — the backend's own parse outcome: the raw text was
   not valid input for it at all. Every adapter must raise exactly this —
   never its native library exception (``SyntaxError``,
   ``libcst.ParserSyntaxError``, ...) — so no caller above this module
@@ -144,8 +144,8 @@ class OpsLeaf:
 Slot = Child | MaybeChild | Children | Leaf | OpLeaf | OpsLeaf
 
 
-class BackendRefused(Exception):
-    """The backend refused the source unit: not valid input for it.
+class BackendCouldNotParse(Exception):
+    """The backend could not parse the source unit: not valid input for it.
 
     Distinct from both panics (panic.py): ``VocabularyMissing`` is a shape
     the backend DID produce that we have no class for; ``BackendDefect``
@@ -155,7 +155,7 @@ class BackendRefused(Exception):
     this on such input, carrying its own backend name, the file, and the
     backend's own reason — never letting its native exception type escape.
 
-    Never caught to continue silently: a refusal is a recorded outcome
+    Never caught to continue silently: a could-not-parse outcome is a recorded outcome
     (corpus.py records it as a failure row), not a substitute for success
     and never a bare ``None``.
     """
@@ -167,7 +167,7 @@ class BackendRefused(Exception):
         self.reason = reason
 
     def __str__(self) -> str:  # pragma: no cover - formatting only
-        return f"BACKEND REFUSED [{self.backend}] {self.file}: {self.reason}"
+        return f"BACKEND COULD NOT PARSE [{self.backend}] {self.file}: {self.reason}"
 
 
 @dataclass(frozen=True)
@@ -206,7 +206,7 @@ class Backend:
     """A parsing backend behind the query contract.
 
     ``root`` is the file-level query: give me this file's root. Two
-    outcomes: a ``BackendNode``, or ``BackendRefused`` — never the
+    outcomes: a ``BackendNode``, or ``BackendCouldNotParse`` — never the
     backend's native library exception.
     """
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/bench_backends.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/bench_backends.py
@@ -3,8 +3,8 @@
 Three independent passes, never conflated:
 
 1. CORRECTNESS — enumerate a SourceTree: every file becomes a SourceFile,
-   every SourceFile enumerates its nodes. Record backend refusals
-   (BackendRefused), panics (VocabularyMissing / BackendDefect), and any
+   every SourceFile enumerates its nodes. Record backend could-not-parse outcomes
+   (BackendCouldNotParse), panics (VocabularyMissing / BackendDefect), and any
    other crash verbatim. Not load sensitive; safe to run on a busy host.
 
 2. RSS — same enumeration, printing ru_maxrss at file-count checkpoints.
@@ -32,9 +32,9 @@ import time
 from pathlib import Path
 from typing import Optional
 
-from sugar_lift_python_source.source_oracle import SourceOracleRefusal, path_source
+from sugar_lift_python_source.source_oracle import SourceUnavailable, path_source
 
-from .backend import BackendRefused
+from .backend import BackendCouldNotParse
 from .corpus import make_backend
 from .panic import SourceTreePanic
 from .tree import SourceFile, SourceTree
@@ -58,7 +58,7 @@ def run_correctness(backend_name: str, root: Path, rss: bool = False) -> int:
     tree = SourceTree(root, backend=make_backend(backend_name))
     parsed = 0
     node_count = 0
-    refused: list[tuple[str, str]] = []
+    could_not_process: list[tuple[str, str]] = []
     panics: list[tuple[str, str]] = []
     crashes: list[tuple[str, str]] = []
     checkpoint = 0
@@ -68,16 +68,16 @@ def run_correctness(backend_name: str, root: Path, rss: bool = False) -> int:
         rel = str(path)
         try:
             identity = path_source(rel)
-        except SourceOracleRefusal as err:
-            refused.append((rel, f"oracle refused: {err}"))
+        except SourceUnavailable as err:
+            could_not_process.append((rel, f"source unavailable: {err}"))
             continue
         try:
             file = SourceFile(identity, backend=tree.backend)
             for _node in file.nodes():
                 node_count += 1
             parsed += 1
-        except BackendRefused as err:
-            refused.append((rel, str(err).splitlines()[0]))
+        except BackendCouldNotParse as err:
+            could_not_process.append((rel, str(err).splitlines()[0]))
         except SourceTreePanic as err:
             panics.append((rel, " | ".join(str(err).splitlines())))
         except Exception as err:  # noqa: BLE001 - a crash IS a result here
@@ -90,9 +90,9 @@ def run_correctness(backend_name: str, root: Path, rss: bool = False) -> int:
     print(f"files:            {total}")
     print(f"constructed:      {parsed}")
     print(f"nodes enumerated: {node_count}")
-    print(f"backend refusals: {len(refused)}")
-    for rel, msg in refused:
-        print(f"  REFUSED  {rel}: {msg}")
+    print(f"backend could-not-parse outcomes: {len(could_not_process)}")
+    for rel, msg in could_not_process:
+        print(f"  COULD NOT PROCESS  {rel}: {msg}")
     print(f"panics:           {len(panics)}")
     for rel, msg in panics:
         print(f"  PANIC    {rel}: {msg}")
@@ -126,7 +126,7 @@ def run_throughput(backend_name: str, root: Path, limit: Optional[int]) -> None:
     for path in paths:
         try:
             identities.append(path_source(str(path)))
-        except SourceOracleRefusal:
+        except SourceUnavailable:
             continue
 
     load_start = _load1()

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/corpus.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/corpus.py
@@ -24,7 +24,7 @@ that diverges is not debugged — it is uninstalled.
 Failures are LOUD: a VocabularyMissing (our vocabulary is incomplete for
 a shape the backend legitimately produced), a BackendDefect (the backend
 or its adapter produced something structurally invalid), or a backend
-refusal (BackendRefused, backend.py — the backend's own "not valid input
+could-not-parse outcome (BackendCouldNotParse, backend.py — the backend's own "not valid input
 for me", never its native exception type) on any file is recorded,
 reported, and fails the run. None of the three ever becomes silence.
 
@@ -48,9 +48,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, Optional
 
-from sugar_lift_python_source.source_oracle import SourceOracleRefusal, path_source
+from sugar_lift_python_source.source_oracle import SourceUnavailable, path_source
 
-from .backend import Backend, BackendRefused
+from .backend import Backend, BackendCouldNotParse
 from .nodes import Node
 from .panic import BackendDefect, VocabularyMissing
 from .tree import SourceFile
@@ -138,23 +138,23 @@ def emit_corpus(
             rel = str(path.relative_to(base)) if base is not None else str(path)
             try:
                 identity = path_source(str(path))
-            except SourceOracleRefusal as err:
-                # The ORACLE refused to mint an identity (unreadable or
+            except SourceUnavailable as err:
+                # The ORACLE reported source unavailable (unreadable or
                 # undecodable). Text enters only through the oracle, so
                 # this is where a bad file surfaces — recorded, never
                 # swallowed.
-                failures.append((rel, "oracle_refused", str(err)))
+                failures.append((rel, "source_unavailable", str(err)))
                 continue
             try:
                 file = SourceFile(identity, backend=backend)
                 recs = records_for_file(file, display=rel)
-            except BackendRefused as err:
-                # The BACKEND refused the file (not valid input for it).
+            except BackendCouldNotParse as err:
+                # The BACKEND could not parse the file (not valid input for it).
                 # Recorded loudly; distinct from a vocabulary MISSING. Never
                 # the backend's native exception type (#5946) — the tree's
                 # own contract type, so this catch works identically no
                 # matter which backend is installed.
-                failures.append((rel, "backend_refused", str(err)))
+                failures.append((rel, "backend_could_not_parse", str(err)))
                 continue
             except VocabularyMissing as err:
                 # OUR vocabulary is incomplete for a shape the backend
@@ -248,7 +248,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         print(f"FAIL[{failure_class}] {rel}: {message.splitlines()[0]}")
     print(f"vocabulary missing (our gaps): {len(missing)}")
     print(f"backend defects: {len(defects)}")
-    print(f"backend refusals / undecodable: {len(other)}")
+    print(f"backend could-not-parse outcomes / undecodable: {len(other)}")
     return 1 if result.failures else 0
 
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/cpython_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/cpython_adapter.py
@@ -23,7 +23,7 @@ boundary — never a permissive fallback.
 Source ``ast.parse`` cannot parse at all (a syntax error, or a null byte —
 ``ValueError`` on some CPython versions, ``SyntaxError`` on others; both
 mean the same thing: this text is not valid Python) is never let through as
-CPython's own exception type. It is re-raised as ``BackendRefused``
+CPython's own exception type. It is re-raised as ``BackendCouldNotParse``
 (backend.py) — the tree's own name for "the backend declined this
 input" — so no caller above this module ever needs to know CPython is
 behind the tree today.
@@ -44,7 +44,7 @@ from .backend import (
     OpsLeaf,
     Backend,
     BackendNode,
-    BackendRefused,
+    BackendCouldNotParse,
     Slot,
 )
 from .nodes import SourceUnit
@@ -413,7 +413,7 @@ class CPythonAstBackend(Backend):
             # IndentationError). ValueError: some CPython versions raise it
             # instead of SyntaxError for a null byte in the source. Both are
             # CPython declining this text — never let either escape as-is.
-            raise BackendRefused(
+            raise BackendCouldNotParse(
                 backend=self.name, file=unit.filename, reason=str(err)
             ) from err
         return _Handle(unit, tree)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/fragment.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/fragment.py
@@ -9,11 +9,11 @@ the sealed minimal address — file, span, two CIDs — inert, never grows.
 They are interchangeable through the SourceOracle, and ONLY through it:
 
     fragment.seal()            -> SourceMemento   (pin)
-    resolve_memento(memento)   -> SourceFragment  (recompute, exact-or-refuse)
+    resolve_memento(memento)   -> SourceFragment  (recompute, exact-or-source-unavailable)
 
 Resolution goes back through the oracle's ``resolve_span_memento``: the
 on-disk file must recompute to the pinned file CID and the sliced segment
-to the pinned segment CID, or the oracle refuses loudly. Nothing here
+to the pinned segment CID, or the source becomes unavailable loudly. Nothing here
 opens a file or mints a hash outside the oracle.
 
 Enumeration is the only fragment constructor: ``SourceFile.fragment``
@@ -28,7 +28,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
 from sugar_lift_python_source.source_oracle import (
-    SourceOracleRefusal,
+    SourceUnavailable,
     resolve_span_memento,
 )
 
@@ -161,13 +161,13 @@ def resolve_memento(
     backend: Optional["Backend"] = None,
     project_root: Optional[str] = None,
 ) -> SourceFragment:
-    """Memento -> fragment, through the oracle. Exact or refuse.
+    """Memento -> fragment, through the oracle. Exact or source unavailable.
 
-    The oracle re-reads the file, recomputes both CIDs, and refuses on any
+    The oracle re-reads the file, recomputes both CIDs, and source is unavailable on any
     drift. On success the file is re-parsed through a backend and the
     fragment is re-bound to the node whose span equals the pinned span, so
     the resolved fragment is as live as the one that sealed. A pinned span
-    that matches no node when the CIDs aligned is a loud refusal — the
+    that matches no node when the CIDs aligned is a loud source-unavailable result — the
     backend disagreed with itself, and that never becomes silence.
     """
     from .tree import SourceFile
@@ -183,7 +183,7 @@ def resolve_memento(
     for node in file.nodes():
         if node.span == span:
             return node.fragment
-    raise SourceOracleRefusal(
+    raise SourceUnavailable(
         f"span [{span.start}, {span.end}) recomputed to the pinned CIDs in "
         f"`{memento.file}` but no enumerated node answers it -- the backend "
         "disagreed with the enumeration that sealed"

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/libcst_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/libcst_adapter.py
@@ -65,7 +65,7 @@ the conformance finding itself.
 
 Source LibCST cannot parse at all raises ``libcst.ParserSyntaxError`` —
 which does NOT subclass ``SyntaxError`` (#5946). This adapter catches it
-and re-raises ``BackendRefused`` (backend.py), never letting the
+and re-raises ``BackendCouldNotParse`` (backend.py), never letting the
 library-native type escape, so a caller written against one backend
 never silently stops working when the other is swapped in.
 """
@@ -87,7 +87,7 @@ from .backend import (
     OpsLeaf,
     Backend,
     BackendNode,
-    BackendRefused,
+    BackendCouldNotParse,
     Slot,
 )
 from .nodes import SourceUnit
@@ -1256,7 +1256,7 @@ def _r_concatstring(ctx: _Ctx, n: cst.ConcatenatedString) -> Description:
             owner="libcst_adapter._r_concatstring",
             observed="implicit concatenation mixing str and bytes pieces",
             requested="pieces of one literal type",
-            fix="this is not valid Python; the backend accepted something CPython would refuse",
+            fix="this is not valid Python; the backend accepted something CPython could not parse",
         )
     return _desc(
         "Constant", span, ("value", Leaf(joined)), ("literal_kind", Leaf(None))
@@ -1540,7 +1540,7 @@ class LibCSTBackend(Backend):
             # param shapes) is always upconverted to ParserSyntaxError before
             # it reaches parse_module (libcst._parser.base_parser) — this is
             # the one exception type that escapes LibCST's own parser.
-            raise BackendRefused(
+            raise BackendCouldNotParse(
                 backend=self.name, file=unit.filename, reason=str(err)
             ) from err
         wrapper = MetadataWrapper(module, unsafe_skip_copy=True)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -670,7 +670,7 @@ class Param(Node):
 
 class Keyword(Node):
     """A keyword argument at a call site. ``arg is None`` means ``**expr``
-    (double-star spread) — a structural absence, not a refusal."""
+    (double-star spread) — a structural absence, not a gap."""
 
     arg: Optional[str]
     value: Expression
@@ -683,7 +683,7 @@ class Keyword(Node):
 
 class DictItem(Node):
     """One ``key: value`` entry of a Dict display. ``key is None`` means
-    ``**expr`` (double-star spread) — a structural absence, not a refusal."""
+    ``**expr`` (double-star spread) — a structural absence, not a gap."""
 
     key: Optional[Expression]
     value: Expression
@@ -914,7 +914,7 @@ class FunctionDef(Statement):
         return annotation) is evaluated in the ENCLOSING scope, unmasked. This
         is why the abstract panics rather than recursing blindly: a blind
         recurse would substitute an outer `x` into a body whose parameter is
-        `x`, capturing it. Masking is that capture, refused.
+        `x`, capturing it. Masking is that capture, left as a gap.
         """
         from .shadow import rewrite
 
@@ -1206,7 +1206,7 @@ class AugAssign(Statement):
         bound yet, so there is no shape where a Name target both fails to
         thread and stays loud). The rebind rode into the tail as the fold
         binding; the statement itself states nothing more. Attribute/subscript
-        targets are the shapes substitution_binding refuses (returns None --
+        targets are the shapes substitution_binding leaves as a gap (returns None --
         they are never threaded), so they stay loud gaps here too, mirrored
         exactly against that same isinstance check."""
         if not isinstance(self.target, Name):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -2,7 +2,7 @@
 
 Every question the tree answers has exactly two outcomes: a resolved,
 Typed answer, or a panic. There is no third arm — no permissive fallback,
-no default case, no quiet ``False``, no bare ``None`` refusal.
+no default case, no quiet ``False``, no bare ``None`` gap.
 
 Two panics were one before, and the merge was itself a bug: an ``owner``
 string a caller had to read and interpret to tell apart two entirely

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/parso_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/parso_adapter.py
@@ -74,7 +74,7 @@ from .backend import (
     OpsLeaf,
     Backend,
     BackendNode,
-    BackendRefused,
+    BackendCouldNotParse,
     Slot,
 )
 from .nodes import SourceUnit
@@ -1509,13 +1509,13 @@ class ParsoBackend(Backend):
         self._grammar = parso.load_grammar(version=version)
 
     def root(self, unit: SourceUnit) -> BackendNode:
-        # parso's own refusal exception (ParserSyntaxError, NOT a
+        # parso's own parse-failure exception (ParserSyntaxError, NOT a
         # SyntaxError subclass) never escapes as-is: it is translated to
-        # BackendRefused, the contract's own type, like every adapter.
+        # BackendCouldNotParse, the contract's own type, like every adapter.
         try:
             module = self._grammar.parse(unit.source, error_recovery=False)
         except parso.parser.ParserSyntaxError as err:
-            raise BackendRefused(
+            raise BackendCouldNotParse(
                 backend=self.name, file=unit.filename, reason=str(err)
             ) from err
         return _Handle(unit, module)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
@@ -31,7 +31,7 @@ from pathlib import Path
 from typing import Iterator, Optional, Tuple
 
 from sugar_lift_python_source.source_oracle import (
-    SourceOracleRefusal,
+    SourceUnavailable,
     installed_module_source,
     path_source,
 )
@@ -64,7 +64,7 @@ class SourceFile:
     ``nodes()`` enumerates every node of the file, pre-order, iterative.
 
     Failure at construction is one of the three loud outcomes:
-    ``BackendRefused`` (the backend's own "not valid input"),
+    ``BackendCouldNotParse`` (the backend's own "not valid input"),
     ``VocabularyMissing`` (our vocabulary has no class for a shape the
     backend produced), or ``BackendDefect`` (the backend produced
     something structurally invalid). Never silence, never a bare None.
@@ -104,7 +104,7 @@ class SourceFile:
         reporter: AuditReporter = NULL_REPORTER,
     ) -> "SourceFile":
         """Through the oracle's path-addressed door. Unreadable/undecodable
-        is the oracle's loud ``SourceOracleRefusal``, never a swallow."""
+        is the oracle's loud ``SourceUnavailable``, never a swallow."""
         return cls(path_source(str(path)), backend=backend, reporter=reporter)
 
     @classmethod
@@ -117,7 +117,7 @@ class SourceFile:
         """Through the oracle's installed-module door."""
         identity = installed_module_source(module_name)
         if identity is None:
-            raise SourceOracleRefusal(
+            raise SourceUnavailable(
                 f"oracle has no installed source for module `{module_name}`"
             )
         return cls(identity, backend=backend, reporter=reporter)
@@ -196,7 +196,7 @@ class SourceTree:
     def fragment_of(self, path: Path) -> "SourceFragment":
         """One file's WHOLE-FILE fragment: the oracle's identity, full span,
         no parse. The per-file unit ``fragments()`` iterates. Loud oracle
-        refusal on unreadable/undecodable input."""
+        source-unavailable result on unreadable/undecodable input."""
         from .fragment import SourceFragment
         from .nodes import SourceUnit
         from .spans import Span
@@ -212,7 +212,7 @@ class SourceTree:
         (source, filename, CID) with the full span. No backend runs, no
         tree is built; this is the ``source_files`` enumeration level, and
         a memento sealed from one of these fragments is the file's locator.
-        An unreadable/undecodable file raises ``SourceOracleRefusal`` loudly
+        An unreadable/undecodable file raises ``SourceUnavailable`` loudly
         here — a caller that wants record-and-continue catches per file and
         records a gap; nothing is swallowed and nothing masquerades as a
         source file.
@@ -224,7 +224,7 @@ class SourceTree:
         """Enumerate ``SourceFile``s, each through the oracle's identity.
         Parse failures propagate loudly — a caller that wants
         record-and-continue catches the three contract types plus
-        ``SourceOracleRefusal`` per file (see corpus.py); nothing here
+        ``SourceUnavailable`` per file (see corpus.py); nothing here
         swallows."""
         for path in self.paths():
             yield SourceFile(path_source(str(path)), backend=self.backend)

--- a/implementations/python/sugar-source-tree/tests/test_could_not_parse_twin.py
+++ b/implementations/python/sugar-source-tree/tests/test_could_not_parse_twin.py
@@ -1,12 +1,12 @@
-"""The refusal contract twin (#5946): both backends refuse identically.
+"""The could-not-parse contract twin (#5946): both backends fail identically.
 
 ``backend.py`` names the outcome: a backend that cannot parse a source
-unit raises ``BackendRefused`` — never its native library exception
+unit raises ``BackendCouldNotParse`` — never its native library exception
 (CPython's ``SyntaxError``, LibCST's ``ParserSyntaxError``, which does NOT
 subclass ``SyntaxError``). Before the fix, ``corpus.py`` caught only
-``SyntaxError``: CPython's refusal was recorded as a row, LibCST's escaped
+``SyntaxError``: CPython's could-not-parse outcome was recorded as a row, LibCST's escaped
 and killed the run. This test drives one deliberately unparseable file
-through BOTH adapters and asserts identical handling — a recorded refusal
+through BOTH adapters and asserts identical handling — a recorded could-not-parse outcome
 row from ``emit_corpus``, never an escaped exception.
 """
 
@@ -19,7 +19,7 @@ import pytest
 libcst = pytest.importorskip("libcst", reason="LibCST backend not installed")
 
 from conftest import oracle_source_file
-from sugar_source_tree.backend import BackendRefused  # noqa: E402
+from sugar_source_tree.backend import BackendCouldNotParse  # noqa: E402
 from sugar_source_tree.tree import SourceFile  # noqa: E402
 from sugar_source_tree.corpus import emit_corpus  # noqa: E402
 from sugar_source_tree.cpython_adapter import CPythonAstBackend  # noqa: E402
@@ -29,7 +29,7 @@ UNPARSEABLE = "def f(:\n    pass\n"
 
 
 def test_libcst_raises_a_type_that_does_not_subclass_syntaxerror():
-    """The defect's root cause, pinned: LibCST's own refusal exception is
+    """The defect's root cause, pinned: LibCST's own could-not-parse outcome exception is
     not a SyntaxError, so ``except SyntaxError`` never catches it."""
     assert not issubclass(libcst.ParserSyntaxError, SyntaxError)
 
@@ -37,25 +37,25 @@ def test_libcst_raises_a_type_that_does_not_subclass_syntaxerror():
 @pytest.mark.parametrize(
     "provider_cls", [CPythonAstBackend, LibCSTBackend], ids=["cpython", "libcst"]
 )
-def test_both_adapters_raise_the_membrane_refusal_not_their_native_exception(
+def test_both_adapters_raise_the_membrane_error_not_their_native_exception(
     provider_cls,
 ):
-    with pytest.raises(BackendRefused) as excinfo:
+    with pytest.raises(BackendCouldNotParse) as excinfo:
         oracle_source_file(UNPARSEABLE, backend=provider_cls())
-    refusal = excinfo.value
-    assert refusal.backend == provider_cls().name
-    assert refusal.file.endswith(".py")
-    assert refusal.reason
+    could_not_parse = excinfo.value
+    assert could_not_parse.backend == provider_cls().name
+    assert could_not_parse.file.endswith(".py")
+    assert could_not_parse.reason
 
 
 @pytest.mark.parametrize(
     "provider_cls", [CPythonAstBackend, LibCSTBackend], ids=["cpython", "libcst"]
 )
-def test_a_refused_file_produces_a_recorded_row_never_an_escaped_exception(
+def test_an_unparseable_file_produces_a_recorded_row_never_an_escaped_exception(
     provider_cls, tmp_path: Path
 ):
     """The HARD LAW, driven end to end through the CLI-facing entry point:
-    a refused file is a recorded failure in the corpus result, not a dead
+    a could not parse file is a recorded failure in the corpus result, not a dead
     process. This is the assertion that failed before the fix for LibCST
     (the exception escaped ``emit_corpus`` and killed the run) and passes
     identically for both backends after it."""
@@ -72,6 +72,8 @@ def test_a_refused_file_produces_a_recorded_row_never_an_escaped_exception(
     )
 
     assert result.files == 1  # only fine.py parsed
-    refused = [f for f in result.failures if f[1] == "backend_refused"]
-    assert len(refused) == 1
-    assert refused[0][0] == "unparseable.py"
+    could_not_parse = [
+        f for f in result.failures if f[1] == "backend_could_not_parse"
+    ]
+    assert len(could_not_parse) == 1
+    assert could_not_parse[0][0] == "unparseable.py"

--- a/implementations/python/sugar-source-tree/tests/test_fragment.py
+++ b/implementations/python/sugar-source-tree/tests/test_fragment.py
@@ -2,14 +2,14 @@
 
 fragment.seal() -> SourceMemento; resolve_memento(memento) -> an EQUAL
 SourceFragment; sealing the resolved fragment reproduces an EQUAL memento.
-Drift refuses loudly (SourceOracleRefusal) — never silence, never None.
+Drift is unavailable loudly (SourceUnavailable) — never silence, never None.
 """
 
 from pathlib import Path
 
 import pytest
 from conftest import oracle_source_file
-from sugar_lift_python_source.source_oracle import SourceOracleRefusal, path_source
+from sugar_lift_python_source.source_oracle import SourceUnavailable, path_source
 from sugar_source_tree import (
     Node,
     SourceFile,
@@ -88,7 +88,7 @@ def test_drifted_source_refuses_loudly_never_silence():
     node = next(n for n in file.nodes() if n.kind == "Return")
     memento = node.fragment.seal()
     Path(file.filename).write_text(SOURCE + "\ny = 3\n", encoding="utf-8")
-    with pytest.raises(SourceOracleRefusal):
+    with pytest.raises(SourceUnavailable):
         resolve_memento(memento)
 
 
@@ -96,7 +96,7 @@ def test_missing_file_refuses_loudly_never_silence():
     file = oracle_source_file(SOURCE)
     memento = file.fragment.seal()
     Path(file.filename).unlink()
-    with pytest.raises(SourceOracleRefusal):
+    with pytest.raises(SourceUnavailable):
         resolve_memento(memento)
 
 

--- a/implementations/python/sugar-source-tree/tests/test_libcst_adapter.py
+++ b/implementations/python/sugar-source-tree/tests/test_libcst_adapter.py
@@ -24,7 +24,7 @@ import pytest
 libcst = pytest.importorskip("libcst", reason="LibCST backend not installed")
 
 from conftest import oracle_source_file
-from sugar_source_tree.backend import BackendRefused  # noqa: E402
+from sugar_source_tree.backend import BackendCouldNotParse  # noqa: E402
 from sugar_source_tree.tree import SourceFile  # noqa: E402
 from sugar_source_tree.cpython_adapter import CPythonAstBackend  # noqa: E402
 from sugar_source_tree.libcst_adapter import LibCSTBackend, _describe, _Ctx  # noqa: E402
@@ -262,23 +262,23 @@ def test_unknown_operator_panics_rather_than_defaulting():
         _op(_BINARY_OPS, libcst.And(), "binop")
 
 
-def test_provider_refusal_is_a_membrane_BackendRefused_never_a_SyntaxError():
+def test_provider_parse_failure_is_a_membrane_BackendCouldNotParse_never_a_SyntaxError():
     """FIX FOR #5946 (the contract finding recorded against #5940): the
-    backend contract now declares how a backend signals refusal
-    (``backend.BackendRefused``), and this adapter maps its native
+    backend contract now declares how a backend signals could-not-parse outcome
+    (``backend.BackendCouldNotParse``), and this adapter maps its native
     ``libcst.ParserSyntaxError`` — which does NOT subclass ``SyntaxError``
     — onto it. Before the fix, ``corpus.py`` caught only ``SyntaxError``,
     so with LibCST installed a corpus containing one unparseable file let
     the exception escape and killed the whole run instead of recording a
     row. This test pins the fix: LibCST's native exception never escapes
-    this adapter, and the tree's own refusal type does.
+    this adapter, and the tree's own could-not-parse outcome type does.
     """
     assert not issubclass(libcst.ParserSyntaxError, SyntaxError), (
         "if this starts failing, LibCST changed its exception base; the "
         "underlying #5946 defect may no longer apply, but the mapping "
         "below must still hold regardless"
     )
-    with pytest.raises(BackendRefused) as excinfo:
+    with pytest.raises(BackendCouldNotParse) as excinfo:
         build("def (:\n")
     assert not isinstance(excinfo.value, SourceTreePanic)
     assert not isinstance(excinfo.value, SyntaxError)

--- a/implementations/python/sugar-source-tree/tests/test_parso_adapter.py
+++ b/implementations/python/sugar-source-tree/tests/test_parso_adapter.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 from conftest import oracle_source_file
 from sugar_source_tree import SourceFile
-from sugar_source_tree.backend import BackendRefused
+from sugar_source_tree.backend import BackendCouldNotParse
 from sugar_source_tree.panic import SourceTreePanic
 from sugar_source_tree.parso_adapter import ParsoBackend
 
@@ -79,15 +79,15 @@ def test_match_statement_is_not_supported_by_parso_080_grammar():
     """The load-bearing finding: parso's shipped grammar311/312/etc. has no
     match_stmt/case_block productions at all (verified by grepping the
     grammar text files directly). This is not an adapter gap — there is no
-    tree to translate. A source using `match` refuses to parse."""
+    tree to translate. A source using `match` could not be parsed."""
     source = "match x:\n    case 0:\n        pass\n"
-    with pytest.raises(BackendRefused):
+    with pytest.raises(BackendCouldNotParse):
         _root(source, filename="match.py")
 
 
 def test_quirks_golden_fails_on_the_known_match_gap():
     source = (GOLDENS / "quirks.py").read_text(encoding="utf-8")
-    with pytest.raises(BackendRefused):
+    with pytest.raises(BackendCouldNotParse):
         _root(source, filename="quirks.py")
 
 


### PR DESCRIPTION
## Summary
- rename construction and lift-accounting vocabulary to gap
- rename backend parse failures to BackendCouldNotParse and source-oracle failures to SourceUnavailable
- rename witness outcomes to unwitnessed and ProofIR boundary outcomes to open
- rename the solver verdict refuted to disproven

## Vocabulary instrument
- raw scoped hits: 210 before -> 4 after
- governed hits: 206 before -> 0 after
- the four excluded remnants are the stdlib ConnectionRefusedError name and three lines in the two explicitly protected scripts
- predicted epsilon R_dead_refusal_vocabulary = -206; floor: protected scripts unchanged

## Focused verification
- sugar-source-tree: 302 passed, 5 skipped, 1 xfailed
- source oracle: 12 passed
- lift-accounting unit partition: 9 passed, 19 deselected
- lift RPC / manifest / witness APIs: 24 passed
- pytest-witness integration: 28 passed
- changed-file py_compile and git diff --check: clean

Non-draft. Do not merge.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove dead refusal vocabulary across source-tree, lift, and witness components
> - Renames exception classes: `BackendRefused` → `BackendCouldNotParse`, `SourceOracleRefusal` → `SourceUnavailable`, `WitnessOracleRefusal` → `WitnessOracleUnwitnessed`, and `WitnessVerifyRefusal` → `WitnessVerifyUnwitnessed` across all adapters, oracles, and tests.
> - Replaces `Verdict` string literals `'refused'` / `'refused-modulo-unavailable-seats'` with `'unwitnessed'` / `'unwitnessed-modulo-unavailable-seats'` in the witness harness and sugar witnesses layer.
> - Renames `AssertionAxis` fields `refused_loud` / `refused_loci` to `gap` / `gap_loci` and updates serialized JSON keys, coverage accounting, and line-painting accordingly.
> - Replaces `'construction-refusal'` verdict literal and `refusal_absence` field with `'construction-open'` / `open_absence` across all `VerdictWitnessCase` nodes (`VendorConjoin`, `BoundaryRecord`, `CallEdgeDecl`, etc.).
> - Risk: these are breaking renames — any external caller importing the old exception classes, reading the old JSON keys (`refused_loud`, `refused_loci`, `refusal`), or comparing against old verdict strings will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da104f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->