### PR TITLE
drain: nested ListComp and GeneratorExp coordinates (pandas R)

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3223,6 +3223,12 @@ class ListComp(Expression):
             for node in root.walk()
         )
 
+    def _contains_named_expression(self, roots: tuple) -> bool:
+        """True when a walrus would bind outside the comprehension coordinate."""
+        return any(
+            node.kind == "NamedExpr" for root in roots for node in root.walk()
+        )
+
     def _calls_shadowed_range(self, iterable, scope) -> bool:
         return (
             iterable.kind == "Call"
@@ -3269,8 +3275,8 @@ class ListComp(Expression):
         )
 
     def _construct_sugar(self):
-        gen = ListComp._simple_generator(self)
-        if gen is None or ListComp._contains_forbidden_shape(self, (self.elt,)):
+        gen = ListComp._simple_generator(self, allow_nested_iterable=True)
+        if gen is None or ListComp._contains_named_expression(self, (self.elt,)):
             return super()._construct_sugar()
         from sugar_lift_py_tests.sugar.comprehension_sugar import ComprehensionSugar
 
@@ -3282,7 +3288,7 @@ class ListComp(Expression):
             site=self.fragment,
         )
 
-    def _simple_generator(self):
+    def _simple_generator(self, *, allow_nested_iterable=False):
         if len(self.generators) != 1:
             return None
         gen = self.generators[0]
@@ -3290,7 +3296,11 @@ class ListComp(Expression):
             gen.is_async
             or gen.ifs
             or gen.target.kind != "Name"
-            or ListComp._contains_forbidden_shape(self, (gen.iter,))
+            or (
+                ListComp._contains_named_expression(self, (gen.iter,))
+                if allow_nested_iterable
+                else ListComp._contains_forbidden_shape(self, (gen.iter,))
+            )
         ):
             return None
         return gen
@@ -3516,8 +3526,8 @@ class GeneratorExp(Expression):
         return self if not changed else rewrite(self, **changed)
 
     def _construct_sugar(self):
-        gen = ListComp._simple_generator(self)
-        if gen is None or ListComp._contains_forbidden_shape(self, (self.elt,)):
+        gen = ListComp._simple_generator(self, allow_nested_iterable=True)
+        if gen is None or ListComp._contains_named_expression(self, (self.elt,)):
             return super()._construct_sugar()
         from sugar_lift_py_tests.sugar.comprehension_sugar import ComprehensionSugar
 

--- a/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
+++ b/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
@@ -150,6 +150,96 @@ def test_nested_lambda_same_name_does_not_escape_comprehension_transform():
     assert _free_vars_in_ir_term(term) == frozenset({"xs"})
 
 
