### PR TITLE
feat: authenticated context-manager preconstruction resolution (With prerequisite 2/2)

### DIFF
--- a/docs/superpowers/plans/2026-07-22-cm-stack-soundness-review.md
+++ b/docs/superpowers/plans/2026-07-22-cm-stack-soundness-review.md
@@ -1,0 +1,80 @@
+# CM Stack Soundness Review Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make prerequisite 1 independently publish sealed typed CM declarations, then give prerequisite 2 discriminating phase-order and complete AST boundary floors.
+
+**Architecture:** Move only the typed kit publication boundary and dedicated compiler-feed integration from the stacked resolution branch into the publisher branch. Rebase the resolver stack, replace observational tests with planted regressions, and retain Rust-owned resolution without adding With semantics.
+
+**Tech Stack:** Python 3, pytest, Rust, cargo tests through battleaxe `bin/sugarbin`, GitHub stacked PRs.
+
+## Global Constraints
+
+- No ContractBody, formula atoms, or function-contract minting in the CM publication arm.
+- Tree and Sugar construction consume only injected typed refs.
+- Heavy Rust verification runs only on battleaxe through `bin/sugarbin`.
+- Both PRs remain non-draft and are never self-merged.
+
+---
+
+### Task 1: Restore the prerequisite-1 publication boundary
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_context_manager_contract.py`
+- Modify: `implementations/rust/sugar-compiler/src/feed_from_tree.rs`
+- Modify: `implementations/rust/sugar-compiler/tests/context_manager_contract_feed.rs`
+
+**Interfaces:**
+- Consumes: `ContextManagerContractIrV1`
+- Produces: typed kit declaration rows sealed by `graph_from_context_manager_contract_ir`
+
+- [ ] Add a failing test proving the publisher branch exposes the typed declaration through the ordinary kit declaration/compiler feed.
+- [ ] Run the focused Python test and observe the missing production door failure.
+- [ ] Move the minimal typed publication boundary from prerequisite 2.
+- [ ] Run focused Python and battleaxe Rust round-trip/feed tests.
+- [ ] Commit and push PR #6072.
+
+### Task 2: Make the RPC order twin discriminating
+
+**Files:**
+- Modify: `implementations/rust/sugar-compiler/tests/prove_from_kit.rs`
+- Modify: the fixture RPC kit used by that test.
+
+**Interfaces:**
+- Consumes: production `fold_kit_to_pool` RPC sequence
+- Produces: an exact ordered event receipt
+
+- [ ] Replace the success-only assertion with a failing sequence assertion.
+- [ ] Confirm the planted bind-after-enumerate ordering fails.
+- [ ] Implement event capture and assert declarations, demands, bind, first semantic enumeration.
+- [ ] Run the focused battleaxe test green.
+
+### Task 3: Replace lexical floors with an AST detector
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_cm_construction_boundary.py`
+- Create: a focused detector helper beside the test if production reuse is unnecessary.
+
+**Interfaces:**
+- Consumes: complete `sugar_source_tree` and Sugar implementation roots
+- Produces: deterministic offender rows and R count
+
+- [ ] Write four planted tests for direct, nested-helper, aliased-import, and out-of-selected-file violations and observe the old floor miss them.
+- [ ] Implement AST import alias and call-chain recognition over every Python file in both roots.
+- [ ] Run all planted tests and the real-tree zero floor.
+- [ ] Rebase and push PR #6076.
+
+### Task 4: Verify and hand off
+
+**Files:**
+- No production changes.
+
+**Interfaces:**
+- Consumes: both final branch heads
+- Produces: battleaxe/Python receipts and architect review requests
+
+- [ ] Run focused and broad Python tests.
+- [ ] Run focused Rust and compiler checks on battleaxe through `bin/sugarbin`.
+- [ ] Confirm #6072 is based on main and #6076 is based on #6072 with no duplicated publication commit.
+- [ ] Re-request architect review on both non-draft PRs.

--- a/docs/superpowers/plans/2026-07-22-formatted-value.md
+++ b/docs/superpowers/plans/2026-07-22-formatted-value.md
@@ -1,0 +1,61 @@
+# FormattedValue Reference Projection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Drain well-formed `FormattedValue` direct gaps by projecting the exact Python-reference `python:fstring_value(value, conversion, format_spec)` coordinate.
+
+**Architecture:** `FormattedValue` validates its backend conversion slot and constructs a sugar carrying its value, typed conversion, and optional nested `JoinedStrSugar`. Desugaring projects the existing ProofIR constructor with explicit `None` terms and a nested `python:fstring` format specification; malformed slots remain typed loud failures.
+
+**Tech Stack:** Python 3, sugar source tree, sugar-lift ProofIR terms, pytest, pandas construction census.
+
+## Global Constraints
+
+- Mirror `sugar_lift_python_source.lifter.fstring_value()` exactly: value, conversion, format spec.
+- Do not emit `py.format` or a conversion intermediate.
+- No vendor or name dispatch.
+- Preserve child gaps exactly and classify malformed backend slots loudly.
+- Python locally; Rust round-trip runs on battleaxe.
+- Do not merge the non-draft PR.
+
+---
+
+### Task 1: Pin the five typed twins
+
+**Files:**
+- Modify: `implementations/python/sugar-source-tree/tests/test_fstring_sugar.py`
+
+**Interfaces:**
+- Consumes: `FormattedValue.sugar()` and ProofIR term constructors.
+- Produces: tests for ordered operands, conversion discrimination, explicit absence, swapped operands, and malformed operands.
+
+- [ ] **Step 1: Extend the red tests** to assert `python:fstring_value(value, conversion, format_spec)` and decoder failures for swapped or malformed terms.
+- [ ] **Step 2: Run the focused test file** with the repository `PYTHONPATH`; expect the well-formed modifier cases to fail at `FormattedValue.sugar` before implementation.
+
+### Task 2: Implement the exact reference projection
+
+**Files:**
+- Modify: `implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/fstring_sugar.py`
+
+**Interfaces:**
+- Consumes: value sugar, conversion integer, optional `JoinedStr` sugar.
+- Produces: `FormattedValueSugar(value, conversion, format_spec, site)` and the ordered `python:fstring_value` term.
+
+- [ ] **Step 1: Validate conversion** as exactly `-1`, `ord("a")`, `ord("r")`, or `ord("s")`; raise `BackendDefect` otherwise.
+- [ ] **Step 2: Carry all three operands** into `FormattedValueSugar`, using the optional child sugar without elision.
+- [ ] **Step 3: Project the reference term** with explicit `none_const()` for absent operands and `python:fstring` for the nested spec.
+- [ ] **Step 4: Run the focused tests** and require all five twins green.
+
+### Task 3: Measure and publish
+
+**Files:**
+- Create: `implementations/python/sugar-lift-py-tests/scripts/measure_formatted_value_frontier.py`
+
+**Interfaces:**
+- Consumes: installed pandas sources and normal function construction.
+- Produces: before/after direct-gap and blocked-descendant counts.
+
+- [ ] **Step 1: Run the family counter** before and after the arm and record the direct-gap delta.
+- [ ] **Step 2: Run focused Python tree tests** and the existing Python-reference f-string tests.
+- [ ] **Step 3: Run Python-to-Rust round-trip on battleaxe** and verify all operands retain reference order.
+- [ ] **Step 4: Rebase onto `origin/main`, commit as T Savo, push, and open a non-draft PR** without merging it.

