### PR TITLE
drain: Delete attribute/subscript effects on the binding machinery

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py
@@ -5,6 +5,7 @@ from .append_runtime_effect import AppendRuntimeEffect
 from .async_context_manager_runtime_effect import AsyncContextManagerRuntimeEffect
 from .async_iteration_runtime_effect import AsyncIterationRuntimeEffect
 from .attribute_store_runtime_effect import AttributeStoreRuntimeEffect
+from .attribute_delete_runtime_effect import AttributeDeleteRuntimeEffect
 from .attribute_augassign_runtime_effect import AttributeAugAssignRuntimeEffect
 from .await_runtime_effect import AwaitRuntimeEffect
 from .block_operator_runtime_effect import BlockOperatorRuntimeEffect
@@ -68,6 +69,7 @@ from .sequence_concatenation_runtime_effect import SequenceConcatenationRuntimeE
 from .source_oracle_effect import SourceOracleEffect
 from .starred_positional_runtime_effect import StarredPositionalRuntimeEffect
 from .subscript_store_runtime_effect import SubscriptStoreRuntimeEffect
+from .subscript_delete_runtime_effect import SubscriptDeleteRuntimeEffect
 from .subscript_result_runtime_effect import SubscriptResultRuntimeEffect
 from .subtract_runtime_effect import SubtractRuntimeEffect, runtime_subtract
 from .type_error_runtime_effect import TypeErrorRuntimeEffect
