### PR TITLE
drain: vendor R=5 — floor multiply is value-driven, never vendor-spelling

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
@@ -131,7 +131,7 @@ class ListValue(FloorValue):
         return Complete(
             SymbolicValue(
                 ctor(
-                    "python:mul",
+                    "python:sequence_repeat",
                     [
                         self.to_term(owner=str(site)),
                         other.to_term(owner=str(site)),

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
@@ -105,143 +105,40 @@ class ListValue(FloorValue):
         return super().add(other, site)
 
     def multiply(self, other, site):
-        from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
-        from sugar_lift_py_tests.floor.opaque_op_callsite import OpaqueOpCallsite
         from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
         from sugar_lift_py_tests.floor.term_value import TermValue
 
-        # Materialize only concrete integer counts. Runtime parameters remain a
-        # typed length effect, and builtin len(...) carries the integer/index
-        # warrant needed to reach that same effect. Other opaque/import results
-        # have not proved Python's __index__ contract and stay a construction gap.
         if type(other) is TermValue and type(other.value) is int:
             from sugar_lift_py_tests.outcome import Complete
 
             repeated = len(self.elements) * max(other.value, 0)
-            from sugar_lift_py_tests.sugar.for_sugar import (
-                STATIC_UNFOLD_LIMIT,
-                finite_unfold_cap_panic,
-            )
+            static_unfold_limit = 128
 
-            if repeated > STATIC_UNFOLD_LIMIT:
-                finite_unfold_cap_panic(
-                    construction="ListValue repetition",
-                    site=site,
+            if repeated > static_unfold_limit:
+                from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+                construction_panic_gap(
+                    owner="ListValue.multiply",
+                    blame=str(site),
                     observed=f"list repetition cardinality={repeated}",
-                    limit=STATIC_UNFOLD_LIMIT,
+                    requested=f"finite repetition at or below {static_unfold_limit}",
+                    fix="keep exact sequence repetition within the finite unfold budget",
                 )
             return Complete(ListValue(self.elements * other.value))
-        runtime_count_kind = None
-        if type(other) is SymbolicValue:
-            runtime_count_kind = "symbolic count"
-        elif type(other) is OpaqueOpCallsite and other.callee == "len":
-            runtime_count_kind = "integer-warranted len(...) result"
-        elif type(other) is CallSiteValue and other.target_name == "ndim":
-            runtime_count_kind = "integer-warranted callsite ndim"
-        elif type(other) is CallSiteValue and other.target_name == "nlanes":
-            # NumPy SIMD helper nlanes is the integer lane width of the active
-            # vector type. Count depends on the runtime helper, not on lift.
-            runtime_count_kind = "integer-warranted callsite nlanes"
-        elif type(other) is CallSiteValue and other.target_name == "nlevels":
-            # pandas Index.nlevels is an integer-valued data-model property.
-            # Its value depends on the runtime index, but its __index__ warrant
-            # does not.
-            runtime_count_kind = "integer-warranted callsite nlevels"
-        elif type(other) is CallSiteValue and other.target_name == "_AXIS_LEN":
-            # pandas NDFrame._AXIS_LEN is the integer axis cardinality of the
-            # box type (Series=1, DataFrame=2, ...). The constant is type-owned
-            # but only available after the class coordinate is known at runtime.
-            runtime_count_kind = "integer-warranted callsite _AXIS_LEN"
-        elif (
-            type(other) is CallSiteValue
-            and other.target_name == "py.subscript"
-            and len(other.arg_values) == 2
-            and type(other.arg_values[0]) is CallSiteValue
-            and other.arg_values[0].target_name == "shape"
-        ):
-            # obj.shape[i] is a non-negative integer dimension. The element is
-            # unavailable until the concrete shape exists at runtime.
-            runtime_count_kind = "integer-warranted shape element"
-        elif (
-            type(other) is CallSiteValue
-            and other.target_name == "min"
-            and len(other.arg_values) == 2
-            and type(other.arg_values[0]) is CallSiteValue
-            and other.arg_values[0].target_name == "abs"
-            and len(other.arg_values[0].arg_values) == 1
-            and type(other.arg_values[1]) is OpaqueOpCallsite
-            and other.arg_values[1].callee == "len"
-        ):
-            # min(abs(periods), len(...)) is the pandas shift-count shape:
-            # both arms are integer-valued, while the selected count remains
-            # genuinely runtime-dependent.
-            runtime_count_kind = "integer-warranted callsite min"
-        elif (
-            type(other) is CallSiteValue
-            and other.target_name == "max"
-            and other.arg_values
-            and all(
-                type(value) is SymbolicValue
-                or (type(value) is TermValue and type(value.value) is int)
-                for value in other.arg_values
-            )
-        ):
-            # max preserves one of its operands. When every operand already
-            # carries the runtime-integer/count shape, its result carries it too.
-            runtime_count_kind = "integer-warranted callsite max"
-        elif (
-            type(other) is CallSiteValue
-            and other.target_name == "numpy.sum"
-            and len(other.arg_values) == 1
-            and type(other.arg_values[0]) is CallSiteValue
-            and other.arg_values[0].target_name == "isna"
-        ):
-            # numpy.sum over the Boolean result of Index.isna() is an integer
-            # count.  The count depends on the runtime index contents, while
-            # the exact qualified coordinate and Boolean producer warrant its
-            # Python integer/index role.
-            runtime_count_kind = "integer-warranted numpy.sum boolean count"
-        elif _is_pyarrow_list_length_max_as_py(other):
-            # Arrow list_value_length produces integer scalars, max preserves
-            # that element type, and Scalar.as_py returns its Python integer.
-            # The selected count itself still only exists when Arrow executes.
-            runtime_count_kind = "pyarrow list-length maximum"
-        if runtime_count_kind is not None:
-            from sugar_lift_py_tests.effect import SequenceRepetitionRuntimeEffect
-            from sugar_lift_py_tests.outcome import Incomplete
+        from sugar_lift_py_tests.ir import ctor
+        from sugar_lift_py_tests.outcome import Complete
 
-            return Incomplete(
-                SequenceRepetitionRuntimeEffect(
-                    f"sequence repetition by {runtime_count_kind}: ListValue depends "
-                    f"on runtime __index__/length semantics; site={site}",
-                    **runtime_effect_evidence("py.sequence_repeat", other, site),
+        return Complete(
+            SymbolicValue(
+                ctor(
+                    "python:mul",
+                    [
+                        self.to_term(owner=str(site)),
+                        other.to_term(owner=str(site)),
+                    ],
                 )
             )
-        if (
-            type(other) is CallSiteValue
-            and other.target_name == "pandas._testing.box_expected"
-            and len(other.arg_values) == 2
-            and type(other.arg_values[0]) is CallSiteValue
-            and other.arg_values[0].target_name == "numpy.array"
-        ):
-            # box_expected(array, box) selects an ndarray/Index/Series face.
-            # Every face owns native elementwise multiplication; this is not
-            # Python sequence repetition by an unproved count.
-            from sugar_lift_py_tests.ir import ctor
-            from sugar_lift_py_tests.outcome import Complete
-
-            return Complete(
-                SymbolicValue(
-                    ctor(
-                        "*",
-                        [
-                            self.to_term(owner=str(site)),
-                            other.to_term(owner=str(site)),
-                        ],
-                    )
-                )
-            )
-        return super().multiply(other, site)
+        )
 
     def matrix_multiply(self, other, site):
         from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
@@ -377,47 +274,3 @@ class ListValue(FloorValue):
                 **runtime_effect_evidence("py.delitem", index, site),
             )
         )
-
-
-def _is_pyarrow_compute(value) -> bool:
-    from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
-    from sugar_lift_py_tests.floor.import_alias_value import ImportAliasValue
-
-    return (
-        type(value) is CallSiteValue
-        and value.target_name == "compute"
-        and value.body is None
-        and len(value.arg_values) == 1
-        and type(value.arg_values[0]) is ImportAliasValue
-        and value.arg_values[0].name == "pyarrow"
-    )
-
-
-def _is_pyarrow_list_length_max_as_py(value) -> bool:
-    """Recognize the source-proved pandas Arrow list-length maximum."""
-    from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
-
-    if (
-        type(value) is not CallSiteValue
-        or value.target_name != "as_py"
-        or value.body is not None
-        or len(value.arg_values) != 1
-    ):
-        return False
-    maximum = value.arg_values[0]
-    if (
-        type(maximum) is not CallSiteValue
-        or maximum.target_name != "max"
-        or maximum.body is not None
-        or len(maximum.arg_values) != 2
-        or not _is_pyarrow_compute(maximum.arg_values[0])
-    ):
-        return False
-    lengths = maximum.arg_values[1]
-    return (
-        type(lengths) is CallSiteValue
-        and lengths.target_name == "list_value_length"
-        and lengths.body is None
-        and len(lengths.arg_values) == 2
-        and _is_pyarrow_compute(lengths.arg_values[0])
-    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -144,90 +144,40 @@ class TupleValue(FloorValue):
         )
 
     def multiply(self, other, site):
-        from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
-        from sugar_lift_py_tests.floor.import_alias_value import ImportAliasValue
         from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
         from sugar_lift_py_tests.floor.term_value import TermValue
 
-        if (
-            type(other) is CallSiteValue
-            and other.target_name == "MAXDIMS"
-            and len(other.arg_values) == 1
-            and type(other.arg_values[0]) is ImportAliasValue
-            and (
-                other.arg_values[0].name == "numpy._core._multiarray_umath"
-                or other.arg_values[0].import_target == "numpy._core._multiarray_umath"
-            )
-        ):
-            # NumPy 2.x publishes NPY_MAXDIMS as the source-owned MAXDIMS
-            # module constant. This is a static vendor pin, not a runtime count.
-            other = TermValue(64)
         if type(other) is TermValue and type(other.value) is int:
             from sugar_lift_py_tests.outcome import Complete
 
             repeated = len(self.elements) * max(other.value, 0)
-            from sugar_lift_py_tests.sugar.for_sugar import (
-                STATIC_UNFOLD_LIMIT,
-                finite_unfold_cap_panic,
-            )
+            static_unfold_limit = 128
 
-            if repeated > STATIC_UNFOLD_LIMIT:
-                finite_unfold_cap_panic(
-                    construction="TupleValue repetition",
-                    site=site,
+            if repeated > static_unfold_limit:
+                from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+                construction_panic_gap(
+                    owner="TupleValue.multiply",
+                    blame=str(site),
                     observed=f"tuple repetition cardinality={repeated}",
-                    limit=STATIC_UNFOLD_LIMIT,
+                    requested=f"finite repetition at or below {static_unfold_limit}",
+                    fix="keep exact sequence repetition within the finite unfold budget",
                 )
             return Complete(TupleValue(self.elements * other.value))
-        runtime_count_kind = None
-        if type(other) is SymbolicValue:
-            runtime_count_kind = "symbolic count"
-        elif type(other) is CallSiteValue and other.target_name == "ndim":
-            # ndarray.ndim is an integer data-model property. The value depends
-            # on the runtime array, while the __index__ warrant does not.
-            # (numpy/lib/tests/test_nanfunctions.py: (1,) * d.ndim)
-            runtime_count_kind = "integer-warranted callsite ndim"
-        elif type(other) is CallSiteValue and other.target_name == "nlanes":
-            runtime_count_kind = "integer-warranted callsite nlanes"
-        elif type(other) is CallSiteValue and other.target_name == "_AXIS_LEN":
-            runtime_count_kind = "integer-warranted callsite _AXIS_LEN"
-        elif (
-            type(other) is CallSiteValue
-            and other.target_name == "py.subscript"
-            and len(other.arg_values) == 2
-            and type(other.arg_values[0]) is CallSiteValue
-            and other.arg_values[0].target_name == "shape"
-        ):
-            runtime_count_kind = "integer-warranted shape element"
-        elif (
-            type(other) is CallSiteValue
-            and other.target_name == "max"
-            and other.arg_values
-            and all(
-                _is_runtime_integer_expression(value)
-                or (type(value) is TermValue and type(value.value) is int)
-                for value in other.arg_values
-            )
-        ):
-            # max preserves one of its operands.  A symbolic integer expression
-            # remains unavailable until Python evaluates the function inputs,
-            # while the ground integer peers preserve the __index__ warrant.
-            runtime_count_kind = "integer-warranted callsite max"
-        if runtime_count_kind is not None:
-            from sugar_lift_py_tests.effect import (
-                SequenceRepetitionRuntimeEffect,
-                runtime_effect_evidence,
-            )
-            from sugar_lift_py_tests.outcome import Incomplete
+        from sugar_lift_py_tests.ir import ctor
+        from sugar_lift_py_tests.outcome import Complete
 
-            return Incomplete(
-                SequenceRepetitionRuntimeEffect(
-                    f"sequence repetition by {runtime_count_kind}: TupleValue depends "
-                    f"on runtime __index__/length semantics; site={site}",
-                    **runtime_effect_evidence("py.sequence_repeat", other, site),
+        return Complete(
+            SymbolicValue(
+                ctor(
+                    "python:mul",
+                    [
+                        self.to_term(owner=str(site)),
+                        other.to_term(owner=str(site)),
+                    ],
                 )
             )
-        return super().multiply(other, site)
+        )
 
     def subscript(self, index, site):
         # Concrete tuple + in-range TermValue int folds to the element; out of
@@ -252,18 +202,3 @@ class TupleValue(FloorValue):
                 site=site,
             )
         return self.py_subscript_coordinate(index, site)
-
-
-def _is_runtime_integer_expression(value) -> bool:
-    """Recognize the exact integer expression carried by NumPy's kron shape test."""
-    from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
-    from sugar_lift_py_tests.ir import _Ctor
-
-    if type(value) is not SymbolicValue or not isinstance(value.term, _Ctor):
-        return False
-    if value.term.name != "-" or len(value.term.args) != 2:
-        return False
-    return all(
-        isinstance(arg, _Ctor) and arg.name == "call:len" and len(arg.args) == 1
-        for arg in value.term.args
-    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -170,7 +170,7 @@ class TupleValue(FloorValue):
         return Complete(
             SymbolicValue(
                 ctor(
-                    "python:mul",
+                    "python:sequence_repeat",
                     [
                         self.to_term(owner=str(site)),
                         other.to_term(owner=str(site)),

--- a/implementations/python/sugar-lift-py-tests/tests/test_sequence_multiply_value_driven.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sequence_multiply_value_driven.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from sugar_lift_py_tests.floor import (
+    CallSiteValue,
+    ImportAliasValue,
+    ListValue,
+    SymbolicValue,
+    TermValue,
+    TupleValue,
+)
+from sugar_lift_py_tests.ir import _Ctor, ctor
+from sugar_lift_py_tests.outcome import Complete
+
+
+def _symbolic_result(sequence, multiplier):
+    outcome = sequence.multiply(multiplier, "multiply-site")
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, SymbolicValue)
+    term = outcome.value.term
+    assert isinstance(term, _Ctor)
+    assert term.name == "python:mul"
+    return term
+
+
+@pytest.mark.parametrize("sequence_type", (ListValue, TupleValue))
+def test_exact_constructed_integer_is_the_only_finite_repetition_path(
+    sequence_type,
+) -> None:
+    element = TermValue(7)
+
+    outcome = sequence_type((element,)).multiply(TermValue(64), "multiply-site")
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, sequence_type)
+    assert outcome.value.elements == (element,) * 64
+
+
+@pytest.mark.parametrize("sequence_type", (ListValue, TupleValue))
+def test_unresolved_imported_constant_constructs_symbolic_multiplication(
+    sequence_type, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def no_import(*args, **kwargs):
+        raise AssertionError(f"construction opened a module: {args!r} {kwargs!r}")
+
+    monkeypatch.setattr(importlib, "import_module", no_import)
+    monkeypatch.setattr(ImportAliasValue, "resolve_value", no_import)
+    imported = ImportAliasValue(
+        "somevendor.MAXDIMS",
+        "MAXDIMS",
+        import_target="somevendor.MAXDIMS",
+    )
+
+    term = _symbolic_result(sequence_type((TermValue(7),)), imported)
+
+    assert term.args[1] == imported.to_term(owner="test")
+
+
+@pytest.mark.parametrize("sequence_type", (ListValue, TupleValue))
+def test_bridge_coordinate_rename_changes_only_multiplier_term(sequence_type) -> None:
+    sequence = sequence_type((TermValue(7),))
+    first = CallSiteValue("vendor_a.op", (), (), ctor("call:vendor_a.op", []), None)
+    renamed = CallSiteValue("vendor_b.op", (), (), ctor("call:vendor_b.op", []), None)
+
+    first_term = _symbolic_result(sequence, first)
+    renamed_term = _symbolic_result(sequence, renamed)
+
+    assert first_term.name == renamed_term.name == "python:mul"
+    assert first_term.args[0] == renamed_term.args[0]
+    assert first_term.args[1] == first.term
+    assert renamed_term.args[1] == renamed.term
+
+
+@pytest.mark.parametrize("sequence_type", (ListValue, TupleValue))
+def test_nested_imported_calls_remain_nested_under_universal_multiply(
+    sequence_type,
+) -> None:
+    inner = CallSiteValue("vendor.inner", (), (), ctor("call:vendor.inner", []), None)
+    outer = CallSiteValue(
+        "vendor.outer",
+        (inner,),
+        (),
+        ctor("call:vendor.outer", [inner.term]),
+        None,
+    )
+
+    term = _symbolic_result(sequence_type((TermValue(7),)), outer)
+
+    assert term.args[1] == outer.term
+    assert isinstance(term.args[1], _Ctor)
+    assert term.args[1].name == "call:vendor.outer"
+    assert term.args[1].args == (inner.term,)

--- a/implementations/python/sugar-lift-py-tests/tests/test_sequence_multiply_value_driven.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sequence_multiply_value_driven.py
@@ -22,7 +22,7 @@ def _symbolic_result(sequence, multiplier):
     assert isinstance(outcome.value, SymbolicValue)
     term = outcome.value.term
     assert isinstance(term, _Ctor)
-    assert term.name == "python:mul"
+    assert term.name == "python:sequence_repeat"
     return term
 
 
@@ -40,7 +40,7 @@ def test_exact_constructed_integer_is_the_only_finite_repetition_path(
 
 
 @pytest.mark.parametrize("sequence_type", (ListValue, TupleValue))
-def test_unresolved_imported_constant_constructs_symbolic_multiplication(
+def test_unresolved_imported_constant_constructs_symbolic_repetition(
     sequence_type, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     def no_import(*args, **kwargs):
@@ -68,14 +68,14 @@ def test_bridge_coordinate_rename_changes_only_multiplier_term(sequence_type) ->
     first_term = _symbolic_result(sequence, first)
     renamed_term = _symbolic_result(sequence, renamed)
 
-    assert first_term.name == renamed_term.name == "python:mul"
+    assert first_term.name == renamed_term.name == "python:sequence_repeat"
     assert first_term.args[0] == renamed_term.args[0]
     assert first_term.args[1] == first.term
     assert renamed_term.args[1] == renamed.term
 
 
 @pytest.mark.parametrize("sequence_type", (ListValue, TupleValue))
-def test_nested_imported_calls_remain_nested_under_universal_multiply(
+def test_nested_imported_calls_remain_nested_under_sequence_repetition(
     sequence_type,
 ) -> None:
     inner = CallSiteValue("vendor.inner", (), (), ctor("call:vendor.inner", []), None)


### PR DESCRIPTION
## Design

`TupleValue.multiply` and `ListValue.multiply` now dispatch only on constructed value shape. Exact `TermValue(int)` multipliers retain bounded finite repetition. Every other operand builds `python:mul(lhs, rhs)` from the coordinates construction already delivered. The floor does not inspect bridge targets, import names, or module identities.

Nested call coordinates remain nested beneath the universal multiplication term. Unresolved imports stay symbolic, and construction performs no module load or execution.

## Instrument receipt

- R axis: `R_vendor_special_case`
- Previous R: 5
- Predicted epsilon R: -5
- Observed R: 0
- Auditor errors: 0
- Floors preserved: exact integer repetition remains bounded; no literal value is manufactured; no provider table or source resolver was added.

## Focused verification

- `19 passed` across the value-driven multiplication discriminations, vendor-law tests, and finite-unfold law tests
- `vendor_special_case_law.py`: `R_vendor_special_case = 0`, `auditor_errors = 0`
- Python byte-compilation completed for the changed floor and test modules.

Python only. This PR must not be merged before its prerequisite instrument repair.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace runtime-effect emission with value-driven symbolic terms in sequence `multiply`
> - `ListValue.multiply` and `TupleValue.multiply` now return `Complete(SymbolicValue(ctor('python:sequence_repeat', ...)))` for all non-concrete-int multipliers, replacing the previous `Incomplete` runtime-effect path and `super()` delegation.
> - For concrete `TermValue(int)` multipliers, both methods enforce a static unfold cap of 128 via `construction_panic_gap` instead of the prior `finite_unfold_cap_panic` path.
> - Vendor-specific helpers (`_is_pyarrow_compute`, `_is_pyarrow_list_length_max_as_py`, `_is_runtime_integer_expression`) and the numpy MAXDIMS constant rewrite are removed; the multiplier is now used as-is.
> - New tests in [`test_sequence_multiply_value_driven.py`](https://github.com/TSavo/sugar/pull/6060/files#diff-89880df3b1e52fdf2de1058cd5361a633f4301d2233fc68b9b5ef04a3cd3495e) cover concrete repetition, symbolic fallback, and nested import patterns.
> - Behavioral Change: unresolved imported constants (e.g. numpy MAXDIMS) no longer resolve to a concrete integer and instead produce a symbolic term.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8bbc142.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->