### PR TITLE
drain: exact bridged imported values flow through calls and Name assignments (pandas)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -113,7 +113,7 @@ class CallSiteSugar(Sugar):
     def _collect_bridged(self, positional: tuple) -> Outcome:
         from sugar_lift_py_tests.floor.bridged_contract_value import BridgedContractValue
         from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
-        from sugar_lift_py_tests.ir import _Ctor, _free_vars_in_term, subst_var_in_term
+        from sugar_lift_py_tests.ir import _free_vars_in_term, subst_var_in_term
         from sugar_lift_py_tests.outcome import Complete
         from sugar_source_tree.panic import SugarNotWritten
 
@@ -130,25 +130,18 @@ class CallSiteSugar(Sugar):
             raise SugarNotWritten(
                 owner="CallSiteSugar.desugar",
                 observed="authenticated contract has no exact return equality",
-                requested="exact structural return testimony",
+                requested="exact return testimony",
                 fix="strengthen the contract or keep the imported value loud",
             )
         if not _free_vars_in_term(term) <= set(reference.formals):
             raise SugarNotWritten(
                 owner="CallSiteSugar.desugar",
-                observed="authenticated structural return contains an unbound projection",
+                observed="authenticated return contains an unbound projection",
                 requested="return variables authenticated by the target formal list",
                 fix="reject the stale or lying contract reference",
             )
         for formal, actual in zip(reference.formals, positional):
             term = subst_var_in_term(term, formal, actual.to_term(owner=str(self.site)))
-        if not isinstance(term, _Ctor) or term.name not in {"tuple", "python:tuple", "python:list"}:
-            raise SugarNotWritten(
-                owner="CallSiteSugar.desugar",
-                observed="authenticated contract has no exact structural return",
-                requested="structural return term carried by the target contract",
-                fix="strengthen the target contract or keep the imported value loud",
-            )
         callsite = CallSiteValue(
             target_name=self.target_name,
             arg_values=positional,

--- a/implementations/python/sugar-lift-py-tests/tests/test_call_contract_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_call_contract_resolution.py
@@ -7,11 +7,13 @@ import pytest
 
 from sugar_lift_py_tests.call_contract_resolution import (
     CallContractRefProtocolError,
+    CallContractResolutionGapKindV1,
+    CallContractResolutionGapV1,
     ResolvedCallContractRefV1,
     ResolvedCallContractRefsV1,
     decode_resolved_call_contract_refs,
 )
-from sugar_lift_py_tests.ir import PrimitiveSort, ctor, make_var, str_const
+from sugar_lift_py_tests.ir import PrimitiveSort, ctor, eq, make_var
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
 from sugar_lift_py_tests.sugar.name_sugar import NameSugar
@@ -66,7 +68,7 @@ def test_authenticated_structural_return_projects_from_one_bridged_contract():
     )
 
 
