### PR TITLE
fix: sequence multiply by a known-invalid ground value is a loud TypeError, not completed

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
@@ -108,7 +108,7 @@ class ListValue(FloorValue):
         from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
         from sugar_lift_py_tests.floor.term_value import TermValue
 
-        if type(other) is TermValue and type(other.value) is int:
+        if type(other) is TermValue and type(other.value) in (int, bool):
             from sugar_lift_py_tests.outcome import Complete
 
             repeated = len(self.elements) * max(other.value, 0)
@@ -125,6 +125,13 @@ class ListValue(FloorValue):
                     fix="keep exact sequence repetition within the finite unfold budget",
                 )
             return Complete(ListValue(self.elements * other.value))
+        from sugar_lift_py_tests.floor.sequence_repetition import (
+            is_known_invalid_repetition_count,
+            known_invalid_repetition_type_error,
+        )
+
+        if is_known_invalid_repetition_count(other):
+            return known_invalid_repetition_type_error(self, other, site)
         from sugar_lift_py_tests.ir import ctor
         from sugar_lift_py_tests.outcome import Complete
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/sequence_repetition.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/sequence_repetition.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+
+def is_known_invalid_repetition_count(value) -> bool:
+    """Whether construction knows this value cannot satisfy ``__index__``."""
+    from sugar_lift_py_tests.floor.bytes_value import BytesValue
+    from sugar_lift_py_tests.floor.none_value import NoneValue
+    from sugar_lift_py_tests.floor.string_value import StringValue
+    from sugar_lift_py_tests.floor.term_value import TermValue
+
+    if type(value) is TermValue:
+        return type(value.value) not in (int, bool)
+    return type(value) in (StringValue, BytesValue, NoneValue)
+
+
+def known_invalid_repetition_type_error(sequence, count, site):
+    """Construct Python's typed exceptional boundary for ``sequence * count``."""
+    from sugar_lift_py_tests.effect import (
+        TypeErrorRuntimeEffect,
+        runtime_effect_evidence,
+    )
+    from sugar_lift_py_tests.ir import ctor
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    operation = ctor(
+        "call:python.sequence_repeat",
+        [
+            sequence.to_term(owner=str(site)),
+            _known_ground_term(count, owner=str(site)),
+        ],
+    )
+    return Incomplete(
+        TypeErrorRuntimeEffect(
+            "sequence repetition count is a known ground value without "
+            f"__index__; count={type(count).__name__} site={site}",
+            **runtime_effect_evidence("python:sequence_repeat", operation, site),
+        )
+    )
+
+
+def _known_ground_term(value, *, owner: str):
+    """Project the concrete multiplier itself without stringifying it."""
+    from sugar_lift_py_tests.floor.term_value import TermValue
+    from sugar_lift_py_tests.ir import ctor, str_const
+
+    if type(value) is TermValue:
+        if type(value.value) is str:
+            return str_const(value.value)
+        if type(value.value) is bytes:
+            return ctor("python:bytes", [str_const(value.value.hex())])
+        if value.value is None:
+            return ctor("None", [])
+    return value.to_term(owner=owner)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -147,7 +147,7 @@ class TupleValue(FloorValue):
         from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
         from sugar_lift_py_tests.floor.term_value import TermValue
 
-        if type(other) is TermValue and type(other.value) is int:
+        if type(other) is TermValue and type(other.value) in (int, bool):
             from sugar_lift_py_tests.outcome import Complete
 
             repeated = len(self.elements) * max(other.value, 0)
@@ -164,6 +164,13 @@ class TupleValue(FloorValue):
                     fix="keep exact sequence repetition within the finite unfold budget",
                 )
             return Complete(TupleValue(self.elements * other.value))
+        from sugar_lift_py_tests.floor.sequence_repetition import (
+            is_known_invalid_repetition_count,
+            known_invalid_repetition_type_error,
+        )
+
+        if is_known_invalid_repetition_count(other):
+            return known_invalid_repetition_type_error(self, other, site)
         from sugar_lift_py_tests.ir import ctor
         from sugar_lift_py_tests.outcome import Complete
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_sequence_multiply_value_driven.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sequence_multiply_value_driven.py
@@ -4,6 +4,7 @@ import importlib
 
 import pytest
 
