### PR TITLE
feat: context-manager contract publisher + decoder (With prerequisite 1/2)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
@@ -1,28 +1,4 @@
-"""The typed context-manager contract, and the recognition membrane that issues it.
-
-T's ruling: three contracts wear the one `with` syntax, and production tree code
-sees a TYPED CONTRACT, never a vendor spelling. `pytest` is a vendor: the
-membrane authenticates community spellings (`pytest.raises(E)`,
-`contextlib.suppress(E)`, `tm.assert_produces_warning(W)`) and issues the
-general contract; the language implementation (nodes.py) consults the membrane
-and never matches names itself.
-
-The exit contracts (the only licenses for temporal dissolution):
-- ``NeverSuppresses`` -- exceptional body effect passes through after __exit__.
-- ``Suppresses(matcher)`` -- matching effects are consumed (permission).
-- ``Expects(matcher)`` -- matching effect is REQUIRED and consumed (obligation).
-- ``RuntimeSelected`` -- suppression undecidable statically; stays loud.
-
-Matching rule (pinned): EXACT exception-name match. Subclass matching needs a
-static type hierarchy the lift does not hold; a subclass raise therefore lands
-as the mismatch twin (loud, never silently matched) until that rule is widened
-deliberately.
-
-Enrollment (issue #5994): community coordinates enter ONLY through an
-explicitly loaded, hashed kit manifest that maps authenticated spellings to
-these contracts. This module holds the provider-neutral TYPES only; no vendor
-spelling may appear in code, tree-side or kit-side.
-"""
+"""Typed context-manager dispositions and sealed CM-contract publications."""
 
 from __future__ import annotations
 
@@ -38,35 +14,19 @@ from .signing import Signer, ed25519_verify_string
 
 @dataclass(frozen=True)
 class MessagePattern:
-    """A payload obligation: the observed effect's message must match this
-    regex. Independently dischargeable -- undischarged (not passed, not failed)
-    until the effect witness carries authenticated message content."""
-
     pattern: str
 
 
 @dataclass(frozen=True)
 class EffectMatcher:
-    """A CONJUNCTION of independently dischargeable obligations (T's ruling:
-    the unit of honesty is the individual obligation, never the surface
-    construct). The type obligation is decidable against the observed halt;
-    each payload obligation (e.g. MessagePattern from `match=`) carries its own
-    closed verdict -- discharged / disproven / undischarged -- sharing the same
-    observed-effect witness identity."""
-
-    kind: str  # "raise" | "warning"
-    name: str  # e.g. "ValueError", "FutureWarning"
-    payload_obligations: tuple = ()  # e.g. (MessagePattern(pat),)
+    kind: str
+    name: str
+    payload_obligations: tuple = ()
 
 
-# Binding projections for `with … as name` — declared by the membrane, never
-# by matching vendor spellings in the tree. Syntax rewrites the name to an
-# ObservationRef(slot, projection=…); routing authenticates the slot.
 EXCEPTION_INFO = "exception_info"
 WARNING_OBSERVATION = "warning_observation"
 EFFECT = "effect"
-# Resource enter-result: tree coordinate for ``with m as x`` under a resource
-# disposition (NeverSuppresses / proven exit). Not an exception witness.
 ENTER_RESULT = "enter_result"
 
 
@@ -83,7 +43,6 @@ class Suppresses:
 @dataclass(frozen=True)
 class Expects:
     matcher: EffectMatcher
-    # What `as name` denotes when this contract is issued (None → no as-export).
     binding: Optional[str] = None
 
 
@@ -95,127 +54,214 @@ class RuntimeSelected:
 Contract = NeverSuppresses | Suppresses | Expects | RuntimeSelected
 
 
+@dataclass(frozen=True)
+class NeverSuppressesDispositionV1:
+    kind: str = "never-suppresses"
+
+
+@dataclass(frozen=True)
+class EnterResultContractV1:
+    sort: Sort
+    completion: str = "total"
+    projection: str = ENTER_RESULT
+
+
+@dataclass(frozen=True)
+class ExitContractV1:
+    disposition: NeverSuppressesDispositionV1
+    completion: str = "total"
+
+
+@dataclass(frozen=True)
+class ContextManagerSemanticsV1:
+    enter: EnterResultContractV1
+    exit: ExitContractV1
+    kind: str = "context-manager-semantics"
+    schema_version: str = "1"
+
+
+@dataclass(frozen=True)
+class PublishedContextManagerContractV1:
+    bridge_source_symbol: str
+    import_formals: tuple[str, ...]
+    import_sorts: tuple[Sort, ...]
+    semantics: ContextManagerSemanticsV1
+    source_warrants: tuple[str, ...]
+    payload_cid: str
+
+
 class ContextManagerContractError(ValueError):
     """A sealed CM-contract member is malformed, stale, or unauthenticated."""
 
 
-@dataclass(frozen=True)
-class PublishedContextManagerContract:
-    name: str
-    kit: str
-    bridge_source_symbol: str
-    constructor_formals: tuple[str, ...]
-    constructor_sorts: tuple[Sort, ...]
-    enter_result_sort: Sort
-    exit_disposition: str
-    source_warrants: tuple[dict[str, Any], ...]
-    contract_cid: str
-
-
-def _payload_value(
-    *, name: str, kit: str, bridge_source_symbol: str,
-    constructor_formals: Sequence[str], constructor_sorts: Sequence[Sort],
-    enter_result_sort: Sort, source_warrants: Sequence[dict[str, Any]],
-):
-    if not all(isinstance(warrant, dict) for warrant in source_warrants):
-        raise ContextManagerContractError("sourceWarrants entries must be objects")
+def semantics_to_value(semantics: ContextManagerSemanticsV1):
+    if semantics.kind != "context-manager-semantics" or semantics.schema_version != "1":
+        raise ContextManagerContractError("unsupported context-manager semantics schema")
+    if semantics.enter.completion != "total" or semantics.enter.projection != ENTER_RESULT:
+        raise ContextManagerContractError("unsupported enter testimony")
+    if semantics.exit.completion != "total" or not isinstance(
+        semantics.exit.disposition, NeverSuppressesDispositionV1
+    ):
+        raise ContextManagerContractError("unsupported exit disposition")
     return vobj([
+        ("kind", vstr("context-manager-semantics")),
         ("schemaVersion", vstr("1")),
-        ("kind", vstr("context-manager-contract")),
-        ("name", vstr(name)),
-        ("kit", vstr(kit)),
-        ("bridgeSourceSymbol", vstr(bridge_source_symbol)),
-        ("constructorSignature", vobj([
-            ("formals", varr([vstr(v) for v in constructor_formals])),
-            ("sorts", varr([sort_to_value(v) for v in constructor_sorts])),
-        ])),
         ("enter", vobj([
-            ("outcome", vstr("total")),
+            ("completion", vstr("total")),
             ("result", vobj([
                 ("kind", vstr("projection")),
                 ("projection", vstr(ENTER_RESULT)),
-                ("sort", sort_to_value(enter_result_sort)),
+                ("sort", sort_to_value(semantics.enter.sort)),
             ])),
         ])),
         ("exit", vobj([
-            ("outcome", vstr("total")),
+            ("completion", vstr("total")),
             ("disposition", vobj([("kind", vstr("never-suppresses"))])),
         ])),
-        ("sourceWarrants", varr([_json_value(warrant) for warrant in source_warrants])),
     ])
 
 
 def publish_never_suppresses_context_manager_contract(
-    *, name: str, kit: str, bridge_source_symbol: str,
-    constructor_formals: Sequence[str], constructor_sorts: Sequence[Sort],
-    enter_result_sort: Sort, source_warrants: Sequence[dict[str, Any]],
+    *, bridge_source_symbol: str, import_signature: Any,
+    enter_result_sort: Sort, source_warrants: Sequence[str],
     signer: Signer, declared_at: str,
 ) -> ClaimEnvelope:
-    if not name or not kit or not bridge_source_symbol:
-        raise ContextManagerContractError("name, kit, and bridgeSourceSymbol must be non-empty")
-    if len(constructor_formals) != len(constructor_sorts):
-        raise ContextManagerContractError("constructor formals and sorts must have equal length")
-    payload = _payload_value(
-        name=name, kit=kit, bridge_source_symbol=bridge_source_symbol,
-        constructor_formals=constructor_formals, constructor_sorts=constructor_sorts,
-        enter_result_sort=enter_result_sort, source_warrants=source_warrants,
+    if not bridge_source_symbol:
+        raise ContextManagerContractError("bridgeSourceSymbol must be non-empty")
+    formals = tuple(import_signature.formals)
+    sorts = tuple(import_signature.sorts)
+    if len(formals) != len(sorts):
+        raise ContextManagerContractError("import signature formals/sorts length mismatch")
+    if not all(isinstance(w, str) and w.startswith("blake3-512:") for w in source_warrants):
+        raise ContextManagerContractError("sourceWarrants must be CID references")
+    semantics = ContextManagerSemanticsV1(
+        enter=EnterResultContractV1(sort=enter_result_sort),
+        exit=ExitContractV1(disposition=NeverSuppressesDispositionV1()),
     )
-    content_cid = blake3_512_of(encode_jcs(payload).encode())
-    raw = json.loads(encode_jcs(payload))
-    header = vobj([(k, vstr(content_cid) if k == "cid" else _json_value(v)) for k, v in ({**raw, "cid": content_cid}).items()])
-    return _assemble_layered(header, vobj([]), declared_at, signer.seed, content_cid)
+    payload = semantics_to_value(semantics)
+    payload_cid = blake3_512_of(encode_jcs(payload).encode())
+    sorted_inputs = sorted(source_warrants)
+    header = vobj([
+        ("schemaVersion", vstr("1.2")),
+        ("kind", vstr("context-manager-contract")),
+        ("cid", vstr(payload_cid)),
+        ("payloadCid", vstr(payload_cid)),
+        ("bridgeSourceSymbol", vstr(bridge_source_symbol)),
+        ("importSignature", vobj([
+            ("formals", varr([vstr(v) for v in formals])),
+            ("sorts", varr([sort_to_value(v) for v in sorts])),
+        ])),
+        ("payload", payload),
+        ("sourceWarrants", varr([vstr(v) for v in source_warrants])),
+        ("inputCids", varr([vstr(v) for v in sorted_inputs])),
+    ])
+    metadata = vobj([
+        ("authoring", vobj([
+            ("producerKind", vstr("kit-author")),
+            ("author", vstr(signer.producer_id)),
+        ])),
+        ("producedBy", vstr(signer.producer_id)),
+        ("producedAt", vstr(declared_at)),
+    ])
+    return _assemble_layered(header, metadata, declared_at, signer.seed, payload_cid)
 
 
 def _json_value(value: Any):
     from .canonicalizer import vbool, vint, vnull
-    if value is None: return vnull()
-    if isinstance(value, bool): return vbool(value)
-    if isinstance(value, int): return vint(value)
-    if isinstance(value, str): return vstr(value)
-    if isinstance(value, list): return varr([_json_value(v) for v in value])
-    if isinstance(value, dict): return vobj([(k, _json_value(v)) for k, v in value.items()])
+    if value is None:
+        return vnull()
+    if isinstance(value, bool):
+        return vbool(value)
+    if isinstance(value, int):
+        return vint(value)
+    if isinstance(value, str):
+        return vstr(value)
+    if isinstance(value, list):
+        return varr([_json_value(v) for v in value])
+    if isinstance(value, dict):
+        return vobj([(k, _json_value(v)) for k, v in value.items()])
     raise ContextManagerContractError(f"unsupported payload value: {type(value)!r}")
 
 
 def _decode_sort(raw: Any) -> Sort:
-    if not isinstance(raw, dict): raise ContextManagerContractError("sort must be an object")
+    if not isinstance(raw, dict):
+        raise ContextManagerContractError("sort must be an object")
     if raw.get("kind") == "primitive" and set(raw) == {"kind", "name"} and isinstance(raw["name"], str):
         return PrimitiveSort(raw["name"])
     if raw.get("kind") == "region" and set(raw) == {"kind", "name"} and isinstance(raw["name"], str):
         return RegionSort(raw["name"])
     if raw.get("kind") == "function" and set(raw) == {"kind", "args", "return"} and isinstance(raw["args"], list):
         return FunctionSort(tuple(_decode_sort(v) for v in raw["args"]), _decode_sort(raw["return"]))
-    raise ContextManagerContractError("unsupported or malformed enter-result sort")
+    raise ContextManagerContractError("unsupported or malformed sort")
 
 
-def decode_context_manager_contract(canonical_bytes: bytes, member_cid: str) -> PublishedContextManagerContract:
-    try: raw = json.loads(canonical_bytes)
-    except (TypeError, ValueError) as exc: raise ContextManagerContractError("member is not JSON") from exc
-    if not isinstance(raw, dict) or set(raw) != {"envelope", "header", "metadata"} or raw["metadata"] != {}:
-        raise ContextManagerContractError("CM contract must be a layered member with empty metadata")
+def _decode_semantics(raw: Any) -> ContextManagerSemanticsV1:
+    if not isinstance(raw, dict) or set(raw) != {"kind", "schemaVersion", "enter", "exit"}:
+        raise ContextManagerContractError("malformed context-manager semantics")
+    if raw["kind"] != "context-manager-semantics" or raw["schemaVersion"] != "1":
+        raise ContextManagerContractError("unknown context-manager semantics schema")
+    enter = raw["enter"]
+    exit_ = raw["exit"]
+    if not isinstance(enter, dict) or set(enter) != {"completion", "result"}:
+        raise ContextManagerContractError("malformed context-manager semantics enter")
+    result = enter["result"]
+    if enter["completion"] != "total" or not isinstance(result, dict) or set(result) != {"kind", "projection", "sort"} or result["kind"] != "projection" or result["projection"] != ENTER_RESULT:
+        raise ContextManagerContractError("unsupported enter testimony")
+    if not isinstance(exit_, dict) or set(exit_) != {"completion", "disposition"}:
+        raise ContextManagerContractError("malformed context-manager semantics exit")
+    disposition = exit_["disposition"]
+    if exit_["completion"] != "total" or not isinstance(disposition, dict) or set(disposition) != {"kind"}:
+        raise ContextManagerContractError("malformed exit disposition")
+    if disposition["kind"] != "never-suppresses":
+        raise ContextManagerContractError("unknown exit disposition")
+    return ContextManagerSemanticsV1(
+        enter=EnterResultContractV1(sort=_decode_sort(result["sort"])),
+        exit=ExitContractV1(disposition=NeverSuppressesDispositionV1()),
+    )
+
+
+def decode_context_manager_contract(
+    canonical_bytes: bytes, member_cid: str
+) -> PublishedContextManagerContractV1:
+    try:
+        raw = json.loads(canonical_bytes)
+    except (TypeError, ValueError) as exc:
+        raise ContextManagerContractError("member is not JSON") from exc
+    if not isinstance(raw, dict) or set(raw) != {"envelope", "header", "metadata"}:
+        raise ContextManagerContractError("CM contract must be a layered member")
     envelope, header = raw["envelope"], raw["header"]
+    if not isinstance(raw["metadata"], dict):
+        raise ContextManagerContractError("layered metadata must be an object")
     if blake3_512_of(encode_jcs(_json_value(envelope)).encode()) != member_cid:
         raise ContextManagerContractError("member attestation CID does not match envelope")
-    signing = vobj([("header", _json_value(header)), ("metadata", vobj([]))])
+    signing = vobj([("header", _json_value(header)), ("metadata", _json_value(raw["metadata"]))])
     if not ed25519_verify_string(envelope.get("signer", ""), envelope.get("signature", ""), encode_jcs(signing).encode()):
         raise ContextManagerContractError("member signature does not verify")
-    expected = {"schemaVersion", "kind", "cid", "name", "kit", "bridgeSourceSymbol", "constructorSignature", "enter", "exit", "sourceWarrants"}
-    if not isinstance(header, dict) or set(header) != expected or header.get("schemaVersion") != "1" or header.get("kind") != "context-manager-contract":
+    expected = {"schemaVersion", "kind", "cid", "payloadCid", "bridgeSourceSymbol", "importSignature", "payload", "sourceWarrants", "inputCids"}
+    if not isinstance(header, dict) or set(header) != expected or header.get("schemaVersion") != "1.2" or header.get("kind") != "context-manager-contract":
         raise ContextManagerContractError("malformed context-manager-contract header")
-    payload = dict(header); claimed = payload.pop("cid")
-    derived = blake3_512_of(encode_jcs(_json_value(payload)).encode())
-    if claimed != derived: raise ContextManagerContractError("context-manager contract content CID does not match payload")
-    sig = header["constructorSignature"]
-    if not isinstance(sig, dict) or set(sig) != {"formals", "sorts"} or not isinstance(sig["formals"], list) or not isinstance(sig["sorts"], list) or len(sig["formals"]) != len(sig["sorts"]):
-        raise ContextManagerContractError("malformed constructorSignature")
-    if not all(isinstance(v, str) for v in sig["formals"]): raise ContextManagerContractError("constructor formals must be strings")
-    enter, exit_ = header["enter"], header["exit"]
-    if enter.get("outcome") != "total" or enter.get("result", {}).get("kind") != "projection" or enter["result"].get("projection") != ENTER_RESULT:
-        raise ContextManagerContractError("enter testimony is not total enter_result projection")
-    if exit_ != {"outcome": "total", "disposition": {"kind": "never-suppresses"}}:
-        raise ContextManagerContractError("exit testimony is not total NeverSuppresses")
-    if not isinstance(header["sourceWarrants"], list) or not all(isinstance(v, dict) for v in header["sourceWarrants"]):
-        raise ContextManagerContractError("sourceWarrants must be an array of objects")
-    if not all(isinstance(header[k], str) and header[k] for k in ("name", "kit", "bridgeSourceSymbol")):
-        raise ContextManagerContractError("identity fields must be non-empty strings")
-    return PublishedContextManagerContract(header["name"], header["kit"], header["bridgeSourceSymbol"], tuple(sig["formals"]), tuple(_decode_sort(v) for v in sig["sorts"]), _decode_sort(enter["result"]["sort"]), "never-suppresses", tuple(header["sourceWarrants"]), derived)
+    semantics = _decode_semantics(header["payload"])
+    payload_cid = blake3_512_of(encode_jcs(semantics_to_value(semantics)).encode())
+    if header["cid"] != payload_cid or header["payloadCid"] != payload_cid:
+        raise ContextManagerContractError("context-manager payload CID does not match semantics")
+    signature = header["importSignature"]
+    if not isinstance(signature, dict) or set(signature) != {"formals", "sorts"} or not isinstance(signature["formals"], list) or not isinstance(signature["sorts"], list) or len(signature["formals"]) != len(signature["sorts"]):
+        raise ContextManagerContractError("malformed importSignature")
+    if not all(isinstance(v, str) for v in signature["formals"]):
+        raise ContextManagerContractError("import formals must be strings")
+    warrants = header["sourceWarrants"]
+    if not isinstance(warrants, list) or not all(isinstance(v, str) and v.startswith("blake3-512:") for v in warrants):
+        raise ContextManagerContractError("sourceWarrants must be CID references")
+    if header["inputCids"] != sorted(warrants):
+        raise ContextManagerContractError("inputCids do not match sourceWarrants")
+    symbol = header["bridgeSourceSymbol"]
+    if not isinstance(symbol, str) or not symbol:
+        raise ContextManagerContractError("bridgeSourceSymbol must be non-empty")
+    return PublishedContextManagerContractV1(
+        bridge_source_symbol=symbol,
+        import_formals=tuple(signature["formals"]),
+        import_sorts=tuple(_decode_sort(v) for v in signature["sorts"]),
+        semantics=semantics,
+        source_warrants=tuple(warrants),
+        payload_cid=payload_cid,
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
@@ -27,7 +27,13 @@ spelling may appear in code, tree-side or kit-side.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+import json
+from typing import Any, Optional, Sequence
+
+from .canonicalizer import blake3_512_of, encode_jcs, varr, vobj, vstr
+from .claim_envelope import ClaimEnvelope, _assemble_layered
+from .ir import FunctionSort, PrimitiveSort, RegionSort, Sort, sort_to_value
+from .signing import Signer, ed25519_verify_string
 
 
 @dataclass(frozen=True)
@@ -89,3 +95,127 @@ class RuntimeSelected:
 Contract = NeverSuppresses | Suppresses | Expects | RuntimeSelected
 
 
+class ContextManagerContractError(ValueError):
+    """A sealed CM-contract member is malformed, stale, or unauthenticated."""
+
+
+@dataclass(frozen=True)
+class PublishedContextManagerContract:
+    name: str
+    kit: str
+    bridge_source_symbol: str
+    constructor_formals: tuple[str, ...]
+    constructor_sorts: tuple[Sort, ...]
+    enter_result_sort: Sort
+    exit_disposition: str
+    source_warrants: tuple[dict[str, Any], ...]
+    contract_cid: str
+
+
+def _payload_value(
+    *, name: str, kit: str, bridge_source_symbol: str,
+    constructor_formals: Sequence[str], constructor_sorts: Sequence[Sort],
+    enter_result_sort: Sort, source_warrants: Sequence[dict[str, Any]],
+):
+    if not all(isinstance(warrant, dict) for warrant in source_warrants):
+        raise ContextManagerContractError("sourceWarrants entries must be objects")
+    return vobj([
+        ("schemaVersion", vstr("1")),
+        ("kind", vstr("context-manager-contract")),
+        ("name", vstr(name)),
+        ("kit", vstr(kit)),
+        ("bridgeSourceSymbol", vstr(bridge_source_symbol)),
+        ("constructorSignature", vobj([
+            ("formals", varr([vstr(v) for v in constructor_formals])),
+            ("sorts", varr([sort_to_value(v) for v in constructor_sorts])),
+        ])),
+        ("enter", vobj([
+            ("outcome", vstr("total")),
+            ("result", vobj([
+                ("kind", vstr("projection")),
+                ("projection", vstr(ENTER_RESULT)),
+                ("sort", sort_to_value(enter_result_sort)),
+            ])),
+        ])),
+        ("exit", vobj([
+            ("outcome", vstr("total")),
+            ("disposition", vobj([("kind", vstr("never-suppresses"))])),
+        ])),
+        ("sourceWarrants", varr([_json_value(warrant) for warrant in source_warrants])),
+    ])
+
+
+def publish_never_suppresses_context_manager_contract(
+    *, name: str, kit: str, bridge_source_symbol: str,
+    constructor_formals: Sequence[str], constructor_sorts: Sequence[Sort],
+    enter_result_sort: Sort, source_warrants: Sequence[dict[str, Any]],
+    signer: Signer, declared_at: str,
+) -> ClaimEnvelope:
+    if not name or not kit or not bridge_source_symbol:
+        raise ContextManagerContractError("name, kit, and bridgeSourceSymbol must be non-empty")
+    if len(constructor_formals) != len(constructor_sorts):
+        raise ContextManagerContractError("constructor formals and sorts must have equal length")
+    payload = _payload_value(
+        name=name, kit=kit, bridge_source_symbol=bridge_source_symbol,
+        constructor_formals=constructor_formals, constructor_sorts=constructor_sorts,
+        enter_result_sort=enter_result_sort, source_warrants=source_warrants,
+    )
+    content_cid = blake3_512_of(encode_jcs(payload).encode())
+    raw = json.loads(encode_jcs(payload))
+    header = vobj([(k, vstr(content_cid) if k == "cid" else _json_value(v)) for k, v in ({**raw, "cid": content_cid}).items()])
+    return _assemble_layered(header, vobj([]), declared_at, signer.seed, content_cid)
+
+
+def _json_value(value: Any):
+    from .canonicalizer import vbool, vint, vnull
+    if value is None: return vnull()
+    if isinstance(value, bool): return vbool(value)
+    if isinstance(value, int): return vint(value)
+    if isinstance(value, str): return vstr(value)
+    if isinstance(value, list): return varr([_json_value(v) for v in value])
+    if isinstance(value, dict): return vobj([(k, _json_value(v)) for k, v in value.items()])
+    raise ContextManagerContractError(f"unsupported payload value: {type(value)!r}")
+
+
+def _decode_sort(raw: Any) -> Sort:
+    if not isinstance(raw, dict): raise ContextManagerContractError("sort must be an object")
+    if raw.get("kind") == "primitive" and set(raw) == {"kind", "name"} and isinstance(raw["name"], str):
+        return PrimitiveSort(raw["name"])
+    if raw.get("kind") == "region" and set(raw) == {"kind", "name"} and isinstance(raw["name"], str):
+        return RegionSort(raw["name"])
+    if raw.get("kind") == "function" and set(raw) == {"kind", "args", "return"} and isinstance(raw["args"], list):
+        return FunctionSort(tuple(_decode_sort(v) for v in raw["args"]), _decode_sort(raw["return"]))
+    raise ContextManagerContractError("unsupported or malformed enter-result sort")
+
+
+def decode_context_manager_contract(canonical_bytes: bytes, member_cid: str) -> PublishedContextManagerContract:
+    try: raw = json.loads(canonical_bytes)
+    except (TypeError, ValueError) as exc: raise ContextManagerContractError("member is not JSON") from exc
+    if not isinstance(raw, dict) or set(raw) != {"envelope", "header", "metadata"} or raw["metadata"] != {}:
+        raise ContextManagerContractError("CM contract must be a layered member with empty metadata")
+    envelope, header = raw["envelope"], raw["header"]
+    if blake3_512_of(encode_jcs(_json_value(envelope)).encode()) != member_cid:
+        raise ContextManagerContractError("member attestation CID does not match envelope")
+    signing = vobj([("header", _json_value(header)), ("metadata", vobj([]))])
+    if not ed25519_verify_string(envelope.get("signer", ""), envelope.get("signature", ""), encode_jcs(signing).encode()):
+        raise ContextManagerContractError("member signature does not verify")
+    expected = {"schemaVersion", "kind", "cid", "name", "kit", "bridgeSourceSymbol", "constructorSignature", "enter", "exit", "sourceWarrants"}
+    if not isinstance(header, dict) or set(header) != expected or header.get("schemaVersion") != "1" or header.get("kind") != "context-manager-contract":
+        raise ContextManagerContractError("malformed context-manager-contract header")
+    payload = dict(header); claimed = payload.pop("cid")
+    derived = blake3_512_of(encode_jcs(_json_value(payload)).encode())
+    if claimed != derived: raise ContextManagerContractError("context-manager contract content CID does not match payload")
+    sig = header["constructorSignature"]
+    if not isinstance(sig, dict) or set(sig) != {"formals", "sorts"} or not isinstance(sig["formals"], list) or not isinstance(sig["sorts"], list) or len(sig["formals"]) != len(sig["sorts"]):
+        raise ContextManagerContractError("malformed constructorSignature")
+    if not all(isinstance(v, str) for v in sig["formals"]): raise ContextManagerContractError("constructor formals must be strings")
+    enter, exit_ = header["enter"], header["exit"]
+    if enter.get("outcome") != "total" or enter.get("result", {}).get("kind") != "projection" or enter["result"].get("projection") != ENTER_RESULT:
+        raise ContextManagerContractError("enter testimony is not total enter_result projection")
+    if exit_ != {"outcome": "total", "disposition": {"kind": "never-suppresses"}}:
+        raise ContextManagerContractError("exit testimony is not total NeverSuppresses")
+    if not isinstance(header["sourceWarrants"], list) or not all(isinstance(v, dict) for v in header["sourceWarrants"]):
+        raise ContextManagerContractError("sourceWarrants must be an array of objects")
+    if not all(isinstance(header[k], str) and header[k] for k in ("name", "kit", "bridgeSourceSymbol")):
+        raise ContextManagerContractError("identity fields must be non-empty strings")
+    return PublishedContextManagerContract(header["name"], header["kit"], header["bridgeSourceSymbol"], tuple(sig["formals"]), tuple(_decode_sort(v) for v in sig["sorts"]), _decode_sort(enter["result"]["sort"]), "never-suppresses", tuple(header["sourceWarrants"]), derived)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/__init__.py
@@ -14,6 +14,7 @@ from .factory_walk_row_dto import (
 )
 from .implication_dto import ImplicationDto
 from .lift_report_payload_dto import LiftReportPayloadDto
+from .context_manager_contract_dto import ContextManagerContractIrV1, ImportSignatureV1
 from .open_lane_dto import (
     CallEdgeDto,
     DiagnosticDto,
@@ -55,6 +56,8 @@ __all__ = [
     "FactoryWalkRowDto",
     "ImplicationDto",
     "LiftReportPayloadDto",
+    "ContextManagerContractIrV1",
+    "ImportSignatureV1",
     "PlanAtomDto",
     "RecoveredAuditDto",
     "RecoveredEffectDto",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/context_manager_contract_dto.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/context_manager_contract_dto.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any
+
+from sugar_lift_py_tests.context_manager_contract import (
+    ContextManagerSemanticsV1,
+    EnterResultContractV1,
+    ExitContractV1,
+    NeverSuppressesDispositionV1,
+    semantics_to_value,
+)
+from sugar_lift_py_tests.ir import Sort, sort_to_value
+
+
+@dataclass(frozen=True)
+class ImportSignatureV1:
+    formals: tuple[str, ...]
+    sorts: tuple[Sort, ...]
+
+    def __post_init__(self) -> None:
+        if len(self.formals) != len(self.sorts):
+            raise ValueError("import signature formals/sorts length mismatch")
+
+
+@dataclass(frozen=True)
+class ContextManagerContractIrV1:
+    bridge_source_symbol: str
+    import_signature: ImportSignatureV1
+    payload: ContextManagerSemanticsV1
+    source_warrants: tuple[str, ...]
+    kind: str = "context-manager-contract"
+    schema_version: str = "1"
+
+    @classmethod
+    def never_suppresses(
+        cls, *, bridge_source_symbol: str, import_signature: ImportSignatureV1,
+        enter_result_sort: Sort, source_warrants: tuple[str, ...],
+    ) -> "ContextManagerContractIrV1":
+        return cls(
+            bridge_source_symbol=bridge_source_symbol,
+            import_signature=import_signature,
+            payload=ContextManagerSemanticsV1(
+                enter=EnterResultContractV1(sort=enter_result_sort),
+                exit=ExitContractV1(disposition=NeverSuppressesDispositionV1()),
+            ),
+            source_warrants=source_warrants,
+        )
+
+    def to_rpc_with_term_table(self, _term_table: Any) -> dict[str, Any]:
+        if not self.bridge_source_symbol:
+            raise ValueError("bridgeSourceSymbol must be non-empty")
+        if not all(w.startswith("blake3-512:") for w in self.source_warrants):
+            raise ValueError("sourceWarrants must be CID references")
+        return {
+            "kind": self.kind,
+            "schemaVersion": self.schema_version,
+            "bridgeSourceSymbol": self.bridge_source_symbol,
+            "importSignature": {
+                "formals": list(self.import_signature.formals),
+                "sorts": [json.loads(_encode(sort_to_value(v))) for v in self.import_signature.sorts],
+            },
+            "payload": json.loads(_encode(semantics_to_value(self.payload))),
+            "sourceWarrants": list(self.source_warrants),
+        }
+
+
+def _encode(value: Any) -> str:
+    from sugar_lift_py_tests.canonicalizer import encode_jcs
+    return encode_jcs(value)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/lift_report_payload_dto.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/lift_report_payload_dto.py
@@ -8,6 +8,7 @@ from typing import Any
 from .assertion_surface_audit_dto import AssertionSurfaceAuditDto
 from .body_universe_dto import BodyUniverseDto
 from .component_plan_memento_dto import ComponentPlanMementoDto
+from .context_manager_contract_dto import ContextManagerContractIrV1
 from .effect_dto import EffectDto
 from .factory_audit_summary_dto import FactoryAuditSummaryDto
 from .factory_walk_row_dto import FactoryWalkRowDto
@@ -32,8 +33,8 @@ _TRANSPORT_LOG = logging.getLogger("sugar.kit.transport")
 class LiftReportPayloadDto:
     # Closed lanes: a DTO already exists for every row, so no raw-dict side
     # door is left for callers to bypass construction law (#3661).
-    ir: list[BodyUniverseDto | SourceFunctionContractDto] = field(
-        default_factory=list[BodyUniverseDto | SourceFunctionContractDto]
+    ir: list[BodyUniverseDto | SourceFunctionContractDto | ContextManagerContractIrV1] = field(
+        default_factory=list[BodyUniverseDto | SourceFunctionContractDto | ContextManagerContractIrV1]
     )
     source_mementos: list[SourceMementoDto] = field(
         default_factory=list[SourceMementoDto]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -38,6 +38,7 @@ from sugar_lift_py_tests.idd.lift_coverage_accounting import (
 )
 from sugar_lift_py_tests.idd.lift_coverage_census import census_paths
 from sugar_lift_py_tests.kit_rpc import (
+    ContextManagerContractIrV1,
     EffectDto,
     LiftReportPayloadDto,
     RecoveredEffectDto,
@@ -66,6 +67,17 @@ _TRANSPORT_LOG = logging.getLogger("sugar.kit.transport")
 _ENUMERATION_PHASES: Dict[str, tuple[int, float, float]] = {}
 _ENUMERATION_REQUEST_COUNT = 0
 _ENUMERATION_ACTIVE = False
+_PUBLISHED_CONTEXT_MANAGER_DECLARATIONS: tuple[ContextManagerContractIrV1, ...] = ()
+
+
+def publish_context_manager_declaration(
+    declaration: ContextManagerContractIrV1,
+) -> None:
+    """Publish a typed bodyless member on the live kit declaration."""
+    global _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS
+    if not isinstance(declaration, ContextManagerContractIrV1):
+        raise ValueError("typed context-manager declaration required")
+    _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS += (declaration,)
 # Passive, process-lifetime context paid for by an enumeration demand. The
 # outer identity is the file content CID; the path seat is retained because
 # source mementos carry the workspace-relative filename even for identical
@@ -553,6 +565,10 @@ def _kit_declaration_result() -> Dict[str, Any]:
             "rpcMethod": "sugar.plugin.resolve_dependency_proofs",
         },
         "residueCategories": [],
+        "contractDeclarations": [
+            row.to_rpc_with_term_table(None)
+            for row in _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS
+        ],
     }
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_contract.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_contract.py
@@ -21,6 +21,7 @@ from sugar_lift_py_tests.kit_rpc import (
 )
 from sugar_lift_py_tests.signing import Signer
 from sugar_lift_py_tests.context_manager_contract import _json_value
+from sugar_lift_py_tests import lift_rpc
 
 
 SEED = bytes(range(32))
@@ -119,3 +120,18 @@ def test_typed_declaration_enters_closed_ir_transport():
     )
     wire = LiftReportPayloadDto(ir=[row]).to_rpc()
     assert wire["ir"] == [row.to_rpc_with_term_table(None)]
+
+
+def test_typed_declaration_is_published_on_the_live_kit_declaration(monkeypatch):
+    row = ContextManagerContractIrV1.never_suppresses(
+        bridge_source_symbol="context-manager:fixture_python.never_closing",
+        import_signature=ImportSignatureV1(formals=(), sorts=()),
+        enter_result_sort=PrimitiveSort("Value"),
+        source_warrants=(),
+    )
+    monkeypatch.setattr(lift_rpc, "_PUBLISHED_CONTEXT_MANAGER_DECLARATIONS", ())
+    lift_rpc.publish_context_manager_declaration(row)
+    declaration = lift_rpc._kit_declaration_result()
+    assert declaration["contractDeclarations"] == [
+        row.to_rpc_with_term_table(None)
+    ]

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_contract.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_contract.py
@@ -1,0 +1,80 @@
+import json
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_contract import (
+    ContextManagerContractError,
+    decode_context_manager_contract,
+    publish_never_suppresses_context_manager_contract,
+)
+from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.signing import Signer
+
+
+SEED = bytes(range(32))
+
+
+def _publish():
+    return publish_never_suppresses_context_manager_contract(
+        name="NeverClosingManager",
+        kit="fixture-python-kit",
+        bridge_source_symbol="context-manager:fixture_python.never_closing",
+        constructor_formals=(),
+        constructor_sorts=(),
+        enter_result_sort=PrimitiveSort("Value"),
+        source_warrants=(),
+        signer=Signer(seed=SEED, producer_id="fixture-python-kit"),
+        declared_at="2026-07-22T00:00:00.000Z",
+    )
+
+
+def test_publish_and_decode_sealed_context_manager_contract():
+    sealed = _publish()
+    decoded = decode_context_manager_contract(sealed.canonical_bytes, sealed.cid)
+    assert decoded.name == "NeverClosingManager"
+    assert decoded.kit == "fixture-python-kit"
+    assert decoded.exit_disposition == "never-suppresses"
+    assert decoded.enter_result_sort == PrimitiveSort("Value")
+    assert decoded.contract_cid == sealed.contract_cid
+
+
+def test_payload_has_exact_architect_shape_plus_sealing_cid():
+    raw = json.loads(_publish().canonical_bytes)
+    header = raw["header"]
+    assert header["schemaVersion"] == "1"
+    assert header["kind"] == "context-manager-contract"
+    assert header["constructorSignature"] == {"formals": [], "sorts": []}
+    assert header["enter"] == {
+        "outcome": "total",
+        "result": {
+            "kind": "projection",
+            "projection": "enter_result",
+            "sort": {"kind": "primitive", "name": "Value"},
+        },
+    }
+    assert header["exit"] == {
+        "outcome": "total",
+        "disposition": {"kind": "never-suppresses"},
+    }
+    assert raw["metadata"] == {}
+
+
+def test_stale_content_cid_is_loud_even_when_shape_is_valid():
+    sealed = _publish()
+    raw = json.loads(sealed.canonical_bytes)
+    raw["header"]["cid"] = "blake3-512:" + "0" * 128
+    with pytest.raises(ContextManagerContractError):
+        decode_context_manager_contract(json.dumps(raw).encode(), sealed.cid)
+
+
+def test_absent_or_non_total_exit_is_not_never_suppresses():
+    sealed = _publish()
+    raw = json.loads(sealed.canonical_bytes)
+    del raw["header"]["exit"]
+    with pytest.raises(ContextManagerContractError):
+        decode_context_manager_contract(json.dumps(raw).encode(), sealed.cid)
+
+    raw = json.loads(sealed.canonical_bytes)
+    raw["header"]["exit"]["outcome"] = "unknown"
+    with pytest.raises(ContextManagerContractError):
+        decode_context_manager_contract(json.dumps(raw).encode(), sealed.cid)

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_contract.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_contract.py
@@ -2,79 +2,120 @@ import json
 
 import pytest
 
+from sugar_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs, vobj
+from sugar_lift_py_tests.claim_envelope import _assemble_layered
 from sugar_lift_py_tests.context_manager_contract import (
     ContextManagerContractError,
+    ContextManagerSemanticsV1,
+    EnterResultContractV1,
+    ExitContractV1,
+    NeverSuppressesDispositionV1,
     decode_context_manager_contract,
     publish_never_suppresses_context_manager_contract,
 )
 from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.kit_rpc import (
+    ContextManagerContractIrV1,
+    ImportSignatureV1,
+    LiftReportPayloadDto,
+)
 from sugar_lift_py_tests.signing import Signer
+from sugar_lift_py_tests.context_manager_contract import _json_value
 
 
 SEED = bytes(range(32))
+DECLARED_AT = "2026-07-22T00:00:00.000Z"
 
 
 def _publish():
     return publish_never_suppresses_context_manager_contract(
-        name="NeverClosingManager",
-        kit="fixture-python-kit",
         bridge_source_symbol="context-manager:fixture_python.never_closing",
-        constructor_formals=(),
-        constructor_sorts=(),
+        import_signature=ImportSignatureV1(formals=(), sorts=()),
         enter_result_sort=PrimitiveSort("Value"),
-        source_warrants=(),
+        source_warrants=("blake3-512:" + "a" * 128,),
         signer=Signer(seed=SEED, producer_id="fixture-python-kit"),
-        declared_at="2026-07-22T00:00:00.000Z",
+        declared_at=DECLARED_AT,
     )
 
 
-def test_publish_and_decode_sealed_context_manager_contract():
+def _reseal(mutator):
+    raw = json.loads(_publish().canonical_bytes)
+    mutator(raw["header"])
+    payload = raw["header"]["payload"]
+    payload_cid = blake3_512_of(encode_jcs(_json_value(payload)).encode())
+    raw["header"]["cid"] = payload_cid
+    raw["header"]["payloadCid"] = payload_cid
+    return _assemble_layered(
+        _json_value(raw["header"]), _json_value(raw["metadata"]), DECLARED_AT, SEED, payload_cid
+    )
+
+
+def test_publish_and_decode_retains_typed_never_suppresses_semantics():
     sealed = _publish()
     decoded = decode_context_manager_contract(sealed.canonical_bytes, sealed.cid)
-    assert decoded.name == "NeverClosingManager"
-    assert decoded.kit == "fixture-python-kit"
-    assert decoded.exit_disposition == "never-suppresses"
-    assert decoded.enter_result_sort == PrimitiveSort("Value")
-    assert decoded.contract_cid == sealed.contract_cid
+    assert decoded.semantics == ContextManagerSemanticsV1(
+        enter=EnterResultContractV1(sort=PrimitiveSort("Value")),
+        exit=ExitContractV1(disposition=NeverSuppressesDispositionV1()),
+    )
+    assert isinstance(decoded.semantics.exit.disposition, NeverSuppressesDispositionV1)
+    assert decoded.payload_cid == sealed.contract_cid
 
 
-def test_payload_has_exact_architect_shape_plus_sealing_cid():
+def test_semantic_payload_is_provider_neutral_and_hashed_alone():
     raw = json.loads(_publish().canonical_bytes)
     header = raw["header"]
-    assert header["schemaVersion"] == "1"
-    assert header["kind"] == "context-manager-contract"
-    assert header["constructorSignature"] == {"formals": [], "sorts": []}
-    assert header["enter"] == {
-        "outcome": "total",
-        "result": {
-            "kind": "projection",
-            "projection": "enter_result",
-            "sort": {"kind": "primitive", "name": "Value"},
+    assert header["schemaVersion"] == "1.2"
+    assert set(header) == {
+        "schemaVersion", "kind", "cid", "payloadCid", "bridgeSourceSymbol",
+        "importSignature", "payload", "sourceWarrants", "inputCids",
+    }
+    assert "name" not in header["payload"] and "kit" not in header["payload"]
+    assert header["payload"] == {
+        "kind": "context-manager-semantics",
+        "schemaVersion": "1",
+        "enter": {
+            "completion": "total",
+            "result": {"kind": "projection", "projection": "enter_result", "sort": {"kind": "primitive", "name": "Value"}},
         },
+        "exit": {"completion": "total", "disposition": {"kind": "never-suppresses"}},
     }
-    assert header["exit"] == {
-        "outcome": "total",
-        "disposition": {"kind": "never-suppresses"},
-    }
-    assert raw["metadata"] == {}
+    assert header["payloadCid"] == blake3_512_of(
+        encode_jcs(_json_value(header["payload"])).encode()
+    )
 
 
-def test_stale_content_cid_is_loud_even_when_shape_is_valid():
+def test_correctly_resealed_unknown_disposition_reaches_typed_decoder():
+    sealed = _reseal(lambda h: h["payload"]["exit"]["disposition"].update(kind="sometimes"))
+    with pytest.raises(ContextManagerContractError, match="unknown exit disposition"):
+        decode_context_manager_contract(sealed.canonical_bytes, sealed.cid)
+
+
+def test_correctly_resealed_missing_enter_reaches_typed_decoder():
+    sealed = _reseal(lambda h: h["payload"].pop("enter"))
+    with pytest.raises(ContextManagerContractError, match="malformed context-manager semantics"):
+        decode_context_manager_contract(sealed.canonical_bytes, sealed.cid)
+
+
+def test_bad_signature_is_distinct_from_stale_payload_cid():
     sealed = _publish()
     raw = json.loads(sealed.canonical_bytes)
-    raw["header"]["cid"] = "blake3-512:" + "0" * 128
-    with pytest.raises(ContextManagerContractError):
-        decode_context_manager_contract(json.dumps(raw).encode(), sealed.cid)
-
-
-def test_absent_or_non_total_exit_is_not_never_suppresses():
-    sealed = _publish()
-    raw = json.loads(sealed.canonical_bytes)
-    del raw["header"]["exit"]
-    with pytest.raises(ContextManagerContractError):
+    raw["header"]["bridgeSourceSymbol"] = "context-manager:mutated"
+    with pytest.raises(ContextManagerContractError, match="signature"):
         decode_context_manager_contract(json.dumps(raw).encode(), sealed.cid)
 
     raw = json.loads(sealed.canonical_bytes)
-    raw["header"]["exit"]["outcome"] = "unknown"
-    with pytest.raises(ContextManagerContractError):
-        decode_context_manager_contract(json.dumps(raw).encode(), sealed.cid)
+    raw["header"]["payloadCid"] = "blake3-512:" + "0" * 128
+    stale = _assemble_layered(_json_value(raw["header"]), _json_value(raw["metadata"]), DECLARED_AT, SEED, raw["header"]["payloadCid"])
+    with pytest.raises(ContextManagerContractError, match="payload CID"):
+        decode_context_manager_contract(stale.canonical_bytes, stale.cid)
+
+
+def test_typed_declaration_enters_closed_ir_transport():
+    row = ContextManagerContractIrV1.never_suppresses(
+        bridge_source_symbol="context-manager:fixture_python.never_closing",
+        import_signature=ImportSignatureV1(formals=(), sorts=()),
+        enter_result_sort=PrimitiveSort("Value"),
+        source_warrants=("blake3-512:" + "a" * 128,),
+    )
+    wire = LiftReportPayloadDto(ir=[row]).to_rpc()
+    assert wire["ir"] == [row.to_rpc_with_term_table(None)]

--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1825,6 +1825,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sugar-canonicalizer",
+ "sugar-ir-types",
  "thiserror",
 ]
 

--- a/implementations/rust/sugar-claim-envelope/src/lib.rs
+++ b/implementations/rust/sugar-claim-envelope/src/lib.rs
@@ -93,6 +93,94 @@ pub struct KitDeclaration {
     pub oracle_host: Option<KitOracleHost>,
     #[serde(rename = "residueCategories")]
     pub residue_categories: Vec<KitResidueCategory>,
+    #[serde(
+        rename = "contractDeclarations",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub contract_declarations: Vec<KitContractDeclarationV1>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum KitContractDeclarationV1 {
+    #[serde(rename = "context-manager-contract")]
+    ContextManager {
+        #[serde(rename = "schemaVersion")]
+        schema_version: String,
+        #[serde(rename = "bridgeSourceSymbol")]
+        bridge_source_symbol: String,
+        #[serde(rename = "importSignature")]
+        import_signature: KitImportSignatureV1,
+        payload: KitContextManagerSemanticsV1,
+        #[serde(rename = "sourceWarrants")]
+        source_warrants: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KitImportSignatureV1 {
+    pub formals: Vec<String>,
+    pub sorts: Vec<sugar_ir_types::Sort>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KitContextManagerSemanticsV1 {
+    pub kind: KitContextManagerSemanticsKindV1,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+    pub enter: KitTotalEnterV1,
+    pub exit: KitTotalExitV1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KitContextManagerSemanticsKindV1 {
+    #[serde(rename = "context-manager-semantics")]
+    ContextManagerSemantics,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KitTotalEnterV1 {
+    pub completion: KitTotalCompletionV1,
+    pub result: KitEnterResultV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KitEnterResultV1 {
+    pub kind: KitProjectionKindV1,
+    pub projection: KitEnterProjectionV1,
+    pub sort: sugar_ir_types::Sort,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KitProjectionKindV1 {
+    #[serde(rename = "projection")]
+    Projection,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KitEnterProjectionV1 {
+    #[serde(rename = "enter_result")]
+    EnterResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KitTotalExitV1 {
+    pub completion: KitTotalCompletionV1,
+    pub disposition: KitExitDispositionV1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KitTotalCompletionV1 {
+    #[serde(rename = "total")]
+    Total,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum KitExitDispositionV1 {
+    #[serde(rename = "never-suppresses")]
+    NeverSuppresses,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -214,6 +302,7 @@ mod kit_declaration_schema_tests {
             },
             oracle_host: None,
             residue_categories: vec![],
+            contract_declarations: vec![],
         }
     }
 

--- a/implementations/rust/sugar-claim-envelope/src/lib.rs
+++ b/implementations/rust/sugar-claim-envelope/src/lib.rs
@@ -36,8 +36,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use sugar_canonicalizer::{blake3_512_of, encode_jcs, json_to_value, Value};
 use sugar_proof_envelope::{
-    ed25519_pubkey_string, ed25519_sign_string, AuthorityMementoRef, ContractMementoRef,
-    Ed25519Seed,
+    context_manager_semantics_v1_to_json, ed25519_pubkey_string, ed25519_sign_string,
+    import_signature_v1_to_json, AuthorityMementoRef, ContextManagerSemanticsV1,
+    ContractMementoRef, Ed25519Seed, ImportSignatureV1,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -404,6 +405,82 @@ fn authoring_to_value(a: &Authoring) -> Arc<Value> {
             Arc::new(Value::Object(entries))
         }
     }
+}
+
+// =============================================================================
+// mint_context_manager_contract
+// =============================================================================
+
+pub struct MintContextManagerContractArgs {
+    pub bridge_source_symbol: String,
+    pub import_signature: ImportSignatureV1,
+    pub semantics: ContextManagerSemanticsV1,
+    pub source_warrants: Vec<String>,
+    pub produced_by: String,
+    pub produced_at: String,
+    pub authoring: Authoring,
+    pub signer_seed: Ed25519Seed,
+}
+
+pub fn mint_context_manager_contract(
+    args: &MintContextManagerContractArgs,
+) -> Result<MintedEnvelope, ClaimEnvelopeError> {
+    if args.bridge_source_symbol.is_empty() {
+        return Err(ClaimEnvelopeError::Other(
+            "context-manager-contract bridgeSourceSymbol must not be empty".into(),
+        ));
+    }
+    if args.import_signature.formals.len() != args.import_signature.sorts.len() {
+        return Err(ClaimEnvelopeError::Other(
+            "context-manager-contract import signature length mismatch".into(),
+        ));
+    }
+    let payload_json = context_manager_semantics_v1_to_json(&args.semantics);
+    let payload = json_to_value(&payload_json)
+        .map_err(|e| ClaimEnvelopeError::Other(format!("CM payload canonicalization: {e}")))?;
+    let payload_cid = hash_value(&payload);
+    let import_signature = json_to_value(&import_signature_v1_to_json(&args.import_signature))
+        .map_err(|e| ClaimEnvelopeError::Other(format!("CM signature canonicalization: {e}")))?;
+    let mut input_cids = args.source_warrants.clone();
+    input_cids.sort();
+    let header = Value::object([
+        ("schemaVersion", Value::string("1.2")),
+        ("kind", Value::string("context-manager-contract")),
+        ("cid", Value::string(payload_cid.clone())),
+        ("payloadCid", Value::string(payload_cid.clone())),
+        (
+            "bridgeSourceSymbol",
+            Value::string(args.bridge_source_symbol.clone()),
+        ),
+        ("importSignature", import_signature),
+        ("payload", payload),
+        (
+            "sourceWarrants",
+            Value::array(
+                args.source_warrants
+                    .iter()
+                    .cloned()
+                    .map(Value::string)
+                    .collect(),
+            ),
+        ),
+        (
+            "inputCids",
+            Value::array(input_cids.into_iter().map(Value::string).collect()),
+        ),
+    ]);
+    let metadata = Value::object([
+        ("authoring", authoring_to_value(&args.authoring)),
+        ("producedBy", Value::string(args.produced_by.clone())),
+        ("producedAt", Value::string(args.produced_at.clone())),
+    ]);
+    Ok(assemble_layered(
+        header,
+        metadata,
+        &args.produced_at,
+        &args.signer_seed,
+        payload_cid,
+    ))
 }
 
 // =============================================================================

--- a/implementations/rust/sugar-compiler/src/feed_from_tree.rs
+++ b/implementations/rust/sugar-compiler/src/feed_from_tree.rs
@@ -34,6 +34,7 @@ use sugar_proof_envelope::{
 
 use crate::kit::{Kit, KitError};
 use crate::tree::{Fact, Sourced, Universe};
+use sugar_claim_envelope::KitDeclaration;
 
 /// Deterministic kit-author seed for feed fragments (content-addressed;
 /// not a sealed production mint identity).
@@ -198,6 +199,20 @@ pub fn graph_from_context_manager_contract_ir(ir: &Json) -> Result<ProofGraph, F
     })?;
     let mut graph = ProofGraph::new();
     graph.push_context_manager_contract(ContextManagerContractMemento::new(minted.canonical_bytes));
+    Ok(graph)
+}
+
+/// Production kit-declaration intake. Every typed declaration is dispatched
+/// through its dedicated member arm before any source-tree construction.
+pub fn graph_from_kit_declaration(declaration: &KitDeclaration) -> Result<ProofGraph, FeedError> {
+    let mut graph = ProofGraph::empty();
+    for row in &declaration.contract_declarations {
+        let wire = serde_json::to_value(row).map_err(|error| FeedError::Incomplete {
+            what: "kit_contract_declaration",
+            detail: error.to_string(),
+        })?;
+        graph = graph.feed(graph_from_context_manager_contract_ir(&wire)?);
+    }
     Ok(graph)
 }
 
@@ -939,7 +954,8 @@ pub fn fold_project(
     // accepted here so the walk face types match the load door; stamping
     // happens in `pool_from_graph_with_speaker`.
     let _ = speaker;
-    fold_claim_tree(kit, workspace_root)
+    let declarations = graph_from_kit_declaration(kit.declaration())?;
+    Ok(declarations.feed(fold_claim_tree(kit, workspace_root)?))
 }
 
 #[cfg(test)]

--- a/implementations/rust/sugar-compiler/src/feed_from_tree.rs
+++ b/implementations/rust/sugar-compiler/src/feed_from_tree.rs
@@ -20,12 +20,16 @@ use serde_json::{json, Value as Json};
 use sugar_canonicalizer::{encode_jcs, json_to_value, Value as CValue};
 use sugar_claim_envelope::{
     body_discharge_default_for_kind, body_discharge_policy_from_fields_with_default, mint_bridge,
-    mint_contract_with_body_cid, Authoring, MintBridgeArgs, MintContractArgs,
+    mint_context_manager_contract, mint_contract_with_body_cid, Authoring, MintBridgeArgs,
+    MintContextManagerContractArgs, MintContractArgs,
 };
+use sugar_ir_types::Sort;
 use sugar_proof_envelope::Speaker;
 use sugar_proof_envelope::{
-    ed25519_pubkey_string, ed25519_sign_string, BridgeMemento, ClaimContractMemento, ContractBody,
-    ContractMementoRef, Ed25519Seed, FlatAtom, ProofGraph, SourceMemento,
+    ed25519_pubkey_string, ed25519_sign_string, BridgeMemento, ClaimContractMemento,
+    ContextManagerContractMemento, ContextManagerSemanticsV1, ContractBody, ContractMementoRef,
+    Ed25519Seed, EnterResultContractV1, ExitContractV1, ExitDispositionV1, FlatAtom,
+    ImportSignatureV1, ProofGraph, SourceMemento,
 };
 
 use crate::kit::{Kit, KitError};
@@ -73,6 +77,128 @@ fn json_to_cvalue(j: &Json) -> Result<Arc<CValue>, FeedError> {
 
 fn true_formula() -> Json {
     json!({"kind": "atomic", "name": "true", "args": []})
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContextManagerContractIrWire {
+    kind: String,
+    #[serde(rename = "schemaVersion")]
+    schema_version: String,
+    #[serde(rename = "bridgeSourceSymbol")]
+    bridge_source_symbol: String,
+    #[serde(rename = "importSignature")]
+    import_signature: ImportSignatureWire,
+    payload: ContextManagerSemanticsWire,
+    #[serde(rename = "sourceWarrants")]
+    source_warrants: Vec<String>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ImportSignatureWire {
+    formals: Vec<String>,
+    sorts: Vec<Sort>,
+}
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContextManagerSemanticsWire {
+    kind: String,
+    #[serde(rename = "schemaVersion")]
+    schema_version: String,
+    enter: EnterWire,
+    exit: ExitWire,
+}
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EnterWire {
+    completion: String,
+    result: EnterResultWire,
+}
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EnterResultWire {
+    kind: String,
+    projection: String,
+    sort: Sort,
+}
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExitWire {
+    completion: String,
+    disposition: DispositionWire,
+}
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DispositionWire {
+    kind: String,
+}
+
+/// Production declaration/feed door for bodyless context-manager contracts.
+/// Registers exactly one signed member and no formula atom or ContractBody.
+pub fn graph_from_context_manager_contract_ir(ir: &Json) -> Result<ProofGraph, FeedError> {
+    let row: ContextManagerContractIrWire =
+        serde_json::from_value(ir.clone()).map_err(|e| FeedError::Incomplete {
+            what: "context_manager_contract_ir",
+            detail: e.to_string(),
+        })?;
+    if row.kind != "context-manager-contract" || row.schema_version != "1" {
+        return Err(FeedError::Incomplete {
+            what: "context_manager_contract_ir",
+            detail: "unsupported declaration schema/kind".into(),
+        });
+    }
+    if row.bridge_source_symbol.is_empty()
+        || row.import_signature.formals.len() != row.import_signature.sorts.len()
+    {
+        return Err(FeedError::Incomplete {
+            what: "context_manager_contract_ir",
+            detail: "invalid binding coordinate or import signature".into(),
+        });
+    }
+    if row.payload.kind != "context-manager-semantics"
+        || row.payload.schema_version != "1"
+        || row.payload.enter.completion != "total"
+        || row.payload.enter.result.kind != "projection"
+        || row.payload.enter.result.projection != "enter_result"
+        || row.payload.exit.completion != "total"
+        || row.payload.exit.disposition.kind != "never-suppresses"
+    {
+        return Err(FeedError::Incomplete {
+            what: "context_manager_contract_ir",
+            detail: "unsupported CM semantics".into(),
+        });
+    }
+    let minted = mint_context_manager_contract(&MintContextManagerContractArgs {
+        bridge_source_symbol: row.bridge_source_symbol,
+        import_signature: ImportSignatureV1 {
+            formals: row.import_signature.formals,
+            sorts: row.import_signature.sorts,
+        },
+        semantics: ContextManagerSemanticsV1 {
+            enter: EnterResultContractV1 {
+                sort: row.payload.enter.result.sort,
+            },
+            exit: ExitContractV1 {
+                disposition: ExitDispositionV1::NeverSuppresses,
+            },
+        },
+        source_warrants: row.source_warrants,
+        produced_by: FEED_PRODUCED_BY.into(),
+        produced_at: FEED_PRODUCED_AT.into(),
+        authoring: Authoring::KitAuthor {
+            author: FEED_PRODUCED_BY.into(),
+            note: Some("bodyless CM declaration feed".into()),
+        },
+        signer_seed: FEED_SIGNER_SEED,
+    })
+    .map_err(|e| FeedError::Mint {
+        what: "mint_context_manager_contract",
+        detail: e.to_string(),
+    })?;
+    let mut graph = ProofGraph::new();
+    graph.push_context_manager_contract(ContextManagerContractMemento::new(minted.canonical_bytes));
+    Ok(graph)
 }
 
 /// Optional IR fields that mint threads onto function-contract / claim members.

--- a/implementations/rust/sugar-compiler/tests/context_manager_contract_feed.rs
+++ b/implementations/rust/sugar-compiler/tests/context_manager_contract_feed.rs
@@ -10,7 +10,8 @@ fn production_kit_declaration_becomes_bodyless_signed_graph_member() {
     let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .ancestors()
         .nth(3)
-        .unwrap();
+        .unwrap()
+        .to_path_buf();
     let python_path = repo.join("implementations/python/sugar-lift-py-tests/src");
     let program = r#"
 import json

--- a/implementations/rust/sugar-compiler/tests/context_manager_contract_feed.rs
+++ b/implementations/rust/sugar-compiler/tests/context_manager_contract_feed.rs
@@ -1,0 +1,48 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_json::Value as Json;
+use sugar_compiler::feed_from_tree::graph_from_context_manager_contract_ir;
+use sugar_proof_envelope::{ExitDispositionV1, Member, MemberKind};
+
+#[test]
+fn production_kit_declaration_becomes_bodyless_signed_graph_member() {
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap();
+    let python_path = repo.join("implementations/python/sugar-lift-py-tests/src");
+    let program = r#"
+import json
+from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.kit_rpc import ContextManagerContractIrV1, ImportSignatureV1
+row = ContextManagerContractIrV1.never_suppresses(bridge_source_symbol='context-manager:fixture_python.never_closing', import_signature=ImportSignatureV1(formals=(), sorts=()), enter_result_sort=PrimitiveSort('Value'), source_warrants=('blake3-512:' + 'a' * 128,))
+print(json.dumps(row.to_rpc_with_term_table(None)))
+"#;
+    let output = Command::new("python3")
+        .env("PYTHONPATH", python_path)
+        .arg("-c")
+        .arg(program)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let row: Json = serde_json::from_slice(&output.stdout).unwrap();
+    let graph = graph_from_context_manager_contract_ir(&row).expect("dedicated CM feed arm");
+    assert_eq!(graph.atoms().count(), 0);
+    assert_eq!(graph.bodies().count(), 0);
+    let views: Vec<_> = graph.members_view().collect();
+    assert_eq!(views.len(), 1);
+    assert_eq!(views[0].kind(), Some(MemberKind::ContextManagerContract));
+    assert_eq!(views[0].body_cid(), None);
+    let Member::ContextManagerContract(cm) = Member::parse(views[0].bytes()).unwrap() else {
+        panic!("dedicated CM member")
+    };
+    assert_eq!(
+        cm.semantics.exit.disposition,
+        ExitDispositionV1::NeverSuppresses
+    );
+}

--- a/implementations/rust/sugar-compiler/tests/context_manager_contract_feed.rs
+++ b/implementations/rust/sugar-compiler/tests/context_manager_contract_feed.rs
@@ -2,7 +2,10 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use serde_json::Value as Json;
-use sugar_compiler::feed_from_tree::graph_from_context_manager_contract_ir;
+use sugar_claim_envelope::KitDeclaration;
+use sugar_compiler::feed_from_tree::{
+    graph_from_context_manager_contract_ir, graph_from_kit_declaration,
+};
 use sugar_compiler::orchestrate::pool_from_graph_with_speaker;
 use sugar_proof_envelope::{ExitDispositionV1, Member, MemberKind, Speaker};
 
@@ -53,4 +56,32 @@ print(json.dumps(row.to_rpc_with_term_table(None)))
         pool.member_count_by_kind(MemberKind::ContextManagerContract),
         1
     );
+}
+
+#[test]
+fn live_kit_declaration_dispatches_cm_rows_through_dedicated_feed_arm() {
+    let declaration: KitDeclaration = serde_json::from_value(serde_json::json!({
+        "kit": {"id": "fixture", "language": "python", "version": "1"},
+        "rpc": {"methods": [{"name": "sugar.plugin.kit_declaration", "required": true}]},
+        "proofResolution": {"strategy": "rpc-proof-bytes"},
+        "residueCategories": [],
+        "contractDeclarations": [{
+            "kind": "context-manager-contract",
+            "schemaVersion": "1",
+            "bridgeSourceSymbol": "context-manager:fixture.manager",
+            "importSignature": {"formals": [], "sorts": []},
+            "payload": {
+                "kind": "context-manager-semantics", "schemaVersion": "1",
+                "enter": {"completion": "total", "result": {"kind": "projection", "projection": "enter_result", "sort": {"kind": "primitive", "name": "Value"}}},
+                "exit": {"completion": "total", "disposition": {"kind": "never-suppresses"}}
+            },
+            "sourceWarrants": []
+        }]
+    })).expect("typed kit declaration");
+    let graph = graph_from_kit_declaration(&declaration).expect("production declaration feed");
+    assert_eq!(graph.atoms().count(), 0);
+    assert_eq!(graph.bodies().count(), 0);
+    let views: Vec<_> = graph.members_view().collect();
+    assert_eq!(views.len(), 1);
+    assert_eq!(views[0].kind(), Some(MemberKind::ContextManagerContract));
 }

--- a/implementations/rust/sugar-compiler/tests/context_manager_contract_feed.rs
+++ b/implementations/rust/sugar-compiler/tests/context_manager_contract_feed.rs
@@ -3,7 +3,8 @@ use std::process::Command;
 
 use serde_json::Value as Json;
 use sugar_compiler::feed_from_tree::graph_from_context_manager_contract_ir;
-use sugar_proof_envelope::{ExitDispositionV1, Member, MemberKind};
+use sugar_compiler::orchestrate::pool_from_graph_with_speaker;
+use sugar_proof_envelope::{ExitDispositionV1, Member, MemberKind, Speaker};
 
 #[test]
 fn production_kit_declaration_becomes_bodyless_signed_graph_member() {
@@ -45,5 +46,11 @@ print(json.dumps(row.to_rpc_with_term_table(None)))
     assert_eq!(
         cm.semantics.exit.disposition,
         ExitDispositionV1::NeverSuppresses
+    );
+    let pool = pool_from_graph_with_speaker(&graph, Speaker::consumer("fixture-consumer"))
+        .expect("ordinary authenticated member-pool intake");
+    assert_eq!(
+        pool.member_count_by_kind(MemberKind::ContextManagerContract),
+        1
     );
 }

--- a/implementations/rust/sugar-proof-envelope/Cargo.toml
+++ b/implementations/rust/sugar-proof-envelope/Cargo.toml
@@ -8,6 +8,7 @@ description = "Sugar: deterministic CBOR (.proof) builder + Ed25519 signing help
 
 [dependencies]
 sugar-canonicalizer = { path = "../sugar-canonicalizer" }
+sugar-ir-types = { path = "../sugar-ir-types" }
 ed25519-dalek = { workspace = true }
 base64 = { workspace = true }
 hex = { workspace = true }

--- a/implementations/rust/sugar-proof-envelope/src/lib.rs
+++ b/implementations/rust/sugar-proof-envelope/src/lib.rs
@@ -53,12 +53,12 @@ pub use proof::{build_proof_envelope, ProofEnvelopeInput, ProofEnvelopeOutput};
 pub use proof_graph::{
     member_body, member_field, member_kind, member_signature, member_signer, recompute_member_cid,
     verify_member_signature, AnchoredMember, AssertionSurfaceMemento, AtomCid, AtomMemento,
-    AuthorityMemento, AuthorityMementoRef, BridgeMemento, ClaimContractMemento, ContractBody,
-    ContractBodyCid, ContractEntry, ContractMemento, ContractMementoRef,
-    EffectSiteAnnotationMemento, FactoryWalkMemento, FlatAtom, ImplicationMemento,
-    LibrarySugarBindingMemento, MemberView, MementoCid, PlanMemberBytesError, PlanMemento,
-    ProofCatalog, ProofGraph, ProofIdentity, ProofRunMemento, SourceMemento, StageReceiptMemento,
-    StoredMember, WitnessClaimMemento, WitnessMemento,
+    AuthorityMemento, AuthorityMementoRef, BridgeMemento, ClaimContractMemento,
+    ContextManagerContractMemento, ContractBody, ContractBodyCid, ContractEntry, ContractMemento,
+    ContractMementoRef, EffectSiteAnnotationMemento, FactoryWalkMemento, FlatAtom,
+    ImplicationMemento, LibrarySugarBindingMemento, MemberView, MementoCid, PlanMemberBytesError,
+    PlanMemento, ProofCatalog, ProofGraph, ProofIdentity, ProofRunMemento, SourceMemento,
+    StageReceiptMemento, StoredMember, WitnessClaimMemento, WitnessMemento,
 };
 pub use sign::{
     ed25519_pubkey_string, ed25519_sign_string, ed25519_sign_with_seed, ed25519_verify_bytes,
@@ -66,10 +66,12 @@ pub use sign::{
     SignatureParseError, ED25519_KEY_PREFIX, ED25519_SIG_PREFIX,
 };
 pub use typed_member::{
+    context_manager_semantics_v1_to_json, import_signature_v1_to_json,
     AssertionSurfaceMementoMember, AuthorityMember, BridgeMember, ContextManagerContractMember,
-    ContractMember, EffectSiteAnnotationMember, FactoryWalkMementoMember, ImplicationMember,
-    LibrarySugarBindingEntryMember, Member, MemberError, MemberKind, PlanMementoMember,
-    ProofRunMember, SourceMementoMember, StageReceiptMember, WitnessClaimMember,
+    ContextManagerSemanticsV1, ContractMember, EffectSiteAnnotationMember, EnterResultContractV1,
+    ExitContractV1, ExitDispositionV1, FactoryWalkMementoMember, ImplicationMember,
+    ImportSignatureV1, LibrarySugarBindingEntryMember, Member, MemberError, MemberKind,
+    PlanMementoMember, ProofRunMember, SourceMementoMember, StageReceiptMember, WitnessClaimMember,
     WitnessMementoMember,
 };
 

--- a/implementations/rust/sugar-proof-envelope/src/lib.rs
+++ b/implementations/rust/sugar-proof-envelope/src/lib.rs
@@ -66,8 +66,8 @@ pub use sign::{
     SignatureParseError, ED25519_KEY_PREFIX, ED25519_SIG_PREFIX,
 };
 pub use typed_member::{
-    AssertionSurfaceMementoMember, AuthorityMember, BridgeMember, ContractMember,
-    EffectSiteAnnotationMember, FactoryWalkMementoMember, ImplicationMember,
+    AssertionSurfaceMementoMember, AuthorityMember, BridgeMember, ContextManagerContractMember,
+    ContractMember, EffectSiteAnnotationMember, FactoryWalkMementoMember, ImplicationMember,
     LibrarySugarBindingEntryMember, Member, MemberError, MemberKind, PlanMementoMember,
     ProofRunMember, SourceMementoMember, StageReceiptMember, WitnessClaimMember,
     WitnessMementoMember,

--- a/implementations/rust/sugar-proof-envelope/src/memento_pool.rs
+++ b/implementations/rust/sugar-proof-envelope/src/memento_pool.rs
@@ -1142,6 +1142,7 @@ impl MementoPool {
             | Some(MemberKind::Authority)
             | Some(MemberKind::Bridge)
             | Some(MemberKind::Contract)
+            | Some(MemberKind::ContextManagerContract)
             | Some(MemberKind::EffectSiteAnnotation)
             | Some(MemberKind::FactoryWalkMemento)
             | Some(MemberKind::Implication)

--- a/implementations/rust/sugar-proof-envelope/src/proof_graph.rs
+++ b/implementations/rust/sugar-proof-envelope/src/proof_graph.rs
@@ -1132,6 +1132,7 @@ fn layered_signature_header(envelope: &Json, header: &Json) -> Result<Json, Stri
         | Ok(MemberKind::Bridge)
         | Ok(MemberKind::ClosureBinding)
         | Ok(MemberKind::Contract)
+        | Ok(MemberKind::ContextManagerContract)
         | Ok(MemberKind::EffectSiteAnnotation)
         | Ok(MemberKind::FactoryWalkMemento)
         | Ok(MemberKind::Implication)

--- a/implementations/rust/sugar-proof-envelope/src/proof_graph.rs
+++ b/implementations/rust/sugar-proof-envelope/src/proof_graph.rs
@@ -553,6 +553,7 @@ macro_rules! layered_memento {
 layered_memento!(AuthorityMemento, ["authority"]);
 layered_memento!(BridgeMemento, ["bridge"]);
 layered_memento!(ClaimContractMemento, ["contract"]);
+layered_memento!(ContextManagerContractMemento, ["context-manager-contract"]);
 layered_memento!(EffectSiteAnnotationMemento, ["effect-site-annotation"]);
 layered_memento!(ImplicationMemento, ["implication"]);
 layered_memento!(ProofRunMemento, ["proof-run"]);
@@ -1601,6 +1602,10 @@ impl ProofGraph {
     }
 
     pub fn push_claim_contract(&mut self, memento: ClaimContractMemento) {
+        self.insert_member(memento.record);
+    }
+
+    pub fn push_context_manager_contract(&mut self, memento: ContextManagerContractMemento) {
         self.insert_member(memento.record);
     }
 

--- a/implementations/rust/sugar-proof-envelope/src/typed_member.rs
+++ b/implementations/rust/sugar-proof-envelope/src/typed_member.rs
@@ -14,7 +14,7 @@
 use std::fmt;
 use std::str::FromStr;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value as Json;
 use sugar_canonicalizer::{blake3_512_of, encode_jcs};
 use sugar_ir_types::Sort;
@@ -889,14 +889,62 @@ impl StageReceiptMember {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContextManagerContractMember {
-    pub cid: MementoCid,
-    pub name: String,
-    pub kit: String,
+    pub payload_cid: MementoCid,
     pub bridge_source_symbol: String,
-    pub constructor_formals: Vec<String>,
-    pub constructor_sorts: Vec<Sort>,
-    pub enter_result_sort: Sort,
-    pub source_warrants: Vec<Json>,
+    pub import_signature: ImportSignatureV1,
+    pub semantics: ContextManagerSemanticsV1,
+    pub source_warrants: Vec<String>,
+    pub input_cids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportSignatureV1 {
+    pub formals: Vec<String>,
+    pub sorts: Vec<Sort>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextManagerSemanticsV1 {
+    pub enter: EnterResultContractV1,
+    pub exit: ExitContractV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnterResultContractV1 {
+    pub sort: Sort,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExitContractV1 {
+    pub disposition: ExitDispositionV1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitDispositionV1 {
+    NeverSuppresses,
+}
+
+pub fn context_manager_semantics_v1_to_json(value: &ContextManagerSemanticsV1) -> Json {
+    serde_json::json!({
+        "kind": "context-manager-semantics",
+        "schemaVersion": "1",
+        "enter": {
+            "completion": "total",
+            "result": {
+                "kind": "projection",
+                "projection": "enter_result",
+                "sort": value.enter.sort,
+            },
+        },
+        "exit": {
+            "completion": "total",
+            "disposition": {"kind": "never-suppresses"},
+        },
+    })
+}
+
+pub fn import_signature_v1_to_json(value: &ImportSignatureV1) -> Json {
+    serde_json::json!({"formals": value.formals, "sorts": value.sorts})
 }
 
 #[derive(Deserialize)]
@@ -906,46 +954,56 @@ struct ContextManagerHeader {
     schema_version: String,
     kind: String,
     cid: String,
-    name: String,
-    kit: String,
+    #[serde(rename = "payloadCid")]
+    payload_cid: String,
     #[serde(rename = "bridgeSourceSymbol")]
     bridge_source_symbol: String,
-    #[serde(rename = "constructorSignature")]
-    constructor_signature: ConstructorSignature,
-    enter: EnterContract,
-    exit: ExitContract,
+    #[serde(rename = "importSignature")]
+    import_signature: ImportSignatureWire,
+    payload: ContextManagerSemanticsWire,
     #[serde(rename = "sourceWarrants")]
-    source_warrants: Vec<Json>,
+    source_warrants: Vec<String>,
+    #[serde(rename = "inputCids")]
+    input_cids: Vec<String>,
 }
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-struct ConstructorSignature {
+struct ImportSignatureWire {
     formals: Vec<String>,
     sorts: Vec<Sort>,
 }
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-struct EnterContract {
-    outcome: String,
-    result: EnterResult,
+struct ContextManagerSemanticsWire {
+    kind: String,
+    #[serde(rename = "schemaVersion")]
+    schema_version: String,
+    enter: EnterContractWire,
+    exit: ExitContractWire,
 }
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-struct EnterResult {
+struct EnterContractWire {
+    completion: String,
+    result: EnterResultWire,
+}
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct EnterResultWire {
     kind: String,
     projection: String,
     sort: Sort,
 }
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-struct ExitContract {
-    outcome: String,
-    disposition: ExitDisposition,
+struct ExitContractWire {
+    completion: String,
+    disposition: ExitDispositionWire,
 }
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-struct ExitDisposition {
+struct ExitDispositionWire {
     kind: String,
 }
 
@@ -964,17 +1022,12 @@ impl ContextManagerContractMember {
                 "expected only envelope, header, and metadata layers".into(),
             ));
         }
-        let metadata = value
+        let _metadata = value
             .get("metadata")
             .and_then(Json::as_object)
             .ok_or_else(|| {
                 MemberError::InvalidContextManagerContract("layered metadata is missing".into())
             })?;
-        if !metadata.is_empty() {
-            return Err(MemberError::InvalidContextManagerContract(
-                "metadata must be empty in schema 1".into(),
-            ));
-        }
         let raw_header = value.get("header").cloned().ok_or_else(|| {
             MemberError::InvalidContextManagerContract("layered header is missing".into())
         })?;
@@ -982,65 +1035,87 @@ impl ContextManagerContractMember {
             serde_json::from_value(raw_header.clone()).map_err(|e| {
                 MemberError::InvalidContextManagerContract(format!("malformed header: {e}"))
             })?;
-        if header.schema_version != "1" || header.kind != "context-manager-contract" {
+        if header.schema_version != "1.2" || header.kind != "context-manager-contract" {
             return Err(MemberError::InvalidContextManagerContract(
                 "schemaVersion/kind mismatch".into(),
             ));
         }
-        if header.name.is_empty() || header.kit.is_empty() || header.bridge_source_symbol.is_empty()
+        if header.bridge_source_symbol.is_empty() {
+            return Err(MemberError::InvalidContextManagerContract(
+                "bridgeSourceSymbol must be non-empty".into(),
+            ));
+        }
+        if header.import_signature.formals.len() != header.import_signature.sorts.len() {
+            return Err(MemberError::InvalidContextManagerContract(
+                "import signature formals/sorts length mismatch".into(),
+            ));
+        }
+        if header.payload.kind != "context-manager-semantics"
+            || header.payload.schema_version != "1"
+            || header.payload.enter.completion != "total"
+            || header.payload.enter.result.kind != "projection"
+            || header.payload.enter.result.projection != "enter_result"
         {
             return Err(MemberError::InvalidContextManagerContract(
-                "identity fields must be non-empty".into(),
+                "unsupported context-manager semantics or enter testimony".into(),
             ));
         }
-        if header.constructor_signature.formals.len() != header.constructor_signature.sorts.len() {
-            return Err(MemberError::InvalidContextManagerContract(
-                "constructor formals/sorts length mismatch".into(),
-            ));
-        }
-        if header.enter.outcome != "total"
-            || header.enter.result.kind != "projection"
-            || header.enter.result.projection != "enter_result"
+        if header.payload.exit.completion != "total"
+            || header.payload.exit.disposition.kind != "never-suppresses"
         {
             return Err(MemberError::InvalidContextManagerContract(
-                "enter testimony is not total enter_result projection".into(),
+                "unknown exit disposition or non-total exit testimony".into(),
             ));
         }
-        if header.exit.outcome != "total" || header.exit.disposition.kind != "never-suppresses" {
-            return Err(MemberError::InvalidContextManagerContract(
-                "exit testimony is not total NeverSuppresses".into(),
-            ));
-        }
-        let mut payload = raw_header;
-        payload
-            .as_object_mut()
-            .expect("decoded header is object")
-            .shift_remove("cid");
+        let payload = serde_json::to_value(&header.payload).expect("typed payload serializes");
         let derived = blake3_512_of(
             encode_jcs(&crate::proof_graph::json_to_canonical_value(&payload)).as_bytes(),
         );
-        if derived != header.cid {
+        if derived != header.cid || derived != header.payload_cid {
             return Err(MemberError::InvalidContextManagerContract(format!(
-                "content CID {} derives to {derived}",
-                header.cid
+                "payload CID mismatch: cid={} payloadCid={} derived={derived}",
+                header.cid, header.payload_cid
             )));
         }
-        let cid = MementoCid::try_parse(header.cid.clone()).map_err(|raw| {
+        let payload_cid = MementoCid::try_parse(header.payload_cid.clone()).map_err(|raw| {
             MemberError::InvalidCidFormat {
                 kind: "context-manager-contract".into(),
-                field: "cid".into(),
+                field: "payloadCid".into(),
                 raw,
             }
         })?;
+        let mut sorted_warrants = header.source_warrants.clone();
+        if sorted_warrants
+            .iter()
+            .any(|cid| AtomCid::try_parse(cid.clone()).is_err())
+        {
+            return Err(MemberError::InvalidContextManagerContract(
+                "sourceWarrants contain a malformed CID".into(),
+            ));
+        }
+        sorted_warrants.sort();
+        if header.input_cids != sorted_warrants {
+            return Err(MemberError::InvalidContextManagerContract(
+                "inputCids do not equal sorted sourceWarrants".into(),
+            ));
+        }
         Ok(Self {
-            cid,
-            name: header.name,
-            kit: header.kit,
+            payload_cid,
             bridge_source_symbol: header.bridge_source_symbol,
-            constructor_formals: header.constructor_signature.formals,
-            constructor_sorts: header.constructor_signature.sorts,
-            enter_result_sort: header.enter.result.sort,
+            import_signature: ImportSignatureV1 {
+                formals: header.import_signature.formals,
+                sorts: header.import_signature.sorts,
+            },
+            semantics: ContextManagerSemanticsV1 {
+                enter: EnterResultContractV1 {
+                    sort: header.payload.enter.result.sort,
+                },
+                exit: ExitContractV1 {
+                    disposition: ExitDispositionV1::NeverSuppresses,
+                },
+            },
             source_warrants: header.source_warrants,
+            input_cids: header.input_cids,
         })
     }
 }

--- a/implementations/rust/sugar-proof-envelope/src/typed_member.rs
+++ b/implementations/rust/sugar-proof-envelope/src/typed_member.rs
@@ -14,7 +14,10 @@
 use std::fmt;
 use std::str::FromStr;
 
+use serde::Deserialize;
 use serde_json::Value as Json;
+use sugar_canonicalizer::{blake3_512_of, encode_jcs};
+use sugar_ir_types::Sort;
 
 use crate::proof_graph::{AtomCid, ContractBodyCid, MementoCid};
 
@@ -49,13 +52,16 @@ pub enum MemberError {
         raw: String,
     },
 
+    #[error("context-manager-contract: {0}")]
+    InvalidContextManagerContract(String),
+
     #[error("CID not present in graph: {0}")]
     UnknownCid(String),
 }
 
 // ─── Member kind ────────────────────────────────────────────────────────────
 
-pub const KNOWN_MEMBER_KINDS: &str = "aliasing-memento, assertion-surface-memento, authority, bridge, closure-binding, contract, effect-site-annotation, factory-walk-memento, implication, library-sugar-binding-entry, loop-invariant, pin-invariant, plan-memento, proof-run, source-memento, stage-receipt, try-branch, witness, witness-memento";
+pub const KNOWN_MEMBER_KINDS: &str = "aliasing-memento, assertion-surface-memento, authority, bridge, closure-binding, context-manager-contract, contract, effect-site-annotation, factory-walk-memento, implication, library-sugar-binding-entry, loop-invariant, pin-invariant, plan-memento, proof-run, source-memento, stage-receipt, try-branch, witness, witness-memento";
 
 /// Wire member kind. Strings enter and leave only at serde/display boundaries;
 /// production branching should match this enum exhaustively.
@@ -67,6 +73,7 @@ pub enum MemberKind {
     Bridge,
     ClosureBinding,
     Contract,
+    ContextManagerContract,
     EffectSiteAnnotation,
     FactoryWalkMemento,
     Implication,
@@ -91,6 +98,7 @@ impl MemberKind {
             MemberKind::Bridge => "bridge",
             MemberKind::ClosureBinding => "closure-binding",
             MemberKind::Contract => "contract",
+            MemberKind::ContextManagerContract => "context-manager-contract",
             MemberKind::EffectSiteAnnotation => "effect-site-annotation",
             MemberKind::FactoryWalkMemento => "factory-walk-memento",
             MemberKind::Implication => "implication",
@@ -125,6 +133,7 @@ impl FromStr for MemberKind {
             "bridge" => Ok(MemberKind::Bridge),
             "closure-binding" => Ok(MemberKind::ClosureBinding),
             "contract" => Ok(MemberKind::Contract),
+            "context-manager-contract" => Ok(MemberKind::ContextManagerContract),
             "effect-site-annotation" => Ok(MemberKind::EffectSiteAnnotation),
             "factory-walk-memento" => Ok(MemberKind::FactoryWalkMemento),
             "implication" => Ok(MemberKind::Implication),
@@ -878,10 +887,169 @@ impl StageReceiptMember {
 
 // ─── Member enum + parse entrypoint ──────────────────────────────────────────
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextManagerContractMember {
+    pub cid: MementoCid,
+    pub name: String,
+    pub kit: String,
+    pub bridge_source_symbol: String,
+    pub constructor_formals: Vec<String>,
+    pub constructor_sorts: Vec<Sort>,
+    pub enter_result_sort: Sort,
+    pub source_warrants: Vec<Json>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContextManagerHeader {
+    #[serde(rename = "schemaVersion")]
+    schema_version: String,
+    kind: String,
+    cid: String,
+    name: String,
+    kit: String,
+    #[serde(rename = "bridgeSourceSymbol")]
+    bridge_source_symbol: String,
+    #[serde(rename = "constructorSignature")]
+    constructor_signature: ConstructorSignature,
+    enter: EnterContract,
+    exit: ExitContract,
+    #[serde(rename = "sourceWarrants")]
+    source_warrants: Vec<Json>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConstructorSignature {
+    formals: Vec<String>,
+    sorts: Vec<Sort>,
+}
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EnterContract {
+    outcome: String,
+    result: EnterResult,
+}
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EnterResult {
+    kind: String,
+    projection: String,
+    sort: Sort,
+}
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExitContract {
+    outcome: String,
+    disposition: ExitDisposition,
+}
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExitDisposition {
+    kind: String,
+}
+
+impl ContextManagerContractMember {
+    fn from_value(value: &Json) -> Result<Self, MemberError> {
+        let root = value.as_object().ok_or_else(|| {
+            MemberError::InvalidContextManagerContract("layered member must be an object".into())
+        })?;
+        if root.len() != 3
+            || !root.contains_key("envelope")
+            || !root.contains_key("header")
+            || !root.contains_key("metadata")
+            || !root.get("envelope").is_some_and(Json::is_object)
+        {
+            return Err(MemberError::InvalidContextManagerContract(
+                "expected only envelope, header, and metadata layers".into(),
+            ));
+        }
+        let metadata = value
+            .get("metadata")
+            .and_then(Json::as_object)
+            .ok_or_else(|| {
+                MemberError::InvalidContextManagerContract("layered metadata is missing".into())
+            })?;
+        if !metadata.is_empty() {
+            return Err(MemberError::InvalidContextManagerContract(
+                "metadata must be empty in schema 1".into(),
+            ));
+        }
+        let raw_header = value.get("header").cloned().ok_or_else(|| {
+            MemberError::InvalidContextManagerContract("layered header is missing".into())
+        })?;
+        let header: ContextManagerHeader =
+            serde_json::from_value(raw_header.clone()).map_err(|e| {
+                MemberError::InvalidContextManagerContract(format!("malformed header: {e}"))
+            })?;
+        if header.schema_version != "1" || header.kind != "context-manager-contract" {
+            return Err(MemberError::InvalidContextManagerContract(
+                "schemaVersion/kind mismatch".into(),
+            ));
+        }
+        if header.name.is_empty() || header.kit.is_empty() || header.bridge_source_symbol.is_empty()
+        {
+            return Err(MemberError::InvalidContextManagerContract(
+                "identity fields must be non-empty".into(),
+            ));
+        }
+        if header.constructor_signature.formals.len() != header.constructor_signature.sorts.len() {
+            return Err(MemberError::InvalidContextManagerContract(
+                "constructor formals/sorts length mismatch".into(),
+            ));
+        }
+        if header.enter.outcome != "total"
+            || header.enter.result.kind != "projection"
+            || header.enter.result.projection != "enter_result"
+        {
+            return Err(MemberError::InvalidContextManagerContract(
+                "enter testimony is not total enter_result projection".into(),
+            ));
+        }
+        if header.exit.outcome != "total" || header.exit.disposition.kind != "never-suppresses" {
+            return Err(MemberError::InvalidContextManagerContract(
+                "exit testimony is not total NeverSuppresses".into(),
+            ));
+        }
+        let mut payload = raw_header;
+        payload
+            .as_object_mut()
+            .expect("decoded header is object")
+            .shift_remove("cid");
+        let derived = blake3_512_of(
+            encode_jcs(&crate::proof_graph::json_to_canonical_value(&payload)).as_bytes(),
+        );
+        if derived != header.cid {
+            return Err(MemberError::InvalidContextManagerContract(format!(
+                "content CID {} derives to {derived}",
+                header.cid
+            )));
+        }
+        let cid = MementoCid::try_parse(header.cid.clone()).map_err(|raw| {
+            MemberError::InvalidCidFormat {
+                kind: "context-manager-contract".into(),
+                field: "cid".into(),
+                raw,
+            }
+        })?;
+        Ok(Self {
+            cid,
+            name: header.name,
+            kit: header.kit,
+            bridge_source_symbol: header.bridge_source_symbol,
+            constructor_formals: header.constructor_signature.formals,
+            constructor_sorts: header.constructor_signature.sorts,
+            enter_result_sort: header.enter.result.sort,
+            source_warrants: header.source_warrants,
+        })
+    }
+}
+
 /// Typed, parsed member. One variant per known kind.
 #[derive(Debug, Clone)]
 pub enum Member {
     Contract(ContractMember),
+    ContextManagerContract(ContextManagerContractMember),
     Bridge(BridgeMember),
     Implication(ImplicationMember),
     Authority(AuthorityMember),
@@ -918,6 +1086,9 @@ impl Member {
         let nb = normalize(value)?;
         match nb.kind {
             MemberKind::Contract => Ok(Member::Contract(ContractMember::from_normalized(&nb)?)),
+            MemberKind::ContextManagerContract => Ok(Member::ContextManagerContract(
+                ContextManagerContractMember::from_value(value)?,
+            )),
             MemberKind::Bridge => Ok(Member::Bridge(BridgeMember::from_normalized(&nb)?)),
             MemberKind::Implication => Ok(Member::Implication(ImplicationMember::from_normalized(
                 &nb,
@@ -981,6 +1152,7 @@ impl Member {
     pub fn kind(&self) -> MemberKind {
         match self {
             Member::Contract(_) => MemberKind::Contract,
+            Member::ContextManagerContract(_) => MemberKind::ContextManagerContract,
             Member::Bridge(_) => MemberKind::Bridge,
             Member::Implication(_) => MemberKind::Implication,
             Member::Authority(_) => MemberKind::Authority,
@@ -1370,6 +1542,10 @@ mod tests {
             ("bridge", MemberKind::Bridge),
             ("closure-binding", MemberKind::ClosureBinding),
             ("contract", MemberKind::Contract),
+            (
+                "context-manager-contract",
+                MemberKind::ContextManagerContract,
+            ),
             ("effect-site-annotation", MemberKind::EffectSiteAnnotation),
             ("factory-walk-memento", MemberKind::FactoryWalkMemento),
             ("implication", MemberKind::Implication),

--- a/implementations/rust/sugar-proof-envelope/tests/context_manager_contract_python_roundtrip.rs
+++ b/implementations/rust/sugar-proof-envelope/tests/context_manager_contract_python_roundtrip.rs
@@ -1,0 +1,77 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_json::Value as Json;
+use sugar_ir_types::Sort;
+use sugar_proof_envelope::{AnchoredMember, Member, MementoCid};
+
+#[test]
+fn python_published_cm_contract_decodes_as_sealed_typed_rust_member() {
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .expect("repository root")
+        .to_path_buf();
+    let python_path = repo.join("implementations/python/sugar-lift-py-tests/src");
+    let program = r#"
+import json
+from sugar_lift_py_tests.context_manager_contract import publish_never_suppresses_context_manager_contract
+from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.signing import Signer
+m = publish_never_suppresses_context_manager_contract(name='NeverClosingManager', kit='fixture-python-kit', bridge_source_symbol='context-manager:fixture_python.never_closing', constructor_formals=(), constructor_sorts=(), enter_result_sort=PrimitiveSort('Value'), source_warrants=(), signer=Signer(bytes(range(32)), 'fixture-python-kit'), declared_at='2026-07-22T00:00:00.000Z')
+print(json.dumps({'cid': m.cid, 'member': json.loads(m.canonical_bytes)}))
+"#;
+    let output = Command::new("python3")
+        .env("PYTHONPATH", python_path)
+        .arg("-c")
+        .arg(program)
+        .output()
+        .expect("run Python CM-contract publisher");
+    assert!(
+        output.status.success(),
+        "Python publisher failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let wire: Json = serde_json::from_slice(&output.stdout).expect("publisher JSON");
+    let cid = MementoCid::try_parse(wire["cid"].as_str().expect("member CID").to_string())
+        .expect("typed member CID");
+    let anchored = AnchoredMember::new(cid, wire["member"].clone())
+        .expect("attestation CID and signature verify");
+    let member = Member::from_value(anchored.envelope()).expect("typed CM contract decoder");
+    let Member::ContextManagerContract(cm) = member else {
+        panic!("expected dedicated CM-contract member")
+    };
+    assert_eq!(cm.name, "NeverClosingManager");
+    assert_eq!(cm.kit, "fixture-python-kit");
+    assert_eq!(
+        cm.bridge_source_symbol,
+        "context-manager:fixture_python.never_closing"
+    );
+    assert!(cm.constructor_formals.is_empty());
+    assert!(cm.constructor_sorts.is_empty());
+    assert_eq!(
+        cm.enter_result_sort,
+        Sort::Primitive {
+            name: "Value".to_string()
+        }
+    );
+    assert!(cm.source_warrants.is_empty());
+}
+
+#[test]
+fn stale_content_cid_stays_loud() {
+    let member = serde_json::json!({
+        "envelope": {}, "metadata": {},
+        "header": {
+            "schemaVersion":"1", "kind":"context-manager-contract",
+            "cid": format!("blake3-512:{}", "0".repeat(128)),
+            "name":"N", "kit":"K", "bridgeSourceSymbol":"context-manager:m.n",
+            "constructorSignature":{"formals":[],"sorts":[]},
+            "enter":{"outcome":"total","result":{"kind":"projection","projection":"enter_result","sort":{"kind":"primitive","name":"Value"}}},
+            "exit":{"outcome":"total","disposition":{"kind":"never-suppresses"}},
+            "sourceWarrants": []
+        }
+    });
+    let error = Member::from_value(&member).expect_err("stale CID must be loud");
+    assert!(error.to_string().contains("content CID"), "{error}");
+}

--- a/implementations/rust/sugar-proof-envelope/tests/context_manager_contract_python_roundtrip.rs
+++ b/implementations/rust/sugar-proof-envelope/tests/context_manager_contract_python_roundtrip.rs
@@ -3,22 +3,23 @@ use std::process::Command;
 
 use serde_json::Value as Json;
 use sugar_ir_types::Sort;
-use sugar_proof_envelope::{AnchoredMember, Member, MementoCid};
+use sugar_proof_envelope::{AnchoredMember, ExitDispositionV1, Member, MementoCid};
 
 #[test]
 fn python_published_cm_contract_decodes_as_sealed_typed_rust_member() {
     let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .ancestors()
         .nth(3)
-        .expect("repository root")
+        .unwrap()
         .to_path_buf();
     let python_path = repo.join("implementations/python/sugar-lift-py-tests/src");
     let program = r#"
 import json
 from sugar_lift_py_tests.context_manager_contract import publish_never_suppresses_context_manager_contract
 from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.kit_rpc import ImportSignatureV1
 from sugar_lift_py_tests.signing import Signer
-m = publish_never_suppresses_context_manager_contract(name='NeverClosingManager', kit='fixture-python-kit', bridge_source_symbol='context-manager:fixture_python.never_closing', constructor_formals=(), constructor_sorts=(), enter_result_sort=PrimitiveSort('Value'), source_warrants=(), signer=Signer(bytes(range(32)), 'fixture-python-kit'), declared_at='2026-07-22T00:00:00.000Z')
+m = publish_never_suppresses_context_manager_contract(bridge_source_symbol='context-manager:fixture_python.never_closing', import_signature=ImportSignatureV1(formals=(), sorts=()), enter_result_sort=PrimitiveSort('Value'), source_warrants=('blake3-512:' + 'a' * 128,), signer=Signer(bytes(range(32)), 'fixture-python-kit'), declared_at='2026-07-22T00:00:00.000Z')
 print(json.dumps({'cid': m.cid, 'member': json.loads(m.canonical_bytes)}))
 "#;
     let output = Command::new("python3")
@@ -26,52 +27,53 @@ print(json.dumps({'cid': m.cid, 'member': json.loads(m.canonical_bytes)}))
         .arg("-c")
         .arg(program)
         .output()
-        .expect("run Python CM-contract publisher");
+        .unwrap();
     assert!(
         output.status.success(),
-        "Python publisher failed: {}",
+        "{}",
         String::from_utf8_lossy(&output.stderr)
     );
-    let wire: Json = serde_json::from_slice(&output.stdout).expect("publisher JSON");
-    let cid = MementoCid::try_parse(wire["cid"].as_str().expect("member CID").to_string())
-        .expect("typed member CID");
-    let anchored = AnchoredMember::new(cid, wire["member"].clone())
-        .expect("attestation CID and signature verify");
-    let member = Member::from_value(anchored.envelope()).expect("typed CM contract decoder");
-    let Member::ContextManagerContract(cm) = member else {
-        panic!("expected dedicated CM-contract member")
+    let wire: Json = serde_json::from_slice(&output.stdout).unwrap();
+    let cid = MementoCid::try_parse(wire["cid"].as_str().unwrap().to_string()).unwrap();
+    let anchored =
+        AnchoredMember::new(cid, wire["member"].clone()).expect("CID and signature verify");
+    let Member::ContextManagerContract(cm) = Member::from_value(anchored.envelope()).unwrap()
+    else {
+        panic!("dedicated CM member")
     };
-    assert_eq!(cm.name, "NeverClosingManager");
-    assert_eq!(cm.kit, "fixture-python-kit");
     assert_eq!(
         cm.bridge_source_symbol,
         "context-manager:fixture_python.never_closing"
     );
-    assert!(cm.constructor_formals.is_empty());
-    assert!(cm.constructor_sorts.is_empty());
+    assert!(cm.import_signature.formals.is_empty());
+    assert!(cm.import_signature.sorts.is_empty());
     assert_eq!(
-        cm.enter_result_sort,
+        cm.semantics.enter.sort,
         Sort::Primitive {
             name: "Value".to_string()
         }
     );
-    assert!(cm.source_warrants.is_empty());
+    assert_eq!(
+        cm.semantics.exit.disposition,
+        ExitDispositionV1::NeverSuppresses
+    );
+    assert_eq!(cm.source_warrants.len(), 1);
 }
 
 #[test]
-fn stale_content_cid_stays_loud() {
+fn stale_payload_cid_stays_loud() {
+    let zero = format!("blake3-512:{}", "0".repeat(128));
     let member = serde_json::json!({
         "envelope": {}, "metadata": {},
         "header": {
-            "schemaVersion":"1", "kind":"context-manager-contract",
-            "cid": format!("blake3-512:{}", "0".repeat(128)),
-            "name":"N", "kit":"K", "bridgeSourceSymbol":"context-manager:m.n",
-            "constructorSignature":{"formals":[],"sorts":[]},
-            "enter":{"outcome":"total","result":{"kind":"projection","projection":"enter_result","sort":{"kind":"primitive","name":"Value"}}},
-            "exit":{"outcome":"total","disposition":{"kind":"never-suppresses"}},
-            "sourceWarrants": []
+            "schemaVersion":"1.2", "kind":"context-manager-contract",
+            "cid": zero, "payloadCid": zero,
+            "bridgeSourceSymbol":"context-manager:m.n",
+            "importSignature":{"formals":[],"sorts":[]},
+            "payload":{"kind":"context-manager-semantics","schemaVersion":"1","enter":{"completion":"total","result":{"kind":"projection","projection":"enter_result","sort":{"kind":"primitive","name":"Value"}}},"exit":{"completion":"total","disposition":{"kind":"never-suppresses"}}},
+            "sourceWarrants": [], "inputCids": []
         }
     });
     let error = Member::from_value(&member).expect_err("stale CID must be loud");
-    assert!(error.to_string().contains("content CID"), "{error}");
+    assert!(error.to_string().contains("payload CID"), "{error}");
 }

--- a/implementations/rust/sugar-verifier/src/load_all_proofs.rs
+++ b/implementations/rust/sugar-verifier/src/load_all_proofs.rs
@@ -501,6 +501,7 @@ fn load_catalog_bytes(
                     | MemberKind::Authority
                     | MemberKind::Bridge
                     | MemberKind::ClosureBinding
+                    | MemberKind::ContextManagerContract
                     | MemberKind::EffectSiteAnnotation
                     | MemberKind::FactoryWalkMemento
                     | MemberKind::Implication
@@ -569,6 +570,7 @@ fn load_catalog_bytes(
                     | MemberKind::Authority
                     | MemberKind::ClosureBinding
                     | MemberKind::Contract
+                    | MemberKind::ContextManagerContract
                     | MemberKind::EffectSiteAnnotation
                     | MemberKind::FactoryWalkMemento
                     | MemberKind::Implication


### PR DESCRIPTION
Implements prerequisite 1 from #6071 using the architect-approved bodyless CM member schema.

Soundness-review fixes:
- `payloadCid` hashes only provider-neutral `ContextManagerSemanticsV1`; publisher identity and opaque `bridgeSourceSymbol` remain signed binding fields outside the payload
- Python and Rust retain typed `NeverSuppresses` semantics after decoding
- independently re-sealed unknown-disposition and missing-enter twins reach typed schema rejection; bad-signature and stale-payload-CID remain separate twins
- `ContextManagerContractIrV1` enters the closed kit IR transport, the dedicated compiler feed arm calls `mint_context_manager_contract`, and the resulting signed member enters the ordinary `ProofGraph` and authenticated `MementoPool`
- the dedicated arm creates zero formula atoms and zero `ContractBody` values

The conflicting-publication/cardinality twin is explicitly deferred to prerequisite 2, where authenticated candidate indexing and zero/one/many selection live. This PR claims no conflict-resolution coverage.

Validation at rebased head `5d0d67519`:
- Python focused CM tests: 7 passed
- battleaxe `sugar-proof-envelope` Python-to-Rust sealed round-trip: 2 passed
- battleaxe production declaration/feed/member-pool twins: 2 passed
- battleaxe `cargo check -p sugar-compiler`: passed

No prerequisite-2 resolver/catalog and no `WithSugar` construction arm are included.

Part of #6071.
Context: #6067.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add context-manager contract publisher and decoder across Python and Rust
> - Adds `publish_never_suppresses_context_manager_contract` in Python and `mint_context_manager_contract` in Rust to build and sign typed context-manager contract layered envelopes with deterministic payload hashing.
> - Adds `decode_context_manager_contract` (Python) and `ContextManagerContractMember::from_value` (Rust) to verify and parse signed envelopes back into strongly typed structs with strict schema and CID checks.
> - Extends the Rust compiler's `fold_project` to translate `contractDeclarations` in a `KitDeclaration` into signed graph members via the new feed arm before tree folding.
> - Adds `ContextManagerContractIrV1` and `publish_context_manager_declaration` on the Python side so the kit RPC response includes a `contractDeclarations` array from a module-level registry.
> - Risk: payload CID mismatch on stale or tampered envelopes now produces hard errors in both Python and Rust rather than silent failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d0d675.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for versioned context-manager contracts with strict validation, signing, serialization, and decoding.
  * Context-manager declarations can now be published through kit responses and included in proof graphs.
  * Added support for “never suppresses” context-manager semantics across Python and Rust interfaces.
  * Added typed contract transport and public exports for context-manager declarations.

* **Tests**
  * Added coverage for publishing, decoding, tamper detection, payload integrity, RPC transport, and cross-language round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
