### PR TITLE
fix: floor instruments emit UTF-8 portably (CP-1252 crash)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
@@ -136,6 +136,11 @@ def _run_child(path: Path, rel: str) -> int:
 
 
 def main() -> int:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (AttributeError, ValueError):
+            pass
     repo_root = Path(__file__).resolve().parents[4]
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(

--- a/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import argparse
 import ast
 from pathlib import Path
+import sys
 from typing import NamedTuple
 
 
@@ -343,6 +344,11 @@ def format_report(offenders: list[PanicCatchOffender]) -> str:
 
 
 def main() -> int:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (AttributeError, ValueError):
+            pass
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--kit-root",

--- a/implementations/python/sugar-lift-py-tests/scripts/factory_ownership_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/factory_ownership_law.py
@@ -26,6 +26,7 @@ import argparse
 import ast
 from collections import Counter
 from pathlib import Path
+import sys
 from typing import NamedTuple
 
 
@@ -315,6 +316,11 @@ def format_report(offenders: list[OwnershipOffender]) -> str:
 
 
 def main() -> int:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (AttributeError, ValueError):
+            pass
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--sugar-root",

--- a/implementations/python/sugar-lift-py-tests/scripts/factory_walk_unclassified_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/factory_walk_unclassified_law.py
@@ -363,6 +363,11 @@ def measure_live_roots(
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (AttributeError, ValueError):
+            pass
     repo_root = Path(__file__).resolve().parents[4]
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(

--- a/implementations/python/sugar-lift-py-tests/scripts/finite_cap_opaque_completion_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/finite_cap_opaque_completion_law.py
@@ -353,6 +353,11 @@ def _default_root() -> Path:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (AttributeError, ValueError):
+            pass
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("roots", nargs="*", type=Path)
     args = parser.parse_args(argv)

--- a/implementations/python/sugar-lift-py-tests/scripts/finite_unfold_compact_projection_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/finite_unfold_compact_projection_law.py
@@ -218,6 +218,11 @@ def _default_root() -> Path:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (AttributeError, ValueError):
+            pass
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("roots", nargs="*", type=Path)
     parser.add_argument("--json", action="store_true")

--- a/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
@@ -215,6 +215,11 @@ def _run_child(path: Path, rel: str) -> int:
 
 
 def main() -> int:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (AttributeError, ValueError):
+            pass
     repo_root = Path(__file__).resolve().parents[4]
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(

--- a/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
@@ -267,6 +267,11 @@ def _run_child(path: Path, rel: str) -> int:
 
 
 def main() -> int:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (AttributeError, ValueError):
+            pass
     repo_root = Path(__file__).resolve().parents[4]
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(

--- a/implementations/python/sugar-lift-py-tests/scripts/source_via_execution_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/source_via_execution_law.py
@@ -440,6 +440,11 @@ def format_report(offenders: Sequence[SourceViaExecution]) -> str:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (AttributeError, ValueError):
+            pass
     package = (
         Path(__file__).resolve().parents[1]
         / "src"

--- a/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
@@ -106,6 +106,11 @@ def _run_child(path: Path, rel: str) -> int:
 
 
 def main() -> int:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (AttributeError, ValueError):
+            pass
     repo_root = Path(__file__).resolve().parents[4]
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(

--- a/implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
@@ -485,6 +485,11 @@ def format_report(offenders: Sequence[VendorSpecialCase]) -> str:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (AttributeError, ValueError):
+            pass
     package = (
         Path(__file__).resolve().parents[1]
         / "src"

--- a/implementations/python/sugar-lift-py-tests/tests/test_floor_output_portability.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_floor_output_portability.py
@@ -1,0 +1,34 @@
+"""Floor instruments emit their Unicode reports under legacy host locales."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+def test_vendor_floor_emits_arrows_under_cp1252(tmp_path: Path) -> None:
+    script = (
+        Path(__file__).resolve().parents[1]
+        / "scripts"
+        / "vendor_special_case_law.py"
+    )
+    surface = tmp_path / "surface"
+    surface.mkdir()
+    (surface / "planted.py").write_text(
+        "def dispatch(name):\n    return name == 'numpy'\n", encoding="utf-8"
+    )
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "cp1252"
+
+    result = subprocess.run(
+        [sys.executable, str(script), str(surface)],
+        env=env,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1, result.stderr.decode("utf-8", errors="replace")
+    output = result.stdout.decode("utf-8")
+    assert "source shape → registered Sugar → SugarBody children → floor" in output


### PR DESCRIPTION
## Scope

- reconfigure stdout and stderr to UTF-8 with `backslashreplace` at the start of every printing floor-axis script main
- preserve every report string, measurement path, and R value unchanged
- add a subprocess regression that runs the planted vendor-special-case report under `PYTHONIOENCODING=cp1252` and verifies the original arrows survive in UTF-8 output

## Verification

```text
79 passed in 2.03s
```

The focused set covers all affected floor-law and zero-tolerance instruments. A structural check also confirms every printing `*_law.py` / `*_zero_tolerance.py` script contains the guarded UTF-8 stream configuration.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix floor instrument scripts to emit UTF-8 output portably to avoid CP-1252 crashes
> - Adds `stream.reconfigure(encoding='utf-8', errors='backslashreplace')` at startup in all 11 floor instrument scripts under `implementations/python/sugar-lift-py-tests/scripts/`, guarded by `try/except` for `AttributeError` and `ValueError` to tolerate runtimes that don't support `reconfigure`.
> - Adds a regression test in [test_floor_output_portability.py](https://github.com/TSavo/sugar/pull/6059/files#diff-00a5f2ba0a1852c1653965f0959f89062ced1d6bb3b6a3c1d375631ba6174b78) that spawns `vendor_special_case_law.py` with `PYTHONIOENCODING=cp1252` and asserts the Unicode arrow sequence appears in stdout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c47147b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->