+from sugar_lift_py_tests.effect import TypeErrorRuntimeEffect
 from sugar_lift_py_tests.floor import (
     CallSiteValue,
     ImportAliasValue,
@@ -13,7 +14,15 @@ from sugar_lift_py_tests.floor import (
     TupleValue,
 )
 from sugar_lift_py_tests.ir import _Ctor, ctor
-from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _site(tmp_path):
+    source = tmp_path / "sequence_repeat.py"
+    source.write_text("def witness():\n    return [1] * 1.5\n", encoding="utf-8")
+    return next(SourceFile(path_source(str(source))).functions()).fragment
 
 
 def _symbolic_result(sequence, multiplier):
@@ -37,6 +46,33 @@ def test_exact_constructed_integer_is_the_only_finite_repetition_path(
     assert isinstance(outcome, Complete)
     assert isinstance(outcome.value, sequence_type)
     assert outcome.value.elements == (element,) * 64
+
+
+@pytest.mark.parametrize("sequence_type", (ListValue, TupleValue))
+def test_exact_constructed_bool_is_a_valid_repetition_count(sequence_type) -> None:
+    element = TermValue(7)
+
+    outcome = sequence_type((element,)).multiply(TermValue(True), "multiply-site")
+
+    assert isinstance(outcome, Complete)
+    assert outcome.value.elements == (element,)
+
+
+def test_list_times_known_ground_float_is_loud_type_error(tmp_path) -> None:
+    outcome = ListValue((TermValue(1),)).multiply(TermValue(1.5), _site(tmp_path))
+
+    assert isinstance(outcome, Incomplete)
+    assert isinstance(outcome.effect, TypeErrorRuntimeEffect)
+
+
+def test_tuple_times_known_ground_string_is_loud_type_error(tmp_path) -> None:
+    outcome = TupleValue((TermValue(1),)).multiply(
+        TermValue("x"),  # type: ignore[arg-type] - planted invalid ground payload
+        _site(tmp_path),
+    )
+
+    assert isinstance(outcome, Incomplete)
+    assert isinstance(outcome.effect, TypeErrorRuntimeEffect)
 
 
 @pytest.mark.parametrize("sequence_type", (ListValue, TupleValue))


### PR DESCRIPTION
## Correctness fix

Sequence repetition now has three construction outcomes:

- exact `TermValue(int | bool)`: bounded concrete repetition
- known ground non-index multiplier: `Incomplete(TypeErrorRuntimeEffect)` with a witnessed `python:sequence_repeat` operation
- unresolved import, call, or symbolic coordinate: completed symbolic `python:sequence_repeat(sequence, count)`

The classification uses constructed value shape only. It adds no provider/module spelling.

## Verification

- Focused floor and law tests: `23 passed`
- `vendor_special_case_law.py`: `R_vendor_special_case = 0`, `auditor_errors = 0`
- Changed Python modules byte-compile cleanly

Python only. Do not merge automatically.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sequence multiply by known-invalid ground value to raise TypeError instead of producing symbolic repeat
> - Multiplying a list or tuple by a known-invalid repetition count (e.g. a `TermValue` wrapping a non-int/bool type, or a `StringValue`, `BytesValue`, or `NoneValue`) now returns an `Incomplete` with `TypeErrorRuntimeEffect` instead of constructing a symbolic `python:sequence_repeat`.
> - Adds `is_known_invalid_repetition_count` and `known_invalid_repetition_type_error` helpers in [`sequence_repetition.py`](https://github.com/TSavo/sugar/pull/6061/files#diff-bd7039efbc375648e0cac67097b2638fa3fa2c4a363b5b44c78f67377f6a9183) for reuse across [`list_value.py`](https://github.com/TSavo/sugar/pull/6061/files#diff-eeacaa87aa5806ebb12e29086e825199b416c15725bb8735d0c4c86c747515bf) and [`tuple_value.py`](https://github.com/TSavo/sugar/pull/6061/files#diff-ee02935e29cc93521433e8c8341cbad2b784d9c95c3a9cee1451a2e504318945).
> - `TermValue` wrapping a `bool` is now treated as a valid repetition count and performs concrete repetition.
> - Behavioral Change: previously, multiplying by a known-invalid ground value silently produced a symbolic repeat; it now produces a typed error effect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d84926c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->