### PR TITLE
feat: in-corpus import bridge — resolved-call contract ref (pandas symbolic floor, #6086)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/call_contract_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/call_contract_resolution.py
@@ -77,14 +77,19 @@ class ResolvedCallContractRefV1:
     sorts: tuple[Sort, ...]
     return_term: Term | None
     source_warrant_cids: tuple[str, ...]
+    contract_decl: Mapping[str, Any]
 
 
 class CallContractResolutionGapKindV1(str, Enum):
+    NO_LEXICAL_BINDING = "no-lexical-binding"
+    SHADOWED_NON_IMPORT = "shadowed-non-import"
+    AMBIGUOUS_LEXICAL_BINDING = "ambiguous-lexical-binding"
     TARGET_NOT_IN_CORPUS = "target-not-in-corpus"
     NO_AUTHENTICATED_CONTRACT = "no-authenticated-contract"
     AMBIGUOUS_TARGET = "ambiguous-target"
     IMPORT_SIGNATURE_MISMATCH = "import-signature-mismatch"
     WRONG_CONTRACT_KIND = "wrong-contract-kind"
+    WRONG_PROVIDER = "wrong-provider"
     STALE_OR_MALFORMED_CONTRACT_REF = "stale-or-malformed-contract-ref"
 
 
@@ -120,7 +125,7 @@ def _decode_ref(raw: Any) -> ResolvedCallContractRefV1:
     expected = {
         "kind", "schemaVersion", "resolutionCid", "demandCid", "useSite",
         "importBindingCid", "catalogCid", "memberCid", "contractCid", "bridgeSourceSymbol",
-        "importSignature", "returnTerm", "sourceWarrantCids",
+        "importSignature", "returnTerm", "sourceWarrantCids", "contractDecl",
     }
     if not isinstance(raw, dict) or set(raw) != expected:
         raise CallContractRefProtocolError("malformed resolved-call contract ref")
@@ -142,7 +147,32 @@ def _decode_ref(raw: Any) -> ResolvedCallContractRefV1:
     warrants = raw["sourceWarrantCids"]
     if not isinstance(warrants, list):
         raise CallContractRefProtocolError("sourceWarrantCids must be a list")
+    resolution_cid = _cid(raw["resolutionCid"], "resolutionCid")
+    demand_cid = _cid(raw["demandCid"], "demandCid")
+    import_binding_cid = _cid(raw["importBindingCid"], "importBindingCid")
+    catalog_cid = _cid(raw["catalogCid"], "catalogCid")
+    member_cid = _cid(raw["memberCid"], "memberCid")
+    contract_cid = _cid(raw["contractCid"], "contractCid")
     return_term = None if raw["returnTerm"] is None else _term(raw["returnTerm"])
+    contract_decl = raw["contractDecl"]
+    if not isinstance(contract_decl, dict) or _hash_json(contract_decl) != raw["contractCid"]:
+        raise CallContractRefProtocolError("stale semantic contract CID")
+    resolution_preimage = {
+        "schemaVersion": "1",
+        "demandCid": raw["demandCid"],
+        "useSite": raw["useSite"],
+        "importBindingCid": raw["importBindingCid"],
+        "catalogCid": raw["catalogCid"],
+        "memberCid": raw["memberCid"],
+        "contractCid": raw["contractCid"],
+        "bridgeSourceSymbol": raw["bridgeSourceSymbol"],
+        "importSignature": raw["importSignature"],
+        "returnTerm": raw["returnTerm"],
+        "sourceWarrantCids": raw["sourceWarrantCids"],
+        "contractDecl": raw["contractDecl"],
+    }
+    if _hash_json(resolution_preimage) != raw["resolutionCid"]:
+        raise CallContractRefProtocolError("resolution CID mismatch")
     if return_term is not None:
         from .ir import _free_vars_in_term
 
@@ -151,16 +181,13 @@ def _decode_ref(raw: Any) -> ResolvedCallContractRefV1:
                 "returnTerm contains a variable not authenticated as a formal"
             )
     return ResolvedCallContractRefV1(
-        _cid(raw["resolutionCid"], "resolutionCid"),
-        _cid(raw["demandCid"], "demandCid"),
+        resolution_cid, demand_cid,
         SourceFragmentCoordinateV1.decode(raw["useSite"]),
-        _cid(raw["importBindingCid"], "importBindingCid"),
-        _cid(raw["catalogCid"], "catalogCid"),
-        _cid(raw["memberCid"], "memberCid"),
-        _cid(raw["contractCid"], "contractCid"),
+        import_binding_cid, catalog_cid, member_cid, contract_cid,
         raw["bridgeSourceSymbol"],
         tuple(signature["formals"]), sorts, return_term,
         tuple(_cid(value, "sourceWarrantCid") for value in warrants),
+        MappingProxyType(dict(contract_decl)),
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/call_contract_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/call_contract_resolution.py
@@ -111,6 +111,11 @@ class ResolvedCallContractRefsV1:
     catalog_cid: str
     table_cid: str
     by_use_site: Mapping[SourceFragmentCoordinateV1, CallContractResolutionV1]
+    enrolled_use_sites: frozenset[SourceFragmentCoordinateV1] | None = None
+
+    def __post_init__(self) -> None:
+        if self.enrolled_use_sites is None:
+            object.__setattr__(self, "enrolled_use_sites", frozenset(self.by_use_site))
 
     def require(self, use_site: SourceFragmentCoordinateV1) -> CallContractResolutionV1:
         try:
@@ -193,7 +198,7 @@ def _decode_ref(raw: Any) -> ResolvedCallContractRefV1:
 
 def decode_resolved_call_contract_refs(raw: Any) -> ResolvedCallContractRefsV1:
     if not isinstance(raw, dict) or set(raw) != {
-        "kind", "schemaVersion", "catalogCid", "tableCid", "byUseSite"
+        "kind", "schemaVersion", "catalogCid", "tableCid", "enrolledUseSites", "byUseSite"
     } or raw["kind"] != "resolved-call-contract-refs" or raw["schemaVersion"] != "1":
         raise CallContractRefProtocolError("malformed resolved-call contract-ref table")
     rows = raw["byUseSite"]
@@ -201,15 +206,29 @@ def decode_resolved_call_contract_refs(raw: Any) -> ResolvedCallContractRefsV1:
         raise CallContractRefProtocolError("byUseSite must be a list")
     decoded: dict[SourceFragmentCoordinateV1, CallContractResolutionV1] = {}
     catalog_cid = _cid(raw["catalogCid"], "catalogCid")
+    enrolled_raw = raw["enrolledUseSites"]
+    if not isinstance(enrolled_raw, list):
+        raise CallContractRefProtocolError("enrolledUseSites must be a list")
+    enrolled = tuple(SourceFragmentCoordinateV1.decode(value) for value in enrolled_raw)
+    if len(set(enrolled)) != len(enrolled):
+        raise CallContractRefProtocolError("duplicate enrolled use-site")
     for row in rows:
         if not isinstance(row, dict) or set(row) != {"useSite", "resolution"}:
             raise CallContractRefProtocolError("malformed call resolution row")
         use_site = SourceFragmentCoordinateV1.decode(row["useSite"])
+        if use_site in decoded:
+            raise CallContractRefProtocolError("duplicate use-site resolution row")
+        if use_site not in enrolled:
+            raise CallContractRefProtocolError("resolution row is not an enrolled call demand")
         resolution = row["resolution"]
         if not isinstance(resolution, dict):
             raise CallContractRefProtocolError("malformed call resolution")
         if resolution.get("kind") == "resolved" and set(resolution) == {"kind", "reference"}:
             value: CallContractResolutionV1 = _decode_ref(resolution["reference"])
+            if value.use_site != use_site:
+                raise CallContractRefProtocolError("resolved reference row use-site mismatch")
+            if value.catalog_cid != catalog_cid:
+                raise CallContractRefProtocolError("resolved reference catalog CID mismatch")
         elif resolution.get("kind") == "unresolved" and set(resolution) == {"kind", "gap"}:
             gap = resolution["gap"]
             candidates = gap.get("candidateMemberCids") if isinstance(gap, dict) else None
@@ -221,12 +240,24 @@ def decode_resolved_call_contract_refs(raw: Any) -> ResolvedCallContractRefsV1:
                 gap.get("targetSymbol"), CallContractResolutionGapKindV1(gap.get("kind")),
                 tuple(_cid(cid, "candidateMemberCid") for cid in candidates),
             )
+            if SourceFragmentCoordinateV1.decode(gap.get("useSite")) != use_site:
+                raise CallContractRefProtocolError("unresolved gap row use-site mismatch")
         else:
             raise CallContractRefProtocolError("unknown call resolution")
         decoded[use_site] = value
