### PR TITLE
fix: project binding-state reads before AugAssign shadow construction

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
@@ -77,7 +77,11 @@ def census(root: Path) -> int:
     print("--- crashes (defects, not gaps) ---")
     for k, n in crashes.most_common():
         print(f"{n:8d}  {k}")
-    return 0
+    # A construction crash is a backend defect, not census residue.  Printing
+    # the row is testimony, but a successful process status would let callers
+    # bank a partial denominator as a complete census.  Keep ordinary
+    # SugarNotWritten gaps measurable while making every defect row red.
+    return 1 if crashes else 0
 
 
 def main() -> int:

--- a/implementations/python/sugar-lift-py-tests/tests/test_census_backend_defects_are_loud.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_census_backend_defects_are_loud.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from sugar_lift_py_tests.census import census
+from sugar_source_tree.panic import BackendDefect
+from sugar_source_tree.tree import SourceFile
+
+
+def test_census_returns_nonzero_when_construction_hits_backend_defect(
+    tmp_path, monkeypatch
+) -> None:
+    (tmp_path / "crash.py").write_text(
+        "def f():\n return 1\n",
+        encoding="utf-8",
+    )
+
+    def backend_crash(*args, **kwargs):
+        del args, kwargs
+        raise BackendDefect(
+            owner="planted census tooth",
+            observed="a malformed backend answer",
+            requested="a valid constructed source tree",
+            fix="repair the backend",
+        )
+
+    monkeypatch.setattr(SourceFile, "from_path", backend_crash)
+
+    assert census(tmp_path) != 0
+
+
+def test_census_returns_zero_when_every_function_constructs(tmp_path) -> None:
+    (tmp_path / "clean.py").write_text(
+        "def f():\n return 1\n",
+        encoding="utf-8",
+    )
+
+    assert census(tmp_path) == 0

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, Callable, TypeAlias
 
 if TYPE_CHECKING:
     from sugar_source_tree.fragment import SourceFragment
@@ -34,6 +34,26 @@ class GuardedBinding:
 
 BindingState: TypeAlias = "Node | UnboundBinding | GuardedBinding"
 BindingMap: TypeAlias = dict[str, BindingState]
