### PR TITLE
drain: FormattedValue reference projection (pandas R)

### DIFF
--- a/docs/superpowers/plans/2026-07-22-formatted-value.md
+++ b/docs/superpowers/plans/2026-07-22-formatted-value.md
@@ -1,0 +1,61 @@
+# FormattedValue Reference Projection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Drain well-formed `FormattedValue` direct gaps by projecting the exact Python-reference `python:fstring_value(value, conversion, format_spec)` coordinate.
+
+**Architecture:** `FormattedValue` validates its backend conversion slot and constructs a sugar carrying its value, typed conversion, and optional nested `JoinedStrSugar`. Desugaring projects the existing ProofIR constructor with explicit `None` terms and a nested `python:fstring` format specification; malformed slots remain typed loud failures.
+
+**Tech Stack:** Python 3, sugar source tree, sugar-lift ProofIR terms, pytest, pandas construction census.
+
+## Global Constraints
+
+- Mirror `sugar_lift_python_source.lifter.fstring_value()` exactly: value, conversion, format spec.
+- Do not emit `py.format` or a conversion intermediate.
+- No vendor or name dispatch.
+- Preserve child gaps exactly and classify malformed backend slots loudly.
+- Python locally; Rust round-trip runs on battleaxe.
+- Do not merge the non-draft PR.
+
+---
+
+### Task 1: Pin the five typed twins
+
+**Files:**
+- Modify: `implementations/python/sugar-source-tree/tests/test_fstring_sugar.py`
+
+**Interfaces:**
+- Consumes: `FormattedValue.sugar()` and ProofIR term constructors.
+- Produces: tests for ordered operands, conversion discrimination, explicit absence, swapped operands, and malformed operands.
+
+- [ ] **Step 1: Extend the red tests** to assert `python:fstring_value(value, conversion, format_spec)` and decoder failures for swapped or malformed terms.
+- [ ] **Step 2: Run the focused test file** with the repository `PYTHONPATH`; expect the well-formed modifier cases to fail at `FormattedValue.sugar` before implementation.
+
+### Task 2: Implement the exact reference projection
+
+**Files:**
+- Modify: `implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/fstring_sugar.py`
+
+**Interfaces:**
+- Consumes: value sugar, conversion integer, optional `JoinedStr` sugar.
+- Produces: `FormattedValueSugar(value, conversion, format_spec, site)` and the ordered `python:fstring_value` term.
+
+- [ ] **Step 1: Validate conversion** as exactly `-1`, `ord("a")`, `ord("r")`, or `ord("s")`; raise `BackendDefect` otherwise.
+- [ ] **Step 2: Carry all three operands** into `FormattedValueSugar`, using the optional child sugar without elision.
+- [ ] **Step 3: Project the reference term** with explicit `none_const()` for absent operands and `python:fstring` for the nested spec.
+- [ ] **Step 4: Run the focused tests** and require all five twins green.
+
+### Task 3: Measure and publish
+
+**Files:**
+- Create: `implementations/python/sugar-lift-py-tests/scripts/measure_formatted_value_frontier.py`
+
+**Interfaces:**
+- Consumes: installed pandas sources and normal function construction.
+- Produces: before/after direct-gap and blocked-descendant counts.
+
+- [ ] **Step 1: Run the family counter** before and after the arm and record the direct-gap delta.
+- [ ] **Step 2: Run focused Python tree tests** and the existing Python-reference f-string tests.
+- [ ] **Step 3: Run Python-to-Rust round-trip on battleaxe** and verify all operands retain reference order.
+- [ ] **Step 4: Rebase onto `origin/main`, commit as T Savo, push, and open a non-draft PR** without merging it.