-    identity = {key: raw[key] for key in ("kind", "schemaVersion", "catalogCid", "byUseSite")}
+    if set(decoded) != set(enrolled):
+        raise CallContractRefProtocolError(
+            "BackendDefect: enrolled call demand missing from resolution table"
+        )
+    identity = {
+        key: raw[key]
+        for key in ("kind", "schemaVersion", "catalogCid", "enrolledUseSites", "byUseSite")
+    }
     if _hash_json(identity) != raw["tableCid"]:
         raise CallContractRefProtocolError("table CID mismatch")
     return ResolvedCallContractRefsV1(
-        catalog_cid, _cid(raw["tableCid"], "tableCid"), MappingProxyType(decoded)
+        catalog_cid,
+        _cid(raw["tableCid"], "tableCid"),
+        MappingProxyType(decoded),
+        frozenset(enrolled),
     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/call_contract_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/call_contract_resolution.py
@@ -1,0 +1,205 @@
+"""Authenticated function-contract coordinates installed before construction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from .canonicalizer import blake3_512_of, encode_jcs
+from .context_manager_contract import _decode_sort, _json_value
+from .context_manager_resolution import SourceFragmentCoordinateV1
+from .ir import (
+    PrimitiveSort,
+    Sort,
+    Term,
+    bool_const,
+    ctor,
+    make_var,
+    num,
+    real_lit,
+    str_const,
+)
+
+
+class CallContractRefProtocolError(ValueError):
+    pass
+
+
+def _cid(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.startswith("blake3-512:"):
+        raise CallContractRefProtocolError(f"{field} must be a CID")
+    return value
+
+
+def _hash_json(raw: Any) -> str:
+    return blake3_512_of(encode_jcs(_json_value(raw)).encode("utf-8"))
+
+
+def _term(raw: Any) -> Term:
+    if not isinstance(raw, dict):
+        raise CallContractRefProtocolError("returnTerm must be a term object")
+    kind = raw.get("kind")
+    if kind == "var" and set(raw) == {"kind", "name"} and isinstance(raw["name"], str):
+        return make_var(raw["name"])
+    if kind == "const" and set(raw) == {"kind", "value", "sort"}:
+        sort = raw["sort"]
+        name = sort.get("name") if isinstance(sort, dict) else None
+        value = raw["value"]
+        if name == "String" and isinstance(value, str):
+            return str_const(value)
+        if name == "Bool" and isinstance(value, bool):
+            return bool_const(value)
+        if name == "Int" and isinstance(value, int) and not isinstance(value, bool):
+            return num(value)
+        if name == "Real" and isinstance(value, (int, float)) and not isinstance(value, bool):
+            return real_lit(str(value))
+        raise CallContractRefProtocolError("unsupported returnTerm constant")
+    if kind == "ctor" and set(raw) == {"kind", "name", "args"}:
+        if not isinstance(raw["name"], str) or not isinstance(raw["args"], list):
+            raise CallContractRefProtocolError("malformed returnTerm ctor")
+        return ctor(raw["name"], [_term(arg) for arg in raw["args"]])
+    raise CallContractRefProtocolError("unsupported returnTerm shape")
+
+
+@dataclass(frozen=True)
+class ResolvedCallContractRefV1:
+    resolution_cid: str
+    demand_cid: str
+    use_site: SourceFragmentCoordinateV1 | None
+    import_binding_cid: str
+    catalog_cid: str
+    member_cid: str
+    contract_cid: str
+    bridge_source_symbol: str
+    formals: tuple[str, ...]
+    sorts: tuple[Sort, ...]
+    return_term: Term | None
+    source_warrant_cids: tuple[str, ...]
+
+
+class CallContractResolutionGapKindV1(str, Enum):
+    TARGET_NOT_IN_CORPUS = "target-not-in-corpus"
+    NO_AUTHENTICATED_CONTRACT = "no-authenticated-contract"
+    AMBIGUOUS_TARGET = "ambiguous-target"
+    IMPORT_SIGNATURE_MISMATCH = "import-signature-mismatch"
+    WRONG_CONTRACT_KIND = "wrong-contract-kind"
+    STALE_OR_MALFORMED_CONTRACT_REF = "stale-or-malformed-contract-ref"
+
+
+@dataclass(frozen=True)
+class CallContractResolutionGapV1:
+    demand_cid: str
+    use_site: SourceFragmentCoordinateV1
+    import_binding_cid: str
+    target_symbol: str | None
+    kind: CallContractResolutionGapKindV1
+    candidate_member_cids: tuple[str, ...]
+
+
+CallContractResolutionV1 = ResolvedCallContractRefV1 | CallContractResolutionGapV1
+
+
+@dataclass(frozen=True)
+class ResolvedCallContractRefsV1:
+    catalog_cid: str
+    table_cid: str
+    by_use_site: Mapping[SourceFragmentCoordinateV1, CallContractResolutionV1]
+
+    def require(self, use_site: SourceFragmentCoordinateV1) -> CallContractResolutionV1:
+        try:
+            return self.by_use_site[use_site]
+        except KeyError as exc:
+            raise CallContractRefProtocolError(
+                "BackendDefect: enrolled call demand missing from resolution table"
+            ) from exc
+
+
+def _decode_ref(raw: Any) -> ResolvedCallContractRefV1:
+    expected = {
+        "kind", "schemaVersion", "resolutionCid", "demandCid", "useSite",
+        "importBindingCid", "catalogCid", "memberCid", "contractCid", "bridgeSourceSymbol",
+        "importSignature", "returnTerm", "sourceWarrantCids",
+    }
+    if not isinstance(raw, dict) or set(raw) != expected:
+        raise CallContractRefProtocolError("malformed resolved-call contract ref")
+    if raw["kind"] != "resolved-call-contract-ref" or raw["schemaVersion"] != "1":
+        raise CallContractRefProtocolError("unsupported resolved-call contract ref")
+    signature = raw["importSignature"]
+    if not isinstance(signature, dict) or set(signature) != {"formals", "sorts"}:
+        raise CallContractRefProtocolError("malformed call import signature")
+    if not isinstance(signature["formals"], list) or not all(
+        isinstance(value, str) for value in signature["formals"]
+    ):
+        raise CallContractRefProtocolError("malformed call import formals")
+    try:
+        sorts = tuple(_decode_sort(value) for value in signature["sorts"])
+    except Exception as exc:
+        raise CallContractRefProtocolError("malformed call import sorts") from exc
+    if len(sorts) != len(signature["formals"]):
+        raise CallContractRefProtocolError("call import signature arity mismatch")
+    warrants = raw["sourceWarrantCids"]
+    if not isinstance(warrants, list):
+        raise CallContractRefProtocolError("sourceWarrantCids must be a list")
+    return_term = None if raw["returnTerm"] is None else _term(raw["returnTerm"])
+    if return_term is not None:
+        from .ir import _free_vars_in_term
+
+        if not _free_vars_in_term(return_term) <= set(signature["formals"]):
+            raise CallContractRefProtocolError(
+                "returnTerm contains a variable not authenticated as a formal"
+            )
+    return ResolvedCallContractRefV1(
+        _cid(raw["resolutionCid"], "resolutionCid"),
+        _cid(raw["demandCid"], "demandCid"),
+        SourceFragmentCoordinateV1.decode(raw["useSite"]),
+        _cid(raw["importBindingCid"], "importBindingCid"),
+        _cid(raw["catalogCid"], "catalogCid"),
+        _cid(raw["memberCid"], "memberCid"),
+        _cid(raw["contractCid"], "contractCid"),
+        raw["bridgeSourceSymbol"],
+        tuple(signature["formals"]), sorts, return_term,
+        tuple(_cid(value, "sourceWarrantCid") for value in warrants),
+    )
+
+
+def decode_resolved_call_contract_refs(raw: Any) -> ResolvedCallContractRefsV1:
+    if not isinstance(raw, dict) or set(raw) != {
+        "kind", "schemaVersion", "catalogCid", "tableCid", "byUseSite"
+    } or raw["kind"] != "resolved-call-contract-refs" or raw["schemaVersion"] != "1":
+        raise CallContractRefProtocolError("malformed resolved-call contract-ref table")
+    rows = raw["byUseSite"]
+    if not isinstance(rows, list):
+        raise CallContractRefProtocolError("byUseSite must be a list")
+    decoded: dict[SourceFragmentCoordinateV1, CallContractResolutionV1] = {}
+    catalog_cid = _cid(raw["catalogCid"], "catalogCid")
+    for row in rows:
+        if not isinstance(row, dict) or set(row) != {"useSite", "resolution"}:
+            raise CallContractRefProtocolError("malformed call resolution row")
+        use_site = SourceFragmentCoordinateV1.decode(row["useSite"])
+        resolution = row["resolution"]
+        if not isinstance(resolution, dict):
+            raise CallContractRefProtocolError("malformed call resolution")
+        if resolution.get("kind") == "resolved" and set(resolution) == {"kind", "reference"}:
+            value: CallContractResolutionV1 = _decode_ref(resolution["reference"])
+        elif resolution.get("kind") == "unresolved" and set(resolution) == {"kind", "gap"}:
+            gap = resolution["gap"]
+            candidates = gap.get("candidateMemberCids") if isinstance(gap, dict) else None
+            if not isinstance(candidates, list) or candidates != sorted(candidates):
+                raise CallContractRefProtocolError("candidate member CIDs must be sorted")
+            value = CallContractResolutionGapV1(
+                _cid(gap.get("demandCid"), "demandCid"), use_site,
+                _cid(gap.get("importBindingCid"), "importBindingCid"),
+                gap.get("targetSymbol"), CallContractResolutionGapKindV1(gap.get("kind")),
+                tuple(_cid(cid, "candidateMemberCid") for cid in candidates),
+            )
+        else:
+            raise CallContractRefProtocolError("unknown call resolution")
+        decoded[use_site] = value
+    identity = {key: raw[key] for key in ("kind", "schemaVersion", "catalogCid", "byUseSite")}
+    if _hash_json(identity) != raw["tableCid"]:
+        raise CallContractRefProtocolError("table CID mismatch")
+    return ResolvedCallContractRefsV1(
+        catalog_cid, _cid(raw["tableCid"], "tableCid"), MappingProxyType(decoded)
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -102,6 +102,8 @@ class ResolvedContractRefsV1:
 class TreeConstructionContextV1:
     contract_refs: ResolvedContractRefsV1
     with_manager_authorities: Any = None
+    call_contract_refs: object | None = None
+    workspace_root: str | None = None
 
     def __post_init__(self) -> None:
         if self.with_manager_authorities is None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bridged_contract_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bridged_contract_value.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class BridgedContractValue(FloorValue):
+    term: object
+    contract_cid: str
+    member_cid: str
+    callsite: object
+
+    def to_term(self, *, owner: str):
+        del owner
+        return self.term
+
+    def callsites(self):
+        return (self.callsite,)
+
+    def edge_contribution(self, source_contract):
+        return self.callsite.edge_contribution(source_contract)
+
+    def subscript(self, index, site):
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+        from sugar_lift_py_tests.floor.term_value import TermValue
+        from sugar_lift_py_tests.ir import _Ctor
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_source_tree.panic import SugarNotWritten
+
+        if (
+            isinstance(self.term, _Ctor)
+            and self.term.name in {"tuple", "python:tuple", "python:list"}
+            and isinstance(index, TermValue)
+            and type(index.value) is int
+            and 0 <= index.value < len(self.term.args)
+        ):
+            return Complete(SymbolicValue(self.term.args[index.value]))
+        raise SugarNotWritten(
+            owner="BridgedContractValue.subscript",
+            observed="contract return does not warrant this projection",
+            requested="ground in-range projection from an authenticated structural return",
+            fix="strengthen the contract or keep the projection loud",
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -100,6 +100,11 @@ class CallSiteValue(FloorValue):
     # Issued by a registered Call Sugar from an authenticated import target.
     # The target spelling alone never grants native behavior.
     native_shape: object | None = None
+    # Semantic ContractDecl CID installed by the linker authority. This is
+    # never an attestation/member CID and is absent for ordinary unresolved
+    # call sites.
+    target_contract_cid: str | None = dataclass_field(default=None, compare=False)
+    authenticated_target_symbol: str | None = dataclass_field(default=None, compare=False)
 
     def __hash__(self) -> int:
         """Hash the finite call coordinate, never the recursively-owned body.
@@ -788,8 +793,10 @@ class CallSiteValue(FloorValue):
         edge = {
             "kind": "call-edge",
             "sourceContract": source_contract,
-            "targetSymbol": f"call:{self.target_name}",
+            "targetSymbol": self.authenticated_target_symbol or f"call:{self.target_name}",
         }
+        if self.target_contract_cid is not None:
+            edge["targetContractCid"] = self.target_contract_cid
         if self.site is not None:
             edge["callSiteLocus"] = {
                 "file": self.site.filename,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_alias_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_alias_value.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 from .floor_value import FloorValue
@@ -8,157 +8,54 @@ from .floor_value import FloorValue
 
 @dataclass(frozen=True)
 class ImportAliasValue(FloorValue):
-    """An inert import binding discovered in source.
+    """An inert source-stated import binding, never a value resolver.
 
-    `import numpy as np` warrants the local binding `np -> numpy`; it does not
-    warrant a predicate by itself. Later sugars may use the binding to resolve a
-    symbol before emitting a bridge or digging source.
+    Import-to-contract resolution has exactly one owner: authenticated
+    preconstruction.  This legacy floor records a coordinate only and has no
+    source-oracle, module-import, re-export-walk, or value-resolution door.
     """
 
     name: str
     bound_name: str
     import_target: str | None = None
-    resolved_value: FloorValue | None = field(default=None, compare=False)
-    install_source_checked: bool = field(default=False, compare=False)
-    install_source_context: Any = field(default=None, compare=False, repr=False)
-
-    def resolve_value(self):
-        """Construct this source-backed value only when a consumer demands it."""
-        if self.resolved_value is not None:
-            return self.resolved_value
-        if self.install_source_context is None:
-            return None
-        target = self.import_target or self.name
-        if not target or "." not in target:
-            return None
-        from sugar_lift_py_tests.sugar.install_source_dig import (
-            resolve_install_source_value,
-        )
-
-        return resolve_install_source_value(target, self.install_source_context)
 
     def extend_scope(self, ctx):
-        """Thread the source-stated import binding into following statements."""
         return ctx.with_temporal(ctx.temporal.bind_value(self.bound_name, self))
 
     def to_term(self, *, owner: str):
         del owner
         from sugar_lift_py_tests.ir import ctor, str_const
 
-        return ctor(
-            "python:import_alias", [str_const(self.bound_name), str_const(self.name)]
-        )
+        return ctor("python:import_alias", [str_const(self.bound_name), str_const(self.name)])
 
     def test_python_type(self, value, site):
         from sugar_lift_py_tests.floor.type_tester import native_type_tester
         from sugar_lift_py_tests.ir import ctor, str_const
 
-        return native_type_tester(
-            value,
-            ctor("python:type", [str_const(self.name)]),
-            site,
-        )
+        return native_type_tester(value, ctor("python:type", [str_const(self.name)]), site)
 
     def qualified_class_attribute(self, attribute: str) -> ImportAliasValue | None:
-        """Construct an exact imported class coordinate when the source proves it.
-
-        A static resolve of ``module.attribute`` to a ``kind="class"``
-        receiver is source-level evidence for the type object's qualified
-        identity.  A function, constant, missing attribute, or unavailable
-        module does not claim this recognizer and remains on AttributeSugar's
-        existing path.  Resolution enters through
-        :func:`_resolve_qualified_import_object` — the sole static
-        import-alias resolver — never through a live import.
-        """
-        module_name = self.import_target or self.name
-        head, separator, _tail = module_name.partition(".")
-        if self.import_target is None and separator and self.bound_name == head:
-            # ``import package.submodule`` binds ``package``.  An explicit
-            # alias (``as sub``) binds the full stated module instead.
-            module_name = head
-        if module_name.startswith("."):
-            # Relative import spellings are not free-standing module coordinates.
-            return None
-        receiver = _resolve_qualified_import_object(f"{module_name}.{attribute}")
-        if receiver is None or receiver.kind != "class":
-            return None
-        qualified = f"{module_name}.{attribute}"
-        return ImportAliasValue(
-            qualified,
-            attribute,
-            import_target=qualified,
-        )
+        del attribute
+        return None
 
     def qualified_attribute(self, attribute: str, site) -> ImportAliasValue | None:
-        """Construct an exact coordinate for a concrete imported object member.
-
-        ``from pandas import Timestamp`` fixes the receiver identity before
-        lift.  When that exact target resolves to a module or class and Python
-        receives a static requested name, ``getattr(Timestamp, "now")`` is the
-        inert coordinate ``pandas.Timestamp.now``.  The coordinate records the
-        requested lookup; it does not claim that Python lookup succeeds.
-        An unavailable receiver returns ``None`` to the caller's loud floor.
-        """
-        target = self.import_target or self.name
-        receiver = _resolve_qualified_import_object(target)
-        if receiver is None:
-            return None
-        del site
-        qualified = f"{target}.{attribute}"
-        return ImportAliasValue(
-            qualified,
-            attribute,
-            import_target=qualified,
-        )
+        del attribute, site
+        return None
 
     def truth(self, site):
-        """Construct decidable truthiness for an import binding.
-
-        Law (#4981 / #4265 ground-operand): ``python:import_alias`` with string
-        coordinates is lift-time ground. Emitting ``py.truthy(import_alias)`` and
-        later minting RuntimeEffect authority is illegal — construct or panic.
-
-        - Dug ``resolved_value`` answers with its own truth.
-        - Module objects are always truthy in Python (``bool(importlib) is True``).
-        - Attribute from-imports without a constructed value cannot invent a
-          soft runtime condition over a ground coordinate: ConstructionPanic.
-        """
-        from sugar_lift_py_tests.outcome import Complete
-        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
-            TrueBoolLiteralSugar,
-        )
-
-        resolved_value = self.resolve_value()
-        if resolved_value is not None:
-            return resolved_value.truth(site)
-
-        coordinate = self._checked_constant_coordinate()
-        if coordinate is not None:
-            return coordinate.truth(site)
-
-        if _import_alias_binds_module(self):
-            return Complete(TrueBoolLiteralSugar(site=site))
-
-        from sugar_lift_py_tests.gap.panic import construction_panic_gap
         from sugar_lift_py_tests.gap.info import GapKind, GapLocus
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
         target = self.import_target or self.name
         construction_panic_gap(
             owner="ImportAliasValue.truth",
             blame=site,
-            observed=(
-                f"py.truthy(python:import_alias({self.bound_name!r}, {self.name!r}))"
-            ),
-            requested="construct decidable import-alias truthiness",
+            observed=f"py.truthy(python:import_alias({self.bound_name!r}, {self.name!r}))",
+            requested="authenticated import value truthiness",
             fix=(
-                f"Import binding `{self.bound_name} -> {self.name}` "
-                f"(import_target={target!r}) has no resolved floor value and is "
-                "not a module object. Module imports construct True "
-                "(Python modules are always truthy). Attribute from-imports must "
-                "dig install-source to the value and construct its truth. Ground "
-                "python:import_alias cannot mint RuntimeEffect via py.truthy — "
-                "replacement=resolve_install_source_value then truth(), or keep "
-                "this ConstructionPanic (never soft RuntimeEffect for ground cases)."
+                f"Import binding `{self.bound_name} -> {target}` has no authenticated "
+                "contract-backed value. Consume ResolvedCallContractRefV1 directly; "
+                "never open installed source or execute the module."
             ),
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
@@ -169,21 +66,16 @@ class ImportAliasValue(FloorValue):
         return self.py_subscript_coordinate(index, site)
 
     def getattr_static(self, name: str, site):
-        """Keep an unresolvable ground alias lookup loud."""
-        from sugar_lift_py_tests.gap.panic import construction_panic_gap
         from sugar_lift_py_tests.gap.info import GapKind, GapLocus
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
         target = self.import_target or self.name
         construction_panic_gap(
             owner="ImportAliasValue",
             blame=site,
             observed=f"{target}.{name}",
-            requested="qualified import attribute coordinate",
-            fix=(
-                f"Resolve imported receiver `{target}` to a concrete module/class "
-                f"before constructing `{target}.{name}`. A ground static getattr "
-                "cannot mint RuntimeEffect authority."
-            ),
+            requested="authenticated import attribute coordinate",
+            fix="consume an authenticated contract bridge; no source-hunt fallback exists",
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
@@ -220,17 +112,7 @@ class ImportAliasValue(FloorValue):
             from sugar_lift_py_tests.ir import ctor
             from sugar_lift_py_tests.outcome import Complete
 
-            return Complete(
-                SymbolicValue(
-                    ctor(
-                        "|",
-                        [
-                            self.to_term(owner=str(site)),
-                            other.to_term(owner=str(site)),
-                        ],
-                    )
-                )
-            )
+            return Complete(SymbolicValue(ctor("|", [self.to_term(owner=str(site)), other.to_term(owner=str(site))])))
         return super().bitwise_or(other, site)
 
     def unary_minus(self, site):
@@ -243,428 +125,64 @@ class ImportAliasValue(FloorValue):
         return self._unary_runtime_effect(site, "~")
 
     def format_data_model(self, spec, site, ctx):
-        resolved_value = self.resolve_value()
-        if resolved_value is not None:
-            return resolved_value.format_data_model(spec, site, ctx)
+        del spec, ctx
         return _runtime_alias_effect_at_site(
-            self,
-            shape=f"format({self.bound_name}, ...)",
-            site=site,
+            self, shape=f"format({self.bound_name}, ...)", site=site,
             replacement="ImportedModuleFormatEffect",
         )
 
     def _binary_runtime_effect(self, other, site, operator):
-        resolved = self.resolve_value() or self._checked_constant_coordinate()
-        if resolved is not None:
-            methods = {
-                "+": "add",
-                "-": "subtract",
-                "*": "multiply",
-                "/": "divide",
-                "**": "power",
-                "&": "bitwise_and",
-                "^": "bitwise_xor",
-            }
-            return getattr(resolved, methods[operator])(other, site)
+        del other
         return _runtime_alias_effect_at_site(
-            self,
-            shape=f"{self.bound_name} {operator} ...",
-            site=site,
+            self, shape=f"{self.bound_name} {operator} ...", site=site,
             replacement="ImportedModuleBinaryEffect",
         )
 
     def _unary_runtime_effect(self, site, operator):
-        resolved_value = self.resolve_value()
-        if resolved_value is not None:
-            methods = {"-": "unary_minus", "+": "unary_plus", "~": "bitwise_invert"}
-            return getattr(resolved_value, methods[operator])(site)
         return _runtime_alias_effect_at_site(
-            self,
-            shape=f"{operator}{self.bound_name}",
-            site=site,
+            self, shape=f"{operator}{self.bound_name}", site=site,
             replacement="ImportedModuleUnaryEffect",
         )
 
     def call_method_with(self, operation: Any, ctx: object):
-        resolved_value = self.resolve_value()
-        if resolved_value is not None:
-            return resolved_value.call_method_with(operation, ctx)
         del ctx
-        return _runtime_alias_effect(
-            self,
-            operation=operation,
+        return _runtime_alias_effect(self, operation=operation,
             shape=f"{self.bound_name}.{operation.name}(...)",
-            replacement="ImportedModuleCallEffect",
-        )
+            replacement="ImportedModuleCallEffect")
 
     def subscript_with(self, operation: Any, ctx: object):
-        resolved_value = self.resolve_value()
-        if resolved_value is not None:
-            return resolved_value.subscript_with(operation, ctx)
         del ctx
-        return _runtime_alias_effect(
-            self,
-            operation=operation,
-            shape=f"{self.bound_name}[...]",
-            replacement="ImportedModuleSubscriptEffect",
-        )
+        return _runtime_alias_effect(self, operation=operation,
+            shape=f"{self.bound_name}[...]", replacement="ImportedModuleSubscriptEffect")
 
     def contains_with(self, operation: Any, ctx: object):
-        resolved_value = self.resolve_value()
-        if resolved_value is not None:
-            return resolved_value.contains_with(operation, ctx)
         del ctx
-        return _runtime_alias_effect(
-            self,
-            operation=operation,
+        return _runtime_alias_effect(self, operation=operation,
             shape="contains membership over imported module binding",
-            replacement="ImportedModuleContainsEffect",
-        )
+            replacement="ImportedModuleContainsEffect")
 
     def attribute_assign_with(self, operation: Any, ctx: object):
-        resolved_value = self.resolve_value()
-        if resolved_value is not None:
-            return resolved_value.attribute_assign_with(operation, ctx)
         del ctx
-        return _runtime_alias_effect(
-            self,
-            operation=operation,
+        return _runtime_alias_effect(self, operation=operation,
             shape=f"{self.bound_name}.{operation.name} = ...",
-            replacement="ImportedModuleAttributeAssignEffect",
-        )
+            replacement="ImportedModuleAttributeAssignEffect")
 
     def binary_operator_with(self, operation: Any, ctx: object):
-        resolved_value = self.resolve_value()
-        if resolved_value is not None:
-            return resolved_value.binary_operator_with(operation, ctx)
         del ctx
-        return _runtime_alias_effect(
-            self,
-            operation=operation,
+        return _runtime_alias_effect(self, operation=operation,
             shape=f"{self.bound_name} {operation.operator} ...",
-            replacement="ImportedModuleBinaryEffect",
-        )
-
-    def _checked_constant_coordinate(self):
-        """Construct a coordinate only after the source door checked this target."""
-        if not self.install_source_checked:
-            return None
-        target = self.import_target or self.name
-        receiver = _resolve_qualified_import_object(target)
-        if receiver is None or receiver.kind != "constant":
-            return None
-        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
-        from sugar_lift_py_tests.ir import ctor, str_const
-
-        return SymbolicValue(
-            ctor(
-                "python:import_alias",
-                [str_const(self.bound_name), str_const(target)],
-            )
-        )
+            replacement="ImportedModuleBinaryEffect")
 
 
-def _static_module_exists(module_name: str) -> bool:
-    """True when ``module_name`` names an importable module, without importing.
-
-    Parent-safe: uses ``importlib.machinery.PathFinder.find_spec`` walked one
-    package segment at a time (the same form ``_installed_native_extension``
-    uses in ``install_source_dig``), which never imports the parents it walks
-    through. A bare top-level name has no parents to protect, so
-    ``PathFinder.find_spec(name, None)`` is used there directly; a name
-    compiled into the interpreter (``sys.builtin_module_names`` — a static
-    data lookup, not an import) covers what PathFinder does not own.
-    """
-    if not module_name or module_name.startswith("."):
-        return False
-    if "." not in module_name:
-        import importlib.machinery
-        import sys
-
-        if module_name in sys.builtin_module_names:
-            return True
-        try:
-            return (
-                importlib.machinery.PathFinder.find_spec(module_name, None)
-                is not None
-            )
-        except (ImportError, ModuleNotFoundError, ValueError, AttributeError):
-            return False
-    import importlib.machinery
-
-    parts = module_name.split(".")
-    search_path = None
-    try:
-        for index in range(1, len(parts) + 1):
-            qualified = ".".join(parts[:index])
-            lookup_name = qualified if search_path is None else parts[index - 1]
-            spec = importlib.machinery.PathFinder.find_spec(lookup_name, search_path)
-            if spec is None:
-                return False
-            if index < len(parts):
-                search_path = spec.submodule_search_locations
-                if search_path is None:
-                    return False
-    except (ImportError, KeyError, ModuleNotFoundError, OSError, TypeError, ValueError):
-        return False
-    return True
-
-
-def _import_alias_binds_module(value: ImportAliasValue) -> bool:
-    """True when the import coordinate names an importable module object.
-
-    ``import m`` / ``import pkg.sub`` / ``from pkg import sub`` (submodule)
-    bind module objects, which are always truthy in Python. Attribute
-    from-imports (``from pkg import HAS_FLAG``) are not modules.
-    """
-    target = value.import_target or value.name
-    return _static_module_exists(target)
-
-
-class _StaticImportReceiver:
-    """A coordinate-only kind marker for a statically resolved import target.
-
-    Never a live object. ``kind`` is one of ``"module"``, ``"class"``,
-    ``"function"``, or ``"constant"`` — exactly the discrimination the two
-    callers (:meth:`ImportAliasValue.qualified_attribute`,
-    :meth:`ImportAliasValue._checked_constant_coordinate`,
-    :meth:`ImportAliasValue.qualified_class_attribute`) need. It carries no
-    Python value because obtaining one would require import execution.
-    """
-
-    __slots__ = ("kind",)
-
-    def __init__(self, kind: str) -> None:
-        self.kind = kind
-
-
-def _resolve_qualified_import_object(target: str) -> _StaticImportReceiver | None:
-    """Resolve one qualified import target statically — never by importing.
-
-    Walks candidate module/attribute splits exactly as the prior dynamic
-    version did, but every module lookup goes through the parent-safe
-    ``_static_module_exists`` and every attribute lookup goes through the
-    SourceOracle's parsed AST (``installed_module_source`` ->
-    ``parsed_tree``), matching the invariant in ``InstallSourceValueOracle``:
-    import-alias resolution enters through source, not through ``import``.
-    Absence stays ``None`` — a MISSING must never become a success by
-    executing.
-    """
-    if not target or target.startswith("."):
-        # Relative spellings need a package context; bare coordinates do not.
-        return None
-    parts = target.split(".")
-    for module_length in range(len(parts), 0, -1):
-        module_name = ".".join(parts[:module_length])
-        if not _static_module_exists(module_name):
-            continue
-        remaining = parts[module_length:]
-        if not remaining:
-            return _StaticImportReceiver("module")
-        return _resolve_static_module_attribute_chain(module_name, remaining)
-    return None
-
-
-def _resolve_static_module_attribute_chain(
-    module_name: str,
-    remaining: list[str],
-    *,
-    resolving: frozenset[str] = frozenset(),
-) -> _StaticImportReceiver | None:
-    """Resolve a dotted attribute chain against one module's static source.
-
-    ``pandas.Timestamp`` is not a direct ``class Timestamp:`` in
-    ``pandas/__init__.py`` — it arrives via ``from pandas.core.api import
-    (..., Timestamp, ...)``, itself re-exported further down to a compiled
-    extension type. This follows exactly the same re-export forms
-    ``install_source_dig`` already proves closed (unconditional top-level
-    ``from``, a literal ``__all__`` star re-export, or a setup-sentinel's
-    provably-selected false branch) — never a guess, never an import. A
-    chain that bottoms out on a native extension can't be proven a class,
-    function, or constant without importing it (the same undecidable
-    question T ruled loud for the exception-class check, #5930): it resolves
-    to kind ``"native"`` — existence only, no further discrimination.
-    """
-    import ast
-
-    from sugar_lift_py_tests.sugar.install_source_dig import (
-        _definite_setup_reexport_target,
-        _definite_star_reexport_target,
-        _definite_unconditional_reexport_target,
-        _install_source_cycle_panic,
-        _installed_native_extension,
-        installed_module_source,
-        parsed_tree,
-    )
-
-    name = remaining[0]
-    rest = remaining[1:]
-    cycle_key = f"{module_name}.{name}"
-    if cycle_key in resolving:
-        # A cycle here is a genuine construction gap, not a decidable
-        # "try the next candidate" negative: nothing further in this walk
-        # can resolve it, unlike the many other `None` returns below (no
-        # module, syntax error, no reexport found) that ARE decidable
-        # negatives callers already fall through on (#5930 ruling: bare
-        # `None` must never be ambiguous between "no" and "cannot tell").
-        _install_source_cycle_panic(
-            guard="import-alias-attribute-chain",
-            target=cycle_key,
-            active=resolving,
-        )
-    resolving = resolving | {cycle_key}
-
-    installed = installed_module_source(module_name)
-    if installed is None:
-        if not rest and _installed_native_extension(module_name) is not None:
-            return _StaticImportReceiver("native")
-        return None
-    source, sourcefile, _source_cid = installed
-    try:
-        parsed = parsed_tree(source, sourcefile)
-    except SyntaxError:
-        return None
-
-    node = next(
-        (
-            statement
-            for statement in parsed.body
-            if isinstance(
-                statement,
-                (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef),
-            )
-            and statement.name == name
-        ),
-        None,
-    )
-    if node is not None:
-        if rest:
-            if not isinstance(node, ast.ClassDef):
-                return None
-            return _resolve_class_body_attribute_chain(node, rest)
-        return _StaticImportReceiver(
-            "class" if isinstance(node, ast.ClassDef) else "function"
-        )
-
-    if not rest and _has_module_level_binding(parsed.body, name):
-        return _StaticImportReceiver("constant")
-
-    reexport = (
-        _definite_unconditional_reexport_target(module_name, name, parsed)
-        or _definite_star_reexport_target(module_name, name, parsed)
-        or _definite_setup_reexport_target(module_name, name, parsed)
-    )
-    if reexport is None:
-        return None
-    target_module, _separator, target_attr = reexport.rpartition(".")
-    if not target_module:
-        return None
-    return _resolve_static_module_attribute_chain(
-        target_module, [target_attr, *rest], resolving=resolving
-    )
-
-
-def _resolve_class_body_attribute_chain(
-    class_node, remaining: list[str]
-) -> _StaticImportReceiver | None:
-    """Resolve a trailing attribute chain nested inside a known class body."""
-    import ast
-
-    body = class_node.body
-    node: ast.AST | None = None
-    for index, name in enumerate(remaining):
-        node = next(
-            (
-                statement
-                for statement in body
-                if isinstance(
-                    statement,
-                    (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef),
-                )
-                and statement.name == name
-            ),
-            None,
-        )
-        if node is None:
-            if index == len(remaining) - 1 and _has_module_level_binding(body, name):
-                return _StaticImportReceiver("constant")
-            return None
-        if index < len(remaining) - 1:
-            if not isinstance(node, ast.ClassDef):
-                return None
-            body = node.body
-    if isinstance(node, ast.ClassDef):
-        return _StaticImportReceiver("class")
-    return _StaticImportReceiver("function")
-
-
-def _has_module_level_binding(body: list, name: str) -> bool:
-    """True when ``name`` is bound by a plain assignment in this scope's body.
-
-    This proves existence and non-callable/class/module kind, never a
-    specific value — extracting the literal is not required by either
-    caller, and evaluating an arbitrary RHS expression would reintroduce
-    execution.
-    """
-    import ast
-
-    for statement in body:
-        if isinstance(statement, ast.Assign):
-            targets = statement.targets
-        elif isinstance(statement, ast.AnnAssign):
-            targets = [statement.target]
-        else:
-            continue
-        for assign_target in targets:
-            if isinstance(assign_target, ast.Name) and assign_target.id == name:
-                return True
-    return False
-
-
-def _runtime_alias_effect(
-    value: ImportAliasValue,
-    *,
-    operation: Any,
-    shape: str,
-    replacement: str,
-):
+def _runtime_alias_effect(value: ImportAliasValue, *, operation: Any, shape: str, replacement: str):
     return _runtime_alias_effect_at_site(
-        value,
-        shape=shape,
-        # Every dispatched operation owns its site fragment; a blame-only
-        # operation is a construction gap, not a soft fallback.
-        site=operation.site,
-        replacement=replacement,
+        value, shape=shape, site=operation.site, replacement=replacement
     )
 
 
 def _runtime_alias_effect_at_site(
     value: ImportAliasValue, *, shape: str, site, replacement: str
 ):
-    from sugar_lift_py_tests.sugar.install_source_dig import installed_module_source
-
-    target = value.import_target or value.name
-    module_name = target.rsplit(".", 1)[0] if "." in target else target
-    # SourceOracle only: presence of Python source is exactly the question
-    # this site asks ("origin ends with .py/.pyi"), and it answers it without
-    # importing — find_spec(dotted) would import every parent package as a
-    # documented side effect.
-    installed = installed_module_source(module_name)
-    origin = installed[1] if installed is not None else None
-    if origin and origin.endswith((".py", ".pyi")):
-        from sugar_lift_py_tests.gap.panic import construction_panic_gap
-        from sugar_lift_py_tests.gap.info import GapKind, GapLocus
-
-        construction_panic_gap(
-            owner="ImportAliasValue",
-            blame=site,
-            observed=target,
-            requested="dig installed import source before applying floor operation",
-            fix=f"route `{shape}` through install_source_dig for source `{origin}`",
-            gap_kind=GapKind.FLOOR,
-            gap_locus=GapLocus.CONSTRUCTION,
-        )
-
     from sugar_lift_py_tests.effect import (
         ImportedModuleRuntimeEffect,
         runtime_effect_evidence_from_terms,
@@ -672,16 +190,14 @@ def _runtime_alias_effect_at_site(
     from sugar_lift_py_tests.ir import ctor, str_const
     from sugar_lift_py_tests.outcome import Incomplete
 
+    target = value.import_target or value.name
     alias = value.to_term(owner="ImportedModuleRuntimeEffect")
     operand = ctor("call:import_module", [alias])
-
     return Incomplete(
         ImportedModuleRuntimeEffect(
             "import alias runtime boundary: "
-            f"`{shape}` requires evaluating imported module binding "
-            f"`{value.bound_name} -> {value.name}` at runtime. "
-            "The alias floor records name binding only; it does not fabricate "
-            "module object semantics. "
+            f"`{shape}` requires evaluating imported binding `{value.bound_name} -> {target}`. "
+            "No authenticated contract-backed value was installed; source hunting is cut. "
             f"replacement={replacement}; blame={site}",
             **runtime_effect_evidence_from_terms(
                 ctor(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/local_exception_class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/local_exception_class_value.py
@@ -14,7 +14,6 @@ def module_class_value(*, name: str, base_names: tuple[str, ...], temporal, reco
     """Seed a module class without losing exact exception ancestry."""
     from .builtin_exception_class_value import BuiltinExceptionClassValue
     from .exception_class_value import ExceptionClassValue
-    from .import_alias_value import ImportAliasValue
 
     for base_name in base_names:
         bound = temporal.value_if_bound(base_name)
@@ -22,9 +21,6 @@ def module_class_value(*, name: str, base_names: tuple[str, ...], temporal, reco
             BuiltinExceptionClassValue,
             ExceptionClassValue,
             LocalExceptionClassValue,
-        ) or (
-            isinstance(bound, ImportAliasValue)
-            and isinstance(bound.resolve_value(), ExceptionClassValue)
         ):
             return LocalExceptionClassValue(name=name, bases=(), record=record)
     return ClassValue(name=name, bases=(), record=record)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -46,9 +46,15 @@ class _ImportDef:
     payload_jcs: str
 
 
+@dataclass(frozen=True)
+class _ModuleFunctionDef:
+    target_symbol: str
+    definition_site: tuple[int, int, int, int]
+
+
 _NON_IMPORT = "non-import"
 _UNBOUND = "unbound"
-Definition = _ImportDef | str
+Definition = _ImportDef | _ModuleFunctionDef | str
 State = dict[str, frozenset[Definition]]
 
 
@@ -94,12 +100,23 @@ def _import_from_module(current: str, node: ast.ImportFrom) -> str | None:
 
 
 class _Pass:
-    def __init__(self, *, source_cid: str, module_name: str, module_identities: dict[str, dict[str, Any]]):
+    def __init__(
+        self,
+        *,
+        source_cid: str,
+        module_name: str,
+        module_identities: dict[str, dict[str, Any]],
+        module_state: State | None = None,
+        analyze_nested: bool = True,
+    ):
         self.source_cid = source_cid
         self.module_name = module_name
         self.module_identities = module_identities
         self.rows: list[dict[str, Any]] = []
         self.outcomes: dict[tuple[int, int, int, int], str] = {}
+        self.module_state = module_state or {}
+        self.analyze_nested = analyze_nested
+        self.class_outer_states: dict[int, State] = {}
 
     def expression(self, node: ast.AST | None, state: State, scope: ast.AST) -> None:
         if node is None:
@@ -242,8 +259,22 @@ class _Pass:
                 self.expression(deco, state, scope)
             for default in (*node.args.defaults, *(d for d in node.args.kw_defaults if d)):
                 self.expression(default, state, scope)
-            state[node.name] = frozenset({_NON_IMPORT})
-            inner = dict(state)
+            if isinstance(scope, ast.Module):
+                state[node.name] = frozenset({
+                    _ModuleFunctionDef(
+                        f"python:{self.module_name}.{node.name}",
+                        (node.lineno, node.col_offset, node.end_lineno, node.end_col_offset),
+                    )
+                })
+            else:
+                state[node.name] = frozenset({_NON_IMPORT})
+            if not self.analyze_nested:
+                return state
+            inner = dict(
+                self.class_outer_states.get(id(scope), state)
+                if isinstance(scope, ast.ClassDef)
+                else state
+            )
             local_names = _function_locals(node)
             for name in local_names:
                 inner[name] = frozenset({_UNBOUND})
@@ -253,12 +284,18 @@ class _Pass:
                 inner[node.args.vararg.arg] = frozenset({_NON_IMPORT})
             if node.args.kwarg:
                 inner[node.args.kwarg.arg] = frozenset({_NON_IMPORT})
+            globals_, _nonlocals = _function_declarations(node)
+            for name in globals_:
+                inner[name] = self.module_state.get(name, frozenset({_UNBOUND}))
             self.statements(node.body, inner, node)
             return state
         if isinstance(node, ast.ClassDef):
             for expr in (*node.decorator_list, *node.bases):
                 self.expression(expr, state, scope)
             state[node.name] = frozenset({_NON_IMPORT})
+            if not self.analyze_nested:
+                return state
+            self.class_outer_states[id(node)] = dict(state)
             self.statements(node.body, dict(state), node)
             return state
         if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign, ast.NamedExpr)):
@@ -359,14 +396,72 @@ def _function_locals(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
     return collector.names - collector.globals - collector.nonlocals
 
 
+def _function_declarations(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> tuple[set[str], set[str]]:
+    class Collector(ast.NodeVisitor):
+        def __init__(self):
+            self.globals: set[str] = set()
+            self.nonlocals: set[str] = set()
+
+        def visit_Global(self, child):
+            self.globals.update(child.names)
+
+        def visit_Nonlocal(self, child):
+            self.nonlocals.update(child.names)
+
+        def visit_FunctionDef(self, child):
+            if child is node:
+                for statement in child.body:
+                    self.visit(statement)
+
+        visit_AsyncFunctionDef = visit_FunctionDef
+
+        def visit_ClassDef(self, child):
+            return
+
+        def visit_Lambda(self, child):
+            return
+
+    collector = Collector()
+    collector.visit(node)
+    return collector.globals, collector.nonlocals
+
+
+def _final_module_state(
+    *,
+    module: ast.Module,
+    source_cid: str,
+    module_name: str,
+    module_identities: dict[str, dict[str, Any]],
+) -> State:
+    prepass = _Pass(
+        source_cid=source_cid,
+        module_name=module_name,
+        module_identities=module_identities,
+        analyze_nested=False,
+    )
+    return prepass.statements(module.body, {}, module)
+
+
 def authenticated_import_uses(
     root: Path, path: Path, source: str, source_cid: str,
     module_identities: dict[str, dict[str, Any]] | None = None,
 ) -> tuple[list[dict[str, Any]], dict[tuple[int, int, int, int], str]]:
     module = ast.parse(source, filename=str(path))
+    module_name = module_name_for_path(root, path)
+    identities = module_identities or {}
+    module_state = _final_module_state(
+        module=module,
+        source_cid=source_cid,
+        module_name=module_name,
+        module_identities=identities,
+    )
     runner = _Pass(
-        source_cid=source_cid, module_name=module_name_for_path(root, path),
-        module_identities=module_identities or {},
+        source_cid=source_cid,
+        module_name=module_name,
+        module_identities=identities,
+        module_state=module_state,
     )
     runner.statements(module.body, {}, module)
     return runner.rows, runner.outcomes
@@ -378,26 +473,40 @@ def authenticated_module_exports(
     """Source-authenticated module-slot declarations for the frozen catalog."""
     module_name = module_name_for_path(root, path)
     module = ast.parse(source, filename=str(path))
+    final_state = _final_module_state(
+        module=module,
+        source_cid=source_cid,
+        module_name=module_name,
+        module_identities={},
+    )
     rows: list[dict[str, Any]] = []
-    for node in module.body:
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            exported = target = f"python:{module_name}.{node.name}"
+    for local, reaching in sorted(final_state.items()):
+        if len(reaching) != 1:
+            continue
+        definition = next(iter(reaching))
+        if isinstance(definition, _ModuleFunctionDef):
+            exported = target = definition.target_symbol
+            start_line, start_col, end_line, end_col = definition.definition_site
             rows.append({
                 "kind": "call-contract-export", "schemaVersion": "1",
-                "sourceCid": source_cid, "definitionSite": _site(source_cid, node),
+                "sourceCid": source_cid,
+                "definitionSite": {
+                    "sourceCid": source_cid,
+                    "startLine": start_line,
+                    "startCol": start_col,
+                    "endLine": end_line,
+                    "endCol": end_col,
+                },
                 "exportedSymbol": exported, "targetSymbol": target,
             })
-        elif isinstance(node, ast.ImportFrom):
-            target_module = _import_from_module(module_name, node)
-            if target_module is None:
-                continue
-            for alias in node.names:
-                if alias.name == "*":
-                    continue
-                rows.append({
-                    "kind": "call-contract-export", "schemaVersion": "1",
-                    "sourceCid": source_cid, "definitionSite": _site(source_cid, node),
-                    "exportedSymbol": f"python:{module_name}.{alias.asname or alias.name}",
-                    "targetSymbol": f"python:{target_module}.{alias.name}",
-                })
+        elif isinstance(definition, _ImportDef):
+            payload = json.loads(definition.payload_jcs)
+            rows.append({
+                "kind": "call-contract-export",
+                "schemaVersion": "1",
+                "sourceCid": source_cid,
+                "definitionSite": payload["definitionSite"],
+                "exportedSymbol": f"python:{module_name}.{local}",
+                "targetSymbol": definition.target_symbol,
+            })
     return rows

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -118,6 +118,40 @@ class _Pass:
         self.analyze_nested = analyze_nested
         self.class_outer_states: dict[int, State] = {}
 
+    def _state_only_statement(
+        self, node: ast.stmt, state: State, scope: ast.AST
+    ) -> State:
+        """Transfer one statement without enrolling any use-site testimony."""
+        transfer = _Pass(
+            source_cid=self.source_cid,
+            module_name=self.module_name,
+            module_identities=self.module_identities,
+            module_state=self.module_state,
+            analyze_nested=False,
+        )
+        return transfer.statement(node, state, scope)
+
+    def _loop_entry(
+        self,
+        node: ast.For | ast.AsyncFor | ast.While,
+        state: State,
+        scope: ast.AST,
+    ) -> State:
+        """Least fixed point for definitions that can arrive on a back-edge."""
+        entry = dict(state)
+        while True:
+            body_in = dict(entry)
+            if hasattr(node, "target"):
+                for name in _bound_names(node.target):
+                    body_in[name] = frozenset({_NON_IMPORT})
+            body_out = body_in
+            for statement in node.body:
+                body_out = self._state_only_statement(statement, body_out, scope)
+            widened = _join(state, body_out)
+            if widened == entry:
+                return entry
+            entry = widened
+
     def expression(self, node: ast.AST | None, state: State, scope: ast.AST) -> None:
         if node is None:
             return
@@ -314,17 +348,27 @@ class _Pass:
             )
         if isinstance(node, (ast.For, ast.AsyncFor, ast.While)):
             self.expression(getattr(node, "iter", None), state, scope)
-            self.expression(getattr(node, "test", None), state, scope)
-            body_in = dict(state)
+            body_in = self._loop_entry(node, state, scope)
+            self.expression(getattr(node, "test", None), body_in, scope)
             if hasattr(node, "target"):
                 for name in _bound_names(node.target):
                     body_in[name] = frozenset({_NON_IMPORT})
             body = self.statements(node.body, body_in, scope)
-            return _join(state, body, self.statements(node.orelse, _join(state, body), scope))
+            return _join(
+                state,
+                body,
+                self.statements(node.orelse, _join(state, body), scope),
+            )
         if isinstance(node, ast.Try):
+            exceptional_prefixes = [dict(state)]
+            prefix = dict(state)
+            for statement in node.body:
+                prefix = self._state_only_statement(statement, prefix, scope)
+                exceptional_prefixes.append(prefix)
+            handler_entry = _join(*exceptional_prefixes)
             paths = [self.statements(node.body, state, scope)]
             for handler in node.handlers:
-                handler_state = dict(state)
+                handler_state = dict(handler_entry)
                 if handler.name:
                     handler_state[handler.name] = frozenset({_NON_IMPORT})
                 paths.append(self.statements(handler.body, handler_state, scope))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -1,0 +1,403 @@
+"""Non-constructing lexical authentication for imported call uses.
+
+This pass owns only Python def-use.  It never imports a module, opens a target
+module, or constructs Sugar.  Its output is the source-authenticated half of
+the import-to-contract bridge protocol.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from .canonicalizer import blake3_512_of, encode_jcs
+from .context_manager_contract import _json_value
+
+
+def _hash(value: Any) -> str:
+    return blake3_512_of(encode_jcs(_json_value(value)).encode("utf-8"))
+
+
+def _site(source_cid: str, node: ast.AST) -> dict[str, Any]:
+    if not hasattr(node, "lineno"):
+        body = getattr(node, "body", ())
+        if not body:
+            return {"sourceCid": source_cid, "startLine": 1, "startCol": 0, "endLine": 1, "endCol": 0}
+        return {
+            "sourceCid": source_cid, "startLine": 1, "startCol": 0,
+            "endLine": body[-1].end_lineno, "endCol": body[-1].end_col_offset,
+        }
+    return {
+        "sourceCid": source_cid,
+        "startLine": node.lineno,
+        "startCol": node.col_offset,
+        "endLine": node.end_lineno,
+        "endCol": node.end_col_offset,
+    }
+
+
+@dataclass(frozen=True)
+class _ImportDef:
+    cid: str
+    target_symbol: str
+    payload_jcs: str
+
+
+_NON_IMPORT = "non-import"
+_UNBOUND = "unbound"
+Definition = _ImportDef | str
+State = dict[str, frozenset[Definition]]
+
+
+def _join(*states: State) -> State:
+    names = set().union(*(state for state in states))
+    return {
+        name: frozenset().union(*(state.get(name, frozenset({_UNBOUND})) for state in states))
+        for name in names
+    }
+
+
+def _bound_names(target: ast.AST) -> set[str]:
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, (ast.Tuple, ast.List)):
+        return set().union(*(_bound_names(item) for item in target.elts), set())
+    if isinstance(target, ast.Starred):
+        return _bound_names(target.value)
+    return set()
+
+
+def module_name_for_path(root: Path, path: Path) -> str:
+    parts = list(path.relative_to(root).with_suffix("").parts)
+    if parts and parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _import_from_module(current: str, node: ast.ImportFrom) -> str | None:
+    if node.level == 0:
+        return node.module
+    package = current.split(".")
+    # A non-__init__ module's package excludes its final component.
+    if package:
+        package.pop()
+    ascend = node.level - 1
+    if ascend > len(package):
+        return None
+    base = package[: len(package) - ascend]
+    if node.module:
+        base.extend(node.module.split("."))
+    return ".".join(base) or None
+
+
+class _Pass:
+    def __init__(self, *, source_cid: str, module_name: str, module_identities: dict[str, dict[str, Any]]):
+        self.source_cid = source_cid
+        self.module_name = module_name
+        self.module_identities = module_identities
+        self.rows: list[dict[str, Any]] = []
+        self.outcomes: dict[tuple[int, int, int, int], str] = {}
+
+    def expression(self, node: ast.AST | None, state: State, scope: ast.AST) -> None:
+        if node is None:
+            return
+        if isinstance(node, ast.Call):
+            self.expression(node.func, state, scope)
+            for arg in node.args:
+                self.expression(arg, state, scope)
+            for keyword in node.keywords:
+                self.expression(keyword.value, state, scope)
+            if (
+                isinstance(node.func, ast.Name)
+                and not node.keywords
+                and not any(isinstance(arg, ast.Starred) for arg in node.args)
+            ):
+                self._call(node, state, scope)
+            return
+        if isinstance(node, ast.Lambda):
+            inner = dict(state)
+            for arg in (*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs):
+                inner[arg.arg] = frozenset({_NON_IMPORT})
+            if node.args.vararg:
+                inner[node.args.vararg.arg] = frozenset({_NON_IMPORT})
+            if node.args.kwarg:
+                inner[node.args.kwarg.arg] = frozenset({_NON_IMPORT})
+            self.expression(node.body, inner, node)
+            return
+        if isinstance(node, (ast.ListComp, ast.SetComp, ast.GeneratorExp, ast.DictComp)):
+            inner = dict(state)
+            for generator in node.generators:
+                self.expression(generator.iter, inner, scope)
+                for name in _bound_names(generator.target):
+                    inner[name] = frozenset({_NON_IMPORT})
+                for condition in generator.ifs:
+                    self.expression(condition, inner, scope)
+            if isinstance(node, ast.DictComp):
+                self.expression(node.key, inner, scope)
+                self.expression(node.value, inner, scope)
+            else:
+                self.expression(node.elt, inner, scope)
+            return
+        for child in ast.iter_child_nodes(node):
+            self.expression(child, state, scope)
+
+    def _call(self, node: ast.Call, state: State, scope: ast.AST) -> None:
+        reaching = state.get(node.func.id, frozenset({_UNBOUND}))
+        imports = {value for value in reaching if isinstance(value, _ImportDef)}
+        nonimports = reaching - imports
+        key = (node.lineno, node.col_offset, node.end_lineno, node.end_col_offset)
+        if len(imports) == 1 and not nonimports:
+            binding = next(iter(imports))
+            self.outcomes[key] = "authenticated-import-use"
+            use_site = _site(self.source_cid, node)
+            use = {
+                "kind": "authenticated-import-use",
+                "schemaVersion": "1",
+                "useSite": use_site,
+                "importBindingCid": binding.cid,
+            }
+            self.rows.append({
+                "schemaVersion": "1",
+                "kind": "call-contract-demand",
+                "authenticatedImportUse": {**use, "cid": _hash(use)},
+                "importBinding": json.loads(binding.payload_jcs),
+                "targetSymbol": binding.target_symbol,
+                "importBindingCid": binding.cid,
+                "importSignature": {
+                    "formals": [],
+                    "sorts": [
+                        {"kind": "primitive", "name": "Value"}
+                        for _ in node.args
+                    ],
+                },
+                "useSite": use_site,
+            })
+        elif imports:
+            self.outcomes[key] = "ambiguous-lexical-binding"
+        elif reaching == frozenset({_NON_IMPORT}):
+            self.outcomes[key] = "shadowed-non-import"
+        else:
+            self.outcomes[key] = "no-lexical-binding"
+
+    def statements(self, statements: Iterable[ast.stmt], state: State, scope: ast.AST) -> State:
+        state = dict(state)
+        for statement in statements:
+            state = self.statement(statement, state, scope)
+        return state
+
+    def statement(self, node: ast.stmt, state: State, scope: ast.AST) -> State:
+        state = dict(state)
+        if isinstance(node, ast.ImportFrom):
+            module = _import_from_module(self.module_name, node)
+            if module is None:
+                return state
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                local = alias.asname or alias.name
+                payload = {
+                    "kind": "python-import-binding",
+                    "schemaVersion": "1",
+                    "sourceCid": self.source_cid,
+                    "scope": _site(self.source_cid, scope),
+                    "definitionSite": _site(self.source_cid, node),
+                    "localSlot": local,
+                    "target": {
+                        "moduleIdentity": self.module_identities.get(module, {
+                            "kind": "unavailable-python-module", "name": module,
+                        }),
+                        "exportedPath": [alias.name],
+                    },
+                }
+                state[local] = frozenset({
+                    _ImportDef(
+                        _hash(payload), f"python:{module}.{alias.name}",
+                        encode_jcs(_json_value(payload)),
+                    )
+                })
+            return state
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                local = alias.asname or alias.name.split(".")[0]
+                payload = {
+                    "kind": "python-import-binding", "schemaVersion": "1",
+                    "sourceCid": self.source_cid, "scope": _site(self.source_cid, scope),
+                    "definitionSite": _site(self.source_cid, node), "localSlot": local,
+                    "target": {"moduleIdentity": self.module_identities.get(alias.name, {
+                        "kind": "unavailable-python-module", "name": alias.name,
+                    }), "exportedPath": []},
+                }
+                state[local] = frozenset({
+                    _ImportDef(
+                        _hash(payload), f"python:{alias.name}",
+                        encode_jcs(_json_value(payload)),
+                    )
+                })
+            return state
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for deco in node.decorator_list:
+                self.expression(deco, state, scope)
+            for default in (*node.args.defaults, *(d for d in node.args.kw_defaults if d)):
+                self.expression(default, state, scope)
+            state[node.name] = frozenset({_NON_IMPORT})
+            inner = dict(state)
+            local_names = _function_locals(node)
+            for name in local_names:
+                inner[name] = frozenset({_UNBOUND})
+            for arg in (*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs):
+                inner[arg.arg] = frozenset({_NON_IMPORT})
+            if node.args.vararg:
+                inner[node.args.vararg.arg] = frozenset({_NON_IMPORT})
+            if node.args.kwarg:
+                inner[node.args.kwarg.arg] = frozenset({_NON_IMPORT})
+            self.statements(node.body, inner, node)
+            return state
+        if isinstance(node, ast.ClassDef):
+            for expr in (*node.decorator_list, *node.bases):
+                self.expression(expr, state, scope)
+            state[node.name] = frozenset({_NON_IMPORT})
+            self.statements(node.body, dict(state), node)
+            return state
+        if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign, ast.NamedExpr)):
+            value = getattr(node, "value", None)
+            self.expression(value, state, scope)
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                for name in _bound_names(target):
+                    state[name] = frozenset({_NON_IMPORT})
+            return state
+        if isinstance(node, ast.If):
+            self.expression(node.test, state, scope)
+            return _join(
+                self.statements(node.body, state, scope),
+                self.statements(node.orelse, state, scope),
+            )
+        if isinstance(node, (ast.For, ast.AsyncFor, ast.While)):
+            self.expression(getattr(node, "iter", None), state, scope)
+            self.expression(getattr(node, "test", None), state, scope)
+            body_in = dict(state)
+            if hasattr(node, "target"):
+                for name in _bound_names(node.target):
+                    body_in[name] = frozenset({_NON_IMPORT})
+            body = self.statements(node.body, body_in, scope)
+            return _join(state, body, self.statements(node.orelse, _join(state, body), scope))
+        if isinstance(node, ast.Try):
+            paths = [self.statements(node.body, state, scope)]
+            for handler in node.handlers:
+                handler_state = dict(state)
+                if handler.name:
+                    handler_state[handler.name] = frozenset({_NON_IMPORT})
+                paths.append(self.statements(handler.body, handler_state, scope))
+            joined = _join(*paths)
+            joined = self.statements(node.orelse, joined, scope)
+            return self.statements(node.finalbody, joined, scope)
+        if isinstance(node, (ast.With, ast.AsyncWith)):
+            for item in node.items:
+                self.expression(item.context_expr, state, scope)
+                if item.optional_vars:
+                    for name in _bound_names(item.optional_vars):
+                        state[name] = frozenset({_NON_IMPORT})
+            return self.statements(node.body, state, scope)
+        if isinstance(node, ast.Delete):
+            for target in node.targets:
+                for name in _bound_names(target):
+                    state[name] = frozenset({_UNBOUND})
+            return state
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.expr):
+                self.expression(child, state, scope)
+        return state
+
+
+def _function_locals(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    class Collector(ast.NodeVisitor):
+        def __init__(self):
+            self.globals: set[str] = set()
+            self.nonlocals: set[str] = set()
+            self.names: set[str] = set()
+
+        def visit_Global(self, child):
+            self.globals.update(child.names)
+
+        def visit_Nonlocal(self, child):
+            self.nonlocals.update(child.names)
+
+        def visit_Import(self, child):
+            self.names.update(alias.asname or alias.name.split(".")[0] for alias in child.names)
+
+        visit_ImportFrom = visit_Import
+
+        def visit_Name(self, child):
+            if isinstance(child.ctx, (ast.Store, ast.Del)):
+                self.names.add(child.id)
+
+        def visit_FunctionDef(self, child):
+            if child is not node:
+                self.names.add(child.name)
+                return
+            for statement in child.body:
+                self.visit(statement)
+
+        visit_AsyncFunctionDef = visit_FunctionDef
+
+        def visit_ClassDef(self, child):
+            self.names.add(child.name)
+
+        def visit_Lambda(self, child):
+            return
+
+        def visit_ExceptHandler(self, child):
+            if child.name:
+                self.names.add(child.name)
+            self.generic_visit(child)
+
+    collector = Collector()
+    collector.visit(node)
+    return collector.names - collector.globals - collector.nonlocals
+
+
+def authenticated_import_uses(
+    root: Path, path: Path, source: str, source_cid: str,
+    module_identities: dict[str, dict[str, Any]] | None = None,
+) -> tuple[list[dict[str, Any]], dict[tuple[int, int, int, int], str]]:
+    module = ast.parse(source, filename=str(path))
+    runner = _Pass(
+        source_cid=source_cid, module_name=module_name_for_path(root, path),
+        module_identities=module_identities or {},
+    )
+    runner.statements(module.body, {}, module)
+    return runner.rows, runner.outcomes
+
+
+def authenticated_module_exports(
+    root: Path, path: Path, source: str, source_cid: str
+) -> list[dict[str, Any]]:
+    """Source-authenticated module-slot declarations for the frozen catalog."""
+    module_name = module_name_for_path(root, path)
+    module = ast.parse(source, filename=str(path))
+    rows: list[dict[str, Any]] = []
+    for node in module.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            exported = target = f"python:{module_name}.{node.name}"
+            rows.append({
+                "kind": "call-contract-export", "schemaVersion": "1",
+                "sourceCid": source_cid, "definitionSite": _site(source_cid, node),
+                "exportedSymbol": exported, "targetSymbol": target,
+            })
+        elif isinstance(node, ast.ImportFrom):
+            target_module = _import_from_module(module_name, node)
+            if target_module is None:
+                continue
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                rows.append({
+                    "kind": "call-contract-export", "schemaVersion": "1",
+                    "sourceCid": source_cid, "definitionSite": _site(source_cid, node),
+                    "exportedSymbol": f"python:{module_name}.{alias.asname or alias.name}",
+                    "targetSymbol": f"python:{target_module}.{alias.name}",
+                })
+    return rows

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -248,69 +248,35 @@ def _legacy_membrane_token_rows(root: Path) -> List[Dict[str, Any]]:
 
 def _call_contract_demand_rows(root: Path) -> List[Dict[str, Any]]:
     """Enroll imported plain calls by their source-authenticated use sites."""
-    from sugar_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs
-    from sugar_lift_py_tests.context_manager_contract import _json_value
+    from sugar_lift_py_tests.import_binding import (
+        authenticated_import_uses, authenticated_module_exports,
+        module_name_for_path,
+    )
     from sugar_lift_python_source.source_oracle import SourceUnavailable, path_source
     from sugar_source_tree.tree import SourceTree
 
     rows: List[Dict[str, Any]] = []
+    units = []
     for path in SourceTree(root).paths():
         try:
             source, _filename, source_cid = path_source(str(path))
         except SourceUnavailable:
             continue
-        module = ast.parse(source, filename=str(path))
-        imports: Dict[str, tuple[str, str]] = {}
-        for node in ast.walk(module):
-            if isinstance(node, ast.ImportFrom) and node.module:
-                for alias in node.names:
-                    binding = {
-                        "kind": "import-binding",
-                        "schemaVersion": "1",
-                        "sourceCid": source_cid,
-                        "module": node.module,
-                        "exportedName": alias.name,
-                        "localName": alias.asname or alias.name,
-                        "startLine": node.lineno,
-                        "startCol": node.col_offset,
-                        "endLine": node.end_lineno,
-                        "endCol": node.end_col_offset,
-                    }
-                    binding_cid = blake3_512_of(
-                        encode_jcs(_json_value(binding)).encode("utf-8")
-                    )
-                    imports[alias.asname or alias.name] = (
-                        f"{node.module}.{alias.name}", binding_cid
-                    )
-        for node in ast.walk(module):
-            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
-                continue
-            if node.keywords or any(isinstance(arg, ast.Starred) for arg in node.args):
-                continue
-            binding = imports.get(node.func.id)
-            if binding is None:
-                continue
-            target, import_binding_cid = binding
-            rows.append({
-                "schemaVersion": "1",
-                "kind": "call-contract-demand",
-                "targetSymbol": f"python:{target}",
-                "importBindingCid": import_binding_cid,
-                "importSignature": {
-                    "formals": [],
-                    "sorts": [
-                        {"kind": "primitive", "name": "Value"}
-                        for _ in node.args
-                    ],
-                },
-                "useSite": {
-                    "sourceCid": source_cid,
-                    "startLine": node.lineno,
-                    "startCol": node.col_offset,
-                    "endLine": node.end_lineno,
-                    "endCol": node.end_col_offset,
-                },
-            })
+        units.append((path, source, source_cid))
+    module_identities = {
+        module_name_for_path(root, path): {
+            "kind": "authenticated-python-module", "schemaVersion": "1",
+            "moduleName": module_name_for_path(root, path),
+            "sourceCid": source_cid,
+        }
+        for path, _source, source_cid in units
+    }
+    for path, source, source_cid in units:
+        enrolled, _outcomes = authenticated_import_uses(
+            root, path, source, source_cid, module_identities
+        )
+        rows.extend(authenticated_module_exports(root, path, source, source_cid))
+        rows.extend(enrolled)
     return rows
 # Passive, process-lifetime context paid for by an enumeration demand. The
 # outer identity is the file content CID; the path seat is retained because

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -57,6 +57,7 @@ COMPONENT_PLAN_RPC_METHOD = "sugar.component.plan"
 RESOLVE_SOURCE_MEMENTO_RPC_METHOD = "sugar.plugin.resolve_source_memento"
 ENUMERATE_RPC_METHOD = "sugar.enumerate"
 BIND_CONTRACT_REFS_RPC_METHOD = "sugar.plugin.bind_contract_refs"
+BIND_CALL_CONTRACT_REFS_RPC_METHOD = "sugar.plugin.bind_call_contract_refs"
 COMPONENT_PROTOCOL_VERSION = "sugar-component/1"
 LIFT_PROTOCOL_VERSION = "pep/1.7.0"
 PYTHON_SURFACE = "python"
@@ -70,6 +71,7 @@ _ENUMERATION_REQUEST_COUNT = 0
 _ENUMERATION_ACTIVE = False
 _BOUND_CONTRACT_REFS = None
 _BOUND_WITH_MANAGER_AUTHORITIES = None
+_BOUND_CALL_CONTRACT_REFS = None
 _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS: tuple[ContextManagerContractIrV1, ...] = ()
 
 
@@ -242,6 +244,74 @@ def _legacy_membrane_token_rows(root: Path) -> List[Dict[str, Any]]:
                 )
                 tokens.append(token.to_wire())
     return tokens
