### PR TITLE
drain: Starred/spread call and literal positions (pandas R)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -69,6 +69,7 @@ from .set_literal_value import SetLiteralValue
 from .set_value import SetValue
 from .slice_value import SliceValue
 from .string_value import StringValue
+from .spread_value import SpreadValue
 from .support_value import SupportValue
 from .symbolic_value import SymbolicValue
 from .term_value import TermValue
@@ -129,6 +130,7 @@ REGISTERED_FLOOR_TYPES: tuple[type[FloorDispatchSurface], ...] = (
     SetValue,
     SliceValue,
     StringValue,
+    SpreadValue,
     SupportValue,
     SymbolicValue,
     TermValue,
@@ -208,6 +210,7 @@ __all__ = [
     "SetValue",
     "SliceValue",
     "StringValue",
+    "SpreadValue",
     "SupportValue",
     "SymbolicValue",
     "TermValue",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/spread_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/spread_value.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class SpreadValue(FloorValue):
+    """A constructed ``*expr`` awaiting its enclosing syntactic role.
+
+    Python gives the same Starred AST node different wire words in a call and
+    a display.  The node constructs this typed value once; only the enclosing
+    call/display may project it.  Projecting it as an ordinary value remains a
+    floor gap, so a spread can never silently become one argument or element.
+    """
+
+    value: FloorValue
+
+    def call_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor
+
+        return ctor("python:starred_arg", [self.value.to_term(owner=owner)])
+
+    def literal_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor
+
+        return ctor("python:starred", [self.value.to_term(owner=owner)])

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_arguments.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_arguments.py
@@ -1,0 +1,17 @@
+"""Role-aware projection of already-constructed call arguments."""
+
+
+def positional_term(value, *, owner: str):
+    from sugar_lift_py_tests.floor.spread_value import SpreadValue
+
+    if type(value) is SpreadValue:
+        return value.call_term(owner=owner)
+    return value.to_term(owner=owner)
+
+
+def keyword_term(name, value, *, owner: str):
+    from sugar_lift_py_tests.ir import ctor, str_const
+
+    if name is None:
+        return ctor("python:double_starred_kwarg", [value.to_term(owner=owner)])
+    return ctor("py.kwarg", [str_const(name), value.to_term(owner=owner)])

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -30,7 +30,7 @@ class CallSiteSugar(Sugar):
     target_name: str
     args: tuple  # the argument sugars, in source order
     site: object = dataclass_field(compare=False)
-    keywords: tuple = ()  # (name, sugar) pairs, in source order
+    keywords: tuple = ()  # (name or structural None for **, sugar), source order
 
     @classmethod
     def witnesses(cls):
@@ -69,16 +69,15 @@ class CallSiteSugar(Sugar):
                 )
             )
         from sugar_lift_py_tests.floor import CallSiteValue
-        from sugar_lift_py_tests.ir import ctor, str_const
+        from sugar_lift_py_tests.ir import ctor
+        from sugar_lift_py_tests.sugar.call_arguments import keyword_term, positional_term
 
         owner = str(self.site)