--- a/implementations/python/sugar-lift-py-tests/scripts/measure_formatted_value_frontier.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/measure_formatted_value_frontier.py
@@ -1,0 +1,166 @@
+"""Measure pandas' FormattedValue construction frontier.
+
+This is a family-local delta instrument, not a baseline gate.  For every
+``FormattedValue`` in the installed pandas source tree it asks that node to
+construct directly and distinguishes the node's own gap from a gap inherited
+from one of its children.  Run the same command before and after the arm; the
+change in ``direct_gap`` is the observed family delta.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib.metadata
+import importlib.util
+import json
+import logging
+from collections import Counter
+from pathlib import Path
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.backend import BackendCouldNotParse, materialize
+from sugar_source_tree.cpython_adapter import _Handle
+from sugar_source_tree.nodes import SourceUnit
+from sugar_source_tree.panic import SourceTreePanic, SugarNotWritten
+
+
+def _installed_package_root(package: str) -> Path:
+    spec = importlib.util.find_spec(package)
+    if spec is None or spec.origin is None:
+        raise RuntimeError(f"could not locate installed package {package!r}")
+    return Path(spec.origin).resolve().parent
+
+
+def _shape(node) -> str:
+    conversion = node.conversion
+    has_spec = node.format_spec is not None
+    if conversion != -1 and has_spec:
+        return "conversion_and_format_spec"
+    if conversion != -1:
+        return "conversion_only"
+    if has_spec:
+        return "format_spec_only"
+    return "plain"
+
+
+def measure(root: Path) -> dict[str, object]:
+    counts: Counter[str] = Counter()
+    direct_by_shape: Counter[str] = Counter()
+    blocked_by_child: Counter[str] = Counter()
+    roll_call_blocked_by_child: Counter[str] = Counter()
+    other_panics: Counter[str] = Counter()
+    roll_call: Counter[str] = Counter()
+
+    paths = sorted(
+        path for path in root.rglob("*.py") if "__pycache__" not in path.parts
+    )
+    for path in paths:
+        counts["files_total"] += 1
+        try:
+            source, filename, source_cid = path_source(path)
+            parsed = ast.parse(source, filename=str(path))
+            native_nodes = [
+                node for node in ast.walk(parsed) if isinstance(node, ast.FormattedValue)
+            ]
+            if not native_nodes:
+                counts["files_without_formatted_value"] += 1
+                counts["files_completed"] += 1
+                continue
+            counts["files_with_formatted_value"] += 1
+            unit = SourceUnit(
+                filename=filename,
+                source=source,
+                source_cid=source_cid,
+            )
+            formatted_values = [
+                materialize(unit, _Handle(unit, native_node))
+                for native_node in native_nodes
+            ]
+            for node in formatted_values:
+                counts["formatted_value_total"] += 1
+                shape = _shape(node)
+                counts[f"shape.{shape}"] += 1
+                try:
+                    node.sugar()
+                except SugarNotWritten as panic:
+                    if panic.owner == "FormattedValue.sugar":
+                        counts["direct_gap"] += 1
+                        direct_by_shape[shape] += 1
+                    else:
+                        counts["blocked_descendant_gap"] += 1
+                        blocked_by_child[panic.observed.split(" at ", 1)[0]] += 1
+                except SourceTreePanic as panic:
+                    counts["other_source_tree_panic"] += 1
+                    other_panics[type(panic).__name__] += 1
+                else:
+                    counts["built"] += 1
+
+            function_nodes = [
+                node
+                for node in ast.walk(parsed)
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and any(
+                    isinstance(descendant, ast.FormattedValue)
+                    for descendant in ast.walk(node)
+                )
+            ]
+            for native_function in function_nodes:
+                roll_call["functions_with_formatted_value"] += 1
+                function = materialize(unit, _Handle(unit, native_function))
+                try:
+                    function.sugar()
+                except SugarNotWritten as panic:
+                    if panic.owner == "FormattedValue.sugar":
+                        roll_call["direct_gap"] += 1
+                    else:
+                        roll_call["blocked_descendant_gap"] += 1
+                        roll_call_blocked_by_child[
+                            panic.observed.split(" at ", 1)[0]
+                        ] += 1
+                except SourceTreePanic as panic:
+                    roll_call["other_source_tree_panic"] += 1
+                    other_panics[type(panic).__name__] += 1
+                except Exception as panic:
+                    roll_call["other_function_failure"] += 1
+                    other_panics[type(panic).__name__] += 1
+                else:
+                    roll_call["built"] += 1
+            counts["files_completed"] += 1
+        except BackendCouldNotParse:
+            counts["files_could_not_parse"] += 1
+        except (OSError, UnicodeError, SourceTreePanic) as panic:
+            counts["files_other_failure"] += 1
+            other_panics[type(panic).__name__] += 1
+
+    return {
+        "root": str(root),
+        "counts": dict(sorted(counts.items())),
+        "direct_gap_by_shape": dict(sorted(direct_by_shape.items())),
+        "roll_call": dict(sorted(roll_call.items())),
+        "roll_call_blocked_by_child": dict(
+            sorted(roll_call_blocked_by_child.items())
+        ),
+        "blocked_descendant_by_child": dict(sorted(blocked_by_child.items())),
+        "other_panics": dict(sorted(other_panics.items())),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="source root (default: installed pandas package)",
+    )
+    args = parser.parse_args()
+    logging.disable(logging.CRITICAL)
+    root = (args.root or _installed_package_root("pandas")).resolve()
+    report = measure(root)
+    report["pandas_version"] = importlib.metadata.version("pandas")
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/fstring_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/fstring_sugar.py
@@ -2,12 +2,11 @@
 
 A JoinedStr is the CONCATENATION of its parts -- literal chunks (StringLiteral)
 and interpolations (FormattedValue). It folds them left with `add`, the same
-string concatenation `+` uses: ground chunks fold to one string, an interpolated
-symbol becomes a `str.++` coordinate. A FormattedValue is `format(value, spec)`:
-with no conversion and no format spec it is the value's own `__format__`
-coordinate (`call:__format__(value, "")`), decidable without inventing a
-rendered string. A conversion (`!r`/`!s`/`!a`) or a format spec (`{x:>10}`) is
-not lifted yet -- LOUD, never a silently dropped modifier.
+string concatenation `+` uses. A FormattedValue projects the Python reference's
+opaque ``python:fstring_value(value, conversion, format_spec)`` coordinate.
+Conversion and format spec remain typed operands: absence is explicit ``None``
+and a present spec is a nested ``python:fstring`` coordinate. The coordinate
+carries Python's conversion-then-format meaning without claiming execution.
 """
 
 from __future__ import annotations
