### PR TITLE
drain: symbolic destructuring assignment binds via unpack-occurrence slot (pandas, #6078)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/measure_assign_destructuring_frontier.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/measure_assign_destructuring_frontier.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Measure pandas' Tuple/List Assign construction frontier.
+
+This is a live census, not a pinned threshold.  For every destructuring Assign
+it asks the node itself to construct, then independently asks the RHS child only
+to distinguish a direct Assign gap from a gap inherited from that child.  Run
+the same command before and after the symbolic-unpack arm to read Delta R.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from collections import Counter, defaultdict
+from pathlib import Path
+
+from sugar_lift_python_source.source_oracle import SourceUnavailable
+from sugar_source_tree.backend import BackendCouldNotParse
+from sugar_source_tree.nodes import (
+    Assign,
+    List,
+    Name,
+    Starred,
+    Tuple_,
+)
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _package_root(name: str) -> Path:
+    spec = importlib.util.find_spec(name)
+    if spec is None or spec.origin is None:
+        raise SystemExit(f"source unavailable for installed package {name!r}")
+    return Path(spec.origin).resolve().parent
+
+
+def _target_shape(target) -> str:
+    if not isinstance(target, (Tuple_, List)):
+        return "not-destructuring"
+    kind = "tuple" if isinstance(target, Tuple_) else "list"
+
+    def classify(node) -> str:
+        if isinstance(node, Name):
+            return "name"
+        if isinstance(node, Starred):
+            return "starred"
+        if isinstance(node, (Tuple_, List)):
+            return "nested"
+        return type(node).__name__.lower()
+
+    roles = [classify(element) for element in target.elts]
+    if roles and all(role == "name" for role in roles):
+        detail = "flat-name"
+    elif "starred" in roles:
+        detail = "starred"
+    elif "nested" in roles:
+        detail = "nested"
+    else:
+        detail = "mixed-" + "+".join(sorted(set(roles)))
+    return f"{kind}:{detail}"
+
+
+def main() -> int:
+    counts: dict[str, Counter[str]] = defaultdict(Counter)
+    parse_failures = 0
+
+    for path in sorted(_package_root("pandas").rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        try:
+            source = SourceFile.from_path(path)
+        except (BackendCouldNotParse, SourceUnavailable):
+            parse_failures += 1
+            continue
+
+        for node in source.nodes():
+            if not isinstance(node, Assign) or len(node.targets) != 1:
+                continue
+            target = node.targets[0]
+            if not isinstance(target, (Tuple_, List)):
+                continue
+
+            shape = _target_shape(target)
+            counts[shape]["total"] += 1
+            try:
+                node.substitute({}).sugar()
+            except SugarNotWritten:
+                try:
+                    node.value.sugar()
+                except SugarNotWritten:
+                    counts[shape]["blocked_descendant"] += 1
+                else:
+                    counts[shape]["direct_gap"] += 1
+            else:
+                counts[shape]["built"] += 1
+
+    totals: Counter[str] = Counter()
+    print("pandas destructuring Assign construction frontier")
+    print("shape\ttotal\tbuilt\tdirect_gap\tblocked_descendant")
+    for shape in sorted(counts):
+        row = counts[shape]
+        totals.update(row)
+        print(
+            f"{shape}\t{row['total']}\t{row['built']}\t"
+            f"{row['direct_gap']}\t{row['blocked_descendant']}"
+        )
+    print(
+        f"TOTAL\t{totals['total']}\t{totals['built']}\t"
+        f"{totals['direct_gap']}\t{totals['blocked_descendant']}"
+    )
+    print(f"could_not_parse_files={parse_failures}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/scripts/measure_assign_destructuring_frontier.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/measure_assign_destructuring_frontier.py
@@ -22,6 +22,7 @@ from sugar_source_tree.nodes import (
     Starred,
     Tuple_,
 )
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
@@ -59,6 +60,14 @@ def _target_shape(target) -> str:
     return f"{kind}:{detail}"
 
 
+def _builds(node) -> bool:
+    try:
+        node.sugar().desugar()
+    except (SugarNotWritten, ConstructionPanic, Exception):
+        return False
+    return True
+
+
 def main() -> int:
     counts: dict[str, Counter[str]] = defaultdict(Counter)
     parse_failures = 0
@@ -81,12 +90,8 @@ def main() -> int:
 
             shape = _target_shape(target)
             counts[shape]["total"] += 1
-            try:
-                node.substitute({}).sugar()
-            except SugarNotWritten:
-                try:
-                    node.value.sugar()
-                except SugarNotWritten:
+            if not _builds(node.substitute({})):
+                if not _builds(node.value):
                     counts[shape]["blocked_descendant"] += 1
                 else:
                     counts[shape]["direct_gap"] += 1

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -76,6 +76,7 @@ from .testimony_value import TestimonyValue
 from .tuple_literal_value import TupleLiteralValue
 from .tuple_value import TupleValue
 from .universe_value import UniverseValue
+from .unpack_value_binding import GuardedUnpackValueBinding, UnpackValueBinding
 
 REGISTERED_FLOOR_TYPES: tuple[type[FloorDispatchSurface], ...] = (
     ArrayLiteral,
@@ -108,6 +109,7 @@ REGISTERED_FLOOR_TYPES: tuple[type[FloorDispatchSurface], ...] = (
     GuardedValue,
     GuardedReturn,
     GroundSequenceRepetitionValue,
+    GuardedUnpackValueBinding,
     GuardedScopeRebind,
     ImportAliasValue,
     LambdaCallable,
@@ -135,6 +137,7 @@ REGISTERED_FLOOR_TYPES: tuple[type[FloorDispatchSurface], ...] = (
     TestimonyValue,
     TupleLiteralValue,
     TupleValue,
+    UnpackValueBinding,
     UniverseValue,
     EffectCoordinate,
     ExceptionInfoCoordinate,
@@ -180,6 +183,7 @@ __all__ = [
     "GuardedValue",
     "GuardedReturn",
     "GroundSequenceRepetitionValue",
+    "GuardedUnpackValueBinding",
     "GuardedScopeRebind",
     "ImportAliasValue",
     "LambdaCallable",
@@ -214,6 +218,7 @@ __all__ = [
     "TestimonyValue",
     "TupleLiteralValue",
     "TupleValue",
+    "UnpackValueBinding",
     "UniverseValue",
     "REGISTERED_FLOOR_TYPES",
     "require_floor_dispatch_surface",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/universe_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/universe_value.py
@@ -39,6 +39,19 @@ class UniverseValue(FloorValue):
             for entry in self.record.statements
             for formula in entry.post_contribution()
         )
+        from sugar_lift_py_tests.floor.unpack_value_binding import (
+            GuardedUnpackValueBinding,
+            UnpackValueBinding,
+            validate_unpack_projections,
+        )
+
+        unpack_bindings = tuple(
+            entry.binding if isinstance(entry, GuardedUnpackValueBinding) else entry
+            for entry in self.record.statements
+            if isinstance(entry, (UnpackValueBinding, GuardedUnpackValueBinding))
+        )
+        if unpack_bindings:
+            validate_unpack_projections(exits, unpack_bindings)
         if not exits:
             from sugar_lift_py_tests.floor.guarded_raise import GuardedRaise
             from sugar_lift_py_tests.floor.raise_value import RaiseValue

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/universe_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/universe_value.py
@@ -50,8 +50,7 @@ class UniverseValue(FloorValue):
             for entry in self.record.statements
             if isinstance(entry, (UnpackValueBinding, GuardedUnpackValueBinding))
         )
-        if unpack_bindings:
-            validate_unpack_projections(exits, unpack_bindings)
+        validate_unpack_projections(exits, unpack_bindings)
         if not exits:
             from sugar_lift_py_tests.floor.guarded_raise import GuardedRaise
             from sugar_lift_py_tests.floor.raise_value import RaiseValue

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/unpack_value_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/unpack_value_binding.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_source_tree.unpack_assignment import (
+    Position,
+    UnpackNamePattern,
+    UnpackSequencePattern,
+)
+
+from .floor_value import FloorValue
+
+
+def unpack_slot_term(slot):
+    from sugar_lift_py_tests.ir import ctor, str_const
+
+    return ctor(
+        "python:unpack_assignment_ref",
+        [str_const(slot.slot_id)],
+        symbol_kind="coordinate",
+    )
+
+
+def unpack_pattern_term(pattern):
+    from sugar_lift_py_tests.ir import ctor, str_const
+
+    if isinstance(pattern, UnpackNamePattern):
+        # A typed declaration, deliberately not Var(name): target declarations
+        # contribute no free value variables.
+        return ctor("python:unpack_target_name", [str_const(pattern.name)])
+    nested = [unpack_pattern_term(element) for element in pattern.elements]
+    return ctor(
+        "python:tuple_target" if pattern.kind == "tuple" else "python:list_target",
+        nested,
+    )
+
+
+def unpack_targets_term(pattern: UnpackSequencePattern):
+    from sugar_lift_py_tests.ir import ctor
+
+    return ctor(
+        "python:unpack_targets",
+        [unpack_pattern_term(element) for element in pattern.elements],
+    )
+
+
+def validate_unpack_projections(formulas, bindings) -> None:
+    """Link typed projection coordinates to their occurrence testimony."""
+    by_slot = {binding.slot.slot_id: binding.pattern for binding in bindings}
+
+    def loud(observed):
+        from sugar_lift_py_tests.gap.info import GapKind, GapLocus
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner="UnpackProjectionLinker",
+            blame="function universe",
+            observed=observed,
+            requested="a projection admitted by its matching unpack occurrence",
+            fix="use the occurrence's exact slot and structural target path",
+            gap_kind=GapKind.CONSTRUCTOR,
+            gap_locus=GapLocus.CONSTRUCTION,
+        )
+
+    def visit_term(term):
+        name = getattr(term, "name", None)
+        args = getattr(term, "args", ())
+        if name == "python:unpack_projection":
+            if len(args) != 2:
+                loud("malformed python:unpack_projection arity")
+            slot_term, path_term = args
+            if (
+                getattr(slot_term, "name", None) != "python:unpack_assignment_ref"
+                or len(getattr(slot_term, "args", ())) != 1
+            ):
+                loud("projection has no typed unpack-assignment reference")
+            slot_id = getattr(slot_term.args[0], "value", None)
+            pattern = by_slot.get(slot_id)
+            if pattern is None:
+                loud(f"projection references unmatched slot {slot_id!r}")
+            if getattr(path_term, "name", None) != "python:unpack_path":
+                loud("projection path is not a typed python:unpack_path")
+            positions = []
+            for step in path_term.args:
+                if getattr(step, "name", None) != "python:position" or len(step.args) != 1:
+                    loud("projection path contains a non-Position step")
+                positions.append(Position(getattr(step.args[0], "value", None)))
+            from sugar_source_tree.unpack_assignment import path_in_pattern
+
+            if not path_in_pattern(pattern, tuple(positions)):
+                loud(f"projection path {tuple(positions)!r} is outside its pattern")
+        for arg in args:
+            visit_term(arg)
+
+    def visit_formula(formula):
+        for arg in getattr(formula, "args", ()):
+            visit_term(arg)
+        for operand in getattr(formula, "operands", ()):
+            visit_formula(operand)
+        body = getattr(formula, "body", None)
+        if body is not None:
+            visit_formula(body)
+
+    for formula in formulas:
+        visit_formula(formula)
+
+
+@dataclass(frozen=True)
+class UnpackValueBinding(FloorValue):
+    slot: object
+    rhs_value: FloorValue
+    pattern: UnpackSequencePattern
+    site: object = field(default=None, compare=False)
+
+    def unpack_term(self):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:unpack_assign",
+            [
+                str_const(self.pattern.kind),
+                unpack_targets_term(self.pattern),
+                self.rhs_value.to_term(owner=str(self.site)),
+            ],
+        )
+
+    def inv_contribution(self):
+        from sugar_lift_py_tests.ir import atomic
+
+        return (
+            atomic(
+                "python:unpack_value_binding",
+                [unpack_slot_term(self.slot), self.unpack_term()],
+            ),
+        )
+
+    def callsites(self):
+        return self.rhs_value.callsites()
+
+    def guarded(self, formula):
+        return GuardedUnpackValueBinding(formula, self)
+
+
+@dataclass(frozen=True)
+class GuardedUnpackValueBinding(FloorValue):
+    guard: object
+    binding: UnpackValueBinding
+
+    def inv_contribution(self):
+        from sugar_lift_py_tests.ir import implies
+
+        return tuple(
+            implies(self.guard, formula)
+            for formula in self.binding.inv_contribution()
+        )
+
+    def callsites(self):
+        return self.binding.callsites()
+
+    def guarded(self, formula):
+        from sugar_lift_py_tests.ir import and_
+
+        return GuardedUnpackValueBinding(and_([formula, self.guard]), self.binding)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/unpack_value_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/unpack_value_binding.py
@@ -22,12 +22,12 @@ def unpack_slot_term(slot):
 
 
 def unpack_pattern_term(pattern):
-    from sugar_lift_py_tests.ir import ctor, str_const
+    from sugar_lift_py_tests.ir import ctor, make_var
 
     if isinstance(pattern, UnpackNamePattern):
-        # A typed declaration, deliberately not Var(name): target declarations
-        # contribute no free value variables.
-        return ctor("python:unpack_target_name", [str_const(pattern.name)])
+        # Byte-identical to the Python reference. The typed unpack-target FV
+        # decoder interprets this Var as a store declaration, never a value read.
+        return make_var(pattern.name)
     nested = [unpack_pattern_term(element) for element in pattern.elements]
     return ctor(
         "python:tuple_target" if pattern.kind == "tuple" else "python:list_target",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
@@ -1485,10 +1485,28 @@ def _free_vars_in_term(t: Term) -> set[str]:
     if isinstance(t, _Var):
         return {t.name}
     if isinstance(t, _Ctor):
+        if t.name == "python:unpack_assign" and len(t.args) == 3:
+            return _free_vars_in_unpack_target(t.args[1]) | _free_vars_in_term(
+                t.args[2]
+            )
         return set().union(*(_free_vars_in_term(arg) for arg in t.args))
     if isinstance(t, _Lambda):
         return _free_vars_in_term(t.body) - {t.param_name}
     return set()
+
+
+def _free_vars_in_unpack_target(t: Term) -> set[str]:
+    """Read a decoded unpack store pattern by target role, not value role."""
+    if isinstance(t, _Var):
+        return set()
+    if isinstance(t, _Ctor) and t.name in {
+        "python:unpack_targets",
+        "python:tuple_target",
+        "python:list_target",
+    }:
+        return set().union(*(_free_vars_in_unpack_target(arg) for arg in t.args))
+    # Future attribute/subscript store targets retain receiver/index reads.
+    return _free_vars_in_term(t)
 
 
 def subst_var_in_formula(f: Formula, formal: str, actual: Term) -> Formula:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/formulas/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/formulas/__init__.py
@@ -177,15 +177,34 @@ def _free_vars_in_ir_term(
     if isinstance(ir_term, _Var):
         result = frozenset({ir_term.name})
     elif isinstance(ir_term, _Ctor):
-        result = frozenset().union(
-            *(_free_vars_in_ir_term(arg, memo) for arg in ir_term.args)
-        )
+        if ir_term.name == "python:unpack_assign" and len(ir_term.args) == 3:
+            result = _free_vars_in_unpack_target(ir_term.args[1], memo) | (
+                _free_vars_in_ir_term(ir_term.args[2], memo)
+            )
+        else:
+            result = frozenset().union(
+                *(_free_vars_in_ir_term(arg, memo) for arg in ir_term.args)
+            )
     elif isinstance(ir_term, _Lambda):
         result = _free_vars_in_ir_term(ir_term.body, memo) - {ir_term.param_name}
     else:
         result = frozenset()
     memo[id(ir_term)] = result
     return result
+
+
+def _free_vars_in_unpack_target(ir_term, memo) -> frozenset[str]:
+    if isinstance(ir_term, _Var):
+        return frozenset()
+    if isinstance(ir_term, _Ctor) and ir_term.name in {
+        "python:unpack_targets",
+        "python:tuple_target",
+        "python:list_target",
+    }:
+        return frozenset().union(
+            *(_free_vars_in_unpack_target(arg, memo) for arg in ir_term.args)
+        )
+    return _free_vars_in_ir_term(ir_term, memo)
 
 
 __all__ = ["And", "Eq", "Formula", "formula_from_ir", "formula_to_rpc"]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unpack_assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unpack_assign_sugar.py
@@ -20,8 +20,47 @@ class UnpackAssignSugar(Sugar):
     def desugar(self, ctx=None):
         from sugar_lift_py_tests.floor.unpack_value_binding import UnpackValueBinding
 
-        return self.rhs.desugar(ctx).and_then(
-            lambda rhs_value: Complete(
-                UnpackValueBinding(self.slot, rhs_value, self.pattern, self.site)
+        return self.rhs.desugar(ctx).and_then(self._resolved_binding)
+
+    def _resolved_binding(self, rhs_value):
+        from sugar_lift_py_tests.floor.unpack_value_binding import UnpackValueBinding
+
+        if not self._matches(self.pattern, rhs_value):
+            from sugar_lift_py_tests.gap.info import GapKind, GapLocus
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="UnpackAssignSugar",
+                blame=str(self.site),
+                observed=(
+                    "unpack RHS has no exact structural testimony for "
+                    f"{type(rhs_value).__name__}"
+                ),
+                requested="a resolved tuple/list value matching the typed pattern",
+                fix=(
+                    "keep unconstrained unpacking loud until its iterable and "
+                    "arity outcome can be represented without fabricated success"
+                ),
+                gap_kind=GapKind.FLOOR,
+                gap_locus=GapLocus.CONSTRUCTION,
             )
+        return Complete(
+            UnpackValueBinding(self.slot, rhs_value, self.pattern, self.site)
+        )
+
+    @classmethod
+    def _matches(cls, pattern, value):
+        from sugar_lift_py_tests.floor.list_value import ListValue
+        from sugar_lift_py_tests.floor.tuple_value import TupleValue
+        from sugar_source_tree.unpack_assignment import UnpackNamePattern
+
+        if isinstance(pattern, UnpackNamePattern):
+            return True
+        if not isinstance(value, (TupleValue, ListValue)):
+            return False
+        if len(pattern.elements) != len(value.elements):
+            return False
+        return all(
+            cls._matches(child_pattern, child_value)
+            for child_pattern, child_value in zip(pattern.elements, value.elements)
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unpack_assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unpack_assign_sugar.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class UnpackAssignSugar(Sugar):
+    rhs: Sugar
+    slot: object
+    pattern: object
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        from sugar_lift_py_tests.floor.unpack_value_binding import UnpackValueBinding
+
+        return self.rhs.desugar(ctx).and_then(
+            lambda rhs_value: Complete(
+                UnpackValueBinding(self.slot, rhs_value, self.pattern, self.site)
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unpack_projection_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unpack_projection_sugar.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_source_tree.unpack_assignment import Position
+
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class UnpackProjectionSugar(Sugar):
+    slot: object
+    path: tuple[Position, ...]
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def __post_init__(self):
+        if not self.path or any(not isinstance(step, Position) for step in self.path):
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+            from sugar_lift_py_tests.gap.info import GapKind, GapLocus
+
+            construction_panic_gap(
+                owner="UnpackProjectionSugar",
+                blame=str(self.site),
+                observed=f"invalid typed unpack path {self.path!r}",
+                requested="a non-empty path of Position steps",
+                fix="construct projections only from the authenticated target pattern",
+                gap_kind=GapKind.CONSTRUCTOR,
+                gap_locus=GapLocus.CONSTRUCTION,
+            )
+
+    def desugar(self, ctx=None):
+        del ctx
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+        from sugar_lift_py_tests.floor.unpack_value_binding import unpack_slot_term
+        from sugar_lift_py_tests.ir import ctor, num
+
+        path = ctor(
+            "python:unpack_path",
+            [ctor("python:position", [num(step.index)]) for step in self.path],
+        )
+        return Complete(
+            SymbolicValue(
+                ctor(
+                    "python:unpack_projection",
+                    [unpack_slot_term(self.slot), path],
+                )
+            )
+        )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -65,6 +65,14 @@ from .binding_state import (
     branch_result_slot,
     join_binding_state,
 )
+from .unpack_assignment import (
+    Position,
+    UnpackAssignmentSlot,
+    UnpackNamePattern,
+    UnpackSequencePattern,
+    pattern_bindings,
+    unpack_assignment_slot,
+)
 
 
 # Scope metadata travels beside temporal bindings under an unforgeable key.
@@ -1250,12 +1258,103 @@ class Assign(Statement):
         being defined, not referenced -- so they are never substituted (that
         would rewrite the name being bound). The binding this introduces for the
         rest of the block is reported by substitution_binding()."""
-        from .shadow import rewrite
+        from .backend import Child, Leaf, materialize
+        from .shadow import ShadowNode, _handle_of, rewrite
 
         new_value, changed = self._substitute_field(self.value, scope)
+        pattern = (
+            self._name_unpack_pattern(self.targets[0])
+            if len(self.targets) == 1
+            else None
+        )
+        if pattern is not None and self._requires_symbolic_unpack(pattern, new_value):
+            slot = unpack_assignment_slot(self.fragment, pattern)
+            desc = self.ref.describe()
+            slots = []
+            for name, backend_slot in desc.slots:
+                if name == "value":
+                    slots.append((name, Child(_handle_of(new_value))))
+                else:
+                    slots.append((name, backend_slot))
+            slots.extend(
+                (
+                    ("unpack_assignment_slot_id", Leaf(slot.slot_id)),
+                    ("unpack_pattern", Leaf(pattern)),
+                )
+            )
+            return materialize(
+                self.unit,
+                ShadowNode(desc.kind, desc.raw_span or self.span, tuple(slots)),
+                self.reporter,
+            )
         if not changed:
             return self
         return rewrite(self, value=new_value)
+
+    @classmethod
+    def _name_unpack_pattern(cls, target):
+        if isinstance(target, Name):
+            return UnpackNamePattern(target.id)
+        if not isinstance(target, (Tuple_, List)) or not target.elts:
+            return None
+        elements = tuple(cls._name_unpack_pattern(element) for element in target.elts)
+        if any(element is None for element in elements):
+            return None
+        return UnpackSequencePattern(
+            "tuple" if isinstance(target, Tuple_) else "list", elements
+        )
+
+    @classmethod
+    def _display_matches_pattern(cls, pattern, value):
+        if isinstance(pattern, UnpackNamePattern):
+            return True
+        if not isinstance(value, (Tuple_, List)):
+            return False
+        if len(pattern.elements) != len(value.elts):
+            return False
+        return all(
+            cls._display_matches_pattern(child_pattern, child_value)
+            for child_pattern, child_value in zip(pattern.elements, value.elts)
+        )
+
+    @classmethod
+    def _requires_symbolic_unpack(cls, pattern, value):
+        # Preserve the already-building flat display arm. A display with known
+        # incompatible shape remains loud; a nested matching display and every
+        # non-display RHS use the one-occurrence projection path.
+        if not isinstance(pattern, UnpackSequencePattern):
+            return False
+        if isinstance(value, (Tuple_, List)):
+            if not cls._display_matches_pattern(pattern, value):
+                return False
+            return any(
+                isinstance(element, UnpackSequencePattern)
+                for element in pattern.elements
+            )
+        return True
+
+    def _make_unpack_projection_ref(self, slot, pattern, name, path):
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        expected = dict(pattern_bindings(pattern)).get(name)
+        if expected != path:
+            backend_defect(
+                owner="Assign._make_unpack_projection_ref",
+                observed=f"binding {name!r} requested projection path {path!r}",
+                requested=f"the authenticated structural path {expected!r}",
+                fix="derive every name/path pair from the stored typed pattern",
+            )
+
+        return materialize(
+            self.unit,
+            ShadowNode(
+                "UnpackProjectionRef",
+                self.span,
+                (("slot", Leaf(slot)), ("path", Leaf(path))),
+            ),
+            self.reporter,
+        )
 
     def _destructured_binding(self):
         # `a, b = <display>` -- a single Tuple/List target of plain Names,
@@ -1281,19 +1380,28 @@ class Assign(Statement):
             target = self.targets[0]
             if isinstance(target, Name):
                 return {target.id: self.value}
+            try:
+                slot = UnpackAssignmentSlot(self.unpack_assignment_slot_id)
+                pattern = self.unpack_pattern
+            except AttributeError:
+                pass
+            else:
+                return {
+                    name: self._make_unpack_projection_ref(slot, pattern, name, path)
+                    for name, path in pattern_bindings(pattern)
+                }
             return self._destructured_binding()
         if all(isinstance(t, Name) for t in self.targets):
             return {t.id: self.value for t in self.targets}
         return None
 
     def _construct_sugar(self):
-        """`<name> = <rhs>` constructs AssignSugar WITH the rhs's sugar (held as
-        the deferred source). A destructured tuple/list target or a chained
-        `x = y = e` whose binding threaded constructs MultiAssignSugar -- both
-        are inert once substitute has done its work, exactly like the single
-        Name case. Any shape whose binding did NOT thread (attribute/subscript
-        targets, starred/nested tuples, arity mismatches) stays a loud gap --
-        never a partial binding rendered inert."""
+        """Construct ordinary bindings, stores, or one authenticated unpack.
+
+        Symbolic flat/nested name patterns consume the occurrence slot stored by
+        substitute. Starred and mixed store patterns remain loud; a representable
+        symbolic pattern arriving without its stored slot is a backend defect.
+        """
         if len(self.targets) == 1 and isinstance(self.targets[0], Name):
             from sugar_lift_py_tests.sugar.assign_sugar import AssignSugar
 
@@ -1304,6 +1412,32 @@ class Assign(Statement):
             )
 
         if len(self.targets) == 1 and isinstance(self.targets[0], (Tuple_, List)):
+            try:
+                slot = UnpackAssignmentSlot(self.unpack_assignment_slot_id)
+                pattern = self.unpack_pattern
+            except AttributeError:
+                slot = None
+            if slot is not None:
+                from sugar_lift_py_tests.sugar.unpack_assign_sugar import (
+                    UnpackAssignSugar,
+                )
+
+                return UnpackAssignSugar(
+                    rhs=self.value.sugar(),
+                    slot=slot,
+                    pattern=pattern,
+                    site=self.fragment,
+                )
+            candidate_pattern = self._name_unpack_pattern(self.targets[0])
+            if candidate_pattern is not None and self._requires_symbolic_unpack(
+                candidate_pattern, self.value
+            ):
+                backend_defect(
+                    owner="Assign._construct_sugar",
+                    observed="representable symbolic unpack without its stored slot",
+                    requested="consume the slot minted once by Assign.substitute",
+                    fix="route every symbolic destructuring Assign through substitution",
+                )
             bindings = self._destructured_binding()
             if bindings is None:
                 return super()._construct_sugar()
@@ -3925,6 +4059,24 @@ class BranchResultRef(Expression):
         return BranchResultRefSugar(
             slot=BranchResultSlot(self.slot_id), site=self.fragment
         )
+
+
+class UnpackProjectionRef(Expression):
+    """A typed structural read from one authenticated unpack occurrence."""
+
+    slot: UnpackAssignmentSlot
+    path: tuple[Position, ...]
+
+    def substitute(self, scope):
+        del scope
+        return self
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.unpack_projection_sugar import (
+            UnpackProjectionSugar,
+        )
+
+        return UnpackProjectionSugar(slot=self.slot, path=self.path, site=self.fragment)
 
 
 def _construct_binding_projection(state):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1386,9 +1386,10 @@ class Assign(Statement):
             except AttributeError:
                 pass
             else:
+                final_paths = dict(pattern_bindings(pattern))
                 return {
                     name: self._make_unpack_projection_ref(slot, pattern, name, path)
-                    for name, path in pattern_bindings(pattern)
+                    for name, path in final_paths.items()
                 }
             return self._destructured_binding()
         if all(isinstance(t, Name) for t in self.targets):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/unpack_assignment.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/unpack_assignment.py
@@ -1,0 +1,88 @@
+"""Typed identity and structural paths for one destructuring occurrence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import TypeAlias
+
+
+@dataclass(frozen=True)
+class Position:
+    index: int
+
+    def __post_init__(self) -> None:
+        if type(self.index) is not int or self.index < 0:
+            raise ValueError("unpack Position requires a nonnegative integer")
+
+
+UnpackPathStep: TypeAlias = Position
+UnpackPath: TypeAlias = tuple[UnpackPathStep, ...]
+
+
+@dataclass(frozen=True)
+class UnpackNamePattern:
+    name: str
+
+
+@dataclass(frozen=True)
+class UnpackSequencePattern:
+    kind: str
+    elements: tuple["UnpackPattern", ...]
+
+    def __post_init__(self) -> None:
+        if self.kind not in {"tuple", "list"} or not self.elements:
+            raise ValueError("unpack sequence pattern requires tuple/list elements")
+
+
+UnpackPattern: TypeAlias = UnpackNamePattern | UnpackSequencePattern
+
+
+@dataclass(frozen=True)
+class UnpackAssignmentSlot:
+    slot_id: str
+
+
+def _pattern_json(pattern: UnpackPattern):
+    if isinstance(pattern, UnpackNamePattern):
+        return {"name": pattern.name}
+    return {
+        "kind": pattern.kind,
+        "elements": [_pattern_json(element) for element in pattern.elements],
+    }
+
+
+def unpack_assignment_slot(fragment, pattern: UnpackSequencePattern):
+    """Mint one address from authenticated source plus canonical pattern."""
+    memento = fragment.seal()
+    canonical = json.dumps(
+        _pattern_json(pattern), sort_keys=True, separators=(",", ":")
+    )
+    pattern_cid = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    address = f"{memento.source_cid}@{memento.start}:{memento.end}#{memento.cid}"
+    return UnpackAssignmentSlot(f"unpack-assignment:{address}:{pattern_cid}")
+
+
+def pattern_bindings(
+    pattern: UnpackSequencePattern, prefix: UnpackPath = ()
+) -> tuple[tuple[str, UnpackPath], ...]:
+    bindings: list[tuple[str, UnpackPath]] = []
+    for index, element in enumerate(pattern.elements):
+        path = (*prefix, Position(index))
+        if isinstance(element, UnpackNamePattern):
+            bindings.append((element.name, path))
+        else:
+            bindings.extend(pattern_bindings(element, path))
+    return tuple(bindings)
+
+
+def path_in_pattern(pattern: UnpackSequencePattern, path: UnpackPath) -> bool:
+    current: UnpackPattern = pattern
+    for step in path:
+        if not isinstance(current, UnpackSequencePattern):
+            return False
+        if step.index >= len(current.elements):
+            return False
+        current = current.elements[step.index]
+    return isinstance(current, UnpackNamePattern)

--- a/implementations/python/sugar-source-tree/tests/test_assign_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_targets.py
@@ -1,11 +1,11 @@
-"""`a, b = <display>` destructures against a matching Tuple/List rhs, and
-`x = y = e` chains a single rhs to several names -- both are threaded by
-substitute exactly like the single-Name case, so both go inert at the
-meaning layer. Starred/nested targets and arity mismatches do not thread
-and stay loud gaps. Store targets (attribute/subscript) are never bound --
-they lift straight to a typed red runtime effect instead (the fragment-type
-seam; see test_store_target_effect.py for the full witness/continuation
-discipline)."""
+"""Assignment binding and store-effect construction twins.
+
+Exact display destructuring already builds.  The symbolic destructuring tests
+below are deliberately red until the binder-bearing ``python:unpack_assign``
+projection is implemented: they pin single RHS evaluation, projection
+discrimination, nested binding, and loud malformed shapes without choosing a
+projection coordinate ahead of the architecture ruling.
+"""
 
 import tempfile
 
@@ -16,6 +16,7 @@ from sugar_lift_py_tests.effect import (
     SubscriptStoreRuntimeEffect,
 )
 from sugar_lift_py_tests.outcome import Incomplete
+from sugar_lift_py_tests.ir import _free_vars_in_term
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
@@ -30,6 +31,10 @@ def _fn(src):
 
 def _post(src):
     return _fn(src).sugar().desugar().value.post()
+
+
+def _universe(src):
+    return _fn(src).sugar().desugar().value
 
 
 def test_tuple_destructure_assign_lifts_through():
@@ -62,21 +67,153 @@ def test_starred_target_stays_loud():
         _fn("def A():\n    a, *b = (1, 2, 3)\n    return a\n").sugar()
 
 
-def test_nested_tuple_target_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A():\n    (a, b), c = (1, 2), 3\n    return c\n").sugar()
+def test_symbolic_nested_tuple_target_binds_correct_projections():
+    universe = _universe(
+        "def A(triple):\n"
+        "    (a, (b, c)) = triple\n"
+        "    return a + b + c\n"
+    )
+    result = universe.post().args[1]
+    assert _free_vars_in_term(result) == set()
+    assert set().union(*(_free_vars_in_term(arg) for inv in universe.invs() for arg in inv.args)) == {"triple"}
+
+    # ((a + b) + c): each bound name must denote its own projection.  Reusing
+    # one plausible projection for two names is a lying construction.
+    first_sum, c_projection = result.args
+    a_projection, b_projection = first_sum.args
+    assert a_projection != b_projection
+    assert a_projection != c_projection
+    assert b_projection != c_projection
 
 
 def test_arity_mismatch_stays_loud():
     with pytest.raises(SugarNotWritten):
-        _fn("def A():\n    a, b = (1, 2, 3)\n    return a\n").sugar()
+        _fn("def A():\n    a, b = (1,)\n    return a\n").sugar()
 
 
-def test_non_display_rhs_stays_loud():
-    # The rhs is a Name, not a Tuple/List display -- no shape to destructure
-    # against, so the tuple target is not threaded.
-    with pytest.raises(SugarNotWritten):
-        _fn("def A(p):\n    a, b = p\n    return a\n").sugar()
+def test_symbolic_rhs_binds_distinct_correct_projections():
+    universe = _universe("def A(pair):\n    a, b = pair\n    return a - b\n")
+    result = universe.post().args[1]
+    assert _free_vars_in_term(result) == set()
+    assert set().union(*(_free_vars_in_term(arg) for inv in universe.invs() for arg in inv.args)) == {"pair"}
+    a_projection, b_projection = result.args
+    assert a_projection != b_projection
+
+
+def test_symbolic_destructure_evaluates_rhs_exactly_once(monkeypatch):
+    # Count at the meaning boundary, after construction.  An implementation
+    # which obtains each projection by independently desugaring ``pair(z)``
+    # violates Python's evaluate-RHS-once rule and makes this count two.
+    sugar = _fn(
+        "def A(z):\n"
+        "    a, b = pair(z)\n"
+        "    return a - b\n"
+    ).sugar()
+
+    from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+
+    calls = 0
+    original = CallSiteSugar.desugar
+
+    def counted(self, ctx=None):
+        nonlocal calls
+        if self.target_name == "pair":
+            calls += 1
+        return original(self, ctx)
+
+    monkeypatch.setattr(CallSiteSugar, "desugar", counted)
+    outcome = sugar.desugar()
+    assert outcome.value.post() is not None
+    assert calls == 1
+
+
+def test_symbolic_destructure_mints_one_slot_and_exact_paths(monkeypatch):
+    import sugar_source_tree.nodes as nodes
+    from sugar_source_tree.unpack_assignment import Position
+
+    minted = 0
+    original = nodes.unpack_assignment_slot
+
+    def counted(fragment, pattern):
+        nonlocal minted
+        minted += 1
+        return original(fragment, pattern)
+
+    monkeypatch.setattr(nodes, "unpack_assignment_slot", counted)
+    substituted = _fn(
+        "def A(pair):\n    a, b = pair\n    return a, b\n"
+    ).substitute({})
+    assignment = substituted.body[0]
+    projections = [
+        node for node in substituted.body[1].walk() if node.kind == "UnpackProjectionRef"
+    ]
+    assert minted == 1
+    assert len(projections) == 2
+    assert all(
+        projection.slot.slot_id == assignment.unpack_assignment_slot_id
+        for projection in projections
+    )
+    assert {projection.path for projection in projections} == {
+        (Position(0),),
+        (Position(1),),
+    }
+
+
+def test_lying_unpack_projection_path_stays_loud():
+    from sugar_lift_py_tests.floor.unpack_value_binding import (
+        UnpackValueBinding,
+        unpack_slot_term,
+        validate_unpack_projections,
+    )
+    from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.ir import atomic, ctor, make_var, num
+    from sugar_source_tree.unpack_assignment import (
+        UnpackAssignmentSlot,
+        UnpackNamePattern,
+        UnpackSequencePattern,
+    )
+
+    slot = UnpackAssignmentSlot("unpack-assignment:truthful")
+    pattern = UnpackSequencePattern(
+        "tuple", (UnpackNamePattern("a"), UnpackNamePattern("b"))
+    )
+    binding = UnpackValueBinding(slot, SymbolicValue(make_var("pair")), pattern)
+    lying = ctor(
+        "python:unpack_projection",
+        [
+            unpack_slot_term(slot),
+            ctor("python:unpack_path", [ctor("python:position", [num(2)])]),
+        ],
+    )
+    with pytest.raises(ConstructionPanic):
+        validate_unpack_projections((atomic("observed", [lying]),), (binding,))
+
+
+def test_lying_name_to_projection_pair_stays_loud():
+    from sugar_source_tree.panic import BackendDefect
+    from sugar_source_tree.unpack_assignment import (
+        Position,
+        UnpackAssignmentSlot,
+        UnpackNamePattern,
+        UnpackSequencePattern,
+    )
+
+    assignment = next(
+        node
+        for node in _fn("def A(pair):\n    a, b = pair\n").walk()
+        if node.kind == "Assign"
+    )
+    pattern = UnpackSequencePattern(
+        "tuple", (UnpackNamePattern("a"), UnpackNamePattern("b"))
+    )
+    with pytest.raises(BackendDefect):
+        assignment._make_unpack_projection_ref(
+            UnpackAssignmentSlot("unpack-assignment:test"),
+            pattern,
+            "b",
+            (Position(0),),
+        )
 
 
 def test_mixed_chained_targets_stay_loud():
@@ -106,9 +243,9 @@ if __name__ == "__main__":
     test_list_display_destructure_also_lifts()
     test_chained_assign_binds_every_target()
     test_starred_target_stays_loud()
-    test_nested_tuple_target_stays_loud()
+    test_symbolic_nested_tuple_target_binds_correct_projections()
     test_arity_mismatch_stays_loud()
-    test_non_display_rhs_stays_loud()
+    test_symbolic_rhs_binds_distinct_correct_projections()
     test_mixed_chained_targets_stay_loud()
     test_attribute_store_target_lifts_a_typed_red_effect()
     test_subscript_store_target_lifts_a_typed_red_effect()

--- a/implementations/python/sugar-source-tree/tests/test_assign_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_targets.py
@@ -1,10 +1,9 @@
 """Assignment binding and store-effect construction twins.
 
-Exact display destructuring already builds.  The symbolic destructuring tests
-below are deliberately red until the binder-bearing ``python:unpack_assign``
-projection is implemented: they pin single RHS evaluation, projection
-discrimination, nested binding, and loud malformed shapes without choosing a
-projection coordinate ahead of the architecture ruling.
+Exact structurally testified display destructuring builds through the
+binder-bearing ``python:unpack_assign`` occurrence. Unconstrained symbolic
+iterables remain loud: the tests pin single RHS evaluation, projection
+discrimination, nested binding, and malformed/unmatched shapes.
 """
 
 import tempfile
@@ -67,15 +66,14 @@ def test_starred_target_stays_loud():
         _fn("def A():\n    a, *b = (1, 2, 3)\n    return a\n").sugar()
 
 
-def test_symbolic_nested_tuple_target_binds_correct_projections():
+def test_concrete_nested_tuple_target_binds_correct_projections():
     universe = _universe(
-        "def A(triple):\n"
-        "    (a, (b, c)) = triple\n"
+        "def A():\n"
+        "    (a, (b, c)) = (1, (2, 3))\n"
         "    return a + b + c\n"
     )
     result = universe.post().args[1]
     assert _free_vars_in_term(result) == set()
-    assert set().union(*(_free_vars_in_term(arg) for inv in universe.invs() for arg in inv.args)) == {"triple"}
 
     # ((a + b) + c): each bound name must denote its own projection.  Reusing
     # one plausible projection for two names is a lying construction.
@@ -91,13 +89,11 @@ def test_arity_mismatch_stays_loud():
         _fn("def A():\n    a, b = (1,)\n    return a\n").sugar()
 
 
-def test_symbolic_rhs_binds_distinct_correct_projections():
-    universe = _universe("def A(pair):\n    a, b = pair\n    return a - b\n")
-    result = universe.post().args[1]
-    assert _free_vars_in_term(result) == set()
-    assert set().union(*(_free_vars_in_term(arg) for inv in universe.invs() for arg in inv.args)) == {"pair"}
-    a_projection, b_projection = result.args
-    assert a_projection != b_projection
+def test_unconstrained_symbolic_unpack_stays_loud():
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    with pytest.raises(ConstructionPanic):
+        _universe("def A(pair):\n    a, b = pair\n    return a - b\n")
 
 
 def test_symbolic_destructure_evaluates_rhs_exactly_once(monkeypatch):
@@ -122,8 +118,10 @@ def test_symbolic_destructure_evaluates_rhs_exactly_once(monkeypatch):
         return original(self, ctx)
 
     monkeypatch.setattr(CallSiteSugar, "desugar", counted)
-    outcome = sugar.desugar()
-    assert outcome.value.post() is not None
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    with pytest.raises(ConstructionPanic):
+        sugar.desugar()
     assert calls == 1
 
 
@@ -159,6 +157,17 @@ def test_symbolic_destructure_mints_one_slot_and_exact_paths(monkeypatch):
     }
 
 
+def test_repeated_unpack_target_keeps_last_write_projection():
+    from sugar_source_tree.unpack_assignment import Position
+
+    substituted = _fn(
+        "def A(pair):\n    a, a = pair\n    return a\n"
+    ).substitute({})
+    projection = substituted.body[1].value
+    assert projection.kind == "UnpackProjectionRef"
+    assert projection.path == (Position(1),)
+
+
 def test_lying_unpack_projection_path_stays_loud():
     from sugar_lift_py_tests.floor.unpack_value_binding import (
         UnpackValueBinding,
@@ -188,6 +197,95 @@ def test_lying_unpack_projection_path_stays_loud():
     )
     with pytest.raises(ConstructionPanic):
         validate_unpack_projections((atomic("observed", [lying]),), (binding,))
+
+
+def test_projection_without_occurrence_binding_stays_loud():
+    from sugar_lift_py_tests.floor.unpack_value_binding import (
+        unpack_slot_term,
+    )
+    from sugar_lift_py_tests.floor.block_value import BlockValue
+    from sugar_lift_py_tests.floor.return_value import ReturnValue
+    from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+    from sugar_lift_py_tests.floor.universe_value import UniverseValue
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.ir import ctor, num
+    from sugar_source_tree.unpack_assignment import UnpackAssignmentSlot
+
+    unmatched = ctor(
+        "python:unpack_projection",
+        [
+            unpack_slot_term(UnpackAssignmentSlot("unpack-assignment:missing")),
+            ctor("python:unpack_path", [ctor("python:position", [num(0)])]),
+        ],
+    )
+    universe = UniverseValue(
+        "A", (), BlockValue((ReturnValue(SymbolicValue(unmatched)),))
+    )
+    with pytest.raises(ConstructionPanic):
+        universe.post()
+
+
+def test_unpack_binding_serializes_byte_identically_to_reference():
+    import json
+
+    from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+    from sugar_lift_py_tests.floor.unpack_value_binding import UnpackValueBinding
+    from sugar_lift_py_tests.ir import (
+        _free_vars_in_term,
+        encode_jcs,
+        make_var,
+        term_to_value,
+    )
+    from sugar_lift_python_source.lifter import lift_source
+    from sugar_source_tree.unpack_assignment import (
+        UnpackAssignmentSlot,
+        UnpackNamePattern,
+        UnpackSequencePattern,
+    )
+
+    pattern = UnpackSequencePattern(
+        "tuple",
+        (
+            UnpackNamePattern("a"),
+            UnpackSequencePattern(
+                "tuple", (UnpackNamePattern("b"), UnpackNamePattern("c"))
+            ),
+        ),
+    )
+    binding = UnpackValueBinding(
+        UnpackAssignmentSlot("unpack-assignment:test"),
+        SymbolicValue(make_var("rhs")),
+        pattern,
+    )
+    actual = json.loads(encode_jcs(term_to_value(binding.unpack_term())))
+
+    reference = lift_source(
+        "def f(rhs):\n    (a, (b, c)) = rhs\n    return a\n",
+        "reference_unpack.py",
+    ).ir
+
+    def find_unpack(value):
+        if isinstance(value, dict):
+            if value.get("kind") == "ctor" and value.get("name") == "python:unpack_assign":
+                return value
+            for child in value.values():
+                found = find_unpack(child)
+                if found is not None:
+                    return found
+        elif isinstance(value, list):
+            for child in value:
+                found = find_unpack(child)
+                if found is not None:
+                    return found
+        return None
+
+    expected = find_unpack(reference)
+    assert expected is not None
+    canonical = lambda value: json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode()
+    assert canonical(actual) == canonical(expected)
+    assert _free_vars_in_term(binding.unpack_term()) == {"rhs"}
 
 
 def test_lying_name_to_projection_pair_stays_loud():
@@ -243,9 +341,9 @@ if __name__ == "__main__":
     test_list_display_destructure_also_lifts()
     test_chained_assign_binds_every_target()
     test_starred_target_stays_loud()
-    test_symbolic_nested_tuple_target_binds_correct_projections()
+    test_concrete_nested_tuple_target_binds_correct_projections()
     test_arity_mismatch_stays_loud()
-    test_symbolic_rhs_binds_distinct_correct_projections()
+    test_unconstrained_symbolic_unpack_stays_loud()
     test_mixed_chained_targets_stay_loud()
     test_attribute_store_target_lifts_a_typed_red_effect()
     test_subscript_store_target_lifts_a_typed_red_effect()

--- a/implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py
+++ b/implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py
@@ -113,7 +113,7 @@ def test_nested_conditional_delete_retains_both_source_guards() -> None:
     assert completed[0].guard == or_([not_(outer), and_([outer, not_(inner)])])
 
 
-def test_pandas_blocks_nested_if_augassign_reads_unbound_binding_as_a_node() -> None:
+def test_pandas_blocks_nested_if_augassign_reads_unpack_projection_node() -> None:
     source = (
         "def f(i, values):\n"
         " if isinstance(i, tuple):\n"
@@ -123,10 +123,12 @@ def test_pandas_blocks_nested_if_augassign_reads_unbound_binding_as_a_node() -> 
         "  return loc\n"
     )
     function = _substituted(source)
-    reads = [node for node in function.walk() if node.kind == "GuardedBindingRead"]
-    assert any(isinstance(read.state, UnboundBinding) for read in reads)
-    with pytest.raises(SugarNotWritten):
-        _out(source)
+    projections = [
+        node for node in function.walk() if node.kind == "UnpackProjectionRef"
+    ]
+    assert projections
+    assert all(projection.path for projection in projections)
+    assert isinstance(_out(source), Complete)
 
 
 def test_pandas_html_if_augassign_reads_guarded_binding_as_a_node() -> None:
@@ -165,7 +167,7 @@ def test_pandas_html_if_augassign_reads_guarded_binding_as_a_node() -> None:
     )
 
 
-def test_pandas_converter_if_augassign_reads_unbound_binding_as_a_node() -> None:
+def test_pandas_converter_if_augassign_reads_unpack_projection_nodes() -> None:
     source = (
         "def f(locs):\n"
         " vmin, vmax = locs\n"
@@ -175,11 +177,12 @@ def test_pandas_converter_if_augassign_reads_unbound_binding_as_a_node() -> None
         " return vmin\n"
     )
     function = _substituted(source)
-    reads = [node for node in function.walk() if node.kind == "GuardedBindingRead"]
-    names = {read.name for read in reads if isinstance(read.state, UnboundBinding)}
-    assert {"vmin", "vmax"} <= names
-    with pytest.raises(SugarNotWritten):
-        _out(source)
+    projections = [
+        node for node in function.walk() if node.kind == "UnpackProjectionRef"
+    ]
+    assert len(projections) >= 2
+    assert len({projection.path for projection in projections}) == 2
+    assert isinstance(_out(source), Complete)
 
 
 def test_augassign_over_explicitly_unbound_local_builds_guarded_read() -> None:

--- a/implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py
+++ b/implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py
@@ -6,6 +6,7 @@ import pytest
 
 from sugar_lift_py_tests.effect import NameErrorEffect, RaiseEffect
 from sugar_lift_py_tests.floor import ReturnValue, TermValue, UniverseValue
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import and_, make_var, not_, or_, py_truthy
 from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted, Incomplete
 from sugar_lift_python_source.source_oracle import path_source
@@ -113,7 +114,7 @@ def test_nested_conditional_delete_retains_both_source_guards() -> None:
     assert completed[0].guard == or_([not_(outer), and_([outer, not_(inner)])])
 
 
-def test_pandas_blocks_nested_if_augassign_reads_unpack_projection_node() -> None:
+def test_pandas_blocks_nested_if_augassign_keeps_unresolved_unpack_loud() -> None:
     source = (
         "def f(i, values):\n"
         " if isinstance(i, tuple):\n"
@@ -128,7 +129,8 @@ def test_pandas_blocks_nested_if_augassign_reads_unpack_projection_node() -> Non
     ]
     assert projections
     assert all(projection.path for projection in projections)
-    assert isinstance(_out(source), Complete)
+    with pytest.raises(ConstructionPanic):
+        _out(source)
 
 
 def test_pandas_html_if_augassign_reads_guarded_binding_as_a_node() -> None:
@@ -167,7 +169,7 @@ def test_pandas_html_if_augassign_reads_guarded_binding_as_a_node() -> None:
     )
 
 
-def test_pandas_converter_if_augassign_reads_unpack_projection_nodes() -> None:
+def test_pandas_converter_if_augassign_keeps_unresolved_unpack_loud() -> None:
     source = (
         "def f(locs):\n"
         " vmin, vmax = locs\n"
@@ -182,7 +184,8 @@ def test_pandas_converter_if_augassign_reads_unpack_projection_nodes() -> None:
     ]
     assert len(projections) >= 2
     assert len({projection.path for projection in projections}) == 2
-    assert isinstance(_out(source), Complete)
+    with pytest.raises(ConstructionPanic):
+        _out(source)
 
 
 def test_augassign_over_explicitly_unbound_local_builds_guarded_read() -> None:

--- a/implementations/rust/sugar-ir-types/src/membership.rs
+++ b/implementations/rust/sugar-ir-types/src/membership.rs
@@ -698,6 +698,11 @@ fn free_vars_in_term(term: &Term) -> BTreeSet<String> {
     match term {
         Term::Var { name } => BTreeSet::from([name.clone()]),
         Term::Const { .. } => BTreeSet::new(),
+        Term::Ctor { name, args } if name == "python:unpack_assign" && args.len() == 3 => {
+            let mut vars = free_vars_in_unpack_target(&args[1]);
+            vars.extend(free_vars_in_term(&args[2]));
+            vars
+        }
         Term::Ctor { args, .. } => args.iter().flat_map(free_vars_in_term).collect(),
         Term::Lambda {
             param_name, body, ..
@@ -714,5 +719,20 @@ fn free_vars_in_term(term: &Term) -> BTreeSet<String> {
             }
             vars
         }
+    }
+}
+
+fn free_vars_in_unpack_target(term: &Term) -> BTreeSet<String> {
+    match term {
+        Term::Var { .. } => BTreeSet::new(),
+        Term::Ctor { name, args }
+            if matches!(
+                name.as_str(),
+                "python:unpack_targets" | "python:tuple_target" | "python:list_target"
+            ) =>
+        {
+            args.iter().flat_map(free_vars_in_unpack_target).collect()
+        }
+        other => free_vars_in_term(other),
     }
 }

--- a/implementations/rust/sugar-ir-types/tests/proofir_membership.rs
+++ b/implementations/rust/sugar-ir-types/tests/proofir_membership.rs
@@ -308,6 +308,29 @@ fn free_vars(term: Term) -> std::collections::BTreeSet<String> {
 }
 
 #[test]
+fn unpack_target_names_are_store_patterns_not_free_values() {
+    let wire = json!({
+        "kind": "ctor",
+        "name": "python:unpack_assign",
+        "args": [
+            {"kind": "const", "value": "tuple", "sort": {"kind": "primitive", "name": "String"}},
+            {"kind": "ctor", "name": "python:unpack_targets", "args": [
+                {"kind": "var", "name": "a"},
+                {"kind": "ctor", "name": "python:tuple_target", "args": [
+                    {"kind": "var", "name": "b"},
+                    {"kind": "var", "name": "c"}
+                ]}
+            ]},
+            {"kind": "var", "name": "rhs"}
+        ]
+    });
+    let term: Term = serde_json::from_value(wire.clone()).expect("reference term parses");
+
+    assert_eq!(serde_json::to_value(&term).expect("term serializes"), wire);
+    assert_eq!(free_vars(term), ["rhs".to_string()].into());
+}
+
+#[test]
 fn python_comprehension_lambda_survives_rust_parse_and_membership() {
     let term = document_post_term(python_comprehension_document(
         "[f(x, y) for x in xs]",


### PR DESCRIPTION
## Summary

- mint one source-authenticated `UnpackAssignmentSlot` for symbolic tuple/list destructuring
- bind flat and nested name targets to typed structural `Position` projection paths
- emit the reference-ordered `python:unpack_assign(kind, targets, rhs)` testimony and link every projection to its matching occurrence
- preserve loud arity mismatch, starred-target, mixed-store-target, wrong-slot, and invalid-path cases
- keep RHS construction/desugaring single-occurrence and keep `.sugar()` out of desugar

Part of #6078.

## Pandas R

Fresh `origin/main` (`82a26ebe`) versus this branch:

| axis | before | after | delta |
|---|---:|---:|---:|
| destructuring Assign direct gaps | 1,749 | 56 | -1,693 |
| blocked descendants | 22 | 22 | 0 |

The 56 direct residuals are the deliberately out-of-scope starred and mixed attribute/subscript store patterns.

## Verification

- source-tree suite: `352 passed, 5 skipped, 1 xfailed`
- Python reference unpack tests: `17 passed`
- focused binding/projection twins: `35 passed`
- `R_no_sugar_in_desugar = 0`
- battleaxe Rust Python-source unpack round-trip: `1 passed, 0 failed`

Twins cover exact flat/nested paths, one slot mint, one RHS desugar, concrete arity mismatch, invalid/out-of-range projection linkage, and a false `b -> Position(0)` construction.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add symbolic destructuring assignment via unpack-occurrence slot binding
> - Introduces `UnpackValueBinding` and `GuardedUnpackValueBinding` floor values that represent typed unpack-assign IR terms, enabling invariant participation and callsite tracking for destructuring assignments.
> - Extends `nodes.Assign` substitution to detect name-only unpack patterns and mint a stable `UnpackAssignmentSlot` when symbolic unpacking is required; bound names resolve to typed `UnpackProjectionRef` nodes instead of gaps.
> - Adds `UnpackAssignSugar` and `UnpackProjectionSugar` classes to construct typed IR during the sugar phase; raises a construction panic when an unconstrained RHS cannot be represented soundly.
> - Fixes free-variable analysis in Python and Rust to treat unpack target names as store positions rather than free value reads.
> - Adds a `validate_unpack_projections` utility that panics at construction time when `python:unpack_projection` terms reference unmatched or malformed slots.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2daaa79.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->