### PR TITLE
feat: authenticated context-manager preconstruction resolution (With prerequisite 2/2)

### DIFF
--- a/docs/superpowers/plans/2026-07-22-cm-stack-soundness-review.md
+++ b/docs/superpowers/plans/2026-07-22-cm-stack-soundness-review.md
@@ -1,0 +1,80 @@
+# CM Stack Soundness Review Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make prerequisite 1 independently publish sealed typed CM declarations, then give prerequisite 2 discriminating phase-order and complete AST boundary floors.
+
+**Architecture:** Move only the typed kit publication boundary and dedicated compiler-feed integration from the stacked resolution branch into the publisher branch. Rebase the resolver stack, replace observational tests with planted regressions, and retain Rust-owned resolution without adding With semantics.
+
+**Tech Stack:** Python 3, pytest, Rust, cargo tests through battleaxe `bin/sugarbin`, GitHub stacked PRs.
+
+## Global Constraints
+
+- No ContractBody, formula atoms, or function-contract minting in the CM publication arm.
+- Tree and Sugar construction consume only injected typed refs.
+- Heavy Rust verification runs only on battleaxe through `bin/sugarbin`.
+- Both PRs remain non-draft and are never self-merged.
+
+---
+
+### Task 1: Restore the prerequisite-1 publication boundary
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_context_manager_contract.py`
+- Modify: `implementations/rust/sugar-compiler/src/feed_from_tree.rs`
+- Modify: `implementations/rust/sugar-compiler/tests/context_manager_contract_feed.rs`
+
+**Interfaces:**
+- Consumes: `ContextManagerContractIrV1`
+- Produces: typed kit declaration rows sealed by `graph_from_context_manager_contract_ir`
+
+- [ ] Add a failing test proving the publisher branch exposes the typed declaration through the ordinary kit declaration/compiler feed.
+- [ ] Run the focused Python test and observe the missing production door failure.
+- [ ] Move the minimal typed publication boundary from prerequisite 2.
+- [ ] Run focused Python and battleaxe Rust round-trip/feed tests.
+- [ ] Commit and push PR #6072.
+
+### Task 2: Make the RPC order twin discriminating
+
+**Files:**
+- Modify: `implementations/rust/sugar-compiler/tests/prove_from_kit.rs`
+- Modify: the fixture RPC kit used by that test.
+
+**Interfaces:**
+- Consumes: production `fold_kit_to_pool` RPC sequence
+- Produces: an exact ordered event receipt
+
+- [ ] Replace the success-only assertion with a failing sequence assertion.
+- [ ] Confirm the planted bind-after-enumerate ordering fails.
+- [ ] Implement event capture and assert declarations, demands, bind, first semantic enumeration.
+- [ ] Run the focused battleaxe test green.
+
+### Task 3: Replace lexical floors with an AST detector
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_cm_construction_boundary.py`
+- Create: a focused detector helper beside the test if production reuse is unnecessary.
+
+**Interfaces:**
+- Consumes: complete `sugar_source_tree` and Sugar implementation roots
+- Produces: deterministic offender rows and R count
+
+- [ ] Write four planted tests for direct, nested-helper, aliased-import, and out-of-selected-file violations and observe the old floor miss them.
+- [ ] Implement AST import alias and call-chain recognition over every Python file in both roots.
+- [ ] Run all planted tests and the real-tree zero floor.
+- [ ] Rebase and push PR #6076.
+
+### Task 4: Verify and hand off
+
+**Files:**
+- No production changes.
+
+**Interfaces:**
+- Consumes: both final branch heads
+- Produces: battleaxe/Python receipts and architect review requests
+
+- [ ] Run focused and broad Python tests.
+- [ ] Run focused Rust and compiler checks on battleaxe through `bin/sugarbin`.
+- [ ] Confirm #6072 is based on main and #6076 is based on #6072 with no duplicated publication commit.
+- [ ] Re-request architect review on both non-draft PRs.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/cm_boundary_detector.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/cm_boundary_detector.py
@@ -1,0 +1,115 @@
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class BoundaryReport:
+    files_scanned: int
+    offenders: tuple[str, ...]
+
+    @property
+    def r(self) -> int:
+        return len(self.offenders)
+
+    def render(self) -> str:
+        return "\n".join(self.offenders)
+
+
+def scan_construction_boundary(
+    *, sugar_root: Path, source_tree_root: Path
+) -> BoundaryReport:
+    files = tuple(sorted(sugar_root.rglob("*.py"))) + tuple(
+        sorted(source_tree_root.rglob("*.py"))
+    )
+    offenders: list[str] = []
+    for path in files:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        visitor = _BoundaryVisitor(path)
+        visitor.visit(tree)
+        offenders.extend(visitor.offenders)
+    return BoundaryReport(
+        files_scanned=len(files), offenders=tuple(sorted(set(offenders)))
+    )
+
+
+_HARD_MODULES = (
+    "sugar_linker",
+    "sugar.linker",
+    "sugar_proof_catalog",
+    "sugar_proof_envelope",
+)
+_SOURCE_ORACLE = "sugar_lift_python_source.source_oracle"
+_SOURCE_ORACLE_BOUNDARIES = frozenset({
+    "tree.py", "corpus.py", "bench_backends.py", "fragment.py",
+})
+_FORBIDDEN_CALLS = frozenset({
+    "resolve_context_manager_demand",
+    "resolve_context_manager_import",
+    "decode_context_manager_contract",
+    "member_field",
+    "member_kind",
+    "read_proof_catalog",
+})
+_SOURCE_CALLS = frozenset({"path_source", "installed_module_source"})
+
+
+def _dotted(node: ast.expr) -> str | None:
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+class _BoundaryVisitor(ast.NodeVisitor):
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.aliases: dict[str, str] = {}
+        self.offenders: list[str] = []
+
+    def _record(self, node: ast.AST, reason: str) -> None:
+        self.offenders.append(f"{self.path}:{getattr(node, 'lineno', 0)}:{reason}")
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            local = alias.asname or alias.name.split(".")[0]
+            self.aliases[local] = alias.name
+            if alias.name.startswith(_HARD_MODULES):
+                self._record(node, f"forbidden import {alias.name}")
+            if alias.name == _SOURCE_ORACLE and self.path.name not in _SOURCE_ORACLE_BOUNDARIES:
+                self._record(node, f"source-oracle import outside setup boundary {alias.name}")
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        module = node.module or ""
+        for alias in node.names:
+            local = alias.asname or alias.name
+            target = f"{module}.{alias.name}" if module else alias.name
+            self.aliases[local] = target
+            if module.startswith(_HARD_MODULES) or alias.name in _FORBIDDEN_CALLS:
+                self._record(node, f"forbidden import {target}")
+            if (
+                module == _SOURCE_ORACLE
+                and self.path.name not in _SOURCE_ORACLE_BOUNDARIES
+            ):
+                self._record(node, f"source-oracle import outside setup boundary {target}")
+
+    def visit_Call(self, node: ast.Call) -> None:
+        dotted = _dotted(node.func)
+        if dotted:
+            head, _, tail = dotted.partition(".")
+            resolved = self.aliases.get(head, head)
+            if tail:
+                resolved = f"{resolved}.{tail}"
+            call_name = resolved.rsplit(".", 1)[-1]
+            if call_name in _FORBIDDEN_CALLS:
+                self._record(node, f"forbidden call {resolved}")
+            if (
+                call_name in _SOURCE_CALLS
+                and self.path.name not in _SOURCE_ORACLE_BOUNDARIES
+            ):
+                self._record(node, f"source-oracle call outside setup boundary {resolved}")
+        self.generic_visit(node)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -122,8 +122,8 @@ def _decode_signature(raw: Any) -> ImportSignatureV1:
     if not isinstance(raw["formals"], list) or not all(isinstance(v, str) for v in raw["formals"]):
         raise ContractRefProtocolError("malformed import formals")
     try:
-        from .context_manager_contract import _sort_from_json
-        sorts = tuple(_sort_from_json(value) for value in raw["sorts"])
+        from .context_manager_contract import _decode_sort
+        sorts = tuple(_decode_sort(value) for value in raw["sorts"])
     except (KeyError, TypeError, ContextManagerContractError) as exc:
         raise ContractRefProtocolError("malformed import sorts") from exc
     if len(sorts) != len(raw["formals"]):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -1,0 +1,216 @@