@@ -21,9 +20,11 @@ from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 @dataclass(frozen=True)
 class FormattedValueSugar(Sugar):
-    """`{value}` inside an f-string -- format(value) with an empty spec."""
+    """A Python-reference formatted-value coordinate, without execution."""
 
     value: Sugar
+    conversion: str | None
+    format_spec: JoinedStrSugar | None
     site: object = dataclass_field(compare=False)
 
     @classmethod
@@ -31,10 +32,36 @@ class FormattedValueSugar(Sugar):
         return ()
 
     def desugar(self, ctx: object = None) -> Outcome:
-        from sugar_lift_py_tests.floor.string_value import StringValue
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+        from sugar_lift_py_tests.ir import ctor, str_const
+        from sugar_lift_py_tests.outcome import Incomplete
 
-        return self.value.desugar(ctx).and_then(
-            lambda value: value.format_data_model(StringValue(""), self.site, ctx)
+        value = self.value.desugar(ctx)
+        if isinstance(value, Incomplete):
+            return value
+        if self.format_spec is None:
+            format_spec_term = ctor("None", [])
+        else:
+            format_spec = self.format_spec.reference_term(ctx)
+            if isinstance(format_spec, Incomplete):
+                return format_spec
+            format_spec_term = format_spec.value
+        conversion_term = (
+            ctor("None", [])
+            if self.conversion is None
+            else str_const(self.conversion)
+        )
+        return Complete(
+            SymbolicValue(
+                ctor(
+                    "python:fstring_value",
+                    [
+                        value.value.to_term(owner="FormattedValueSugar.value"),
+                        conversion_term,
+                        format_spec_term,
+                    ],
+                )
+            )
         )
 
 
@@ -70,3 +97,18 @@ class JoinedStrSugar(Sugar):
                 return right
             acc = acc.value.add(right.value, self.site)
         return acc
+
+    def reference_term(self, ctx: object = None) -> Outcome:
+        """Project this JoinedStr as the reference ``python:fstring`` ctor."""
+        from sugar_lift_py_tests.ir import ctor
+        from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+        terms = []
+        for part in self.parts:
+            projected = part.desugar(ctx)
+            if isinstance(projected, Incomplete):
+                return projected
+            terms.append(
+                projected.value.to_term(owner="JoinedStrSugar.reference_term")
+            )
+        return Complete(ctor("python:fstring", terms))

--- a/implementations/python/sugar-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_lifter.py
@@ -1530,6 +1530,42 @@ def test_fstring_roundtrip_is_structurally_stable() -> None:
     assert cid_of_json(body) == cid_of_json(_return(term))
 
 
+def test_fstring_decoder_rejects_swapped_conversion_and_format_spec() -> None:
+    swapped = _fstring(
+        _fstring_value(
+            _var("x"),
+            conversion=_fstring(_str_const(">10")),
+            format_spec=_str_const("r"),
+        )
+    )
+
+    with pytest.raises(ValueError):
+        compile_body_term(_return(swapped), formals=["x"])
+
+
+@pytest.mark.parametrize(
+    "conversion, format_spec",
+    [
+        (_str_const("q"), None),
+        (None, _str_const(">10")),
+    ],
+)
+def test_fstring_decoder_rejects_malformed_typed_operands(
+    conversion: dict[str, object] | None,
+    format_spec: dict[str, object] | None,
+) -> None:
+    malformed = _fstring(
+        _fstring_value(
+            _var("x"),
+            conversion=conversion,
+            format_spec=format_spec,
+        )
+    )
+
+    with pytest.raises(ValueError):
+        compile_body_term(_return(malformed), formals=["x"])
+
+
 def test_bare_assert_lifts_to_assert_statement_with_assertion_error_locus() -> None:
     source = "def f(x):\n    assert x\n"
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3684,13 +3684,41 @@ class FormattedValue(Expression):
         return self._substitute_children(scope)
 
     def _construct_sugar(self):
-        """`{value}` in an f-string. A conversion (!r/!s/!a) or a format spec is
-        not lifted yet -- LOUD rather than a silently dropped modifier."""
+        """Project the Python-reference three-operand formatted-value shape.
+
+        CPython carries conversion as ``-1`` or the codepoint for exactly
+        ``a``/``r``/``s``.  Anything else is malformed backend testimony, not
+        a new language arm.  The optional format spec remains its own nested
+        JoinedStr sugar; neither operand is dropped or replaced with an empty
+        string.
+        """
         from sugar_lift_py_tests.sugar.fstring_sugar import FormattedValueSugar
 
-        if self.conversion != -1 or self.format_spec is not None:
-            return super()._construct_sugar()
-        return FormattedValueSugar(value=self.value.sugar(), site=self.fragment)
+        if self.conversion == -1:
+            conversion = None
+        elif self.conversion in {ord("a"), ord("r"), ord("s")}:
+            conversion = chr(self.conversion)
+        else:
+            backend_defect(
+                owner="FormattedValue._construct_sugar",
+                observed=f"unsupported f-string conversion slot {self.conversion!r}",
+                requested="-1 or the codepoint for 'a', 'r', or 's'",
+                fix="repair the backend adapter; never invent a conversion",
+            )
+        format_spec = self.format_spec
+        if format_spec is not None and not isinstance(format_spec, JoinedStr):
+            backend_defect(
+                owner="FormattedValue._construct_sugar",
+                observed=f"format_spec constructed as {type(format_spec).__name__}",
+                requested="None or a nested JoinedStr",
+                fix="repair the backend adapter; never coerce a bare expression",
+            )
+        return FormattedValueSugar(
+            value=self.value.sugar(),
+            conversion=conversion,
+            format_spec=format_spec.sugar() if format_spec is not None else None,
+            site=self.fragment,
+        )
 
 
 class JoinedStr(Expression):

--- a/implementations/python/sugar-source-tree/tests/test_fstring_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_fstring_sugar.py
@@ -1,14 +1,13 @@
-"""f-strings: JoinedStr concatenates its parts; FormattedValue is format(value).
-
-Modifiers -- a conversion (!r/!s/!a) or a format spec ({x:>10}) -- stay loud.
-"""
+"""f-strings: JoinedStr concatenates its parts; FormattedValue is format(value)."""
 
 import tempfile
 
 import pytest
 
 from sugar_lift_python_source.source_oracle import path_source
-from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.backend import Leaf, MaybeChild, materialize
+from sugar_source_tree.panic import BackendDefect
+from sugar_source_tree.shadow import ShadowNode
 from sugar_source_tree.tree import SourceFile
 
 
@@ -23,12 +22,44 @@ def _post_term(src):
     return _fn(src).sugar().desugar().value.post().args[1]
 
 
+def _formatted_value(src):
+    fn = _fn(src)
+    joined = fn.body[0].value
+    return next(value for value in joined.values if value.kind == "FormattedValue")
+
+
+def _with_conversion(node, conversion):
+    desc = node.ref.describe()
+    slots = tuple(
+        (name, Leaf(conversion) if name == "conversion" else slot)
+        for name, slot in desc.slots
+    )
+    return materialize(
+        node.unit,
+        ShadowNode("FormattedValue", desc.raw_span or node.span, slots),
+        node.reporter,
+    )
+
+
+def _with_bare_format_spec(node):
+    desc = node.ref.describe()
+    slots = tuple(
+        (name, MaybeChild(node.value.ref) if name == "format_spec" else slot)
+        for name, slot in desc.slots
+    )
+    return materialize(
+        node.unit,
+        ShadowNode("FormattedValue", desc.raw_span or node.span, slots),
+        node.reporter,
+    )
+
+
 def test_fstring_concatenates_literal_and_interpolation():
-    # f"n={z}" -> "n=" ++ format(z)
+    # f"n={z}" -> "n=" ++ python:fstring_value(z, None, None)
     term = _post_term('def A(z):\n    return f"n={z}"\n')
     assert term.name == "+"
     assert term.args[0].value == "n="
-    assert term.args[1].name == "call:__format__"
+    assert term.args[1].name == "python:fstring_value"
 
 
 def test_fstring_with_only_a_literal_is_the_string():
@@ -36,19 +67,64 @@ def test_fstring_with_only_a_literal_is_the_string():
     assert type(term).__name__ == "_ConstStr" and term.value == "hello"
 
 
-def test_conversion_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn('def A(z):\n    return f"{z!r}"\n').sugar()
+def test_conversion_and_format_spec_survive_in_reference_operand_order():
+    """`value, conversion, format_spec` is the Python-reference order."""
+    term = _post_term('def A(x):\n    return f"{x!r:>10}"\n')
+
+    assert term.name == "python:fstring_value"
+    assert term.args[0].name == "x"
+    assert term.args[1].value == "r"
+    assert term.args[2].name == "python:fstring"
+    assert len(term.args[2].args) == 1
+    assert term.args[2].args[0].value == ">10"
 
 
-def test_format_spec_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn('def A(z):\n    return f"{z:>3}"\n').sugar()
+def test_fstring_conversions_are_distinct_typed_string_operands():
+    conversions = {
+        marker: _post_term(f'def A(x):\n    return f"{{x!{marker}}}"\n').args[1]
+        for marker in ("r", "s", "a")
+    }
+
+    assert {marker: term.value for marker, term in conversions.items()} == {
+        "r": "r",
+        "s": "s",
+        "a": "a",
+    }
+    assert {type(term).__name__ for term in conversions.values()} == {"_ConstStr"}
+
+
+def test_absent_conversion_and_format_spec_are_explicit_none_operands():
+    term = _post_term('def A(x):\n    return f"{x}"\n')
+
+    assert term.name == "python:fstring_value"
+    assert len(term.args) == 3
+    assert term.args[1].name == "None" and term.args[1].args == ()
+    assert term.args[2].name == "None" and term.args[2].args == ()
+
+
+def test_malformed_conversion_slot_is_a_backend_defect():
+    """Discrimination twin: a backend cannot claim an invented ``!q`` slot."""
+    formatted = _formatted_value('def A(z):\n    return f"{z!r}"\n')
+    lying = _with_conversion(formatted, ord("q"))
+
+    with pytest.raises(BackendDefect):
+        lying.sugar()
+
+
+def test_bare_format_spec_slot_is_a_backend_defect():
+    formatted = _formatted_value('def A(z):\n    return f"{z}"\n')
+    lying = _with_bare_format_spec(formatted)
+
+    with pytest.raises(BackendDefect):
+        lying.sugar()
 
 
 if __name__ == "__main__":
     test_fstring_concatenates_literal_and_interpolation()
     test_fstring_with_only_a_literal_is_the_string()
-    test_conversion_stays_loud()
-    test_format_spec_stays_loud()
-    print("ok: f-strings concatenate; modifiers loud")
+    test_conversion_and_format_spec_survive_in_reference_operand_order()
+    test_fstring_conversions_are_distinct_typed_string_operands()
+    test_absent_conversion_and_format_spec_are_explicit_none_operands()
+    test_malformed_conversion_slot_is_a_backend_defect()
+    test_bare_format_spec_slot_is_a_backend_defect()
+    print("ok: f-strings concatenate; modifiers build; malformed slots loud")

--- a/implementations/rust/sugar-walk/tests/term_boundary_totality.rs
+++ b/implementations/rust/sugar-walk/tests/term_boundary_totality.rs
@@ -240,6 +240,30 @@ fn ir_terms_round_trip_through_term_boundary_byte_identically() {
 }
 
 #[test]
+fn python_formatted_value_operands_round_trip_in_reference_order() {
+    let original = ctor(
+        "python:fstring_value",
+        vec![
+            var("x"),
+            string_const("r"),
+            ctor("python:fstring", vec![string_const(">10")]),
+        ],
+    );
+
+    let raised = raise_ir(&lower_ir(&original));
+
+    assert_same_term_json_bytes("python:fstring_value", &original, &raised);
+    let ir::Term::Ctor { name, args } = raised else {
+        panic!("formatted value did not remain a ctor");
+    };
+    assert_eq!(name, "python:fstring_value");
+    assert_eq!(args.len(), 3);
+    assert_eq!(args[0], var("x"));
+    assert_eq!(args[1], string_const("r"));
+    assert_eq!(args[2], ctor("python:fstring", vec![string_const(">10")]));
+}
+
+#[test]
 fn ir_formulas_round_trip_through_term_boundary_byte_identically() {
     let corpus = formula_corpus();
     for (label, original) in &corpus {


### PR DESCRIPTION
## What changed

- construct every well-formed `FormattedValue` as the Python-reference `python:fstring_value(value, conversion, format_spec)` coordinate
- preserve explicit `None` operands and nested `python:fstring` format specs
- keep malformed conversion and format-spec backend slots loud as `BackendDefect`
- add the five ordered/typed/malformed twins, a pandas family counter, and a Rust term-boundary order twin

## Measured pandas 3.0.3 impact

Against `origin/main` at `03fad733`:

- roll-call direct `FormattedValue` gaps: 149 -> 0 (`Delta direct_gap_R = -149`)
- functions built: 1,134 -> 1,253
- functions advancing to deeper honest blockers: 967 -> 997
- raw modifier nodes: 303 -> 0 direct gaps (163 conversions, 140 format specs)
- two `ListComp`-blocked interpolation nodes remain blocked

## Verification

- source-tree suite: 348 passed, 5 skipped, 1 xfailed
- Python source-lifter suite: 324 passed
- battleaxe Rust term boundary: 1 passed, 0 failed

No `py.format` or intermediate conversion coordinate is introduced; operand order mirrors the Python reference exactly.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Project FormattedValue to `python:fstring_value` IR term with explicit conversion and format_spec operands
> - `FormattedValueSugar` now produces a `python:fstring_value(value, conversion, format_spec)` IR term instead of modeling `call:__format__`. Conversion codes (`r`, `s`, `a`) and format specs are preserved as typed operands; absent slots are explicit `None`.
> - `JoinedStrSugar` gains a `reference_term(ctx)` method that projects the joined string as a nested `python:fstring` IR term, used to represent format specs inside `fstring_value`.
> - `FormattedValue._construct_sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/6075/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now validates and maps CPython's integer conversion codes to string constants, raising `BackendDefect` for unsupported codes or non-`JoinedStr` format spec slots.
> - A measurement script [measure_formatted_value_frontier.py](https://github.com/TSavo/sugar/pull/6075/files#diff-3410d8ec53d98b1cdab983cf50b02e3de6d0bb54142fb073201817337c0edd9f) scans the pandas source tree and reports coverage gaps and panic rates for `FormattedValue` nodes.
> - Behavioral Change: desugaring any `FormattedValue` with modifiers previously fell through; it now succeeds for well-formed modifiers and raises `BackendDefect` for malformed ones.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6521827.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->