### PR TITLE
feat: narrow authenticated With arm builds ExitSet (pandas, #6071)

### DIFF
--- a/docs/superpowers/specs/2026-07-22-with-arm-narrow-design.md
+++ b/docs/superpowers/specs/2026-07-22-with-arm-narrow-design.md
@@ -1,0 +1,44 @@
+# Narrow Authenticated With Arm Design
+
+## Scope
+
+Implement issue #6071 step 4 on top of prerequisites 1 and 2. Admit only a synchronous `With` containing one manager item whose exact manager-expression source coordinate resolves to an authenticated `ContextManagerContractRefV1` with total `Value` enter testimony and typed `NeverSuppressesDispositionV1`. Preserve the existing independently authenticated membrane arms without allowing them to satisfy or broaden this bridge-backed arm.
+
+## Construction boundary
+
+`With._construct_sugar` reads only `SourceUnit.construction_context.contract_refs`. It converts the manager expression's existing source CID and line/column span into `SourceFragmentCoordinateV1`, requires the corresponding immutable resolution row, and validates the complete admission predicate before constructing any manager, enter, exit, or body Sugar child. It never calls the linker, opens source, matches manager/vendor spelling, or decodes member metadata.
+
+A missing resolution-table row after demand enrollment raises `BackendDefect`. A typed `ContextManagerResolutionGapV1` remains a structured loud With gap carrying its original kind and coordinates. Unsupported syntax or authenticated semantics produces a closed typed With gap: multiple items, async manager, unsupported binding target, or unsupported context-manager semantics. No case silently falls through or upgrades testimony.
+
+## Binding and product
+
+For an optional simple `as Name`, substitution reads the same frozen typed resolution row and rewrites body uses to `ObservationRef(<manager-slot>#enter_result, ENTER_RESULT)`. This coordinate is authenticated only on completed enter faces by `EnterResultBinding`; no value is fabricated.
+
+The admitted node constructs one `WithResourceSugar` with:
+
+- the original manager occurrence exactly once;
+- a stable `ManagerRef`-based enter call;
+- one parametric exit call using the stable exit-face coordinate;
+- already-constructed body Sugars;
+- the exact typed `NeverSuppressesDispositionV1` carried by the ref;
+- the immutable `ContextManagerContractRefV1` itself.
+
+The Sugar exposes authenticated edge testimony derived only from `catalog_cid`, `member_cid`, `payload_cid`, `demand_cid`, and `resolution_cid`. It does not reconstruct an edge from a source spelling.
+
+## ExitSet semantics
+
+`WithResourceSugar.desugar` retains the existing manager-once, enter, body, and parametric-exit composition. Manager and enter halts propagate. Exit runs for every body face. Exit failure supersedes the body face. A completed exit preserves a completed body's state, and typed NeverSuppresses restores a halted body's original effect. Conditional body exits retain both guarded faces, and no suppression-created `Completed(None)` face is emitted.
+
+## Executable discrimination
+
+Tests establish:
+
+1. an authenticated resolved manager constructs `WithResourceSugar`, evaluates the manager once, binds the actual enter-result slot, and carries the exact ref CIDs;
+2. a body raise remains halted after completed exit, including complementary completed conditional faces and tail sequencing only on completion;
+3. authenticated Suppresses or unsupported semantics stays a typed loud gap;
+4. an unresolved row stays the same typed loud gap with no linker, source-oracle, or decoder access;
+5. async and multi-item forms stay typed loud and emit no synchronous resource edge;
+6. planted linker/source/decoder calls below construction fail the boundary floor, while positive construction succeeds with those doors patched to raise;
+7. `R_no_sugar_in_desugar` remains zero.
+
+Rust verification, if required by the final edge checker, runs only on battleaxe through `bin/sugarbin`. The branch remains stacked and is not finalized until prerequisites 1 and 2 merge.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -101,6 +101,16 @@ class ResolvedContractRefsV1:
 @dataclass(frozen=True)
 class TreeConstructionContextV1:
     contract_refs: ResolvedContractRefsV1
+    with_manager_authorities: Any = None
+
+    def __post_init__(self) -> None:
+        if self.with_manager_authorities is None:
+            from .with_manager_authority import WithManagerAuthoritiesV1
+            object.__setattr__(
+                self,
+                "with_manager_authorities",
+                WithManagerAuthoritiesV1.assemble(self.contract_refs, ()),
+            )
 
 
 _GAP_KINDS = frozenset({

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/__init__.py
@@ -15,6 +15,10 @@ from .factory_walk_row_dto import (
 from .implication_dto import ImplicationDto
 from .lift_report_payload_dto import LiftReportPayloadDto
 from .context_manager_contract_dto import ContextManagerContractIrV1, ImportSignatureV1
+from .context_manager_edge_dto import (
+    ContextManagerEdgeDtoV1,
+    ContextManagerEdgeTransportError,
+)
 from .open_lane_dto import (
     CallEdgeDto,
     DiagnosticDto,
@@ -57,6 +61,8 @@ __all__ = [
     "ImplicationDto",
     "LiftReportPayloadDto",
     "ContextManagerContractIrV1",
+    "ContextManagerEdgeDtoV1",
+    "ContextManagerEdgeTransportError",
     "ImportSignatureV1",
     "PlanAtomDto",
     "RecoveredAuditDto",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/context_manager_edge_dto.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/context_manager_edge_dto.py
@@ -1,0 +1,133 @@
+"""Closed context-manager occurrence edge for the dedicated report lane."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any
+
+from sugar_lift_py_tests.context_manager_contract import (
+    NeverSuppressesDispositionV1,
+    semantics_to_value,
+)
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContextManagerContractRefV1,
+    ImportSignatureV1,
+    SourceFragmentCoordinateV1,
+    _hash_json,
+)
+from sugar_lift_py_tests.ir import PrimitiveSort, sort_to_value
+
+
+class ContextManagerEdgeTransportError(ValueError):
+    pass
+
+
+def _json(value) -> Any:
+    from sugar_lift_py_tests.canonicalizer import encode_jcs
+
+    return json.loads(encode_jcs(value))
+
+
+def _signature_wire(signature: ImportSignatureV1) -> dict[str, Any]:
+    return {
+        "formals": list(signature.formals),
+        "sorts": [_json(sort_to_value(sort)) for sort in signature.sorts],
+    }
+
+
+def _admitted(reference: ContextManagerContractRefV1) -> bool:
+    semantics = reference.semantics
+    return (
+        semantics.kind == "context-manager-semantics"
+        and semantics.schema_version == "1"
+        and semantics.enter.completion == "total"
+        and semantics.enter.projection == "enter_result"
+        and isinstance(semantics.enter.sort, PrimitiveSort)
+        and semantics.enter.sort.name == "Value"
+        and semantics.exit.completion == "total"
+        and isinstance(semantics.exit.disposition, NeverSuppressesDispositionV1)
+    )
+
+
+@dataclass(frozen=True)
+class ContextManagerEdgeDtoV1:
+    edge_cid: str
+    use_site: SourceFragmentCoordinateV1
+    bridge_source_symbol: str
+    import_signature: ImportSignatureV1
+    target_contract_cid: str
+    payload_cid: str
+    demand_cid: str
+    resolution_cid: str
+    catalog_cid: str
+    source_warrant_cids: tuple[str, ...]
+    semantics: object
+    kind: str = "context-manager-edge"
+    schema_version: str = "1"
+
+    @classmethod
+    def from_resolved(cls, reference, use_site) -> "ContextManagerEdgeDtoV1":
+        if not isinstance(reference, ContextManagerContractRefV1):
+            raise ContextManagerEdgeTransportError(
+                "context-manager edge requires a resolved authenticated ref"
+            )
+        if use_site != reference.use_site:
+            raise ContextManagerEdgeTransportError("context-manager edge use-site mismatch")
+        if not _admitted(reference):
+            raise ContextManagerEdgeTransportError(
+                "context-manager edge requires admitted typed NeverSuppresses semantics"
+            )
+        warrants = tuple(sorted(reference.source_warrant_cids))
+        if len(warrants) != len(set(warrants)):
+            raise ContextManagerEdgeTransportError(
+                "context-manager edge warrant CIDs must be unique"
+            )
+        values = {
+            "kind": "context-manager-edge",
+            "schemaVersion": "1",
+            "useSite": use_site.wire(),
+            "managerIdentity": {
+                "bridgeSourceSymbol": reference.bridge_source_symbol,
+                "importSignature": _signature_wire(reference.import_signature),
+            },
+            "targetContractCid": reference.member_cid,
+            "payloadCid": reference.payload_cid,
+            "demandCid": reference.demand_cid,
+            "resolutionCid": reference.resolution_cid,
+            "catalogCid": reference.catalog_cid,
+            "sourceWarrantCids": list(warrants),
+            "semantics": _json(semantics_to_value(reference.semantics)),
+        }
+        return cls(
+            edge_cid=_hash_json(values),
+            use_site=use_site,
+            bridge_source_symbol=reference.bridge_source_symbol,
+            import_signature=reference.import_signature,
+            target_contract_cid=reference.member_cid,
+            payload_cid=reference.payload_cid,
+            demand_cid=reference.demand_cid,
+            resolution_cid=reference.resolution_cid,
+            catalog_cid=reference.catalog_cid,
+            source_warrant_cids=warrants,
+            semantics=reference.semantics,
+        )
+
+    def to_rpc(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "schemaVersion": self.schema_version,
+            "edgeCid": self.edge_cid,
+            "useSite": self.use_site.wire(),
+            "managerIdentity": {
+                "bridgeSourceSymbol": self.bridge_source_symbol,
+                "importSignature": _signature_wire(self.import_signature),
+            },
+            "targetContractCid": self.target_contract_cid,
+            "payloadCid": self.payload_cid,
+            "demandCid": self.demand_cid,
+            "resolutionCid": self.resolution_cid,
+            "catalogCid": self.catalog_cid,
+            "sourceWarrantCids": list(self.source_warrant_cids),
+            "semantics": _json(semantics_to_value(self.semantics)),
+        }

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/lift_report_payload_dto.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/lift_report_payload_dto.py
@@ -9,6 +9,7 @@ from .assertion_surface_audit_dto import AssertionSurfaceAuditDto
 from .body_universe_dto import BodyUniverseDto
 from .component_plan_memento_dto import ComponentPlanMementoDto
 from .context_manager_contract_dto import ContextManagerContractIrV1
+from .context_manager_edge_dto import ContextManagerEdgeDtoV1
 from .effect_dto import EffectDto
 from .factory_audit_summary_dto import FactoryAuditSummaryDto
 from .factory_walk_row_dto import FactoryWalkRowDto
@@ -60,6 +61,9 @@ class LiftReportPayloadDto:
     source_audits: list[SourceAuditDto] = field(default_factory=list[SourceAuditDto])
     factory_audits: list[FactoryAuditDto] = field(default_factory=list[FactoryAuditDto])
     call_edges: list[CallEdgeDto] = field(default_factory=list[CallEdgeDto])
+    context_manager_edges: list[ContextManagerEdgeDtoV1] = field(
+        default_factory=list[ContextManagerEdgeDtoV1]
+    )
     vendor_conjoins: list[VendorConjoinDto] = field(
         default_factory=list[VendorConjoinDto]
     )
@@ -121,6 +125,9 @@ class LiftReportPayloadDto:
             "implications": [to_rpc_value(edge) for edge in self.implications],
             "effects": [to_rpc_value(effect) for effect in self.effects],
             "callEdges": [to_rpc_value(edge) for edge in self.call_edges],
+            "contextManagerEdges": [
+                to_rpc_value(edge) for edge in self.context_manager_edges
+            ],
             "vendorConjoins": [to_rpc_value(row) for row in self.vendor_conjoins],
             "diagnostics": [to_rpc_value(row) for row in self.diagnostics],
             "warnings": [],

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -69,6 +69,7 @@ _ENUMERATION_PHASES: Dict[str, tuple[int, float, float]] = {}
 _ENUMERATION_REQUEST_COUNT = 0
 _ENUMERATION_ACTIVE = False
 _BOUND_CONTRACT_REFS = None
+_BOUND_WITH_MANAGER_AUTHORITIES = None
 _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS: tuple[ContextManagerContractIrV1, ...] = ()
 
 
@@ -135,6 +136,112 @@ def _context_manager_demand_rows(root: Path) -> List[Dict[str, Any]]:
                     "gapKind": None if target else "runtime-selected",
                 })
     return rows
+
+
+def _legacy_membrane_token_rows(root: Path) -> List[Dict[str, Any]]:
+    """Authenticate legacy manifest enrollments before any Tree construction."""
+    import re
+
+    from sugar_lift_python_source.source_oracle import SourceUnavailable, path_source
+    from sugar_source_tree.tree import SourceTree
+    from sugar_lift_py_tests.context_manager_contract import EffectMatcher, MessagePattern
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1, _hash_json,
+    )
+    from sugar_lift_py_tests.manifest_membrane import (
+        _CONTRACT_BUILDERS, default_community_manifest,
+    )
+    from sugar_lift_py_tests.with_manager_authority import (
+        AuthenticatedLegacyMembraneRefV1,
+    )
+
+    manifest = default_community_manifest()
+    tokens = []
+    for path in SourceTree(root).paths():
+        try:
+            source, _filename, source_cid = path_source(str(path))
+        except SourceUnavailable:
+            continue
+        module = ast.parse(source, filename=str(path))
+        imports: Dict[str, str] = {}
+        for node in ast.walk(module):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                for alias in node.names:
+                    imports[alias.asname or alias.name] = f"{node.module}.{alias.name}"
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    imports[alias.asname or alias.name.split(".")[0]] = alias.name
+
+        def resolved_callee(call: ast.Call) -> Optional[str]:
+            if isinstance(call.func, ast.Name):
+                return imports.get(call.func.id)
+            if isinstance(call.func, ast.Attribute) and isinstance(call.func.value, ast.Name):
+                base = imports.get(call.func.value.id)
+                return f"{base}.{call.func.attr}" if base else None
+            return None
+
+        def dotted(node: ast.AST) -> Optional[str]:
+            if isinstance(node, ast.Name):
+                return node.id
+            if isinstance(node, ast.Attribute):
+                base = dotted(node.value)
+                return f"{base}.{node.attr}" if base else None
+            return None
+
+        for with_node in ast.walk(module):
+            if not isinstance(with_node, (ast.With, ast.AsyncWith)):
+                continue
+            for item in with_node.items:
+                call = item.context_expr
+                if not isinstance(call, ast.Call):
+                    continue
+                target = resolved_callee(call)
+                row = manifest.row_for_spelling(target) if target else None
+                if row is None or len(call.args) != 1:
+                    continue
+                matcher_name = dotted(call.args[0])
+                if matcher_name is None:
+                    continue
+                obligations = ()
+                if row.arity == "one-exception-arg":
+                    if call.keywords:
+                        continue
+                elif row.arity == "exception-arg-optional-match":
+                    if call.keywords:
+                        if len(call.keywords) != 1 or call.keywords[0].arg != "match" \
+                                or not isinstance(call.keywords[0].value, ast.Constant) \
+                                or not isinstance(call.keywords[0].value.value, str):
+                            continue
+                        try:
+                            re.compile(call.keywords[0].value.value)
+                        except re.error:
+                            continue
+                        obligations = (MessagePattern(call.keywords[0].value.value),)
+                else:
+                    continue
+                builder = _CONTRACT_BUILDERS.get(row.contract)
+                if builder is None:
+                    continue
+                contract = builder(EffectMatcher(row.effect_kind, matcher_name, obligations))
+                site = SourceFragmentCoordinateV1(
+                    source_cid, call.lineno, call.col_offset, call.end_lineno, call.end_col_offset
+                )
+                demand_preimage = {
+                    "useSite": site.wire(), "targetSymbol": None,
+                    "importSignature": {"formals": [], "sorts": []},
+                    "expectedKind": "context-manager-contract",
+                }
+                enrollment = {
+                    "spelling": row.spelling, "arity": row.arity,
+                    "contract": row.contract, "effect_kind": row.effect_kind,
+                }
+                token = AuthenticatedLegacyMembraneRefV1.mint_from_authenticated_identity(
+                    demand_cid=_hash_json(demand_preimage), use_site=site,
+                    manifest_cid=manifest.cid, enrollment_cid=_hash_json(enrollment),
+                    contract=contract,
+                )
+                tokens.append(token.to_wire())
+    return tokens
 # Passive, process-lifetime context paid for by an enumeration demand. The
 # outer identity is the file content CID; the path seat is retained because
 # source mementos carry the workspace-relative filename even for identical
@@ -1425,6 +1532,43 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 "rows": _context_manager_demand_rows(root)
             }})
             return
+        if level == "legacy-membrane-tokens":
+            _send({"jsonrpc": "2.0", "id": msg_id, "result": {
+                "rows": _legacy_membrane_token_rows(root)
+            }})
+            return
+        if level == "context-manager-edges":
+            if _BOUND_CONTRACT_REFS is None:
+                raise ValueError(
+                    "context-manager edge enumeration requires frozen contract refs"
+                )
+            from sugar_lift_python_source.source_oracle import path_source
+            from sugar_source_tree.tree import SourceFile as _TreeSourceFile
+            from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+
+            rows = []
+            construction_context = TreeConstructionContextV1(
+                _BOUND_CONTRACT_REFS, _BOUND_WITH_MANAGER_AUTHORITIES
+            )
+            for source_path in sorted(root.rglob("*.py")):
+                identity = path_source(str(source_path))
+                source_file = _TreeSourceFile(
+                    identity, construction_context=construction_context
+                )
+                for function in source_file.functions():
+                    function_sugar = function.sugar()
+                    rows.extend(
+                        edge.to_rpc()
+                        for edge in function_sugar.context_manager_edges()
+                    )
+            _send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {"contextManagerEdges": rows},
+                }
+            )
+            return
         if level == "source_files":
             # The source_files level IS SourceTree.fragments(): whole-file
             # fragments minted through the SourceOracle — identity without
@@ -1619,7 +1763,9 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 
                 construction_context = (
-                    TreeConstructionContextV1(_BOUND_CONTRACT_REFS)
+                    TreeConstructionContextV1(
+                        _BOUND_CONTRACT_REFS, _BOUND_WITH_MANAGER_AUTHORITIES
+                    )
                     if _BOUND_CONTRACT_REFS is not None
                     else None
                 )
@@ -2096,13 +2242,25 @@ def _dispatch_request(msg: Dict[str, Any]) -> bool:
         )
     elif method == BIND_CONTRACT_REFS_RPC_METHOD:
         from sugar_lift_py_tests.context_manager_resolution import decode_resolved_contract_refs
+        from sugar_lift_py_tests.with_manager_authority import (
+            WithManagerAuthoritiesV1, _decode_legacy_ref,
+        )
 
-        global _BOUND_CONTRACT_REFS
-        installed = decode_resolved_contract_refs(params)
+        global _BOUND_CONTRACT_REFS, _BOUND_WITH_MANAGER_AUTHORITIES
+        if not isinstance(params, dict) or set(params) != {"contractRefs", "legacyMembraneRefs"} \
+                or not isinstance(params["legacyMembraneRefs"], list):
+            raise ValueError("malformed preconstruction With authority bind")
+        installed = decode_resolved_contract_refs(params["contractRefs"])
+        legacy_tokens = tuple(_decode_legacy_ref(row) for row in params["legacyMembraneRefs"])
+        authorities = WithManagerAuthoritiesV1.assemble(installed, legacy_tokens)
         if _BOUND_CONTRACT_REFS is not None and _BOUND_CONTRACT_REFS.table_cid != installed.table_cid:
             raise ValueError("contract-ref generation is already frozen")
         _BOUND_CONTRACT_REFS = installed
-        _send({"jsonrpc": "2.0", "id": msg_id, "result": {"tableCid": installed.table_cid}})
+        _BOUND_WITH_MANAGER_AUTHORITIES = authorities
+        _send({"jsonrpc": "2.0", "id": msg_id, "result": {
+            "tableCid": installed.table_cid,
+            "withManagerAuthoritiesCid": authorities.table_cid,
+        }})
     elif method == ENUMERATE_RPC_METHOD:
         global _ENUMERATION_ACTIVE, _ENUMERATION_REQUEST_COUNT
         enumerate_started = time.monotonic()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/resource_bindings.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/resource_bindings.py
@@ -20,13 +20,13 @@ class ManagerBinding:
 
     def to_facts(self, site=None) -> tuple:
         from sugar_lift_py_tests.floor.inv_value import InvValue
-        from sugar_lift_py_tests.ir import atomic, eq, str_const
+        from sugar_lift_py_tests.ir import ctor, eq, str_const
 
         slot = str_const(self.slot_id)
         term = self.manager_value.to_term(owner="ManagerBinding")
         return (
             InvValue(
-                eq(atomic("manager_slot_value", [slot]), term),
+                eq(ctor("manager_slot_value", [slot]), term),
                 site=site,
             ),
         )
@@ -41,13 +41,13 @@ class EnterResultBinding:
 
     def to_facts(self, site=None) -> tuple:
         from sugar_lift_py_tests.floor.inv_value import InvValue
-        from sugar_lift_py_tests.ir import atomic, eq, str_const
+        from sugar_lift_py_tests.ir import ctor, eq, str_const
 
         slot = str_const(self.slot_id)
         term = self.enter_value.to_term(owner="EnterResultBinding")
         return (
             InvValue(
-                eq(atomic("enter_result_value", [slot]), term),
+                eq(ctor("enter_result_value", [slot]), term),
                 site=site,
             ),
         )
@@ -94,7 +94,7 @@ class ExitFaceBinding:
 
     def to_facts(self, site=None, guard=None) -> tuple:
         from sugar_lift_py_tests.floor.inv_value import InvValue
-        from sugar_lift_py_tests.ir import atomic, ctor, eq, str_const
+        from sugar_lift_py_tests.ir import ctor, eq, str_const
         from sugar_lift_py_tests.outcome.exit_set import true_guard
 
         face = str_const(self.face_id)
@@ -105,9 +105,9 @@ class ExitFaceBinding:
 
         if self.kind == "completed":
             rows = (
-                eq(atomic("exit_type", [face]), none),
-                eq(atomic("exit_value", [face]), none),
-                eq(atomic("exit_traceback", [face]), none),
+                eq(ctor("exit_type", [face]), none),
+                eq(ctor("exit_value", [face]), none),
+                eq(ctor("exit_traceback", [face]), none),
             )
         elif self.kind == "raised":
             type_term = (
@@ -120,15 +120,15 @@ class ExitFaceBinding:
                 [str_const(self.occurrence or "unknown-raise")],
             )
             rows = (
-                eq(atomic("exit_type", [face]), type_term),
-                eq(atomic("exit_value", [face]), value_term),
-                eq(atomic("exit_traceback", [face]), open_tb),
+                eq(ctor("exit_type", [face]), type_term),
+                eq(ctor("exit_value", [face]), value_term),
+                eq(ctor("exit_traceback", [face]), open_tb),
             )
         else:
             rows = (
-                eq(atomic("exit_type", [face]), open_type),
-                eq(atomic("exit_value", [face]), open_val),
-                eq(atomic("exit_traceback", [face]), open_tb),
+                eq(ctor("exit_type", [face]), open_type),
+                eq(ctor("exit_value", [face]), open_val),
+                eq(ctor("exit_traceback", [face]), open_tb),
             )
 
         facts = tuple(InvValue(row, site=site) for row in rows)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/resource_exit_disposition.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/resource_exit_disposition.py
@@ -25,6 +25,7 @@ def disposition_verdict(disposition: object, effect: object) -> Verdict:
     """
     from sugar_lift_py_tests.context_manager_contract import (
         NeverSuppresses,
+        NeverSuppressesDispositionV1,
         RuntimeSelected,
         Suppresses,
     )
@@ -33,7 +34,7 @@ def disposition_verdict(disposition: object, effect: object) -> Verdict:
     if disposition is None or isinstance(disposition, RuntimeSelected):
         return "open"
 
-    if isinstance(disposition, NeverSuppresses):
+    if isinstance(disposition, (NeverSuppresses, NeverSuppressesDispositionV1)):
         return "restore"
 
     if isinstance(disposition, ExitSuppressionContract):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -253,3 +253,37 @@ class FunctionUniverseSugar(Sugar):
                 UniverseValue(name=self.name, formals=self.formals, record=record)
             )
         )
+
+    def context_manager_edges(self) -> tuple:
+        """Project already-constructed CM edges without re-entering the tree."""
+        from dataclasses import fields, is_dataclass
+
+        edges = []
+        stack = list(reversed(self.statements))
+        seen = set()
+        while stack:
+            sugar = stack.pop()
+            marker = id(sugar)
+            if marker in seen:
+                continue
+            seen.add(marker)
+            edge = getattr(sugar, "context_manager_edge", None)
+            if edge is not None:
+                edges.append(edge)
+            if not is_dataclass(sugar):
+                continue
+            for field in reversed(fields(sugar)):
+                if field.name in {
+                    "site",
+                    "contract_ref",
+                    "context_manager_edge",
+                }:
+                    continue
+                value = getattr(sugar, field.name)
+                if isinstance(value, Sugar):
+                    stack.append(value)
+                elif isinstance(value, tuple):
+                    stack.extend(
+                        reversed(tuple(item for item in value if isinstance(item, Sugar)))
+                    )
+        return tuple(edges)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
@@ -35,6 +35,8 @@ class WithResourceSugar(Sugar):
 
     body: tuple
     disposition: object
+    contract_ref: object | None = None
+    context_manager_edge: object | None = None
     enter_slot_id: str | None = None
     site: object = dataclass_field(compare=False, default=None)
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/with_manager_authority.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/with_manager_authority.py
@@ -1,0 +1,318 @@
+"""Closed preconstruction routing authority for every enrolled ``with`` site."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+
+from .context_manager_contract import (
+    EFFECT,
+    EXCEPTION_INFO,
+    WARNING_OBSERVATION,
+    EffectMatcher,
+    Expects,
+    MessagePattern,
+    Suppresses,
+    semantics_to_value,
+    _json_value,
+)
+from .context_manager_resolution import (
+    ContextManagerContractRefV1,
+    ContextManagerResolutionGapV1,
+    ResolvedContractRefsV1,
+    SourceFragmentCoordinateV1,
+    _cid,
+    _decode_ref,
+    _hash_json,
+)
+from .canonicalizer import encode_jcs
+
+
+class WithManagerAuthorityProtocolError(ValueError):
+    pass
+
+
+LegacyMembraneContractV1 = Expects | Suppresses
+
+
+def _matcher_wire(matcher: EffectMatcher) -> dict[str, Any]:
+    obligations = []
+    for obligation in matcher.payload_obligations:
+        if not isinstance(obligation, MessagePattern):
+            raise WithManagerAuthorityProtocolError("unsupported legacy matcher obligation")
+        obligations.append({"kind": "message-pattern", "pattern": obligation.pattern})
+    return {
+        "kind": matcher.kind,
+        "name": matcher.name,
+        "payloadObligations": obligations,
+    }
+
+
+def _contract_wire(contract: LegacyMembraneContractV1) -> dict[str, Any]:
+    if isinstance(contract, Expects):
+        if contract.binding not in (None, EXCEPTION_INFO, WARNING_OBSERVATION, EFFECT):
+            raise WithManagerAuthorityProtocolError("unsupported legacy binding projection")
+        return {
+            "kind": "expects",
+            "matcher": _matcher_wire(contract.matcher),
+            "binding": contract.binding,
+        }
+    if isinstance(contract, Suppresses):
+        return {"kind": "suppresses", "matcher": _matcher_wire(contract.matcher)}
+    raise WithManagerAuthorityProtocolError("legacy token requires Expects or Suppresses")
+
+
+def _decode_matcher(raw: Any) -> EffectMatcher:
+    if not isinstance(raw, dict) or set(raw) != {"kind", "name", "payloadObligations"}:
+        raise WithManagerAuthorityProtocolError("malformed legacy effect matcher")
+    if raw["kind"] not in ("raise", "warning") or not isinstance(raw["name"], str):
+        raise WithManagerAuthorityProtocolError("unsupported legacy effect matcher")
+    obligations = raw["payloadObligations"]
+    if not isinstance(obligations, list):
+        raise WithManagerAuthorityProtocolError("malformed matcher obligations")
+    decoded = []
+    for obligation in obligations:
+        if not isinstance(obligation, dict) or set(obligation) != {"kind", "pattern"} \
+                or obligation["kind"] != "message-pattern" \
+                or not isinstance(obligation["pattern"], str):
+            raise WithManagerAuthorityProtocolError("malformed matcher obligation")
+        decoded.append(MessagePattern(obligation["pattern"]))
+    return EffectMatcher(raw["kind"], raw["name"], tuple(decoded))
+
+
+def _decode_contract(raw: Any) -> LegacyMembraneContractV1:
+    if not isinstance(raw, dict):
+        raise WithManagerAuthorityProtocolError("malformed legacy membrane contract")
+    if raw.get("kind") == "expects" and set(raw) == {"kind", "matcher", "binding"}:
+        binding = raw["binding"]
+        if binding not in (None, EXCEPTION_INFO, WARNING_OBSERVATION, EFFECT):
+            raise WithManagerAuthorityProtocolError("unsupported legacy binding projection")
+        return Expects(_decode_matcher(raw["matcher"]), binding)
+    if raw.get("kind") == "suppresses" and set(raw) == {"kind", "matcher"}:
+        return Suppresses(_decode_matcher(raw["matcher"]))
+    raise WithManagerAuthorityProtocolError("unknown legacy membrane contract")
+
+
+@dataclass(frozen=True)
+class AuthenticatedLegacyMembraneRefV1:
+    authentication_cid: str
+    demand_cid: str
+    use_site: SourceFragmentCoordinateV1
+    manifest_cid: str
+    enrollment_cid: str
+    contract: LegacyMembraneContractV1
+
+    @classmethod
+    def mint_from_authenticated_identity(
+        cls, *, demand_cid: str, use_site: SourceFragmentCoordinateV1,
+        manifest_cid: str, enrollment_cid: str,
+        contract: LegacyMembraneContractV1,
+    ) -> "AuthenticatedLegacyMembraneRefV1":
+        # This door consumes an authenticated identity CID. It never derives one.
+        for value, field in ((demand_cid, "demandCid"),
+                             (manifest_cid, "manifestCid"),
+                             (enrollment_cid, "enrollmentCid")):
+            _cid(value, field)
+        preimage = {
+            "schemaVersion": "1", "useSite": use_site.wire(),
+            "demandCid": demand_cid,
+            "manifestCid": manifest_cid, "enrollmentCid": enrollment_cid,
+            "contract": _contract_wire(contract),
+        }
+        return cls(_hash_json(preimage), demand_cid, use_site, manifest_cid,
+                   enrollment_cid, contract)
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "kind": "authenticated-legacy-membrane-ref", "schemaVersion": "1",
+            "authenticationCid": self.authentication_cid,
+            "demandCid": self.demand_cid,
+            "useSite": self.use_site.wire(),
+            "manifestCid": self.manifest_cid,
+            "enrollmentCid": self.enrollment_cid,
+            "contract": _contract_wire(self.contract),
+        }
+
+
+def _decode_legacy_ref(raw: Any) -> AuthenticatedLegacyMembraneRefV1:
+    expected = {"kind", "schemaVersion", "authenticationCid", "demandCid", "useSite",
+                "manifestCid", "enrollmentCid", "contract"}
+    if not isinstance(raw, dict) or set(raw) != expected \
+            or raw["kind"] != "authenticated-legacy-membrane-ref" \
+            or raw["schemaVersion"] != "1":
+        raise WithManagerAuthorityProtocolError("malformed legacy membrane reference")
+    token = AuthenticatedLegacyMembraneRefV1.mint_from_authenticated_identity(
+        demand_cid=_cid(raw["demandCid"], "demandCid"),
+        use_site=SourceFragmentCoordinateV1.decode(raw["useSite"]),
+        manifest_cid=_cid(raw["manifestCid"], "manifestCid"),
+        enrollment_cid=_cid(raw["enrollmentCid"], "enrollmentCid"),
+        contract=_decode_contract(raw["contract"]),
+    )
+    if _cid(raw["authenticationCid"], "authenticationCid") != token.authentication_cid:
+        raise WithManagerAuthorityProtocolError("legacy membrane authentication CID mismatch")
+    return token
+
+
+@dataclass(frozen=True)
+class AuthenticatedLegacyMembrane:
+    reference: AuthenticatedLegacyMembraneRefV1
+
+
+@dataclass(frozen=True)
+class ResolvedContextManager:
+    reference: ContextManagerContractRefV1
+
+
+@dataclass(frozen=True)
+class UnresolvedContextManager:
+    gap: ContextManagerResolutionGapV1
+
+
+@dataclass(frozen=True)
+class WithManagerAuthorityGapV1:
+    use_site: SourceFragmentCoordinateV1
+    kind: str
+
+
+@dataclass(frozen=True)
+class ConflictingAuthority:
+    gap: WithManagerAuthorityGapV1
+
+
+WithManagerAuthorityV1 = (
+    AuthenticatedLegacyMembrane | ResolvedContextManager |
+    UnresolvedContextManager | ConflictingAuthority
+)
+
+
+def _gap_wire(gap: ContextManagerResolutionGapV1) -> dict[str, Any]:
+    return {
+        "demandCid": gap.demand_cid, "useSite": gap.use_site.wire(),
+        "targetSymbol": gap.target_symbol, "kind": gap.kind,
+        "candidateMemberCids": list(gap.candidate_member_cids),
+    }
+
+
+def _ref_wire(reference: ContextManagerContractRefV1) -> dict[str, Any]:
+    import json
+    from .canonicalizer import encode_jcs
+    from .ir import sort_to_value
+    return {
+        "kind": "context-manager-contract-ref", "schemaVersion": "1",
+        "resolutionCid": reference.resolution_cid, "demandCid": reference.demand_cid,
+        "useSite": reference.use_site.wire(), "catalogCid": reference.catalog_cid,
+        "memberCid": reference.member_cid, "payloadCid": reference.payload_cid,
+        "bridgeSourceSymbol": reference.bridge_source_symbol,
+        "importSignature": {
+            "formals": list(reference.import_signature.formals),
+            "sorts": [json.loads(encode_jcs(sort_to_value(sort))) for sort in reference.import_signature.sorts],
+        },
+        "semantics": json.loads(encode_jcs(semantics_to_value(reference.semantics))),
+        "sourceWarrantCids": list(reference.source_warrant_cids),
+    }
+
+
+def _authority_wire(authority: WithManagerAuthorityV1) -> dict[str, Any]:
+    if isinstance(authority, AuthenticatedLegacyMembrane):
+        return {"kind": "authenticated-legacy-membrane", "reference": authority.reference.to_wire()}
+    if isinstance(authority, ResolvedContextManager):
+        return {"kind": "resolved-context-manager", "reference": _ref_wire(authority.reference)}
+    if isinstance(authority, UnresolvedContextManager):
+        return {"kind": "unresolved-context-manager", "gap": _gap_wire(authority.gap)}
+    return {"kind": "conflicting-authority", "gap": {
+        "kind": authority.gap.kind, "useSite": authority.gap.use_site.wire(),
+    }}
+
+
+@dataclass(frozen=True)
+class WithManagerAuthoritiesV1:
+    table_cid: str
+    by_use_site: Mapping[SourceFragmentCoordinateV1, WithManagerAuthorityV1]
+
+    @classmethod
+    def assemble(cls, refs: ResolvedContractRefsV1,
+                 legacy_tokens: Sequence[AuthenticatedLegacyMembraneRefV1]):
+        tokens: dict[SourceFragmentCoordinateV1, list[AuthenticatedLegacyMembraneRefV1]] = {}
+        for token in legacy_tokens:
+            tokens.setdefault(token.use_site, []).append(token)
+        unknown = set(tokens).difference(refs.by_use_site)
+        if unknown:
+            raise WithManagerAuthorityProtocolError("legacy token use-site has no enrolled demand")
+        rows: dict[SourceFragmentCoordinateV1, WithManagerAuthorityV1] = {}
+        for site, resolution in refs.by_use_site.items():
+            candidates = tokens.get(site, [])
+            if len(candidates) > 1:
+                rows[site] = ConflictingAuthority(
+                    WithManagerAuthorityGapV1(site, "duplicate-legacy-membrane-token"))
+            elif candidates and candidates[0].demand_cid != resolution.demand_cid:
+                rows[site] = ConflictingAuthority(
+                    WithManagerAuthorityGapV1(site, "mismatched-legacy-demand"))
+            elif isinstance(resolution, ContextManagerContractRefV1) and candidates:
+                rows[site] = ConflictingAuthority(
+                    WithManagerAuthorityGapV1(site, "conflicting-manager-authority"))
+            elif candidates:
+                rows[site] = AuthenticatedLegacyMembrane(candidates[0])
+            elif isinstance(resolution, ContextManagerContractRefV1):
+                rows[site] = ResolvedContextManager(resolution)
+            else:
+                rows[site] = UnresolvedContextManager(resolution)
+        temporary = cls("", MappingProxyType(rows))
+        return cls(_hash_json(temporary._identity()), MappingProxyType(rows))
+
+    def _identity(self) -> dict[str, Any]:
+        return {"kind": "with-manager-authorities", "schemaVersion": "1",
+                "byUseSite": [{"useSite": site.wire(), "authority": _authority_wire(authority)}
+                              for site, authority in sorted(self.by_use_site.items())]}
+
+    def to_wire(self) -> dict[str, Any]:
+        return {**self._identity(), "tableCid": self.table_cid}
+
+    def require(self, site: SourceFragmentCoordinateV1) -> WithManagerAuthorityV1:
+        try:
+            return self.by_use_site[site]
+        except KeyError as exc:
+            raise WithManagerAuthorityProtocolError(
+                "BackendDefect: enrolled With missing from authority table") from exc
+
+
+def decode_with_manager_authorities(raw: Any) -> WithManagerAuthoritiesV1:
+    if not isinstance(raw, dict) or set(raw) != {"kind", "schemaVersion", "tableCid", "byUseSite"} \
+            or raw["kind"] != "with-manager-authorities" or raw["schemaVersion"] != "1" \
+            or not isinstance(raw["byUseSite"], list):
+        raise WithManagerAuthorityProtocolError("malformed With authority table")
+    identity = {key: raw[key] for key in ("kind", "schemaVersion", "byUseSite")}
+    if _hash_json(identity) != _cid(raw["tableCid"], "tableCid"):
+        raise WithManagerAuthorityProtocolError("With authority table CID mismatch")
+    decoded = {}
+    for row in raw["byUseSite"]:
+        if not isinstance(row, dict) or set(row) != {"useSite", "authority"}:
+            raise WithManagerAuthorityProtocolError("malformed With authority row")
+        site = SourceFragmentCoordinateV1.decode(row["useSite"])
+        authority = row["authority"]
+        if not isinstance(authority, dict):
+            raise WithManagerAuthorityProtocolError("malformed With authority")
+        if authority.get("kind") == "authenticated-legacy-membrane" and set(authority) == {"kind", "reference"}:
+            value: WithManagerAuthorityV1 = AuthenticatedLegacyMembrane(_decode_legacy_ref(authority["reference"]))
+        elif authority.get("kind") == "resolved-context-manager" and set(authority) == {"kind", "reference"}:
+            value = ResolvedContextManager(_decode_ref(authority["reference"]))
+        elif authority.get("kind") == "unresolved-context-manager" and set(authority) == {"kind", "gap"}:
+            gap = authority["gap"]
+            if not isinstance(gap, dict) or set(gap) != {"demandCid", "useSite", "targetSymbol", "kind", "candidateMemberCids"}:
+                raise WithManagerAuthorityProtocolError("malformed unresolved With authority")
+            value = UnresolvedContextManager(ContextManagerResolutionGapV1(
+                _cid(gap["demandCid"], "demandCid"),
+                SourceFragmentCoordinateV1.decode(gap["useSite"]), gap["targetSymbol"],
+                gap["kind"], tuple(_cid(cid, "candidateMemberCid") for cid in gap["candidateMemberCids"]),
+            ))
+        elif authority.get("kind") == "conflicting-authority" and set(authority) == {"kind", "gap"}:
+            gap = authority["gap"]
+            value = ConflictingAuthority(WithManagerAuthorityGapV1(
+                SourceFragmentCoordinateV1.decode(gap["useSite"]), gap["kind"]))
+        else:
+            raise WithManagerAuthorityProtocolError("unknown With authority variant")
+        coordinate = value.reference.use_site if isinstance(value, (AuthenticatedLegacyMembrane, ResolvedContextManager)) else value.gap.use_site
+        if coordinate != site or site in decoded:
+            raise WithManagerAuthorityProtocolError("duplicate or mismatched With authority coordinate")
+        decoded[site] = value
+    return WithManagerAuthoritiesV1(raw["tableCid"], MappingProxyType(decoded))

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_edge_transport.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_edge_transport.py
@@ -1,0 +1,85 @@
+from types import MappingProxyType
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_contract import (
+    ContextManagerSemanticsV1,
+    EnterResultContractV1,
+    ExitContractV1,
+    NeverSuppressesDispositionV1,
+)
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContextManagerContractRefV1,
+    ContextManagerResolutionGapV1,
+    ImportSignatureV1,
+    SourceFragmentCoordinateV1,
+)
+from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.kit_rpc.context_manager_edge_dto import (
+    ContextManagerEdgeDtoV1,
+    ContextManagerEdgeTransportError,
+)
+from sugar_lift_py_tests.kit_rpc.lift_report_payload_dto import LiftReportPayloadDto
+
+
+def _cid(char):
+    return "blake3-512:" + char * 128
+
+
+def _ref(warrants=None):
+    site = SourceFragmentCoordinateV1(_cid("s"), 3, 9, 3, 18)
+    return ContextManagerContractRefV1(
+        resolution_cid=_cid("r"),
+        demand_cid=_cid("d"),
+        use_site=site,
+        catalog_cid=_cid("c"),
+        member_cid=_cid("m"),
+        payload_cid=_cid("p"),
+        bridge_source_symbol="context-manager:dependency.manager",
+        import_signature=ImportSignatureV1((), ()),
+        semantics=ContextManagerSemanticsV1(
+            enter=EnterResultContractV1(PrimitiveSort("Value")),
+            exit=ExitContractV1(NeverSuppressesDispositionV1()),
+        ),
+        source_warrant_cids=tuple(warrants or (_cid("a"), _cid("b"))),
+    )
+
+
+def test_edge_from_resolved_is_content_addressed_and_report_lane_is_separate():
+    reference = _ref()
+    edge = ContextManagerEdgeDtoV1.from_resolved(reference, reference.use_site)
+    wire = edge.to_rpc()
+    assert wire["kind"] == "context-manager-edge"
+    assert wire["schemaVersion"] == "1"
+    assert wire["targetContractCid"] == reference.member_cid
+    assert wire["payloadCid"] == reference.payload_cid
+    assert wire["demandCid"] == reference.demand_cid
+    assert wire["resolutionCid"] == reference.resolution_cid
+    assert wire["catalogCid"] == reference.catalog_cid
+    assert wire["sourceWarrantCids"] == sorted(reference.source_warrant_cids)
+    assert wire["semantics"]["exit"]["disposition"] == {"kind": "never-suppresses"}
+
+    report = LiftReportPayloadDto(context_manager_edges=[edge]).to_rpc()
+    assert report["contextManagerEdges"] == [wire]
+    assert report["callEdges"] == []
+
+
+def test_edge_constructor_rejects_coordinate_gap_and_duplicate_warrants():
+    reference = _ref()
+    other_site = SourceFragmentCoordinateV1(_cid("s"), 4, 0, 4, 3)
+    with pytest.raises(ContextManagerEdgeTransportError, match="use-site"):
+        ContextManagerEdgeDtoV1.from_resolved(reference, other_site)
+
+    gap = ContextManagerResolutionGapV1(
+        demand_cid=_cid("d"),
+        use_site=reference.use_site,
+        target_symbol="context-manager:dependency.manager",
+        kind="unresolved-symbol",
+        candidate_member_cids=(),
+    )
+    with pytest.raises(ContextManagerEdgeTransportError, match="resolved"):
+        ContextManagerEdgeDtoV1.from_resolved(gap, gap.use_site)
+
+    duplicate = _ref((_cid("a"), _cid("a")))
+    with pytest.raises(ContextManagerEdgeTransportError, match="unique"):
+        ContextManagerEdgeDtoV1.from_resolved(duplicate, duplicate.use_site)

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
@@ -55,14 +55,16 @@ def test_table_is_frozen_and_missing_enrolled_coordinate_is_backend_defect():
 def test_bind_rpc_freezes_one_generation_and_acknowledges_exact_table_cid(monkeypatch):
     sent = []
     monkeypatch.setattr(lift_rpc, "_BOUND_CONTRACT_REFS", None)
+    monkeypatch.setattr(lift_rpc, "_BOUND_WITH_MANAGER_AUTHORITIES", None)
     monkeypatch.setattr(lift_rpc, "_send", sent.append)
     wire = unresolved_table()
     assert lift_rpc._dispatch_request({
         "jsonrpc": "2.0", "id": 7,
         "method": lift_rpc.BIND_CONTRACT_REFS_RPC_METHOD,
-        "params": wire,
+        "params": {"contractRefs": wire, "legacyMembraneRefs": []},
     })
-    assert sent == [{"jsonrpc": "2.0", "id": 7, "result": {"tableCid": wire["tableCid"]}}]
+    assert sent[0]["result"]["tableCid"] == wire["tableCid"]
+    assert sent[0]["result"]["withManagerAuthoritiesCid"].startswith("blake3-512:")
     assert isinstance(lift_rpc._BOUND_CONTRACT_REFS.by_use_site, MappingProxyType)
 
     other = unresolved_table()
@@ -73,7 +75,7 @@ def test_bind_rpc_freezes_one_generation_and_acknowledges_exact_table_cid(monkey
         lift_rpc._dispatch_request({
             "jsonrpc": "2.0", "id": 8,
             "method": lift_rpc.BIND_CONTRACT_REFS_RPC_METHOD,
-            "params": other,
+            "params": {"contractRefs": other, "legacyMembraneRefs": []},
         })
 
 
@@ -136,6 +138,7 @@ def test_published_typed_declaration_is_served_only_by_declaration_pass(monkeypa
     sent = []
     monkeypatch.setattr(lift_rpc, "_PUBLISHED_CONTEXT_MANAGER_DECLARATIONS", ())
     monkeypatch.setattr(lift_rpc, "_BOUND_CONTRACT_REFS", None)
+    monkeypatch.setattr(lift_rpc, "_BOUND_WITH_MANAGER_AUTHORITIES", None)
     monkeypatch.setattr(lift_rpc, "_ENUMERATION_ACTIVE", False)
     monkeypatch.setattr(lift_rpc, "_send", sent.append)
     lift_rpc.publish_context_manager_declaration(declaration)

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_manager_authorities.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_manager_authorities.py
@@ -1,0 +1,107 @@
+from types import MappingProxyType
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_contract import EffectMatcher, Expects
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContextManagerResolutionGapV1,
+    ResolvedContractRefsV1,
+    SourceFragmentCoordinateV1,
+)
+from sugar_lift_py_tests.with_manager_authority import (
+    AuthenticatedLegacyMembrane,
+    AuthenticatedLegacyMembraneRefV1,
+    ConflictingAuthority,
+    UnresolvedContextManager,
+    WithManagerAuthorityProtocolError,
+    WithManagerAuthoritiesV1,
+    decode_with_manager_authorities,
+)
+from sugar_lift_py_tests.lift_rpc import _legacy_membrane_token_rows
+
+
+def _cid(fill: str) -> str:
+    return "blake3-512:" + fill * 128
+
+
+def _site() -> SourceFragmentCoordinateV1:
+    return SourceFragmentCoordinateV1(_cid("s"), 4, 9, 4, 25)
+
+
+def _unresolved():
+    return ContextManagerResolutionGapV1(
+        _cid("d"), _site(), "context-manager:dependency.manager",
+        "unresolved-symbol", (),
+    )
+
+
+def _refs():
+    return ResolvedContractRefsV1(
+        _cid("c"), _cid("t"), MappingProxyType({_site(): _unresolved()})
+    )
+
+
+def _token():
+    return AuthenticatedLegacyMembraneRefV1.mint_from_authenticated_identity(
+        demand_cid=_cid("d"), use_site=_site(),
+        manifest_cid=_cid("m"),
+        enrollment_cid=_cid("e"),
+        contract=Expects(EffectMatcher("raise", "ValueError"), "exception_info"),
+    )
+
+
+def test_unresolved_without_token_stays_the_exact_typed_gap():
+    table = WithManagerAuthoritiesV1.assemble(_refs(), ())
+    authority = table.require(_site())
+    assert isinstance(authority, UnresolvedContextManager)
+    assert authority.gap == _refs().require(_site())
+
+
+def test_authenticated_token_wins_only_over_underlying_unresolved_row_and_round_trips():
+    token = _token()
+    table = WithManagerAuthoritiesV1.assemble(_refs(), (token,))
+    authority = table.require(_site())
+    assert isinstance(authority, AuthenticatedLegacyMembrane)
+    assert authority.reference == token
+    decoded = decode_with_manager_authorities(table.to_wire())
+    assert decoded == table
+    assert decoded.require(_site()).reference.demand_cid == _cid("d")
+
+
+def test_duplicate_tokens_are_conflicting_authority_not_first_match():
+    table = WithManagerAuthoritiesV1.assemble(_refs(), (_token(), _token()))
+    authority = table.require(_site())
+    assert isinstance(authority, ConflictingAuthority)
+    assert authority.gap.kind == "duplicate-legacy-membrane-token"
+
+
+@pytest.mark.parametrize("field", [
+    "authenticationCid", "demandCid", "manifestCid", "enrollmentCid",
+])
+def test_mutated_authenticated_token_is_loud(field):
+    table = WithManagerAuthoritiesV1.assemble(_refs(), (_token(),))
+    wire = table.to_wire()
+    wire["byUseSite"][0]["authority"]["reference"][field] = _cid("z")
+    with pytest.raises(WithManagerAuthorityProtocolError):
+        decode_with_manager_authorities(wire)
+
+
+def test_preconstruction_prebinder_authenticates_alias_but_not_same_spelled_local(tmp_path):
+    (tmp_path / "consumer.py").write_text(
+        "from pytest import raises as expect_error\n"
+        "def admitted():\n"
+        "    with expect_error(ValueError) as caught:\n"
+        "        return caught\n"
+        "def raises(value):\n"
+        "    return value\n"
+        "def local():\n"
+        "    with raises(ValueError):\n"
+        "        pass\n"
+    )
+    rows = _legacy_membrane_token_rows(tmp_path)
+    assert len(rows) == 1
+    token = rows[0]
+    assert token["kind"] == "authenticated-legacy-membrane-ref"
+    assert token["demandCid"].startswith("blake3-512:")
+    assert token["contract"]["kind"] == "expects"
+    assert token["contract"]["matcher"]["name"] == "ValueError"

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -9,6 +9,7 @@ import inspect
 
 from sugar_lift_py_tests.context_manager_contract import (
     NeverSuppresses,
+    NeverSuppressesDispositionV1,
     RuntimeSelected,
 )
 from sugar_lift_py_tests.effect import RaiseEffect
@@ -21,6 +22,8 @@ from sugar_lift_py_tests.floor.manager_coordinate import (
     ManagerCoordinate,
 )
 from sugar_lift_py_tests.floor.inv_value import InvValue
+from sugar_lift_py_tests.floor.guarded_faces import GuardedFaces
+from sugar_lift_py_tests.ir import atomic, make_var, not_
 from sugar_lift_py_tests.outcome import Complete, Incomplete
 from sugar_lift_py_tests.outcome.exit_set import Completed, Halted, true_guard
 from sugar_lift_py_tests.outcome.resource_bindings import ExitFaceBinding
@@ -199,6 +202,47 @@ def test_never_suppresses_restores_body_halt():
     out = sugar.desugar()
     reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
     assert any(r.effect.exception_name == "ValueError" for r in reds)
+
+
+def test_typed_never_suppresses_preserves_conditional_raise_and_normal_face():
+    guard = atomic("with_body_guard", [make_var("state")])
+    effect = RaiseEffect(exception_name="ValueError", occurrence="body.py:4:8")
+
+    class _ConditionalRaise(Sugar):
+        def desugar(self, ctx=None):
+            del ctx
+            return Complete(
+                GuardedFaces(
+                    guard=guard,
+                    entries=(Incomplete(effect).guarded(guard),),
+                    then_exits=True,
+                    else_exits=False,
+                    can_fall_through=True,
+                    continuation_guard=not_(guard),
+                )
+            )
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    exit_runs = []
+    out = _resource(
+        body=(_ConditionalRaise(),),
+        disposition=NeverSuppressesDispositionV1(),
+        exit_probe=exit_runs,
+    ).desugar()
+    contributions = out.value.contribution()
+    raises = [
+        entry
+        for entry in contributions
+        if isinstance(entry, Incomplete) and entry.effect == effect
+    ]
+    assert len(raises) == 1
+    assert raises[0].branch_conditions == (guard,)
+    assert out.value.can_fall_through
+    assert exit_runs == [1]
+    assert all(entry is not None for entry in contributions)
 
 
 def test_proven_contract_consumes_matching_body_halt():

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2094,6 +2094,136 @@ class With(Statement):
     body: Tuple[Statement, ...]
     _child_fields = ("items", "body")
 
+    def _prebound_manager_authority(self, item: WithItem):
+        """Read the sole preconstruction routing authority for this occurrence."""
+        context = self.unit.construction_context
+        if context is None:
+            return None
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+            TreeConstructionContextV1,
+        )
+        from sugar_lift_py_tests.with_manager_authority import (
+            WithManagerAuthorityProtocolError,
+        )
+
+        if not isinstance(context, TreeConstructionContextV1):
+            backend_defect(
+                owner="With._construct_sugar",
+                observed="tree construction context is not TreeConstructionContextV1",
+                requested="the immutable prereq-2 contract-ref table",
+                fix="inject the decoded typed table before SourceFile construction",
+            )
+        span = item.context_expr.line_col_span()
+        coordinate = SourceFragmentCoordinateV1(
+            self.unit.source_cid,
+            span.start_line,
+            span.start_col,
+            span.end_line,
+            span.end_col,
+        )
+        try:
+            return context.with_manager_authorities.require(coordinate)
+        except WithManagerAuthorityProtocolError as exc:
+            backend_defect(
+                owner="With._construct_sugar",
+                observed=str(exc),
+                requested="one resolution row for every enrolled With demand",
+                fix="repair prereq-2 demand/table generation; never search at construction",
+            )
+
+    def _prebound_manager_resolution(self, item: WithItem):
+        authority = self._prebound_manager_authority(item)
+        if authority is None:
+            return None
+        from sugar_lift_py_tests.with_manager_authority import (
+            ConflictingAuthority,
+            ResolvedContextManager,
+            UnresolvedContextManager,
+            WithManagerAuthorityProtocolError,
+        )
+        if isinstance(authority, ResolvedContextManager):
+            return authority.reference
+        if isinstance(authority, UnresolvedContextManager):
+            return authority.gap
+        if isinstance(authority, ConflictingAuthority):
+            backend_defect(
+                owner="With._construct_sugar",
+                observed=authority.gap.kind,
+                requested="exactly one authenticated With manager authority",
+                fix="repair preconstruction authority assembly; never choose precedence",
+            )
+        raise WithManagerAuthorityProtocolError(
+            "legacy membrane authority is not a context-manager resolution"
+        )
+
+    def _raise_resolution_gap(self, resolution) -> None:
+        from .panic import ContextManagerResolutionConstructionGap
+
+        panic = ContextManagerResolutionConstructionGap(
+            kind=resolution.kind,
+            demand_cid=resolution.demand_cid,
+            candidate_member_cids=resolution.candidate_member_cids,
+            owner="With._construct_sugar",
+            observed=f"authenticated preconstruction resolution gap: {resolution.kind}",
+            requested="one resolved authenticated ContextManagerContractRefV1",
+            fix="publish or resolve the exact typed CM contract before construction",
+        )
+        self.reporter.report_gap(self, panic)
+        raise panic
+
+    def _require_narrow_cm_ref(self, item: WithItem):
+        resolution = self._prebound_manager_resolution(item)
+        if resolution is None:
+            return None
+        from sugar_lift_py_tests.context_manager_contract import (
+            NeverSuppressesDispositionV1,
+        )
+        from sugar_lift_py_tests.context_manager_resolution import (
+            ContextManagerContractRefV1,
+            ContextManagerResolutionGapV1,
+        )
+        from sugar_lift_py_tests.ir import PrimitiveSort
+        from .panic import UnsupportedContextManagerSemantics
+
+        if isinstance(resolution, ContextManagerResolutionGapV1):
+            self._raise_resolution_gap(resolution)
+        if not isinstance(resolution, ContextManagerContractRefV1):
+            backend_defect(
+                owner="With._construct_sugar",
+                observed=f"unexpected resolution value {type(resolution).__name__}",
+                requested="ContextManagerContractRefV1 or ContextManagerResolutionGapV1",
+                fix="keep the injected table closed and typed",
+            )
+        semantics = resolution.semantics
+        admitted = (
+            semantics.kind == "context-manager-semantics"
+            and semantics.schema_version == "1"
+            and semantics.enter.completion == "total"
+            and semantics.enter.projection == "enter_result"
+            and isinstance(semantics.enter.sort, PrimitiveSort)
+            and semantics.enter.sort.name == "Value"
+            and semantics.exit.completion == "total"
+            and isinstance(
+                semantics.exit.disposition, NeverSuppressesDispositionV1
+            )
+        )
+        if not admitted:
+            panic = UnsupportedContextManagerSemantics(
+                demand_cid=resolution.demand_cid,
+                member_cid=resolution.member_cid,
+                owner="With._construct_sugar",
+                observed=(
+                    "authenticated CM member carries unsupported enter/exit semantics "
+                    f"at {resolution.member_cid}"
+                ),
+                requested="total Value enter testimony and typed NeverSuppresses exit",
+                fix="leave unsupported authenticated semantics loud; never upgrade testimony",
+            )
+            self.reporter.report_gap(self, panic)
+            raise panic
+        return resolution
+
     def _construct_sugar(self):
         """`with <manager> [as <name>]: <body>` -- the node consults the
         MEMBRANE, never a vendor name (#5994). A single manager whose
@@ -2108,6 +2238,17 @@ class With(Statement):
         → ``NeverSuppresses`` via ``WithResourceSugar``. Generator CMs and
         builtins (``open``) stay RuntimeSelected until their separate proofs.
         Non-Name as-targets, Suppresses+as, and multiple managers stay loud."""
+        if self.unit.construction_context is not None and len(self.items) != 1:
+            from .panic import MultipleContextManagerItems
+
+            panic = MultipleContextManagerItems(
+                owner="With._construct_sugar",
+                observed=f"synchronous With contains {len(self.items)} manager items",
+                requested="exactly one pre-resolved synchronous manager item",
+                fix="keep multi-item context-manager composition loud",
+            )
+            self.reporter.report_gap(self, panic)
+            raise panic
         if len(self.items) != 1:
             return super()._construct_sugar()
         item = self.items[0]
@@ -2116,97 +2257,72 @@ class With(Statement):
             # ``as <Name>`` only: substitute already rewrote loads to
             # ObservationRef(slot). Non-Name targets stay loud.
             if item.optional_vars.kind != "Name":
+                if self.unit.construction_context is not None:
+                    from .panic import UnsupportedWithBindingTarget
+
+                    panic = UnsupportedWithBindingTarget(
+                        owner="With._construct_sugar",
+                        observed=f"unsupported with binding target {item.optional_vars.kind}",
+                        requested="no target or one simple Name target",
+                        fix="leave destructuring and attribute targets loud",
+                    )
+                    self.reporter.report_gap(self, panic)
+                    raise panic
                 return super()._construct_sugar()
             as_name = item.optional_vars.id
-        from sugar_lift_py_tests.context_manager_contract import (
-            Expects,
-            NeverSuppresses,
-            RuntimeSelected,
-            Suppresses,
-        )
-        from sugar_lift_py_tests.manifest_membrane import (
-            contract_for_manager,
-            default_community_manifest,
-        )
-        from sugar_lift_py_tests.sugar.with_contract_sugar import WithContractSugar
-        from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
 
-        contract = contract_for_manager(
-            default_community_manifest(), item.context_expr
-        )
-        if isinstance(contract, (Expects, Suppresses)):
-            if contract.matcher.kind not in ("raise", "warning"):
-                return super()._construct_sugar()
-            # Suppresses+as is not a routed observation surface — stay loud.
-            if as_name is not None and not isinstance(contract, Expects):
-                return super()._construct_sugar()
-            slot_id = None
-            if as_name is not None and isinstance(contract, Expects):
-                slot_id = item._effect_slot_id()
-            return WithContractSugar(
-                contract=contract,
-                body=tuple(stmt.sugar() for stmt in self.body),
-                site=self.fragment,
-                slot_id=slot_id,
+        authority = self._prebound_manager_authority(item)
+        if authority is not None:
+            from sugar_lift_py_tests.with_manager_authority import (
+                AuthenticatedLegacyMembrane,
             )
-        def _resource_sugar(disposition):
+            if isinstance(authority, AuthenticatedLegacyMembrane):
+                from sugar_lift_py_tests.context_manager_contract import Expects, Suppresses
+                from sugar_lift_py_tests.sugar.with_contract_sugar import WithContractSugar
+                contract = authority.reference.contract
+                if as_name is not None and not isinstance(contract, Expects):
+                    return super()._construct_sugar()
+                return WithContractSugar(
+                    contract=contract,
+                    body=tuple(stmt.sugar() for stmt in self.body),
+                    site=self.fragment,
+                    slot_id=(item._effect_slot_id()
+                             if as_name is not None and isinstance(contract, Expects)
+                             else None),
+                )
+
+        resolved_ref = self._require_narrow_cm_ref(item)
+        if resolved_ref is not None:
+            from sugar_lift_py_tests.kit_rpc import ContextManagerEdgeDtoV1
+            from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
+
             manager_slot = item._manager_slot_id()
-            enter_node = item._make_enter_call()
-            exit_node = item._make_parametric_exit_call()
             enter_slot = (
                 f"{manager_slot}#enter_result" if as_name is not None else None
             )
             return WithResourceSugar(
                 manager=item.context_expr.sugar(),
                 manager_slot_id=manager_slot,
-                enter=enter_node.sugar(),
-                exit=exit_node.sugar(),
+                enter=item._make_enter_call().sugar(),
+                exit=item._make_parametric_exit_call().sugar(),
                 exit_face_id=item._exit_face_id(),
                 body=tuple(stmt.sugar() for stmt in self.body),
-                disposition=disposition,
+                disposition=resolved_ref.semantics.exit.disposition,
+                contract_ref=resolved_ref,
+                context_manager_edge=ContextManagerEdgeDtoV1.from_resolved(
+                    resolved_ref, resolved_ref.use_site
+                ),
                 enter_slot_id=enter_slot,
                 site=self.fragment,
             )
-
-        if isinstance(contract, NeverSuppresses):
-            # Membrane-issued NeverSuppresses (if ever enrolled) uses resource path.
-            return _resource_sugar(contract)
-
-        # Unauthenticated / RuntimeSelected: try source-visible __exit__ proof
-        # before the named residual. Generator CMs (switchdir) stay loud here.
-        if contract is None or isinstance(contract, RuntimeSelected):
-            from sugar_lift_py_tests.exit_disposition_proof import (
-                prove_exit_disposition_from_manager_expr,
-            )
-
-            proof = prove_exit_disposition_from_manager_expr(item.context_expr)
-            if proof is not None and proof.kind == "never_suppresses":
-                return _resource_sugar(proof.disposition())
-
-            where = f"{self.unit.filename}"
-            try:
-                lc = self.line_col_span()
-                where = f"{self.unit.filename}:{lc.start_line}:{lc.start_col}"
-            except SourceTreePanic:
-                pass
-            panic = RuntimeSelectedContextManager(
-                owner="With.sugar",
-                observed=(
-                    "unauthenticated context manager — exit suppression "
-                    f"runtime-selected at {where}"
-                ),
-                requested=(
-                    "a typed exit contract (NeverSuppresses from source-visible "
-                    "__exit__ proof, or Expects/Suppresses via the membrane)"
-                ),
-                fix=(
-                    "prove every completed __exit__ return is exact None/False "
-                    "(incl. implicit None); never invent a normal-path-only expansion"
-                ),
-            )
-            self.reporter.report_gap(self, panic)
-            raise panic
-        return super()._construct_sugar()
+        panic = RuntimeSelectedContextManager(
+            owner="With.sugar",
+            observed="With manager has no injected authenticated preconstruction authority",
+            requested="one typed WithManagerAuthorityV1 at the exact use-site",
+            fix="run the preconstruction authority assembler before tree construction",
+        )
+        self.reporter.report_gap(self, panic)
+        raise panic
 
     def substitute(self, scope):
         """with ... as <Name>: rewrite name → ObservationRef(slot, projection).
@@ -2219,11 +2335,6 @@ class With(Statement):
         from sugar_lift_py_tests.context_manager_contract import (
             ENTER_RESULT,
             Expects,
-            NeverSuppresses,
-        )
-        from sugar_lift_py_tests.manifest_membrane import (
-            contract_for_manager,
-            default_community_manifest,
         )
 
         changed = {}
@@ -2233,29 +2344,35 @@ class With(Statement):
         items = new_items if d else self.items
 
         body_scope = dict(scope)
+        if self.unit.construction_context is not None:
+            if len(items) != 1:
+                return self if not changed else rewrite(self, **changed)
+            item = items[0]
+            if item.optional_vars is not None and item.optional_vars.kind == "Name":
+                from sugar_lift_py_tests.with_manager_authority import (
+                    AuthenticatedLegacyMembrane,
+                )
+                authority = self._prebound_manager_authority(item)
+                if isinstance(authority, AuthenticatedLegacyMembrane):
+                    contract = authority.reference.contract
+                    if isinstance(contract, Expects) and contract.binding:
+                        body_scope[item.optional_vars.id] = item._make_observation_ref(
+                            item._effect_slot_id(), contract.binding
+                        )
+                else:
+                    resolved_ref = self._require_narrow_cm_ref(item)
+                    enter_slot = f"{item._manager_slot_id()}#enter_result"
+                    body_scope[item.optional_vars.id] = item._make_observation_ref(
+                        enter_slot, ENTER_RESULT
+                    )
+            new_body, d = self._substitute_body(self.body, body_scope)
+            if d:
+                changed["body"] = new_body
+            return self if not changed else rewrite(self, **changed)
         for item in items:
-            if item.optional_vars is None or item.optional_vars.kind != "Name":
-                # Non-Name as-targets: mask only (no coordinate invented).
-                if item.optional_vars is not None:
-                    for n in self._bound_names_in(item.optional_vars):
-                        body_scope.pop(n, None)
-                continue
-            contract = contract_for_manager(
-                default_community_manifest(), item.context_expr
-            )
-            slot_id = item._effect_slot_id()
-            if isinstance(contract, Expects) and contract.binding:
-                ref = item._make_observation_ref(slot_id, contract.binding)
-                body_scope[item.optional_vars.id] = ref
-                continue
-            if isinstance(contract, NeverSuppresses):
-                # Enter-result slot is distinct from manager slot.
-                enter_slot = f"{item._manager_slot_id()}#enter_result"
-                ref = item._make_observation_ref(enter_slot, ENTER_RESULT)
-                body_scope[item.optional_vars.id] = ref
-                continue
-            # Unauthenticated / suppresses: mask the name, stay without ref.
-            body_scope.pop(item.optional_vars.id, None)
+            if item.optional_vars is not None:
+                for name in self._bound_names_in(item.optional_vars):
+                    body_scope.pop(name, None)
 
         new_body, d = self._substitute_body(self.body, body_scope)
         if d:
@@ -2267,32 +2384,34 @@ class With(Statement):
         from sugar_lift_py_tests.context_manager_contract import (
             ENTER_RESULT,
             Expects,
-            NeverSuppresses,
-        )
-        from sugar_lift_py_tests.manifest_membrane import (
-            contract_for_manager,
-            default_community_manifest,
         )
 
         del scope
-        exported: dict[str, Node] = {}
-        for item in self.items:
+        if self.unit.construction_context is not None:
+            if len(self.items) != 1:
+                return None
+            item = self.items[0]
             if item.optional_vars is None or item.optional_vars.kind != "Name":
-                continue
-            contract = contract_for_manager(
-                default_community_manifest(), item.context_expr
+                return None
+            from sugar_lift_py_tests.with_manager_authority import (
+                AuthenticatedLegacyMembrane,
             )
-            slot_id = item._effect_slot_id()
-            if isinstance(contract, Expects) and contract.binding:
-                exported[item.optional_vars.id] = item._make_observation_ref(
-                    slot_id, contract.binding
-                )
-            elif isinstance(contract, NeverSuppresses):
-                enter_slot = f"{item._manager_slot_id()}#enter_result"
-                exported[item.optional_vars.id] = item._make_observation_ref(
+            authority = self._prebound_manager_authority(item)
+            if isinstance(authority, AuthenticatedLegacyMembrane):
+                contract = authority.reference.contract
+                if isinstance(contract, Expects) and contract.binding:
+                    return {item.optional_vars.id: item._make_observation_ref(
+                        item._effect_slot_id(), contract.binding
+                    )}
+                return None
+            self._require_narrow_cm_ref(item)
+            enter_slot = f"{item._manager_slot_id()}#enter_result"
+            return {
+                item.optional_vars.id: item._make_observation_ref(
                     enter_slot, ENTER_RESULT
                 )
-        return exported or None
+            }
+        return None
 
 
 class AsyncWith(Statement):
@@ -2301,8 +2420,24 @@ class AsyncWith(Statement):
     _child_fields = ("items", "body")
 
     def substitute(self, scope):
-        """Same as With: masks the as-targets for the body."""
-        return With.substitute(self, scope)
+        """Async context management stays loud before child construction."""
+        del scope
+        return self._raise_async_gap()
+
+    def _raise_async_gap(self):
+        from .panic import AsyncContextManagerUnsupported
+
+        panic = AsyncContextManagerUnsupported(
+            owner="AsyncWith._construct_sugar",
+            observed="async context manager is outside the narrow synchronous arm",
+            requested="one synchronous pre-resolved NeverSuppresses manager",
+            fix="keep async enter/exit semantics loud until separately specified",
+        )
+        self.reporter.report_gap(self, panic)
+        raise panic
+
+    def _construct_sugar(self):
+        return self._raise_async_gap()
 
 
 class Raise(Statement):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -39,6 +39,8 @@ tree (#5940 builds the tree in isolation).
 
 from __future__ import annotations
 
+from enum import Enum
+
 
 class SourceTreePanic(Exception):
     """Common base. Never raised directly — always one of the two below."""
@@ -103,6 +105,93 @@ class RuntimeSelectedContextManager(SugarNotWritten):
     """
 
     _LABEL = "RUNTIME-SELECTED CONTEXT MANAGER"
+
+
+class WithConstructionGapKind(str, Enum):
+    RUNTIME_SELECTED = "runtime-selected"
+    UNRESOLVED_SYMBOL = "unresolved-symbol"
+    AMBIGUOUS_SYMBOL = "ambiguous-symbol"
+    WRONG_CONTRACT_KIND = "wrong-contract-kind"
+    SIGNATURE_MISMATCH = "signature-mismatch"
+    UNAUTHENTICATED_MEMBER = "unauthenticated-member"
+    PAYLOAD_CID_MISMATCH = "payload-cid-mismatch"
+    UNSUPPORTED_CM_SCHEMA = "unsupported-cm-schema"
+    UNSUPPORTED_CONTEXT_MANAGER_SEMANTICS = "unsupported-context-manager-semantics"
+    MULTIPLE_CONTEXT_MANAGER_ITEMS = "multiple-context-manager-items"
+    UNSUPPORTED_WITH_BINDING_TARGET = "unsupported-with-binding-target"
+    ASYNC_CONTEXT_MANAGER_UNSUPPORTED = "async-context-manager-unsupported"
+
+
+class WithConstructionGap(SugarNotWritten):
+    def __init__(
+        self,
+        *,
+        gap_kind: WithConstructionGapKind,
+        demand_cid: str | None = None,
+        candidate_member_cids: tuple[str, ...] = (),
+        member_cid: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.gap_kind = gap_kind
+        self.kind = gap_kind.value
+        self.demand_cid = demand_cid
+        self.candidate_member_cids = candidate_member_cids
+        self.member_cid = member_cid
+
+
+class ContextManagerResolutionConstructionGap(WithConstructionGap):
+    """A prereq-2 typed resolution gap consumed unchanged by ``With``."""
+
+    _LABEL = "CONTEXT MANAGER RESOLUTION GAP"
+
+    def __init__(self, *, kind: str, demand_cid: str, candidate_member_cids: tuple[str, ...], **kwargs) -> None:
+        super().__init__(
+            gap_kind=WithConstructionGapKind(kind),
+            demand_cid=demand_cid,
+            candidate_member_cids=candidate_member_cids,
+            **kwargs,
+        )
+
+
+class UnsupportedContextManagerSemantics(WithConstructionGap):
+    _LABEL = "UNSUPPORTED CONTEXT MANAGER SEMANTICS"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(
+            gap_kind=WithConstructionGapKind.UNSUPPORTED_CONTEXT_MANAGER_SEMANTICS,
+            **kwargs,
+        )
+
+
+class MultipleContextManagerItems(WithConstructionGap):
+    _LABEL = "MULTIPLE CONTEXT MANAGER ITEMS"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(
+            gap_kind=WithConstructionGapKind.MULTIPLE_CONTEXT_MANAGER_ITEMS,
+            **kwargs,
+        )
+
+
+class UnsupportedWithBindingTarget(WithConstructionGap):
+    _LABEL = "UNSUPPORTED WITH BINDING TARGET"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(
+            gap_kind=WithConstructionGapKind.UNSUPPORTED_WITH_BINDING_TARGET,
+            **kwargs,
+        )
+
+
+class AsyncContextManagerUnsupported(WithConstructionGap):
+    _LABEL = "ASYNC CONTEXT MANAGER UNSUPPORTED"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(
+            gap_kind=WithConstructionGapKind.ASYNC_CONTEXT_MANAGER_UNSUPPORTED,
+            **kwargs,
+        )
 
 
 class SubstituteNotWritten(SourceTreePanic):

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -5,26 +5,28 @@ loud residuals stay loud. Mirror of test_with_contract.py for the native-syntax
 twin."""
 
 import tempfile
+from pathlib import Path
 
 import pytest
 
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
+from with_authority_fixture import source_file_with_preconstruction
 
 
 def _val(src):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
-        f.write(src)
+        f.write("import pytest\nimport contextlib\nimport tm\n" + src)
         path = f.name
-    return next(SourceFile(path_source(path)).functions()).sugar().desugar().value
+    return next(source_file_with_preconstruction(Path(path)).functions()).sugar().desugar().value
 
 
 def _fn(src):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
-        f.write(src)
+        f.write("import pytest\nimport contextlib\nimport tm\n" + src)
         path = f.name
-    return next(SourceFile(path_source(path)).functions())
+    return next(source_file_with_preconstruction(Path(path)).functions())
 
 
 def _incompletes(v):

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_contract import (
+    ContextManagerSemanticsV1,
+    EnterResultContractV1,
+    ExitContractV1,
+    NeverSuppressesDispositionV1,
+)
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContextManagerContractRefV1,
+    ContextManagerResolutionGapV1,
+    ImportSignatureV1,
+    ResolvedContractRefsV1,
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
+from sugar_lift_py_tests.sugar.with_contract_sugar import WithContractSugar
+from sugar_lift_py_tests.context_manager_contract import EffectMatcher, Expects
+from sugar_lift_py_tests.with_manager_authority import (
+    AuthenticatedLegacyMembraneRefV1,
+    WithManagerAuthoritiesV1,
+)
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _cid(char: str) -> str:
+    return "blake3-512:" + char * 128
+
+
+def _coordinate(node) -> SourceFragmentCoordinateV1:
+    span = node.line_col_span()
+    return SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
+def _source_with_resolution(source_identity, resolution):
+    first = SourceFile(source_identity)
+    with_node = next(node for node in first.nodes() if node.kind in {"With", "AsyncWith"})
+    use_site = _coordinate(with_node.items[0].context_expr)
+    if callable(resolution):
+        resolution = resolution(use_site)
+    table = ResolvedContractRefsV1(
+        catalog_cid=_cid("c"),
+        table_cid=_cid("t"),
+        by_use_site=MappingProxyType({use_site: resolution}),
+    )
+    return SourceFile(
+        source_identity,
+        construction_context=TreeConstructionContextV1(table),
+    )
+
+
+def _resolved(use_site) -> ContextManagerContractRefV1:
+    semantics = ContextManagerSemanticsV1(
+        enter=EnterResultContractV1(sort=PrimitiveSort("Value")),
+        exit=ExitContractV1(disposition=NeverSuppressesDispositionV1()),
+    )
+    return ContextManagerContractRefV1(
+        resolution_cid=_cid("r"),
+        demand_cid=_cid("d"),
+        use_site=use_site,
+        catalog_cid=_cid("c"),
+        member_cid=_cid("m"),
+        payload_cid=_cid("p"),
+        bridge_source_symbol="context-manager:dependency.manager",
+        import_signature=ImportSignatureV1((), ()),
+        semantics=semantics,
+        source_warrant_cids=(_cid("w"),),
+    )
+
+
+def _function_sugar(source_identity, resolution):
+    source = _source_with_resolution(source_identity, resolution)
+    return next(source.functions()).sugar()
+
+
+def test_authenticated_ref_constructs_resource_once_and_binds_enter_result(tmp_path, monkeypatch):
+    path = tmp_path / "consumer.py"
+    path.write_text(
+        "from dependency import manager\n"
+        "def f():\n"
+        "    with manager() as entered:\n"
+        "        return entered\n"
+    )
+    from sugar_lift_python_source.source_oracle import path_source
+    import sugar_lift_py_tests.exit_disposition_proof as source_proof
+    import sugar_lift_py_tests.manifest_membrane as membrane
+    from sugar_source_tree.nodes import Call
+
+    manager_constructions = []
+    original_call_sugar = Call.sugar
+
+    def count_original_manager(self):
+        if self.func.kind == "Name" and self.func.id == "manager":
+            manager_constructions.append(self)
+        return original_call_sugar(self)
+
+    monkeypatch.setattr(Call, "sugar", count_original_manager)
+
+    monkeypatch.setattr(
+        source_proof,
+        "prove_exit_disposition_from_manager_expr",
+        lambda *_: (_ for _ in ()).throw(AssertionError("source proof invoked")),
+    )
+    monkeypatch.setattr(
+        membrane,
+        "contract_for_manager",
+        lambda *_: (_ for _ in ()).throw(AssertionError("membrane invoked")),
+    )
+
+    sugar = _function_sugar(path_source(str(path)), _resolved)
+    resource = next(statement for statement in sugar.statements if isinstance(statement, WithResourceSugar))
+    assert resource.contract_ref.member_cid == _cid("m")
+    assert resource.contract_ref.payload_cid == _cid("p")
+    assert resource.enter_slot_id == f"{resource.manager_slot_id}#enter_result"
+    assert len(manager_constructions) == 1
+    bound_return = resource.body[0]
+    assert bound_return.value.slot_id == resource.enter_slot_id
+    assert bound_return.value.projection == "enter_result"
+
+
+def test_unresolved_ref_stays_typed_loud(tmp_path, monkeypatch):
+    path = tmp_path / "unresolved.py"
+    path.write_text(
+        "from dependency import manager\n"
+        "def f():\n"
+        "    with manager():\n"
+        "        pass\n"
+    )
+    from sugar_lift_python_source.source_oracle import path_source
+    import sugar_lift_py_tests.exit_disposition_proof as source_proof
+    import sugar_lift_py_tests.manifest_membrane as membrane
+
+    monkeypatch.setattr(membrane, "contract_for_manager", lambda *_: pytest.fail("membrane invoked"))
+    monkeypatch.setattr(source_proof, "prove_exit_disposition_from_manager_expr", lambda *_: pytest.fail("source proof invoked"))
+
+    def unresolved(use_site):
+        return ContextManagerResolutionGapV1(
+            demand_cid=_cid("d"),
+            use_site=use_site,
+            target_symbol="context-manager:dependency.manager",
+            kind="unresolved-symbol",
+            candidate_member_cids=(),
+        )
+
+    with pytest.raises(SugarNotWritten) as caught:
+        _function_sugar(path_source(str(path)), unresolved)
+    assert type(caught.value).__name__ == "ContextManagerResolutionConstructionGap"
+    assert caught.value.kind == "unresolved-symbol"
+
+
+def test_authenticated_legacy_token_routes_without_tree_name_lookup(tmp_path, monkeypatch):
+    path = tmp_path / "aliased.py"
+    path.write_text(
+        "from community import enrolled as renamed\n"
+        "def f():\n"
+        "    with renamed(ValueError) as caught:\n"
+        "        return caught\n"
+    )
+    from sugar_lift_python_source.source_oracle import path_source
+    import sugar_lift_py_tests.manifest_membrane as membrane
+
+    identity = path_source(str(path))
+    first = SourceFile(identity)
+    with_node = next(node for node in first.nodes() if node.kind == "With")
+    site = _coordinate(with_node.items[0].context_expr)
+    gap = ContextManagerResolutionGapV1(
+        _cid("d"), site, "context-manager:community.enrolled",
+        "unresolved-symbol", (),
+    )
+    refs = ResolvedContractRefsV1(
+        _cid("c"), _cid("t"), MappingProxyType({site: gap})
+    )
+    token = AuthenticatedLegacyMembraneRefV1.mint_from_authenticated_identity(
+        demand_cid=_cid("d"), use_site=site, manifest_cid=_cid("m"),
+        enrollment_cid=_cid("e"),
+        contract=Expects(EffectMatcher("raise", "ValueError"), "exception_info"),
+    )
+    authorities = WithManagerAuthoritiesV1.assemble(refs, (token,))
+    monkeypatch.setattr(
+        membrane, "contract_for_manager", lambda *_: pytest.fail("name lookup invoked")
+    )
+    source = SourceFile(
+        identity,
+        construction_context=TreeConstructionContextV1(refs, authorities),
+    )
+    sugar = next(source.functions()).sugar()
+    routed = next(stmt for stmt in sugar.statements if isinstance(stmt, WithContractSugar))
+    assert routed.contract == token.contract
+    assert routed.slot_id is not None
+
+
+def test_unsupported_semantics_gap_does_not_construct_resource(tmp_path):
+    path = tmp_path / "unsupported.py"
+    path.write_text(
+        "from dependency import manager\n"
+        "def f():\n"
+        "    with manager():\n"
+        "        pass\n"
+    )
+    from sugar_lift_python_source.source_oracle import path_source
+
+    def unsupported(use_site):
+        return ContextManagerResolutionGapV1(
+            demand_cid=_cid("d"),
+            use_site=use_site,
+            target_symbol="context-manager:dependency.manager",
+            kind="unsupported-cm-schema",
+            candidate_member_cids=(_cid("m"),),
+        )
+
+    with pytest.raises(SugarNotWritten) as caught:
+        _function_sugar(path_source(str(path)), unsupported)
+    assert type(caught.value).__name__ == "ContextManagerResolutionConstructionGap"
+    assert caught.value.kind == "unsupported-cm-schema"
+
+
+def test_async_with_stays_typed_loud_even_with_sync_ref(tmp_path):
+    path = tmp_path / "async_manager.py"
+    path.write_text(
+        "from dependency import manager\n"
+        "async def f():\n"
+        "    async with manager():\n"
+        "        pass\n"
+    )
+    from sugar_lift_python_source.source_oracle import path_source
+
+    source = _source_with_resolution(path_source(str(path)), _resolved)
+    async_with = next(node for node in source.nodes() if node.kind == "AsyncWith")
+    with pytest.raises(SugarNotWritten) as caught:
+        async_with.sugar()
+    assert type(caught.value).__name__ == "AsyncContextManagerUnsupported"
+
+
+def test_missing_enrolled_resolution_row_is_backend_defect(tmp_path):
+    path = tmp_path / "missing_row.py"
+    path.write_text(
+        "from dependency import manager\n"
+        "def f():\n"
+        "    with manager():\n"
+        "        pass\n"
+    )
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.panic import BackendDefect
+
+    identity = path_source(str(path))
+    table = ResolvedContractRefsV1(
+        catalog_cid=_cid("c"),
+        table_cid=_cid("t"),
+        by_use_site=MappingProxyType({}),
+    )
+    source = SourceFile(identity, construction_context=TreeConstructionContextV1(table))
+    with pytest.raises(BackendDefect):
+        next(source.functions()).sugar()
+
+
+def test_multiple_items_and_non_name_binding_stay_typed_loud(tmp_path):
+    from sugar_lift_python_source.source_oracle import path_source
+
+    multiple = tmp_path / "multiple.py"
+    multiple.write_text(
+        "from dependency import manager\n"
+        "def f():\n"
+        "    with manager(), manager():\n"
+        "        pass\n"
+    )
+    first = SourceFile(path_source(str(multiple)))
+    with_node = next(node for node in first.nodes() if node.kind == "With")
+    rows = {
+        _coordinate(item.context_expr): _resolved(_coordinate(item.context_expr))
+        for item in with_node.items
+    }
+    context = TreeConstructionContextV1(
+        ResolvedContractRefsV1(_cid("c"), _cid("t"), MappingProxyType(rows))
+    )
+    source = SourceFile(path_source(str(multiple)), construction_context=context)
+    with pytest.raises(SugarNotWritten) as caught:
+        next(source.functions()).sugar()
+    assert type(caught.value).__name__ == "MultipleContextManagerItems"
+
+    target = tmp_path / "target.py"
+    target.write_text(
+        "from dependency import manager\n"
+        "def f():\n"
+        "    with manager() as (left, right):\n"
+        "        pass\n"
+    )
+    with pytest.raises(SugarNotWritten) as caught:
+        _function_sugar(path_source(str(target)), _resolved)
+    assert type(caught.value).__name__ == "UnsupportedWithBindingTarget"

--- a/implementations/python/sugar-source-tree/tests/test_with_contract.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_contract.py
@@ -4,26 +4,28 @@ is wireable today (resource expansion, `as` witnesses, warning-kind are later
 steps and stay loud)."""
 
 import tempfile
+from pathlib import Path
 
 import pytest
 
 from sugar_lift_python_source.source_oracle import path_source
-from sugar_source_tree.panic import RuntimeSelectedContextManager, SugarNotWritten
+from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
+from with_authority_fixture import source_file_with_preconstruction
 
 
 def _val(src):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
-        f.write(src)
+        f.write("import pytest\nimport contextlib\nimport tm\n" + src)
         path = f.name
-    return next(SourceFile(path_source(path)).functions()).sugar().desugar().value
+    return next(source_file_with_preconstruction(Path(path)).functions()).sugar().desugar().value
 
 
 def _fn(src):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
-        f.write(src)
+        f.write("import pytest\nimport contextlib\nimport tm\n" + src)
         path = f.name
-    return next(SourceFile(path_source(path)).functions())
+    return next(source_file_with_preconstruction(Path(path)).functions())
 
 
 def test_expected_matching_raise_discharges_and_consumes():
@@ -86,15 +88,12 @@ def test_suppress_non_match_propagates():
 
 
 def test_unauthenticated_manager_stays_loud():
-    # Named residual (step 4): RuntimeSelectedContextManager, not bare
-    # SugarNotWritten — census can count resource managers separately.
-    with pytest.raises(RuntimeSelectedContextManager) as ei:
+    # Preserve the exact prereq-2 runtime-selected resolution gap.
+    with pytest.raises(SugarNotWritten) as ei:
         _fn("def A(z):\n    with open(z):\n        pass\n    return z\n").sugar()
     assert isinstance(ei.value, SugarNotWritten)
-    assert (
-        "unauthenticated context manager — exit suppression runtime-selected"
-        in ei.value.observed
-    )
+    assert type(ei.value).__name__ == "ContextManagerResolutionConstructionGap"
+    assert ei.value.kind == "runtime-selected"
 
 
 def test_as_exception_info_completes_when_effect_matches():

--- a/implementations/python/sugar-source-tree/tests/test_with_resource.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_resource.py
@@ -9,22 +9,21 @@ constructed enter/exit or explicit red.
 from __future__ import annotations
 
 import tempfile
+from pathlib import Path
 
 import pytest
 
 from sugar_lift_python_source.source_oracle import path_source
-from sugar_source_tree.panic import (
-    RuntimeSelectedContextManager,
-    SugarNotWritten,
-)
+from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
+from with_authority_fixture import source_file_with_preconstruction
 
 
 def _fn(src: str):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
-        f.write(src)
+        f.write("import pytest\nimport contextlib\n" + src)
         path = f.name
-    return next(SourceFile(path_source(path)).functions())
+    return next(source_file_with_preconstruction(Path(path)).functions())
 
 
 def _val(src: str):
@@ -33,19 +32,16 @@ def _val(src: str):
 
 def test_resource_open_is_runtime_selected_named_residual():
     """`with open(f): ...` is loud, distinctly named — not dissolved."""
-    with pytest.raises(RuntimeSelectedContextManager) as ei:
+    with pytest.raises(SugarNotWritten) as ei:
         _fn("def A(f):\n    with open(f):\n        pass\n    return f\n").sugar()
     panic = ei.value
     assert isinstance(panic, SugarNotWritten)
-    assert type(panic) is RuntimeSelectedContextManager
-    assert "unauthenticated context manager — exit suppression runtime-selected" in (
-        panic.observed
-    )
-    assert panic.owner == "With.sugar"
+    assert type(panic).__name__ == "ContextManagerResolutionConstructionGap"
+    assert panic.kind == "runtime-selected"
 
 
 def test_resource_open_is_not_silent_dissolve():
-    with pytest.raises(RuntimeSelectedContextManager):
+    with pytest.raises(SugarNotWritten):
         sugar = _fn(
             "def A(f):\n    with open(f):\n        x = 1\n    return f\n"
         ).sugar()
@@ -53,9 +49,9 @@ def test_resource_open_is_not_silent_dissolve():
 
 
 def test_resource_named_residual_distinct_from_bare_sugar_not_written():
-    with pytest.raises(RuntimeSelectedContextManager) as ei:
+    with pytest.raises(SugarNotWritten) as ei:
         _fn("def A(z):\n    with open(z):\n        pass\n    return z\n").sugar()
-    assert type(ei.value) is not SugarNotWritten
+    assert type(ei.value).__name__ == "ContextManagerResolutionConstructionGap"
     assert issubclass(type(ei.value), SugarNotWritten)
 
 

--- a/implementations/python/sugar-source-tree/tests/test_with_resource_disposition.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_resource_disposition.py
@@ -3,38 +3,34 @@
 from __future__ import annotations
 
 import tempfile
+from pathlib import Path
 
 import pytest
 
 from sugar_lift_python_source.source_oracle import path_source
-from sugar_source_tree.panic import RuntimeSelectedContextManager
+from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
+from with_authority_fixture import source_file_with_preconstruction
 
 
 def _fn(src: str):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
-        f.write(src)
+        f.write("import pytest\nimport contextlib\n" + src)
         path = f.name
-    return next(SourceFile(path_source(path)).functions())
+    return next(source_file_with_preconstruction(Path(path)).functions())
 
 
-def test_errstate_routes_to_with_resource_sugar():
-    sugar = _fn(
-        "import numpy as np\n"
-        "def A(z):\n"
-        "    with np.errstate(all='ignore'):\n"
-        "        z = z\n"
-        "    return z\n"
-    ).sugar()
-    # FunctionUniverseSugar body contains WithResourceSugar
-    from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
-
-    kinds = [type(s).__name__ for s in sugar.statements]
-    assert any(isinstance(s, WithResourceSugar) for s in sugar.statements), kinds
-    with_s = next(s for s in sugar.statements if isinstance(s, WithResourceSugar))
-    from sugar_lift_py_tests.context_manager_contract import NeverSuppresses
-
-    assert isinstance(with_s.disposition, NeverSuppresses)
+def test_errstate_without_published_cm_contract_stays_loud():
+    with pytest.raises(SugarNotWritten) as caught:
+        _fn(
+            "import numpy as np\n"
+            "def A(z):\n"
+            "    with np.errstate(all='ignore'):\n"
+            "        z = z\n"
+            "    return z\n"
+        ).sugar()
+    assert type(caught.value).__name__ == "ContextManagerResolutionConstructionGap"
+    assert caught.value.kind == "runtime-selected"
 
 
 @pytest.mark.xfail(
@@ -61,7 +57,7 @@ def test_option_context_routes_to_with_resource_sugar():
 
 
 def test_open_still_runtime_selected():
-    with pytest.raises(RuntimeSelectedContextManager):
+    with pytest.raises(SugarNotWritten):
         _fn("def A(f):\n    with open(f):\n        pass\n    return f\n").sugar()
 
 

--- a/implementations/python/sugar-source-tree/tests/with_authority_fixture.py
+++ b/implementations/python/sugar-source-tree/tests/with_authority_fixture.py
@@ -1,0 +1,53 @@
+"""Test-only driver for the production preconstruction With authority boundary."""
+
+from types import MappingProxyType
+from pathlib import Path
+import shutil
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContextManagerResolutionGapV1,
+    ResolvedContractRefsV1,
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+    _hash_json,
+)
+from sugar_lift_py_tests.lift_rpc import (
+    _context_manager_demand_rows,
+    _legacy_membrane_token_rows,
+)
+from sugar_lift_py_tests.with_manager_authority import (
+    WithManagerAuthoritiesV1,
+    _decode_legacy_ref,
+)
+from sugar_source_tree.tree import SourceFile
+
+
+def _cid(fill: str) -> str:
+    return "blake3-512:" + fill * 128
+
+
+def source_file_with_preconstruction(path):
+    isolated = Path(tempfile.mkdtemp(prefix="sugar-with-authority-")) / path.name
+    shutil.copyfile(path, isolated)
+    path = isolated
+    resolutions = {}
+    for row in _context_manager_demand_rows(path.parent):
+        site = SourceFragmentCoordinateV1.decode(row["useSite"])
+        preimage = {key: row[key] for key in (
+            "useSite", "targetSymbol", "importSignature", "expectedKind"
+        )}
+        resolutions[site] = ContextManagerResolutionGapV1(
+            _hash_json(preimage), site, row["targetSymbol"],
+            row["gapKind"] or "unresolved-symbol", (),
+        )
+    refs = ResolvedContractRefsV1(
+        _cid("c"), _cid("t"), MappingProxyType(resolutions)
+    )
+    tokens = tuple(_decode_legacy_ref(row) for row in _legacy_membrane_token_rows(path.parent))
+    authorities = WithManagerAuthoritiesV1.assemble(refs, tokens)
+    return SourceFile(
+        path_source(str(path)),
+        construction_context=TreeConstructionContextV1(refs, authorities),
+    )

--- a/implementations/rust/sugar-compiler/src/kit.rs
+++ b/implementations/rust/sugar-compiler/src/kit.rs
@@ -500,6 +500,7 @@ impl Kit {
     pub fn bind_contract_refs(
         &self,
         table: &Value,
+        legacy_membrane_refs: &[Value],
     ) -> Result<String, crate::kit_path::LiftPluginKitError> {
         let catalog_cid = table
             .get("catalogCid")
@@ -521,7 +522,10 @@ impl Kit {
             .connection
             .clone()
             .with_method("sugar.plugin.bind_contract_refs")
-            .request(table)?;
+            .request(&serde_json::json!({
+                "contractRefs": table,
+                "legacyMembraneRefs": legacy_membrane_refs,
+            }))?;
         let acknowledged = response
             .get("tableCid")
             .and_then(Value::as_str)

--- a/implementations/rust/sugar-compiler/src/orchestrate.rs
+++ b/implementations/rust/sugar-compiler/src/orchestrate.rs
@@ -56,7 +56,8 @@ use std::path::Path;
 
 use sugar_ir_compiler::registry::Registry as CompilerRegistry;
 use sugar_linker::{
-    link, AuthenticatedContextManagerCatalog, ContextManagerContractDemandV1, LinkerError,
+    decode_context_manager_edge, final_check_context_manager_edges, link,
+    AuthenticatedContextManagerCatalog, ContextManagerContractDemandV1, LinkerError,
     LinkerErrorKind, LinkerInputs, ResolvedContractRefsV1, SourceFragmentCoordinateV1, Symbol,
 };
 use sugar_proof_envelope::ImportSignatureV1;
@@ -469,7 +470,10 @@ pub fn fold_kit_to_pool(
             .map(context_manager_demand_from_wire)
             .collect::<Result<Vec<_>, _>>()?;
         let table = ResolvedContractRefsV1::new(&catalog, &demands);
-        kit.bind_contract_refs(&table.to_wire_value())
+        let legacy_membrane_refs = kit
+            .legacy_membrane_tokens(workspace_root)
+            .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+        kit.bind_contract_refs(&table.to_wire_value(), &legacy_membrane_refs)
             .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
         active_cm_preconstruction = Some((catalog, table));
     }
@@ -490,6 +494,15 @@ pub fn fold_kit_to_pool(
     // after construction. Future CM edges use the same ref-owned equality
     // check; this pass never reselects a candidate from the enlarged pool.
     if let Some((catalog, table)) = &active_cm_preconstruction {
+        let edges = kit
+            .context_manager_edges(workspace_root)
+            .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?
+            .iter()
+            .map(decode_context_manager_edge)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+        final_check_context_manager_edges(&edges, table, catalog)
+            .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
         table
             .final_check(catalog)
             .map_err(|error| ProveFromKitError::Preconstruction(error.into()))?;

--- a/implementations/rust/sugar-compiler/src/tree.rs
+++ b/implementations/rust/sugar-compiler/src/tree.rs
@@ -106,6 +106,8 @@ pub enum Level {
     Exports,
     ContractDeclarations,
     ContractDemands,
+    LegacyMembraneTokens,
+    ContextManagerEdges,
 }
 
 impl Level {
@@ -121,6 +123,8 @@ impl Level {
             Level::Exports => "exports",
             Level::ContractDeclarations => "contract-declarations",
             Level::ContractDemands => "contract-demands",
+            Level::LegacyMembraneTokens => "legacy-membrane-tokens",
+            Level::ContextManagerEdges => "context-manager-edges",
         }
     }
 }
@@ -912,6 +916,50 @@ fn preconstruction_rows_rpc(conn: &KitConn, level: Level) -> Result<Vec<Value>, 
         })
 }
 
+fn context_manager_edges_rpc(conn: &KitConn) -> Result<Vec<Value>, EnumerateError> {
+    let plugin = conn.surface.clone();
+    let Some((catalog_cid, table_cid)) =
+        conn.transport
+            .contract_ref_generation()
+            .map_err(|error| EnumerateError::Unavailable {
+                plugin: plugin.clone(),
+                reason: error.to_string(),
+            })?
+    else {
+        return Err(EnumerateError::Malformed {
+            plugin,
+            reason: "context-manager edge enumeration requires frozen contract refs".into(),
+        });
+    };
+    let response = conn
+        .transport
+        .request(&json!({
+            "level": Level::ContextManagerEdges.wire(),
+            "workspace_root": conn.workspace_root.display().to_string(),
+            "options": {"contractRefs": {"catalogCid": catalog_cid, "tableCid": table_cid}},
+        }))
+        .map_err(|error| EnumerateError::Unavailable {
+            plugin: plugin.clone(),
+            reason: error.to_string(),
+        })?;
+    let result = response
+        .get("result")
+        .unwrap_or(&response)
+        .as_object()
+        .ok_or_else(|| EnumerateError::Malformed {
+            plugin: plugin.clone(),
+            reason: "context-manager edge result must be an object".into(),
+        })?;
+    result
+        .get("contextManagerEdges")
+        .and_then(Value::as_array)
+        .cloned()
+        .ok_or_else(|| EnumerateError::Malformed {
+            plugin,
+            reason: "context-manager edge result missing contextManagerEdges array".into(),
+        })
+}
+
 /// `LiftPluginKit::request` has already checked and removed the JSON-RPC
 /// envelope. Keep this boundary explicit: enumeration consumes that result
 /// payload directly. A second `result` unwrap turns every lawful node set into
@@ -1389,6 +1437,12 @@ fn merge_recovered_audit_leaf(
 }
 
 impl Kit {
+    pub fn context_manager_edges(&self, workspace_root: &Path) -> Result<Vec<Value>, KitError> {
+        Ok(context_manager_edges_rpc(
+            &self.enumerate_conn(workspace_root),
+        )?)
+    }
+
     pub fn context_manager_declarations(
         &self,
         workspace_root: &Path,
@@ -1403,6 +1457,13 @@ impl Kit {
         Ok(preconstruction_rows_rpc(
             &self.enumerate_conn(workspace_root),
             Level::ContractDemands,
+        )?)
+    }
+
+    pub fn legacy_membrane_tokens(&self, workspace_root: &Path) -> Result<Vec<Value>, KitError> {
+        Ok(preconstruction_rows_rpc(
+            &self.enumerate_conn(workspace_root),
+            Level::LegacyMembraneTokens,
         )?)
     }
 

--- a/implementations/rust/sugar-compiler/tests/prove_from_kit.rs
+++ b/implementations/rust/sugar-compiler/tests/prove_from_kit.rs
@@ -196,6 +196,7 @@ fn validate_cm_preconstruction_sequence(sequence: &str) -> Result<(), String> {
     };
     let declarations = position("sugar.enumerate:contract-declarations")?;
     let demands = position("sugar.enumerate:contract-demands")?;
+    let legacy = position("sugar.enumerate:legacy-membrane-tokens")?;
     let bind = position("sugar.plugin.bind_contract_refs")?;
     let first_semantic = events
         .iter()
@@ -203,9 +204,10 @@ fn validate_cm_preconstruction_sequence(sequence: &str) -> Result<(), String> {
             event.starts_with("sugar.enumerate:")
                 && !event.ends_with(":contract-declarations")
                 && !event.ends_with(":contract-demands")
+                && !event.ends_with(":legacy-membrane-tokens")
         })
         .ok_or_else(|| format!("missing semantic enumeration; events={events:?}"))?;
-    if declarations < demands && demands < bind && bind < first_semantic {
+    if declarations < demands && demands < legacy && legacy < bind && bind < first_semantic {
         Ok(())
     } else {
         Err(format!("invalid CM preconstruction order: {events:?}"))
@@ -217,6 +219,7 @@ fn phase_order_detector_rejects_bind_after_first_semantic_enumeration() {
     let planted = concat!(
         "sugar.enumerate:contract-declarations\n",
         "sugar.enumerate:contract-demands\n",
+        "sugar.enumerate:legacy-membrane-tokens\n",
         "sugar.enumerate:source_files\n",
         "sugar.plugin.bind_contract_refs\n",
     );

--- a/implementations/rust/sugar-linker/src/lib.rs
+++ b/implementations/rust/sugar-linker/src/lib.rs
@@ -753,21 +753,234 @@ pub fn final_check_context_manager_ref(
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContextManagerEdgeV1 {
+    edge_cid: Cid,
+    use_site: SourceFragmentCoordinateV1,
+    bridge_source_symbol: Symbol,
+    import_signature: ImportSignatureV1,
     target_contract_cid: Cid,
+    payload_cid: Cid,
     demand_cid: Cid,
     resolution_cid: Cid,
     catalog_cid: Cid,
+    source_warrant_cids: Vec<Cid>,
+    semantics: ContextManagerSemanticsV1,
 }
 
 impl ContextManagerEdgeV1 {
     pub fn from_resolved(reference: &ContextManagerContractRefV1) -> Self {
-        Self {
+        let mut edge = Self {
+            edge_cid: Cid::from(""),
+            use_site: reference.use_site.clone(),
+            bridge_source_symbol: reference.bridge_source_symbol.clone(),
+            import_signature: reference.import_signature.clone(),
             target_contract_cid: reference.member_cid.clone(),
+            payload_cid: reference.payload_cid.clone(),
             demand_cid: reference.demand_cid.clone(),
             resolution_cid: reference.resolution_cid.clone(),
             catalog_cid: reference.catalog_cid.clone(),
+            source_warrant_cids: reference.source_warrant_cids.clone(),
+            semantics: reference.semantics.clone(),
+        };
+        edge.source_warrant_cids.sort();
+        edge.edge_cid = Cid::from(jcs_cid(&edge.preimage()));
+        edge
+    }
+
+    fn preimage(&self) -> Json {
+        serde_json::json!({
+            "kind": "context-manager-edge", "schemaVersion": "1",
+            "useSite": self.use_site,
+            "managerIdentity": {
+                "bridgeSourceSymbol": self.bridge_source_symbol,
+                "importSignature": import_signature_to_json(&self.import_signature),
+            },
+            "targetContractCid": self.target_contract_cid,
+            "payloadCid": self.payload_cid,
+            "demandCid": self.demand_cid,
+            "resolutionCid": self.resolution_cid,
+            "catalogCid": self.catalog_cid,
+            "sourceWarrantCids": self.source_warrant_cids,
+            "semantics": sugar_proof_envelope::context_manager_semantics_v1_to_json(&self.semantics),
+        })
+    }
+
+    pub fn to_wire_value(&self) -> Json {
+        let mut value = self.preimage();
+        value
+            .as_object_mut()
+            .expect("edge preimage is an object")
+            .insert("edgeCid".into(), Json::String(self.edge_cid.to_string()));
+        value
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ContextManagerEdgeTransportErrorV1 {
+    Malformed(String),
+    EdgeCidMismatch,
+    StaleResolution,
+    Unresolved,
+    Duplicate,
+}
+
+impl std::fmt::Display for ContextManagerEdgeTransportErrorV1 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Malformed(reason) => {
+                write!(formatter, "malformed-context-manager-edge: {reason}")
+            }
+            Self::EdgeCidMismatch => formatter.write_str("edge-cid-mismatch"),
+            Self::StaleResolution => formatter.write_str("stale-resolution"),
+            Self::Unresolved => formatter.write_str("unresolved-context-manager-edge"),
+            Self::Duplicate => formatter.write_str("duplicate-context-manager-edge"),
         }
     }
+}
+
+impl std::error::Error for ContextManagerEdgeTransportErrorV1 {}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContextManagerEdgeWireV1 {
+    kind: String,
+    #[serde(rename = "schemaVersion")]
+    schema_version: String,
+    #[serde(rename = "edgeCid")]
+    edge_cid: Cid,
+    #[serde(rename = "useSite")]
+    use_site: SourceFragmentCoordinateV1,
+    #[serde(rename = "managerIdentity")]
+    manager_identity: ContextManagerIdentityWireV1,
+    #[serde(rename = "targetContractCid")]
+    target_contract_cid: Cid,
+    #[serde(rename = "payloadCid")]
+    payload_cid: Cid,
+    #[serde(rename = "demandCid")]
+    demand_cid: Cid,
+    #[serde(rename = "resolutionCid")]
+    resolution_cid: Cid,
+    #[serde(rename = "catalogCid")]
+    catalog_cid: Cid,
+    #[serde(rename = "sourceWarrantCids")]
+    source_warrant_cids: Vec<Cid>,
+    semantics: ContextManagerEdgeSemanticsWireV1,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContextManagerIdentityWireV1 {
+    #[serde(rename = "bridgeSourceSymbol")]
+    bridge_source_symbol: Symbol,
+    #[serde(rename = "importSignature")]
+    import_signature: ContextManagerImportSignatureWireV1,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContextManagerImportSignatureWireV1 {
+    formals: Vec<String>,
+    sorts: Vec<Sort>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContextManagerEdgeSemanticsWireV1 {
+    kind: String,
+    #[serde(rename = "schemaVersion")]
+    schema_version: String,
+    enter: ContextManagerEnterWireV1,
+    exit: ContextManagerExitWireV1,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContextManagerEnterWireV1 {
+    completion: String,
+    result: ContextManagerEnterResultWireV1,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContextManagerEnterResultWireV1 {
+    kind: String,
+    projection: String,
+    sort: Sort,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContextManagerExitWireV1 {
+    completion: String,
+    disposition: ContextManagerDispositionWireV1,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContextManagerDispositionWireV1 {
+    kind: String,
+}
+
+pub fn decode_context_manager_edge(
+    value: &Json,
+) -> Result<ContextManagerEdgeV1, ContextManagerEdgeTransportErrorV1> {
+    let wire: ContextManagerEdgeWireV1 = serde_json::from_value(value.clone())
+        .map_err(|error| ContextManagerEdgeTransportErrorV1::Malformed(error.to_string()))?;
+    if wire.kind != "context-manager-edge"
+        || wire.schema_version != "1"
+        || wire.semantics.kind != "context-manager-semantics"
+        || wire.semantics.schema_version != "1"
+        || wire.semantics.enter.completion != "total"
+        || wire.semantics.enter.result.kind != "projection"
+        || wire.semantics.enter.result.projection != "enter_result"
+        || wire.semantics.enter.result.sort
+            != (Sort::Primitive {
+                name: "Value".into(),
+            })
+        || wire.semantics.exit.completion != "total"
+        || wire.semantics.exit.disposition.kind != "never-suppresses"
+    {
+        return Err(ContextManagerEdgeTransportErrorV1::Malformed(
+            "unsupported kind, schema, or semantics".into(),
+        ));
+    }
+    if wire
+        .source_warrant_cids
+        .windows(2)
+        .any(|pair| pair[0] >= pair[1])
+    {
+        return Err(ContextManagerEdgeTransportErrorV1::Malformed(
+            "sourceWarrantCids must be sorted and unique".into(),
+        ));
+    }
+    let edge = ContextManagerEdgeV1 {
+        edge_cid: wire.edge_cid,
+        use_site: wire.use_site,
+        bridge_source_symbol: wire.manager_identity.bridge_source_symbol,
+        import_signature: ImportSignatureV1 {
+            formals: wire.manager_identity.import_signature.formals,
+            sorts: wire.manager_identity.import_signature.sorts,
+        },
+        target_contract_cid: wire.target_contract_cid,
+        payload_cid: wire.payload_cid,
+        demand_cid: wire.demand_cid,
+        resolution_cid: wire.resolution_cid,
+        catalog_cid: wire.catalog_cid,
+        source_warrant_cids: wire.source_warrant_cids,
+        semantics: ContextManagerSemanticsV1 {
+            enter: sugar_proof_envelope::EnterResultContractV1 {
+                sort: Sort::Primitive {
+                    name: "Value".into(),
+                },
+            },
+            exit: sugar_proof_envelope::ExitContractV1 {
+                disposition: sugar_proof_envelope::ExitDispositionV1::NeverSuppresses,
+            },
+        },
+    };
+    if Cid::from(jcs_cid(&edge.preimage())) != edge.edge_cid {
+        return Err(ContextManagerEdgeTransportErrorV1::EdgeCidMismatch);
+    }
+    Ok(edge)
 }
 
 pub fn final_check_context_manager_edge(
@@ -776,13 +989,39 @@ pub fn final_check_context_manager_edge(
     catalog: &AuthenticatedContextManagerCatalog,
 ) -> Result<(), &'static str> {
     if edge.target_contract_cid != reference.member_cid
+        || edge.use_site != reference.use_site
+        || edge.bridge_source_symbol != reference.bridge_source_symbol
+        || edge.import_signature != reference.import_signature
+        || edge.payload_cid != reference.payload_cid
         || edge.demand_cid != reference.demand_cid
         || edge.resolution_cid != reference.resolution_cid
         || edge.catalog_cid != reference.catalog_cid
+        || edge.source_warrant_cids != reference.source_warrant_cids
+        || edge.semantics != reference.semantics
     {
         return Err("stale-resolution");
     }
     final_check_context_manager_ref(reference, catalog)
+}
+
+pub fn final_check_context_manager_edges(
+    edges: &[ContextManagerEdgeV1],
+    table: &ResolvedContractRefsV1,
+    catalog: &AuthenticatedContextManagerCatalog,
+) -> Result<(), ContextManagerEdgeTransportErrorV1> {
+    let mut seen = BTreeSet::new();
+    for edge in edges {
+        if !seen.insert(edge.use_site.clone()) {
+            return Err(ContextManagerEdgeTransportErrorV1::Duplicate);
+        }
+        let Some(ContextManagerResolutionV1::Resolved(reference)) = table.get(&edge.use_site)
+        else {
+            return Err(ContextManagerEdgeTransportErrorV1::Unresolved);
+        };
+        final_check_context_manager_edge(edge, reference, catalog)
+            .map_err(|_| ContextManagerEdgeTransportErrorV1::StaleResolution)?;
+    }
+    Ok(())
 }
 
 /// The formals / sorts / EUF-coordinate triple a contract *exports* or a call
@@ -916,6 +1155,7 @@ impl LinkerContract {
 /// calls have `target_contract_cid: None` and `target_symbol` set to a
 /// `"<kit>:<name>"` string for linker resolution.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct LinkerCallEdge {
     /// CID of the calling function's contract, as a typed [`Cid`].
     pub source_contract_cid: Cid,

--- a/implementations/rust/sugar-linker/tests/context_manager_prebind.rs
+++ b/implementations/rust/sugar-linker/tests/context_manager_prebind.rs
@@ -4,7 +4,8 @@ use sugar_claim_envelope::{
 };
 use sugar_ir_types::Sort;
 use sugar_linker::{
-    final_check_context_manager_edge, final_check_context_manager_ref,
+    decode_context_manager_edge, final_check_context_manager_edge,
+    final_check_context_manager_edges, final_check_context_manager_ref,
     resolve_context_manager_demand, AuthenticatedContextManagerCatalog, Cid,
     ContextManagerContractDemandV1, ContextManagerEdgeV1, ContextManagerResolutionGapKindV1,
     ContextManagerResolutionV1, ResolvedContractRefsV1, SourceFragmentCoordinateV1,
@@ -245,6 +246,86 @@ fn exact_symbol_with_different_signature_stays_a_typed_gap() {
     assert_eq!(
         gap.kind,
         ContextManagerResolutionGapKindV1::SignatureMismatch
+    );
+}
+
+#[test]
+fn strict_context_manager_edge_round_trips_and_final_checks_every_pin() {
+    let member = minted("context-manager:fixture.never_closing", 15);
+    let catalog = AuthenticatedContextManagerCatalog::freeze(vec![member]).unwrap();
+    let table =
+        ResolvedContractRefsV1::new(&catalog, &[demand("context-manager:fixture.never_closing")]);
+    let Some(ContextManagerResolutionV1::Resolved(reference)) = table.get(&use_site()) else {
+        panic!("resolved")
+    };
+    let edge = ContextManagerEdgeV1::from_resolved(reference);
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap()
+        .to_path_buf();
+    let mut child = Command::new("python3")
+        .env("PYTHONPATH", repo.join("implementations/python/sugar-lift-py-tests/src"))
+        .arg("-c")
+        .arg("import json,sys; from sugar_lift_py_tests.context_manager_resolution import decode_resolved_contract_refs, ContextManagerContractRefV1; from sugar_lift_py_tests.kit_rpc.context_manager_edge_dto import ContextManagerEdgeDtoV1; t=decode_resolved_contract_refs(json.load(sys.stdin)); r=t.require(next(iter(t.by_use_site))); assert isinstance(r, ContextManagerContractRefV1); json.dump(ContextManagerEdgeDtoV1.from_resolved(r, r.use_site).to_rpc(), sys.stdout)")
+        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped())
+        .spawn().unwrap();
+    serde_json::to_writer(child.stdin.as_mut().unwrap(), &table.to_wire_value()).unwrap();
+    child.stdin.as_mut().unwrap().flush().unwrap();
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let wire: Json = serde_json::from_slice(&output.stdout).unwrap();
+    let decoded = decode_context_manager_edge(&wire).expect("strict edge decode");
+    assert_eq!(decoded, edge);
+    final_check_context_manager_edges(&[decoded], &table, &catalog)
+        .expect("same frozen table and catalog");
+}
+
+#[test]
+fn malformed_cross_schema_and_unresolved_context_manager_edges_are_loud() {
+    let member = minted("context-manager:fixture.never_closing", 16);
+    let catalog = AuthenticatedContextManagerCatalog::freeze(vec![member]).unwrap();
+    let table =
+        ResolvedContractRefsV1::new(&catalog, &[demand("context-manager:fixture.never_closing")]);
+    let Some(ContextManagerResolutionV1::Resolved(reference)) = table.get(&use_site()) else {
+        panic!("resolved")
+    };
+    let wire = ContextManagerEdgeV1::from_resolved(reference).to_wire_value();
+    for field in ["edgeCid", "targetContractCid", "payloadCid"] {
+        let mut changed = wire.clone();
+        changed[field] = Json::String(cid('f').to_string());
+        assert!(
+            decode_context_manager_edge(&changed).is_err(),
+            "field={field}"
+        );
+    }
+    let mut stringly = wire.clone();
+    stringly["semantics"]["exit"]["disposition"] = Json::String("never-suppresses".into());
+    assert!(decode_context_manager_edge(&stringly).is_err());
+    assert!(decode_context_manager_edge(&serde_json::json!({
+        "kind": "call-edge", "schemaVersion": "1"
+    }))
+    .is_err());
+    assert!(serde_json::from_value::<sugar_linker::LinkerCallEdge>(wire).is_err());
+
+    let unresolved_table = ResolvedContractRefsV1::new(
+        &AuthenticatedContextManagerCatalog::freeze(vec![]).unwrap(),
+        &[demand("context-manager:fixture.never_closing")],
+    );
+    assert_eq!(
+        final_check_context_manager_edges(
+            &[ContextManagerEdgeV1::from_resolved(reference)],
+            &unresolved_table,
+            &catalog,
+        )
+        .unwrap_err()
+        .to_string(),
+        "unresolved-context-manager-edge"
     );
 }
 use std::io::Write;


### PR DESCRIPTION
Implements issue #6071 step 4 on top of the merged CM contract and preconstruction-resolution prerequisites.

- consumes the immutable preconstruction With manager authority union
- authenticates legacy membrane enrollments before tree construction
- constructs only the synchronous single-item total Value/NeverSuppresses resource arm
- emits a dedicated typed contextManagerEdges lane and strictly decodes/final-checks it in Rust
- preserves unresolved, ambiguous, async, multi-item, unsupported-schema, and unsupported-binding cases as typed loud gaps
- removes Tree/Sugar manifest lookup and source-exit inference

Validation:
- Python source tree: 371 passed, 5 skipped, 1 xfailed
- focused With/authority/edge/boundary twins: 37 passed
- strict authority/protocol twins: 13 passed
- battleaxe sugar-linker context_manager_prebind: 9 passed
- battleaxe compiler RPC-order plant: passed
- battleaxe compiler production preconstruction test: passed

Wider Python lift tests are independently blocked by the existing missing itsdangerous vendor dependency; excluding vendor reaches the existing binary-handoff shelf fixture failure after 15 passes.

Part of #6071

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add narrow authenticated `with` arm construction using pre-bound `WithManagerAuthoritiesV1`
> - Introduces `WithManagerAuthoritiesV1`, a closed authority table that combines resolved context-manager contract refs and authenticated legacy membrane tokens, with content-addressed identity (`tableCid`) and conflict detection.
> - Reworks `With._construct_sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/6087/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to require a pre-bound authority at construction time: produces `WithResourceSugar` for narrow authenticated refs, `WithContractSugar` for legacy membrane `Expects`/`Suppresses`, and raises a structured `ContextManagerResolutionConstructionGap` panic if no authority is injected.
> - Extends the `sugar.bind.contractRefs` RPC to also accept `legacyMembraneRefs`, store a `WithManagerAuthoritiesV1` in-process, and return a `withManagerAuthoritiesCid`; adds `legacy-membrane-tokens` and `context-manager-edges` enumeration levels to the lift RPC.
> - Adds `ContextManagerEdgeDtoV1` with content-addressed `edgeCid` and strict round-trip validation in both Python and Rust, including `final_check_context_manager_edges` for batch use-site uniqueness and stale-resolution checks.
> - `AsyncWith` now unconditionally raises `AsyncContextManagerUnsupported` rather than delegating to `With`.
> - Risk: `sugar.bind.contractRefs` callers must now supply `legacyMembraneRefs`; omitting it will cause the RPC to fail. Outside a construction context, `With` no longer exports observation-ref bindings derived from manifest/membrane lookups.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8f2665.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added authenticated context-manager support for synchronous `with` statements.
  - Added context-manager edge reporting and validation during compilation.
  - Added support for legacy membrane-based manager authorization.
  - Added explicit handling for optional `as` bindings.

- **Bug Fixes**
  - Unsupported, unresolved, asynchronous, or multi-manager `with` forms now produce clear typed errors instead of silently falling through.
  - Improved exit behavior preserves conditional failures and prevents unintended suppression.
  - Added stricter validation for context-manager report data and authorization integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->