--- a/implementations/python/sugar-lift-py-tests/scripts/measure_formatted_value_frontier.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/measure_formatted_value_frontier.py
@@ -1,0 +1,166 @@
+"""Measure pandas' FormattedValue construction frontier.
+
+This is a family-local delta instrument, not a baseline gate.  For every
+``FormattedValue`` in the installed pandas source tree it asks that node to
+construct directly and distinguishes the node's own gap from a gap inherited
+from one of its children.  Run the same command before and after the arm; the
+change in ``direct_gap`` is the observed family delta.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib.metadata
+import importlib.util
+import json
+import logging
+from collections import Counter
+from pathlib import Path
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.backend import BackendCouldNotParse, materialize
+from sugar_source_tree.cpython_adapter import _Handle
+from sugar_source_tree.nodes import SourceUnit
+from sugar_source_tree.panic import SourceTreePanic, SugarNotWritten
+
+
+def _installed_package_root(package: str) -> Path:
+    spec = importlib.util.find_spec(package)
+    if spec is None or spec.origin is None:
+        raise RuntimeError(f"could not locate installed package {package!r}")
+    return Path(spec.origin).resolve().parent
+
+
+def _shape(node) -> str:
+    conversion = node.conversion
+    has_spec = node.format_spec is not None
+    if conversion != -1 and has_spec:
+        return "conversion_and_format_spec"
+    if conversion != -1:
+        return "conversion_only"
+    if has_spec:
+        return "format_spec_only"
+    return "plain"
+
+
+def measure(root: Path) -> dict[str, object]:
+    counts: Counter[str] = Counter()
+    direct_by_shape: Counter[str] = Counter()
+    blocked_by_child: Counter[str] = Counter()
+    roll_call_blocked_by_child: Counter[str] = Counter()
+    other_panics: Counter[str] = Counter()
+    roll_call: Counter[str] = Counter()
+
+    paths = sorted(
+        path for path in root.rglob("*.py") if "__pycache__" not in path.parts
+    )
+    for path in paths:
+        counts["files_total"] += 1
+        try:
+            source, filename, source_cid = path_source(path)
+            parsed = ast.parse(source, filename=str(path))
+            native_nodes = [
+                node for node in ast.walk(parsed) if isinstance(node, ast.FormattedValue)
+            ]
+            if not native_nodes:
+                counts["files_without_formatted_value"] += 1
+                counts["files_completed"] += 1
+                continue
+            counts["files_with_formatted_value"] += 1
+            unit = SourceUnit(
+                filename=filename,
+                source=source,
+                source_cid=source_cid,
+            )
+            formatted_values = [
+                materialize(unit, _Handle(unit, native_node))
+                for native_node in native_nodes
+            ]
+            for node in formatted_values:
+                counts["formatted_value_total"] += 1
+                shape = _shape(node)
+                counts[f"shape.{shape}"] += 1
+                try:
+                    node.sugar()
+                except SugarNotWritten as panic:
+                    if panic.owner == "FormattedValue.sugar":
+                        counts["direct_gap"] += 1
+                        direct_by_shape[shape] += 1
+                    else:
+                        counts["blocked_descendant_gap"] += 1
+                        blocked_by_child[panic.observed.split(" at ", 1)[0]] += 1
+                except SourceTreePanic as panic:
+                    counts["other_source_tree_panic"] += 1
+                    other_panics[type(panic).__name__] += 1
+                else:
+                    counts["built"] += 1
+
+            function_nodes = [
+                node
+                for node in ast.walk(parsed)
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and any(
+                    isinstance(descendant, ast.FormattedValue)
+                    for descendant in ast.walk(node)
+                )
+            ]
+            for native_function in function_nodes:
+                roll_call["functions_with_formatted_value"] += 1
+                function = materialize(unit, _Handle(unit, native_function))
+                try:
+                    function.sugar()
+                except SugarNotWritten as panic:
+                    if panic.owner == "FormattedValue.sugar":
+                        roll_call["direct_gap"] += 1
+                    else:
+                        roll_call["blocked_descendant_gap"] += 1
+                        roll_call_blocked_by_child[
+                            panic.observed.split(" at ", 1)[0]
+                        ] += 1
+                except SourceTreePanic as panic:
+                    roll_call["other_source_tree_panic"] += 1
+                    other_panics[type(panic).__name__] += 1
+                except Exception as panic:
+                    roll_call["other_function_failure"] += 1
+                    other_panics[type(panic).__name__] += 1
+                else:
+                    roll_call["built"] += 1
+            counts["files_completed"] += 1
+        except BackendCouldNotParse:
+            counts["files_could_not_parse"] += 1
+        except (OSError, UnicodeError, SourceTreePanic) as panic:
+            counts["files_other_failure"] += 1
+            other_panics[type(panic).__name__] += 1
+
+    return {
+        "root": str(root),
+        "counts": dict(sorted(counts.items())),
+        "direct_gap_by_shape": dict(sorted(direct_by_shape.items())),
+        "roll_call": dict(sorted(roll_call.items())),
+        "roll_call_blocked_by_child": dict(
+            sorted(roll_call_blocked_by_child.items())
+        ),
+        "blocked_descendant_by_child": dict(sorted(blocked_by_child.items())),
+        "other_panics": dict(sorted(other_panics.items())),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="source root (default: installed pandas package)",
+    )
+    args = parser.parse_args()
+    logging.disable(logging.CRITICAL)
+    root = (args.root or _installed_package_root("pandas")).resolve()
+    report = measure(root)
+    report["pandas_version"] = importlib.metadata.version("pandas")
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
@@ -77,7 +77,11 @@ def census(root: Path) -> int:
     print("--- crashes (defects, not gaps) ---")
     for k, n in crashes.most_common():
         print(f"{n:8d}  {k}")
-    return 0
+    # A construction crash is a backend defect, not census residue.  Printing
+    # the row is testimony, but a successful process status would let callers
+    # bank a partial denominator as a complete census.  Keep ordinary
+    # SugarNotWritten gaps measurable while making every defect row red.
+    return 1 if crashes else 0
 
 
 def main() -> int:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/cm_boundary_detector.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/cm_boundary_detector.py
@@ -1,0 +1,115 @@
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class BoundaryReport:
+    files_scanned: int
+    offenders: tuple[str, ...]
+
+    @property
+    def r(self) -> int:
+        return len(self.offenders)
+
+    def render(self) -> str:
+        return "\n".join(self.offenders)
+
+
+def scan_construction_boundary(
+    *, sugar_root: Path, source_tree_root: Path
+) -> BoundaryReport:
+    files = tuple(sorted(sugar_root.rglob("*.py"))) + tuple(
+        sorted(source_tree_root.rglob("*.py"))
+    )
+    offenders: list[str] = []
+    for path in files:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        visitor = _BoundaryVisitor(path)
+        visitor.visit(tree)
+        offenders.extend(visitor.offenders)
+    return BoundaryReport(
+        files_scanned=len(files), offenders=tuple(sorted(set(offenders)))
+    )
+
+
+_HARD_MODULES = (
+    "sugar_linker",
+    "sugar.linker",
+    "sugar_proof_catalog",
+    "sugar_proof_envelope",
+)
+_SOURCE_ORACLE = "sugar_lift_python_source.source_oracle"
+_SOURCE_ORACLE_BOUNDARIES = frozenset({
+    "tree.py", "corpus.py", "bench_backends.py", "fragment.py",
+})
+_FORBIDDEN_CALLS = frozenset({
+    "resolve_context_manager_demand",
+    "resolve_context_manager_import",
+    "decode_context_manager_contract",
+    "member_field",
+    "member_kind",
+    "read_proof_catalog",
+})
+_SOURCE_CALLS = frozenset({"path_source", "installed_module_source"})
+
+
+def _dotted(node: ast.expr) -> str | None:
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+class _BoundaryVisitor(ast.NodeVisitor):
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.aliases: dict[str, str] = {}
+        self.offenders: list[str] = []
+
+    def _record(self, node: ast.AST, reason: str) -> None:
+        self.offenders.append(f"{self.path}:{getattr(node, 'lineno', 0)}:{reason}")
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            local = alias.asname or alias.name.split(".")[0]
+            self.aliases[local] = alias.name
+            if alias.name.startswith(_HARD_MODULES):
+                self._record(node, f"forbidden import {alias.name}")
+            if alias.name == _SOURCE_ORACLE and self.path.name not in _SOURCE_ORACLE_BOUNDARIES:
+                self._record(node, f"source-oracle import outside setup boundary {alias.name}")
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        module = node.module or ""
+        for alias in node.names:
+            local = alias.asname or alias.name
+            target = f"{module}.{alias.name}" if module else alias.name
+            self.aliases[local] = target
+            if module.startswith(_HARD_MODULES) or alias.name in _FORBIDDEN_CALLS:
+                self._record(node, f"forbidden import {target}")
+            if (
+                module == _SOURCE_ORACLE
+                and self.path.name not in _SOURCE_ORACLE_BOUNDARIES
+            ):
+                self._record(node, f"source-oracle import outside setup boundary {target}")
+
+    def visit_Call(self, node: ast.Call) -> None:
+        dotted = _dotted(node.func)
+        if dotted:
+            head, _, tail = dotted.partition(".")
+            resolved = self.aliases.get(head, head)
+            if tail:
+                resolved = f"{resolved}.{tail}"
+            call_name = resolved.rsplit(".", 1)[-1]
+            if call_name in _FORBIDDEN_CALLS:
+                self._record(node, f"forbidden call {resolved}")
+            if (
+                call_name in _SOURCE_CALLS
+                and self.path.name not in _SOURCE_ORACLE_BOUNDARIES
+            ):
+                self._record(node, f"source-oracle call outside setup boundary {resolved}")
+        self.generic_visit(node)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
@@ -1,66 +1,32 @@
-"""The typed context-manager contract, and the recognition membrane that issues it.
-
-T's ruling: three contracts wear the one `with` syntax, and production tree code
-sees a TYPED CONTRACT, never a vendor spelling. `pytest` is a vendor: the
-membrane authenticates community spellings (`pytest.raises(E)`,
-`contextlib.suppress(E)`, `tm.assert_produces_warning(W)`) and issues the
-general contract; the language implementation (nodes.py) consults the membrane
-and never matches names itself.
-
-The exit contracts (the only licenses for temporal dissolution):
-- ``NeverSuppresses`` -- exceptional body effect passes through after __exit__.
-- ``Suppresses(matcher)`` -- matching effects are consumed (permission).
-- ``Expects(matcher)`` -- matching effect is REQUIRED and consumed (obligation).
-- ``RuntimeSelected`` -- suppression undecidable statically; stays loud.
-
-Matching rule (pinned): EXACT exception-name match. Subclass matching needs a
-static type hierarchy the lift does not hold; a subclass raise therefore lands
-as the mismatch twin (loud, never silently matched) until that rule is widened
-deliberately.
-
-Enrollment (issue #5994): community coordinates enter ONLY through an
-explicitly loaded, hashed kit manifest that maps authenticated spellings to
-these contracts. This module holds the provider-neutral TYPES only; no vendor
-spelling may appear in code, tree-side or kit-side.
-"""
+"""Typed context-manager dispositions and sealed CM-contract publications."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+import json
+from typing import Any, Optional, Sequence
+
+from .canonicalizer import blake3_512_of, encode_jcs, varr, vobj, vstr
+from .claim_envelope import ClaimEnvelope, _assemble_layered
+from .ir import FunctionSort, PrimitiveSort, RegionSort, Sort, sort_to_value
+from .signing import Signer, ed25519_verify_string
 
 
 @dataclass(frozen=True)
 class MessagePattern:
-    """A payload obligation: the observed effect's message must match this
-    regex. Independently dischargeable -- undischarged (not passed, not failed)
-    until the effect witness carries authenticated message content."""
-
     pattern: str
 
 
 @dataclass(frozen=True)
 class EffectMatcher:
-    """A CONJUNCTION of independently dischargeable obligations (T's ruling:
-    the unit of honesty is the individual obligation, never the surface
-    construct). The type obligation is decidable against the observed halt;
-    each payload obligation (e.g. MessagePattern from `match=`) carries its own
-    closed verdict -- discharged / disproven / undischarged -- sharing the same
-    observed-effect witness identity."""
-
-    kind: str  # "raise" | "warning"
-    name: str  # e.g. "ValueError", "FutureWarning"
-    payload_obligations: tuple = ()  # e.g. (MessagePattern(pat),)
+    kind: str
+    name: str
+    payload_obligations: tuple = ()
 
 
-# Binding projections for `with … as name` — declared by the membrane, never
-# by matching vendor spellings in the tree. Syntax rewrites the name to an
-# ObservationRef(slot, projection=…); routing authenticates the slot.
 EXCEPTION_INFO = "exception_info"
 WARNING_OBSERVATION = "warning_observation"
 EFFECT = "effect"
-# Resource enter-result: tree coordinate for ``with m as x`` under a resource
-# disposition (NeverSuppresses / proven exit). Not an exception witness.
 ENTER_RESULT = "enter_result"
 
 
@@ -77,7 +43,6 @@ class Suppresses:
 @dataclass(frozen=True)
 class Expects:
     matcher: EffectMatcher
-    # What `as name` denotes when this contract is issued (None → no as-export).
     binding: Optional[str] = None
 
 
@@ -89,3 +54,214 @@ class RuntimeSelected:
 Contract = NeverSuppresses | Suppresses | Expects | RuntimeSelected
 
 
+@dataclass(frozen=True)
+class NeverSuppressesDispositionV1:
+    kind: str = "never-suppresses"
+
+
+@dataclass(frozen=True)
+class EnterResultContractV1:
+    sort: Sort
+    completion: str = "total"
+    projection: str = ENTER_RESULT
+
+
+@dataclass(frozen=True)
+class ExitContractV1:
+    disposition: NeverSuppressesDispositionV1
+    completion: str = "total"
+
+
+@dataclass(frozen=True)
+class ContextManagerSemanticsV1:
+    enter: EnterResultContractV1
+    exit: ExitContractV1
+    kind: str = "context-manager-semantics"
+    schema_version: str = "1"
+
+
+@dataclass(frozen=True)
+class PublishedContextManagerContractV1:
+    bridge_source_symbol: str
+    import_formals: tuple[str, ...]
+    import_sorts: tuple[Sort, ...]
+    semantics: ContextManagerSemanticsV1
+    source_warrants: tuple[str, ...]
+    payload_cid: str
+
+
+class ContextManagerContractError(ValueError):
+    """A sealed CM-contract member is malformed, stale, or unauthenticated."""
+
+
+def semantics_to_value(semantics: ContextManagerSemanticsV1):
+    if semantics.kind != "context-manager-semantics" or semantics.schema_version != "1":
+        raise ContextManagerContractError("unsupported context-manager semantics schema")
+    if semantics.enter.completion != "total" or semantics.enter.projection != ENTER_RESULT:
+        raise ContextManagerContractError("unsupported enter testimony")
+    if semantics.exit.completion != "total" or not isinstance(
+        semantics.exit.disposition, NeverSuppressesDispositionV1
+    ):
+        raise ContextManagerContractError("unsupported exit disposition")
+    return vobj([
+        ("kind", vstr("context-manager-semantics")),
+        ("schemaVersion", vstr("1")),
+        ("enter", vobj([
+            ("completion", vstr("total")),
+            ("result", vobj([
+                ("kind", vstr("projection")),
+                ("projection", vstr(ENTER_RESULT)),
+                ("sort", sort_to_value(semantics.enter.sort)),
+            ])),
+        ])),
+        ("exit", vobj([
+            ("completion", vstr("total")),
+            ("disposition", vobj([("kind", vstr("never-suppresses"))])),
+        ])),
+    ])
+
+
+def publish_never_suppresses_context_manager_contract(
+    *, bridge_source_symbol: str, import_signature: Any,
+    enter_result_sort: Sort, source_warrants: Sequence[str],
+    signer: Signer, declared_at: str,
+) -> ClaimEnvelope:
+    if not bridge_source_symbol:
+        raise ContextManagerContractError("bridgeSourceSymbol must be non-empty")
+    formals = tuple(import_signature.formals)
+    sorts = tuple(import_signature.sorts)
+    if len(formals) != len(sorts):
+        raise ContextManagerContractError("import signature formals/sorts length mismatch")
+    if not all(isinstance(w, str) and w.startswith("blake3-512:") for w in source_warrants):
+        raise ContextManagerContractError("sourceWarrants must be CID references")
+    semantics = ContextManagerSemanticsV1(
+        enter=EnterResultContractV1(sort=enter_result_sort),
+        exit=ExitContractV1(disposition=NeverSuppressesDispositionV1()),
+    )
+    payload = semantics_to_value(semantics)
+    payload_cid = blake3_512_of(encode_jcs(payload).encode())
+    sorted_inputs = sorted(source_warrants)
+    header = vobj([
+        ("schemaVersion", vstr("1.2")),
+        ("kind", vstr("context-manager-contract")),
+        ("cid", vstr(payload_cid)),
+        ("payloadCid", vstr(payload_cid)),
+        ("bridgeSourceSymbol", vstr(bridge_source_symbol)),
+        ("importSignature", vobj([
+            ("formals", varr([vstr(v) for v in formals])),
+            ("sorts", varr([sort_to_value(v) for v in sorts])),
+        ])),
+        ("payload", payload),
+        ("sourceWarrants", varr([vstr(v) for v in source_warrants])),
+        ("inputCids", varr([vstr(v) for v in sorted_inputs])),
+    ])
+    metadata = vobj([
+        ("authoring", vobj([
+            ("producerKind", vstr("kit-author")),
+            ("author", vstr(signer.producer_id)),
+        ])),
+        ("producedBy", vstr(signer.producer_id)),
+        ("producedAt", vstr(declared_at)),
+    ])
+    return _assemble_layered(header, metadata, declared_at, signer.seed, payload_cid)
+
+
+def _json_value(value: Any):
+    from .canonicalizer import vbool, vint, vnull
+    if value is None:
+        return vnull()
+    if isinstance(value, bool):
+        return vbool(value)
+    if isinstance(value, int):
+        return vint(value)
+    if isinstance(value, str):
+        return vstr(value)
+    if isinstance(value, list):
+        return varr([_json_value(v) for v in value])
+    if isinstance(value, dict):
+        return vobj([(k, _json_value(v)) for k, v in value.items()])
+    raise ContextManagerContractError(f"unsupported payload value: {type(value)!r}")
+
+
+def _decode_sort(raw: Any) -> Sort:
+    if not isinstance(raw, dict):
+        raise ContextManagerContractError("sort must be an object")
+    if raw.get("kind") == "primitive" and set(raw) == {"kind", "name"} and isinstance(raw["name"], str):
+        return PrimitiveSort(raw["name"])
+    if raw.get("kind") == "region" and set(raw) == {"kind", "name"} and isinstance(raw["name"], str):
+        return RegionSort(raw["name"])
+    if raw.get("kind") == "function" and set(raw) == {"kind", "args", "return"} and isinstance(raw["args"], list):
+        return FunctionSort(tuple(_decode_sort(v) for v in raw["args"]), _decode_sort(raw["return"]))
+    raise ContextManagerContractError("unsupported or malformed sort")
+
+
+def _decode_semantics(raw: Any) -> ContextManagerSemanticsV1:
+    if not isinstance(raw, dict) or set(raw) != {"kind", "schemaVersion", "enter", "exit"}:
+        raise ContextManagerContractError("malformed context-manager semantics")
+    if raw["kind"] != "context-manager-semantics" or raw["schemaVersion"] != "1":
+        raise ContextManagerContractError("unknown context-manager semantics schema")
+    enter = raw["enter"]
+    exit_ = raw["exit"]
+    if not isinstance(enter, dict) or set(enter) != {"completion", "result"}:
+        raise ContextManagerContractError("malformed context-manager semantics enter")
+    result = enter["result"]
+    if enter["completion"] != "total" or not isinstance(result, dict) or set(result) != {"kind", "projection", "sort"} or result["kind"] != "projection" or result["projection"] != ENTER_RESULT:
+        raise ContextManagerContractError("unsupported enter testimony")
+    if not isinstance(exit_, dict) or set(exit_) != {"completion", "disposition"}:
+        raise ContextManagerContractError("malformed context-manager semantics exit")
+    disposition = exit_["disposition"]
+    if exit_["completion"] != "total" or not isinstance(disposition, dict) or set(disposition) != {"kind"}:
+        raise ContextManagerContractError("malformed exit disposition")
+    if disposition["kind"] != "never-suppresses":
+        raise ContextManagerContractError("unknown exit disposition")
+    return ContextManagerSemanticsV1(
+        enter=EnterResultContractV1(sort=_decode_sort(result["sort"])),
+        exit=ExitContractV1(disposition=NeverSuppressesDispositionV1()),
+    )
+
+
+def decode_context_manager_contract(
+    canonical_bytes: bytes, member_cid: str
+) -> PublishedContextManagerContractV1:
+    try:
+        raw = json.loads(canonical_bytes)
+    except (TypeError, ValueError) as exc:
+        raise ContextManagerContractError("member is not JSON") from exc
+    if not isinstance(raw, dict) or set(raw) != {"envelope", "header", "metadata"}:
+        raise ContextManagerContractError("CM contract must be a layered member")
+    envelope, header = raw["envelope"], raw["header"]
+    if not isinstance(raw["metadata"], dict):
+        raise ContextManagerContractError("layered metadata must be an object")
+    if blake3_512_of(encode_jcs(_json_value(envelope)).encode()) != member_cid:
+        raise ContextManagerContractError("member attestation CID does not match envelope")
+    signing = vobj([("header", _json_value(header)), ("metadata", _json_value(raw["metadata"]))])
+    if not ed25519_verify_string(envelope.get("signer", ""), envelope.get("signature", ""), encode_jcs(signing).encode()):
+        raise ContextManagerContractError("member signature does not verify")
+    expected = {"schemaVersion", "kind", "cid", "payloadCid", "bridgeSourceSymbol", "importSignature", "payload", "sourceWarrants", "inputCids"}
+    if not isinstance(header, dict) or set(header) != expected or header.get("schemaVersion") != "1.2" or header.get("kind") != "context-manager-contract":
+        raise ContextManagerContractError("malformed context-manager-contract header")
+    semantics = _decode_semantics(header["payload"])
+    payload_cid = blake3_512_of(encode_jcs(semantics_to_value(semantics)).encode())
+    if header["cid"] != payload_cid or header["payloadCid"] != payload_cid:
+        raise ContextManagerContractError("context-manager payload CID does not match semantics")
+    signature = header["importSignature"]
+    if not isinstance(signature, dict) or set(signature) != {"formals", "sorts"} or not isinstance(signature["formals"], list) or not isinstance(signature["sorts"], list) or len(signature["formals"]) != len(signature["sorts"]):
+        raise ContextManagerContractError("malformed importSignature")
+    if not all(isinstance(v, str) for v in signature["formals"]):
+        raise ContextManagerContractError("import formals must be strings")
+    warrants = header["sourceWarrants"]
+    if not isinstance(warrants, list) or not all(isinstance(v, str) and v.startswith("blake3-512:") for v in warrants):
+        raise ContextManagerContractError("sourceWarrants must be CID references")
+    if header["inputCids"] != sorted(warrants):
+        raise ContextManagerContractError("inputCids do not match sourceWarrants")
+    symbol = header["bridgeSourceSymbol"]
+    if not isinstance(symbol, str) or not symbol:
+        raise ContextManagerContractError("bridgeSourceSymbol must be non-empty")
+    return PublishedContextManagerContractV1(
+        bridge_source_symbol=symbol,
+        import_formals=tuple(signature["formals"]),
+        import_sorts=tuple(_decode_sort(v) for v in signature["sorts"]),
+        semantics=semantics,
+        source_warrants=tuple(warrants),
+        payload_cid=payload_cid,
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -122,8 +122,8 @@ def _decode_signature(raw: Any) -> ImportSignatureV1:
     if not isinstance(raw["formals"], list) or not all(isinstance(v, str) for v in raw["formals"]):
         raise ContractRefProtocolError("malformed import formals")
     try:
-        from .context_manager_contract import _sort_from_json
-        sorts = tuple(_sort_from_json(value) for value in raw["sorts"])
+        from .context_manager_contract import _decode_sort
+        sorts = tuple(_decode_sort(value) for value in raw["sorts"])
     except (KeyError, TypeError, ContextManagerContractError) as exc:
         raise ContractRefProtocolError("malformed import sorts") from exc
     if len(sorts) != len(raw["formals"]):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -1,0 +1,216 @@
+"""Frozen, authenticated context-manager coordinates installed before construction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from .canonicalizer import blake3_512_of, encode_jcs
+from .context_manager_contract import (
+    ContextManagerContractError,
+    ContextManagerSemanticsV1,
+    _decode_semantics,
+    _json_value,
+)
+from .ir import Sort
+
+
+class ContractRefProtocolError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, order=True)
+class SourceFragmentCoordinateV1:
+    source_cid: str
+    start_line: int
+    start_col: int
+    end_line: int
+    end_col: int
+
+    @classmethod
+    def decode(cls, raw: Any) -> "SourceFragmentCoordinateV1":
+        if not isinstance(raw, dict) or set(raw) != {
+            "sourceCid", "startLine", "startCol", "endLine", "endCol"
+        }:
+            raise ContractRefProtocolError("malformed source-fragment coordinate")
+        values = (raw["startLine"], raw["startCol"], raw["endLine"], raw["endCol"])
+        if not isinstance(raw["sourceCid"], str) or not all(
+            isinstance(value, int) and value >= 0 for value in values
+        ):
+            raise ContractRefProtocolError("malformed source-fragment coordinate fields")
+        return cls(raw["sourceCid"], *values)
+
+    def wire(self) -> dict[str, Any]:
+        return {
+            "sourceCid": self.source_cid,
+            "startLine": self.start_line,
+            "startCol": self.start_col,
+            "endLine": self.end_line,
+            "endCol": self.end_col,
+        }
+
+
+@dataclass(frozen=True)
+class ImportSignatureV1:
+    formals: tuple[str, ...]
+    sorts: tuple[Sort, ...]
+
+
+@dataclass(frozen=True)
+class ContextManagerContractRefV1:
+    resolution_cid: str
+    demand_cid: str
+    use_site: SourceFragmentCoordinateV1
+    catalog_cid: str
+    member_cid: str
+    payload_cid: str
+    bridge_source_symbol: str
+    import_signature: ImportSignatureV1
+    semantics: ContextManagerSemanticsV1
+    source_warrant_cids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ContextManagerResolutionGapV1:
+    demand_cid: str
+    use_site: SourceFragmentCoordinateV1
+    target_symbol: str | None
+    kind: str
+    candidate_member_cids: tuple[str, ...]
+
+
+ContextManagerResolutionV1 = ContextManagerContractRefV1 | ContextManagerResolutionGapV1
+
+
+@dataclass(frozen=True)
+class ResolvedContractRefsV1:
+    catalog_cid: str
+    table_cid: str
+    by_use_site: Mapping[SourceFragmentCoordinateV1, ContextManagerResolutionV1]
+
+    def require(self, use_site: SourceFragmentCoordinateV1) -> ContextManagerResolutionV1:
+        try:
+            return self.by_use_site[use_site]
+        except KeyError as exc:
+            raise ContractRefProtocolError(
+                "BackendDefect: enrolled context-manager demand missing from resolution table"
+            ) from exc
+
+
+_GAP_KINDS = frozenset({
+    "runtime-selected", "unresolved-symbol", "ambiguous-symbol",
+    "wrong-contract-kind", "signature-mismatch", "unauthenticated-member",
+    "payload-cid-mismatch", "unsupported-cm-schema",
+})
+
+
+def _cid(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.startswith("blake3-512:"):
+        raise ContractRefProtocolError(f"{field} must be a CID")
+    return value
+
+
+def _decode_signature(raw: Any) -> ImportSignatureV1:
+    if not isinstance(raw, dict) or set(raw) != {"formals", "sorts"}:
+        raise ContractRefProtocolError("malformed import signature")
+    if not isinstance(raw["formals"], list) or not all(isinstance(v, str) for v in raw["formals"]):
+        raise ContractRefProtocolError("malformed import formals")
+    try:
+        from .context_manager_contract import _sort_from_json
+        sorts = tuple(_sort_from_json(value) for value in raw["sorts"])
+    except (KeyError, TypeError, ContextManagerContractError) as exc:
+        raise ContractRefProtocolError("malformed import sorts") from exc
+    if len(sorts) != len(raw["formals"]):
+        raise ContractRefProtocolError("import signature arity mismatch")
+    return ImportSignatureV1(tuple(raw["formals"]), sorts)
+
+
+def _resolution_cid_preimage(raw: dict[str, Any]) -> dict[str, Any]:
+    return {key: raw[key] for key in (
+        "schemaVersion", "demandCid", "useSite", "catalogCid", "memberCid",
+        "payloadCid", "bridgeSourceSymbol", "importSignature", "semantics",
+        "sourceWarrantCids",
+    )}
+
+
+def _hash_json(raw: Any) -> str:
+    return blake3_512_of(encode_jcs(_json_value(raw)))
+
+
+def _decode_ref(raw: Any) -> ContextManagerContractRefV1:
+    expected = {
+        "kind", "schemaVersion", "resolutionCid", "demandCid", "useSite",
+        "catalogCid", "memberCid", "payloadCid", "bridgeSourceSymbol",
+        "importSignature", "semantics", "sourceWarrantCids",
+    }
+    if not isinstance(raw, dict) or set(raw) != expected:
+        raise ContractRefProtocolError("malformed context-manager contract ref")
+    if raw["kind"] != "context-manager-contract-ref" or raw["schemaVersion"] != "1":
+        raise ContractRefProtocolError("unsupported context-manager contract ref")
+    resolution_cid = _cid(raw["resolutionCid"], "resolutionCid")
+    if _hash_json(_resolution_cid_preimage(raw)) != resolution_cid:
+        raise ContractRefProtocolError("resolution CID mismatch")
+    try:
+        semantics = _decode_semantics(raw["semantics"])
+    except ContextManagerContractError as exc:
+        raise ContractRefProtocolError("unsupported context-manager semantics") from exc
+    warrants = raw["sourceWarrantCids"]
+    if not isinstance(warrants, list):
+        raise ContractRefProtocolError("sourceWarrantCids must be a list")
+    return ContextManagerContractRefV1(
+        resolution_cid, _cid(raw["demandCid"], "demandCid"),
+        SourceFragmentCoordinateV1.decode(raw["useSite"]),
+        _cid(raw["catalogCid"], "catalogCid"), _cid(raw["memberCid"], "memberCid"),
+        _cid(raw["payloadCid"], "payloadCid"), raw["bridgeSourceSymbol"],
+        _decode_signature(raw["importSignature"]), semantics,
+        tuple(_cid(value, "sourceWarrantCid") for value in warrants),
+    )
+
+
+def decode_resolved_contract_refs(raw: Any) -> ResolvedContractRefsV1:
+    if not isinstance(raw, dict) or set(raw) != {
+        "kind", "schemaVersion", "catalogCid", "tableCid", "byUseSite"
+    } or raw["kind"] != "resolved-contract-refs" or raw["schemaVersion"] != "1":
+        raise ContractRefProtocolError("malformed resolved-contract-ref table")
+    table_cid = _cid(raw["tableCid"], "tableCid")
+    identity = {key: raw[key] for key in ("kind", "schemaVersion", "catalogCid", "byUseSite")}
+    if _hash_json(identity) != table_cid:
+        raise ContractRefProtocolError("resolution table CID mismatch")
+    rows = raw["byUseSite"]
+    if not isinstance(rows, list):
+        raise ContractRefProtocolError("byUseSite must be a list")
+    decoded: dict[SourceFragmentCoordinateV1, ContextManagerResolutionV1] = {}
+    catalog_cid = _cid(raw["catalogCid"], "catalogCid")
+    for row in rows:
+        if not isinstance(row, dict) or set(row) != {"useSite", "resolution"}:
+            raise ContractRefProtocolError("malformed resolution row")
+        use_site = SourceFragmentCoordinateV1.decode(row["useSite"])
+        resolution = row["resolution"]
+        if not isinstance(resolution, dict):
+            raise ContractRefProtocolError("malformed resolution")
+        if resolution.get("kind") == "resolved" and set(resolution) == {"kind", "reference"}:
+            value: ContextManagerResolutionV1 = _decode_ref(resolution["reference"])
+            if value.use_site != use_site or value.catalog_cid != catalog_cid:
+                raise ContractRefProtocolError("resolution coordinate/catalog mismatch")
+        elif resolution.get("kind") == "unresolved" and set(resolution) == {"kind", "gap"}:
+            gap = resolution["gap"]
+            if not isinstance(gap, dict) or gap.get("kind") not in _GAP_KINDS:
+                raise ContractRefProtocolError("malformed context-manager resolution gap")
+            candidates = gap.get("candidateMemberCids")
+            if not isinstance(candidates, list) or candidates != sorted(candidates):
+                raise ContractRefProtocolError("candidate member CIDs must be sorted")
+            value = ContextManagerResolutionGapV1(
+                _cid(gap.get("demandCid"), "demandCid"),
+                SourceFragmentCoordinateV1.decode(gap.get("useSite")),
+                gap.get("targetSymbol"), gap["kind"],
+                tuple(_cid(v, "candidateMemberCid") for v in candidates),
+            )
+            if value.use_site != use_site:
+                raise ContractRefProtocolError("gap coordinate mismatch")
+        else:
+            raise ContractRefProtocolError("unknown context-manager resolution")
+        if use_site in decoded:
+            raise ContractRefProtocolError("duplicate resolution coordinate")
+        decoded[use_site] = value
+    return ResolvedContractRefsV1(catalog_cid, table_cid, MappingProxyType(decoded))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -98,6 +98,11 @@ class ResolvedContractRefsV1:
             ) from exc
 
 
+@dataclass(frozen=True)
+class TreeConstructionContextV1:
+    contract_refs: ResolvedContractRefsV1
+
+
 _GAP_KINDS = frozenset({
     "runtime-selected", "unresolved-symbol", "ambiguous-symbol",
     "wrong-contract-kind", "signature-mismatch", "unauthenticated-member",
@@ -135,7 +140,7 @@ def _resolution_cid_preimage(raw: dict[str, Any]) -> dict[str, Any]:
 
 
 def _hash_json(raw: Any) -> str:
-    return blake3_512_of(encode_jcs(_json_value(raw)))
+    return blake3_512_of(encode_jcs(_json_value(raw)).encode("utf-8"))
 
 
 def _decode_ref(raw: Any) -> ContextManagerContractRefV1:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/__init__.py
@@ -14,6 +14,7 @@ from .factory_walk_row_dto import (
 )
 from .implication_dto import ImplicationDto
 from .lift_report_payload_dto import LiftReportPayloadDto
+from .context_manager_contract_dto import ContextManagerContractIrV1, ImportSignatureV1
 from .open_lane_dto import (
     CallEdgeDto,
     DiagnosticDto,
@@ -55,6 +56,8 @@ __all__ = [
     "FactoryWalkRowDto",
     "ImplicationDto",
     "LiftReportPayloadDto",
+    "ContextManagerContractIrV1",
+    "ImportSignatureV1",
     "PlanAtomDto",
     "RecoveredAuditDto",
     "RecoveredEffectDto",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/context_manager_contract_dto.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/context_manager_contract_dto.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any
+
+from sugar_lift_py_tests.context_manager_contract import (
+    ContextManagerSemanticsV1,
+    EnterResultContractV1,
+    ExitContractV1,
+    NeverSuppressesDispositionV1,
+    semantics_to_value,
+)
+from sugar_lift_py_tests.ir import Sort, sort_to_value
+
+
+@dataclass(frozen=True)
+class ImportSignatureV1:
+    formals: tuple[str, ...]
+    sorts: tuple[Sort, ...]
+
+    def __post_init__(self) -> None:
+        if len(self.formals) != len(self.sorts):
+            raise ValueError("import signature formals/sorts length mismatch")
+
+
+@dataclass(frozen=True)
+class ContextManagerContractIrV1:
+    bridge_source_symbol: str
+    import_signature: ImportSignatureV1
+    payload: ContextManagerSemanticsV1
+    source_warrants: tuple[str, ...]
+    kind: str = "context-manager-contract"
+    schema_version: str = "1"
+
+    @classmethod
+    def never_suppresses(
+        cls, *, bridge_source_symbol: str, import_signature: ImportSignatureV1,
+        enter_result_sort: Sort, source_warrants: tuple[str, ...],
+    ) -> "ContextManagerContractIrV1":
+        return cls(
+            bridge_source_symbol=bridge_source_symbol,
+            import_signature=import_signature,
+            payload=ContextManagerSemanticsV1(
+                enter=EnterResultContractV1(sort=enter_result_sort),
+                exit=ExitContractV1(disposition=NeverSuppressesDispositionV1()),
+            ),
+            source_warrants=source_warrants,
+        )
+
+    def to_rpc_with_term_table(self, _term_table: Any) -> dict[str, Any]:
+        if not self.bridge_source_symbol:
+            raise ValueError("bridgeSourceSymbol must be non-empty")
+        if not all(w.startswith("blake3-512:") for w in self.source_warrants):
+            raise ValueError("sourceWarrants must be CID references")
+        return {
+            "kind": self.kind,
+            "schemaVersion": self.schema_version,
+            "bridgeSourceSymbol": self.bridge_source_symbol,
+            "importSignature": {
+                "formals": list(self.import_signature.formals),
+                "sorts": [json.loads(_encode(sort_to_value(v))) for v in self.import_signature.sorts],
+            },
+            "payload": json.loads(_encode(semantics_to_value(self.payload))),
+            "sourceWarrants": list(self.source_warrants),
+        }
+
+
+def _encode(value: Any) -> str:
+    from sugar_lift_py_tests.canonicalizer import encode_jcs
+    return encode_jcs(value)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/lift_report_payload_dto.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/lift_report_payload_dto.py
@@ -8,6 +8,7 @@ from typing import Any
 from .assertion_surface_audit_dto import AssertionSurfaceAuditDto
 from .body_universe_dto import BodyUniverseDto
 from .component_plan_memento_dto import ComponentPlanMementoDto
+from .context_manager_contract_dto import ContextManagerContractIrV1
 from .effect_dto import EffectDto
 from .factory_audit_summary_dto import FactoryAuditSummaryDto
 from .factory_walk_row_dto import FactoryWalkRowDto
@@ -32,8 +33,8 @@ _TRANSPORT_LOG = logging.getLogger("sugar.kit.transport")
 class LiftReportPayloadDto:
     # Closed lanes: a DTO already exists for every row, so no raw-dict side
     # door is left for callers to bypass construction law (#3661).
-    ir: list[BodyUniverseDto | SourceFunctionContractDto] = field(
-        default_factory=list[BodyUniverseDto | SourceFunctionContractDto]
+    ir: list[BodyUniverseDto | SourceFunctionContractDto | ContextManagerContractIrV1] = field(
+        default_factory=list[BodyUniverseDto | SourceFunctionContractDto | ContextManagerContractIrV1]
     )
     source_mementos: list[SourceMementoDto] = field(
         default_factory=list[SourceMementoDto]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -38,6 +38,7 @@ from sugar_lift_py_tests.idd.lift_coverage_accounting import (
 )
 from sugar_lift_py_tests.idd.lift_coverage_census import census_paths
 from sugar_lift_py_tests.kit_rpc import (
+    ContextManagerContractIrV1,
     EffectDto,
     LiftReportPayloadDto,
     RecoveredEffectDto,
@@ -66,6 +67,17 @@ _TRANSPORT_LOG = logging.getLogger("sugar.kit.transport")
 _ENUMERATION_PHASES: Dict[str, tuple[int, float, float]] = {}
 _ENUMERATION_REQUEST_COUNT = 0
 _ENUMERATION_ACTIVE = False
+_PUBLISHED_CONTEXT_MANAGER_DECLARATIONS: tuple[ContextManagerContractIrV1, ...] = ()
+
+
+def publish_context_manager_declaration(
+    declaration: ContextManagerContractIrV1,
+) -> None:
+    """Publish a typed bodyless member on the live kit declaration."""
+    global _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS
+    if not isinstance(declaration, ContextManagerContractIrV1):
+        raise ValueError("typed context-manager declaration required")
+    _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS += (declaration,)
 # Passive, process-lifetime context paid for by an enumeration demand. The
 # outer identity is the file content CID; the path seat is retained because
 # source mementos carry the workspace-relative filename even for identical
@@ -553,6 +565,10 @@ def _kit_declaration_result() -> Dict[str, Any]:
             "rpcMethod": "sugar.plugin.resolve_dependency_proofs",
         },
         "residueCategories": [],
+        "contractDeclarations": [
+            row.to_rpc_with_term_table(None)
+            for row in _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS
+        ],
     }
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2058,6 +2058,13 @@ def _dispatch_request(msg: Dict[str, Any]) -> bool:
     msg_id = msg.get("id")
     method = msg.get("method")
     params = msg.get("params", {})
+    sequence_path = os.environ.get("SUGAR_RPC_SEQUENCE_LOG")
+    if sequence_path:
+        suffix = ""
+        if method == ENUMERATE_RPC_METHOD and isinstance(params, dict):
+            suffix = f":{params.get('level', '')}"
+        with Path(sequence_path).open("a", encoding="utf-8") as sequence_log:
+            sequence_log.write(f"{method}{suffix}\n")
 
     if method == "initialize":
         _handle_initialize(msg_id)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -56,6 +56,7 @@ KIT_DECLARATION_RPC_METHOD = "sugar.plugin.kit_declaration"
 COMPONENT_PLAN_RPC_METHOD = "sugar.component.plan"
 RESOLVE_SOURCE_MEMENTO_RPC_METHOD = "sugar.plugin.resolve_source_memento"
 ENUMERATE_RPC_METHOD = "sugar.enumerate"
+BIND_CONTRACT_REFS_RPC_METHOD = "sugar.plugin.bind_contract_refs"
 COMPONENT_PROTOCOL_VERSION = "sugar-component/1"
 LIFT_PROTOCOL_VERSION = "pep/1.7.0"
 PYTHON_SURFACE = "python"
@@ -67,6 +68,7 @@ _TRANSPORT_LOG = logging.getLogger("sugar.kit.transport")
 _ENUMERATION_PHASES: Dict[str, tuple[int, float, float]] = {}
 _ENUMERATION_REQUEST_COUNT = 0
 _ENUMERATION_ACTIVE = False
+_BOUND_CONTRACT_REFS = None
 _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS: tuple[ContextManagerContractIrV1, ...] = ()
 
 
@@ -75,9 +77,64 @@ def publish_context_manager_declaration(
 ) -> None:
     """Publish a typed bodyless member on the live kit declaration."""
     global _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS
+    if _BOUND_CONTRACT_REFS is not None:
+        raise RuntimeError("context-manager declarations are frozen for this generation")
     if not isinstance(declaration, ContextManagerContractIrV1):
         raise ValueError("typed context-manager declaration required")
     _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS += (declaration,)
+
+
+def _context_manager_demand_rows(root: Path) -> List[Dict[str, Any]]:
+    """Enroll with-site import coordinates without constructing any Sugar."""
+    from sugar_lift_python_source.source_oracle import SourceUnavailable, path_source
+    from sugar_source_tree.tree import SourceTree
+
+    rows: List[Dict[str, Any]] = []
+    for path in SourceTree(root).paths():
+        try:
+            source, _filename, source_cid = path_source(str(path))
+        except SourceUnavailable:
+            continue
+        module = ast.parse(source, filename=str(path))
+        imports: Dict[str, str] = {}
+        for node in ast.walk(module):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                for alias in node.names:
+                    imports[alias.asname or alias.name] = f"{node.module}.{alias.name}"
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    imports[alias.asname or alias.name.split(".")[0]] = alias.name
+        for node in ast.walk(module):
+            if not isinstance(node, (ast.With, ast.AsyncWith)):
+                continue
+            for item in node.items:
+                expression = item.context_expr
+                target = None
+                if isinstance(expression, ast.Call) and not expression.args and not expression.keywords:
+                    callee = expression.func
+                    if isinstance(callee, ast.Name):
+                        target = imports.get(callee.id)
+                    elif isinstance(callee, ast.Attribute) and isinstance(callee.value, ast.Name):
+                        base = imports.get(callee.value.id)
+                        if base:
+                            target = f"{base}.{callee.attr}"
+                coordinate = {
+                    "sourceCid": source_cid,
+                    "startLine": expression.lineno,
+                    "startCol": expression.col_offset,
+                    "endLine": expression.end_lineno,
+                    "endCol": expression.end_col_offset,
+                }
+                rows.append({
+                    "schemaVersion": "1",
+                    "kind": "context-manager-demand",
+                    "useSite": coordinate,
+                    "targetSymbol": f"context-manager:{target}" if target else None,
+                    "importSignature": {"formals": [], "sorts": []},
+                    "expectedKind": "context-manager-contract",
+                    "gapKind": None if target else "runtime-selected",
+                })
+    return rows
 # Passive, process-lifetime context paid for by an enumeration demand. The
 # outer identity is the file content CID; the path seat is retained because
 # source mementos carry the workspace-relative filename even for identical
@@ -548,6 +605,7 @@ def _kit_declaration_result() -> Dict[str, Any]:
                 {"name": COMPONENT_PLAN_RPC_METHOD, "required": False},
                 {"name": RESOLVE_SOURCE_MEMENTO_RPC_METHOD, "required": False},
                 {"name": ENUMERATE_RPC_METHOD, "required": False},
+                {"name": BIND_CONTRACT_REFS_RPC_METHOD, "required": False},
                 {"name": "lift", "required": True},
                 {"name": "sugar.plugin.lift_implications", "required": False},
                 {"name": "sugar.plugin.resolve_dependency_proofs", "required": False},
@@ -1330,6 +1388,13 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
     at = params.get("at") if isinstance(params.get("at"), dict) else None
     seek = bool(params.get("seek", False))
     options = params.get("options") if isinstance(params.get("options"), dict) else {}
+    if _BOUND_CONTRACT_REFS is not None:
+        generation = options.get("contractRefs")
+        if generation != {
+            "catalogCid": _BOUND_CONTRACT_REFS.catalog_cid,
+            "tableCid": _BOUND_CONTRACT_REFS.table_cid,
+        }:
+            raise ValueError("semantic construction request has a stale contract-ref generation")
     # The audit frontier's factory census is deleted; auditFrontier now short-
     # circuits to an empty frontier (its R census re-homes onto the source
     # tree's reporter channel, not yet wired). allowedBrokenComponents was the
@@ -1347,6 +1412,16 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
     )
 
     try:
+        if level == "contract-declarations":
+            _send({"jsonrpc": "2.0", "id": msg_id, "result": {
+                "rows": [dict(row) for row in _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS]
+            }})
+            return
+        if level == "contract-demands":
+            _send({"jsonrpc": "2.0", "id": msg_id, "result": {
+                "rows": _context_manager_demand_rows(root)
+            }})
+            return
         if level == "source_files":
             # The source_files level IS SourceTree.fragments(): whole-file
             # fragments minted through the SourceOracle — identity without
@@ -1538,7 +1613,16 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                         ],
                     )
                     return
-                tree_file = _TreeSourceFile(identity)
+                from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+
+                construction_context = (
+                    TreeConstructionContextV1(_BOUND_CONTRACT_REFS)
+                    if _BOUND_CONTRACT_REFS is not None
+                    else None
+                )
+                tree_file = _TreeSourceFile(
+                    identity, construction_context=construction_context
+                )
                 nodes = []
                 for fn in tree_file.functions():
                     lc = fn.line_col_span()
@@ -2000,6 +2084,15 @@ def _dispatch_request(msg: Dict[str, Any]) -> bool:
         _handle_resolve_dependency_proofs(
             msg_id, params if isinstance(params, dict) else {}
         )
+    elif method == BIND_CONTRACT_REFS_RPC_METHOD:
+        from sugar_lift_py_tests.context_manager_resolution import decode_resolved_contract_refs
+
+        global _BOUND_CONTRACT_REFS
+        installed = decode_resolved_contract_refs(params)
+        if _BOUND_CONTRACT_REFS is not None and _BOUND_CONTRACT_REFS.table_cid != installed.table_cid:
+            raise ValueError("contract-ref generation is already frozen")
+        _BOUND_CONTRACT_REFS = installed
+        _send({"jsonrpc": "2.0", "id": msg_id, "result": {"tableCid": installed.table_cid}})
     elif method == ENUMERATE_RPC_METHOD:
         global _ENUMERATION_ACTIVE, _ENUMERATION_REQUEST_COUNT
         enumerate_started = time.monotonic()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -1414,7 +1414,10 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
     try:
         if level == "contract-declarations":
             _send({"jsonrpc": "2.0", "id": msg_id, "result": {
-                "rows": [dict(row) for row in _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS]
+                "rows": [
+                    row.to_rpc_with_term_table(None)
+                    for row in _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS
+                ]
             }})
             return
         if level == "contract-demands":

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/fstring_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/fstring_sugar.py
@@ -2,12 +2,11 @@
 
 A JoinedStr is the CONCATENATION of its parts -- literal chunks (StringLiteral)
 and interpolations (FormattedValue). It folds them left with `add`, the same
-string concatenation `+` uses: ground chunks fold to one string, an interpolated
-symbol becomes a `str.++` coordinate. A FormattedValue is `format(value, spec)`:
-with no conversion and no format spec it is the value's own `__format__`
-coordinate (`call:__format__(value, "")`), decidable without inventing a
-rendered string. A conversion (`!r`/`!s`/`!a`) or a format spec (`{x:>10}`) is
-not lifted yet -- LOUD, never a silently dropped modifier.
+string concatenation `+` uses. A FormattedValue projects the Python reference's
+opaque ``python:fstring_value(value, conversion, format_spec)`` coordinate.
+Conversion and format spec remain typed operands: absence is explicit ``None``
+and a present spec is a nested ``python:fstring`` coordinate. The coordinate
+carries Python's conversion-then-format meaning without claiming execution.
 """
 
 from __future__ import annotations
@@ -21,9 +20,11 @@ from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 @dataclass(frozen=True)
 class FormattedValueSugar(Sugar):
-    """`{value}` inside an f-string -- format(value) with an empty spec."""
+    """A Python-reference formatted-value coordinate, without execution."""
 
     value: Sugar
+    conversion: str | None
+    format_spec: JoinedStrSugar | None
     site: object = dataclass_field(compare=False)
 
     @classmethod
@@ -31,10 +32,36 @@ class FormattedValueSugar(Sugar):
         return ()
 
     def desugar(self, ctx: object = None) -> Outcome:
-        from sugar_lift_py_tests.floor.string_value import StringValue
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+        from sugar_lift_py_tests.ir import ctor, str_const
+        from sugar_lift_py_tests.outcome import Incomplete
 
-        return self.value.desugar(ctx).and_then(
-            lambda value: value.format_data_model(StringValue(""), self.site, ctx)
+        value = self.value.desugar(ctx)
+        if isinstance(value, Incomplete):
+            return value
+        if self.format_spec is None:
+            format_spec_term = ctor("None", [])
+        else:
+            format_spec = self.format_spec.reference_term(ctx)
+            if isinstance(format_spec, Incomplete):
+                return format_spec
+            format_spec_term = format_spec.value
+        conversion_term = (
+            ctor("None", [])
+            if self.conversion is None
+            else str_const(self.conversion)
+        )
+        return Complete(
+            SymbolicValue(
+                ctor(
+                    "python:fstring_value",
+                    [
+                        value.value.to_term(owner="FormattedValueSugar.value"),
+                        conversion_term,
+                        format_spec_term,
+                    ],
+                )
+            )
         )
 
 
@@ -70,3 +97,18 @@ class JoinedStrSugar(Sugar):
                 return right
             acc = acc.value.add(right.value, self.site)
         return acc
+
+    def reference_term(self, ctx: object = None) -> Outcome:
+        """Project this JoinedStr as the reference ``python:fstring`` ctor."""
+        from sugar_lift_py_tests.ir import ctor
+        from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+        terms = []
+        for part in self.parts:
+            projected = part.desugar(ctx)
+            if isinstance(projected, Incomplete):
+                return projected
+            terms.append(
+                projected.value.to_term(owner="JoinedStrSugar.reference_term")
+            )
+        return Complete(ctor("python:fstring", terms))

--- a/implementations/python/sugar-lift-py-tests/tests/test_census_backend_defects_are_loud.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_census_backend_defects_are_loud.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from sugar_lift_py_tests.census import census
+from sugar_source_tree.panic import BackendDefect
+from sugar_source_tree.tree import SourceFile
+
+
+def test_census_returns_nonzero_when_construction_hits_backend_defect(
+    tmp_path, monkeypatch
+) -> None:
+    (tmp_path / "crash.py").write_text(
+        "def f():\n return 1\n",
+        encoding="utf-8",
+    )
+
+    def backend_crash(*args, **kwargs):
+        del args, kwargs
+        raise BackendDefect(
+            owner="planted census tooth",
+            observed="a malformed backend answer",
+            requested="a valid constructed source tree",
+            fix="repair the backend",
+        )
+
+    monkeypatch.setattr(SourceFile, "from_path", backend_crash)
+
+    assert census(tmp_path) != 0
+
+
+def test_census_returns_zero_when_every_function_constructs(tmp_path) -> None:
+    (tmp_path / "clean.py").write_text(
+        "def f():\n return 1\n",
+        encoding="utf-8",
+    )
+
+    assert census(tmp_path) == 0

--- a/implementations/python/sugar-lift-py-tests/tests/test_cm_construction_boundary.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_cm_construction_boundary.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+
+def test_tree_and_sugar_construction_have_no_linker_catalog_or_metadata_door():
+    python_root = Path(__file__).resolve().parents[2]
+    sugar_root = python_root / "sugar-lift-py-tests/src/sugar_lift_py_tests/sugar"
+    tree_root = python_root / "sugar-source-tree/src/sugar_source_tree"
+    tree_construction = [
+        tree_root / "nodes.py",
+        tree_root / "backend.py",
+        *tree_root.glob("*_adapter.py"),
+    ]
+    files = [*sugar_root.rglob("*.py"), *tree_construction]
+    forbidden = (
+        "sugar_linker",
+        "sugar-linker",
+        "proof_catalog",
+        "member_envelope",
+        "decode_context_manager_contract",
+        "path_source(",
+        "installed_module_source(",
+    )
+    offenders = []
+    for path in files:
+        text = path.read_text()
+        for needle in forbidden:
+            if needle in text:
+                offenders.append(f"{path.relative_to(python_root)}: {needle}")
+    assert offenders == [], "construction-law offenders:\n" + "\n".join(offenders)
+
+
+def test_with_sugar_does_not_retain_raw_cm_json_or_invoke_resolution():
+    python_root = Path(__file__).resolve().parents[2]
+    files = [
+        python_root / "sugar-source-tree/src/sugar_source_tree/nodes.py",
+        *(
+            python_root / "sugar-lift-py-tests/src/sugar_lift_py_tests/sugar"
+        ).glob("with*_sugar.py"),
+    ]
+    forbidden = (
+        "resolve_context_manager",
+        "decode_context_manager",
+        "member_json",
+        "payload_json",
+        "catalog_json",
+    )
+    offenders = [
+        f"{path.name}: {needle}"
+        for path in files
+        for needle in forbidden
+        if needle in path.read_text()
+    ]
+    assert offenders == [], "With boundary offenders:\n" + "\n".join(offenders)

--- a/implementations/python/sugar-lift-py-tests/tests/test_cm_construction_boundary.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_cm_construction_boundary.py
@@ -1,53 +1,69 @@
 from pathlib import Path
 
+import pytest
 
-def test_tree_and_sugar_construction_have_no_linker_catalog_or_metadata_door():
-    python_root = Path(__file__).resolve().parents[2]
-    sugar_root = python_root / "sugar-lift-py-tests/src/sugar_lift_py_tests/sugar"
-    tree_root = python_root / "sugar-source-tree/src/sugar_source_tree"
-    tree_construction = [
-        tree_root / "nodes.py",
-        tree_root / "backend.py",
-        *tree_root.glob("*_adapter.py"),
-    ]
-    files = [*sugar_root.rglob("*.py"), *tree_construction]
-    forbidden = (
-        "sugar_linker",
-        "sugar-linker",
-        "proof_catalog",
-        "member_envelope",
-        "decode_context_manager_contract",
-        "path_source(",
-        "installed_module_source(",
+from sugar_lift_py_tests.cm_boundary_detector import scan_construction_boundary
+
+
+def _write(root: Path, relative: str, source: str) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "files",
+    [
+        {
+            "sugar/direct.py": (
+                "from sugar_linker import resolve_context_manager_demand\n"
+                "def sugar():\n    return resolve_context_manager_demand()\n"
+            )
+        },
+        {
+            "sugar/nested.py": (
+                "from sugar_linker import resolve_context_manager_demand\n"
+                "def helper():\n    return resolve_context_manager_demand()\n"
+                "def sugar():\n    return helper()\n"
+            )
+        },
+        {
+            "sugar/aliased.py": (
+                "import sugar_linker as hidden\n"
+                "def sugar():\n    return hidden.resolve_context_manager_demand()\n"
+            )
+        },
+        {
+            "sugar/entry.py": (
+                "from sugar_source_tree.outside_helper import lookup\n"
+                "def sugar():\n    return lookup()\n"
+            ),
+            "sugar_source_tree/outside_helper.py": (
+                "from sugar_linker import resolve_context_manager_demand as lookup\n"
+            ),
+        },
+    ],
+    ids=("direct", "nested-helper", "aliased-import", "outside-helper"),
+)
+def test_planted_boundary_violations_each_raise_r(files, tmp_path):
+    for relative, source in files.items():
+        _write(tmp_path, relative, source)
+    report = scan_construction_boundary(
+        sugar_root=tmp_path / "sugar",
+        source_tree_root=tmp_path / "sugar_source_tree",
     )
-    offenders = []
-    for path in files:
-        text = path.read_text()
-        for needle in forbidden:
-            if needle in text:
-                offenders.append(f"{path.relative_to(python_root)}: {needle}")
-    assert offenders == [], "construction-law offenders:\n" + "\n".join(offenders)
+    assert report.r > 0, report
 
 
-def test_with_sugar_does_not_retain_raw_cm_json_or_invoke_resolution():
+def test_complete_real_roots_have_stable_zero_boundary_residue():
     python_root = Path(__file__).resolve().parents[2]
-    files = [
-        python_root / "sugar-source-tree/src/sugar_source_tree/nodes.py",
-        *(
-            python_root / "sugar-lift-py-tests/src/sugar_lift_py_tests/sugar"
-        ).glob("with*_sugar.py"),
-    ]
-    forbidden = (
-        "resolve_context_manager",
-        "decode_context_manager",
-        "member_json",
-        "payload_json",
-        "catalog_json",
+    report = scan_construction_boundary(
+        sugar_root=python_root / "sugar-lift-py-tests/src/sugar_lift_py_tests/sugar",
+        source_tree_root=python_root / "sugar-source-tree/src/sugar_source_tree",
     )
-    offenders = [
-        f"{path.name}: {needle}"
-        for path in files
-        for needle in forbidden
-        if needle in path.read_text()
-    ]
-    assert offenders == [], "With boundary offenders:\n" + "\n".join(offenders)
+    assert report.files_scanned == len(list(
+        (python_root / "sugar-lift-py-tests/src/sugar_lift_py_tests/sugar").rglob("*.py")
+    )) + len(list(
+        (python_root / "sugar-source-tree/src/sugar_source_tree").rglob("*.py")
+    ))
+    assert report.r == 0, report.render()

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_contract.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_contract.py
@@ -1,0 +1,137 @@
+import json
+
+import pytest
+
+from sugar_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs, vobj
+from sugar_lift_py_tests.claim_envelope import _assemble_layered
+from sugar_lift_py_tests.context_manager_contract import (
+    ContextManagerContractError,
+    ContextManagerSemanticsV1,
+    EnterResultContractV1,
+    ExitContractV1,
+    NeverSuppressesDispositionV1,
+    decode_context_manager_contract,
+    publish_never_suppresses_context_manager_contract,
+)
+from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.kit_rpc import (
+    ContextManagerContractIrV1,
+    ImportSignatureV1,
+    LiftReportPayloadDto,
+)
+from sugar_lift_py_tests.signing import Signer
+from sugar_lift_py_tests.context_manager_contract import _json_value
+from sugar_lift_py_tests import lift_rpc
+
+
+SEED = bytes(range(32))
+DECLARED_AT = "2026-07-22T00:00:00.000Z"
+
+
+def _publish():
+    return publish_never_suppresses_context_manager_contract(
+        bridge_source_symbol="context-manager:fixture_python.never_closing",
+        import_signature=ImportSignatureV1(formals=(), sorts=()),
+        enter_result_sort=PrimitiveSort("Value"),
+        source_warrants=("blake3-512:" + "a" * 128,),
+        signer=Signer(seed=SEED, producer_id="fixture-python-kit"),
+        declared_at=DECLARED_AT,
+    )
+
+
+def _reseal(mutator):
+    raw = json.loads(_publish().canonical_bytes)
+    mutator(raw["header"])
+    payload = raw["header"]["payload"]
+    payload_cid = blake3_512_of(encode_jcs(_json_value(payload)).encode())
+    raw["header"]["cid"] = payload_cid
+    raw["header"]["payloadCid"] = payload_cid
+    return _assemble_layered(
+        _json_value(raw["header"]), _json_value(raw["metadata"]), DECLARED_AT, SEED, payload_cid
+    )
+
+
+def test_publish_and_decode_retains_typed_never_suppresses_semantics():
+    sealed = _publish()
+    decoded = decode_context_manager_contract(sealed.canonical_bytes, sealed.cid)
+    assert decoded.semantics == ContextManagerSemanticsV1(
+        enter=EnterResultContractV1(sort=PrimitiveSort("Value")),
+        exit=ExitContractV1(disposition=NeverSuppressesDispositionV1()),
+    )
+    assert isinstance(decoded.semantics.exit.disposition, NeverSuppressesDispositionV1)
+    assert decoded.payload_cid == sealed.contract_cid
+
+
+def test_semantic_payload_is_provider_neutral_and_hashed_alone():
+    raw = json.loads(_publish().canonical_bytes)
+    header = raw["header"]
+    assert header["schemaVersion"] == "1.2"
+    assert set(header) == {
+        "schemaVersion", "kind", "cid", "payloadCid", "bridgeSourceSymbol",
+        "importSignature", "payload", "sourceWarrants", "inputCids",
+    }
+    assert "name" not in header["payload"] and "kit" not in header["payload"]
+    assert header["payload"] == {
+        "kind": "context-manager-semantics",
+        "schemaVersion": "1",
+        "enter": {
+            "completion": "total",
+            "result": {"kind": "projection", "projection": "enter_result", "sort": {"kind": "primitive", "name": "Value"}},
+        },
+        "exit": {"completion": "total", "disposition": {"kind": "never-suppresses"}},
+    }
+    assert header["payloadCid"] == blake3_512_of(
+        encode_jcs(_json_value(header["payload"])).encode()
+    )
+
+
+def test_correctly_resealed_unknown_disposition_reaches_typed_decoder():
+    sealed = _reseal(lambda h: h["payload"]["exit"]["disposition"].update(kind="sometimes"))
+    with pytest.raises(ContextManagerContractError, match="unknown exit disposition"):
+        decode_context_manager_contract(sealed.canonical_bytes, sealed.cid)
+
+
+def test_correctly_resealed_missing_enter_reaches_typed_decoder():
+    sealed = _reseal(lambda h: h["payload"].pop("enter"))
+    with pytest.raises(ContextManagerContractError, match="malformed context-manager semantics"):
+        decode_context_manager_contract(sealed.canonical_bytes, sealed.cid)
+
+
+def test_bad_signature_is_distinct_from_stale_payload_cid():
+    sealed = _publish()
+    raw = json.loads(sealed.canonical_bytes)
+    raw["header"]["bridgeSourceSymbol"] = "context-manager:mutated"
+    with pytest.raises(ContextManagerContractError, match="signature"):
+        decode_context_manager_contract(json.dumps(raw).encode(), sealed.cid)
+
+    raw = json.loads(sealed.canonical_bytes)
+    raw["header"]["payloadCid"] = "blake3-512:" + "0" * 128
+    stale = _assemble_layered(_json_value(raw["header"]), _json_value(raw["metadata"]), DECLARED_AT, SEED, raw["header"]["payloadCid"])
+    with pytest.raises(ContextManagerContractError, match="payload CID"):
+        decode_context_manager_contract(stale.canonical_bytes, stale.cid)
+
+
+def test_typed_declaration_enters_closed_ir_transport():
+    row = ContextManagerContractIrV1.never_suppresses(
+        bridge_source_symbol="context-manager:fixture_python.never_closing",
+        import_signature=ImportSignatureV1(formals=(), sorts=()),
+        enter_result_sort=PrimitiveSort("Value"),
+        source_warrants=("blake3-512:" + "a" * 128,),
+    )
+    wire = LiftReportPayloadDto(ir=[row]).to_rpc()
+    assert wire["ir"] == [row.to_rpc_with_term_table(None)]
+
+
+def test_typed_declaration_is_published_on_the_live_kit_declaration(monkeypatch):
+    row = ContextManagerContractIrV1.never_suppresses(
+        bridge_source_symbol="context-manager:fixture_python.never_closing",
+        import_signature=ImportSignatureV1(formals=(), sorts=()),
+        enter_result_sort=PrimitiveSort("Value"),
+        source_warrants=(),
+    )
+    monkeypatch.setattr(lift_rpc, "_PUBLISHED_CONTEXT_MANAGER_DECLARATIONS", ())
+    lift_rpc.publish_context_manager_declaration(row)
+    declaration = lift_rpc._kit_declaration_result()
+    assert declaration["contractDeclarations"] == [
+        row.to_rpc_with_term_table(None)
+    ]

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
@@ -126,18 +126,19 @@ def test_published_typed_declaration_is_served_only_by_declaration_pass(monkeypa
     from sugar_lift_py_tests.ir import PrimitiveSort
     from sugar_lift_py_tests.kit_rpc import ContextManagerContractIrV1, ImportSignatureV1
 
-    row = ContextManagerContractIrV1.never_suppresses(
+    declaration = ContextManagerContractIrV1.never_suppresses(
         bridge_source_symbol="context-manager:dependency.manager",
         import_signature=ImportSignatureV1(formals=(), sorts=()),
         enter_result_sort=PrimitiveSort("Value"),
         source_warrants=(),
-    ).to_rpc_with_term_table(None)
+    )
+    row = declaration.to_rpc_with_term_table(None)
     sent = []
     monkeypatch.setattr(lift_rpc, "_PUBLISHED_CONTEXT_MANAGER_DECLARATIONS", ())
     monkeypatch.setattr(lift_rpc, "_BOUND_CONTRACT_REFS", None)
     monkeypatch.setattr(lift_rpc, "_ENUMERATION_ACTIVE", False)
     monkeypatch.setattr(lift_rpc, "_send", sent.append)
-    lift_rpc.publish_context_manager_declaration(row)
+    lift_rpc.publish_context_manager_declaration(declaration)
     lift_rpc._handle_enumerate(9, {
         "level": "contract-declarations",
         "workspace_root": ".",

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
@@ -1,0 +1,96 @@
+from types import MappingProxyType
+
+import pytest
+
+from sugar_lift_py_tests import lift_rpc
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContractRefProtocolError,
+    ResolvedContractRefsV1,
+    SourceFragmentCoordinateV1,
+    _hash_json,
+    decode_resolved_contract_refs,
+)
+
+
+def unresolved_table():
+    cid = "blake3-512:" + "1" * 128
+    demand_cid = "blake3-512:" + "2" * 128
+    use_site = {
+        "sourceCid": cid,
+        "startLine": 3,
+        "startCol": 4,
+        "endLine": 3,
+        "endCol": 12,
+    }
+    identity = {
+        "kind": "resolved-contract-refs",
+        "schemaVersion": "1",
+        "catalogCid": cid,
+        "byUseSite": [{
+            "useSite": use_site,
+            "resolution": {
+                "kind": "unresolved",
+                "gap": {
+                    "demandCid": demand_cid,
+                    "useSite": use_site,
+                    "targetSymbol": "context-manager:fixture.missing",
+                    "kind": "unresolved-symbol",
+                    "candidateMemberCids": [],
+                },
+            },
+        }],
+    }
+    return {**identity, "tableCid": _hash_json(identity)}
+
+
+def test_table_is_frozen_and_missing_enrolled_coordinate_is_backend_defect():
+    table = decode_resolved_contract_refs(unresolved_table())
+    with pytest.raises(TypeError):
+        table.by_use_site[next(iter(table.by_use_site))] = object()
+    missing = SourceFragmentCoordinateV1("blake3-512:" + "3" * 128, 1, 0, 1, 1)
+    with pytest.raises(ContractRefProtocolError, match="BackendDefect"):
+        table.require(missing)
+
+
+def test_bind_rpc_freezes_one_generation_and_acknowledges_exact_table_cid(monkeypatch):
+    sent = []
+    monkeypatch.setattr(lift_rpc, "_BOUND_CONTRACT_REFS", None)
+    monkeypatch.setattr(lift_rpc, "_send", sent.append)
+    wire = unresolved_table()
+    assert lift_rpc._dispatch_request({
+        "jsonrpc": "2.0", "id": 7,
+        "method": lift_rpc.BIND_CONTRACT_REFS_RPC_METHOD,
+        "params": wire,
+    })
+    assert sent == [{"jsonrpc": "2.0", "id": 7, "result": {"tableCid": wire["tableCid"]}}]
+    assert isinstance(lift_rpc._BOUND_CONTRACT_REFS.by_use_site, MappingProxyType)
+
+    other = unresolved_table()
+    other["catalogCid"] = "blake3-512:" + "4" * 128
+    identity = {key: other[key] for key in ("kind", "schemaVersion", "catalogCid", "byUseSite")}
+    other["tableCid"] = _hash_json(identity)
+    with pytest.raises(ValueError, match="already frozen"):
+        lift_rpc._dispatch_request({
+            "jsonrpc": "2.0", "id": 8,
+            "method": lift_rpc.BIND_CONTRACT_REFS_RPC_METHOD,
+            "params": other,
+        })
+
+
+def test_malformed_table_cid_and_unsorted_ambiguity_are_loud():
+    stale = unresolved_table()
+    stale["tableCid"] = "blake3-512:" + "f" * 128
+    with pytest.raises(ContractRefProtocolError, match="table CID mismatch"):
+        decode_resolved_contract_refs(stale)
+
+    ambiguous = unresolved_table()
+    gap = ambiguous["byUseSite"][0]["resolution"]["gap"]
+    gap["kind"] = "ambiguous-symbol"
+    gap["candidateMemberCids"] = [
+        "blake3-512:" + "b" * 128,
+        "blake3-512:" + "a" * 128,
+    ]
+    identity = {key: ambiguous[key] for key in ("kind", "schemaVersion", "catalogCid", "byUseSite")}
+    ambiguous["tableCid"] = _hash_json(identity)
+    with pytest.raises(ContractRefProtocolError, match="must be sorted"):
+        decode_resolved_contract_refs(ambiguous)

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
@@ -94,3 +94,29 @@ def test_malformed_table_cid_and_unsorted_ambiguity_are_loud():
     ambiguous["tableCid"] = _hash_json(identity)
     with pytest.raises(ContractRefProtocolError, match="must be sorted"):
         decode_resolved_contract_refs(ambiguous)
+
+
+def test_demand_enrollment_uses_import_coordinate_without_sugar_or_target_source(
+    tmp_path, monkeypatch
+):
+    consumer = tmp_path / "consumer.py"
+    consumer.write_text(
+        "from dependency_that_is_not_present import manager as renamed\n"
+        "def f():\n"
+        "    with renamed():\n"
+        "        pass\n"
+    )
+    from sugar_source_tree.nodes import With
+
+    monkeypatch.setattr(
+        With,
+        "sugar",
+        lambda self: (_ for _ in ()).throw(AssertionError("demand pass constructed Sugar")),
+    )
+    rows = lift_rpc._context_manager_demand_rows(tmp_path)
+    assert len(rows) == 1
+    assert rows[0]["targetSymbol"] == (
+        "context-manager:dependency_that_is_not_present.manager"
+    )
+    assert rows[0]["gapKind"] is None
+    assert rows[0]["useSite"]["sourceCid"].startswith("blake3-512:")

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
@@ -120,3 +120,26 @@ def test_demand_enrollment_uses_import_coordinate_without_sugar_or_target_source
     )
     assert rows[0]["gapKind"] is None
     assert rows[0]["useSite"]["sourceCid"].startswith("blake3-512:")
+
+
+def test_published_typed_declaration_is_served_only_by_declaration_pass(monkeypatch):
+    from sugar_lift_py_tests.ir import PrimitiveSort
+    from sugar_lift_py_tests.kit_rpc import ContextManagerContractIrV1, ImportSignatureV1
+
+    row = ContextManagerContractIrV1.never_suppresses(
+        bridge_source_symbol="context-manager:dependency.manager",
+        import_signature=ImportSignatureV1(formals=(), sorts=()),
+        enter_result_sort=PrimitiveSort("Value"),
+        source_warrants=(),
+    ).to_rpc_with_term_table(None)
+    sent = []
+    monkeypatch.setattr(lift_rpc, "_PUBLISHED_CONTEXT_MANAGER_DECLARATIONS", ())
+    monkeypatch.setattr(lift_rpc, "_BOUND_CONTRACT_REFS", None)
+    monkeypatch.setattr(lift_rpc, "_ENUMERATION_ACTIVE", False)
+    monkeypatch.setattr(lift_rpc, "_send", sent.append)
+    lift_rpc.publish_context_manager_declaration(row)
+    lift_rpc._handle_enumerate(9, {
+        "level": "contract-declarations",
+        "workspace_root": ".",
+    })
+    assert sent[-1] == {"jsonrpc": "2.0", "id": 9, "result": {"rows": [row]}}

--- a/implementations/python/sugar-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_lifter.py
@@ -1530,6 +1530,42 @@ def test_fstring_roundtrip_is_structurally_stable() -> None:
     assert cid_of_json(body) == cid_of_json(_return(term))
 
 
+def test_fstring_decoder_rejects_swapped_conversion_and_format_spec() -> None:
+    swapped = _fstring(
+        _fstring_value(
+            _var("x"),
+            conversion=_fstring(_str_const(">10")),
+            format_spec=_str_const("r"),
+        )
+    )
+
+    with pytest.raises(ValueError):
+        compile_body_term(_return(swapped), formals=["x"])
+
+
+@pytest.mark.parametrize(
+    "conversion, format_spec",
+    [
+        (_str_const("q"), None),
+        (None, _str_const(">10")),
+    ],
+)
+def test_fstring_decoder_rejects_malformed_typed_operands(
+    conversion: dict[str, object] | None,
+    format_spec: dict[str, object] | None,
+) -> None:
+    malformed = _fstring(
+        _fstring_value(
+            _var("x"),
+            conversion=conversion,
+            format_spec=format_spec,
+        )
+    )
+
+    with pytest.raises(ValueError):
+        compile_body_term(_return(malformed), formals=["x"])
+
+
 def test_bare_assert_lifts_to_assert_statement_with_assertion_error_locus() -> None:
     source = "def f(x):\n    assert x\n"
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, Callable, TypeAlias
 
 if TYPE_CHECKING:
     from sugar_source_tree.fragment import SourceFragment
@@ -34,6 +34,26 @@ class GuardedBinding:
 
 BindingState: TypeAlias = "Node | UnboundBinding | GuardedBinding"
 BindingMap: TypeAlias = dict[str, BindingState]
+
+
+def binding_state_read_node(
+    state: BindingState,
+    *,
+    make_read: Callable[[UnboundBinding | GuardedBinding], Node],
+) -> Node:
+    """Project binding availability into the tree's ordinary Node currency.
+
+    Binding-state witnesses are deliberately not AST nodes.  A consumer that
+    reads a binding must project an unbound/guarded state into the explicit
+    read node owned by the read site before placing it in a shadow child slot.
+    """
+    from sugar_source_tree.nodes import Node
+
+    if isinstance(state, Node):
+        return state
+    if isinstance(state, (UnboundBinding, GuardedBinding)):
+        return make_read(state)
+    raise TypeError(type(state))
 
 
 def join_binding_state(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -61,6 +61,7 @@ from .binding_state import (
     BranchResultSlot,
     GuardedBinding,
     UnboundBinding,
+    binding_state_read_node,
     branch_result_slot,
     join_binding_state,
 )
@@ -391,7 +392,25 @@ class Node(Typed):
         borrows this node's span (so it still addresses this source site). Used
         by an augmented assignment to synthesize its ``x OP e`` rebind."""
         from .backend import Child, OpLeaf, materialize
+        from .panic import backend_defect
         from .shadow import ShadowNode, _handle_of
+
+        if not isinstance(left, Node) or not isinstance(right, Node):
+            backend_defect(
+                owner="nodes.Node._make_binop",
+                observed=(
+                    "a synthesized binary operation received non-Node "
+                    f"operands {type(left).__name__}, {type(right).__name__}"
+                ),
+                requested=(
+                    "both binary-operation operands projected into constructed "
+                    "tree Nodes before shadow enrollment"
+                ),
+                fix=(
+                    "project BindingState through binding_state_read_node at "
+                    "the read site; never put state-only testimony in Child"
+                ),
+            )
 
         slots = (
             ("left", Child(_handle_of(left))),
@@ -1347,8 +1366,12 @@ class AugAssign(Statement):
         if not isinstance(self.target, Name):
             return None
         name = self.target.id
-        old = scope.get(name, self.target)
-        return {name: self._make_binop(old, self.op, self.value)}
+        old_state = scope.get(name, self.target)
+        old_read = binding_state_read_node(
+            old_state,
+            make_read=self.target._make_binding_read,
+        )
+        return {name: self._make_binop(old_read, self.op, self.value)}
 
     def _construct_sugar(self):
         """`<target> OP= <value>` -- a plain Name target is INERT at the

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -104,6 +104,7 @@ class SourceUnit:
     filename: str
     source: str
     source_cid: str
+    construction_context: object | None = None
 
     # populated in __post_init__, never by callers
     line_table: LineTable = field(init=False, default=None)  # type: ignore[assignment]

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3684,13 +3684,41 @@ class FormattedValue(Expression):
         return self._substitute_children(scope)
 
     def _construct_sugar(self):
-        """`{value}` in an f-string. A conversion (!r/!s/!a) or a format spec is
-        not lifted yet -- LOUD rather than a silently dropped modifier."""
+        """Project the Python-reference three-operand formatted-value shape.
+
+        CPython carries conversion as ``-1`` or the codepoint for exactly
+        ``a``/``r``/``s``.  Anything else is malformed backend testimony, not
+        a new language arm.  The optional format spec remains its own nested
+        JoinedStr sugar; neither operand is dropped or replaced with an empty
+        string.
+        """
         from sugar_lift_py_tests.sugar.fstring_sugar import FormattedValueSugar
 
-        if self.conversion != -1 or self.format_spec is not None:
-            return super()._construct_sugar()
-        return FormattedValueSugar(value=self.value.sugar(), site=self.fragment)
+        if self.conversion == -1:
+            conversion = None
+        elif self.conversion in {ord("a"), ord("r"), ord("s")}:
+            conversion = chr(self.conversion)
+        else:
+            backend_defect(
+                owner="FormattedValue._construct_sugar",
+                observed=f"unsupported f-string conversion slot {self.conversion!r}",
+                requested="-1 or the codepoint for 'a', 'r', or 's'",
+                fix="repair the backend adapter; never invent a conversion",
+            )
+        format_spec = self.format_spec
+        if format_spec is not None and not isinstance(format_spec, JoinedStr):
+            backend_defect(
+                owner="FormattedValue._construct_sugar",
+                observed=f"format_spec constructed as {type(format_spec).__name__}",
+                requested="None or a nested JoinedStr",
+                fix="repair the backend adapter; never coerce a bare expression",
+            )
+        return FormattedValueSugar(
+            value=self.value.sugar(),
+            conversion=conversion,
+            format_spec=format_spec.sugar() if format_spec is not None else None,
+            site=self.fragment,
+        )
 
 
 class JoinedStr(Expression):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
@@ -75,10 +75,14 @@ class SourceFile:
         identity: Tuple[str, str, str],
         backend: Optional[Backend] = None,
         reporter: AuditReporter = NULL_REPORTER,
+        construction_context: object | None = None,
     ) -> None:
         source, filename, source_cid = identity
         self.unit = SourceUnit(
-            filename=filename, source=source, source_cid=source_cid
+            filename=filename,
+            source=source,
+            source_cid=source_cid,
+            construction_context=construction_context,
         )
         self.backend = backend if backend is not None else _default_backend()
         # The reporter enters the whole tree here: the root carries it and

--- a/implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py
+++ b/implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py
@@ -2,11 +2,16 @@ from __future__ import annotations
 
 import tempfile
 
+import pytest
+
 from sugar_lift_py_tests.effect import NameErrorEffect, RaiseEffect
 from sugar_lift_py_tests.floor import ReturnValue, TermValue, UniverseValue
 from sugar_lift_py_tests.ir import and_, make_var, not_, or_, py_truthy
 from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted, Incomplete
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.binding_state import BranchResultSlot, GuardedBinding, UnboundBinding
+from sugar_source_tree.nodes import Node
+from sugar_source_tree.panic import BackendDefect, SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
 
@@ -15,6 +20,13 @@ def _out(source: str):
         f.write(source)
         path = f.name
     return next(SourceFile(path_source(path)).functions()).sugar().desugar()
+
+
+def _substituted(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(source)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).substitute({})
 
 
 def _return(exit_):
@@ -99,6 +111,110 @@ def test_nested_conditional_delete_retains_both_source_guards() -> None:
     outer, inner = halted[0].guard.operands
     assert outer != inner
     assert completed[0].guard == or_([not_(outer), and_([outer, not_(inner)])])
+
+
+def test_pandas_blocks_nested_if_augassign_reads_unbound_binding_as_a_node() -> None:
+    source = (
+        "def f(i, values):\n"
+        " if isinstance(i, tuple):\n"
+        "  col, loc = i\n"
+        "  if loc < 0:\n"
+        "   loc += len(values)\n"
+        "  return loc\n"
+    )
+    function = _substituted(source)
+    reads = [node for node in function.walk() if node.kind == "GuardedBindingRead"]
+    assert any(isinstance(read.state, UnboundBinding) for read in reads)
+    with pytest.raises(SugarNotWritten):
+        _out(source)
+
+
+def test_pandas_html_if_augassign_reads_guarded_binding_as_a_node() -> None:
+    function = _substituted(
+        "def f(c, foot):\n"
+        " if c:\n"
+        "  body = 1\n"
+        " if foot:\n"
+        "  body += foot\n"
+        " return body\n"
+    )
+    first_if, second_if = function.body[:2]
+    reads = [node for node in function.walk() if node.kind == "GuardedBindingRead"]
+    outer = next(read for read in reads if isinstance(read.state, GuardedBinding))
+    addition = outer.state.when_true
+    old_read = addition.left
+    assert old_read.kind == "GuardedBindingRead"
+    assert isinstance(old_read.state, GuardedBinding)
+    assert old_read.state.slot.slot_id == first_if.branch_result_slot_id
+    assert outer.state.slot.slot_id == second_if.branch_result_slot_id
+
+    halted, completed = _partition(
+        _out(
+            "def f(c, foot):\n"
+            " if c:\n"
+            "  body = 1\n"
+            " if foot:\n"
+            "  body += foot\n"
+            " return body\n"
+        )
+    )
+    assert any(isinstance(face.effect, NameErrorEffect) for face in halted)
+    assert any(
+        getattr(getattr(_return(face).value, "term", None), "name", None) == "+"
+        for face in completed
+    )
+
+
+def test_pandas_converter_if_augassign_reads_unbound_binding_as_a_node() -> None:
+    source = (
+        "def f(locs):\n"
+        " vmin, vmax = locs\n"
+        " if vmin == vmax:\n"
+        "  vmin -= 1\n"
+        "  vmax += 1\n"
+        " return vmin\n"
+    )
+    function = _substituted(source)
+    reads = [node for node in function.walk() if node.kind == "GuardedBindingRead"]
+    names = {read.name for read in reads if isinstance(read.state, UnboundBinding)}
+    assert {"vmin", "vmax"} <= names
+    with pytest.raises(SugarNotWritten):
+        _out(source)
+
+
+def test_augassign_over_explicitly_unbound_local_builds_guarded_read() -> None:
+    out = _out("def f():\n x += 1\n return x\n")
+    assert isinstance(out, Incomplete)
+    assert isinstance(out.effect, NameErrorEffect)
+    assert out.effect.name == "x"
+
+
+def test_bound_augassign_control_remains_completed_value() -> None:
+    out = _out("def f():\n x = 1\n x += 2\n return x\n")
+    assert isinstance(out, Complete)
+    returns = [
+        entry
+        for entry in out.value.record.statements
+        if isinstance(entry, ReturnValue)
+    ]
+    assert returns[0].value == TermValue(3)
+
+
+def test_binding_state_is_never_an_ast_child_or_node_protocol_value() -> None:
+    unbound = UnboundBinding(name="x", cause=_substituted("def f():\n pass\n").fragment)
+    guarded = GuardedBinding(
+        slot=BranchResultSlot("test-slot"),
+        when_true=unbound,
+        when_false=unbound,
+    )
+    for state in (unbound, guarded):
+        assert not isinstance(state, Node)
+        assert not hasattr(state, "ref")
+        assert not hasattr(state, "sugar")
+
+    target = _substituted("def f(x):\n x += 1\n").body[0].target
+    with pytest.raises(BackendDefect, match="non-Node operands"):
+        target._make_binop(unbound, None, target)
 
 
 def test_try_handler_binding_exports_on_the_handler_completion_edge() -> None:

--- a/implementations/python/sugar-source-tree/tests/test_fstring_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_fstring_sugar.py
@@ -1,14 +1,13 @@
-"""f-strings: JoinedStr concatenates its parts; FormattedValue is format(value).
-
-Modifiers -- a conversion (!r/!s/!a) or a format spec ({x:>10}) -- stay loud.
-"""
+"""f-strings: JoinedStr concatenates its parts; FormattedValue is format(value)."""
 
 import tempfile
 
 import pytest
 
 from sugar_lift_python_source.source_oracle import path_source
-from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.backend import Leaf, MaybeChild, materialize
+from sugar_source_tree.panic import BackendDefect
+from sugar_source_tree.shadow import ShadowNode
 from sugar_source_tree.tree import SourceFile
 
 
@@ -23,12 +22,44 @@ def _post_term(src):
     return _fn(src).sugar().desugar().value.post().args[1]
 
 
+def _formatted_value(src):
+    fn = _fn(src)
+    joined = fn.body[0].value
+    return next(value for value in joined.values if value.kind == "FormattedValue")
+
+
+def _with_conversion(node, conversion):
+    desc = node.ref.describe()
+    slots = tuple(
+        (name, Leaf(conversion) if name == "conversion" else slot)
+        for name, slot in desc.slots
+    )
+    return materialize(
+        node.unit,
+        ShadowNode("FormattedValue", desc.raw_span or node.span, slots),
+        node.reporter,
+    )
+
+
+def _with_bare_format_spec(node):
+    desc = node.ref.describe()
+    slots = tuple(
+        (name, MaybeChild(node.value.ref) if name == "format_spec" else slot)
+        for name, slot in desc.slots
+    )
+    return materialize(
+        node.unit,
+        ShadowNode("FormattedValue", desc.raw_span or node.span, slots),
+        node.reporter,
+    )
+
+
 def test_fstring_concatenates_literal_and_interpolation():
-    # f"n={z}" -> "n=" ++ format(z)
+    # f"n={z}" -> "n=" ++ python:fstring_value(z, None, None)
     term = _post_term('def A(z):\n    return f"n={z}"\n')
     assert term.name == "+"
     assert term.args[0].value == "n="
-    assert term.args[1].name == "call:__format__"
+    assert term.args[1].name == "python:fstring_value"
 
 
 def test_fstring_with_only_a_literal_is_the_string():
@@ -36,19 +67,64 @@ def test_fstring_with_only_a_literal_is_the_string():
     assert type(term).__name__ == "_ConstStr" and term.value == "hello"
 
 
-def test_conversion_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn('def A(z):\n    return f"{z!r}"\n').sugar()
+def test_conversion_and_format_spec_survive_in_reference_operand_order():
+    """`value, conversion, format_spec` is the Python-reference order."""
+    term = _post_term('def A(x):\n    return f"{x!r:>10}"\n')
+
+    assert term.name == "python:fstring_value"
+    assert term.args[0].name == "x"
+    assert term.args[1].value == "r"
+    assert term.args[2].name == "python:fstring"
+    assert len(term.args[2].args) == 1
+    assert term.args[2].args[0].value == ">10"
 
 
-def test_format_spec_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn('def A(z):\n    return f"{z:>3}"\n').sugar()
+def test_fstring_conversions_are_distinct_typed_string_operands():
+    conversions = {
+        marker: _post_term(f'def A(x):\n    return f"{{x!{marker}}}"\n').args[1]
+        for marker in ("r", "s", "a")
+    }
+
+    assert {marker: term.value for marker, term in conversions.items()} == {
+        "r": "r",
+        "s": "s",
+        "a": "a",
+    }
+    assert {type(term).__name__ for term in conversions.values()} == {"_ConstStr"}
+
+
+def test_absent_conversion_and_format_spec_are_explicit_none_operands():
+    term = _post_term('def A(x):\n    return f"{x}"\n')
+
+    assert term.name == "python:fstring_value"
+    assert len(term.args) == 3
+    assert term.args[1].name == "None" and term.args[1].args == ()
+    assert term.args[2].name == "None" and term.args[2].args == ()
+
+
+def test_malformed_conversion_slot_is_a_backend_defect():
+    """Discrimination twin: a backend cannot claim an invented ``!q`` slot."""
+    formatted = _formatted_value('def A(z):\n    return f"{z!r}"\n')
+    lying = _with_conversion(formatted, ord("q"))
+
+    with pytest.raises(BackendDefect):
+        lying.sugar()
+
+
+def test_bare_format_spec_slot_is_a_backend_defect():
+    formatted = _formatted_value('def A(z):\n    return f"{z}"\n')
+    lying = _with_bare_format_spec(formatted)
+
+    with pytest.raises(BackendDefect):
+        lying.sugar()
 
 
 if __name__ == "__main__":
     test_fstring_concatenates_literal_and_interpolation()
     test_fstring_with_only_a_literal_is_the_string()
-    test_conversion_stays_loud()
-    test_format_spec_stays_loud()
-    print("ok: f-strings concatenate; modifiers loud")
+    test_conversion_and_format_spec_survive_in_reference_operand_order()
+    test_fstring_conversions_are_distinct_typed_string_operands()
+    test_absent_conversion_and_format_spec_are_explicit_none_operands()
+    test_malformed_conversion_slot_is_a_backend_defect()
+    test_bare_format_spec_slot_is_a_backend_defect()
+    print("ok: f-strings concatenate; modifiers build; malformed slots loud")

--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1765,6 +1765,7 @@ dependencies = [
  "sugar-ir-compiler",
  "sugar-ir-compiler-smt-lib",
  "sugar-ir-types",
+ "sugar-proof-envelope",
  "sugar-verifier",
 ]
 

--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1825,6 +1825,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sugar-canonicalizer",
+ "sugar-ir-types",
  "thiserror",
 ]
 

--- a/implementations/rust/sugar-claim-envelope/src/lib.rs
+++ b/implementations/rust/sugar-claim-envelope/src/lib.rs
@@ -36,8 +36,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use sugar_canonicalizer::{blake3_512_of, encode_jcs, json_to_value, Value};
 use sugar_proof_envelope::{
-    ed25519_pubkey_string, ed25519_sign_string, AuthorityMementoRef, ContractMementoRef,
-    Ed25519Seed,
+    context_manager_semantics_v1_to_json, ed25519_pubkey_string, ed25519_sign_string,
+    import_signature_v1_to_json, AuthorityMementoRef, ContextManagerSemanticsV1,
+    ContractMementoRef, Ed25519Seed, ImportSignatureV1,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -92,6 +93,94 @@ pub struct KitDeclaration {
     pub oracle_host: Option<KitOracleHost>,
     #[serde(rename = "residueCategories")]
     pub residue_categories: Vec<KitResidueCategory>,
+    #[serde(
+        rename = "contractDeclarations",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub contract_declarations: Vec<KitContractDeclarationV1>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum KitContractDeclarationV1 {
+    #[serde(rename = "context-manager-contract")]
+    ContextManager {
+        #[serde(rename = "schemaVersion")]
+        schema_version: String,
+        #[serde(rename = "bridgeSourceSymbol")]
+        bridge_source_symbol: String,
+        #[serde(rename = "importSignature")]
+        import_signature: KitImportSignatureV1,
+        payload: KitContextManagerSemanticsV1,
+        #[serde(rename = "sourceWarrants")]
+        source_warrants: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KitImportSignatureV1 {
+    pub formals: Vec<String>,
+    pub sorts: Vec<sugar_ir_types::Sort>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KitContextManagerSemanticsV1 {
+    pub kind: KitContextManagerSemanticsKindV1,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+    pub enter: KitTotalEnterV1,
+    pub exit: KitTotalExitV1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KitContextManagerSemanticsKindV1 {
+    #[serde(rename = "context-manager-semantics")]
+    ContextManagerSemantics,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KitTotalEnterV1 {
+    pub completion: KitTotalCompletionV1,
+    pub result: KitEnterResultV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KitEnterResultV1 {
+    pub kind: KitProjectionKindV1,
+    pub projection: KitEnterProjectionV1,
+    pub sort: sugar_ir_types::Sort,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KitProjectionKindV1 {
+    #[serde(rename = "projection")]
+    Projection,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KitEnterProjectionV1 {
+    #[serde(rename = "enter_result")]
+    EnterResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KitTotalExitV1 {
+    pub completion: KitTotalCompletionV1,
+    pub disposition: KitExitDispositionV1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KitTotalCompletionV1 {
+    #[serde(rename = "total")]
+    Total,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum KitExitDispositionV1 {
+    #[serde(rename = "never-suppresses")]
+    NeverSuppresses,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -213,6 +302,7 @@ mod kit_declaration_schema_tests {
             },
             oracle_host: None,
             residue_categories: vec![],
+            contract_declarations: vec![],
         }
     }
 
@@ -404,6 +494,82 @@ fn authoring_to_value(a: &Authoring) -> Arc<Value> {
             Arc::new(Value::Object(entries))
         }
     }
+}
+
+// =============================================================================
+// mint_context_manager_contract
+// =============================================================================
+
+pub struct MintContextManagerContractArgs {
+    pub bridge_source_symbol: String,
+    pub import_signature: ImportSignatureV1,
+    pub semantics: ContextManagerSemanticsV1,
+    pub source_warrants: Vec<String>,
+    pub produced_by: String,
+    pub produced_at: String,
+    pub authoring: Authoring,
+    pub signer_seed: Ed25519Seed,
+}
+
+pub fn mint_context_manager_contract(
+    args: &MintContextManagerContractArgs,
+) -> Result<MintedEnvelope, ClaimEnvelopeError> {
+    if args.bridge_source_symbol.is_empty() {
+        return Err(ClaimEnvelopeError::Other(
+            "context-manager-contract bridgeSourceSymbol must not be empty".into(),
+        ));
+    }
+    if args.import_signature.formals.len() != args.import_signature.sorts.len() {
+        return Err(ClaimEnvelopeError::Other(
+            "context-manager-contract import signature length mismatch".into(),
+        ));
+    }
+    let payload_json = context_manager_semantics_v1_to_json(&args.semantics);
+    let payload = json_to_value(&payload_json)
+        .map_err(|e| ClaimEnvelopeError::Other(format!("CM payload canonicalization: {e}")))?;
+    let payload_cid = hash_value(&payload);
+    let import_signature = json_to_value(&import_signature_v1_to_json(&args.import_signature))
+        .map_err(|e| ClaimEnvelopeError::Other(format!("CM signature canonicalization: {e}")))?;
+    let mut input_cids = args.source_warrants.clone();
+    input_cids.sort();
+    let header = Value::object([
+        ("schemaVersion", Value::string("1.2")),
+        ("kind", Value::string("context-manager-contract")),
+        ("cid", Value::string(payload_cid.clone())),
+        ("payloadCid", Value::string(payload_cid.clone())),
+        (
+            "bridgeSourceSymbol",
+            Value::string(args.bridge_source_symbol.clone()),
+        ),
+        ("importSignature", import_signature),
+        ("payload", payload),
+        (
+            "sourceWarrants",
+            Value::array(
+                args.source_warrants
+                    .iter()
+                    .cloned()
+                    .map(Value::string)
+                    .collect(),
+            ),
+        ),
+        (
+            "inputCids",
+            Value::array(input_cids.into_iter().map(Value::string).collect()),
+        ),
+    ]);
+    let metadata = Value::object([
+        ("authoring", authoring_to_value(&args.authoring)),
+        ("producedBy", Value::string(args.produced_by.clone())),
+        ("producedAt", Value::string(args.produced_at.clone())),
+    ]);
+    Ok(assemble_layered(
+        header,
+        metadata,
+        &args.produced_at,
+        &args.signer_seed,
+        payload_cid,
+    ))
 }
 
 // =============================================================================

--- a/implementations/rust/sugar-compiler/src/feed_from_tree.rs
+++ b/implementations/rust/sugar-compiler/src/feed_from_tree.rs
@@ -20,16 +20,21 @@ use serde_json::{json, Value as Json};
 use sugar_canonicalizer::{encode_jcs, json_to_value, Value as CValue};
 use sugar_claim_envelope::{
     body_discharge_default_for_kind, body_discharge_policy_from_fields_with_default, mint_bridge,
-    mint_contract_with_body_cid, Authoring, MintBridgeArgs, MintContractArgs,
+    mint_context_manager_contract, mint_contract_with_body_cid, Authoring, MintBridgeArgs,
+    MintContextManagerContractArgs, MintContractArgs,
 };
+use sugar_ir_types::Sort;
 use sugar_proof_envelope::Speaker;
 use sugar_proof_envelope::{
-    ed25519_pubkey_string, ed25519_sign_string, BridgeMemento, ClaimContractMemento, ContractBody,
-    ContractMementoRef, Ed25519Seed, FlatAtom, ProofGraph, SourceMemento,
+    ed25519_pubkey_string, ed25519_sign_string, BridgeMemento, ClaimContractMemento,
+    ContextManagerContractMemento, ContextManagerSemanticsV1, ContractBody, ContractMementoRef,
+    Ed25519Seed, EnterResultContractV1, ExitContractV1, ExitDispositionV1, FlatAtom,
+    ImportSignatureV1, ProofGraph, SourceMemento,
 };
 
 use crate::kit::{Kit, KitError};
 use crate::tree::{Fact, Sourced, Universe};
+use sugar_claim_envelope::KitDeclaration;
 
 /// Deterministic kit-author seed for feed fragments (content-addressed;
 /// not a sealed production mint identity).
@@ -73,6 +78,142 @@ fn json_to_cvalue(j: &Json) -> Result<Arc<CValue>, FeedError> {
 
 fn true_formula() -> Json {
     json!({"kind": "atomic", "name": "true", "args": []})
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContextManagerContractIrWire {
+    kind: String,
+    #[serde(rename = "schemaVersion")]
+    schema_version: String,
+    #[serde(rename = "bridgeSourceSymbol")]
+    bridge_source_symbol: String,
+    #[serde(rename = "importSignature")]
+    import_signature: ImportSignatureWire,
+    payload: ContextManagerSemanticsWire,
+    #[serde(rename = "sourceWarrants")]
+    source_warrants: Vec<String>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ImportSignatureWire {
+    formals: Vec<String>,
+    sorts: Vec<Sort>,
+}
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContextManagerSemanticsWire {
+    kind: String,
+    #[serde(rename = "schemaVersion")]
+    schema_version: String,
+    enter: EnterWire,
+    exit: ExitWire,
+}
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EnterWire {
+    completion: String,
+    result: EnterResultWire,
+}
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EnterResultWire {
+    kind: String,
+    projection: String,
+    sort: Sort,
+}
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExitWire {
+    completion: String,
+    disposition: DispositionWire,
+}
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DispositionWire {
+    kind: String,
+}
+
+/// Production declaration/feed door for bodyless context-manager contracts.
+/// Registers exactly one signed member and no formula atom or ContractBody.
+pub fn graph_from_context_manager_contract_ir(ir: &Json) -> Result<ProofGraph, FeedError> {
+    let row: ContextManagerContractIrWire =
+        serde_json::from_value(ir.clone()).map_err(|e| FeedError::Incomplete {
+            what: "context_manager_contract_ir",
+            detail: e.to_string(),
+        })?;
+    if row.kind != "context-manager-contract" || row.schema_version != "1" {
+        return Err(FeedError::Incomplete {
+            what: "context_manager_contract_ir",
+            detail: "unsupported declaration schema/kind".into(),
+        });
+    }
+    if row.bridge_source_symbol.is_empty()
+        || row.import_signature.formals.len() != row.import_signature.sorts.len()
+    {
+        return Err(FeedError::Incomplete {
+            what: "context_manager_contract_ir",
+            detail: "invalid binding coordinate or import signature".into(),
+        });
+    }
+    if row.payload.kind != "context-manager-semantics"
+        || row.payload.schema_version != "1"
+        || row.payload.enter.completion != "total"
+        || row.payload.enter.result.kind != "projection"
+        || row.payload.enter.result.projection != "enter_result"
+        || row.payload.exit.completion != "total"
+        || row.payload.exit.disposition.kind != "never-suppresses"
+    {
+        return Err(FeedError::Incomplete {
+            what: "context_manager_contract_ir",
+            detail: "unsupported CM semantics".into(),
+        });
+    }
+    let minted = mint_context_manager_contract(&MintContextManagerContractArgs {
+        bridge_source_symbol: row.bridge_source_symbol,
+        import_signature: ImportSignatureV1 {
+            formals: row.import_signature.formals,
+            sorts: row.import_signature.sorts,
+        },
+        semantics: ContextManagerSemanticsV1 {
+            enter: EnterResultContractV1 {
+                sort: row.payload.enter.result.sort,
+            },
+            exit: ExitContractV1 {
+                disposition: ExitDispositionV1::NeverSuppresses,
+            },
+        },
+        source_warrants: row.source_warrants,
+        produced_by: FEED_PRODUCED_BY.into(),
+        produced_at: FEED_PRODUCED_AT.into(),
+        authoring: Authoring::KitAuthor {
+            author: FEED_PRODUCED_BY.into(),
+            note: Some("bodyless CM declaration feed".into()),
+        },
+        signer_seed: FEED_SIGNER_SEED,
+    })
+    .map_err(|e| FeedError::Mint {
+        what: "mint_context_manager_contract",
+        detail: e.to_string(),
+    })?;
+    let mut graph = ProofGraph::new();
+    graph.push_context_manager_contract(ContextManagerContractMemento::new(minted.canonical_bytes));
+    Ok(graph)
+}
+
+/// Production kit-declaration intake. Every typed declaration is dispatched
+/// through its dedicated member arm before any source-tree construction.
+pub fn graph_from_kit_declaration(declaration: &KitDeclaration) -> Result<ProofGraph, FeedError> {
+    let mut graph = ProofGraph::empty();
+    for row in &declaration.contract_declarations {
+        let wire = serde_json::to_value(row).map_err(|error| FeedError::Incomplete {
+            what: "kit_contract_declaration",
+            detail: error.to_string(),
+        })?;
+        graph = graph.feed(graph_from_context_manager_contract_ir(&wire)?);
+    }
+    Ok(graph)
 }
 
 /// Optional IR fields that mint threads onto function-contract / claim members.
@@ -813,7 +954,8 @@ pub fn fold_project(
     // accepted here so the walk face types match the load door; stamping
     // happens in `pool_from_graph_with_speaker`.
     let _ = speaker;
-    fold_claim_tree(kit, workspace_root)
+    let declarations = graph_from_kit_declaration(kit.declaration())?;
+    Ok(declarations.feed(fold_claim_tree(kit, workspace_root)?))
 }
 
 #[cfg(test)]

--- a/implementations/rust/sugar-compiler/src/kit.rs
+++ b/implementations/rust/sugar-compiler/src/kit.rs
@@ -497,6 +497,49 @@ impl Kit {
         }
     }
 
+    pub fn bind_contract_refs(
+        &self,
+        table: &Value,
+    ) -> Result<String, crate::kit_path::LiftPluginKitError> {
+        let catalog_cid = table
+            .get("catalogCid")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                crate::kit_path::LiftPluginKitError::Failed(
+                    "contract-ref table missing catalogCid".into(),
+                )
+            })?;
+        let table_cid = table
+            .get("tableCid")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                crate::kit_path::LiftPluginKitError::Failed(
+                    "contract-ref table missing tableCid".into(),
+                )
+            })?;
+        let response = self
+            .connection
+            .clone()
+            .with_method("sugar.plugin.bind_contract_refs")
+            .request(table)?;
+        let acknowledged = response
+            .get("tableCid")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                crate::kit_path::LiftPluginKitError::Failed(
+                    "contract-ref bind response missing tableCid".into(),
+                )
+            })?;
+        if acknowledged != table_cid {
+            return Err(crate::kit_path::LiftPluginKitError::Failed(
+                "contract-ref bind acknowledged a different table CID".into(),
+            ));
+        }
+        self.connection
+            .install_contract_ref_generation(catalog_cid.to_owned(), table_cid.to_owned())?;
+        Ok(acknowledged.to_owned())
+    }
+
     /// SEAM 4 -- the testimony verb. Asks THIS kit (the one this handle
     /// rendezvous'd with) for its vendor dependency-proof catalog over
     /// `sugar.plugin.resolve_dependency_proofs`, decoded into typed,

--- a/implementations/rust/sugar-compiler/src/kit_path/lift_plugin.rs
+++ b/implementations/rust/sugar-compiler/src/kit_path/lift_plugin.rs
@@ -94,6 +94,7 @@ pub struct LiftPluginKit {
     resident: std::sync::Arc<ResidentSlot>,
     resident_max_requests: usize,
     terminal_error: std::sync::Arc<Mutex<Option<LiftPluginKitError>>>,
+    contract_ref_generation: std::sync::Arc<Mutex<Option<(String, String)>>>,
 }
 
 struct ResidentSlot(Mutex<Option<ResidentLifter>>);
@@ -186,6 +187,7 @@ impl LiftPluginKit {
             resident: std::sync::Arc::new(ResidentSlot(Mutex::new(None))),
             resident_max_requests,
             terminal_error: std::sync::Arc::new(Mutex::new(None)),
+            contract_ref_generation: std::sync::Arc::new(Mutex::new(None)),
         }
     }
 
@@ -256,6 +258,29 @@ impl LiftPluginKit {
         cache.ask(params, || {
             self.dispatch(params).map(|(_, response)| response)
         })
+    }
+
+    pub(crate) fn install_contract_ref_generation(
+        &self,
+        catalog_cid: String,
+        table_cid: String,
+    ) -> Result<(), LiftPluginKitError> {
+        *self.contract_ref_generation.lock().map_err(|_| {
+            LiftPluginKitError::Failed("contract-ref generation lock poisoned".into())
+        })? = Some((catalog_cid, table_cid));
+        Ok(())
+    }
+
+    pub(crate) fn contract_ref_generation(
+        &self,
+    ) -> Result<Option<(String, String)>, LiftPluginKitError> {
+        Ok(self
+            .contract_ref_generation
+            .lock()
+            .map_err(|_| {
+                LiftPluginKitError::Failed("contract-ref generation lock poisoned".into())
+            })?
+            .clone())
     }
 
     /// Promote a lift-plugin response term into the first-class primitive claim.

--- a/implementations/rust/sugar-compiler/src/orchestrate.rs
+++ b/implementations/rust/sugar-compiler/src/orchestrate.rs
@@ -475,7 +475,13 @@ pub fn fold_kit_to_pool(
     }
 
     // 7-8. Local semantic construction occurs only after ref installation.
-    let local = feed_from_tree::fold_project(kit, workspace_root, Some(&speaker))?;
+    let local = if active_cm_preconstruction.is_some() {
+        // The declaration graph was already sealed into the preliminary pool;
+        // this pass is semantic construction only.
+        feed_from_tree::fold_claim_tree(kit, workspace_root)?
+    } else {
+        feed_from_tree::fold_project(kit, workspace_root, Some(&speaker))?
+    };
     let local_pool =
         pool_from_graph_with_speaker(&local, speaker).map_err(ProveFromKitError::LocalLoad)?;
     pool.merge(local_pool);

--- a/implementations/rust/sugar-compiler/src/orchestrate.rs
+++ b/implementations/rust/sugar-compiler/src/orchestrate.rs
@@ -444,6 +444,7 @@ pub fn fold_kit_to_pool(
     // 3. Declaration-only enrollment and sealing. These rows never construct
     // a body and enter the ordinary authenticated pool through the dedicated
     // context-manager member arm.
+    let mut active_cm_preconstruction = None;
     if kit.supports_rpc_method("sugar.plugin.bind_contract_refs") {
         let declaration_rows = kit
             .context_manager_declarations(workspace_root)
@@ -470,6 +471,7 @@ pub fn fold_kit_to_pool(
         let table = ResolvedContractRefsV1::new(&catalog, &demands);
         kit.bind_contract_refs(&table.to_wire_value())
             .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+        active_cm_preconstruction = Some((catalog, table));
     }
 
     // 7-8. Local semantic construction occurs only after ref installation.
@@ -477,6 +479,15 @@ pub fn fold_kit_to_pool(
     let local_pool =
         pool_from_graph_with_speaker(&local, speaker).map_err(ProveFromKitError::LocalLoad)?;
     pool.merge(local_pool);
+
+    // 9. Recheck every resolved coordinate against the exact frozen snapshot
+    // after construction. Future CM edges use the same ref-owned equality
+    // check; this pass never reselects a candidate from the enlarged pool.
+    if let Some((catalog, table)) = &active_cm_preconstruction {
+        table
+            .final_check(catalog)
+            .map_err(|error| ProveFromKitError::Preconstruction(error.into()))?;
+    }
 
     Ok(pool)
 }

--- a/implementations/rust/sugar-compiler/src/orchestrate.rs
+++ b/implementations/rust/sugar-compiler/src/orchestrate.rs
@@ -55,7 +55,11 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use sugar_ir_compiler::registry::Registry as CompilerRegistry;
-use sugar_linker::{link, LinkerError, LinkerErrorKind, LinkerInputs};
+use sugar_linker::{
+    link, AuthenticatedContextManagerCatalog, ContextManagerContractDemandV1, LinkerError,
+    LinkerErrorKind, LinkerInputs, ResolvedContractRefsV1, SourceFragmentCoordinateV1, Symbol,
+};
+use sugar_proof_envelope::ImportSignatureV1;
 use sugar_proof_envelope::{build_proof_envelope, ProofEnvelopeInput, ProofGraph};
 use sugar_proof_envelope::{MementoPool, Speaker};
 use sugar_verifier::consistency::verify_consistency;
@@ -346,6 +350,8 @@ pub enum ProveFromKitError {
     LocalLoad(String),
     #[error("prove_from_kit: vendor testimony resolve failed: {0}")]
     Testimony(#[from] TestimonyError),
+    #[error("prove_from_kit: context-manager preconstruction failed: {0}")]
+    Preconstruction(String),
     #[error(transparent)]
     Solve(#[from] SolveError),
 }
@@ -391,15 +397,13 @@ pub fn fold_kit_to_pool(
     speaker: Speaker,
     cfg: &RunnerConfig,
 ) -> Result<MementoPool, ProveFromKitError> {
-    // 1. Local claim walk. Speaker is typed through fold so walk face and
-    // pool intake share one identity; stamping happens at step 2.
-    let local = feed_from_tree::fold_project(kit, workspace_root, Some(&speaker))?;
+    // Dependency testimony is the preliminary authenticated pool. It must be
+    // resident before any local tree construction: preconstruction contract
+    // declaration/catalog/demand binding reads this pool, while Sugar never
+    // does. Local construction is merged only after that front completes.
+    let mut pool = MementoPool::default();
 
-    // 2. Graph→pool intake with the consumer speaker (Task 7 door).
-    let mut pool =
-        pool_from_graph_with_speaker(&local, speaker).map_err(ProveFromKitError::LocalLoad)?;
-
-    // 3. Vendor testimony when the kit implements resolve_dependency_proofs.
+    // 1. Vendor testimony when the kit implements resolve_dependency_proofs.
     // Unavailable is a LINK-class absence (local-only prove still runs), not
     // a hard error — same law as Kit::testimony / resolve_testimony.
     //
@@ -430,14 +434,113 @@ pub fn fold_kit_to_pool(
         }
     }
 
-    // 4. CLI / RunnerConfig dependency proofs (same merge disk load_pool uses).
+    // 2. CLI / RunnerConfig dependency proofs (same merge disk load_pool uses).
     // Must happen here: `run_with_proof_run_with_pool` does not re-apply
     // `cfg.extra_proofs` (pool is already assembled).
     if !cfg.extra_proofs.is_empty() {
         load_proof_bytes_into_pool(&cfg.extra_proofs, &mut pool);
     }
 
+    // 3. Declaration-only enrollment and sealing. These rows never construct
+    // a body and enter the ordinary authenticated pool through the dedicated
+    // context-manager member arm.
+    if kit.supports_rpc_method("sugar.plugin.bind_contract_refs") {
+        let declaration_rows = kit
+            .context_manager_declarations(workspace_root)
+            .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+        for row in declaration_rows {
+            let graph = feed_from_tree::graph_from_context_manager_contract_ir(&row)?;
+            let declaration_pool = pool_from_graph_with_speaker(&graph, speaker.clone())
+                .map_err(ProveFromKitError::LocalLoad)?;
+            pool.merge(declaration_pool);
+        }
+
+        // 4-6. Freeze one authenticated snapshot, enroll non-constructing demands,
+        // prebind in Rust, then install the immutable typed table in the resident
+        // kit before any semantic enumeration begins.
+        let catalog = AuthenticatedContextManagerCatalog::freeze_from_pool(&pool)
+            .map_err(ProveFromKitError::Preconstruction)?;
+        let demand_rows = kit
+            .context_manager_demands(workspace_root)
+            .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+        let demands = demand_rows
+            .iter()
+            .map(context_manager_demand_from_wire)
+            .collect::<Result<Vec<_>, _>>()?;
+        let table = ResolvedContractRefsV1::new(&catalog, &demands);
+        kit.bind_contract_refs(&table.to_wire_value())
+            .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+    }
+
+    // 7-8. Local semantic construction occurs only after ref installation.
+    let local = feed_from_tree::fold_project(kit, workspace_root, Some(&speaker))?;
+    let local_pool =
+        pool_from_graph_with_speaker(&local, speaker).map_err(ProveFromKitError::LocalLoad)?;
+    pool.merge(local_pool);
+
     Ok(pool)
+}
+
+fn context_manager_demand_from_wire(
+    row: &serde_json::Value,
+) -> Result<ContextManagerContractDemandV1, ProveFromKitError> {
+    let schema = row.get("schemaVersion").and_then(serde_json::Value::as_str);
+    let kind = row.get("kind").and_then(serde_json::Value::as_str);
+    let expected = row.get("expectedKind").and_then(serde_json::Value::as_str);
+    if schema != Some("1")
+        || kind != Some("context-manager-demand")
+        || expected != Some("context-manager-contract")
+    {
+        return Err(ProveFromKitError::Preconstruction(
+            "unsupported context-manager demand row".into(),
+        ));
+    }
+    let use_site: SourceFragmentCoordinateV1 = serde_json::from_value(
+        row.get("useSite")
+            .cloned()
+            .ok_or_else(|| ProveFromKitError::Preconstruction("demand missing useSite".into()))?,
+    )
+    .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+    let signature = row
+        .get("importSignature")
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| {
+            ProveFromKitError::Preconstruction("demand missing importSignature".into())
+        })?;
+    let formals = serde_json::from_value(
+        signature
+            .get("formals")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!([])),
+    )
+    .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+    let sorts = serde_json::from_value(
+        signature
+            .get("sorts")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!([])),
+    )
+    .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+    let import_signature = ImportSignatureV1 { formals, sorts };
+    match row.get("targetSymbol") {
+        Some(serde_json::Value::String(symbol)) => Ok(ContextManagerContractDemandV1::new(
+            use_site,
+            Symbol::from(symbol.as_str()),
+            import_signature,
+        )),
+        Some(serde_json::Value::Null)
+            if row.get("gapKind").and_then(serde_json::Value::as_str)
+                == Some("runtime-selected") =>
+        {
+            Ok(ContextManagerContractDemandV1::runtime_selected(
+                use_site,
+                import_signature,
+            ))
+        }
+        _ => Err(ProveFromKitError::Preconstruction(
+            "demand target is neither an authenticated symbol nor runtime-selected".into(),
+        )),
+    }
 }
 
 impl From<ProofRunArtifactError> for SolveError {

--- a/implementations/rust/sugar-compiler/src/tree.rs
+++ b/implementations/rust/sugar-compiler/src/tree.rs
@@ -104,6 +104,8 @@ pub enum Level {
     Universe,
     Implications,
     Exports,
+    ContractDeclarations,
+    ContractDemands,
 }
 
 impl Level {
@@ -117,6 +119,8 @@ impl Level {
             Level::Universe => "universe",
             Level::Implications => "implications",
             Level::Exports => "exports",
+            Level::ContractDeclarations => "contract-declarations",
+            Level::ContractDemands => "contract-demands",
         }
     }
 }
@@ -805,6 +809,19 @@ fn enumerate_rpc(
     if !conn.allowed_broken_components.is_empty() {
         options["allowedBrokenComponents"] = json!(conn.allowed_broken_components);
     }
+    if let Some((catalog_cid, table_cid)) =
+        conn.transport
+            .contract_ref_generation()
+            .map_err(|error| EnumerateError::Unavailable {
+                plugin: plugin.clone(),
+                reason: error.to_string(),
+            })?
+    {
+        options["contractRefs"] = json!({
+            "catalogCid": catalog_cid,
+            "tableCid": table_cid,
+        });
+    }
     let response = conn
         .transport
         .request(&json!({
@@ -863,6 +880,36 @@ fn enumerate_rpc(
         .map(|arr| arr.iter().map(decode_gap).collect())
         .unwrap_or_default();
     Ok((nodes, gaps))
+}
+
+fn preconstruction_rows_rpc(conn: &KitConn, level: Level) -> Result<Vec<Value>, EnumerateError> {
+    let plugin = conn.surface.clone();
+    let response = conn
+        .transport
+        .request(&json!({
+            "level": level.wire(),
+            "workspace_root": conn.workspace_root.display().to_string(),
+        }))
+        .map_err(|error| EnumerateError::Unavailable {
+            plugin: plugin.clone(),
+            reason: error.to_string(),
+        })?;
+    let result = response
+        .get("result")
+        .unwrap_or(&response)
+        .as_object()
+        .ok_or_else(|| EnumerateError::Malformed {
+            plugin: plugin.clone(),
+            reason: "preconstruction response result must be an object".into(),
+        })?;
+    result
+        .get("rows")
+        .and_then(Value::as_array)
+        .cloned()
+        .ok_or_else(|| EnumerateError::Malformed {
+            plugin,
+            reason: "preconstruction response missing rows array".into(),
+        })
 }
 
 /// `LiftPluginKit::request` has already checked and removed the JSON-RPC
@@ -1342,6 +1389,23 @@ fn merge_recovered_audit_leaf(
 }
 
 impl Kit {
+    pub fn context_manager_declarations(
+        &self,
+        workspace_root: &Path,
+    ) -> Result<Vec<Value>, KitError> {
+        Ok(preconstruction_rows_rpc(
+            &self.enumerate_conn(workspace_root),
+            Level::ContractDeclarations,
+        )?)
+    }
+
+    pub fn context_manager_demands(&self, workspace_root: &Path) -> Result<Vec<Value>, KitError> {
+        Ok(preconstruction_rows_rpc(
+            &self.enumerate_conn(workspace_root),
+            Level::ContractDemands,
+        )?)
+    }
+
     /// Scan the producer surface. Export answers reuse the existing linker
     /// contract type; malformed or identity-mismatched answers are loud wire
     /// errors, never silently omitted exports.

--- a/implementations/rust/sugar-compiler/tests/context_manager_contract_feed.rs
+++ b/implementations/rust/sugar-compiler/tests/context_manager_contract_feed.rs
@@ -1,0 +1,87 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_json::Value as Json;
+use sugar_claim_envelope::KitDeclaration;
+use sugar_compiler::feed_from_tree::{
+    graph_from_context_manager_contract_ir, graph_from_kit_declaration,
+};
+use sugar_compiler::orchestrate::pool_from_graph_with_speaker;
+use sugar_proof_envelope::{ExitDispositionV1, Member, MemberKind, Speaker};
+
+#[test]
+fn production_kit_declaration_becomes_bodyless_signed_graph_member() {
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap()
+        .to_path_buf();
+    let python_path = repo.join("implementations/python/sugar-lift-py-tests/src");
+    let program = r#"
+import json
+from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.kit_rpc import ContextManagerContractIrV1, ImportSignatureV1
+row = ContextManagerContractIrV1.never_suppresses(bridge_source_symbol='context-manager:fixture_python.never_closing', import_signature=ImportSignatureV1(formals=(), sorts=()), enter_result_sort=PrimitiveSort('Value'), source_warrants=('blake3-512:' + 'a' * 128,))
+print(json.dumps(row.to_rpc_with_term_table(None)))
+"#;
+    let output = Command::new("python3")
+        .env("PYTHONPATH", python_path)
+        .arg("-c")
+        .arg(program)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let row: Json = serde_json::from_slice(&output.stdout).unwrap();
+    let graph = graph_from_context_manager_contract_ir(&row).expect("dedicated CM feed arm");
+    assert_eq!(graph.atoms().count(), 0);
+    assert_eq!(graph.bodies().count(), 0);
+    let views: Vec<_> = graph.members_view().collect();
+    assert_eq!(views.len(), 1);
+    assert_eq!(views[0].kind(), Some(MemberKind::ContextManagerContract));
+    assert_eq!(views[0].body_cid(), None);
+    let Member::ContextManagerContract(cm) = Member::parse(views[0].bytes()).unwrap() else {
+        panic!("dedicated CM member")
+    };
+    assert_eq!(
+        cm.semantics.exit.disposition,
+        ExitDispositionV1::NeverSuppresses
+    );
+    let pool = pool_from_graph_with_speaker(&graph, Speaker::consumer("fixture-consumer"))
+        .expect("ordinary authenticated member-pool intake");
+    assert_eq!(
+        pool.member_count_by_kind(MemberKind::ContextManagerContract),
+        1
+    );
+}
+
+#[test]
+fn live_kit_declaration_dispatches_cm_rows_through_dedicated_feed_arm() {
+    let declaration: KitDeclaration = serde_json::from_value(serde_json::json!({
+        "kit": {"id": "fixture", "language": "python", "version": "1"},
+        "rpc": {"methods": [{"name": "sugar.plugin.kit_declaration", "required": true}]},
+        "proofResolution": {"strategy": "rpc-proof-bytes"},
+        "residueCategories": [],
+        "contractDeclarations": [{
+            "kind": "context-manager-contract",
+            "schemaVersion": "1",
+            "bridgeSourceSymbol": "context-manager:fixture.manager",
+            "importSignature": {"formals": [], "sorts": []},
+            "payload": {
+                "kind": "context-manager-semantics", "schemaVersion": "1",
+                "enter": {"completion": "total", "result": {"kind": "projection", "projection": "enter_result", "sort": {"kind": "primitive", "name": "Value"}}},
+                "exit": {"completion": "total", "disposition": {"kind": "never-suppresses"}}
+            },
+            "sourceWarrants": []
+        }]
+    })).expect("typed kit declaration");
+    let graph = graph_from_kit_declaration(&declaration).expect("production declaration feed");
+    assert_eq!(graph.atoms().count(), 0);
+    assert_eq!(graph.bodies().count(), 0);
+    let views: Vec<_> = graph.members_view().collect();
+    assert_eq!(views.len(), 1);
+    assert_eq!(views[0].kind(), Some(MemberKind::ContextManagerContract));
+}

--- a/implementations/rust/sugar-compiler/tests/prove_from_kit.rs
+++ b/implementations/rust/sugar-compiler/tests/prove_from_kit.rs
@@ -280,6 +280,26 @@ fn fold_project_loads_with_consumer_speaker() {
     }
 }
 
+#[test]
+fn production_fold_installs_cm_ref_generation_before_semantic_enumeration() {
+    if !python_blake3_available() {
+        eprintln!("skip: python3/blake3 unavailable");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let project = stage_fixture(dir.path());
+    let kit = Kit::rendezvous(python_kit_manifest(dir.path())).expect("rendezvous");
+    assert!(kit.supports_rpc_method("sugar.plugin.bind_contract_refs"));
+    let pool = fold_kit_to_pool(
+        &kit,
+        &project,
+        Speaker::consumer("cm-preconstruction-order"),
+        &runner_cfg(&project),
+    )
+    .expect("preconstruction bind must precede the first semantic enumerate request");
+    assert!(pool.mementos.len() > 0);
+}
+
 /// Full door: prove_from_kit discharges the enumerate fixture; verdict rows
 /// match solve_project_with_pool over the same consumer pool (identity of
 /// the thin face vs the preloaded-pool beats).

--- a/implementations/rust/sugar-compiler/tests/prove_from_kit.rs
+++ b/implementations/rust/sugar-compiler/tests/prove_from_kit.rs
@@ -101,12 +101,14 @@ fn python_kit_manifest(dir: &Path) -> LiftManifest {
         .join("sugar-lift-python-source")
         .join("src");
     let script = dir.join("python-lift.sh");
+    let rpc_sequence = dir.join("rpc-sequence.log");
     write_executable(
         &script,
         &format!(
-            "#!/bin/sh\nexport PYTHONPATH=\"{}:{}${{PYTHONPATH:+:$PYTHONPATH}}\"\nexec python3 -m sugar_lift_py_tests.lift_rpc --rpc\n",
+            "#!/bin/sh\nexport PYTHONPATH=\"{}:{}${{PYTHONPATH:+:$PYTHONPATH}}\"\nexport SUGAR_RPC_SEQUENCE_LOG=\"{}\"\nexec python3 -m sugar_lift_py_tests.lift_rpc --rpc\n",
             py_tests_src.display(),
-            py_source_src.display()
+            py_source_src.display(),
+            rpc_sequence.display(),
         ),
     );
     LiftManifest::resolved(
@@ -182,6 +184,43 @@ fn runner_cfg(project_root: &Path) -> RunnerConfig {
         legacy_z3_fallback: Some(LegacyZ3Fallback::compat("z3")),
         ..Default::default()
     }
+}
+
+fn validate_cm_preconstruction_sequence(sequence: &str) -> Result<(), String> {
+    let events: Vec<_> = sequence.lines().collect();
+    let position = |needle: &str| {
+        events
+            .iter()
+            .position(|event| *event == needle)
+            .ok_or_else(|| format!("missing {needle}; events={events:?}"))
+    };
+    let declarations = position("sugar.enumerate:contract-declarations")?;
+    let demands = position("sugar.enumerate:contract-demands")?;
+    let bind = position("sugar.plugin.bind_contract_refs")?;
+    let first_semantic = events
+        .iter()
+        .position(|event| {
+            event.starts_with("sugar.enumerate:")
+                && !event.ends_with(":contract-declarations")
+                && !event.ends_with(":contract-demands")
+        })
+        .ok_or_else(|| format!("missing semantic enumeration; events={events:?}"))?;
+    if declarations < demands && demands < bind && bind < first_semantic {
+        Ok(())
+    } else {
+        Err(format!("invalid CM preconstruction order: {events:?}"))
+    }
+}
+
+#[test]
+fn phase_order_detector_rejects_bind_after_first_semantic_enumeration() {
+    let planted = concat!(
+        "sugar.enumerate:contract-declarations\n",
+        "sugar.enumerate:contract-demands\n",
+        "sugar.enumerate:source_files\n",
+        "sugar.plugin.bind_contract_refs\n",
+    );
+    assert!(validate_cm_preconstruction_sequence(planted).is_err());
 }
 
 /// Sorted (property_name, status) pairs from a prove artifact — the gate
@@ -298,6 +337,10 @@ fn production_fold_installs_cm_ref_generation_before_semantic_enumeration() {
     )
     .expect("preconstruction bind must precede the first semantic enumerate request");
     assert!(pool.mementos.len() > 0);
+    let sequence = fs::read_to_string(dir.path().join("rpc-sequence.log"))
+        .expect("production kit must record the actual RPC sequence");
+    validate_cm_preconstruction_sequence(&sequence)
+        .expect("CM preconstruction RPC sequence must precede semantic enumeration");
 }
 
 /// Full door: prove_from_kit discharges the enumerate fixture; verdict rows

--- a/implementations/rust/sugar-linker/Cargo.toml
+++ b/implementations/rust/sugar-linker/Cargo.toml
@@ -20,5 +20,6 @@ sugar-verifier = { path = "../sugar-verifier" }
 sugar-ir-compiler = { path = "../sugar-ir-compiler" }
 sugar-ir-compiler-smt-lib = { path = "../sugar-ir-compiler-smt-lib" }
 sugar-claim-envelope = { path = "../sugar-claim-envelope" }
+sugar-proof-envelope = { path = "../sugar-proof-envelope" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/implementations/rust/sugar-linker/src/lib.rs
+++ b/implementations/rust/sugar-linker/src/lib.rs
@@ -48,6 +48,9 @@ use sugar_canonicalizer::{blake3_512_of, encode_jcs, Value as CanonValue};
 use sugar_ir_compiler::{CompilerInput, IrCompiler};
 use sugar_ir_compiler_smt_lib::{SmtLibCompiler, DIALECT as SMT_DIALECT};
 use sugar_ir_types::{IrFormula, Sort};
+use sugar_proof_envelope::{
+    AnchoredMember, ContextManagerSemanticsV1, ImportSignatureV1, Member, MemberKind, MementoCid,
+};
 use sugar_verifier::solvers::{run_plan, SolverHandle, SolverPlan, SolverSeat};
 use sugar_verifier::types::ObligationVerdict;
 
@@ -260,6 +263,317 @@ impl std::fmt::Display for Cid {
 impl AsRef<str> for Cid {
     fn as_ref(&self) -> &str {
         &self.0
+    }
+}
+
+// -------------------------------------------------------------------
+// Authenticated context-manager preconstruction resolution (#6071)
+// -------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct SourceFragmentCoordinateV1 {
+    #[serde(rename = "sourceCid")]
+    pub source_cid: Cid,
+    #[serde(rename = "startLine")]
+    pub start_line: usize,
+    #[serde(rename = "startCol")]
+    pub start_col: usize,
+    #[serde(rename = "endLine")]
+    pub end_line: usize,
+    #[serde(rename = "endCol")]
+    pub end_col: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextManagerContractDemandV1 {
+    pub demand_cid: Cid,
+    pub use_site: SourceFragmentCoordinateV1,
+    pub target_symbol: Symbol,
+    pub import_signature: ImportSignatureV1,
+}
+
+impl ContextManagerContractDemandV1 {
+    pub fn new(
+        use_site: SourceFragmentCoordinateV1,
+        target_symbol: Symbol,
+        import_signature: ImportSignatureV1,
+    ) -> Self {
+        let preimage = serde_json::json!({
+            "useSite": use_site,
+            "targetSymbol": target_symbol,
+            "importSignature": {
+                "formals": import_signature.formals,
+                "sorts": import_signature.sorts,
+            },
+            "expectedKind": "context-manager-contract",
+        });
+        let demand_cid = Cid::from(jcs_cid(&preimage));
+        Self {
+            demand_cid,
+            use_site,
+            target_symbol,
+            import_signature,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AuthenticatedContextManagerCatalog {
+    catalog_cid: Cid,
+    members: BTreeMap<Cid, Json>,
+}
+
+impl AuthenticatedContextManagerCatalog {
+    pub fn freeze(members: Vec<(Cid, Json)>) -> Result<Self, String> {
+        let mut by_cid = BTreeMap::new();
+        for (cid, envelope) in members {
+            let typed = MementoCid::try_parse(cid.as_str().to_string())
+                .map_err(|bad| format!("invalid catalog member CID: {bad}"))?;
+            AnchoredMember::new(typed, envelope.clone())?;
+            if by_cid.insert(cid.clone(), envelope).is_some() {
+                return Err(format!("duplicate catalog member CID: {cid}"));
+            }
+        }
+        let member_cids: Vec<&str> = by_cid.keys().map(Cid::as_str).collect();
+        let catalog_cid = Cid::from(jcs_cid(&serde_json::json!({"memberCids": member_cids})));
+        Ok(Self {
+            catalog_cid,
+            members: by_cid,
+        })
+    }
+
+    pub fn catalog_cid(&self) -> &Cid {
+        &self.catalog_cid
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ContextManagerResolutionGapKindV1 {
+    RuntimeSelected,
+    UnresolvedSymbol,
+    AmbiguousSymbol,
+    WrongContractKind,
+    SignatureMismatch,
+    UnauthenticatedMember,
+    PayloadCidMismatch,
+    UnsupportedCmSchema,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextManagerResolutionGapV1 {
+    pub demand_cid: Cid,
+    pub use_site: SourceFragmentCoordinateV1,
+    pub target_symbol: Option<Symbol>,
+    pub kind: ContextManagerResolutionGapKindV1,
+    pub candidate_member_cids: Vec<Cid>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextManagerContractRefV1 {
+    resolution_cid: Cid,
+    demand_cid: Cid,
+    use_site: SourceFragmentCoordinateV1,
+    catalog_cid: Cid,
+    member_cid: Cid,
+    payload_cid: Cid,
+    bridge_source_symbol: Symbol,
+    import_signature: ImportSignatureV1,
+    semantics: ContextManagerSemanticsV1,
+    source_warrant_cids: Vec<Cid>,
+}
+
+impl ContextManagerContractRefV1 {
+    pub fn resolution_cid(&self) -> &Cid {
+        &self.resolution_cid
+    }
+    pub fn demand_cid(&self) -> &Cid {
+        &self.demand_cid
+    }
+    pub fn use_site(&self) -> &SourceFragmentCoordinateV1 {
+        &self.use_site
+    }
+    pub fn catalog_cid(&self) -> &Cid {
+        &self.catalog_cid
+    }
+    pub fn member_cid(&self) -> &Cid {
+        &self.member_cid
+    }
+    pub fn payload_cid(&self) -> &Cid {
+        &self.payload_cid
+    }
+    pub fn bridge_source_symbol(&self) -> &Symbol {
+        &self.bridge_source_symbol
+    }
+    pub fn import_signature(&self) -> &ImportSignatureV1 {
+        &self.import_signature
+    }
+    pub fn semantics(&self) -> &ContextManagerSemanticsV1 {
+        &self.semantics
+    }
+    pub fn source_warrant_cids(&self) -> &[Cid] {
+        &self.source_warrant_cids
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContextManagerResolutionV1 {
+    Resolved(ContextManagerContractRefV1),
+    Unresolved(ContextManagerResolutionGapV1),
+}
+
+fn cm_gap(
+    demand: &ContextManagerContractDemandV1,
+    kind: ContextManagerResolutionGapKindV1,
+    mut candidates: Vec<Cid>,
+) -> ContextManagerResolutionV1 {
+    candidates.sort();
+    ContextManagerResolutionV1::Unresolved(ContextManagerResolutionGapV1 {
+        demand_cid: demand.demand_cid.clone(),
+        use_site: demand.use_site.clone(),
+        target_symbol: Some(demand.target_symbol.clone()),
+        kind,
+        candidate_member_cids: candidates,
+    })
+}
+
+pub fn resolve_context_manager_demand(
+    demand: &ContextManagerContractDemandV1,
+    catalog: &AuthenticatedContextManagerCatalog,
+) -> ContextManagerResolutionV1 {
+    let mut candidates = Vec::new();
+    for (cid, envelope) in &catalog.members {
+        if sugar_proof_envelope::member_field(envelope, "bridgeSourceSymbol").and_then(Json::as_str)
+            == Some(&demand.target_symbol.to_string())
+        {
+            candidates.push((cid.clone(), envelope));
+        }
+    }
+    if candidates.is_empty() {
+        return cm_gap(
+            demand,
+            ContextManagerResolutionGapKindV1::UnresolvedSymbol,
+            vec![],
+        );
+    }
+    if candidates.len() > 1 {
+        return cm_gap(
+            demand,
+            ContextManagerResolutionGapKindV1::AmbiguousSymbol,
+            candidates.into_iter().map(|v| v.0).collect(),
+        );
+    }
+    let (member_cid, envelope) = candidates.pop().expect("one candidate");
+    if sugar_proof_envelope::member_kind(envelope).ok() != Some(MemberKind::ContextManagerContract)
+    {
+        return cm_gap(
+            demand,
+            ContextManagerResolutionGapKindV1::WrongContractKind,
+            vec![member_cid],
+        );
+    }
+    let typed_cid = match MementoCid::try_parse(member_cid.as_str().to_string()) {
+        Ok(cid) => cid,
+        Err(_) => {
+            return cm_gap(
+                demand,
+                ContextManagerResolutionGapKindV1::UnauthenticatedMember,
+                vec![member_cid],
+            )
+        }
+    };
+    if AnchoredMember::new(typed_cid, envelope.clone()).is_err() {
+        return cm_gap(
+            demand,
+            ContextManagerResolutionGapKindV1::UnauthenticatedMember,
+            vec![member_cid],
+        );
+    }
+    let cm = match Member::from_value(envelope) {
+        Ok(Member::ContextManagerContract(cm)) => cm,
+        Err(error) if error.to_string().contains("payload CID") => {
+            return cm_gap(
+                demand,
+                ContextManagerResolutionGapKindV1::PayloadCidMismatch,
+                vec![member_cid],
+            );
+        }
+        Err(_) | Ok(_) => {
+            return cm_gap(
+                demand,
+                ContextManagerResolutionGapKindV1::UnsupportedCmSchema,
+                vec![member_cid],
+            )
+        }
+    };
+    if demand.import_signature.formals != cm.import_signature.formals
+        || demand.import_signature.sorts != cm.import_signature.sorts
+    {
+        return cm_gap(
+            demand,
+            ContextManagerResolutionGapKindV1::SignatureMismatch,
+            vec![member_cid],
+        );
+    }
+    let source_warrant_cids: Vec<Cid> = cm.source_warrants.iter().cloned().map(Cid::from).collect();
+    if source_warrant_cids
+        .iter()
+        .any(|cid| !catalog.members.contains_key(cid))
+    {
+        return cm_gap(
+            demand,
+            ContextManagerResolutionGapKindV1::UnauthenticatedMember,
+            vec![member_cid],
+        );
+    }
+    let payload_cid = Cid::from(cm.payload_cid.as_str());
+    let preimage = serde_json::json!({
+        "schemaVersion": "1", "demandCid": demand.demand_cid,
+        "useSite": demand.use_site, "catalogCid": catalog.catalog_cid,
+        "memberCid": member_cid, "payloadCid": payload_cid,
+        "bridgeSourceSymbol": demand.target_symbol,
+        "importSignature": {"formals": cm.import_signature.formals, "sorts": cm.import_signature.sorts},
+        "semantics": sugar_proof_envelope::context_manager_semantics_v1_to_json(&cm.semantics),
+        "sourceWarrantCids": source_warrant_cids,
+    });
+    let resolution_cid = Cid::from(jcs_cid(&preimage));
+    ContextManagerResolutionV1::Resolved(ContextManagerContractRefV1 {
+        resolution_cid,
+        demand_cid: demand.demand_cid.clone(),
+        use_site: demand.use_site.clone(),
+        catalog_cid: catalog.catalog_cid.clone(),
+        member_cid,
+        payload_cid,
+        bridge_source_symbol: demand.target_symbol.clone(),
+        import_signature: cm.import_signature,
+        semantics: cm.semantics,
+        source_warrant_cids,
+    })
+}
+
+pub fn final_check_context_manager_ref(
+    reference: &ContextManagerContractRefV1,
+    catalog: &AuthenticatedContextManagerCatalog,
+) -> Result<(), &'static str> {
+    if reference.catalog_cid != catalog.catalog_cid
+        || !catalog.members.contains_key(&reference.member_cid)
+    {
+        return Err("stale-resolution");
+    }
+    let demand = ContextManagerContractDemandV1 {
+        demand_cid: reference.demand_cid.clone(),
+        use_site: reference.use_site.clone(),
+        target_symbol: reference.bridge_source_symbol.clone(),
+        import_signature: reference.import_signature.clone(),
+    };
+    match resolve_context_manager_demand(&demand, catalog) {
+        ContextManagerResolutionV1::Resolved(now)
+            if now.member_cid == reference.member_cid
+                && now.resolution_cid == reference.resolution_cid =>
+        {
+            Ok(())
+        }
+        _ => Err("stale-resolution"),
     }
 }
 
@@ -1837,6 +2151,10 @@ fn compute_set_cid_sorted(sorted_items: &[String]) -> String {
 
 fn jcs_of_json(v: &Json) -> Vec<u8> {
     encode_jcs(&json_to_canon_value(v)).into_bytes()
+}
+
+fn jcs_cid(v: &Json) -> String {
+    blake3_512_of(&jcs_of_json(v))
 }
 
 /// JCS-canonical bytes of a typed formula. Lowers the `IrFormula` to its

--- a/implementations/rust/sugar-linker/src/lib.rs
+++ b/implementations/rust/sugar-linker/src/lib.rs
@@ -532,6 +532,21 @@ impl ResolvedContractRefsV1 {
         value
     }
 
+    pub fn final_check(
+        &self,
+        catalog: &AuthenticatedContextManagerCatalog,
+    ) -> Result<(), &'static str> {
+        if &self.catalog_cid != catalog.catalog_cid() {
+            return Err("stale-resolution");
+        }
+        for resolution in self.by_use_site.values() {
+            if let ContextManagerResolutionV1::Resolved(reference) = resolution {
+                final_check_context_manager_ref(reference, catalog)?;
+            }
+        }
+        Ok(())
+    }
+
     fn identity_value(&self) -> Json {
         let rows = self
             .by_use_site

--- a/implementations/rust/sugar-linker/src/lib.rs
+++ b/implementations/rust/sugar-linker/src/lib.rs
@@ -422,6 +422,120 @@ pub enum ContextManagerResolutionV1 {
     Unresolved(ContextManagerResolutionGapV1),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedContractRefsV1 {
+    catalog_cid: Cid,
+    table_cid: Cid,
+    by_use_site: BTreeMap<SourceFragmentCoordinateV1, ContextManagerResolutionV1>,
+}
+
+impl ResolvedContractRefsV1 {
+    pub fn new(
+        catalog: &AuthenticatedContextManagerCatalog,
+        demands: &[ContextManagerContractDemandV1],
+    ) -> Self {
+        let by_use_site = demands
+            .iter()
+            .map(|demand| {
+                (
+                    demand.use_site.clone(),
+                    resolve_context_manager_demand(demand, catalog),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let mut table = Self {
+            catalog_cid: catalog.catalog_cid.clone(),
+            table_cid: Cid::from(""),
+            by_use_site,
+        };
+        table.table_cid = Cid::from(jcs_cid(&table.identity_value()));
+        table
+    }
+
+    pub fn catalog_cid(&self) -> &Cid {
+        &self.catalog_cid
+    }
+
+    pub fn table_cid(&self) -> &Cid {
+        &self.table_cid
+    }
+
+    pub fn get(
+        &self,
+        use_site: &SourceFragmentCoordinateV1,
+    ) -> Option<&ContextManagerResolutionV1> {
+        self.by_use_site.get(use_site)
+    }
+
+    pub fn to_wire_value(&self) -> Json {
+        let mut value = self.identity_value();
+        value
+            .as_object_mut()
+            .expect("table object")
+            .insert("tableCid".into(), Json::String(self.table_cid.to_string()));
+        value
+    }
+
+    fn identity_value(&self) -> Json {
+        let rows = self
+            .by_use_site
+            .iter()
+            .map(|(use_site, resolution)| {
+                serde_json::json!({
+                    "useSite": use_site,
+                    "resolution": resolution_to_json(resolution),
+                })
+            })
+            .collect::<Vec<_>>();
+        serde_json::json!({
+            "kind": "resolved-contract-refs",
+            "schemaVersion": "1",
+            "catalogCid": self.catalog_cid,
+            "byUseSite": rows,
+        })
+    }
+}
+
+fn import_signature_to_json(value: &ImportSignatureV1) -> Json {
+    serde_json::json!({"formals": value.formals, "sorts": value.sorts})
+}
+
+fn reference_to_json(value: &ContextManagerContractRefV1) -> Json {
+    serde_json::json!({
+        "kind": "context-manager-contract-ref",
+        "schemaVersion": "1",
+        "resolutionCid": value.resolution_cid,
+        "demandCid": value.demand_cid,
+        "useSite": value.use_site,
+        "catalogCid": value.catalog_cid,
+        "memberCid": value.member_cid,
+        "payloadCid": value.payload_cid,
+        "bridgeSourceSymbol": value.bridge_source_symbol,
+        "importSignature": import_signature_to_json(&value.import_signature),
+        "semantics": sugar_proof_envelope::context_manager_semantics_v1_to_json(&value.semantics),
+        "sourceWarrantCids": value.source_warrant_cids,
+    })
+}
+
+fn resolution_to_json(value: &ContextManagerResolutionV1) -> Json {
+    match value {
+        ContextManagerResolutionV1::Resolved(reference) => serde_json::json!({
+            "kind": "resolved",
+            "reference": reference_to_json(reference),
+        }),
+        ContextManagerResolutionV1::Unresolved(gap) => serde_json::json!({
+            "kind": "unresolved",
+            "gap": {
+                "demandCid": gap.demand_cid,
+                "useSite": gap.use_site,
+                "targetSymbol": gap.target_symbol,
+                "kind": gap.kind,
+                "candidateMemberCids": gap.candidate_member_cids,
+            },
+        }),
+    }
+}
+
 fn cm_gap(
     demand: &ContextManagerContractDemandV1,
     kind: ContextManagerResolutionGapKindV1,

--- a/implementations/rust/sugar-linker/src/lib.rs
+++ b/implementations/rust/sugar-linker/src/lib.rs
@@ -366,6 +366,18 @@ impl AuthenticatedContextManagerCatalog {
     }
 
     pub fn freeze_from_pool(pool: &MementoPool) -> Result<Self, String> {
+        for cid in pool.mementos.keys() {
+            let attributed = pool.member_speaker(cid).is_some();
+            let enrolled = pool
+                .bundle_members
+                .values()
+                .any(|members| members.contains(cid));
+            if !attributed || !enrolled {
+                return Err(format!(
+                    "unauthenticated-member: {cid} lacks verified pool intake testimony"
+                ));
+            }
+        }
         let members = pool
             .mementos
             .iter()

--- a/implementations/rust/sugar-linker/src/lib.rs
+++ b/implementations/rust/sugar-linker/src/lib.rs
@@ -645,7 +645,7 @@ pub fn resolve_context_manager_demand(
                 vec![member_cid],
             );
         }
-        Err(_) | Ok(_) => {
+        Err(_) => {
             return cm_gap(
                 demand,
                 ContextManagerResolutionGapKindV1::UnsupportedCmSchema,

--- a/implementations/rust/sugar-linker/src/lib.rs
+++ b/implementations/rust/sugar-linker/src/lib.rs
@@ -39,7 +39,7 @@
 //! - `LinkerOutput.linker_errors` carries a `file` field so the daemon can
 //!   attach LSP diagnostics to the correct editor pane.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -49,7 +49,8 @@ use sugar_ir_compiler::{CompilerInput, IrCompiler};
 use sugar_ir_compiler_smt_lib::{SmtLibCompiler, DIALECT as SMT_DIALECT};
 use sugar_ir_types::{IrFormula, Sort};
 use sugar_proof_envelope::{
-    AnchoredMember, ContextManagerSemanticsV1, ImportSignatureV1, Member, MemberKind, MementoCid,
+    context_manager_contract_from_stored, AnchoredMember, ContextManagerSemanticsV1,
+    ImportSignatureV1, MemberKind, MementoCid, MementoPool, StoredMember,
 };
 use sugar_verifier::solvers::{run_plan, SolverHandle, SolverPlan, SolverSeat};
 use sugar_verifier::types::ObligationVerdict;
@@ -288,7 +289,7 @@ pub struct SourceFragmentCoordinateV1 {
 pub struct ContextManagerContractDemandV1 {
     pub demand_cid: Cid,
     pub use_site: SourceFragmentCoordinateV1,
-    pub target_symbol: Symbol,
+    pub target_symbol: Option<Symbol>,
     pub import_signature: ImportSignatureV1,
 }
 
@@ -311,7 +312,25 @@ impl ContextManagerContractDemandV1 {
         Self {
             demand_cid,
             use_site,
-            target_symbol,
+            target_symbol: Some(target_symbol),
+            import_signature,
+        }
+    }
+
+    pub fn runtime_selected(
+        use_site: SourceFragmentCoordinateV1,
+        import_signature: ImportSignatureV1,
+    ) -> Self {
+        let preimage = serde_json::json!({
+            "useSite": use_site,
+            "targetSymbol": Json::Null,
+            "importSignature": import_signature_to_json(&import_signature),
+            "expectedKind": "context-manager-contract",
+        });
+        Self {
+            demand_cid: Cid::from(jcs_cid(&preimage)),
+            use_site,
+            target_symbol: None,
             import_signature,
         }
     }
@@ -320,7 +339,8 @@ impl ContextManagerContractDemandV1 {
 #[derive(Debug, Clone)]
 pub struct AuthenticatedContextManagerCatalog {
     catalog_cid: Cid,
-    members: BTreeMap<Cid, Json>,
+    members: BTreeMap<Cid, StoredMember>,
+    authenticated_cids: BTreeSet<Cid>,
 }
 
 impl AuthenticatedContextManagerCatalog {
@@ -329,8 +349,10 @@ impl AuthenticatedContextManagerCatalog {
         for (cid, envelope) in members {
             let typed = MementoCid::try_parse(cid.as_str().to_string())
                 .map_err(|bad| format!("invalid catalog member CID: {bad}"))?;
-            AnchoredMember::new(typed, envelope.clone())?;
-            if by_cid.insert(cid.clone(), envelope).is_some() {
+            AnchoredMember::new(typed.clone(), envelope.clone())?;
+            let stored = StoredMember::from_envelope(typed, &envelope)
+                .map_err(|error| format!("invalid catalog member: {error}"))?;
+            if by_cid.insert(cid.clone(), stored).is_some() {
                 return Err(format!("duplicate catalog member CID: {cid}"));
             }
         }
@@ -338,7 +360,29 @@ impl AuthenticatedContextManagerCatalog {
         let catalog_cid = Cid::from(jcs_cid(&serde_json::json!({"memberCids": member_cids})));
         Ok(Self {
             catalog_cid,
+            authenticated_cids: by_cid.keys().cloned().collect(),
             members: by_cid,
+        })
+    }
+
+    pub fn freeze_from_pool(pool: &MementoPool) -> Result<Self, String> {
+        let members = pool
+            .mementos
+            .iter()
+            .map(|(cid, member)| (Cid::from(cid.as_str()), member.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let member_cids: Vec<&str> = members.keys().map(Cid::as_str).collect();
+        let catalog_cid = Cid::from(jcs_cid(&serde_json::json!({"memberCids": member_cids})));
+        let authenticated_cids = members
+            .keys()
+            .cloned()
+            .chain(pool.atoms.keys().map(|cid| Cid::from(cid.as_str())))
+            .chain(pool.body.keys().map(|cid| Cid::from(cid.as_str())))
+            .collect();
+        Ok(Self {
+            catalog_cid,
+            members,
+            authenticated_cids,
         })
     }
 
@@ -545,7 +589,7 @@ fn cm_gap(
     ContextManagerResolutionV1::Unresolved(ContextManagerResolutionGapV1 {
         demand_cid: demand.demand_cid.clone(),
         use_site: demand.use_site.clone(),
-        target_symbol: Some(demand.target_symbol.clone()),
+        target_symbol: demand.target_symbol.clone(),
         kind,
         candidate_member_cids: candidates,
     })
@@ -555,12 +599,19 @@ pub fn resolve_context_manager_demand(
     demand: &ContextManagerContractDemandV1,
     catalog: &AuthenticatedContextManagerCatalog,
 ) -> ContextManagerResolutionV1 {
+    let Some(target_symbol) = demand.target_symbol.as_ref() else {
+        return cm_gap(
+            demand,
+            ContextManagerResolutionGapKindV1::RuntimeSelected,
+            vec![],
+        );
+    };
     let mut candidates = Vec::new();
-    for (cid, envelope) in &catalog.members {
-        if sugar_proof_envelope::member_field(envelope, "bridgeSourceSymbol").and_then(Json::as_str)
-            == Some(&demand.target_symbol.to_string())
+    for (cid, member) in &catalog.members {
+        if member.field("bridgeSourceSymbol").and_then(Json::as_str)
+            == Some(&target_symbol.to_string())
         {
-            candidates.push((cid.clone(), envelope));
+            candidates.push((cid.clone(), member));
         }
     }
     if candidates.is_empty() {
@@ -577,34 +628,16 @@ pub fn resolve_context_manager_demand(
             candidates.into_iter().map(|v| v.0).collect(),
         );
     }
-    let (member_cid, envelope) = candidates.pop().expect("one candidate");
-    if sugar_proof_envelope::member_kind(envelope).ok() != Some(MemberKind::ContextManagerContract)
-    {
+    let (member_cid, member) = candidates.pop().expect("one candidate");
+    if member.kind() != MemberKind::ContextManagerContract {
         return cm_gap(
             demand,
             ContextManagerResolutionGapKindV1::WrongContractKind,
             vec![member_cid],
         );
     }
-    let typed_cid = match MementoCid::try_parse(member_cid.as_str().to_string()) {
-        Ok(cid) => cid,
-        Err(_) => {
-            return cm_gap(
-                demand,
-                ContextManagerResolutionGapKindV1::UnauthenticatedMember,
-                vec![member_cid],
-            )
-        }
-    };
-    if AnchoredMember::new(typed_cid, envelope.clone()).is_err() {
-        return cm_gap(
-            demand,
-            ContextManagerResolutionGapKindV1::UnauthenticatedMember,
-            vec![member_cid],
-        );
-    }
-    let cm = match Member::from_value(envelope) {
-        Ok(Member::ContextManagerContract(cm)) => cm,
+    let cm = match context_manager_contract_from_stored(member) {
+        Ok(cm) => cm,
         Err(error) if error.to_string().contains("payload CID") => {
             return cm_gap(
                 demand,
@@ -632,7 +665,7 @@ pub fn resolve_context_manager_demand(
     let source_warrant_cids: Vec<Cid> = cm.source_warrants.iter().cloned().map(Cid::from).collect();
     if source_warrant_cids
         .iter()
-        .any(|cid| !catalog.members.contains_key(cid))
+        .any(|cid| !catalog.authenticated_cids.contains(cid))
     {
         return cm_gap(
             demand,
@@ -645,7 +678,7 @@ pub fn resolve_context_manager_demand(
         "schemaVersion": "1", "demandCid": demand.demand_cid,
         "useSite": demand.use_site, "catalogCid": catalog.catalog_cid,
         "memberCid": member_cid, "payloadCid": payload_cid,
-        "bridgeSourceSymbol": demand.target_symbol,
+        "bridgeSourceSymbol": target_symbol,
         "importSignature": {"formals": cm.import_signature.formals, "sorts": cm.import_signature.sorts},
         "semantics": sugar_proof_envelope::context_manager_semantics_v1_to_json(&cm.semantics),
         "sourceWarrantCids": source_warrant_cids,
@@ -658,7 +691,7 @@ pub fn resolve_context_manager_demand(
         catalog_cid: catalog.catalog_cid.clone(),
         member_cid,
         payload_cid,
-        bridge_source_symbol: demand.target_symbol.clone(),
+        bridge_source_symbol: target_symbol.clone(),
         import_signature: cm.import_signature,
         semantics: cm.semantics,
         source_warrant_cids,
@@ -677,7 +710,7 @@ pub fn final_check_context_manager_ref(
     let demand = ContextManagerContractDemandV1 {
         demand_cid: reference.demand_cid.clone(),
         use_site: reference.use_site.clone(),
-        target_symbol: reference.bridge_source_symbol.clone(),
+        target_symbol: Some(reference.bridge_source_symbol.clone()),
         import_signature: reference.import_signature.clone(),
     };
     match resolve_context_manager_demand(&demand, catalog) {
@@ -689,6 +722,40 @@ pub fn final_check_context_manager_ref(
         }
         _ => Err("stale-resolution"),
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextManagerEdgeV1 {
+    target_contract_cid: Cid,
+    demand_cid: Cid,
+    resolution_cid: Cid,
+    catalog_cid: Cid,
+}
+
+impl ContextManagerEdgeV1 {
+    pub fn from_resolved(reference: &ContextManagerContractRefV1) -> Self {
+        Self {
+            target_contract_cid: reference.member_cid.clone(),
+            demand_cid: reference.demand_cid.clone(),
+            resolution_cid: reference.resolution_cid.clone(),
+            catalog_cid: reference.catalog_cid.clone(),
+        }
+    }
+}
+
+pub fn final_check_context_manager_edge(
+    edge: &ContextManagerEdgeV1,
+    reference: &ContextManagerContractRefV1,
+    catalog: &AuthenticatedContextManagerCatalog,
+) -> Result<(), &'static str> {
+    if edge.target_contract_cid != reference.member_cid
+        || edge.demand_cid != reference.demand_cid
+        || edge.resolution_cid != reference.resolution_cid
+        || edge.catalog_cid != reference.catalog_cid
+    {
+        return Err("stale-resolution");
+    }
+    final_check_context_manager_ref(reference, catalog)
 }
 
 /// The formals / sorts / EUF-coordinate triple a contract *exports* or a call

--- a/implementations/rust/sugar-linker/tests/context_manager_prebind.rs
+++ b/implementations/rust/sugar-linker/tests/context_manager_prebind.rs
@@ -4,10 +4,10 @@ use sugar_claim_envelope::{
 };
 use sugar_ir_types::Sort;
 use sugar_linker::{
-    final_check_context_manager_ref, resolve_context_manager_demand,
-    AuthenticatedContextManagerCatalog, Cid, ContextManagerContractDemandV1,
-    ContextManagerResolutionGapKindV1, ContextManagerResolutionV1, ResolvedContractRefsV1,
-    SourceFragmentCoordinateV1,
+    final_check_context_manager_edge, final_check_context_manager_ref,
+    resolve_context_manager_demand, AuthenticatedContextManagerCatalog, Cid,
+    ContextManagerContractDemandV1, ContextManagerEdgeV1, ContextManagerResolutionGapKindV1,
+    ContextManagerResolutionV1, ResolvedContractRefsV1, SourceFragmentCoordinateV1,
 };
 use sugar_proof_envelope::{
     ContextManagerSemanticsV1, EnterResultContractV1, ExitContractV1, ExitDispositionV1,
@@ -174,6 +174,52 @@ fn rust_owned_table_decodes_to_frozen_typed_python_refs() {
     assert_eq!(
         String::from_utf8(output.stdout).unwrap().trim(),
         table.table_cid().as_str()
+    );
+}
+
+#[test]
+fn runtime_selected_and_mutated_signed_member_never_construct_a_ref() {
+    let empty = AuthenticatedContextManagerCatalog::freeze(vec![]).unwrap();
+    let runtime = ContextManagerContractDemandV1::runtime_selected(
+        use_site(),
+        ImportSignatureV1 {
+            formals: vec![],
+            sorts: vec![],
+        },
+    );
+    let ContextManagerResolutionV1::Unresolved(gap) =
+        resolve_context_manager_demand(&runtime, &empty)
+    else {
+        panic!("runtime-selected gap")
+    };
+    assert_eq!(gap.kind, ContextManagerResolutionGapKindV1::RuntimeSelected);
+    assert!(gap.target_symbol.is_none());
+
+    let (cid, mut envelope) = minted("context-manager:fixture.never_closing", 12);
+    envelope["header"]["payload"]["exit"]["disposition"]["kind"] =
+        Json::String("unknown-disposition".into());
+    let error = AuthenticatedContextManagerCatalog::freeze(vec![(cid, envelope)]).unwrap_err();
+    assert!(
+        error.contains("attestation") || error.contains("signature"),
+        "{error}"
+    );
+}
+
+#[test]
+fn final_edge_is_pinned_to_the_exact_resolution_and_catalog() {
+    let member = minted("context-manager:fixture.never_closing", 13);
+    let catalog = AuthenticatedContextManagerCatalog::freeze(vec![member]).unwrap();
+    let ContextManagerResolutionV1::Resolved(reference) =
+        resolve_context_manager_demand(&demand("context-manager:fixture.never_closing"), &catalog)
+    else {
+        panic!("resolved")
+    };
+    let edge = ContextManagerEdgeV1::from_resolved(&reference);
+    final_check_context_manager_edge(&edge, &reference, &catalog).expect("exact pinned edge");
+    let drifted = AuthenticatedContextManagerCatalog::freeze(vec![]).unwrap();
+    assert_eq!(
+        final_check_context_manager_edge(&edge, &reference, &drifted).unwrap_err(),
+        "stale-resolution"
     );
 }
 use std::io::Write;

--- a/implementations/rust/sugar-linker/tests/context_manager_prebind.rs
+++ b/implementations/rust/sugar-linker/tests/context_manager_prebind.rs
@@ -6,7 +6,8 @@ use sugar_ir_types::Sort;
 use sugar_linker::{
     final_check_context_manager_ref, resolve_context_manager_demand,
     AuthenticatedContextManagerCatalog, Cid, ContextManagerContractDemandV1,
-    ContextManagerResolutionGapKindV1, ContextManagerResolutionV1, SourceFragmentCoordinateV1,
+    ContextManagerResolutionGapKindV1, ContextManagerResolutionV1, ResolvedContractRefsV1,
+    SourceFragmentCoordinateV1,
 };
 use sugar_proof_envelope::{
     ContextManagerSemanticsV1, EnterResultContractV1, ExitContractV1, ExitDispositionV1,
@@ -131,3 +132,50 @@ fn removing_selected_member_makes_final_check_stale_without_relinking() {
         "stale-resolution"
     );
 }
+
+#[test]
+fn rust_owned_table_decodes_to_frozen_typed_python_refs() {
+    let member = minted("context-manager:fixture.never_closing", 11);
+    let catalog = AuthenticatedContextManagerCatalog::freeze(vec![member]).unwrap();
+    let table =
+        ResolvedContractRefsV1::new(&catalog, &[demand("context-manager:fixture.never_closing")]);
+    assert_eq!(table.catalog_cid(), catalog.catalog_cid());
+    assert!(matches!(
+        table.get(&use_site()),
+        Some(ContextManagerResolutionV1::Resolved(_))
+    ));
+
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap()
+        .to_path_buf();
+    let mut child = Command::new("python3")
+        .env(
+            "PYTHONPATH",
+            repo.join("implementations/python/sugar-lift-py-tests/src"),
+        )
+        .arg("-c")
+        .arg("import json,sys; from sugar_lift_py_tests.context_manager_resolution import decode_resolved_contract_refs, ContextManagerContractRefV1; t=decode_resolved_contract_refs(json.load(sys.stdin)); v=t.require(next(iter(t.by_use_site))); assert isinstance(v, ContextManagerContractRefV1); assert v.member_cid and v.semantics.exit.disposition.kind == 'never-suppresses'; print(t.table_cid)")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    serde_json::to_writer(child.stdin.as_mut().unwrap(), &table.to_wire_value()).unwrap();
+    child.stdin.as_mut().unwrap().flush().unwrap();
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap().trim(),
+        table.table_cid().as_str()
+    );
+}
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};

--- a/implementations/rust/sugar-linker/tests/context_manager_prebind.rs
+++ b/implementations/rust/sugar-linker/tests/context_manager_prebind.rs
@@ -222,6 +222,31 @@ fn final_edge_is_pinned_to_the_exact_resolution_and_catalog() {
         "stale-resolution"
     );
 }
+
+#[test]
+fn exact_symbol_with_different_signature_stays_a_typed_gap() {
+    let member = minted("context-manager:fixture.never_closing", 14);
+    let catalog = AuthenticatedContextManagerCatalog::freeze(vec![member]).unwrap();
+    let mismatched = ContextManagerContractDemandV1::new(
+        use_site(),
+        "context-manager:fixture.never_closing".into(),
+        ImportSignatureV1 {
+            formals: vec!["value".into()],
+            sorts: vec![Sort::Primitive {
+                name: "Value".into(),
+            }],
+        },
+    );
+    let ContextManagerResolutionV1::Unresolved(gap) =
+        resolve_context_manager_demand(&mismatched, &catalog)
+    else {
+        panic!("signature-mismatch gap")
+    };
+    assert_eq!(
+        gap.kind,
+        ContextManagerResolutionGapKindV1::SignatureMismatch
+    );
+}
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};

--- a/implementations/rust/sugar-linker/tests/context_manager_prebind.rs
+++ b/implementations/rust/sugar-linker/tests/context_manager_prebind.rs
@@ -1,0 +1,133 @@
+use serde_json::Value as Json;
+use sugar_claim_envelope::{
+    mint_context_manager_contract, Authoring, MintContextManagerContractArgs,
+};
+use sugar_ir_types::Sort;
+use sugar_linker::{
+    final_check_context_manager_ref, resolve_context_manager_demand,
+    AuthenticatedContextManagerCatalog, Cid, ContextManagerContractDemandV1,
+    ContextManagerResolutionGapKindV1, ContextManagerResolutionV1, SourceFragmentCoordinateV1,
+};
+use sugar_proof_envelope::{
+    ContextManagerSemanticsV1, EnterResultContractV1, ExitContractV1, ExitDispositionV1,
+    ImportSignatureV1,
+};
+
+fn cid(fill: char) -> Cid {
+    Cid::from(format!("blake3-512:{}", fill.to_string().repeat(128)))
+}
+
+fn use_site() -> SourceFragmentCoordinateV1 {
+    SourceFragmentCoordinateV1 {
+        source_cid: cid('1'),
+        start_line: 3,
+        start_col: 9,
+        end_line: 3,
+        end_col: 22,
+    }
+}
+
+fn minted(symbol: &str, seed_byte: u8) -> (Cid, Json) {
+    let m = mint_context_manager_contract(&MintContextManagerContractArgs {
+        bridge_source_symbol: symbol.into(),
+        import_signature: ImportSignatureV1 {
+            formals: vec![],
+            sorts: vec![],
+        },
+        semantics: ContextManagerSemanticsV1 {
+            enter: EnterResultContractV1 {
+                sort: Sort::Primitive {
+                    name: "Value".into(),
+                },
+            },
+            exit: ExitContractV1 {
+                disposition: ExitDispositionV1::NeverSuppresses,
+            },
+        },
+        source_warrants: vec![],
+        produced_by: "fixture".into(),
+        produced_at: "2026-07-22T00:00:00.000Z".into(),
+        authoring: Authoring::KitAuthor {
+            author: "fixture".into(),
+            note: None,
+        },
+        signer_seed: [seed_byte; 32],
+    })
+    .unwrap();
+    (
+        Cid::from(m.cid),
+        serde_json::from_slice(&m.canonical_bytes).unwrap(),
+    )
+}
+
+fn demand(symbol: &str) -> ContextManagerContractDemandV1 {
+    ContextManagerContractDemandV1::new(
+        use_site(),
+        symbol.into(),
+        ImportSignatureV1 {
+            formals: vec![],
+            sorts: vec![],
+        },
+    )
+}
+
+#[test]
+fn truthful_member_prebinds_to_immutable_typed_ref() {
+    let member = minted("context-manager:fixture.never_closing", 7);
+    let catalog = AuthenticatedContextManagerCatalog::freeze(vec![member.clone()]).unwrap();
+    let ContextManagerResolutionV1::Resolved(reference) =
+        resolve_context_manager_demand(&demand("context-manager:fixture.never_closing"), &catalog)
+    else {
+        panic!("resolved")
+    };
+    assert_eq!(reference.member_cid(), &member.0);
+    assert_eq!(reference.catalog_cid(), catalog.catalog_cid());
+    assert_eq!(
+        reference.semantics().exit.disposition,
+        ExitDispositionV1::NeverSuppresses
+    );
+    final_check_context_manager_ref(&reference, &catalog)
+        .expect("same frozen catalog remains valid");
+}
+
+#[test]
+fn zero_and_many_candidates_are_loud_and_many_is_sorted() {
+    let empty = AuthenticatedContextManagerCatalog::freeze(vec![]).unwrap();
+    let ContextManagerResolutionV1::Unresolved(gap) =
+        resolve_context_manager_demand(&demand("context-manager:missing"), &empty)
+    else {
+        panic!("gap")
+    };
+    assert_eq!(
+        gap.kind,
+        ContextManagerResolutionGapKindV1::UnresolvedSymbol
+    );
+
+    let a = minted("context-manager:fixture.never_closing", 8);
+    let b = minted("context-manager:fixture.never_closing", 9);
+    let catalog = AuthenticatedContextManagerCatalog::freeze(vec![b.clone(), a.clone()]).unwrap();
+    let ContextManagerResolutionV1::Unresolved(gap) =
+        resolve_context_manager_demand(&demand("context-manager:fixture.never_closing"), &catalog)
+    else {
+        panic!("gap")
+    };
+    assert_eq!(gap.kind, ContextManagerResolutionGapKindV1::AmbiguousSymbol);
+    assert_eq!(gap.candidate_member_cids.len(), 2);
+    assert!(gap.candidate_member_cids[0] < gap.candidate_member_cids[1]);
+}
+
+#[test]
+fn removing_selected_member_makes_final_check_stale_without_relinking() {
+    let member = minted("context-manager:fixture.never_closing", 10);
+    let catalog = AuthenticatedContextManagerCatalog::freeze(vec![member]).unwrap();
+    let ContextManagerResolutionV1::Resolved(reference) =
+        resolve_context_manager_demand(&demand("context-manager:fixture.never_closing"), &catalog)
+    else {
+        panic!("resolved")
+    };
+    let drifted = AuthenticatedContextManagerCatalog::freeze(vec![]).unwrap();
+    assert_eq!(
+        final_check_context_manager_ref(&reference, &drifted).unwrap_err(),
+        "stale-resolution"
+    );
+}

--- a/implementations/rust/sugar-proof-envelope/Cargo.toml
+++ b/implementations/rust/sugar-proof-envelope/Cargo.toml
@@ -8,6 +8,7 @@ description = "Sugar: deterministic CBOR (.proof) builder + Ed25519 signing help
 
 [dependencies]
 sugar-canonicalizer = { path = "../sugar-canonicalizer" }
+sugar-ir-types = { path = "../sugar-ir-types" }
 ed25519-dalek = { workspace = true }
 base64 = { workspace = true }
 hex = { workspace = true }

--- a/implementations/rust/sugar-proof-envelope/src/lib.rs
+++ b/implementations/rust/sugar-proof-envelope/src/lib.rs
@@ -66,13 +66,13 @@ pub use sign::{
     SignatureParseError, ED25519_KEY_PREFIX, ED25519_SIG_PREFIX,
 };
 pub use typed_member::{
-    context_manager_semantics_v1_to_json, import_signature_v1_to_json,
-    AssertionSurfaceMementoMember, AuthorityMember, BridgeMember, ContextManagerContractMember,
-    ContextManagerSemanticsV1, ContractMember, EffectSiteAnnotationMember, EnterResultContractV1,
-    ExitContractV1, ExitDispositionV1, FactoryWalkMementoMember, ImplicationMember,
-    ImportSignatureV1, LibrarySugarBindingEntryMember, Member, MemberError, MemberKind,
-    PlanMementoMember, ProofRunMember, SourceMementoMember, StageReceiptMember, WitnessClaimMember,
-    WitnessMementoMember,
+    context_manager_contract_from_stored, context_manager_semantics_v1_to_json,
+    import_signature_v1_to_json, AssertionSurfaceMementoMember, AuthorityMember, BridgeMember,
+    ContextManagerContractMember, ContextManagerSemanticsV1, ContractMember,
+    EffectSiteAnnotationMember, EnterResultContractV1, ExitContractV1, ExitDispositionV1,
+    FactoryWalkMementoMember, ImplicationMember, ImportSignatureV1, LibrarySugarBindingEntryMember,
+    Member, MemberError, MemberKind, PlanMementoMember, ProofRunMember, SourceMementoMember,
+    StageReceiptMember, WitnessClaimMember, WitnessMementoMember,
 };
 
 #[derive(Debug, thiserror::Error)]

--- a/implementations/rust/sugar-proof-envelope/src/lib.rs
+++ b/implementations/rust/sugar-proof-envelope/src/lib.rs
@@ -53,12 +53,12 @@ pub use proof::{build_proof_envelope, ProofEnvelopeInput, ProofEnvelopeOutput};
 pub use proof_graph::{
     member_body, member_field, member_kind, member_signature, member_signer, recompute_member_cid,
     verify_member_signature, AnchoredMember, AssertionSurfaceMemento, AtomCid, AtomMemento,
-    AuthorityMemento, AuthorityMementoRef, BridgeMemento, ClaimContractMemento, ContractBody,
-    ContractBodyCid, ContractEntry, ContractMemento, ContractMementoRef,
-    EffectSiteAnnotationMemento, FactoryWalkMemento, FlatAtom, ImplicationMemento,
-    LibrarySugarBindingMemento, MemberView, MementoCid, PlanMemberBytesError, PlanMemento,
-    ProofCatalog, ProofGraph, ProofIdentity, ProofRunMemento, SourceMemento, StageReceiptMemento,
-    StoredMember, WitnessClaimMemento, WitnessMemento,
+    AuthorityMemento, AuthorityMementoRef, BridgeMemento, ClaimContractMemento,
+    ContextManagerContractMemento, ContractBody, ContractBodyCid, ContractEntry, ContractMemento,
+    ContractMementoRef, EffectSiteAnnotationMemento, FactoryWalkMemento, FlatAtom,
+    ImplicationMemento, LibrarySugarBindingMemento, MemberView, MementoCid, PlanMemberBytesError,
+    PlanMemento, ProofCatalog, ProofGraph, ProofIdentity, ProofRunMemento, SourceMemento,
+    StageReceiptMemento, StoredMember, WitnessClaimMemento, WitnessMemento,
 };
 pub use sign::{
     ed25519_pubkey_string, ed25519_sign_string, ed25519_sign_with_seed, ed25519_verify_bytes,
@@ -66,10 +66,12 @@ pub use sign::{
     SignatureParseError, ED25519_KEY_PREFIX, ED25519_SIG_PREFIX,
 };
 pub use typed_member::{
-    AssertionSurfaceMementoMember, AuthorityMember, BridgeMember, ContractMember,
-    EffectSiteAnnotationMember, FactoryWalkMementoMember, ImplicationMember,
-    LibrarySugarBindingEntryMember, Member, MemberError, MemberKind, PlanMementoMember,
-    ProofRunMember, SourceMementoMember, StageReceiptMember, WitnessClaimMember,
+    context_manager_semantics_v1_to_json, import_signature_v1_to_json,
+    AssertionSurfaceMementoMember, AuthorityMember, BridgeMember, ContextManagerContractMember,
+    ContextManagerSemanticsV1, ContractMember, EffectSiteAnnotationMember, EnterResultContractV1,
+    ExitContractV1, ExitDispositionV1, FactoryWalkMementoMember, ImplicationMember,
+    ImportSignatureV1, LibrarySugarBindingEntryMember, Member, MemberError, MemberKind,
+    PlanMementoMember, ProofRunMember, SourceMementoMember, StageReceiptMember, WitnessClaimMember,
     WitnessMementoMember,
 };
 

--- a/implementations/rust/sugar-proof-envelope/src/memento_pool.rs
+++ b/implementations/rust/sugar-proof-envelope/src/memento_pool.rs
@@ -1142,6 +1142,7 @@ impl MementoPool {
             | Some(MemberKind::Authority)
             | Some(MemberKind::Bridge)
             | Some(MemberKind::Contract)
+            | Some(MemberKind::ContextManagerContract)
             | Some(MemberKind::EffectSiteAnnotation)
             | Some(MemberKind::FactoryWalkMemento)
             | Some(MemberKind::Implication)

--- a/implementations/rust/sugar-proof-envelope/src/proof_graph.rs
+++ b/implementations/rust/sugar-proof-envelope/src/proof_graph.rs
@@ -553,6 +553,7 @@ macro_rules! layered_memento {
 layered_memento!(AuthorityMemento, ["authority"]);
 layered_memento!(BridgeMemento, ["bridge"]);
 layered_memento!(ClaimContractMemento, ["contract"]);
+layered_memento!(ContextManagerContractMemento, ["context-manager-contract"]);
 layered_memento!(EffectSiteAnnotationMemento, ["effect-site-annotation"]);
 layered_memento!(ImplicationMemento, ["implication"]);
 layered_memento!(ProofRunMemento, ["proof-run"]);
@@ -1132,6 +1133,7 @@ fn layered_signature_header(envelope: &Json, header: &Json) -> Result<Json, Stri
         | Ok(MemberKind::Bridge)
         | Ok(MemberKind::ClosureBinding)
         | Ok(MemberKind::Contract)
+        | Ok(MemberKind::ContextManagerContract)
         | Ok(MemberKind::EffectSiteAnnotation)
         | Ok(MemberKind::FactoryWalkMemento)
         | Ok(MemberKind::Implication)
@@ -1600,6 +1602,10 @@ impl ProofGraph {
     }
 
     pub fn push_claim_contract(&mut self, memento: ClaimContractMemento) {
+        self.insert_member(memento.record);
+    }
+
+    pub fn push_context_manager_contract(&mut self, memento: ContextManagerContractMemento) {
         self.insert_member(memento.record);
     }
 

--- a/implementations/rust/sugar-proof-envelope/src/typed_member.rs
+++ b/implementations/rust/sugar-proof-envelope/src/typed_member.rs
@@ -1120,6 +1120,45 @@ impl ContextManagerContractMember {
     }
 }
 
+/// Decode a CM contract from a member already authenticated and normalized by
+/// `MementoPool`. This is the compiler/linker catalog boundary: it retains the
+/// typed fields needed for prebinding without reopening source or exposing a
+/// raw envelope to tree construction.
+pub fn context_manager_contract_from_stored(
+    member: &crate::StoredMember,
+) -> Result<ContextManagerContractMember, MemberError> {
+    if member.kind() != MemberKind::ContextManagerContract {
+        return Err(MemberError::InvalidContextManagerContract(
+            "stored member has the wrong contract kind".into(),
+        ));
+    }
+    let names = [
+        "schemaVersion",
+        "kind",
+        "cid",
+        "payloadCid",
+        "bridgeSourceSymbol",
+        "importSignature",
+        "payload",
+        "sourceWarrants",
+        "inputCids",
+    ];
+    let mut header = serde_json::Map::new();
+    for name in names {
+        let value = member.field(name).ok_or_else(|| {
+            MemberError::InvalidContextManagerContract(format!(
+                "authenticated stored member is missing `{name}`"
+            ))
+        })?;
+        header.insert(name.into(), value.clone());
+    }
+    ContextManagerContractMember::from_value(&serde_json::json!({
+        "envelope": {},
+        "header": header,
+        "metadata": {},
+    }))
+}
+
 /// Typed, parsed member. One variant per known kind.
 #[derive(Debug, Clone)]
 pub enum Member {

--- a/implementations/rust/sugar-proof-envelope/src/typed_member.rs
+++ b/implementations/rust/sugar-proof-envelope/src/typed_member.rs
@@ -14,7 +14,10 @@
 use std::fmt;
 use std::str::FromStr;
 
+use serde::{Deserialize, Serialize};
 use serde_json::Value as Json;
+use sugar_canonicalizer::{blake3_512_of, encode_jcs};
+use sugar_ir_types::Sort;
 
 use crate::proof_graph::{AtomCid, ContractBodyCid, MementoCid};
 
@@ -49,13 +52,16 @@ pub enum MemberError {
         raw: String,
     },
 
+    #[error("context-manager-contract: {0}")]
+    InvalidContextManagerContract(String),
+
     #[error("CID not present in graph: {0}")]
     UnknownCid(String),
 }
 
 // ─── Member kind ────────────────────────────────────────────────────────────
 
-pub const KNOWN_MEMBER_KINDS: &str = "aliasing-memento, assertion-surface-memento, authority, bridge, closure-binding, contract, effect-site-annotation, factory-walk-memento, implication, library-sugar-binding-entry, loop-invariant, pin-invariant, plan-memento, proof-run, source-memento, stage-receipt, try-branch, witness, witness-memento";
+pub const KNOWN_MEMBER_KINDS: &str = "aliasing-memento, assertion-surface-memento, authority, bridge, closure-binding, context-manager-contract, contract, effect-site-annotation, factory-walk-memento, implication, library-sugar-binding-entry, loop-invariant, pin-invariant, plan-memento, proof-run, source-memento, stage-receipt, try-branch, witness, witness-memento";
 
 /// Wire member kind. Strings enter and leave only at serde/display boundaries;
 /// production branching should match this enum exhaustively.
@@ -67,6 +73,7 @@ pub enum MemberKind {
     Bridge,
     ClosureBinding,
     Contract,
+    ContextManagerContract,
     EffectSiteAnnotation,
     FactoryWalkMemento,
     Implication,
@@ -91,6 +98,7 @@ impl MemberKind {
             MemberKind::Bridge => "bridge",
             MemberKind::ClosureBinding => "closure-binding",
             MemberKind::Contract => "contract",
+            MemberKind::ContextManagerContract => "context-manager-contract",
             MemberKind::EffectSiteAnnotation => "effect-site-annotation",
             MemberKind::FactoryWalkMemento => "factory-walk-memento",
             MemberKind::Implication => "implication",
@@ -125,6 +133,7 @@ impl FromStr for MemberKind {
             "bridge" => Ok(MemberKind::Bridge),
             "closure-binding" => Ok(MemberKind::ClosureBinding),
             "contract" => Ok(MemberKind::Contract),
+            "context-manager-contract" => Ok(MemberKind::ContextManagerContract),
             "effect-site-annotation" => Ok(MemberKind::EffectSiteAnnotation),
             "factory-walk-memento" => Ok(MemberKind::FactoryWalkMemento),
             "implication" => Ok(MemberKind::Implication),
@@ -878,10 +887,244 @@ impl StageReceiptMember {
 
 // ─── Member enum + parse entrypoint ──────────────────────────────────────────
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextManagerContractMember {
+    pub payload_cid: MementoCid,
+    pub bridge_source_symbol: String,
+    pub import_signature: ImportSignatureV1,
+    pub semantics: ContextManagerSemanticsV1,
+    pub source_warrants: Vec<String>,
+    pub input_cids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportSignatureV1 {
+    pub formals: Vec<String>,
+    pub sorts: Vec<Sort>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextManagerSemanticsV1 {
+    pub enter: EnterResultContractV1,
+    pub exit: ExitContractV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnterResultContractV1 {
+    pub sort: Sort,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExitContractV1 {
+    pub disposition: ExitDispositionV1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitDispositionV1 {
+    NeverSuppresses,
+}
+
+pub fn context_manager_semantics_v1_to_json(value: &ContextManagerSemanticsV1) -> Json {
+    serde_json::json!({
+        "kind": "context-manager-semantics",
+        "schemaVersion": "1",
+        "enter": {
+            "completion": "total",
+            "result": {
+                "kind": "projection",
+                "projection": "enter_result",
+                "sort": value.enter.sort,
+            },
+        },
+        "exit": {
+            "completion": "total",
+            "disposition": {"kind": "never-suppresses"},
+        },
+    })
+}
+
+pub fn import_signature_v1_to_json(value: &ImportSignatureV1) -> Json {
+    serde_json::json!({"formals": value.formals, "sorts": value.sorts})
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContextManagerHeader {
+    #[serde(rename = "schemaVersion")]
+    schema_version: String,
+    kind: String,
+    cid: String,
+    #[serde(rename = "payloadCid")]
+    payload_cid: String,
+    #[serde(rename = "bridgeSourceSymbol")]
+    bridge_source_symbol: String,
+    #[serde(rename = "importSignature")]
+    import_signature: ImportSignatureWire,
+    payload: ContextManagerSemanticsWire,
+    #[serde(rename = "sourceWarrants")]
+    source_warrants: Vec<String>,
+    #[serde(rename = "inputCids")]
+    input_cids: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ImportSignatureWire {
+    formals: Vec<String>,
+    sorts: Vec<Sort>,
+}
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ContextManagerSemanticsWire {
+    kind: String,
+    #[serde(rename = "schemaVersion")]
+    schema_version: String,
+    enter: EnterContractWire,
+    exit: ExitContractWire,
+}
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct EnterContractWire {
+    completion: String,
+    result: EnterResultWire,
+}
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct EnterResultWire {
+    kind: String,
+    projection: String,
+    sort: Sort,
+}
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ExitContractWire {
+    completion: String,
+    disposition: ExitDispositionWire,
+}
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ExitDispositionWire {
+    kind: String,
+}
+
+impl ContextManagerContractMember {
+    fn from_value(value: &Json) -> Result<Self, MemberError> {
+        let root = value.as_object().ok_or_else(|| {
+            MemberError::InvalidContextManagerContract("layered member must be an object".into())
+        })?;
+        if root.len() != 3
+            || !root.contains_key("envelope")
+            || !root.contains_key("header")
+            || !root.contains_key("metadata")
+            || !root.get("envelope").is_some_and(Json::is_object)
+        {
+            return Err(MemberError::InvalidContextManagerContract(
+                "expected only envelope, header, and metadata layers".into(),
+            ));
+        }
+        let _metadata = value
+            .get("metadata")
+            .and_then(Json::as_object)
+            .ok_or_else(|| {
+                MemberError::InvalidContextManagerContract("layered metadata is missing".into())
+            })?;
+        let raw_header = value.get("header").cloned().ok_or_else(|| {
+            MemberError::InvalidContextManagerContract("layered header is missing".into())
+        })?;
+        let header: ContextManagerHeader =
+            serde_json::from_value(raw_header.clone()).map_err(|e| {
+                MemberError::InvalidContextManagerContract(format!("malformed header: {e}"))
+            })?;
+        if header.schema_version != "1.2" || header.kind != "context-manager-contract" {
+            return Err(MemberError::InvalidContextManagerContract(
+                "schemaVersion/kind mismatch".into(),
+            ));
+        }
+        if header.bridge_source_symbol.is_empty() {
+            return Err(MemberError::InvalidContextManagerContract(
+                "bridgeSourceSymbol must be non-empty".into(),
+            ));
+        }
+        if header.import_signature.formals.len() != header.import_signature.sorts.len() {
+            return Err(MemberError::InvalidContextManagerContract(
+                "import signature formals/sorts length mismatch".into(),
+            ));
+        }
+        if header.payload.kind != "context-manager-semantics"
+            || header.payload.schema_version != "1"
+            || header.payload.enter.completion != "total"
+            || header.payload.enter.result.kind != "projection"
+            || header.payload.enter.result.projection != "enter_result"
+        {
+            return Err(MemberError::InvalidContextManagerContract(
+                "unsupported context-manager semantics or enter testimony".into(),
+            ));
+        }
+        if header.payload.exit.completion != "total"
+            || header.payload.exit.disposition.kind != "never-suppresses"
+        {
+            return Err(MemberError::InvalidContextManagerContract(
+                "unknown exit disposition or non-total exit testimony".into(),
+            ));
+        }
+        let payload = serde_json::to_value(&header.payload).expect("typed payload serializes");
+        let derived = blake3_512_of(
+            encode_jcs(&crate::proof_graph::json_to_canonical_value(&payload)).as_bytes(),
+        );
+        if derived != header.cid || derived != header.payload_cid {
+            return Err(MemberError::InvalidContextManagerContract(format!(
+                "payload CID mismatch: cid={} payloadCid={} derived={derived}",
+                header.cid, header.payload_cid
+            )));
+        }
+        let payload_cid = MementoCid::try_parse(header.payload_cid.clone()).map_err(|raw| {
+            MemberError::InvalidCidFormat {
+                kind: "context-manager-contract".into(),
+                field: "payloadCid".into(),
+                raw,
+            }
+        })?;
+        let mut sorted_warrants = header.source_warrants.clone();
+        if sorted_warrants
+            .iter()
+            .any(|cid| AtomCid::try_parse(cid.clone()).is_err())
+        {
+            return Err(MemberError::InvalidContextManagerContract(
+                "sourceWarrants contain a malformed CID".into(),
+            ));
+        }
+        sorted_warrants.sort();
+        if header.input_cids != sorted_warrants {
+            return Err(MemberError::InvalidContextManagerContract(
+                "inputCids do not equal sorted sourceWarrants".into(),
+            ));
+        }
+        Ok(Self {
+            payload_cid,
+            bridge_source_symbol: header.bridge_source_symbol,
+            import_signature: ImportSignatureV1 {
+                formals: header.import_signature.formals,
+                sorts: header.import_signature.sorts,
+            },
+            semantics: ContextManagerSemanticsV1 {
+                enter: EnterResultContractV1 {
+                    sort: header.payload.enter.result.sort,
+                },
+                exit: ExitContractV1 {
+                    disposition: ExitDispositionV1::NeverSuppresses,
+                },
+            },
+            source_warrants: header.source_warrants,
+            input_cids: header.input_cids,
+        })
+    }
+}
+
 /// Typed, parsed member. One variant per known kind.
 #[derive(Debug, Clone)]
 pub enum Member {
     Contract(ContractMember),
+    ContextManagerContract(ContextManagerContractMember),
     Bridge(BridgeMember),
     Implication(ImplicationMember),
     Authority(AuthorityMember),
@@ -918,6 +1161,9 @@ impl Member {
         let nb = normalize(value)?;
         match nb.kind {
             MemberKind::Contract => Ok(Member::Contract(ContractMember::from_normalized(&nb)?)),
+            MemberKind::ContextManagerContract => Ok(Member::ContextManagerContract(
+                ContextManagerContractMember::from_value(value)?,
+            )),
             MemberKind::Bridge => Ok(Member::Bridge(BridgeMember::from_normalized(&nb)?)),
             MemberKind::Implication => Ok(Member::Implication(ImplicationMember::from_normalized(
                 &nb,
@@ -981,6 +1227,7 @@ impl Member {
     pub fn kind(&self) -> MemberKind {
         match self {
             Member::Contract(_) => MemberKind::Contract,
+            Member::ContextManagerContract(_) => MemberKind::ContextManagerContract,
             Member::Bridge(_) => MemberKind::Bridge,
             Member::Implication(_) => MemberKind::Implication,
             Member::Authority(_) => MemberKind::Authority,
@@ -1370,6 +1617,10 @@ mod tests {
             ("bridge", MemberKind::Bridge),
             ("closure-binding", MemberKind::ClosureBinding),
             ("contract", MemberKind::Contract),
+            (
+                "context-manager-contract",
+                MemberKind::ContextManagerContract,
+            ),
             ("effect-site-annotation", MemberKind::EffectSiteAnnotation),
             ("factory-walk-memento", MemberKind::FactoryWalkMemento),
             ("implication", MemberKind::Implication),

--- a/implementations/rust/sugar-proof-envelope/tests/context_manager_contract_python_roundtrip.rs
+++ b/implementations/rust/sugar-proof-envelope/tests/context_manager_contract_python_roundtrip.rs
@@ -1,0 +1,79 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_json::Value as Json;
+use sugar_ir_types::Sort;
+use sugar_proof_envelope::{AnchoredMember, ExitDispositionV1, Member, MementoCid};
+
+#[test]
+fn python_published_cm_contract_decodes_as_sealed_typed_rust_member() {
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap()
+        .to_path_buf();
+    let python_path = repo.join("implementations/python/sugar-lift-py-tests/src");
+    let program = r#"
+import json
+from sugar_lift_py_tests.context_manager_contract import publish_never_suppresses_context_manager_contract
+from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.kit_rpc import ImportSignatureV1
+from sugar_lift_py_tests.signing import Signer
+m = publish_never_suppresses_context_manager_contract(bridge_source_symbol='context-manager:fixture_python.never_closing', import_signature=ImportSignatureV1(formals=(), sorts=()), enter_result_sort=PrimitiveSort('Value'), source_warrants=('blake3-512:' + 'a' * 128,), signer=Signer(bytes(range(32)), 'fixture-python-kit'), declared_at='2026-07-22T00:00:00.000Z')
+print(json.dumps({'cid': m.cid, 'member': json.loads(m.canonical_bytes)}))
+"#;
+    let output = Command::new("python3")
+        .env("PYTHONPATH", python_path)
+        .arg("-c")
+        .arg(program)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let wire: Json = serde_json::from_slice(&output.stdout).unwrap();
+    let cid = MementoCid::try_parse(wire["cid"].as_str().unwrap().to_string()).unwrap();
+    let anchored =
+        AnchoredMember::new(cid, wire["member"].clone()).expect("CID and signature verify");
+    let Member::ContextManagerContract(cm) = Member::from_value(anchored.envelope()).unwrap()
+    else {
+        panic!("dedicated CM member")
+    };
+    assert_eq!(
+        cm.bridge_source_symbol,
+        "context-manager:fixture_python.never_closing"
+    );
+    assert!(cm.import_signature.formals.is_empty());
+    assert!(cm.import_signature.sorts.is_empty());
+    assert_eq!(
+        cm.semantics.enter.sort,
+        Sort::Primitive {
+            name: "Value".to_string()
+        }
+    );
+    assert_eq!(
+        cm.semantics.exit.disposition,
+        ExitDispositionV1::NeverSuppresses
+    );
+    assert_eq!(cm.source_warrants.len(), 1);
+}
+
+#[test]
+fn stale_payload_cid_stays_loud() {
+    let zero = format!("blake3-512:{}", "0".repeat(128));
+    let member = serde_json::json!({
+        "envelope": {}, "metadata": {},
+        "header": {
+            "schemaVersion":"1.2", "kind":"context-manager-contract",
+            "cid": zero, "payloadCid": zero,
+            "bridgeSourceSymbol":"context-manager:m.n",
+            "importSignature":{"formals":[],"sorts":[]},
+            "payload":{"kind":"context-manager-semantics","schemaVersion":"1","enter":{"completion":"total","result":{"kind":"projection","projection":"enter_result","sort":{"kind":"primitive","name":"Value"}}},"exit":{"completion":"total","disposition":{"kind":"never-suppresses"}}},
+            "sourceWarrants": [], "inputCids": []
+        }
+    });
+    let error = Member::from_value(&member).expect_err("stale CID must be loud");
+    assert!(error.to_string().contains("payload CID"), "{error}");
+}

--- a/implementations/rust/sugar-verifier/src/load_all_proofs.rs
+++ b/implementations/rust/sugar-verifier/src/load_all_proofs.rs
@@ -501,6 +501,7 @@ fn load_catalog_bytes(
                     | MemberKind::Authority
                     | MemberKind::Bridge
                     | MemberKind::ClosureBinding
+                    | MemberKind::ContextManagerContract
                     | MemberKind::EffectSiteAnnotation
                     | MemberKind::FactoryWalkMemento
                     | MemberKind::Implication
@@ -569,6 +570,7 @@ fn load_catalog_bytes(
                     | MemberKind::Authority
                     | MemberKind::ClosureBinding
                     | MemberKind::Contract
+                    | MemberKind::ContextManagerContract
                     | MemberKind::EffectSiteAnnotation
                     | MemberKind::FactoryWalkMemento
                     | MemberKind::Implication

--- a/implementations/rust/sugar-walk/tests/term_boundary_totality.rs
+++ b/implementations/rust/sugar-walk/tests/term_boundary_totality.rs
@@ -240,6 +240,30 @@ fn ir_terms_round_trip_through_term_boundary_byte_identically() {
 }
 
 #[test]
+fn python_formatted_value_operands_round_trip_in_reference_order() {
+    let original = ctor(
+        "python:fstring_value",
+        vec![
+            var("x"),
+            string_const("r"),
+            ctor("python:fstring", vec![string_const(">10")]),
+        ],
+    );
+
+    let raised = raise_ir(&lower_ir(&original));
+
+    assert_same_term_json_bytes("python:fstring_value", &original, &raised);
+    let ir::Term::Ctor { name, args } = raised else {
+        panic!("formatted value did not remain a ctor");
+    };
+    assert_eq!(name, "python:fstring_value");
+    assert_eq!(args.len(), 3);
+    assert_eq!(args[0], var("x"));
+    assert_eq!(args[1], string_const("r"));
+    assert_eq!(args[2], ctor("python:fstring", vec![string_const(">10")]));
+}
+
+#[test]
 fn ir_formulas_round_trip_through_term_boundary_byte_identically() {
     let corpus = formula_corpus();
     for (label, original) in &corpus {


### PR DESCRIPTION
Part of #6071.

Stacks on #6072 and implements prerequisite 2 only.

- loads dependency testimony before local semantic construction
- adds declaration-only and non-constructing CM-demand enumeration phases
- freezes an authenticated content-addressed catalog and prebinds in Rust
- installs an immutable typed `ResolvedContractRefsV1` table through `sugar.plugin.bind_contract_refs` before `.sugar()`
- keeps unresolved/runtime-selected/ambiguous/signature/stale outcomes typed and loud
- rechecks resolved refs and final CM edge coordinates against the exact frozen catalog
- injects only the frozen typed construction context; tree/Sugar code has no linker, catalog, source-target, or raw-envelope door

Validation:
- Python focused CM/protocol/construction floors: 17 passed
- Python source-tree suite: 339 passed, 5 skipped, 1 xfailed
- battleaxe `sugar-linker` CM twins: 7 passed
- battleaxe actual-RPC phase-order twin: 1 passed
- battleaxe planted bind-after-semantic-order regression twin: 1 passed
- battleaxe `cargo check -p sugar-compiler`: passed

The construction-boundary floor now AST-scans the complete `sugar_source_tree` and Sugar implementation roots. Its direct, nested-helper, aliased-import, and out-of-selected-file-helper plants each independently produce `R > 0`.

Wider `sugar-linker` currently has one legacy discharge assertion mismatch (`ImplicationUndecidable` vs its older expected variant); the same focused failure reproduces unchanged on #6072 head, so it is not introduced by this stack.

Do not merge before #6072 and architect review.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add authenticated context-manager preconstruction resolution to the compiler pipeline
> - Introduces end-to-end context-manager contract preconstruction: the compiler now fetches declaration and demand rows from the kit via new `contract-declarations` and `contract-demands` RPC levels, mints signed `ContextManagerContract` members, freezes an authenticated catalog, binds a resolved reference table back into the kit, and validates final references before semantic construction.
> - Adds `mint_context_manager_contract` in `sugar-claim-envelope` and corresponding `ContextManagerContractMember` typed parsing in `sugar-proof-envelope`, making context-manager contracts a first-class member kind recognized across the proof graph, memento pool, and verifier.
> - Adds `AuthenticatedContextManagerCatalog` and `ContextManagerContractDemandV1` in `sugar-linker` with stable CIDs derived from canonical JSON, enabling demand resolution and final consistency checks.
> - Adds `publish_never_suppresses_context_manager_contract` in the Python test kit and a `_context_manager_demand_rows` enumeration path that scans with-sites from source AST without constructing Sugar.
> - Rewrites `FormattedValue` sugar to emit a typed `python:fstring_value` coordinate with explicit conversion and format-spec operands instead of calling `__format__`; invalid conversion codes and non-`JoinedStr` format specs now raise `BackendDefect`.
> - Behavioral Change: `fold_project` now merges kit-declared contract members into the proof graph; `census()` now exits with status 1 when backend crashes are recorded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5afe66e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