+
+
+def binding_state_read_node(
+    state: BindingState,
+    *,
+    make_read: Callable[[UnboundBinding | GuardedBinding], Node],
+) -> Node:
+    """Project binding availability into the tree's ordinary Node currency.
+
+    Binding-state witnesses are deliberately not AST nodes.  A consumer that
+    reads a binding must project an unbound/guarded state into the explicit
+    read node owned by the read site before placing it in a shadow child slot.
+    """
+    from sugar_source_tree.nodes import Node
+
+    if isinstance(state, Node):
+        return state
+    if isinstance(state, (UnboundBinding, GuardedBinding)):
+        return make_read(state)
+    raise TypeError(type(state))
 
 
 def join_binding_state(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -61,6 +61,7 @@ from .binding_state import (
     BranchResultSlot,
     GuardedBinding,
     UnboundBinding,
+    binding_state_read_node,
     branch_result_slot,
     join_binding_state,
 )
@@ -391,7 +392,25 @@ class Node(Typed):
         borrows this node's span (so it still addresses this source site). Used
         by an augmented assignment to synthesize its ``x OP e`` rebind."""
         from .backend import Child, OpLeaf, materialize
+        from .panic import backend_defect
         from .shadow import ShadowNode, _handle_of
+
+        if not isinstance(left, Node) or not isinstance(right, Node):
+            backend_defect(
+                owner="nodes.Node._make_binop",
+                observed=(
+                    "a synthesized binary operation received non-Node "
+                    f"operands {type(left).__name__}, {type(right).__name__}"
+                ),
+                requested=(
+                    "both binary-operation operands projected into constructed "
+                    "tree Nodes before shadow enrollment"
+                ),
+                fix=(
+                    "project BindingState through binding_state_read_node at "
+                    "the read site; never put state-only testimony in Child"
+                ),
+            )
 
         slots = (
             ("left", Child(_handle_of(left))),
@@ -1347,8 +1366,12 @@ class AugAssign(Statement):
         if not isinstance(self.target, Name):
             return None
         name = self.target.id
-        old = scope.get(name, self.target)
-        return {name: self._make_binop(old, self.op, self.value)}
+        old_state = scope.get(name, self.target)
+        old_read = binding_state_read_node(
+            old_state,
+            make_read=self.target._make_binding_read,
+        )
+        return {name: self._make_binop(old_read, self.op, self.value)}
 
     def _construct_sugar(self):
         """`<target> OP= <value>` -- a plain Name target is INERT at the

--- a/implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py
+++ b/implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py
@@ -2,11 +2,16 @@ from __future__ import annotations
 
 import tempfile
 
+import pytest
+
 from sugar_lift_py_tests.effect import NameErrorEffect, RaiseEffect
 from sugar_lift_py_tests.floor import ReturnValue, TermValue, UniverseValue
 from sugar_lift_py_tests.ir import and_, make_var, not_, or_, py_truthy
 from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted, Incomplete
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.binding_state import BranchResultSlot, GuardedBinding, UnboundBinding
+from sugar_source_tree.nodes import Node
+from sugar_source_tree.panic import BackendDefect, SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
 
@@ -15,6 +20,13 @@ def _out(source: str):
         f.write(source)
         path = f.name
     return next(SourceFile(path_source(path)).functions()).sugar().desugar()
+
+
+def _substituted(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(source)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).substitute({})
 
 
 def _return(exit_):
@@ -99,6 +111,110 @@ def test_nested_conditional_delete_retains_both_source_guards() -> None:
     outer, inner = halted[0].guard.operands
     assert outer != inner
     assert completed[0].guard == or_([not_(outer), and_([outer, not_(inner)])])
+
+
+def test_pandas_blocks_nested_if_augassign_reads_unbound_binding_as_a_node() -> None:
+    source = (
+        "def f(i, values):\n"
+        " if isinstance(i, tuple):\n"
+        "  col, loc = i\n"
+        "  if loc < 0:\n"
+        "   loc += len(values)\n"
+        "  return loc\n"
+    )
+    function = _substituted(source)
+    reads = [node for node in function.walk() if node.kind == "GuardedBindingRead"]
+    assert any(isinstance(read.state, UnboundBinding) for read in reads)
+    with pytest.raises(SugarNotWritten):
+        _out(source)
+
+
+def test_pandas_html_if_augassign_reads_guarded_binding_as_a_node() -> None:
+    function = _substituted(
+        "def f(c, foot):\n"
+        " if c:\n"
+        "  body = 1\n"
+        " if foot:\n"
+        "  body += foot\n"
+        " return body\n"
+    )
+    first_if, second_if = function.body[:2]
+    reads = [node for node in function.walk() if node.kind == "GuardedBindingRead"]
+    outer = next(read for read in reads if isinstance(read.state, GuardedBinding))
+    addition = outer.state.when_true
+    old_read = addition.left
+    assert old_read.kind == "GuardedBindingRead"
+    assert isinstance(old_read.state, GuardedBinding)
+    assert old_read.state.slot.slot_id == first_if.branch_result_slot_id
+    assert outer.state.slot.slot_id == second_if.branch_result_slot_id
+
+    halted, completed = _partition(
+        _out(
+            "def f(c, foot):\n"
+            " if c:\n"
+            "  body = 1\n"
+            " if foot:\n"
+            "  body += foot\n"
+            " return body\n"
+        )
+    )
+    assert any(isinstance(face.effect, NameErrorEffect) for face in halted)
+    assert any(
+        getattr(getattr(_return(face).value, "term", None), "name", None) == "+"
+        for face in completed
+    )
+
+
+def test_pandas_converter_if_augassign_reads_unbound_binding_as_a_node() -> None:
+    source = (
+        "def f(locs):\n"
+        " vmin, vmax = locs\n"
+        " if vmin == vmax:\n"
+        "  vmin -= 1\n"
+        "  vmax += 1\n"
+        " return vmin\n"
+    )
+    function = _substituted(source)
+    reads = [node for node in function.walk() if node.kind == "GuardedBindingRead"]
+    names = {read.name for read in reads if isinstance(read.state, UnboundBinding)}
+    assert {"vmin", "vmax"} <= names
+    with pytest.raises(SugarNotWritten):
+        _out(source)
+
+
+def test_augassign_over_explicitly_unbound_local_builds_guarded_read() -> None:
+    out = _out("def f():\n x += 1\n return x\n")
+    assert isinstance(out, Incomplete)
+    assert isinstance(out.effect, NameErrorEffect)
+    assert out.effect.name == "x"
+
+
+def test_bound_augassign_control_remains_completed_value() -> None:
+    out = _out("def f():\n x = 1\n x += 2\n return x\n")
+    assert isinstance(out, Complete)
+    returns = [
+        entry
+        for entry in out.value.record.statements
+        if isinstance(entry, ReturnValue)
+    ]
+    assert returns[0].value == TermValue(3)
+
+
+def test_binding_state_is_never_an_ast_child_or_node_protocol_value() -> None:
+    unbound = UnboundBinding(name="x", cause=_substituted("def f():\n pass\n").fragment)
+    guarded = GuardedBinding(
+        slot=BranchResultSlot("test-slot"),
+        when_true=unbound,
+        when_false=unbound,
+    )
+    for state in (unbound, guarded):
+        assert not isinstance(state, Node)
+        assert not hasattr(state, "ref")
+        assert not hasattr(state, "sugar")
+
+    target = _substituted("def f(x):\n x += 1\n").body[0].target
+    with pytest.raises(BackendDefect, match="non-Node operands"):
+        target._make_binop(unbound, None, target)
 
 
 def test_try_handler_binding_exports_on_the_handler_completion_edge() -> None:


### PR DESCRIPTION
The pandas construction census exposed three backend crashes after #6068: `UnboundBinding`/`GuardedBinding` reached `AugAssign._make_binop`, whose shadow child enrollment requires a Node `.ref`.

This fix keeps binding states state-only and introduces the architect-ruled tree-time read projection before constructing the augmented-assignment BinOp. It also makes `_make_binop` report a named `BackendDefect` for non-Node operands and makes census defect rows return non-zero.

Twins cover the live `blocks.py::iget`, `html.py::_data_to_frame`, and `converter.py::autoscale` shapes, direct unbound/bound AugAssign controls, the state-only structural invariant, and census red/green discrimination.

Receipts:
- Full sugar-source-tree suite: 345 passed, 5 skipped, 1 xfailed
- Census loudness twins: 2 passed
- `R_no_sugar_in_desugar=0`, `auditor_errors=0`
- Battleaxe real-pandas replay: no AttributeError at all three loci; `iget` constructs, the other two reach their existing honest Assign gaps

Predicted epsilon: 3 backend crash sites -> 0. Floors preserved: no `.sugar()` under desugar; no ambient mutable scope; binding states remain outside AST child enrollment.

DO NOT MERGE: awaiting architect review.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `AugAssign` substitution to project binding state into read nodes before BinOp construction
> - `AugAssign.substitution_binding` now calls `binding_state_read_node` to convert raw `UnboundBinding`/`GuardedBinding` scope values into concrete read `Node`s before passing them to `_make_binop`, fixing a bug where binding state was used directly as an AST operand.
> - Adds `binding_state_read_node` helper in [`binding_state.py`](https://github.com/TSavo/sugar/pull/6074/files#diff-1b664ec8aefadd4725220316e83263615391d340ba859576e2ac417ab1cc5e40) to project a `BindingState` witness into a `Node` at a read site, or raise `TypeError` for unsupported types.
> - `Node._make_binop` now calls `backend_defect` if either operand is not a `Node`, making invalid construction loud rather than silent.
> - `census` now returns `1` when any construction crashes are recorded, so backend defects cause test failures rather than silent gaps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24d9c8a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->