@@ -80,6 +82,7 @@ __all__ = [
     "AsyncContextManagerRuntimeEffect",
     "AsyncIterationRuntimeEffect",
     "AttributeStoreRuntimeEffect",
+    "AttributeDeleteRuntimeEffect",
     "AttributeAugAssignRuntimeEffect",
     "AwaitRuntimeEffect",
     "BlockOperatorRuntimeEffect",
@@ -137,6 +140,7 @@ __all__ = [
     "SourceOracleEffect",
     "StarredPositionalRuntimeEffect",
     "SubscriptStoreRuntimeEffect",
+    "SubscriptDeleteRuntimeEffect",
     "SubscriptResultRuntimeEffect",
     "SubtractRuntimeEffect",
     "runtime_subtract",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/attribute_delete_runtime_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/attribute_delete_runtime_effect.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .runtime_effect import RuntimeEffect
+
+
+@dataclass(frozen=True)
+class AttributeDeleteRuntimeEffect(RuntimeEffect):
+    """Python runtime dispatch of ``del receiver.attribute``."""
+
+    def kind(self) -> type[RuntimeEffect]:
+        return AttributeDeleteRuntimeEffect

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/subscript_delete_runtime_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/subscript_delete_runtime_effect.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .runtime_effect import RuntimeEffect
+
+
+@dataclass(frozen=True)
+class SubscriptDeleteRuntimeEffect(RuntimeEffect):
+    """Python runtime dispatch of ``del receiver[index]``."""
+
+    def kind(self) -> type[RuntimeEffect]:
+        return SubscriptDeleteRuntimeEffect

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/incomplete.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/incomplete.py
@@ -95,7 +95,9 @@ def _effect_continues_control_flow(effect) -> bool:
     """
     from sugar_lift_py_tests.effect import (
         AttributeAugAssignRuntimeEffect,
+        AttributeDeleteRuntimeEffect,
         AttributeStoreRuntimeEffect,
+        SubscriptDeleteRuntimeEffect,
         SubscriptStoreRuntimeEffect,
     )
 
@@ -105,5 +107,7 @@ def _effect_continues_control_flow(effect) -> bool:
             SubscriptStoreRuntimeEffect,
             AttributeStoreRuntimeEffect,
             AttributeAugAssignRuntimeEffect,
+            AttributeDeleteRuntimeEffect,
+            SubscriptDeleteRuntimeEffect,
         ),
     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_effect_sugar.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Incomplete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class AttributeDeleteEffectSugar(Sugar):
+    receiver: Sugar
+    attr: str
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.effect import (
+            AttributeDeleteRuntimeEffect,
+            runtime_effect_evidence,
+        )
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        def delete(receiver):
+            operand = ctor(
+                "python:attribute_delete_target",
+                [receiver.to_term(owner="attribute delete"), str_const(self.attr)],
+            )
+            return Incomplete(
+                AttributeDeleteRuntimeEffect(
+                    "attribute deletion runtime boundary: Python dispatches "
+                    f"__delattr__/descriptor deletion for .{self.attr}",
+                    **runtime_effect_evidence("py.delattr", operand, self.site),
+                )
+            )
+
+        return self.receiver.desugar(ctx).and_then(delete)
+
+
+@dataclass(frozen=True)
+class SubscriptDeleteEffectSugar(Sugar):
+    receiver: Sugar
+    index: Sugar
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.effect import (
+            SubscriptDeleteRuntimeEffect,
+            runtime_effect_evidence,
+        )
+        from sugar_lift_py_tests.ir import ctor
+
+        return self.receiver.desugar(ctx).and_then(
+            lambda receiver: self.index.desugar(ctx).and_then(
+                lambda index: self._delete(receiver, index, runtime_effect_evidence, ctor)
+            )
+        )
+
+    def _delete(self, receiver, index, evidence, make_ctor):
+        operand = make_ctor(
+            "python:subscript_delete_target",
+            [
+                receiver.to_term(owner="subscript delete receiver"),
+                index.to_term(owner="subscript delete index"),
+            ],
+        )
+        from sugar_lift_py_tests.effect import SubscriptDeleteRuntimeEffect
+
+        return Incomplete(
+            SubscriptDeleteRuntimeEffect(
+                "subscript deletion runtime boundary: Python dispatches __delitem__",
+                **evidence("py.delitem", operand, self.site),
+            )
+        )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1127,18 +1127,37 @@ class Delete(Statement):
     _child_fields = ("targets",)
 
     def substitute(self, scope):
-        """A plain name delete captures availability without loading its target."""
-        if len(self.targets) != 1 or not isinstance(self.targets[0], Name):
+        """Lower supported targets to ordered delete operations."""
+        if any(not isinstance(t, (Name, Attribute, Subscript)) for t in self.targets):
             return self._substitute_children(scope)
-        target = self.targets[0]
-        prior = _explicit_state(
-            target.id,
-            scope,
-            lambda name: self._make_formal_ref(name, target.span),
-        )
-        if prior is _MISSING:
-            prior = UnboundBinding(name=target.id, cause=target.fragment)
-        return self._make_delete_name(target.id, prior)
+
+        current = dict(scope)
+        operations = []
+        for target in self.targets:
+            if isinstance(target, Name):
+                prior = _explicit_state(
+                    target.id,
+                    current,
+                    lambda name: self._make_formal_ref(name, target.span),
+                )
+                if prior is _MISSING:
+                    prior = UnboundBinding(name=target.id, cause=target.fragment)
+                operation = self._make_delete_name(target.id, prior, target.span)
+                current[target.id] = UnboundBinding(
+                    name=target.id, cause=target.fragment
+                )
+            elif isinstance(target, Attribute):
+                operation = self._make_delete_attribute(
+                    target.value.substitute(current), target.attr, target.span
+                )
+            else:
+                operation = self._make_delete_subscript(
+                    target.value.substitute(current),
+                    target.slice_.substitute(current),
+                    target.span,
+                )
+            operations.append(operation)
+        return operations[0] if len(operations) == 1 else _Splice(tuple(operations))
 
     def _make_formal_ref(self, name: str, span: Span) -> "Node":
         from .backend import Leaf, materialize
@@ -1150,7 +1169,9 @@ class Delete(Statement):
             self.reporter,
         )
 
-    def _make_delete_name(self, name: str, prior: BindingState) -> "Node":
+    def _make_delete_name(
+        self, name: str, prior: BindingState, span: Span | None = None
+    ) -> "Node":
         from .backend import Leaf, materialize
         from .shadow import ShadowNode
 
@@ -1158,8 +1179,39 @@ class Delete(Statement):
             self.unit,
             ShadowNode(
                 "DeleteName",
-                self.span,
+                span or self.span,
                 (("name", Leaf(name)), ("prior", Leaf(prior))),
+            ),
+            self.reporter,
+        )
+
+    def _make_delete_attribute(self, receiver, attr: str, span: Span) -> "Node":
+        from .backend import Child, Leaf, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        return materialize(
+            self.unit,
+            ShadowNode(
+                "DeleteAttribute",
+                span,
+                (("receiver", Child(_handle_of(receiver))), ("attr", Leaf(attr))),
+            ),
+            self.reporter,
+        )
+
+    def _make_delete_subscript(self, receiver, index, span: Span) -> "Node":
+        from .backend import Child, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        return materialize(
+            self.unit,
+            ShadowNode(
+                "DeleteSubscript",
+                span,
+                (
+                    ("receiver", Child(_handle_of(receiver))),
+                    ("index", Child(_handle_of(index))),
+                ),
             ),
             self.reporter,
         )
@@ -3699,6 +3751,46 @@ class DeleteName(Statement):
         from sugar_lift_py_tests.sugar.delete_name_sugar import DeleteNameSugar
 
         return DeleteNameSugar(name=self.name, prior=self.prior, site=self.fragment)
+
+
+class DeleteAttribute(Statement):
+    receiver: Expression
+    attr: str
+    _child_fields = ("receiver",)
+
+    def substitute(self, scope):
+        del scope
+        return self
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.delete_effect_sugar import (
+            AttributeDeleteEffectSugar,
+        )
+
+        return AttributeDeleteEffectSugar(
+            receiver=self.receiver.sugar(), attr=self.attr, site=self.fragment
+        )
+
+
+class DeleteSubscript(Statement):
+    receiver: Expression
+    index: Expression
+    _child_fields = ("receiver", "index")
+
+    def substitute(self, scope):
+        del scope
+        return self
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.delete_effect_sugar import (
+            SubscriptDeleteEffectSugar,
+        )
+
+        return SubscriptDeleteEffectSugar(
+            receiver=self.receiver.sugar(),
+            index=self.index.sugar(),
+            site=self.fragment,
+        )
 
 
 class EffectRef(Expression):

--- a/implementations/python/sugar-source-tree/tests/test_delete_effect_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_delete_effect_targets.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from sugar_lift_py_tests.effect import (
+    AttributeDeleteRuntimeEffect,
+    NameErrorEffect,
+    RaiseEffect,
+    SubscriptDeleteRuntimeEffect,
+)
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _out(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(source)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).sugar().desugar()
+
+
+def _entries(source: str):
+    out = _out(source)
+    assert isinstance(out, Complete)
+    return out.value.record.statements
+
+
+@pytest.mark.parametrize(
+    ("source", "effect_type"),
+    [
+        ("def f(o):\n del o.attr\n return o\n", AttributeDeleteRuntimeEffect),
+        ("def f(d,k):\n del d[k]\n return d\n", SubscriptDeleteRuntimeEffect),
+    ],
+)
+def test_store_delete_builds_typed_effect_and_continues(source, effect_type):
+    entries = _entries(source)
+    effects = [entry.effect for entry in entries if isinstance(entry, Incomplete)]
+    assert len(effects) == 1
+    assert isinstance(effects[0], effect_type)
+    assert any(type(entry).__name__ == "ReturnValue" for entry in entries)
+
+
+def test_multi_target_delete_effects_preserve_source_order() -> None:
+    entries = _entries("def f(o,d,k):\n del o.attr, d[k]\n return o\n")
+    effects = [entry.effect for entry in entries if isinstance(entry, Incomplete)]
+    assert [type(effect) for effect in effects] == [
+        AttributeDeleteRuntimeEffect,
+        SubscriptDeleteRuntimeEffect,
+    ]
+
+
+def test_mixed_delete_uses_tombstone_before_later_target_load() -> None:
+    out = _out("def f(o):\n del o, o.attr\n")
+    assert isinstance(out, Incomplete)
+    assert isinstance(out.effect, NameErrorEffect)
+
+
+@pytest.mark.parametrize("target", ["(a,b)", "[a,b]"])
+def test_tuple_and_list_delete_grammar_stays_a_gap(target: str) -> None:
+    with pytest.raises(SugarNotWritten):
+        _out(f"def f(a,b):\n del {target}\n")
+
+
+def test_delete_effect_after_halt_is_not_emitted() -> None:
+    out = _out("def f(o,E):\n raise E\n del o.attr\n")
+    assert isinstance(out, Incomplete)
+    assert isinstance(out.effect, RaiseEffect)
+    assert not isinstance(out.effect, AttributeDeleteRuntimeEffect)


### PR DESCRIPTION
Stacks on #6064.

This ports only the remaining Delete effect layer:

- `del obj.attr` builds `AttributeDeleteRuntimeEffect` from the constructed receiver
- `del d[k]` builds `SubscriptDeleteRuntimeEffect` after receiver/index construction
- comma-separated targets expand into source-ordered delete operations
- plain names continue through `UnboundBinding`; no scope-pop or parallel unbinding mechanism
- tuple/list delete target grammar remains a loud gap
- delete effects are continuing typed-red statements, while unreachable delete tails remain unexecuted

Receipts:

- focused Delete + guarded-binding twins: 19 passed
- full source-tree suite: 325 passed, 5 skipped, 1 xfailed

Base is `feat-binding-state-unbound` so this can land immediately after #6064. Do not merge from this branch.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `del` statement lowering for names, attributes, and subscripts in the binding machinery
> - Adds `UnboundBinding` and `GuardedBinding` to [binding_state.py](https://github.com/TSavo/sugar/pull/6066/files#diff-1b664ec8aefadd4725220316e83263615391d340ba859576e2ac417ab1cc5e40) to represent tombstoned and conditionally available names; `join_binding_state` merges these across control-flow join points.
> - Introduces `DeleteName`, `DeleteAttribute`, and `DeleteSubscript` AST nodes in [nodes.py](https://github.com/TSavo/sugar/pull/6066/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0); `del` statements now lower to these nodes, tombstone names in the binding map, and carry prior availability for downstream sugar.
> - Adds `AttributeDeleteRuntimeEffect`, `SubscriptDeleteRuntimeEffect`, and `NameErrorEffect` effect types; desugar implementations in [delete_effect_sugar.py](https://github.com/TSavo/sugar/pull/6066/files#diff-d5a3db73a2e419b12a61ff4b4c0616c177ae77361c5f7de3a02053c360131345) and [delete_name_sugar.py](https://github.com/TSavo/sugar/pull/6066/files#diff-93a5ffbb2b078a311327a1d0598ffa094308c47fc2f9e2b741e3b64a944096f4) emit these effects with correct evaluation order.
> - Reads of guarded or unbound names now produce a `GuardedBindingRead` node that lowers to a guard-partitioned `ExitSet`, raising `NameError` on the unbound branch instead of falling through silently.
> - Adds `ExitSet.and_then` for monadic sequencing and extends block reduction in [function_universe_sugar.py](https://github.com/TSavo/sugar/pull/6066/files#diff-1a034881b3b9f8294d507d8d13e7d0addd04ec63a0ccc585b95ed6ae81f9f21b) to handle `ExitSet`-returning statements and guarded halts.
> - Risk: `If`, `Try`, and `FunctionDef` substitution behavior changes — locals are now initially unbound, one-armed `if` branches export `GuardedBinding`/`UnboundBinding` rather than the original `Name`, and try blocks route conditional raises to matching handlers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05f0dfb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->