### PR TITLE
test: comprehension lambda-binder acceptance twins (laziness, capture, lying round-trip)

### DIFF
--- a/implementations/rust/sugar-ir-types/tests/proofir_membership.rs
+++ b/implementations/rust/sugar-ir-types/tests/proofir_membership.rs
@@ -383,3 +383,42 @@ fn same_spelling_binds_only_transform_body_after_rust_parse() {
     );
     assert_eq!(free_vars(term), ["x".to_string()].into());
 }
+
+#[test]
+fn python_generator_expression_stays_lazy_after_rust_parse() {
+    let eager = document_post_term(python_comprehension_document("[f(x) for x in xs]", "xs"));
+    let lazy = document_post_term(python_comprehension_document("(f(x) for x in xs)", "xs"));
+
+    let Term::Ctor {
+        name: eager_name,
+        args: eager_args,
+    } = &eager
+    else {
+        panic!("eager comprehension must remain a constructor coordinate")
+    };
+    let Term::Ctor {
+        name: lazy_name,
+        args: lazy_args,
+    } = &lazy
+    else {
+        panic!("generator expression must remain a constructor coordinate")
+    };
+
+    assert_eq!(eager_name, "py.listcomp");
+    assert_eq!(lazy_name, "py.generatorexp");
+    assert_ne!(eager, lazy, "eager and lazy coordinates must stay distinct");
+
+    let Some(Term::Lambda { body, .. }) = lazy_args.get(1) else {
+        panic!("generator transform must remain a real lambda binder")
+    };
+    assert!(
+        matches!(body.as_ref(), Term::Ctor { name, .. } if name == "call:f"),
+        "generator creation must retain the call inside the unforced transform"
+    );
+    assert_eq!(
+        eager_args.get(1),
+        lazy_args.get(1),
+        "only the eager/lazy consumer coordinate differs"
+    );
+    assert_eq!(free_vars(lazy), ["xs".to_string()].into());
+}


### PR DESCRIPTION
## What changed

- Add the missing Rust round-trip laziness twin for Python generator expressions.
- Assert the generator remains a distinct `py.generatorexp` coordinate whose transform parses as `Term::Lambda`.
- Assert the call stays inside the unforced lambda body and only the outer eager/lazy consumer coordinate differs.
- Run alongside the existing capture and same-spelling/empty-scope admission twins from main.

This is test-only; production code is unchanged.

## Validation

- battleaxe, detached via `bin/sugarbin`: `cargo test --manifest-path implementations/rust/Cargo.toml -p sugar-ir-types --test proofir_membership -- --nocapture`
- Result: 12 passed, 0 failed (including lambda identity/capture, same-spelling lying boundary, and generator laziness).
- `git diff --check origin/main...HEAD`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests for Python comprehension lambda-binder laziness, capture, and round-trip parsing
> Adds `python_generator_expression_stays_lazy_after_rust_parse` in [proofir_membership.rs](https://github.com/TSavo/sugar/pull/6073/files#diff-671781e31a5ffa0d8359fab2e3a115c84c904ba4877b7a08cf76d018e3564c09) to verify correct parsing of Python list comprehensions vs generator expressions.
>
> - Builds both forms via `python_comprehension_document`, parses with `document_post_term`, and checks constructor names (`py.listcomp` vs `py.generatorexp`)
> - Asserts the transform lambda (second argument) is equal between the eager and lazy cases and contains a `call:f` constructor in its body
> - Verifies free variables of the lazy term equal `{"xs"}`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dcb292b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that list comprehensions remain eager while generator expressions remain lazy after parsing.
  * Confirmed their structures stay distinct, preserve expected transformation behavior, and correctly identify free variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->