+
+
+def _call_contract_demand_rows(root: Path) -> List[Dict[str, Any]]:
+    """Enroll imported plain calls by their source-authenticated use sites."""
+    from sugar_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs
+    from sugar_lift_py_tests.context_manager_contract import _json_value
+    from sugar_lift_python_source.source_oracle import SourceUnavailable, path_source
+    from sugar_source_tree.tree import SourceTree
+
+    rows: List[Dict[str, Any]] = []
+    for path in SourceTree(root).paths():
+        try:
+            source, _filename, source_cid = path_source(str(path))
+        except SourceUnavailable:
+            continue
+        module = ast.parse(source, filename=str(path))
+        imports: Dict[str, tuple[str, str]] = {}
+        for node in ast.walk(module):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                for alias in node.names:
+                    binding = {
+                        "kind": "import-binding",
+                        "schemaVersion": "1",
+                        "sourceCid": source_cid,
+                        "module": node.module,
+                        "exportedName": alias.name,
+                        "localName": alias.asname or alias.name,
+                        "startLine": node.lineno,
+                        "startCol": node.col_offset,
+                        "endLine": node.end_lineno,
+                        "endCol": node.end_col_offset,
+                    }
+                    binding_cid = blake3_512_of(
+                        encode_jcs(_json_value(binding)).encode("utf-8")
+                    )
+                    imports[alias.asname or alias.name] = (
+                        f"{node.module}.{alias.name}", binding_cid
+                    )
+        for node in ast.walk(module):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+                continue
+            if node.keywords or any(isinstance(arg, ast.Starred) for arg in node.args):
+                continue
+            binding = imports.get(node.func.id)
+            if binding is None:
+                continue
+            target, import_binding_cid = binding
+            rows.append({
+                "schemaVersion": "1",
+                "kind": "call-contract-demand",
+                "targetSymbol": f"python:{target}",
+                "importBindingCid": import_binding_cid,
+                "importSignature": {
+                    "formals": [],
+                    "sorts": [
+                        {"kind": "primitive", "name": "Value"}
+                        for _ in node.args
+                    ],
+                },
+                "useSite": {
+                    "sourceCid": source_cid,
+                    "startLine": node.lineno,
+                    "startCol": node.col_offset,
+                    "endLine": node.end_lineno,
+                    "endCol": node.end_col_offset,
+                },
+            })
+    return rows
 # Passive, process-lifetime context paid for by an enumeration demand. The
 # outer identity is the file content CID; the path seat is retained because
 # source mementos carry the workspace-relative filename even for identical
@@ -713,6 +783,7 @@ def _kit_declaration_result() -> Dict[str, Any]:
                 {"name": RESOLVE_SOURCE_MEMENTO_RPC_METHOD, "required": False},
                 {"name": ENUMERATE_RPC_METHOD, "required": False},
                 {"name": BIND_CONTRACT_REFS_RPC_METHOD, "required": False},
+                {"name": BIND_CALL_CONTRACT_REFS_RPC_METHOD, "required": False},
                 {"name": "lift", "required": True},
                 {"name": "sugar.plugin.lift_implications", "required": False},
                 {"name": "sugar.plugin.resolve_dependency_proofs", "required": False},
@@ -1502,6 +1573,15 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
             "tableCid": _BOUND_CONTRACT_REFS.table_cid,
         }:
             raise ValueError("semantic construction request has a stale contract-ref generation")
