### PR TITLE
drain: starred call and literal spreads (pandas)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
@@ -1,0 +1,166 @@
+"""Reference-shaped construction for Python starred/spread expressions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
+
+
+def _collect(sugars: tuple, ctx, done: tuple, finish):
+    if not sugars:
+        return finish(done)
+    head, *tail = sugars
+    return head.desugar(ctx).and_then(
+        lambda value: _collect(tuple(tail), ctx, (*done, value), finish)
+    )
+
+
+@dataclass(frozen=True)
+class SpreadCollectionSugar(Sugar):
+    """A display containing spread operands, as encoded by the reference lifter.
+
+    ``elements`` is ``(wrapper-or-None, child-sugar)`` in source order.
+    """
+
+    kind: str
+    elements: tuple
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return _call_return_pair(
+            name="spread_collection_len",
+            owner_sugar="SpreadCollectionSugar",
+            body="len([*z])",
+            truthful="len(z)",
+            lying="len(z) + 1",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        sugars = tuple(sugar for _, sugar in self.elements)
+
+        def finish(values):
+            from sugar_lift_py_tests.floor import SymbolicValue
+            from sugar_lift_py_tests.ir import ctor
+
+            owner = str(self.site)
+            terms = []
+            for (wrapper, _), value in zip(self.elements, values):
+                term = value.to_term(owner=owner)
+                terms.append(ctor(wrapper, [term]) if wrapper is not None else term)
+            return Complete(SymbolicValue(ctor(f"python:{self.kind}", terms)))
+
+        return _collect(sugars, ctx, (), finish)
+
+
+@dataclass(frozen=True)
+class SpreadDictSugar(Sugar):
+    """A dict display whose entries include reference ``None``-key spreads."""
+
+    entries: tuple  # (key-sugar-or-None, value-sugar), source order
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return _call_return_pair(
+            name="spread_dict_len",
+            owner_sugar="SpreadDictSugar",
+            body="len({**z})",
+            truthful="len(z)",
+            lying="len(z) + 1",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        flattened = tuple(
+            sugar
+            for key, value in self.entries
+            for sugar in ((value,) if key is None else (key, value))
+        )
+
+        def finish(values):
+            from sugar_lift_py_tests.floor import SymbolicValue
+            from sugar_lift_py_tests.ir import ctor
+
+            owner = str(self.site)
+            value_iter = iter(values)
+            terms = []
+            for key, _ in self.entries:
+                if key is None:
+                    key_term = ctor("None", [])
+                    value_term = next(value_iter).to_term(owner=owner)
+                else:
+                    key_term = next(value_iter).to_term(owner=owner)
+                    value_term = next(value_iter).to_term(owner=owner)
+                terms.append(ctor("python:dict_entry", [key_term, value_term]))
+            return Complete(SymbolicValue(ctor("python:dict", terms)))
+
+        return _collect(flattened, ctx, (), finish)
+
+
+@dataclass(frozen=True)
+class SpreadCallSugar(Sugar):
+    """A call containing ``*``/``**``, using the reference call vocabulary."""
+
+    callee_name: str | None
+    callee: Sugar | None
+    arguments: tuple  # (role, optional-name, sugar), source order
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return _call_return_pair(
+            name="spread_call",
+            owner_sugar="SpreadCallSugar",
+            body="tuple((*z,))",
+            truthful="tuple(z)",
+            lying="tuple((*z, 0))",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        def after_callee(callee_value):
+            sugars = tuple(sugar for _, _, sugar in self.arguments)
+            return _collect(
+                sugars,
+                ctx,
+                (),
+                lambda values: self._finish(callee_value, values),
+            )
+
+        if self.callee is None:
+            return after_callee(None)
+        return self.callee.desugar(ctx).and_then(after_callee)
+
+    def _finish(self, callee_value, values) -> Outcome:
+        from sugar_lift_py_tests.floor import CallSiteValue
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        owner = str(self.site)
+        callee_term = (
+            str_const(self.callee_name)
+            if self.callee_name is not None
+            else callee_value.to_term(owner=owner)
+        )
+        arg_terms = []
+        for (role, name, _), value in zip(self.arguments, values):
+            term = value.to_term(owner=owner)
+            if role == "star":
+                term = ctor("python:starred_arg", [term])
+            elif role == "double-star":
+                term = ctor("python:double_starred_kwarg", [term])
+            elif role == "keyword":
+                term = ctor("python:kwarg", [str_const(name), term])
+            arg_terms.append(term)
+        term = ctor("python:call", [callee_term, *arg_terms])
+        return Complete(
+            CallSiteValue(
+                target_name=self.callee_name or "python:call",
+                arg_values=tuple(values),
+                parameters=(),
+                term=term,
+                body=None,
+                site=self.site,
+            )
+        )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3104,12 +3104,23 @@ class Dict(Expression):
         return self._substitute_children(scope)
 
     def _construct_sugar(self):
-        """`{k: v, ...}` constructs DictSugar WITH each key and value sugar. A
-        `**d` spread (a DictItem with key None) stays loud until its own sugar."""
+        """`{k: v, ...}` constructs DictSugar WITH each key and value sugar.
+        A `**d` entry uses the reference lifter's None-key spread shape."""
         from sugar_lift_py_tests.sugar.collection_sugar import DictSugar
 
         if any(item.key is None for item in self.items):
