### PR TITLE
feat: NameErrorEffect (peer of TypeErrorRuntimeEffect)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py
@@ -45,6 +45,7 @@ from .imported_module_runtime_effect import ImportedModuleRuntimeEffect
 from .key_error_runtime_effect import KeyErrorRuntimeEffect
 from .modulo_runtime_effect import ModuloRuntimeEffect, runtime_modulo
 from .modulo_by_zero_runtime_effect import ModuloByZeroRuntimeEffect
+from .name_error_effect import NameErrorEffect
 from .os_exit_runtime_effect import OSExitRuntimeEffect
 from .power_runtime_effect import PowerRuntimeEffect
 from .raise_effect import RaiseEffect
@@ -115,6 +116,7 @@ __all__ = [
     "ModuloRuntimeEffect",
     "runtime_modulo",
     "ModuloByZeroRuntimeEffect",
+    "NameErrorEffect",
     "OSExitRuntimeEffect",
     "PowerRuntimeEffect",
     "RaiseEffect",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/name_error_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/name_error_effect.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .runtime_effect import RuntimeEffect
+
+
+@dataclass(frozen=True)
+class NameErrorEffect(RuntimeEffect):
+    """A Python read of an unbound name halts with a typed runtime NameError."""
+
+    def kind(self) -> type[RuntimeEffect]:
+        return NameErrorEffect

--- a/implementations/python/sugar-lift-py-tests/tests/test_name_error_effect.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_name_error_effect.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+import tempfile
+
+from sugar_lift_py_tests.effect import (
+    NameErrorEffect,
+    TypeErrorRuntimeEffect,
+    effect_kind,
+    effect_reason,
+    effect_status,
+    runtime_effect_evidence,
+)
+from sugar_lift_py_tests.ir import make_var
+from sugar_lift_py_tests.outcome import Incomplete
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _site():
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write("def witness(name):\n    return name\n")
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).fragment
+
+
+def test_name_error_effect_is_incomplete_carryable_like_type_error_peer() -> None:
+    site = _site()
+    evidence = runtime_effect_evidence("python:name_read", make_var("name"), site)
+    effect = NameErrorEffect("unbound name read", **evidence)
+    peer = TypeErrorRuntimeEffect("invalid runtime type", **evidence)
+
+    outcome = Incomplete(effect)
+
+    assert outcome.effect is effect
+    assert effect.kind() is NameErrorEffect
+    assert effect_status(effect) == effect_status(peer) == "runtime-effect"
+    assert effect_kind(effect) == effect_kind(peer) == "RuntimeEffect"
+    assert effect_reason(effect) == "unbound name read"
+    assert asdict(effect).keys() == asdict(peer).keys()
+    assert effect.witness.site is site


### PR DESCRIPTION
## Scope

Adds `NameErrorEffect` as a frozen `RuntimeEffect` peer of `TypeErrorRuntimeEffect`. It inherits the same `reason`, `runtime_operand`, and `witness` construction fields, declares its own typed `kind()`, and is exported from `sugar_lift_py_tests.effect`.

No name-read, lookup, binding, or rewrite path is changed in this PR.

## Focused evidence

- `Incomplete(NameErrorEffect(...))` is admitted by the typed effect surface.
- Status, effect kind, reason projection, witness site, and dataclass serialization shape match the TypeError peer.
- Focused effect tests: `32 passed`.
- Python byte-compilation and diff checks completed cleanly.

Python only. Do not merge automatically.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `NameErrorEffect` as a new `RuntimeEffect` subtype
> Adds [name_error_effect.py](https://github.com/TSavo/sugar/pull/6062/files#diff-0a0f0cb0799023886d994f28a155daf5b9b83a83ec073e4b6fb5622836829814), a frozen dataclass subclassing `RuntimeEffect` with a `kind()` method returning `NameErrorEffect`, mirroring the existing `TypeErrorRuntimeEffect` pattern. The new class is exported from the `effect` package in [__init__.py](https://github.com/TSavo/sugar/pull/6062/files#diff-47992a15bafcc4cae706ce55accca57387b20a50a9208cbd7f8194c0588cd904).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f4ef1f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a typed runtime effect for reads of unbound names.
  * Exposed the new effect through the public effects package.

* **Tests**
  * Added coverage verifying effect handling, classification, serialization compatibility, error reasoning, and source-site tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->