-        kwarg_terms = [
-            ctor("py.kwarg", [str_const(name), value.to_term(owner=owner)])
-            for name, value in kw_values
-        ]
+        kwarg_terms = [keyword_term(name, value, owner=owner) for name, value in kw_values]
         term = ctor(
             f"call:{self.target_name}",
-            [value.to_term(owner=owner) for value in positional] + kwarg_terms,
+            [positional_term(value, owner=owner) for value in positional]
+            + kwarg_terms,
             symbol_kind=(
                 "builtin"
                 if hasattr(builtins, self.target_name)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
@@ -32,6 +32,23 @@ def _reduce_all(element_sugars, ctx):
     return tuple(values), None
 
 
+def _spread_display(values, ctor_name, site):
+    from sugar_lift_py_tests.floor.spread_value import SpreadValue
+    from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+    from sugar_lift_py_tests.ir import ctor
+
+    if not any(type(value) is SpreadValue for value in values):
+        return None
+    owner = str(site)
+    terms = [
+        value.literal_term(owner=owner)
+        if type(value) is SpreadValue
+        else value.to_term(owner=owner)
+        for value in values
+    ]
+    return Complete(SymbolicValue(ctor(ctor_name, terms)))
+
+
 @dataclass(frozen=True)
 class ListSugar(Sugar):
     elements: tuple
@@ -48,7 +65,10 @@ class ListSugar(Sugar):
         from sugar_lift_py_tests.floor.list_value import ListValue
 
         values, effect = _reduce_all(self.elements, ctx)
-        return effect if effect is not None else Complete(ListValue(values))
+        if effect is not None:
+            return effect
+        spread = _spread_display(values, "python:list", self.site)
+        return spread if spread is not None else Complete(ListValue(values))
 
 
 @dataclass(frozen=True)
@@ -67,7 +87,10 @@ class TupleSugar(Sugar):
         from sugar_lift_py_tests.floor.tuple_value import TupleValue
 
         values, effect = _reduce_all(self.elements, ctx)
-        return effect if effect is not None else Complete(TupleValue(values))
+        if effect is not None:
+            return effect
+        spread = _spread_display(values, "python:tuple", self.site)
+        return spread if spread is not None else Complete(TupleValue(values))
 
 
 @dataclass(frozen=True)
@@ -86,12 +109,15 @@ class SetSugar(Sugar):
         from sugar_lift_py_tests.floor.set_value import SetValue
 
         values, effect = _reduce_all(self.elements, ctx)
-        return effect if effect is not None else Complete(SetValue(values))
+        if effect is not None:
+            return effect
+        spread = _spread_display(values, "python:set", self.site)
+        return spread if spread is not None else Complete(SetValue(values))
 
 
 @dataclass(frozen=True)
 class DictSugar(Sugar):
-    keys: tuple  # key sugars, in source order
+    keys: tuple  # key sugars; None is the AST-authenticated ** entry
     values: tuple  # value sugars, in source order
     site: object = dataclass_field(compare=False)
 
@@ -105,6 +131,9 @@ class DictSugar(Sugar):
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.floor.dict_value import DictValue
 
+        if any(key is None for key in self.keys):
+            return self._desugar_with_spread(ctx)
+
         key_values, effect = _reduce_all(self.keys, ctx)
         if effect is not None:
             return effect
@@ -113,3 +142,29 @@ class DictSugar(Sugar):
             return effect
         entries = tuple(zip(key_values, val_values))
         return Complete(DictValue(entries))
+
+    def _desugar_with_spread(self, ctx: object) -> Outcome:
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+        from sugar_lift_py_tests.ir import ctor
+        from sugar_lift_py_tests.outcome import Incomplete
+
+        entries = []
+        owner = str(self.site)
+        for key_sugar, value_sugar in zip(self.keys, self.values, strict=True):
+            if key_sugar is None:
+                key_term = ctor("None", [])
+            else:
+                key_out = key_sugar.desugar(ctx)
+                if isinstance(key_out, Incomplete):
+                    return key_out
+                key_term = key_out.value.to_term(owner=owner)
+            value_out = value_sugar.desugar(ctx)
+            if isinstance(value_out, Incomplete):
+                return value_out
+            entries.append(
+                ctor(
+                    "python:dict_entry",
+                    [key_term, value_out.value.to_term(owner=owner)],
+                )
+            )
+        return Complete(SymbolicValue(ctor("python:dict", entries)))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/computed_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/computed_call_sugar.py
@@ -10,9 +10,9 @@ unlike MethodCallSugar's attribute-callee case.
 A callee whose own node has no `.sugar()` (a Lambda called inline, for example)
 stays loud through the ordinary recursion: this sugar never masks that gap.
 
-Keyword arguments and ``**`` spreads ride as explicit ``py.kwarg`` operands,
-the same bridge vocabulary used by named and method calls. They are pointed at,
-not interpreted or silently expanded here.
+Named keywords ride as ``py.kwarg``; ``**`` spreads use the Python reference's
+``python:double_starred_kwarg`` operand. They are pointed at, not interpreted
+or silently expanded here.
 """
 
 from __future__ import annotations
@@ -29,7 +29,7 @@ class ComputedCallSugar(Sugar):
     callee: Sugar
     args: tuple  # the argument sugars, in source order
     site: object = dataclass_field(compare=False)
-    keywords: tuple = ()  # (name or explicit "**", sugar), source order
+    keywords: tuple = ()  # (name or structural None for **, sugar), source order
 
     @classmethod
     def witnesses(cls):
@@ -73,17 +73,15 @@ class ComputedCallSugar(Sugar):
                 )
             )
         from sugar_lift_py_tests.floor import CallSiteValue
-        from sugar_lift_py_tests.ir import ctor, str_const
+        from sugar_lift_py_tests.ir import ctor
+        from sugar_lift_py_tests.sugar.call_arguments import keyword_term, positional_term
 
         owner = str(self.site)
-        keyword_terms = [
-            ctor("py.kwarg", [str_const(name), value.to_term(owner=owner)])
-            for name, value in kw_values
-        ]
+        keyword_terms = [keyword_term(name, value, owner=owner) for name, value in kw_values]
         term = ctor(
             "py.call",
             [callee.to_term(owner=owner)]
-            + [value.to_term(owner=owner) for value in positional]
+            + [positional_term(value, owner=owner) for value in positional]
             + keyword_terms,
             symbol_kind="coordinate",
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
@@ -28,7 +28,7 @@ class MethodCallSugar(Sugar):
     name: str
     args: tuple  # the argument sugars, in source order
     site: object = dataclass_field(compare=False)
-    keywords: tuple = ()  # (name, sugar) pairs, in source order
+    keywords: tuple = ()  # (name or structural None for **, sugar), source order
 
     @classmethod
     def witnesses(cls):
@@ -68,17 +68,15 @@ class MethodCallSugar(Sugar):
                 )
             )
         from sugar_lift_py_tests.floor import CallSiteValue
-        from sugar_lift_py_tests.ir import ctor, str_const
+        from sugar_lift_py_tests.ir import ctor
+        from sugar_lift_py_tests.sugar.call_arguments import keyword_term, positional_term
 
         owner = str(self.site)
-        kwarg_terms = [
-            ctor("py.kwarg", [str_const(name), value.to_term(owner=owner)])
-            for name, value in kw_values
-        ]
+        kwarg_terms = [keyword_term(name, value, owner=owner) for name, value in kw_values]
         term = ctor(
             f"call:{self.name}",
             [receiver.to_term(owner=owner)]
-            + [value.to_term(owner=owner) for value in positional]
+            + [positional_term(value, owner=owner) for value in positional]
             + kwarg_terms,
             symbol_kind="method-coordinate",
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class SpreadSugar(Sugar):
+    value: Sugar
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        # Witnessed through the enclosing call/display, where Starred has a role.
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.spread_value import SpreadValue
+        from sugar_lift_py_tests.outcome import Complete
+
+        return self.value.desugar(ctx).and_then(
+            lambda value: Complete(SpreadValue(value))
+        )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3105,13 +3105,14 @@ class Dict(Expression):
 
     def _construct_sugar(self):
         """`{k: v, ...}` constructs DictSugar WITH each key and value sugar. A
-        `**d` spread (a DictItem with key None) stays loud until its own sugar."""
+        `**d` is the reference lifter's None-keyed ``python:dict_entry``."""
         from sugar_lift_py_tests.sugar.collection_sugar import DictSugar
 
-        if any(item.key is None for item in self.items):
-            return super()._construct_sugar()
         return DictSugar(
-            keys=tuple(item.key.sugar() for item in self.items),
+            keys=tuple(
+                item.key.sugar() if item.key is not None else None
+                for item in self.items
+            ),
             values=tuple(item.value.sugar() for item in self.items),
             site=self.fragment,
         )
@@ -3126,11 +3127,9 @@ class Set(Expression):
         return self._substitute_children(scope)
 
     def _construct_sugar(self):
-        """`{e, ...}` constructs SetSugar WITH each element's sugar; `*xs` is loud."""
+        """`{e, ...}` constructs SetSugar WITH every ordinary/spread element."""
         from sugar_lift_py_tests.sugar.collection_sugar import SetSugar
 
-        if any(e.kind == "Starred" for e in self.elts):
-            return super()._construct_sugar()
         return SetSugar(
             elements=tuple(e.sugar() for e in self.elts), site=self.fragment
         )
@@ -3641,7 +3640,7 @@ class Call(Expression):
         loud through the ordinary recursion. Named keywords and ``**`` spreads
         ride explicitly on every coordinate; none is dropped or interpreted."""
         keyword_sugars = tuple(
-            (kw.arg if kw.arg is not None else "**", kw.value.sugar())
+            (kw.arg, kw.value.sugar())
             for kw in self.keywords
         )
         if isinstance(self.func, Name):
@@ -3826,6 +3825,12 @@ class Starred(Expression):
     def substitute(self, scope):
         """Binds nothing: recurse into children and reassemble."""
         return self._substitute_children(scope)
+
+    def _construct_sugar(self):
+        """Construct the spread as a typed value; its parent supplies the role."""
+        from sugar_lift_py_tests.sugar.spread_sugar import SpreadSugar
+
+        return SpreadSugar(value=self.value.sugar(), site=self.fragment)
 
 
 class Name(Expression):
@@ -4127,11 +4132,9 @@ class List(Expression):
 
     def _construct_sugar(self):
         """`[e, ...]` constructs ListSugar WITH each element's sugar. A `*xs`
-        spread is not one element -- it stays loud until its own sugar lands."""
+        spread is carried as a typed child for role-aware projection."""
         from sugar_lift_py_tests.sugar.collection_sugar import ListSugar
 
-        if any(e.kind == "Starred" for e in self.elts):
-            return super()._construct_sugar()
         return ListSugar(
             elements=tuple(e.sugar() for e in self.elts), site=self.fragment
         )
@@ -4146,11 +4149,9 @@ class Tuple_(Expression):
         return self._substitute_children(scope)
 
     def _construct_sugar(self):
-        """`(e, ...)` constructs TupleSugar WITH each element's sugar; `*xs` is loud."""
+        """`(e, ...)` constructs TupleSugar WITH every ordinary/spread element."""
         from sugar_lift_py_tests.sugar.collection_sugar import TupleSugar
 
-        if any(e.kind == "Starred" for e in self.elts):
-            return super()._construct_sugar()
         return TupleSugar(
             elements=tuple(e.sugar() for e in self.elts), site=self.fragment
         )

--- a/implementations/python/sugar-source-tree/tests/test_call_kwargs.py
+++ b/implementations/python/sugar-source-tree/tests/test_call_kwargs.py
@@ -2,6 +2,8 @@
 
 import tempfile
 
+import pytest
+
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.tree import SourceFile
 
@@ -47,6 +49,52 @@ def test_named_call_spread_builds_explicit_bridge_operand():
 
     assert t.name == "call:f"
     spread = t.args[-1]
-    assert spread.name == "py.kwarg"
-    assert spread.args[0].value == "**"
-    assert spread.args[1].name == "d"
+    assert spread.name == "python:double_starred_kwarg"
+    assert spread.args[0].name == "d"
+
+
+def test_named_call_positional_spread_builds_reference_bridge_operand():
+    t = _out("def A(xs):\n    return f(0, *xs)\n")
+
+    assert t.name == "call:f"
+    spread = t.args[-1]
+    assert spread.name == "python:starred_arg"
+    assert spread.args[0].name == "xs"
+
+
+def test_spread_call_discriminates_the_wrapped_value():
+    left = _out("def A(xs, ys):\n    return f(*xs)\n")
+    right = _out("def A(xs, ys):\n    return f(*ys)\n")
+
+    assert left.args[0].name == "python:starred_arg"
+    assert right.args[0].name == "python:starred_arg"
+    assert left.args[0].args[0].name == "xs"
+    assert right.args[0].args[0].name == "ys"
+    assert left != right
+
+
+def test_same_spelling_keyword_is_not_admitted_as_double_spread():
+    from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+    from sugar_lift_py_tests.sugar.name_sugar import NameSugar
+
+    term = CallSiteSugar(
+        target_name="f",
+        args=(),
+        keywords=(("**", NameSugar(name="d", site="lying")),),
+        site="lying",
+    ).desugar().value.to_term(owner="lying")
+
+    assert term.args[0].name == "py.kwarg"
+    assert term.args[0].args[0].value == "**"
+    assert term.args[0].name != "python:double_starred_kwarg"
+
+
+def test_contextless_spread_value_stays_a_loud_floor_gap():
+    from sugar_lift_py_tests.floor.spread_value import SpreadValue
+    from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.ir import make_var
+
+    lying = SpreadValue(SymbolicValue(make_var("xs")))
+    with pytest.raises(ConstructionPanic):
+        lying.to_term(owner="no enclosing spread role")

--- a/implementations/python/sugar-source-tree/tests/test_collection_literals.py
+++ b/implementations/python/sugar-source-tree/tests/test_collection_literals.py
@@ -1,7 +1,8 @@
 """Collection displays: list, tuple, set, dict -- through the node.
 
 Each reduces its elements and holds them as the collection floor value; the
-value owns len/subscript/membership. Star / double-star spreads stay loud.
+value owns len/subscript/membership. Spread displays preserve the Python
+reference constructors rather than treating a spread as one ordinary element.
 """
 
 import tempfile
@@ -38,19 +39,48 @@ def test_collection_composes_with_a_call():
     assert term.args[0].name == "array" and len(term.args[0].args) == 3
 
 
-def test_star_spread_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A(xs):\n    return [1, *xs]\n").sugar()
+@pytest.mark.parametrize(
+    ("expression", "outer"),
+    [
+        ("[1, *xs]", "python:list"),
+        ("(1, *xs)", "python:tuple"),
+        ("{1, *xs}", "python:set"),
+    ],
+)
+def test_star_spread_builds_reference_literal_shape(expression, outer):
+    term = _post_term(f"def A(xs):\n    return {expression}\n")
+
+    assert term.name == outer
+    spread = term.args[-1]
+    assert spread.name == "python:starred"
+    assert spread.args[0].name == "xs"
 
 
-def test_double_star_spread_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A(d):\n    return {1: 2, **d}\n").sugar()
+def test_double_star_spread_builds_reference_dict_entry():
+    term = _post_term("def A(d):\n    return {1: 2, **d}\n")
+
+    assert term.name == "python:dict"
+    spread_entry = term.args[-1]
+    assert spread_entry.name == "python:dict_entry"
+    assert spread_entry.args[0].name == "None"
+    assert spread_entry.args[0].args == ()
+    assert spread_entry.args[1].name == "d"
+
+
+def test_literal_spread_discriminates_the_wrapped_value():
+    left = _post_term("def A(xs, ys):\n    return [*xs]\n")
+    right = _post_term("def A(xs, ys):\n    return [*ys]\n")
+
+    assert left.args[0].name == right.args[0].name == "python:starred"
+    assert left.args[0].args[0].name == "xs"
+    assert right.args[0].args[0].name == "ys"
+    assert left != right
 
 
 if __name__ == "__main__":
     test_list_tuple_set_dict_construct_their_terms()
     test_collection_composes_with_a_call()
-    test_star_spread_stays_loud()
-    test_double_star_spread_stays_loud()
-    print("ok: list/tuple/set/dict literals drained; spreads loud")
+    test_star_spread_builds_reference_literal_shape("[1, *xs]", "python:list")
+    test_double_star_spread_builds_reference_dict_entry()
+    test_literal_spread_discriminates_the_wrapped_value()
+    print("ok: list/tuple/set/dict literals and reference spreads build")

--- a/implementations/python/sugar-source-tree/tests/test_computed_call.py
+++ b/implementations/python/sugar-source-tree/tests/test_computed_call.py
@@ -57,11 +57,11 @@ def test_computed_call_keywords_build_on_the_py_call_bridge():
     assert t.name == "py.call"
     assert t.args[0].name == "py.subscript"
     named, spread = t.args[-2:]
-    assert named.name == spread.name == "py.kwarg"
+    assert named.name == "py.kwarg"
     assert named.args[0].value == "key"
     assert named.args[1].value == 1
-    assert spread.args[0].value == "**"
-    assert spread.args[1].name == "d"
+    assert spread.name == "python:double_starred_kwarg"
+    assert spread.args[0].name == "d"
 
 
 def test_lambda_callee_uses_the_computed_call_path():

--- a/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
@@ -55,9 +55,8 @@ def test_spread_keyword_args_build_method_bridge():
     assert t.name == "call:get"
     assert t.args[0].name == "z"
     spread = t.args[-1]
-    assert spread.name == "py.kwarg"
-    assert spread.args[0].value == "**"
-    assert spread.args[1].name == "d"
+    assert spread.name == "python:double_starred_kwarg"
+    assert spread.args[0].name == "d"
 
 
 if __name__ == "__main__":

--- a/implementations/rust/sugar-ir-types/tests/proofir_membership.rs
+++ b/implementations/rust/sugar-ir-types/tests/proofir_membership.rs
@@ -422,3 +422,71 @@ fn python_generator_expression_stays_lazy_after_rust_parse() {
     );
     assert_eq!(free_vars(lazy), ["xs".to_string()].into());
 }
+
+#[test]
+fn python_spread_call_and_literals_survive_rust_parse() {
+    let call = document_post_term(python_comprehension_document("f(0, *xs, **kw)", "xs, kw"));
+    let Term::Ctor {
+        name: call_name,
+        args: call_args,
+    } = call
+    else {
+        panic!("spread call must remain a constructor coordinate")
+    };
+    assert_eq!(call_name, "call:f");
+    assert!(matches!(
+        call_args.get(1),
+        Some(Term::Ctor { name, args })
+            if name == "python:starred_arg" && matches!(args.as_slice(), [Term::Var { name }] if name == "xs")
+    ));
+    assert!(matches!(
+        call_args.get(2),
+        Some(Term::Ctor { name, args })
+            if name == "python:double_starred_kwarg" && matches!(args.as_slice(), [Term::Var { name }] if name == "kw")
+    ));
+
+    for (expression, outer) in [
+        ("[0, *xs]", "python:list"),
+        ("(0, *xs)", "python:tuple"),
+        ("{0, *xs}", "python:set"),
+    ] {
+        let term = document_post_term(python_comprehension_document(expression, "xs"));
+        let Term::Ctor { name, args } = term else {
+            panic!("spread display must remain a constructor coordinate")
+        };
+        assert_eq!(name, outer);
+        assert!(matches!(
+            args.last(),
+            Some(Term::Ctor { name, args })
+                if name == "python:starred" && matches!(args.as_slice(), [Term::Var { name }] if name == "xs")
+        ));
+    }
+
+    let dict = document_post_term(python_comprehension_document("{0: 1, **kw}", "kw"));
+    let Term::Ctor { name, args } = dict else {
+        panic!("spread dict must remain a constructor coordinate")
+    };
+    assert_eq!(name, "python:dict");
+    assert!(matches!(
+        args.last(),
+        Some(Term::Ctor { name, args })
+            if name == "python:dict_entry"
+                && matches!(args.as_slice(), [Term::Ctor { name: none, args }, Term::Var { name: kw }]
+                    if none == "None" && args.is_empty() && kw == "kw")
+    ));
+}
+
+#[test]
+fn malformed_spread_spelling_remains_an_ordinary_ctor_after_rust_parse() {
+    let malformed: Term = serde_json::from_value(json!({
+        "kind": "ctor",
+        "name": "python:starred_arg",
+        "args": []
+    }))
+    .expect("generic ProofIR constructors do not fabricate spread admission");
+
+    assert!(matches!(
+        malformed,
+        Term::Ctor { name, args } if name == "python:starred_arg" && args.is_empty()
+    ));
+}

--- a/tools/census_starred_spread.py
+++ b/tools/census_starred_spread.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Classify pandas starred/spread sites against the construction roll call."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+def _key(node) -> tuple[str, int, int, int, int]:
+    span = node.line_col_span()
+    return (node.kind, span.start_line, span.start_col, span.end_line, span.end_col)
+
+
+def _role(node, parents):
+    parent_info = parents.get(_key(node))
+    if node.kind == "Keyword" and node.arg is None:
+        return ("call_double_star", parent_info[0]) if parent_info else None
+    if node.kind == "DictItem" and node.key is None:
+        return ("literal_dict_double_star", parent_info[0]) if parent_info else None
+    if node.kind != "Starred" or parent_info is None:
+        return None
+
+    parent, field = parent_info
+    if parent.kind == "Call" and field == "args":
+        return "call_star", parent
+    if parent.kind in {"List", "Tuple", "Set"} and field == "elts":
+        # A Starred inside a Store-context sequence is an assignment target.
+        ancestor = parent
+        while (info := parents.get(_key(ancestor))) is not None:
+            ancestor, ancestor_field = info
+            if ancestor.kind in {"Assign", "AnnAssign", "For", "Comprehension"}:
+                if ancestor_field in {"targets", "target"}:
+                    return "assignment_star", ancestor
+                break
+        return "literal_star", parent
+    return "other_star", parent
+
+
+def census(root: Path) -> dict:
+    from sugar_source_tree.panic import SugarNotWritten
+    from sugar_source_tree.reporter import CollectingReporter
+    from sugar_source_tree.tree import SourceFile
+
+    counts: Counter[tuple[str, str]] = Counter()
+    files = sorted(root.rglob("*.py"))
+    defects: Counter[str] = Counter()
+    completed = 0
+    for index, path in enumerate(files, 1):
+        try:
+            reporter = CollectingReporter()
+            source_file = SourceFile.from_path(path, reporter=reporter)
+            nodes = list(source_file.nodes())
+            parents = {}
+            by_key = {}
+            for parent in nodes:
+                by_key.setdefault(_key(parent), parent)
+                for field, _position, child in parent.children():
+                    parents.setdefault(_key(child), (parent, field))
+
+            for function in source_file.functions():
+                try:
+                    function.sugar()
+                except SugarNotWritten:
+                    pass
+
+            direct = {_key(node) for node, _panic in reporter.gaps}
+            present = {_key(node) for node in reporter.present}
+            for key, node in by_key.items():
+                classified = _role(node, parents)
+                if classified is None:
+                    continue
+                role, owner = classified
+                owner_key = _key(owner)
+                if key in direct or owner_key in direct:
+                    status = "direct_gap"
+                elif owner_key in present:
+                    status = "built"
+                else:
+                    status = "blocked_descendant"
+                counts[(role, status)] += 1
+            completed += 1
+            if index % 100 == 0 or index == len(files):
+                print(f"[{index}/{len(files)}] {path.relative_to(root)}", flush=True)
+        except Exception as error:
+            defects[type(error).__name__] += 1
+            print(
+                f"[{index}/{len(files)}] DEFECT {type(error).__name__} "
+                f"{path.relative_to(root)}: {error}",
+                flush=True,
+            )
+
+    result = {
+        "root": str(root),
+        "files_total": len(files),
+        "files_completed": completed,
+        "defects": dict(sorted(defects.items())),
+        "roles": {
+            role: {
+                status: counts[(role, status)]
+                for status in ("direct_gap", "blocked_descendant", "built")
+            }
+            for role in sorted({role for role, _status in counts})
+        },
+    }
+    print(json.dumps(result, indent=2, sort_keys=True), flush=True)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("root", type=Path)
+    args = parser.parse_args()
+    sys.setrecursionlimit(100_000)
+    result = census(args.root)
+    return 1 if result["defects"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- construct `Starred` as a typed spread value, projected only by its enclosing call or literal role
- emit the Python reference shapes: `python:starred_arg`, `python:double_starred_kwarg`, `python:starred`, and None-keyed `python:dict_entry`
- keep ordinary non-spread collection/call paths unchanged
- leave runtime-shaped starred assignment binding loud
- add a reproducible role-aware pandas census plus Python and Rust round-trip twins

## Pandas 2.3.3 census (1,415/1,415 files, zero defects)

| position | direct before | direct after | total minority before | total minority after |
|---|---:|---:|---:|---:|
| call `*args` | 268 | 0 | 594 | 241 |
| call `**kwargs` | 0 | 0 | 621 | 436 |
| list/tuple/set `*` | 11 | 0 | 45 | 34 |
| dict `**` | 12 | 0 | 50 | 36 |
| starred assignment | 0 | 0 | 1 | 1 |

Direct Delta R = -291. Aggregate minority movement across these positions = -563 because resolving earlier spread gaps exposed and built later spread sites in the same functions.

The sole assignment site is `header, separator, first_line, *rest, last_line = table`; its RHS is runtime-shaped, so this PR does not claim a binder or fabricate the remainder.

## Validation

- focused Python spread twins on battleaxe: 25 passed
- Rust Python-to-ProofIR round-trip on battleaxe via `bin/sugarbin`: 14 passed
- full source-tree suite locally: 352 passed, 5 skipped, 1 xfailed
- full source-tree suite on battleaxe reached 352 passed, 5 skipped, with one unrelated strict XPASS in `test_option_context_routes_to_with_resource_sugar`; the same strict XPASS reproduces on unchanged main
- `cargo fmt --check`
- both before/after pandas censuses completed 1,415/1,415 files with zero defects


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add starred/spread support for call arguments and collection literals in pandas R sugar
> - Introduces `SpreadValue` and `SpreadSugar` types so starred expressions (`*x`, `**kw`) are carried as typed values through the sugar/floor pipeline rather than producing gaps.
> - Call sites (`CallSiteSugar`, `ComputedCallSugar`, `MethodCallSugar`) now emit `python:starred_arg` for positional spreads and `python:double_starred_kwarg` for `**` spreads; named kwargs remain `py.kwarg`.
> - List, tuple, and set literals containing spreads now produce `python:list/tuple/set` ctor terms with `python:starred` entries instead of concrete value types or loud gaps.
> - Dict literals with `**` spreads now produce a `python:dict` ctor with `python:dict_entry` entries (None key for spread entries) instead of a concrete `DictValue`.
> - Adds a `census_starred_spread.py` tool that walks Python source files and reports present/gap/built status for starred/spread nodes by role.
> - Behavioral Change: `**` kwargs previously emitted as `py.kwarg` with literal `"**"` name now emit as `python:double_starred_kwarg`; downstream consumers of call term IR must be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1b5107.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->