-            return super()._construct_sugar()
+            from sugar_lift_py_tests.sugar.spread_sugar import SpreadDictSugar
+
+            return SpreadDictSugar(
+                entries=tuple(
+                    (
+                        item.key.sugar() if item.key is not None else None,
+                        item.value.sugar(),
+                    )
+                    for item in self.items
+                ),
+                site=self.fragment,
+            )
         return DictSugar(
             keys=tuple(item.key.sugar() for item in self.items),
             values=tuple(item.value.sugar() for item in self.items),
@@ -3126,11 +3137,22 @@ class Set(Expression):
         return self._substitute_children(scope)
 
     def _construct_sugar(self):
-        """`{e, ...}` constructs SetSugar WITH each element's sugar; `*xs` is loud."""
+        """`{e, ...}` constructs SetSugar; a spread uses its reference term."""
         from sugar_lift_py_tests.sugar.collection_sugar import SetSugar
 
-        if any(e.kind == "Starred" for e in self.elts):
-            return super()._construct_sugar()
+        if any(isinstance(e, Starred) for e in self.elts):
+            from sugar_lift_py_tests.sugar.spread_sugar import SpreadCollectionSugar
+
+            return SpreadCollectionSugar(
+                kind="set",
+                elements=tuple(
+                    ("python:starred", e.value.sugar())
+                    if isinstance(e, Starred)
+                    else (None, e.sugar())
+                    for e in self.elts
+                ),
+                site=self.fragment,
+            )
         return SetSugar(
             elements=tuple(e.sugar() for e in self.elts), site=self.fragment
         )
@@ -3640,6 +3662,38 @@ class Call(Expression):
         built, so a callee with no sugar (a Lambda called inline) still stays
         loud through the ordinary recursion. Named keywords and ``**`` spreads
         ride explicitly on every coordinate; none is dropped or interpreted."""
+        # ``**`` already has a lawful bridge on all three call coordinates.
+        # Switch vocabulary only for the direct residue: positional ``*``.
+        # A sibling ``**`` then receives the reference wrapper in the same call.
+        has_spread = any(isinstance(arg, Starred) for arg in self.args)
+        if has_spread:
+            from sugar_lift_py_tests.sugar.spread_sugar import SpreadCallSugar
+
+            arguments = tuple(
+                ("star", None, arg.value.sugar())
+                if isinstance(arg, Starred)
+                else ("positional", None, arg.sugar())
+                for arg in self.args
+            ) + tuple(
+                (
+                    "double-star" if kw.arg is None else "keyword",
+                    kw.arg,
+                    kw.value.sugar(),
+                )
+                for kw in self.keywords
+            )
+            callee_name = self._spread_callee_name(self.func)
+            return SpreadCallSugar(
+                callee_name=callee_name,
+                callee=(
+                    None
+                    if isinstance(self.func, Name)
+                    else self.func.sugar()
+                ),
+                arguments=arguments,
+                site=self.fragment,
+            )
+
         keyword_sugars = tuple(
             (kw.arg if kw.arg is not None else "**", kw.value.sugar())
             for kw in self.keywords
@@ -3671,6 +3725,20 @@ class Call(Expression):
             site=self.fragment,
             keywords=keyword_sugars,
         )
+
+    @staticmethod
+    def _spread_callee_name(callee: Expression) -> Optional[str]:
+        """The reference lifter spells Name/Attribute chains as one callee.
+
+        A computed callee has no spelling and is carried by its constructed
+        child sugar instead.
+        """
+        if isinstance(callee, Name):
+            return callee.id
+        if isinstance(callee, Attribute):
+            base = Call._spread_callee_name(callee.value)
+            return f"{base}.{callee.attr}" if base is not None else None
+        return None
 
 
 class FormattedValue(Expression):
@@ -4154,12 +4222,22 @@ class List(Expression):
         return self._substitute_children(scope)
 
     def _construct_sugar(self):
-        """`[e, ...]` constructs ListSugar WITH each element's sugar. A `*xs`
-        spread is not one element -- it stays loud until its own sugar lands."""
+        """`[e, ...]` constructs ListSugar; a spread uses its reference term."""
         from sugar_lift_py_tests.sugar.collection_sugar import ListSugar
 
-        if any(e.kind == "Starred" for e in self.elts):
-            return super()._construct_sugar()
+        if any(isinstance(e, Starred) for e in self.elts):
+            from sugar_lift_py_tests.sugar.spread_sugar import SpreadCollectionSugar
+
+            return SpreadCollectionSugar(
+                kind="list",
+                elements=tuple(
+                    ("python:starred", e.value.sugar())
+                    if isinstance(e, Starred)
+                    else (None, e.sugar())
+                    for e in self.elts
+                ),
+                site=self.fragment,
+            )
         return ListSugar(
             elements=tuple(e.sugar() for e in self.elts), site=self.fragment
         )
@@ -4174,11 +4252,22 @@ class Tuple_(Expression):
         return self._substitute_children(scope)
 
     def _construct_sugar(self):
-        """`(e, ...)` constructs TupleSugar WITH each element's sugar; `*xs` is loud."""
+        """`(e, ...)` constructs TupleSugar; a spread uses its reference term."""
         from sugar_lift_py_tests.sugar.collection_sugar import TupleSugar
 
-        if any(e.kind == "Starred" for e in self.elts):
-            return super()._construct_sugar()
+        if any(isinstance(e, Starred) for e in self.elts):
+            from sugar_lift_py_tests.sugar.spread_sugar import SpreadCollectionSugar
+
+            return SpreadCollectionSugar(
+                kind="tuple",
+                elements=tuple(
+                    ("python:starred", e.value.sugar())
+                    if isinstance(e, Starred)
+                    else (None, e.sugar())
+                    for e in self.elts
+                ),
+                site=self.fragment,
+            )
         return TupleSugar(
             elements=tuple(e.sugar() for e in self.elts), site=self.fragment
         )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3662,10 +3662,12 @@ class Call(Expression):
         built, so a callee with no sugar (a Lambda called inline) still stays
         loud through the ordinary recursion. Named keywords and ``**`` spreads
         ride explicitly on every coordinate; none is dropped or interpreted."""
-        # ``**`` already has a lawful bridge on all three call coordinates.
-        # Switch vocabulary only for the direct residue: positional ``*``.
-        # A sibling ``**`` then receives the reference wrapper in the same call.
-        has_spread = any(isinstance(arg, Starred) for arg in self.args)
+        # Either spread form selects the reference call coordinate. In
+        # particular, a lone ``**d`` must not fall through to the legacy
+        # keyword bridge as ``py.kwarg("**", d)``.
+        has_spread = any(isinstance(arg, Starred) for arg in self.args) or any(
+            keyword.arg is None for keyword in self.keywords
+        )
         if has_spread:
             from sugar_lift_py_tests.sugar.spread_sugar import SpreadCallSugar
 

--- a/implementations/python/sugar-source-tree/tests/test_call_kwargs.py
+++ b/implementations/python/sugar-source-tree/tests/test_call_kwargs.py
@@ -42,11 +42,11 @@ def test_kwarg_value_discriminates():
     assert t1 != t2
 
 
-def test_named_call_spread_builds_explicit_bridge_operand():
+def test_named_call_spread_builds_reference_call_operand():
     t = _out("def A(x, d):\n    return f(x, **d)\n")
 
-    assert t.name == "call:f"
+    assert t.name == "python:call"
+    assert t.args[0].value == "f"
     spread = t.args[-1]
-    assert spread.name == "py.kwarg"
-    assert spread.args[0].value == "**"
-    assert spread.args[1].name == "d"
+    assert spread.name == "python:double_starred_kwarg"
+    assert spread.args[0].name == "d"

--- a/implementations/python/sugar-source-tree/tests/test_collection_literals.py
+++ b/implementations/python/sugar-source-tree/tests/test_collection_literals.py
@@ -1,15 +1,12 @@
 """Collection displays: list, tuple, set, dict -- through the node.
 
 Each reduces its elements and holds them as the collection floor value; the
-value owns len/subscript/membership. Star / double-star spreads stay loud.
+value owns len/subscript/membership. Spread displays use the reference terms.
 """
 
 import tempfile
 
-import pytest
-
 from sugar_lift_python_source.source_oracle import path_source
-from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
 
@@ -38,19 +35,22 @@ def test_collection_composes_with_a_call():
     assert term.args[0].name == "array" and len(term.args[0].args) == 3
 
 
-def test_star_spread_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A(xs):\n    return [1, *xs]\n").sugar()
+def test_star_spread_builds_reference_list_shape():
+    term = _post_term("def A(xs):\n    return [1, *xs]\n")
+    assert term.name == "python:list"
+    assert term.args[1].name == "python:starred"
 
 
-def test_double_star_spread_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A(d):\n    return {1: 2, **d}\n").sugar()
+def test_double_star_spread_builds_reference_dict_shape():
+    term = _post_term("def A(d):\n    return {1: 2, **d}\n")
+    assert term.name == "python:dict"
+    assert term.args[1].name == "python:dict_entry"
+    assert term.args[1].args[0].name == "None"
 
 
 if __name__ == "__main__":
     test_list_tuple_set_dict_construct_their_terms()
     test_collection_composes_with_a_call()
-    test_star_spread_stays_loud()
-    test_double_star_spread_stays_loud()
+    test_star_spread_builds_reference_list_shape()
+    test_double_star_spread_builds_reference_dict_shape()
     print("ok: list/tuple/set/dict literals drained; spreads loud")

--- a/implementations/python/sugar-source-tree/tests/test_computed_call.py
+++ b/implementations/python/sugar-source-tree/tests/test_computed_call.py
@@ -51,17 +51,17 @@ def test_discrimination_differs_by_callee_operand():
     assert t0 != t1
 
 
-def test_computed_call_keywords_build_on_the_py_call_bridge():
+def test_computed_call_spread_uses_reference_call_shape():
     t = _out("def A(fs, x, d):\n    return fs[0](x, key=1, **d)\n")
 
-    assert t.name == "py.call"
+    assert t.name == "python:call"
     assert t.args[0].name == "py.subscript"
     named, spread = t.args[-2:]
-    assert named.name == spread.name == "py.kwarg"
+    assert named.name == "python:kwarg"
     assert named.args[0].value == "key"
     assert named.args[1].value == 1
-    assert spread.args[0].value == "**"
-    assert spread.args[1].name == "d"
+    assert spread.name == "python:double_starred_kwarg"
+    assert spread.args[0].name == "d"
 
 
 def test_lambda_callee_uses_the_computed_call_path():

--- a/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
@@ -49,15 +49,14 @@ def test_keyword_args_lift():
     assert kwarg.args[0].value == "default"
 
 
-def test_spread_keyword_args_build_method_bridge():
+def test_spread_keyword_args_build_reference_method_call():
     t = _out("def A(z, d):\n    return z.get(1, **d)\n")
 
-    assert t.name == "call:get"
-    assert t.args[0].name == "z"
+    assert t.name == "python:call"
+    assert t.args[0].value == "z.get"
     spread = t.args[-1]
-    assert spread.name == "py.kwarg"
-    assert spread.args[0].value == "**"
-    assert spread.args[1].name == "d"
+    assert spread.name == "python:double_starred_kwarg"
+    assert spread.args[0].name == "d"
 
 
 if __name__ == "__main__":

--- a/implementations/python/sugar-source-tree/tests/test_starred_spread.py
+++ b/implementations/python/sugar-source-tree/tests/test_starred_spread.py
@@ -1,0 +1,82 @@
+"""Starred expression construction mirrors the reference Python lifter."""
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.floor import ReturnValue
+from sugar_lift_py_tests.outcome import Complete
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _function(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(source)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _returned_term(expression: str):
+    out = _function(f"def f(a, b, d):\n    return {expression}\n").sugar().desugar()
+    assert isinstance(out, Complete)
+    returns = [
+        entry
+        for entry in out.value.record.statements
+        if isinstance(entry, ReturnValue)
+    ]
+    assert len(returns) == 1
+    return returns[0].value.to_term(owner="starred-spread-test")
+
+
+def test_call_star_and_double_star_use_reference_wrappers() -> None:
+    term = _returned_term("make(*a, b, **d)")
+    assert term.name == "python:call"
+    assert term.args[0].value == "make"
+    assert term.args[1].name == "python:starred_arg"
+    assert term.args[1].args[0].name == "a"
+    assert term.args[2].name == "b"
+    assert term.args[3].name == "python:double_starred_kwarg"
+    assert term.args[3].args[0].name == "d"
+
+
+@pytest.mark.parametrize(
+    ("expression", "outer"),
+    [
+        ("[*a, *b]", "python:list"),
+        ("(*a,)", "python:tuple"),
+        ("{*a}", "python:set"),
+    ],
+)
+def test_literal_star_uses_reference_wrapper(expression: str, outer: str) -> None:
+    term = _returned_term(expression)
+    assert term.name == outer
+    assert term.args[0].name == "python:starred"
+    assert term.args[0].args[0].name == "a"
+
+
+def test_dict_double_star_uses_none_key_entry_reference_shape() -> None:
+    term = _returned_term("{**d, 'x': a}")
+    assert term.name == "python:dict"
+    assert term.args[0].name == "python:dict_entry"
+    assert term.args[0].args[0].name == "None"
+    assert term.args[0].args[1].name == "d"
+    assert term.args[1].name == "python:dict_entry"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "async def f(xs):\n    return [*(await xs)]\n",
+        "async def f(xs):\n    return make(*(await xs))\n",
+    ],
+)
+def test_spread_with_unwritten_inner_expression_stays_loud(body: str) -> None:
+    with pytest.raises(SugarNotWritten):
+        _function(body).sugar()
+
+
+def test_starred_assignment_target_remains_a_binding_design_gap() -> None:
+    with pytest.raises(SugarNotWritten):
+        _function("def f(xs):\n    a, *rest = xs\n    return rest\n").sugar()

--- a/implementations/python/sugar-source-tree/tests/test_starred_spread.py
+++ b/implementations/python/sugar-source-tree/tests/test_starred_spread.py
@@ -41,6 +41,15 @@ def test_call_star_and_double_star_use_reference_wrappers() -> None:
     assert term.args[3].args[0].name == "d"
 
 
+def test_call_with_only_double_star_uses_reference_shape() -> None:
+    term = _returned_term("make(**d)")
+    assert term.name == "python:call"
+    assert len(term.args) == 2
+    assert term.args[0].value == "make"
+    assert term.args[1].name == "python:double_starred_kwarg"
+    assert term.args[1].args[0].name == "d"
+
+
 @pytest.mark.parametrize(
     ("expression", "outer"),
     [

--- a/implementations/rust/sugar-ir-symbolic/tests/serializer.rs
+++ b/implementations/rust/sugar-ir-symbolic/tests/serializer.rs
@@ -11,6 +11,7 @@
 // JCS-sorted order at hash time. Both are tested.
 
 use sugar_canonicalizer::{blake3_512_of, encode_jcs, Value};
+use sugar_ir_symbolic::parse::parse_term;
 use sugar_ir_symbolic::serialize::{
     formula_to_value, marshal_declarations, sort_to_value, term_to_value,
 };
@@ -125,6 +126,17 @@ fn term_ctor_emits_kind_name_args() {
     assert!(s.starts_with("{\"args\":["));
     assert!(s.contains("\"kind\":\"ctor\""));
     assert!(s.contains("\"name\":\"parseInt\""));
+}
+
+#[test]
+fn python_double_starred_call_round_trips_reference_shape() {
+    let raw = r#"{"kind":"ctor","name":"python:call","args":[{"kind":"const","value":"f","sort":{"kind":"primitive","name":"String"}},{"kind":"ctor","name":"python:double_starred_kwarg","args":[{"kind":"var","name":"kwargs"}]}]}"#;
+    let json: serde_json::Value = serde_json::from_str(raw).expect("valid ProofIR");
+    let term = parse_term(&json).expect("Rust accepts Python reference call term");
+
+    let round_tripped: serde_json::Value =
+        serde_json::from_str(&encode_jcs(&term_to_value(&term))).expect("Rust emits ProofIR");
+    assert_eq!(round_tripped, json);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- construct positional call spreads with the Python reference `python:starred_arg` / `python:call` shape
- construct list, tuple, set, and dict display spreads with the reference `python:starred` and None-key `python:dict_entry` shapes
- keep starred assignment targets loud pending the binding design

## Pandas measurement (3.0.3, 1,415 files)
Direct-gap delta: **-290**.
- call `*args`: 268 -> 0 (delta -268); blocked descendants 27 -> 33
- call `**kwargs`: 0 -> 0 (already built); blocked descendants 79 -> 83
- list spread: 7 -> 0 (delta -7); blocked descendants 2 -> 2
- tuple spread: 3 -> 0 (delta -3); blocked descendants 1 -> 1
- set spread: 0 -> 0; its sole pandas site remains blocked-descendant
- dict spread: 12 -> 0 (delta -12); blocked descendants 3 -> 3
- starred assignment: one pandas site, not direct in the live traversal (upstream-blocked/unreached); isolated target remains a loud binding-design gap

## Tests
- focused source-tree: 36 passed
- battleaxe focused + Rust-backed reference round-trips: 28 passed at final head
- `R_no_sugar_in_desugar = 0`, auditor errors 0

Predicted epsilon was direct starred/spread gaps -290; observed delta is -290.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add desugaring support for starred calls and literal spreads in Python sugar
> - Adds `SpreadCallSugar`, `SpreadCollectionSugar`, and `SpreadDictSugar` dataclasses in [spread_sugar.py](https://github.com/TSavo/sugar/pull/6077/files#diff-462f912508b271ce479f5b6c3757a9e656e009ab945f3b9c632e8cb7bdfc4945) to desugar Python expressions containing `*`/`**` spreads into reference IR terms.
> - Calls with `*` or `**` args now produce a `python:call` term with `python:starred_arg`, `python:double_starred_kwarg`, and `python:kwarg` wrappers instead of the legacy `py.kwarg("**", d)` bridge.
> - List, tuple, and set literals with starred elements produce `python:list`/`python:tuple`/`python:set` terms with `python:starred` entries; dict literals with `**` produce `python:dict` with `None`-key `python:dict_entry` items.
> - Updates existing tests and adds [test_starred_spread.py](https://github.com/TSavo/sugar/pull/6077/files#diff-11cda315548e40d359744b2365f3b3aa17be3b17498d8ed124d517aeb972282a) to cover the new reference shapes and verify loudness is preserved for unwritten inner expressions.
> - Behavioral Change: spread calls and collection literals no longer fall through to legacy bridges or raise `SugarNotWritten`; they now produce structured IR terms.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 544031f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->