+    if _BOUND_CALL_CONTRACT_REFS is not None:
+        generation = options.get("callContractRefs")
+        if generation != {
+            "catalogCid": _BOUND_CALL_CONTRACT_REFS.catalog_cid,
+            "tableCid": _BOUND_CALL_CONTRACT_REFS.table_cid,
+        }:
+            raise ValueError(
+                "semantic construction request has a stale call-contract-ref generation"
+            )
     # The audit frontier's factory census is deleted; auditFrontier now short-
     # circuits to an empty frontier (its R census re-homes onto the source
     # tree's reporter channel, not yet wired). allowedBrokenComponents was the
@@ -1529,7 +1609,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
             return
         if level == "contract-demands":
             _send({"jsonrpc": "2.0", "id": msg_id, "result": {
-                "rows": _context_manager_demand_rows(root)
+                "rows": _context_manager_demand_rows(root) + _call_contract_demand_rows(root)
             }})
             return
         if level == "legacy-membrane-tokens":
@@ -1764,9 +1844,12 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
 
                 construction_context = (
                     TreeConstructionContextV1(
-                        _BOUND_CONTRACT_REFS, _BOUND_WITH_MANAGER_AUTHORITIES
+                        _BOUND_CONTRACT_REFS,
+                        _BOUND_WITH_MANAGER_AUTHORITIES,
+                        call_contract_refs=_BOUND_CALL_CONTRACT_REFS,
+                        workspace_root=str(root),
                     )
-                    if _BOUND_CONTRACT_REFS is not None
+                    if _BOUND_CONTRACT_REFS is not None or _BOUND_CALL_CONTRACT_REFS is not None
                     else None
                 )
                 tree_file = _TreeSourceFile(
@@ -2261,6 +2344,20 @@ def _dispatch_request(msg: Dict[str, Any]) -> bool:
             "tableCid": installed.table_cid,
             "withManagerAuthoritiesCid": authorities.table_cid,
         }})
+    elif method == BIND_CALL_CONTRACT_REFS_RPC_METHOD:
+        from sugar_lift_py_tests.call_contract_resolution import (
+            decode_resolved_call_contract_refs,
+        )
+
+        global _BOUND_CALL_CONTRACT_REFS
+        installed = decode_resolved_call_contract_refs(params)
+        if (
+            _BOUND_CALL_CONTRACT_REFS is not None
+            and _BOUND_CALL_CONTRACT_REFS.table_cid != installed.table_cid
+        ):
+            raise ValueError("call-contract-ref generation is already frozen")
+        _BOUND_CALL_CONTRACT_REFS = installed
+        _send({"jsonrpc": "2.0", "id": msg_id, "result": {"tableCid": installed.table_cid}})
     elif method == ENUMERATE_RPC_METHOD:
         global _ENUMERATION_ACTIVE, _ENUMERATION_REQUEST_COUNT
         enumerate_started = time.monotonic()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import builtins
 from dataclasses import dataclass, field as dataclass_field
+from typing import Any
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
@@ -31,6 +32,8 @@ class CallSiteSugar(Sugar):
     args: tuple  # the argument sugars, in source order
     site: object = dataclass_field(compare=False)
     keywords: tuple = ()  # (name, sugar) pairs, in source order
+    contract_ref: Any = dataclass_field(default=None, compare=False)
+    contract_resolution_gap: str | None = dataclass_field(default=None, compare=False)
 
     @classmethod
     def witnesses(cls):
@@ -46,6 +49,15 @@ class CallSiteSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
+        if self.contract_resolution_gap is not None:
+            from sugar_source_tree.panic import SugarNotWritten
+
+            raise SugarNotWritten(
+                owner="CallSiteSugar.desugar",
+                observed=self.contract_resolution_gap,
+                requested="authenticated resolved-call contract reference",
+                fix="publish and resolve the imported target contract or keep the call loud",
+            )
         return self._collect(self.args, (), ctx)
 
     def _collect(self, remaining: tuple, accumulated: tuple, ctx: object) -> Outcome:
@@ -85,6 +97,8 @@ class CallSiteSugar(Sugar):
                 else "coordinate"
             ),
         )
+        if self.contract_ref is not None:
+            return self._collect_bridged(positional)
         return Complete(
             CallSiteValue(
                 target_name=self.target_name,
@@ -95,3 +109,56 @@ class CallSiteSugar(Sugar):
                 site=self.site,
             )
         )
+
+    def _collect_bridged(self, positional: tuple) -> Outcome:
+        from sugar_lift_py_tests.floor.bridged_contract_value import BridgedContractValue
+        from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+        from sugar_lift_py_tests.ir import _Ctor, _free_vars_in_term, subst_var_in_term
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_source_tree.panic import SugarNotWritten
+
+        reference = self.contract_ref
+        if len(reference.formals) != len(positional):
+            raise SugarNotWritten(
+                owner="CallSiteSugar.desugar",
+                observed="signature mismatch",
+                requested="actual arguments matching the authenticated import signature",
+                fix="correct the call signature or keep the call loud",
+            )
+        term = reference.return_term
+        if term is None:
+            raise SugarNotWritten(
+                owner="CallSiteSugar.desugar",
+                observed="authenticated contract has no exact return equality",
+                requested="exact structural return testimony",
+                fix="strengthen the contract or keep the imported value loud",
+            )
+        if not _free_vars_in_term(term) <= set(reference.formals):
+            raise SugarNotWritten(
+                owner="CallSiteSugar.desugar",
+                observed="authenticated structural return contains an unbound projection",
+                requested="return variables authenticated by the target formal list",
+                fix="reject the stale or lying contract reference",
+            )
+        for formal, actual in zip(reference.formals, positional):
+            term = subst_var_in_term(term, formal, actual.to_term(owner=str(self.site)))
+        if not isinstance(term, _Ctor) or term.name not in {"tuple", "python:tuple", "python:list"}:
+            raise SugarNotWritten(
+                owner="CallSiteSugar.desugar",
+                observed="authenticated contract has no exact structural return",
+                requested="structural return term carried by the target contract",
+                fix="strengthen the target contract or keep the imported value loud",
+            )
+        callsite = CallSiteValue(
+            target_name=self.target_name,
+            arg_values=positional,
+            parameters=reference.formals,
+            term=term,
+            body=None,
+            site=self.site,
+            target_contract_cid=reference.contract_cid,
+            authenticated_target_symbol=reference.bridge_source_symbol,
+        )
+        return Complete(BridgedContractValue(
+            term, reference.contract_cid, reference.member_cid, callsite
+        ))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -228,6 +228,7 @@ class FunctionUniverseSugar(Sugar):
     formals: tuple[str, ...]
     statements: tuple  # the body statements' sugars, in source order
     site: object = dataclass_field(compare=False, default=None)
+    bridge_source_symbol: str | None = None
 
     @classmethod
     def witnesses(cls):
@@ -250,7 +251,12 @@ class FunctionUniverseSugar(Sugar):
         del ctx
         return reduce_body(self.statements).and_then(
             lambda record: Complete(
-                UniverseValue(name=self.name, formals=self.formals, record=record)
+                UniverseValue(
+                    name=self.name,
+                    formals=self.formals,
+                    record=record,
+                    bridge_source_symbol=self.bridge_source_symbol,
+                )
             )
         )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_call_contract_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_call_contract_resolution.py
@@ -16,7 +16,7 @@ from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
 from sugar_lift_py_tests.sugar.name_sugar import NameSugar
 from sugar_lift_py_tests import lift_rpc
-from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.panic import BackendDefect, SugarNotWritten
 
 
 CID = "blake3-512:" + "1" * 128
@@ -25,6 +25,97 @@ CATALOG_CID = "blake3-512:" + "3" * 128
 DEMAND_CID = "blake3-512:" + "4" * 128
 RESOLUTION_CID = "blake3-512:" + "5" * 128
 TABLE_CID = "blake3-512:" + "6" * 128
+
+
+def _site(line: int = 2) -> dict:
+    return {
+        "sourceCid": CID,
+        "startLine": line,
+        "startCol": 4,
+        "endLine": line,
+        "endCol": 11,
+    }
+
+
+def _gap_row(line: int = 2) -> dict:
+    return {
+        "useSite": _site(line),
+        "resolution": {
+            "kind": "unresolved",
+            "gap": {
+                "demandCid": DEMAND_CID,
+                "useSite": _site(line),
+                "importBindingCid": CATALOG_CID,
+                "targetSymbol": "python:producer.pair",
+                "kind": "no-authenticated-contract",
+                "candidateMemberCids": [],
+            },
+        },
+    }
+
+
+def _table(rows: list[dict], enrolled: list[dict] | None = None) -> dict:
+    from sugar_lift_py_tests.call_contract_resolution import _hash_json
+
+    value = {
+        "kind": "resolved-call-contract-refs",
+        "schemaVersion": "1",
+        "catalogCid": CATALOG_CID,
+        "enrolledUseSites": enrolled if enrolled is not None else [row["useSite"] for row in rows],
+        "byUseSite": rows,
+    }
+    return {**value, "tableCid": _hash_json(value)}
+
+
+def test_decoder_rejects_duplicate_rows_and_row_identity_mismatches():
+    row = _gap_row()
+    with pytest.raises(CallContractRefProtocolError, match="duplicate use-site"):
+        decode_resolved_call_contract_refs(_table([row, row], enrolled=[_site()]))
+
+    mismatched_gap = _gap_row()
+    mismatched_gap["resolution"]["gap"]["useSite"] = _site(3)
+    with pytest.raises(CallContractRefProtocolError, match="row use-site"):
+        decode_resolved_call_contract_refs(_table([mismatched_gap]))
+
+
+def test_decoder_rejects_missing_enrolled_row():
+    with pytest.raises(CallContractRefProtocolError, match="enrolled call demand missing"):
+        decode_resolved_call_contract_refs(_table([], enrolled=[_site()]))
+
+
+def test_call_distinguishes_non_enrolled_local_call_from_missing_enrolled_row(tmp_path):
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ResolvedContractRefsV1,
+        SourceFragmentCoordinateV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_source_tree.nodes import Call
+    from sugar_source_tree.tree import SourceFile
+
+    path = tmp_path / "consumer.py"
+    path.write_text("local(value)\nimported(value)\n")
+    source = path_source(str(path))
+    source_cid = source[2]
+    local_site = SourceFragmentCoordinateV1(source_cid, 1, 0, 1, 12)
+    imported_site = SourceFragmentCoordinateV1(source_cid, 2, 0, 2, 15)
+    call_refs = ResolvedCallContractRefsV1(
+        CATALOG_CID,
+        TABLE_CID,
+        MappingProxyType({}),
+        frozenset({imported_site}),
+    )
+    cm_refs = ResolvedContractRefsV1(CATALOG_CID, TABLE_CID, MappingProxyType({}))
+    tree = SourceFile(
+        source,
+        construction_context=TreeConstructionContextV1(cm_refs, call_contract_refs=call_refs),
+    )
+    calls = list(node for node in tree.nodes() if isinstance(node, Call))
+
+    assert local_site not in call_refs.enrolled_use_sites
+    assert calls[0].sugar().contract_ref is None
+    with pytest.raises(BackendDefect, match="enrolled call demand missing"):
+        calls[1].sugar()
 
 
 def _reference() -> ResolvedCallContractRefV1:
@@ -96,6 +187,7 @@ def test_fabricated_or_unauthenticated_reference_fails_decode():
         "schemaVersion": "1",
         "catalogCid": CATALOG_CID,
         "tableCid": TABLE_CID,
+        "enrolledUseSites": [_site()],
         "byUseSite": [
             {
                 "useSite": {
@@ -240,6 +332,46 @@ def test_import_binding_is_lexical_and_shadowing_never_inherits_import(tmp_path)
     assert "shadowed-non-import" in outcomes.values()
     assert "no-lexical-binding" in outcomes.values()
     assert "ambiguous-lexical-binding" in outcomes.values()
+
+
+def test_global_and_method_lookup_never_inherit_enclosing_or_class_import(tmp_path):
+    (tmp_path / "consumer.py").write_text(
+        "from right import pair\n"
+        "def outer():\n"
+        "    from wrong import pair\n"
+        "    def inner():\n"
+        "        global pair\n"
+        "        return pair(1)\n"
+        "    return inner\n"
+        "class C:\n"
+        "    from wrong import pair\n"
+        "    def method(self):\n"
+        "        return pair(2)\n"
+    )
+
+    rows = [
+        row
+        for row in lift_rpc._call_contract_demand_rows(tmp_path)
+        if row["kind"] == "call-contract-demand"
+    ]
+
+    assert [row["targetSymbol"] for row in rows] == [
+        "python:right.pair",
+        "python:right.pair",
+    ]
+
+
+def test_shadowed_reexport_is_not_published(tmp_path):
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.import_binding import authenticated_module_exports
+
+    public = tmp_path / "public.py"
+    public.write_text("from provider import pair\npair = lambda x: x\n")
+    source, _filename, source_cid = path_source(str(public))
+
+    rows = authenticated_module_exports(tmp_path, public, source, source_cid)
+
+    assert not any(row["exportedSymbol"] == "python:public.pair" for row in rows)
 
 
 def test_spelling_without_authenticated_import_use_has_no_authority(tmp_path):

--- a/implementations/python/sugar-lift-py-tests/tests/test_call_contract_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_call_contract_resolution.py
@@ -41,6 +41,7 @@ def _reference() -> ResolvedCallContractRefV1:
         sorts=(PrimitiveSort("Value"),),
         return_term=ctor("python:tuple", [make_var("x"), make_var("x")]),
         source_warrant_cids=(),
+        contract_decl=MappingProxyType({"kind": "contract"}),
     )
 
 
@@ -133,6 +134,7 @@ def test_fabricated_or_unauthenticated_reference_fails_decode():
                             "args": [{"kind": "var", "name": "x"}],
                         },
                         "sourceWarrantCids": [],
+                        "contractDecl": {"kind": "contract"},
                     },
                 },
             }
@@ -140,6 +142,24 @@ def test_fabricated_or_unauthenticated_reference_fails_decode():
     }
     with pytest.raises(CallContractRefProtocolError, match="memberCid must be a CID"):
         decode_resolved_call_contract_refs(wire)
+
+
+def test_python_intake_rejects_stale_semantic_contract_cid():
+    from sugar_lift_py_tests.call_contract_resolution import _decode_ref
+
+    raw = {
+        "kind": "resolved-call-contract-ref", "schemaVersion": "1",
+        "resolutionCid": RESOLUTION_CID, "demandCid": DEMAND_CID,
+        "useSite": {"sourceCid": CID, "startLine": 2, "startCol": 0, "endLine": 2, "endCol": 7},
+        "importBindingCid": CATALOG_CID, "catalogCid": CATALOG_CID,
+        "memberCid": MEMBER_CID, "contractCid": CID,
+        "bridgeSourceSymbol": "python:producer.pair",
+        "importSignature": {"formals": [], "sorts": []},
+        "returnTerm": None, "sourceWarrantCids": [],
+        "contractDecl": {"kind": "contract", "name": "changed"},
+    }
+    with pytest.raises(CallContractRefProtocolError, match="stale semantic contract CID"):
+        _decode_ref(raw)
 
 
 def test_return_projection_with_unauthenticated_free_name_stays_loud():
@@ -166,7 +186,8 @@ def test_import_demand_enrollment_has_positional_arity_and_module_identity(tmp_p
         "not_enrolled = pair(x=1)\n"
     )
 
-    rows = lift_rpc._call_contract_demand_rows(tmp_path)
+    rows = [row for row in lift_rpc._call_contract_demand_rows(tmp_path)
+            if row["kind"] == "call-contract-demand"]
 
     assert len(rows) == 1
     assert rows[0]["targetSymbol"] == "python:producer.pair"
@@ -187,12 +208,99 @@ def test_import_binding_authenticates_alias_and_module_identity(tmp_path):
         "c = pair()\n"
     )
 
-    rows = lift_rpc._call_contract_demand_rows(tmp_path)
+    rows = [row for row in lift_rpc._call_contract_demand_rows(tmp_path)
+            if row["kind"] == "call-contract-demand"]
 
     assert [row["targetSymbol"] for row in rows] == [
         "python:first.pair", "python:second.pair"
     ]
     assert rows[0]["importBindingCid"] != rows[1]["importBindingCid"]
+
+
+def test_import_binding_is_lexical_and_shadowing_never_inherits_import(tmp_path):
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.import_binding import authenticated_import_uses
+
+    consumer = tmp_path / "consumer.py"
+    consumer.write_text(
+        "from producer import pair as renamed\n"
+        "direct = renamed(0)\n"
+        "def parameter(renamed):\n    return renamed(1)\n"
+        "def assigned():\n    renamed(2)\n    renamed = local\n"
+        "def nested():\n    def renamed(x): return x\n    return renamed(3)\n"
+        "def branch(flag):\n"
+        "    if flag:\n        from producer import pair as maybe\n"
+        "    else:\n        maybe = local\n"
+        "    return maybe(4)\n"
+    )
+    source, _filename, source_cid = path_source(str(consumer))
+    rows, outcomes = authenticated_import_uses(tmp_path, consumer, source, source_cid)
+
+    assert [row["targetSymbol"] for row in rows] == ["python:producer.pair"]
+    assert "shadowed-non-import" in outcomes.values()
+    assert "no-lexical-binding" in outcomes.values()
+    assert "ambiguous-lexical-binding" in outcomes.values()
+
+
+def test_spelling_without_authenticated_import_use_has_no_authority(tmp_path):
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.import_binding import authenticated_import_uses
+
+    consumer = tmp_path / "consumer.py"
+    consumer.write_text(
+        "def use(pair, pandas_magic):\n"
+        "    pair(1)\n"
+        "    pandas_magic(2)\n"
+    )
+    source, _filename, source_cid = path_source(str(consumer))
+    rows, outcomes = authenticated_import_uses(
+        tmp_path, consumer, source, source_cid
+    )
+
+    assert rows == []
+    assert set(outcomes.values()) == {"shadowed-non-import"}
+
+
+def test_relative_import_is_package_qualified_and_binding_coordinate_is_typed(tmp_path):
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.import_binding import authenticated_import_uses
+
+    package = tmp_path / "pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("")
+    consumer = package / "consumer.py"
+    consumer.write_text("from .producer import pair as renamed\nrenamed(1)\n")
+    source, _filename, source_cid = path_source(str(consumer))
+    rows, _ = authenticated_import_uses(tmp_path, consumer, source, source_cid)
+
+    assert rows[0]["targetSymbol"] == "python:pkg.producer.pair"
+    use = rows[0]["authenticatedImportUse"]
+    assert use["kind"] == "authenticated-import-use"
+    assert use["importBindingCid"] == rows[0]["importBindingCid"]
+    assert use["cid"].startswith("blake3-512:")
+
+
+def test_reexport_declaration_is_static_and_source_authenticated(tmp_path):
+    (tmp_path / "provider.py").write_text("def pair(x):\n    return (x, x)\n")
+    (tmp_path / "public.py").write_text("from provider import pair\n")
+    (tmp_path / "consumer.py").write_text("from public import pair as renamed\nrenamed(1)\n")
+
+    rows = lift_rpc._call_contract_demand_rows(tmp_path)
+    export = next(row for row in rows if row.get("exportedSymbol") == "python:public.pair")
+    demand = next(row for row in rows if row["kind"] == "call-contract-demand")
+
+    assert export["targetSymbol"] == "python:provider.pair"
+    assert export["sourceCid"].startswith("blake3-512:")
+    assert demand["targetSymbol"] == "python:public.pair"
+    assert demand["authenticatedImportUse"]["kind"] == "authenticated-import-use"
+
+
+def test_import_alias_has_no_parallel_install_source_resolver(monkeypatch):
+    from sugar_lift_py_tests.floor.import_alias_value import ImportAliasValue
+    del monkeypatch
+    value = ImportAliasValue("producer.pair", "pair", import_target="producer.pair")
+
+    assert not hasattr(value, "resolve_value")
 
 
 def test_parser_backed_imported_call_consumes_prebound_contract_ref(tmp_path):
@@ -207,7 +315,8 @@ def test_parser_backed_imported_call_consumes_prebound_contract_ref(tmp_path):
 
     consumer = tmp_path / "consumer.py"
     consumer.write_text("from producer import pair\nvalue = pair(v)\n")