-def test_unresolved_or_non_structural_reference_stays_loud():
+def test_unresolved_or_non_exact_reference_stays_loud():
     unresolved = CallSiteSugar(
         target_name="missing",
         args=(),
@@ -77,16 +79,32 @@ def test_unresolved_or_non_structural_reference_stays_loud():
     with pytest.raises(SugarNotWritten, match="unresolved-symbol"):
         unresolved.desugar(None)
 
-    non_structural = _reference().__class__(
-        **{**_reference().__dict__, "return_term": ctor("call:other", [str_const("x")])}
+    non_exact = _reference().__class__(
+        **{**_reference().__dict__, "return_term": None}
     )
-    with pytest.raises(SugarNotWritten, match="structural return"):
+    with pytest.raises(SugarNotWritten, match="exact return equality"):
         CallSiteSugar(
             target_name="pair",
             args=(NameSugar("value", site="value"),),
             site="consumer.py:2",
-            contract_ref=non_structural,
+            contract_ref=non_exact,
         ).desugar(None)
+
+
+def test_exact_scalar_return_builds_contract_backed_call_value():
+    reference = replace(_reference(), return_term=make_var("x"))
+
+    outcome = CallSiteSugar(
+        target_name="identity",
+        args=(NameSugar("value", site="value"),),
+        site="consumer.py:2",
+        contract_ref=reference,
+    ).desugar(None)
+
+    assert isinstance(outcome, Complete)
+    assert outcome.value.to_term(owner="test") == make_var("value")
+    assert outcome.value.contract_cid == CID
+    assert outcome.value.callsites()[0].target_contract_cid == CID
 
 
 def test_fabricated_or_unauthenticated_reference_fails_decode():
@@ -233,6 +251,90 @@ def test_parser_backed_imported_call_consumes_prebound_contract_ref(tmp_path):
     assert isinstance(outcome, Complete)
     assert outcome.value.contract_cid == CID
     assert outcome.value.callsites()[0].target_contract_cid == CID
+
+
+def test_name_assignment_inherits_exact_bridged_scalar_value(tmp_path):
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ResolvedContractRefsV1,
+        SourceFragmentCoordinateV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_source_tree.tree import SourceFile
+
+    consumer = tmp_path / "consumer.py"
+    consumer.write_text(
+        "from producer import identity\n"
+        "def consume(v):\n"
+        "    y = identity(v)\n"
+        "    return y\n"
+    )
+    row = lift_rpc._call_contract_demand_rows(tmp_path)[0]
+    coordinate = SourceFragmentCoordinateV1.decode(row["useSite"])
+    reference = replace(
+        _reference(),
+        use_site=coordinate,
+        import_binding_cid=row["importBindingCid"],
+        bridge_source_symbol="python:producer.identity",
+        return_term=make_var("x"),
+    )
+    table = ResolvedCallContractRefsV1(
+        CATALOG_CID, TABLE_CID, MappingProxyType({coordinate: reference})
+    )
+    cm_refs = ResolvedContractRefsV1(CATALOG_CID, TABLE_CID, MappingProxyType({}))
+    tree = SourceFile(
+        path_source(str(consumer)),
+        construction_context=TreeConstructionContextV1(
+            cm_refs, call_contract_refs=table, workspace_root=str(tmp_path)
+        ),
+    )
+
+    outcome = next(tree.functions()).sugar().desugar(None)
+
+    assert isinstance(outcome, Complete)
+    assert outcome.value.post() == eq(make_var("out"), make_var("v"))
+    assert outcome.value.call_edges()[0]["targetContractCid"] == CID
+
+
+def test_unresolved_import_name_assignment_stays_loud(tmp_path):
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ResolvedContractRefsV1,
+        SourceFragmentCoordinateV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_source_tree.tree import SourceFile
+
+    consumer = tmp_path / "consumer.py"
+    consumer.write_text(
+        "from outside import identity\n"
+        "def consume(v):\n"
+        "    y = identity(v)\n"
+        "    return y\n"
+    )
+    row = lift_rpc._call_contract_demand_rows(tmp_path)[0]
+    coordinate = SourceFragmentCoordinateV1.decode(row["useSite"])
+    gap = CallContractResolutionGapV1(
+        DEMAND_CID,
+        coordinate,
+        row["importBindingCid"],
+        row["targetSymbol"],
+        CallContractResolutionGapKindV1.TARGET_NOT_IN_CORPUS,
+        (),
+    )
+    table = ResolvedCallContractRefsV1(
+        CATALOG_CID, TABLE_CID, MappingProxyType({coordinate: gap})
+    )
+    cm_refs = ResolvedContractRefsV1(CATALOG_CID, TABLE_CID, MappingProxyType({}))
+    tree = SourceFile(
+        path_source(str(consumer)),
+        construction_context=TreeConstructionContextV1(
+            cm_refs, call_contract_refs=table, workspace_root=str(tmp_path)
+        ),
+    )
+
+    with pytest.raises(SugarNotWritten, match="target-not-in-corpus"):
+        next(tree.functions()).sugar().desugar(None)
 
 
 def test_producer_contract_exports_the_same_module_qualified_symbol(tmp_path):


### PR DESCRIPTION
Stacked on #6090.

The resolver foundation already authenticates imported calls and installs an exact contract return term, but its construction consumer admitted only tuple/list terms. This narrow follow-on removes only that container-shape gate:

- any exact decoded return term whose free variables are authenticated formals becomes a `BridgedContractValue`;
- the ordinary call edge retains the semantic ContractDecl CID from #6090;
- existing Name substitution carries that contract-backed value through `y = imported_fn(x)` and later reads without adding new assignment semantics;
- unresolved imports, missing exact posts, signature mismatches, and unauthenticated free variables remain loud.

Twins:
- exact scalar imported call builds contract-backed and carries targetContractCid;
- parser-backed Name assignment returns the bridged value and emits the authenticated call edge;
- unresolved imported call beneath the Name assignment remains SugarNotWritten.

Honest pandas 3.0.3 measurement:
- exact, constructible, decoder-representable imported-call occurrences: 463
- already structural/building on #6090: 1
- newly building exact non-structural occurrences: 462
- unexpected construction failures: 0
- observed Delta direct_gap_R: -462

The measurement constructs producer contract rows, requires an exact `out = term` post, enforces free-vars <= authenticated formals and exact arity, decodes through the production Python term decoder, then exercises CallSiteSugar. It excludes 16 raw candidates whose terms are not decoder-representable; no optimistic/static count is claimed.

Receipts:
- focused Python bridge/With authority suite: 26 passed
- focused call-contract suite: 11 passed
- battleaxe Rust call_contract_prebind round-trip: 5 passed
- battleaxe sugar-compiler --lib --no-run: passed

Epsilon R_direct_gap = -462. No merge requested.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow scalar return terms to flow through calls and Name assignments in `CallSiteSugar`
> - Removes the restriction in `CallSiteSugar._collect_bridged` that required the authenticated return term to be a `tuple`/`list` constructor; any exact return term with free vars confined to formals is now accepted.
> - Adds tests covering scalar return desugaring, Name assignment inheritance of scalar bridged values, and unresolved import gap handling.
> - Behavioral Change: error messages no longer use "structural" wording; they now request "exact return testimony" instead of "exact structural return testimony".
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0772154.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->