### PR TITLE
feat: explicit UnboundBinding tombstone + ExitSet guarded-read binding machinery (del across branches)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py
@@ -45,6 +45,7 @@ from .imported_module_runtime_effect import ImportedModuleRuntimeEffect
 from .key_error_runtime_effect import KeyErrorRuntimeEffect
 from .modulo_runtime_effect import ModuloRuntimeEffect, runtime_modulo
 from .modulo_by_zero_runtime_effect import ModuloByZeroRuntimeEffect
+from .name_error_effect import NameErrorEffect
 from .os_exit_runtime_effect import OSExitRuntimeEffect
 from .power_runtime_effect import PowerRuntimeEffect
 from .raise_effect import RaiseEffect
@@ -115,6 +116,7 @@ __all__ = [
     "ModuloRuntimeEffect",
     "runtime_modulo",
     "ModuloByZeroRuntimeEffect",
+    "NameErrorEffect",
     "OSExitRuntimeEffect",
     "PowerRuntimeEffect",
     "RaiseEffect",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/name_error_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/name_error_effect.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .runtime_effect import RuntimeEffect
+
+
+@dataclass(frozen=True)
+class NameErrorEffect(RuntimeEffect):
+    """A Python read of an unbound name halts with a typed runtime NameError."""
+
+    def kind(self) -> type[RuntimeEffect]:
+        return NameErrorEffect

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/name_error_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/name_error_effect.py
@@ -1,13 +1,32 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+import hashlib
+from dataclasses import dataclass, field
 
-from .runtime_effect import RuntimeEffect
+from .raise_effect import RaiseEffect
 
 
 @dataclass(frozen=True)
-class NameErrorEffect(RuntimeEffect):
-    """A Python read of an unbound name halts with a typed runtime NameError."""
+class NameErrorEffect(RaiseEffect):
+    """Deterministic Python halt caused by an unbound source name."""
 
-    def kind(self) -> type[RuntimeEffect]:
-        return NameErrorEffect
+    name: str = ""
+    site: object = field(default=None, compare=False)
+
+    def __post_init__(self) -> None:
+        locus = f"{self.site.filename}:{self.site.line}:{self.site.col}"
+        source = getattr(getattr(self.site, "unit", None), "source", None)
+        object.__setattr__(self, "exception_name", "NameError")
+        object.__setattr__(self, "blame", locus)
+        object.__setattr__(
+            self,
+            "source_sha256",
+            hashlib.sha256(source.encode()).hexdigest()
+            if isinstance(source, str)
+            else None,
+        )
+        object.__setattr__(self, "occurrence", locus)
+
+    @property
+    def reason(self) -> str:
+        return f"NameError for unbound name {self.name!r} at {self.blame}"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from .complete import Complete
 from .complete_value import complete_value
-from .exit_set import Completed, ExitSet, Halted
+from .exit_set import Completed, ExitSet, Halted, outcome_to_exitset, true_guard
 from .incomplete import Incomplete
 from .outcome import Outcome
 
@@ -14,4 +14,6 @@ __all__ = [
     "Incomplete",
     "Outcome",
     "complete_value",
+    "outcome_to_exitset",
+    "true_guard",
 ]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -60,6 +60,8 @@ def _or_guards(left: Formula, right: Formula) -> Formula:
         return right
     if _is_false(right) or left == right:
         return left
+    if getattr(left, "kind", None) == "and" and getattr(right, "kind", None) == "not":
+        return or_([right, left])
     return or_([left, right])
 
 
@@ -161,6 +163,9 @@ class ExitSet(Generic[T]):
                     exits.append(Halted(guard, following.effect))
         return ExitSet(tuple(exits)).normalize()
 
+    def and_then(self, step):
+        return self.sequence(lambda value: outcome_to_exitset(step(value)))
+
     def and_finally(
         self,
         cleanup: Callable[[], "ExitSet[object]"],
@@ -261,10 +266,25 @@ class ExitSet(Generic[T]):
         return Incomplete(exit_.effect)
 
 
+def outcome_to_exitset(outcome) -> ExitSet:
+    if isinstance(outcome, ExitSet):
+        return outcome
+    if isinstance(outcome, Complete):
+        return ExitSet.completed(outcome.value)
+    if isinstance(outcome, Incomplete):
+        if outcome.branch_conditions:
+            return ExitSet.halted(
+                outcome.effect, and_(list(outcome.branch_conditions))
+            )
+        return ExitSet.halted(outcome.effect)
+    raise TypeError(type(outcome))
+
+
 __all__ = [
     "Completed",
     "ExitSet",
     "Halted",
     "false_guard",
     "true_guard",
+    "outcome_to_exitset",
 ]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/outcome.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/outcome.py
@@ -2,5 +2,6 @@ from __future__ import annotations
 
 from .complete import Complete
 from .incomplete import Incomplete
+from .exit_set import ExitSet
 
-Outcome = Complete | Incomplete
+Outcome = Complete | Incomplete | ExitSet

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_name_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_name_sugar.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.effect import NameErrorEffect
+from sugar_lift_py_tests.floor.block_value import BlockValue
+from sugar_lift_py_tests.ir import not_
+from sugar_lift_py_tests.outcome import Complete, ExitSet, Outcome, outcome_to_exitset
+from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_source_tree.binding_state import GuardedBinding, UnboundBinding
+from sugar_source_tree.nodes import Node
+
+
+def delete_binding(state, *, name: str, site, ctx) -> ExitSet:
+    if isinstance(state, Node):
+        return ExitSet.completed(BlockValue((), can_fall_through=True))
+    if isinstance(state, UnboundBinding):
+        return ExitSet.halted(NameErrorEffect(name=name, site=site))
+    if not isinstance(state, GuardedBinding):
+        raise TypeError(type(state))
+    return outcome_to_exitset(state.test.sugar().desugar(ctx)).and_then(
+        lambda guard_value: delete_binding(
+            state.when_true, name=name, site=site, ctx=ctx
+        )
+        .guarded(predicate_formula(guard_value, site))
+        .union(
+            delete_binding(state.when_false, name=name, site=site, ctx=ctx).guarded(
+                not_(predicate_formula(guard_value, site))
+            )
+        )
+    )
+
+
+@dataclass(frozen=True)
+class DeleteNameSugar(Sugar):
+    name: str
+    prior: object
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        return delete_binding(
+            self.prior, name=self.name, site=self.site, ctx=ctx
+        ).collapse()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -21,7 +21,15 @@ from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.floor import BlockValue
 from sugar_lift_py_tests.floor.universe_value import UniverseValue
-from sugar_lift_py_tests.outcome import Complete, ExitSet, Incomplete, Outcome
+from sugar_lift_py_tests.outcome import (
+    Complete,
+    Completed,
+    ExitSet,
+    Halted,
+    Incomplete,
+    Outcome,
+    true_guard,
+)
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
@@ -44,6 +52,77 @@ def reduce_block_to_exitset(statements: tuple) -> ExitSet[_ReducedBlock]:
 
         def reduce_next(state: _ReducedBlock) -> ExitSet[_ReducedBlock]:
             outcome = head.desugar()
+            from sugar_lift_py_tests.floor.guarded_faces import GuardedFaces
+
+            if isinstance(outcome, Complete) and isinstance(
+                outcome.value, GuardedFaces
+            ) and any(
+                isinstance(entry, Incomplete)
+                for entry in outcome.value.contribution()
+            ):
+                faces = outcome.value
+                entries = []
+                exits = []
+                for entry in faces.contribution():
+                    if isinstance(entry, Incomplete):
+                        from sugar_lift_py_tests.ir import and_
+
+                        guard = (
+                            entry.branch_conditions[0]
+                            if len(entry.branch_conditions) == 1
+                            else and_(list(entry.branch_conditions))
+                        )
+                        exits.append(Halted(guard, entry.effect))
+                    else:
+                        entries.append(entry)
+                completed_state = _ReducedBlock(
+                    (*state.entries, *entries),
+                    faces.can_fall_through,
+                    (),
+                    state.transforms,
+                )
+                if faces.can_fall_through:
+                    exits.append(
+                        Completed(
+                            faces.continuation_guard
+                            if faces.continuation_guard is not None
+                            else true_guard(),
+                            completed_state,
+                        )
+                    )
+                return ExitSet(tuple(exits)).normalize()
+            if isinstance(outcome, ExitSet):
+                if state.fall_through:
+                    from sugar_lift_py_tests.ir import and_
+
+                    continuation = (
+                        state.fall_through[0]
+                        if len(state.fall_through) == 1
+                        else and_(list(state.fall_through))
+                    )
+                    outcome = outcome.guarded(continuation)
+
+                def project(value):
+                    linear = Complete(value)
+                    contribution = linear.contribution()
+                    for transform in reversed(state.transforms):
+                        contribution = transform(contribution)
+                    entries = (*state.entries, *contribution)
+                    follow = linear.follow()
+                    if not follow.continues:
+                        return ExitSet.completed(
+                            _ReducedBlock(entries, False, ())
+                        )
+                    return ExitSet.completed(
+                        _ReducedBlock(
+                            entries,
+                            True,
+                            state.fall_through,
+                            state.transforms,
+                        )
+                    )
+
+                return outcome.and_then(project)
             contribution = outcome.contribution()
             for transform in reversed(state.transforms):
                 contribution = transform(contribution)
@@ -51,13 +130,6 @@ def reduce_block_to_exitset(statements: tuple) -> ExitSet[_ReducedBlock]:
 
             follow = outcome.follow()
             if not follow.continues:
-                if follow.keeps_rest and index + 1 < len(statements):
-                    raise NotImplementedError(
-                        "block early-exit with a kept tail is not ported to the "
-                        "tree reduction yet: port the SugarBody raw-tail wrapper "
-                        "when the first halting statement sugar lands "
-                        f"(halted at index {index})"
-                    )
                 if isinstance(outcome, Incomplete):
                     if outcome.branch_conditions:
                         from sugar_lift_py_tests.ir import and_
@@ -118,7 +190,15 @@ def reduce_body(statements: tuple):
     if isinstance(collapsed, Incomplete):
         return collapsed
     if not isinstance(collapsed, Complete):
-        return collapsed
+        return exits.and_then(
+            lambda state: Complete(
+                BlockValue(
+                    state.entries,
+                    fall_through=state.fall_through,
+                    can_fall_through=state.can_fall_through,
+                )
+            )
+        )
     state = collapsed.value
     entries = state.entries
     # A body that is nothing but a single propagating effect IS that effect --

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.effect import NameErrorEffect
+from sugar_lift_py_tests.ir import not_
+from sugar_lift_py_tests.outcome import ExitSet, Outcome, outcome_to_exitset
+from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_source_tree.binding_state import GuardedBinding, UnboundBinding
+from sugar_source_tree.nodes import Node
+
+
+def read_binding(state, *, read_name: str, read_site, ctx) -> ExitSet:
+    if isinstance(state, Node):
+        return outcome_to_exitset(state.sugar().desugar(ctx))
+    if isinstance(state, UnboundBinding):
+        return ExitSet.halted(NameErrorEffect(name=read_name, site=read_site))
+    if not isinstance(state, GuardedBinding):
+        raise TypeError(type(state))
+
+    return outcome_to_exitset(state.test.sugar().desugar(ctx)).and_then(
+        lambda guard_value: read_binding(
+            state.when_true,
+            read_name=read_name,
+            read_site=read_site,
+            ctx=ctx,
+        )
+        .guarded(predicate_formula(guard_value, read_site))
+        .union(
+            read_binding(
+                state.when_false,
+                read_name=read_name,
+                read_site=read_site,
+                ctx=ctx,
+            ).guarded(not_(predicate_formula(guard_value, read_site)))
+        )
+    )
+
+
+@dataclass(frozen=True)
+class GuardedBindingReadSugar(Sugar):
+    name: str
+    state: object
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        return read_binding(
+            self.state, read_name=self.name, read_site=self.site, ctx=ctx
+        ).collapse()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass, field as dataclass_field
 from sugar_lift_py_tests.outcome import Complete, Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
+from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
 
 
 @dataclass(frozen=True)
@@ -56,12 +57,7 @@ class IfExpSugar(Sugar):
         # `.truth`: a predicate test (`5 if a == b else 6`) stands as its formula,
         # a bare value (`5 if c else 6`) emits `py.truthy(c)`. A ground-bool test
         # folds to a literal with no formula and is not lifted yet -- LOUD.
-        formula = getattr(getattr(cond.value.truth(self.site), "value", None), "formula", None)
-        if formula is None:
-            raise NotImplementedError(
-                "conditional-expression test that folds to a ground boolean is "
-                f"not lifted yet (got {type(getattr(cond, 'value', cond)).__name__})"
-            )
+        formula = predicate_formula(cond.value, self.site)
 
         then_out = self.body.desugar(ctx)
         else_out = self.orelse.desugar(ctx)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
@@ -29,6 +29,23 @@ from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
 
+def predicate_formula(value, site):
+    """The one truth-to-formula projection shared by all guarded constructs."""
+    from sugar_lift_py_tests.outcome import Complete
+
+    truth = value.truth(site)
+    if not isinstance(truth, Complete):
+        raise NotImplementedError(
+            f"condition truth did not produce one value: {type(truth).__name__}"
+        )
+    formula = getattr(truth.value, "formula", None)
+    if formula is None:
+        raise NotImplementedError(
+            f"condition folded without a symbolic formula: {type(value).__name__}"
+        )
+    return formula
+
+
 @dataclass(frozen=True)
 class IfSugar(Sugar):
     """`if <test>: <then> [else: <else>]`, constructed by `If.sugar()` with the
@@ -84,13 +101,7 @@ class IfSugar(Sugar):
         # `py.truthy(c)` relation. A ground bool (`if True:`) folds to a literal
         # with no formula and is not lifted yet -- LOUD, never guard by nothing.
         cond = self.test.desugar(ctx)
-        formula = getattr(getattr(cond.value.truth(self.site), "value", None), "formula", None)
-        if formula is None:
-            raise NotImplementedError(
-                "if-condition that folds to a ground boolean is not lifted yet "
-                f"(got {type(getattr(cond, 'value', cond)).__name__}); a symbolic "
-                "predicate or bare-truthiness condition guards, a constant does not"
-            )
+        formula = predicate_formula(cond.value, self.site)
 
         # If is union in the exit algebra: each branch is restricted to its
         # polarity, then the partitions normalize together. In particular, a

--- a/implementations/python/sugar-lift-py-tests/tests/test_name_error_effect.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_name_error_effect.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+import tempfile
+
+from sugar_lift_py_tests.effect import (
+    NameErrorEffect,
+    TypeErrorRuntimeEffect,
+    effect_kind,
+    effect_reason,
+    effect_status,
+    runtime_effect_evidence,
+)
+from sugar_lift_py_tests.ir import make_var
+from sugar_lift_py_tests.outcome import Incomplete
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _site():
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write("def witness(name):\n    return name\n")
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).fragment
+
+
+def test_name_error_effect_is_incomplete_carryable_like_type_error_peer() -> None:
+    site = _site()
+    evidence = runtime_effect_evidence("python:name_read", make_var("name"), site)
+    effect = NameErrorEffect("unbound name read", **evidence)
+    peer = TypeErrorRuntimeEffect("invalid runtime type", **evidence)
+
+    outcome = Incomplete(effect)
+
+    assert outcome.effect is effect
+    assert effect.kind() is NameErrorEffect
+    assert effect_status(effect) == effect_status(peer) == "runtime-effect"
+    assert effect_kind(effect) == effect_kind(peer) == "RuntimeEffect"
+    assert effect_reason(effect) == "unbound name read"
+    assert asdict(effect).keys() == asdict(peer).keys()
+    assert effect.witness.site is site

--- a/implementations/python/sugar-lift-py-tests/tests/test_name_error_effect.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_name_error_effect.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
-from dataclasses import asdict
 import tempfile
 
 from sugar_lift_py_tests.effect import (
     NameErrorEffect,
-    TypeErrorRuntimeEffect,
     effect_kind,
     effect_reason,
     effect_status,
-    runtime_effect_evidence,
 )
-from sugar_lift_py_tests.ir import make_var
 from sugar_lift_py_tests.outcome import Incomplete
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.tree import SourceFile
@@ -24,18 +20,16 @@ def _site():
     return next(SourceFile(path_source(path)).functions()).fragment
 
 
-def test_name_error_effect_is_incomplete_carryable_like_type_error_peer() -> None:
+def test_name_error_effect_is_a_deterministic_incomplete_halt() -> None:
     site = _site()
-    evidence = runtime_effect_evidence("python:name_read", make_var("name"), site)
-    effect = NameErrorEffect("unbound name read", **evidence)
-    peer = TypeErrorRuntimeEffect("invalid runtime type", **evidence)
+    effect = NameErrorEffect(name="name", site=site)
 
     outcome = Incomplete(effect)
 
     assert outcome.effect is effect
-    assert effect.kind() is NameErrorEffect
-    assert effect_status(effect) == effect_status(peer) == "runtime-effect"
-    assert effect_kind(effect) == effect_kind(peer) == "RuntimeEffect"
-    assert effect_reason(effect) == "unbound name read"
-    assert asdict(effect).keys() == asdict(peer).keys()
-    assert effect.witness.site is site
+    assert effect_status(effect) == "raise-effect"
+    assert effect_kind(effect) == "RaiseEffect"
+    assert "unbound name 'name'" in effect_reason(effect)
+    assert effect.exception_name == "NameError"
+    assert effect.occurrence == f"{site.filename}:{site.line}:{site.col}"
+    assert not hasattr(effect, "runtime_operand")

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, TypeAlias
+
+if TYPE_CHECKING:
+    from sugar_source_tree.fragment import SourceFragment
+    from sugar_source_tree.nodes import Node
+
+
+@dataclass(frozen=True)
+class UnboundBinding:
+    name: str
+    cause: SourceFragment
+
+
+@dataclass(frozen=True)
+class GuardedBinding:
+    test: Node
+    when_true: BindingState
+    when_false: BindingState
+
+
+BindingState: TypeAlias = "Node | UnboundBinding | GuardedBinding"
+BindingMap: TypeAlias = dict[str, BindingState]
+
+
+def join_binding_state(
+    *,
+    test: Node,
+    when_true: BindingState,
+    when_false: BindingState,
+    make_ifexp: Callable[[Node, Node, Node], Node],
+) -> BindingState:
+    from sugar_source_tree.nodes import Node
+
+    if when_true is when_false or when_true == when_false:
+        return when_true
+    if isinstance(when_true, Node) and isinstance(when_false, Node):
+        return make_ifexp(test, when_true, when_false)
+    if isinstance(when_true, UnboundBinding) and isinstance(
+        when_false, UnboundBinding
+    ):
+        return UnboundBinding(name=when_true.name, cause=when_true.cause)
+    return GuardedBinding(test=test, when_true=when_true, when_false=when_false)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -54,12 +54,29 @@ from .panic import (
 )
 from .reporter import NULL_REPORTER, AuditReporter
 from .spans import LineColSpan, LineTable, Span
+from .binding_state import (
+    BindingMap,
+    BindingState,
+    GuardedBinding,
+    UnboundBinding,
+    join_binding_state,
+)
 
 
 # Scope metadata travels beside temporal bindings under an unforgeable key.
 # It lets recognition distinguish a builtin spelling from a lexically bound
 # formal without substituting a fake value for that formal.
 _LEXICALLY_BOUND_NAMES = object()
+_FUNCTION_PARAMETERS = object()
+_MISSING = object()
+
+
+def _explicit_state(name: str, state, make_formal_ref):
+    if name in state:
+        return state[name]
+    if name in state.get(_FUNCTION_PARAMETERS, frozenset()):
+        return make_formal_ref(name)
+    return _MISSING
 
 
 @dataclass(frozen=True)
@@ -81,10 +98,13 @@ class SourceUnit:
     module_bound_names: frozenset[str] = field(
         init=False, default_factory=frozenset
     )
+    module_symtable: object = field(init=False, default=None)
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "line_table", LineTable(self.source))
-        symbols = symtable.symtable(self.source, self.filename, "exec").get_symbols()
+        table = symtable.symtable(self.source, self.filename, "exec")
+        object.__setattr__(self, "module_symtable", table)
+        symbols = table.get_symbols()
         object.__setattr__(
             self,
             "module_bound_names",
@@ -96,6 +116,31 @@ class SourceUnit:
                 or symbol.is_namespace()
             ),
         )
+
+    def function_symtable(self, name: str, lineno: int):
+        matches = []
+
+        def visit(table) -> None:
+            for child in table.get_children():
+                if (
+                    child.get_type() == "function"
+                    and child.get_name() == name
+                    and child.get_lineno() == lineno
+                ):
+                    matches.append(child)
+                visit(child)
+
+        visit(self.module_symtable)
+        if len(matches) != 1:
+            raise SourceTreePanic(
+                owner="SourceUnit.function_symtable",
+                observed=(
+                    f"{len(matches)} function symtables for {name!r} at line {lineno}"
+                ),
+                requested="one CPython function symtable selected by type, name, and line",
+                fix="preserve the source function's exact CPython symtable identity",
+            )
+        return matches[0]
 
 
 class Typeable:
@@ -155,10 +200,11 @@ class _Splice:
     Not a Node -- only ``_substitute_body`` handles it, and a `for` is always a
     statement in a block, so it is never substituted anywhere else."""
 
-    __slots__ = ("statements",)
+    __slots__ = ("statements", "bindings")
 
-    def __init__(self, statements: tuple) -> None:
+    def __init__(self, statements: tuple, bindings: BindingMap | None = None) -> None:
         self.statements = statements
+        self.bindings = bindings or {}
 
 
 @_abstract
@@ -304,7 +350,7 @@ class Node(Typed):
         changed = any(new is not old for new, old in zip(new_items, items))
         return (new_items if changed else value), changed
 
-    def _substitute_children(self, scope: "dict[str, Node]") -> "Node":
+    def _substitute_children(self, scope: BindingMap) -> "Node":
         """The structural recurse a NON-binding compound opts into: substitute
         every child against the SAME scope; if any changed, rebuild me around
         them (a shadow node borrowing my span); if none changed, return myself.
@@ -321,9 +367,7 @@ class Node(Typed):
             return self
         return rewrite(self, **changed)
 
-    def substitution_binding(
-        self, scope: "dict[str, Node]"
-    ) -> "Optional[dict[str, Node]]":
+    def substitution_binding(self, scope: BindingMap) -> "Optional[BindingMap]":
         """The binding this STATEMENT introduces for the rest of its block, or
         None. An assignment returns ``{name: its substituted rhs}``; an augmented
         assignment reads the OLD value from ``scope`` to build ``x OP e``;
@@ -433,11 +477,11 @@ class Node(Typed):
             self.reporter,
         )
 
-    def _substitute_body(self, statements: tuple, scope: "dict[str, Node]"):
+    def _substitute_body(self, statements: tuple, scope: BindingMap):
         new_items, changed, _net = self._substitute_body_tracked(statements, scope)
         return new_items, changed
 
-    def _substitute_body_tracked(self, statements: tuple, scope: "dict[str, Node]"):
+    def _substitute_body_tracked(self, statements: tuple, scope: BindingMap):
         """Substitute a statement sequence, THREADING each statement's binding:
         an assignment binds its name to its substituted rhs for the rest of the
         block. This is the temporal that used to live in ``ctx.temporal`` -- now
@@ -482,6 +526,8 @@ class Node(Typed):
                         wb = node.substitution_binding(scope)
                         if wb:
                             scope = {**scope, **wb}
+            if isinstance(new_stmt, _Splice) and new_stmt.bindings:
+                scope = {**scope, **new_stmt.bindings}
         net = {k: v for k, v in scope.items() if initial.get(k) is not v}
         return (tuple(new_items) if changed else statements), changed, net
 
@@ -918,6 +964,9 @@ class FunctionDef(Statement):
         """
         from .shadow import rewrite
 
+        table = self.unit.function_symtable(self.name, self.line_col_span().start_line)
+        parameters = frozenset(table.get_parameters())
+        locals_ = frozenset(table.get_locals()) - parameters
         bound = {p.name for p in self.params}
         for tp in self.type_params:
             name = getattr(tp, "name", None)
@@ -929,7 +978,12 @@ class FunctionDef(Statement):
         inherited_bound = scope.get(_LEXICALLY_BOUND_NAMES, frozenset())
         body_scope = {
             **body_scope,
-            _LEXICALLY_BOUND_NAMES: frozenset(inherited_bound) | bound,
+            **{
+                name: UnboundBinding(name=name, cause=self.fragment)
+                for name in locals_
+            },
+            _LEXICALLY_BOUND_NAMES: frozenset(inherited_bound) | bound | locals_,
+            _FUNCTION_PARAMETERS: parameters,
         }
 
         changed: dict[str, object] = {}
@@ -1066,8 +1120,42 @@ class Delete(Statement):
     _child_fields = ("targets",)
 
     def substitute(self, scope):
-        """Binds nothing: recurse into children and reassemble."""
-        return self._substitute_children(scope)
+        """A plain name delete captures availability without loading its target."""
+        if len(self.targets) != 1 or not isinstance(self.targets[0], Name):
+            return self._substitute_children(scope)
+        target = self.targets[0]
+        prior = _explicit_state(
+            target.id,
+            scope,
+            lambda name: self._make_formal_ref(name, target.span),
+        )
+        if prior is _MISSING:
+            prior = UnboundBinding(name=target.id, cause=target.fragment)
+        return self._make_delete_name(target.id, prior)
+
+    def _make_formal_ref(self, name: str, span: Span) -> "Node":
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        return materialize(
+            self.unit,
+            ShadowNode("FormalRef", span, (("name", Leaf(name)),)),
+            self.reporter,
+        )
+
+    def _make_delete_name(self, name: str, prior: BindingState) -> "Node":
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        return materialize(
+            self.unit,
+            ShadowNode(
+                "DeleteName",
+                self.span,
+                (("name", Leaf(name)), ("prior", Leaf(prior))),
+            ),
+            self.reporter,
+        )
 
 
 class Assign(Statement):
@@ -1793,17 +1881,40 @@ class If(Statement):
 
         names = set(then_net) | set(else_net)
         phis = []
+        availability: BindingMap = {}
         for name in sorted(names):
-            then_val = then_net.get(name, scope.get(name))
-            else_val = else_net.get(name, scope.get(name))
-            if then_val is None or else_val is None:
-                continue  # bound in one branch, no prior: honest gap, not a guess
-            phis.append(
-                self._make_assign(name, self._make_ifexp(test, then_val, else_val))
+            incoming = _explicit_state(
+                name,
+                scope,
+                lambda spelling: self._make_formal_ref(spelling),
             )
-        if not phis:
+            then_val = then_net.get(name, incoming)
+            else_val = else_net.get(name, incoming)
+            if then_val is _MISSING or else_val is _MISSING:
+                continue
+            joined = join_binding_state(
+                test=test,
+                when_true=then_val,
+                when_false=else_val,
+                make_ifexp=self._make_ifexp,
+            )
+            if isinstance(joined, Node):
+                phis.append(self._make_assign(name, joined))
+            else:
+                availability[name] = joined
+        if not phis and not availability:
             return node
-        return _Splice((node, *phis))
+        return _Splice((node, *phis), availability)
+
+    def _make_formal_ref(self, name: str) -> "Node":
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        return materialize(
+            self.unit,
+            ShadowNode("FormalRef", self.span, (("name", Leaf(name)),)),
+            self.reporter,
+        )
 
     def _make_assign(self, name: str, value: "Node") -> "Node":
         """Synthesize `name = <value>` -- the phi as an explicit SSA assignment,
@@ -2121,21 +2232,184 @@ class Try(Statement):
     _child_fields = ("body", "handlers", "orelse", "finalbody")
 
     def substitute(self, scope):
-        """Binds nothing itself (its handlers mask their own names). Its
-        statement tuples are BLOCKS: threaded via _substitute_body, which also
-        flattens a spliced loop/phi -- the generic child walk cannot, and a
-        _Splice leaking through it was the census's 24 AttributeErrors."""
+        """Rewrite each routed completion edge and export its binding state."""
         from .shadow import rewrite
 
-        changed = {}
-        new_handlers, d = self._substitute_field(self.handlers, scope)
-        if d:
-            changed["handlers"] = new_handlers
-        for f in ("body", "orelse", "finalbody"):
-            new, d = self._substitute_body(getattr(self, f), scope)
+        if type(self) is not Try:
+            changed = {}
+            new_handlers, d = self._substitute_field(self.handlers, scope)
             if d:
-                changed[f] = new
-        return self if not changed else rewrite(self, **changed)
+                changed["handlers"] = new_handlers
+            for field_name in ("body", "orelse", "finalbody"):
+                new_value, d = self._substitute_body(
+                    getattr(self, field_name), scope
+                )
+                if d:
+                    changed[field_name] = new_value
+            return self if not changed else rewrite(self, **changed)
+
+        changed = {}
+        new_body, d, body_net = self._substitute_body_tracked(self.body, scope)
+        if d:
+            changed["body"] = new_body
+        body_state = {**scope, **body_net}
+        new_orelse, d, else_net = self._substitute_body_tracked(
+            self.orelse, body_state
+        )
+        if d:
+            changed["orelse"] = new_orelse
+        body_completion = {**body_net, **else_net}
+
+        handler_nets = []
+        new_handlers = []
+        for handler in self.handlers:
+            handler_changed = {}
+            new_type, type_changed = handler._substitute_field(handler.type_, scope)
+            if type_changed:
+                handler_changed["type_"] = new_type
+            handler_scope = dict(scope)
+            if handler.name:
+                handler_scope[handler.name] = handler._make_effect_ref(
+                    handler._effect_slot_id()
+                )
+            new_handler_body, body_changed, handler_net = (
+                handler._substitute_body_tracked(handler.body, handler_scope)
+            )
+            if body_changed:
+                handler_changed["body"] = new_handler_body
+            rewritten = (
+                handler
+                if not handler_changed
+                else rewrite(handler, **handler_changed)
+            )
+            new_handlers.append(rewritten)
+            if handler.name:
+                handler_net = {
+                    **handler_net,
+                    handler.name: UnboundBinding(
+                        name=handler.name, cause=handler.fragment
+                    ),
+                }
+            handler_nets.append(handler_net)
+        if any(new is not old for new, old in zip(new_handlers, self.handlers)):
+            changed["handlers"] = tuple(new_handlers)
+
+        unconditional = self._unconditional_raise_name(self.body)
+        conditional = self._conditional_raise(self.body)
+        completion_nets = []
+        if unconditional is None:
+            completion_nets.append(body_completion)
+        for handler, handler_net in zip(self.handlers, handler_nets):
+            if unconditional is not None:
+                include = self._handler_matches(handler, unconditional)
+            elif conditional is not None:
+                include = self._handler_matches(handler, conditional[1])
+            else:
+                include = True
+            if include:
+                completion_nets.append(handler_net)
+
+        merged = self._merge_completion_nets(
+            scope,
+            completion_nets,
+            conditional_test=conditional[0] if conditional is not None else None,
+        )
+        final_scope = {**scope, **merged}
+        new_finalbody, d, final_net = self._substitute_body_tracked(
+            self.finalbody, final_scope
+        )
+        if d:
+            changed["finalbody"] = new_finalbody
+        merged = {**merged, **final_net}
+
+        node = self if not changed else rewrite(self, **changed)
+        return _Splice((node,), merged) if merged else node
+
+    @staticmethod
+    def _handler_matches(handler, exception_name: str) -> bool:
+        if handler.type_ is None:
+            return True
+        nodes = (
+            handler.type_.elts
+            if isinstance(handler.type_, Tuple_)
+            else (handler.type_,)
+        )
+        return any(Try._except_type_name(node) == exception_name for node in nodes)
+
+    @staticmethod
+    def _unconditional_raise_name(statements):
+        for statement in statements:
+            if isinstance(statement, Raise):
+                return statement._exception_name()
+            if isinstance(statement, Return):
+                return None
+            if isinstance(statement, If):
+                left = Try._unconditional_raise_name(statement.body)
+                right = Try._unconditional_raise_name(statement.orelse)
+                if left is not None and left == right:
+                    return left
+            # The first ordinary statement can complete, so continue scanning.
+        return None
+
+    @staticmethod
+    def _conditional_raise(statements):
+        for statement in statements:
+            if not isinstance(statement, If):
+                continue
+            left = Try._unconditional_raise_name(statement.body)
+            right = Try._unconditional_raise_name(statement.orelse)
+            if left is not None and right is None:
+                return statement.test, left
+        return None
+
+    def _merge_completion_nets(
+        self,
+        scope,
+        nets,
+        *,
+        conditional_test,
+    ) -> BindingMap:
+        if not nets:
+            return {}
+        if len(nets) == 1:
+            return dict(nets[0])
+        names = set().union(*(net.keys() for net in nets))
+        merged: BindingMap = {}
+        for name in sorted(names):
+            states = [
+                net.get(name, _explicit_state(name, scope, self._make_formal_ref))
+                for net in nets
+            ]
+            if any(state is _MISSING for state in states):
+                continue
+            if all(state is states[0] or state == states[0] for state in states[1:]):
+                merged[name] = states[0]
+                continue
+            if conditional_test is not None and len(states) == 2:
+                # body completion is the false edge; the matching handler is true.
+                merged[name] = join_binding_state(
+                    test=conditional_test,
+                    when_true=states[1],
+                    when_false=states[0],
+                    make_ifexp=self._make_ifexp,
+                )
+                continue
+            if all(isinstance(state, UnboundBinding) for state in states):
+                merged[name] = states[0]
+        return merged
+
+    def _make_formal_ref(self, name: str) -> "Node":
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        return materialize(
+            self.unit,
+            ShadowNode("FormalRef", self.span, (("name", Leaf(name)),)),
+            self.reporter,
+        )
+
+    def _make_ifexp(self, test, body, orelse):
+        return If._make_ifexp(self, test, body, orelse)
 
     @staticmethod
     def _except_type_name(type_node):
@@ -3314,12 +3588,30 @@ class Starred(Expression):
 class Name(Expression):
     id: str
 
-    def substitute(self, scope: "dict[str, Node]") -> "Node":
+    def substitute(self, scope: BindingMap) -> "Node":
         # A name resolves to its bound node, or stands unbound. This is the
         # whole substitution base case — it returns an EXISTING node, so it
         # needs no synthetic construction.
-        bound = scope.get(self.id)
-        return bound if bound is not None else self
+        bound = scope.get(self.id, _MISSING)
+        if bound is _MISSING:
+            return self
+        if isinstance(bound, Node):
+            return bound
+        return self._make_binding_read(bound)
+
+    def _make_binding_read(self, state: BindingState) -> "Node":
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        return materialize(
+            self.unit,
+            ShadowNode(
+                "GuardedBindingRead",
+                self.span,
+                (("name", Leaf(self.id)), ("state", Leaf(state))),
+            ),
+            self.reporter,
+        )
 
     def _construct_sugar(self):
         """A name constructs NameSugar with its identifier. A name is a leaf:
@@ -3328,6 +3620,61 @@ class Name(Expression):
         from sugar_lift_py_tests.sugar.name_sugar import NameSugar
 
         return NameSugar(name=self.id, site=self.fragment)
+
+
+class FormalRef(Expression):
+    """A lazily materialized formal used only when availability becomes explicit."""
+
+    name: str
+
+    def substitute(self, scope):
+        del scope
+        return self
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.name_sugar import NameSugar
+
+        return NameSugar(name=self.name, site=self.fragment)
+
+
+class GuardedBindingRead(Expression):
+    """A read-site projection of immutable binding-state testimony."""
+
+    name: str
+    state: BindingState
+
+    def substitute(self, scope):
+        del scope
+        return self
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import (
+            GuardedBindingReadSugar,
+        )
+
+        return GuardedBindingReadSugar(
+            name=self.name, state=self.state, site=self.fragment
+        )
+
+
+class DeleteName(Statement):
+    """A plain-name delete carrying its pre-delete availability."""
+
+    name: str
+    prior: BindingState
+
+    def substitute(self, scope):
+        del scope
+        return self
+
+    def substitution_binding(self, scope):
+        del scope
+        return {self.name: UnboundBinding(name=self.name, cause=self.fragment)}
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.delete_name_sugar import DeleteNameSugar
+
+        return DeleteNameSugar(name=self.name, prior=self.prior, site=self.fragment)
 
 
 class EffectRef(Expression):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -80,6 +80,13 @@ def _explicit_state(name: str, state, make_formal_ref):
 
 
 @dataclass(frozen=True)
+class _ConditionalRaiseRoute:
+    test: "Node"
+    raised_on_true: bool
+    exception_name: str
+
+
+@dataclass(frozen=True)
 class SourceUnit:
     """One parsed source: oracle-pinned text, its content address, its line table.
 
@@ -2303,7 +2310,9 @@ class Try(Statement):
             if unconditional is not None:
                 include = self._handler_matches(handler, unconditional)
             elif conditional is not None:
-                include = self._handler_matches(handler, conditional[1])
+                include = self._handler_matches(
+                    handler, conditional.exception_name
+                )
             else:
                 include = True
             if include:
@@ -2312,7 +2321,7 @@ class Try(Statement):
         merged = self._merge_completion_nets(
             scope,
             completion_nets,
-            conditional_test=conditional[0] if conditional is not None else None,
+            conditional_route=conditional,
         )
         final_scope = {**scope, **merged}
         new_finalbody, d, final_net = self._substitute_body_tracked(
@@ -2359,7 +2368,17 @@ class Try(Statement):
             left = Try._unconditional_raise_name(statement.body)
             right = Try._unconditional_raise_name(statement.orelse)
             if left is not None and right is None:
-                return statement.test, left
+                return _ConditionalRaiseRoute(
+                    test=statement.test,
+                    raised_on_true=True,
+                    exception_name=left,
+                )
+            if right is not None and left is None:
+                return _ConditionalRaiseRoute(
+                    test=statement.test,
+                    raised_on_true=False,
+                    exception_name=right,
+                )
         return None
 
     def _merge_completion_nets(
@@ -2367,7 +2386,7 @@ class Try(Statement):
         scope,
         nets,
         *,
-        conditional_test,
+        conditional_route,
     ) -> BindingMap:
         if not nets:
             return {}
@@ -2385,12 +2404,17 @@ class Try(Statement):
             if all(state is states[0] or state == states[0] for state in states[1:]):
                 merged[name] = states[0]
                 continue
-            if conditional_test is not None and len(states) == 2:
-                # body completion is the false edge; the matching handler is true.
+            if conditional_route is not None and len(states) == 2:
+                body_state, handler_state = states
+                when_true, when_false = (
+                    (handler_state, body_state)
+                    if conditional_route.raised_on_true
+                    else (body_state, handler_state)
+                )
                 merged[name] = join_binding_state(
-                    test=conditional_test,
-                    when_true=states[1],
-                    when_false=states[0],
+                    test=conditional_route.test,
+                    when_true=when_true,
+                    when_false=when_false,
                     make_ifexp=self._make_ifexp,
                 )
                 continue

--- a/implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py
+++ b/implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import tempfile
+
+from sugar_lift_py_tests.effect import NameErrorEffect, RaiseEffect
+from sugar_lift_py_tests.floor import ReturnValue, TermValue, UniverseValue
+from sugar_lift_py_tests.ir import and_, make_var, not_, or_, py_truthy
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted, Incomplete
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _out(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(source)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).sugar().desugar()
+
+
+def _return(exit_):
+    assert isinstance(exit_, Completed)
+    assert isinstance(exit_.value, UniverseValue)
+    returns = [e for e in exit_.value.record.statements if isinstance(e, ReturnValue)]
+    assert len(returns) == 1
+    return returns[0]
+
+
+def _partition(out):
+    assert isinstance(out, ExitSet)
+    halted = [e for e in out.exits if isinstance(e, Halted)]
+    completed = [e for e in out.exits if isinstance(e, Completed)]
+    return halted, completed
+
+
+def test_delete_one_branch_then_read_has_exact_guard_partition() -> None:
+    out = _out("def f(c):\n x=1\n if c:\n  del x\n return x\n")
+    halted, completed = _partition(out)
+    guard = py_truthy(make_var("c"))
+    assert len(halted) == len(completed) == 1
+    assert halted[0].guard == guard
+    assert isinstance(halted[0].effect, NameErrorEffect)
+    assert completed[0].guard == not_(guard)
+    assert _return(completed[0]).value == TermValue(1)
+
+    reverse = _out("def f(c):\n x=1\n if c:\n  pass\n else:\n  del x\n return x\n")
+    halted, completed = _partition(reverse)
+    assert halted[0].guard == not_(guard)
+    assert completed[0].guard == guard
+
+
+def test_delete_both_branches_then_read_is_unconditionally_unbound() -> None:
+    out = _out("def f(c):\n x=1\n if c:\n  del x\n else:\n  del x\n return x\n")
+    assert isinstance(out, Incomplete)
+    assert isinstance(out.effect, NameErrorEffect)
+
+
+def test_neither_branch_deletes_keeps_ordinary_value_phi() -> None:
+    out = _out("def f(c):\n x=1\n if c:\n  x=2\n else:\n  x=3\n return x\n")
+    assert isinstance(out, Complete)
+    assert isinstance(out.value, UniverseValue)
+    assert not any(isinstance(e, NameErrorEffect) for e in out.value.record.statements)
+
+
+def test_unconditional_reassignment_replaces_tombstone_but_read_rhs_does_not() -> None:
+    out = _out("def f(c):\n x=1\n if c:\n  del x\n x=2\n return x\n")
+    assert isinstance(out, Complete)
+    returns = [e for e in out.value.record.statements if isinstance(e, ReturnValue)]
+    assert returns[0].value == TermValue(2)
+
+    bad = _out("def f(c):\n x=1\n if c:\n  del x\n x=x+1\n return x\n")
+    halted, completed = _partition(bad)
+    assert isinstance(halted[0].effect, NameErrorEffect)
+    assert halted[0].guard == py_truthy(make_var("c"))
+    assert completed[0].guard == not_(py_truthy(make_var("c")))
+
+
+def test_delete_after_halt_does_not_create_a_reachable_name_error() -> None:
+    out = _out("def f(c, E):\n x=1\n if c:\n  raise E\n  del x\n return x\n")
+    halted, completed = _partition(out)
+    assert len(halted) == len(completed) == 1
+    assert isinstance(halted[0].effect, RaiseEffect)
+    assert not isinstance(halted[0].effect, NameErrorEffect)
+    assert halted[0].guard == py_truthy(make_var("c"))
+    assert completed[0].guard == not_(py_truthy(make_var("c")))
+
+
+def test_delete_already_unbound_and_second_delete_are_loud() -> None:
+    out = _out("def f():\n del x\n")
+    assert isinstance(out, Incomplete)
+    assert isinstance(out.effect, NameErrorEffect)
+    twice = _out("def f():\n x=1\n del x\n del x\n")
+    assert isinstance(twice, Incomplete)
+    assert isinstance(twice.effect, NameErrorEffect)
+
+
+def test_nested_conditional_delete_retains_both_source_guards() -> None:
+    out = _out("def f(a,b):\n x=1\n if a:\n  if b:\n   del x\n return x\n")
+    halted, completed = _partition(out)
+    ga = py_truthy(make_var("a"))
+    gb = py_truthy(make_var("b"))
+    assert halted[0].guard == and_([ga, gb])
+    assert completed[0].guard == or_([not_(ga), and_([ga, not_(gb)])])
+
+
+def test_try_handler_binding_exports_on_the_handler_completion_edge() -> None:
+    out = _out(
+        "def f():\n"
+        " try:\n  raise ValueError\n"
+        " except ValueError as first:\n  a=first\n"
+        " return a\n"
+    )
+    assert isinstance(out, Complete)
+    assert isinstance(out.value, UniverseValue)
+    assert not any(
+        isinstance(entry, NameErrorEffect) for entry in out.value.record.statements
+    )
+
+
+def test_try_exception_alias_is_tombstoned_after_handler() -> None:
+    out = _out(
+        "def f():\n"
+        " try:\n  raise ValueError\n"
+        " except ValueError as first:\n  pass\n"
+        " return first\n"
+    )
+    assert isinstance(out, Incomplete)
+    assert isinstance(out.effect, NameErrorEffect)
+    assert out.effect.name == "first"
+
+
+def test_try_uncaught_raise_remains_a_halted_face() -> None:
+    out = _out(
+        "def f():\n"
+        " try:\n  raise TypeError\n"
+        " except ValueError:\n  pass\n"
+    )
+    assert isinstance(out, Incomplete)
+    assert isinstance(out.effect, RaiseEffect)
+    assert out.effect.exception_name == "TypeError"
+
+
+def test_try_finally_rebinding_applies_to_normal_and_handler_completions() -> None:
+    out = _out(
+        "def f(c):\n x=0\n"
+        " try:\n  if c:\n   raise ValueError\n  x=1\n"
+        " except ValueError:\n  x=2\n"
+        " finally:\n  x=9\n"
+        " return x\n"
+    )
+    assert isinstance(out, Complete)
+    returns = [e for e in out.value.record.statements if isinstance(e, ReturnValue)]
+    assert returns[0].value == TermValue(9)
+
+
+def test_try_conditional_raise_routes_to_handler_and_joins_bindings() -> None:
+    out = _out(
+        "def f(c):\n"
+        " try:\n  if c:\n   raise ValueError\n  x=1\n"
+        " except ValueError:\n  x=2\n"
+        " return x\n"
+    )
+    assert isinstance(out, Complete)
+    assert isinstance(out.value, UniverseValue)

--- a/implementations/python/sugar-source-tree/tests/test_if_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_if_sugar.py
@@ -59,7 +59,7 @@ def test_one_armed_if_with_no_prior_is_an_honest_gap_not_a_guess():
     # than invent a value for the not-c arm, x stays unbound: `return x` keeps a
     # free Name (a gap the sugar layer meets loudly), never a wrong phi.
     ret = _return_of(_fn("def A(c):\n    if c:\n        x = 5\n    return x\n"))
-    assert ret.value.kind == "Name" and ret.value.id == "x"
+    assert ret.value.kind == "GuardedBindingRead" and ret.value.name == "x"
 
 
 def test_the_phi_borrows_the_if_source_span():
@@ -126,26 +126,26 @@ def test_guarded_raise_halts_its_branch_and_guards_the_tail():
     # if z == 1: raise ValueError ; assert z == 2 ; return z
     # The raise halts the z == 1 branch, so the tail rides under its negation:
     # the assert becomes  not(z == 1) -> (z == 2).
-    from sugar_lift_py_tests.outcome import Incomplete
+    from sugar_lift_py_tests.outcome import Completed, ExitSet, Halted
 
-    v = _fn(
+    out = _fn(
         "def A(z):\n    if z == 1:\n        raise ValueError\n    assert z == 2\n    return z\n"
-    ).sugar().desugar().value
+    ).sugar().desugar()
+    assert isinstance(out, ExitSet)
+    completed = next(e for e in out.exits if isinstance(e, Completed))
+    halted = next(e for e in out.exits if isinstance(e, Halted))
+    v = completed.value
     invs = v.invs()
     assert len(invs) == 1
     tail = invs[0]
-    assert tail.kind == "implies"
-    assert tail.operands[0].kind == "not"  # guarded by not(z == 1)
-    assert tail.operands[1].args[1].value == 2  # the tail fact z == 2
+    assert completed.guard.kind == "not"  # tail edge is guarded by not(z == 1)
+    assert tail.args[1].value == 2  # the tail fact z == 2
 
     # The raise itself is red testimony, pristine RaiseEffect, with the branch
     # condition recorded on the Incomplete wrapper (not smashed into the effect).
-    raises = [e for e in v.record.contribution() if isinstance(e, Incomplete)]
-    assert len(raises) == 1
-    assert type(raises[0].effect).__name__ == "RaiseEffect"
-    assert raises[0].effect.exception_name == "ValueError"
-    assert len(raises[0].branch_conditions) == 1
-    assert raises[0].branch_conditions[0].args[1].value == 1  # under z == 1
+    assert type(halted.effect).__name__ == "RaiseEffect"
+    assert halted.effect.exception_name == "ValueError"
+    assert halted.guard.args[1].value == 1  # under z == 1
 
 
 if __name__ == "__main__":

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -279,6 +279,30 @@ def test_conditional_raise_assign_paths_through_finally_no_residual_halt():
     post = v.post()
     assert post.kind == "and"
     assert {face.operands[1].args[1].value for face in post.operands} == {1, 2}
+    by_value = {face.operands[1].args[1].value: face.operands[0] for face in post.operands}
+    assert by_value[2].name == "py.truthy"
+    assert by_value[1].kind == "not"
+
+
+def test_false_arm_conditional_raise_routes_with_reverse_polarity():
+    v = _val(
+        "def A(c):\n"
+        "    try:\n"
+        "        if c:\n"
+        "            pass\n"
+        "        else:\n"
+        "            raise ValueError\n"
+        "        x = 1\n"
+        "    except ValueError:\n"
+        "        x = 2\n"
+        "    return x\n"
+    )
+    assert _incompletes(v) == []
+    post = v.post()
+    assert post.kind == "and"
+    by_value = {face.operands[1].args[1].value: face.operands[0] for face in post.operands}
+    assert by_value[1].name == "py.truthy"
+    assert by_value[2].kind == "not"
 
 
 def test_except_as_binds_matching_raise_witness_in_handler():

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -276,8 +276,9 @@ def test_conditional_raise_assign_paths_through_finally_no_residual_halt():
         "    return x\n"
     )
     assert _incompletes(v) == []
-    assert v.post().args[0].name == "out"
-    assert v.post().args[1].name == "x"
+    post = v.post()
+    assert post.kind == "and"
+    assert {face.operands[1].args[1].value for face in post.operands} == {1, 2}
 
 
 def test_except_as_binds_matching_raise_witness_in_handler():


### PR DESCRIPTION
Implements the explicit AST-rewrite binding-state model:

- adds UnboundBinding and GuardedBinding state-only testimony
- seeds function locals from the exact CPython symtable and materializes formals lazily
- makes NameErrorEffect a deterministic RaiseEffect peer with no fabricated operand
- promotes ExitSet to a first-class Outcome and sequences tails only over Completed faces
- models plain-name delete, guarded reads, reassignment, and nested joins
- exports Try handler bindings, tombstones except aliases, joins conditional body/handler completion states, and applies finally rebindings across outgoing completion edges

Receipts after rebase onto origin/main:

- focused binding/Try/effect tests: 37 passed
- full source-tree suite: 318 passed, 5 skipped, 1 xfailed

The seven delete twins and five Try discrimination twins assert Completed/Halted partitions and typed NameError effects.

Do not merge from this branch; coordinator owns integration.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add guarded-binding read/delete machinery with `UnboundBinding` tombstones and `ExitSet` propagation across branches
> - Introduces `UnboundBinding` and `GuardedBinding` dataclasses in [`binding_state.py`](https://github.com/TSavo/sugar/pull/6064/files#diff-1b664ec8aefadd4725220316e83263615391d340ba859576e2ac417ab1cc5e40) to track name availability across `if`/`try` branches during substitution.
> - Adds `DeleteName`, `GuardedBindingRead`, and `FormalRef` nodes so that plain-name deletes and conditionally-bound reads carry their prior availability state into the sugar layer.
> - `If.substitute` and `Try.substitute` now export binding nets via `_Splice.bindings`, so names deleted or conditionally bound in one branch become `GuardedBinding` or `UnboundBinding` in subsequent code.
> - Adds `DeleteNameSugar` and `GuardedBindingReadSugar` lowering these nodes to `ExitSet` outcomes: guarded completion when the name is available, or `NameErrorEffect` (a new `RaiseEffect` subclass) when it is unbound.
> - Extends `reduce_block_to_exitset` and `reduce_body` in [`function_universe_sugar.py`](https://github.com/TSavo/sugar/pull/6064/files#diff-1a034881b3b9f8294d507d8d13e7d0addd04ec63a0ccc585b95ed6ae81f9f21b) and adds `ExitSet.and_then` to propagate partitioned `ExitSet` results across statement sequences.
> - Risk: `Outcome` type now includes `ExitSet`, and `reduce_body` may return an `ExitSet` instead of always collapsing to `Complete`, which changes the return type seen by callers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 06dd2af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->