-    row = lift_rpc._call_contract_demand_rows(tmp_path)[0]
+    row = next(row for row in lift_rpc._call_contract_demand_rows(tmp_path)
+               if row["kind"] == "call-contract-demand")
     coordinate = SourceFragmentCoordinateV1.decode(row["useSite"])
     reference = replace(
         _reference(),
@@ -259,3 +368,29 @@ def test_producer_contract_exports_the_same_module_qualified_symbol(tmp_path):
 
     assert rows is not None
     assert rows[0].bridge_source_symbol == "python:producer.pair"
+
+
+def test_only_module_level_function_publishes_import_export_symbol(tmp_path):
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.context_manager_resolution import ResolvedContractRefsV1, TreeConstructionContextV1
+    from sugar_source_tree.tree import SourceFile
+
+    producer = tmp_path / "producer.py"
+    producer.write_text(
+        "def pair():\n    return 1\n"
+        "class C:\n    def pair(self):\n        return 2\n"
+        "def outer():\n    def pair():\n        return 3\n    return pair()\n"
+    )
+    tree = SourceFile(
+        path_source(str(producer)),
+        construction_context=TreeConstructionContextV1(
+            ResolvedContractRefsV1(CATALOG_CID, TABLE_CID, MappingProxyType({})),
+            workspace_root=str(tmp_path),
+        ),
+    )
+    functions = list(tree.functions())
+
+    assert functions[0].sugar().bridge_source_symbol == "python:producer.pair"
+    assert functions[1].sugar().bridge_source_symbol is None
+    assert functions[2].sugar().bridge_source_symbol == "python:producer.outer"
+    assert functions[3].sugar().bridge_source_symbol is None

--- a/implementations/python/sugar-lift-py-tests/tests/test_call_contract_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_call_contract_resolution.py
@@ -374,6 +374,50 @@ def test_shadowed_reexport_is_not_published(tmp_path):
     assert not any(row["exportedSymbol"] == "python:public.pair" for row in rows)
 
 
+def test_try_handler_sees_exceptional_prefix_rebind_and_never_authenticates_import(tmp_path):
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.import_binding import authenticated_import_uses
+
+    consumer = tmp_path / "consumer.py"
+    consumer.write_text(
+        "from producer import pair\n"
+        "try:\n"
+        "    pair = local\n"
+        "    raise E\n"
+        "except E:\n"
+        "    pair()\n"
+    )
+    source, _filename, source_cid = path_source(str(consumer))
+
+    rows, outcomes = authenticated_import_uses(
+        tmp_path, consumer, source, source_cid
+    )
+
+    assert rows == []
+    assert "ambiguous-lexical-binding" in outcomes.values()
+
+
+def test_loop_backedge_rebind_never_authenticates_import_use(tmp_path):
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.import_binding import authenticated_import_uses
+
+    consumer = tmp_path / "consumer.py"
+    consumer.write_text(
+        "from producer import pair\n"
+        "while cond:\n"
+        "    pair()\n"
+        "    pair = local\n"
+    )
+    source, _filename, source_cid = path_source(str(consumer))
+
+    rows, outcomes = authenticated_import_uses(
+        tmp_path, consumer, source, source_cid
+    )
+
+    assert rows == []
+    assert "ambiguous-lexical-binding" in outcomes.values()
+
+
 def test_spelling_without_authenticated_import_use_has_no_authority(tmp_path):
     from sugar_lift_python_source.source_oracle import path_source
     from sugar_lift_py_tests.import_binding import authenticated_import_uses

--- a/implementations/python/sugar-lift-py-tests/tests/test_call_contract_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_call_contract_resolution.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from types import MappingProxyType
+
+import pytest
+
+from sugar_lift_py_tests.call_contract_resolution import (
+    CallContractRefProtocolError,
+    ResolvedCallContractRefV1,
+    ResolvedCallContractRefsV1,
+    decode_resolved_call_contract_refs,
+)
+from sugar_lift_py_tests.ir import PrimitiveSort, ctor, make_var, str_const
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+from sugar_lift_py_tests.sugar.name_sugar import NameSugar
+from sugar_lift_py_tests import lift_rpc
+from sugar_source_tree.panic import SugarNotWritten
+
+
+CID = "blake3-512:" + "1" * 128
+MEMBER_CID = "blake3-512:" + "2" * 128
+CATALOG_CID = "blake3-512:" + "3" * 128
+DEMAND_CID = "blake3-512:" + "4" * 128
+RESOLUTION_CID = "blake3-512:" + "5" * 128
+TABLE_CID = "blake3-512:" + "6" * 128
+
+
+def _reference() -> ResolvedCallContractRefV1:
+    return ResolvedCallContractRefV1(
+        resolution_cid=RESOLUTION_CID,
+        demand_cid=DEMAND_CID,
+        use_site=None,
+        import_binding_cid=CATALOG_CID,
+        catalog_cid=CATALOG_CID,
+        member_cid=MEMBER_CID,
+        contract_cid=CID,
+        bridge_source_symbol="python:pandas.fixture.pair",
+        formals=("x",),
+        sorts=(PrimitiveSort("Value"),),
+        return_term=ctor("python:tuple", [make_var("x"), make_var("x")]),
+        source_warrant_cids=(),
+    )
+
+
+def test_authenticated_structural_return_projects_from_one_bridged_contract():
+    sugar = CallSiteSugar(
+        target_name="pair",
+        args=(NameSugar("value", site="value"),),
+        site="consumer.py:2",
+        contract_ref=_reference(),
+    )
+
+    outcome = sugar.desugar(None)
+
+    assert isinstance(outcome, Complete)
+    assert outcome.value.to_term(owner="test") == ctor(
+        "python:tuple", [make_var("value"), make_var("value")]
+    )
+    assert outcome.value.contract_cid == CID
+    assert outcome.value.member_cid == MEMBER_CID
+    assert outcome.value.callsites()[0].target_contract_cid == CID
+    assert outcome.value.callsites()[0].authenticated_target_symbol == (
+        "python:pandas.fixture.pair"
+    )
+
+
+def test_unresolved_or_non_structural_reference_stays_loud():
+    unresolved = CallSiteSugar(
+        target_name="missing",
+        args=(),
+        site="consumer.py:2",
+        contract_ref=None,
+        contract_resolution_gap="unresolved-symbol",
+    )
+    with pytest.raises(SugarNotWritten, match="unresolved-symbol"):
+        unresolved.desugar(None)
+
+    non_structural = _reference().__class__(
+        **{**_reference().__dict__, "return_term": ctor("call:other", [str_const("x")])}
+    )
+    with pytest.raises(SugarNotWritten, match="structural return"):
+        CallSiteSugar(
+            target_name="pair",
+            args=(NameSugar("value", site="value"),),
+            site="consumer.py:2",
+            contract_ref=non_structural,
+        ).desugar(None)
+
+
+def test_fabricated_or_unauthenticated_reference_fails_decode():
+    wire = {
+        "kind": "resolved-call-contract-refs",
+        "schemaVersion": "1",
+        "catalogCid": CATALOG_CID,
+        "tableCid": TABLE_CID,
+        "byUseSite": [
+            {
+                "useSite": {
+                    "sourceCid": CID,
+                    "startLine": 2,
+                    "startCol": 4,
+                    "endLine": 2,
+                    "endCol": 11,
+                },
+                "resolution": {
+                    "kind": "resolved",
+                    "reference": {
+                        "kind": "resolved-call-contract-ref",
+                        "schemaVersion": "1",
+                        "resolutionCid": RESOLUTION_CID,
+                        "demandCid": DEMAND_CID,
+                        "useSite": {
+                            "sourceCid": CID,
+                            "startLine": 2,
+                            "startCol": 4,
+                            "endLine": 2,
+                            "endCol": 11,
+                        },
+                        "importBindingCid": CATALOG_CID,
+                        "catalogCid": CATALOG_CID,
+                        "memberCid": "fabricated:member",
+                        "contractCid": CID,
+                        "bridgeSourceSymbol": "python:pandas.fixture.pair",
+                        "importSignature": {
+                            "formals": ["x"],
+                            "sorts": [{"kind": "primitive", "name": "Value"}],
+                        },
+                        "returnTerm": {
+                            "kind": "ctor",
+                            "name": "python:tuple",
+                            "args": [{"kind": "var", "name": "x"}],
+                        },
+                        "sourceWarrantCids": [],
+                    },
+                },
+            }
+        ],
+    }
+    with pytest.raises(CallContractRefProtocolError, match="memberCid must be a CID"):
+        decode_resolved_call_contract_refs(wire)
+
+
+def test_return_projection_with_unauthenticated_free_name_stays_loud():
+    reference = _reference().__class__(
+        **{
+            **_reference().__dict__,
+            "return_term": ctor("python:tuple", [make_var("not_a_formal")]),
+        }
+    )
+    with pytest.raises(SugarNotWritten, match="unbound projection"):
+        CallSiteSugar(
+            target_name="pair",
+            args=(NameSugar("value", site="value"),),
+            site="consumer.py:2",
+            contract_ref=reference,
+        ).desugar(None)
+
+
+def test_import_demand_enrollment_has_positional_arity_and_module_identity(tmp_path):
+    (tmp_path / "producer.py").write_text("def pair(x):\n    return (x, x)\n")
+    (tmp_path / "consumer.py").write_text(
+        "from producer import pair\n"
+        "value = pair(1)\n"
+        "not_enrolled = pair(x=1)\n"
+    )
+
+    rows = lift_rpc._call_contract_demand_rows(tmp_path)
+
+    assert len(rows) == 1
+    assert rows[0]["targetSymbol"] == "python:producer.pair"
+    assert rows[0]["importBindingCid"].startswith("blake3-512:")
+    assert rows[0]["importSignature"] == {
+        "formals": [],
+        "sorts": [{"kind": "primitive", "name": "Value"}],
+    }
+
+
+def test_import_binding_authenticates_alias_and_module_identity(tmp_path):
+    (tmp_path / "consumer.py").write_text(
+        "from first import pair as renamed\n"
+        "from second import pair as other\n"
+        "a = renamed()\n"
+        "b = other()\n"
+        "def pair():\n    return (0, 0)\n"
+        "c = pair()\n"
+    )
+
+    rows = lift_rpc._call_contract_demand_rows(tmp_path)
+
+    assert [row["targetSymbol"] for row in rows] == [
+        "python:first.pair", "python:second.pair"
+    ]
+    assert rows[0]["importBindingCid"] != rows[1]["importBindingCid"]
+
+
+def test_parser_backed_imported_call_consumes_prebound_contract_ref(tmp_path):
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ResolvedContractRefsV1,
+        SourceFragmentCoordinateV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_source_tree.nodes import Call
+    from sugar_source_tree.tree import SourceFile
+
+    consumer = tmp_path / "consumer.py"
+    consumer.write_text("from producer import pair\nvalue = pair(v)\n")
+    row = lift_rpc._call_contract_demand_rows(tmp_path)[0]
+    coordinate = SourceFragmentCoordinateV1.decode(row["useSite"])
+    reference = replace(
+        _reference(),
+        use_site=coordinate,
+        import_binding_cid=row["importBindingCid"],
+    )
+    table = ResolvedCallContractRefsV1(
+        CATALOG_CID,
+        TABLE_CID,
+        MappingProxyType({coordinate: reference}),
+    )
+    cm_refs = ResolvedContractRefsV1(CATALOG_CID, TABLE_CID, MappingProxyType({}))
+    tree = SourceFile(
+        path_source(str(consumer)),
+        construction_context=TreeConstructionContextV1(
+            cm_refs, call_contract_refs=table, workspace_root=str(tmp_path)
+        ),
+    )
+    call = next(node for node in tree.nodes() if isinstance(node, Call))
+
+    outcome = call.sugar().desugar(None)
+
+    assert isinstance(outcome, Complete)
+    assert outcome.value.contract_cid == CID
+    assert outcome.value.callsites()[0].target_contract_cid == CID
+
+
+def test_producer_contract_exports_the_same_module_qualified_symbol(tmp_path):
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ResolvedContractRefsV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_py_tests.tree_enumerate import function_contract_rows
+    from sugar_source_tree.tree import SourceFile
+
+    producer = tmp_path / "producer.py"
+    producer.write_text("def pair():\n    return (1, 2)\n")
+    tree = SourceFile(
+        path_source(str(producer)),
+        construction_context=TreeConstructionContextV1(
+            ResolvedContractRefsV1(CATALOG_CID, TABLE_CID, MappingProxyType({})),
+            workspace_root=str(tmp_path),
+        ),
+    )
+    function = next(tree.functions())
+
+    _, rows = function_contract_rows(function, "producer.py")
+
+    assert rows is not None
+    assert rows[0].bridge_source_symbol == "python:producer.pair"

--- a/implementations/python/sugar-lift-py-tests/tests/test_sequence_multiply_value_driven.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sequence_multiply_value_driven.py
@@ -83,7 +83,7 @@ def test_unresolved_imported_constant_constructs_symbolic_repetition(
         raise AssertionError(f"construction opened a module: {args!r} {kwargs!r}")
 
     monkeypatch.setattr(importlib, "import_module", no_import)
-    monkeypatch.setattr(ImportAliasValue, "resolve_value", no_import)
+    assert not hasattr(ImportAliasValue, "resolve_value")
     imported = ImportAliasValue(
         "somevendor.MAXDIMS",
         "MAXDIMS",

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1068,11 +1068,26 @@ class FunctionDef(Statement):
                 # (stay free -> symbolic), locals thread/inline, phis -> IfExps.
                 substituted = self.substitute({})
             with reduction_span(sugar="Construct", role="construction", site=where):
+                bridge_source_symbol = None
+                context = self.unit.construction_context
+                workspace_root = getattr(context, "workspace_root", None)
+                if workspace_root is not None:
+                    from pathlib import Path
+
+                    relative = Path(self.unit.filename).resolve().relative_to(
+                        Path(workspace_root).resolve()
+                    )
+                    module_parts = list(relative.with_suffix("").parts)
+                    if module_parts and module_parts[-1] == "__init__":
+                        module_parts.pop()
+                    module_name = ".".join(module_parts)
+                    bridge_source_symbol = f"python:{module_name}.{self.name}"
                 return FunctionUniverseSugar(
                     name=self.name,
                     formals=tuple(p.name for p in self.params),
                     statements=tuple(stmt.sugar() for stmt in substituted.body),
                     site=self.fragment,
+                    bridge_source_symbol=bridge_source_symbol,
                 )
 
 
@@ -3848,11 +3863,39 @@ class Call(Expression):
         if isinstance(self.func, Name):
             from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
 
+            contract_ref = None
+            contract_resolution_gap = None
+            context = self.unit.construction_context
+            call_refs = getattr(context, "call_contract_refs", None)
+            if call_refs is not None:
+                from sugar_lift_py_tests.call_contract_resolution import (
+                    CallContractResolutionGapV1,
+                )
+                from sugar_lift_py_tests.context_manager_resolution import (
+                    SourceFragmentCoordinateV1,
+                )
+
+                span = self.line_col_span()
+                coordinate = SourceFragmentCoordinateV1(
+                    self.unit.source_cid,
+                    span.start_line,
+                    span.start_col,
+                    span.end_line,
+                    span.end_col,
+                )
+                resolution = call_refs.by_use_site.get(coordinate)
+                if isinstance(resolution, CallContractResolutionGapV1):
+                    contract_resolution_gap = resolution.kind.value
+                elif resolution is not None:
+                    contract_ref = resolution
+
             return CallSiteSugar(
                 target_name=self.func.id,
                 args=tuple(a.sugar() for a in self.args),
                 site=self.fragment,
                 keywords=keyword_sugars,
+                contract_ref=contract_ref,
+                contract_resolution_gap=contract_resolution_gap,
             )
         if isinstance(self.func, Attribute):
             from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -155,6 +155,18 @@ class SourceUnit:
             )
         return matches[0]
 
+    def is_module_level_function(self, name: str, lineno: int) -> bool:
+        """Whether this exact definition occupies an importable module slot."""
+        import ast
+
+        module = ast.parse(self.source, filename=self.filename)
+        return any(
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == name
+            and node.lineno == lineno
+            for node in module.body
+        )
+
 
 class Typeable:
     """The interface: you may ask me for my node type.
@@ -1071,7 +1083,9 @@ class FunctionDef(Statement):
                 bridge_source_symbol = None
                 context = self.unit.construction_context
                 workspace_root = getattr(context, "workspace_root", None)
-                if workspace_root is not None:
+                if workspace_root is not None and self.unit.is_module_level_function(
+                    self.name, self.line_col_span().start_line
+                ):
                     from pathlib import Path
 
                     relative = Path(self.unit.filename).resolve().relative_to(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3883,6 +3883,7 @@ class Call(Expression):
             call_refs = getattr(context, "call_contract_refs", None)
             if call_refs is not None:
                 from sugar_lift_py_tests.call_contract_resolution import (
+                    CallContractRefProtocolError,
                     CallContractResolutionGapV1,
                 )
                 from sugar_lift_py_tests.context_manager_resolution import (
@@ -3897,7 +3898,19 @@ class Call(Expression):
                     span.end_line,
                     span.end_col,
                 )
-                resolution = call_refs.by_use_site.get(coordinate)
+                resolution = None
+                if coordinate in call_refs.enrolled_use_sites:
+                    try:
+                        resolution = call_refs.require(coordinate)
+                    except CallContractRefProtocolError as exc:
+                        from sugar_source_tree.panic import BackendDefect
+
+                        raise BackendDefect(
+                            owner="Call._construct_sugar",
+                            observed="enrolled call demand missing from resolution table",
+                            requested="one typed resolution row for every enrolled imported call",
+                            fix="repair call-contract preconstruction; never fall through to an ordinary call",
+                        ) from exc
                 if isinstance(resolution, CallContractResolutionGapV1):
                     contract_resolution_gap = resolution.kind.value
                 elif resolution is not None:

--- a/implementations/rust/sugar-claim-envelope/src/lib.rs
+++ b/implementations/rust/sugar-claim-envelope/src/lib.rs
@@ -1102,6 +1102,29 @@ pub fn contract_cid(args: &MintContractArgs) -> String {
     )
 }
 
+/// Semantic identity for a body-bearing ContractDecl. The body CID is a
+/// pointer inside the declaration preimage, never a substitute for the
+/// declaration CID. Attestation-only metadata is deliberately absent.
+pub fn body_contract_cid(args: &MintContractArgs, body_cid: &str) -> String {
+    let mut fields: Vec<(String, Arc<Value>)> = vec![
+        ("kind".into(), Value::string("contract")),
+        ("name".into(), Value::string(args.contract_name.clone())),
+        ("outBinding".into(), Value::string(args.out_binding.clone())),
+        ("bodyCid".into(), Value::string(body_cid.to_string())),
+    ];
+    if !args.formals.is_empty() || args.emit_empty_formals {
+        fields.push((
+            "formals".into(),
+            Value::array(args.formals.iter().cloned().map(Value::string).collect()),
+        ));
+        fields.push((
+            "formalSorts".into(),
+            Value::array(args.formal_sorts.clone()),
+        ));
+    }
+    blake3_512_of(encode_jcs(&Value::object(fields)).as_bytes())
+}
+
 /// Recompute the canonical content CID of a lifted IR contract decl exactly as
 /// `mint` would — extracting the same identity-bearing fields from the decl and
 /// funneling them through [`contract_cid_from_parts`]. Consumers (e.g. the lift
@@ -1254,7 +1277,10 @@ pub fn mint_contract_with_body_cid(
     let binding_hash = hash_value(&bh_obj);
 
     // Header: schemaVersion + kind + cid + kind-specific REQUIRED fields.
-    let header_cid = contract_content_cid(args);
+    let header_cid = body_cid
+        .filter(|cid| !cid.is_empty())
+        .map(|cid| body_contract_cid(args, cid))
+        .unwrap_or_else(|| contract_content_cid(args));
     let mut kind_specific: Vec<(String, Arc<Value>)> = vec![
         ("name".into(), Value::string(args.contract_name.clone())),
         ("outBinding".into(), Value::string(args.out_binding.clone())),

--- a/implementations/rust/sugar-compiler/src/kit.rs
+++ b/implementations/rust/sugar-compiler/src/kit.rs
@@ -544,6 +544,49 @@ impl Kit {
         Ok(acknowledged.to_owned())
     }
 
+    pub fn bind_call_contract_refs(
+        &self,
+        table: &Value,
+    ) -> Result<String, crate::kit_path::LiftPluginKitError> {
+        let catalog_cid = table
+            .get("catalogCid")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                crate::kit_path::LiftPluginKitError::Failed(
+                    "call-contract-ref table missing catalogCid".into(),
+                )
+            })?;
+        let table_cid = table
+            .get("tableCid")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                crate::kit_path::LiftPluginKitError::Failed(
+                    "call-contract-ref table missing tableCid".into(),
+                )
+            })?;
+        let response = self
+            .connection
+            .clone()
+            .with_method("sugar.plugin.bind_call_contract_refs")
+            .request(table)?;
+        let acknowledged = response
+            .get("tableCid")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                crate::kit_path::LiftPluginKitError::Failed(
+                    "call-contract-ref bind response missing tableCid".into(),
+                )
+            })?;
+        if acknowledged != table_cid {
+            return Err(crate::kit_path::LiftPluginKitError::Failed(
+                "call-contract-ref bind acknowledged a different table CID".into(),
+            ));
+        }
+        self.connection
+            .install_call_contract_ref_generation(catalog_cid.to_owned(), table_cid.to_owned())?;
+        Ok(acknowledged.to_owned())
+    }
+
     /// SEAM 4 -- the testimony verb. Asks THIS kit (the one this handle
     /// rendezvous'd with) for its vendor dependency-proof catalog over
     /// `sugar.plugin.resolve_dependency_proofs`, decoded into typed,

--- a/implementations/rust/sugar-compiler/src/kit_path/lift_plugin.rs
+++ b/implementations/rust/sugar-compiler/src/kit_path/lift_plugin.rs
@@ -95,6 +95,7 @@ pub struct LiftPluginKit {
     resident_max_requests: usize,
     terminal_error: std::sync::Arc<Mutex<Option<LiftPluginKitError>>>,
     contract_ref_generation: std::sync::Arc<Mutex<Option<(String, String)>>>,
+    call_contract_ref_generation: std::sync::Arc<Mutex<Option<(String, String)>>>,
 }
 
 struct ResidentSlot(Mutex<Option<ResidentLifter>>);
@@ -188,6 +189,7 @@ impl LiftPluginKit {
             resident_max_requests,
             terminal_error: std::sync::Arc::new(Mutex::new(None)),
             contract_ref_generation: std::sync::Arc::new(Mutex::new(None)),
+            call_contract_ref_generation: std::sync::Arc::new(Mutex::new(None)),
         }
     }
 
@@ -279,6 +281,29 @@ impl LiftPluginKit {
             .lock()
             .map_err(|_| {
                 LiftPluginKitError::Failed("contract-ref generation lock poisoned".into())
+            })?
+            .clone())
+    }
+
+    pub(crate) fn install_call_contract_ref_generation(
+        &self,
+        catalog_cid: String,
+        table_cid: String,
+    ) -> Result<(), LiftPluginKitError> {
+        *self.call_contract_ref_generation.lock().map_err(|_| {
+            LiftPluginKitError::Failed("call-contract-ref generation lock poisoned".into())
+        })? = Some((catalog_cid, table_cid));
+        Ok(())
+    }
+
+    pub(crate) fn call_contract_ref_generation(
+        &self,
+    ) -> Result<Option<(String, String)>, LiftPluginKitError> {
+        Ok(self
+            .call_contract_ref_generation
+            .lock()
+            .map_err(|_| {
+                LiftPluginKitError::Failed("call-contract-ref generation lock poisoned".into())
             })?
             .clone())
     }

--- a/implementations/rust/sugar-compiler/src/orchestrate.rs
+++ b/implementations/rust/sugar-compiler/src/orchestrate.rs
@@ -57,8 +57,9 @@ use std::path::Path;
 use sugar_ir_compiler::registry::Registry as CompilerRegistry;
 use sugar_linker::{
     decode_context_manager_edge, final_check_context_manager_edges, link,
-    AuthenticatedContextManagerCatalog, ContextManagerContractDemandV1, LinkerError,
-    LinkerErrorKind, LinkerInputs, ResolvedContractRefsV1, SourceFragmentCoordinateV1, Symbol,
+    AuthenticatedCallContractCatalog, AuthenticatedContextManagerCatalog, CallContractDemandV1,
+    Cid, ContextManagerContractDemandV1, LinkerError, LinkerErrorKind, LinkerInputs,
+    ResolvedCallContractRefsV1, ResolvedContractRefsV1, SourceFragmentCoordinateV1, Symbol,
 };
 use sugar_proof_envelope::ImportSignatureV1;
 use sugar_proof_envelope::{build_proof_envelope, ProofEnvelopeInput, ProofGraph};
@@ -467,6 +468,10 @@ pub fn fold_kit_to_pool(
             .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
         let demands = demand_rows
             .iter()
+            .filter(|row| {
+                row.get("kind").and_then(serde_json::Value::as_str)
+                    == Some("context-manager-demand")
+            })
             .map(context_manager_demand_from_wire)
             .collect::<Result<Vec<_>, _>>()?;
         let table = ResolvedContractRefsV1::new(&catalog, &demands);
@@ -478,8 +483,37 @@ pub fn fold_kit_to_pool(
         active_cm_preconstruction = Some((catalog, table));
     }
 
+    // Function contracts are ordinary body-derived contracts, so collect one
+    // complete workspace pass before resolving imported call demands. This is
+    // a corpus pass, never a target-file hunt: the consumer does not select or
+    // open its callee. Only signed members in the resulting pool may answer.
+    let mut active_call_preconstruction = None;
+    if kit.supports_rpc_method("sugar.plugin.bind_call_contract_refs") {
+        let preliminary = feed_from_tree::fold_claim_tree(kit, workspace_root)?;
+        let preliminary_pool = pool_from_graph_with_speaker(&preliminary, speaker.clone())
+            .map_err(ProveFromKitError::LocalLoad)?;
+        pool.merge(preliminary_pool);
+
+        let catalog = AuthenticatedCallContractCatalog::freeze_from_pool(&pool)
+            .map_err(ProveFromKitError::Preconstruction)?;
+        let demand_rows = kit
+            .context_manager_demands(workspace_root)
+            .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+        let demands = demand_rows
+            .iter()
+            .filter(|row| {
+                row.get("kind").and_then(serde_json::Value::as_str) == Some("call-contract-demand")
+            })
+            .map(call_contract_demand_from_wire)
+            .collect::<Result<Vec<_>, _>>()?;
+        let table = ResolvedCallContractRefsV1::new(&catalog, &demands);
+        kit.bind_call_contract_refs(&table.to_wire_value())
+            .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+        active_call_preconstruction = Some((catalog, table));
+    }
+
     // 7-8. Local semantic construction occurs only after ref installation.
-    let local = if active_cm_preconstruction.is_some() {
+    let local = if active_cm_preconstruction.is_some() || active_call_preconstruction.is_some() {
         // The declaration graph was already sealed into the preliminary pool;
         // this pass is semantic construction only.
         feed_from_tree::fold_claim_tree(kit, workspace_root)?
@@ -506,6 +540,11 @@ pub fn fold_kit_to_pool(
         table
             .final_check(catalog)
             .map_err(|error| ProveFromKitError::Preconstruction(error.into()))?;
+    }
+    if let Some((catalog, table)) = &active_call_preconstruction {
+        table.final_check(catalog).map_err(|error| {
+            ProveFromKitError::Preconstruction(format!("stale call-contract ref: {error:?}"))
+        })?;
     }
 
     Ok(pool)
@@ -571,6 +610,61 @@ fn context_manager_demand_from_wire(
             "demand target is neither an authenticated symbol nor runtime-selected".into(),
         )),
     }
+}
+
+fn call_contract_demand_from_wire(
+    row: &serde_json::Value,
+) -> Result<CallContractDemandV1, ProveFromKitError> {
+    if row.get("schemaVersion").and_then(serde_json::Value::as_str) != Some("1")
+        || row.get("kind").and_then(serde_json::Value::as_str) != Some("call-contract-demand")
+    {
+        return Err(ProveFromKitError::Preconstruction(
+            "unsupported call-contract demand row".into(),
+        ));
+    }
+    let use_site: SourceFragmentCoordinateV1 =
+        serde_json::from_value(row.get("useSite").cloned().ok_or_else(|| {
+            ProveFromKitError::Preconstruction("call demand missing useSite".into())
+        })?)
+        .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+    let target = row
+        .get("targetSymbol")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            ProveFromKitError::Preconstruction("call demand missing targetSymbol".into())
+        })?;
+    let import_binding_cid = row
+        .get("importBindingCid")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            ProveFromKitError::Preconstruction(
+                "call demand missing authenticated importBindingCid".into(),
+            )
+        })?;
+    let signature = row.get("importSignature").ok_or_else(|| {
+        ProveFromKitError::Preconstruction("call demand missing importSignature".into())
+    })?;
+    let formals = serde_json::from_value(
+        signature
+            .get("formals")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!([])),
+    )
+    .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+    let sorts = serde_json::from_value(
+        signature
+            .get("sorts")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!([])),
+    )
+    .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
+    Ok(CallContractDemandV1::new(
+        use_site,
+        Cid::from(import_binding_cid),
+        Symbol::from(target),
+        formals,
+        sorts,
+    ))
 }
 
 impl From<ProofRunArtifactError> for SolveError {

--- a/implementations/rust/sugar-compiler/src/orchestrate.rs
+++ b/implementations/rust/sugar-compiler/src/orchestrate.rs
@@ -56,7 +56,7 @@ use std::path::Path;
 
 use sugar_ir_compiler::registry::Registry as CompilerRegistry;
 use sugar_linker::{
-    decode_context_manager_edge, final_check_context_manager_edges, link,
+    canonical_json_cid, decode_context_manager_edge, final_check_context_manager_edges, link,
     AuthenticatedCallContractCatalog, AuthenticatedContextManagerCatalog, CallContractDemandV1,
     Cid, ContextManagerContractDemandV1, LinkerError, LinkerErrorKind, LinkerInputs,
     ResolvedCallContractRefsV1, ResolvedContractRefsV1, SourceFragmentCoordinateV1, Symbol,
@@ -494,7 +494,7 @@ pub fn fold_kit_to_pool(
             .map_err(ProveFromKitError::LocalLoad)?;
         pool.merge(preliminary_pool);
 
-        let catalog = AuthenticatedCallContractCatalog::freeze_from_pool(&pool)
+        let mut catalog = AuthenticatedCallContractCatalog::freeze_from_pool(&pool)
             .map_err(ProveFromKitError::Preconstruction)?;
         let demand_rows = kit
             .context_manager_demands(workspace_root)
@@ -506,6 +506,14 @@ pub fn fold_kit_to_pool(
             })
             .map(call_contract_demand_from_wire)
             .collect::<Result<Vec<_>, _>>()?;
+        let exports = demand_rows
+            .iter()
+            .filter(|row| {
+                row.get("kind").and_then(serde_json::Value::as_str) == Some("call-contract-export")
+            })
+            .map(|row| call_contract_export_from_wire(row, &speaker.id))
+            .collect::<Result<Vec<_>, _>>()?;
+        catalog.install_exports(exports);
         let table = ResolvedCallContractRefsV1::new(&catalog, &demands);
         kit.bind_call_contract_refs(&table.to_wire_value())
             .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
@@ -641,6 +649,14 @@ fn call_contract_demand_from_wire(
                 "call demand missing authenticated importBindingCid".into(),
             )
         })?;
+    let import_binding = row.get("importBinding").ok_or_else(|| {
+        ProveFromKitError::Preconstruction("call demand missing ImportBindingV1".into())
+    })?;
+    if canonical_json_cid(import_binding).as_str() != import_binding_cid {
+        return Err(ProveFromKitError::Preconstruction(
+            "call demand ImportBindingV1 CID mismatch".into(),
+        ));
+    }
     let signature = row.get("importSignature").ok_or_else(|| {
         ProveFromKitError::Preconstruction("call demand missing importSignature".into())
     })?;
@@ -658,13 +674,63 @@ fn call_contract_demand_from_wire(
             .unwrap_or_else(|| serde_json::json!([])),
     )
     .map_err(|error| ProveFromKitError::Preconstruction(error.to_string()))?;
-    Ok(CallContractDemandV1::new(
+    let demand = CallContractDemandV1::new(
         use_site,
         Cid::from(import_binding_cid),
         Symbol::from(target),
         formals,
         sorts,
-    ))
+    );
+    let authenticated_use = row.get("authenticatedImportUse").ok_or_else(|| {
+        ProveFromKitError::Preconstruction("call demand missing AuthenticatedImportUseV1".into())
+    })?;
+    let supplied_use_cid = authenticated_use
+        .get("cid")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            ProveFromKitError::Preconstruction("authenticated import use missing cid".into())
+        })?;
+    let mut use_preimage = authenticated_use.clone();
+    use_preimage
+        .as_object_mut()
+        .expect("checked object")
+        .remove("cid");
+    if canonical_json_cid(&use_preimage).as_str() != supplied_use_cid
+        || demand.authenticated_import_use_cid.as_str() != supplied_use_cid
+    {
+        return Err(ProveFromKitError::Preconstruction(
+            "AuthenticatedImportUseV1 CID mismatch".into(),
+        ));
+    }
+    Ok(demand)
+}
+
+fn call_contract_export_from_wire(
+    row: &serde_json::Value,
+    provider_id: &str,
+) -> Result<sugar_linker::AuthenticatedCallExportV1, ProveFromKitError> {
+    if row.get("schemaVersion").and_then(serde_json::Value::as_str) != Some("1") {
+        return Err(ProveFromKitError::Preconstruction(
+            "unsupported call export row".into(),
+        ));
+    }
+    let exported = row
+        .get("exportedSymbol")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            ProveFromKitError::Preconstruction("call export missing exportedSymbol".into())
+        })?;
+    let target = row
+        .get("targetSymbol")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            ProveFromKitError::Preconstruction("call export missing targetSymbol".into())
+        })?;
+    Ok(sugar_linker::AuthenticatedCallExportV1 {
+        exported_symbol: Symbol::from(exported),
+        target_symbol: Symbol::from(target),
+        provider_id: provider_id.to_string(),
+    })
 }
 
 impl From<ProofRunArtifactError> for SolveError {

--- a/implementations/rust/sugar-compiler/src/tree.rs
+++ b/implementations/rust/sugar-compiler/src/tree.rs
@@ -826,6 +826,19 @@ fn enumerate_rpc(
             "tableCid": table_cid,
         });
     }
+    if let Some((catalog_cid, table_cid)) =
+        conn.transport
+            .call_contract_ref_generation()
+            .map_err(|error| EnumerateError::Unavailable {
+                plugin: plugin.clone(),
+                reason: error.to_string(),
+            })?
+    {
+        options["callContractRefs"] = json!({
+            "catalogCid": catalog_cid,
+            "tableCid": table_cid,
+        });
+    }
     let response = conn
         .transport
         .request(&json!({

--- a/implementations/rust/sugar-linker/src/lib.rs
+++ b/implementations/rust/sugar-linker/src/lib.rs
@@ -291,6 +291,7 @@ pub struct SourceFragmentCoordinateV1 {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CallContractDemandV1 {
     pub demand_cid: Cid,
+    pub authenticated_import_use_cid: Cid,
     pub use_site: SourceFragmentCoordinateV1,
     pub import_binding_cid: Cid,
     pub target_symbol: Symbol,
@@ -306,15 +307,23 @@ impl CallContractDemandV1 {
         sorts: Vec<Sort>,
     ) -> Self {
         let import_signature = ImportSignatureV1 { formals, sorts };
+        let authenticated_import_use_cid = Cid::from(jcs_cid(&serde_json::json!({
+            "kind": "authenticated-import-use",
+            "schemaVersion": "1",
+            "useSite": use_site,
+            "importBindingCid": import_binding_cid,
+        })));
         let preimage = serde_json::json!({
             "useSite": use_site,
             "importBindingCid": import_binding_cid,
+            "authenticatedImportUseCid": authenticated_import_use_cid,
             "targetSymbol": target_symbol,
             "importSignature": import_signature_to_json(&import_signature),
             "expectedKind": "function-contract",
         });
         Self {
             demand_cid: Cid::from(jcs_cid(&preimage)),
+            authenticated_import_use_cid,
             use_site,
             import_binding_cid,
             target_symbol,
@@ -331,17 +340,29 @@ struct AuthenticatedCallContract {
     import_signature: ImportSignatureV1,
     return_term: Option<Json>,
     source_warrant_cids: Vec<Cid>,
+    provider_id: String,
+    contract_decl: Json,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedCallExportV1 {
+    pub exported_symbol: Symbol,
+    pub target_symbol: Symbol,
+    pub provider_id: String,
 }
 
 #[derive(Debug, Clone)]
 pub struct AuthenticatedCallContractCatalog {
     catalog_cid: Cid,
     contracts: Vec<AuthenticatedCallContract>,
+    exports: Vec<AuthenticatedCallExportV1>,
+    occupied_non_contract_symbols: Vec<(Symbol, Cid, String)>,
 }
 
 impl AuthenticatedCallContractCatalog {
     pub fn freeze(members: Vec<(Cid, Json)>) -> Result<Self, String> {
         let mut contracts = Vec::new();
+        let mut occupied_non_contract_symbols = Vec::new();
         let mut member_cids = Vec::new();
         for (member_cid, envelope) in members {
             let typed = MementoCid::try_parse(member_cid.as_str().to_string())
@@ -350,7 +371,18 @@ impl AuthenticatedCallContractCatalog {
             let member = StoredMember::from_envelope(typed, &envelope)
                 .map_err(|error| format!("invalid catalog member: {error}"))?;
             member_cids.push(member_cid.clone());
-            if let Some(contract) = authenticated_call_contract(member_cid, &member, None)? {
+            if member.kind() != MemberKind::Contract {
+                if let Some(symbol) = member.field("bridgeSourceSymbol").and_then(Json::as_str) {
+                    occupied_non_contract_symbols.push((
+                        symbol.into(),
+                        member_cid.clone(),
+                        "fixture".into(),
+                    ));
+                }
+            }
+            if let Some(contract) =
+                authenticated_call_contract(member_cid, &member, None, "fixture")?
+            {
                 contracts.push(contract);
             }
         }
@@ -359,6 +391,8 @@ impl AuthenticatedCallContractCatalog {
         Ok(Self {
             catalog_cid,
             contracts,
+            exports: Vec::new(),
+            occupied_non_contract_symbols,
         })
     }
 
@@ -380,6 +414,7 @@ impl AuthenticatedCallContractCatalog {
             }
         }
         let mut contracts = Vec::new();
+        let mut occupied_non_contract_symbols = Vec::new();
         let mut member_cids = Vec::new();
         let resolved_bodies = pool
             .contract_members_with_bodies()
@@ -388,9 +423,22 @@ impl AuthenticatedCallContractCatalog {
         for (cid, member) in &pool.mementos {
             let member_cid = Cid::from(cid.as_str());
             member_cids.push(member_cid.clone());
-            if let Some(contract) =
-                authenticated_call_contract(member_cid, member, resolved_bodies.get(cid))?
-            {
+            let provider_id = pool.member_speaker(cid).expect("checked above").id.as_str();
+            if member.kind() != MemberKind::Contract {
+                if let Some(symbol) = member.field("bridgeSourceSymbol").and_then(Json::as_str) {
+                    occupied_non_contract_symbols.push((
+                        symbol.into(),
+                        member_cid.clone(),
+                        provider_id.to_string(),
+                    ));
+                }
+            }
+            if let Some(contract) = authenticated_call_contract(
+                member_cid,
+                member,
+                resolved_bodies.get(cid),
+                provider_id,
+            )? {
                 contracts.push(contract);
             }
         }
@@ -399,7 +447,28 @@ impl AuthenticatedCallContractCatalog {
         Ok(Self {
             catalog_cid,
             contracts,
+            exports: Vec::new(),
+            occupied_non_contract_symbols,
         })
+    }
+
+    pub fn install_exports(&mut self, mut exports: Vec<AuthenticatedCallExportV1>) {
+        exports.sort_by(|a, b| {
+            (&a.exported_symbol, &a.target_symbol, &a.provider_id).cmp(&(
+                &b.exported_symbol,
+                &b.target_symbol,
+                &b.provider_id,
+            ))
+        });
+        self.exports = exports;
+        self.catalog_cid = Cid::from(jcs_cid(&serde_json::json!({
+            "memberCatalogCid": self.catalog_cid,
+            "exports": self.exports.iter().map(|e| serde_json::json!({
+                "exportedSymbol": e.exported_symbol,
+                "targetSymbol": e.target_symbol,
+                "providerId": e.provider_id,
+            })).collect::<Vec<_>>(),
+        })));
     }
 }
 
@@ -407,6 +476,7 @@ fn authenticated_call_contract(
     member_cid: Cid,
     member: &StoredMember,
     resolved_body: Option<&Json>,
+    provider_id: &str,
 ) -> Result<Option<AuthenticatedCallContract>, String> {
     if member.kind() != MemberKind::Contract {
         return Ok(None);
@@ -418,6 +488,7 @@ fn authenticated_call_contract(
         .field("cid")
         .and_then(Json::as_str)
         .ok_or_else(|| format!("contract member {member_cid} lacks semantic cid"))?;
+    let body_cid = member.field("bodyCid").and_then(Json::as_str);
     let formals = member
         .field("formals")
         .and_then(Json::as_array)
@@ -454,14 +525,66 @@ fn authenticated_call_contract(
             "contract member {member_cid} has signature arity mismatch"
         ));
     }
+    let mut declaration = serde_json::Map::from_iter([
+        (
+            "name".into(),
+            member
+                .field("name")
+                .cloned()
+                .ok_or_else(|| format!("contract member {member_cid} lacks name"))?,
+        ),
+        (
+            "outBinding".into(),
+            member
+                .field("outBinding")
+                .cloned()
+                .ok_or_else(|| format!("contract member {member_cid} lacks outBinding"))?,
+        ),
+    ]);
+    if let Some(body_cid) = body_cid {
+        declaration.insert("kind".into(), Json::String("contract".into()));
+        declaration.insert("bodyCid".into(), Json::String(body_cid.to_string()));
+    } else {
+        for field in ["pre", "post", "inv"] {
+            if let Some(value) = member.field(field) {
+                declaration.insert(field.into(), value.clone());
+            }
+        }
+    }
+    if member.field("formals").is_some() {
+        declaration.insert(
+            "formals".into(),
+            serde_json::to_value(&formals).expect("strings"),
+        );
+        declaration.insert(
+            "formalSorts".into(),
+            member
+                .field("formalSorts")
+                .cloned()
+                .unwrap_or_else(|| Json::Array(vec![])),
+        );
+    }
+    let contract_decl = Json::Object(declaration);
+    if jcs_cid(&contract_decl) != contract_cid {
+        return Err(format!(
+            "contract member {member_cid} carries stale semantic cid"
+        ));
+    }
     let post = resolved_body
         .and_then(|body| body.get("post"))
         .or_else(|| member.field("post"));
-    let return_term = post.and_then(exact_return_term).filter(|term| {
-        let mut free = BTreeSet::new();
-        collect_term_vars(term, &mut free);
-        free.iter().all(|name| formals.contains(name))
-    });
+    let pre = resolved_body
+        .and_then(|body| body.get("pre"))
+        .or_else(|| member.field("pre"));
+    let return_term = pre
+        .is_none()
+        .then(|| post.and_then(exact_return_term))
+        .flatten()
+        .filter(|term| {
+            let mut free = BTreeSet::new();
+            collect_term_vars(term, &mut free);
+            free.iter().all(|name| formals.contains(name))
+        });
     Ok(Some(AuthenticatedCallContract {
         member_cid,
         contract_cid: Cid::from(contract_cid),
@@ -469,6 +592,8 @@ fn authenticated_call_contract(
         import_signature: ImportSignatureV1 { formals, sorts },
         return_term,
         source_warrant_cids: Vec::new(),
+        provider_id: provider_id.to_string(),
+        contract_decl,
     }))
 }
 
@@ -511,11 +636,15 @@ fn collect_term_vars(term: &Json, free: &mut BTreeSet<String>) {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum CallContractResolutionGapKindV1 {
+    NoLexicalBinding,
+    ShadowedNonImport,
+    AmbiguousLexicalBinding,
     TargetNotInCorpus,
     NoAuthenticatedContract,
     AmbiguousTarget,
     ImportSignatureMismatch,
     WrongContractKind,
+    WrongProvider,
     StaleOrMalformedContractRef,
 }
 
@@ -542,6 +671,7 @@ pub struct ResolvedCallContractRefV1 {
     import_signature: ImportSignatureV1,
     return_term: Option<Json>,
     source_warrant_cids: Vec<Cid>,
+    contract_decl: Json,
 }
 
 impl ResolvedCallContractRefV1 {
@@ -685,6 +815,7 @@ fn call_resolution_to_json(resolution: &CallContractResolutionV1) -> Json {
                 "importSignature": import_signature_to_json(&reference.import_signature),
                 "returnTerm": reference.return_term,
                 "sourceWarrantCids": reference.source_warrant_cids,
+                "contractDecl": reference.contract_decl,
             },
         }),
         CallContractResolutionV1::Unresolved(gap) => serde_json::json!({
@@ -705,10 +836,34 @@ pub fn resolve_call_contract_demand(
     demand: &CallContractDemandV1,
     catalog: &AuthenticatedCallContractCatalog,
 ) -> CallContractResolutionV1 {
+    let mut terminal_symbol = demand.target_symbol.clone();
+    let mut authenticated_owner: Option<String> = None;
+    if !catalog.exports.is_empty() {
+        let mut seen = BTreeSet::new();
+        loop {
+            if !seen.insert(terminal_symbol.clone()) {
+                break;
+            }
+            let edges = catalog
+                .exports
+                .iter()
+                .filter(|edge| edge.exported_symbol == terminal_symbol)
+                .collect::<Vec<_>>();
+            if edges.len() != 1 {
+                break;
+            }
+            let edge = edges[0];
+            authenticated_owner.get_or_insert_with(|| edge.provider_id.clone());
+            if edge.target_symbol == terminal_symbol {
+                break;
+            }
+            terminal_symbol = edge.target_symbol.clone();
+        }
+    }
     let mut candidates = catalog
         .contracts
         .iter()
-        .filter(|candidate| candidate.bridge_source_symbol == demand.target_symbol)
+        .filter(|candidate| candidate.bridge_source_symbol == terminal_symbol)
         .collect::<Vec<_>>();
     let gap = |kind, mut cids: Vec<Cid>| {
         cids.sort();
@@ -721,8 +876,40 @@ pub fn resolve_call_contract_demand(
             candidate_member_cids: cids,
         })
     };
+    if catalog
+        .exports
+        .iter()
+        .filter(|edge| edge.exported_symbol == demand.target_symbol)
+        .count()
+        > 1
+    {
+        return gap(CallContractResolutionGapKindV1::AmbiguousTarget, vec![]);
+    }
     if candidates.is_empty() {
-        return gap(CallContractResolutionGapKindV1::TargetNotInCorpus, vec![]);
+        let wrong_kind = catalog
+            .occupied_non_contract_symbols
+            .iter()
+            .filter(|(symbol, _, _)| symbol == &terminal_symbol)
+            .map(|(_, cid, _)| cid.clone())
+            .collect::<Vec<_>>();
+        if !wrong_kind.is_empty() {
+            return gap(
+                CallContractResolutionGapKindV1::WrongContractKind,
+                wrong_kind,
+            );
+        }
+        return gap(
+            if catalog
+                .exports
+                .iter()
+                .any(|edge| edge.exported_symbol == demand.target_symbol)
+            {
+                CallContractResolutionGapKindV1::NoAuthenticatedContract
+            } else {
+                CallContractResolutionGapKindV1::TargetNotInCorpus
+            },
+            vec![],
+        );
     }
     if candidates.len() > 1 {
         return gap(
@@ -734,6 +921,15 @@ pub fn resolve_call_contract_demand(
         );
     }
     let candidate = candidates.pop().expect("one candidate");
+    if authenticated_owner
+        .as_ref()
+        .is_some_and(|owner| owner != &candidate.provider_id)
+    {
+        return gap(
+            CallContractResolutionGapKindV1::WrongProvider,
+            vec![candidate.member_cid.clone()],
+        );
+    }
     let signature_matches = demand.import_signature.sorts.len()
         == candidate.import_signature.sorts.len()
         && (demand.import_signature.formals.is_empty()
@@ -757,6 +953,7 @@ pub fn resolve_call_contract_demand(
         "importSignature": import_signature_to_json(&candidate.import_signature),
         "returnTerm": candidate.return_term,
         "sourceWarrantCids": candidate.source_warrant_cids,
+        "contractDecl": candidate.contract_decl,
     });
     CallContractResolutionV1::Resolved(ResolvedCallContractRefV1 {
         resolution_cid: Cid::from(jcs_cid(&preimage)),
@@ -770,6 +967,7 @@ pub fn resolve_call_contract_demand(
         import_signature: candidate.import_signature.clone(),
         return_term: candidate.return_term.clone(),
         source_warrant_cids: candidate.source_warrant_cids.clone(),
+        contract_decl: candidate.contract_decl.clone(),
     })
 }
 
@@ -782,6 +980,12 @@ pub fn final_check_call_contract_ref(
     }
     let demand = CallContractDemandV1 {
         demand_cid: reference.demand_cid.clone(),
+        authenticated_import_use_cid: Cid::from(jcs_cid(&serde_json::json!({
+            "kind": "authenticated-import-use",
+            "schemaVersion": "1",
+            "useSite": reference.use_site,
+            "importBindingCid": reference.import_binding_cid,
+        }))),
         use_site: reference.use_site.clone(),
         import_binding_cid: reference.import_binding_cid.clone(),
         target_symbol: reference.bridge_source_symbol.clone(),
@@ -3117,6 +3321,10 @@ fn jcs_of_json(v: &Json) -> Vec<u8> {
 
 fn jcs_cid(v: &Json) -> String {
     blake3_512_of(&jcs_of_json(v))
+}
+
+pub fn canonical_json_cid(v: &Json) -> Cid {
+    Cid::from(jcs_cid(v))
 }
 
 /// JCS-canonical bytes of a typed formula. Lowers the `IrFormula` to its

--- a/implementations/rust/sugar-linker/src/lib.rs
+++ b/implementations/rust/sugar-linker/src/lib.rs
@@ -778,6 +778,7 @@ impl ResolvedCallContractRefsV1 {
     }
 
     fn identity_value(&self) -> Json {
+        let enrolled_use_sites = self.by_use_site.keys().collect::<Vec<_>>();
         let rows = self
             .by_use_site
             .iter()
@@ -792,6 +793,7 @@ impl ResolvedCallContractRefsV1 {
             "kind": "resolved-call-contract-refs",
             "schemaVersion": "1",
             "catalogCid": self.catalog_cid,
+            "enrolledUseSites": enrolled_use_sites,
             "byUseSite": rows,
         })
     }

--- a/implementations/rust/sugar-linker/src/lib.rs
+++ b/implementations/rust/sugar-linker/src/lib.rs
@@ -285,6 +285,520 @@ pub struct SourceFragmentCoordinateV1 {
     pub end_col: usize,
 }
 
+// Authenticated imported-call preconstruction resolution (#6086)
+// -------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallContractDemandV1 {
+    pub demand_cid: Cid,
+    pub use_site: SourceFragmentCoordinateV1,
+    pub import_binding_cid: Cid,
+    pub target_symbol: Symbol,
+    pub import_signature: ImportSignatureV1,
+}
+
+impl CallContractDemandV1 {
+    pub fn new(
+        use_site: SourceFragmentCoordinateV1,
+        import_binding_cid: Cid,
+        target_symbol: Symbol,
+        formals: Vec<String>,
+        sorts: Vec<Sort>,
+    ) -> Self {
+        let import_signature = ImportSignatureV1 { formals, sorts };
+        let preimage = serde_json::json!({
+            "useSite": use_site,
+            "importBindingCid": import_binding_cid,
+            "targetSymbol": target_symbol,
+            "importSignature": import_signature_to_json(&import_signature),
+            "expectedKind": "function-contract",
+        });
+        Self {
+            demand_cid: Cid::from(jcs_cid(&preimage)),
+            use_site,
+            import_binding_cid,
+            target_symbol,
+            import_signature,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct AuthenticatedCallContract {
+    member_cid: Cid,
+    contract_cid: Cid,
+    bridge_source_symbol: Symbol,
+    import_signature: ImportSignatureV1,
+    return_term: Option<Json>,
+    source_warrant_cids: Vec<Cid>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AuthenticatedCallContractCatalog {
+    catalog_cid: Cid,
+    contracts: Vec<AuthenticatedCallContract>,
+}
+
+impl AuthenticatedCallContractCatalog {
+    pub fn freeze(members: Vec<(Cid, Json)>) -> Result<Self, String> {
+        let mut contracts = Vec::new();
+        let mut member_cids = Vec::new();
+        for (member_cid, envelope) in members {
+            let typed = MementoCid::try_parse(member_cid.as_str().to_string())
+                .map_err(|bad| format!("invalid catalog member CID: {bad}"))?;
+            AnchoredMember::new(typed.clone(), envelope.clone())?;
+            let member = StoredMember::from_envelope(typed, &envelope)
+                .map_err(|error| format!("invalid catalog member: {error}"))?;
+            member_cids.push(member_cid.clone());
+            if let Some(contract) = authenticated_call_contract(member_cid, &member, None)? {
+                contracts.push(contract);
+            }
+        }
+        member_cids.sort();
+        let catalog_cid = Cid::from(jcs_cid(&serde_json::json!({"memberCids": member_cids})));
+        Ok(Self {
+            catalog_cid,
+            contracts,
+        })
+    }
+
+    pub fn catalog_cid(&self) -> &Cid {
+        &self.catalog_cid
+    }
+
+    pub fn freeze_from_pool(pool: &MementoPool) -> Result<Self, String> {
+        for cid in pool.mementos.keys() {
+            let attributed = pool.member_speaker(cid).is_some();
+            let enrolled = pool
+                .bundle_members
+                .values()
+                .any(|members| members.contains(cid));
+            if !attributed || !enrolled {
+                return Err(format!(
+                    "unauthenticated-member: {cid} lacks verified pool intake testimony"
+                ));
+            }
+        }
+        let mut contracts = Vec::new();
+        let mut member_cids = Vec::new();
+        let resolved_bodies = pool
+            .contract_members_with_bodies()
+            .map(|(cid, body)| (cid.clone(), body))
+            .collect::<BTreeMap<_, _>>();
+        for (cid, member) in &pool.mementos {
+            let member_cid = Cid::from(cid.as_str());
+            member_cids.push(member_cid.clone());
+            if let Some(contract) =
+                authenticated_call_contract(member_cid, member, resolved_bodies.get(cid))?
+            {
+                contracts.push(contract);
+            }
+        }
+        member_cids.sort();
+        let catalog_cid = Cid::from(jcs_cid(&serde_json::json!({"memberCids": member_cids})));
+        Ok(Self {
+            catalog_cid,
+            contracts,
+        })
+    }
+}
+
+fn authenticated_call_contract(
+    member_cid: Cid,
+    member: &StoredMember,
+    resolved_body: Option<&Json>,
+) -> Result<Option<AuthenticatedCallContract>, String> {
+    if member.kind() != MemberKind::Contract {
+        return Ok(None);
+    }
+    let Some(symbol) = member.field("bridgeSourceSymbol").and_then(Json::as_str) else {
+        return Ok(None);
+    };
+    let contract_cid = member
+        .field("cid")
+        .and_then(Json::as_str)
+        .ok_or_else(|| format!("contract member {member_cid} lacks semantic cid"))?;
+    let formals = member
+        .field("formals")
+        .and_then(Json::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .map(|value| {
+                    value
+                        .as_str()
+                        .map(str::to_string)
+                        .ok_or_else(|| "contract formal is not a string".to_string())
+                })
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?
+        .unwrap_or_default();
+    let sorts = member
+        .field("formalSorts")
+        .and_then(Json::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .cloned()
+                .map(|value| {
+                    serde_json::from_value::<Sort>(value)
+                        .map_err(|error| format!("malformed contract formal sort: {error}"))
+                })
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?
+        .unwrap_or_default();
+    if formals.len() != sorts.len() {
+        return Err(format!(
+            "contract member {member_cid} has signature arity mismatch"
+        ));
+    }
+    let post = resolved_body
+        .and_then(|body| body.get("post"))
+        .or_else(|| member.field("post"));
+    let return_term = post.and_then(exact_return_term).filter(|term| {
+        let mut free = BTreeSet::new();
+        collect_term_vars(term, &mut free);
+        free.iter().all(|name| formals.contains(name))
+    });
+    Ok(Some(AuthenticatedCallContract {
+        member_cid,
+        contract_cid: Cid::from(contract_cid),
+        bridge_source_symbol: symbol.into(),
+        import_signature: ImportSignatureV1 { formals, sorts },
+        return_term,
+        source_warrant_cids: Vec::new(),
+    }))
+}
+
+fn exact_return_term(post: &Json) -> Option<Json> {
+    let object = post.as_object()?;
+    if object.get("kind")?.as_str()? != "atomic" || object.get("name")?.as_str()? != "=" {
+        return None;
+    }
+    let args = object.get("args")?.as_array()?;
+    if args.len() != 2
+        || args[0].get("kind")?.as_str()? != "var"
+        || args[0].get("name")?.as_str()? != "out"
+    {
+        return None;
+    }
+    Some(args[1].clone())
+}
+
+fn collect_term_vars(term: &Json, free: &mut BTreeSet<String>) {
+    let Some(object) = term.as_object() else {
+        return;
+    };
+    match object.get("kind").and_then(Json::as_str) {
+        Some("var") => {
+            if let Some(name) = object.get("name").and_then(Json::as_str) {
+                free.insert(name.to_string());
+            }
+        }
+        Some("ctor") => {
+            if let Some(args) = object.get("args").and_then(Json::as_array) {
+                for arg in args {
+                    collect_term_vars(arg, free);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CallContractResolutionGapKindV1 {
+    TargetNotInCorpus,
+    NoAuthenticatedContract,
+    AmbiguousTarget,
+    ImportSignatureMismatch,
+    WrongContractKind,
+    StaleOrMalformedContractRef,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallContractResolutionGapV1 {
+    pub demand_cid: Cid,
+    pub use_site: SourceFragmentCoordinateV1,
+    pub import_binding_cid: Cid,
+    pub target_symbol: Symbol,
+    pub kind: CallContractResolutionGapKindV1,
+    pub candidate_member_cids: Vec<Cid>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedCallContractRefV1 {
+    resolution_cid: Cid,
+    demand_cid: Cid,
+    use_site: SourceFragmentCoordinateV1,
+    import_binding_cid: Cid,
+    catalog_cid: Cid,
+    member_cid: Cid,
+    contract_cid: Cid,
+    bridge_source_symbol: Symbol,
+    import_signature: ImportSignatureV1,
+    return_term: Option<Json>,
+    source_warrant_cids: Vec<Cid>,
+}
+
+impl ResolvedCallContractRefV1 {
+    pub fn member_cid(&self) -> &Cid {
+        &self.member_cid
+    }
+    pub fn contract_cid(&self) -> &Cid {
+        &self.contract_cid
+    }
+    pub fn catalog_cid(&self) -> &Cid {
+        &self.catalog_cid
+    }
+    pub fn return_term(&self) -> Option<&Json> {
+        self.return_term.as_ref()
+    }
+    pub fn import_binding_cid(&self) -> &Cid {
+        &self.import_binding_cid
+    }
+
+    pub fn to_call_edge(
+        &self,
+        source_contract_cid: Cid,
+        call_site_locus: Option<CallSiteLocus>,
+    ) -> LinkerCallEdge {
+        LinkerCallEdge {
+            source_contract_cid,
+            target_contract_cid: Some(self.contract_cid.clone()),
+            target_symbol: self.bridge_source_symbol.clone(),
+            call_site_locus,
+            import_signature: Some(ImportSignature {
+                symbol: self.bridge_source_symbol.clone(),
+                signature: Signature {
+                    formals: self.import_signature.formals.clone(),
+                    sorts: self.import_signature.sorts.clone(),
+                    euf_coordinate: None,
+                },
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CallContractResolutionV1 {
+    Resolved(ResolvedCallContractRefV1),
+    Unresolved(CallContractResolutionGapV1),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedCallContractRefsV1 {
+    catalog_cid: Cid,
+    table_cid: Cid,
+    by_use_site: BTreeMap<SourceFragmentCoordinateV1, CallContractResolutionV1>,
+}
+
+impl ResolvedCallContractRefsV1 {
+    pub fn new(
+        catalog: &AuthenticatedCallContractCatalog,
+        demands: &[CallContractDemandV1],
+    ) -> Self {
+        let by_use_site = demands
+            .iter()
+            .map(|demand| {
+                (
+                    demand.use_site.clone(),
+                    resolve_call_contract_demand(demand, catalog),
+                )
+            })
+            .collect();
+        let mut table = Self {
+            catalog_cid: catalog.catalog_cid.clone(),
+            table_cid: Cid::from(""),
+            by_use_site,
+        };
+        table.table_cid = Cid::from(jcs_cid(&table.identity_value()));
+        table
+    }
+
+    pub fn table_cid(&self) -> &Cid {
+        &self.table_cid
+    }
+
+    pub fn final_check(
+        &self,
+        catalog: &AuthenticatedCallContractCatalog,
+    ) -> Result<(), CallContractResolutionGapKindV1> {
+        if self.catalog_cid != catalog.catalog_cid {
+            return Err(CallContractResolutionGapKindV1::StaleOrMalformedContractRef);
+        }
+        for resolution in self.by_use_site.values() {
+            if let CallContractResolutionV1::Resolved(reference) = resolution {
+                final_check_call_contract_ref(reference, catalog)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn to_wire_value(&self) -> Json {
+        let mut value = self.identity_value();
+        value
+            .as_object_mut()
+            .expect("table object")
+            .insert("tableCid".into(), Json::String(self.table_cid.to_string()));
+        value
+    }
+
+    fn identity_value(&self) -> Json {
+        let rows = self
+            .by_use_site
+            .iter()
+            .map(|(use_site, resolution)| {
+                serde_json::json!({
+                    "useSite": use_site,
+                    "resolution": call_resolution_to_json(resolution),
+                })
+            })
+            .collect::<Vec<_>>();
+        serde_json::json!({
+            "kind": "resolved-call-contract-refs",
+            "schemaVersion": "1",
+            "catalogCid": self.catalog_cid,
+            "byUseSite": rows,
+        })
+    }
+}
+
+fn call_resolution_to_json(resolution: &CallContractResolutionV1) -> Json {
+    match resolution {
+        CallContractResolutionV1::Resolved(reference) => serde_json::json!({
+            "kind": "resolved",
+            "reference": {
+                "kind": "resolved-call-contract-ref",
+                "schemaVersion": "1",
+                "resolutionCid": reference.resolution_cid,
+                "demandCid": reference.demand_cid,
+                "useSite": reference.use_site,
+                "importBindingCid": reference.import_binding_cid,
+                "catalogCid": reference.catalog_cid,
+                "memberCid": reference.member_cid,
+                "contractCid": reference.contract_cid,
+                "bridgeSourceSymbol": reference.bridge_source_symbol,
+                "importSignature": import_signature_to_json(&reference.import_signature),
+                "returnTerm": reference.return_term,
+                "sourceWarrantCids": reference.source_warrant_cids,
+            },
+        }),
+        CallContractResolutionV1::Unresolved(gap) => serde_json::json!({
+            "kind": "unresolved",
+            "gap": {
+                "demandCid": gap.demand_cid,
+                "useSite": gap.use_site,
+                "importBindingCid": gap.import_binding_cid,
+                "targetSymbol": gap.target_symbol,
+                "kind": gap.kind,
+                "candidateMemberCids": gap.candidate_member_cids,
+            },
+        }),
+    }
+}
+
+pub fn resolve_call_contract_demand(
+    demand: &CallContractDemandV1,
+    catalog: &AuthenticatedCallContractCatalog,
+) -> CallContractResolutionV1 {
+    let mut candidates = catalog
+        .contracts
+        .iter()
+        .filter(|candidate| candidate.bridge_source_symbol == demand.target_symbol)
+        .collect::<Vec<_>>();
+    let gap = |kind, mut cids: Vec<Cid>| {
+        cids.sort();
+        CallContractResolutionV1::Unresolved(CallContractResolutionGapV1 {
+            demand_cid: demand.demand_cid.clone(),
+            use_site: demand.use_site.clone(),
+            import_binding_cid: demand.import_binding_cid.clone(),
+            target_symbol: demand.target_symbol.clone(),
+            kind,
+            candidate_member_cids: cids,
+        })
+    };
+    if candidates.is_empty() {
+        return gap(CallContractResolutionGapKindV1::TargetNotInCorpus, vec![]);
+    }
+    if candidates.len() > 1 {
+        return gap(
+            CallContractResolutionGapKindV1::AmbiguousTarget,
+            candidates
+                .iter()
+                .map(|candidate| candidate.member_cid.clone())
+                .collect(),
+        );
+    }
+    let candidate = candidates.pop().expect("one candidate");
+    let signature_matches = demand.import_signature.sorts.len()
+        == candidate.import_signature.sorts.len()
+        && (demand.import_signature.formals.is_empty()
+            || candidate.import_signature.formals == demand.import_signature.formals)
+        && candidate.import_signature.sorts == demand.import_signature.sorts;
+    if !signature_matches {
+        return gap(
+            CallContractResolutionGapKindV1::ImportSignatureMismatch,
+            vec![candidate.member_cid.clone()],
+        );
+    }
+    let preimage = serde_json::json!({
+        "schemaVersion": "1",
+        "demandCid": demand.demand_cid,
+        "useSite": demand.use_site,
+        "importBindingCid": demand.import_binding_cid,
+        "catalogCid": catalog.catalog_cid,
+        "memberCid": candidate.member_cid,
+        "contractCid": candidate.contract_cid,
+        "bridgeSourceSymbol": candidate.bridge_source_symbol,
+        "importSignature": import_signature_to_json(&candidate.import_signature),
+        "returnTerm": candidate.return_term,
+        "sourceWarrantCids": candidate.source_warrant_cids,
+    });
+    CallContractResolutionV1::Resolved(ResolvedCallContractRefV1 {
+        resolution_cid: Cid::from(jcs_cid(&preimage)),
+        demand_cid: demand.demand_cid.clone(),
+        use_site: demand.use_site.clone(),
+        import_binding_cid: demand.import_binding_cid.clone(),
+        catalog_cid: catalog.catalog_cid.clone(),
+        member_cid: candidate.member_cid.clone(),
+        contract_cid: candidate.contract_cid.clone(),
+        bridge_source_symbol: candidate.bridge_source_symbol.clone(),
+        import_signature: candidate.import_signature.clone(),
+        return_term: candidate.return_term.clone(),
+        source_warrant_cids: candidate.source_warrant_cids.clone(),
+    })
+}
+
+pub fn final_check_call_contract_ref(
+    reference: &ResolvedCallContractRefV1,
+    catalog: &AuthenticatedCallContractCatalog,
+) -> Result<(), CallContractResolutionGapKindV1> {
+    if reference.catalog_cid != catalog.catalog_cid {
+        return Err(CallContractResolutionGapKindV1::StaleOrMalformedContractRef);
+    }
+    let demand = CallContractDemandV1 {
+        demand_cid: reference.demand_cid.clone(),
+        use_site: reference.use_site.clone(),
+        import_binding_cid: reference.import_binding_cid.clone(),
+        target_symbol: reference.bridge_source_symbol.clone(),
+        import_signature: reference.import_signature.clone(),
+    };
+    match resolve_call_contract_demand(&demand, catalog) {
+        CallContractResolutionV1::Resolved(now)
+            if now.resolution_cid == reference.resolution_cid
+                && now.contract_cid == reference.contract_cid
+                && now.member_cid == reference.member_cid =>
+        {
+            Ok(())
+        }
+        _ => Err(CallContractResolutionGapKindV1::StaleOrMalformedContractRef),
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContextManagerContractDemandV1 {
     pub demand_cid: Cid,

--- a/implementations/rust/sugar-linker/tests/call_contract_negative_full_chain.rs
+++ b/implementations/rust/sugar-linker/tests/call_contract_negative_full_chain.rs
@@ -102,3 +102,56 @@ fn wrong_provider_is_loud_through_python_construction() {
     assert!(verdict["gap"].as_str().unwrap().contains("wrong-provider"));
     assert!(verdict["edge"].is_null());
 }
+
+#[test]
+fn python_intake_rejects_duplicate_and_misbound_resolution_rows() {
+    let repo = support::repo();
+    let demand = support::enrolled_demand(&repo, SOURCE);
+    let mut catalog = support::catalog(&[7]);
+    catalog.install_exports(vec![AuthenticatedCallExportV1 {
+        exported_symbol: "python:pandas.public.pair".into(),
+        target_symbol: "python:pandas.fixture.pair".into(),
+        provider_id: "fixture".into(),
+    }]);
+    let table = ResolvedCallContractRefsV1::new(&catalog, &[demand]);
+    let wire = table.to_wire_value();
+
+    let mut duplicate = wire.clone();
+    duplicate["byUseSite"]
+        .as_array_mut()
+        .unwrap()
+        .push(wire["byUseSite"][0].clone());
+    let verdict = support::python_chain_verdict(&repo, SOURCE, &duplicate);
+    assert_eq!(verdict["stage"], "intake");
+    assert!(verdict["gap"]
+        .as_str()
+        .unwrap()
+        .contains("duplicate use-site"));
+
+    let mut wrong_row = wire.clone();
+    wrong_row["byUseSite"][0]["useSite"]["startLine"] = serde_json::json!(9);
+    wrong_row["enrolledUseSites"][0]["startLine"] = serde_json::json!(9);
+    let verdict = support::python_chain_verdict(&repo, SOURCE, &wrong_row);
+    assert_eq!(verdict["stage"], "intake");
+    assert!(verdict["gap"]
+        .as_str()
+        .unwrap()
+        .contains("row use-site mismatch"));
+
+    let mut wrong_catalog = wire;
+    let replacement = if wrong_catalog["catalogCid"] == support::cid('f').to_string() {
+        support::cid('e')
+    } else {
+        support::cid('f')
+    };
+    wrong_catalog["catalogCid"] = serde_json::json!(replacement.to_string());
+    let verdict = support::python_chain_verdict(&repo, SOURCE, &wrong_catalog);
+    assert_eq!(verdict["stage"], "intake");
+    assert!(
+        verdict["gap"]
+            .as_str()
+            .unwrap()
+            .contains("catalog CID mismatch"),
+        "{verdict}"
+    );
+}

--- a/implementations/rust/sugar-linker/tests/call_contract_negative_full_chain.rs
+++ b/implementations/rust/sugar-linker/tests/call_contract_negative_full_chain.rs
@@ -1,0 +1,104 @@
+#[path = "support/call_contract_full_chain.rs"]
+mod support;
+
+use sugar_linker::{
+    AuthenticatedCallExportV1, CallContractResolutionGapKindV1, ResolvedCallContractRefsV1,
+};
+
+const SOURCE: &str = "from pandas.public import pair\nresult = pair(value)\n";
+
+#[test]
+fn stale_contract_cid_is_loud_across_final_check_and_python_intake() {
+    let repo = support::repo();
+    let demand = support::enrolled_demand(&repo, SOURCE);
+    let mut original_catalog = support::catalog(&[7]);
+    original_catalog.install_exports(vec![AuthenticatedCallExportV1 {
+        exported_symbol: "python:pandas.public.pair".into(),
+        target_symbol: "python:pandas.fixture.pair".into(),
+        provider_id: "fixture".into(),
+    }]);
+    let table = ResolvedCallContractRefsV1::new(&original_catalog, &[demand]);
+
+    let mut changed_catalog = support::catalog(&[8]);
+    changed_catalog.install_exports(vec![AuthenticatedCallExportV1 {
+        exported_symbol: "python:pandas.public.pair".into(),
+        target_symbol: "python:pandas.fixture.pair".into(),
+        provider_id: "fixture".into(),
+    }]);
+    assert_eq!(
+        table.final_check(&changed_catalog),
+        Err(CallContractResolutionGapKindV1::StaleOrMalformedContractRef)
+    );
+
+    let mut stale_wire = table.to_wire_value();
+    stale_wire["byUseSite"][0]["resolution"]["reference"]["contractCid"] =
+        serde_json::Value::String(support::cid('f').to_string());
+    let verdict = support::python_chain_verdict(&repo, SOURCE, &stale_wire);
+    assert_eq!(verdict["stage"], "intake");
+    assert!(
+        verdict["gap"]
+            .as_str()
+            .unwrap()
+            .contains("stale semantic contract CID"),
+        "{verdict}"
+    );
+    assert!(verdict["edge"].is_null());
+}
+
+#[test]
+fn two_provider_exports_are_ambiguous_through_python_construction() {
+    let repo = support::repo();
+    let demand = support::enrolled_demand(&repo, SOURCE);
+    let mut catalog = support::catalog(&[7]);
+    catalog.install_exports(vec![
+        AuthenticatedCallExportV1 {
+            exported_symbol: "python:pandas.public.pair".into(),
+            target_symbol: "python:pandas.fixture.pair".into(),
+            provider_id: "provider-a".into(),
+        },
+        AuthenticatedCallExportV1 {
+            exported_symbol: "python:pandas.public.pair".into(),
+            target_symbol: "python:pandas.fixture.pair".into(),
+            provider_id: "provider-b".into(),
+        },
+    ]);
+    let table = ResolvedCallContractRefsV1::new(&catalog, &[demand]);
+    table.final_check(&catalog).unwrap();
+
+    let wire = table.to_wire_value();
+    assert_eq!(
+        wire["byUseSite"][0]["resolution"]["gap"]["kind"],
+        "ambiguous-target"
+    );
+    let verdict = support::python_chain_verdict(&repo, SOURCE, &wire);
+    assert_eq!(verdict["stage"], "construction");
+    assert!(verdict["gap"]
+        .as_str()
+        .unwrap()
+        .contains("ambiguous-target"));
+    assert!(verdict["edge"].is_null());
+}
+
+#[test]
+fn wrong_provider_is_loud_through_python_construction() {
+    let repo = support::repo();
+    let demand = support::enrolled_demand(&repo, SOURCE);
+    let mut catalog = support::catalog(&[7]);
+    catalog.install_exports(vec![AuthenticatedCallExportV1 {
+        exported_symbol: "python:pandas.public.pair".into(),
+        target_symbol: "python:pandas.fixture.pair".into(),
+        provider_id: "wrong-provider".into(),
+    }]);
+    let table = ResolvedCallContractRefsV1::new(&catalog, &[demand]);
+    table.final_check(&catalog).unwrap();
+
+    let wire = table.to_wire_value();
+    assert_eq!(
+        wire["byUseSite"][0]["resolution"]["gap"]["kind"],
+        "wrong-provider"
+    );
+    let verdict = support::python_chain_verdict(&repo, SOURCE, &wire);
+    assert_eq!(verdict["stage"], "construction");
+    assert!(verdict["gap"].as_str().unwrap().contains("wrong-provider"));
+    assert!(verdict["edge"].is_null());
+}

--- a/implementations/rust/sugar-linker/tests/call_contract_prebind.rs
+++ b/implementations/rust/sugar-linker/tests/call_contract_prebind.rs
@@ -2,17 +2,189 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use sugar_claim_envelope::{
-    body_contract_cid, mint_contract, Authoring, MintContractArgs, MintedEnvelope,
+    body_contract_cid, mint_context_manager_contract, mint_contract, mint_contract_with_body_cid,
+    Authoring, MintContextManagerContractArgs, MintContractArgs, MintedEnvelope,
 };
 use sugar_ir_types::Sort;
 use sugar_linker::{
     final_check_call_contract_ref, resolve_call_contract_demand, AuthenticatedCallContractCatalog,
-    CallContractDemandV1, CallContractResolutionGapKindV1, CallContractResolutionV1, Cid,
-    ResolvedCallContractRefsV1, SourceFragmentCoordinateV1,
+    AuthenticatedCallExportV1, CallContractDemandV1, CallContractResolutionGapKindV1,
+    CallContractResolutionV1, Cid, ResolvedCallContractRefsV1, SourceFragmentCoordinateV1,
+};
+use sugar_proof_envelope::{
+    ContextManagerSemanticsV1, EnterResultContractV1, ExitContractV1, ExitDispositionV1,
+    ImportSignatureV1,
 };
 
 fn cid(fill: char) -> Cid {
     Cid::from(format!("blake3-512:{}", fill.to_string().repeat(128)))
+}
+
+#[test]
+fn alias_and_reexport_terminate_at_the_same_contract_and_call_edge() {
+    let (mut catalog, _, contract_cid) = catalog();
+    catalog.install_exports(vec![
+        AuthenticatedCallExportV1 {
+            exported_symbol: "python:pandas.fixture.pair".into(),
+            target_symbol: "python:pandas.fixture.pair".into(),
+            provider_id: "fixture".into(),
+        },
+        AuthenticatedCallExportV1 {
+            exported_symbol: "python:pandas.public.pair".into(),
+            target_symbol: "python:pandas.fixture.pair".into(),
+            provider_id: "fixture".into(),
+        },
+    ]);
+    let direct = CallContractDemandV1::new(
+        use_site(),
+        cid('8'),
+        "python:pandas.fixture.pair".into(),
+        vec![],
+        vec![Sort::Primitive {
+            name: "Value".into(),
+        }],
+    );
+    let mut alias_site = use_site();
+    alias_site.start_line = 3;
+    alias_site.end_line = 3;
+    let reexport = CallContractDemandV1::new(
+        alias_site,
+        cid('9'),
+        "python:pandas.public.pair".into(),
+        vec![],
+        vec![Sort::Primitive {
+            name: "Value".into(),
+        }],
+    );
+    let CallContractResolutionV1::Resolved(direct_ref) =
+        resolve_call_contract_demand(&direct, &catalog)
+    else {
+        panic!("direct")
+    };
+    let CallContractResolutionV1::Resolved(reexport_ref) =
+        resolve_call_contract_demand(&reexport, &catalog)
+    else {
+        panic!("reexport")
+    };
+    assert_ne!(
+        direct_ref.import_binding_cid(),
+        reexport_ref.import_binding_cid()
+    );
+    assert_eq!(direct_ref.contract_cid(), &contract_cid);
+    assert_eq!(reexport_ref.contract_cid(), &contract_cid);
+    assert_eq!(
+        direct_ref.to_call_edge(cid('a'), None).target_contract_cid,
+        reexport_ref
+            .to_call_edge(cid('a'), None)
+            .target_contract_cid
+    );
+}
+
+#[test]
+fn ambiguous_export_and_wrong_provider_are_distinct_typed_gaps() {
+    let (mut ambiguous, _, _) = catalog();
+    ambiguous.install_exports(vec![
+        AuthenticatedCallExportV1 {
+            exported_symbol: "python:public.pair".into(),
+            target_symbol: "python:pandas.fixture.pair".into(),
+            provider_id: "fixture".into(),
+        },
+        AuthenticatedCallExportV1 {
+            exported_symbol: "python:public.pair".into(),
+            target_symbol: "python:other.pair".into(),
+            provider_id: "fixture".into(),
+        },
+    ]);
+    let demand = CallContractDemandV1::new(
+        use_site(),
+        cid('9'),
+        "python:public.pair".into(),
+        vec![],
+        vec![Sort::Primitive {
+            name: "Value".into(),
+        }],
+    );
+    assert!(
+        matches!(resolve_call_contract_demand(&demand, &ambiguous), CallContractResolutionV1::Unresolved(gap) if gap.kind == CallContractResolutionGapKindV1::AmbiguousTarget)
+    );
+
+    let (mut wrong, _, _) = catalog();
+    wrong.install_exports(vec![AuthenticatedCallExportV1 {
+        exported_symbol: "python:public.pair".into(),
+        target_symbol: "python:pandas.fixture.pair".into(),
+        provider_id: "wrong-kit".into(),
+    }]);
+    assert!(
+        matches!(resolve_call_contract_demand(&demand, &wrong), CallContractResolutionV1::Unresolved(gap) if gap.kind == CallContractResolutionGapKindV1::WrongProvider)
+    );
+}
+
+#[test]
+fn authenticated_export_without_contract_and_wrong_contract_kind_are_distinct() {
+    let (mut missing, _, _) = catalog();
+    missing.install_exports(vec![AuthenticatedCallExportV1 {
+        exported_symbol: "python:public.missing".into(),
+        target_symbol: "python:provider.missing".into(),
+        provider_id: "fixture".into(),
+    }]);
+    let demand = CallContractDemandV1::new(
+        use_site(),
+        cid('9'),
+        "python:public.missing".into(),
+        vec![],
+        vec![],
+    );
+    assert!(
+        matches!(resolve_call_contract_demand(&demand, &missing), CallContractResolutionV1::Unresolved(gap) if gap.kind == CallContractResolutionGapKindV1::NoAuthenticatedContract)
+    );
+
+    let bare = mint_context_manager_contract(&MintContextManagerContractArgs {
+        bridge_source_symbol: "python:pandas.fixture.pair".into(),
+        import_signature: ImportSignatureV1 {
+            formals: vec![],
+            sorts: vec![],
+        },
+        semantics: ContextManagerSemanticsV1 {
+            enter: EnterResultContractV1 {
+                sort: Sort::Primitive {
+                    name: "Value".into(),
+                },
+            },
+            exit: ExitContractV1 {
+                disposition: ExitDispositionV1::NeverSuppresses,
+            },
+        },
+        source_warrants: vec![],
+        produced_by: "fixture".into(),
+        produced_at: "2026-07-22T00:00:00.000Z".into(),
+        authoring: Authoring::KitAuthor {
+            author: "fixture".into(),
+            note: None,
+        },
+        signer_seed: [7; 32],
+    })
+    .unwrap();
+    let member_cid = Cid::from(bare.cid.clone());
+    let envelope = serde_json::from_slice(&bare.canonical_bytes).unwrap();
+    let mut wrong_kind =
+        AuthenticatedCallContractCatalog::freeze(vec![(member_cid, envelope)]).unwrap();
+    wrong_kind.install_exports(vec![AuthenticatedCallExportV1 {
+        exported_symbol: "python:public.pair".into(),
+        target_symbol: "python:pandas.fixture.pair".into(),
+        provider_id: "fixture".into(),
+    }]);
+    let wrong_demand = CallContractDemandV1::new(
+        use_site(),
+        cid('9'),
+        "python:public.pair".into(),
+        vec![],
+        vec![Sort::Primitive {
+            name: "Value".into(),
+        }],
+    );
+    assert!(
+        matches!(resolve_call_contract_demand(&wrong_demand, &wrong_kind), CallContractResolutionV1::Unresolved(gap) if gap.kind == CallContractResolutionGapKindV1::WrongContractKind)
+    );
 }
 
 fn json_to_cvalue(j: &serde_json::Value) -> std::sync::Arc<sugar_canonicalizer::Value> {
@@ -164,6 +336,64 @@ fn in_corpus_contract_resolves_to_semantic_contract_cid_not_member_cid() {
 }
 
 #[test]
+fn nontrivial_precondition_never_projects_an_unconditional_return() {
+    let mut args = contract_args(7);
+    args.pre = Some(json_to_cvalue(&serde_json::json!({
+        "kind":"atomic", "name":"eligible", "args":[{"kind":"var","name":"x"}]
+    })));
+    let minted = mint_contract_with_body_cid(&args, Some(cid('b').as_str())).unwrap();
+    let member_cid = Cid::from(minted.cid.clone());
+    let envelope = serde_json::from_slice(&minted.canonical_bytes).unwrap();
+    let catalog = AuthenticatedCallContractCatalog::freeze(vec![(member_cid, envelope)]).unwrap();
+    let demand = CallContractDemandV1::new(
+        use_site(),
+        cid('9'),
+        "python:pandas.fixture.pair".into(),
+        vec![],
+        vec![Sort::Primitive {
+            name: "Value".into(),
+        }],
+    );
+    let CallContractResolutionV1::Resolved(reference) =
+        resolve_call_contract_demand(&demand, &catalog)
+    else {
+        panic!("resolved")
+    };
+    assert!(reference.return_term().is_none());
+}
+
+#[test]
+fn stale_contract_reference_is_rejected_against_changed_semantic_declaration() {
+    let (old_catalog, _, old_contract_cid) = catalog();
+    let demand = CallContractDemandV1::new(
+        use_site(),
+        cid('9'),
+        "python:pandas.fixture.pair".into(),
+        vec![],
+        vec![Sort::Primitive {
+            name: "Value".into(),
+        }],
+    );
+    let CallContractResolutionV1::Resolved(old_ref) =
+        resolve_call_contract_demand(&demand, &old_catalog)
+    else {
+        panic!("old resolved")
+    };
+
+    let args = contract_args(7);
+    let changed = mint_contract_with_body_cid(&args, Some(cid('c').as_str())).unwrap();
+    assert_ne!(changed.contract_cid, old_contract_cid.as_str());
+    let changed_member = Cid::from(changed.cid.clone());
+    let changed_envelope = serde_json::from_slice(&changed.canonical_bytes).unwrap();
+    let changed_catalog =
+        AuthenticatedCallContractCatalog::freeze(vec![(changed_member, changed_envelope)]).unwrap();
+    assert_eq!(
+        final_check_call_contract_ref(&old_ref, &changed_catalog),
+        Err(CallContractResolutionGapKindV1::StaleOrMalformedContractRef)
+    );
+}
+
+#[test]
 fn missing_target_and_signature_mismatch_are_typed_gaps() {
     let (catalog, _, _) = catalog();
     let missing = CallContractDemandV1::new(
@@ -229,4 +459,168 @@ fn rust_table_round_trips_to_python_with_contract_and_member_cids_distinct() {
         String::from_utf8(output.stdout).unwrap(),
         format!("{member_cid}\n{contract_cid}\n")
     );
+}
+
+fn python_paths(repo: &std::path::Path) -> std::ffi::OsString {
+    let roots = std::fs::read_dir(repo.join("implementations/python"))
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path().join("src"))
+        .filter(|path| path.is_dir())
+        .collect::<Vec<_>>();
+    std::env::join_paths(roots).unwrap()
+}
+
+fn enrolled_demand(
+    repo: &std::path::Path,
+    source: &str,
+) -> (CallContractDemandV1, serde_json::Value) {
+    let script = r#"
+import json, pathlib, sys, tempfile
+from sugar_lift_py_tests import lift_rpc
+with tempfile.TemporaryDirectory() as raw:
+    root = pathlib.Path(raw)
+    (root / 'consumer.py').write_text(sys.stdin.read())
+    rows = [r for r in lift_rpc._call_contract_demand_rows(root)
+            if r.get('kind') == 'call-contract-demand']
+    assert len(rows) == 1, rows
+    print(json.dumps(rows[0]))
+"#;
+    let mut child = Command::new("python3")
+        .env("PYTHONPATH", python_paths(repo))
+        .arg("-c")
+        .arg(script)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(source.as_bytes())
+        .unwrap();
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let row: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let use_site: SourceFragmentCoordinateV1 =
+        serde_json::from_value(row["useSite"].clone()).unwrap();
+    let sorts: Vec<Sort> = serde_json::from_value(row["importSignature"]["sorts"].clone()).unwrap();
+    let formals: Vec<String> =
+        serde_json::from_value(row["importSignature"]["formals"].clone()).unwrap();
+    let demand = CallContractDemandV1::new(
+        use_site,
+        Cid::from(row["importBindingCid"].as_str().unwrap()),
+        row["targetSymbol"].as_str().unwrap().into(),
+        formals,
+        sorts,
+    );
+    (demand, row)
+}
+
+fn python_constructed_edge(
+    repo: &std::path::Path,
+    source: &str,
+    table: &serde_json::Value,
+) -> serde_json::Value {
+    let script = r#"
+import json, pathlib, sys, tempfile
+from types import MappingProxyType
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.call_contract_resolution import decode_resolved_call_contract_refs
+from sugar_lift_py_tests.context_manager_resolution import ResolvedContractRefsV1, TreeConstructionContextV1
+from sugar_source_tree.nodes import Call
+from sugar_source_tree.tree import SourceFile
+payload = json.load(sys.stdin)
+table = decode_resolved_call_contract_refs(payload['table'])
+with tempfile.TemporaryDirectory() as raw:
+    root = pathlib.Path(raw)
+    path = root / 'consumer.py'
+    path.write_text(payload['source'])
+    cm = ResolvedContractRefsV1(table.catalog_cid, 'blake3-512:' + '0' * 128, MappingProxyType({}))
+    tree = SourceFile(path_source(str(path)), construction_context=TreeConstructionContextV1(
+        cm, call_contract_refs=table, workspace_root=str(root)))
+    call = next(node for node in tree.nodes() if isinstance(node, Call))
+    outcome = call.sugar().desugar(None)
+    value = outcome.value
+    edge = value.callsites()[0]
+    print(json.dumps({'contractCid': value.contract_cid,
+                      'edgeTargetCid': edge.target_contract_cid,
+                      'edgeTargetSymbol': edge.authenticated_target_symbol}))
+"#;
+    let mut child = Command::new("python3")
+        .env("PYTHONPATH", python_paths(repo))
+        .arg("-c")
+        .arg(script)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    serde_json::to_writer(
+        child.stdin.as_mut().unwrap(),
+        &serde_json::json!({"source": source, "table": table}),
+    )
+    .unwrap();
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+#[test]
+fn alias_and_authenticated_reexport_resolve_through_python_rust_python_to_one_edge_target() {
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap()
+        .to_path_buf();
+    let direct_source = "from pandas.fixture import pair\nresult = pair(value)\n";
+    let alias_source = "from pandas.fixture import pair as renamed\nresult = renamed(value)\n";
+    let reexport_source = "from pandas.public import pair\nresult = pair(value)\n";
+    let (direct, _) = enrolled_demand(&repo, direct_source);
+    let (alias, _) = enrolled_demand(&repo, alias_source);
+    let (reexport, _) = enrolled_demand(&repo, reexport_source);
+    assert_ne!(direct.import_binding_cid, alias.import_binding_cid);
+    assert_eq!(direct.target_symbol, alias.target_symbol);
+
+    let (mut catalog, _, contract_cid) = catalog();
+    catalog.install_exports(vec![
+        AuthenticatedCallExportV1 {
+            exported_symbol: "python:pandas.fixture.pair".into(),
+            target_symbol: "python:pandas.fixture.pair".into(),
+            provider_id: "fixture".into(),
+        },
+        AuthenticatedCallExportV1 {
+            exported_symbol: "python:pandas.public.pair".into(),
+            target_symbol: "python:pandas.fixture.pair".into(),
+            provider_id: "fixture".into(),
+        },
+    ]);
+    let direct_table = ResolvedCallContractRefsV1::new(&catalog, &[direct]);
+    let alias_table = ResolvedCallContractRefsV1::new(&catalog, &[alias]);
+    let reexport_table = ResolvedCallContractRefsV1::new(&catalog, &[reexport]);
+    direct_table.final_check(&catalog).unwrap();
+    alias_table.final_check(&catalog).unwrap();
+    reexport_table.final_check(&catalog).unwrap();
+
+    let direct_edge = python_constructed_edge(&repo, direct_source, &direct_table.to_wire_value());
+    let alias_edge = python_constructed_edge(&repo, alias_source, &alias_table.to_wire_value());
+    let reexport_edge =
+        python_constructed_edge(&repo, reexport_source, &reexport_table.to_wire_value());
+    for edge in [&direct_edge, &alias_edge, &reexport_edge] {
+        assert_eq!(edge["contractCid"], contract_cid.as_str());
+        assert_eq!(edge["edgeTargetCid"], contract_cid.as_str());
+        assert_eq!(edge["edgeTargetSymbol"], "python:pandas.fixture.pair");
+    }
 }

--- a/implementations/rust/sugar-linker/tests/call_contract_prebind.rs
+++ b/implementations/rust/sugar-linker/tests/call_contract_prebind.rs
@@ -1,0 +1,232 @@
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use sugar_claim_envelope::{
+    body_contract_cid, mint_contract, Authoring, MintContractArgs, MintedEnvelope,
+};
+use sugar_ir_types::Sort;
+use sugar_linker::{
+    final_check_call_contract_ref, resolve_call_contract_demand, AuthenticatedCallContractCatalog,
+    CallContractDemandV1, CallContractResolutionGapKindV1, CallContractResolutionV1, Cid,
+    ResolvedCallContractRefsV1, SourceFragmentCoordinateV1,
+};
+
+fn cid(fill: char) -> Cid {
+    Cid::from(format!("blake3-512:{}", fill.to_string().repeat(128)))
+}
+
+fn json_to_cvalue(j: &serde_json::Value) -> std::sync::Arc<sugar_canonicalizer::Value> {
+    use sugar_canonicalizer::Value as CValue;
+    match j {
+        serde_json::Value::Null => CValue::null(),
+        serde_json::Value::Bool(value) => CValue::boolean(*value),
+        serde_json::Value::Number(value) => CValue::integer(i128::from(value.as_i64().unwrap())),
+        serde_json::Value::String(value) => CValue::string(value.clone()),
+        serde_json::Value::Array(items) => {
+            CValue::array(items.iter().map(json_to_cvalue).collect())
+        }
+        serde_json::Value::Object(map) => CValue::object(
+            map.iter()
+                .map(|(key, value)| (key.clone(), json_to_cvalue(value)))
+                .collect::<Vec<_>>(),
+        ),
+    }
+}
+
+fn use_site() -> SourceFragmentCoordinateV1 {
+    SourceFragmentCoordinateV1 {
+        source_cid: cid('1'),
+        start_line: 2,
+        start_col: 4,
+        end_line: 2,
+        end_col: 11,
+    }
+}
+
+fn contract_args(seed: u8) -> MintContractArgs {
+    let post = serde_json::json!({
+        "kind":"atomic", "name":"=", "args":[
+            {"kind":"var","name":"out"},
+            {"kind":"ctor","name":"python:tuple","args":[{"kind":"var","name":"x"}]}
+        ]
+    });
+    MintContractArgs {
+        contract_name: "pandas.fixture.pair".into(),
+        pre: None,
+        post: Some(json_to_cvalue(&post)),
+        inv: None,
+        evidence_term: None,
+        out_binding: "out".into(),
+        produced_by: "call-contract-prebind-test".into(),
+        produced_at: "2026-07-22T00:00:00.000Z".into(),
+        input_cids: vec![],
+        authoring: Authoring::KitAuthor {
+            author: "fixture".into(),
+            note: None,
+        },
+        signer_seed: [seed; 32],
+        formals: vec!["x".into()],
+        emit_empty_formals: false,
+        formal_sorts: vec![json_to_cvalue(
+            &serde_json::json!({"kind":"primitive","name":"Value"}),
+        )],
+        library: None,
+        bridge_source_symbol: Some("python:pandas.fixture.pair".into()),
+        body_discharge_eligible: true,
+        body_discharge_refusal_reason: None,
+        panic_loci: vec![],
+        class_shapes: vec![],
+        source_warrants: vec![],
+        proofir_provenance: None,
+    }
+}
+
+fn minted(seed: u8) -> MintedEnvelope {
+    mint_contract(&contract_args(seed)).unwrap()
+}
+
+fn catalog() -> (AuthenticatedCallContractCatalog, Cid, Cid) {
+    let minted = minted(7);
+    let member_cid = Cid::from(minted.cid.clone());
+    let contract_cid = Cid::from(minted.contract_cid.clone());
+    let envelope = serde_json::from_slice(&minted.canonical_bytes).unwrap();
+    (
+        AuthenticatedCallContractCatalog::freeze(vec![(member_cid.clone(), envelope)]).unwrap(),
+        member_cid,
+        contract_cid,
+    )
+}
+
+#[test]
+fn semantic_contract_identity_is_signer_independent() {
+    let first = minted(7);
+    let second = minted(8);
+    assert_eq!(first.contract_cid, second.contract_cid);
+    assert_ne!(first.cid, second.cid);
+}
+
+#[test]
+fn body_pointer_is_part_of_semantic_contract_identity() {
+    let args = contract_args(7);
+    let body_a = cid('a');
+    let rust_cid = body_contract_cid(&args, body_a.as_str());
+    assert_ne!(rust_cid, body_contract_cid(&args, cid('b').as_str()));
+    let declaration = serde_json::json!({
+        "kind": "contract",
+        "name": args.contract_name,
+        "outBinding": args.out_binding,
+        "bodyCid": body_a,
+        "formals": args.formals,
+        "formalSorts": [{"kind": "primitive", "name": "Value"}],
+    });
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap()
+        .to_path_buf();
+    let mut child = Command::new("python3")
+        .env("PYTHONPATH", repo.join("implementations/python/sugar-lift-py-tests/src"))
+        .arg("-c")
+        .arg("import json,sys; from sugar_lift_py_tests.canonicalizer import blake3_512_of,encode_jcs; from sugar_lift_py_tests.context_manager_contract import _json_value; print(blake3_512_of(encode_jcs(_json_value(json.load(sys.stdin))).encode()))")
+        .stdin(Stdio::piped()).stdout(Stdio::piped()).spawn().unwrap();
+    serde_json::to_writer(child.stdin.as_mut().unwrap(), &declaration).unwrap();
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8(output.stdout).unwrap().trim(), rust_cid);
+}
+
+#[test]
+fn in_corpus_contract_resolves_to_semantic_contract_cid_not_member_cid() {
+    let (catalog, member_cid, contract_cid) = catalog();
+    let demand = CallContractDemandV1::new(
+        use_site(),
+        cid('9'),
+        "python:pandas.fixture.pair".into(),
+        vec![],
+        vec![Sort::Primitive {
+            name: "Value".into(),
+        }],
+    );
+
+    let CallContractResolutionV1::Resolved(reference) =
+        resolve_call_contract_demand(&demand, &catalog)
+    else {
+        panic!("resolved")
+    };
+    assert_eq!(reference.member_cid(), &member_cid);
+    assert_eq!(reference.contract_cid(), &contract_cid);
+    assert_ne!(reference.member_cid(), reference.contract_cid());
+    assert!(final_check_call_contract_ref(&reference, &catalog).is_ok());
+    let edge = reference.to_call_edge(cid('7'), None);
+    assert_eq!(edge.target_contract_cid.as_ref(), Some(&contract_cid));
+    assert_ne!(edge.target_contract_cid.as_ref(), Some(&member_cid));
+}
+
+#[test]
+fn missing_target_and_signature_mismatch_are_typed_gaps() {
+    let (catalog, _, _) = catalog();
+    let missing = CallContractDemandV1::new(
+        use_site(),
+        cid('8'),
+        "python:not.in.corpus".into(),
+        vec![],
+        vec![],
+    );
+    let mismatch = CallContractDemandV1::new(
+        use_site(),
+        cid('9'),
+        "python:pandas.fixture.pair".into(),
+        vec![],
+        vec![],
+    );
+
+    assert!(matches!(
+        resolve_call_contract_demand(&missing, &catalog),
+        CallContractResolutionV1::Unresolved(gap)
+            if gap.kind == CallContractResolutionGapKindV1::TargetNotInCorpus
+    ));
+    assert!(matches!(
+        resolve_call_contract_demand(&mismatch, &catalog),
+        CallContractResolutionV1::Unresolved(gap)
+            if gap.kind == CallContractResolutionGapKindV1::ImportSignatureMismatch
+    ));
+}
+
+#[test]
+fn rust_table_round_trips_to_python_with_contract_and_member_cids_distinct() {
+    let (catalog, member_cid, contract_cid) = catalog();
+    let demand = CallContractDemandV1::new(
+        use_site(),
+        cid('9'),
+        "python:pandas.fixture.pair".into(),
+        vec![],
+        vec![Sort::Primitive {
+            name: "Value".into(),
+        }],
+    );
+    let table = ResolvedCallContractRefsV1::new(&catalog, &[demand]);
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap()
+        .to_path_buf();
+    let mut child = Command::new("python3")
+        .env("PYTHONPATH", repo.join("implementations/python/sugar-lift-py-tests/src"))
+        .arg("-c")
+        .arg("import json,sys; from sugar_lift_py_tests.call_contract_resolution import decode_resolved_call_contract_refs,ResolvedCallContractRefV1; t=decode_resolved_call_contract_refs(json.load(sys.stdin)); r=next(iter(t.by_use_site.values())); assert isinstance(r,ResolvedCallContractRefV1); print(r.member_cid); print(r.contract_cid)")
+        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped()).spawn().unwrap();
+    serde_json::to_writer(child.stdin.as_mut().unwrap(), &table.to_wire_value()).unwrap();
+    child.stdin.as_mut().unwrap().flush().unwrap();
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        format!("{member_cid}\n{contract_cid}\n")
+    );
+}

--- a/implementations/rust/sugar-linker/tests/support/call_contract_full_chain.rs
+++ b/implementations/rust/sugar-linker/tests/support/call_contract_full_chain.rs
@@ -1,0 +1,209 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use sugar_claim_envelope::{mint_contract, Authoring, MintContractArgs};
+use sugar_ir_types::Sort;
+use sugar_linker::{
+    AuthenticatedCallContractCatalog, CallContractDemandV1, Cid, SourceFragmentCoordinateV1,
+};
+
+pub fn cid(fill: char) -> Cid {
+    Cid::from(format!("blake3-512:{}", fill.to_string().repeat(128)))
+}
+
+fn json_to_cvalue(j: &serde_json::Value) -> std::sync::Arc<sugar_canonicalizer::Value> {
+    use sugar_canonicalizer::Value as CValue;
+    match j {
+        serde_json::Value::Null => CValue::null(),
+        serde_json::Value::Bool(value) => CValue::boolean(*value),
+        serde_json::Value::Number(value) => CValue::integer(i128::from(value.as_i64().unwrap())),
+        serde_json::Value::String(value) => CValue::string(value.clone()),
+        serde_json::Value::Array(items) => {
+            CValue::array(items.iter().map(json_to_cvalue).collect())
+        }
+        serde_json::Value::Object(map) => CValue::object(
+            map.iter()
+                .map(|(key, value)| (key.clone(), json_to_cvalue(value)))
+                .collect::<Vec<_>>(),
+        ),
+    }
+}
+
+fn contract_args(seed: u8) -> MintContractArgs {
+    MintContractArgs {
+        contract_name: "pandas.fixture.pair".into(),
+        pre: None,
+        post: Some(json_to_cvalue(&serde_json::json!({
+            "kind":"atomic", "name":"=", "args":[
+                {"kind":"var","name":"out"},
+                {"kind":"ctor","name":"python:tuple","args":[{"kind":"var","name":"x"}]}
+            ]
+        }))),
+        inv: None,
+        evidence_term: None,
+        out_binding: "out".into(),
+        produced_by: "call-contract-full-chain-negative-test".into(),
+        produced_at: "2026-07-22T00:00:00.000Z".into(),
+        input_cids: vec![],
+        authoring: Authoring::KitAuthor {
+            author: format!("provider-{seed}"),
+            note: None,
+        },
+        signer_seed: [seed; 32],
+        formals: vec!["x".into()],
+        emit_empty_formals: false,
+        formal_sorts: vec![json_to_cvalue(
+            &serde_json::json!({"kind":"primitive","name":"Value"}),
+        )],
+        library: None,
+        bridge_source_symbol: Some("python:pandas.fixture.pair".into()),
+        body_discharge_eligible: true,
+        body_discharge_refusal_reason: None,
+        panic_loci: vec![],
+        class_shapes: vec![],
+        source_warrants: vec![],
+        proofir_provenance: None,
+    }
+}
+
+pub fn catalog(seeds: &[u8]) -> AuthenticatedCallContractCatalog {
+    let members = seeds
+        .iter()
+        .map(|seed| {
+            let minted = mint_contract(&contract_args(*seed)).unwrap();
+            (
+                Cid::from(minted.cid),
+                serde_json::from_slice(&minted.canonical_bytes).unwrap(),
+            )
+        })
+        .collect();
+    AuthenticatedCallContractCatalog::freeze(members).unwrap()
+}
+
+pub fn repo() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap()
+        .to_path_buf()
+}
+
+fn python_paths(repo: &Path) -> std::ffi::OsString {
+    let roots = std::fs::read_dir(repo.join("implementations/python"))
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path().join("src"))
+        .filter(|path| path.is_dir())
+        .collect::<Vec<_>>();
+    std::env::join_paths(roots).unwrap()
+}
+
+pub fn enrolled_demand(repo: &Path, source: &str) -> CallContractDemandV1 {
+    let script = r#"
+import json, pathlib, sys, tempfile
+from sugar_lift_py_tests import lift_rpc
+with tempfile.TemporaryDirectory() as raw:
+    root = pathlib.Path(raw)
+    (root / 'consumer.py').write_text(sys.stdin.read())
+    rows = [r for r in lift_rpc._call_contract_demand_rows(root)
+            if r.get('kind') == 'call-contract-demand']
+    assert len(rows) == 1, rows
+    print(json.dumps(rows[0]))
+"#;
+    let mut child = Command::new("python3")
+        .env("PYTHONPATH", python_paths(repo))
+        .arg("-c")
+        .arg(script)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(source.as_bytes())
+        .unwrap();
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let row: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let use_site: SourceFragmentCoordinateV1 =
+        serde_json::from_value(row["useSite"].clone()).unwrap();
+    let sorts: Vec<Sort> = serde_json::from_value(row["importSignature"]["sorts"].clone()).unwrap();
+    let formals: Vec<String> =
+        serde_json::from_value(row["importSignature"]["formals"].clone()).unwrap();
+    CallContractDemandV1::new(
+        use_site,
+        Cid::from(row["importBindingCid"].as_str().unwrap()),
+        row["targetSymbol"].as_str().unwrap().into(),
+        formals,
+        sorts,
+    )
+}
+
+pub fn python_chain_verdict(
+    repo: &Path,
+    source: &str,
+    table: &serde_json::Value,
+) -> serde_json::Value {
+    let script = r#"
+import json, pathlib, sys, tempfile
+from types import MappingProxyType
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.call_contract_resolution import CallContractRefProtocolError, decode_resolved_call_contract_refs
+from sugar_lift_py_tests.context_manager_resolution import ResolvedContractRefsV1, TreeConstructionContextV1
+from sugar_source_tree.nodes import Call
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+payload = json.load(sys.stdin)
+try:
+    table = decode_resolved_call_contract_refs(payload['table'])
+except CallContractRefProtocolError as error:
+    print(json.dumps({'stage':'intake', 'gap':str(error), 'edge':None}))
+    raise SystemExit(0)
+with tempfile.TemporaryDirectory() as raw:
+    root = pathlib.Path(raw)
+    path = root / 'consumer.py'
+    path.write_text(payload['source'])
+    cm = ResolvedContractRefsV1(table.catalog_cid, 'blake3-512:' + '0' * 128, MappingProxyType({}))
+    tree = SourceFile(path_source(str(path)), construction_context=TreeConstructionContextV1(
+        cm, call_contract_refs=table, workspace_root=str(root)))
+    call = next(node for node in tree.nodes() if isinstance(node, Call))
+    try:
+        outcome = call.sugar().desugar(None)
+    except SugarNotWritten as error:
+        print(json.dumps({'stage':'construction', 'gap':str(error), 'edge':None}))
+        raise SystemExit(0)
+    edges = outcome.value.callsites()
+    print(json.dumps({'stage':'edge', 'gap':None, 'edgeCount':len(edges)}))
+"#;
+    let mut child = Command::new("python3")
+        .env("PYTHONPATH", python_paths(repo))
+        .arg("-c")
+        .arg(script)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    serde_json::to_writer(
+        child.stdin.as_mut().unwrap(),
+        &serde_json::json!({"source": source, "table": table}),
+    )
+    .unwrap();
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}


### PR DESCRIPTION
Part of #6086

Introduces the minimal authenticated imported-call preconstruction bridge:

- source-authority import binding CID + stable call use-site + positional ImportSignature demand
- final frozen in-corpus contract catalog resolution in the existing Rust linker authority
- immutable ResolvedCallContractRefV1 installed before Python construction
- ordinary call edge carries the semantic ContractDecl CID (never the attestation/member CID)
- exact structural contract posts may project a value; unresolved, mismatched, stale, unauthenticated, non-structural, or free-name projections remain loud
- no consumer-side source hunting or body inlining

Identity evidence:
- signer-independent semantic contract CID with bodyCid in its JCS preimage
- distinct member/attestation CID retained only as authentication testimony
- Python/Rust compute the same semantic CID
- resolved ref and LinkerCallEdge target the same semantic CID

Honest pandas measurement (pandas 3.0.3): direct-gap delta = 0. The PoC makes an authenticated in-corpus imported call value contract-backed, but the sole currently constructible exact structural pandas producer observed (`fill_mi_header`) remains under an independently loud mixed-store assignment target. No fall-through was fabricated and no R gain is claimed.

Receipts:
- focused Python: 23 passed
- battleaxe sugar-linker call_contract_prebind: 5 passed
- battleaxe sugar-compiler --lib --no-run: passed

Epsilon R_direct_gap = 0; the change establishes the bridge substrate for the authenticated/projectable portion of the symbolic floor.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add in-corpus import bridge for resolved call-contract references with pandas symbolic floor
> - Introduces end-to-end support for authenticated cross-module call-contract references: the orchestrator performs a preliminary corpus pass, resolves call-contract demands and exports into a typed table, binds it to the kit via a new `sugar.plugin.bind_call_contract_refs` RPC, and validates the table after merge.
> - Adds [`call_contract_resolution.py`](https://github.com/TSavo/sugar/pull/6090/files#diff-50d61642e00ccc146e5908abd4fc29cd677ec72ef884925013ab63fb3f007634) with strict hash-authenticated decoders for resolved and gap call-contract ref tables, including CID recomputation and free-variable checks.
> - Adds [`BridgedContractValue`](https://github.com/TSavo/sugar/pull/6090/files#diff-42d7fff9d6e111db2053a607dc7714fdbf0c6fd49d9a560448d8f888c58ab21b) and extends [`CallSiteSugar`](https://github.com/TSavo/sugar/pull/6090/files#diff-d7d594636ed207e69db76dd7b89c48760b0d3de93da23981143b3c45da88a3c7) to substitute authenticated structural return terms and project tuple elements at authenticated call sites.
> - Strips value-resolution logic from [`ImportAliasValue`](https://github.com/TSavo/sugar/pull/6090/files#diff-b1992669bfd368dc6ab4f8563e3a5a0417a646087f11e82ae95e168a9ec5ad62): all operator, truthiness, and attribute operations now uniformly emit construction gaps instead of attempting runtime resolution.
> - Adds `bridge_source_symbol` computation for module-level functions in [`nodes.py`](https://github.com/TSavo/sugar/pull/6090/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) and propagates it through `FunctionUniverseSugar` and `UniverseValue` so producers can be identified by qualified Python symbol.
> - Risk: `ImportAliasValue` behavior is a breaking change — code paths that previously returned resolved values or truthy results now always raise construction gap errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68e4a6a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->