+"""Frozen, authenticated context-manager coordinates installed before construction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from .canonicalizer import blake3_512_of, encode_jcs
+from .context_manager_contract import (
+    ContextManagerContractError,
+    ContextManagerSemanticsV1,
+    _decode_semantics,
+    _json_value,
+)
+from .ir import Sort
+
+
+class ContractRefProtocolError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, order=True)
+class SourceFragmentCoordinateV1:
+    source_cid: str
+    start_line: int
+    start_col: int
+    end_line: int
+    end_col: int
+
+    @classmethod
+    def decode(cls, raw: Any) -> "SourceFragmentCoordinateV1":
+        if not isinstance(raw, dict) or set(raw) != {
+            "sourceCid", "startLine", "startCol", "endLine", "endCol"
+        }:
+            raise ContractRefProtocolError("malformed source-fragment coordinate")
+        values = (raw["startLine"], raw["startCol"], raw["endLine"], raw["endCol"])
+        if not isinstance(raw["sourceCid"], str) or not all(
+            isinstance(value, int) and value >= 0 for value in values
+        ):
+            raise ContractRefProtocolError("malformed source-fragment coordinate fields")
+        return cls(raw["sourceCid"], *values)
+
+    def wire(self) -> dict[str, Any]:
+        return {
+            "sourceCid": self.source_cid,
+            "startLine": self.start_line,
+            "startCol": self.start_col,
+            "endLine": self.end_line,
+            "endCol": self.end_col,
+        }
+
+
+@dataclass(frozen=True)
+class ImportSignatureV1:
+    formals: tuple[str, ...]
+    sorts: tuple[Sort, ...]
+
+
+@dataclass(frozen=True)
+class ContextManagerContractRefV1:
+    resolution_cid: str
+    demand_cid: str
+    use_site: SourceFragmentCoordinateV1
+    catalog_cid: str
+    member_cid: str
+    payload_cid: str
+    bridge_source_symbol: str
+    import_signature: ImportSignatureV1
+    semantics: ContextManagerSemanticsV1
+    source_warrant_cids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ContextManagerResolutionGapV1:
+    demand_cid: str
+    use_site: SourceFragmentCoordinateV1
+    target_symbol: str | None
+    kind: str
+    candidate_member_cids: tuple[str, ...]
+
+
+ContextManagerResolutionV1 = ContextManagerContractRefV1 | ContextManagerResolutionGapV1
+
+
+@dataclass(frozen=True)
+class ResolvedContractRefsV1:
+    catalog_cid: str
+    table_cid: str
+    by_use_site: Mapping[SourceFragmentCoordinateV1, ContextManagerResolutionV1]
+
+    def require(self, use_site: SourceFragmentCoordinateV1) -> ContextManagerResolutionV1:
+        try:
+            return self.by_use_site[use_site]
+        except KeyError as exc:
+            raise ContractRefProtocolError(
+                "BackendDefect: enrolled context-manager demand missing from resolution table"
+            ) from exc
+
+
+_GAP_KINDS = frozenset({
+    "runtime-selected", "unresolved-symbol", "ambiguous-symbol",
+    "wrong-contract-kind", "signature-mismatch", "unauthenticated-member",
+    "payload-cid-mismatch", "unsupported-cm-schema",
+})
+
+
+def _cid(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.startswith("blake3-512:"):
+        raise ContractRefProtocolError(f"{field} must be a CID")
+    return value
+
+
+def _decode_signature(raw: Any) -> ImportSignatureV1:
+    if not isinstance(raw, dict) or set(raw) != {"formals", "sorts"}:
+        raise ContractRefProtocolError("malformed import signature")
+    if not isinstance(raw["formals"], list) or not all(isinstance(v, str) for v in raw["formals"]):
+        raise ContractRefProtocolError("malformed import formals")
+    try:
+        from .context_manager_contract import _sort_from_json
+        sorts = tuple(_sort_from_json(value) for value in raw["sorts"])
+    except (KeyError, TypeError, ContextManagerContractError) as exc:
+        raise ContractRefProtocolError("malformed import sorts") from exc
+    if len(sorts) != len(raw["formals"]):
+        raise ContractRefProtocolError("import signature arity mismatch")
+    return ImportSignatureV1(tuple(raw["formals"]), sorts)
+
+
+def _resolution_cid_preimage(raw: dict[str, Any]) -> dict[str, Any]:
+    return {key: raw[key] for key in (
+        "schemaVersion", "demandCid", "useSite", "catalogCid", "memberCid",
+        "payloadCid", "bridgeSourceSymbol", "importSignature", "semantics",
+        "sourceWarrantCids",
+    )}
+
+
+def _hash_json(raw: Any) -> str:
+    return blake3_512_of(encode_jcs(_json_value(raw)))
+
+
+def _decode_ref(raw: Any) -> ContextManagerContractRefV1:
+    expected = {
+        "kind", "schemaVersion", "resolutionCid", "demandCid", "useSite",
+        "catalogCid", "memberCid", "payloadCid", "bridgeSourceSymbol",
+        "importSignature", "semantics", "sourceWarrantCids",
+    }
+    if not isinstance(raw, dict) or set(raw) != expected:
+        raise ContractRefProtocolError("malformed context-manager contract ref")
+    if raw["kind"] != "context-manager-contract-ref" or raw["schemaVersion"] != "1":
+        raise ContractRefProtocolError("unsupported context-manager contract ref")
+    resolution_cid = _cid(raw["resolutionCid"], "resolutionCid")
+    if _hash_json(_resolution_cid_preimage(raw)) != resolution_cid:
+        raise ContractRefProtocolError("resolution CID mismatch")
+    try:
+        semantics = _decode_semantics(raw["semantics"])
+    except ContextManagerContractError as exc:
+        raise ContractRefProtocolError("unsupported context-manager semantics") from exc
+    warrants = raw["sourceWarrantCids"]
+    if not isinstance(warrants, list):
+        raise ContractRefProtocolError("sourceWarrantCids must be a list")
+    return ContextManagerContractRefV1(
+        resolution_cid, _cid(raw["demandCid"], "demandCid"),
+        SourceFragmentCoordinateV1.decode(raw["useSite"]),
+        _cid(raw["catalogCid"], "catalogCid"), _cid(raw["memberCid"], "memberCid"),
+        _cid(raw["payloadCid"], "payloadCid"), raw["bridgeSourceSymbol"],
+        _decode_signature(raw["importSignature"]), semantics,
+        tuple(_cid(value, "sourceWarrantCid") for value in warrants),
+    )
+
+
+def decode_resolved_contract_refs(raw: Any) -> ResolvedContractRefsV1:
+    if not isinstance(raw, dict) or set(raw) != {
+        "kind", "schemaVersion", "catalogCid", "tableCid", "byUseSite"
+    } or raw["kind"] != "resolved-contract-refs" or raw["schemaVersion"] != "1":
+        raise ContractRefProtocolError("malformed resolved-contract-ref table")
+    table_cid = _cid(raw["tableCid"], "tableCid")
+    identity = {key: raw[key] for key in ("kind", "schemaVersion", "catalogCid", "byUseSite")}
+    if _hash_json(identity) != table_cid:
+        raise ContractRefProtocolError("resolution table CID mismatch")
+    rows = raw["byUseSite"]
+    if not isinstance(rows, list):
+        raise ContractRefProtocolError("byUseSite must be a list")
+    decoded: dict[SourceFragmentCoordinateV1, ContextManagerResolutionV1] = {}
+    catalog_cid = _cid(raw["catalogCid"], "catalogCid")
+    for row in rows:
+        if not isinstance(row, dict) or set(row) != {"useSite", "resolution"}:
+            raise ContractRefProtocolError("malformed resolution row")
+        use_site = SourceFragmentCoordinateV1.decode(row["useSite"])
+        resolution = row["resolution"]
+        if not isinstance(resolution, dict):
+            raise ContractRefProtocolError("malformed resolution")
+        if resolution.get("kind") == "resolved" and set(resolution) == {"kind", "reference"}:
+            value: ContextManagerResolutionV1 = _decode_ref(resolution["reference"])
+            if value.use_site != use_site or value.catalog_cid != catalog_cid:
+                raise ContractRefProtocolError("resolution coordinate/catalog mismatch")
+        elif resolution.get("kind") == "unresolved" and set(resolution) == {"kind", "gap"}:
+            gap = resolution["gap"]
+            if not isinstance(gap, dict) or gap.get("kind") not in _GAP_KINDS:
+                raise ContractRefProtocolError("malformed context-manager resolution gap")
+            candidates = gap.get("candidateMemberCids")
+            if not isinstance(candidates, list) or candidates != sorted(candidates):
+                raise ContractRefProtocolError("candidate member CIDs must be sorted")
+            value = ContextManagerResolutionGapV1(
+                _cid(gap.get("demandCid"), "demandCid"),
+                SourceFragmentCoordinateV1.decode(gap.get("useSite")),
+                gap.get("targetSymbol"), gap["kind"],
+                tuple(_cid(v, "candidateMemberCid") for v in candidates),
+            )
+            if value.use_site != use_site:
+                raise ContractRefProtocolError("gap coordinate mismatch")
+        else:
+            raise ContractRefProtocolError("unknown context-manager resolution")
+        if use_site in decoded:
+            raise ContractRefProtocolError("duplicate resolution coordinate")
+        decoded[use_site] = value
+    return ResolvedContractRefsV1(catalog_cid, table_cid, MappingProxyType(decoded))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -98,6 +98,11 @@ class ResolvedContractRefsV1:
             ) from exc
 
 
+@dataclass(frozen=True)
+class TreeConstructionContextV1:
+    contract_refs: ResolvedContractRefsV1
+
+
 _GAP_KINDS = frozenset({
     "runtime-selected", "unresolved-symbol", "ambiguous-symbol",
     "wrong-contract-kind", "signature-mismatch", "unauthenticated-member",
@@ -135,7 +140,7 @@ def _resolution_cid_preimage(raw: dict[str, Any]) -> dict[str, Any]:
 
 
 def _hash_json(raw: Any) -> str:
-    return blake3_512_of(encode_jcs(_json_value(raw)))
+    return blake3_512_of(encode_jcs(_json_value(raw)).encode("utf-8"))
 
 
 def _decode_ref(raw: Any) -> ContextManagerContractRefV1:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2058,6 +2058,13 @@ def _dispatch_request(msg: Dict[str, Any]) -> bool:
     msg_id = msg.get("id")
     method = msg.get("method")
     params = msg.get("params", {})
+    sequence_path = os.environ.get("SUGAR_RPC_SEQUENCE_LOG")
+    if sequence_path:
+        suffix = ""
+        if method == ENUMERATE_RPC_METHOD and isinstance(params, dict):
+            suffix = f":{params.get('level', '')}"
+        with Path(sequence_path).open("a", encoding="utf-8") as sequence_log:
+            sequence_log.write(f"{method}{suffix}\n")
 
     if method == "initialize":
         _handle_initialize(msg_id)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -56,6 +56,7 @@ KIT_DECLARATION_RPC_METHOD = "sugar.plugin.kit_declaration"
 COMPONENT_PLAN_RPC_METHOD = "sugar.component.plan"
 RESOLVE_SOURCE_MEMENTO_RPC_METHOD = "sugar.plugin.resolve_source_memento"
 ENUMERATE_RPC_METHOD = "sugar.enumerate"
+BIND_CONTRACT_REFS_RPC_METHOD = "sugar.plugin.bind_contract_refs"
 COMPONENT_PROTOCOL_VERSION = "sugar-component/1"
 LIFT_PROTOCOL_VERSION = "pep/1.7.0"
 PYTHON_SURFACE = "python"
@@ -67,6 +68,7 @@ _TRANSPORT_LOG = logging.getLogger("sugar.kit.transport")
 _ENUMERATION_PHASES: Dict[str, tuple[int, float, float]] = {}
 _ENUMERATION_REQUEST_COUNT = 0
 _ENUMERATION_ACTIVE = False
+_BOUND_CONTRACT_REFS = None
 _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS: tuple[ContextManagerContractIrV1, ...] = ()
 
 
@@ -75,9 +77,64 @@ def publish_context_manager_declaration(
 ) -> None:
     """Publish a typed bodyless member on the live kit declaration."""
     global _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS
+    if _BOUND_CONTRACT_REFS is not None:
+        raise RuntimeError("context-manager declarations are frozen for this generation")
     if not isinstance(declaration, ContextManagerContractIrV1):
         raise ValueError("typed context-manager declaration required")
     _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS += (declaration,)
+
+
+def _context_manager_demand_rows(root: Path) -> List[Dict[str, Any]]:
+    """Enroll with-site import coordinates without constructing any Sugar."""
+    from sugar_lift_python_source.source_oracle import SourceUnavailable, path_source
+    from sugar_source_tree.tree import SourceTree
+
+    rows: List[Dict[str, Any]] = []
+    for path in SourceTree(root).paths():
+        try:
+            source, _filename, source_cid = path_source(str(path))
+        except SourceUnavailable:
+            continue
+        module = ast.parse(source, filename=str(path))
+        imports: Dict[str, str] = {}
+        for node in ast.walk(module):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                for alias in node.names:
+                    imports[alias.asname or alias.name] = f"{node.module}.{alias.name}"
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    imports[alias.asname or alias.name.split(".")[0]] = alias.name
+        for node in ast.walk(module):
+            if not isinstance(node, (ast.With, ast.AsyncWith)):
+                continue
+            for item in node.items:
+                expression = item.context_expr
+                target = None
+                if isinstance(expression, ast.Call) and not expression.args and not expression.keywords:
+                    callee = expression.func
+                    if isinstance(callee, ast.Name):
+                        target = imports.get(callee.id)
+                    elif isinstance(callee, ast.Attribute) and isinstance(callee.value, ast.Name):
+                        base = imports.get(callee.value.id)
+                        if base:
+                            target = f"{base}.{callee.attr}"
+                coordinate = {
+                    "sourceCid": source_cid,
+                    "startLine": expression.lineno,
+                    "startCol": expression.col_offset,
+                    "endLine": expression.end_lineno,
+                    "endCol": expression.end_col_offset,
+                }
+                rows.append({
+                    "schemaVersion": "1",
+                    "kind": "context-manager-demand",
+                    "useSite": coordinate,
+                    "targetSymbol": f"context-manager:{target}" if target else None,
+                    "importSignature": {"formals": [], "sorts": []},
+                    "expectedKind": "context-manager-contract",
+                    "gapKind": None if target else "runtime-selected",
+                })
+    return rows
 # Passive, process-lifetime context paid for by an enumeration demand. The
 # outer identity is the file content CID; the path seat is retained because
 # source mementos carry the workspace-relative filename even for identical
@@ -548,6 +605,7 @@ def _kit_declaration_result() -> Dict[str, Any]:
                 {"name": COMPONENT_PLAN_RPC_METHOD, "required": False},
                 {"name": RESOLVE_SOURCE_MEMENTO_RPC_METHOD, "required": False},
                 {"name": ENUMERATE_RPC_METHOD, "required": False},
+                {"name": BIND_CONTRACT_REFS_RPC_METHOD, "required": False},
                 {"name": "lift", "required": True},
                 {"name": "sugar.plugin.lift_implications", "required": False},
                 {"name": "sugar.plugin.resolve_dependency_proofs", "required": False},
@@ -1330,6 +1388,13 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
     at = params.get("at") if isinstance(params.get("at"), dict) else None
     seek = bool(params.get("seek", False))
     options = params.get("options") if isinstance(params.get("options"), dict) else {}
+    if _BOUND_CONTRACT_REFS is not None:
+        generation = options.get("contractRefs")
+        if generation != {
+            "catalogCid": _BOUND_CONTRACT_REFS.catalog_cid,
+            "tableCid": _BOUND_CONTRACT_REFS.table_cid,
+        }:
+            raise ValueError("semantic construction request has a stale contract-ref generation")
     # The audit frontier's factory census is deleted; auditFrontier now short-
     # circuits to an empty frontier (its R census re-homes onto the source
     # tree's reporter channel, not yet wired). allowedBrokenComponents was the
@@ -1347,6 +1412,16 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
     )
 
     try:
+        if level == "contract-declarations":
+            _send({"jsonrpc": "2.0", "id": msg_id, "result": {
+                "rows": [dict(row) for row in _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS]
+            }})
+            return
+        if level == "contract-demands":
+            _send({"jsonrpc": "2.0", "id": msg_id, "result": {
+                "rows": _context_manager_demand_rows(root)
+            }})
+            return
         if level == "source_files":
             # The source_files level IS SourceTree.fragments(): whole-file
             # fragments minted through the SourceOracle — identity without
@@ -1538,7 +1613,16 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                         ],
                     )
                     return
-                tree_file = _TreeSourceFile(identity)
+                from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+
+                construction_context = (
+                    TreeConstructionContextV1(_BOUND_CONTRACT_REFS)
+                    if _BOUND_CONTRACT_REFS is not None
+                    else None
+                )
+                tree_file = _TreeSourceFile(
+                    identity, construction_context=construction_context
+                )
                 nodes = []
                 for fn in tree_file.functions():
                     lc = fn.line_col_span()
@@ -2000,6 +2084,15 @@ def _dispatch_request(msg: Dict[str, Any]) -> bool:
         _handle_resolve_dependency_proofs(
             msg_id, params if isinstance(params, dict) else {}
         )
+    elif method == BIND_CONTRACT_REFS_RPC_METHOD:
+        from sugar_lift_py_tests.context_manager_resolution import decode_resolved_contract_refs
+
+        global _BOUND_CONTRACT_REFS
+        installed = decode_resolved_contract_refs(params)
+        if _BOUND_CONTRACT_REFS is not None and _BOUND_CONTRACT_REFS.table_cid != installed.table_cid:
+            raise ValueError("contract-ref generation is already frozen")
+        _BOUND_CONTRACT_REFS = installed
+        _send({"jsonrpc": "2.0", "id": msg_id, "result": {"tableCid": installed.table_cid}})
     elif method == ENUMERATE_RPC_METHOD:
         global _ENUMERATION_ACTIVE, _ENUMERATION_REQUEST_COUNT
         enumerate_started = time.monotonic()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -1414,7 +1414,10 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
     try:
         if level == "contract-declarations":
             _send({"jsonrpc": "2.0", "id": msg_id, "result": {
-                "rows": [dict(row) for row in _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS]
+                "rows": [
+                    row.to_rpc_with_term_table(None)
+                    for row in _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS
+                ]
             }})
             return
         if level == "contract-demands":

--- a/implementations/python/sugar-lift-py-tests/tests/test_cm_construction_boundary.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_cm_construction_boundary.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+
+def test_tree_and_sugar_construction_have_no_linker_catalog_or_metadata_door():
+    python_root = Path(__file__).resolve().parents[2]
+    sugar_root = python_root / "sugar-lift-py-tests/src/sugar_lift_py_tests/sugar"
+    tree_root = python_root / "sugar-source-tree/src/sugar_source_tree"
+    tree_construction = [
+        tree_root / "nodes.py",
+        tree_root / "backend.py",
+        *tree_root.glob("*_adapter.py"),
+    ]
+    files = [*sugar_root.rglob("*.py"), *tree_construction]
+    forbidden = (
+        "sugar_linker",
+        "sugar-linker",
+        "proof_catalog",
+        "member_envelope",
+        "decode_context_manager_contract",
+        "path_source(",
+        "installed_module_source(",
+    )
+    offenders = []
+    for path in files:
+        text = path.read_text()
+        for needle in forbidden:
+            if needle in text:
+                offenders.append(f"{path.relative_to(python_root)}: {needle}")
+    assert offenders == [], "construction-law offenders:\n" + "\n".join(offenders)
+
+
+def test_with_sugar_does_not_retain_raw_cm_json_or_invoke_resolution():
+    python_root = Path(__file__).resolve().parents[2]
+    files = [
+        python_root / "sugar-source-tree/src/sugar_source_tree/nodes.py",
+        *(
+            python_root / "sugar-lift-py-tests/src/sugar_lift_py_tests/sugar"
+        ).glob("with*_sugar.py"),
+    ]
+    forbidden = (
+        "resolve_context_manager",
+        "decode_context_manager",
+        "member_json",
+        "payload_json",
+        "catalog_json",
+    )
+    offenders = [
+        f"{path.name}: {needle}"
+        for path in files
+        for needle in forbidden
+        if needle in path.read_text()
+    ]
+    assert offenders == [], "With boundary offenders:\n" + "\n".join(offenders)

--- a/implementations/python/sugar-lift-py-tests/tests/test_cm_construction_boundary.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_cm_construction_boundary.py
@@ -1,53 +1,69 @@
 from pathlib import Path
 
+import pytest
 
-def test_tree_and_sugar_construction_have_no_linker_catalog_or_metadata_door():
-    python_root = Path(__file__).resolve().parents[2]
-    sugar_root = python_root / "sugar-lift-py-tests/src/sugar_lift_py_tests/sugar"
-    tree_root = python_root / "sugar-source-tree/src/sugar_source_tree"
-    tree_construction = [
-        tree_root / "nodes.py",
-        tree_root / "backend.py",
-        *tree_root.glob("*_adapter.py"),
-    ]
-    files = [*sugar_root.rglob("*.py"), *tree_construction]
-    forbidden = (
-        "sugar_linker",
-        "sugar-linker",
-        "proof_catalog",
-        "member_envelope",
-        "decode_context_manager_contract",
-        "path_source(",
-        "installed_module_source(",
+from sugar_lift_py_tests.cm_boundary_detector import scan_construction_boundary
+
+
+def _write(root: Path, relative: str, source: str) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "files",
+    [
+        {
+            "sugar/direct.py": (
+                "from sugar_linker import resolve_context_manager_demand\n"
+                "def sugar():\n    return resolve_context_manager_demand()\n"
+            )
+        },
+        {
+            "sugar/nested.py": (
+                "from sugar_linker import resolve_context_manager_demand\n"
+                "def helper():\n    return resolve_context_manager_demand()\n"
+                "def sugar():\n    return helper()\n"
+            )
+        },
+        {
+            "sugar/aliased.py": (
+                "import sugar_linker as hidden\n"
+                "def sugar():\n    return hidden.resolve_context_manager_demand()\n"
+            )
+        },
+        {
+            "sugar/entry.py": (
+                "from sugar_source_tree.outside_helper import lookup\n"
+                "def sugar():\n    return lookup()\n"
+            ),
+            "sugar_source_tree/outside_helper.py": (
+                "from sugar_linker import resolve_context_manager_demand as lookup\n"
+            ),
+        },
+    ],
+    ids=("direct", "nested-helper", "aliased-import", "outside-helper"),
+)
+def test_planted_boundary_violations_each_raise_r(files, tmp_path):
+    for relative, source in files.items():
+        _write(tmp_path, relative, source)
+    report = scan_construction_boundary(
+        sugar_root=tmp_path / "sugar",
+        source_tree_root=tmp_path / "sugar_source_tree",
     )
-    offenders = []
-    for path in files:
-        text = path.read_text()
-        for needle in forbidden:
-            if needle in text:
-                offenders.append(f"{path.relative_to(python_root)}: {needle}")
-    assert offenders == [], "construction-law offenders:\n" + "\n".join(offenders)
+    assert report.r > 0, report
 
 
-def test_with_sugar_does_not_retain_raw_cm_json_or_invoke_resolution():
+def test_complete_real_roots_have_stable_zero_boundary_residue():
     python_root = Path(__file__).resolve().parents[2]
-    files = [
-        python_root / "sugar-source-tree/src/sugar_source_tree/nodes.py",
-        *(
-            python_root / "sugar-lift-py-tests/src/sugar_lift_py_tests/sugar"
-        ).glob("with*_sugar.py"),
-    ]
-    forbidden = (
-        "resolve_context_manager",
-        "decode_context_manager",
-        "member_json",
-        "payload_json",
-        "catalog_json",
+    report = scan_construction_boundary(
+        sugar_root=python_root / "sugar-lift-py-tests/src/sugar_lift_py_tests/sugar",
+        source_tree_root=python_root / "sugar-source-tree/src/sugar_source_tree",
     )
-    offenders = [
-        f"{path.name}: {needle}"
-        for path in files
-        for needle in forbidden
-        if needle in path.read_text()
-    ]
-    assert offenders == [], "With boundary offenders:\n" + "\n".join(offenders)
+    assert report.files_scanned == len(list(
+        (python_root / "sugar-lift-py-tests/src/sugar_lift_py_tests/sugar").rglob("*.py")
+    )) + len(list(
+        (python_root / "sugar-source-tree/src/sugar_source_tree").rglob("*.py")
+    ))
+    assert report.r == 0, report.render()

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
@@ -126,18 +126,19 @@ def test_published_typed_declaration_is_served_only_by_declaration_pass(monkeypa
     from sugar_lift_py_tests.ir import PrimitiveSort
     from sugar_lift_py_tests.kit_rpc import ContextManagerContractIrV1, ImportSignatureV1
 
-    row = ContextManagerContractIrV1.never_suppresses(
+    declaration = ContextManagerContractIrV1.never_suppresses(
         bridge_source_symbol="context-manager:dependency.manager",
         import_signature=ImportSignatureV1(formals=(), sorts=()),
         enter_result_sort=PrimitiveSort("Value"),
         source_warrants=(),
-    ).to_rpc_with_term_table(None)
+    )
+    row = declaration.to_rpc_with_term_table(None)
     sent = []
     monkeypatch.setattr(lift_rpc, "_PUBLISHED_CONTEXT_MANAGER_DECLARATIONS", ())
     monkeypatch.setattr(lift_rpc, "_BOUND_CONTRACT_REFS", None)
     monkeypatch.setattr(lift_rpc, "_ENUMERATION_ACTIVE", False)
     monkeypatch.setattr(lift_rpc, "_send", sent.append)
-    lift_rpc.publish_context_manager_declaration(row)
+    lift_rpc.publish_context_manager_declaration(declaration)
     lift_rpc._handle_enumerate(9, {
         "level": "contract-declarations",
         "workspace_root": ".",

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
@@ -1,0 +1,96 @@
+from types import MappingProxyType
+
+import pytest
+
+from sugar_lift_py_tests import lift_rpc
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContractRefProtocolError,
+    ResolvedContractRefsV1,
+    SourceFragmentCoordinateV1,
+    _hash_json,
+    decode_resolved_contract_refs,
+)
+
+
+def unresolved_table():
+    cid = "blake3-512:" + "1" * 128
+    demand_cid = "blake3-512:" + "2" * 128
+    use_site = {
+        "sourceCid": cid,
+        "startLine": 3,
+        "startCol": 4,
+        "endLine": 3,
+        "endCol": 12,
+    }
+    identity = {
+        "kind": "resolved-contract-refs",
+        "schemaVersion": "1",
+        "catalogCid": cid,
+        "byUseSite": [{
+            "useSite": use_site,
+            "resolution": {
+                "kind": "unresolved",
+                "gap": {
+                    "demandCid": demand_cid,
+                    "useSite": use_site,
+                    "targetSymbol": "context-manager:fixture.missing",
+                    "kind": "unresolved-symbol",
+                    "candidateMemberCids": [],
+                },
+            },
+        }],
+    }
+    return {**identity, "tableCid": _hash_json(identity)}
+
+
+def test_table_is_frozen_and_missing_enrolled_coordinate_is_backend_defect():
+    table = decode_resolved_contract_refs(unresolved_table())
+    with pytest.raises(TypeError):
+        table.by_use_site[next(iter(table.by_use_site))] = object()
+    missing = SourceFragmentCoordinateV1("blake3-512:" + "3" * 128, 1, 0, 1, 1)
+    with pytest.raises(ContractRefProtocolError, match="BackendDefect"):
+        table.require(missing)
+
+
+def test_bind_rpc_freezes_one_generation_and_acknowledges_exact_table_cid(monkeypatch):
+    sent = []
+    monkeypatch.setattr(lift_rpc, "_BOUND_CONTRACT_REFS", None)
+    monkeypatch.setattr(lift_rpc, "_send", sent.append)
+    wire = unresolved_table()
+    assert lift_rpc._dispatch_request({
+        "jsonrpc": "2.0", "id": 7,
+        "method": lift_rpc.BIND_CONTRACT_REFS_RPC_METHOD,
+        "params": wire,
+    })
+    assert sent == [{"jsonrpc": "2.0", "id": 7, "result": {"tableCid": wire["tableCid"]}}]
+    assert isinstance(lift_rpc._BOUND_CONTRACT_REFS.by_use_site, MappingProxyType)
+
+    other = unresolved_table()
+    other["catalogCid"] = "blake3-512:" + "4" * 128
+    identity = {key: other[key] for key in ("kind", "schemaVersion", "catalogCid", "byUseSite")}
+    other["tableCid"] = _hash_json(identity)
+    with pytest.raises(ValueError, match="already frozen"):
+        lift_rpc._dispatch_request({
+            "jsonrpc": "2.0", "id": 8,
+            "method": lift_rpc.BIND_CONTRACT_REFS_RPC_METHOD,
+            "params": other,
+        })
+
+
+def test_malformed_table_cid_and_unsorted_ambiguity_are_loud():
+    stale = unresolved_table()
+    stale["tableCid"] = "blake3-512:" + "f" * 128
+    with pytest.raises(ContractRefProtocolError, match="table CID mismatch"):
+        decode_resolved_contract_refs(stale)
+
+    ambiguous = unresolved_table()
+    gap = ambiguous["byUseSite"][0]["resolution"]["gap"]
+    gap["kind"] = "ambiguous-symbol"
+    gap["candidateMemberCids"] = [
+        "blake3-512:" + "b" * 128,
+        "blake3-512:" + "a" * 128,
+    ]
+    identity = {key: ambiguous[key] for key in ("kind", "schemaVersion", "catalogCid", "byUseSite")}
+    ambiguous["tableCid"] = _hash_json(identity)
+    with pytest.raises(ContractRefProtocolError, match="must be sorted"):
+        decode_resolved_contract_refs(ambiguous)

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
@@ -94,3 +94,29 @@ def test_malformed_table_cid_and_unsorted_ambiguity_are_loud():
     ambiguous["tableCid"] = _hash_json(identity)
     with pytest.raises(ContractRefProtocolError, match="must be sorted"):
         decode_resolved_contract_refs(ambiguous)
+
+
+def test_demand_enrollment_uses_import_coordinate_without_sugar_or_target_source(
+    tmp_path, monkeypatch
+):
+    consumer = tmp_path / "consumer.py"
+    consumer.write_text(
+        "from dependency_that_is_not_present import manager as renamed\n"
+        "def f():\n"
+        "    with renamed():\n"
+        "        pass\n"
+    )
+    from sugar_source_tree.nodes import With
+
+    monkeypatch.setattr(
+        With,
+        "sugar",
+        lambda self: (_ for _ in ()).throw(AssertionError("demand pass constructed Sugar")),
+    )
+    rows = lift_rpc._context_manager_demand_rows(tmp_path)
+    assert len(rows) == 1
+    assert rows[0]["targetSymbol"] == (
+        "context-manager:dependency_that_is_not_present.manager"
+    )
+    assert rows[0]["gapKind"] is None
+    assert rows[0]["useSite"]["sourceCid"].startswith("blake3-512:")

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
@@ -120,3 +120,26 @@ def test_demand_enrollment_uses_import_coordinate_without_sugar_or_target_source
     )
     assert rows[0]["gapKind"] is None
     assert rows[0]["useSite"]["sourceCid"].startswith("blake3-512:")
+
+
+def test_published_typed_declaration_is_served_only_by_declaration_pass(monkeypatch):
+    from sugar_lift_py_tests.ir import PrimitiveSort
+    from sugar_lift_py_tests.kit_rpc import ContextManagerContractIrV1, ImportSignatureV1
+
+    row = ContextManagerContractIrV1.never_suppresses(
+        bridge_source_symbol="context-manager:dependency.manager",
+        import_signature=ImportSignatureV1(formals=(), sorts=()),
+        enter_result_sort=PrimitiveSort("Value"),
+        source_warrants=(),
+    ).to_rpc_with_term_table(None)
+    sent = []
+    monkeypatch.setattr(lift_rpc, "_PUBLISHED_CONTEXT_MANAGER_DECLARATIONS", ())
+    monkeypatch.setattr(lift_rpc, "_BOUND_CONTRACT_REFS", None)
+    monkeypatch.setattr(lift_rpc, "_ENUMERATION_ACTIVE", False)
+    monkeypatch.setattr(lift_rpc, "_send", sent.append)
+    lift_rpc.publish_context_manager_declaration(row)
+    lift_rpc._handle_enumerate(9, {
+        "level": "contract-declarations",
+        "workspace_root": ".",
+    })
+    assert sent[-1] == {"jsonrpc": "2.0", "id": 9, "result": {"rows": [row]}}

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -104,6 +104,7 @@ class SourceUnit:
     filename: str
     source: str
     source_cid: str
+    construction_context: object | None = None
 
     # populated in __post_init__, never by callers
     line_table: LineTable = field(init=False, default=None)  # type: ignore[assignment]

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
@@ -75,10 +75,14 @@ class SourceFile:
         identity: Tuple[str, str, str],
         backend: Optional[Backend] = None,
         reporter: AuditReporter = NULL_REPORTER,
+        construction_context: object | None = None,
     ) -> None:
         source, filename, source_cid = identity
         self.unit = SourceUnit(
-            filename=filename, source=source, source_cid=source_cid
+            filename=filename,
+            source=source,
+            source_cid=source_cid,
+            construction_context=construction_context,
         )
         self.backend = backend if backend is not None else _default_backend()
         # The reporter enters the whole tree here: the root carries it and

--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1765,6 +1765,7 @@ dependencies = [
  "sugar-ir-compiler",
  "sugar-ir-compiler-smt-lib",
  "sugar-ir-types",
+ "sugar-proof-envelope",
  "sugar-verifier",
 ]
 

--- a/implementations/rust/sugar-compiler/src/kit.rs
+++ b/implementations/rust/sugar-compiler/src/kit.rs
@@ -497,6 +497,49 @@ impl Kit {
         }
     }
 
+    pub fn bind_contract_refs(
+        &self,
+        table: &Value,
+    ) -> Result<String, crate::kit_path::LiftPluginKitError> {
+        let catalog_cid = table
+            .get("catalogCid")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                crate::kit_path::LiftPluginKitError::Failed(
+                    "contract-ref table missing catalogCid".into(),
+                )
+            })?;
+        let table_cid = table
+            .get("tableCid")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                crate::kit_path::LiftPluginKitError::Failed(
+                    "contract-ref table missing tableCid".into(),
+                )
+            })?;
+        let response = self
+            .connection
+            .clone()
+            .with_method("sugar.plugin.bind_contract_refs")
+            .request(table)?;
+        let acknowledged = response
+            .get("tableCid")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                crate::kit_path::LiftPluginKitError::Failed(
+                    "contract-ref bind response missing tableCid".into(),
+                )
+            })?;
+        if acknowledged != table_cid {
+            return Err(crate::kit_path::LiftPluginKitError::Failed(
+                "contract-ref bind acknowledged a different table CID".into(),
+            ));
+        }
+        self.connection
+            .install_contract_ref_generation(catalog_cid.to_owned(), table_cid.to_owned())?;
+        Ok(acknowledged.to_owned())
+    }
+
     /// SEAM 4 -- the testimony verb. Asks THIS kit (the one this handle
     /// rendezvous'd with) for its vendor dependency-proof catalog over
     /// `sugar.plugin.resolve_dependency_proofs`, decoded into typed,

--- a/implementations/rust/sugar-compiler/src/kit_path/lift_plugin.rs
+++ b/implementations/rust/sugar-compiler/src/kit_path/lift_plugin.rs
@@ -94,6 +94,7 @@ pub struct LiftPluginKit {
     resident: std::sync::Arc<ResidentSlot>,
     resident_max_requests: usize,
     terminal_error: std::sync::Arc<Mutex<Option<LiftPluginKitError>>>,
+    contract_ref_generation: std::sync::Arc<Mutex<Option<(String, String)>>>,
 }
 
 struct ResidentSlot(Mutex<Option<ResidentLifter>>);
@@ -186,6 +187,7 @@ impl LiftPluginKit {
             resident: std::sync::Arc::new(ResidentSlot(Mutex::new(None))),
             resident_max_requests,
             terminal_error: std::sync::Arc::new(Mutex::new(None)),
+            contract_ref_generation: std::sync::Arc::new(Mutex::new(None)),
         }
     }
 
@@ -256,6 +258,29 @@ impl LiftPluginKit {
         cache.ask(params, || {
             self.dispatch(params).map(|(_, response)| response)
         })
+    }
+
+    pub(crate) fn install_contract_ref_generation(
+        &self,
+        catalog_cid: String,
+        table_cid: String,
+    ) -> Result<(), LiftPluginKitError> {
+        *self.contract_ref_generation.lock().map_err(|_| {
+            LiftPluginKitError::Failed("contract-ref generation lock poisoned".into())
+        })? = Some((catalog_cid, table_cid));
+        Ok(())
+    }
+
+    pub(crate) fn contract_ref_generation(
+        &self,
+    ) -> Result<Option<(String, String)>, LiftPluginKitError> {
+        Ok(self
+            .contract_ref_generation
+            .lock()
+            .map_err(|_| {
+                LiftPluginKitError::Failed("contract-ref generation lock poisoned".into())
+            })?
+            .clone())
     }
 
     /// Promote a lift-plugin response term into the first-class primitive claim.

--- a/implementations/rust/sugar-compiler/src/orchestrate.rs
+++ b/implementations/rust/sugar-compiler/src/orchestrate.rs
@@ -475,7 +475,13 @@ pub fn fold_kit_to_pool(
     }
 
     // 7-8. Local semantic construction occurs only after ref installation.
-    let local = feed_from_tree::fold_project(kit, workspace_root, Some(&speaker))?;
+    let local = if active_cm_preconstruction.is_some() {
+        // The declaration graph was already sealed into the preliminary pool;
+        // this pass is semantic construction only.
+        feed_from_tree::fold_claim_tree(kit, workspace_root)?
+    } else {
+        feed_from_tree::fold_project(kit, workspace_root, Some(&speaker))?
+    };
     let local_pool =
         pool_from_graph_with_speaker(&local, speaker).map_err(ProveFromKitError::LocalLoad)?;
     pool.merge(local_pool);

--- a/implementations/rust/sugar-compiler/src/orchestrate.rs
+++ b/implementations/rust/sugar-compiler/src/orchestrate.rs
@@ -444,6 +444,7 @@ pub fn fold_kit_to_pool(
     // 3. Declaration-only enrollment and sealing. These rows never construct
     // a body and enter the ordinary authenticated pool through the dedicated
     // context-manager member arm.
+    let mut active_cm_preconstruction = None;
     if kit.supports_rpc_method("sugar.plugin.bind_contract_refs") {
         let declaration_rows = kit
             .context_manager_declarations(workspace_root)
@@ -470,6 +471,7 @@ pub fn fold_kit_to_pool(
         let table = ResolvedContractRefsV1::new(&catalog, &demands);
         kit.bind_contract_refs(&table.to_wire_value())
             .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+        active_cm_preconstruction = Some((catalog, table));
     }
 
     // 7-8. Local semantic construction occurs only after ref installation.
@@ -477,6 +479,15 @@ pub fn fold_kit_to_pool(
     let local_pool =
         pool_from_graph_with_speaker(&local, speaker).map_err(ProveFromKitError::LocalLoad)?;
     pool.merge(local_pool);
+
+    // 9. Recheck every resolved coordinate against the exact frozen snapshot
+    // after construction. Future CM edges use the same ref-owned equality
+    // check; this pass never reselects a candidate from the enlarged pool.
+    if let Some((catalog, table)) = &active_cm_preconstruction {
+        table
+            .final_check(catalog)
+            .map_err(|error| ProveFromKitError::Preconstruction(error.into()))?;
+    }
 
     Ok(pool)
 }

--- a/implementations/rust/sugar-compiler/src/orchestrate.rs
+++ b/implementations/rust/sugar-compiler/src/orchestrate.rs
@@ -55,7 +55,11 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use sugar_ir_compiler::registry::Registry as CompilerRegistry;
-use sugar_linker::{link, LinkerError, LinkerErrorKind, LinkerInputs};
+use sugar_linker::{
+    link, AuthenticatedContextManagerCatalog, ContextManagerContractDemandV1, LinkerError,
+    LinkerErrorKind, LinkerInputs, ResolvedContractRefsV1, SourceFragmentCoordinateV1, Symbol,
+};
+use sugar_proof_envelope::ImportSignatureV1;
 use sugar_proof_envelope::{build_proof_envelope, ProofEnvelopeInput, ProofGraph};
 use sugar_proof_envelope::{MementoPool, Speaker};
 use sugar_verifier::consistency::verify_consistency;
@@ -346,6 +350,8 @@ pub enum ProveFromKitError {
     LocalLoad(String),
     #[error("prove_from_kit: vendor testimony resolve failed: {0}")]
     Testimony(#[from] TestimonyError),
+    #[error("prove_from_kit: context-manager preconstruction failed: {0}")]
+    Preconstruction(String),
     #[error(transparent)]
     Solve(#[from] SolveError),
 }
@@ -391,15 +397,13 @@ pub fn fold_kit_to_pool(
     speaker: Speaker,
     cfg: &RunnerConfig,
 ) -> Result<MementoPool, ProveFromKitError> {
-    // 1. Local claim walk. Speaker is typed through fold so walk face and
-    // pool intake share one identity; stamping happens at step 2.
-    let local = feed_from_tree::fold_project(kit, workspace_root, Some(&speaker))?;
+    // Dependency testimony is the preliminary authenticated pool. It must be
+    // resident before any local tree construction: preconstruction contract
+    // declaration/catalog/demand binding reads this pool, while Sugar never
+    // does. Local construction is merged only after that front completes.
+    let mut pool = MementoPool::default();
 
-    // 2. Graph→pool intake with the consumer speaker (Task 7 door).
-    let mut pool =
-        pool_from_graph_with_speaker(&local, speaker).map_err(ProveFromKitError::LocalLoad)?;
-
-    // 3. Vendor testimony when the kit implements resolve_dependency_proofs.
+    // 1. Vendor testimony when the kit implements resolve_dependency_proofs.
     // Unavailable is a LINK-class absence (local-only prove still runs), not
     // a hard error — same law as Kit::testimony / resolve_testimony.
     //
@@ -430,14 +434,113 @@ pub fn fold_kit_to_pool(
         }
     }
 
-    // 4. CLI / RunnerConfig dependency proofs (same merge disk load_pool uses).
+    // 2. CLI / RunnerConfig dependency proofs (same merge disk load_pool uses).
     // Must happen here: `run_with_proof_run_with_pool` does not re-apply
     // `cfg.extra_proofs` (pool is already assembled).
     if !cfg.extra_proofs.is_empty() {
         load_proof_bytes_into_pool(&cfg.extra_proofs, &mut pool);
     }
 
+    // 3. Declaration-only enrollment and sealing. These rows never construct
+    // a body and enter the ordinary authenticated pool through the dedicated
+    // context-manager member arm.
+    if kit.supports_rpc_method("sugar.plugin.bind_contract_refs") {
+        let declaration_rows = kit
+            .context_manager_declarations(workspace_root)
+            .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+        for row in declaration_rows {
+            let graph = feed_from_tree::graph_from_context_manager_contract_ir(&row)?;
+            let declaration_pool = pool_from_graph_with_speaker(&graph, speaker.clone())
+                .map_err(ProveFromKitError::LocalLoad)?;
+            pool.merge(declaration_pool);
+        }
+
+        // 4-6. Freeze one authenticated snapshot, enroll non-constructing demands,
+        // prebind in Rust, then install the immutable typed table in the resident
+        // kit before any semantic enumeration begins.
+        let catalog = AuthenticatedContextManagerCatalog::freeze_from_pool(&pool)
+            .map_err(ProveFromKitError::Preconstruction)?;
+        let demand_rows = kit
+            .context_manager_demands(workspace_root)
+            .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+        let demands = demand_rows
+            .iter()
+            .map(context_manager_demand_from_wire)
+            .collect::<Result<Vec<_>, _>>()?;
+        let table = ResolvedContractRefsV1::new(&catalog, &demands);
+        kit.bind_contract_refs(&table.to_wire_value())
+            .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+    }
+
+    // 7-8. Local semantic construction occurs only after ref installation.
+    let local = feed_from_tree::fold_project(kit, workspace_root, Some(&speaker))?;
+    let local_pool =
+        pool_from_graph_with_speaker(&local, speaker).map_err(ProveFromKitError::LocalLoad)?;
+    pool.merge(local_pool);
+
     Ok(pool)
+}
+
+fn context_manager_demand_from_wire(
+    row: &serde_json::Value,
+) -> Result<ContextManagerContractDemandV1, ProveFromKitError> {
+    let schema = row.get("schemaVersion").and_then(serde_json::Value::as_str);
+    let kind = row.get("kind").and_then(serde_json::Value::as_str);
+    let expected = row.get("expectedKind").and_then(serde_json::Value::as_str);
+    if schema != Some("1")
+        || kind != Some("context-manager-demand")
+        || expected != Some("context-manager-contract")
+    {
+        return Err(ProveFromKitError::Preconstruction(
+            "unsupported context-manager demand row".into(),
+        ));
+    }
+    let use_site: SourceFragmentCoordinateV1 = serde_json::from_value(
+        row.get("useSite")
+            .cloned()
+            .ok_or_else(|| ProveFromKitError::Preconstruction("demand missing useSite".into()))?,
+    )
+    .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+    let signature = row
+        .get("importSignature")
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| {
+            ProveFromKitError::Preconstruction("demand missing importSignature".into())
+        })?;
+    let formals = serde_json::from_value(
+        signature
+            .get("formals")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!([])),
+    )
+    .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+    let sorts = serde_json::from_value(
+        signature
+            .get("sorts")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!([])),
+    )
+    .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+    let import_signature = ImportSignatureV1 { formals, sorts };
+    match row.get("targetSymbol") {
+        Some(serde_json::Value::String(symbol)) => Ok(ContextManagerContractDemandV1::new(
+            use_site,
+            Symbol::from(symbol.as_str()),
+            import_signature,
+        )),
+        Some(serde_json::Value::Null)
+            if row.get("gapKind").and_then(serde_json::Value::as_str)
+                == Some("runtime-selected") =>
+        {
+            Ok(ContextManagerContractDemandV1::runtime_selected(
+                use_site,
+                import_signature,
+            ))
+        }
+        _ => Err(ProveFromKitError::Preconstruction(
+            "demand target is neither an authenticated symbol nor runtime-selected".into(),
+        )),
+    }
 }
 
 impl From<ProofRunArtifactError> for SolveError {

--- a/implementations/rust/sugar-compiler/src/tree.rs
+++ b/implementations/rust/sugar-compiler/src/tree.rs
@@ -104,6 +104,8 @@ pub enum Level {
     Universe,
     Implications,
     Exports,
+    ContractDeclarations,
+    ContractDemands,
 }
 
 impl Level {
@@ -117,6 +119,8 @@ impl Level {
             Level::Universe => "universe",
             Level::Implications => "implications",
             Level::Exports => "exports",
+            Level::ContractDeclarations => "contract-declarations",
+            Level::ContractDemands => "contract-demands",
         }
     }
 }
@@ -805,6 +809,19 @@ fn enumerate_rpc(
     if !conn.allowed_broken_components.is_empty() {
         options["allowedBrokenComponents"] = json!(conn.allowed_broken_components);
     }
+    if let Some((catalog_cid, table_cid)) =
+        conn.transport
+            .contract_ref_generation()
+            .map_err(|error| EnumerateError::Unavailable {
+                plugin: plugin.clone(),
+                reason: error.to_string(),
+            })?
+    {
+        options["contractRefs"] = json!({
+            "catalogCid": catalog_cid,
+            "tableCid": table_cid,
+        });
+    }
     let response = conn
         .transport
         .request(&json!({
@@ -863,6 +880,36 @@ fn enumerate_rpc(
         .map(|arr| arr.iter().map(decode_gap).collect())
         .unwrap_or_default();
     Ok((nodes, gaps))
+}
+
+fn preconstruction_rows_rpc(conn: &KitConn, level: Level) -> Result<Vec<Value>, EnumerateError> {
+    let plugin = conn.surface.clone();
+    let response = conn
+        .transport
+        .request(&json!({
+            "level": level.wire(),
+            "workspace_root": conn.workspace_root.display().to_string(),
+        }))
+        .map_err(|error| EnumerateError::Unavailable {
+            plugin: plugin.clone(),
+            reason: error.to_string(),
+        })?;
+    let result = response
+        .get("result")
+        .unwrap_or(&response)
+        .as_object()
+        .ok_or_else(|| EnumerateError::Malformed {
+            plugin: plugin.clone(),
+            reason: "preconstruction response result must be an object".into(),
+        })?;
+    result
+        .get("rows")
+        .and_then(Value::as_array)
+        .cloned()
+        .ok_or_else(|| EnumerateError::Malformed {
+            plugin,
+            reason: "preconstruction response missing rows array".into(),
+        })
 }
 
 /// `LiftPluginKit::request` has already checked and removed the JSON-RPC
@@ -1342,6 +1389,23 @@ fn merge_recovered_audit_leaf(
 }
 
 impl Kit {
+    pub fn context_manager_declarations(
+        &self,
+        workspace_root: &Path,
+    ) -> Result<Vec<Value>, KitError> {
+        Ok(preconstruction_rows_rpc(
+            &self.enumerate_conn(workspace_root),
+            Level::ContractDeclarations,
+        )?)
+    }
+
+    pub fn context_manager_demands(&self, workspace_root: &Path) -> Result<Vec<Value>, KitError> {
+        Ok(preconstruction_rows_rpc(
+            &self.enumerate_conn(workspace_root),
+            Level::ContractDemands,
+        )?)
+    }
+
     /// Scan the producer surface. Export answers reuse the existing linker
     /// contract type; malformed or identity-mismatched answers are loud wire
     /// errors, never silently omitted exports.

--- a/implementations/rust/sugar-compiler/tests/prove_from_kit.rs
+++ b/implementations/rust/sugar-compiler/tests/prove_from_kit.rs
@@ -280,6 +280,26 @@ fn fold_project_loads_with_consumer_speaker() {
     }
 }
 
+#[test]
+fn production_fold_installs_cm_ref_generation_before_semantic_enumeration() {
+    if !python_blake3_available() {
+        eprintln!("skip: python3/blake3 unavailable");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let project = stage_fixture(dir.path());
+    let kit = Kit::rendezvous(python_kit_manifest(dir.path())).expect("rendezvous");
+    assert!(kit.supports_rpc_method("sugar.plugin.bind_contract_refs"));
+    let pool = fold_kit_to_pool(
+        &kit,
+        &project,
+        Speaker::consumer("cm-preconstruction-order"),
+        &runner_cfg(&project),
+    )
+    .expect("preconstruction bind must precede the first semantic enumerate request");
+    assert!(pool.mementos.len() > 0);
+}
+
 /// Full door: prove_from_kit discharges the enumerate fixture; verdict rows
 /// match solve_project_with_pool over the same consumer pool (identity of
 /// the thin face vs the preloaded-pool beats).

--- a/implementations/rust/sugar-compiler/tests/prove_from_kit.rs
+++ b/implementations/rust/sugar-compiler/tests/prove_from_kit.rs
@@ -101,12 +101,14 @@ fn python_kit_manifest(dir: &Path) -> LiftManifest {
         .join("sugar-lift-python-source")
         .join("src");
     let script = dir.join("python-lift.sh");
+    let rpc_sequence = dir.join("rpc-sequence.log");
     write_executable(
         &script,
         &format!(
-            "#!/bin/sh\nexport PYTHONPATH=\"{}:{}${{PYTHONPATH:+:$PYTHONPATH}}\"\nexec python3 -m sugar_lift_py_tests.lift_rpc --rpc\n",
+            "#!/bin/sh\nexport PYTHONPATH=\"{}:{}${{PYTHONPATH:+:$PYTHONPATH}}\"\nexport SUGAR_RPC_SEQUENCE_LOG=\"{}\"\nexec python3 -m sugar_lift_py_tests.lift_rpc --rpc\n",
             py_tests_src.display(),
-            py_source_src.display()
+            py_source_src.display(),
+            rpc_sequence.display(),
         ),
     );
     LiftManifest::resolved(
@@ -182,6 +184,43 @@ fn runner_cfg(project_root: &Path) -> RunnerConfig {
         legacy_z3_fallback: Some(LegacyZ3Fallback::compat("z3")),
         ..Default::default()
     }
+}
+
+fn validate_cm_preconstruction_sequence(sequence: &str) -> Result<(), String> {
+    let events: Vec<_> = sequence.lines().collect();
+    let position = |needle: &str| {
+        events
+            .iter()
+            .position(|event| *event == needle)
+            .ok_or_else(|| format!("missing {needle}; events={events:?}"))
+    };
+    let declarations = position("sugar.enumerate:contract-declarations")?;
+    let demands = position("sugar.enumerate:contract-demands")?;
+    let bind = position("sugar.plugin.bind_contract_refs")?;
+    let first_semantic = events
+        .iter()
+        .position(|event| {
+            event.starts_with("sugar.enumerate:")
+                && !event.ends_with(":contract-declarations")
+                && !event.ends_with(":contract-demands")
+        })
+        .ok_or_else(|| format!("missing semantic enumeration; events={events:?}"))?;
+    if declarations < demands && demands < bind && bind < first_semantic {
+        Ok(())
+    } else {
+        Err(format!("invalid CM preconstruction order: {events:?}"))
+    }
+}
+
+#[test]
+fn phase_order_detector_rejects_bind_after_first_semantic_enumeration() {
+    let planted = concat!(
+        "sugar.enumerate:contract-declarations\n",
+        "sugar.enumerate:contract-demands\n",
+        "sugar.enumerate:source_files\n",
+        "sugar.plugin.bind_contract_refs\n",
+    );
+    assert!(validate_cm_preconstruction_sequence(planted).is_err());
 }
 
 /// Sorted (property_name, status) pairs from a prove artifact — the gate
@@ -298,6 +337,10 @@ fn production_fold_installs_cm_ref_generation_before_semantic_enumeration() {
     )
     .expect("preconstruction bind must precede the first semantic enumerate request");
     assert!(pool.mementos.len() > 0);
+    let sequence = fs::read_to_string(dir.path().join("rpc-sequence.log"))
+        .expect("production kit must record the actual RPC sequence");
+    validate_cm_preconstruction_sequence(&sequence)
+        .expect("CM preconstruction RPC sequence must precede semantic enumeration");
 }
 
 /// Full door: prove_from_kit discharges the enumerate fixture; verdict rows

--- a/implementations/rust/sugar-linker/Cargo.toml
+++ b/implementations/rust/sugar-linker/Cargo.toml
@@ -20,5 +20,6 @@ sugar-verifier = { path = "../sugar-verifier" }
 sugar-ir-compiler = { path = "../sugar-ir-compiler" }
 sugar-ir-compiler-smt-lib = { path = "../sugar-ir-compiler-smt-lib" }
 sugar-claim-envelope = { path = "../sugar-claim-envelope" }
+sugar-proof-envelope = { path = "../sugar-proof-envelope" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/implementations/rust/sugar-linker/src/lib.rs
+++ b/implementations/rust/sugar-linker/src/lib.rs
@@ -48,6 +48,9 @@ use sugar_canonicalizer::{blake3_512_of, encode_jcs, Value as CanonValue};
 use sugar_ir_compiler::{CompilerInput, IrCompiler};
 use sugar_ir_compiler_smt_lib::{SmtLibCompiler, DIALECT as SMT_DIALECT};
 use sugar_ir_types::{IrFormula, Sort};
+use sugar_proof_envelope::{
+    AnchoredMember, ContextManagerSemanticsV1, ImportSignatureV1, Member, MemberKind, MementoCid,
+};
 use sugar_verifier::solvers::{run_plan, SolverHandle, SolverPlan, SolverSeat};
 use sugar_verifier::types::ObligationVerdict;
 
@@ -260,6 +263,317 @@ impl std::fmt::Display for Cid {
 impl AsRef<str> for Cid {
     fn as_ref(&self) -> &str {
         &self.0
+    }
+}
+
+// -------------------------------------------------------------------
+// Authenticated context-manager preconstruction resolution (#6071)
+// -------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct SourceFragmentCoordinateV1 {
+    #[serde(rename = "sourceCid")]
+    pub source_cid: Cid,
+    #[serde(rename = "startLine")]
+    pub start_line: usize,
+    #[serde(rename = "startCol")]
+    pub start_col: usize,
+    #[serde(rename = "endLine")]
+    pub end_line: usize,
+    #[serde(rename = "endCol")]
+    pub end_col: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextManagerContractDemandV1 {
+    pub demand_cid: Cid,
+    pub use_site: SourceFragmentCoordinateV1,
+    pub target_symbol: Symbol,
+    pub import_signature: ImportSignatureV1,
+}
+
+impl ContextManagerContractDemandV1 {
+    pub fn new(
+        use_site: SourceFragmentCoordinateV1,
+        target_symbol: Symbol,
+        import_signature: ImportSignatureV1,
+    ) -> Self {
+        let preimage = serde_json::json!({
+            "useSite": use_site,
+            "targetSymbol": target_symbol,
+            "importSignature": {
+                "formals": import_signature.formals,
+                "sorts": import_signature.sorts,
+            },
+            "expectedKind": "context-manager-contract",
+        });
+        let demand_cid = Cid::from(jcs_cid(&preimage));
+        Self {
+            demand_cid,
+            use_site,
+            target_symbol,
+            import_signature,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AuthenticatedContextManagerCatalog {
+    catalog_cid: Cid,
+    members: BTreeMap<Cid, Json>,
+}
+
+impl AuthenticatedContextManagerCatalog {
+    pub fn freeze(members: Vec<(Cid, Json)>) -> Result<Self, String> {
+        let mut by_cid = BTreeMap::new();
+        for (cid, envelope) in members {
+            let typed = MementoCid::try_parse(cid.as_str().to_string())
+                .map_err(|bad| format!("invalid catalog member CID: {bad}"))?;
+            AnchoredMember::new(typed, envelope.clone())?;
+            if by_cid.insert(cid.clone(), envelope).is_some() {
+                return Err(format!("duplicate catalog member CID: {cid}"));
+            }
+        }
+        let member_cids: Vec<&str> = by_cid.keys().map(Cid::as_str).collect();
+        let catalog_cid = Cid::from(jcs_cid(&serde_json::json!({"memberCids": member_cids})));
+        Ok(Self {
+            catalog_cid,
+            members: by_cid,
+        })
+    }
+
+    pub fn catalog_cid(&self) -> &Cid {
+        &self.catalog_cid
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ContextManagerResolutionGapKindV1 {
+    RuntimeSelected,
+    UnresolvedSymbol,
+    AmbiguousSymbol,
+    WrongContractKind,
+    SignatureMismatch,
+    UnauthenticatedMember,
+    PayloadCidMismatch,
+    UnsupportedCmSchema,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextManagerResolutionGapV1 {
+    pub demand_cid: Cid,
+    pub use_site: SourceFragmentCoordinateV1,
+    pub target_symbol: Option<Symbol>,
+    pub kind: ContextManagerResolutionGapKindV1,
+    pub candidate_member_cids: Vec<Cid>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextManagerContractRefV1 {
+    resolution_cid: Cid,
+    demand_cid: Cid,
+    use_site: SourceFragmentCoordinateV1,
+    catalog_cid: Cid,
+    member_cid: Cid,
+    payload_cid: Cid,
+    bridge_source_symbol: Symbol,
+    import_signature: ImportSignatureV1,
+    semantics: ContextManagerSemanticsV1,
+    source_warrant_cids: Vec<Cid>,
+}
+
+impl ContextManagerContractRefV1 {
+    pub fn resolution_cid(&self) -> &Cid {
+        &self.resolution_cid
+    }
+    pub fn demand_cid(&self) -> &Cid {
+        &self.demand_cid
+    }
+    pub fn use_site(&self) -> &SourceFragmentCoordinateV1 {
+        &self.use_site
+    }
+    pub fn catalog_cid(&self) -> &Cid {
+        &self.catalog_cid
+    }
+    pub fn member_cid(&self) -> &Cid {
+        &self.member_cid
+    }
+    pub fn payload_cid(&self) -> &Cid {
+        &self.payload_cid
+    }
+    pub fn bridge_source_symbol(&self) -> &Symbol {
+        &self.bridge_source_symbol
+    }
+    pub fn import_signature(&self) -> &ImportSignatureV1 {
+        &self.import_signature
+    }
+    pub fn semantics(&self) -> &ContextManagerSemanticsV1 {
+        &self.semantics
+    }
+    pub fn source_warrant_cids(&self) -> &[Cid] {
+        &self.source_warrant_cids
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContextManagerResolutionV1 {
+    Resolved(ContextManagerContractRefV1),
+    Unresolved(ContextManagerResolutionGapV1),
+}
+
+fn cm_gap(
+    demand: &ContextManagerContractDemandV1,
+    kind: ContextManagerResolutionGapKindV1,
+    mut candidates: Vec<Cid>,
+) -> ContextManagerResolutionV1 {
+    candidates.sort();
+    ContextManagerResolutionV1::Unresolved(ContextManagerResolutionGapV1 {
+        demand_cid: demand.demand_cid.clone(),
+        use_site: demand.use_site.clone(),
+        target_symbol: Some(demand.target_symbol.clone()),
+        kind,
+        candidate_member_cids: candidates,
+    })
+}
+
+pub fn resolve_context_manager_demand(
+    demand: &ContextManagerContractDemandV1,
+    catalog: &AuthenticatedContextManagerCatalog,
+) -> ContextManagerResolutionV1 {
+    let mut candidates = Vec::new();
+    for (cid, envelope) in &catalog.members {
+        if sugar_proof_envelope::member_field(envelope, "bridgeSourceSymbol").and_then(Json::as_str)
+            == Some(&demand.target_symbol.to_string())
+        {
+            candidates.push((cid.clone(), envelope));
+        }
+    }
+    if candidates.is_empty() {
+        return cm_gap(
+            demand,
+            ContextManagerResolutionGapKindV1::UnresolvedSymbol,
+            vec![],
+        );
+    }
+    if candidates.len() > 1 {
+        return cm_gap(
+            demand,
+            ContextManagerResolutionGapKindV1::AmbiguousSymbol,
+            candidates.into_iter().map(|v| v.0).collect(),
+        );
+    }
+    let (member_cid, envelope) = candidates.pop().expect("one candidate");
+    if sugar_proof_envelope::member_kind(envelope).ok() != Some(MemberKind::ContextManagerContract)
+    {
+        return cm_gap(
+            demand,
+            ContextManagerResolutionGapKindV1::WrongContractKind,
+            vec![member_cid],
+        );
+    }
+    let typed_cid = match MementoCid::try_parse(member_cid.as_str().to_string()) {
+        Ok(cid) => cid,
+        Err(_) => {
+            return cm_gap(
+                demand,
+                ContextManagerResolutionGapKindV1::UnauthenticatedMember,
+                vec![member_cid],
+            )
+        }
+    };
+    if AnchoredMember::new(typed_cid, envelope.clone()).is_err() {
+        return cm_gap(
+            demand,
+            ContextManagerResolutionGapKindV1::UnauthenticatedMember,
+            vec![member_cid],
+        );
+    }
+    let cm = match Member::from_value(envelope) {
+        Ok(Member::ContextManagerContract(cm)) => cm,
+        Err(error) if error.to_string().contains("payload CID") => {
+            return cm_gap(
+                demand,
+                ContextManagerResolutionGapKindV1::PayloadCidMismatch,
+                vec![member_cid],
+            );
+        }
+        Err(_) | Ok(_) => {
+            return cm_gap(
+                demand,
+                ContextManagerResolutionGapKindV1::UnsupportedCmSchema,
+                vec![member_cid],
+            )
+        }
+    };
+    if demand.import_signature.formals != cm.import_signature.formals
+        || demand.import_signature.sorts != cm.import_signature.sorts
+    {
+        return cm_gap(
+            demand,
+            ContextManagerResolutionGapKindV1::SignatureMismatch,
+            vec![member_cid],
+        );
+    }
+    let source_warrant_cids: Vec<Cid> = cm.source_warrants.iter().cloned().map(Cid::from).collect();
+    if source_warrant_cids
+        .iter()
+        .any(|cid| !catalog.members.contains_key(cid))
+    {
+        return cm_gap(
+            demand,
+            ContextManagerResolutionGapKindV1::UnauthenticatedMember,
+            vec![member_cid],
+        );
+    }
+    let payload_cid = Cid::from(cm.payload_cid.as_str());
+    let preimage = serde_json::json!({
+        "schemaVersion": "1", "demandCid": demand.demand_cid,
+        "useSite": demand.use_site, "catalogCid": catalog.catalog_cid,
+        "memberCid": member_cid, "payloadCid": payload_cid,
+        "bridgeSourceSymbol": demand.target_symbol,
+        "importSignature": {"formals": cm.import_signature.formals, "sorts": cm.import_signature.sorts},
+        "semantics": sugar_proof_envelope::context_manager_semantics_v1_to_json(&cm.semantics),
+        "sourceWarrantCids": source_warrant_cids,
+    });
+    let resolution_cid = Cid::from(jcs_cid(&preimage));
+    ContextManagerResolutionV1::Resolved(ContextManagerContractRefV1 {
+        resolution_cid,
+        demand_cid: demand.demand_cid.clone(),
+        use_site: demand.use_site.clone(),
+        catalog_cid: catalog.catalog_cid.clone(),
+        member_cid,
+        payload_cid,
+        bridge_source_symbol: demand.target_symbol.clone(),
+        import_signature: cm.import_signature,
+        semantics: cm.semantics,
+        source_warrant_cids,
+    })
+}
+
+pub fn final_check_context_manager_ref(
+    reference: &ContextManagerContractRefV1,
+    catalog: &AuthenticatedContextManagerCatalog,
+) -> Result<(), &'static str> {
+    if reference.catalog_cid != catalog.catalog_cid
+        || !catalog.members.contains_key(&reference.member_cid)
+    {
+        return Err("stale-resolution");
+    }
+    let demand = ContextManagerContractDemandV1 {
+        demand_cid: reference.demand_cid.clone(),
+        use_site: reference.use_site.clone(),
+        target_symbol: reference.bridge_source_symbol.clone(),
+        import_signature: reference.import_signature.clone(),
+    };
+    match resolve_context_manager_demand(&demand, catalog) {
+        ContextManagerResolutionV1::Resolved(now)
+            if now.member_cid == reference.member_cid
+                && now.resolution_cid == reference.resolution_cid =>
+        {
+            Ok(())
+        }
+        _ => Err("stale-resolution"),
     }
 }
 
@@ -1837,6 +2151,10 @@ fn compute_set_cid_sorted(sorted_items: &[String]) -> String {
 
 fn jcs_of_json(v: &Json) -> Vec<u8> {
     encode_jcs(&json_to_canon_value(v)).into_bytes()
+}
+
+fn jcs_cid(v: &Json) -> String {
+    blake3_512_of(&jcs_of_json(v))
 }
 
 /// JCS-canonical bytes of a typed formula. Lowers the `IrFormula` to its

--- a/implementations/rust/sugar-linker/src/lib.rs
+++ b/implementations/rust/sugar-linker/src/lib.rs
@@ -532,6 +532,21 @@ impl ResolvedContractRefsV1 {
         value
     }
 
+    pub fn final_check(
+        &self,
+        catalog: &AuthenticatedContextManagerCatalog,
+    ) -> Result<(), &'static str> {
+        if &self.catalog_cid != catalog.catalog_cid() {
+            return Err("stale-resolution");
+        }
+        for resolution in self.by_use_site.values() {
+            if let ContextManagerResolutionV1::Resolved(reference) = resolution {
+                final_check_context_manager_ref(reference, catalog)?;
+            }
+        }
+        Ok(())
+    }
+
     fn identity_value(&self) -> Json {
         let rows = self
             .by_use_site

--- a/implementations/rust/sugar-linker/src/lib.rs
+++ b/implementations/rust/sugar-linker/src/lib.rs
@@ -422,6 +422,120 @@ pub enum ContextManagerResolutionV1 {
     Unresolved(ContextManagerResolutionGapV1),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedContractRefsV1 {
+    catalog_cid: Cid,
+    table_cid: Cid,
+    by_use_site: BTreeMap<SourceFragmentCoordinateV1, ContextManagerResolutionV1>,
+}
+
+impl ResolvedContractRefsV1 {
+    pub fn new(
+        catalog: &AuthenticatedContextManagerCatalog,
+        demands: &[ContextManagerContractDemandV1],
+    ) -> Self {
+        let by_use_site = demands
+            .iter()
+            .map(|demand| {
+                (
+                    demand.use_site.clone(),
+                    resolve_context_manager_demand(demand, catalog),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let mut table = Self {
+            catalog_cid: catalog.catalog_cid.clone(),
+            table_cid: Cid::from(""),
+            by_use_site,
+        };
+        table.table_cid = Cid::from(jcs_cid(&table.identity_value()));
+        table
+    }
+
+    pub fn catalog_cid(&self) -> &Cid {
+        &self.catalog_cid
+    }
+
+    pub fn table_cid(&self) -> &Cid {
+        &self.table_cid
+    }
+
+    pub fn get(
+        &self,
+        use_site: &SourceFragmentCoordinateV1,
+    ) -> Option<&ContextManagerResolutionV1> {
+        self.by_use_site.get(use_site)
+    }
+
+    pub fn to_wire_value(&self) -> Json {
+        let mut value = self.identity_value();
+        value
+            .as_object_mut()
+            .expect("table object")
+            .insert("tableCid".into(), Json::String(self.table_cid.to_string()));
+        value
+    }
+
+    fn identity_value(&self) -> Json {
+        let rows = self
+            .by_use_site
+            .iter()
+            .map(|(use_site, resolution)| {
+                serde_json::json!({
+                    "useSite": use_site,
+                    "resolution": resolution_to_json(resolution),
+                })
+            })
+            .collect::<Vec<_>>();
+        serde_json::json!({
+            "kind": "resolved-contract-refs",
+            "schemaVersion": "1",
+            "catalogCid": self.catalog_cid,
+            "byUseSite": rows,
+        })
+    }
+}
+
+fn import_signature_to_json(value: &ImportSignatureV1) -> Json {
+    serde_json::json!({"formals": value.formals, "sorts": value.sorts})
+}
+
+fn reference_to_json(value: &ContextManagerContractRefV1) -> Json {
+    serde_json::json!({
+        "kind": "context-manager-contract-ref",
+        "schemaVersion": "1",
+        "resolutionCid": value.resolution_cid,
+        "demandCid": value.demand_cid,
+        "useSite": value.use_site,
+        "catalogCid": value.catalog_cid,
+        "memberCid": value.member_cid,
+        "payloadCid": value.payload_cid,
+        "bridgeSourceSymbol": value.bridge_source_symbol,
+        "importSignature": import_signature_to_json(&value.import_signature),
+        "semantics": sugar_proof_envelope::context_manager_semantics_v1_to_json(&value.semantics),
+        "sourceWarrantCids": value.source_warrant_cids,
+    })
+}
+
+fn resolution_to_json(value: &ContextManagerResolutionV1) -> Json {
+    match value {
+        ContextManagerResolutionV1::Resolved(reference) => serde_json::json!({
+            "kind": "resolved",
+            "reference": reference_to_json(reference),
+        }),
+        ContextManagerResolutionV1::Unresolved(gap) => serde_json::json!({
+            "kind": "unresolved",
+            "gap": {
+                "demandCid": gap.demand_cid,
+                "useSite": gap.use_site,
+                "targetSymbol": gap.target_symbol,
+                "kind": gap.kind,
+                "candidateMemberCids": gap.candidate_member_cids,
+            },
+        }),
+    }
+}
+
 fn cm_gap(
     demand: &ContextManagerContractDemandV1,
     kind: ContextManagerResolutionGapKindV1,

--- a/implementations/rust/sugar-linker/src/lib.rs
+++ b/implementations/rust/sugar-linker/src/lib.rs
@@ -366,6 +366,18 @@ impl AuthenticatedContextManagerCatalog {
     }
 
     pub fn freeze_from_pool(pool: &MementoPool) -> Result<Self, String> {
+        for cid in pool.mementos.keys() {
+            let attributed = pool.member_speaker(cid).is_some();
+            let enrolled = pool
+                .bundle_members
+                .values()
+                .any(|members| members.contains(cid));
+            if !attributed || !enrolled {
+                return Err(format!(
+                    "unauthenticated-member: {cid} lacks verified pool intake testimony"
+                ));
+            }
+        }
         let members = pool
             .mementos
             .iter()

--- a/implementations/rust/sugar-linker/src/lib.rs
+++ b/implementations/rust/sugar-linker/src/lib.rs
@@ -645,7 +645,7 @@ pub fn resolve_context_manager_demand(
                 vec![member_cid],
             );
         }
-        Err(_) | Ok(_) => {
+        Err(_) => {
             return cm_gap(
                 demand,
                 ContextManagerResolutionGapKindV1::UnsupportedCmSchema,

--- a/implementations/rust/sugar-linker/src/lib.rs
+++ b/implementations/rust/sugar-linker/src/lib.rs
@@ -39,7 +39,7 @@
 //! - `LinkerOutput.linker_errors` carries a `file` field so the daemon can
 //!   attach LSP diagnostics to the correct editor pane.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -49,7 +49,8 @@ use sugar_ir_compiler::{CompilerInput, IrCompiler};
 use sugar_ir_compiler_smt_lib::{SmtLibCompiler, DIALECT as SMT_DIALECT};
 use sugar_ir_types::{IrFormula, Sort};
 use sugar_proof_envelope::{
-    AnchoredMember, ContextManagerSemanticsV1, ImportSignatureV1, Member, MemberKind, MementoCid,
+    context_manager_contract_from_stored, AnchoredMember, ContextManagerSemanticsV1,
+    ImportSignatureV1, MemberKind, MementoCid, MementoPool, StoredMember,
 };
 use sugar_verifier::solvers::{run_plan, SolverHandle, SolverPlan, SolverSeat};
 use sugar_verifier::types::ObligationVerdict;
@@ -288,7 +289,7 @@ pub struct SourceFragmentCoordinateV1 {
 pub struct ContextManagerContractDemandV1 {
     pub demand_cid: Cid,
     pub use_site: SourceFragmentCoordinateV1,
-    pub target_symbol: Symbol,
+    pub target_symbol: Option<Symbol>,
     pub import_signature: ImportSignatureV1,
 }
 
@@ -311,7 +312,25 @@ impl ContextManagerContractDemandV1 {
         Self {
             demand_cid,
             use_site,
-            target_symbol,
+            target_symbol: Some(target_symbol),
+            import_signature,
+        }
+    }
+
+    pub fn runtime_selected(
+        use_site: SourceFragmentCoordinateV1,
+        import_signature: ImportSignatureV1,
+    ) -> Self {
+        let preimage = serde_json::json!({
+            "useSite": use_site,
+            "targetSymbol": Json::Null,
+            "importSignature": import_signature_to_json(&import_signature),
+            "expectedKind": "context-manager-contract",
+        });
+        Self {
+            demand_cid: Cid::from(jcs_cid(&preimage)),
+            use_site,
+            target_symbol: None,
             import_signature,
         }
     }
@@ -320,7 +339,8 @@ impl ContextManagerContractDemandV1 {
 #[derive(Debug, Clone)]
 pub struct AuthenticatedContextManagerCatalog {
     catalog_cid: Cid,
-    members: BTreeMap<Cid, Json>,
+    members: BTreeMap<Cid, StoredMember>,
+    authenticated_cids: BTreeSet<Cid>,
 }
 
 impl AuthenticatedContextManagerCatalog {
@@ -329,8 +349,10 @@ impl AuthenticatedContextManagerCatalog {
         for (cid, envelope) in members {
             let typed = MementoCid::try_parse(cid.as_str().to_string())
                 .map_err(|bad| format!("invalid catalog member CID: {bad}"))?;
-            AnchoredMember::new(typed, envelope.clone())?;
-            if by_cid.insert(cid.clone(), envelope).is_some() {
+            AnchoredMember::new(typed.clone(), envelope.clone())?;
+            let stored = StoredMember::from_envelope(typed, &envelope)
+                .map_err(|error| format!("invalid catalog member: {error}"))?;
+            if by_cid.insert(cid.clone(), stored).is_some() {
                 return Err(format!("duplicate catalog member CID: {cid}"));
             }
         }
@@ -338,7 +360,29 @@ impl AuthenticatedContextManagerCatalog {
         let catalog_cid = Cid::from(jcs_cid(&serde_json::json!({"memberCids": member_cids})));
         Ok(Self {
             catalog_cid,
+            authenticated_cids: by_cid.keys().cloned().collect(),
             members: by_cid,
+        })
+    }
+
+    pub fn freeze_from_pool(pool: &MementoPool) -> Result<Self, String> {
+        let members = pool
+            .mementos
+            .iter()
+            .map(|(cid, member)| (Cid::from(cid.as_str()), member.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let member_cids: Vec<&str> = members.keys().map(Cid::as_str).collect();
+        let catalog_cid = Cid::from(jcs_cid(&serde_json::json!({"memberCids": member_cids})));
+        let authenticated_cids = members
+            .keys()
+            .cloned()
+            .chain(pool.atoms.keys().map(|cid| Cid::from(cid.as_str())))
+            .chain(pool.body.keys().map(|cid| Cid::from(cid.as_str())))
+            .collect();
+        Ok(Self {
+            catalog_cid,
+            members,
+            authenticated_cids,
         })
     }
 
@@ -545,7 +589,7 @@ fn cm_gap(
     ContextManagerResolutionV1::Unresolved(ContextManagerResolutionGapV1 {
         demand_cid: demand.demand_cid.clone(),
         use_site: demand.use_site.clone(),
-        target_symbol: Some(demand.target_symbol.clone()),
+        target_symbol: demand.target_symbol.clone(),
         kind,
         candidate_member_cids: candidates,
     })
@@ -555,12 +599,19 @@ pub fn resolve_context_manager_demand(
     demand: &ContextManagerContractDemandV1,
     catalog: &AuthenticatedContextManagerCatalog,
 ) -> ContextManagerResolutionV1 {
+    let Some(target_symbol) = demand.target_symbol.as_ref() else {
+        return cm_gap(
+            demand,
+            ContextManagerResolutionGapKindV1::RuntimeSelected,
+            vec![],
+        );
+    };
     let mut candidates = Vec::new();
-    for (cid, envelope) in &catalog.members {
-        if sugar_proof_envelope::member_field(envelope, "bridgeSourceSymbol").and_then(Json::as_str)
-            == Some(&demand.target_symbol.to_string())
+    for (cid, member) in &catalog.members {
+        if member.field("bridgeSourceSymbol").and_then(Json::as_str)
+            == Some(&target_symbol.to_string())
         {
-            candidates.push((cid.clone(), envelope));
+            candidates.push((cid.clone(), member));
         }
     }
     if candidates.is_empty() {
@@ -577,34 +628,16 @@ pub fn resolve_context_manager_demand(
             candidates.into_iter().map(|v| v.0).collect(),
         );
     }
-    let (member_cid, envelope) = candidates.pop().expect("one candidate");
-    if sugar_proof_envelope::member_kind(envelope).ok() != Some(MemberKind::ContextManagerContract)
-    {
+    let (member_cid, member) = candidates.pop().expect("one candidate");
+    if member.kind() != MemberKind::ContextManagerContract {
         return cm_gap(
             demand,
             ContextManagerResolutionGapKindV1::WrongContractKind,
             vec![member_cid],
         );
     }
-    let typed_cid = match MementoCid::try_parse(member_cid.as_str().to_string()) {
-        Ok(cid) => cid,
-        Err(_) => {
-            return cm_gap(
-                demand,
-                ContextManagerResolutionGapKindV1::UnauthenticatedMember,
-                vec![member_cid],
-            )
-        }
-    };
-    if AnchoredMember::new(typed_cid, envelope.clone()).is_err() {
-        return cm_gap(
-            demand,
-            ContextManagerResolutionGapKindV1::UnauthenticatedMember,
-            vec![member_cid],
-        );
-    }
-    let cm = match Member::from_value(envelope) {
-        Ok(Member::ContextManagerContract(cm)) => cm,
+    let cm = match context_manager_contract_from_stored(member) {
+        Ok(cm) => cm,
         Err(error) if error.to_string().contains("payload CID") => {
             return cm_gap(
                 demand,
@@ -632,7 +665,7 @@ pub fn resolve_context_manager_demand(
     let source_warrant_cids: Vec<Cid> = cm.source_warrants.iter().cloned().map(Cid::from).collect();
     if source_warrant_cids
         .iter()
-        .any(|cid| !catalog.members.contains_key(cid))
+        .any(|cid| !catalog.authenticated_cids.contains(cid))
     {
         return cm_gap(
             demand,
@@ -645,7 +678,7 @@ pub fn resolve_context_manager_demand(
         "schemaVersion": "1", "demandCid": demand.demand_cid,
         "useSite": demand.use_site, "catalogCid": catalog.catalog_cid,
         "memberCid": member_cid, "payloadCid": payload_cid,
-        "bridgeSourceSymbol": demand.target_symbol,
+        "bridgeSourceSymbol": target_symbol,
         "importSignature": {"formals": cm.import_signature.formals, "sorts": cm.import_signature.sorts},
         "semantics": sugar_proof_envelope::context_manager_semantics_v1_to_json(&cm.semantics),
         "sourceWarrantCids": source_warrant_cids,
@@ -658,7 +691,7 @@ pub fn resolve_context_manager_demand(
         catalog_cid: catalog.catalog_cid.clone(),
         member_cid,
         payload_cid,
-        bridge_source_symbol: demand.target_symbol.clone(),
+        bridge_source_symbol: target_symbol.clone(),
         import_signature: cm.import_signature,
         semantics: cm.semantics,
         source_warrant_cids,
@@ -677,7 +710,7 @@ pub fn final_check_context_manager_ref(
     let demand = ContextManagerContractDemandV1 {
         demand_cid: reference.demand_cid.clone(),
         use_site: reference.use_site.clone(),
-        target_symbol: reference.bridge_source_symbol.clone(),
+        target_symbol: Some(reference.bridge_source_symbol.clone()),
         import_signature: reference.import_signature.clone(),
     };
     match resolve_context_manager_demand(&demand, catalog) {
@@ -689,6 +722,40 @@ pub fn final_check_context_manager_ref(
         }
         _ => Err("stale-resolution"),
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextManagerEdgeV1 {
+    target_contract_cid: Cid,
+    demand_cid: Cid,
+    resolution_cid: Cid,
+    catalog_cid: Cid,
+}
+
+impl ContextManagerEdgeV1 {
+    pub fn from_resolved(reference: &ContextManagerContractRefV1) -> Self {
+        Self {
+            target_contract_cid: reference.member_cid.clone(),
+            demand_cid: reference.demand_cid.clone(),
+            resolution_cid: reference.resolution_cid.clone(),
+            catalog_cid: reference.catalog_cid.clone(),
+        }
+    }
+}
+
+pub fn final_check_context_manager_edge(
+    edge: &ContextManagerEdgeV1,
+    reference: &ContextManagerContractRefV1,
+    catalog: &AuthenticatedContextManagerCatalog,
+) -> Result<(), &'static str> {
+    if edge.target_contract_cid != reference.member_cid
+        || edge.demand_cid != reference.demand_cid
+        || edge.resolution_cid != reference.resolution_cid
+        || edge.catalog_cid != reference.catalog_cid
+    {
+        return Err("stale-resolution");
+    }
+    final_check_context_manager_ref(reference, catalog)
 }
 
 /// The formals / sorts / EUF-coordinate triple a contract *exports* or a call

--- a/implementations/rust/sugar-linker/tests/context_manager_prebind.rs
+++ b/implementations/rust/sugar-linker/tests/context_manager_prebind.rs
@@ -4,10 +4,10 @@ use sugar_claim_envelope::{
 };
 use sugar_ir_types::Sort;
 use sugar_linker::{
-    final_check_context_manager_ref, resolve_context_manager_demand,
-    AuthenticatedContextManagerCatalog, Cid, ContextManagerContractDemandV1,
-    ContextManagerResolutionGapKindV1, ContextManagerResolutionV1, ResolvedContractRefsV1,
-    SourceFragmentCoordinateV1,
+    final_check_context_manager_edge, final_check_context_manager_ref,
+    resolve_context_manager_demand, AuthenticatedContextManagerCatalog, Cid,
+    ContextManagerContractDemandV1, ContextManagerEdgeV1, ContextManagerResolutionGapKindV1,
+    ContextManagerResolutionV1, ResolvedContractRefsV1, SourceFragmentCoordinateV1,
 };
 use sugar_proof_envelope::{
     ContextManagerSemanticsV1, EnterResultContractV1, ExitContractV1, ExitDispositionV1,
@@ -174,6 +174,52 @@ fn rust_owned_table_decodes_to_frozen_typed_python_refs() {
     assert_eq!(
         String::from_utf8(output.stdout).unwrap().trim(),
         table.table_cid().as_str()
+    );
+}
+
+#[test]
+fn runtime_selected_and_mutated_signed_member_never_construct_a_ref() {
+    let empty = AuthenticatedContextManagerCatalog::freeze(vec![]).unwrap();
+    let runtime = ContextManagerContractDemandV1::runtime_selected(
+        use_site(),
+        ImportSignatureV1 {
+            formals: vec![],
+            sorts: vec![],
+        },
+    );
+    let ContextManagerResolutionV1::Unresolved(gap) =
+        resolve_context_manager_demand(&runtime, &empty)
+    else {
+        panic!("runtime-selected gap")
+    };
+    assert_eq!(gap.kind, ContextManagerResolutionGapKindV1::RuntimeSelected);
+    assert!(gap.target_symbol.is_none());
+
+    let (cid, mut envelope) = minted("context-manager:fixture.never_closing", 12);
+    envelope["header"]["payload"]["exit"]["disposition"]["kind"] =
+        Json::String("unknown-disposition".into());
+    let error = AuthenticatedContextManagerCatalog::freeze(vec![(cid, envelope)]).unwrap_err();
+    assert!(
+        error.contains("attestation") || error.contains("signature"),
+        "{error}"
+    );
+}
+
+#[test]
+fn final_edge_is_pinned_to_the_exact_resolution_and_catalog() {
+    let member = minted("context-manager:fixture.never_closing", 13);
+    let catalog = AuthenticatedContextManagerCatalog::freeze(vec![member]).unwrap();
+    let ContextManagerResolutionV1::Resolved(reference) =
+        resolve_context_manager_demand(&demand("context-manager:fixture.never_closing"), &catalog)
+    else {
+        panic!("resolved")
+    };
+    let edge = ContextManagerEdgeV1::from_resolved(&reference);
+    final_check_context_manager_edge(&edge, &reference, &catalog).expect("exact pinned edge");
+    let drifted = AuthenticatedContextManagerCatalog::freeze(vec![]).unwrap();
+    assert_eq!(
+        final_check_context_manager_edge(&edge, &reference, &drifted).unwrap_err(),
+        "stale-resolution"
     );
 }
 use std::io::Write;

--- a/implementations/rust/sugar-linker/tests/context_manager_prebind.rs
+++ b/implementations/rust/sugar-linker/tests/context_manager_prebind.rs
@@ -6,7 +6,8 @@ use sugar_ir_types::Sort;
 use sugar_linker::{
     final_check_context_manager_ref, resolve_context_manager_demand,
     AuthenticatedContextManagerCatalog, Cid, ContextManagerContractDemandV1,
-    ContextManagerResolutionGapKindV1, ContextManagerResolutionV1, SourceFragmentCoordinateV1,
+    ContextManagerResolutionGapKindV1, ContextManagerResolutionV1, ResolvedContractRefsV1,
+    SourceFragmentCoordinateV1,
 };
 use sugar_proof_envelope::{
     ContextManagerSemanticsV1, EnterResultContractV1, ExitContractV1, ExitDispositionV1,
@@ -131,3 +132,50 @@ fn removing_selected_member_makes_final_check_stale_without_relinking() {
         "stale-resolution"
     );
 }
+
+#[test]
+fn rust_owned_table_decodes_to_frozen_typed_python_refs() {
+    let member = minted("context-manager:fixture.never_closing", 11);
+    let catalog = AuthenticatedContextManagerCatalog::freeze(vec![member]).unwrap();
+    let table =
+        ResolvedContractRefsV1::new(&catalog, &[demand("context-manager:fixture.never_closing")]);
+    assert_eq!(table.catalog_cid(), catalog.catalog_cid());
+    assert!(matches!(
+        table.get(&use_site()),
+        Some(ContextManagerResolutionV1::Resolved(_))
+    ));
+
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap()
+        .to_path_buf();
+    let mut child = Command::new("python3")
+        .env(
+            "PYTHONPATH",
+            repo.join("implementations/python/sugar-lift-py-tests/src"),
+        )
+        .arg("-c")
+        .arg("import json,sys; from sugar_lift_py_tests.context_manager_resolution import decode_resolved_contract_refs, ContextManagerContractRefV1; t=decode_resolved_contract_refs(json.load(sys.stdin)); v=t.require(next(iter(t.by_use_site))); assert isinstance(v, ContextManagerContractRefV1); assert v.member_cid and v.semantics.exit.disposition.kind == 'never-suppresses'; print(t.table_cid)")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    serde_json::to_writer(child.stdin.as_mut().unwrap(), &table.to_wire_value()).unwrap();
+    child.stdin.as_mut().unwrap().flush().unwrap();
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap().trim(),
+        table.table_cid().as_str()
+    );
+}
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};

--- a/implementations/rust/sugar-linker/tests/context_manager_prebind.rs
+++ b/implementations/rust/sugar-linker/tests/context_manager_prebind.rs
@@ -222,6 +222,31 @@ fn final_edge_is_pinned_to_the_exact_resolution_and_catalog() {
         "stale-resolution"
     );
 }
+
+#[test]
+fn exact_symbol_with_different_signature_stays_a_typed_gap() {
+    let member = minted("context-manager:fixture.never_closing", 14);
+    let catalog = AuthenticatedContextManagerCatalog::freeze(vec![member]).unwrap();
+    let mismatched = ContextManagerContractDemandV1::new(
+        use_site(),
+        "context-manager:fixture.never_closing".into(),
+        ImportSignatureV1 {
+            formals: vec!["value".into()],
+            sorts: vec![Sort::Primitive {
+                name: "Value".into(),
+            }],
+        },
+    );
+    let ContextManagerResolutionV1::Unresolved(gap) =
+        resolve_context_manager_demand(&mismatched, &catalog)
+    else {
+        panic!("signature-mismatch gap")
+    };
+    assert_eq!(
+        gap.kind,
+        ContextManagerResolutionGapKindV1::SignatureMismatch
+    );
+}
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};

--- a/implementations/rust/sugar-linker/tests/context_manager_prebind.rs
+++ b/implementations/rust/sugar-linker/tests/context_manager_prebind.rs
@@ -1,0 +1,133 @@
+use serde_json::Value as Json;
+use sugar_claim_envelope::{
+    mint_context_manager_contract, Authoring, MintContextManagerContractArgs,
+};
+use sugar_ir_types::Sort;
+use sugar_linker::{
+    final_check_context_manager_ref, resolve_context_manager_demand,
+    AuthenticatedContextManagerCatalog, Cid, ContextManagerContractDemandV1,
+    ContextManagerResolutionGapKindV1, ContextManagerResolutionV1, SourceFragmentCoordinateV1,
+};
+use sugar_proof_envelope::{
+    ContextManagerSemanticsV1, EnterResultContractV1, ExitContractV1, ExitDispositionV1,
+    ImportSignatureV1,
+};
+
+fn cid(fill: char) -> Cid {
+    Cid::from(format!("blake3-512:{}", fill.to_string().repeat(128)))
+}
+
+fn use_site() -> SourceFragmentCoordinateV1 {
+    SourceFragmentCoordinateV1 {
+        source_cid: cid('1'),
+        start_line: 3,
+        start_col: 9,
+        end_line: 3,
+        end_col: 22,
+    }
+}
+
+fn minted(symbol: &str, seed_byte: u8) -> (Cid, Json) {
+    let m = mint_context_manager_contract(&MintContextManagerContractArgs {
+        bridge_source_symbol: symbol.into(),
+        import_signature: ImportSignatureV1 {
+            formals: vec![],
+            sorts: vec![],
+        },
+        semantics: ContextManagerSemanticsV1 {
+            enter: EnterResultContractV1 {
+                sort: Sort::Primitive {
+                    name: "Value".into(),
+                },
+            },
+            exit: ExitContractV1 {
+                disposition: ExitDispositionV1::NeverSuppresses,
+            },
+        },
+        source_warrants: vec![],
+        produced_by: "fixture".into(),
+        produced_at: "2026-07-22T00:00:00.000Z".into(),
+        authoring: Authoring::KitAuthor {
+            author: "fixture".into(),
+            note: None,
+        },
+        signer_seed: [seed_byte; 32],
+    })
+    .unwrap();
+    (
+        Cid::from(m.cid),
+        serde_json::from_slice(&m.canonical_bytes).unwrap(),
+    )
+}
+
+fn demand(symbol: &str) -> ContextManagerContractDemandV1 {
+    ContextManagerContractDemandV1::new(
+        use_site(),
+        symbol.into(),
+        ImportSignatureV1 {
+            formals: vec![],
+            sorts: vec![],
+        },
+    )
+}
+
+#[test]
+fn truthful_member_prebinds_to_immutable_typed_ref() {
+    let member = minted("context-manager:fixture.never_closing", 7);
+    let catalog = AuthenticatedContextManagerCatalog::freeze(vec![member.clone()]).unwrap();
+    let ContextManagerResolutionV1::Resolved(reference) =
+        resolve_context_manager_demand(&demand("context-manager:fixture.never_closing"), &catalog)
+    else {
+        panic!("resolved")
+    };
+    assert_eq!(reference.member_cid(), &member.0);
+    assert_eq!(reference.catalog_cid(), catalog.catalog_cid());
+    assert_eq!(
+        reference.semantics().exit.disposition,
+        ExitDispositionV1::NeverSuppresses
+    );
+    final_check_context_manager_ref(&reference, &catalog)
+        .expect("same frozen catalog remains valid");
+}
+
+#[test]
+fn zero_and_many_candidates_are_loud_and_many_is_sorted() {
+    let empty = AuthenticatedContextManagerCatalog::freeze(vec![]).unwrap();
+    let ContextManagerResolutionV1::Unresolved(gap) =
+        resolve_context_manager_demand(&demand("context-manager:missing"), &empty)
+    else {
+        panic!("gap")
+    };
+    assert_eq!(
+        gap.kind,
+        ContextManagerResolutionGapKindV1::UnresolvedSymbol
+    );
+
+    let a = minted("context-manager:fixture.never_closing", 8);
+    let b = minted("context-manager:fixture.never_closing", 9);
+    let catalog = AuthenticatedContextManagerCatalog::freeze(vec![b.clone(), a.clone()]).unwrap();
+    let ContextManagerResolutionV1::Unresolved(gap) =
+        resolve_context_manager_demand(&demand("context-manager:fixture.never_closing"), &catalog)
+    else {
+        panic!("gap")
+    };
+    assert_eq!(gap.kind, ContextManagerResolutionGapKindV1::AmbiguousSymbol);
+    assert_eq!(gap.candidate_member_cids.len(), 2);
+    assert!(gap.candidate_member_cids[0] < gap.candidate_member_cids[1]);
+}
+
+#[test]
+fn removing_selected_member_makes_final_check_stale_without_relinking() {
+    let member = minted("context-manager:fixture.never_closing", 10);
+    let catalog = AuthenticatedContextManagerCatalog::freeze(vec![member]).unwrap();
+    let ContextManagerResolutionV1::Resolved(reference) =
+        resolve_context_manager_demand(&demand("context-manager:fixture.never_closing"), &catalog)
+    else {
+        panic!("resolved")
+    };
+    let drifted = AuthenticatedContextManagerCatalog::freeze(vec![]).unwrap();
+    assert_eq!(
+        final_check_context_manager_ref(&reference, &drifted).unwrap_err(),
+        "stale-resolution"
+    );
+}

--- a/implementations/rust/sugar-proof-envelope/src/lib.rs
+++ b/implementations/rust/sugar-proof-envelope/src/lib.rs
@@ -66,13 +66,13 @@ pub use sign::{
     SignatureParseError, ED25519_KEY_PREFIX, ED25519_SIG_PREFIX,
 };
 pub use typed_member::{
-    context_manager_semantics_v1_to_json, import_signature_v1_to_json,
-    AssertionSurfaceMementoMember, AuthorityMember, BridgeMember, ContextManagerContractMember,
-    ContextManagerSemanticsV1, ContractMember, EffectSiteAnnotationMember, EnterResultContractV1,
-    ExitContractV1, ExitDispositionV1, FactoryWalkMementoMember, ImplicationMember,
-    ImportSignatureV1, LibrarySugarBindingEntryMember, Member, MemberError, MemberKind,
-    PlanMementoMember, ProofRunMember, SourceMementoMember, StageReceiptMember, WitnessClaimMember,
-    WitnessMementoMember,
+    context_manager_contract_from_stored, context_manager_semantics_v1_to_json,
+    import_signature_v1_to_json, AssertionSurfaceMementoMember, AuthorityMember, BridgeMember,
+    ContextManagerContractMember, ContextManagerSemanticsV1, ContractMember,
+    EffectSiteAnnotationMember, EnterResultContractV1, ExitContractV1, ExitDispositionV1,
+    FactoryWalkMementoMember, ImplicationMember, ImportSignatureV1, LibrarySugarBindingEntryMember,
+    Member, MemberError, MemberKind, PlanMementoMember, ProofRunMember, SourceMementoMember,
+    StageReceiptMember, WitnessClaimMember, WitnessMementoMember,
 };
 
 #[derive(Debug, thiserror::Error)]

--- a/implementations/rust/sugar-proof-envelope/src/typed_member.rs
+++ b/implementations/rust/sugar-proof-envelope/src/typed_member.rs
@@ -1120,6 +1120,45 @@ impl ContextManagerContractMember {
     }
 }
 
+/// Decode a CM contract from a member already authenticated and normalized by
+/// `MementoPool`. This is the compiler/linker catalog boundary: it retains the
+/// typed fields needed for prebinding without reopening source or exposing a
+/// raw envelope to tree construction.
+pub fn context_manager_contract_from_stored(
+    member: &crate::StoredMember,
+) -> Result<ContextManagerContractMember, MemberError> {
+    if member.kind() != MemberKind::ContextManagerContract {
+        return Err(MemberError::InvalidContextManagerContract(
+            "stored member has the wrong contract kind".into(),
+        ));
+    }
+    let names = [
+        "schemaVersion",
+        "kind",
+        "cid",
+        "payloadCid",
+        "bridgeSourceSymbol",
+        "importSignature",
+        "payload",
+        "sourceWarrants",
+        "inputCids",
+    ];
+    let mut header = serde_json::Map::new();
+    for name in names {
+        let value = member.field(name).ok_or_else(|| {
+            MemberError::InvalidContextManagerContract(format!(
+                "authenticated stored member is missing `{name}`"
+            ))
+        })?;
+        header.insert(name.into(), value.clone());
+    }
+    ContextManagerContractMember::from_value(&serde_json::json!({
+        "envelope": {},
+        "header": header,
+        "metadata": {},
+    }))
+}
+
 /// Typed, parsed member. One variant per known kind.
 #[derive(Debug, Clone)]
 pub enum Member {


### PR DESCRIPTION
Replacement for #6076 after prerequisite 1 was squash-merged and GitHub made the closed, force-updated stacked PR impossible to reopen.

Implements prerequisite 2 from #6071 only:
- dependency/declaration loading and authenticated catalog freeze before semantic construction
- non-constructing CM-demand pass
- Rust-owned authenticated prebinding
- immutable typed ContextManagerContractRefV1 table injection before `.sugar()`
- typed loud unresolved/ambiguous/stale outcomes
- final linker CID consistency checks
- complete-root AST construction-boundary detector

Soundness twins:
- actual RPC order is declarations → demands → bind_contract_refs → first semantic sugar.enumerate
- planted bind-after-semantic sequence fails
- direct, nested-helper, aliased-import, and out-of-selected-file helper boundary violations each produce R > 0
- 7 authenticated prebinding/final-consistency twins pass on battleaxe

Validation at `5afe66e0a`:
- Python resolution + boundary focused: 10 passed
- battleaxe RPC-order twins: 2 passed
- battleaxe prebinding twins: 7 passed
- battleaxe cargo check -p sugar-compiler: passed

Part of #6071. Supersedes closed #6076.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add authenticated context-manager preconstruction resolution to the sugar compiler pipeline
> - Introduces a full preconstruction phase in [`orchestrate.rs`](https://github.com/TSavo/sugar/pull/6083/files#diff-0d18d3a8e114962da023e503539ccc32f8b551df4a336fcb701b0771d8238389): the compiler fetches CM contract declarations, authenticates a catalog, resolves demands against it, binds an immutable contract-ref generation via a new `sugar.plugin.bind_contract_refs` RPC, and verifies the binding post-construction before any semantic enumeration.
> - Adds `mint_context_manager_contract` in [`sugar-claim-envelope`](https://github.com/TSavo/sugar/pull/6083/files#diff-6ea4c24765a2c4d22efc09c18b613ee72025f19231827937424d071898895c6f) to produce signed, content-addressed context-manager contract envelopes with canonical JSON payloads and CID derivation.
> - Adds `AuthenticatedContextManagerCatalog` in [`sugar-linker`](https://github.com/TSavo/sugar/pull/6083/files#diff-40bcfb0dc37289a8b909fa64a8225cdf263ae8df46bb4d7be2bd79fed9b24d95) to build a verified catalog from raw envelopes or a `MementoPool`, rejecting unauthenticated members and producing a stable catalog CID for downstream resolution.
> - Introduces `ContextManagerContractMember` in [`typed_member.rs`](https://github.com/TSavo/sugar/pull/6083/files#diff-49af34c86e3e770a6efb57b43f610586381d5d1db08898f3f4d097328301aeeb) with strict schema/CID validation; `ProofGraph` gains a `push_context_manager_contract` method and `fold_project` now merges CM contract declarations into the proof graph.
> - Adds Python-side contract publishing (`publish_context_manager_declaration`), demand discovery (AST walking for `with`/`async with` uses), boundary violation scanning, and RPC binding/generation management in [`lift_rpc.py`](https://github.com/TSavo/sugar/pull/6083/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) and related modules.
> - Risk: the preconstruction bind step is irreversible per session — attempting to rebind to a different contract-ref generation raises an error, and local folding behavior changes (declaration step skipped) when preconstruction is active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e528a78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->