+def test_nested_symbolic_listcomp_builds_composed_lambda_binders():
+    term = _out(
+        "def A(xs, ys, z):\n"
+        "    return [[f(x, y, z) for y in ys] for x in xs]\n"
+    )
+
+    assert term.name == "py.listcomp"
+    assert term.args[1].param_name == "x"
+    inner = term.args[1].body
+    assert inner.name == "py.listcomp"
+    assert inner.args[1].param_name == "y"
+    assert inner.args[1].body.name == "call:f"
+    assert _free_vars_in_ir_term(term) == frozenset({"xs", "ys", "z"})
+
+
+def test_nested_comprehension_iterable_builds_without_flattening():
+    term = _out(
+        "def A(ys):\n"
+        "    return [f(x) for x in [g(y) for y in ys]]\n"
+    )
+
+    assert term.name == "py.listcomp"
+    assert term.args[0].name == "py.listcomp"
+    assert term.args[0].args[1].param_name == "y"
+    assert term.args[1].param_name == "x"
+    assert _free_vars_in_ir_term(term) == frozenset({"ys"})
+
+
+def test_nested_generator_expression_retains_both_lazy_coordinates():
+    term = _out(
+        "def A(xs, ys):\n"
+        "    return ((f(x, y) for y in ys) for x in xs)\n"
+    )
+
+    assert term.name == "py.generatorexp"
+    assert term.args[1].param_name == "x"
+    inner = term.args[1].body
+    assert inner.name == "py.generatorexp"
+    assert inner.args[1].param_name == "y"
+    assert _free_vars_in_ir_term(term) == frozenset({"xs", "ys"})
+
+
+@pytest.mark.parametrize(
+    ("source", "outer", "inner", "free"),
+    [
+        (
+            "[{f(y) for y in ys} for x in xs]",
+            "py.listcomp",
+            "py.setcomp",
+            {"xs", "ys"},
+        ),
+        (
+            "({y: f(y) for y in ys} for x in xs)",
+            "py.generatorexp",
+            "py.dictcomp",
+            {"xs", "ys"},
+        ),
+        ("[x for x in {f(y) for y in ys}]", "py.listcomp", "py.setcomp", {"ys"}),
+    ],
+)
+def test_nested_arm_composes_already_built_comprehension_kinds(
+    source, outer, inner, free
+):
+    term = _out(f"def A(xs, ys):\n    return {source}\n")
+
+    assert term.name == outer
+    assert inner in {term.args[0].name, term.args[1].body.name}
+    assert _free_vars_in_ir_term(term) == frozenset(free)
+
+
+def test_nested_comprehension_does_not_admit_an_inner_filtered_gap():
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(xs, ys):\n"
+            "    return [[y for y in ys if keep(y)] for x in xs]\n"
+        ).sugar()
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "{x for x in [y for y in ys]}",
+        "{x: x for x in [y for y in ys]}",
+    ],
+)
+def test_list_generator_nested_arm_does_not_widen_set_or_dict(source):
+    with pytest.raises(SugarNotWritten):
+        _fn(f"def A(ys):\n    return {source}\n").sugar()
+
+
 def test_bound_target_masks_outer_same_spelling_and_keeps_call_coordinate():
     term = _out(
         "def A(xs):\n"
@@ -238,8 +328,6 @@ def test_every_filter_must_be_ground_decidable():
 @pytest.mark.parametrize(
     "source",
     [
-        "[y for x in [[1]] for y in x]",
-        "[[y for y in [1]] for x in [1]]",
         "[(y := x) for x in [1]]",
     ],
 )
@@ -248,7 +336,7 @@ def test_unsupported_comprehension_structures_stay_loud(source):
         _fn(f"def A():\n    return {source}\n").sugar()
 
 
-def test_nested_comprehension_substitutes_outer_capture_before_own_gap():
+def test_nested_comprehension_substitutes_outer_capture_before_building():
     fn = _fn(
         "def A():\n"
         "    values = [1]\n"
@@ -257,8 +345,10 @@ def test_nested_comprehension_substitutes_outer_capture_before_own_gap():
     expression = fn.substitute({}).body[-1].value
     nested = expression.elt
     assert nested.generators[0].iter.kind == "List"
-    with pytest.raises(SugarNotWritten):
-        expression.sugar()
+    value = expression.sugar().desugar().value
+    assert value.term.name == "py.listcomp"
+    assert value.term.args[1].body.name == "py.listcomp"
+    assert value.term.args[1].body.args[0].name == "array"
 
 
 def test_walrus_comprehension_substitutes_outer_capture_before_own_gap():

--- a/implementations/rust/sugar-ir-types/tests/proofir_membership.rs
+++ b/implementations/rust/sugar-ir-types/tests/proofir_membership.rs
@@ -422,3 +422,53 @@ fn python_generator_expression_stays_lazy_after_rust_parse() {
     );
     assert_eq!(free_vars(lazy), ["xs".to_string()].into());
 }
+
+#[test]
+fn nested_python_comprehension_lambdas_survive_rust_parse() {
+    let term = document_post_term(python_comprehension_document(
+        "[[f(x, y, z) for y in ys] for x in xs]",
+        "xs, ys, z",
+    ));
+    let Term::Ctor { name, args } = &term else {
+        panic!("outer comprehension must remain a constructor coordinate")
+    };
+    assert_eq!(name, "py.listcomp");
+    let Some(Term::Lambda { body, .. }) = args.get(1) else {
+        panic!("outer transform must remain a real lambda binder")
+    };
+    let Term::Ctor {
+        name: inner_name,
+        args: inner_args,
+    } = body.as_ref()
+    else {
+        panic!("nested comprehension must remain inside the outer transform")
+    };
+    assert_eq!(inner_name, "py.listcomp");
+    assert!(matches!(inner_args.get(1), Some(Term::Lambda { .. })));
+    assert_eq!(
+        free_vars(term),
+        ["xs".to_string(), "ys".to_string(), "z".to_string()].into()
+    );
+}
+
+#[test]
+fn nested_python_generator_coordinates_stay_lazy_after_rust_parse() {
+    let term = document_post_term(python_comprehension_document(
+        "((f(x, y) for y in ys) for x in xs)",
+        "xs, ys",
+    ));
+    let Term::Ctor { name, args } = &term else {
+        panic!("outer generator must remain a constructor coordinate")
+    };
+    assert_eq!(name, "py.generatorexp");
+    let Some(Term::Lambda { body, .. }) = args.get(1) else {
+        panic!("outer generator transform must remain a real lambda binder")
+    };
+    assert!(matches!(
+        body.as_ref(),
+        Term::Ctor { name, args }
+            if name == "py.generatorexp"
+                && matches!(args.get(1), Some(Term::Lambda { .. }))
+    ));
+    assert_eq!(free_vars(term), ["xs".to_string(), "ys".to_string()].into());
+}


### PR DESCRIPTION
## What changed

- compose already-constructed comprehension coordinates recursively in ListComp and GeneratorExp element/iterable positions
- preserve each comprehension target as its existing real lambda binder; introduce no new constructor
- retain GeneratorExp as `py.generatorexp`, including when nested
- keep filters, multiple generators, walrus, and non-Name targets loud
- keep SetComp/DictComp outer admission boundaries unchanged

The Python reference recursively constructs comprehension expressions. This arm mirrors that recursion using the existing `py.*comp(iterable, Lambda(...))` coordinate and never flattens or eagerly evaluates a nested generator.

## Pandas measurement

Complete detached battleaxe census: 1,415/1,415 files, zero defects in both baseline and final runs.

- ListComp root-parent edges: 604 -> 511 (`Delta R = -93`)
- GeneratorExp root-parent edges: 212 -> 180 (`Delta R = -32`)
- direct gap events: ListComp 225 -> 191; GeneratorExp 52 -> 49

Residual direct causes remain filters, tuple targets (#6078 dependency), multiple generators, and their combinations.

## Twins

- nested list comprehensions preserve both lambda binders and captures
- nested comprehension iterable composes without flattening
- nested generator expressions retain both lazy coordinates
- already-built set/dict coordinates compose under the outer ListComp/GeneratorExp arm
- an inner filtered comprehension remains loud
- outer SetComp/DictComp nested boundaries remain loud

## Validation

- source-tree suite: 355 passed, 5 skipped, 1 xfailed
- battleaxe `sugar-ir-types --test proofir_membership`: 14 passed
- baseline/final pandas census: 1,415/1,415 files, zero defects
- `cargo fmt --all --check`
- `git diff --check`

DO NOT MERGE from this lane.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow nested comprehensions in `ListComp` and `GeneratorExp` sugar construction
> - `ListComp._construct_sugar` and `GeneratorExp._construct_sugar` now accept nested comprehensions in both the element and iterable positions, previously rejecting them via `_contains_forbidden_shape`.
> - A new `_contains_named_expression` helper narrows the rejection condition to walrus (`:=`) expressions only, replacing the broader forbidden-shape check for the element.
> - `ListComp._simple_generator` gains an `allow_nested_iterable` keyword parameter; when `True`, iterables containing nested comprehension shapes are accepted unless they contain a `NamedExpr`.
> - New Python and Rust tests confirm nested comprehensions produce composed lambda-binder IR terms and that inner filtered gaps still raise `SugarNotWritten`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ca5a5e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->