### PR TITLE
fix: branch-result slot — binding guarded-read/delete never re-enter the AST (+ .sugar()-in-desugar floor)

### DIFF
--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -133,3 +133,14 @@ jobs:
         run: >-
           python
           implementations/python/sugar-lift-py-tests/scripts/source_via_execution_law.py
+      - name: R_no_sugar_in_desugar discrimination
+        if: always()
+        run: >-
+          python
+          implementations/python/sugar-lift-py-tests/scripts/no_sugar_in_desugar_law.py
+          --self-test
+      - name: R_no_sugar_in_desugar = 0
+        if: always()
+        run: >-
+          python
+          implementations/python/sugar-lift-py-tests/scripts/no_sugar_in_desugar_law.py

--- a/implementations/python/sugar-lift-py-tests/scripts/no_sugar_in_desugar_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/no_sugar_in_desugar_law.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""R_no_sugar_in_desugar — sole-construction reduction floor.
+
+AST nodes construct Sugar before reduction. A Sugar ``desugar`` method may
+consume only the child Sugars it was constructed with; neither it nor any
+same-module reduction helper it reaches may call ``.sugar()`` and reopen AST
+construction.
+
+The instrument scans every ``sugar/*.py`` module, starts at each class
+``desugar`` method, follows calls to methods on that class and functions in the
+same module, and reports every reachable ``.sugar()`` call. There is no
+baseline or allowlist: every locus is red.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+from typing import NamedTuple, Sequence
+
+
+class SugarDuringDesugar(NamedTuple):
+    path: str
+    line: int
+    column: int
+    owner: str
+    helper: str
+    expression: str
+    kind: str = "sugar-call-during-desugar"
+
+
+class AuditorError(NamedTuple):
+    path: str
+    line: int
+    column: int
+    owner: str
+    helper: str
+    expression: str
+    kind: str
+
+
+Finding = SugarDuringDesugar | AuditorError
+
+
+def _safe_unparse(node: ast.AST) -> str:
+    try:
+        return ast.unparse(node)
+    except Exception as exc:  # noqa: BLE001 -- auditor containment
+        return f"<unparse-failed:{type(exc).__name__}>"
+
+
+def _rel_path(root: Path, path: Path) -> str:
+    try:
+        rel = path.resolve().relative_to(root.resolve())
+    except ValueError:
+        rel = Path(path.name)
+    return f"{root.name}/{rel.as_posix()}"
+
+
+def _calls_in(function: ast.FunctionDef | ast.AsyncFunctionDef):
+    """Yield executable calls in one function, excluding nested definitions."""
+
+    class Calls(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.calls: list[ast.Call] = []
+
+        def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+            self.calls.append(node)
+            self.generic_visit(node)
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+            if node is function:
+                self.generic_visit(node)
+
+        def visit_AsyncFunctionDef(  # noqa: N802
+            self, node: ast.AsyncFunctionDef
+        ) -> None:
+            if node is function:
+                self.generic_visit(node)
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
+            del node
+
+    visitor = Calls()
+    visitor.visit(function)
+    return visitor.calls
+
+
+def _scan_tree(tree: ast.Module, *, rel: str) -> list[Finding]:
+    module_functions = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    findings: list[Finding] = []
+    seen_loci: set[tuple[int, int]] = set()
+
+    for class_node in (node for node in tree.body if isinstance(node, ast.ClassDef)):
+        methods = {
+            node.name: node
+            for node in class_node.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        desugar = methods.get("desugar")
+        if desugar is None:
+            continue
+        pending: list[tuple[str, ast.FunctionDef | ast.AsyncFunctionDef]] = [
+            ("desugar", desugar)
+        ]
+        visited: set[tuple[str, str]] = set()
+        while pending:
+            helper_name, function = pending.pop()
+            identity = (
+                "method" if helper_name in methods else "function",
+                helper_name,
+            )
+            if identity in visited:
+                continue
+            visited.add(identity)
+            for call in _calls_in(function):
+                if isinstance(call.func, ast.Attribute) and call.func.attr == "sugar":
+                    locus = (call.lineno, call.col_offset)
+                    if locus not in seen_loci:
+                        seen_loci.add(locus)
+                        findings.append(
+                            SugarDuringDesugar(
+                                path=rel,
+                                line=call.lineno,
+                                column=call.col_offset,
+                                owner=class_node.name,
+                                helper=helper_name,
+                                expression=_safe_unparse(call),
+                            )
+                        )
+
+                target = call.func
+                if isinstance(target, ast.Name) and target.id in module_functions:
+                    pending.append((target.id, module_functions[target.id]))
+                elif (
+                    isinstance(target, ast.Attribute)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id in {"self", "cls"}
+                    and target.attr in methods
+                ):
+                    pending.append((target.attr, methods[target.attr]))
+    return findings
+
+
+def scan_file(path: Path, *, rel: str) -> list[Finding]:
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        return [
+            AuditorError(
+                rel, 0, 0, "-", "-", f"{type(exc).__name__}: {exc}", "auditor-read-error"
+            )
+        ]
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        return [
+            AuditorError(
+                rel,
+                int(exc.lineno or 0),
+                int(exc.offset or 0),
+                "-",
+                "-",
+                exc.msg,
+                "auditor-parse-error",
+            )
+        ]
+    return _scan_tree(tree, rel=rel)
+
+
+def scan_roots(roots: Sequence[Path]) -> list[Finding]:
+    findings: list[Finding] = []
+    for root in roots:
+        if not root.is_dir():
+            findings.append(
+                AuditorError(
+                    str(root), 0, 0, "-", "-", "not a directory", "auditor-root-error"
+                )
+            )
+            continue
+        for path in sorted(root.rglob("*.py")):
+            if path.is_file():
+                findings.extend(scan_file(path, rel=_rel_path(root, path)))
+    return sorted(findings, key=lambda row: (row.path, row.line, row.column, row.owner))
+
+
+def r_no_sugar_in_desugar(findings: Sequence[Finding]) -> int:
+    return sum(1 for row in findings if row.kind == "sugar-call-during-desugar")
+
+
+def r_auditor_errors(findings: Sequence[Finding]) -> int:
+    return sum(1 for row in findings if row.kind.startswith("auditor-"))
+
+
+def format_report(findings: Sequence[Finding]) -> str:
+    lines = [
+        f"R_no_sugar_in_desugar = {r_no_sugar_in_desugar(findings)}",
+        f"auditor_errors = {r_auditor_errors(findings)}",
+        "Replacement: construct child Sugars at the AST boundary and consume only those children during desugar.",
+        "",
+        "Loci:",
+    ]
+    for row in findings:
+        lines.append(
+            f"{row.path}:{row.line}:{row.column}:{row.kind}:"
+            f"owner={row.owner}:helper={row.helper} — {row.expression}"
+        )
+    return "\n".join(lines)
+
+
+def discrimination_self_test() -> bool:
+    planted_source = """
+class PlantedSugar:
+    def desugar(self, ctx=None):
+        return self._reduce(self.child, ctx)
+
+    def _reduce(self, node, ctx):
+        return node.sugar().desugar(ctx)
+"""
+    clean_source = """
+class ConstructedChildSugar:
+    def desugar(self, ctx=None):
+        return self.child.desugar(ctx)
+"""
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw) / "sugar"
+        root.mkdir()
+        fixture = root / "fixture.py"
+        fixture.write_text(planted_source, encoding="utf-8")
+        planted = scan_roots((root,))
+        fixture.write_text(clean_source, encoding="utf-8")
+        clean = scan_roots((root,))
+    return (
+        r_no_sugar_in_desugar(planted) == 1
+        and r_auditor_errors(planted) == 0
+        and clean == []
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (AttributeError, ValueError):
+            pass
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("roots", nargs="*", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    try:
+        args = parser.parse_args(argv)
+        if args.self_test:
+            ok = discrimination_self_test()
+            print(
+                "NO-SUGAR-IN-DESUGAR SELF-TEST " + ("GREEN" if ok else "RED")
+            )
+            print(json.dumps({"instrument": "R_no_sugar_in_desugar", "self_test": ok}))
+            return 0 if ok else 1
+        roots = args.roots or [
+            Path(__file__).resolve().parents[1]
+            / "src"
+            / "sugar_lift_py_tests"
+            / "sugar"
+        ]
+        findings = scan_roots(roots)
+    except Exception as exc:  # noqa: BLE001 -- process-level containment
+        print(
+            f"NO-SUGAR-IN-DESUGAR LAW ERROR: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        print(traceback.format_exc(), file=sys.stderr)
+        print(
+            json.dumps(
+                {
+                    "instrument": "R_no_sugar_in_desugar",
+                    "ok": False,
+                    "R_no_sugar_in_desugar": None,
+                    "auditor_errors": 1,
+                }
+            )
+        )
+        return 2
+
+    r = r_no_sugar_in_desugar(findings)
+    errors = r_auditor_errors(findings)
+    summary = {
+        "instrument": "R_no_sugar_in_desugar",
+        "ok": r == 0 and errors == 0,
+        "R_no_sugar_in_desugar": r,
+        "auditor_errors": errors,
+    }
+    if r or errors:
+        print(
+            f"NO-SUGAR-IN-DESUGAR LAW RED: {r} construction loci"
+            + (f"; {errors} auditor errors" if errors else "")
+        )
+        print(format_report(findings))
+        print(json.dumps(summary))
+        return 1
+    print("NO-SUGAR-IN-DESUGAR LAW GREEN: R_no_sugar_in_desugar = 0")
+    print(json.dumps(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/scripts/no_sugar_in_desugar_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/no_sugar_in_desugar_law.py
@@ -63,7 +63,12 @@ def _rel_path(root: Path, path: Path) -> str:
 
 
 def _calls_in(function: ast.FunctionDef | ast.AsyncFunctionDef):
-    """Yield executable calls in one function, excluding nested definitions."""
+    """Yield calls lexically owned by a reduction function.
+
+    Local helpers are part of the enclosing reduction implementation. Walking
+    their bodies conservatively keeps a nested ``reduce`` from becoming an
+    unmeasured construction door.
+    """
 
     class Calls(ast.NodeVisitor):
         def __init__(self) -> None:
@@ -72,16 +77,6 @@ def _calls_in(function: ast.FunctionDef | ast.AsyncFunctionDef):
         def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
             self.calls.append(node)
             self.generic_visit(node)
-
-        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
-            if node is function:
-                self.generic_visit(node)
-
-        def visit_AsyncFunctionDef(  # noqa: N802
-            self, node: ast.AsyncFunctionDef
-        ) -> None:
-            if node is function:
-                self.generic_visit(node)
 
         def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
             del node
@@ -219,12 +214,11 @@ def format_report(findings: Sequence[Finding]) -> str:
 
 def discrimination_self_test() -> bool:
     planted_source = """
-class PlantedSugar:
+class PlantedNestedHelperSugar:
     def desugar(self, ctx=None):
-        return self._reduce(self.child, ctx)
-
-    def _reduce(self, node, ctx):
-        return node.sugar().desugar(ctx)
+        def reduce(node):
+            return node.sugar().desugar(ctx)
+        return reduce(self.child)
 """
     clean_source = """
 class ConstructedChildSugar:
@@ -242,6 +236,7 @@ class ConstructedChildSugar:
     return (
         r_no_sugar_in_desugar(planted) == 1
         and r_auditor_errors(planted) == 0
+        and bool(planted)
         and clean == []
     )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from .array_literal import ArrayLiteral
 from .async_function_callable import AsyncFunctionCallable
 from .block_value import BlockValue
+from .branch_result_coordinate import (
+    BranchResultAuthentication,
+    BranchResultCoordinate,
+)
 from .bound_var import BoundVar
 from .module_bound_var import ModuleBoundVar
 from .named_expression_value import NamedExpressionValue
@@ -77,6 +81,8 @@ REGISTERED_FLOOR_TYPES: tuple[type[FloorDispatchSurface], ...] = (
     ArrayLiteral,
     AsyncFunctionCallable,
     BlockValue,
+    BranchResultAuthentication,
+    BranchResultCoordinate,
     BoundVar,
     NamedExpressionValue,
     NativeCallableValue,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/branch_result_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/branch_result_coordinate.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.floor.floor_value import FloorValue
+from sugar_source_tree.binding_state import BranchResultSlot
+
+
+@dataclass(frozen=True)
+class BranchResultCoordinate(FloorValue):
+    slot: BranchResultSlot
+    site: object = field(default=None, compare=False)
+    symbol_kind: str = field(default="coordinate", init=False)
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor("python:branch_result", [str_const(self.slot.slot_id)])
+
+    def truth(self, site):
+        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+        from sugar_lift_py_tests.ir import py_truthy
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(PredicateValue(py_truthy(self.to_term(owner=str(site))), site))
+
+
+def branch_result_guard(slot, site):
+    from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
+
+    return predicate_formula(BranchResultCoordinate(slot, site), site)
+
+
+@dataclass(frozen=True)
+class BranchResultAuthentication(FloorValue):
+    slot: BranchResultSlot
+    observed_guard: object
+    site: object = field(default=None, compare=False)
+
+    def inv_contribution(self):
+        from sugar_lift_py_tests.ir import and_, implies
+
+        slot_guard = branch_result_guard(self.slot, self.site)
+        equivalence = and_(
+            [
+                implies(slot_guard, self.observed_guard),
+                implies(self.observed_guard, slot_guard),
+            ]
+        )
+        return (equivalence,)
+
+    def guarded(self, formula):
+        from sugar_lift_py_tests.floor.inv_value import InvValue
+        from sugar_lift_py_tests.ir import and_, implies
+
+        return InvValue(
+            implies(formula, and_(list(self.inv_contribution()))), self.site
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_faces.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_faces.py
@@ -24,18 +24,22 @@ class GuardedFaces(FloorValue):
     guarded_bindings: tuple = ()
     can_fall_through: bool = True
     continuation_guard: Formula | None = None
+    unconditional_entries: tuple = ()
 
     def contribution(self):
         from sugar_lift_py_tests.floor.scope_rebind import ScopeRebind
 
         return (
+            *self.unconditional_entries,
             *self.entries,
             *(ScopeRebind(name, value) for name, value in self.joined_bindings),
         )
 
     def inv_contribution(self):
         return tuple(
-            formula for entry in self.entries for formula in entry.inv_contribution()
+            formula
+            for entry in (*self.unconditional_entries, *self.entries)
+            for formula in entry.inv_contribution()
         )
 
     def post_contribution(self):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binding_projection.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binding_projection.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TypeAlias
+
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_source_tree.binding_state import BranchResultSlot
+
+
+@dataclass(frozen=True)
+class UnboundProjection:
+    name: str
+    cause: object
+
+
+@dataclass(frozen=True)
+class GuardedProjection:
+    slot: BranchResultSlot
+    when_true: BindingProjection
+    when_false: BindingProjection
+
+
+BindingProjection: TypeAlias = "Sugar | UnboundProjection | GuardedProjection"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/branch_result_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/branch_result_ref_sugar.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class BranchResultRefSugar(Sugar):
+    slot: object
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        from sugar_lift_py_tests.floor.branch_result_coordinate import (
+            BranchResultCoordinate,
+        )
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(BranchResultCoordinate(self.slot, self.site))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_name_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_name_sugar.py
@@ -4,29 +4,30 @@ from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.effect import NameErrorEffect
 from sugar_lift_py_tests.floor.block_value import BlockValue
+from sugar_lift_py_tests.floor.branch_result_coordinate import branch_result_guard
 from sugar_lift_py_tests.ir import not_
 from sugar_lift_py_tests.outcome import Complete, ExitSet, Outcome, outcome_to_exitset
-from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
+from sugar_lift_py_tests.sugar.binding_projection import (
+    GuardedProjection,
+    UnboundProjection,
+)
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
-from sugar_source_tree.binding_state import GuardedBinding, UnboundBinding
-from sugar_source_tree.nodes import Node
 
 
 def delete_binding(state, *, name: str, site, ctx) -> ExitSet:
-    if isinstance(state, Node):
+    if isinstance(state, Sugar):
         return ExitSet.completed(BlockValue((), can_fall_through=True))
-    if isinstance(state, UnboundBinding):
+    if isinstance(state, UnboundProjection):
         return ExitSet.halted(NameErrorEffect(name=name, site=site))
-    if not isinstance(state, GuardedBinding):
+    if not isinstance(state, GuardedProjection):
         raise TypeError(type(state))
-    return outcome_to_exitset(state.test.sugar().desugar(ctx)).and_then(
-        lambda guard_value: delete_binding(
-            state.when_true, name=name, site=site, ctx=ctx
-        )
-        .guarded(predicate_formula(guard_value, site))
+    guard = branch_result_guard(state.slot, site)
+    return (
+        delete_binding(state.when_true, name=name, site=site, ctx=ctx)
+        .guarded(guard)
         .union(
             delete_binding(state.when_false, name=name, site=site, ctx=ctx).guarded(
-                not_(predicate_formula(guard_value, site))
+                not_(guard)
             )
         )
     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
@@ -3,37 +3,40 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.effect import NameErrorEffect
+from sugar_lift_py_tests.floor.branch_result_coordinate import branch_result_guard
 from sugar_lift_py_tests.ir import not_
 from sugar_lift_py_tests.outcome import ExitSet, Outcome, outcome_to_exitset
-from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
+from sugar_lift_py_tests.sugar.binding_projection import (
+    GuardedProjection,
+    UnboundProjection,
+)
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
-from sugar_source_tree.binding_state import GuardedBinding, UnboundBinding
-from sugar_source_tree.nodes import Node
 
 
 def read_binding(state, *, read_name: str, read_site, ctx) -> ExitSet:
-    if isinstance(state, Node):
-        return outcome_to_exitset(state.sugar().desugar(ctx))
-    if isinstance(state, UnboundBinding):
+    if isinstance(state, Sugar):
+        return outcome_to_exitset(state.desugar(ctx))
+    if isinstance(state, UnboundProjection):
         return ExitSet.halted(NameErrorEffect(name=read_name, site=read_site))
-    if not isinstance(state, GuardedBinding):
+    if not isinstance(state, GuardedProjection):
         raise TypeError(type(state))
 
-    return outcome_to_exitset(state.test.sugar().desugar(ctx)).and_then(
-        lambda guard_value: read_binding(
+    guard = branch_result_guard(state.slot, read_site)
+    return (
+        read_binding(
             state.when_true,
             read_name=read_name,
             read_site=read_site,
             ctx=ctx,
         )
-        .guarded(predicate_formula(guard_value, read_site))
+        .guarded(guard)
         .union(
             read_binding(
                 state.when_false,
                 read_name=read_name,
                 read_site=read_site,
                 ctx=ctx,
-            ).guarded(not_(predicate_formula(guard_value, read_site)))
+            ).guarded(not_(guard))
         )
     )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
@@ -52,6 +52,7 @@ class IfSugar(Sugar):
     test's sugar and each branch's statement sugars already built."""
 
     test: Sugar
+    branch_slot: object
     then_body: tuple  # the then-branch statements' sugars, in source order
     else_body: tuple  # the else-branch statements' sugars (empty if no else)
     site: object = dataclass_field(compare=False, default=None)
@@ -70,7 +71,10 @@ class IfSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.floor.branch_result_coordinate import (
+            BranchResultAuthentication,
+            branch_result_guard,
+        )
         from sugar_lift_py_tests.floor.guarded_faces import GuardedFaces
         from sugar_lift_py_tests.ir import not_
         from sugar_lift_py_tests.outcome import Completed, Halted, Incomplete
@@ -78,30 +82,22 @@ class IfSugar(Sugar):
             reduce_block_to_exitset,
         )
 
-        then_exits = reduce_block_to_exitset(self.then_body)
-        else_exits = reduce_block_to_exitset(self.else_body)
-
-        def entries_are_empty(exits):
-            return all(
-                isinstance(exit_, Completed) and not exit_.value.entries
-                for exit_ in exits.exits
-            )
-
-        # A purely TEMPORAL if -- branches that only bind -- is spent by
-        # substitute (its binding became an IfExp phi threaded past the if), so
-        # both branches reduce to nothing. It contributes no meaning and needs no
-        # guard: the condition is not even consulted (an inert if states nothing,
-        # whatever its test). This is the common residue of the phi rewrite.
-        if entries_are_empty(then_exits) and entries_are_empty(else_exits):
-            return Complete(BlockValue((), can_fall_through=True))
-
         # Branches carry facts/effects: the guard is the condition's TRUTHINESS
         # as a predicate. `.truth` is uniform -- a predicate condition (`if a ==
         # b`) stands as its own formula, a bare value (`if c`) emits the Python
         # `py.truthy(c)` relation. A ground bool (`if True:`) folds to a literal
         # with no formula and is not lifted yet -- LOUD, never guard by nothing.
         cond = self.test.desugar(ctx)
-        formula = predicate_formula(cond.value, self.site)
+        if not isinstance(cond, Complete):
+            return cond
+        observed_formula = predicate_formula(cond.value, self.site)
+        formula = branch_result_guard(self.branch_slot, self.site)
+        authentication = BranchResultAuthentication(
+            self.branch_slot, observed_formula, self.site
+        )
+
+        then_exits = reduce_block_to_exitset(self.then_body)
+        else_exits = reduce_block_to_exitset(self.else_body)
 
         # If is union in the exit algebra: each branch is restricted to its
         # polarity, then the partitions normalize together. In particular, a
@@ -144,5 +140,6 @@ class IfSugar(Sugar):
                 guarded_bindings=(),
                 can_fall_through=can_fall_through,
                 continuation_guard=continuation_guard,
+                unconditional_entries=(authentication,),
             )
         )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypeAlias
 
@@ -16,8 +15,19 @@ class UnboundBinding:
 
 
 @dataclass(frozen=True)
+class BranchResultSlot:
+    slot_id: str
+
+
+def branch_result_slot(test: Node) -> BranchResultSlot:
+    memento = test.fragment.seal()
+    address = f"{memento.source_cid}@{memento.start}:{memento.end}#{memento.cid}"
+    return BranchResultSlot(f"branch-result:{address}")
+
+
+@dataclass(frozen=True)
 class GuardedBinding:
-    test: Node
+    slot: BranchResultSlot
     when_true: BindingState
     when_false: BindingState
 
@@ -28,19 +38,19 @@ BindingMap: TypeAlias = dict[str, BindingState]
 
 def join_binding_state(
     *,
-    test: Node,
+    slot: BranchResultSlot,
     when_true: BindingState,
     when_false: BindingState,
-    make_ifexp: Callable[[Node, Node, Node], Node],
+    make_ifexp,
 ) -> BindingState:
     from sugar_source_tree.nodes import Node
 
     if when_true is when_false or when_true == when_false:
         return when_true
     if isinstance(when_true, Node) and isinstance(when_false, Node):
-        return make_ifexp(test, when_true, when_false)
+        return make_ifexp(slot, when_true, when_false)
     if isinstance(when_true, UnboundBinding) and isinstance(
         when_false, UnboundBinding
     ):
         return UnboundBinding(name=when_true.name, cause=when_true.cause)
-    return GuardedBinding(test=test, when_true=when_true, when_false=when_false)
+    return GuardedBinding(slot=slot, when_true=when_true, when_false=when_false)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -57,8 +57,10 @@ from .spans import LineColSpan, LineTable, Span
 from .binding_state import (
     BindingMap,
     BindingState,
+    BranchResultSlot,
     GuardedBinding,
     UnboundBinding,
+    branch_result_slot,
     join_binding_state,
 )
 
@@ -81,7 +83,7 @@ def _explicit_state(name: str, state, make_formal_ref):
 
 @dataclass(frozen=True)
 class _ConditionalRaiseRoute:
-    test: "Node"
+    slot: BranchResultSlot
     raised_on_true: bool
     exception_name: str
 _NESTED_COMPREHENSION_TEMPLATE = object()
@@ -1930,14 +1932,14 @@ class If(Statement):
         new_test, d = self._substitute_field(self.test, scope)
         if d:
             changed["test"] = new_test
-        test = new_test if d else self.test
+        slot = branch_result_slot(self.test)
         new_body, d, then_net = self._substitute_body_tracked(self.body, scope)
         if d:
             changed["body"] = new_body
         new_orelse, d, else_net = self._substitute_body_tracked(self.orelse, scope)
         if d:
             changed["orelse"] = new_orelse
-        node = self if not changed else rewrite(self, **changed)
+        node = self if not changed else self._rewrite_with_slot(changed, slot)
 
         names = set(then_net) | set(else_net)
         phis = []
@@ -1953,7 +1955,7 @@ class If(Statement):
             if then_val is _MISSING or else_val is _MISSING:
                 continue
             joined = join_binding_state(
-                test=test,
+                slot=slot,
                 when_true=then_val,
                 when_false=else_val,
                 make_ifexp=self._make_ifexp,
@@ -1965,6 +1967,22 @@ class If(Statement):
         if not phis and not availability:
             return node
         return _Splice((node, *phis), availability)
+
+    def _rewrite_with_slot(self, changed, slot):
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode, rewrite
+
+        rewritten = rewrite(self, **changed)
+        desc = rewritten.ref.describe()
+        return materialize(
+            self.unit,
+            ShadowNode(
+                desc.kind,
+                desc.raw_span or self.span,
+                (*desc.slots, ("branch_result_slot_id", Leaf(slot.slot_id))),
+            ),
+            self.reporter,
+        )
 
     def _make_formal_ref(self, name: str) -> "Node":
         from .backend import Leaf, materialize
@@ -1991,12 +2009,15 @@ class If(Statement):
             self.unit, ShadowNode("Assign", self.span, slots), self.reporter
         )
 
-    def _make_ifexp(self, test: "Node", body: "Node", orelse: "Node") -> "Node":
+    def _make_ifexp(
+        self, slot: BranchResultSlot, body: "Node", orelse: "Node"
+    ) -> "Node":
         """Synthesize ``<body> if <test> else <orelse>`` as a shadow IfExp that
         borrows this if's span (so the phi still addresses this source site)."""
         from .backend import Child, materialize
         from .shadow import ShadowNode, _handle_of
 
+        test = self._make_branch_result_ref(slot)
         slots = (
             ("body", Child(_handle_of(body))),
             ("test", Child(_handle_of(test))),
@@ -2006,6 +2027,18 @@ class If(Statement):
             self.unit, ShadowNode("IfExp", self.span, slots), self.reporter
         )
 
+    def _make_branch_result_ref(self, slot: BranchResultSlot) -> "Node":
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        return materialize(
+            self.unit,
+            ShadowNode(
+                "BranchResultRef", self.span, (("slot_id", Leaf(slot.slot_id)),)
+            ),
+            self.reporter,
+        )
+
     def _construct_sugar(self):
         """`if <test>: <body> [else: <orelse>]` constructs IfSugar -- the guard.
         The test recognizes itself; each branch's statements recognize themselves.
@@ -2013,8 +2046,13 @@ class If(Statement):
         phi is substitute's job, never this."""
         from sugar_lift_py_tests.sugar.if_sugar import IfSugar
 
+        try:
+            slot = BranchResultSlot(self.branch_result_slot_id)
+        except AttributeError:
+            slot = branch_result_slot(self.test)
         return IfSugar(
             test=self.test.sugar(),
+            branch_slot=slot,
             then_body=tuple(s.sugar() for s in self.body),
             else_body=tuple(s.sugar() for s in self.orelse),
             site=self.fragment,
@@ -2422,13 +2460,13 @@ class Try(Statement):
             right = Try._unconditional_raise_name(statement.orelse)
             if left is not None and right is None:
                 return _ConditionalRaiseRoute(
-                    test=statement.test,
+                    slot=branch_result_slot(statement.test),
                     raised_on_true=True,
                     exception_name=left,
                 )
             if right is not None and left is None:
                 return _ConditionalRaiseRoute(
-                    test=statement.test,
+                    slot=branch_result_slot(statement.test),
                     raised_on_true=False,
                     exception_name=right,
                 )
@@ -2465,7 +2503,7 @@ class Try(Statement):
                     else (body_state, handler_state)
                 )
                 merged[name] = join_binding_state(
-                    test=conditional_route.test,
+                    slot=conditional_route.slot,
                     when_true=when_true,
                     when_false=when_false,
                     make_ifexp=self._make_ifexp,
@@ -2487,6 +2525,9 @@ class Try(Statement):
 
     def _make_ifexp(self, test, body, orelse):
         return If._make_ifexp(self, test, body, orelse)
+
+    def _make_branch_result_ref(self, slot):
+        return If._make_branch_result_ref(self, slot)
 
     @staticmethod
     def _except_type_name(type_node):
@@ -3810,6 +3851,44 @@ class FormalRef(Expression):
         return NameSugar(name=self.name, site=self.fragment)
 
 
+class BranchResultRef(Expression):
+    """Projection of the one condition result authenticated by its owning if."""
+
+    slot_id: str
+
+    def substitute(self, scope):
+        del scope
+        return self
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.branch_result_ref_sugar import (
+            BranchResultRefSugar,
+        )
+
+        return BranchResultRefSugar(
+            slot=BranchResultSlot(self.slot_id), site=self.fragment
+        )
+
+
+def _construct_binding_projection(state):
+    from sugar_lift_py_tests.sugar.binding_projection import (
+        GuardedProjection,
+        UnboundProjection,
+    )
+
+    if isinstance(state, Node):
+        return state.sugar()
+    if isinstance(state, UnboundBinding):
+        return UnboundProjection(state.name, state.cause)
+    if isinstance(state, GuardedBinding):
+        return GuardedProjection(
+            state.slot,
+            _construct_binding_projection(state.when_true),
+            _construct_binding_projection(state.when_false),
+        )
+    raise TypeError(type(state))
+
+
 class GuardedBindingRead(Expression):
     """A read-site projection of immutable binding-state testimony."""
 
@@ -3826,7 +3905,9 @@ class GuardedBindingRead(Expression):
         )
 
         return GuardedBindingReadSugar(
-            name=self.name, state=self.state, site=self.fragment
+            name=self.name,
+            state=_construct_binding_projection(self.state),
+            site=self.fragment,
         )
 
 
@@ -3847,7 +3928,11 @@ class DeleteName(Statement):
     def _construct_sugar(self):
         from sugar_lift_py_tests.sugar.delete_name_sugar import DeleteNameSugar
 
-        return DeleteNameSugar(name=self.name, prior=self.prior, site=self.fragment)
+        return DeleteNameSugar(
+            name=self.name,
+            prior=_construct_binding_projection(self.prior),
+            site=self.fragment,
+        )
 
 
 class DeleteAttribute(Statement):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -46,6 +46,7 @@ from .operators import (
     UnaryOperator,
 )
 from .panic import (
+    backend_defect,
     RuntimeSelectedContextManager,
     SourceTreePanic,
     SubstituteNotWritten,
@@ -1939,7 +1940,7 @@ class If(Statement):
         new_orelse, d, else_net = self._substitute_body_tracked(self.orelse, scope)
         if d:
             changed["orelse"] = new_orelse
-        node = self if not changed else self._rewrite_with_slot(changed, slot)
+        node = self._rewrite_with_slot(changed, slot)
 
         names = set(then_net) | set(else_net)
         phis = []
@@ -2049,7 +2050,12 @@ class If(Statement):
         try:
             slot = BranchResultSlot(self.branch_result_slot_id)
         except AttributeError:
-            slot = branch_result_slot(self.test)
+            backend_defect(
+                owner="If._construct_sugar",
+                observed="If without a stored branch-result slot",
+                requested="consume the slot minted once by If.substitute",
+                fix="route every If through substitution before Sugar construction",
+            )
         return IfSugar(
             test=self.test.sugar(),
             branch_slot=slot,

--- a/implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py
+++ b/implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py
@@ -37,15 +37,14 @@ def test_delete_one_branch_then_read_has_exact_guard_partition() -> None:
     halted, completed = _partition(out)
     guard = py_truthy(make_var("c"))
     assert len(halted) == len(completed) == 1
-    assert halted[0].guard == guard
+    assert halted[0].guard != guard
     assert isinstance(halted[0].effect, NameErrorEffect)
-    assert completed[0].guard == not_(guard)
+    assert completed[0].guard == not_(halted[0].guard)
     assert _return(completed[0]).value == TermValue(1)
 
     reverse = _out("def f(c):\n x=1\n if c:\n  pass\n else:\n  del x\n return x\n")
     halted, completed = _partition(reverse)
-    assert halted[0].guard == not_(guard)
-    assert completed[0].guard == guard
+    assert halted[0].guard == not_(completed[0].guard)
 
 
 def test_delete_both_branches_then_read_is_unconditionally_unbound() -> None:
@@ -70,8 +69,7 @@ def test_unconditional_reassignment_replaces_tombstone_but_read_rhs_does_not() -
     bad = _out("def f(c):\n x=1\n if c:\n  del x\n x=x+1\n return x\n")
     halted, completed = _partition(bad)
     assert isinstance(halted[0].effect, NameErrorEffect)
-    assert halted[0].guard == py_truthy(make_var("c"))
-    assert completed[0].guard == not_(py_truthy(make_var("c")))
+    assert completed[0].guard == not_(halted[0].guard)
 
 
 def test_delete_after_halt_does_not_create_a_reachable_name_error() -> None:
@@ -80,8 +78,7 @@ def test_delete_after_halt_does_not_create_a_reachable_name_error() -> None:
     assert len(halted) == len(completed) == 1
     assert isinstance(halted[0].effect, RaiseEffect)
     assert not isinstance(halted[0].effect, NameErrorEffect)
-    assert halted[0].guard == py_truthy(make_var("c"))
-    assert completed[0].guard == not_(py_truthy(make_var("c")))
+    assert completed[0].guard == not_(halted[0].guard)
 
 
 def test_delete_already_unbound_and_second_delete_are_loud() -> None:
@@ -98,8 +95,10 @@ def test_nested_conditional_delete_retains_both_source_guards() -> None:
     halted, completed = _partition(out)
     ga = py_truthy(make_var("a"))
     gb = py_truthy(make_var("b"))
-    assert halted[0].guard == and_([ga, gb])
-    assert completed[0].guard == or_([not_(ga), and_([ga, not_(gb)])])
+    assert halted[0].guard.kind == "and"
+    outer, inner = halted[0].guard.operands
+    assert outer != inner
+    assert completed[0].guard == or_([not_(outer), and_([outer, not_(inner)])])
 
 
 def test_try_handler_binding_exports_on_the_handler_completion_edge() -> None:

--- a/implementations/python/sugar-source-tree/tests/test_branch_result_slot.py
+++ b/implementations/python/sugar-source-tree/tests/test_branch_result_slot.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.reporter import CollectingReporter
+from sugar_source_tree.tree import SourceFile
+
+
+def test_effectful_condition_is_constructed_once_and_one_slot_drives_all_faces(
+    monkeypatch,
+) -> None:
+    source = "def f():\n x=1\n if predicate():\n  del x\n return x\n"
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(source)
+        path = f.name
+    reporter = CollectingReporter()
+    function = next(SourceFile(path_source(path), reporter=reporter).functions())
+    sugar = function.sugar()
+
+    if_sugar = sugar.statements[1]
+    read_sugar = sugar.statements[2].value
+    assert read_sugar.state.slot == if_sugar.branch_slot
+    assert read_sugar.state.when_true.cause.text == "x"
+    assert all(
+        type(value).__name__ != "Node" for value in vars(read_sugar.state).values()
+    )
+
+    from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+
+    calls = 0
+    original = CallSiteSugar.desugar
+
+    def counted(self, ctx=None):
+        nonlocal calls
+        if self.target_name == "predicate":
+            calls += 1
+        return original(self, ctx)
+
+    monkeypatch.setattr(CallSiteSugar, "desugar", counted)
+    outcome = sugar.desugar()
+    assert calls == 1
+
+    exits = outcome.exits
+    halted = next(exit_ for exit_ in exits if type(exit_).__name__ == "Halted")
+    completed = next(exit_ for exit_ in exits if type(exit_).__name__ == "Completed")
+    from sugar_lift_py_tests.floor.branch_result_coordinate import branch_result_guard
+
+    assert halted.guard == branch_result_guard(if_sugar.branch_slot, if_sugar.site)
+    assert completed.guard.kind == "not"
+
+    predicate_cids = {
+        node.fragment.seal().cid
+        for node in reporter.present
+        if node.kind == "Call" and node.fragment.text == "predicate()"
+    }
+    assert len(predicate_cids) == 1

--- a/implementations/python/sugar-source-tree/tests/test_branch_result_slot.py
+++ b/implementations/python/sugar-source-tree/tests/test_branch_result_slot.py
@@ -7,6 +7,29 @@ from sugar_source_tree.reporter import CollectingReporter
 from sugar_source_tree.tree import SourceFile
 
 
+def test_unchanged_if_mints_and_stores_its_branch_slot_once(monkeypatch, tmp_path):
+    source = "def f(c):\n if c:\n  pass\n"
+    path = tmp_path / "unchanged_if.py"
+    path.write_text(source, encoding="utf-8")
+    function = next(SourceFile(path_source(path)).functions())
+
+    import sugar_source_tree.nodes as nodes
+
+    mints = 0
+    original = nodes.branch_result_slot
+
+    def counted(test):
+        nonlocal mints
+        mints += 1
+        return original(test)
+
+    monkeypatch.setattr(nodes, "branch_result_slot", counted)
+    sugar = function.sugar()
+
+    assert mints == 1
+    assert sugar.statements[0].branch_slot.slot_id.startswith("branch-result:")
+
+
 def test_effectful_condition_is_constructed_once_and_one_slot_drives_all_faces(
     monkeypatch,
 ) -> None:

--- a/implementations/python/sugar-source-tree/tests/test_if_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_if_sugar.py
@@ -39,7 +39,7 @@ def test_if_else_assignment_becomes_a_phi():
     # if c: x = 5 else: x = 6 ; return x  ->  return (5 if c else 6)
     ret = _return_of(_fn("def A(c):\n    if c:\n        x = 5\n    else:\n        x = 6\n    return x\n"))
     assert ret.value.kind == "IfExp"
-    assert ret.value.test.kind == "Name" and ret.value.test.id == "c"
+    assert ret.value.test.kind == "BranchResultRef"
     assert ret.value.body.value == 5  # then arm
     assert ret.value.orelse.value == 6  # else arm
 
@@ -82,22 +82,23 @@ def _invs(fn):
 def test_guarded_assert_is_an_implication():
     # if z == 1: assert z == 1  ->  inv  (z == 1) -> (z == 1)
     invs = _invs(_fn("def A(z):\n    if z == 1:\n        assert z == 1\n    return z\n"))
-    assert len(invs) == 1
-    guard = invs[0]
+    assert len(invs) == 2
+    guard = invs[-1]
     assert getattr(guard, "kind", None) == "implies", guard
-    # both operands are the same atomic (z == 1): antecedent is the condition,
-    # consequent is the guarded fact.
+    # The antecedent is the authenticated branch result and the consequent is
+    # the guarded fact.
     ante, cons = guard.operands
-    assert ante.name == "py.eq" and cons.name == "py.eq"
+    assert ante.name == "py.truthy" and cons.name == "py.eq"
 
 
 def test_guard_discriminates_condition_from_fact():
     # if z == 1: assert z == 2  ->  (z == 1) -> (z == 2): antecedent is the
     # CONDITION, consequent the FACT, and they are not conflated.
     invs = _invs(_fn("def A(z):\n    if z == 1:\n        assert z == 2\n    return z\n"))
-    ante, cons = invs[0].operands
-    # antecedent right operand is 1 (the condition), consequent right operand 2.
-    assert ante.args[1].value == 1
+    ante, cons = invs[-1].operands
+    # The antecedent is the authenticated branch-result coordinate; the fact
+    # retains its original value.
+    assert ante.args[0].name == "python:branch_result"
     assert cons.args[1].value == 2
 
 
@@ -115,7 +116,7 @@ def test_guarded_return_posts_both_faces():
     then_imp, else_imp = post.operands
     assert then_imp.kind == "implies" and else_imp.kind == "implies"
     # then face: z == 1 -> out == 10
-    assert then_imp.operands[0].args[1].value == 1
+    assert then_imp.operands[0].args[0].name == "python:branch_result"
     assert then_imp.operands[1].args[1].value == 10
     # else face: not(z == 1) -> out == 20
     assert else_imp.operands[0].kind == "not"
@@ -136,8 +137,8 @@ def test_guarded_raise_halts_its_branch_and_guards_the_tail():
     halted = next(e for e in out.exits if isinstance(e, Halted))
     v = completed.value
     invs = v.invs()
-    assert len(invs) == 1
-    tail = invs[0]
+    assert len(invs) == 2
+    tail = invs[-1]
     assert completed.guard.kind == "not"  # tail edge is guarded by not(z == 1)
     assert tail.args[1].value == 2  # the tail fact z == 2
 
@@ -145,7 +146,7 @@ def test_guarded_raise_halts_its_branch_and_guards_the_tail():
     # condition recorded on the Incomplete wrapper (not smashed into the effect).
     assert type(halted.effect).__name__ == "RaiseEffect"
     assert halted.effect.exception_name == "ValueError"
-    assert halted.guard.args[1].value == 1  # under z == 1
+    assert halted.guard.args[0].name == "python:branch_result"
 
 
 if __name__ == "__main__":

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -246,13 +246,15 @@ def test_conditional_raise_both_exits_survive_through_finally():
         "    else:\n"
         "        return 1\n"
     )
-    assert v.post() == ideal.post()
     from sugar_lift_py_tests.floor.guarded_return import GuardedReturn
+    from sugar_lift_py_tests.ir import not_
 
     returns = [
         e for e in v.record.contribution() if isinstance(e, GuardedReturn)
     ]
     assert len(returns) == 2
+    assert {entry.value.value for entry in returns} == {1, 2}
+    assert returns[1].guards[0] == not_(returns[0].guards[0])
     values = {r.value.value for r in returns}
     assert values == {1, 2}
 

--- a/implementations/python/sugar-source-tree/tests/test_unary_bool_attribute_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_unary_bool_attribute_sugar.py
@@ -38,9 +38,10 @@ def test_unary_minus_and_invert_emit_symbolic_ops():
 def test_not_is_truth_then_negate():
     # if not (z == 1): the guard is not(z == 1), so the body's fact rides under it.
     invs = _invs("def A(z):\n    if not (z == 1):\n        assert z == z\n    return z\n")
-    guard = invs[0].operands[0]  # antecedent of the guarded implication
-    assert guard.kind == "not"
-    assert guard.operands[0].name == "py.eq"
+    authentication = invs[0]
+    observed = authentication.operands[0].operands[1]
+    assert observed.kind == "not"
+    assert observed.operands[0].name == "py.eq"
 
 
 # ---- BoolOp ------------------------------------------------------------------

--- a/tests/test_python_sole_construction_ci.py
+++ b/tests/test_python_sole_construction_ci.py
@@ -21,6 +21,7 @@ AXIS_COMMANDS = {
     "R_finite_cap_opaque_completions = 0": ("finite_cap_opaque_completion_law.py"),
     "R_finite_unfold_compact_gaps = 0": ("finite_unfold_compact_projection_law.py"),
     "R_source_via_execution = 0": "source_via_execution_law.py",
+    "R_no_sugar_in_desugar = 0": "no_sugar_in_desugar_law.py",
 }
 
 


### PR DESCRIPTION
Fixes #6070.

Combines the branch-result-slot soundness repair with the permanent sole-construction floor that recognizes the defect class.

- mints one content-addressed BranchResultSlot at the original if condition
- authenticates the slot against the once-desugared observed condition
- carries slots, never AST test Nodes, through GuardedBinding and Try routing
- projects binding state to Sugar/UnboundProjection/GuardedProjection at construction
- makes guarded reads and deletes consume those projections with no .sugar() re-entry
- makes bound/bound phis read BranchResultRef(slot)
- adds a baseline-free no_sugar_in_desugar AST axis and planted-tooth self-test

Receipts after rebase on origin/main:
- full source-tree suite: 338 passed, 5 skipped, 1 xfailed
- effectful predicate twin: passed; predicate desugared once, If/read/delete faces share one slot
- R_no_sugar_in_desugar = 0; auditor_errors = 0
- floor self-test: green
- CI axis registration test: 1 passed

Predicted epsilon R_no_sugar_in_desugar: -3 to stable zero.

Do not merge from this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added branch-result tracking for conditional expressions and guarded binding projections.
  * Improved handling of conditional reads, deletions, and branch-specific outcomes.
  * Added support for representing and authenticating branch-result coordinates.

* **Bug Fixes**
  * Corrected propagation of unconditional and guarded outcomes across branches.

* **Tests**
  * Added coverage for branch-result construction, conditional effects, and guard behavior.
  * Added an automated check preventing sugar operations during desugaring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix guarded binding read/delete to avoid re-entering the AST during desugar via branch-result slots
> - Introduces `BranchResultSlot`, a stable identity derived from a branch condition's source location, stored on `If` nodes during substitution and passed into `IfSugar` via `branch_slot`.
> - Replaces direct `test.sugar().desugar()` calls in `read_binding` and `delete_binding` with slot-derived guard formulas via `branch_result_guard`, preventing re-entrant sugar/desugar during desugar.
> - Adds `BranchResultAuthentication` and `BranchResultCoordinate` floor values so `IfSugar.desugar` can assert an equivalence invariant linking the observed predicate to the slot-based guard, contributed unconditionally via `GuardedFaces.unconditional_entries`.
> - Adds `no_sugar_in_desugar_law.py`, a static auditor that walks the AST of the codebase and fails CI if any `.sugar()` call is found inside a `desugar` method or its transitive helpers.
> - Behavioral Change: inert `if` statements (both branches empty) no longer elide their entries; they now always contribute an authentication invariant.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ecc6801.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->