### PR TITLE
fix: Python formatting (core format check)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/measurements/issue-5338-repeatability/probe_script.py
+++ b/implementations/python/sugar-lift-py-tests/measurements/issue-5338-repeatability/probe_script.py
@@ -6,7 +6,9 @@ import sys
 import time
 from pathlib import Path
 
-SCRIPT = Path("/workspace/sugar/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py")
+SCRIPT = Path(
+    "/workspace/sugar/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py"
+)
 
 TARGETS = [
     ("numpy", "random/tests/test_random.py"),
@@ -31,7 +33,9 @@ def run_one(rel, abspath):
     cmd = [sys.executable, str(SCRIPT), "--child-file", abspath, "--child-rel", rel]
     t0 = time.time()
     try:
-        proc = subprocess.run(cmd, text=True, capture_output=True, timeout=30, env=env, check=False)
+        proc = subprocess.run(
+            cmd, text=True, capture_output=True, timeout=30, env=env, check=False
+        )
         elapsed = time.time() - t0
         out = proc.stdout.strip().splitlines()
         last_json = None
@@ -48,7 +52,8 @@ def run_one(rel, abspath):
             "returncode": proc.returncode,
             "signal": signal_num,
             "outcome": (last_json or {}).get("outcome"),
-            "detail": (last_json or {}).get("mechanism") or (last_json or {}).get("reason"),
+            "detail": (last_json or {}).get("mechanism")
+            or (last_json or {}).get("reason"),
             "timed_out": False,
             "stderr_tail": proc.stderr[-500:] if proc.returncode != 0 else "",
         }

--- a/implementations/python/sugar-lift-py-tests/measurements/issue-5919/probe_script.py
+++ b/implementations/python/sugar-lift-py-tests/measurements/issue-5919/probe_script.py
@@ -49,7 +49,9 @@ def run_one(rel, abspath, with_manifest):
     cmd = [sys.executable, str(SCRIPT), "--child-file", abspath, "--child-rel", rel]
     t0 = time.time()
     try:
-        proc = subprocess.run(cmd, text=True, capture_output=True, timeout=30, env=env, check=False)
+        proc = subprocess.run(
+            cmd, text=True, capture_output=True, timeout=30, env=env, check=False
+        )
         elapsed = time.time() - t0
         out = proc.stdout.strip().splitlines()
         last_json = None
@@ -87,7 +89,9 @@ for package, rels in TARGETS.items():
         abspath = str(root / rel)
         full_rel = f"{package}/{rel}"
         if not (root / rel).exists():
-            results.append({"file": full_rel, "error": "file not found in installed package"})
+            results.append(
+                {"file": full_rel, "error": "file not found in installed package"}
+            )
             continue
         for wm in (False, True):
             results.append(run_one(full_rel, abspath, wm))
@@ -98,10 +102,19 @@ if sk_spec and sk_spec.origin:
     sk_path = sk_root / "utils" / "tests" / "test_stats.py"
     if sk_path.exists():
         for wm in (False, True):
-            results.append(run_one("sklearn/utils/tests/test_stats.py", str(sk_path), wm))
+            results.append(
+                run_one("sklearn/utils/tests/test_stats.py", str(sk_path), wm)
+            )
     else:
-        results.append({"file": "sklearn/utils/tests/test_stats.py", "error": "not found under sklearn root"})
+        results.append(
+            {
+                "file": "sklearn/utils/tests/test_stats.py",
+                "error": "not found under sklearn root",
+            }
+        )
 else:
-    results.append({"file": "sklearn/utils/tests/test_stats.py", "error": "sklearn not installed"})
+    results.append(
+        {"file": "sklearn/utils/tests/test_stats.py", "error": "sklearn not installed"}
+    )
 
 print(json.dumps(results, indent=2))

--- a/implementations/python/sugar-lift-py-tests/measurements/issue-5919/repeat_script.py
+++ b/implementations/python/sugar-lift-py-tests/measurements/issue-5919/repeat_script.py
@@ -39,7 +39,9 @@ def run_one(rel, abspath, with_manifest):
     cmd = [sys.executable, str(SCRIPT), "--child-file", abspath, "--child-rel", rel]
     t0 = time.time()
     try:
-        proc = subprocess.run(cmd, text=True, capture_output=True, timeout=30, env=env, check=False)
+        proc = subprocess.run(
+            cmd, text=True, capture_output=True, timeout=30, env=env, check=False
+        )
         elapsed = time.time() - t0
         out = proc.stdout.strip().splitlines()
         last_json = None

--- a/implementations/python/sugar-lift-py-tests/measurements/issue-5919/sklearn_script.py
+++ b/implementations/python/sugar-lift-py-tests/measurements/issue-5919/sklearn_script.py
@@ -27,10 +27,19 @@ def run_one(with_manifest):
         env["SUGAR_KIT_MANIFEST"] = manifest_path
     else:
         env.pop("SUGAR_KIT_MANIFEST", None)
-    cmd = [sys.executable, str(SCRIPT), "--child-file", str(sk_path), "--child-rel", "sklearn/utils/tests/test_stats.py"]
+    cmd = [
+        sys.executable,
+        str(SCRIPT),
+        "--child-file",
+        str(sk_path),
+        "--child-rel",
+        "sklearn/utils/tests/test_stats.py",
+    ]
     t0 = time.time()
     try:
-        proc = subprocess.run(cmd, text=True, capture_output=True, timeout=30, env=env, check=False)
+        proc = subprocess.run(
+            cmd, text=True, capture_output=True, timeout=30, env=env, check=False
+        )
         elapsed = time.time() - t0
         out = proc.stdout.strip().splitlines()
         last_json = None
@@ -51,7 +60,11 @@ def run_one(with_manifest):
         }
     except subprocess.TimeoutExpired:
         elapsed = time.time() - t0
-        return {"with_manifest": with_manifest, "elapsed_s": round(elapsed, 2), "timed_out": True}
+        return {
+            "with_manifest": with_manifest,
+            "elapsed_s": round(elapsed, 2),
+            "timed_out": True,
+        }
 
 
 for wm in (False, True):

--- a/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
@@ -92,9 +92,7 @@ def require_python_paths(roots: Sequence[Path]) -> list[Path]:
     return paths
 
 
-def _run_isolated(
-    path: Path, *, root: Path, file_timeout: int
-) -> ChildResult:
+def _run_isolated(path: Path, *, root: Path, file_timeout: int) -> ChildResult:
     rel = path.resolve().relative_to(root.resolve()).as_posix()
     env = dict(os.environ)
     env["PYTHONFAULTHANDLER"] = "1"

--- a/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
@@ -92,9 +92,7 @@ def _handler_names(handler: ast.ExceptHandler) -> set[str]:
 
 def _catches_construction_panic(handler: ast.ExceptHandler) -> bool:
     names = _handler_names(handler)
-    return bool(names & {"ConstructionPanic", "BaseException"}) or names == {
-        "<bare>"
-    }
+    return bool(names & {"ConstructionPanic", "BaseException"}) or names == {"<bare>"}
 
 
 def _is_terminal_raise(stmt: ast.AST) -> bool:
@@ -287,7 +285,11 @@ def scan_package(package_root: Path) -> list[PanicCatchOffender]:
             ):
                 continue
             body_text = ast.unparse(node)
-            if "return None" in body_text or "return" in body_text and "raise" not in body_text:
+            if (
+                "return None" in body_text
+                or "return" in body_text
+                and "raise" not in body_text
+            ):
                 offenders.append(
                     PanicCatchOffender(
                         path=rel,
@@ -324,12 +326,8 @@ def scan_repository(kit_root: Path) -> list[PanicCatchOffender]:
 
 
 def format_report(offenders: list[PanicCatchOffender]) -> str:
-    panic_offenders = [
-        row for row in offenders if not row.kind.startswith("auditor-")
-    ]
-    auditor_errors = [
-        row for row in offenders if row.kind.startswith("auditor-")
-    ]
+    panic_offenders = [row for row in offenders if not row.kind.startswith("auditor-")]
+    auditor_errors = [row for row in offenders if row.kind.startswith("auditor-")]
     lines = [
         f"R_construction_panic_catches_outside_audit = {len(panic_offenders)}",
         f"auditor_errors = {len(auditor_errors)}",
@@ -366,7 +364,9 @@ def main() -> int:
         )
         print(format_report(offenders))
         return 1
-    print("FACTORY-PANIC-CATCH LAW GREEN: R_construction_panic_catches_outside_audit = 0")
+    print(
+        "FACTORY-PANIC-CATCH LAW GREEN: R_construction_panic_catches_outside_audit = 0"
+    )
     return 0
 
 

--- a/implementations/python/sugar-lift-py-tests/scripts/corpus_factory_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/corpus_factory_recensus.py
@@ -140,9 +140,9 @@ def main() -> None:
                 counts[f"lift_coverage.{key}"] += value
 
         for row in payload.factory_walk:
-            status_value = getattr(
-                getattr(row, "status", None), "value", None
-            ) or str(getattr(row, "status", "") or "")
+            status_value = getattr(getattr(row, "status", None), "value", None) or str(
+                getattr(row, "status", "") or ""
+            )
             # Permanent product-completeness axis (#5252): unclassified /
             # wire-unresolved walk rows are honest red residue, not success.
             # Retain a row-addressable locus for shape-split drain.

--- a/implementations/python/sugar-lift-py-tests/scripts/factory_ownership_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/factory_ownership_law.py
@@ -294,9 +294,7 @@ def format_report(offenders: list[OwnershipOffender]) -> str:
     ownership_offenders = [
         row for row in offenders if not row.kind.startswith("auditor-")
     ]
-    auditor_errors = [
-        row for row in offenders if row.kind.startswith("auditor-")
-    ]
+    auditor_errors = [row for row in offenders if row.kind.startswith("auditor-")]
     lines = [
         f"R_ownership = {len(ownership_offenders)}",
         f"auditor_errors = {len(auditor_errors)}",

--- a/implementations/python/sugar-lift-py-tests/scripts/factory_walk_unclassified_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/factory_walk_unclassified_law.py
@@ -74,7 +74,9 @@ def r_factory_walk_unclassified(rows: Sequence[Any] | Iterable[Any]) -> int:
     return sum(1 for row in rows if is_unclassified_row(row))
 
 
-def _synthesize_unclassified_from_counts(counts: Mapping[Any, Any]) -> list[dict[str, str]]:
+def _synthesize_unclassified_from_counts(
+    counts: Mapping[Any, Any],
+) -> list[dict[str, str]]:
     """Expand a status→count map into opaque unclassified/unresolved rows."""
     synthetic: list[dict[str, str]] = []
     for status_name in ("unclassified", "unresolved"):
@@ -344,11 +346,11 @@ def measure_live_roots(
     counts = {
         "files_discovered": len(results),
         "files_completed": sum(row.get("category") == "completed" for row in results),
-        "construction_panics": sum(row.get("category") == "factory-panic" for row in results),
-        "timeouts": sum(row.get("category") == "timeout" for row in results),
-        "native_crashes": sum(
-            row.get("category") == "native-crash" for row in results
+        "construction_panics": sum(
+            row.get("category") == "factory-panic" for row in results
         ),
+        "timeouts": sum(row.get("category") == "timeout" for row in results),
+        "native_crashes": sum(row.get("category") == "native-crash" for row in results),
         "auditor_errors": sum(
             row.get("category") == "auditor-error" for row in results
         ),
@@ -498,8 +500,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 2
     if r > 0:
         print(
-            "FACTORY-WALK-UNCLASSIFIED LAW RED: "
-            f"{r} unclassified factory-walk rows"
+            "FACTORY-WALK-UNCLASSIFIED LAW RED: " f"{r} unclassified factory-walk rows"
         )
         print(format_report(rows, limit=args.limit))
         print(json.dumps(summary))

--- a/implementations/python/sugar-lift-py-tests/scripts/finite_cap_opaque_completion_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/finite_cap_opaque_completion_law.py
@@ -109,9 +109,7 @@ def _is_forbidden_cap_complete(node: ast.Call) -> bool:
         return False
     payload = node.args[0]
     constructor = (
-        _name(payload.func).split(".")[-1]
-        if isinstance(payload, ast.Call)
-        else ""
+        _name(payload.func).split(".")[-1] if isinstance(payload, ast.Call) else ""
     )
     # Over-cap Complete is closed by default.  Only an exact compact value whose
     # identity contains the finite constructor/elements/count is admitted.
@@ -131,9 +129,7 @@ def _forbidden_exit(
         helper = node.value.func.id
         if helper not in resolving:
             for returned in helpers.get(helper, ()):
-                forbidden = _forbidden_exit(
-                    returned, helpers, resolving | {helper}
-                )
+                forbidden = _forbidden_exit(returned, helpers, resolving | {helper})
                 if forbidden is not None:
                     return forbidden
     for child in ast.walk(node.value):
@@ -166,9 +162,9 @@ def _over_cap_returns(tree: ast.AST, node: ast.If) -> list[ast.Return]:
     left_is_cardinality = _looks_like_finite_cardinality(node.test.left)
     right_is_cardinality = _looks_like_finite_cardinality(node.test.comparators[0])
     op = node.test.ops[0]
-    body_is_over = (
-        left_is_cardinality and isinstance(op, (ast.Gt, ast.GtE))
-    ) or (right_is_cardinality and isinstance(op, (ast.Lt, ast.LtE)))
+    body_is_over = (left_is_cardinality and isinstance(op, (ast.Gt, ast.GtE))) or (
+        right_is_cardinality and isinstance(op, (ast.Lt, ast.LtE))
+    )
     if body_is_over:
         return _returns_in(node.body)
     if node.orelse:
@@ -220,7 +216,9 @@ def scan_source(source: str, *, path: str) -> list[FiniteCapOpaqueCompletion]:
     offenders: list[FiniteCapOpaqueCompletion] = []
     seen: set[tuple[int, str]] = set()
     parents = {
-        child: parent for parent in ast.walk(tree) for child in ast.iter_child_nodes(parent)
+        child: parent
+        for parent in ast.walk(tree)
+        for child in ast.iter_child_nodes(parent)
     }
 
     # A force-curry inside a branch that has already authenticated a finite
@@ -273,8 +271,7 @@ def scan_source(source: str, *, path: str) -> list[FiniteCapOpaqueCompletion]:
         helpers = {
             item.name: _returns_in(item.body)
             for item in ast.walk(tree)
-            if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
-            and item.name
+            if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and item.name
         }
         controlled = _over_cap_returns(tree, node)
         for returned in controlled:

--- a/implementations/python/sugar-lift-py-tests/scripts/measure_exit_disposition_delta.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/measure_exit_disposition_delta.py
@@ -79,7 +79,11 @@ def main() -> int:
                     if id_ is None:
                         continue
                     for family, spellings in FAMILIES.items():
-                        if id_ in spellings or id_.endswith("." + family) or id_ == family:
+                        if (
+                            id_ in spellings
+                            or id_.endswith("." + family)
+                            or id_ == family
+                        ):
                             # proven iff class proof exists (same definition)
                             if proofs[family] is not None:
                                 counts[family]["proven_never_suppresses"] += 1

--- a/implementations/python/sugar-lift-py-tests/scripts/measure_formatted_value_frontier.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/measure_formatted_value_frontier.py
@@ -61,7 +61,9 @@ def measure(root: Path) -> dict[str, object]:
             source, filename, source_cid = path_source(path)
             parsed = ast.parse(source, filename=str(path))
             native_nodes = [
-                node for node in ast.walk(parsed) if isinstance(node, ast.FormattedValue)
+                node
+                for node in ast.walk(parsed)
+                if isinstance(node, ast.FormattedValue)
             ]
             if not native_nodes:
                 counts["files_without_formatted_value"] += 1
@@ -138,9 +140,7 @@ def measure(root: Path) -> dict[str, object]:
         "counts": dict(sorted(counts.items())),
         "direct_gap_by_shape": dict(sorted(direct_by_shape.items())),
         "roll_call": dict(sorted(roll_call.items())),
-        "roll_call_blocked_by_child": dict(
-            sorted(roll_call_blocked_by_child.items())
-        ),
+        "roll_call_blocked_by_child": dict(sorted(roll_call_blocked_by_child.items())),
         "blocked_descendant_by_child": dict(sorted(blocked_by_child.items())),
         "other_panics": dict(sorted(other_panics.items())),
     }

--- a/implementations/python/sugar-lift-py-tests/scripts/measure_raise_from_direct_gaps.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/measure_raise_from_direct_gaps.py
@@ -26,9 +26,7 @@ def classify_raise_from(
         byte_col = getattr(node, "col_offset", -1)
         if line < 1 or byte_col < 0:
             return type(node).__name__, line, byte_col
-        normalized_col = len(
-            lines[line - 1].encode("utf-8")[:byte_col].decode("utf-8")
-        )
+        normalized_col = len(lines[line - 1].encode("utf-8")[:byte_col].decode("utf-8"))
         return type(node).__name__, line, normalized_col
 
     direct: Counter[str] = Counter()
@@ -42,9 +40,7 @@ def classify_raise_from(
             continue
 
         descendant_sites = {
-            site(descendant)
-            for descendant in ast.walk(node)
-            if descendant is not node
+            site(descendant) for descendant in ast.walk(node) if descendant is not node
         }
         if descendant_sites & gap_sites:
             blocked["raise_from"] += 1
@@ -78,9 +74,7 @@ def measure(root: Path) -> dict[str, object]:
             shape = (
                 "bare"
                 if node.exc is None
-                else "raise_from"
-                if node.cause is not None
-                else "without_cause"
+                else "raise_from" if node.cause is not None else "without_cause"
             )
             syntax[shape] += 1
         if not raises:
@@ -94,7 +88,9 @@ def measure(root: Path) -> dict[str, object]:
             # Raise directly. An unwritten enclosing function must not hide a
             # cause descendant, and an unrelated sibling gap must not label
             # the Raise blocked.
-            for raise_node in (node for node in source_file.nodes() if node.kind == "Raise"):
+            for raise_node in (
+                node for node in source_file.nodes() if node.kind == "Raise"
+            ):
                 descendant_gap = False
                 for operand in (raise_node.exc, raise_node.cause):
                     if operand is None:

--- a/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
@@ -22,6 +22,7 @@ import sys
 # Floors share ``_production_lift_child`` (this directory); make it
 # importable whether run standalone, as a child, or spec-loaded by a test.
 from pathlib import Path as _P
+
 sys.path.insert(0, str(_P(__file__).resolve().parent))
 from typing import NamedTuple, Sequence
 
@@ -82,9 +83,7 @@ def format_report(offenders: Sequence[NativeCrashOffender]) -> str:
         "Loci:",
     ]
     for row in offenders:
-        lines.append(
-            f"{row.file}:returncode={row.returncode}:signal={row.signal}"
-        )
+        lines.append(f"{row.file}:returncode={row.returncode}:signal={row.signal}")
         if row.stderr_tail:
             lines.append(row.stderr_tail)
     return "\n".join(lines)
@@ -95,9 +94,7 @@ def _python_paths(roots: Sequence[Path]) -> list[Path]:
         {
             path
             for root in roots
-            for path in (
-                root.rglob("*.py") if root.is_dir() else (root,)
-            )
+            for path in (root.rglob("*.py") if root.is_dir() else (root,))
             if path.is_file() and "__pycache__" not in path.parts
         }
     )
@@ -183,9 +180,7 @@ def audit_paths(
                 sorted(paths),
             )
         )
-    offenders = tuple(
-        row.offender for row in rows if row.offender is not None
-    )
+    offenders = tuple(row.offender for row in rows if row.offender is not None)
     for row in rows:
         if row.category == "timeout":
             print(

--- a/implementations/python/sugar-lift-py-tests/scripts/no_sugar_in_desugar_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/no_sugar_in_desugar_law.py
@@ -152,7 +152,13 @@ def scan_file(path: Path, *, rel: str) -> list[Finding]:
     except (OSError, UnicodeError) as exc:
         return [
             AuditorError(
-                rel, 0, 0, "-", "-", f"{type(exc).__name__}: {exc}", "auditor-read-error"
+                rel,
+                0,
+                0,
+                "-",
+                "-",
+                f"{type(exc).__name__}: {exc}",
+                "auditor-read-error",
             )
         ]
     try:
@@ -254,9 +260,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         args = parser.parse_args(argv)
         if args.self_test:
             ok = discrimination_self_test()
-            print(
-                "NO-SUGAR-IN-DESUGAR SELF-TEST " + ("GREEN" if ok else "RED")
-            )
+            print("NO-SUGAR-IN-DESUGAR SELF-TEST " + ("GREEN" if ok else "RED"))
             print(json.dumps({"instrument": "R_no_sugar_in_desugar", "self_test": ok}))
             return 0 if ok else 1
         roots = args.roots or [

--- a/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
@@ -48,9 +48,7 @@ def _roll_call_keys(audit: Mapping[str, Any]) -> set[tuple[str, int, int, str]]:
         status = raw.get("status")
         locus = raw.get("locus")
         kind = raw.get("kind")
-        if status not in {"warranted", "unresolved"} or not isinstance(
-            locus, Mapping
-        ):
+        if status not in {"warranted", "unresolved"} or not isinstance(locus, Mapping):
             continue
         file = locus.get("file")
         line = locus.get("line")
@@ -72,9 +70,7 @@ def silent_offenders(
     constructed_or_gap = _roll_call_keys(audit)
     disk_loci = [
         (locus.file, locus.line, locus.col, "Assert") for locus in census.asserts
-    ] + [
-        (locus.file, locus.line, locus.col, locus.kind) for locus in census.bodies
-    ]
+    ] + [(locus.file, locus.line, locus.col, locus.kind) for locus in census.bodies]
     return [
         SilentOffender(
             file=f"{file}:{line}:{col}",

--- a/implementations/python/sugar-lift-py-tests/scripts/source_via_execution_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/source_via_execution_law.py
@@ -156,17 +156,12 @@ def _build_alias_table(tree: ast.AST) -> _AliasTable:
                         attr = attr_node.value
                         if base_canonical == "importlib" and attr == "import_module":
                             aliases.add(target.id, "importlib.import_module")
-                        elif (
-                            base_canonical == "importlib.util"
-                            and attr == "find_spec"
-                        ):
+                        elif base_canonical == "importlib.util" and attr == "find_spec":
                             aliases.add(target.id, "importlib.util.find_spec")
     return aliases
 
 
-def _classify_call(
-    node: ast.Call, aliases: _AliasTable
-) -> tuple[str, str] | None:
+def _classify_call(node: ast.Call, aliases: _AliasTable) -> tuple[str, str] | None:
     """Return (kind, resolved-target) for an executing importlib call, else None."""
     func = node.func
 
@@ -186,14 +181,23 @@ def _classify_call(
     # "find_spec")(...) -- indirection that a plain qualified-name walk misses.
     if isinstance(func, ast.Call):
         inner = func.func
-        if isinstance(inner, ast.Name) and inner.id == "getattr" and len(func.args) >= 2:
+        if (
+            isinstance(inner, ast.Name)
+            and inner.id == "getattr"
+            and len(func.args) >= 2
+        ):
             base_qualified = _qualified_name(func.args[0])
-            base_canonical = aliases.canonicalize(base_qualified) if base_qualified else ""
+            base_canonical = (
+                aliases.canonicalize(base_qualified) if base_qualified else ""
+            )
             attr_node = func.args[1]
             if isinstance(attr_node, ast.Constant) and isinstance(attr_node.value, str):
                 attr = attr_node.value
                 if base_canonical == "importlib" and attr == "import_module":
-                    return "import-module-call", f"getattr({base_canonical!r}, {attr!r})"
+                    return (
+                        "import-module-call",
+                        f"getattr({base_canonical!r}, {attr!r})",
+                    )
                 if base_canonical == "importlib.util" and attr == "find_spec":
                     return "find-spec-call", f"getattr({base_canonical!r}, {attr!r})"
     return None
@@ -445,11 +449,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             stream.reconfigure(encoding="utf-8", errors="backslashreplace")
         except (AttributeError, ValueError):
             pass
-    package = (
-        Path(__file__).resolve().parents[1]
-        / "src"
-        / "sugar_lift_py_tests"
-    )
+    package = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests"
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "roots",
@@ -511,8 +511,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if r > 0 or err > 0:
         print(
             "SOURCE-VIA-EXECUTION LAW RED: "
-            f"{r} executing loci"
-            + (f"; {err} auditor errors" if err else "")
+            f"{r} executing loci" + (f"; {err} auditor errors" if err else "")
         )
         print(format_report(offenders))
         print(json.dumps(summary))

--- a/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
@@ -18,6 +18,7 @@ import sys
 # Floors share ``_production_lift_child`` (this directory); make it
 # importable whether run standalone, as a child, or spec-loaded by a test.
 from pathlib import Path as _P
+
 sys.path.insert(0, str(_P(__file__).resolve().parent))
 from typing import NamedTuple, Sequence
 
@@ -64,9 +65,7 @@ def require_python_paths(roots: Sequence[Path]) -> list[Path]:
     return paths
 
 
-def _run_isolated(
-    path: Path, *, root: Path, file_timeout: int
-) -> ChildResult:
+def _run_isolated(path: Path, *, root: Path, file_timeout: int) -> ChildResult:
     rel = path.resolve().relative_to(root.resolve()).as_posix()
     env = dict(os.environ)
     env["PYTHONFAULTHANDLER"] = "1"

--- a/implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
@@ -33,7 +33,6 @@ import traceback
 from pathlib import Path
 from typing import NamedTuple, Sequence
 
-
 VENDORS = frozenset(
     {
         "numpy",
@@ -114,20 +113,14 @@ def _vendor_symbols(tree: ast.AST) -> dict[str, set[str]]:
     return symbols
 
 
-def _is_name_match(
-    node: ast.Compare, symbols: dict[str, set[str]]
-) -> set[str]:
+def _is_name_match(node: ast.Compare, symbols: dict[str, set[str]]) -> set[str]:
     operands: tuple[ast.AST, ...] = (node.left, *node.comparators)
     if all(
         isinstance(operand, (ast.Constant, ast.Tuple, ast.List, ast.Set))
         for operand in operands
     ):
         return set()
-    direct = {
-        vendor
-        for operand in operands
-        for vendor in _vendor_strings(operand)
-    }
+    direct = {vendor for operand in operands for vendor in _vendor_strings(operand)}
     indirect = {
         vendor
         for operand in operands
@@ -144,11 +137,7 @@ def _isinstance_vendor(node: ast.Call) -> str | None:
     if len(node.args) < 2:
         return None
     type_arg = node.args[1]
-    candidates = (
-        type_arg.elts
-        if isinstance(type_arg, ast.Tuple)
-        else (type_arg,)
-    )
+    candidates = type_arg.elts if isinstance(type_arg, ast.Tuple) else (type_arg,)
     for candidate in candidates:
         vendor = _vendor_from_text(_qualified_name(candidate))
         if vendor is not None:
@@ -276,15 +265,17 @@ def scan_file(path: Path, *, rel: str) -> list[VendorSpecialCase]:
     source, read_error = _read_source(path)
     if read_error is not None:
         return [
-            read_error._replace(path=rel)
-            if read_error.path == path.as_posix()
-            else VendorSpecialCase(
-                path=rel,
-                line=read_error.line,
-                kind=read_error.kind,
-                vendor=read_error.vendor,
-                expression=read_error.expression,
-                note=read_error.note,
+            (
+                read_error._replace(path=rel)
+                if read_error.path == path.as_posix()
+                else VendorSpecialCase(
+                    path=rel,
+                    line=read_error.line,
+                    kind=read_error.kind,
+                    vendor=read_error.vendor,
+                    expression=read_error.expression,
+                    note=read_error.note,
+                )
             )
         ]
     assert source is not None
@@ -490,11 +481,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             stream.reconfigure(encoding="utf-8", errors="backslashreplace")
         except (AttributeError, ValueError):
             pass
-    package = (
-        Path(__file__).resolve().parents[1]
-        / "src"
-        / "sugar_lift_py_tests"
-    )
+    package = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests"
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "roots",
@@ -556,8 +543,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if r > 0 or err > 0:
         print(
             "VENDOR-SPECIAL-CASE LAW RED: "
-            f"{r} logo-dispatch loci"
-            + (f"; {err} auditor errors" if err else "")
+            f"{r} logo-dispatch loci" + (f"; {err} auditor errors" if err else "")
         )
         print(format_report(offenders))
         print(json.dumps(summary))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/call_contract_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/call_contract_resolution.py
@@ -53,7 +53,11 @@ def _term(raw: Any) -> Term:
             return bool_const(value)
         if name == "Int" and isinstance(value, int) and not isinstance(value, bool):
             return num(value)
-        if name == "Real" and isinstance(value, (int, float)) and not isinstance(value, bool):
+        if (
+            name == "Real"
+            and isinstance(value, (int, float))
+            and not isinstance(value, bool)
+        ):
             return real_lit(str(value))
         raise CallContractRefProtocolError("unsupported returnTerm constant")
     if kind == "ctor" and set(raw) == {"kind", "name", "args"}:
@@ -128,9 +132,20 @@ class ResolvedCallContractRefsV1:
 
 def _decode_ref(raw: Any) -> ResolvedCallContractRefV1:
     expected = {
-        "kind", "schemaVersion", "resolutionCid", "demandCid", "useSite",
-        "importBindingCid", "catalogCid", "memberCid", "contractCid", "bridgeSourceSymbol",
-        "importSignature", "returnTerm", "sourceWarrantCids", "contractDecl",
+        "kind",
+        "schemaVersion",
+        "resolutionCid",
+        "demandCid",
+        "useSite",
+        "importBindingCid",
+        "catalogCid",
+        "memberCid",
+        "contractCid",
+        "bridgeSourceSymbol",
+        "importSignature",
+        "returnTerm",
+        "sourceWarrantCids",
+        "contractDecl",
     }
     if not isinstance(raw, dict) or set(raw) != expected:
         raise CallContractRefProtocolError("malformed resolved-call contract ref")
@@ -160,7 +175,10 @@ def _decode_ref(raw: Any) -> ResolvedCallContractRefV1:
     contract_cid = _cid(raw["contractCid"], "contractCid")
     return_term = None if raw["returnTerm"] is None else _term(raw["returnTerm"])
     contract_decl = raw["contractDecl"]
-    if not isinstance(contract_decl, dict) or _hash_json(contract_decl) != raw["contractCid"]:
+    if (
+        not isinstance(contract_decl, dict)
+        or _hash_json(contract_decl) != raw["contractCid"]
+    ):
         raise CallContractRefProtocolError("stale semantic contract CID")
     resolution_preimage = {
         "schemaVersion": "1",
@@ -186,20 +204,37 @@ def _decode_ref(raw: Any) -> ResolvedCallContractRefV1:
                 "returnTerm contains a variable not authenticated as a formal"
             )
     return ResolvedCallContractRefV1(
-        resolution_cid, demand_cid,
+        resolution_cid,
+        demand_cid,
         SourceFragmentCoordinateV1.decode(raw["useSite"]),
-        import_binding_cid, catalog_cid, member_cid, contract_cid,
+        import_binding_cid,
+        catalog_cid,
+        member_cid,
+        contract_cid,
         raw["bridgeSourceSymbol"],
-        tuple(signature["formals"]), sorts, return_term,
+        tuple(signature["formals"]),
+        sorts,
+        return_term,
         tuple(_cid(value, "sourceWarrantCid") for value in warrants),
         MappingProxyType(dict(contract_decl)),
     )
 
 
 def decode_resolved_call_contract_refs(raw: Any) -> ResolvedCallContractRefsV1:
-    if not isinstance(raw, dict) or set(raw) != {
-        "kind", "schemaVersion", "catalogCid", "tableCid", "enrolledUseSites", "byUseSite"
-    } or raw["kind"] != "resolved-call-contract-refs" or raw["schemaVersion"] != "1":
+    if (
+        not isinstance(raw, dict)
+        or set(raw)
+        != {
+            "kind",
+            "schemaVersion",
+            "catalogCid",
+            "tableCid",
+            "enrolledUseSites",
+            "byUseSite",
+        }
+        or raw["kind"] != "resolved-call-contract-refs"
+        or raw["schemaVersion"] != "1"
+    ):
         raise CallContractRefProtocolError("malformed resolved-call contract-ref table")
     rows = raw["byUseSite"]
     if not isinstance(rows, list):
@@ -219,29 +254,49 @@ def decode_resolved_call_contract_refs(raw: Any) -> ResolvedCallContractRefsV1:
         if use_site in decoded:
             raise CallContractRefProtocolError("duplicate use-site resolution row")
         if use_site not in enrolled:
-            raise CallContractRefProtocolError("resolution row is not an enrolled call demand")
+            raise CallContractRefProtocolError(
+                "resolution row is not an enrolled call demand"
+            )
         resolution = row["resolution"]
         if not isinstance(resolution, dict):
             raise CallContractRefProtocolError("malformed call resolution")
-        if resolution.get("kind") == "resolved" and set(resolution) == {"kind", "reference"}:
+        if resolution.get("kind") == "resolved" and set(resolution) == {
+            "kind",
+            "reference",
+        }:
             value: CallContractResolutionV1 = _decode_ref(resolution["reference"])
             if value.use_site != use_site:
-                raise CallContractRefProtocolError("resolved reference row use-site mismatch")
+                raise CallContractRefProtocolError(
+                    "resolved reference row use-site mismatch"
+                )
             if value.catalog_cid != catalog_cid:
-                raise CallContractRefProtocolError("resolved reference catalog CID mismatch")
-        elif resolution.get("kind") == "unresolved" and set(resolution) == {"kind", "gap"}:
+                raise CallContractRefProtocolError(
+                    "resolved reference catalog CID mismatch"
+                )
+        elif resolution.get("kind") == "unresolved" and set(resolution) == {
+            "kind",
+            "gap",
+        }:
             gap = resolution["gap"]
-            candidates = gap.get("candidateMemberCids") if isinstance(gap, dict) else None
+            candidates = (
+                gap.get("candidateMemberCids") if isinstance(gap, dict) else None
+            )
             if not isinstance(candidates, list) or candidates != sorted(candidates):
-                raise CallContractRefProtocolError("candidate member CIDs must be sorted")
+                raise CallContractRefProtocolError(
+                    "candidate member CIDs must be sorted"
+                )
             value = CallContractResolutionGapV1(
-                _cid(gap.get("demandCid"), "demandCid"), use_site,
+                _cid(gap.get("demandCid"), "demandCid"),
+                use_site,
                 _cid(gap.get("importBindingCid"), "importBindingCid"),
-                gap.get("targetSymbol"), CallContractResolutionGapKindV1(gap.get("kind")),
+                gap.get("targetSymbol"),
+                CallContractResolutionGapKindV1(gap.get("kind")),
                 tuple(_cid(cid, "candidateMemberCid") for cid in candidates),
             )
             if SourceFragmentCoordinateV1.decode(gap.get("useSite")) != use_site:
-                raise CallContractRefProtocolError("unresolved gap row use-site mismatch")
+                raise CallContractRefProtocolError(
+                    "unresolved gap row use-site mismatch"
+                )
         else:
             raise CallContractRefProtocolError("unknown call resolution")
         decoded[use_site] = value
@@ -251,7 +306,13 @@ def decode_resolved_call_contract_refs(raw: Any) -> ResolvedCallContractRefsV1:
         )
     identity = {
         key: raw[key]
-        for key in ("kind", "schemaVersion", "catalogCid", "enrolledUseSites", "byUseSite")
+        for key in (
+            "kind",
+            "schemaVersion",
+            "catalogCid",
+            "enrolledUseSites",
+            "byUseSite",
+        )
     }
     if _hash_json(identity) != raw["tableCid"]:
         raise CallContractRefProtocolError("table CID mismatch")

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/cm_boundary_detector.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/cm_boundary_detector.py
@@ -40,17 +40,24 @@ _HARD_MODULES = (
     "sugar_proof_envelope",
 )
 _SOURCE_ORACLE = "sugar_lift_python_source.source_oracle"
-_SOURCE_ORACLE_BOUNDARIES = frozenset({
-    "tree.py", "corpus.py", "bench_backends.py", "fragment.py",
-})
-_FORBIDDEN_CALLS = frozenset({
-    "resolve_context_manager_demand",
-    "resolve_context_manager_import",
-    "decode_context_manager_contract",
-    "member_field",
-    "member_kind",
-    "read_proof_catalog",
-})
+_SOURCE_ORACLE_BOUNDARIES = frozenset(
+    {
+        "tree.py",
+        "corpus.py",
+        "bench_backends.py",
+        "fragment.py",
+    }
+)
+_FORBIDDEN_CALLS = frozenset(
+    {
+        "resolve_context_manager_demand",
+        "resolve_context_manager_import",
+        "decode_context_manager_contract",
+        "member_field",
+        "member_kind",
+        "read_proof_catalog",
+    }
+)
 _SOURCE_CALLS = frozenset({"path_source", "installed_module_source"})
 
 
@@ -80,8 +87,13 @@ class _BoundaryVisitor(ast.NodeVisitor):
             self.aliases[local] = alias.name
             if alias.name.startswith(_HARD_MODULES):
                 self._record(node, f"forbidden import {alias.name}")
-            if alias.name == _SOURCE_ORACLE and self.path.name not in _SOURCE_ORACLE_BOUNDARIES:
-                self._record(node, f"source-oracle import outside setup boundary {alias.name}")
+            if (
+                alias.name == _SOURCE_ORACLE
+                and self.path.name not in _SOURCE_ORACLE_BOUNDARIES
+            ):
+                self._record(
+                    node, f"source-oracle import outside setup boundary {alias.name}"
+                )
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
         module = node.module or ""
@@ -95,7 +107,9 @@ class _BoundaryVisitor(ast.NodeVisitor):
                 module == _SOURCE_ORACLE
                 and self.path.name not in _SOURCE_ORACLE_BOUNDARIES
             ):
-                self._record(node, f"source-oracle import outside setup boundary {target}")
+                self._record(
+                    node, f"source-oracle import outside setup boundary {target}"
+                )
 
     def visit_Call(self, node: ast.Call) -> None:
         dotted = _dotted(node.func)
@@ -111,5 +125,7 @@ class _BoundaryVisitor(ast.NodeVisitor):
                 call_name in _SOURCE_CALLS
                 and self.path.name not in _SOURCE_ORACLE_BOUNDARIES
             ):
-                self._record(node, f"source-oracle call outside setup boundary {resolved}")
+                self._record(
+                    node, f"source-oracle call outside setup boundary {resolved}"
+                )
         self.generic_visit(node)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py
@@ -8,7 +8,9 @@ import re
 from typing import Any, Mapping, Optional, Sequence, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
     from sugar_lift_py_tests.sugar.sugar_base import Sugar
 
 from .canonicalizer import blake3_512_of, encode_jcs, varr, vobj, vstr
@@ -189,13 +191,25 @@ class VariadicKeywordV1:
 def _validate_literal_default(value: Any) -> None:
     if not isinstance(value, dict):
         raise ContextManagerContractError("literal default must be an exact typed term")
-    if set(value) == {"kind", "name", "args"} and value == {"kind": "ctor", "name": "None", "args": []}:
+    if set(value) == {"kind", "name", "args"} and value == {
+        "kind": "ctor",
+        "name": "None",
+        "args": [],
+    }:
         return
     if set(value) != {"kind", "value", "sort"} or value.get("kind") != "const":
-        raise ContextManagerContractError("literal default must be None or an exact typed constant")
+        raise ContextManagerContractError(
+            "literal default must be None or an exact typed constant"
+        )
     sort = value["sort"]
-    if not isinstance(sort, dict) or set(sort) != {"kind", "name"} or sort.get("kind") != "primitive":
-        raise ContextManagerContractError("literal default has malformed sort testimony")
+    if (
+        not isinstance(sort, dict)
+        or set(sort) != {"kind", "name"}
+        or sort.get("kind") != "primitive"
+    ):
+        raise ContextManagerContractError(
+            "literal default has malformed sort testimony"
+        )
     name = sort.get("name")
     literal = value["value"]
     valid = (
@@ -228,8 +242,13 @@ class ProviderValueRefV1:
     kind: str = "provider-value-ref"
 
     def __post_init__(self) -> None:
-        if not isinstance(self.value_ref_cid, str) or re.fullmatch(r"blake3-512:[0-9a-f]{128}", self.value_ref_cid) is None:
-            raise ContextManagerContractError("provider default valueRefCid must be a CID")
+        if (
+            not isinstance(self.value_ref_cid, str)
+            or re.fullmatch(r"blake3-512:[0-9a-f]{128}", self.value_ref_cid) is None
+        ):
+            raise ContextManagerContractError(
+                "provider default valueRefCid must be a CID"
+            )
 
 
 @dataclass(frozen=True)
@@ -240,9 +259,13 @@ class ProviderKitKeyBindingV1:
 
     def __post_init__(self) -> None:
         if re.fullmatch(r"blake3-512:[0-9a-f]{128}", self.provider_kit_cid) is None:
-            raise ContextManagerContractError("provider key binding requires a provider kit CID")
+            raise ContextManagerContractError(
+                "provider key binding requires a provider kit CID"
+            )
         if not self.signer_key_id or not self.signer_public_key.startswith("ed25519:"):
-            raise ContextManagerContractError("provider key binding requires an authorized signer")
+            raise ContextManagerContractError(
+                "provider key binding requires an authorized signer"
+            )
 
 
 @dataclass(frozen=True)
@@ -251,9 +274,12 @@ class ProviderValueCatalogMemberV1:
     canonical_bytes: bytes
 
     def __post_init__(self) -> None:
-        if re.fullmatch(r"blake3-512:[0-9a-f]{128}", self.member_cid) is None \
-                or not isinstance(self.canonical_bytes, bytes):
-            raise ContextManagerContractError("provider value catalog member is malformed")
+        if re.fullmatch(
+            r"blake3-512:[0-9a-f]{128}", self.member_cid
+        ) is None or not isinstance(self.canonical_bytes, bytes):
+            raise ContextManagerContractError(
+                "provider value catalog member is malformed"
+            )
 
 
 @dataclass(frozen=True)
@@ -263,13 +289,20 @@ class AuthenticatedProviderValueCatalogV1:
 
     def __post_init__(self) -> None:
         if not isinstance(self.key_binding, ProviderKitKeyBindingV1):
-            raise ContextManagerContractError("provider value catalog requires a key binding")
+            raise ContextManagerContractError(
+                "provider value catalog requires a key binding"
+            )
         if not isinstance(self.members_by_value_cid, Mapping):
-            raise ContextManagerContractError("provider value catalog requires canonical members")
+            raise ContextManagerContractError(
+                "provider value catalog requires canonical members"
+            )
         for cid, member in self.members_by_value_cid.items():
-            if re.fullmatch(r"blake3-512:[0-9a-f]{128}", cid) is None \
-                    or not isinstance(member, ProviderValueCatalogMemberV1):
-                raise ContextManagerContractError("provider value catalog member is malformed")
+            if re.fullmatch(r"blake3-512:[0-9a-f]{128}", cid) is None or not isinstance(
+                member, ProviderValueCatalogMemberV1
+            ):
+                raise ContextManagerContractError(
+                    "provider value catalog member is malformed"
+                )
 
 
 @dataclass(frozen=True)
@@ -287,7 +320,13 @@ class ResolvedProviderValueV1:
 class CallParameterV1:
     name: str
     sort: Sort
-    passing: PositionalOnlyV1 | PositionalOrKeywordV1 | KeywordOnlyV1 | VariadicPositionalV1 | VariadicKeywordV1
+    passing: (
+        PositionalOnlyV1
+        | PositionalOrKeywordV1
+        | KeywordOnlyV1
+        | VariadicPositionalV1
+        | VariadicKeywordV1
+    )
     required: bool
     default: NoDefaultV1 | LiteralDefaultV1 | ProviderValueRefV1
 
@@ -303,19 +342,34 @@ def _validate_call_parameter_v1(parameter: CallParameterV1) -> None:
         raise ContextManagerContractError("call parameter required must be bool")
     variadic = isinstance(self.passing, (VariadicPositionalV1, VariadicKeywordV1))
     if variadic:
-        if self.required or not isinstance(self.default, NoDefaultV1) or self.sort != PrimitiveSort("Value"):
-            raise ContextManagerContractError("variadic parameter requires Value, required=false, default=no-default")
+        if (
+            self.required
+            or not isinstance(self.default, NoDefaultV1)
+            or self.sort != PrimitiveSort("Value")
+        ):
+            raise ContextManagerContractError(
+                "variadic parameter requires Value, required=false, default=no-default"
+            )
     elif self.required:
         if not isinstance(self.default, NoDefaultV1):
             raise ContextManagerContractError("required parameter must have no-default")
     elif isinstance(self.default, NoDefaultV1):
-        raise ContextManagerContractError("optional fixed parameter requires authenticated default")
-    if isinstance(self.default, LiteralDefaultV1) and self.default.value.get("kind") == "const":
+        raise ContextManagerContractError(
+            "optional fixed parameter requires authenticated default"
+        )
+    if (
+        isinstance(self.default, LiteralDefaultV1)
+        and self.default.value.get("kind") == "const"
+    ):
         literal_sort = _decode_sort(self.default.value["sort"])
         if literal_sort != self.sort:
-            raise ContextManagerContractError("literal default sort must equal parameter sort")
+            raise ContextManagerContractError(
+                "literal default sort must equal parameter sort"
+            )
     if isinstance(self.default, ProviderValueRefV1) and self.default.sort != self.sort:
-        raise ContextManagerContractError("provider default sort must equal parameter sort")
+        raise ContextManagerContractError(
+            "provider default sort must equal parameter sort"
+        )
 
 
 @dataclass(frozen=True)
@@ -340,17 +394,35 @@ class ImportSignatureV2:
                 raise ContextManagerContractError("unknown parameter passing mode")
             ranks.append(rank)
         if ranks != sorted(ranks):
-            raise ContextManagerContractError("call parameter passing modes are illegally ordered")
-        if sum(isinstance(p.passing, VariadicPositionalV1) for p in self.parameters) > 1 or sum(isinstance(p.passing, VariadicKeywordV1) for p in self.parameters) > 1:
-            raise ContextManagerContractError("at most one variadic positional and keyword parameter")
+            raise ContextManagerContractError(
+                "call parameter passing modes are illegally ordered"
+            )
+        if (
+            sum(isinstance(p.passing, VariadicPositionalV1) for p in self.parameters)
+            > 1
+            or sum(isinstance(p.passing, VariadicKeywordV1) for p in self.parameters)
+            > 1
+        ):
+            raise ContextManagerContractError(
+                "at most one variadic positional and keyword parameter"
+            )
 
 
 @dataclass(frozen=True)
 class EffectBoundarySemanticsV1:
     mode: ExpectsModeV1 | SuppressesModeV1
     effect_kind: RaiseEffectKindV1 | WarningEffectKindV1
-    expected_type_operand: FormalArgumentProjectionV1 | VariadicPositionalElementProjectionV1 | VariadicKeywordEntryProjectionV1
-    message_pattern_operand: NoMessagePatternV1 | OptionalFormalArgumentProjectionV1 | VariadicPositionalElementProjectionV1 | VariadicKeywordEntryProjectionV1
+    expected_type_operand: (
+        FormalArgumentProjectionV1
+        | VariadicPositionalElementProjectionV1
+        | VariadicKeywordEntryProjectionV1
+    )
+    message_pattern_operand: (
+        NoMessagePatternV1
+        | OptionalFormalArgumentProjectionV1
+        | VariadicPositionalElementProjectionV1
+        | VariadicKeywordEntryProjectionV1
+    )
     binding: NoBindingV1 | ExceptionInfoBindingV1 | WarningObservationBindingV1
     kind: str = "effect-boundary"
     schema_version: str = "1"
@@ -371,8 +443,9 @@ class ConstructedOperandOccurrenceV1:
         )
         from sugar_lift_py_tests.sugar.sugar_base import Sugar
 
-        if not isinstance(self.occurrence, SourceFragmentCoordinateV1) \
-                or not isinstance(self.value, Sugar):
+        if not isinstance(
+            self.occurrence, SourceFragmentCoordinateV1
+        ) or not isinstance(self.value, Sugar):
             raise ContextManagerContractError(
                 "constructed operand occurrence requires a source coordinate and Sugar child"
             )
@@ -390,10 +463,18 @@ class VariadicPositionalActualV1:
     elements: tuple[ConstructedOperandOccurrenceV1, ...]
 
     def __post_init__(self) -> None:
-        if isinstance(self.formal_index, bool) or not isinstance(self.formal_index, int) or self.formal_index < 0:
-            raise ContextManagerContractError("variadic positional actual requires a nonnegative formal index")
+        if (
+            isinstance(self.formal_index, bool)
+            or not isinstance(self.formal_index, int)
+            or self.formal_index < 0
+        ):
+            raise ContextManagerContractError(
+                "variadic positional actual requires a nonnegative formal index"
+            )
         if any(element.keyword is not None for element in self.elements):
-            raise ContextManagerContractError("variadic positional actual cannot carry keyword entries")
+            raise ContextManagerContractError(
+                "variadic positional actual cannot carry keyword entries"
+            )
 
 
 @dataclass(frozen=True)
@@ -402,11 +483,21 @@ class VariadicKeywordActualV1:
     entries: tuple[ConstructedOperandOccurrenceV1, ...]
 
     def __post_init__(self) -> None:
-        if isinstance(self.formal_index, bool) or not isinstance(self.formal_index, int) or self.formal_index < 0:
-            raise ContextManagerContractError("variadic keyword actual requires a nonnegative formal index")
+        if (
+            isinstance(self.formal_index, bool)
+            or not isinstance(self.formal_index, int)
+            or self.formal_index < 0
+        ):
+            raise ContextManagerContractError(
+                "variadic keyword actual requires a nonnegative formal index"
+            )
         keys = tuple(entry.keyword for entry in self.entries)
-        if any(not isinstance(key, str) or not key for key in keys) or len(set(keys)) != len(keys):
-            raise ContextManagerContractError("variadic keyword actuals require unique real keywords")
+        if any(not isinstance(key, str) or not key for key in keys) or len(
+            set(keys)
+        ) != len(keys):
+            raise ContextManagerContractError(
+                "variadic keyword actuals require unique real keywords"
+            )
 
 
 def project_formal_selector_v1(
@@ -417,13 +508,17 @@ def project_formal_selector_v1(
     variadic_keyword_actuals: Mapping[int, VariadicKeywordActualV1],
 ):
     """Project an already-constructed actual; never create a replacement value."""
-    if isinstance(selector, (FormalArgumentProjectionV1, OptionalFormalArgumentProjectionV1)):
+    if isinstance(
+        selector, (FormalArgumentProjectionV1, OptionalFormalArgumentProjectionV1)
+    ):
         try:
             return fixed_actuals[selector.parameter_index]
         except KeyError as exc:
             if isinstance(selector, OptionalFormalArgumentProjectionV1):
                 return None
-            raise ContextManagerContractError("required formal actual is absent") from exc
+            raise ContextManagerContractError(
+                "required formal actual is absent"
+            ) from exc
     if isinstance(selector, VariadicPositionalElementProjectionV1):
         pack = variadic_positional_actuals.get(selector.parameter_index)
         if pack is None or pack.formal_index != selector.parameter_index:
@@ -431,14 +526,20 @@ def project_formal_selector_v1(
         try:
             return pack.elements[selector.element_index].value
         except IndexError as exc:
-            raise ContextManagerContractError("variadic positional element is out of range") from exc
+            raise ContextManagerContractError(
+                "variadic positional element is out of range"
+            ) from exc
     if isinstance(selector, VariadicKeywordEntryProjectionV1):
         pack = variadic_keyword_actuals.get(selector.parameter_index)
         if pack is None or pack.formal_index != selector.parameter_index:
             raise ContextManagerContractError("variadic keyword actual is absent")
-        matches = tuple(entry for entry in pack.entries if entry.keyword == selector.keyword)
+        matches = tuple(
+            entry for entry in pack.entries if entry.keyword == selector.keyword
+        )
         if len(matches) != 1:
-            raise ContextManagerContractError("variadic keyword entry is absent or ambiguous")
+            raise ContextManagerContractError(
+                "variadic keyword entry is absent or ambiguous"
+            )
         return matches[0].value
     raise ContextManagerContractError("unknown formal selector")
 
@@ -482,58 +583,106 @@ class ContextManagerContractError(ValueError):
 def _selector_to_value(selector):
     index = getattr(selector, "parameter_index", None)
     if isinstance(index, bool) or not isinstance(index, int) or index < 0:
-        raise ContextManagerContractError("selector requires a nonnegative parameter index")
+        raise ContextManagerContractError(
+            "selector requires a nonnegative parameter index"
+        )
     if isinstance(selector, FormalArgumentProjectionV1):
-        return vobj([("kind", vstr("formal-argument")), ("parameterIndex", _json_value(index))])
+        return vobj(
+            [("kind", vstr("formal-argument")), ("parameterIndex", _json_value(index))]
+        )
     if isinstance(selector, OptionalFormalArgumentProjectionV1):
-        return vobj([("kind", vstr("optional-formal-argument")), ("parameterIndex", _json_value(index))])
+        return vobj(
+            [
+                ("kind", vstr("optional-formal-argument")),
+                ("parameterIndex", _json_value(index)),
+            ]
+        )
     if isinstance(selector, VariadicPositionalElementProjectionV1):
-        if isinstance(selector.element_index, bool) or not isinstance(selector.element_index, int) or selector.element_index < 0:
-            raise ContextManagerContractError("variadic element selector requires a nonnegative element index")
-        return vobj([
-            ("kind", vstr("variadic-positional-element")),
-            ("parameterIndex", _json_value(index)),
-            ("elementIndex", _json_value(selector.element_index)),
-        ])
+        if (
+            isinstance(selector.element_index, bool)
+            or not isinstance(selector.element_index, int)
+            or selector.element_index < 0
+        ):
+            raise ContextManagerContractError(
+                "variadic element selector requires a nonnegative element index"
+            )
+        return vobj(
+            [
+                ("kind", vstr("variadic-positional-element")),
+                ("parameterIndex", _json_value(index)),
+                ("elementIndex", _json_value(selector.element_index)),
+            ]
+        )
     if isinstance(selector, VariadicKeywordEntryProjectionV1):
         if not isinstance(selector.keyword, str) or not selector.keyword:
-            raise ContextManagerContractError("variadic keyword selector requires a keyword")
-        return vobj([
-            ("kind", vstr("variadic-keyword-entry")),
-            ("parameterIndex", _json_value(index)),
-            ("keyword", vstr(selector.keyword)),
-        ])
+            raise ContextManagerContractError(
+                "variadic keyword selector requires a keyword"
+            )
+        return vobj(
+            [
+                ("kind", vstr("variadic-keyword-entry")),
+                ("parameterIndex", _json_value(index)),
+                ("keyword", vstr(selector.keyword)),
+            ]
+        )
     raise ContextManagerContractError("unknown formal selector")
 
 
 def semantics_to_value(semantics: ContextManagerSemanticsV1):
     if isinstance(semantics, ProtocolResourceSemanticsV1):
-        if semantics.schema_version != "1" or not isinstance(semantics.enter.completion, TotalCompletionV1) or semantics.enter.projection != ENTER_RESULT:
-            raise ContextManagerContractError("unsupported protocol-resource enter testimony")
+        if (
+            semantics.schema_version != "1"
+            or not isinstance(semantics.enter.completion, TotalCompletionV1)
+            or semantics.enter.projection != ENTER_RESULT
+        ):
+            raise ContextManagerContractError(
+                "unsupported protocol-resource enter testimony"
+            )
         if not isinstance(semantics.exit.completion, TotalCompletionV1):
-            raise ContextManagerContractError("unsupported protocol-resource exit testimony")
+            raise ContextManagerContractError(
+                "unsupported protocol-resource exit testimony"
+            )
         if isinstance(semantics.exit.disposition, NeverSuppressesDispositionV1):
             disposition = "never-suppresses"
         elif isinstance(semantics.exit.disposition, ReturnTruthinessDispositionV1):
             disposition = "return-truthiness"
         else:
-            raise ContextManagerContractError("unknown protocol-resource exit disposition")
-        return vobj([
-        ("kind", vstr("protocol-resource")),
-        ("schemaVersion", vstr("1")),
-        ("enter", vobj([
-            ("completion", vobj([("kind", vstr("total"))])),
-            ("result", vobj([
-                ("kind", vstr("projection")),
-                ("projection", vstr(ENTER_RESULT)),
-                ("sort", sort_to_value(semantics.enter.sort)),
-            ])),
-        ])),
-        ("exit", vobj([
-            ("completion", vobj([("kind", vstr("total"))])),
-            ("disposition", vobj([("kind", vstr(disposition))])),
-        ])),
-        ])
+            raise ContextManagerContractError(
+                "unknown protocol-resource exit disposition"
+            )
+        return vobj(
+            [
+                ("kind", vstr("protocol-resource")),
+                ("schemaVersion", vstr("1")),
+                (
+                    "enter",
+                    vobj(
+                        [
+                            ("completion", vobj([("kind", vstr("total"))])),
+                            (
+                                "result",
+                                vobj(
+                                    [
+                                        ("kind", vstr("projection")),
+                                        ("projection", vstr(ENTER_RESULT)),
+                                        ("sort", sort_to_value(semantics.enter.sort)),
+                                    ]
+                                ),
+                            ),
+                        ]
+                    ),
+                ),
+                (
+                    "exit",
+                    vobj(
+                        [
+                            ("completion", vobj([("kind", vstr("total"))])),
+                            ("disposition", vobj([("kind", vstr(disposition))])),
+                        ]
+                    ),
+                ),
+            ]
+        )
     if isinstance(semantics, EffectBoundarySemanticsV1):
         if semantics.schema_version != "1":
             raise ContextManagerContractError("unsupported effect-boundary schema")
@@ -563,24 +712,35 @@ def semantics_to_value(semantics: ContextManagerSemanticsV1):
             message_value = vobj([("kind", vstr("none"))])
         else:
             message_value = _selector_to_value(message)
-        return vobj([
-            ("kind", vstr("effect-boundary")),
-            ("schemaVersion", vstr("1")),
-            ("mode", vobj([("kind", vstr(mode))])),
-            ("matcher", vobj([
-                ("effectKind", vobj([("kind", vstr(effect_kind))])),
-                ("expectedTypeOperand", expected_value),
-                ("messagePatternOperand", message_value),
-            ])),
-            ("binding", vobj([("kind", vstr(binding))])),
-        ])
+        return vobj(
+            [
+                ("kind", vstr("effect-boundary")),
+                ("schemaVersion", vstr("1")),
+                ("mode", vobj([("kind", vstr(mode))])),
+                (
+                    "matcher",
+                    vobj(
+                        [
+                            ("effectKind", vobj([("kind", vstr(effect_kind))])),
+                            ("expectedTypeOperand", expected_value),
+                            ("messagePatternOperand", message_value),
+                        ]
+                    ),
+                ),
+                ("binding", vobj([("kind", vstr(binding))])),
+            ]
+        )
     raise ContextManagerContractError("unknown context-manager semantics variant")
 
 
 def publish_never_suppresses_context_manager_contract(
-    *, bridge_source_symbol: str, import_signature: Any,
-    enter_result_sort: Sort, source_warrants: Sequence[str],
-    signer: Signer, declared_at: str,
+    *,
+    bridge_source_symbol: str,
+    import_signature: Any,
+    enter_result_sort: Sort,
+    source_warrants: Sequence[str],
+    signer: Signer,
+    declared_at: str,
 ) -> ClaimEnvelope:
     semantics = ProtocolResourceSemanticsV1(
         enter=EnterResultContractV1(sort=enter_result_sort),
@@ -597,13 +757,26 @@ def publish_never_suppresses_context_manager_contract(
 
 
 def publish_effect_boundary_context_manager_contract(
-    *, bridge_source_symbol: str, import_signature: ImportSignatureV2,
+    *,
+    bridge_source_symbol: str,
+    import_signature: ImportSignatureV2,
     mode: ExpectsModeV1 | SuppressesModeV1,
     effect_kind: RaiseEffectKindV1 | WarningEffectKindV1,
-    expected_type_operand: FormalArgumentProjectionV1 | VariadicPositionalElementProjectionV1 | VariadicKeywordEntryProjectionV1,
-    message_pattern_operand: NoMessagePatternV1 | OptionalFormalArgumentProjectionV1 | VariadicPositionalElementProjectionV1 | VariadicKeywordEntryProjectionV1,
+    expected_type_operand: (
+        FormalArgumentProjectionV1
+        | VariadicPositionalElementProjectionV1
+        | VariadicKeywordEntryProjectionV1
+    ),
+    message_pattern_operand: (
+        NoMessagePatternV1
+        | OptionalFormalArgumentProjectionV1
+        | VariadicPositionalElementProjectionV1
+        | VariadicKeywordEntryProjectionV1
+    ),
     binding: NoBindingV1 | ExceptionInfoBindingV1 | WarningObservationBindingV1,
-    source_warrants: Sequence[str], signer: Signer, declared_at: str,
+    source_warrants: Sequence[str],
+    signer: Signer,
+    declared_at: str,
 ) -> ClaimEnvelope:
     """Publish a provider-owned EffectBoundary through the sole CM envelope door."""
     return publish_context_manager_contract(
@@ -623,82 +796,118 @@ def publish_effect_boundary_context_manager_contract(
 
 
 def publish_context_manager_contract(
-    *, bridge_source_symbol: str, import_signature: ImportSignatureV2,
-    semantics: ContextManagerSemanticsV1, source_warrants: Sequence[str],
-    signer: Signer, declared_at: str,
+    *,
+    bridge_source_symbol: str,
+    import_signature: ImportSignatureV2,
+    semantics: ContextManagerSemanticsV1,
+    source_warrants: Sequence[str],
+    signer: Signer,
+    declared_at: str,
 ) -> ClaimEnvelope:
     if not bridge_source_symbol:
         raise ContextManagerContractError("bridgeSourceSymbol must be non-empty")
     if not isinstance(import_signature, ImportSignatureV2):
         raise ContextManagerContractError("ImportSignatureV2 required")
-    if not all(isinstance(w, str) and w.startswith("blake3-512:") for w in source_warrants):
+    if not all(
+        isinstance(w, str) and w.startswith("blake3-512:") for w in source_warrants
+    ):
         raise ContextManagerContractError("sourceWarrants must be CID references")
     payload = semantics_to_value(semantics)
     decoded_payload = json.loads(encode_jcs(payload))
-    if decode_context_manager_semantics_v1(decoded_payload, import_signature) != semantics:
-        raise ContextManagerContractError("context-manager semantics failed canonical validation")
+    if (
+        decode_context_manager_semantics_v1(decoded_payload, import_signature)
+        != semantics
+    ):
+        raise ContextManagerContractError(
+            "context-manager semantics failed canonical validation"
+        )
     payload_cid = blake3_512_of(encode_jcs(payload).encode())
     sorted_inputs = sorted(source_warrants)
-    header = vobj([
-        ("schemaVersion", vstr("1.2")),
-        ("kind", vstr("context-manager-contract")),
-        ("cid", vstr(payload_cid)),
-        ("payloadCid", vstr(payload_cid)),
-        ("bridgeSourceSymbol", vstr(bridge_source_symbol)),
-        ("importSignature", import_signature_to_value(import_signature)),
-        ("payload", payload),
-        ("sourceWarrants", varr([vstr(v) for v in source_warrants])),
-        ("inputCids", varr([vstr(v) for v in sorted_inputs])),
-    ])
-    metadata = vobj([
-        ("authoring", vobj([
-            ("producerKind", vstr("kit-author")),
-            ("author", vstr(signer.producer_id)),
-        ])),
-        ("producedBy", vstr(signer.producer_id)),
-        ("producedAt", vstr(declared_at)),
-    ])
+    header = vobj(
+        [
+            ("schemaVersion", vstr("1.2")),
+            ("kind", vstr("context-manager-contract")),
+            ("cid", vstr(payload_cid)),
+            ("payloadCid", vstr(payload_cid)),
+            ("bridgeSourceSymbol", vstr(bridge_source_symbol)),
+            ("importSignature", import_signature_to_value(import_signature)),
+            ("payload", payload),
+            ("sourceWarrants", varr([vstr(v) for v in source_warrants])),
+            ("inputCids", varr([vstr(v) for v in sorted_inputs])),
+        ]
+    )
+    metadata = vobj(
+        [
+            (
+                "authoring",
+                vobj(
+                    [
+                        ("producerKind", vstr("kit-author")),
+                        ("author", vstr(signer.producer_id)),
+                    ]
+                ),
+            ),
+            ("producedBy", vstr(signer.producer_id)),
+            ("producedAt", vstr(declared_at)),
+        ]
+    )
     return _assemble_layered(header, metadata, declared_at, signer.seed, payload_cid)
 
 
 def publish_provider_value_v1(
-    *, provider_kit_cid: str, signer_key_id: str, sort: Sort,
-    value: Mapping[str, object], signer: Signer, declared_at: str,
+    *,
+    provider_kit_cid: str,
+    signer_key_id: str,
+    sort: Sort,
+    value: Mapping[str, object],
+    signer: Signer,
+    declared_at: str,
 ) -> ClaimEnvelope:
     """Seal one provider-owned opaque value coordinate for signature defaults."""
     if re.fullmatch(r"blake3-512:[0-9a-f]{128}", provider_kit_cid) is None:
         raise ContextManagerContractError("provider value requires a provider kit CID")
     if not signer_key_id or not isinstance(value, Mapping):
-        raise ContextManagerContractError("provider value requires a signer key and value preimage")
-    payload = vobj([
-        ("kind", vstr("provider-value")),
-        ("schemaVersion", vstr("1")),
-        ("sort", sort_to_value(sort)),
-        ("value", _json_value(dict(value))),
-    ])
-    payload_cid = blake3_512_of(encode_jcs(payload).encode())
-    header = vobj([
-        ("schemaVersion", vstr("1")),
-        ("kind", vstr("provider-value")),
-        ("cid", vstr(payload_cid)),
-        ("payloadCid", vstr(payload_cid)),
-        ("providerKitCid", vstr(provider_kit_cid)),
-        ("signerKeyId", vstr(signer_key_id)),
-        ("sort", sort_to_value(sort)),
-        ("payload", payload),
-        ("inputCids", varr([])),
-    ])
-    metadata = vobj([
-        ("authoring", vobj([
-            ("producerKind", vstr("kit-author")),
-            ("author", vstr(signer.producer_id)),
-        ])),
-        ("producedBy", vstr(signer.producer_id)),
-        ("producedAt", vstr(declared_at)),
-    ])
-    return _assemble_layered(
-        header, metadata, declared_at, signer.seed, payload_cid
+        raise ContextManagerContractError(
+            "provider value requires a signer key and value preimage"
+        )
+    payload = vobj(
+        [
+            ("kind", vstr("provider-value")),
+            ("schemaVersion", vstr("1")),
+            ("sort", sort_to_value(sort)),
+            ("value", _json_value(dict(value))),
+        ]
     )
+    payload_cid = blake3_512_of(encode_jcs(payload).encode())
+    header = vobj(
+        [
+            ("schemaVersion", vstr("1")),
+            ("kind", vstr("provider-value")),
+            ("cid", vstr(payload_cid)),
+            ("payloadCid", vstr(payload_cid)),
+            ("providerKitCid", vstr(provider_kit_cid)),
+            ("signerKeyId", vstr(signer_key_id)),
+            ("sort", sort_to_value(sort)),
+            ("payload", payload),
+            ("inputCids", varr([])),
+        ]
+    )
+    metadata = vobj(
+        [
+            (
+                "authoring",
+                vobj(
+                    [
+                        ("producerKind", vstr("kit-author")),
+                        ("author", vstr(signer.producer_id)),
+                    ]
+                ),
+            ),
+            ("producedBy", vstr(signer.producer_id)),
+            ("producedAt", vstr(declared_at)),
+        ]
+    )
+    return _assemble_layered(header, metadata, declared_at, signer.seed, payload_cid)
 
 
 def _resolve_provider_value_member_v1(
@@ -713,40 +922,73 @@ def _resolve_provider_value_member_v1(
     try:
         raw = json.loads(canonical_bytes)
     except (TypeError, ValueError) as exc:
-        raise ContextManagerContractError("provider default member is not canonical JSON") from exc
+        raise ContextManagerContractError(
+            "provider default member is not canonical JSON"
+        ) from exc
     if not isinstance(raw, dict) or set(raw) != {"envelope", "header", "metadata"}:
         raise ContextManagerContractError("provider default member is malformed")
     envelope, header, metadata = raw["envelope"], raw["header"], raw["metadata"]
-    if not isinstance(envelope, dict) or not isinstance(header, dict) or not isinstance(metadata, dict):
-        raise ContextManagerContractError("provider default member layers are malformed")
+    if (
+        not isinstance(envelope, dict)
+        or not isinstance(header, dict)
+        or not isinstance(metadata, dict)
+    ):
+        raise ContextManagerContractError(
+            "provider default member layers are malformed"
+        )
     actual_member_cid = blake3_512_of(encode_jcs(_json_value(envelope)).encode())
     if actual_member_cid != catalog_member.member_cid:
         raise ContextManagerContractError("provider default member CID is stale")
     expected_header = {
-        "schemaVersion", "kind", "cid", "payloadCid", "providerKitCid",
-        "signerKeyId", "sort", "payload", "inputCids",
+        "schemaVersion",
+        "kind",
+        "cid",
+        "payloadCid",
+        "providerKitCid",
+        "signerKeyId",
+        "sort",
+        "payload",
+        "inputCids",
     }
-    if set(header) != expected_header or header.get("schemaVersion") != "1" \
-            or header.get("kind") != "provider-value" or header.get("inputCids") != []:
+    if (
+        set(header) != expected_header
+        or header.get("schemaVersion") != "1"
+        or header.get("kind") != "provider-value"
+        or header.get("inputCids") != []
+    ):
         raise ContextManagerContractError("provider default member header is malformed")
     payload = header["payload"]
-    if not isinstance(payload, dict) or set(payload) != {
-        "kind", "schemaVersion", "sort", "value"
-    } or payload.get("kind") != "provider-value" or payload.get("schemaVersion") != "1":
+    if (
+        not isinstance(payload, dict)
+        or set(payload) != {"kind", "schemaVersion", "sort", "value"}
+        or payload.get("kind") != "provider-value"
+        or payload.get("schemaVersion") != "1"
+    ):
         raise ContextManagerContractError("provider default payload is malformed")
     payload_cid = blake3_512_of(encode_jcs(_json_value(payload)).encode())
-    if requested_cid != payload_cid or header.get("cid") != payload_cid \
-            or header.get("payloadCid") != payload_cid:
-        raise ContextManagerContractError("provider default content CID does not match preimage")
+    if (
+        requested_cid != payload_cid
+        or header.get("cid") != payload_cid
+        or header.get("payloadCid") != payload_cid
+    ):
+        raise ContextManagerContractError(
+            "provider default content CID does not match preimage"
+        )
     binding = catalog.key_binding
-    if header.get("providerKitCid") != binding.provider_kit_cid \
-            or header.get("signerKeyId") != binding.signer_key_id \
-            or envelope.get("signer") != binding.signer_public_key:
-        raise ContextManagerContractError("provider default provider signer is not authorized")
-    signing = vobj([
-        ("header", _json_value(header)),
-        ("metadata", _json_value(metadata)),
-    ])
+    if (
+        header.get("providerKitCid") != binding.provider_kit_cid
+        or header.get("signerKeyId") != binding.signer_key_id
+        or envelope.get("signer") != binding.signer_public_key
+    ):
+        raise ContextManagerContractError(
+            "provider default provider signer is not authorized"
+        )
+    signing = vobj(
+        [
+            ("header", _json_value(header)),
+            ("metadata", _json_value(metadata)),
+        ]
+    )
     if not ed25519_verify_string(
         binding.signer_public_key,
         envelope.get("signature", ""),
@@ -767,6 +1009,7 @@ def _resolve_provider_value_member_v1(
 
 def _json_value(value: Any):
     from .canonicalizer import vbool, vint, vnull
+
     if value is None:
         return vnull()
     if isinstance(value, bool):
@@ -785,12 +1028,26 @@ def _json_value(value: Any):
 def _decode_sort(raw: Any) -> Sort:
     if not isinstance(raw, dict):
         raise ContextManagerContractError("sort must be an object")
-    if raw.get("kind") == "primitive" and set(raw) == {"kind", "name"} and isinstance(raw["name"], str):
+    if (
+        raw.get("kind") == "primitive"
+        and set(raw) == {"kind", "name"}
+        and isinstance(raw["name"], str)
+    ):
         return PrimitiveSort(raw["name"])
-    if raw.get("kind") == "region" and set(raw) == {"kind", "name"} and isinstance(raw["name"], str):
+    if (
+        raw.get("kind") == "region"
+        and set(raw) == {"kind", "name"}
+        and isinstance(raw["name"], str)
+    ):
         return RegionSort(raw["name"])
-    if raw.get("kind") == "function" and set(raw) == {"kind", "args", "return"} and isinstance(raw["args"], list):
-        return FunctionSort(tuple(_decode_sort(v) for v in raw["args"]), _decode_sort(raw["return"]))
+    if (
+        raw.get("kind") == "function"
+        and set(raw) == {"kind", "args", "return"}
+        and isinstance(raw["args"], list)
+    ):
+        return FunctionSort(
+            tuple(_decode_sort(v) for v in raw["args"]), _decode_sort(raw["return"])
+        )
     raise ContextManagerContractError("unsupported or malformed sort")
 
 
@@ -818,29 +1075,42 @@ def import_signature_to_value(signature: ImportSignatureV2):
             default = vobj([("kind", vstr("no-default"))])
         elif isinstance(parameter.default, LiteralDefaultV1):
             _validate_literal_default(parameter.default.value)
-            default = vobj([("kind", vstr("literal-default")), ("value", _json_value(parameter.default.value))])
+            default = vobj(
+                [
+                    ("kind", vstr("literal-default")),
+                    ("value", _json_value(parameter.default.value)),
+                ]
+            )
         elif isinstance(parameter.default, ProviderValueRefV1):
-            default = vobj([
-                ("kind", vstr("provider-value-ref")),
-                ("valueRefCid", vstr(parameter.default.value_ref_cid)),
-                ("sort", sort_to_value(parameter.default.sort)),
-            ])
+            default = vobj(
+                [
+                    ("kind", vstr("provider-value-ref")),
+                    ("valueRefCid", vstr(parameter.default.value_ref_cid)),
+                    ("sort", sort_to_value(parameter.default.sort)),
+                ]
+            )
         else:
             raise ContextManagerContractError("unknown authenticated default")
-        rows.append(vobj([
-            ("name", vstr(parameter.name)),
-            ("sort", sort_to_value(parameter.sort)),
-            ("passing", vobj([("kind", vstr(passing))])),
-            ("required", _json_value(parameter.required)),
-            ("default", default),
-        ]))
-    return vobj([("parameters", varr([
-        *rows
-    ]))])
+        rows.append(
+            vobj(
+                [
+                    ("name", vstr(parameter.name)),
+                    ("sort", sort_to_value(parameter.sort)),
+                    ("passing", vobj([("kind", vstr(passing))])),
+                    ("required", _json_value(parameter.required)),
+                    ("default", default),
+                ]
+            )
+        )
+    return vobj([("parameters", varr([*rows]))])
 
 
 def decode_import_signature_v2(raw: Any) -> ImportSignatureV2:
-    if not isinstance(raw, dict) or set(raw) != {"parameters"} or not isinstance(raw["parameters"], list):
+    if (
+        not isinstance(raw, dict)
+        or set(raw) != {"parameters"}
+        or not isinstance(raw["parameters"], list)
+    ):
         raise ContextManagerContractError("malformed ImportSignatureV2")
     parameters = []
     passing_types = {
@@ -851,9 +1121,19 @@ def decode_import_signature_v2(raw: Any) -> ImportSignatureV2:
         "variadic-keyword": VariadicKeywordV1,
     }
     for value in raw["parameters"]:
-        if not isinstance(value, dict) or set(value) != {"name", "sort", "passing", "required", "default"}:
+        if not isinstance(value, dict) or set(value) != {
+            "name",
+            "sort",
+            "passing",
+            "required",
+            "default",
+        }:
             raise ContextManagerContractError("malformed call parameter")
-        if not isinstance(value["name"], str) or not value["name"] or type(value["required"]) is not bool:
+        if (
+            not isinstance(value["name"], str)
+            or not value["name"]
+            or type(value["required"]) is not bool
+        ):
             raise ContextManagerContractError("malformed call parameter fields")
         passing = _tag(value["passing"], passing_types, "parameter passing mode")
         raw_default = value["default"]
@@ -861,13 +1141,32 @@ def decode_import_signature_v2(raw: Any) -> ImportSignatureV2:
             raise ContextManagerContractError("malformed authenticated default")
         if raw_default.get("kind") == "no-default" and set(raw_default) == {"kind"}:
             default = NoDefaultV1()
-        elif raw_default.get("kind") == "literal-default" and set(raw_default) == {"kind", "value"}:
+        elif raw_default.get("kind") == "literal-default" and set(raw_default) == {
+            "kind",
+            "value",
+        }:
             default = LiteralDefaultV1(raw_default["value"])
-        elif raw_default.get("kind") == "provider-value-ref" and set(raw_default) == {"kind", "valueRefCid", "sort"}:
-            default = ProviderValueRefV1(raw_default["valueRefCid"], _decode_sort(raw_default["sort"]))
+        elif raw_default.get("kind") == "provider-value-ref" and set(raw_default) == {
+            "kind",
+            "valueRefCid",
+            "sort",
+        }:
+            default = ProviderValueRefV1(
+                raw_default["valueRefCid"], _decode_sort(raw_default["sort"])
+            )
         else:
-            raise ContextManagerContractError("unknown or malformed authenticated default")
-        parameters.append(CallParameterV1(value["name"], _decode_sort(value["sort"]), passing, value["required"], default))
+            raise ContextManagerContractError(
+                "unknown or malformed authenticated default"
+            )
+        parameters.append(
+            CallParameterV1(
+                value["name"],
+                _decode_sort(value["sort"]),
+                passing,
+                value["required"],
+                default,
+            )
+        )
     return ImportSignatureV2(tuple(parameters))
 
 
@@ -878,7 +1177,10 @@ def _decode_total(raw: Any) -> TotalCompletionV1:
 
 
 def _decode_protocol_resource(raw: Any) -> ProtocolResourceSemanticsV1:
-    if set(raw) != {"kind", "schemaVersion", "enter", "exit"} or raw["schemaVersion"] != "1":
+    if (
+        set(raw) != {"kind", "schemaVersion", "enter", "exit"}
+        or raw["schemaVersion"] != "1"
+    ):
         raise ContextManagerContractError("malformed protocol-resource semantics")
     enter = raw["enter"]
     exit_ = raw["exit"]
@@ -886,7 +1188,12 @@ def _decode_protocol_resource(raw: Any) -> ProtocolResourceSemanticsV1:
         raise ContextManagerContractError("malformed context-manager semantics enter")
     result = enter["result"]
     completion = _decode_total(enter["completion"])
-    if not isinstance(result, dict) or set(result) != {"kind", "projection", "sort"} or result["kind"] != "projection" or result["projection"] != ENTER_RESULT:
+    if (
+        not isinstance(result, dict)
+        or set(result) != {"kind", "projection", "sort"}
+        or result["kind"] != "projection"
+        or result["projection"] != ENTER_RESULT
+    ):
         raise ContextManagerContractError("unsupported enter testimony")
     if not isinstance(exit_, dict) or set(exit_) != {"completion", "disposition"}:
         raise ContextManagerContractError("malformed context-manager semantics exit")
@@ -901,8 +1208,12 @@ def _decode_protocol_resource(raw: Any) -> ProtocolResourceSemanticsV1:
     else:
         raise ContextManagerContractError("unknown exit disposition")
     return ProtocolResourceSemanticsV1(
-        enter=EnterResultContractV1(sort=_decode_sort(result["sort"]), completion=completion),
-        exit=ExitContractV1(disposition=decoded_disposition, completion=exit_completion),
+        enter=EnterResultContractV1(
+            sort=_decode_sort(result["sort"]), completion=completion
+        ),
+        exit=ExitContractV1(
+            disposition=decoded_disposition, completion=exit_completion
+        ),
     )
 
 
@@ -916,14 +1227,30 @@ def _decode_selector(raw: Any, *, allow_optional: bool):
     if not isinstance(raw, dict) or not isinstance(raw.get("kind"), str):
         raise ContextManagerContractError("malformed formal selector")
     kind = raw["kind"]
-    fixed_cls = OptionalFormalArgumentProjectionV1 if allow_optional else FormalArgumentProjectionV1
+    fixed_cls = (
+        OptionalFormalArgumentProjectionV1
+        if allow_optional
+        else FormalArgumentProjectionV1
+    )
     fixed_kind = "optional-formal-argument" if allow_optional else "formal-argument"
     if kind == fixed_kind and set(raw) == {"kind", "parameterIndex"}:
         selector = fixed_cls(raw["parameterIndex"])
-    elif kind == "variadic-positional-element" and set(raw) == {"kind", "parameterIndex", "elementIndex"}:
-        selector = VariadicPositionalElementProjectionV1(raw["parameterIndex"], raw["elementIndex"])
-    elif kind == "variadic-keyword-entry" and set(raw) == {"kind", "parameterIndex", "keyword"}:
-        selector = VariadicKeywordEntryProjectionV1(raw["parameterIndex"], raw["keyword"])
+    elif kind == "variadic-positional-element" and set(raw) == {
+        "kind",
+        "parameterIndex",
+        "elementIndex",
+    }:
+        selector = VariadicPositionalElementProjectionV1(
+            raw["parameterIndex"], raw["elementIndex"]
+        )
+    elif kind == "variadic-keyword-entry" and set(raw) == {
+        "kind",
+        "parameterIndex",
+        "keyword",
+    }:
+        selector = VariadicKeywordEntryProjectionV1(
+            raw["parameterIndex"], raw["keyword"]
+        )
     else:
         raise ContextManagerContractError("unknown or malformed formal selector")
     _selector_to_value(selector)
@@ -934,58 +1261,114 @@ def _selector_parameter(selector, signature: ImportSignatureV2) -> CallParameter
     if selector.parameter_index >= len(signature.parameters):
         raise ContextManagerContractError("selector is outside ImportSignatureV2")
     parameter = signature.parameters[selector.parameter_index]
-    if isinstance(selector, (FormalArgumentProjectionV1, OptionalFormalArgumentProjectionV1)):
+    if isinstance(
+        selector, (FormalArgumentProjectionV1, OptionalFormalArgumentProjectionV1)
+    ):
         if isinstance(parameter.passing, (VariadicPositionalV1, VariadicKeywordV1)):
-            raise ContextManagerContractError("fixed selector cannot address a variadic parameter")
+            raise ContextManagerContractError(
+                "fixed selector cannot address a variadic parameter"
+            )
     elif isinstance(selector, VariadicPositionalElementProjectionV1):
         if not isinstance(parameter.passing, VariadicPositionalV1):
-            raise ContextManagerContractError("variadic element selector requires *args")
+            raise ContextManagerContractError(
+                "variadic element selector requires *args"
+            )
     elif isinstance(selector, VariadicKeywordEntryProjectionV1):
         if not isinstance(parameter.passing, VariadicKeywordV1):
-            raise ContextManagerContractError("variadic keyword selector requires **kwargs")
+            raise ContextManagerContractError(
+                "variadic keyword selector requires **kwargs"
+            )
     else:
         raise ContextManagerContractError("unknown formal selector")
     return parameter
 
 
-def _decode_effect_boundary(raw: Any, signature: ImportSignatureV2) -> EffectBoundarySemanticsV1:
-    if set(raw) != {"kind", "schemaVersion", "mode", "matcher", "binding"} or raw["schemaVersion"] != "1":
+def _decode_effect_boundary(
+    raw: Any, signature: ImportSignatureV2
+) -> EffectBoundarySemanticsV1:
+    if (
+        set(raw) != {"kind", "schemaVersion", "mode", "matcher", "binding"}
+        or raw["schemaVersion"] != "1"
+    ):
         raise ContextManagerContractError("malformed effect-boundary semantics")
     matcher = raw["matcher"]
-    if not isinstance(matcher, dict) or set(matcher) != {"effectKind", "expectedTypeOperand", "messagePatternOperand"}:
+    if not isinstance(matcher, dict) or set(matcher) != {
+        "effectKind",
+        "expectedTypeOperand",
+        "messagePatternOperand",
+    }:
         raise ContextManagerContractError("malformed effect-boundary matcher")
-    mode = _tag(raw["mode"], {"expects": ExpectsModeV1, "suppresses": SuppressesModeV1}, "effect-boundary mode")
-    effect_kind = _tag(matcher["effectKind"], {"raise": RaiseEffectKindV1, "warning": WarningEffectKindV1}, "effect kind")
+    mode = _tag(
+        raw["mode"],
+        {"expects": ExpectsModeV1, "suppresses": SuppressesModeV1},
+        "effect-boundary mode",
+    )
+    effect_kind = _tag(
+        matcher["effectKind"],
+        {"raise": RaiseEffectKindV1, "warning": WarningEffectKindV1},
+        "effect kind",
+    )
     expected = _decode_selector(matcher["expectedTypeOperand"], allow_optional=False)
     message_raw = matcher["messagePatternOperand"]
-    if isinstance(message_raw, dict) and set(message_raw) == {"kind"} and message_raw["kind"] == "none":
+    if (
+        isinstance(message_raw, dict)
+        and set(message_raw) == {"kind"}
+        and message_raw["kind"] == "none"
+    ):
         message = NoMessagePatternV1()
     else:
         message = _decode_selector(message_raw, allow_optional=True)
-    binding = _tag(raw["binding"], {"none": NoBindingV1, "exception-info": ExceptionInfoBindingV1, "warning-observation": WarningObservationBindingV1}, "effect-boundary binding")
+    binding = _tag(
+        raw["binding"],
+        {
+            "none": NoBindingV1,
+            "exception-info": ExceptionInfoBindingV1,
+            "warning-observation": WarningObservationBindingV1,
+        },
+        "effect-boundary binding",
+    )
     expected_parameter = _selector_parameter(expected, signature)
     if expected_parameter.sort != PrimitiveSort("Value"):
-        raise ContextManagerContractError("expected-type selector requires a Value formal")
+        raise ContextManagerContractError(
+            "expected-type selector requires a Value formal"
+        )
     if not isinstance(message, NoMessagePatternV1):
         parameter = _selector_parameter(message, signature)
         if message == expected:
-            raise ContextManagerContractError("effect-boundary selectors must be distinct")
+            raise ContextManagerContractError(
+                "effect-boundary selectors must be distinct"
+            )
         if isinstance(message, OptionalFormalArgumentProjectionV1):
-            if parameter.required or not isinstance(parameter.passing, (PositionalOrKeywordV1, KeywordOnlyV1)) or parameter.sort not in (PrimitiveSort("String"), PrimitiveSort("Value")):
-                raise ContextManagerContractError("message selector requires an optional keyword-bindable String-or-Value formal")
+            if (
+                parameter.required
+                or not isinstance(
+                    parameter.passing, (PositionalOrKeywordV1, KeywordOnlyV1)
+                )
+                or parameter.sort
+                not in (PrimitiveSort("String"), PrimitiveSort("Value"))
+            ):
+                raise ContextManagerContractError(
+                    "message selector requires an optional keyword-bindable String-or-Value formal"
+                )
         elif parameter.sort != PrimitiveSort("Value"):
-            raise ContextManagerContractError("variadic message selector requires a Value pack")
+            raise ContextManagerContractError(
+                "variadic message selector requires a Value pack"
+            )
     return EffectBoundarySemanticsV1(mode, effect_kind, expected, message, binding)
 
 
-def decode_context_manager_semantics_v1(raw: Any, signature: ImportSignatureV2 | None = None) -> ContextManagerSemanticsV1:
+def decode_context_manager_semantics_v1(
+    raw: Any, signature: ImportSignatureV2 | None = None
+) -> ContextManagerSemanticsV1:
     if not isinstance(raw, dict) or "kind" not in raw:
         raise ContextManagerContractError("malformed context-manager semantics")
     if raw["kind"] == "protocol-resource":
         return _decode_protocol_resource(raw)
     if raw["kind"] == "effect-boundary":
         if signature is None:
-            raise ContextManagerContractError("EffectBoundary decoding requires ImportSignatureV2")
+            raise ContextManagerContractError(
+                "EffectBoundary decoding requires ImportSignatureV2"
+            )
         return _decode_effect_boundary(raw, signature)
     raise ContextManagerContractError("unknown context-manager semantics variant")
 
@@ -1003,20 +1386,47 @@ def decode_context_manager_contract(
     if not isinstance(raw["metadata"], dict):
         raise ContextManagerContractError("layered metadata must be an object")
     if blake3_512_of(encode_jcs(_json_value(envelope)).encode()) != member_cid:
-        raise ContextManagerContractError("member attestation CID does not match envelope")
-    signing = vobj([("header", _json_value(header)), ("metadata", _json_value(raw["metadata"]))])
-    if not ed25519_verify_string(envelope.get("signer", ""), envelope.get("signature", ""), encode_jcs(signing).encode()):
+        raise ContextManagerContractError(
+            "member attestation CID does not match envelope"
+        )
+    signing = vobj(
+        [("header", _json_value(header)), ("metadata", _json_value(raw["metadata"]))]
+    )
+    if not ed25519_verify_string(
+        envelope.get("signer", ""),
+        envelope.get("signature", ""),
+        encode_jcs(signing).encode(),
+    ):
         raise ContextManagerContractError("member signature does not verify")
-    expected = {"schemaVersion", "kind", "cid", "payloadCid", "bridgeSourceSymbol", "importSignature", "payload", "sourceWarrants", "inputCids"}
-    if not isinstance(header, dict) or set(header) != expected or header.get("schemaVersion") != "1.2" or header.get("kind") != "context-manager-contract":
+    expected = {
+        "schemaVersion",
+        "kind",
+        "cid",
+        "payloadCid",
+        "bridgeSourceSymbol",
+        "importSignature",
+        "payload",
+        "sourceWarrants",
+        "inputCids",
+    }
+    if (
+        not isinstance(header, dict)
+        or set(header) != expected
+        or header.get("schemaVersion") != "1.2"
+        or header.get("kind") != "context-manager-contract"
+    ):
         raise ContextManagerContractError("malformed context-manager-contract header")
     signature = decode_import_signature_v2(header["importSignature"])
     semantics = decode_context_manager_semantics_v1(header["payload"], signature)
     payload_cid = blake3_512_of(encode_jcs(semantics_to_value(semantics)).encode())
     if header["cid"] != payload_cid or header["payloadCid"] != payload_cid:
-        raise ContextManagerContractError("context-manager payload CID does not match semantics")
+        raise ContextManagerContractError(
+            "context-manager payload CID does not match semantics"
+        )
     warrants = header["sourceWarrants"]
-    if not isinstance(warrants, list) or not all(isinstance(v, str) and v.startswith("blake3-512:") for v in warrants):
+    if not isinstance(warrants, list) or not all(
+        isinstance(v, str) and v.startswith("blake3-512:") for v in warrants
+    ):
         raise ContextManagerContractError("sourceWarrants must be CID references")
     if header["inputCids"] != sorted(warrants):
         raise ContextManagerContractError("inputCids do not match sourceWarrants")

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -33,14 +33,20 @@ class SourceFragmentCoordinateV1:
     @classmethod
     def decode(cls, raw: Any) -> "SourceFragmentCoordinateV1":
         if not isinstance(raw, dict) or set(raw) != {
-            "sourceCid", "startLine", "startCol", "endLine", "endCol"
+            "sourceCid",
+            "startLine",
+            "startCol",
+            "endLine",
+            "endCol",
         }:
             raise ContractRefProtocolError("malformed source-fragment coordinate")
         values = (raw["startLine"], raw["startCol"], raw["endLine"], raw["endCol"])
         if not isinstance(raw["sourceCid"], str) or not all(
             isinstance(value, int) and value >= 0 for value in values
         ):
-            raise ContractRefProtocolError("malformed source-fragment coordinate fields")
+            raise ContractRefProtocolError(
+                "malformed source-fragment coordinate fields"
+            )
         return cls(raw["sourceCid"], *values)
 
     def wire(self) -> dict[str, Any]:
@@ -85,7 +91,9 @@ class ResolvedContractRefsV1:
     table_cid: str
     by_use_site: Mapping[SourceFragmentCoordinateV1, ContextManagerResolutionV1]
 
-    def require(self, use_site: SourceFragmentCoordinateV1) -> ContextManagerResolutionV1:
+    def require(
+        self, use_site: SourceFragmentCoordinateV1
+    ) -> ContextManagerResolutionV1:
         try:
             return self.by_use_site[use_site]
         except KeyError as exc:
@@ -101,11 +109,18 @@ class TreeConstructionContextV1:
     workspace_root: str | None = None
 
 
-_GAP_KINDS = frozenset({
-    "runtime-selected", "unresolved-symbol", "ambiguous-symbol",
-    "wrong-contract-kind", "signature-mismatch", "unauthenticated-member",
-    "payload-cid-mismatch", "unsupported-cm-schema",
-})
+_GAP_KINDS = frozenset(
+    {
+        "runtime-selected",
+        "unresolved-symbol",
+        "ambiguous-symbol",
+        "wrong-contract-kind",
+        "signature-mismatch",
+        "unauthenticated-member",
+        "payload-cid-mismatch",
+        "unsupported-cm-schema",
+    }
+)
 
 
 def _cid(value: Any, field: str) -> str:
@@ -122,11 +137,21 @@ def _decode_signature(raw: Any) -> ImportSignatureV2:
 
 
 def _resolution_cid_preimage(raw: dict[str, Any]) -> dict[str, Any]:
-    return {key: raw[key] for key in (
-        "schemaVersion", "demandCid", "useSite", "catalogCid", "memberCid",
-        "payloadCid", "bridgeSourceSymbol", "importSignature", "semantics",
-        "sourceWarrantCids",
-    )}
+    return {
+        key: raw[key]
+        for key in (
+            "schemaVersion",
+            "demandCid",
+            "useSite",
+            "catalogCid",
+            "memberCid",
+            "payloadCid",
+            "bridgeSourceSymbol",
+            "importSignature",
+            "semantics",
+            "sourceWarrantCids",
+        )
+    }
 
 
 def _hash_json(raw: Any) -> str:
@@ -135,9 +160,18 @@ def _hash_json(raw: Any) -> str:
 
 def _decode_ref(raw: Any) -> ContextManagerContractRefV1:
     expected = {
-        "kind", "schemaVersion", "resolutionCid", "demandCid", "useSite",
-        "catalogCid", "memberCid", "payloadCid", "bridgeSourceSymbol",
-        "importSignature", "semantics", "sourceWarrantCids",
+        "kind",
+        "schemaVersion",
+        "resolutionCid",
+        "demandCid",
+        "useSite",
+        "catalogCid",
+        "memberCid",
+        "payloadCid",
+        "bridgeSourceSymbol",
+        "importSignature",
+        "semantics",
+        "sourceWarrantCids",
     }
     if not isinstance(raw, dict) or set(raw) != expected:
         raise ContractRefProtocolError("malformed context-manager contract ref")
@@ -155,22 +189,31 @@ def _decode_ref(raw: Any) -> ContextManagerContractRefV1:
     if not isinstance(warrants, list):
         raise ContractRefProtocolError("sourceWarrantCids must be a list")
     return ContextManagerContractRefV1(
-        resolution_cid, _cid(raw["demandCid"], "demandCid"),
+        resolution_cid,
+        _cid(raw["demandCid"], "demandCid"),
         SourceFragmentCoordinateV1.decode(raw["useSite"]),
-        _cid(raw["catalogCid"], "catalogCid"), _cid(raw["memberCid"], "memberCid"),
-        _cid(raw["payloadCid"], "payloadCid"), raw["bridgeSourceSymbol"],
-        signature, semantics,
+        _cid(raw["catalogCid"], "catalogCid"),
+        _cid(raw["memberCid"], "memberCid"),
+        _cid(raw["payloadCid"], "payloadCid"),
+        raw["bridgeSourceSymbol"],
+        signature,
+        semantics,
         tuple(_cid(value, "sourceWarrantCid") for value in warrants),
     )
 
 
 def decode_resolved_contract_refs(raw: Any) -> ResolvedContractRefsV1:
-    if not isinstance(raw, dict) or set(raw) != {
-        "kind", "schemaVersion", "catalogCid", "tableCid", "byUseSite"
-    } or raw["kind"] != "resolved-contract-refs" or raw["schemaVersion"] != "1":
+    if (
+        not isinstance(raw, dict)
+        or set(raw) != {"kind", "schemaVersion", "catalogCid", "tableCid", "byUseSite"}
+        or raw["kind"] != "resolved-contract-refs"
+        or raw["schemaVersion"] != "1"
+    ):
         raise ContractRefProtocolError("malformed resolved-contract-ref table")
     table_cid = _cid(raw["tableCid"], "tableCid")
-    identity = {key: raw[key] for key in ("kind", "schemaVersion", "catalogCid", "byUseSite")}
+    identity = {
+        key: raw[key] for key in ("kind", "schemaVersion", "catalogCid", "byUseSite")
+    }
     if _hash_json(identity) != table_cid:
         raise ContractRefProtocolError("resolution table CID mismatch")
     rows = raw["byUseSite"]
@@ -185,21 +228,30 @@ def decode_resolved_contract_refs(raw: Any) -> ResolvedContractRefsV1:
         resolution = row["resolution"]
         if not isinstance(resolution, dict):
             raise ContractRefProtocolError("malformed resolution")
-        if resolution.get("kind") == "resolved" and set(resolution) == {"kind", "reference"}:
+        if resolution.get("kind") == "resolved" and set(resolution) == {
+            "kind",
+            "reference",
+        }:
             value: ContextManagerResolutionV1 = _decode_ref(resolution["reference"])
             if value.use_site != use_site or value.catalog_cid != catalog_cid:
                 raise ContractRefProtocolError("resolution coordinate/catalog mismatch")
-        elif resolution.get("kind") == "unresolved" and set(resolution) == {"kind", "gap"}:
+        elif resolution.get("kind") == "unresolved" and set(resolution) == {
+            "kind",
+            "gap",
+        }:
             gap = resolution["gap"]
             if not isinstance(gap, dict) or gap.get("kind") not in _GAP_KINDS:
-                raise ContractRefProtocolError("malformed context-manager resolution gap")
+                raise ContractRefProtocolError(
+                    "malformed context-manager resolution gap"
+                )
             candidates = gap.get("candidateMemberCids")
             if not isinstance(candidates, list) or candidates != sorted(candidates):
                 raise ContractRefProtocolError("candidate member CIDs must be sorted")
             value = ContextManagerResolutionGapV1(
                 _cid(gap.get("demandCid"), "demandCid"),
                 SourceFragmentCoordinateV1.decode(gap.get("useSite")),
-                gap.get("targetSymbol"), gap["kind"],
+                gap.get("targetSymbol"),
+                gap["kind"],
                 tuple(_cid(v, "candidateMemberCid") for v in candidates),
             )
             if value.use_site != use_site:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/name_error_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/name_error_effect.py
@@ -21,9 +21,11 @@ class NameErrorEffect(RaiseEffect):
         object.__setattr__(
             self,
             "source_sha256",
-            hashlib.sha256(source.encode()).hexdigest()
-            if isinstance(source, str)
-            else None,
+            (
+                hashlib.sha256(source.encode()).hexdigest()
+                if isinstance(source, str)
+                else None
+            ),
         )
         object.__setattr__(self, "occurrence", locus)
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
@@ -177,9 +177,7 @@ def _route_expects(
                 )
             )
         bindings = _binding_for_slot(slot_id, observation)
-        binding_facts = tuple(
-            f for b in bindings for f in b.to_facts(site=site)
-        )
+        binding_facts = tuple(f for b in bindings for f in b.to_facts(site=site))
         remaining = entries[:index] + entries[index + 1 :]
         all_facts = (*facts, *binding_facts)
         return RoutedOutcome(
@@ -202,9 +200,7 @@ def _route_expects(
             str_const(o.pattern) for o in matcher.payload_obligations
         ]
         obligation = InvValue(atomic(_EFFECT_EXPECTED_OBLIGATION, operands), site=site)
-        return RoutedOutcome(
-            entries=(*entries, obligation), stated_facts=(obligation,)
-        )
+        return RoutedOutcome(entries=(*entries, obligation), stated_facts=(obligation,))
 
     fact = InvValue(
         eq(str_const(matcher.name), str_const(_EFFECT_ABSENT_NAME)), site=site
@@ -235,13 +231,9 @@ def route(
 ) -> RoutedOutcome:
     """Route once. Optional ``slot_id`` receives EffectBinding testimony on match."""
     if isinstance(contract, Expects):
-        return _route_expects(
-            entries, contract.matcher, slot_id=slot_id, site=site
-        )
+        return _route_expects(entries, contract.matcher, slot_id=slot_id, site=site)
     if isinstance(contract, Suppresses):
-        return _route_suppresses(
-            entries, contract.matcher, slot_id=slot_id, site=site
-        )
+        return _route_suppresses(entries, contract.matcher, slot_id=slot_id, site=site)
     if isinstance(contract, NeverSuppresses):
         return RoutedOutcome(entries=entries)
     if isinstance(contract, RuntimeSelected):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/engine_log.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/engine_log.py
@@ -181,10 +181,9 @@ def configure_live_log(path: str | None = None) -> None:
     if not selected or _LIVE_HANDLER is not None:
         return
     handler = logging.FileHandler(selected, mode="a", encoding="utf-8", delay=False)
-    trace_events = (
-        os.environ.get("SUGAR_ENGINE_TRACE_EVENTS", "1").strip().lower()
-        not in {"0", "false", "no", "off"}
-    )
+    trace_events = os.environ.get(
+        "SUGAR_ENGINE_TRACE_EVENTS", "1"
+    ).strip().lower() not in {"0", "false", "no", "off"}
     handler.setLevel(logging.DEBUG if trace_events else logging.WARNING)
     handler.setFormatter(logging.Formatter("%(message)s"))
     LOGGER.addHandler(handler)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/exit_disposition_proof.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/exit_disposition_proof.py
@@ -324,9 +324,7 @@ def _lookup_name_in_module(
             bound = alias.asname or alias.name
             if bound != name:
                 continue
-            target = _resolve_relative(
-                module_name, filename, node.level, node.module
-            )
+            target = _resolve_relative(module_name, filename, node.level, node.module)
             if target is None:
                 return None
             return _lookup_name_in_module(target, alias.name, depth=depth + 1)
@@ -335,7 +333,11 @@ def _lookup_name_in_module(
     for node in _module_level_nodes(tree):
         if isinstance(node, ast.Assign) and len(node.targets) == 1:
             t = node.targets[0]
-            if isinstance(t, ast.Name) and t.id == name and isinstance(node.value, ast.Name):
+            if (
+                isinstance(t, ast.Name)
+                and t.id == name
+                and isinstance(node.value, ast.Name)
+            ):
                 return _lookup_name_in_module(
                     module_name, node.value.id, depth=depth + 1
                 )
@@ -365,7 +367,11 @@ def _local_import_bindings(source: str) -> dict[str, tuple[str, str]]:
                     # import a.b.c binds only top-level name `a`
                     top = alias.name.split(".")[0]
                     out[top] = ("module", top)
-        if isinstance(node, ast.ImportFrom) and node.module is not None and node.level == 0:
+        if (
+            isinstance(node, ast.ImportFrom)
+            and node.module is not None
+            and node.level == 0
+        ):
             for alias in node.names:
                 if alias.name == "*":
                     continue

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -7,7 +7,7 @@ from typing import Any, NoReturn
 from sugar_lift_py_tests.ir import Term, TermTableBuilder
 from sugar_lift_py_tests.sugar.function_body_universe import FunctionBodyUniverse
 from sugar_lift_py_tests.sugar_body import SugarBody
- 
+
 
 from .floor_value import FloorValue
 
@@ -104,7 +104,9 @@ class CallSiteValue(FloorValue):
     # never an attestation/member CID and is absent for ordinary unresolved
     # call sites.
     target_contract_cid: str | None = dataclass_field(default=None, compare=False)
-    authenticated_target_symbol: str | None = dataclass_field(default=None, compare=False)
+    authenticated_target_symbol: str | None = dataclass_field(
+        default=None, compare=False
+    )
 
     def __hash__(self) -> int:
         """Hash the finite call coordinate, never the recursively-owned body.
@@ -793,7 +795,8 @@ class CallSiteValue(FloorValue):
         edge = {
             "kind": "call-edge",
             "sourceContract": source_contract,
-            "targetSymbol": self.authenticated_target_symbol or f"call:{self.target_name}",
+            "targetSymbol": self.authenticated_target_symbol
+            or f"call:{self.target_name}",
         }
         if self.target_contract_cid is not None:
             edge["targetContractCid"] = self.target_contract_cid

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -297,9 +297,7 @@ class FloorValue:
         ctx: FactoryBuildContext | None,
     ) -> Outcome:
         del ctx
-        return self._operation_construction_gap(
-            operation, "callable_application_with"
-        )
+        return self._operation_construction_gap(operation, "callable_application_with")
 
     def call_method_with(
         self, operation: MethodCallOperation, ctx: FactoryBuildContext | None

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_alias_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_alias_value.py
@@ -26,13 +26,17 @@ class ImportAliasValue(FloorValue):
         del owner
         from sugar_lift_py_tests.ir import ctor, str_const
 
-        return ctor("python:import_alias", [str_const(self.bound_name), str_const(self.name)])
+        return ctor(
+            "python:import_alias", [str_const(self.bound_name), str_const(self.name)]
+        )
 
     def test_python_type(self, value, site):
         from sugar_lift_py_tests.floor.type_tester import native_type_tester
         from sugar_lift_py_tests.ir import ctor, str_const
 
-        return native_type_tester(value, ctor("python:type", [str_const(self.name)]), site)
+        return native_type_tester(
+            value, ctor("python:type", [str_const(self.name)]), site
+        )
 
     def qualified_class_attribute(self, attribute: str) -> ImportAliasValue | None:
         del attribute
@@ -112,7 +116,14 @@ class ImportAliasValue(FloorValue):
             from sugar_lift_py_tests.ir import ctor
             from sugar_lift_py_tests.outcome import Complete
 
-            return Complete(SymbolicValue(ctor("|", [self.to_term(owner=str(site)), other.to_term(owner=str(site))])))
+            return Complete(
+                SymbolicValue(
+                    ctor(
+                        "|",
+                        [self.to_term(owner=str(site)), other.to_term(owner=str(site))],
+                    )
+                )
+            )
         return super().bitwise_or(other, site)
 
     def unary_minus(self, site):
@@ -127,54 +138,78 @@ class ImportAliasValue(FloorValue):
     def format_data_model(self, spec, site, ctx):
         del spec, ctx
         return _runtime_alias_effect_at_site(
-            self, shape=f"format({self.bound_name}, ...)", site=site,
+            self,
+            shape=f"format({self.bound_name}, ...)",
+            site=site,
             replacement="ImportedModuleFormatEffect",
         )
 
     def _binary_runtime_effect(self, other, site, operator):
         del other
         return _runtime_alias_effect_at_site(
-            self, shape=f"{self.bound_name} {operator} ...", site=site,
+            self,
+            shape=f"{self.bound_name} {operator} ...",
+            site=site,
             replacement="ImportedModuleBinaryEffect",
         )
 
     def _unary_runtime_effect(self, site, operator):
         return _runtime_alias_effect_at_site(
-            self, shape=f"{operator}{self.bound_name}", site=site,
+            self,
+            shape=f"{operator}{self.bound_name}",
+            site=site,
             replacement="ImportedModuleUnaryEffect",
         )
 
     def call_method_with(self, operation: Any, ctx: object):
         del ctx
-        return _runtime_alias_effect(self, operation=operation,
+        return _runtime_alias_effect(
+            self,
+            operation=operation,
             shape=f"{self.bound_name}.{operation.name}(...)",
-            replacement="ImportedModuleCallEffect")
+            replacement="ImportedModuleCallEffect",
+        )
 
     def subscript_with(self, operation: Any, ctx: object):
         del ctx
-        return _runtime_alias_effect(self, operation=operation,
-            shape=f"{self.bound_name}[...]", replacement="ImportedModuleSubscriptEffect")
+        return _runtime_alias_effect(
+            self,
+            operation=operation,
+            shape=f"{self.bound_name}[...]",
+            replacement="ImportedModuleSubscriptEffect",
+        )
 
     def contains_with(self, operation: Any, ctx: object):
         del ctx
-        return _runtime_alias_effect(self, operation=operation,
+        return _runtime_alias_effect(
+            self,
+            operation=operation,
             shape="contains membership over imported module binding",
-            replacement="ImportedModuleContainsEffect")
+            replacement="ImportedModuleContainsEffect",
+        )
 
     def attribute_assign_with(self, operation: Any, ctx: object):
         del ctx
-        return _runtime_alias_effect(self, operation=operation,
+        return _runtime_alias_effect(
+            self,
+            operation=operation,
             shape=f"{self.bound_name}.{operation.name} = ...",
-            replacement="ImportedModuleAttributeAssignEffect")
+            replacement="ImportedModuleAttributeAssignEffect",
+        )
 
     def binary_operator_with(self, operation: Any, ctx: object):
         del ctx
-        return _runtime_alias_effect(self, operation=operation,
+        return _runtime_alias_effect(
+            self,
+            operation=operation,
             shape=f"{self.bound_name} {operation.operator} ...",
-            replacement="ImportedModuleBinaryEffect")
+            replacement="ImportedModuleBinaryEffect",
+        )
 
 
-def _runtime_alias_effect(value: ImportAliasValue, *, operation: Any, shape: str, replacement: str):
+def _runtime_alias_effect(
+    value: ImportAliasValue, *, operation: Any, shape: str, replacement: str
+):
     return _runtime_alias_effect_at_site(
         value, shape=shape, site=operation.site, replacement=replacement
     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -440,9 +440,7 @@ class SymbolicValue(FloorValue):
         from sugar_lift_py_tests.outcome import Complete
 
         return Complete(
-            PredicateValue(
-                atomic("py.in", [item.to_term(owner="contains"), self.term])
-            )
+            PredicateValue(atomic("py.in", [item.to_term(owner="contains"), self.term]))
         )
 
     def format_data_model(self, spec, site, ctx):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/gap/audit_row.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/gap/audit_row.py
@@ -60,7 +60,6 @@ def _unhandled_gap_kind(kind: Never) -> NoReturn:
     raise TypeError(f"unhandled GapKind arm: {type(kind).__name__}")
 
 
-
 @dataclass(frozen=True)
 class ConstructionAuditRow:
     role: str

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/factory_walk_unclassified_locus.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/factory_walk_unclassified_locus.py
@@ -114,9 +114,9 @@ def project_unclassified_locus(row: Any) -> dict[str, Any] | None:
         )
         reason = row.get("reason") or ""
         extra = row.get("extra") if isinstance(row.get("extra"), Mapping) else {}
-        resolution_kind = row.get("resolution_kind") or extra.get(
-            "resolution_kind"
-        ) or ""
+        resolution_kind = (
+            row.get("resolution_kind") or extra.get("resolution_kind") or ""
+        )
     else:
         file = getattr(row, "file", None) or getattr(row, "path", None) or ""
         line = getattr(row, "line", None)
@@ -177,13 +177,12 @@ def locus_is_addressable(locus: Mapping[str, Any]) -> bool:
         line_int = 0
     ast_kind = str(locus.get("ast_kind") or locus.get("astKind") or "").strip()
     role = str(
-        locus.get("role")
-        or locus.get("requested_role")
-        or locus.get("selected")
-        or ""
+        locus.get("role") or locus.get("requested_role") or locus.get("selected") or ""
     ).strip()
     reason = str(locus.get("reason") or "").strip()
-    return bool(file) and line_int > 0 and bool(ast_kind) and bool(role) and bool(reason)
+    return (
+        bool(file) and line_int > 0 and bool(ast_kind) and bool(role) and bool(reason)
+    )
 
 
 def shape_split_unclassified(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/timeout_mechanism_fingerprint.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/timeout_mechanism_fingerprint.py
@@ -114,7 +114,11 @@ def fingerprint_engine_events(
             continue
         event_count += 1
         event = raw.get("event")
-        role = raw.get("role") if isinstance(raw.get("role"), str) else str(raw.get("role") or "")
+        role = (
+            raw.get("role")
+            if isinstance(raw.get("role"), str)
+            else str(raw.get("role") or "")
+        )
         sugar = str(raw.get("sugar") or "?")
         if event == "enter":
             enter_roles[role or "?"] += 1
@@ -131,7 +135,9 @@ def fingerprint_engine_events(
 
     multi_miss = {name: count for name, count in resolve_miss.items() if count > 1}
     wasted_reresolves = sum(count - 1 for count in multi_miss.values())
-    dominant = mechanism_hb.most_common(1)[0][0] if mechanism_hb else MECHANISM_ROOT_OR_OTHER
+    dominant = (
+        mechanism_hb.most_common(1)[0][0] if mechanism_hb else MECHANISM_ROOT_OR_OTHER
+    )
     miss_total = sum(resolve_miss.values())
     hit_total = sum(resolve_hit.values())
     return {

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -25,10 +25,19 @@ def _site(source_cid: str, node: ast.AST) -> dict[str, Any]:
     if not hasattr(node, "lineno"):
         body = getattr(node, "body", ())
         if not body:
-            return {"sourceCid": source_cid, "startLine": 1, "startCol": 0, "endLine": 1, "endCol": 0}
+            return {
+                "sourceCid": source_cid,
+                "startLine": 1,
+                "startCol": 0,
+                "endLine": 1,
+                "endCol": 0,
+            }
         return {
-            "sourceCid": source_cid, "startLine": 1, "startCol": 0,
-            "endLine": body[-1].end_lineno, "endCol": body[-1].end_col_offset,
+            "sourceCid": source_cid,
+            "startLine": 1,
+            "startCol": 0,
+            "endLine": body[-1].end_lineno,
+            "endCol": body[-1].end_col_offset,
         }
     return {
         "sourceCid": source_cid,
@@ -61,7 +70,9 @@ State = dict[str, frozenset[Definition]]
 def _join(*states: State) -> State:
     names = set().union(*(state for state in states))
     return {
-        name: frozenset().union(*(state.get(name, frozenset({_UNBOUND})) for state in states))
+        name: frozenset().union(
+            *(state.get(name, frozenset({_UNBOUND})) for state in states)
+        )
         for name in names
     }
 
@@ -178,7 +189,9 @@ class _Pass:
                 inner[node.args.kwarg.arg] = frozenset({_NON_IMPORT})
             self.expression(node.body, inner, node)
             return
-        if isinstance(node, (ast.ListComp, ast.SetComp, ast.GeneratorExp, ast.DictComp)):
+        if isinstance(
+            node, (ast.ListComp, ast.SetComp, ast.GeneratorExp, ast.DictComp)
+        ):
             inner = dict(state)
             for generator in node.generators:
                 self.expression(generator.iter, inner, scope)
@@ -210,22 +223,23 @@ class _Pass:
                 "useSite": use_site,
                 "importBindingCid": binding.cid,
             }
-            self.rows.append({
-                "schemaVersion": "1",
-                "kind": "call-contract-demand",
-                "authenticatedImportUse": {**use, "cid": _hash(use)},
-                "importBinding": json.loads(binding.payload_jcs),
-                "targetSymbol": binding.target_symbol,
-                "importBindingCid": binding.cid,
-                "importSignature": {
-                    "formals": [],
-                    "sorts": [
-                        {"kind": "primitive", "name": "Value"}
-                        for _ in node.args
-                    ],
-                },
-                "useSite": use_site,
-            })
+            self.rows.append(
+                {
+                    "schemaVersion": "1",
+                    "kind": "call-contract-demand",
+                    "authenticatedImportUse": {**use, "cid": _hash(use)},
+                    "importBinding": json.loads(binding.payload_jcs),
+                    "targetSymbol": binding.target_symbol,
+                    "importBindingCid": binding.cid,
+                    "importSignature": {
+                        "formals": [],
+                        "sorts": [
+                            {"kind": "primitive", "name": "Value"} for _ in node.args
+                        ],
+                    },
+                    "useSite": use_site,
+                }
+            )
         elif imports:
             self.outcomes[key] = "ambiguous-lexical-binding"
         elif reaching == frozenset({_NON_IMPORT}):
@@ -233,7 +247,9 @@ class _Pass:
         else:
             self.outcomes[key] = "no-lexical-binding"
 
-    def statements(self, statements: Iterable[ast.stmt], state: State, scope: ast.AST) -> State:
+    def statements(
+        self, statements: Iterable[ast.stmt], state: State, scope: ast.AST
+    ) -> State:
         state = dict(state)
         for statement in statements:
             state = self.statement(statement, state, scope)
@@ -257,49 +273,79 @@ class _Pass:
                     "definitionSite": _site(self.source_cid, node),
                     "localSlot": local,
                     "target": {
-                        "moduleIdentity": self.module_identities.get(module, {
-                            "kind": "unavailable-python-module", "name": module,
-                        }),
+                        "moduleIdentity": self.module_identities.get(
+                            module,
+                            {
+                                "kind": "unavailable-python-module",
+                                "name": module,
+                            },
+                        ),
                         "exportedPath": [alias.name],
                     },
                 }
-                state[local] = frozenset({
-                    _ImportDef(
-                        _hash(payload), f"python:{module}.{alias.name}",
-                        encode_jcs(_json_value(payload)),
-                    )
-                })
+                state[local] = frozenset(
+                    {
+                        _ImportDef(
+                            _hash(payload),
+                            f"python:{module}.{alias.name}",
+                            encode_jcs(_json_value(payload)),
+                        )
+                    }
+                )
             return state
         if isinstance(node, ast.Import):
             for alias in node.names:
                 local = alias.asname or alias.name.split(".")[0]
                 payload = {
-                    "kind": "python-import-binding", "schemaVersion": "1",
-                    "sourceCid": self.source_cid, "scope": _site(self.source_cid, scope),
-                    "definitionSite": _site(self.source_cid, node), "localSlot": local,
-                    "target": {"moduleIdentity": self.module_identities.get(alias.name, {
-                        "kind": "unavailable-python-module", "name": alias.name,
-                    }), "exportedPath": []},
+                    "kind": "python-import-binding",
+                    "schemaVersion": "1",
+                    "sourceCid": self.source_cid,
+                    "scope": _site(self.source_cid, scope),
+                    "definitionSite": _site(self.source_cid, node),
+                    "localSlot": local,
+                    "target": {
+                        "moduleIdentity": self.module_identities.get(
+                            alias.name,
+                            {
+                                "kind": "unavailable-python-module",
+                                "name": alias.name,
+                            },
+                        ),
+                        "exportedPath": [],
+                    },
                 }
-                state[local] = frozenset({
-                    _ImportDef(
-                        _hash(payload), f"python:{alias.name}",
-                        encode_jcs(_json_value(payload)),
-                    )
-                })
+                state[local] = frozenset(
+                    {
+                        _ImportDef(
+                            _hash(payload),
+                            f"python:{alias.name}",
+                            encode_jcs(_json_value(payload)),
+                        )
+                    }
+                )
             return state
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             for deco in node.decorator_list:
                 self.expression(deco, state, scope)
-            for default in (*node.args.defaults, *(d for d in node.args.kw_defaults if d)):
+            for default in (
+                *node.args.defaults,
+                *(d for d in node.args.kw_defaults if d),
+            ):
                 self.expression(default, state, scope)
             if isinstance(scope, ast.Module):
-                state[node.name] = frozenset({
-                    _ModuleFunctionDef(
-                        f"python:{self.module_name}.{node.name}",
-                        (node.lineno, node.col_offset, node.end_lineno, node.end_col_offset),
-                    )
-                })
+                state[node.name] = frozenset(
+                    {
+                        _ModuleFunctionDef(
+                            f"python:{self.module_name}.{node.name}",
+                            (
+                                node.lineno,
+                                node.col_offset,
+                                node.end_lineno,
+                                node.end_col_offset,
+                            ),
+                        )
+                    }
+                )
             else:
                 state[node.name] = frozenset({_NON_IMPORT})
             if not self.analyze_nested:
@@ -407,7 +453,9 @@ def _function_locals(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
             self.nonlocals.update(child.names)
 
         def visit_Import(self, child):
-            self.names.update(alias.asname or alias.name.split(".")[0] for alias in child.names)
+            self.names.update(
+                alias.asname or alias.name.split(".")[0] for alias in child.names
+            )
 
         visit_ImportFrom = visit_Import
 
@@ -489,7 +537,10 @@ def _final_module_state(
 
 
 def authenticated_import_uses(
-    root: Path, path: Path, source: str, source_cid: str,
+    root: Path,
+    path: Path,
+    source: str,
+    source_cid: str,
     module_identities: dict[str, dict[str, Any]] | None = None,
 ) -> tuple[list[dict[str, Any]], dict[tuple[int, int, int, int], str]]:
     module = ast.parse(source, filename=str(path))
@@ -531,26 +582,32 @@ def authenticated_module_exports(
         if isinstance(definition, _ModuleFunctionDef):
             exported = target = definition.target_symbol
             start_line, start_col, end_line, end_col = definition.definition_site
-            rows.append({
-                "kind": "call-contract-export", "schemaVersion": "1",
-                "sourceCid": source_cid,
-                "definitionSite": {
+            rows.append(
+                {
+                    "kind": "call-contract-export",
+                    "schemaVersion": "1",
                     "sourceCid": source_cid,
-                    "startLine": start_line,
-                    "startCol": start_col,
-                    "endLine": end_line,
-                    "endCol": end_col,
-                },
-                "exportedSymbol": exported, "targetSymbol": target,
-            })
+                    "definitionSite": {
+                        "sourceCid": source_cid,
+                        "startLine": start_line,
+                        "startCol": start_col,
+                        "endLine": end_line,
+                        "endCol": end_col,
+                    },
+                    "exportedSymbol": exported,
+                    "targetSymbol": target,
+                }
+            )
         elif isinstance(definition, _ImportDef):
             payload = json.loads(definition.payload_jcs)
-            rows.append({
-                "kind": "call-contract-export",
-                "schemaVersion": "1",
-                "sourceCid": source_cid,
-                "definitionSite": payload["definitionSite"],
-                "exportedSymbol": f"python:{module_name}.{local}",
-                "targetSymbol": definition.target_symbol,
-            })
+            rows.append(
+                {
+                    "kind": "call-contract-export",
+                    "schemaVersion": "1",
+                    "sourceCid": source_cid,
+                    "definitionSite": payload["definitionSite"],
+                    "exportedSymbol": f"python:{module_name}.{local}",
+                    "targetSymbol": definition.target_symbol,
+                }
+            )
     return rows

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
@@ -311,9 +311,7 @@ def _intern_term(term: Term) -> Term:
             children = (
                 node.args
                 if isinstance(node, _Ctor)
-                else (node.body,)
-                if isinstance(node, _Lambda)
-                else ()
+                else (node.body,) if isinstance(node, _Lambda) else ()
             )
             if not children:
                 done[node_id] = _commit_interned_term(by_key, by_id, node, ())
@@ -688,7 +686,9 @@ class _Atomic:
         return hash(_formula_cycle_key(self))
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, _Atomic) and _formula_cycle_key(self) == _formula_cycle_key(other)
+        return isinstance(other, _Atomic) and _formula_cycle_key(
+            self
+        ) == _formula_cycle_key(other)
 
 
 @dataclass(frozen=True)
@@ -700,7 +700,9 @@ class _Connective:
         return hash(_formula_cycle_key(self))
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, _Connective) and _formula_cycle_key(self) == _formula_cycle_key(other)
+        return isinstance(other, _Connective) and _formula_cycle_key(
+            self
+        ) == _formula_cycle_key(other)
 
 
 @dataclass(frozen=True)
@@ -714,7 +716,9 @@ class _Quantifier:
         return hash(_formula_cycle_key(self))
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, _Quantifier) and _formula_cycle_key(self) == _formula_cycle_key(other)
+        return isinstance(other, _Quantifier) and _formula_cycle_key(
+            self
+        ) == _formula_cycle_key(other)
 
 
 Formula = Union[_Atomic, _Connective, _Quantifier]
@@ -1131,9 +1135,7 @@ class TermTableBuilder:
             children = (
                 term.get("args", []) or []
                 if kind == "ctor"
-                else [term["body"]]
-                if kind == "lambda"
-                else []
+                else [term["body"]] if kind == "lambda" else []
             )
             for child in children:
                 if not isinstance(child, dict):
@@ -1159,9 +1161,7 @@ class TermTableBuilder:
             if kind in {"ctor", "lambda"} and not finishing:
                 work.append((term, True))
                 children = (
-                    term.get("args", []) or []
-                    if kind == "ctor"
-                    else [term["body"]]
+                    term.get("args", []) or [] if kind == "ctor" else [term["body"]]
                 )
                 work.extend((child, False) for child in reversed(children))
                 continue
@@ -1286,9 +1286,7 @@ class TermTableBuilder:
             children = (
                 term.args
                 if isinstance(term, _Ctor)
-                else (term.body,)
-                if isinstance(term, _Lambda)
-                else ()
+                else (term.body,) if isinstance(term, _Lambda) else ()
             )
             for child in children:
                 child_id = id(child)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/context_manager_contract_dto.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/context_manager_contract_dto.py
@@ -42,8 +42,12 @@ class ContextManagerContractIrV1:
 
     @classmethod
     def never_suppresses(
-        cls, *, bridge_source_symbol: str, import_signature: ImportSignatureV2,
-        enter_result_sort: Sort, source_warrants: tuple[str, ...],
+        cls,
+        *,
+        bridge_source_symbol: str,
+        import_signature: ImportSignatureV2,
+        enter_result_sort: Sort,
+        source_warrants: tuple[str, ...],
     ) -> "ContextManagerContractIrV1":
         return cls(
             bridge_source_symbol=bridge_source_symbol,
@@ -57,11 +61,23 @@ class ContextManagerContractIrV1:
 
     @classmethod
     def effect_boundary(
-        cls, *, bridge_source_symbol: str, import_signature: ImportSignatureV2,
+        cls,
+        *,
+        bridge_source_symbol: str,
+        import_signature: ImportSignatureV2,
         mode: ExpectsModeV1 | SuppressesModeV1,
         effect_kind: RaiseEffectKindV1 | WarningEffectKindV1,
-        expected_type_operand: FormalArgumentProjectionV1 | VariadicPositionalElementProjectionV1 | VariadicKeywordEntryProjectionV1,
-        message_pattern_operand: NoMessagePatternV1 | OptionalFormalArgumentProjectionV1 | VariadicPositionalElementProjectionV1 | VariadicKeywordEntryProjectionV1,
+        expected_type_operand: (
+            FormalArgumentProjectionV1
+            | VariadicPositionalElementProjectionV1
+            | VariadicKeywordEntryProjectionV1
+        ),
+        message_pattern_operand: (
+            NoMessagePatternV1
+            | OptionalFormalArgumentProjectionV1
+            | VariadicPositionalElementProjectionV1
+            | VariadicKeywordEntryProjectionV1
+        ),
         binding: NoBindingV1 | ExceptionInfoBindingV1 | WarningObservationBindingV1,
         source_warrants: tuple[str, ...],
     ) -> "ContextManagerContractIrV1":
@@ -84,13 +100,18 @@ class ContextManagerContractIrV1:
         if not all(w.startswith("blake3-512:") for w in self.source_warrants):
             raise ValueError("sourceWarrants must be CID references")
         payload = json.loads(_encode(semantics_to_value(self.payload)))
-        if decode_context_manager_semantics_v1(payload, self.import_signature) != self.payload:
+        if (
+            decode_context_manager_semantics_v1(payload, self.import_signature)
+            != self.payload
+        ):
             raise ValueError("context-manager semantics failed canonical validation")
         return {
             "kind": self.kind,
             "schemaVersion": self.schema_version,
             "bridgeSourceSymbol": self.bridge_source_symbol,
-            "importSignature": json.loads(_encode(import_signature_to_value(self.import_signature))),
+            "importSignature": json.loads(
+                _encode(import_signature_to_value(self.import_signature))
+            ),
             "payload": payload,
             "sourceWarrants": list(self.source_warrants),
         }
@@ -98,4 +119,5 @@ class ContextManagerContractIrV1:
 
 def _encode(value: Any) -> str:
     from sugar_lift_py_tests.canonicalizer import encode_jcs
+
     return encode_jcs(value)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/context_manager_edge_dto.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/context_manager_edge_dto.py
@@ -73,7 +73,9 @@ class ContextManagerEdgeDtoV1:
                 "context-manager edge requires a resolved authenticated ref"
             )
         if use_site != reference.use_site:
-            raise ContextManagerEdgeTransportError("context-manager edge use-site mismatch")
+            raise ContextManagerEdgeTransportError(
+                "context-manager edge use-site mismatch"
+            )
         if not _admitted(reference):
             raise ContextManagerEdgeTransportError(
                 "context-manager edge requires admitted typed NeverSuppresses semantics"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/lift_report_payload_dto.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/lift_report_payload_dto.py
@@ -34,8 +34,12 @@ _TRANSPORT_LOG = logging.getLogger("sugar.kit.transport")
 class LiftReportPayloadDto:
     # Closed lanes: a DTO already exists for every row, so no raw-dict side
     # door is left for callers to bypass construction law (#3661).
-    ir: list[BodyUniverseDto | SourceFunctionContractDto | ContextManagerContractIrV1] = field(
-        default_factory=list[BodyUniverseDto | SourceFunctionContractDto | ContextManagerContractIrV1]
+    ir: list[
+        BodyUniverseDto | SourceFunctionContractDto | ContextManagerContractIrV1
+    ] = field(
+        default_factory=list[
+            BodyUniverseDto | SourceFunctionContractDto | ContextManagerContractIrV1
+        ]
     )
     source_mementos: list[SourceMementoDto] = field(
         default_factory=list[SourceMementoDto]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/recovered_audit_dto.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/recovered_audit_dto.py
@@ -111,7 +111,10 @@ class RecoveredConstructionPanicDto:
     def from_rpc(cls, data: object) -> RecoveredConstructionPanicDto:
         row = _require_mapping(data, "recovered panic")
         _reject_unknown(row, set(_LEAF_PANIC_FIELDS), "recovered panic")
-        if row.get("kind") != "ConstructionPanic" or row.get("status") != "mandatory-panic":
+        if (
+            row.get("kind") != "ConstructionPanic"
+            or row.get("status") != "mandatory-panic"
+        ):
             raise ValueError("recovered panic must be a mandatory ConstructionPanic")
         gap = _require_mapping(row.get("gap"), "recovered panic gap")
         return cls(
@@ -322,8 +325,13 @@ class RecoveredConstructionPanicTreeDto:
     def from_rpc(cls, data: object) -> RecoveredConstructionPanicTreeDto:
         row = _require_mapping(data, "recovered tree panic")
         _reject_unknown(row, set(_TREE_PANIC_FIELDS), "recovered tree panic")
-        if row.get("kind") != "ConstructionPanic" or row.get("status") != "mandatory-panic":
-            raise ValueError("recovered tree panic must be a mandatory ConstructionPanic")
+        if (
+            row.get("kind") != "ConstructionPanic"
+            or row.get("status") != "mandatory-panic"
+        ):
+            raise ValueError(
+                "recovered tree panic must be a mandatory ConstructionPanic"
+            )
         gap = _require_mapping(row.get("gap"), "recovered tree panic gap")
         body = _require_mapping(
             row.get("demandedBody"), "recovered tree panic demandedBody"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -80,7 +80,9 @@ def publish_context_manager_declaration(
     """Publish a typed bodyless member on the live kit declaration."""
     global _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS
     if _BOUND_CONTRACT_REFS is not None:
-        raise RuntimeError("context-manager declarations are frozen for this generation")
+        raise RuntimeError(
+            "context-manager declarations are frozen for this generation"
+        )
     if not isinstance(declaration, ContextManagerContractIrV1):
         raise ValueError("typed context-manager declaration required")
     _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS += (declaration,)
@@ -112,11 +114,17 @@ def _context_manager_demand_rows(root: Path) -> List[Dict[str, Any]]:
             for item in node.items:
                 expression = item.context_expr
                 target = None
-                if isinstance(expression, ast.Call) and not expression.args and not expression.keywords:
+                if (
+                    isinstance(expression, ast.Call)
+                    and not expression.args
+                    and not expression.keywords
+                ):
                     callee = expression.func
                     if isinstance(callee, ast.Name):
                         target = imports.get(callee.id)
-                    elif isinstance(callee, ast.Attribute) and isinstance(callee.value, ast.Name):
+                    elif isinstance(callee, ast.Attribute) and isinstance(
+                        callee.value, ast.Name
+                    ):
                         base = imports.get(callee.value.id)
                         if base:
                             target = f"{base}.{callee.attr}"
@@ -127,22 +135,25 @@ def _context_manager_demand_rows(root: Path) -> List[Dict[str, Any]]:
                     "endLine": expression.end_lineno,
                     "endCol": expression.end_col_offset,
                 }
-                rows.append({
-                    "schemaVersion": "1",
-                    "kind": "context-manager-demand",
-                    "useSite": coordinate,
-                    "targetSymbol": f"context-manager:{target}" if target else None,
-                    "importSignature": {"formals": [], "sorts": []},
-                    "expectedKind": "context-manager-contract",
-                    "gapKind": None if target else "runtime-selected",
-                })
+                rows.append(
+                    {
+                        "schemaVersion": "1",
+                        "kind": "context-manager-demand",
+                        "useSite": coordinate,
+                        "targetSymbol": f"context-manager:{target}" if target else None,
+                        "importSignature": {"formals": [], "sorts": []},
+                        "expectedKind": "context-manager-contract",
+                        "gapKind": None if target else "runtime-selected",
+                    }
+                )
     return rows
 
 
 def _call_contract_demand_rows(root: Path) -> List[Dict[str, Any]]:
     """Enroll imported plain calls by their source-authenticated use sites."""
     from sugar_lift_py_tests.import_binding import (
-        authenticated_import_uses, authenticated_module_exports,
+        authenticated_import_uses,
+        authenticated_module_exports,
         module_name_for_path,
     )
     from sugar_lift_python_source.source_oracle import SourceUnavailable, path_source
@@ -158,7 +169,8 @@ def _call_contract_demand_rows(root: Path) -> List[Dict[str, Any]]:
         units.append((path, source, source_cid))
     module_identities = {
         module_name_for_path(root, path): {
-            "kind": "authenticated-python-module", "schemaVersion": "1",
+            "kind": "authenticated-python-module",
+            "schemaVersion": "1",
             "moduleName": module_name_for_path(root, path),
             "sourceCid": source_cid,
         }
@@ -171,6 +183,8 @@ def _call_contract_demand_rows(root: Path) -> List[Dict[str, Any]]:
         rows.extend(authenticated_module_exports(root, path, source, source_cid))
         rows.extend(enrolled)
     return rows
+
+
 # Passive, process-lifetime context paid for by an enumeration demand. The
 # outer identity is the file content CID; the path seat is retained because
 # source mementos carry the workspace-relative filename even for identical
@@ -1368,9 +1382,7 @@ def _roll_call_audit_leaf(full_path: Path, file_rel: str) -> dict:
             f"{lc.end_line}:{lc.end_col}[{node.kind}]"
         )
         panic_kind = (
-            type(panic).__name__
-            if panic is not None
-            else "UnaccountedConstruction"
+            type(panic).__name__ if panic is not None else "UnaccountedConstruction"
         )
         reason = (
             panic.observed or str(panic)
@@ -1431,7 +1443,9 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
             "catalogCid": _BOUND_CONTRACT_REFS.catalog_cid,
             "tableCid": _BOUND_CONTRACT_REFS.table_cid,
         }:
-            raise ValueError("semantic construction request has a stale contract-ref generation")
+            raise ValueError(
+                "semantic construction request has a stale contract-ref generation"
+            )
     if _BOUND_CALL_CONTRACT_REFS is not None:
         generation = options.get("callContractRefs")
         if generation != {
@@ -1459,17 +1473,30 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
 
     try:
         if level == "contract-declarations":
-            _send({"jsonrpc": "2.0", "id": msg_id, "result": {
-                "rows": [
-                    row.to_rpc_with_term_table(None)
-                    for row in _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS
-                ]
-            }})
+            _send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {
+                        "rows": [
+                            row.to_rpc_with_term_table(None)
+                            for row in _PUBLISHED_CONTEXT_MANAGER_DECLARATIONS
+                        ]
+                    },
+                }
+            )
             return
         if level == "contract-demands":
-            _send({"jsonrpc": "2.0", "id": msg_id, "result": {
-                "rows": _context_manager_demand_rows(root) + _call_contract_demand_rows(root)
-            }})
+            _send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {
+                        "rows": _context_manager_demand_rows(root)
+                        + _call_contract_demand_rows(root)
+                    },
+                }
+            )
             return
         if level == "context-manager-edges":
             if _BOUND_CONTRACT_REFS is None:
@@ -1478,7 +1505,9 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 )
             from sugar_lift_python_source.source_oracle import path_source
             from sugar_source_tree.tree import SourceFile as _TreeSourceFile
-            from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+            from sugar_lift_py_tests.context_manager_resolution import (
+                TreeConstructionContextV1,
+            )
 
             rows = []
             construction_context = TreeConstructionContextV1(_BOUND_CONTRACT_REFS)
@@ -1490,8 +1519,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 for function in source_file.functions():
                     function_sugar = function.sugar()
                     rows.extend(
-                        edge.to_rpc()
-                        for edge in function_sugar.context_manager_edges()
+                        edge.to_rpc() for edge in function_sugar.context_manager_edges()
                     )
             _send(
                 {
@@ -1617,9 +1645,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                         return
                     _src, _fname, file_cid = identity
                     sf = _tree.source_file(full_path)
-                    memento = _tree.module_definition_memento(
-                        sf, file_rel, file_cid
-                    )
+                    memento = _tree.module_definition_memento(sf, file_rel, file_cid)
                     _send_enumerate_result(
                         msg_id,
                         [{"memento": memento, "audit": None, "payload": None}],
@@ -1692,7 +1718,9 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                         ],
                     )
                     return
-                from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+                from sugar_lift_py_tests.context_manager_resolution import (
+                    TreeConstructionContextV1,
+                )
 
                 construction_context = (
                     TreeConstructionContextV1(
@@ -1700,7 +1728,8 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                         call_contract_refs=_BOUND_CALL_CONTRACT_REFS,
                         workspace_root=str(root),
                     )
-                    if _BOUND_CONTRACT_REFS is not None or _BOUND_CALL_CONTRACT_REFS is not None
+                    if _BOUND_CONTRACT_REFS is not None
+                    or _BOUND_CALL_CONTRACT_REFS is not None
                     else None
                 )
                 tree_file = _TreeSourceFile(
@@ -1755,14 +1784,17 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     _send_enumerate_result(
                         msg_id,
                         [],
-                        [{"memento": at, "reason": "implications requires a call-site memento"}],
+                        [
+                            {
+                                "memento": at,
+                                "reason": "implications requires a call-site memento",
+                            }
+                        ],
                     )
                     return
                 sf = _tree.source_file(full_path)
                 span = at.get("span") if isinstance(at, dict) else None
-                source_assert, assert_node = _tree.temporally_rewritten_assert(
-                    sf, span
-                )
+                source_assert, assert_node = _tree.temporally_rewritten_assert(sf, span)
                 if source_assert is None or assert_node is None:
                     _send_enumerate_result(
                         msg_id,
@@ -1960,17 +1992,19 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 _send_enumerate_result(
                     msg_id,
                     cued,
-                    []
-                    if cued
-                    else [
-                        {
-                            "memento": at,
-                            "reason": (
-                                "no universe for the callee(s) this call site cues: "
-                                f"{targets or 'none'}"
-                            ),
-                        }
-                    ],
+                    (
+                        []
+                        if cued
+                        else [
+                            {
+                                "memento": at,
+                                "reason": (
+                                    "no universe for the callee(s) this call site cues: "
+                                    f"{targets or 'none'}"
+                                ),
+                            }
+                        ]
+                    ),
                     term_tables=[term_table.nodes],
                 )
                 _log_enumeration_demand(
@@ -1995,8 +2029,10 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     if fn is not None:
                         for a in _tree.asserts_of(fn):
                             memento = _tree.assert_memento(a, file_rel)
-                            if seek and at is not None and not _memento_matches(
-                                memento, at
+                            if (
+                                seek
+                                and at is not None
+                                and not _memento_matches(memento, at)
                             ):
                                 continue
                             built.append(
@@ -2045,7 +2081,6 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     str(level), at, cache="miss", started=demand_started
                 )
                 return
-
 
         _send(
             {
@@ -2175,17 +2210,29 @@ def _dispatch_request(msg: Dict[str, Any]) -> bool:
             msg_id, params if isinstance(params, dict) else {}
         )
     elif method == BIND_CONTRACT_REFS_RPC_METHOD:
-        from sugar_lift_py_tests.context_manager_resolution import decode_resolved_contract_refs
+        from sugar_lift_py_tests.context_manager_resolution import (
+            decode_resolved_contract_refs,
+        )
+
         global _BOUND_CONTRACT_REFS
         if not isinstance(params, dict) or set(params) != {"contractRefs"}:
             raise ValueError("malformed preconstruction contract-ref bind")
         installed = decode_resolved_contract_refs(params["contractRefs"])
-        if _BOUND_CONTRACT_REFS is not None and _BOUND_CONTRACT_REFS.table_cid != installed.table_cid:
+        if (
+            _BOUND_CONTRACT_REFS is not None
+            and _BOUND_CONTRACT_REFS.table_cid != installed.table_cid
+        ):
             raise ValueError("contract-ref generation is already frozen")
         _BOUND_CONTRACT_REFS = installed
-        _send({"jsonrpc": "2.0", "id": msg_id, "result": {
-            "tableCid": installed.table_cid,
-        }})
+        _send(
+            {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {
+                    "tableCid": installed.table_cid,
+                },
+            }
+        )
     elif method == BIND_CALL_CONTRACT_REFS_RPC_METHOD:
         from sugar_lift_py_tests.call_contract_resolution import (
             decode_resolved_call_contract_refs,
@@ -2199,7 +2246,13 @@ def _dispatch_request(msg: Dict[str, Any]) -> bool:
         ):
             raise ValueError("call-contract-ref generation is already frozen")
         _BOUND_CALL_CONTRACT_REFS = installed
-        _send({"jsonrpc": "2.0", "id": msg_id, "result": {"tableCid": installed.table_cid}})
+        _send(
+            {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {"tableCid": installed.table_cid},
+            }
+        )
     elif method == ENUMERATE_RPC_METHOD:
         global _ENUMERATION_ACTIVE, _ENUMERATION_REQUEST_COUNT
         enumerate_started = time.monotonic()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -11,7 +11,6 @@ from sugar_lift_py_tests.ir import Formula, and_, not_, or_
 from .complete import Complete
 from .incomplete import Incomplete
 
-
 T = TypeVar("T")
 U = TypeVar("U")
 
@@ -98,9 +97,7 @@ class ExitSet(Generic[T]):
         return cls((Halted(guard or true_guard(), effect),)).normalize()
 
     @classmethod
-    def conditional_halt(
-        cls, guard: Formula, effect: Effect, state: T
-    ) -> "ExitSet[T]":
+    def conditional_halt(cls, guard: Formula, effect: Effect, state: T) -> "ExitSet[T]":
         return cls((Halted(guard, effect), Completed(not_(guard), state))).normalize()
 
     def union(self, other: "ExitSet[T]") -> "ExitSet[T]":
@@ -273,9 +270,7 @@ def outcome_to_exitset(outcome) -> ExitSet:
         return ExitSet.completed(outcome.value)
     if isinstance(outcome, Incomplete):
         if outcome.branch_conditions:
-            return ExitSet.halted(
-                outcome.effect, and_(list(outcome.branch_conditions))
-            )
+            return ExitSet.halted(outcome.effect, and_(list(outcome.branch_conditions)))
         return ExitSet.halted(outcome.effect)
     raise TypeError(type(outcome))
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/resource_bindings.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/resource_bindings.py
@@ -74,9 +74,7 @@ class ExitFaceBinding:
 
         if isinstance(body_exit, Completed):
             return cls(face_id=face_id, kind="completed")
-        if isinstance(body_exit, Halted) and isinstance(
-            body_exit.effect, RaiseEffect
-        ):
+        if isinstance(body_exit, Halted) and isinstance(body_exit.effect, RaiseEffect):
             effect = body_exit.effect
             occurrence = (
                 getattr(effect, "occurrence_id", None)
@@ -111,9 +109,7 @@ class ExitFaceBinding:
             )
         elif self.kind == "raised":
             type_term = (
-                str_const(self.exception_name)
-                if self.exception_name
-                else open_type
+                str_const(self.exception_name) if self.exception_name else open_type
             )
             value_term = ctor(
                 "python:raise_effect_occurrence",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/nodes/boundary_record.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/proofir/nodes/boundary_record.py
@@ -24,7 +24,6 @@ from . import (
     _witness_provenance,
 )
 
-    
 
 @dataclass(frozen=True, init=False)
 class BoundaryRecord:
@@ -86,7 +85,7 @@ class BoundaryRecord:
     def agreement_violation_diagnostic(
         violation: FloorContractAgreementViolation,
     ) -> dict[str, Any]:
-        
+
         if not isinstance(violation, FloorContractAgreementViolation):
             raise TypeError(
                 "agreement_violation_diagnostic requires "

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assert_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assert_sugar.py
@@ -47,6 +47,4 @@ class AssertSugar(Sugar):
 
     def desugar(self, ctx: object = None) -> Outcome:
         # Desugar the test, and the result states itself.
-        return self.test.desugar(ctx).and_then(
-            lambda value: value.stated(self.site)
-        )
+        return self.test.desugar(ctx).and_then(lambda value: value.stated(self.site))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binop_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binop_sugar.py
@@ -6,7 +6,6 @@ from sugar_lift_py_tests.outcome import Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
-
 # Binary operator kind -> the floor method that owns its meaning. The value
 # owns what each operation MEANS (ints fold, strings concatenate on `+`, mixed
 # types hit the honest gap); this sugar only routes to it. Every entry maps to

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -64,9 +64,7 @@ class CallSiteSugar(Sugar):
         if remaining:
             head, *rest = remaining
             return head.desugar(ctx).and_then(
-                lambda value: self._collect(
-                    tuple(rest), accumulated + (value,), ctx
-                )
+                lambda value: self._collect(tuple(rest), accumulated + (value,), ctx)
             )
         return self._collect_kwargs(self.keywords, (), accumulated, ctx)
 
@@ -92,9 +90,7 @@ class CallSiteSugar(Sugar):
             f"call:{self.target_name}",
             [value.to_term(owner=owner) for value in positional] + kwarg_terms,
             symbol_kind=(
-                "builtin"
-                if hasattr(builtins, self.target_name)
-                else "coordinate"
+                "builtin" if hasattr(builtins, self.target_name) else "coordinate"
             ),
         )
         if self.contract_ref is not None:
@@ -111,7 +107,9 @@ class CallSiteSugar(Sugar):
         )
 
     def _collect_bridged(self, positional: tuple) -> Outcome:
-        from sugar_lift_py_tests.floor.bridged_contract_value import BridgedContractValue
+        from sugar_lift_py_tests.floor.bridged_contract_value import (
+            BridgedContractValue,
+        )
         from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
         from sugar_lift_py_tests.ir import _Ctor, _free_vars_in_term, subst_var_in_term
         from sugar_lift_py_tests.outcome import Complete
@@ -142,7 +140,11 @@ class CallSiteSugar(Sugar):
             )
         for formal, actual in zip(reference.formals, positional):
             term = subst_var_in_term(term, formal, actual.to_term(owner=str(self.site)))
-        if not isinstance(term, _Ctor) or term.name not in {"tuple", "python:tuple", "python:list"}:
+        if not isinstance(term, _Ctor) or term.name not in {
+            "tuple",
+            "python:tuple",
+            "python:list",
+        }:
             raise SugarNotWritten(
                 owner="CallSiteSugar.desugar",
                 observed="authenticated contract has no exact structural return",
@@ -159,6 +161,8 @@ class CallSiteSugar(Sugar):
             target_contract_cid=reference.contract_cid,
             authenticated_target_symbol=reference.bridge_source_symbol,
         )
-        return Complete(BridgedContractValue(
-            term, reference.contract_cid, reference.member_cid, callsite
-        ))
+        return Complete(
+            BridgedContractValue(
+                term, reference.contract_cid, reference.member_cid, callsite
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
@@ -40,8 +40,11 @@ class ListSugar(Sugar):
     @classmethod
     def witnesses(cls):
         return _call_return_pair(
-            name="list_len", owner_sugar="ListSugar", body="len([z, z, z])",
-            truthful="3", lying="2",
+            name="list_len",
+            owner_sugar="ListSugar",
+            body="len([z, z, z])",
+            truthful="3",
+            lying="2",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
@@ -59,8 +62,11 @@ class TupleSugar(Sugar):
     @classmethod
     def witnesses(cls):
         return _call_return_pair(
-            name="tuple_len", owner_sugar="TupleSugar", body="len((z, z))",
-            truthful="2", lying="3",
+            name="tuple_len",
+            owner_sugar="TupleSugar",
+            body="len((z, z))",
+            truthful="2",
+            lying="3",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
@@ -78,8 +84,11 @@ class SetSugar(Sugar):
     @classmethod
     def witnesses(cls):
         return _call_return_pair(
-            name="set_len", owner_sugar="SetSugar", body="len({1, 2, 3})",
-            truthful="3", lying="2",
+            name="set_len",
+            owner_sugar="SetSugar",
+            body="len({1, 2, 3})",
+            truthful="3",
+            lying="2",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
@@ -98,8 +107,11 @@ class DictSugar(Sugar):
     @classmethod
     def witnesses(cls):
         return _call_return_pair(
-            name="dict_len", owner_sugar="DictSugar", body="len({1: z, 2: z})",
-            truthful="2", lying="3",
+            name="dict_len",
+            owner_sugar="DictSugar",
+            body="len({1: z, 2: z})",
+            truthful="2",
+            lying="3",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_effect_sugar.py
@@ -58,7 +58,9 @@ class SubscriptDeleteEffectSugar(Sugar):
 
         return self.receiver.desugar(ctx).and_then(
             lambda receiver: self.index.desugar(ctx).and_then(
-                lambda index: self._delete(receiver, index, runtime_effect_evidence, ctor)
+                lambda index: self._delete(
+                    receiver, index, runtime_effect_evidence, ctor
+                )
             )
         )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/effect_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/effect_ref_sugar.py
@@ -53,8 +53,6 @@ class ObservationRefSugar(Sugar):
                 EnterResultCoordinate,
             )
 
-            return Complete(
-                EnterResultCoordinate(slot_id=self.slot_id, site=self.site)
-            )
+            return Complete(EnterResultCoordinate(slot_id=self.slot_id, site=self.site))
         # warning_observation / effect: pure coordinate until binding facts exist
         return Complete(EffectCoordinate(slot_id=self.slot_id, site=self.site))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/ellipsis_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/ellipsis_literal_sugar.py
@@ -19,10 +19,7 @@ class EllipsisLiteralSugar(Sugar):
     @classmethod
     def witnesses(cls):
         prefix = (
-            "def A(z):\n"
-            "    if z is ...:\n"
-            "        return 0\n"
-            "    return z\n\n"
+            "def A(z):\n" "    if z is ...:\n" "        return 0\n" "    return z\n\n"
         )
         return _call_pair(
             name="ellipsis_is_return",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
@@ -30,6 +30,7 @@ class EqualityOpSugar(Sugar):
             )
         )
 
+
 def _finite_equality_face(value, peer, *, matches: bool):
     """Filter an exact construction-time finite join by a ground equality."""
     from sugar_lift_py_tests.floor.guarded_value import GuardedValue

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/exit_set_routing.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/exit_set_routing.py
@@ -188,9 +188,7 @@ def site_inv_values(entries: tuple, site) -> tuple:
     from sugar_lift_py_tests.floor.inv_value import InvValue
 
     return tuple(
-        dc_replace(e, site=site)
-        if isinstance(e, InvValue) and e.site is None
-        else e
+        dc_replace(e, site=site) if isinstance(e, InvValue) and e.site is None else e
         for e in entries
     )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/false_bool_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/false_bool_literal_sugar.py
@@ -8,6 +8,7 @@ from sugar_lift_py_tests.outcome import Complete, Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
+
 @dataclass(frozen=True)
 class FalseBoolLiteralSugar(Sugar, FloorValue):
     """The literal `False`. It holds no value -- the boolean IS the type. It is its own

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/for_universal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/for_universal_sugar.py
@@ -32,7 +32,9 @@ class ForUniversalSugar(Sugar):
 
     @classmethod
     def witnesses(cls):
-        prefix = "def A(xs):\n    for x in xs:\n        assert x == x\n    return xs\n\n"
+        prefix = (
+            "def A(xs):\n    for x in xs:\n        assert x == x\n    return xs\n\n"
+        )
         return _call_pair(
             name="for_universal",
             owner_sugar="ForUniversalSugar",
@@ -43,7 +45,13 @@ class ForUniversalSugar(Sugar):
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.floor.block_value import BlockValue
         from sugar_lift_py_tests.floor.inv_value import InvValue
-        from sugar_lift_py_tests.ir import PrimitiveSort, atomic, forall, implies, make_var
+        from sugar_lift_py_tests.ir import (
+            PrimitiveSort,
+            atomic,
+            forall,
+            implies,
+            make_var,
+        )
         from sugar_lift_py_tests.outcome import Incomplete
         from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_statements
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/fstring_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/fstring_sugar.py
@@ -47,9 +47,7 @@ class FormattedValueSugar(Sugar):
                 return format_spec
             format_spec_term = format_spec.value
         conversion_term = (
-            ctor("None", [])
-            if self.conversion is None
-            else str_const(self.conversion)
+            ctor("None", []) if self.conversion is None else str_const(self.conversion)
         )
         return Complete(
             SymbolicValue(
@@ -108,7 +106,5 @@ class JoinedStrSugar(Sugar):
             projected = part.desugar(ctx)
             if isinstance(projected, Incomplete):
                 return projected
-            terms.append(
-                projected.value.to_term(owner="JoinedStrSugar.reference_term")
-            )
+            terms.append(projected.value.to_term(owner="JoinedStrSugar.reference_term"))
         return Complete(ctor("python:fstring", terms))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -54,11 +54,13 @@ def reduce_block_to_exitset(statements: tuple) -> ExitSet[_ReducedBlock]:
             outcome = head.desugar()
             from sugar_lift_py_tests.floor.guarded_faces import GuardedFaces
 
-            if isinstance(outcome, Complete) and isinstance(
-                outcome.value, GuardedFaces
-            ) and any(
-                isinstance(entry, Incomplete)
-                for entry in outcome.value.contribution()
+            if (
+                isinstance(outcome, Complete)
+                and isinstance(outcome.value, GuardedFaces)
+                and any(
+                    isinstance(entry, Incomplete)
+                    for entry in outcome.value.contribution()
+                )
             ):
                 faces = outcome.value
                 entries = []
@@ -84,9 +86,11 @@ def reduce_block_to_exitset(statements: tuple) -> ExitSet[_ReducedBlock]:
                 if faces.can_fall_through:
                     exits.append(
                         Completed(
-                            faces.continuation_guard
-                            if faces.continuation_guard is not None
-                            else true_guard(),
+                            (
+                                faces.continuation_guard
+                                if faces.continuation_guard is not None
+                                else true_guard()
+                            ),
                             completed_state,
                         )
                     )
@@ -110,9 +114,7 @@ def reduce_block_to_exitset(statements: tuple) -> ExitSet[_ReducedBlock]:
                     entries = (*state.entries, *contribution)
                     follow = linear.follow()
                     if not follow.continues:
-                        return ExitSet.completed(
-                            _ReducedBlock(entries, False, ())
-                        )
+                        return ExitSet.completed(_ReducedBlock(entries, False, ()))
                     return ExitSet.completed(
                         _ReducedBlock(
                             entries,
@@ -290,6 +292,8 @@ class FunctionUniverseSugar(Sugar):
                     stack.append(value)
                 elif isinstance(value, tuple):
                     stack.extend(
-                        reversed(tuple(item for item in value if isinstance(item, Sugar)))
+                        reversed(
+                            tuple(item for item in value if isinstance(item, Sugar))
+                        )
                     )
         return tuple(edges)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/real_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/real_literal_sugar.py
@@ -20,8 +20,11 @@ class RealLiteralSugar(Sugar):
     @classmethod
     def witnesses(cls):
         return _call_return_pair(
-            name="real_literal_return", owner_sugar="RealLiteralSugar",
-            body="2.5", truthful="2.5", lying="2.6",
+            name="real_literal_return",
+            owner_sugar="RealLiteralSugar",
+            body="2.5",
+            truthful="2.5",
+            lying="2.6",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/resource_coord_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/resource_coord_sugar.py
@@ -83,6 +83,4 @@ class ExitTracebackRefSugar(Sugar):
             ExitTracebackCoordinate,
         )
 
-        return Complete(
-            ExitTracebackCoordinate(face_id=self.face_id, site=self.site)
-        )
+        return Complete(ExitTracebackCoordinate(face_id=self.face_id, site=self.site))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/true_bool_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/true_bool_literal_sugar.py
@@ -7,6 +7,7 @@ from sugar_lift_py_tests.outcome import Complete, Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
+
 @dataclass(frozen=True)
 class TrueBoolLiteralSugar(Sugar, FloorValue):
     """The literal `True`. It holds no value -- the boolean IS the type. It is its own

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
@@ -103,9 +103,7 @@ class WithResourceSugar(Sugar):
             for enter_exit in enter_es.exits:
                 face_guard = _and_guards(mgr_exit.guard, enter_exit.guard)
                 if isinstance(enter_exit, Halted):
-                    parts.append(
-                        ExitSet((Halted(face_guard, enter_exit.effect),))
-                    )
+                    parts.append(ExitSet((Halted(face_guard, enter_exit.effect),)))
                     continue
 
                 enter_facts = ()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/witness_harness.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/witness_harness.py
@@ -15,7 +15,11 @@ from sugar_lift_py_tests.sugar_binary import (
 )
 
 Verdict = Literal[
-    "sat", "unsat", "unwitnessed", "unwitnessed-modulo-unavailable-seats", "solver-timeout"
+    "sat",
+    "unsat",
+    "unwitnessed",
+    "unwitnessed-modulo-unavailable-seats",
+    "solver-timeout",
 ]
 
 ROOT = Path(__file__).resolve().parents[5]

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_alias.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_alias.py
@@ -1,8 +1,20 @@
 from provider_authority import DoorB as Q
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
-class ContextManagerContractRefV1: pass
+
+
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
+class ContextManagerContractRefV1:
+    pass
+
+
 class With:
     def _construct_sugar(self, value: ContextManagerContractRefV1 | Q):
-        if isinstance(value, Q): return WithResourceSugar()
+        if isinstance(value, Q):
+            return WithResourceSugar()
         raise RuntimeError

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_cross_file.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_cross_file.py
@@ -1,8 +1,17 @@
 from authority_helper import DoorB, build_authority
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
+
+
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
 class With:
     def _construct_sugar(self):
         value = build_authority()
-        if isinstance(value, DoorB): return WithResourceSugar()
+        if isinstance(value, DoorB):
+            return WithResourceSugar()
         raise RuntimeError

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_data.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_data.py
@@ -1,3 +1,6 @@
-class DoorB: pass
+class DoorB:
+    pass
+
+
 Choice = DoorB | int
 ordinary = {"authority": DoorB(), "count": 1}

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_doorb.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_doorb.py
@@ -1,9 +1,23 @@
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
-class ContextManagerContractRefV1: pass
-class DoorB: pass
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
+class ContextManagerContractRefV1:
+    pass
+
+
+class DoorB:
+    pass
+
+
 class With:
     def _construct_sugar(self, value: ContextManagerContractRefV1 | DoorB):
-        if isinstance(value, ContextManagerContractRefV1): return WithResourceSugar()
-        if isinstance(value, DoorB): return WithResourceSugar()
+        if isinstance(value, ContextManagerContractRefV1):
+            return WithResourceSugar()
+        if isinstance(value, DoorB):
+            return WithResourceSugar()
         raise RuntimeError

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_gap.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_gap.py
@@ -1,9 +1,25 @@
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
-class ContextManagerContractRefV1: pass
-class ContextManagerResolutionGapV1: pass
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
+class ContextManagerContractRefV1:
+    pass
+
+
+class ContextManagerResolutionGapV1:
+    pass
+
+
 class With:
-    def _construct_sugar(self, value: ContextManagerContractRefV1 | ContextManagerResolutionGapV1):
-        if isinstance(value, ContextManagerContractRefV1): return WithResourceSugar()
-        if isinstance(value, ContextManagerResolutionGapV1): raise RuntimeError
+    def _construct_sugar(
+        self, value: ContextManagerContractRefV1 | ContextManagerResolutionGapV1
+    ):
+        if isinstance(value, ContextManagerContractRefV1):
+            return WithResourceSugar()
+        if isinstance(value, ContextManagerResolutionGapV1):
+            raise RuntimeError
         raise RuntimeError

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_helper.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_helper.py
@@ -1,2 +1,6 @@
-class DoorB: pass
-def build_authority(): return DoorB()
+class DoorB:
+    pass
+
+
+def build_authority():
+    return DoorB()

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_legitimate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_legitimate.py
@@ -1,7 +1,17 @@
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
-class ContextManagerContractRefV1: pass
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
+class ContextManagerContractRefV1:
+    pass
+
+
 class With:
     def _construct_sugar(self, value: ContextManagerContractRefV1):
-        if isinstance(value, ContextManagerContractRefV1): return WithResourceSugar()
+        if isinstance(value, ContextManagerContractRefV1):
+            return WithResourceSugar()
         raise RuntimeError

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_nested.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_nested.py
@@ -1,10 +1,26 @@
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
-class DoorB: pass
-def make_authority(): return DoorB()
-def outer(): return make_authority()
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
+class DoorB:
+    pass
+
+
+def make_authority():
+    return DoorB()
+
+
+def outer():
+    return make_authority()
+
+
 class With:
     def _construct_sugar(self):
         value = outer()
-        if isinstance(value, DoorB): return WithResourceSugar()
+        if isinstance(value, DoorB):
+            return WithResourceSugar()
         raise RuntimeError

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_opaque.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_opaque.py
@@ -1,5 +1,11 @@
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
 class With:
     def _construct_sugar(self, module, runtime_name):
         value = getattr(module, runtime_name)()

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_registered.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_registered.py
@@ -1,10 +1,25 @@
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
-class DoorB: pass
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
+class DoorB:
+    pass
+
+
 doors = {"arbitrary": DoorB()}
-def require(key): return doors.get(key)
+
+
+def require(key):
+    return doors.get(key)
+
+
 class With:
     def _construct_sugar(self):
         value = require("arbitrary")
-        if isinstance(value, DoorB): return WithResourceSugar()
+        if isinstance(value, DoorB):
+            return WithResourceSugar()
         raise RuntimeError

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_rpc.py
@@ -1,10 +1,26 @@
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
-class DoorB: pass
-def write(value): return {"z9": value}
-def read(message): return message["z9"]
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
+class DoorB:
+    pass
+
+
+def write(value):
+    return {"z9": value}
+
+
+def read(message):
+    return message["z9"]
+
+
 class With:
     def _construct_sugar(self):
         value = read(write(DoorB()))
-        if isinstance(value, DoorB): return WithResourceSugar()
+        if isinstance(value, DoorB):
+            return WithResourceSugar()
         raise RuntimeError

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_rpc_data.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_rpc_data.py
@@ -1,3 +1,9 @@
-def write(value): return {"z9": value}
-def read(message): return message["z9"]
+def write(value):
+    return {"z9": value}
+
+
+def read(message):
+    return message["z9"]
+
+
 ordinary = read(write({"x": 1}))

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_zero.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/authority_zero.py
@@ -1,2 +1,5 @@
 from authority_helper import DoorB, build_authority
-def unrelated(): return build_authority()
+
+
+def unrelated():
+    return build_authority()

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_alias.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_alias.py
@@ -1,6 +1,14 @@
 from provider_catalog import choose as q
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
+
+
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
 def demand(imported):
     targetSymbol = imported
     return WithResourceSugar(q(targetSymbol))

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_boundary_b.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_boundary_b.py
@@ -1,8 +1,22 @@
-class BoundaryB: pass
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
-def build(): return BoundaryB()
+class BoundaryB:
+    pass
+
+
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
+def build():
+    return BoundaryB()
+
+
 table = {"anything": build}
+
+
 def demand(imported):
     lookup_key = imported
     chosen = table[lookup_key]

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_cross_file.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_cross_file.py
@@ -1,6 +1,14 @@
 from enrollment_helper import resolve
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
+
+
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
 def demand(imported):
     targetSymbol = imported
     return WithResourceSugar(resolve(targetSymbol))

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_direct.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_direct.py
@@ -1,8 +1,22 @@
-class ProtocolResource: pass
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
-def make_payload(): return ProtocolResource()
+class ProtocolResource:
+    pass
+
+
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
+def make_payload():
+    return ProtocolResource()
+
+
 doors = {"anything": make_payload}
+
+
 def demand(imported):
     targetSymbol = imported
     builder = doors[targetSymbol]

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_generic_rename.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_generic_rename.py
@@ -1,8 +1,22 @@
-class ProtocolResource: pass
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
-def build(): return ProtocolResource()
+class ProtocolResource:
+    pass
+
+
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
+def build():
+    return ProtocolResource()
+
+
 table = {"anything": build}
+
+
 def demand(imported):
     lookup_key = imported
     chosen = table[lookup_key]

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_helper.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_helper.py
@@ -1,4 +1,13 @@
-class ProtocolResource: pass
-def create(): return ProtocolResource()
+class ProtocolResource:
+    pass
+
+
+def create():
+    return ProtocolResource()
+
+
 rows = {"k": create}
-def resolve(symbol): return rows.get(symbol)()
+
+
+def resolve(symbol):
+    return rows.get(symbol)()

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_nested.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_nested.py
@@ -1,10 +1,30 @@
-class EffectBoundary: pass
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
-def construct(): return EffectBoundary()
+class EffectBoundary:
+    pass
+
+
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
+def construct():
+    return EffectBoundary()
+
+
 doors = {"k": construct}
-def first(symbol): return second(symbol)
-def second(symbol): return doors.get(symbol)()
+
+
+def first(symbol):
+    return second(symbol)
+
+
+def second(symbol):
+    return doors.get(symbol)()
+
+
 def demand(imported):
     targetSymbol = imported
     return WithResourceSugar(first(targetSymbol))

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_opaque.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_opaque.py
@@ -1,5 +1,11 @@
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
 def demand(imported, module, runtime_name):
     targetSymbol = imported
     registry = getattr(module, runtime_name)

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_ordinary_dict.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_ordinary_dict.py
@@ -1,4 +1,6 @@
 values = {"pytest.raises": 1, "other": 2}
+
+
 def demand(imported):
     targetSymbol = imported
     return values[targetSymbol]

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_ordinary_get.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_ordinary_get.py
@@ -1,4 +1,7 @@
-def read(mapping, key): return mapping.get(key)
+def read(mapping, key):
+    return mapping.get(key)
+
+
 def demand(imported):
     targetSymbol = imported
     return read({"x": "ordinary"}, targetSymbol)

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_renamed.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_renamed.py
@@ -1,9 +1,26 @@
-class EffectBoundary: pass
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
-def f9(): return EffectBoundary()
+class EffectBoundary:
+    pass
+
+
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
+def f9():
+    return EffectBoundary()
+
+
 q3 = {"opaque_key": f9}
-def z2(k): return q3[k]()
+
+
+def z2(k):
+    return q3[k]()
+
+
 def demand(imported):
     targetSymbol = imported
     return WithResourceSugar(z2(targetSymbol))

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_rpc.py
@@ -1,10 +1,30 @@
-class EffectBoundary: pass
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
-def create(): return EffectBoundary()
+class EffectBoundary:
+    pass
+
+
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
+def create():
+    return EffectBoundary()
+
+
 rows = {"k": create}
-def write_spelling(value): return {"q7": value}
-def read_spelling(message): return message["q7"]
+
+
+def write_spelling(value):
+    return {"q7": value}
+
+
+def read_spelling(message):
+    return message["q7"]
+
+
 def demand(imported):
     targetSymbol = imported
     key = read_spelling(write_spelling(targetSymbol))

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_rpc_semantics.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_rpc_semantics.py
@@ -1,10 +1,30 @@
-class EffectBoundary: pass
-class Sugar: pass
-class WithResourceSugar(Sugar): pass
-def create(): return EffectBoundary()
+class EffectBoundary:
+    pass
+
+
+class Sugar:
+    pass
+
+
+class WithResourceSugar(Sugar):
+    pass
+
+
+def create():
+    return EffectBoundary()
+
+
 rows = {"k": create}
-def write(value): return {"q8": value}
-def read(message): return message["q8"]
+
+
+def write(value):
+    return {"q8": value}
+
+
+def read(message):
+    return message["q8"]
+
+
 def demand(imported):
     targetSymbol = imported
     value = rows[targetSymbol]()

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_semantics_unreachable.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/enrollment_semantics_unreachable.py
@@ -1,6 +1,14 @@
-class EffectBoundary: pass
-def create(): return EffectBoundary()
+class EffectBoundary:
+    pass
+
+
+def create():
+    return EffectBoundary()
+
+
 rows = {"x": create}
+
+
 def unused(symbol):
     builder = rows.get(symbol)
     return builder()

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/provider_authority.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/provider_authority.py
@@ -1,1 +1,2 @@
-class DoorB: pass
+class DoorB:
+    pass

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/provider_catalog.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_v2_laws/provider_catalog.py
@@ -1,4 +1,13 @@
-class ProtocolResource: pass
-def make_payload(): return ProtocolResource()
+class ProtocolResource:
+    pass
+
+
+def make_payload():
+    return ProtocolResource()
+
+
 doors = {"anything": make_payload}
-def choose(target): return doors[target]()
+
+
+def choose(target):
+    return doors[target]()

--- a/implementations/python/sugar-lift-py-tests/tests/test_assert_sugar_from_node.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assert_sugar_from_node.py
@@ -6,6 +6,7 @@ recursion, Assert → Compare → two Constants, all node.sugar() calling
 node.sugar(). No factory in the chain. The message operand is source
 provenance only: AssertSugar carries its pinned fragment but never reduces it.
 """
+
 from __future__ import annotations
 
 import tempfile

--- a/implementations/python/sugar-lift-py-tests/tests/test_audit_status_construction_authority.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_audit_status_construction_authority.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 _SEMANTIC_ROOTS = ("floor", "temporal", "proofir", "audit_only")
 _FACTORY_AUDIT_NAMES = ("ConstructionAuditStatus", "ConstructionAuditRow")
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_bare_exception_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bare_exception_zero_tolerance.py
@@ -10,7 +10,6 @@ import sys
 
 import pytest
 
-
 _KIT = Path(__file__).resolve().parents[1]
 _SCANNER_PATH = _KIT / "scripts" / "bare_exception_zero_tolerance.py"
 _SPEC = importlib.util.spec_from_file_location(
@@ -29,9 +28,7 @@ def test_planted_python_exception_trips_bare_floor() -> None:
         check=False,
     )
 
-    offender = _SCANNER.bare_exception_offender(
-        file="planted.py", result=result
-    )
+    offender = _SCANNER.bare_exception_offender(file="planted.py", result=result)
 
     assert offender is not None
     assert offender.returncode == 1
@@ -51,10 +48,7 @@ def test_typed_gap_testimony_is_not_bare() -> None:
         stderr="",
     )
 
-    assert (
-        _SCANNER.bare_exception_offender(file="typed-red.py", result=result)
-        is None
-    )
+    assert _SCANNER.bare_exception_offender(file="typed-red.py", result=result) is None
 
 
 def test_signal_death_is_not_bare() -> None:
@@ -67,8 +61,7 @@ def test_signal_death_is_not_bare() -> None:
 
 def test_production_roots_cover_package_and_corpus_tooling(tmp_path: Path) -> None:
     assert _SCANNER.production_roots(tmp_path) == (
-        tmp_path
-        / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests",
+        tmp_path / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests",
         tmp_path / "implementations/python/sugar-lift-py-tests/scripts",
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_call_contract_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_call_contract_resolution.py
@@ -18,7 +18,6 @@ from sugar_lift_py_tests.sugar.name_sugar import NameSugar
 from sugar_lift_py_tests import lift_rpc
 from sugar_source_tree.panic import BackendDefect, SugarNotWritten
 
-
 CID = "blake3-512:" + "1" * 128
 MEMBER_CID = "blake3-512:" + "2" * 128
 CATALOG_CID = "blake3-512:" + "3" * 128
@@ -61,7 +60,9 @@ def _table(rows: list[dict], enrolled: list[dict] | None = None) -> dict:
         "kind": "resolved-call-contract-refs",
         "schemaVersion": "1",
         "catalogCid": CATALOG_CID,
-        "enrolledUseSites": enrolled if enrolled is not None else [row["useSite"] for row in rows],
+        "enrolledUseSites": (
+            enrolled if enrolled is not None else [row["useSite"] for row in rows]
+        ),
         "byUseSite": rows,
     }
     return {**value, "tableCid": _hash_json(value)}
@@ -79,7 +80,9 @@ def test_decoder_rejects_duplicate_rows_and_row_identity_mismatches():
 
 
 def test_decoder_rejects_missing_enrolled_row():
-    with pytest.raises(CallContractRefProtocolError, match="enrolled call demand missing"):
+    with pytest.raises(
+        CallContractRefProtocolError, match="enrolled call demand missing"
+    ):
         decode_resolved_call_contract_refs(_table([], enrolled=[_site()]))
 
 
@@ -108,7 +111,9 @@ def test_call_distinguishes_non_enrolled_local_call_from_missing_enrolled_row(tm
     cm_refs = ResolvedContractRefsV1(CATALOG_CID, TABLE_CID, MappingProxyType({}))
     tree = SourceFile(
         source,
-        construction_context=TreeConstructionContextV1(cm_refs, call_contract_refs=call_refs),
+        construction_context=TreeConstructionContextV1(
+            cm_refs, call_contract_refs=call_refs
+        ),
     )
     calls = list(node for node in tree.nodes() if isinstance(node, Call))
 
@@ -240,17 +245,30 @@ def test_python_intake_rejects_stale_semantic_contract_cid():
     from sugar_lift_py_tests.call_contract_resolution import _decode_ref
 
     raw = {
-        "kind": "resolved-call-contract-ref", "schemaVersion": "1",
-        "resolutionCid": RESOLUTION_CID, "demandCid": DEMAND_CID,
-        "useSite": {"sourceCid": CID, "startLine": 2, "startCol": 0, "endLine": 2, "endCol": 7},
-        "importBindingCid": CATALOG_CID, "catalogCid": CATALOG_CID,
-        "memberCid": MEMBER_CID, "contractCid": CID,
+        "kind": "resolved-call-contract-ref",
+        "schemaVersion": "1",
+        "resolutionCid": RESOLUTION_CID,
+        "demandCid": DEMAND_CID,
+        "useSite": {
+            "sourceCid": CID,
+            "startLine": 2,
+            "startCol": 0,
+            "endLine": 2,
+            "endCol": 7,
+        },
+        "importBindingCid": CATALOG_CID,
+        "catalogCid": CATALOG_CID,
+        "memberCid": MEMBER_CID,
+        "contractCid": CID,
         "bridgeSourceSymbol": "python:producer.pair",
         "importSignature": {"formals": [], "sorts": []},
-        "returnTerm": None, "sourceWarrantCids": [],
+        "returnTerm": None,
+        "sourceWarrantCids": [],
         "contractDecl": {"kind": "contract", "name": "changed"},
     }
-    with pytest.raises(CallContractRefProtocolError, match="stale semantic contract CID"):
+    with pytest.raises(
+        CallContractRefProtocolError, match="stale semantic contract CID"
+    ):
         _decode_ref(raw)
 
 
@@ -273,13 +291,14 @@ def test_return_projection_with_unauthenticated_free_name_stays_loud():
 def test_import_demand_enrollment_has_positional_arity_and_module_identity(tmp_path):
     (tmp_path / "producer.py").write_text("def pair(x):\n    return (x, x)\n")
     (tmp_path / "consumer.py").write_text(
-        "from producer import pair\n"
-        "value = pair(1)\n"
-        "not_enrolled = pair(x=1)\n"
+        "from producer import pair\n" "value = pair(1)\n" "not_enrolled = pair(x=1)\n"
     )
 
-    rows = [row for row in lift_rpc._call_contract_demand_rows(tmp_path)
-            if row["kind"] == "call-contract-demand"]
+    rows = [
+        row
+        for row in lift_rpc._call_contract_demand_rows(tmp_path)
+        if row["kind"] == "call-contract-demand"
+    ]
 
     assert len(rows) == 1
     assert rows[0]["targetSymbol"] == "python:producer.pair"
@@ -300,11 +319,15 @@ def test_import_binding_authenticates_alias_and_module_identity(tmp_path):
         "c = pair()\n"
     )
 
-    rows = [row for row in lift_rpc._call_contract_demand_rows(tmp_path)
-            if row["kind"] == "call-contract-demand"]
+    rows = [
+        row
+        for row in lift_rpc._call_contract_demand_rows(tmp_path)
+        if row["kind"] == "call-contract-demand"
+    ]
 
     assert [row["targetSymbol"] for row in rows] == [
-        "python:first.pair", "python:second.pair"
+        "python:first.pair",
+        "python:second.pair",
     ]
     assert rows[0]["importBindingCid"] != rows[1]["importBindingCid"]
 
@@ -374,7 +397,9 @@ def test_shadowed_reexport_is_not_published(tmp_path):
     assert not any(row["exportedSymbol"] == "python:public.pair" for row in rows)
 
 
-def test_try_handler_sees_exceptional_prefix_rebind_and_never_authenticates_import(tmp_path):
+def test_try_handler_sees_exceptional_prefix_rebind_and_never_authenticates_import(
+    tmp_path,
+):
     from sugar_lift_python_source.source_oracle import path_source
     from sugar_lift_py_tests.import_binding import authenticated_import_uses
 
@@ -389,9 +414,7 @@ def test_try_handler_sees_exceptional_prefix_rebind_and_never_authenticates_impo
     )
     source, _filename, source_cid = path_source(str(consumer))
 
-    rows, outcomes = authenticated_import_uses(
-        tmp_path, consumer, source, source_cid
-    )
+    rows, outcomes = authenticated_import_uses(tmp_path, consumer, source, source_cid)
 
     assert rows == []
     assert "ambiguous-lexical-binding" in outcomes.values()
@@ -410,9 +433,7 @@ def test_loop_backedge_rebind_never_authenticates_import_use(tmp_path):
     )
     source, _filename, source_cid = path_source(str(consumer))
 
-    rows, outcomes = authenticated_import_uses(
-        tmp_path, consumer, source, source_cid
-    )
+    rows, outcomes = authenticated_import_uses(tmp_path, consumer, source, source_cid)
 
     assert rows == []
     assert "ambiguous-lexical-binding" in outcomes.values()
@@ -424,14 +445,10 @@ def test_spelling_without_authenticated_import_use_has_no_authority(tmp_path):
 
     consumer = tmp_path / "consumer.py"
     consumer.write_text(
-        "def use(pair, pandas_magic):\n"
-        "    pair(1)\n"
-        "    pandas_magic(2)\n"
+        "def use(pair, pandas_magic):\n" "    pair(1)\n" "    pandas_magic(2)\n"
     )
     source, _filename, source_cid = path_source(str(consumer))
-    rows, outcomes = authenticated_import_uses(
-        tmp_path, consumer, source, source_cid
-    )
+    rows, outcomes = authenticated_import_uses(tmp_path, consumer, source, source_cid)
 
     assert rows == []
     assert set(outcomes.values()) == {"shadowed-non-import"}
@@ -459,10 +476,14 @@ def test_relative_import_is_package_qualified_and_binding_coordinate_is_typed(tm
 def test_reexport_declaration_is_static_and_source_authenticated(tmp_path):
     (tmp_path / "provider.py").write_text("def pair(x):\n    return (x, x)\n")
     (tmp_path / "public.py").write_text("from provider import pair\n")
-    (tmp_path / "consumer.py").write_text("from public import pair as renamed\nrenamed(1)\n")
+    (tmp_path / "consumer.py").write_text(
+        "from public import pair as renamed\nrenamed(1)\n"
+    )
 
     rows = lift_rpc._call_contract_demand_rows(tmp_path)
-    export = next(row for row in rows if row.get("exportedSymbol") == "python:public.pair")
+    export = next(
+        row for row in rows if row.get("exportedSymbol") == "python:public.pair"
+    )
     demand = next(row for row in rows if row["kind"] == "call-contract-demand")
 
     assert export["targetSymbol"] == "python:provider.pair"
@@ -473,6 +494,7 @@ def test_reexport_declaration_is_static_and_source_authenticated(tmp_path):
 
 def test_import_alias_has_no_parallel_install_source_resolver(monkeypatch):
     from sugar_lift_py_tests.floor.import_alias_value import ImportAliasValue
+
     del monkeypatch
     value = ImportAliasValue("producer.pair", "pair", import_target="producer.pair")
 
@@ -491,8 +513,11 @@ def test_parser_backed_imported_call_consumes_prebound_contract_ref(tmp_path):
 
     consumer = tmp_path / "consumer.py"
     consumer.write_text("from producer import pair\nvalue = pair(v)\n")
-    row = next(row for row in lift_rpc._call_contract_demand_rows(tmp_path)
-               if row["kind"] == "call-contract-demand")
+    row = next(
+        row
+        for row in lift_rpc._call_contract_demand_rows(tmp_path)
+        if row["kind"] == "call-contract-demand"
+    )
     coordinate = SourceFragmentCoordinateV1.decode(row["useSite"])
     reference = replace(
         _reference(),
@@ -548,7 +573,10 @@ def test_producer_contract_exports_the_same_module_qualified_symbol(tmp_path):
 
 def test_only_module_level_function_publishes_import_export_symbol(tmp_path):
     from sugar_lift_python_source.source_oracle import path_source
-    from sugar_lift_py_tests.context_manager_resolution import ResolvedContractRefsV1, TreeConstructionContextV1
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ResolvedContractRefsV1,
+        TreeConstructionContextV1,
+    )
     from sugar_source_tree.tree import SourceFile
 
     producer = tmp_path / "producer.py"

--- a/implementations/python/sugar-lift-py-tests/tests/test_callsite_term_cycle_key_volume.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_callsite_term_cycle_key_volume.py
@@ -63,9 +63,9 @@ def test_term_cycle_key_under_intern_scope_stays_under_budget() -> None:
         elapsed = time.perf_counter() - started
     assert warm.startswith("blake3-512:")
     assert len(set(keys)) == 1 and keys[0] == warm
-    assert not warm.startswith("term-id:"), (
-        "term-id: keys are the scope-dependent #5477 bug (#5569)."
-    )
+    assert not warm.startswith(
+        "term-id:"
+    ), "term-id: keys are the scope-dependent #5477 bug (#5569)."
     assert elapsed < budget_seconds, (
         f"R=1 memoized _term_cycle_key×{repeats} over depth={depth} paid "
         f"{elapsed:.3f}s (budget {budget_seconds}s after first materialize). "

--- a/implementations/python/sugar-lift-py-tests/tests/test_cm_construction_boundary.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_cm_construction_boundary.py
@@ -61,9 +61,13 @@ def test_complete_real_roots_have_stable_zero_boundary_residue():
         sugar_root=python_root / "sugar-lift-py-tests/src/sugar_lift_py_tests/sugar",
         source_tree_root=python_root / "sugar-source-tree/src/sugar_source_tree",
     )
-    assert report.files_scanned == len(list(
-        (python_root / "sugar-lift-py-tests/src/sugar_lift_py_tests/sugar").rglob("*.py")
-    )) + len(list(
-        (python_root / "sugar-source-tree/src/sugar_source_tree").rglob("*.py")
-    ))
+    assert report.files_scanned == len(
+        list(
+            (python_root / "sugar-lift-py-tests/src/sugar_lift_py_tests/sugar").rglob(
+                "*.py"
+            )
+        )
+    ) + len(
+        list((python_root / "sugar-source-tree/src/sugar_source_tree").rglob("*.py"))
+    )
     assert report.r == 0, report.render()

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_panic_catch_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_panic_catch_law.py
@@ -7,7 +7,9 @@ from pathlib import Path
 
 _KIT = Path(__file__).resolve().parents[1]
 _SCANNER_PATH = _KIT / "scripts" / "construction_panic_catch_law.py"
-_SPEC = importlib.util.spec_from_file_location("construction_panic_catch_law", _SCANNER_PATH)
+_SPEC = importlib.util.spec_from_file_location(
+    "construction_panic_catch_law", _SCANNER_PATH
+)
 assert _SPEC is not None and _SPEC.loader is not None
 _SCANNER = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_SCANNER)

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_panic_fronts.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_panic_fronts.py
@@ -47,7 +47,9 @@ def test_fingerprint_from_typed_gap_info_matches_json() -> None:
     )
 
 
-def test_rank_construction_panic_fronts_orders_owner_families_and_exact_fronts() -> None:
+def test_rank_construction_panic_fronts_orders_owner_families_and_exact_fronts() -> (
+    None
+):
     rows = [
         {
             "file": "numpy/a.py",

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_contract.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_contract.py
@@ -24,7 +24,6 @@ from sugar_lift_py_tests.signing import Signer
 from sugar_lift_py_tests.context_manager_contract import _json_value
 from sugar_lift_py_tests import lift_rpc
 
-
 SEED = bytes(range(32))
 DECLARED_AT = "2026-07-22T00:00:00.000Z"
 
@@ -48,7 +47,11 @@ def _reseal(mutator):
     raw["header"]["cid"] = payload_cid
     raw["header"]["payloadCid"] = payload_cid
     return _assemble_layered(
-        _json_value(raw["header"]), _json_value(raw["metadata"]), DECLARED_AT, SEED, payload_cid
+        _json_value(raw["header"]),
+        _json_value(raw["metadata"]),
+        DECLARED_AT,
+        SEED,
+        payload_cid,
     )
 
 
@@ -68,8 +71,15 @@ def test_semantic_payload_is_provider_neutral_and_hashed_alone():
     header = raw["header"]
     assert header["schemaVersion"] == "1.2"
     assert set(header) == {
-        "schemaVersion", "kind", "cid", "payloadCid", "bridgeSourceSymbol",
-        "importSignature", "payload", "sourceWarrants", "inputCids",
+        "schemaVersion",
+        "kind",
+        "cid",
+        "payloadCid",
+        "bridgeSourceSymbol",
+        "importSignature",
+        "payload",
+        "sourceWarrants",
+        "inputCids",
     }
     assert "name" not in header["payload"] and "kit" not in header["payload"]
     assert header["payload"] == {
@@ -77,9 +87,16 @@ def test_semantic_payload_is_provider_neutral_and_hashed_alone():
         "schemaVersion": "1",
         "enter": {
             "completion": {"kind": "total"},
-            "result": {"kind": "projection", "projection": "enter-result", "sort": {"kind": "primitive", "name": "Value"}},
+            "result": {
+                "kind": "projection",
+                "projection": "enter-result",
+                "sort": {"kind": "primitive", "name": "Value"},
+            },
         },
-        "exit": {"completion": {"kind": "total"}, "disposition": {"kind": "never-suppresses"}},
+        "exit": {
+            "completion": {"kind": "total"},
+            "disposition": {"kind": "never-suppresses"},
+        },
     }
     assert header["payloadCid"] == blake3_512_of(
         encode_jcs(_json_value(header["payload"])).encode()
@@ -87,14 +104,18 @@ def test_semantic_payload_is_provider_neutral_and_hashed_alone():
 
 
 def test_correctly_resealed_unknown_disposition_reaches_typed_decoder():
-    sealed = _reseal(lambda h: h["payload"]["exit"]["disposition"].update(kind="sometimes"))
+    sealed = _reseal(
+        lambda h: h["payload"]["exit"]["disposition"].update(kind="sometimes")
+    )
     with pytest.raises(ContextManagerContractError, match="unknown exit disposition"):
         decode_context_manager_contract(sealed.canonical_bytes, sealed.cid)
 
 
 def test_correctly_resealed_missing_enter_reaches_typed_decoder():
     sealed = _reseal(lambda h: h["payload"].pop("enter"))
-    with pytest.raises(ContextManagerContractError, match="malformed protocol-resource semantics"):
+    with pytest.raises(
+        ContextManagerContractError, match="malformed protocol-resource semantics"
+    ):
         decode_context_manager_contract(sealed.canonical_bytes, sealed.cid)
 
 
@@ -107,7 +128,13 @@ def test_bad_signature_is_distinct_from_stale_payload_cid():
 
     raw = json.loads(sealed.canonical_bytes)
     raw["header"]["payloadCid"] = "blake3-512:" + "0" * 128
-    stale = _assemble_layered(_json_value(raw["header"]), _json_value(raw["metadata"]), DECLARED_AT, SEED, raw["header"]["payloadCid"])
+    stale = _assemble_layered(
+        _json_value(raw["header"]),
+        _json_value(raw["metadata"]),
+        DECLARED_AT,
+        SEED,
+        raw["header"]["payloadCid"],
+    )
     with pytest.raises(ContextManagerContractError, match="payload CID"):
         decode_context_manager_contract(stale.canonical_bytes, stale.cid)
 
@@ -133,6 +160,4 @@ def test_typed_declaration_is_published_on_the_live_kit_declaration(monkeypatch)
     monkeypatch.setattr(lift_rpc, "_PUBLISHED_CONTEXT_MANAGER_DECLARATIONS", ())
     lift_rpc.publish_context_manager_declaration(row)
     declaration = lift_rpc._kit_declaration_result()
-    assert declaration["contractDeclarations"] == [
-        row.to_rpc_with_term_table(None)
-    ]
+    assert declaration["contractDeclarations"] == [row.to_rpc_with_term_table(None)]

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
@@ -26,19 +26,21 @@ def unresolved_table():
         "kind": "resolved-contract-refs",
         "schemaVersion": "1",
         "catalogCid": cid,
-        "byUseSite": [{
-            "useSite": use_site,
-            "resolution": {
-                "kind": "unresolved",
-                "gap": {
-                    "demandCid": demand_cid,
-                    "useSite": use_site,
-                    "targetSymbol": "context-manager:fixture.missing",
-                    "kind": "unresolved-symbol",
-                    "candidateMemberCids": [],
+        "byUseSite": [
+            {
+                "useSite": use_site,
+                "resolution": {
+                    "kind": "unresolved",
+                    "gap": {
+                        "demandCid": demand_cid,
+                        "useSite": use_site,
+                        "targetSymbol": "context-manager:fixture.missing",
+                        "kind": "unresolved-symbol",
+                        "candidateMemberCids": [],
+                    },
                 },
-            },
-        }],
+            }
+        ],
     }
     return {**identity, "tableCid": _hash_json(identity)}
 
@@ -57,25 +59,33 @@ def test_bind_rpc_freezes_one_generation_and_acknowledges_exact_table_cid(monkey
     monkeypatch.setattr(lift_rpc, "_BOUND_CONTRACT_REFS", None)
     monkeypatch.setattr(lift_rpc, "_send", sent.append)
     wire = unresolved_table()
-    assert lift_rpc._dispatch_request({
-        "jsonrpc": "2.0", "id": 7,
-        "method": lift_rpc.BIND_CONTRACT_REFS_RPC_METHOD,
-        "params": {"contractRefs": wire},
-    })
+    assert lift_rpc._dispatch_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": lift_rpc.BIND_CONTRACT_REFS_RPC_METHOD,
+            "params": {"contractRefs": wire},
+        }
+    )
     assert sent[0]["result"]["tableCid"] == wire["tableCid"]
     assert set(sent[0]["result"]) == {"tableCid"}
     assert isinstance(lift_rpc._BOUND_CONTRACT_REFS.by_use_site, MappingProxyType)
 
     other = unresolved_table()
     other["catalogCid"] = "blake3-512:" + "4" * 128
-    identity = {key: other[key] for key in ("kind", "schemaVersion", "catalogCid", "byUseSite")}
+    identity = {
+        key: other[key] for key in ("kind", "schemaVersion", "catalogCid", "byUseSite")
+    }
     other["tableCid"] = _hash_json(identity)
     with pytest.raises(ValueError, match="already frozen"):
-        lift_rpc._dispatch_request({
-            "jsonrpc": "2.0", "id": 8,
-            "method": lift_rpc.BIND_CONTRACT_REFS_RPC_METHOD,
-            "params": {"contractRefs": other},
-        })
+        lift_rpc._dispatch_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 8,
+                "method": lift_rpc.BIND_CONTRACT_REFS_RPC_METHOD,
+                "params": {"contractRefs": other},
+            }
+        )
 
 
 def test_malformed_table_cid_and_unsorted_ambiguity_are_loud():
@@ -91,7 +101,10 @@ def test_malformed_table_cid_and_unsorted_ambiguity_are_loud():
         "blake3-512:" + "b" * 128,
         "blake3-512:" + "a" * 128,
     ]
-    identity = {key: ambiguous[key] for key in ("kind", "schemaVersion", "catalogCid", "byUseSite")}
+    identity = {
+        key: ambiguous[key]
+        for key in ("kind", "schemaVersion", "catalogCid", "byUseSite")
+    }
     ambiguous["tableCid"] = _hash_json(identity)
     with pytest.raises(ContractRefProtocolError, match="must be sorted"):
         decode_resolved_contract_refs(ambiguous)
@@ -112,7 +125,9 @@ def test_demand_enrollment_uses_import_coordinate_without_sugar_or_target_source
     monkeypatch.setattr(
         With,
         "sugar",
-        lambda self: (_ for _ in ()).throw(AssertionError("demand pass constructed Sugar")),
+        lambda self: (_ for _ in ()).throw(
+            AssertionError("demand pass constructed Sugar")
+        ),
     )
     rows = lift_rpc._context_manager_demand_rows(tmp_path)
     assert len(rows) == 1
@@ -125,7 +140,10 @@ def test_demand_enrollment_uses_import_coordinate_without_sugar_or_target_source
 
 def test_published_typed_declaration_is_served_only_by_declaration_pass(monkeypatch):
     from sugar_lift_py_tests.ir import PrimitiveSort
-    from sugar_lift_py_tests.kit_rpc import ContextManagerContractIrV1, ImportSignatureV2
+    from sugar_lift_py_tests.kit_rpc import (
+        ContextManagerContractIrV1,
+        ImportSignatureV2,
+    )
 
     declaration = ContextManagerContractIrV1.never_suppresses(
         bridge_source_symbol="context-manager:dependency.manager",
@@ -140,8 +158,11 @@ def test_published_typed_declaration_is_served_only_by_declaration_pass(monkeypa
     monkeypatch.setattr(lift_rpc, "_ENUMERATION_ACTIVE", False)
     monkeypatch.setattr(lift_rpc, "_send", sent.append)
     lift_rpc.publish_context_manager_declaration(declaration)
-    lift_rpc._handle_enumerate(9, {
-        "level": "contract-declarations",
-        "workspace_root": ".",
-    })
+    lift_rpc._handle_enumerate(
+        9,
+        {
+            "level": "contract-declarations",
+            "workspace_root": ".",
+        },
+    )
     assert sent[-1] == {"jsonrpc": "2.0", "id": 9, "result": {"rows": [row]}}

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_semantics_v2.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_semantics_v2.py
@@ -59,9 +59,7 @@ def _resource(disposition=ReturnTruthinessDispositionV1()):
         enter=EnterResultContractV1(
             sort=PrimitiveSort("Value"), completion=TotalCompletionV1()
         ),
-        exit=ExitContractV1(
-            disposition=disposition, completion=TotalCompletionV1()
-        ),
+        exit=ExitContractV1(disposition=disposition, completion=TotalCompletionV1()),
     )
 
 
@@ -85,10 +83,24 @@ def test_protocol_resource_return_truthiness_round_trips_closed_decoder():
 
 
 def _signature():
-    return ImportSignatureV2((
-        CallParameterV1("expected_exception", PrimitiveSort("Value"), PositionalOrKeywordV1(), True, NoDefaultV1()),
-        CallParameterV1("match", PrimitiveSort("String"), KeywordOnlyV1(), False, LiteralDefaultV1({"kind": "ctor", "name": "None", "args": []})),
-    ))
+    return ImportSignatureV2(
+        (
+            CallParameterV1(
+                "expected_exception",
+                PrimitiveSort("Value"),
+                PositionalOrKeywordV1(),
+                True,
+                NoDefaultV1(),
+            ),
+            CallParameterV1(
+                "match",
+                PrimitiveSort("String"),
+                KeywordOnlyV1(),
+                False,
+                LiteralDefaultV1({"kind": "ctor", "name": "None", "args": []}),
+            ),
+        )
+    )
 
 
 def test_effect_boundary_round_trips_by_formal_position_without_baked_values():
@@ -131,7 +143,9 @@ def test_effect_boundary_selector_role_and_sort_mismatch_is_loud():
 def test_effect_boundary_unknown_field_is_loud():
     wire = _wire(_effect_boundary())
     wire["matcher"]["extra"] = True
-    with pytest.raises(ContextManagerContractError, match="malformed effect-boundary matcher"):
+    with pytest.raises(
+        ContextManagerContractError, match="malformed effect-boundary matcher"
+    ):
         decode_context_manager_semantics_v1(wire, _signature())
 
 
@@ -182,27 +196,66 @@ def test_provider_kit_effect_boundary_member_uses_the_closed_union_payload():
     wire = member.to_rpc_with_term_table(None)
     assert wire["payload"] == _wire(_effect_boundary())
     assert wire["importSignature"]["parameters"][0]["sort"] == {
-        "kind": "primitive", "name": "Value",
+        "kind": "primitive",
+        "name": "Value",
     }
     assert wire["importSignature"]["parameters"][1]["sort"] == {
-        "kind": "primitive", "name": "String",
+        "kind": "primitive",
+        "name": "String",
     }
 
 
 def test_effect_boundary_selectors_are_positions_not_privileged_formal_names():
-    renamed = ImportSignatureV2((
-        CallParameterV1("arbitrary_expected", PrimitiveSort("Value"), PositionalOrKeywordV1(), True, NoDefaultV1()),
-        CallParameterV1("arbitrary_pattern", PrimitiveSort("String"), KeywordOnlyV1(), False, LiteralDefaultV1({"kind": "ctor", "name": "None", "args": []})),
-    ))
-    assert decode_context_manager_semantics_v1(_wire(_effect_boundary()), renamed) == _effect_boundary()
+    renamed = ImportSignatureV2(
+        (
+            CallParameterV1(
+                "arbitrary_expected",
+                PrimitiveSort("Value"),
+                PositionalOrKeywordV1(),
+                True,
+                NoDefaultV1(),
+            ),
+            CallParameterV1(
+                "arbitrary_pattern",
+                PrimitiveSort("String"),
+                KeywordOnlyV1(),
+                False,
+                LiteralDefaultV1({"kind": "ctor", "name": "None", "args": []}),
+            ),
+        )
+    )
+    assert (
+        decode_context_manager_semantics_v1(_wire(_effect_boundary()), renamed)
+        == _effect_boundary()
+    )
 
 
 def test_effect_boundary_lying_selector_for_an_unrelated_formal_is_loud():
-    signature = ImportSignatureV2((
-        CallParameterV1("unrelated", PrimitiveSort("String"), PositionalOrKeywordV1(), True, NoDefaultV1()),
-        CallParameterV1("expected", PrimitiveSort("Value"), PositionalOrKeywordV1(), True, NoDefaultV1()),
-        CallParameterV1("pattern", PrimitiveSort("String"), KeywordOnlyV1(), False, LiteralDefaultV1({"kind": "ctor", "name": "None", "args": []})),
-    ))
+    signature = ImportSignatureV2(
+        (
+            CallParameterV1(
+                "unrelated",
+                PrimitiveSort("String"),
+                PositionalOrKeywordV1(),
+                True,
+                NoDefaultV1(),
+            ),
+            CallParameterV1(
+                "expected",
+                PrimitiveSort("Value"),
+                PositionalOrKeywordV1(),
+                True,
+                NoDefaultV1(),
+            ),
+            CallParameterV1(
+                "pattern",
+                PrimitiveSort("String"),
+                KeywordOnlyV1(),
+                False,
+                LiteralDefaultV1({"kind": "ctor", "name": "None", "args": []}),
+            ),
+        )
+    )
     with pytest.raises(ContextManagerContractError, match="Value formal"):
         decode_context_manager_semantics_v1(_wire(_effect_boundary()), signature)
 
@@ -211,9 +264,17 @@ def test_effect_boundary_publisher_does_not_sign_a_lying_selector():
     with pytest.raises(ContextManagerContractError, match="Value formal"):
         publish_effect_boundary_context_manager_contract(
             bridge_source_symbol="context-manager:fixture_provider.expect",
-            import_signature=ImportSignatureV2((
-                CallParameterV1("unrelated", PrimitiveSort("String"), PositionalOrKeywordV1(), True, NoDefaultV1()),
-            )),
+            import_signature=ImportSignatureV2(
+                (
+                    CallParameterV1(
+                        "unrelated",
+                        PrimitiveSort("String"),
+                        PositionalOrKeywordV1(),
+                        True,
+                        NoDefaultV1(),
+                    ),
+                )
+            ),
             mode=ExpectsModeV1(),
             effect_kind=RaiseEffectKindV1(),
             expected_type_operand=FormalArgumentProjectionV1(0),
@@ -226,168 +287,331 @@ def test_effect_boundary_publisher_does_not_sign_a_lying_selector():
 
 
 def test_variadic_signature_and_selectors_round_trip_exhaustively():
-    signature = ImportSignatureV2((
-        CallParameterV1("args", PrimitiveSort("Value"), VariadicPositionalV1(), False, NoDefaultV1()),
-        CallParameterV1("kwargs", PrimitiveSort("Value"), VariadicKeywordV1(), False, NoDefaultV1()),
-    ))
-    assert decode_import_signature_v2(json.loads(encode_jcs(import_signature_to_value(signature)))) == signature
+    signature = ImportSignatureV2(
+        (
+            CallParameterV1(
+                "args",
+                PrimitiveSort("Value"),
+                VariadicPositionalV1(),
+                False,
+                NoDefaultV1(),
+            ),
+            CallParameterV1(
+                "kwargs",
+                PrimitiveSort("Value"),
+                VariadicKeywordV1(),
+                False,
+                NoDefaultV1(),
+            ),
+        )
+    )
+    assert (
+        decode_import_signature_v2(
+            json.loads(encode_jcs(import_signature_to_value(signature)))
+        )
+        == signature
+    )
 
     positional = VariadicPositionalElementProjectionV1(0, 2)
     keyword = VariadicKeywordEntryProjectionV1(1, "match")
     semantics = EffectBoundarySemanticsV1(
-        ExpectsModeV1(), RaiseEffectKindV1(), positional, keyword, ExceptionInfoBindingV1(),
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        positional,
+        keyword,
+        ExceptionInfoBindingV1(),
     )
     assert _wire(semantics)["matcher"] == {
         "effectKind": {"kind": "raise"},
-        "expectedTypeOperand": {"kind": "variadic-positional-element", "parameterIndex": 0, "elementIndex": 2},
-        "messagePatternOperand": {"kind": "variadic-keyword-entry", "parameterIndex": 1, "keyword": "match"},
+        "expectedTypeOperand": {
+            "kind": "variadic-positional-element",
+            "parameterIndex": 0,
+            "elementIndex": 2,
+        },
+        "messagePatternOperand": {
+            "kind": "variadic-keyword-entry",
+            "parameterIndex": 1,
+            "keyword": "match",
+        },
     }
     assert decode_context_manager_semantics_v1(_wire(semantics), signature) == semantics
 
 
 def test_ensure_clean_variadic_keyword_pack_projects_real_constructed_entries():
-    signature = ImportSignatureV2((
-        CallParameterV1(
-            "filename", PrimitiveSort("Value"), PositionalOrKeywordV1(), False,
-            LiteralDefaultV1({"kind": "ctor", "name": "None", "args": []}),
-        ),
-        CallParameterV1(
-            "return_filelike", PrimitiveSort("Bool"), PositionalOrKeywordV1(), False,
-            LiteralDefaultV1({
-                "kind": "const", "value": False,
-                "sort": {"kind": "primitive", "name": "Bool"},
-            }),
-        ),
-        CallParameterV1(
-            "kwargs", PrimitiveSort("Value"), VariadicKeywordV1(), False,
-            NoDefaultV1(),
-        ),
-    ))
+    signature = ImportSignatureV2(
+        (
+            CallParameterV1(
+                "filename",
+                PrimitiveSort("Value"),
+                PositionalOrKeywordV1(),
+                False,
+                LiteralDefaultV1({"kind": "ctor", "name": "None", "args": []}),
+            ),
+            CallParameterV1(
+                "return_filelike",
+                PrimitiveSort("Bool"),
+                PositionalOrKeywordV1(),
+                False,
+                LiteralDefaultV1(
+                    {
+                        "kind": "const",
+                        "value": False,
+                        "sort": {"kind": "primitive", "name": "Bool"},
+                    }
+                ),
+            ),
+            CallParameterV1(
+                "kwargs",
+                PrimitiveSort("Value"),
+                VariadicKeywordV1(),
+                False,
+                NoDefaultV1(),
+            ),
+        )
+    )
     assert isinstance(signature.parameters[2].passing, VariadicKeywordV1)
-    from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
     from sugar_lift_py_tests.sugar.name_sugar import NameSugar
+
     first = NameSugar("first", None)
     second = NameSugar("second", None)
-    pack = VariadicKeywordActualV1(2, (
-        ConstructedOperandOccurrenceV1(SourceFragmentCoordinateV1(_cid("1"), 1, 0, 1, 5), "foo", first),
-        ConstructedOperandOccurrenceV1(SourceFragmentCoordinateV1(_cid("2"), 2, 0, 2, 6), "bar", second),
-    ))
-    assert project_formal_selector_v1(
-        VariadicKeywordEntryProjectionV1(2, "bar"),
-        fixed_actuals={}, variadic_positional_actuals={}, variadic_keyword_actuals={2: pack},
-    ) is second
+    pack = VariadicKeywordActualV1(
+        2,
+        (
+            ConstructedOperandOccurrenceV1(
+                SourceFragmentCoordinateV1(_cid("1"), 1, 0, 1, 5), "foo", first
+            ),
+            ConstructedOperandOccurrenceV1(
+                SourceFragmentCoordinateV1(_cid("2"), 2, 0, 2, 6), "bar", second
+            ),
+        ),
+    )
+    assert (
+        project_formal_selector_v1(
+            VariadicKeywordEntryProjectionV1(2, "bar"),
+            fixed_actuals={},
+            variadic_positional_actuals={},
+            variadic_keyword_actuals={2: pack},
+        )
+        is second
+    )
 
 
 def test_variadic_parameter_with_non_value_sort_is_loud():
     with pytest.raises(ContextManagerContractError, match="requires Value"):
         CallParameterV1(
-            "kwargs", PrimitiveSort("String"), VariadicKeywordV1(), False,
+            "kwargs",
+            PrimitiveSort("String"),
+            VariadicKeywordV1(),
+            False,
             NoDefaultV1(),
         )
 
 
 def test_real_positional_and_mapping_pack_projections_preserve_occurrence_identity():
-    from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
     from sugar_lift_py_tests.sugar.name_sugar import NameSugar
+
     positional_value = NameSugar("positional", None)
     mapping_value = NameSugar("mapping", None)
-    positional = VariadicPositionalActualV1(0, (
-        ConstructedOperandOccurrenceV1(SourceFragmentCoordinateV1(_cid("3"), 1, 0, 1, 10), None, positional_value),
-    ))
-    mapping = VariadicKeywordActualV1(1, (
-        ConstructedOperandOccurrenceV1(SourceFragmentCoordinateV1(_cid("4"), 2, 0, 2, 12), "key", mapping_value),
-    ))
-    assert project_formal_selector_v1(
-        VariadicPositionalElementProjectionV1(0, 0), fixed_actuals={},
-        variadic_positional_actuals={0: positional}, variadic_keyword_actuals={1: mapping},
-    ) is positional_value
-    assert project_formal_selector_v1(
-        VariadicKeywordEntryProjectionV1(1, "key"), fixed_actuals={},
-        variadic_positional_actuals={0: positional}, variadic_keyword_actuals={1: mapping},
-    ) is mapping_value
+    positional = VariadicPositionalActualV1(
+        0,
+        (
+            ConstructedOperandOccurrenceV1(
+                SourceFragmentCoordinateV1(_cid("3"), 1, 0, 1, 10),
+                None,
+                positional_value,
+            ),
+        ),
+    )
+    mapping = VariadicKeywordActualV1(
+        1,
+        (
+            ConstructedOperandOccurrenceV1(
+                SourceFragmentCoordinateV1(_cid("4"), 2, 0, 2, 12), "key", mapping_value
+            ),
+        ),
+    )
+    assert (
+        project_formal_selector_v1(
+            VariadicPositionalElementProjectionV1(0, 0),
+            fixed_actuals={},
+            variadic_positional_actuals={0: positional},
+            variadic_keyword_actuals={1: mapping},
+        )
+        is positional_value
+    )
+    assert (
+        project_formal_selector_v1(
+            VariadicKeywordEntryProjectionV1(1, "key"),
+            fixed_actuals={},
+            variadic_positional_actuals={0: positional},
+            variadic_keyword_actuals={1: mapping},
+        )
+        is mapping_value
+    )
     with pytest.raises(ContextManagerContractError, match="out of range"):
         project_formal_selector_v1(
-            VariadicPositionalElementProjectionV1(0, 1), fixed_actuals={},
-            variadic_positional_actuals={0: positional}, variadic_keyword_actuals={},
+            VariadicPositionalElementProjectionV1(0, 1),
+            fixed_actuals={},
+            variadic_positional_actuals={0: positional},
+            variadic_keyword_actuals={},
         )
     with pytest.raises(ContextManagerContractError, match="unique real keywords"):
-        VariadicKeywordActualV1(1, (
-            ConstructedOperandOccurrenceV1(SourceFragmentCoordinateV1(_cid("5"), 3, 0, 3, 4), "same", NameSugar("one", None)),
-            ConstructedOperandOccurrenceV1(SourceFragmentCoordinateV1(_cid("6"), 4, 0, 4, 4), "same", NameSugar("two", None)),
-        ))
+        VariadicKeywordActualV1(
+            1,
+            (
+                ConstructedOperandOccurrenceV1(
+                    SourceFragmentCoordinateV1(_cid("5"), 3, 0, 3, 4),
+                    "same",
+                    NameSugar("one", None),
+                ),
+                ConstructedOperandOccurrenceV1(
+                    SourceFragmentCoordinateV1(_cid("6"), 4, 0, 4, 4),
+                    "same",
+                    NameSugar("two", None),
+                ),
+            ),
+        )
 
 
 def test_source_call_variadic_projection_returns_the_exact_constructed_child(tmp_path):
     from sugar_lift_python_source.source_oracle import path_source
-    from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
     from sugar_source_tree.nodes import Call
     from sugar_source_tree.tree import SourceFile
 
     path = tmp_path / "actual.py"
     path.write_text("def f():\n    ensure_clean(foo=side_effect())\n")
     call = next(
-        node for node in SourceFile(path_source(str(path))).nodes()
+        node
+        for node in SourceFile(path_source(str(path))).nodes()
         if isinstance(node, Call) and getattr(node.func, "id", None) == "ensure_clean"
     )
     call_sugar = call.sugar()
     constructed_child = call_sugar.keywords[0][1]
     span = call.keywords[0].value.line_col_span()
     occurrence = SourceFragmentCoordinateV1(
-        call.unit.source_cid, span.start_line, span.start_col, span.end_line, span.end_col
+        call.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
     )
-    pack = VariadicKeywordActualV1(2, (
-        ConstructedOperandOccurrenceV1(occurrence, "foo", constructed_child),
-    ))
+    pack = VariadicKeywordActualV1(
+        2, (ConstructedOperandOccurrenceV1(occurrence, "foo", constructed_child),)
+    )
 
     projected = project_formal_selector_v1(
-        VariadicKeywordEntryProjectionV1(2, "foo"), fixed_actuals={},
-        variadic_positional_actuals={}, variadic_keyword_actuals={2: pack},
+        VariadicKeywordEntryProjectionV1(2, "foo"),
+        fixed_actuals={},
+        variadic_positional_actuals={},
+        variadic_keyword_actuals={2: pack},
     )
 
     assert projected is constructed_child
 
 
 def test_fabricated_variadic_occurrence_wrapper_is_loud():
-    from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
     from sugar_lift_py_tests.sugar.name_sugar import NameSugar
 
-    with pytest.raises(ContextManagerContractError, match="constructed operand occurrence"):
+    with pytest.raises(
+        ContextManagerContractError, match="constructed operand occurrence"
+    ):
         ConstructedOperandOccurrenceV1(
             "source:invented", "key", NameSugar("real-child", None)
         )
-    with pytest.raises(ContextManagerContractError, match="constructed operand occurrence"):
+    with pytest.raises(
+        ContextManagerContractError, match="constructed operand occurrence"
+    ):
         ConstructedOperandOccurrenceV1(
             SourceFragmentCoordinateV1(_cid("7"), 1, 0, 1, 1), "key", object()
         )
 
 
 def test_cross_kind_variadic_selectors_are_loud():
-    signature = ImportSignatureV2((
-        CallParameterV1("fixed", PrimitiveSort("Value"), PositionalOrKeywordV1(), True, NoDefaultV1()),
-        CallParameterV1("args", PrimitiveSort("Value"), VariadicPositionalV1(), False, NoDefaultV1()),
-        CallParameterV1("kwargs", PrimitiveSort("Value"), VariadicKeywordV1(), False, NoDefaultV1()),
-    ))
-    base = _wire(EffectBoundarySemanticsV1(
-        ExpectsModeV1(), RaiseEffectKindV1(), FormalArgumentProjectionV1(0),
-        VariadicKeywordEntryProjectionV1(2, "match"), ExceptionInfoBindingV1(),
-    ))
+    signature = ImportSignatureV2(
+        (
+            CallParameterV1(
+                "fixed",
+                PrimitiveSort("Value"),
+                PositionalOrKeywordV1(),
+                True,
+                NoDefaultV1(),
+            ),
+            CallParameterV1(
+                "args",
+                PrimitiveSort("Value"),
+                VariadicPositionalV1(),
+                False,
+                NoDefaultV1(),
+            ),
+            CallParameterV1(
+                "kwargs",
+                PrimitiveSort("Value"),
+                VariadicKeywordV1(),
+                False,
+                NoDefaultV1(),
+            ),
+        )
+    )
+    base = _wire(
+        EffectBoundarySemanticsV1(
+            ExpectsModeV1(),
+            RaiseEffectKindV1(),
+            FormalArgumentProjectionV1(0),
+            VariadicKeywordEntryProjectionV1(2, "match"),
+            ExceptionInfoBindingV1(),
+        )
+    )
     base["matcher"]["messagePatternOperand"] = {
-        "kind": "variadic-keyword-entry", "parameterIndex": 1, "keyword": "match",
+        "kind": "variadic-keyword-entry",
+        "parameterIndex": 1,
+        "keyword": "match",
     }
     with pytest.raises(ContextManagerContractError, match=r"requires \*\*kwargs"):
         decode_context_manager_semantics_v1(base, signature)
 
 
-@pytest.mark.parametrize("mutation", [
-    lambda wire: wire["parameters"][0]["passing"].update(kind="future-pack"),
-    lambda wire: wire["parameters"][0].update(required=True),
-    lambda wire: wire["parameters"][0].update(default={"kind": "literal-default", "value": {"kind": "const", "value": 1, "sort": {"kind": "primitive", "name": "Int"}}}),
-    lambda wire: wire["parameters"][0].update(extra=True),
-])
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda wire: wire["parameters"][0]["passing"].update(kind="future-pack"),
+        lambda wire: wire["parameters"][0].update(required=True),
+        lambda wire: wire["parameters"][0].update(
+            default={
+                "kind": "literal-default",
+                "value": {
+                    "kind": "const",
+                    "value": 1,
+                    "sort": {"kind": "primitive", "name": "Int"},
+                },
+            }
+        ),
+        lambda wire: wire["parameters"][0].update(extra=True),
+    ],
+)
 def test_malformed_variadic_signature_is_loud(mutation):
-    signature = ImportSignatureV2((
-        CallParameterV1("kwargs", PrimitiveSort("Value"), VariadicKeywordV1(), False, NoDefaultV1()),
-    ))
+    signature = ImportSignatureV2(
+        (
+            CallParameterV1(
+                "kwargs",
+                PrimitiveSort("Value"),
+                VariadicKeywordV1(),
+                False,
+                NoDefaultV1(),
+            ),
+        )
+    )
     wire = json.loads(encode_jcs(import_signature_to_value(signature)))
     mutation(wire)
     with pytest.raises(ContextManagerContractError):
@@ -396,22 +620,49 @@ def test_malformed_variadic_signature_is_loud(mutation):
 
 def test_authenticated_defaults_round_trip_and_provider_refs_resolve_only_from_catalog():
     provider_cid = "blake3-512:" + "d" * 128
-    signature = ImportSignatureV2((
-        CallParameterV1("mode", PrimitiveSort("String"), KeywordOnlyV1(), False, LiteralDefaultV1({"kind": "const", "value": "r", "sort": {"kind": "primitive", "name": "String"}})),
-        CallParameterV1("category", PrimitiveSort("Value"), KeywordOnlyV1(), False, ProviderValueRefV1(provider_cid, PrimitiveSort("Value"))),
-    ))
+    signature = ImportSignatureV2(
+        (
+            CallParameterV1(
+                "mode",
+                PrimitiveSort("String"),
+                KeywordOnlyV1(),
+                False,
+                LiteralDefaultV1(
+                    {
+                        "kind": "const",
+                        "value": "r",
+                        "sort": {"kind": "primitive", "name": "String"},
+                    }
+                ),
+            ),
+            CallParameterV1(
+                "category",
+                PrimitiveSort("Value"),
+                KeywordOnlyV1(),
+                False,
+                ProviderValueRefV1(provider_cid, PrimitiveSort("Value")),
+            ),
+        )
+    )
     wire = json.loads(encode_jcs(import_signature_to_value(signature)))
     assert decode_import_signature_v2(wire) == signature
     from sugar_lift_py_tests.signing import Signer
+
     signer = Signer(bytes(range(32)), "provider")
     sealed = publish_provider_value_v1(
-        provider_kit_cid=_cid("a"), signer_key_id="provider-key",
-        sort=PrimitiveSort("Value"), value={"kind": "provider-coordinate", "export": "Warning"},
-        signer=signer, declared_at="2026-07-23T00:00:00.000Z",
+        provider_kit_cid=_cid("a"),
+        signer_key_id="provider-key",
+        sort=PrimitiveSort("Value"),
+        value={"kind": "provider-coordinate", "export": "Warning"},
+        signer=signer,
+        declared_at="2026-07-23T00:00:00.000Z",
     )
     value_cid = json.loads(sealed.canonical_bytes)["header"]["payloadCid"]
     parameter = CallParameterV1(
-        "category", PrimitiveSort("Value"), KeywordOnlyV1(), False,
+        "category",
+        PrimitiveSort("Value"),
+        KeywordOnlyV1(),
+        False,
         ProviderValueRefV1(value_cid, PrimitiveSort("Value")),
     )
     binding = ProviderKitKeyBindingV1(_cid("a"), "provider-key", signer.pubkey_string())
@@ -421,21 +672,32 @@ def test_authenticated_defaults_round_trip_and_provider_refs_resolve_only_from_c
     assert isinstance(resolved, ResolvedProviderValueV1)
     assert resolved.member_cid == sealed.cid
     assert resolved.provider_kit_cid == _cid("a")
-    with pytest.raises(ContextManagerContractError, match="unresolved provider default"):
-        resolve_parameter_default_v1(parameter, AuthenticatedProviderValueCatalogV1(binding, {}))
+    with pytest.raises(
+        ContextManagerContractError, match="unresolved provider default"
+    ):
+        resolve_parameter_default_v1(
+            parameter, AuthenticatedProviderValueCatalogV1(binding, {})
+        )
 
 
 def test_forged_stale_and_wrong_provider_defaults_are_loud():
     from sugar_lift_py_tests.signing import Signer
+
     signer = Signer(bytes(range(32)), "provider")
     sealed = publish_provider_value_v1(
-        provider_kit_cid=_cid("a"), signer_key_id="provider-key",
-        sort=PrimitiveSort("Value"), value={"kind": "provider-coordinate", "export": "Warning"},
-        signer=signer, declared_at="2026-07-23T00:00:00.000Z",
+        provider_kit_cid=_cid("a"),
+        signer_key_id="provider-key",
+        sort=PrimitiveSort("Value"),
+        value={"kind": "provider-coordinate", "export": "Warning"},
+        signer=signer,
+        declared_at="2026-07-23T00:00:00.000Z",
     )
     value_cid = json.loads(sealed.canonical_bytes)["header"]["payloadCid"]
     parameter = CallParameterV1(
-        "category", PrimitiveSort("Value"), KeywordOnlyV1(), False,
+        "category",
+        PrimitiveSort("Value"),
+        KeywordOnlyV1(),
+        False,
         ProviderValueRefV1(value_cid, PrimitiveSort("Value")),
     )
     binding = ProviderKitKeyBindingV1(_cid("a"), "provider-key", signer.pubkey_string())
@@ -445,26 +707,35 @@ def test_forged_stale_and_wrong_provider_defaults_are_loud():
     with pytest.raises(ContextManagerContractError, match="content CID"):
         resolve_parameter_default_v1(
             parameter,
-            AuthenticatedProviderValueCatalogV1(binding, {
-                value_cid: ProviderValueCatalogMemberV1(
-                    sealed.cid, json.dumps(forged).encode()
-                )
-            }),
+            AuthenticatedProviderValueCatalogV1(
+                binding,
+                {
+                    value_cid: ProviderValueCatalogMemberV1(
+                        sealed.cid, json.dumps(forged).encode()
+                    )
+                },
+            ),
         )
 
     stale_cid = _cid("b")
     stale_parameter = CallParameterV1(
-        "category", PrimitiveSort("Value"), KeywordOnlyV1(), False,
+        "category",
+        PrimitiveSort("Value"),
+        KeywordOnlyV1(),
+        False,
         ProviderValueRefV1(stale_cid, PrimitiveSort("Value")),
     )
     with pytest.raises(ContextManagerContractError, match="content CID"):
         resolve_parameter_default_v1(
             stale_parameter,
-            AuthenticatedProviderValueCatalogV1(binding, {
-                stale_cid: ProviderValueCatalogMemberV1(
-                    sealed.cid, sealed.canonical_bytes
-                )
-            }),
+            AuthenticatedProviderValueCatalogV1(
+                binding,
+                {
+                    stale_cid: ProviderValueCatalogMemberV1(
+                        sealed.cid, sealed.canonical_bytes
+                    )
+                },
+            ),
         )
 
     wrong_signer = Signer(bytes([9] * 32), "other-provider")
@@ -474,49 +745,79 @@ def test_forged_stale_and_wrong_provider_defaults_are_loud():
     with pytest.raises(ContextManagerContractError, match="provider signer"):
         resolve_parameter_default_v1(
             parameter,
-            AuthenticatedProviderValueCatalogV1(wrong_binding, {
-                value_cid: ProviderValueCatalogMemberV1(
-                    sealed.cid, sealed.canonical_bytes
-                )
-            }),
+            AuthenticatedProviderValueCatalogV1(
+                wrong_binding,
+                {
+                    value_cid: ProviderValueCatalogMemberV1(
+                        sealed.cid, sealed.canonical_bytes
+                    )
+                },
+            ),
         )
 
     wrong_sort_member = publish_provider_value_v1(
-        provider_kit_cid=_cid("a"), signer_key_id="provider-key",
+        provider_kit_cid=_cid("a"),
+        signer_key_id="provider-key",
         sort=PrimitiveSort("String"),
         value={"kind": "provider-coordinate", "export": "Warning"},
-        signer=signer, declared_at="2026-07-23T00:00:00.000Z",
+        signer=signer,
+        declared_at="2026-07-23T00:00:00.000Z",
     )
-    wrong_sort_cid = json.loads(
-        wrong_sort_member.canonical_bytes
-    )["header"]["payloadCid"]
+    wrong_sort_cid = json.loads(wrong_sort_member.canonical_bytes)["header"][
+        "payloadCid"
+    ]
     wrong_sort_parameter = CallParameterV1(
-        "category", PrimitiveSort("Value"), KeywordOnlyV1(), False,
+        "category",
+        PrimitiveSort("Value"),
+        KeywordOnlyV1(),
+        False,
         ProviderValueRefV1(wrong_sort_cid, PrimitiveSort("Value")),
     )
     with pytest.raises(ContextManagerContractError, match="provider default sort"):
         resolve_parameter_default_v1(
             wrong_sort_parameter,
-            AuthenticatedProviderValueCatalogV1(binding, {
-                wrong_sort_cid: ProviderValueCatalogMemberV1(
-                    wrong_sort_member.cid, wrong_sort_member.canonical_bytes
-                )
-            }),
+            AuthenticatedProviderValueCatalogV1(
+                binding,
+                {
+                    wrong_sort_cid: ProviderValueCatalogMemberV1(
+                        wrong_sort_member.cid, wrong_sort_member.canonical_bytes
+                    )
+                },
+            ),
         )
 
 
 def test_optional_expected_and_value_message_formals_rely_on_authenticated_actual_or_default():
     provider_cid = "blake3-512:" + "e" * 128
-    signature = ImportSignatureV2((
-        CallParameterV1("expected", PrimitiveSort("Value"), PositionalOrKeywordV1(), False, ProviderValueRefV1(provider_cid, PrimitiveSort("Value"))),
-        CallParameterV1("match", PrimitiveSort("Value"), PositionalOrKeywordV1(), False, LiteralDefaultV1({"kind": "ctor", "name": "None", "args": []})),
-    ))
+    signature = ImportSignatureV2(
+        (
+            CallParameterV1(
+                "expected",
+                PrimitiveSort("Value"),
+                PositionalOrKeywordV1(),
+                False,
+                ProviderValueRefV1(provider_cid, PrimitiveSort("Value")),
+            ),
+            CallParameterV1(
+                "match",
+                PrimitiveSort("Value"),
+                PositionalOrKeywordV1(),
+                False,
+                LiteralDefaultV1({"kind": "ctor", "name": "None", "args": []}),
+            ),
+        )
+    )
     semantics = EffectBoundarySemanticsV1(
-        ExpectsModeV1(), RaiseEffectKindV1(), FormalArgumentProjectionV1(0),
-        OptionalFormalArgumentProjectionV1(1), ExceptionInfoBindingV1(),
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        OptionalFormalArgumentProjectionV1(1),
+        ExceptionInfoBindingV1(),
     )
     assert decode_context_manager_semantics_v1(_wire(semantics), signature) == semantics
-    with pytest.raises(ContextManagerContractError, match="unresolved provider default"):
+    with pytest.raises(
+        ContextManagerContractError, match="unresolved provider default"
+    ):
         resolve_parameter_default_v1(
             signature.parameters[0],
             AuthenticatedProviderValueCatalogV1(
@@ -527,18 +828,37 @@ def test_optional_expected_and_value_message_formals_rely_on_authenticated_actua
 
 def test_optional_parameter_without_authenticated_default_is_loud():
     with pytest.raises(ContextManagerContractError, match="optional fixed parameter"):
-        CallParameterV1("match", PrimitiveSort("String"), KeywordOnlyV1(), False, NoDefaultV1())
+        CallParameterV1(
+            "match", PrimitiveSort("String"), KeywordOnlyV1(), False, NoDefaultV1()
+        )
     with pytest.raises(ContextManagerContractError, match="literal default sort"):
         CallParameterV1(
-            "flag", PrimitiveSort("Bool"), KeywordOnlyV1(), False,
-            LiteralDefaultV1({"kind": "const", "value": 1, "sort": {"kind": "primitive", "name": "Int"}}),
+            "flag",
+            PrimitiveSort("Bool"),
+            KeywordOnlyV1(),
+            False,
+            LiteralDefaultV1(
+                {
+                    "kind": "const",
+                    "value": 1,
+                    "sort": {"kind": "primitive", "name": "Int"},
+                }
+            ),
         )
 
 
 def test_mutated_literal_default_cannot_be_signed_as_authenticated_testimony():
-    value = {"kind": "const", "value": False, "sort": {"kind": "primitive", "name": "Bool"}}
+    value = {
+        "kind": "const",
+        "value": False,
+        "sort": {"kind": "primitive", "name": "Bool"},
+    }
     parameter = CallParameterV1(
-        "flag", PrimitiveSort("Bool"), KeywordOnlyV1(), False, LiteralDefaultV1(value),
+        "flag",
+        PrimitiveSort("Bool"),
+        KeywordOnlyV1(),
+        False,
+        LiteralDefaultV1(value),
     )
     value["sort"] = {"kind": "primitive", "name": "Int"}
     with pytest.raises(ContextManagerContractError, match="literal default sort"):

--- a/implementations/python/sugar-lift-py-tests/tests/test_dig_with_args.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dig_with_args.py
@@ -79,9 +79,7 @@ def test_hole_args_serve_the_abstract_contract():
     # A(ys) where ys is the caller's own formal: the pre is still a hole, so
     # the curried (abstract) contract stands -- post over the fold coordinate,
     # not a literal.
-    uni, gaps, kw = _enumerate(
-        SUM_HELPER + "def test_a(ys):\n    assert A(ys) == 6\n"
-    )
+    uni, gaps, kw = _enumerate(SUM_HELPER + "def test_a(ys):\n    assert A(ys) == 6\n")
     assert len(uni) == 1
     post = _resolved_post(uni, kw)
     assert post["name"] == "="

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-
 _ROOT = Path(__file__).resolve().parents[1]
 _SRC = _ROOT / "src" / "sugar_lift_py_tests"
 
@@ -46,9 +45,7 @@ def test_router_match_once_emits_binding_facts() -> None:
     from sugar_lift_py_tests.outcome import Incomplete
 
     entries = (
-        Incomplete(
-            RaiseEffect(exception_name="ValueError", occurrence="t.py:2:4")
-        ),
+        Incomplete(RaiseEffect(exception_name="ValueError", occurrence="t.py:2:4")),
     )
     out = route(
         entries,

--- a/implementations/python/sugar-lift-py-tests/tests/test_engine_logging.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_engine_logging.py
@@ -110,9 +110,7 @@ def test_heartbeat_only_live_log_omits_high_volume_debug_spans(
     monkeypatch.setenv("SUGAR_ENGINE_TRACE_EVENTS", "0")
     try:
         engine_log.configure_live_log(str(path))
-        with engine_log.reduction_span(
-            sugar="NameSugar", role="term", site="t.py:1:0"
-        ):
+        with engine_log.reduction_span(sugar="NameSugar", role="term", site="t.py:1:0"):
             engine_log._emit_heartbeats(
                 now=time.monotonic() + 1.0, minimum_seconds=0.01
             )

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
@@ -28,7 +28,6 @@ def test_add():
 """
 
 
-
 @pytest.fixture()
 def project(tmp_path: Path) -> Path:
     (tmp_path / "mathy.py").write_text(FIXTURE_SOURCE, encoding="utf-8")
@@ -66,10 +65,6 @@ def _enumerate(
     response = captured[0]
     assert "error" not in response, response
     return response["result"]
-
-
-
-
 
 
 def test_enumeration_file_context_cache_is_bounded(
@@ -1066,8 +1061,6 @@ def test_term_ref_bridge_recovery_is_shared_by_callsite_universe_and_implication
     assert len(universe["nodes"]) == 1
     assert universe["nodes"][0]["memento"]["function_name"] == "mathy.add"
     assert universe["termTable"]
-
-
 
 
 def test_universe_seek_refuses_ambiguous_leaf_bridge(tmp_path: Path) -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc_frontier_honest.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc_frontier_honest.py
@@ -71,7 +71,9 @@ def _drive_frontier(source: str):
                             "demandedSource": p["demandedSource"],
                             "terminalGapLocus": p["terminalGapLocus"],
                         }
-                        all_panics.append({**p, "demandedBody": body, "ownerIdentity": owner})
+                        all_panics.append(
+                            {**p, "demandedBody": body, "ownerIdentity": owner}
+                        )
                     audit_leaves_completed += 1
             status = (
                 "valid-empty"

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc_tree_served.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc_tree_served.py
@@ -21,9 +21,9 @@ def _run_ladder():
 
     # The factory is DELETED, not merely bypassed -- a stronger guarantee than
     # the old tripwire: there is no _lift_file_for_enumeration to consult.
-    assert not hasattr(lift_rpc, "_lift_file_for_enumeration"), (
-        "the factory enumeration fallback must be deleted, not present"
-    )
+    assert not hasattr(
+        lift_rpc, "_lift_file_for_enumeration"
+    ), "the factory enumeration fallback must be deleted, not present"
 
     lift_rpc._send_enumerate_result = lambda mid, nodes, gaps, **kw: captured.update(
         nodes=nodes, gaps=gaps

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_proof.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_proof.py
@@ -27,7 +27,8 @@ def _exit_fn(src: str) -> ast.FunctionDef:
     return next(
         n
         for n in cls.body
-        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name == "__exit__"
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and n.name == "__exit__"
     )
 
 
@@ -43,109 +44,91 @@ def _prove_src(src: str) -> ExitDispositionProof:
 
 
 def test_truthful_implicit_none_fallthrough():
-    assert _prove_src(
-        """
+    assert _prove_src("""
         class M:
             def __exit__(self, *a):
                 self.cleanup()
-        """
-    ).kind == "never_suppresses"
+        """).kind == "never_suppresses"
 
 
 def test_truthful_explicit_none_and_false():
-    assert _prove_src(
-        """
+    assert _prove_src("""
         class M:
             def __exit__(self, *a):
                 if a[0] is None:
                     return None
                 return False
-        """
-    ).kind == "never_suppresses"
+        """).kind == "never_suppresses"
 
 
 def test_truthful_raise_inside_exit_is_halt_not_suppress():
-    assert _prove_src(
-        """
+    assert _prove_src("""
         class M:
             def __exit__(self, *a):
                 if a[0] is not None:
                     raise RuntimeError("exit failed")
-        """
-    ).kind == "never_suppresses"
+        """).kind == "never_suppresses"
 
 
 def test_lying_return_true():
     with pytest.raises(ExitDispositionUnproven, match="not exact None/False"):
-        _prove_src(
-            """
+        _prove_src("""
             class M:
                 def __exit__(self, *a):
                     return True
-            """
-        )
+            """)
 
 
 def test_lying_symbolic_return():
     with pytest.raises(ExitDispositionUnproven, match="not exact None/False"):
-        _prove_src(
-            """
+        _prove_src("""
             class M:
                 def __exit__(self, *a):
                     return a[0]
-            """
-        )
+            """)
 
 
 def test_lying_mixed_branch():
     with pytest.raises(ExitDispositionUnproven, match="not exact None/False"):
-        _prove_src(
-            """
+        _prove_src("""
             class M:
                 def __exit__(self, *a):
                     if a[0] is None:
                         return None
                     return True
-            """
-        )
+            """)
 
 
 def test_lying_swallowed_exception_then_return_true():
     with pytest.raises(ExitDispositionUnproven, match="not exact None/False"):
-        _prove_src(
-            """
+        _prove_src("""
             class M:
                 def __exit__(self, *a):
                     try:
                         self.close()
                     except Exception:
                         return True
-            """
-        )
+            """)
 
 
 def test_truthful_swallowed_exception_then_none():
-    assert _prove_src(
-        """
+    assert _prove_src("""
         class M:
             def __exit__(self, *a):
                 try:
                     self.close()
                 except Exception:
                     pass
-        """
-    ).kind == "never_suppresses"
+        """).kind == "never_suppresses"
 
 
 def test_lying_ambiguous_dispatch_return_call():
     with pytest.raises(ExitDispositionUnproven, match="not exact None/False"):
-        _prove_src(
-            """
+        _prove_src("""
             class M:
                 def __exit__(self, *a):
                     return self._maybe_suppress(a)
-            """
-        )
+            """)
 
 
 def test_no_runtime_resolve_authority_floor():
@@ -225,4 +208,7 @@ def test_open_still_unproven_statically():
         path = f.name
     fn = next(SourceFile(path_source(path)).functions())
     with_node = next(s for s in fn.body if s.kind == "With")
-    assert prove_exit_disposition_from_manager_expr(with_node.items[0].context_expr) is None
+    assert (
+        prove_exit_disposition_from_manager_expr(with_node.items[0].context_expr)
+        is None
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
@@ -149,18 +149,14 @@ def test_and_finally_runs_cleanup_on_every_conditional_exit():
 
 def test_and_exit_completion_keeps_body_completed():
     incoming = ExitSet.completed("body")
-    after = incoming.and_exit(
-        ExitSet.completed(False), disposition=NeverSuppresses()
-    )
+    after = incoming.and_exit(ExitSet.completed(False), disposition=NeverSuppresses())
     assert after.collapse() == Complete("body")
 
 
 def test_and_exit_halt_supersedes_body_completed():
     exit_halt = RaiseEffect(exception_name="RuntimeError")
     incoming = ExitSet.completed("body")
-    after = incoming.and_exit(
-        ExitSet.halted(exit_halt), disposition=NeverSuppresses()
-    )
+    after = incoming.and_exit(ExitSet.halted(exit_halt), disposition=NeverSuppresses())
     assert after.collapse() == Incomplete(exit_halt)
 
 
@@ -168,18 +164,14 @@ def test_and_exit_halt_supersedes_body_halted():
     body = RaiseEffect(exception_name="ValueError")
     exit_halt = RaiseEffect(exception_name="RuntimeError")
     incoming = ExitSet.halted(body)
-    after = incoming.and_exit(
-        ExitSet.halted(exit_halt), disposition=NeverSuppresses()
-    )
+    after = incoming.and_exit(ExitSet.halted(exit_halt), disposition=NeverSuppresses())
     assert after.collapse() == Incomplete(exit_halt)
 
 
 def test_and_exit_never_suppresses_restores_body_halt():
     body = RaiseEffect(exception_name="ValueError")
     incoming = ExitSet.halted(body)
-    after = incoming.and_exit(
-        ExitSet.completed(False), disposition=NeverSuppresses()
-    )
+    after = incoming.and_exit(ExitSet.completed(False), disposition=NeverSuppresses())
     assert after.collapse() == Incomplete(body)
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_factory_walk_unclassified_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factory_walk_unclassified_law.py
@@ -6,7 +6,6 @@ import importlib.util
 import json
 from pathlib import Path
 
-
 _KIT = Path(__file__).resolve().parents[1]
 _SCANNER_PATH = _KIT / "scripts" / "factory_walk_unclassified_law.py"
 _SPEC = importlib.util.spec_from_file_location(
@@ -40,7 +39,12 @@ def test_clean_walk_is_zero() -> None:
 
 def test_extract_from_audit_summary_status_counts() -> None:
     payload = {
-        "statusCounts": {"warranted": 10, "support": 3, "unresolved": 4, "incomplete": 1}
+        "statusCounts": {
+            "warranted": 10,
+            "support": 3,
+            "unresolved": 4,
+            "incomplete": 1,
+        }
     }
     rows = _SCANNER.extract_walk_rows(payload)
     assert _SCANNER.r_factory_walk_unclassified(rows) == 4
@@ -53,7 +57,10 @@ def test_extract_from_recensus_red_statuses() -> None:
             "raise-effect": 12,
         }
     }
-    assert _SCANNER.r_factory_walk_unclassified(_SCANNER.extract_walk_rows(payload)) == 1389
+    assert (
+        _SCANNER.r_factory_walk_unclassified(_SCANNER.extract_walk_rows(payload))
+        == 1389
+    )
 
 
 def test_extract_from_factory_walk_statuses_aggregate() -> None:
@@ -122,7 +129,9 @@ def test_extract_from_unclassified_rows_alias() -> None:
 
 def test_extract_from_map_shaped_factory_walk() -> None:
     payload = {"factory_walk": {"unclassified": 12, "warranted": 40}}
-    assert _SCANNER.r_factory_walk_unclassified(_SCANNER.extract_walk_rows(payload)) == 12
+    assert (
+        _SCANNER.r_factory_walk_unclassified(_SCANNER.extract_walk_rows(payload)) == 12
+    )
 
 
 def test_extract_from_nested_accounting_factory() -> None:
@@ -132,7 +141,9 @@ def test_extract_from_nested_accounting_factory() -> None:
             "typed_effect": 26,
         }
     }
-    assert _SCANNER.r_factory_walk_unclassified(_SCANNER.extract_walk_rows(payload)) == 393
+    assert (
+        _SCANNER.r_factory_walk_unclassified(_SCANNER.extract_walk_rows(payload)) == 393
+    )
 
 
 def test_cli_red_on_planted_json(tmp_path: Path) -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_finite_cap_opaque_completion_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_finite_cap_opaque_completion_law.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-
 _KIT = Path(__file__).resolve().parents[1]
 _PATH = _KIT / "scripts" / "finite_cap_opaque_completion_law.py"
 _SPEC = importlib.util.spec_from_file_location("finite_cap_law", _PATH)
@@ -19,68 +18,57 @@ def _scan(source: str):
 
 
 def test_planted_opaque_complete_trips() -> None:
-    rows = _scan(
-        """
+    rows = _scan("""
 def reduce(values):
     if len(values) > MATERIALIZE_LIMIT:
         return Complete(CallSiteValue(body=None, term=exact_term))
     return build_all(values)
-"""
-    )
+""")
     assert [row.kind for row in rows] == ["finite-cap-opaque-complete"]
 
 
 def test_planted_under_cap_early_return_then_opaque_fallthrough_trips() -> None:
-    rows = _scan(
-        """
+    rows = _scan("""
 def reduce(values):
     if len(values) <= MATERIALIZE_LIMIT:
         return build_all(values)
     return Complete(CallSiteValue(body=None, term=exact_term))
-"""
-    )
+""")
     assert [row.kind for row in rows] == ["finite-cap-opaque-complete"]
 
 
 def test_planted_novel_opaque_complete_is_closed_by_default() -> None:
-    rows = _scan(
-        """
+    rows = _scan("""
 def reduce(values):
     if len(values) > MATERIALIZE_LIMIT:
         return Complete(FutureOpaqueSuccess(source_shape=values[0]))
     return Complete(ListValue(tuple(build(value) for value in values)))
-"""
-    )
+""")
     assert [row.kind for row in rows] == ["finite-cap-opaque-complete"]
 
 
 def test_planted_coordinate_fallback_trips() -> None:
-    rows = _scan(
-        """
+    rows = _scan("""
 def reduce(parts):
     if len(parts) > 1024:
         return opaque_coordinate()
     return build_all(parts)
-"""
-    )
+""")
     assert [row.kind for row in rows] == ["finite-cap-opaque-coordinate"]
 
 
 def test_planted_force_curry_trips() -> None:
-    rows = _scan(
-        """
+    rows = _scan("""
 def reduce(elements):
     if len(elements) > cap:
         return bind(elements, force_curry=True)
     return unfold(elements)
-"""
-    )
+""")
     assert [row.kind for row in rows] == ["finite-cap-force-curry"]
 
 
 def test_planted_finite_semantic_short_circuit_force_curry_trips() -> None:
-    rows = _scan(
-        """
+    rows = _scan("""
 def reduce(iterable):
     elements = finite_elements(iterable)
     if elements is not None:
@@ -88,26 +76,22 @@ def reduce(iterable):
             return bind(iterable, force_curry=True)
         return unfold(elements)
     return runtime_coordinate(iterable)
-"""
-    )
+""")
     assert [row.kind for row in rows] == ["finite-cap-force-curry"]
 
 
 def test_cardinality_attribute_cap_force_curry_trips() -> None:
-    rows = _scan(
-        """
+    rows = _scan("""
 def reduce(values):
     if values.cardinality > cap:
         return bind(values, force_curry=True)
     return unfold(values)
-"""
-    )
+""")
     assert [row.kind for row in rows] == ["finite-cap-force-curry"]
 
 
 def test_cap_helper_delegation_trips() -> None:
-    rows = _scan(
-        """
+    rows = _scan("""
 def opaque_helper(values):
     return bind(values, force_curry=True)
 
@@ -115,46 +99,33 @@ def reduce(values):
     if len(values) > cap:
         return opaque_helper(values)
     return unfold(values)
-"""
-    )
+""")
     assert [row.kind for row in rows] == ["finite-cap-force-curry"]
 
 
 def test_cap_none_success_trips() -> None:
-    rows = _scan(
-        """
+    rows = _scan("""
 def reduce(values):
     if len(values) > cap:
         return None
     return unfold(values)
-"""
-    )
+""")
     assert [row.kind for row in rows] == ["finite-cap-none-success"]
 
 
 def test_loud_terminal_and_exact_symbolic_stay_green() -> None:
-    assert (
-        _scan(
-            """
+    assert _scan("""
 def reduce(values):
     if len(values) > MATERIALIZE_LIMIT:
         return construction_panic_gap(owner="finite_unfold", observed=len(values))
     return build_all(values)
-"""
-        )
-        == []
-    )
-    assert (
-        _scan(
-            """
+""") == []
+    assert _scan("""
 def reduce(values):
     if len(values) > MATERIALIZE_LIMIT:
         return Complete(GroundSequenceRepetitionValue(values, exact_count))
     return build_all(values)
-"""
-        )
-        == []
-    )
+""") == []
 
 
 def test_bad_parse_and_missing_root_are_structured(tmp_path: Path) -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_floor_output_portability.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_floor_output_portability.py
@@ -10,9 +10,7 @@ import sys
 
 def test_vendor_floor_emits_arrows_under_cp1252(tmp_path: Path) -> None:
     script = (
-        Path(__file__).resolve().parents[1]
-        / "scripts"
-        / "vendor_special_case_law.py"
+        Path(__file__).resolve().parents[1] / "scripts" / "vendor_special_case_law.py"
     )
     surface = tmp_path / "surface"
     surface.mkdir()

--- a/implementations/python/sugar-lift-py-tests/tests/test_formula_hash_scope_stable.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_formula_hash_scope_stable.py
@@ -69,9 +69,9 @@ def test_content_cid_evict_and_recompute_preserves_identity() -> None:
         cid_before = _term_content_cid(term)
         hash_before = hash(formula)
         assert _term_content_cid_memo_size() >= 1
-        assert _evict_term_content_cid(term) is True, (
-            "R=1 expected a live content-CID memo entry to evict (#5572)."
-        )
+        assert (
+            _evict_term_content_cid(term) is True
+        ), "R=1 expected a live content-CID memo entry to evict (#5572)."
         # Second evict is a no-op (already gone) — not a soft success for identity.
         assert _evict_term_content_cid(term) is False
         cid_after = _term_content_cid(term)
@@ -116,9 +116,9 @@ def test_content_cid_memo_does_not_strong_pin_dead_terms() -> None:
     with term_intern_scope():
         twin = ctor("ephemeral", [make_var("z")])
         cid = _term_content_cid(twin)
-    assert cid == TermTableBuilder().reference(
-        ctor("ephemeral", [make_var("z")])
-    )["cid"]
+    assert (
+        cid == TermTableBuilder().reference(ctor("ephemeral", [make_var("z")]))["cid"]
+    )
 
 
 def test_cross_scope_dictionary_twin() -> None:
@@ -174,9 +174,9 @@ def test_cross_scope_set_twin() -> None:
         bucket.add(right)
         bucket.add(lying)
 
-    assert left == right, (
-        "R=1 structural formula twins compare unequal across scopes (#5568)."
-    )
+    assert (
+        left == right
+    ), "R=1 structural formula twins compare unequal across scopes (#5568)."
     assert hash(left) == hash(right), (
         f"R=1 structural formula twins hash differently "
         f"({hash(left)!r} vs {hash(right)!r}) (#5568)."
@@ -275,9 +275,9 @@ def test_formula_and_callsite_keys_match_wire_cid_prefix() -> None:
     with term_intern_scope():
         term = _deep_term(20)
         key = _term_cycle_key(term)
-    assert key.startswith("blake3-512:"), (
-        f"R=1 cycle key must be wire CID, not intern object id; got {key!r}"
-    )
-    assert not key.startswith("term-id:"), (
-        "R=1 term-id: keys are the #5477 scope-dependent bug (#5569)."
-    )
+    assert key.startswith(
+        "blake3-512:"
+    ), f"R=1 cycle key must be wire CID, not intern object id; got {key!r}"
+    assert not key.startswith(
+        "term-id:"
+    ), "R=1 term-id: keys are the #5477 scope-dependent bug (#5569)."

--- a/implementations/python/sugar-lift-py-tests/tests/test_gap_testimony_independent_of_audit.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_gap_testimony_independent_of_audit.py
@@ -11,7 +11,6 @@ from sugar_lift_py_tests.gap.audit_row import (
 )
 from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind
 
-
 _GAP = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests" / "gap"
 
 
@@ -27,17 +26,16 @@ def test_info_module_does_not_import_audit_row() -> None:
             for alias in node.names:
                 if "audit_row" in alias.name:
                     offenders.append(f"Import {alias.name}")
-    assert offenders == [], (
-        "gap/info.py must not import audit projection:\n" + "\n".join(offenders)
-    )
+    assert (
+        offenders == []
+    ), "gap/info.py must not import audit projection:\n" + "\n".join(offenders)
 
 
 def test_gap_kind_status_lives_on_audit_boundary() -> None:
     assert gap_kind_status(GapKind.FLOOR) is ConstructionAuditStatus.FLOOR_GAP
     assert gap_kind_status(GapKind.SUGAR) is ConstructionAuditStatus.SUGAR_GAP
     assert (
-        gap_kind_status(GapKind.CONSTRUCTOR)
-        is ConstructionAuditStatus.CONSTRUCTOR_GAP
+        gap_kind_status(GapKind.CONSTRUCTOR) is ConstructionAuditStatus.CONSTRUCTOR_GAP
     )
     # Pure testimony constructs without touching audit status.
     gap = ConstructionGap(

--- a/implementations/python/sugar-lift-py-tests/tests/test_int_literal_sugar_from_node.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_int_literal_sugar_from_node.py
@@ -6,6 +6,7 @@ the Constant node recognizes ITSELF (its value is an int) and constructs
 its sugar directly. A literal kind not yet converted throws SugarNotWritten
 loudly, by kind — the honest gap arm.
 """
+
 from __future__ import annotations
 
 import tempfile
@@ -78,6 +79,7 @@ def test_an_unconverted_literal_kind_throws_loudly_by_kind():
 
 # ── the Sugar base contract: meaning-only, enforced by ABC ──────────────
 
+
 def test_a_sugar_cannot_exist_without_desugar_and_witnesses():
     """The base's whole job: a sugar IS desugar + witnesses. ABC enforces it
     at construction — a half-sugar is unconstructable, no bookkeeping, no
@@ -119,6 +121,7 @@ def test_int_and_equality_sugars_are_meaning_only():
 
 
 # ── the whole point, from a source string: `1 == 1` → sugar ──────────────
+
 
 def test_source_string_one_equals_one_gives_back_sugar():
     """Python source as a string. Parse it. Ask the comparison node for its

--- a/implementations/python/sugar-lift-py-tests/tests/test_ir_intern_cyclic_hash.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_ir_intern_cyclic_hash.py
@@ -52,9 +52,9 @@ def test_cyclic_ctor_intern_is_construction_panic_not_recursion_or_segv() -> Non
         f"R=1 cyclic intern owner wrong: {info.owner!r}; "
         "replacement=ConstructionPanic from ir._intern_term naming the cyclic graph"
     )
-    assert "cyclic" in info.observed, (
-        f"R=1 observed must name the cyclic IR term shape, got {info.observed!r}"
-    )
+    assert (
+        "cyclic" in info.observed
+    ), f"R=1 observed must name the cyclic IR term shape, got {info.observed!r}"
     assert "DAG" in info.requested or "hash-cons" in info.requested
     assert "RuntimeEffect" in info.fix or "timeout" in info.fix.lower()
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_lift_coverage_harness.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_lift_coverage_harness.py
@@ -194,9 +194,6 @@ def test_assertions_cited_assert_is_not_silent() -> None:
     assert cov.assertions.to_json()["is_zero"] is True
 
 
-
-
-
 # ---------------------------------------------------------------------------
 # Integration: statistics vendor on battleaxe (real sugar lift --report)
 # ---------------------------------------------------------------------------
@@ -816,7 +813,9 @@ def test_heavy_vendor_live_per_file_isolation_conservation_delta_is_zero(
     assert (
         result["delta"] == 0
     ), f"{package} live isolation conservation delta must be 0; R={result}"
-    assert result["R_live_construction_panic_files"] == result["construction_panic_files"]
+    assert (
+        result["R_live_construction_panic_files"] == result["construction_panic_files"]
+    )
     assert result["onDisk"] == result["accounted"]
     assert result["onDisk"] > 0, f"{package}: vacuous live isolation (no asserts)"
     assert result["assert_files"] == len(files)

--- a/implementations/python/sugar-lift-py-tests/tests/test_lift_one_file_end_to_end.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_lift_one_file_end_to_end.py
@@ -9,6 +9,7 @@ SourceTree -> SourceFile (source_files)
 Every step is a real tree operation over oracle-pinned source. No factory,
 no catalog, no owns anywhere in the chain.
 """
+
 from __future__ import annotations
 
 import tempfile
@@ -64,6 +65,7 @@ def test_lift_a_single_assertion_all_the_way_to_sugar():
         # the whole assertion desugars — no context, no temporal, no factory:
         #   1 == 1 reduces to True; True states its inv; the assert is testimony
         from sugar_lift_py_tests.outcome import Complete as _C
+
         outcome = sugar.desugar(None)
         assert isinstance(outcome, _C)
         # the assertion EMITS a fact: the vendor asserted 1 == 1, so the record
@@ -72,6 +74,6 @@ def test_lift_a_single_assertion_all_the_way_to_sugar():
         # emission; the value does not get to opt out because it is ground-true.
         inv = outcome.value
         assert type(inv).__name__ == "InvValue"
-        assert inv.operand_callsites == ()          # no call site
-        assert inv.formula.name == "="              # the fact is an equality
-        assert [a.value for a in inv.formula.args] == [1, 1]   # 1 = 1
+        assert inv.operand_callsites == ()  # no call site
+        assert inv.formula.name == "="  # the fact is an equality
+        assert [a.value for a in inv.formula.args] == [1, 1]  # 1 = 1

--- a/implementations/python/sugar-lift-py-tests/tests/test_live_construction_panic_isolation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_live_construction_panic_isolation.py
@@ -33,7 +33,9 @@ def test_assert_bearing_py_files_finds_only_assert_sources(tmp_path: Path) -> No
 def test_panic_owner_fallback_and_engaged_report_shape() -> None:
     assert panic_owner_from_message("no owner here") == "unknown"
     assert (
-        panic_owner_from_message("ConstructionPanic: owner=TemporalContext observed=result")
+        panic_owner_from_message(
+            "ConstructionPanic: owner=TemporalContext observed=result"
+        )
         == "TemporalContext"
     )
     engaged = factory_engaged_empty_report()

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_crash_zero_tolerance.py
@@ -10,7 +10,6 @@ import subprocess
 import sys
 import pytest
 
-
 _KIT = Path(__file__).resolve().parents[1]
 _SCANNER_PATH = _KIT / "scripts" / "native_crash_zero_tolerance.py"
 _SPEC = importlib.util.spec_from_file_location(
@@ -69,8 +68,7 @@ def test_production_roots_cover_package_and_corpus_tooling(tmp_path: Path) -> No
     roots = _SCANNER.production_roots(tmp_path)
 
     assert roots == (
-        tmp_path
-        / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests",
+        tmp_path / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests",
         tmp_path / "implementations/python/sugar-lift-py-tests/scripts",
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_numpy_literal_call_sibling_red.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_numpy_literal_call_sibling_red.py
@@ -412,7 +412,6 @@ def test_identical_stated_and_computed_equality_retains_both_warrants() -> None:
     ] == ["Stated", "Derived"]
 
 
-
 @dataclass(frozen=True)
 class CaseResult:
     verdict: str

--- a/implementations/python/sugar-lift-py-tests/tests/test_production_lift_child.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_production_lift_child.py
@@ -49,7 +49,9 @@ def test_intentional_typed_gap_is_typed_gap_not_failure(tmp_path: Path, capsys) 
     assert terminal in _CHILD.NON_FAILURE_OUTCOMES
 
 
-def test_kit_construction_panic_is_typed_gap_not_failure(tmp_path: Path, capsys, monkeypatch) -> None:
+def test_kit_construction_panic_is_typed_gap_not_failure(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
     # Kit ConstructionPanic is a sanctioned typed gap alongside SugarNotWritten.
     # The child must mark typed-gap and exit 0 — never misclassify as bare exception.
     from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_via_execution_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_via_execution_law.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-
 _KIT = Path(__file__).resolve().parents[1]
 _SCANNER_PATH = _KIT / "scripts" / "source_via_execution_law.py"
 _SPEC = importlib.util.spec_from_file_location(
@@ -154,9 +153,7 @@ def _load(name):
 """,
         encoding="utf-8",
     )
-    assert (
-        _SCANNER.r_source_via_execution(_SCANNER.scan_roots((sugar,))) == 1
-    )
+    assert _SCANNER.r_source_via_execution(_SCANNER.scan_roots((sugar,))) == 1
 
     # Revert: replace the executing call with the non-executing PathFinder
     # form -- the legitimate replacement named in the floor's own docstring.

--- a/implementations/python/sugar-lift-py-tests/tests/test_timeout_mechanism_fingerprint.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_timeout_mechanism_fingerprint.py
@@ -120,7 +120,10 @@ def test_fingerprint_engine_events_names_dominant_and_multi_miss() -> None:
     report = fingerprint_engine_events(events)
     assert report["schema"] == "sugar.timeout.mechanism.v1"
     assert report["dominant_mechanism"] == MECHANISM_RECURSIVE_FUNCTION_CONSTRUCT
-    assert report["mechanism_heartbeat_counts"][MECHANISM_RECURSIVE_FUNCTION_CONSTRUCT] == 2
+    assert (
+        report["mechanism_heartbeat_counts"][MECHANISM_RECURSIVE_FUNCTION_CONSTRUCT]
+        == 2
+    )
     assert report["mechanism_heartbeat_counts"][MECHANISM_FACTORY_BUILD] == 1
     assert report["resolve_value_miss"] == 3
     assert report["resolve_value_hit"] == 1

--- a/implementations/python/sugar-lift-py-tests/tests/test_timeout_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_timeout_zero_tolerance.py
@@ -9,7 +9,6 @@ import sys
 
 import pytest
 
-
 _KIT = Path(__file__).resolve().parents[1]
 _SCANNER_PATH = _KIT / "scripts" / "timeout_zero_tolerance.py"
 _SPEC = importlib.util.spec_from_file_location("timeout_zero_tolerance", _SCANNER_PATH)
@@ -40,8 +39,7 @@ def test_completed_child_is_not_timeout() -> None:
 
 def test_production_roots_cover_package_and_corpus_tooling(tmp_path: Path) -> None:
     assert _SCANNER.production_roots(tmp_path) == (
-        tmp_path
-        / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests",
+        tmp_path / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests",
         tmp_path / "implementations/python/sugar-lift-py-tests/scripts",
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_vendor_special_case_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_vendor_special_case_law.py
@@ -5,12 +5,9 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-
 _KIT = Path(__file__).resolve().parents[1]
 _SCANNER_PATH = _KIT / "scripts" / "vendor_special_case_law.py"
-_SPEC = importlib.util.spec_from_file_location(
-    "vendor_special_case_law", _SCANNER_PATH
-)
+_SPEC = importlib.util.spec_from_file_location("vendor_special_case_law", _SCANNER_PATH)
 assert _SPEC is not None and _SPEC.loader is not None
 _SCANNER = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_SCANNER)

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -56,17 +56,13 @@ class _FixedSugar(Sugar):
 
 class _Pass(_FixedSugar):
     def __init__(self, probe=None):
-        super().__init__(
-            Complete(BlockValue((), can_fall_through=True)), probe=probe
-        )
+        super().__init__(Complete(BlockValue((), can_fall_through=True)), probe=probe)
 
 
 class _Raise(_FixedSugar):
     def __init__(self, name: str, *, occurrence: str = "t.py:1:0", probe=None):
         super().__init__(
-            Incomplete(
-                RaiseEffect(exception_name=name, occurrence=occurrence)
-            ),
+            Incomplete(RaiseEffect(exception_name=name, occurrence=occurrence)),
             probe=probe,
         )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_v2_fixture_truth_set.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_v2_fixture_truth_set.py
@@ -8,7 +8,6 @@ from with_v2_law_detector import (
     analyze_single_authority,
 )
 
-
 FIXTURES = Path(__file__).parent / "fixtures" / "with_v2_laws"
 
 AUTHORITY_CASES = {
@@ -41,7 +40,9 @@ ENROLLMENT_CASES = {
     "enrollment_loop_backedge": ("enrollment_loop_backedge.py",),
     "enrollment_for_backedge": ("enrollment_for_backedge.py",),
     "enrollment_async_for_backedge": ("enrollment_async_for_backedge.py",),
-    "enrollment_lookup_only_coexists_with_sugar": ("enrollment_lookup_only_coexists_with_sugar.py",),
+    "enrollment_lookup_only_coexists_with_sugar": (
+        "enrollment_lookup_only_coexists_with_sugar.py",
+    ),
     "enrollment_ordinary_dict": ("enrollment_ordinary_dict.py",),
     "enrollment_ordinary_get": ("enrollment_ordinary_get.py",),
     "enrollment_string_dict": ("enrollment_string_dict.py",),
@@ -71,7 +72,13 @@ def test_single_authority_planted_detector_cases():
         rows = analyze_single_authority(graph(AUTHORITY_CASES[case]))
         assert len(rows) == 1, (case, rows)
         assert rows[0].reason == reason
-    for case in ("authority_legitimate", "authority_data", "authority_zero", "authority_gap", "authority_rpc_data"):
+    for case in (
+        "authority_legitimate",
+        "authority_data",
+        "authority_zero",
+        "authority_gap",
+        "authority_rpc_data",
+    ):
         assert analyze_single_authority(graph(AUTHORITY_CASES[case])) == (), case
 
 
@@ -116,8 +123,28 @@ def test_truth_set_reports_zero_false_negatives_and_false_positives():
     for case, names in ENROLLMENT_CASES.items():
         verdicts[case] = bool(analyze_consumer_enrollment(graph(names)))
     expected = {
-        **{name: name not in {"authority_legitimate", "authority_data", "authority_zero", "authority_gap", "authority_rpc_data"} for name in AUTHORITY_CASES},
-        **{name: name not in {"enrollment_ordinary_dict", "enrollment_ordinary_get", "enrollment_string_dict", "enrollment_semantics_unreachable", "enrollment_lookup_only_coexists_with_sugar"} for name in ENROLLMENT_CASES},
+        **{
+            name: name
+            not in {
+                "authority_legitimate",
+                "authority_data",
+                "authority_zero",
+                "authority_gap",
+                "authority_rpc_data",
+            }
+            for name in AUTHORITY_CASES
+        },
+        **{
+            name: name
+            not in {
+                "enrollment_ordinary_dict",
+                "enrollment_ordinary_get",
+                "enrollment_string_dict",
+                "enrollment_semantics_unreachable",
+                "enrollment_lookup_only_coexists_with_sugar",
+            }
+            for name in ENROLLMENT_CASES
+        },
     }
     false_negatives = sum(expected[name] and not verdicts[name] for name in expected)
     false_positives = sum(not expected[name] and verdicts[name] for name in expected)

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_v2_step1_laws.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_v2_step1_laws.py
@@ -2,8 +2,11 @@
 
 from pathlib import Path
 
-from with_v2_law_detector import ModuleGraph, analyze_consumer_enrollment, analyze_single_authority
-
+from with_v2_law_detector import (
+    ModuleGraph,
+    analyze_consumer_enrollment,
+    analyze_single_authority,
+)
 
 PYTHON_ROOT = Path(__file__).resolve().parents[2]
 PRODUCTION_ROOTS = (

--- a/implementations/python/sugar-lift-py-tests/tests/with_v2_law_detector.py
+++ b/implementations/python/sugar-lift-py-tests/tests/with_v2_law_detector.py
@@ -38,7 +38,9 @@ class Atom:
     rpc: bool = False
 
     def step(self, text: str, *, rpc: bool = False) -> "Atom":
-        return Atom(self.kind, self.identity, self.origin, self.chain + (text,), self.rpc or rpc)
+        return Atom(
+            self.kind, self.identity, self.origin, self.chain + (text,), self.rpc or rpc
+        )
 
 
 @dataclass(frozen=True)
@@ -47,7 +49,9 @@ class AbstractValue:
     entries: tuple[tuple[str | None, "AbstractValue"], ...] = ()
 
     def join(self, other: "AbstractValue") -> "AbstractValue":
-        entries = self.entries + tuple(entry for entry in other.entries if entry not in self.entries)
+        entries = self.entries + tuple(
+            entry for entry in other.entries if entry not in self.entries
+        )
         return AbstractValue(self.atoms | other.atoms, entries)
 
     def stepped(self, text: str, *, rpc: bool = False) -> "AbstractValue":
@@ -126,7 +130,11 @@ class ModuleGraph:
         modules = {}
         for path in sorted((Path(p) for p in paths), key=lambda p: str(p)):
             name = path.stem if path.name != "__init__.py" else path.parent.name
-            modules[name] = ModuleUnit(name, path, ast.parse(path.read_text(encoding="utf-8"), filename=str(path)))
+            modules[name] = ModuleUnit(
+                name,
+                path,
+                ast.parse(path.read_text(encoding="utf-8"), filename=str(path)),
+            )
         return cls(modules)
 
     @classmethod
@@ -146,7 +154,11 @@ class ModuleGraph:
                 if parts[-1] == "__init__":
                     parts.pop()
                 name = ".".join([package, *parts]) if parts else package
-                rebuilt[name] = ModuleUnit(name, path, ast.parse(path.read_text(encoding="utf-8"), filename=str(path)))
+                rebuilt[name] = ModuleUnit(
+                    name,
+                    path,
+                    ast.parse(path.read_text(encoding="utf-8"), filename=str(path)),
+                )
         graph.modules = rebuilt
         return graph
 
@@ -184,7 +196,11 @@ class Index:
         self._base_closure()
 
     def site(self, module: str, node: ast.AST) -> Site:
-        return Site(str(self.graph.modules[module].path), getattr(node, "lineno", 1), getattr(node, "col_offset", 0))
+        return Site(
+            str(self.graph.modules[module].path),
+            getattr(node, "lineno", 1),
+            getattr(node, "col_offset", 0),
+        )
 
     def _definitions(self) -> None:
         for module, unit in sorted(self.graph.modules.items()):
@@ -193,20 +209,28 @@ class Index:
                 if isinstance(node, ast.ClassDef):
                     identity = f"{module}.{node.name}"
                     bases = tuple(ast.unparse(base) for base in node.bases)
-                    self.classes[identity] = ClassDef(identity, module, node, self.site(module, node), bases)
+                    self.classes[identity] = ClassDef(
+                        identity, module, node, self.site(module, node), bases
+                    )
                     symbols[node.name] = identity
                     for child in node.body:
                         if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
                             fid = f"{identity}.{child.name}"
-                            self.functions[fid] = FunctionDef(fid, module, child, self.site(module, child), identity)
+                            self.functions[fid] = FunctionDef(
+                                fid, module, child, self.site(module, child), identity
+                            )
                 elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                     fid = f"{module}.{node.name}"
-                    self.functions[fid] = FunctionDef(fid, module, node, self.site(module, node), None)
+                    self.functions[fid] = FunctionDef(
+                        fid, module, node, self.site(module, node), None
+                    )
                     symbols[node.name] = fid
             self.module_symbols[module] = symbols
             self.module_values[module] = {}
 
-    def _resolve_module(self, current: str, imported: str | None, level: int) -> str | None:
+    def _resolve_module(
+        self, current: str, imported: str | None, level: int
+    ) -> str | None:
         imported = imported or ""
         if level:
             base = current.split(".")[:-level]
@@ -216,7 +240,11 @@ class Index:
         if candidate in self.graph.modules:
             return candidate
         tail = candidate.split(".")[-1]
-        matches = [name for name in self.graph.modules if name == tail or name.endswith(f".{tail}")]
+        matches = [
+            name
+            for name in self.graph.modules
+            if name == tail or name.endswith(f".{tail}")
+        ]
         return sorted(matches)[0] if len(matches) == 1 else None
 
     def _imports(self) -> None:
@@ -224,7 +252,9 @@ class Index:
             symbols = self.module_symbols[module]
             for node in unit.tree.body:
                 if isinstance(node, ast.ImportFrom):
-                    target_module = self._resolve_module(module, node.module, node.level)
+                    target_module = self._resolve_module(
+                        module, node.module, node.level
+                    )
                     if target_module is None:
                         continue
                     for alias in node.names:
@@ -235,9 +265,16 @@ class Index:
                     for alias in node.names:
                         target_module = self._resolve_module(module, alias.name, 0)
                         if target_module:
-                            symbols[alias.asname or alias.name.split(".")[0]] = f"module:{target_module}"
+                            symbols[alias.asname or alias.name.split(".")[0]] = (
+                                f"module:{target_module}"
+                            )
 
-    def resolve(self, module: str, expr: ast.expr, env: Mapping[str, AbstractValue] | None = None) -> str | None:
+    def resolve(
+        self,
+        module: str,
+        expr: ast.expr,
+        env: Mapping[str, AbstractValue] | None = None,
+    ) -> str | None:
         if isinstance(expr, ast.Name):
             return self.module_symbols.get(module, {}).get(expr.id)
         if isinstance(expr, ast.Attribute):
@@ -281,7 +318,9 @@ class Index:
 class Interpreter:
     def __init__(self, graph: ModuleGraph):
         self.index = Index(graph)
-        self.summaries: dict[tuple[str, tuple[tuple[Atom, ...], ...]], AbstractValue] = {}
+        self.summaries: dict[
+            tuple[str, tuple[tuple[Atom, ...], ...]], AbstractValue
+        ] = {}
         self.summary_revision = 0
         self.active: set[tuple[str, tuple[tuple[Atom, ...], ...]]] = set()
         self.tables: dict[tuple[str, str], AbstractValue] = {}
@@ -303,7 +342,11 @@ class Interpreter:
                         if rhs is None:
                             continue
                         value = self.eval_expr(module, rhs, env, (), sink_slice=False)
-                        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                        targets = (
+                            node.targets
+                            if isinstance(node, ast.Assign)
+                            else [node.target]
+                        )
                         for target in targets:
                             if isinstance(target, ast.Name):
                                 old = env.get(target.id, AbstractValue())
@@ -313,25 +356,51 @@ class Interpreter:
                                     changed = True
                 self.index.module_values[module] = env
 
-    def _key(self, fid: str, args: tuple[AbstractValue, ...]) -> tuple[str, tuple[tuple[Atom, ...], ...]]:
+    def _key(
+        self, fid: str, args: tuple[AbstractValue, ...]
+    ) -> tuple[str, tuple[tuple[Atom, ...], ...]]:
         return fid, tuple(tuple(sorted(value.atoms, key=repr)) for value in args)
 
-    def call(self, fid: str, args: tuple[AbstractValue, ...], chain: tuple[str, ...], *, sink_slice: bool) -> AbstractValue:
+    def call(
+        self,
+        fid: str,
+        args: tuple[AbstractValue, ...],
+        chain: tuple[str, ...],
+        *,
+        sink_slice: bool,
+    ) -> AbstractValue:
         fn = self.index.functions[fid]
         key = self._key(fid, args)
         if key in self.active:
             return self.summaries.get(key, AbstractValue())
         self.active.add(key)
-        params = [*fn.node.args.posonlyargs, *fn.node.args.args, *fn.node.args.kwonlyargs]
+        params = [
+            *fn.node.args.posonlyargs,
+            *fn.node.args.args,
+            *fn.node.args.kwonlyargs,
+        ]
         env = dict(self.index.module_values[fn.module])
         for i, param in enumerate(params):
             if i == 0 and fn.owner:
-                env[param.arg] = AbstractValue(frozenset({Atom("ClassObject", fn.owner, self.index.classes[fn.owner].site, chain)}))
+                env[param.arg] = AbstractValue(
+                    frozenset(
+                        {
+                            Atom(
+                                "ClassObject",
+                                fn.owner,
+                                self.index.classes[fn.owner].site,
+                                chain,
+                            )
+                        }
+                    )
+                )
             elif i < len(args):
                 env[param.arg] = args[i].stepped(f"argument -> {fid}.{param.arg}")
             else:
                 env[param.arg] = ORDINARY
-        result = self.exec_block(fn.module, fn.node.body, env, chain + (fid,), sink_slice=sink_slice)
+        result = self.exec_block(
+            fn.module, fn.node.body, env, chain + (fid,), sink_slice=sink_slice
+        )
         previous = self.summaries.get(key, AbstractValue())
         result = previous.join(result)
         self.summaries[key] = result
@@ -340,7 +409,15 @@ class Interpreter:
         self.active.remove(key)
         return result.stepped(f"return <- {fid}", rpc=bool(result.entries))
 
-    def exec_block(self, module: str, body: list[ast.stmt], env: dict[str, AbstractValue], chain: tuple[str, ...], *, sink_slice: bool) -> AbstractValue:
+    def exec_block(
+        self,
+        module: str,
+        body: list[ast.stmt],
+        env: dict[str, AbstractValue],
+        chain: tuple[str, ...],
+        *,
+        sink_slice: bool,
+    ) -> AbstractValue:
         flow = self._flow_block(module, body, env, chain, sink_slice=sink_slice)
         if flow.exits:
             merged = self._join_envs(flow.exits)
@@ -369,7 +446,9 @@ class Interpreter:
 
         def enqueue(index: int, candidate: Mapping[str, AbstractValue]) -> None:
             old = states.get(index)
-            joined = dict(candidate) if old is None else self._join_envs((old, candidate))
+            joined = (
+                dict(candidate) if old is None else self._join_envs((old, candidate))
+            )
             if old is None or joined != old:
                 states[index] = joined
                 if index not in pending:
@@ -385,34 +464,87 @@ class Interpreter:
             stmt = body[index]
             prefixes.append(dict(current))
             if isinstance(stmt, ast.ImportFrom):
-                target_module = self.index._resolve_module(module, stmt.module, stmt.level)
+                target_module = self.index._resolve_module(
+                    module, stmt.module, stmt.level
+                )
                 if target_module:
                     for alias in stmt.names:
-                        canonical = self.index.module_symbols[target_module].get(alias.name)
+                        canonical = self.index.module_symbols[target_module].get(
+                            alias.name
+                        )
                         if canonical in self.index.classes:
-                            current[alias.asname or alias.name] = AbstractValue(frozenset({Atom("ClassObject", canonical, self.index.classes[canonical].site, chain)}))
+                            current[alias.asname or alias.name] = AbstractValue(
+                                frozenset(
+                                    {
+                                        Atom(
+                                            "ClassObject",
+                                            canonical,
+                                            self.index.classes[canonical].site,
+                                            chain,
+                                        )
+                                    }
+                                )
+                            )
                         elif canonical in self.index.functions:
-                            current[alias.asname or alias.name] = AbstractValue(frozenset({Atom("Callable", canonical, self.index.functions[canonical].site, chain)}))
+                            current[alias.asname or alias.name] = AbstractValue(
+                                frozenset(
+                                    {
+                                        Atom(
+                                            "Callable",
+                                            canonical,
+                                            self.index.functions[canonical].site,
+                                            chain,
+                                        )
+                                    }
+                                )
+                            )
                 enqueue(index + 1, current)
             elif isinstance(stmt, ast.Import):
                 for alias in stmt.names:
                     target_module = self.index._resolve_module(module, alias.name, 0)
                     if target_module:
-                        current[alias.asname or alias.name.split(".")[0]] = AbstractValue(frozenset({Atom("Module", target_module, self.index.site(module, stmt), chain)}))
+                        current[alias.asname or alias.name.split(".")[0]] = (
+                            AbstractValue(
+                                frozenset(
+                                    {
+                                        Atom(
+                                            "Module",
+                                            target_module,
+                                            self.index.site(module, stmt),
+                                            chain,
+                                        )
+                                    }
+                                )
+                            )
+                        )
                 enqueue(index + 1, current)
-            elif isinstance(stmt, (ast.Assign, ast.AnnAssign)) and stmt.value is not None:
-                value = self.eval_expr(module, stmt.value, current, chain, sink_slice=sink_slice)
-                targets = stmt.targets if isinstance(stmt, ast.Assign) else [stmt.target]
+            elif (
+                isinstance(stmt, (ast.Assign, ast.AnnAssign)) and stmt.value is not None
+            ):
+                value = self.eval_expr(
+                    module, stmt.value, current, chain, sink_slice=sink_slice
+                )
+                targets = (
+                    stmt.targets if isinstance(stmt, ast.Assign) else [stmt.target]
+                )
                 for target in targets:
                     if isinstance(target, ast.Name):
-                        current[target.id] = current.get(target.id, AbstractValue()).join(value)
+                        current[target.id] = current.get(
+                            target.id, AbstractValue()
+                        ).join(value)
                 enqueue(index + 1, current)
             elif isinstance(stmt, ast.Return):
                 if stmt.value is not None:
-                    returns = returns.join(self.eval_expr(module, stmt.value, current, chain, sink_slice=sink_slice))
+                    returns = returns.join(
+                        self.eval_expr(
+                            module, stmt.value, current, chain, sink_slice=sink_slice
+                        )
+                    )
             elif isinstance(stmt, ast.If):
                 body_env = dict(current)
-                refinement = self._isinstance_refinement(module, stmt.test, current, chain)
+                refinement = self._isinstance_refinement(
+                    module, stmt.test, current, chain
+                )
                 if refinement:
                     name, value = refinement
                     body_env[name] = body_env.get(name, AbstractValue()).join(value)
@@ -447,7 +579,9 @@ class Interpreter:
                     loop_raises.extend(body_flow.raises)
                     loop_prefixes.extend(body_flow.prefixes)
                     loop_breaks.extend(body_flow.breaks)
-                    next_header = self._join_envs((header, *body_flow.exits, *body_flow.continues))
+                    next_header = self._join_envs(
+                        (header, *body_flow.exits, *body_flow.continues)
+                    )
                     if next_header == header:
                         break
                     header = next_header
@@ -465,7 +599,9 @@ class Interpreter:
                 for successor in (*else_flow.exits, *loop_breaks):
                     enqueue(index + 1, successor)
             elif isinstance(stmt, (ast.For, ast.AsyncFor)):
-                iterable = self.eval_expr(module, stmt.iter, current, chain, sink_slice=sink_slice)
+                iterable = self.eval_expr(
+                    module, stmt.iter, current, chain, sink_slice=sink_slice
+                )
                 header = dict(current)
                 loop_returns = AbstractValue()
                 loop_raises: list[dict[str, AbstractValue]] = []
@@ -481,7 +617,9 @@ class Interpreter:
                     loop_raises.extend(body_flow.raises)
                     loop_prefixes.extend(body_flow.prefixes)
                     loop_breaks.extend(body_flow.breaks)
-                    next_header = self._join_envs((header, *body_flow.exits, *body_flow.continues))
+                    next_header = self._join_envs(
+                        (header, *body_flow.exits, *body_flow.continues)
+                    )
                     if next_header == header:
                         break
                     header = next_header
@@ -503,11 +641,17 @@ class Interpreter:
                     module, stmt.body, current, chain, sink_slice=sink_slice
                 )
                 try_returns = try_flow.returns
-                handler_entry = self._join_envs((current, *try_flow.prefixes, *try_flow.raises))
+                handler_entry = self._join_envs(
+                    (current, *try_flow.prefixes, *try_flow.raises)
+                )
                 handler_flows: list[FlowResult] = []
                 for handler in stmt.handlers:
                     handler_flow = self._flow_block(
-                        module, handler.body, handler_entry, chain, sink_slice=sink_slice
+                        module,
+                        handler.body,
+                        handler_entry,
+                        chain,
+                        sink_slice=sink_slice,
                     )
                     handler_flows.append(handler_flow)
                     try_returns = try_returns.join(handler_flow.returns)
@@ -520,15 +664,25 @@ class Interpreter:
                 )
                 try_returns = try_returns.join(normal_flow.returns)
                 returns = returns.join(try_returns)
-                handler_exits = tuple(env for flow in handler_flows for env in flow.exits)
+                handler_exits = tuple(
+                    env for flow in handler_flows for env in flow.exits
+                )
                 uncaught_try_raises = () if handler_flows else try_flow.raises
                 abrupt_raises = (
                     *uncaught_try_raises,
                     *(env for flow in handler_flows for env in flow.raises),
                     *normal_flow.raises,
                 )
-                abrupt_breaks = (*try_flow.breaks, *(env for flow in handler_flows for env in flow.breaks), *normal_flow.breaks)
-                abrupt_continues = (*try_flow.continues, *(env for flow in handler_flows for env in flow.continues), *normal_flow.continues)
+                abrupt_breaks = (
+                    *try_flow.breaks,
+                    *(env for flow in handler_flows for env in flow.breaks),
+                    *normal_flow.breaks,
+                )
+                abrupt_continues = (
+                    *try_flow.continues,
+                    *(env for flow in handler_flows for env in flow.continues),
+                    *normal_flow.continues,
+                )
                 normal_exits = (*normal_flow.exits, *handler_exits)
                 all_prefixes = (
                     *try_flow.prefixes,
@@ -537,7 +691,9 @@ class Interpreter:
                 )
                 prefixes.extend(all_prefixes)
 
-                def through_final(inputs: tuple[dict[str, AbstractValue], ...]) -> FlowResult:
+                def through_final(
+                    inputs: tuple[dict[str, AbstractValue], ...],
+                ) -> FlowResult:
                     if not inputs:
                         return FlowResult()
                     return self._flow_block(
@@ -552,8 +708,18 @@ class Interpreter:
                 raised_final = through_final(tuple(abrupt_raises))
                 break_final = through_final(tuple(abrupt_breaks))
                 continue_final = through_final(tuple(abrupt_continues))
-                return_final = through_final((current, *all_prefixes)) if try_returns.atoms else FlowResult()
-                final_flows = (normal_final, raised_final, break_final, continue_final, return_final)
+                return_final = (
+                    through_final((current, *all_prefixes))
+                    if try_returns.atoms
+                    else FlowResult()
+                )
+                final_flows = (
+                    normal_final,
+                    raised_final,
+                    break_final,
+                    continue_final,
+                    return_final,
+                )
                 for final_flow in final_flows:
                     returns = returns.join(final_flow.returns)
                     raises.extend(final_flow.raises)
@@ -568,7 +734,13 @@ class Interpreter:
             elif isinstance(stmt, (ast.With, ast.AsyncWith)):
                 body_env = dict(current)
                 for item in stmt.items:
-                    value = self.eval_expr(module, item.context_expr, body_env, chain, sink_slice=sink_slice)
+                    value = self.eval_expr(
+                        module,
+                        item.context_expr,
+                        body_env,
+                        chain,
+                        sink_slice=sink_slice,
+                    )
                     if item.optional_vars is not None:
                         self._bind_target(body_env, item.optional_vars, value)
                 body_flow = self._flow_block(
@@ -582,13 +754,17 @@ class Interpreter:
                 for successor in body_flow.exits:
                     enqueue(index + 1, successor)
             elif isinstance(stmt, ast.Match):
-                subject = self.eval_expr(module, stmt.subject, current, chain, sink_slice=sink_slice)
+                subject = self.eval_expr(
+                    module, stmt.subject, current, chain, sink_slice=sink_slice
+                )
                 enqueue(index + 1, current)
                 for case in stmt.cases:
                     case_env = dict(current)
                     self._bind_pattern(case_env, case.pattern, subject)
                     if case.guard is not None:
-                        self.eval_expr(module, case.guard, case_env, chain, sink_slice=sink_slice)
+                        self.eval_expr(
+                            module, case.guard, case_env, chain, sink_slice=sink_slice
+                        )
                     case_flow = self._flow_block(
                         module, case.body, case_env, chain, sink_slice=sink_slice
                     )
@@ -600,7 +776,9 @@ class Interpreter:
                     for successor in case_flow.exits:
                         enqueue(index + 1, successor)
             elif isinstance(stmt, ast.Expr):
-                self.eval_expr(module, stmt.value, current, chain, sink_slice=sink_slice)
+                self.eval_expr(
+                    module, stmt.value, current, chain, sink_slice=sink_slice
+                )
                 enqueue(index + 1, current)
             elif isinstance(stmt, ast.Raise):
                 raises.append(current)
@@ -611,10 +789,14 @@ class Interpreter:
             elif isinstance(stmt, ast.Assert):
                 self.eval_expr(module, stmt.test, current, chain, sink_slice=sink_slice)
                 if stmt.msg is not None:
-                    self.eval_expr(module, stmt.msg, current, chain, sink_slice=sink_slice)
+                    self.eval_expr(
+                        module, stmt.msg, current, chain, sink_slice=sink_slice
+                    )
                 enqueue(index + 1, current)
             elif isinstance(stmt, ast.AugAssign):
-                value = self.eval_expr(module, stmt.value, current, chain, sink_slice=sink_slice)
+                value = self.eval_expr(
+                    module, stmt.value, current, chain, sink_slice=sink_slice
+                )
                 if isinstance(stmt.target, ast.Name):
                     value = current.get(stmt.target.id, AbstractValue()).join(value)
                 self._bind_target(current, stmt.target, value)
@@ -625,10 +807,22 @@ class Interpreter:
                         current.pop(target.id, None)
                 enqueue(index + 1, current)
             elif isinstance(stmt, ast.TypeAlias):
-                value = self.eval_expr(module, stmt.value, current, chain, sink_slice=sink_slice)
+                value = self.eval_expr(
+                    module, stmt.value, current, chain, sink_slice=sink_slice
+                )
                 self._bind_target(current, stmt.name, value)
                 enqueue(index + 1, current)
-            elif isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Global, ast.Nonlocal, ast.Pass)):
+            elif isinstance(
+                stmt,
+                (
+                    ast.FunctionDef,
+                    ast.AsyncFunctionDef,
+                    ast.ClassDef,
+                    ast.Global,
+                    ast.Nonlocal,
+                    ast.Pass,
+                ),
+            ):
                 enqueue(index + 1, current)
             else:
                 raise AssertionError(f"unmodeled statement node: {type(stmt).__name__}")
@@ -642,7 +836,9 @@ class Interpreter:
         )
 
     @staticmethod
-    def _join_envs(envs: Iterable[Mapping[str, AbstractValue]]) -> dict[str, AbstractValue]:
+    def _join_envs(
+        envs: Iterable[Mapping[str, AbstractValue]],
+    ) -> dict[str, AbstractValue]:
         joined: dict[str, AbstractValue] = {}
         for env in envs:
             for name, value in env.items():
@@ -650,7 +846,9 @@ class Interpreter:
         return joined
 
     @staticmethod
-    def _bind_target(env: dict[str, AbstractValue], target: ast.expr, value: AbstractValue) -> None:
+    def _bind_target(
+        env: dict[str, AbstractValue], target: ast.expr, value: AbstractValue
+    ) -> None:
         if isinstance(target, ast.Name):
             env[target.id] = env.get(target.id, AbstractValue()).join(value)
         elif isinstance(target, (ast.Tuple, ast.List)):
@@ -660,7 +858,9 @@ class Interpreter:
             Interpreter._bind_target(env, target.value, value)
 
     @staticmethod
-    def _bind_pattern(env: dict[str, AbstractValue], pattern: ast.pattern, value: AbstractValue) -> None:
+    def _bind_pattern(
+        env: dict[str, AbstractValue], pattern: ast.pattern, value: AbstractValue
+    ) -> None:
         for node in ast.walk(pattern):
             name = None
             if isinstance(node, (ast.MatchAs, ast.MatchStar)):
@@ -670,7 +870,13 @@ class Interpreter:
             if name is not None:
                 env[name] = env.get(name, AbstractValue()).join(value)
 
-    def _isinstance_refinement(self, module: str, expr: ast.expr, env: Mapping[str, AbstractValue], chain: tuple[str, ...]) -> tuple[str, AbstractValue] | None:
+    def _isinstance_refinement(
+        self,
+        module: str,
+        expr: ast.expr,
+        env: Mapping[str, AbstractValue],
+        chain: tuple[str, ...],
+    ) -> tuple[str, AbstractValue] | None:
         if not (isinstance(expr, ast.Call) and len(expr.args) >= 2):
             return None
         if not isinstance(expr.args[0], ast.Name):
@@ -683,136 +889,279 @@ class Interpreter:
                     break
         if class_id not in self.index.classes:
             return None
-        atom = Atom("Instance", class_id, self.index.classes[class_id].site, chain + (f"isinstance -> {class_id}",))
+        atom = Atom(
+            "Instance",
+            class_id,
+            self.index.classes[class_id].site,
+            chain + (f"isinstance -> {class_id}",),
+        )
         return expr.args[0].id, AbstractValue(frozenset({atom}))
 
-    def eval_expr(self, module: str, expr: ast.expr, env: Mapping[str, AbstractValue], chain: tuple[str, ...], *, sink_slice: bool) -> AbstractValue:
+    def eval_expr(
+        self,
+        module: str,
+        expr: ast.expr,
+        env: Mapping[str, AbstractValue],
+        chain: tuple[str, ...],
+        *,
+        sink_slice: bool,
+    ) -> AbstractValue:
         site = self.index.site(module, expr)
         if isinstance(expr, ast.Name):
             if expr.id in env:
-                return env[expr.id].stepped(f"name {expr.id} at {site.path}:{site.line}")
+                return env[expr.id].stepped(
+                    f"name {expr.id} at {site.path}:{site.line}"
+                )
             resolved = self.index.resolve(module, expr)
             if resolved in self.index.classes:
-                return AbstractValue(frozenset({Atom("ClassObject", resolved, self.index.classes[resolved].site, chain)}))
+                return AbstractValue(
+                    frozenset(
+                        {
+                            Atom(
+                                "ClassObject",
+                                resolved,
+                                self.index.classes[resolved].site,
+                                chain,
+                            )
+                        }
+                    )
+                )
             if resolved in self.index.functions:
-                return AbstractValue(frozenset({Atom("Callable", resolved, self.index.functions[resolved].site, chain)}))
+                return AbstractValue(
+                    frozenset(
+                        {
+                            Atom(
+                                "Callable",
+                                resolved,
+                                self.index.functions[resolved].site,
+                                chain,
+                            )
+                        }
+                    )
+                )
             return ORDINARY
         if isinstance(expr, ast.Constant):
             return ORDINARY
         if isinstance(expr, ast.NamedExpr):
-            value = self.eval_expr(module, expr.value, env, chain, sink_slice=sink_slice)
+            value = self.eval_expr(
+                module, expr.value, env, chain, sink_slice=sink_slice
+            )
             if isinstance(env, dict):
                 self._bind_target(env, expr.target, value)
             return value
-        if isinstance(expr, (ast.ListComp, ast.SetComp, ast.GeneratorExp, ast.DictComp)):
+        if isinstance(
+            expr, (ast.ListComp, ast.SetComp, ast.GeneratorExp, ast.DictComp)
+        ):
             comp_env = dict(env)
             provenance = AbstractValue()
             while True:
                 before = dict(comp_env)
                 for generator in expr.generators:
-                    iterable = self.eval_expr(module, generator.iter, comp_env, chain, sink_slice=sink_slice)
+                    iterable = self.eval_expr(
+                        module, generator.iter, comp_env, chain, sink_slice=sink_slice
+                    )
                     provenance = provenance.join(iterable)
                     self._bind_target(comp_env, generator.target, iterable)
                     for condition in generator.ifs:
                         provenance = provenance.join(
-                            self.eval_expr(module, condition, comp_env, chain, sink_slice=sink_slice)
+                            self.eval_expr(
+                                module,
+                                condition,
+                                comp_env,
+                                chain,
+                                sink_slice=sink_slice,
+                            )
                         )
                 if isinstance(expr, ast.DictComp):
                     provenance = provenance.join(
-                        self.eval_expr(module, expr.key, comp_env, chain, sink_slice=sink_slice)
-                    ).join(self.eval_expr(module, expr.value, comp_env, chain, sink_slice=sink_slice))
+                        self.eval_expr(
+                            module, expr.key, comp_env, chain, sink_slice=sink_slice
+                        )
+                    ).join(
+                        self.eval_expr(
+                            module, expr.value, comp_env, chain, sink_slice=sink_slice
+                        )
+                    )
                 else:
                     provenance = provenance.join(
-                        self.eval_expr(module, expr.elt, comp_env, chain, sink_slice=sink_slice)
+                        self.eval_expr(
+                            module, expr.elt, comp_env, chain, sink_slice=sink_slice
+                        )
                     )
                 if comp_env == before:
                     return provenance
         if isinstance(expr, ast.IfExp):
-            return self.eval_expr(module, expr.test, env, chain, sink_slice=sink_slice).join(
-                self.eval_expr(module, expr.body, env, chain, sink_slice=sink_slice)
-            ).join(self.eval_expr(module, expr.orelse, env, chain, sink_slice=sink_slice))
+            return (
+                self.eval_expr(module, expr.test, env, chain, sink_slice=sink_slice)
+                .join(
+                    self.eval_expr(module, expr.body, env, chain, sink_slice=sink_slice)
+                )
+                .join(
+                    self.eval_expr(
+                        module, expr.orelse, env, chain, sink_slice=sink_slice
+                    )
+                )
+            )
         if isinstance(expr, ast.BoolOp):
             value = AbstractValue()
             for operand in expr.values:
-                value = value.join(self.eval_expr(module, operand, env, chain, sink_slice=sink_slice))
+                value = value.join(
+                    self.eval_expr(module, operand, env, chain, sink_slice=sink_slice)
+                )
             return value
         if isinstance(expr, (ast.Tuple, ast.List, ast.Set)):
             value = AbstractValue()
             for elt in expr.elts:
-                value = value.join(self.eval_expr(module, elt, env, chain, sink_slice=sink_slice))
+                value = value.join(
+                    self.eval_expr(module, elt, env, chain, sink_slice=sink_slice)
+                )
             # Container does not itself become an authority; origins remain available to a sink slice.
             return value
         if isinstance(expr, ast.Dict):
             entries = []
             atoms = frozenset()
             for key, value_expr in zip(expr.keys, expr.values):
-                key_literal = key.value if isinstance(key, ast.Constant) and isinstance(key.value, str) else None
-                value = self.eval_expr(module, value_expr, env, chain, sink_slice=sink_slice)
+                key_literal = (
+                    key.value
+                    if isinstance(key, ast.Constant) and isinstance(key.value, str)
+                    else None
+                )
+                value = self.eval_expr(
+                    module, value_expr, env, chain, sink_slice=sink_slice
+                )
                 entries.append((key_literal, value))
                 atoms |= value.atoms
             return AbstractValue(atoms, tuple(entries))
         if isinstance(expr, ast.Subscript):
-            table = self.eval_expr(module, expr.value, env, chain, sink_slice=sink_slice)
+            table = self.eval_expr(
+                module, expr.value, env, chain, sink_slice=sink_slice
+            )
             key = self.eval_expr(module, expr.slice, env, chain, sink_slice=sink_slice)
             return self._lookup(table, key, f"subscript at {site.path}:{site.line}")
         if isinstance(expr, ast.Attribute):
             return self.eval_expr(module, expr.value, env, chain, sink_slice=sink_slice)
         if isinstance(expr, ast.Call):
             if isinstance(expr.func, ast.Attribute) and expr.args:
-                table = self.eval_expr(module, expr.func.value, env, chain, sink_slice=sink_slice)
+                table = self.eval_expr(
+                    module, expr.func.value, env, chain, sink_slice=sink_slice
+                )
                 if table.entries:
-                    key = self.eval_expr(module, expr.args[0], env, chain, sink_slice=sink_slice)
-                    return self._lookup(table, key, f"selection at {site.path}:{site.line}")
+                    key = self.eval_expr(
+                        module, expr.args[0], env, chain, sink_slice=sink_slice
+                    )
+                    return self._lookup(
+                        table, key, f"selection at {site.path}:{site.line}"
+                    )
             callee = self.index.resolve(module, expr.func)
             if callee is None and isinstance(expr.func, ast.Attribute):
-                receiver = self.eval_expr(module, expr.func.value, env, chain, sink_slice=sink_slice)
+                receiver = self.eval_expr(
+                    module, expr.func.value, env, chain, sink_slice=sink_slice
+                )
                 for atom in sorted(receiver.atoms, key=repr):
                     if atom.kind == "ClassObject":
                         candidate = f"{atom.identity}.{expr.func.attr}"
                         if candidate in self.index.functions:
                             callee = candidate
                             break
-            args = tuple(self.eval_expr(module, arg, env, chain, sink_slice=sink_slice) for arg in expr.args)
+            args = tuple(
+                self.eval_expr(module, arg, env, chain, sink_slice=sink_slice)
+                for arg in expr.args
+            )
             if callee in self.index.classes:
-                atom = Atom("Instance", callee, self.index.classes[callee].site, chain + (f"construct {callee}",))
+                atom = Atom(
+                    "Instance",
+                    callee,
+                    self.index.classes[callee].site,
+                    chain + (f"construct {callee}",),
+                )
                 value = AbstractValue(frozenset({atom}))
                 for arg in args:
                     value = value.join(arg)
                 if self.index.is_sugar(callee):
-                    value = value.with_atom(Atom("SuccessSugar", callee, site, chain + (f"success {callee}",)))
+                    value = value.with_atom(
+                        Atom(
+                            "SuccessSugar", callee, site, chain + (f"success {callee}",)
+                        )
+                    )
                 return value
             if callee in self.index.functions:
                 return self.call(callee, args, chain, sink_slice=sink_slice)
-            callable_value = self.eval_expr(module, expr.func, env, chain, sink_slice=sink_slice)
+            callable_value = self.eval_expr(
+                module, expr.func, env, chain, sink_slice=sink_slice
+            )
             results = AbstractValue()
             for atom in callable_value.atoms:
                 if atom.kind == "Callable" and atom.identity in self.index.functions:
-                    results = results.join(self.call(atom.identity, args, chain, sink_slice=sink_slice))
+                    results = results.join(
+                        self.call(atom.identity, args, chain, sink_slice=sink_slice)
+                    )
                 elif atom.kind == "ClassObject" and atom.identity in self.index.classes:
-                    made = Atom("Instance", atom.identity, self.index.classes[atom.identity].site, chain + (f"construct {atom.identity}",))
+                    made = Atom(
+                        "Instance",
+                        atom.identity,
+                        self.index.classes[atom.identity].site,
+                        chain + (f"construct {atom.identity}",),
+                    )
                     value = AbstractValue(frozenset({made}))
                     if self.index.is_sugar(atom.identity):
-                        value = value.with_atom(Atom("SuccessSugar", atom.identity, site, chain + (f"success {atom.identity}",)))
+                        value = value.with_atom(
+                            Atom(
+                                "SuccessSugar",
+                                atom.identity,
+                                site,
+                                chain + (f"success {atom.identity}",),
+                            )
+                        )
                         for arg in args:
                             value = value.join(arg)
                     results = results.join(value)
             if results.atoms or results.entries:
                 if callable_value.has("AdmissionLookup"):
-                    results = results.join(AbstractValue(frozenset(
-                        Atom("LookupConstructed", atom.identity, atom.origin, atom.chain, atom.rpc)
-                        for atom in results.atoms
-                        if atom.kind == "Instance" and not self.index.is_sugar(atom.identity)
-                    )))
-                provenance = AbstractValue(frozenset(a for a in callable_value.atoms if a.kind != "Callable"))
+                    results = results.join(
+                        AbstractValue(
+                            frozenset(
+                                Atom(
+                                    "LookupConstructed",
+                                    atom.identity,
+                                    atom.origin,
+                                    atom.chain,
+                                    atom.rpc,
+                                )
+                                for atom in results.atoms
+                                if atom.kind == "Instance"
+                                and not self.index.is_sugar(atom.identity)
+                            )
+                        )
+                    )
+                provenance = AbstractValue(
+                    frozenset(a for a in callable_value.atoms if a.kind != "Callable")
+                )
                 return results.join(provenance)
             if sink_slice:
-                return AbstractValue(frozenset({Atom("UnknownOnAdmissionSlice", origin=site, chain=chain + (f"unresolved call at {site.path}:{site.line}",))}))
+                return AbstractValue(
+                    frozenset(
+                        {
+                            Atom(
+                                "UnknownOnAdmissionSlice",
+                                origin=site,
+                                chain=chain
+                                + (f"unresolved call at {site.path}:{site.line}",),
+                            )
+                        }
+                    )
+                )
             return ORDINARY
         if isinstance(expr, ast.BinOp) and isinstance(expr.op, ast.BitOr):
-            return self.eval_expr(module, expr.left, env, chain, sink_slice=sink_slice).join(self.eval_expr(module, expr.right, env, chain, sink_slice=sink_slice))
+            return self.eval_expr(
+                module, expr.left, env, chain, sink_slice=sink_slice
+            ).join(
+                self.eval_expr(module, expr.right, env, chain, sink_slice=sink_slice)
+            )
         return ORDINARY
 
-    def _lookup(self, table: AbstractValue, key: AbstractValue, label: str) -> AbstractValue:
+    def _lookup(
+        self, table: AbstractValue, key: AbstractValue, label: str
+    ) -> AbstractValue:
         result = AbstractValue()
         for _, value in table.entries:
             result = result.join(value)
@@ -821,61 +1170,136 @@ class Interpreter:
             result = result.stepped(label, rpc=rpc)
             result = result.with_atom(Atom("AdmissionLookup", chain=(label,), rpc=rpc))
         elif table.has("UnknownOnAdmissionSlice"):
-            unknown = sorted((atom for atom in table.atoms if atom.kind == "UnknownOnAdmissionSlice"), key=repr)[0]
+            unknown = sorted(
+                (
+                    atom
+                    for atom in table.atoms
+                    if atom.kind == "UnknownOnAdmissionSlice"
+                ),
+                key=repr,
+            )[0]
             result = table.with_atom(
-                Atom("LookupUnknown", unknown.identity, unknown.origin, unknown.chain + (label,), rpc or unknown.rpc)
+                Atom(
+                    "LookupUnknown",
+                    unknown.identity,
+                    unknown.origin,
+                    unknown.chain + (label,),
+                    rpc or unknown.rpc,
+                )
             ).with_atom(Atom("AdmissionLookup", chain=(label,), rpc=rpc))
         return result
 
     def authority_rows(self) -> tuple[ReportRow, ...]:
         rows = []
-        sinks = [fn for fn in self.index.functions.values() if fn.node.name == "_construct_sugar" and fn.owner and fn.owner.rsplit(".", 1)[-1] == "With"]
+        sinks = [
+            fn
+            for fn in self.index.functions.values()
+            if fn.node.name == "_construct_sugar"
+            and fn.owner
+            and fn.owner.rsplit(".", 1)[-1] == "With"
+        ]
         for sink in sorted(sinks, key=lambda f: f.identity):
-            params = [*sink.node.args.posonlyargs, *sink.node.args.args, *sink.node.args.kwonlyargs]
+            params = [
+                *sink.node.args.posonlyargs,
+                *sink.node.args.args,
+                *sink.node.args.kwonlyargs,
+            ]
             args = []
             for index, param in enumerate(params):
                 if index == 0 and sink.owner:
                     args.append(ORDINARY)
                     continue
-                args.append(self._annotation_value(sink.module, param.annotation, sink.site))
+                args.append(
+                    self._annotation_value(sink.module, param.annotation, sink.site)
+                )
             result = self._fixed_call(sink.identity, tuple(args), (sink.identity,))
             if not result.has("SuccessSugar"):
                 continue
             for atom in sorted(result.atoms, key=repr):
                 if atom.kind == "UnknownOnAdmissionSlice":
-                    rows.append(self._row("R_with_noncontract_admission_authority", sink.site, atom, "opaque-admission-flow"))
+                    rows.append(
+                        self._row(
+                            "R_with_noncontract_admission_authority",
+                            sink.site,
+                            atom,
+                            "opaque-admission-flow",
+                        )
+                    )
                 elif atom.kind == "Instance":
                     leaf = atom.identity.rsplit(".", 1)[-1]
                     if (
                         atom.identity == sink.owner
-                        or leaf in {"ContextManagerContractRefV1", "ContextManagerResolutionGapV1"}
+                        or leaf
+                        in {
+                            "ContextManagerContractRefV1",
+                            "ContextManagerResolutionGapV1",
+                        }
                         or self.index.is_sugar(atom.identity)
                     ):
                         continue
-                    rows.append(self._row("R_with_noncontract_admission_authority", sink.site, atom, "secondary-admission-authority"))
+                    rows.append(
+                        self._row(
+                            "R_with_noncontract_admission_authority",
+                            sink.site,
+                            atom,
+                            "secondary-admission-authority",
+                        )
+                    )
             # Union members may not be instantiated, but a guarded success makes them authority.
             for atom in sorted(result.atoms, key=repr):
-                if atom.kind == "UnionMember" and atom.identity.rsplit(".", 1)[-1] not in {"ContextManagerContractRefV1", "ContextManagerResolutionGapV1"}:
-                    rows.append(self._row("R_with_noncontract_admission_authority", sink.site, atom, "secondary-admission-authority"))
+                if atom.kind == "UnionMember" and atom.identity.rsplit(".", 1)[
+                    -1
+                ] not in {
+                    "ContextManagerContractRefV1",
+                    "ContextManagerResolutionGapV1",
+                }:
+                    rows.append(
+                        self._row(
+                            "R_with_noncontract_admission_authority",
+                            sink.site,
+                            atom,
+                            "secondary-admission-authority",
+                        )
+                    )
         return _dedupe(rows)
 
-    def _annotation_value(self, module: str, annotation: ast.expr | None, site: Site) -> AbstractValue:
+    def _annotation_value(
+        self, module: str, annotation: ast.expr | None, site: Site
+    ) -> AbstractValue:
         if annotation is None:
             return ORDINARY
         classes = self._annotation_classes(module, annotation)
-        atoms = {Atom("UnionMember", class_id, self.index.classes[class_id].site, (f"annotation at {site.path}:{site.line}",)) for class_id in classes}
+        atoms = {
+            Atom(
+                "UnionMember",
+                class_id,
+                self.index.classes[class_id].site,
+                (f"annotation at {site.path}:{site.line}",),
+            )
+            for class_id in classes
+        }
         return AbstractValue(frozenset(atoms)) or ORDINARY
 
     def _annotation_classes(self, module: str, annotation: ast.expr) -> set[str]:
         if isinstance(annotation, ast.BinOp) and isinstance(annotation.op, ast.BitOr):
-            return self._annotation_classes(module, annotation.left) | self._annotation_classes(module, annotation.right)
+            return self._annotation_classes(
+                module, annotation.left
+            ) | self._annotation_classes(module, annotation.right)
         if isinstance(annotation, ast.Subscript):
             name = ast.unparse(annotation.value).split(".")[-1]
             if name == "Annotated":
-                elt = annotation.slice.elts[0] if isinstance(annotation.slice, ast.Tuple) else annotation.slice
+                elt = (
+                    annotation.slice.elts[0]
+                    if isinstance(annotation.slice, ast.Tuple)
+                    else annotation.slice
+                )
                 return self._annotation_classes(module, elt)
             if name in {"Union", "Optional"}:
-                elts = annotation.slice.elts if isinstance(annotation.slice, ast.Tuple) else [annotation.slice]
+                elts = (
+                    annotation.slice.elts
+                    if isinstance(annotation.slice, ast.Tuple)
+                    else [annotation.slice]
+                )
                 result = set()
                 for elt in elts:
                     result |= self._annotation_classes(module, elt)
@@ -888,7 +1312,11 @@ class Interpreter:
         for fn in sorted(self.index.functions.values(), key=lambda f: f.identity):
             if not self._has_structural_admission_lookup(fn):
                 continue
-            params = [*fn.node.args.posonlyargs, *fn.node.args.args, *fn.node.args.kwonlyargs]
+            params = [
+                *fn.node.args.posonlyargs,
+                *fn.node.args.args,
+                *fn.node.args.kwonlyargs,
+            ]
             args = tuple(ORDINARY for _ in params)
             result = self._fixed_call(fn.identity, args, (fn.identity,))
             if not result.has("SuccessSugar"):
@@ -897,11 +1325,26 @@ class Interpreter:
             admission_lookup = [a for a in result.atoms if a.kind == "AdmissionLookup"]
             if constructed and admission_lookup:
                 origin = sorted(constructed, key=repr)[0]
-                reason = "consumer-enrollment-rpc-lane" if any(a.rpc for a in constructed + admission_lookup) else "consumer-spelling-enrollment"
-                rows.append(self._row("R_consumer_manager_enrollment", fn.site, origin, reason))
+                reason = (
+                    "consumer-enrollment-rpc-lane"
+                    if any(a.rpc for a in constructed + admission_lookup)
+                    else "consumer-spelling-enrollment"
+                )
+                rows.append(
+                    self._row("R_consumer_manager_enrollment", fn.site, origin, reason)
+                )
             elif result.has("LookupUnknown") and admission_lookup:
-                atom = sorted((a for a in result.atoms if a.kind == "LookupUnknown"), key=repr)[0]
-                rows.append(self._row("R_consumer_manager_enrollment", fn.site, atom, "opaque-consumer-enrollment-flow"))
+                atom = sorted(
+                    (a for a in result.atoms if a.kind == "LookupUnknown"), key=repr
+                )[0]
+                rows.append(
+                    self._row(
+                        "R_consumer_manager_enrollment",
+                        fn.site,
+                        atom,
+                        "opaque-consumer-enrollment-flow",
+                    )
+                )
         if not rows:
             rows.extend(self._structural_consumer_debt_rows())
         return _dedupe(rows)
@@ -921,7 +1364,8 @@ class Interpreter:
                 callee
                 for node in nodes
                 if isinstance(node, ast.Call)
-                and (callee := self.index.resolve(fn.module, node.func)) in self.index.functions
+                and (callee := self.index.resolve(fn.module, node.func))
+                in self.index.functions
             }
             has_lookup[identity] = any(
                 isinstance(node, ast.Subscript)
@@ -934,7 +1378,8 @@ class Interpreter:
             )
             has_constructed_sink[identity] = any(
                 isinstance(node, ast.Call)
-                and (callee := self.index.resolve(fn.module, node.func)) in self.index.classes
+                and (callee := self.index.resolve(fn.module, node.func))
+                in self.index.classes
                 and self.index.is_sugar(callee)
                 for node in nodes
             )
@@ -943,11 +1388,16 @@ class Interpreter:
         while changed:
             changed = False
             for identity in sorted(edges):
-                lookup = has_lookup[identity] or any(has_lookup[callee] for callee in edges[identity])
+                lookup = has_lookup[identity] or any(
+                    has_lookup[callee] for callee in edges[identity]
+                )
                 sink = has_constructed_sink[identity] or any(
                     has_constructed_sink[callee] for callee in edges[identity]
                 )
-                if lookup != has_lookup[identity] or sink != has_constructed_sink[identity]:
+                if (
+                    lookup != has_lookup[identity]
+                    or sink != has_constructed_sink[identity]
+                ):
                     has_lookup[identity] = lookup
                     has_constructed_sink[identity] = sink
                     changed = True
@@ -957,7 +1407,9 @@ class Interpreter:
             if has_lookup[identity] and has_constructed_sink[identity]
         )
 
-    def _fixed_call(self, fid: str, args: tuple[AbstractValue, ...], chain: tuple[str, ...]) -> AbstractValue:
+    def _fixed_call(
+        self, fid: str, args: tuple[AbstractValue, ...], chain: tuple[str, ...]
+    ) -> AbstractValue:
         """Iterate the finite tag/summary lattice to a deterministic fixed point."""
         result = AbstractValue()
         limit = max(4, len(self.index.functions) * 2 + len(self.index.classes))
@@ -966,7 +1418,9 @@ class Interpreter:
             result = result.join(self.call(fid, args, chain, sink_slice=True))
             if self.summary_revision == before:
                 return result
-        raise AssertionError("With-v2 abstract interpreter did not reach its finite fixed point")
+        raise AssertionError(
+            "With-v2 abstract interpreter did not reach its finite fixed point"
+        )
 
     def _structural_consumer_debt_rows(self) -> list[ReportRow]:
         """Close the production meta-analysis/RPC lane conservatively.
@@ -980,7 +1434,11 @@ class Interpreter:
         """
         builders: set[str] = set()
         for fid, fn in self.index.functions.items():
-            for ret in (node for node in ast.walk(fn.node) if isinstance(node, ast.Return) and node.value is not None):
+            for ret in (
+                node
+                for node in ast.walk(fn.node)
+                if isinstance(node, ast.Return) and node.value is not None
+            ):
                 calls = [ret.value] if isinstance(ret.value, ast.Call) else []
                 for call in calls:
                     callee = self.index.resolve(fn.module, call.func)
@@ -990,7 +1448,12 @@ class Interpreter:
         tables: dict[tuple[str, str], Site] = {}
         for module, unit in self.index.graph.modules.items():
             for node in unit.tree.body:
-                if not (isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name) and isinstance(node.value, ast.Dict)):
+                if not (
+                    isinstance(node, ast.Assign)
+                    and len(node.targets) == 1
+                    and isinstance(node.targets[0], ast.Name)
+                    and isinstance(node.value, ast.Dict)
+                ):
                     continue
                 semantic = False
                 for value in node.value.values:
@@ -1007,7 +1470,9 @@ class Interpreter:
             aliases: dict[str, tuple[str, str]] = {}
             for node in ast.walk(fn.node):
                 if isinstance(node, ast.ImportFrom):
-                    target_module = self.index._resolve_module(fn.module, node.module, node.level)
+                    target_module = self.index._resolve_module(
+                        fn.module, node.module, node.level
+                    )
                     if target_module:
                         for alias in node.names:
                             key = (target_module, alias.name)
@@ -1017,8 +1482,14 @@ class Interpreter:
                 key = (fn.module, name)
                 if key in tables:
                     aliases[name] = key
-            for call in (node for node in ast.walk(fn.node) if isinstance(node, ast.Call)):
-                if not (isinstance(call.func, ast.Attribute) and call.args and isinstance(call.func.value, ast.Name)):
+            for call in (
+                node for node in ast.walk(fn.node) if isinstance(node, ast.Call)
+            ):
+                if not (
+                    isinstance(call.func, ast.Attribute)
+                    and call.args
+                    and isinstance(call.func.value, ast.Name)
+                ):
                     continue
                 table_key = aliases.get(call.func.value.id)
                 if table_key is None:
@@ -1027,7 +1498,9 @@ class Interpreter:
                 if assigned is None or not _name_reaches_return(fn.node, assigned):
                     continue
                 key_expr = call.args[0] if call.args else None
-                if key_expr is None or not _key_came_from_spelling_selection(fn.node, key_expr):
+                if key_expr is None or not _key_came_from_spelling_selection(
+                    fn.node, key_expr
+                ):
                     continue
                 # The runtime-AST producer makes this key opaque, but the
                 # prior selector call and returned semantic
@@ -1037,9 +1510,20 @@ class Interpreter:
                     "UnknownOnAdmissionSlice",
                     f"{table_key[0]}.{table_key[1]}",
                     origin,
-                    (f"semantic-builder table {table_key[0]}.{table_key[1]}", f"lookup at {origin.path}:{origin.line}", "legacy semantic result -> authority/RPC admission lane"),
+                    (
+                        f"semantic-builder table {table_key[0]}.{table_key[1]}",
+                        f"lookup at {origin.path}:{origin.line}",
+                        "legacy semantic result -> authority/RPC admission lane",
+                    ),
                 )
-                rows.append(self._row("R_consumer_manager_enrollment", fn.site, atom, "opaque-consumer-enrollment-flow"))
+                rows.append(
+                    self._row(
+                        "R_consumer_manager_enrollment",
+                        fn.site,
+                        atom,
+                        "opaque-consumer-enrollment-flow",
+                    )
+                )
         return rows
 
     def _row(self, law: str, sink: Site, atom: Atom, reason: str) -> ReportRow:
@@ -1049,7 +1533,9 @@ class Interpreter:
 
 
 def _dedupe(rows: Iterable[ReportRow]) -> tuple[ReportRow, ...]:
-    unique = {(r.law, r.sink_site, r.origin_site, r.canonical, r.reason): r for r in rows}
+    unique = {
+        (r.law, r.sink_site, r.origin_site, r.canonical, r.reason): r for r in rows
+    }
     return tuple(unique[key] for key in sorted(unique, key=repr))
 
 
@@ -1063,7 +1549,12 @@ def _assigned_name(function: ast.AST, expression: ast.AST) -> str | None:
             for target in node.targets:
                 if isinstance(target, ast.Name):
                     return target.id
-        if isinstance(node, ast.AnnAssign) and node.value is not None and _contains_identity(node.value, expression) and isinstance(node.target, ast.Name):
+        if (
+            isinstance(node, ast.AnnAssign)
+            and node.value is not None
+            and _contains_identity(node.value, expression)
+            and isinstance(node.target, ast.Name)
+        ):
             return node.target.id
     return None
 
@@ -1075,21 +1566,43 @@ def _name_reaches_return(function: ast.AST, seed: str) -> bool:
         changed = False
         for node in ast.walk(function):
             if isinstance(node, (ast.Assign, ast.AnnAssign)) and node.value is not None:
-                if any(isinstance(name, ast.Name) and isinstance(name.ctx, ast.Load) and name.id in tainted for name in ast.walk(node.value)):
-                    targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                if any(
+                    isinstance(name, ast.Name)
+                    and isinstance(name.ctx, ast.Load)
+                    and name.id in tainted
+                    for name in ast.walk(node.value)
+                ):
+                    targets = (
+                        node.targets if isinstance(node, ast.Assign) else [node.target]
+                    )
                     for target in targets:
                         if isinstance(target, ast.Name) and target.id not in tainted:
                             tainted.add(target.id)
                             changed = True
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name):
-                if any(isinstance(name, ast.Name) and isinstance(name.ctx, ast.Load) and name.id in tainted for arg in node.args for name in ast.walk(arg)):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+            ):
+                if any(
+                    isinstance(name, ast.Name)
+                    and isinstance(name.ctx, ast.Load)
+                    and name.id in tainted
+                    for arg in node.args
+                    for name in ast.walk(arg)
+                ):
                     if node.func.value.id not in tainted:
                         tainted.add(node.func.value.id)
                         changed = True
     return any(
         isinstance(node, ast.Return)
         and node.value is not None
-        and any(isinstance(name, ast.Name) and isinstance(name.ctx, ast.Load) and name.id in tainted for name in ast.walk(node.value))
+        and any(
+            isinstance(name, ast.Name)
+            and isinstance(name.ctx, ast.Load)
+            and name.id in tainted
+            for name in ast.walk(node.value)
+        )
         for node in ast.walk(function)
     )
 
@@ -1105,7 +1618,10 @@ def _key_came_from_spelling_selection(function: ast.AST, key: ast.AST) -> bool:
         targets = node.targets if isinstance(node, ast.Assign) else [node.target]
         if not isinstance(node.value, ast.Call) or not node.value.args:
             continue
-        if any(isinstance(target, ast.Name) and target.id == selected_name for target in targets):
+        if any(
+            isinstance(target, ast.Name) and target.id == selected_name
+            for target in targets
+        ):
             return True
     return False
 

--- a/implementations/python/sugar-lift-py-tests/tests/witness_seeds/nested_star_unpack_lying.py
+++ b/implementations/python/sugar-lift-py-tests/tests/witness_seeds/nested_star_unpack_lying.py
@@ -1,5 +1,5 @@
 def A():
-    ((q_raw, tau), r, *rest) = ((2, 3), 4, 5, 6)
+    (q_raw, tau), r, *rest = ((2, 3), 4, 5, 6)
     return q_raw + tau + r + rest[0] + rest[1]
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/witness_seeds/nested_star_unpack_truthful.py
+++ b/implementations/python/sugar-lift-py-tests/tests/witness_seeds/nested_star_unpack_truthful.py
@@ -1,5 +1,5 @@
 def A():
-    ((q_raw, tau), r, *rest) = ((2, 3), 4, 5, 6)
+    (q_raw, tau), r, *rest = ((2, 3), 4, 5, 6)
     return q_raw + tau + r + rest[0] + rest[1]
 
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py
@@ -942,9 +942,7 @@ class _Emitter:
             self.effects.add_panics()
             value = self.expr(node.exc)
             cause = (
-                ctor("python:no_value")
-                if node.cause is None
-                else self.expr(node.cause)
+                ctor("python:no_value") if node.cause is None else self.expr(node.cause)
             )
             self.panic_loci.append(
                 self.runtime_failure_locus(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
@@ -167,7 +167,11 @@ def resolve_span_memento(
     if not isinstance(span, dict):
         raise SourceUnavailable("span memento missing `span`")
     start, end = span.get("start"), span.get("end")
-    if not isinstance(start, int) or not isinstance(end, int) or not (0 <= start <= end):
+    if (
+        not isinstance(start, int)
+        or not isinstance(end, int)
+        or not (0 <= start <= end)
+    ):
         raise SourceUnavailable(f"span memento has degenerate span {span!r}")
 
     path = str(Path(project_root) / file) if project_root else file
@@ -303,9 +307,7 @@ def _node_source_locator(
     elif isinstance(node, ast.expr):
         ast_template = expr_to_template(node, params)
     else:
-        raise SourceUnavailable(
-            f"unsupported source node kind `{type(node).__name__}`"
-        )
+        raise SourceUnavailable(f"unsupported source node kind `{type(node).__name__}`")
     return {
         "file": rel_path,
         "source_cid": blake3_512_of(body_text.encode("utf-8")),

--- a/implementations/python/sugar-lift-python-source/tests/test_source_tables.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_tables.py
@@ -72,7 +72,10 @@ def test_tables_evict_past_capacity_without_losing_semantics() -> None:
     assert source_lines(first) == tuple(ast._splitlines_no_ff(first))
     assert parsed_tree(first).body[0].targets[0].id == "x_0"  # type: ignore[attr-defined]
     assign = parsed_tree(first).body[0]
-    assert locate_parsed_node(first, type(assign), assign.lineno, assign.col_offset) is assign
+    assert (
+        locate_parsed_node(first, type(assign), assign.lineno, assign.col_offset)
+        is assign
+    )
     assert source_symtable(first) is not None
 
     # Cache never grows past capacity.

--- a/implementations/python/sugar-source-tree/goldens/quirks.py
+++ b/implementations/python/sugar-source-tree/goldens/quirks.py
@@ -18,13 +18,11 @@ d = ()
 a += 2
 del c, d
 
-s_implicit = ("one "
-              "two "
-              "three")
+s_implicit = "one " "two " "three"
 s_f = f"pre {after_unicode!r:>10} post {CONST:{a}} end"
 s_nested = f"outer {f'inner {CONST}'} done"
 s_bytes = b"\x00" b"more"
-s_u = u"legacy"
+s_u = "legacy"
 
 numbers = [1, 2.5, 3j, 0x10, 0o7, 0b11, 1_000, ...]
 mapping = {"k": 1, **{"j": 2}}
@@ -33,7 +31,7 @@ a_set = {1, 2, 3}
 result = system.maxsize + (CONST * 2) - (-CONST)
 shifted = (CONST << 2) | (CONST & 1) ^ (CONST >> 1)
 divided = CONST / 2 // 1 % 2
-powed = CONST ** 2
+powed = CONST**2
 inverted = ~CONST
 truthy = not CONST
 chained = 0 < CONST <= 10 != 11
@@ -46,7 +44,7 @@ comp_gen = (x async for x in aiter) if False else (x for x in range(2))
 nested_comp = [[y for y in range(x)] for x in range(3)]
 
 fn = lambda p, q=1, *rest, kw_only=2, **extra: p + q
-walrus_result = [(n := len(numbers)), n ** 2]
+walrus_result = [(n := len(numbers)), n**2]
 
 multi_call = OD(
     first=1,
@@ -54,11 +52,20 @@ multi_call = OD(
 )
 star_call = print(*numbers[:2], **{"sep": ", "})
 subscripted = numbers[0], numbers[1:2], numbers[::2], mapping["k"]
-sliced = numbers[CONST:CONST + 1:1]
+sliced = numbers[CONST : CONST + 1 : 1]
 
 
-def plain(pos_only, /, normal, with_ann: int, with_def="d", *args,
-          kw1, kw2: float = 2.0, **kwargs) -> str:
+def plain(
+    pos_only,
+    /,
+    normal,
+    with_ann: int,
+    with_def="d",
+    *args,
+    kw1,
+    kw2: float = 2.0,
+    **kwargs,
+) -> str:
     """doc"""
     global CONST
     x: list = []

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
@@ -75,7 +75,9 @@ class Child:
 
     handle: "BackendNode"
 
-    def resolve(self, unit: SourceUnit, reporter: AuditReporter = NULL_REPORTER) -> Node:
+    def resolve(
+        self, unit: SourceUnit, reporter: AuditReporter = NULL_REPORTER
+    ) -> Node:
         return materialize(unit, self.handle, reporter)
 
 
@@ -88,9 +90,7 @@ class MaybeChild:
     def resolve(
         self, unit: SourceUnit, reporter: AuditReporter = NULL_REPORTER
     ) -> Optional[Node]:
-        return (
-            None if self.handle is None else materialize(unit, self.handle, reporter)
-        )
+        return None if self.handle is None else materialize(unit, self.handle, reporter)
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/bench_backends.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/bench_backends.py
@@ -174,5 +174,6 @@ def main(argv: Optional[list[str]] = None) -> int:
     run_throughput(args.backend, args.path, args.limit)
     return 0
 
+
 if __name__ == "__main__":
     sys.exit(main())

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -69,8 +69,6 @@ def join_binding_state(
         return when_true
     if isinstance(when_true, Node) and isinstance(when_false, Node):
         return make_ifexp(slot, when_true, when_false)
-    if isinstance(when_true, UnboundBinding) and isinstance(
-        when_false, UnboundBinding
-    ):
+    if isinstance(when_true, UnboundBinding) and isinstance(when_false, UnboundBinding):
         return UnboundBinding(name=when_true.name, cause=when_true.cause)
     return GuardedBinding(slot=slot, when_true=when_true, when_false=when_false)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/cpython_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/cpython_adapter.py
@@ -281,6 +281,7 @@ def _comprehension_for_anchor(unit: SourceUnit, comp: ast.comprehension) -> Span
         for_start = k - 5
     return Span(for_start, for_start)
 
+
 # kinds the backend does not position: envelope-spanned per the spec
 _ENVELOPE_KINDS = frozenset({"comprehension", "withitem", "match_case"})
 
@@ -386,7 +387,9 @@ def _describe(unit: SourceUnit, node: ast.AST) -> Description:
     else:
         raw_span = _node_span(unit, node)
 
-    return Description(kind=kind, raw_span=raw_span, anchors=anchors, slots=tuple(slots))
+    return Description(
+        kind=kind, raw_span=raw_span, anchors=anchors, slots=tuple(slots)
+    )
 
 
 class CPythonAstBackend(Backend):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/libcst_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/libcst_adapter.py
@@ -95,7 +95,6 @@ from .operators import Operator, operator_for
 from .panic import vocabulary_missing, backend_defect
 from .spans import Span
 
-
 # --------------------------------------------------------------------------
 # Context: the position map, resolved once per parse
 # --------------------------------------------------------------------------
@@ -150,7 +149,9 @@ class _Handle(BackendNode):
         return self._desc
 
     def __repr__(self) -> str:  # pragma: no cover
-        return f"<libcst-handle {type(self._node).__name__} in {self._ctx.unit.filename}>"
+        return (
+            f"<libcst-handle {type(self._node).__name__} in {self._ctx.unit.filename}>"
+        )
 
 
 class _Synth(BackendNode):
@@ -776,7 +777,10 @@ def _r_functiondef(ctx: _Ctx, n: cst.FunctionDef) -> Description:
         ("name", Leaf(n.name.value)),
         ("params", _params(ctx, n.params)),
         ("body", Children(_statements(ctx, n.body))),
-        ("decorators", Children(tuple(_Handle(ctx, d.decorator) for d in n.decorators))),
+        (
+            "decorators",
+            Children(tuple(_Handle(ctx, d.decorator) for d in n.decorators)),
+        ),
         ("returns", _maybe(ctx, _unwrap_annotation(n.returns))),
         ("type_params", _type_params(ctx, n.type_parameters)),
     )
@@ -792,7 +796,10 @@ def _r_classdef(ctx: _Ctx, n: cst.ClassDef) -> Description:
         ("bases", Children(bases)),
         ("keywords", Children(keywords)),
         ("body", Children(_statements(ctx, n.body))),
-        ("decorators", Children(tuple(_Handle(ctx, d.decorator) for d in n.decorators))),
+        (
+            "decorators",
+            Children(tuple(_Handle(ctx, d.decorator) for d in n.decorators)),
+        ),
         ("type_params", _type_params(ctx, n.type_parameters)),
     )
 
@@ -1410,7 +1417,10 @@ def _r_comparison(ctx: _Ctx, n: cst.Comparison) -> Description:
                 tuple(_op(_COMPARE_OPS, t.operator, "compare") for t in n.comparisons)
             ),
         ),
-        ("comparators", Children(tuple(_Handle(ctx, t.comparator) for t in n.comparisons))),
+        (
+            "comparators",
+            Children(tuple(_Handle(ctx, t.comparator) for t in n.comparisons)),
+        ),
     )
 
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -66,7 +66,6 @@ from .binding_state import (
     join_binding_state,
 )
 
-
 # Scope metadata travels beside temporal bindings under an unforgeable key.
 # It lets recognition distinguish a builtin spelling from a lexically bound
 # formal without substituting a fake value for that formal.
@@ -88,6 +87,8 @@ class _ConditionalRaiseRoute:
     slot: BranchResultSlot
     raised_on_true: bool
     exception_name: str
+
+
 _NESTED_COMPREHENSION_TEMPLATE = object()
 
 
@@ -108,9 +109,7 @@ class SourceUnit:
 
     # populated in __post_init__, never by callers
     line_table: LineTable = field(init=False, default=None)  # type: ignore[assignment]
-    module_bound_names: frozenset[str] = field(
-        init=False, default_factory=frozenset
-    )
+    module_bound_names: frozenset[str] = field(init=False, default_factory=frozenset)
     module_symtable: object = field(init=False, default=None)
 
     def __post_init__(self) -> None:
@@ -124,9 +123,7 @@ class SourceUnit:
             frozenset(
                 symbol.get_name()
                 for symbol in symbols
-                if symbol.is_assigned()
-                or symbol.is_imported()
-                or symbol.is_namespace()
+                if symbol.is_assigned() or symbol.is_imported() or symbol.is_namespace()
             ),
         )
 
@@ -1022,8 +1019,7 @@ class FunctionDef(Statement):
         body_scope = {
             **body_scope,
             **{
-                name: UnboundBinding(name=name, cause=self.fragment)
-                for name in locals_
+                name: UnboundBinding(name=name, cause=self.fragment) for name in locals_
             },
             _LEXICALLY_BOUND_NAMES: frozenset(inherited_bound) | bound | locals_,
             _FUNCTION_PARAMETERS: parameters,
@@ -1088,8 +1084,10 @@ class FunctionDef(Statement):
                 ):
                     from pathlib import Path
 
-                    relative = Path(self.unit.filename).resolve().relative_to(
-                        Path(workspace_root).resolve()
+                    relative = (
+                        Path(self.unit.filename)
+                        .resolve()
+                        .relative_to(Path(workspace_root).resolve())
                     )
                     module_parts = list(relative.with_suffix("").parts)
                     if module_parts and module_parts[-1] == "__init__":
@@ -1724,7 +1722,9 @@ class For(Statement):
             return super()._construct_sugar()
         carried, facts = self._carried_and_facts()
         if carried and facts:
-            return super()._construct_sugar()  # accumulator-referencing assert -- point 3
+            return (
+                super()._construct_sugar()
+            )  # accumulator-referencing assert -- point 3
         if carried:
             # Pure fold: the loop states nothing; its meaning is the fold binding
             # (substitution_binding), consumed where the carried name is read.
@@ -2208,9 +2208,7 @@ class With(Statement):
             and isinstance(semantics.enter.sort, PrimitiveSort)
             and semantics.enter.sort.name == "Value"
             and isinstance(semantics.exit.completion, TotalCompletionV1)
-            and isinstance(
-                semantics.exit.disposition, NeverSuppressesDispositionV1
-            )
+            and isinstance(semantics.exit.disposition, NeverSuppressesDispositionV1)
         )
         if not admitted:
             panic = UnsupportedContextManagerSemantics(
@@ -2266,7 +2264,9 @@ class With(Statement):
 
         resolved_ref = self._require_narrow_cm_ref(item)
         if resolved_ref is not None:
-            from sugar_lift_py_tests.context_manager_contract import ProtocolResourceSemanticsV1
+            from sugar_lift_py_tests.context_manager_contract import (
+                ProtocolResourceSemanticsV1,
+            )
             from sugar_lift_py_tests.kit_rpc import ContextManagerEdgeDtoV1
             from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
 
@@ -2279,9 +2279,7 @@ class With(Statement):
                 )
 
             manager_slot = item._manager_slot_id()
-            enter_slot = (
-                f"{manager_slot}#enter_result" if as_name is not None else None
-            )
+            enter_slot = f"{manager_slot}#enter_result" if as_name is not None else None
             return WithResourceSugar(
                 manager=item.context_expr.sugar(),
                 manager_slot_id=manager_slot,
@@ -2456,9 +2454,7 @@ class Try(Statement):
             if d:
                 changed["handlers"] = new_handlers
             for field_name in ("body", "orelse", "finalbody"):
-                new_value, d = self._substitute_body(
-                    getattr(self, field_name), scope
-                )
+                new_value, d = self._substitute_body(getattr(self, field_name), scope)
                 if d:
                     changed[field_name] = new_value
             return self if not changed else rewrite(self, **changed)
@@ -2468,9 +2464,7 @@ class Try(Statement):
         if d:
             changed["body"] = new_body
         body_state = {**scope, **body_net}
-        new_orelse, d, else_net = self._substitute_body_tracked(
-            self.orelse, body_state
-        )
+        new_orelse, d, else_net = self._substitute_body_tracked(self.orelse, body_state)
         if d:
             changed["orelse"] = new_orelse
         body_completion = {**body_net, **else_net}
@@ -2493,9 +2487,7 @@ class Try(Statement):
             if body_changed:
                 handler_changed["body"] = new_handler_body
             rewritten = (
-                handler
-                if not handler_changed
-                else rewrite(handler, **handler_changed)
+                handler if not handler_changed else rewrite(handler, **handler_changed)
             )
             new_handlers.append(rewritten)
             if handler.name:
@@ -2518,9 +2510,7 @@ class Try(Statement):
             if unconditional is not None:
                 include = self._handler_matches(handler, unconditional)
             elif conditional is not None:
-                include = self._handler_matches(
-                    handler, conditional.exception_name
-                )
+                include = self._handler_matches(handler, conditional.exception_name)
             else:
                 include = True
             if include:
@@ -2705,14 +2695,18 @@ class Try(Statement):
                 continue
 
             type_nodes = (
-                handler.type_.elts if handler.type_.kind == "Tuple" else (handler.type_,)
+                handler.type_.elts
+                if handler.type_.kind == "Tuple"
+                else (handler.type_,)
             )
             if not type_nodes:
                 return super()._construct_sugar()  # empty tuple: no honest matcher
             for type_node in type_nodes:
                 type_name = self._except_type_name(type_node)
                 if type_name is None:
-                    return super()._construct_sugar()  # exotic tuple elt/type -- stay loud
+                    return (
+                        super()._construct_sugar()
+                    )  # exotic tuple elt/type -- stay loud
                 handler_specs.append(
                     (
                         EffectMatcher(kind="raise", name=type_name),
@@ -2997,7 +2991,9 @@ class Match(Statement):
                 return super()._construct_sugar()  # `case P if g:` not written
             alternatives = self._pattern_alternatives(case.pattern)
             if alternatives is None:
-                return super()._construct_sugar()  # structural pattern (sequence/class/...)
+                return (
+                    super()._construct_sugar()
+                )  # structural pattern (sequence/class/...)
             specs.append(
                 MatchCaseSpec(
                     alternatives=alternatives,
@@ -3140,11 +3136,15 @@ class Lambda(Expression):
         """
         from .shadow import ShadowNode
 
-        if not isinstance(self.ref, ShadowNode) or len(self.params) != 1 or any(
-            param.param_kind != "positional_or_keyword"
-            or param.default is not None
-            or param.annotation is not None
-            for param in self.params
+        if (
+            not isinstance(self.ref, ShadowNode)
+            or len(self.params) != 1
+            or any(
+                param.param_kind != "positional_or_keyword"
+                or param.default is not None
+                or param.annotation is not None
+                for param in self.params
+            )
         ):
             return super()._construct_sugar()
 
@@ -3234,9 +3234,11 @@ class Set(Expression):
             return SpreadCollectionSugar(
                 kind="set",
                 elements=tuple(
-                    ("python:starred", e.value.sugar())
-                    if isinstance(e, Starred)
-                    else (None, e.sugar())
+                    (
+                        ("python:starred", e.value.sugar())
+                        if isinstance(e, Starred)
+                        else (None, e.sugar())
+                    )
                     for e in self.elts
                 ),
                 site=self.fragment,
@@ -3335,26 +3337,28 @@ class ListComp(Expression):
 
     def _contains_named_expression(self, roots: tuple) -> bool:
         """True when a walrus would bind outside the comprehension coordinate."""
-        return any(
-            node.kind == "NamedExpr" for root in roots for node in root.walk()
-        )
+        return any(node.kind == "NamedExpr" for root in roots for node in root.walk())
 
     def _calls_shadowed_range(self, iterable, scope) -> bool:
         return (
-            iterable.kind == "Call"
-            and iterable.func.kind == "Name"
-            and iterable.func.id == "range"
-            and "range" in scope
-        ) or (
-            iterable.kind == "Call"
-            and iterable.func.kind == "Name"
-            and iterable.func.id == "range"
-            and "range" in scope.get(_LEXICALLY_BOUND_NAMES, ())
-        ) or (
-            iterable.kind == "Call"
-            and iterable.func.kind == "Name"
-            and iterable.func.id == "range"
-            and "range" in self.unit.module_bound_names
+            (
+                iterable.kind == "Call"
+                and iterable.func.kind == "Name"
+                and iterable.func.id == "range"
+                and "range" in scope
+            )
+            or (
+                iterable.kind == "Call"
+                and iterable.func.kind == "Name"
+                and iterable.func.id == "range"
+                and "range" in scope.get(_LEXICALLY_BOUND_NAMES, ())
+            )
+            or (
+                iterable.kind == "Call"
+                and iterable.func.kind == "Name"
+                and iterable.func.id == "range"
+                and "range" in self.unit.module_bound_names
+            )
         )
 
     def _ground_hash_key(self, expression):
@@ -3451,8 +3455,10 @@ class SetComp(Expression):
         ):
             return None
         gen = self.generators[0]
-        if gen.is_async or gen.ifs or ListComp._contains_forbidden_shape(
-            self, (gen.iter,)
+        if (
+            gen.is_async
+            or gen.ifs
+            or ListComp._contains_forbidden_shape(self, (gen.iter,))
         ):
             return None
         new_iter, changed = self._substitute_field(gen.iter, scope)
@@ -3468,9 +3474,7 @@ class SetComp(Expression):
             bindings = For._target_bindings_for(self, gen.target, element)
             if bindings is None:
                 return None
-            new_elt, changed = self._substitute_field(
-                self.elt, {**scope, **bindings}
-            )
+            new_elt, changed = self._substitute_field(self.elt, {**scope, **bindings})
             result = new_elt if changed else self.elt
             key = ListComp._ground_hash_key(self, result)
             if key is None:
@@ -3541,8 +3545,10 @@ class DictComp(Expression):
         ):
             return None
         gen = self.generators[0]
-        if gen.is_async or gen.ifs or ListComp._contains_forbidden_shape(
-            self, (gen.iter,)
+        if (
+            gen.is_async
+            or gen.ifs
+            or ListComp._contains_forbidden_shape(self, (gen.iter,))
         ):
             return None
         new_iter, changed = self._substitute_field(gen.iter, scope)
@@ -3648,6 +3654,7 @@ class GeneratorExp(Expression):
             element=self.elt.sugar(),
             site=self.fragment,
         )
+
 
 class Await(Expression):
     value: Expression
@@ -3770,9 +3777,11 @@ class Call(Expression):
             from sugar_lift_py_tests.sugar.spread_sugar import SpreadCallSugar
 
             arguments = tuple(
-                ("star", None, arg.value.sugar())
-                if isinstance(arg, Starred)
-                else ("positional", None, arg.sugar())
+                (
+                    ("star", None, arg.value.sugar())
+                    if isinstance(arg, Starred)
+                    else ("positional", None, arg.sugar())
+                )
                 for arg in self.args
             ) + tuple(
                 (
@@ -3785,11 +3794,7 @@ class Call(Expression):
             callee_name = self._spread_callee_name(self.func)
             return SpreadCallSugar(
                 callee_name=callee_name,
-                callee=(
-                    None
-                    if isinstance(self.func, Name)
-                    else self.func.sugar()
-                ),
+                callee=(None if isinstance(self.func, Name) else self.func.sugar()),
                 arguments=arguments,
                 site=self.fragment,
             )
@@ -4372,9 +4377,11 @@ class List(Expression):
             return SpreadCollectionSugar(
                 kind="list",
                 elements=tuple(
-                    ("python:starred", e.value.sugar())
-                    if isinstance(e, Starred)
-                    else (None, e.sugar())
+                    (
+                        ("python:starred", e.value.sugar())
+                        if isinstance(e, Starred)
+                        else (None, e.sugar())
+                    )
                     for e in self.elts
                 ),
                 site=self.fragment,
@@ -4402,9 +4409,11 @@ class Tuple_(Expression):
             return SpreadCollectionSugar(
                 kind="tuple",
                 elements=tuple(
-                    ("python:starred", e.value.sugar())
-                    if isinstance(e, Starred)
-                    else (None, e.sugar())
+                    (
+                        ("python:starred", e.value.sugar())
+                        if isinstance(e, Starred)
+                        else (None, e.sugar())
+                    )
                     for e in self.elts
                 ),
                 site=self.fragment,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/operators.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/operators.py
@@ -67,38 +67,50 @@ class ComparisonOperator(Operator):
 class Add(BinaryOperator):
     kind, symbol = "Add", "+"
 
+
 class Sub(BinaryOperator):
     kind, symbol = "Sub", "-"
+
 
 class Mult(BinaryOperator):
     kind, symbol = "Mult", "*"
 
+
 class MatMult(BinaryOperator):
     kind, symbol = "MatMult", "@"
+
 
 class Div(BinaryOperator):
     kind, symbol = "Div", "/"
 
+
 class Mod(BinaryOperator):
     kind, symbol = "Mod", "%"
+
 
 class Pow(BinaryOperator):
     kind, symbol = "Pow", "**"
 
+
 class LShift(BinaryOperator):
     kind, symbol = "LShift", "<<"
+
 
 class RShift(BinaryOperator):
     kind, symbol = "RShift", ">>"
 
+
 class BitOr(BinaryOperator):
     kind, symbol = "BitOr", "|"
+
 
 class BitXor(BinaryOperator):
     kind, symbol = "BitXor", "^"
 
+
 class BitAnd(BinaryOperator):
     kind, symbol = "BitAnd", "&"
+
 
 class FloorDiv(BinaryOperator):
     kind, symbol = "FloorDiv", "//"
@@ -107,11 +119,14 @@ class FloorDiv(BinaryOperator):
 class UAdd(UnaryOperator):
     kind, symbol = "UAdd", "+"
 
+
 class USub(UnaryOperator):
     kind, symbol = "USub", "-"
 
+
 class Not(UnaryOperator):
     kind, symbol = "Not", "not"
+
 
 class Invert(UnaryOperator):
     kind, symbol = "Invert", "~"
@@ -120,6 +135,7 @@ class Invert(UnaryOperator):
 class And(BooleanOperator):
     kind, symbol = "And", "and"
 
+
 class Or(BooleanOperator):
     kind, symbol = "Or", "or"
 
@@ -127,29 +143,38 @@ class Or(BooleanOperator):
 class Eq(ComparisonOperator):
     kind, symbol = "Eq", "=="
 
+
 class NotEq(ComparisonOperator):
     kind, symbol = "NotEq", "!="
+
 
 class Lt(ComparisonOperator):
     kind, symbol = "Lt", "<"
 
+
 class LtE(ComparisonOperator):
     kind, symbol = "LtE", "<="
+
 
 class Gt(ComparisonOperator):
     kind, symbol = "Gt", ">"
 
+
 class GtE(ComparisonOperator):
     kind, symbol = "GtE", ">="
+
 
 class Is(ComparisonOperator):
     kind, symbol = "Is", "is"
 
+
 class IsNot(ComparisonOperator):
     kind, symbol = "IsNot", "is not"
 
+
 class In(ComparisonOperator):
     kind, symbol = "In", "in"
+
 
 class NotIn(ComparisonOperator):
     kind, symbol = "NotIn", "not in"
@@ -158,9 +183,35 @@ class NotIn(ComparisonOperator):
 _OPERATORS: dict[str, type[Operator]] = {
     cls.kind: cls
     for cls in (
-        Add, Sub, Mult, MatMult, Div, Mod, Pow, LShift, RShift, BitOr,
-        BitXor, BitAnd, FloorDiv, UAdd, USub, Not, Invert, And, Or,
-        Eq, NotEq, Lt, LtE, Gt, GtE, Is, IsNot, In, NotIn,
+        Add,
+        Sub,
+        Mult,
+        MatMult,
+        Div,
+        Mod,
+        Pow,
+        LShift,
+        RShift,
+        BitOr,
+        BitXor,
+        BitAnd,
+        FloorDiv,
+        UAdd,
+        USub,
+        Not,
+        Invert,
+        And,
+        Or,
+        Eq,
+        NotEq,
+        Lt,
+        LtE,
+        Gt,
+        GtE,
+        Is,
+        IsNot,
+        In,
+        NotIn,
     )
 }
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -145,7 +145,14 @@ class ContextManagerResolutionConstructionGap(WithConstructionGap):
 
     _LABEL = "CONTEXT MANAGER RESOLUTION GAP"
 
-    def __init__(self, *, kind: str, demand_cid: str, candidate_member_cids: tuple[str, ...], **kwargs) -> None:
+    def __init__(
+        self,
+        *,
+        kind: str,
+        demand_cid: str,
+        candidate_member_cids: tuple[str, ...],
+        **kwargs,
+    ) -> None:
         super().__init__(
             gap_kind=WithConstructionGapKind(kind),
             demand_cid=demand_cid,
@@ -222,8 +229,12 @@ class BackendDefect(SourceTreePanic):
     _LABEL = "BACKEND DEFECT"
 
 
-def vocabulary_missing(owner: str, observed: str, requested: str, fix: str) -> "VocabularyMissing":
-    raise VocabularyMissing(owner=owner, observed=observed, requested=requested, fix=fix)
+def vocabulary_missing(
+    owner: str, observed: str, requested: str, fix: str
+) -> "VocabularyMissing":
+    raise VocabularyMissing(
+        owner=owner, observed=observed, requested=requested, fix=fix
+    )
 
 
 def backend_defect(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/parso_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/parso_adapter.py
@@ -136,9 +136,15 @@ class _Fixed(BackendNode):
         return f"<parso-fixed {self._desc.kind}>"
 
 
-def _fixed(kind: str, raw_span: Optional[Span], slots: Tuple[Tuple[str, Slot], ...],
-           anchors: Tuple[Span, ...] = ()) -> _Fixed:
-    return _Fixed(Description(kind=kind, raw_span=raw_span, anchors=anchors, slots=slots))
+def _fixed(
+    kind: str,
+    raw_span: Optional[Span],
+    slots: Tuple[Tuple[str, Slot], ...],
+    anchors: Tuple[Span, ...] = (),
+) -> _Fixed:
+    return _Fixed(
+        Description(kind=kind, raw_span=raw_span, anchors=anchors, slots=slots)
+    )
 
 
 def _h(unit: SourceUnit, node: ParsoNode) -> BackendNode:
@@ -150,18 +156,43 @@ def _h(unit: SourceUnit, node: ParsoNode) -> BackendNode:
 # --------------------------------------------------------------------------
 
 _BIN_TOKEN = {
-    "+": "Add", "-": "Sub", "*": "Mult", "@": "MatMult", "/": "Div",
-    "%": "Mod", "**": "Pow", "<<": "LShift", ">>": "RShift", "|": "BitOr",
-    "^": "BitXor", "&": "BitAnd", "//": "FloorDiv",
+    "+": "Add",
+    "-": "Sub",
+    "*": "Mult",
+    "@": "MatMult",
+    "/": "Div",
+    "%": "Mod",
+    "**": "Pow",
+    "<<": "LShift",
+    ">>": "RShift",
+    "|": "BitOr",
+    "^": "BitXor",
+    "&": "BitAnd",
+    "//": "FloorDiv",
 }
 _AUG_TOKEN = {
-    "+=": "Add", "-=": "Sub", "*=": "Mult", "@=": "MatMult", "/=": "Div",
-    "%=": "Mod", "**=": "Pow", "<<=": "LShift", ">>=": "RShift", "|=": "BitOr",
-    "^=": "BitXor", "&=": "BitAnd", "//=": "FloorDiv",
+    "+=": "Add",
+    "-=": "Sub",
+    "*=": "Mult",
+    "@=": "MatMult",
+    "/=": "Div",
+    "%=": "Mod",
+    "**=": "Pow",
+    "<<=": "LShift",
+    ">>=": "RShift",
+    "|=": "BitOr",
+    "^=": "BitXor",
+    "&=": "BitAnd",
+    "//=": "FloorDiv",
 }
 _UNARY_TOKEN = {"+": "UAdd", "-": "USub", "~": "Invert"}
 _CMP_TOKEN = {
-    "<": "Lt", ">": "Gt", "==": "Eq", ">=": "GtE", "<=": "LtE", "<>": "NotEq",
+    "<": "Lt",
+    ">": "Gt",
+    "==": "Eq",
+    ">=": "GtE",
+    "<=": "LtE",
+    "<>": "NotEq",
     "!=": "NotEq",
 }
 
@@ -268,7 +299,9 @@ def _compare(unit: SourceUnit, node: ParsoNode) -> Description:
     )
 
 
-def _bare_tuple(unit: SourceUnit, elts: Sequence[ParsoNode], unit_span: Optional[Span] = None) -> BackendNode:
+def _bare_tuple(
+    unit: SourceUnit, elts: Sequence[ParsoNode], unit_span: Optional[Span] = None
+) -> BackendNode:
     handles = tuple(_h(unit, e) for e in elts)
     return _fixed("Tuple", unit_span, (("elts", Children(handles)),))
 
@@ -321,7 +354,9 @@ def _join_string_pieces(unit: SourceUnit, pieces: Sequence[ParsoNode]) -> Backen
     # plain string(s): concatenate python-literal values
     import ast as _pyast  # value decoding only — never structure; see docstring
 
-    text = "".join(unit.source[_span(unit, p).start:_span(unit, p).end] for p in pieces)
+    text = "".join(
+        unit.source[_span(unit, p).start : _span(unit, p).end] for p in pieces
+    )
     try:
         value = _pyast.literal_eval(text)
     except Exception:
@@ -330,7 +365,9 @@ def _join_string_pieces(unit: SourceUnit, pieces: Sequence[ParsoNode]) -> Backen
 
 
 # _Fixed has no _replace_value; build Constant directly instead.
-def _fixed_constant(span: Span, value: object, literal_kind: Optional[str] = None) -> BackendNode:
+def _fixed_constant(
+    span: Span, value: object, literal_kind: Optional[str] = None
+) -> BackendNode:
     return _fixed(
         "Constant",
         span,
@@ -340,13 +377,15 @@ def _fixed_constant(span: Span, value: object, literal_kind: Optional[str] = Non
 
 def _constant_leaf(unit: SourceUnit, node: ParsoNode) -> BackendNode:
     span = _span(unit, node)
-    text = unit.source[span.start:span.end]
+    text = unit.source[span.start : span.end]
     if node.type == "number":
         import ast as _pyast
+
         value = _pyast.literal_eval(text)
         return _fixed_constant(span, value)
     if node.type == "string":
         import ast as _pyast
+
         try:
             value = _pyast.literal_eval(text)
         except Exception:
@@ -371,7 +410,7 @@ def _fstring_values(unit: SourceUnit, node: ParsoNode) -> List[BackendNode]:
     for c in _kids(node):
         if c.type == "fstring_string":
             span = _span(unit, c)
-            out.append(_fixed_constant(span, unit.source[span.start:span.end]))
+            out.append(_fixed_constant(span, unit.source[span.start : span.end]))
         elif c.type == "fstring_expr":
             out.append(_h(unit, c))
         elif c.type in ("fstring_start", "fstring_end"):
@@ -439,8 +478,13 @@ def _describe_fstring_expr(unit: SourceUnit, node: ParsoNode) -> Description:
     )
 
 
-def _fold_trailers(unit: SourceUnit, atom: ParsoNode, trailers: Sequence[ParsoNode],
-                    has_await: bool, await_start: Optional[int]) -> BackendNode:
+def _fold_trailers(
+    unit: SourceUnit,
+    atom: ParsoNode,
+    trailers: Sequence[ParsoNode],
+    has_await: bool,
+    await_start: Optional[int],
+) -> BackendNode:
     base_start = _span(unit, atom).start
     acc: BackendNode = _h(unit, atom)
     for tr in trailers:
@@ -480,17 +524,24 @@ def _fold_trailers(unit: SourceUnit, atom: ParsoNode, trailers: Sequence[ParsoNo
                 fix="extend _fold_trailers deliberately",
             )
     if has_await:
-        acc = _fixed("Await", Span(await_start, end if trailers else _span(unit, atom).end),
-                      (("value", Child(acc)),))
+        acc = _fixed(
+            "Await",
+            Span(await_start, end if trailers else _span(unit, atom).end),
+            (("value", Child(acc)),),
+        )
     return acc
 
 
-def _call_args(unit: SourceUnit, inner: Sequence[ParsoNode]) -> Tuple[List[BackendNode], List[BackendNode]]:
+def _call_args(
+    unit: SourceUnit, inner: Sequence[ParsoNode]
+) -> Tuple[List[BackendNode], List[BackendNode]]:
     if len(inner) == 1 and inner[0].type == "arglist":
         inner = _kids(inner[0])
     inner = _strip_commas(inner)
-    if len(inner) == 1 and inner[0].type == "argument" and any(
-        c.type in ("comp_for", "sync_comp_for") for c in _kids(inner[0])
+    if (
+        len(inner) == 1
+        and inner[0].type == "argument"
+        and any(c.type in ("comp_for", "sync_comp_for") for c in _kids(inner[0]))
     ):
         # bare generator expression as the sole call argument
         ik = _kids(inner[0])
@@ -502,17 +553,32 @@ def _call_args(unit: SourceUnit, inner: Sequence[ParsoNode]) -> Tuple[List[Backe
         if item.type == "argument":
             ik = _kids(item)
             if _is_leaf(ik[0]) and ik[0].value == "**":
-                keywords.append(_fixed("Keyword", None,
-                                        (("arg", SlotLeaf(None)), ("value", Child(_h(unit, ik[1]))))))
+                keywords.append(
+                    _fixed(
+                        "Keyword",
+                        None,
+                        (("arg", SlotLeaf(None)), ("value", Child(_h(unit, ik[1])))),
+                    )
+                )
             elif _is_leaf(ik[0]) and ik[0].value == "*":
-                args.append(_fixed("Starred", Span(_span(unit, item).start, _span(unit, item).end),
-                                    (("value", Child(_h(unit, ik[1]))),)))
+                args.append(
+                    _fixed(
+                        "Starred",
+                        Span(_span(unit, item).start, _span(unit, item).end),
+                        (("value", Child(_h(unit, ik[1]))),),
+                    )
+                )
             elif len(ik) >= 2 and _is_leaf(ik[1]) and ik[1].value == "=":
-                keywords.append(_fixed(
-                    "Keyword",
-                    Span(_span(unit, item).start, _span(unit, item).end),
-                    (("arg", SlotLeaf(ik[0].value)), ("value", Child(_h(unit, ik[2])))),
-                ))
+                keywords.append(
+                    _fixed(
+                        "Keyword",
+                        Span(_span(unit, item).start, _span(unit, item).end),
+                        (
+                            ("arg", SlotLeaf(ik[0].value)),
+                            ("value", Child(_h(unit, ik[2]))),
+                        ),
+                    )
+                )
             else:
                 vocabulary_missing(
                     owner="parso_adapter._call_args",
@@ -524,7 +590,11 @@ def _call_args(unit: SourceUnit, inner: Sequence[ParsoNode]) -> Tuple[List[Backe
             continue  # handled as part of an 'argument' pairing above in real grammars
         elif item.type == "star_expr":
             sk = _kids(item)
-            args.append(_fixed("Starred", _span(unit, item), (("value", Child(_h(unit, sk[1]))),)))
+            args.append(
+                _fixed(
+                    "Starred", _span(unit, item), (("value", Child(_h(unit, sk[1]))),)
+                )
+            )
         else:
             args.append(_h(unit, item))
     return args, keywords
@@ -583,7 +653,9 @@ def _one_subscript_item(unit: SourceUnit, node: ParsoNode) -> BackendNode:
 # --------------------------------------------------------------------------
 
 
-def _flatten_params(unit: SourceUnit, node: Optional[ParsoNode]) -> Tuple[BackendNode, ...]:
+def _flatten_params(
+    unit: SourceUnit, node: Optional[ParsoNode]
+) -> Tuple[BackendNode, ...]:
     if node is None:
         return ()
     if node.type == "param":
@@ -595,12 +667,19 @@ def _flatten_params(unit: SourceUnit, node: Optional[ParsoNode]) -> Tuple[Backen
     if node.type == "name":
         # a single plain (no annotation, no default) parameter collapses all
         # the way down to a bare Name leaf when it is the only parameter.
-        return (_fixed(
-            "Param", None,
-            (("name", SlotLeaf(node.value)), ("annotation", MaybeChild(None)),
-             ("default", MaybeChild(None)), ("param_kind", SlotLeaf("positional_or_keyword"))),
-            anchors=(_span(unit, node),),
-        ),)
+        return (
+            _fixed(
+                "Param",
+                None,
+                (
+                    ("name", SlotLeaf(node.value)),
+                    ("annotation", MaybeChild(None)),
+                    ("default", MaybeChild(None)),
+                    ("param_kind", SlotLeaf("positional_or_keyword")),
+                ),
+                anchors=(_span(unit, node),),
+            ),
+        )
     kids = _kids(node)
     if node.type == "parameters":
         kids = kids[1:-1]  # drop '(' ')'
@@ -614,8 +693,11 @@ def _flatten_params(unit: SourceUnit, node: Optional[ParsoNode]) -> Tuple[Backen
                 pass  # positional-only marker: retroactive tagging not needed —
                 # every param before '/' was already emitted; re-tag them.
             params = [
-                p if p.describe().slots[3][1].value != "positional_or_keyword"
-                else _retag(p, "positional_only")
+                (
+                    p
+                    if p.describe().slots[3][1].value != "positional_or_keyword"
+                    else _retag(p, "positional_only")
+                )
                 for p in params
             ]
             continue
@@ -673,7 +755,10 @@ def _one_param(unit: SourceUnit, node: ParsoNode, kind: str) -> BackendNode:
         None,
         (
             ("name", SlotLeaf(name_node.value)),
-            ("annotation", MaybeChild(_h(unit, annotation) if annotation is not None else None)),
+            (
+                "annotation",
+                MaybeChild(_h(unit, annotation) if annotation is not None else None),
+            ),
             ("default", MaybeChild(_h(unit, default) if default is not None else None)),
             ("param_kind", SlotLeaf(kind)),
         ),
@@ -741,8 +826,12 @@ def _describe(unit: SourceUnit, node: ParsoNode) -> Description:
 
 def _describe_leaf(unit: SourceUnit, node: ParsoNode) -> Description:
     if node.type == "name":
-        return Description(kind="Name", raw_span=_span(unit, node), anchors=(),
-                             slots=(("id", SlotLeaf(node.value)),))
+        return Description(
+            kind="Name",
+            raw_span=_span(unit, node),
+            anchors=(),
+            slots=(("id", SlotLeaf(node.value)),),
+        )
     if node.type in ("number", "string"):
         d = _constant_leaf(unit, node)
         return d.describe()
@@ -751,27 +840,58 @@ def _describe_leaf(unit: SourceUnit, node: ParsoNode) -> Description:
     if node.type == "operator" and node.value == "...":
         return _constant_leaf(unit, node).describe()
     if node.type == "fstring":
-        return _fixed("JoinedStr", _span(unit, node),
-                       (("values", Children(tuple(_fstring_values(unit, node)))),)).describe()
+        return _fixed(
+            "JoinedStr",
+            _span(unit, node),
+            (("values", Children(tuple(_fstring_values(unit, node)))),),
+        ).describe()
     if node.type == "keyword" and node.value == "pass":
-        return Description(kind="Pass", raw_span=_span(unit, node), anchors=(), slots=())
+        return Description(
+            kind="Pass", raw_span=_span(unit, node), anchors=(), slots=()
+        )
     if node.type == "keyword" and node.value == "break":
-        return Description(kind="Break", raw_span=_span(unit, node), anchors=(), slots=())
+        return Description(
+            kind="Break", raw_span=_span(unit, node), anchors=(), slots=()
+        )
     if node.type == "keyword" and node.value == "continue":
-        return Description(kind="Continue", raw_span=_span(unit, node), anchors=(), slots=())
+        return Description(
+            kind="Continue", raw_span=_span(unit, node), anchors=(), slots=()
+        )
     if node.type == "keyword" and node.value == "return":
         # bare `return` with no value: parso collapses the return_stmt
         # wrapper down to just this keyword leaf (single-child collapsing).
-        return Description(kind="Return", raw_span=_span(unit, node), anchors=(), slots=(("value", MaybeChild(None)),))
+        return Description(
+            kind="Return",
+            raw_span=_span(unit, node),
+            anchors=(),
+            slots=(("value", MaybeChild(None)),),
+        )
     if node.type == "keyword" and node.value == "raise":
-        return Description(kind="Raise", raw_span=_span(unit, node), anchors=(),
-                            slots=(("exc", MaybeChild(None)), ("cause", MaybeChild(None))))
+        return Description(
+            kind="Raise",
+            raw_span=_span(unit, node),
+            anchors=(),
+            slots=(("exc", MaybeChild(None)), ("cause", MaybeChild(None))),
+        )
     if node.type == "keyword" and node.value == "yield":
-        return Description(kind="Yield", raw_span=_span(unit, node), anchors=(), slots=(("value", MaybeChild(None)),))
+        return Description(
+            kind="Yield",
+            raw_span=_span(unit, node),
+            anchors=(),
+            slots=(("value", MaybeChild(None)),),
+        )
     if node.type == "operator" and node.value == ":":
         # bare `a[:]`: subscript's slice collapses to just the ':' leaf.
-        return Description(kind="Slice", raw_span=_span(unit, node), anchors=(),
-                            slots=(("lower", MaybeChild(None)), ("upper", MaybeChild(None)), ("step", MaybeChild(None))))
+        return Description(
+            kind="Slice",
+            raw_span=_span(unit, node),
+            anchors=(),
+            slots=(
+                ("lower", MaybeChild(None)),
+                ("upper", MaybeChild(None)),
+                ("step", MaybeChild(None)),
+            ),
+        )
     vocabulary_missing(
         owner="parso_adapter._describe_leaf",
         observed=f"leaf {node.type}:{node.value!r} has no translation rule",
@@ -787,8 +907,12 @@ def _module(unit: SourceUnit, node: ParsoNode) -> Description:
         if c.type in ("endmarker", "newline"):
             continue
         body.extend(_stmt_handles(unit, c))
-    return Description(kind="Module", raw_span=Span(0, len(unit.source)), anchors=(),
-                        slots=(("body", Children(tuple(body))),))
+    return Description(
+        kind="Module",
+        raw_span=Span(0, len(unit.source)),
+        anchors=(),
+        slots=(("body", Children(tuple(body))),),
+    )
 
 
 def _atom(unit: SourceUnit, node: ParsoNode) -> Description:
@@ -802,7 +926,11 @@ def _atom(unit: SourceUnit, node: ParsoNode) -> Description:
             return _describe(unit, inner)
         if inner.type == "testlist_comp":
             ik = _kids(inner)
-            if len(ik) >= 2 and ik[1].type == "comp_for" or (len(ik) >= 2 and ik[1].type == "sync_comp_for"):
+            if (
+                len(ik) >= 2
+                and ik[1].type == "comp_for"
+                or (len(ik) >= 2 and ik[1].type == "sync_comp_for")
+            ):
                 return _genexp(unit, ik[0], ik[1:]).describe()
             elts = _strip_commas(ik)
             has_trailing_comma = _is_leaf(ik[-1]) and ik[-1].value == ","
@@ -814,25 +942,45 @@ def _atom(unit: SourceUnit, node: ParsoNode) -> Description:
         return _describe(unit, inner)
     if _is_leaf(first) and first.value == "[":
         if len(kids) == 2:
-            return Description(kind="List", raw_span=_span(unit, node), anchors=(),
-                                slots=(("elts", Children(())),))
+            return Description(
+                kind="List",
+                raw_span=_span(unit, node),
+                anchors=(),
+                slots=(("elts", Children(())),),
+            )
         inner = kids[1]
         if inner.type in ("testlist_comp",):
             ik = _kids(inner)
             if len(ik) >= 2 and ik[1].type in ("comp_for", "sync_comp_for"):
                 elt = _h(unit, ik[0])
                 gens = _comp_clauses(unit, ik[1:])
-                return Description(kind="ListComp", raw_span=_span(unit, node), anchors=(),
-                                    slots=(("elt", Child(elt)), ("generators", Children(gens))))
+                return Description(
+                    kind="ListComp",
+                    raw_span=_span(unit, node),
+                    anchors=(),
+                    slots=(("elt", Child(elt)), ("generators", Children(gens))),
+                )
             elts = _strip_commas(ik)
-            return Description(kind="List", raw_span=_span(unit, node), anchors=(),
-                                slots=(("elts", Children(tuple(_h(unit, e) for e in elts))),))
-        return Description(kind="List", raw_span=_span(unit, node), anchors=(),
-                            slots=(("elts", Children((_h(unit, inner),))),))
+            return Description(
+                kind="List",
+                raw_span=_span(unit, node),
+                anchors=(),
+                slots=(("elts", Children(tuple(_h(unit, e) for e in elts))),),
+            )
+        return Description(
+            kind="List",
+            raw_span=_span(unit, node),
+            anchors=(),
+            slots=(("elts", Children((_h(unit, inner),))),),
+        )
     if _is_leaf(first) and first.value == "{":
         if len(kids) == 2:
-            return Description(kind="Dict", raw_span=_span(unit, node), anchors=(),
-                                slots=(("items", Children(())),))
+            return Description(
+                kind="Dict",
+                raw_span=_span(unit, node),
+                anchors=(),
+                slots=(("items", Children(())),),
+            )
         return _dictorset(unit, node, kids[1])
     if first.type == "fstring":
         return _describe(unit, first)
@@ -852,13 +1000,22 @@ def _dictorset(unit: SourceUnit, atom_node: ParsoNode, inner: ParsoNode) -> Desc
         has_colon = any(_is_leaf(c) and c.value == ":" for c in ik)
         has_comp = any(c.type in ("comp_for", "sync_comp_for") for c in ik)
         if has_colon and has_comp:
-            colon_i = next(i for i, c in enumerate(ik) if _is_leaf(c) and c.value == ":")
+            colon_i = next(
+                i for i, c in enumerate(ik) if _is_leaf(c) and c.value == ":"
+            )
             key = _h(unit, ik[0])
             value = _h(unit, ik[colon_i + 1])
-            gens = _comp_clauses(unit, ik[colon_i + 2:])
-            return Description(kind="DictComp", raw_span=span, anchors=(),
-                                slots=(("key", Child(key)), ("value", Child(value)),
-                                       ("generators", Children(gens))))
+            gens = _comp_clauses(unit, ik[colon_i + 2 :])
+            return Description(
+                kind="DictComp",
+                raw_span=span,
+                anchors=(),
+                slots=(
+                    ("key", Child(key)),
+                    ("value", Child(value)),
+                    ("generators", Children(gens)),
+                ),
+            )
         if has_colon:
             items: List[BackendNode] = []
             i = 0
@@ -868,31 +1025,65 @@ def _dictorset(unit: SourceUnit, atom_node: ParsoNode, inner: ParsoNode) -> Desc
                     i += 1
                     continue
                 if _is_leaf(c) and c.value == "**":
-                    items.append(_fixed("DictItem", None,
-                                         (("key", MaybeChild(None)), ("value", Child(_h(unit, ik[i + 1]))))))
+                    items.append(
+                        _fixed(
+                            "DictItem",
+                            None,
+                            (
+                                ("key", MaybeChild(None)),
+                                ("value", Child(_h(unit, ik[i + 1]))),
+                            ),
+                        )
+                    )
                     i += 2
                     continue
                 key_n = c
                 value_n = ik[i + 2]
-                items.append(_fixed("DictItem", None,
-                                     (("key", MaybeChild(_h(unit, key_n))), ("value", Child(_h(unit, value_n))))))
+                items.append(
+                    _fixed(
+                        "DictItem",
+                        None,
+                        (
+                            ("key", MaybeChild(_h(unit, key_n))),
+                            ("value", Child(_h(unit, value_n))),
+                        ),
+                    )
+                )
                 i += 3
-            return Description(kind="Dict", raw_span=span, anchors=(),
-                                slots=(("items", Children(tuple(items))),))
+            return Description(
+                kind="Dict",
+                raw_span=span,
+                anchors=(),
+                slots=(("items", Children(tuple(items))),),
+            )
         if has_comp:
             elt = _h(unit, ik[0])
             gens = _comp_clauses(unit, ik[1:])
-            return Description(kind="SetComp", raw_span=span, anchors=(),
-                                slots=(("elt", Child(elt)), ("generators", Children(gens))))
+            return Description(
+                kind="SetComp",
+                raw_span=span,
+                anchors=(),
+                slots=(("elt", Child(elt)), ("generators", Children(gens))),
+            )
         elts = _strip_commas(ik)
-        return Description(kind="Set", raw_span=span, anchors=(),
-                            slots=(("elts", Children(tuple(_h(unit, e) for e in elts))),))
+        return Description(
+            kind="Set",
+            raw_span=span,
+            anchors=(),
+            slots=(("elts", Children(tuple(_h(unit, e) for e in elts))),),
+        )
     # single element -> a one-item set
-    return Description(kind="Set", raw_span=span, anchors=(),
-                        slots=(("elts", Children((_h(unit, inner),))),))
+    return Description(
+        kind="Set",
+        raw_span=span,
+        anchors=(),
+        slots=(("elts", Children((_h(unit, inner),))),),
+    )
 
 
-def _comp_clauses(unit: SourceUnit, nodes: Sequence[ParsoNode]) -> Tuple[BackendNode, ...]:
+def _comp_clauses(
+    unit: SourceUnit, nodes: Sequence[ParsoNode]
+) -> Tuple[BackendNode, ...]:
     out: List[BackendNode] = []
     for n in nodes:
         if n.type in ("comp_for", "sync_comp_for"):
@@ -961,10 +1152,14 @@ def _comprehension(unit: SourceUnit, node: ParsoNode) -> Description:
     )
 
 
-def _genexp(unit: SourceUnit, elt_node: ParsoNode, clause_nodes: Sequence[ParsoNode]) -> BackendNode:
+def _genexp(
+    unit: SourceUnit, elt_node: ParsoNode, clause_nodes: Sequence[ParsoNode]
+) -> BackendNode:
     elt = _h(unit, elt_node)
     gens = _comp_clauses(unit, clause_nodes)
-    return _fixed("GeneratorExp", None, (("elt", Child(elt)), ("generators", Children(gens))))
+    return _fixed(
+        "GeneratorExp", None, (("elt", Child(elt)), ("generators", Children(gens)))
+    )
 
 
 # ---- statements -----------------------------------------------------------
@@ -974,16 +1169,26 @@ def _expr_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
     kids = _kids(node)
     span = _span(unit, node)
     # annotated assignment: NAME ':' test ['=' test]
-    colon_idx = next((i for i, c in enumerate(kids) if _is_leaf(c) and c.value == ":"), None)
+    colon_idx = next(
+        (i for i, c in enumerate(kids) if _is_leaf(c) and c.value == ":"), None
+    )
     if colon_idx is not None:
         target = _h(unit, kids[0])
         annotation = _h(unit, kids[colon_idx + 1])
         value = None
         if len(kids) > colon_idx + 2:
             value = _h(unit, kids[colon_idx + 3])
-        return Description(kind="AnnAssign", raw_span=span, anchors=(),
-                            slots=(("target", Child(target)), ("annotation", Child(annotation)),
-                                   ("value", MaybeChild(value)), ("simple", SlotLeaf(True))))
+        return Description(
+            kind="AnnAssign",
+            raw_span=span,
+            anchors=(),
+            slots=(
+                ("target", Child(target)),
+                ("annotation", Child(annotation)),
+                ("value", MaybeChild(value)),
+                ("simple", SlotLeaf(True)),
+            ),
+        )
     if len(kids) == 1:
         return _describe(unit, kids[0])
     op = kids[1]
@@ -991,10 +1196,17 @@ def _expr_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
         # parso wraps `: annotation [= value]` in one annassign node.
         ann_kids = _kids(op)  # [':', annotation] or [':', annotation, '=', value]
         value = _h(unit, ann_kids[3]) if len(ann_kids) > 3 else None
-        return Description(kind="AnnAssign", raw_span=span, anchors=(),
-                            slots=(("target", Child(_h(unit, kids[0]))),
-                                   ("annotation", Child(_h(unit, ann_kids[1]))),
-                                   ("value", MaybeChild(value)), ("simple", SlotLeaf(True))))
+        return Description(
+            kind="AnnAssign",
+            raw_span=span,
+            anchors=(),
+            slots=(
+                ("target", Child(_h(unit, kids[0]))),
+                ("annotation", Child(_h(unit, ann_kids[1]))),
+                ("value", MaybeChild(value)),
+                ("simple", SlotLeaf(True)),
+            ),
+        )
     if not _is_leaf(op):
         vocabulary_missing(
             owner="parso_adapter._expr_stmt",
@@ -1005,9 +1217,15 @@ def _expr_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
     if op.value == "=":
         targets = [kids[0]] + [kids[i] for i in range(2, len(kids) - 1, 2)]
         value = kids[-1]
-        return Description(kind="Assign", raw_span=span, anchors=(),
-                            slots=(("targets", Children(tuple(_h(unit, t) for t in targets))),
-                                   ("value", Child(_h(unit, value)))))
+        return Description(
+            kind="Assign",
+            raw_span=span,
+            anchors=(),
+            slots=(
+                ("targets", Children(tuple(_h(unit, t) for t in targets))),
+                ("value", Child(_h(unit, value))),
+            ),
+        )
     aug_kind = _AUG_TOKEN.get(op.value)
     if aug_kind is None:
         vocabulary_missing(
@@ -1016,34 +1234,63 @@ def _expr_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
             requested="'=' (chained) or an augmented-assignment token",
             fix="extend _expr_stmt deliberately",
         )
-    return Description(kind="AugAssign", raw_span=span, anchors=(),
-                        slots=(("target", Child(_h(unit, kids[0]))),
-                               ("op", OpLeaf(operator_for(aug_kind))),
-                               ("value", Child(_h(unit, kids[2])))))
+    return Description(
+        kind="AugAssign",
+        raw_span=span,
+        anchors=(),
+        slots=(
+            ("target", Child(_h(unit, kids[0]))),
+            ("op", OpLeaf(operator_for(aug_kind))),
+            ("value", Child(_h(unit, kids[2]))),
+        ),
+    )
 
 
 def _return_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
     kids = _kids(node)
     value = _h(unit, kids[1]) if len(kids) > 1 else None
-    return Description(kind="Return", raw_span=_span(unit, node), anchors=(),
-                        slots=(("value", MaybeChild(value)),))
+    return Description(
+        kind="Return",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("value", MaybeChild(value)),),
+    )
 
 
 def _yield_expr(unit: SourceUnit, node: ParsoNode) -> Description:
     kids = _kids(node)
     span = _span(unit, node)
     if len(kids) == 1:
-        return Description(kind="Yield", raw_span=span, anchors=(), slots=(("value", MaybeChild(None)),))
+        return Description(
+            kind="Yield",
+            raw_span=span,
+            anchors=(),
+            slots=(("value", MaybeChild(None)),),
+        )
     arg = kids[1]
     if arg.type == "yield_arg":
         ak = _kids(arg)
-        return Description(kind="YieldFrom", raw_span=span, anchors=(),
-                            slots=(("value", Child(_h(unit, ak[1]))),))
+        return Description(
+            kind="YieldFrom",
+            raw_span=span,
+            anchors=(),
+            slots=(("value", Child(_h(unit, ak[1]))),),
+        )
     if arg.type == "testlist_star_expr" or arg.type == "testlist":
         elts = _strip_commas(_kids(arg))
         value = _bare_tuple(unit, elts) if len(elts) > 1 else _h(unit, elts[0])
-        return Description(kind="Yield", raw_span=span, anchors=(), slots=(("value", MaybeChild(value)),))
-    return Description(kind="Yield", raw_span=span, anchors=(), slots=(("value", MaybeChild(_h(unit, arg))),))
+        return Description(
+            kind="Yield",
+            raw_span=span,
+            anchors=(),
+            slots=(("value", MaybeChild(value)),),
+        )
+    return Description(
+        kind="Yield",
+        raw_span=span,
+        anchors=(),
+        slots=(("value", MaybeChild(_h(unit, arg))),),
+    )
 
 
 def _raise_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
@@ -1053,9 +1300,15 @@ def _raise_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
         exc = kids[1]
         if len(kids) > 2:
             cause = kids[3]
-    return Description(kind="Raise", raw_span=_span(unit, node), anchors=(),
-                        slots=(("exc", MaybeChild(_h(unit, exc) if exc is not None else None)),
-                               ("cause", MaybeChild(_h(unit, cause) if cause is not None else None))))
+    return Description(
+        kind="Raise",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("exc", MaybeChild(_h(unit, exc) if exc is not None else None)),
+            ("cause", MaybeChild(_h(unit, cause) if cause is not None else None)),
+        ),
+    )
 
 
 def _del_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
@@ -1065,21 +1318,31 @@ def _del_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
         elts = _strip_commas(_kids(target))
     else:
         elts = [target]
-    return Description(kind="Delete", raw_span=_span(unit, node), anchors=(),
-                        slots=(("targets", Children(tuple(_h(unit, e) for e in elts))),))
+    return Description(
+        kind="Delete",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("targets", Children(tuple(_h(unit, e) for e in elts))),),
+    )
 
 
 def _import_name(unit: SourceUnit, node: ParsoNode) -> Description:
     kids = _kids(node)
     dotted = kids[1]
     names = _dotted_as_names(unit, dotted)
-    return Description(kind="Import", raw_span=_span(unit, node), anchors=(),
-                        slots=(("names", Children(names)),))
+    return Description(
+        kind="Import",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("names", Children(names)),),
+    )
 
 
 def _dotted_name_str(node: ParsoNode) -> str:
     if node.type == "dotted_name":
-        return "".join(c.value for c in _kids(node) if not (_is_leaf(c) and c.value == "."))
+        return "".join(
+            c.value for c in _kids(node) if not (_is_leaf(c) and c.value == ".")
+        )
     return node.value
 
 
@@ -1102,8 +1365,11 @@ def _dotted_as_name(unit: SourceUnit, node: ParsoNode) -> BackendNode:
     else:
         name = _dotted_name_str(node)
         asname = None
-    return _fixed("ImportAlias", _span(unit, node),
-                  (("name", SlotLeaf(name)), ("asname", SlotLeaf(asname))))
+    return _fixed(
+        "ImportAlias",
+        _span(unit, node),
+        (("name", SlotLeaf(name)), ("asname", SlotLeaf(asname))),
+    )
 
 
 def _import_from(unit: SourceUnit, node: ParsoNode) -> Description:
@@ -1120,14 +1386,27 @@ def _import_from(unit: SourceUnit, node: ParsoNode) -> Description:
     assert _is_leaf(kids[i]) and kids[i].value == "import"
     i += 1
     if _is_leaf(kids[i]) and kids[i].value == "*":
-        names = (_fixed("ImportAlias", _span(unit, kids[i]), (("name", SlotLeaf("*")), ("asname", SlotLeaf(None)))),)
+        names = (
+            _fixed(
+                "ImportAlias",
+                _span(unit, kids[i]),
+                (("name", SlotLeaf("*")), ("asname", SlotLeaf(None))),
+            ),
+        )
     elif _is_leaf(kids[i]) and kids[i].value == "(":
         names = _import_as_names(unit, kids[i + 1])
     else:
         names = _import_as_names(unit, kids[i])
-    return Description(kind="ImportFrom", raw_span=_span(unit, node), anchors=(),
-                        slots=(("module", SlotLeaf(module)), ("names", Children(names)),
-                               ("level", SlotLeaf(level))))
+    return Description(
+        kind="ImportFrom",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("module", SlotLeaf(module)),
+            ("names", Children(names)),
+            ("level", SlotLeaf(level)),
+        ),
+    )
 
 
 def _import_as_names(unit: SourceUnit, node: ParsoNode) -> Tuple[BackendNode, ...]:
@@ -1139,32 +1418,54 @@ def _import_as_names(unit: SourceUnit, node: ParsoNode) -> Tuple[BackendNode, ..
     for it in items:
         if it.type == "import_as_name":
             k = _kids(it)
-            out.append(_fixed("ImportAlias", _span(unit, it),
-                               (("name", SlotLeaf(k[0].value)), ("asname", SlotLeaf(k[2].value)))))
+            out.append(
+                _fixed(
+                    "ImportAlias",
+                    _span(unit, it),
+                    (("name", SlotLeaf(k[0].value)), ("asname", SlotLeaf(k[2].value))),
+                )
+            )
         else:
-            out.append(_fixed("ImportAlias", _span(unit, it),
-                               (("name", SlotLeaf(it.value)), ("asname", SlotLeaf(None)))))
+            out.append(
+                _fixed(
+                    "ImportAlias",
+                    _span(unit, it),
+                    (("name", SlotLeaf(it.value)), ("asname", SlotLeaf(None))),
+                )
+            )
     return tuple(out)
 
 
 def _global_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
     kids = _strip_commas(_kids(node)[1:])
-    return Description(kind="Global", raw_span=_span(unit, node), anchors=(),
-                        slots=(("names", SlotLeaf(tuple(k.value for k in kids))),))
+    return Description(
+        kind="Global",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("names", SlotLeaf(tuple(k.value for k in kids))),),
+    )
 
 
 def _nonlocal_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
     kids = _strip_commas(_kids(node)[1:])
-    return Description(kind="Nonlocal", raw_span=_span(unit, node), anchors=(),
-                        slots=(("names", SlotLeaf(tuple(k.value for k in kids))),))
+    return Description(
+        kind="Nonlocal",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("names", SlotLeaf(tuple(k.value for k in kids))),),
+    )
 
 
 def _assert_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
     kids = _kids(node)
     test = _h(unit, kids[1])
     msg = _h(unit, kids[3]) if len(kids) > 3 else None
-    return Description(kind="Assert", raw_span=_span(unit, node), anchors=(),
-                        slots=(("test", Child(test)), ("msg", MaybeChild(msg))))
+    return Description(
+        kind="Assert",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("test", Child(test)), ("msg", MaybeChild(msg))),
+    )
 
 
 def _if_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
@@ -1173,7 +1474,9 @@ def _if_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
     return _if_chain(unit, kids, 0, _span(unit, node))
 
 
-def _if_chain(unit: SourceUnit, kids: List[ParsoNode], i: int, outer_span: Span) -> Description:
+def _if_chain(
+    unit: SourceUnit, kids: List[ParsoNode], i: int, outer_span: Span
+) -> Description:
     keyword = kids[i]
     test = _h(unit, kids[i + 1])
     body = _stmts(unit, kids[i + 3])
@@ -1185,11 +1488,21 @@ def _if_chain(unit: SourceUnit, kids: List[ParsoNode], i: int, outer_span: Span)
     else:
         orelse = ()
     span = Span(_span(unit, keyword).start, outer_span.end) if i > 0 else outer_span
-    return Description(kind="If", raw_span=span, anchors=(),
-                        slots=(("test", Child(test)), ("body", Children(body)), ("orelse", Children(orelse))))
+    return Description(
+        kind="If",
+        raw_span=span,
+        anchors=(),
+        slots=(
+            ("test", Child(test)),
+            ("body", Children(body)),
+            ("orelse", Children(orelse)),
+        ),
+    )
 
 
-def _fixed_if_chain(unit: SourceUnit, kids: List[ParsoNode], i: int, outer_span: Span) -> BackendNode:
+def _fixed_if_chain(
+    unit: SourceUnit, kids: List[ParsoNode], i: int, outer_span: Span
+) -> BackendNode:
     d = _if_chain(unit, kids, i, outer_span)
     return _fixed(d.kind, d.raw_span, d.slots, d.anchors)
 
@@ -1201,8 +1514,16 @@ def _while_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
     orelse: Tuple[BackendNode, ...] = ()
     if len(kids) > 4:
         orelse = _stmts(unit, kids[6])
-    return Description(kind="While", raw_span=_span(unit, node), anchors=(),
-                        slots=(("test", Child(test)), ("body", Children(body)), ("orelse", Children(orelse))))
+    return Description(
+        kind="While",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("test", Child(test)),
+            ("body", Children(body)),
+            ("orelse", Children(orelse)),
+        ),
+    )
 
 
 def _for_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
@@ -1223,9 +1544,17 @@ def _for_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
     orelse: Tuple[BackendNode, ...] = ()
     if len(kids) > 6:
         orelse = _stmts(unit, kids[8])
-    return Description(kind="For", raw_span=_span(unit, node), anchors=(),
-                        slots=(("target", Child(target)), ("iter", Child(iter_handle)),
-                               ("body", Children(body)), ("orelse", Children(orelse))))
+    return Description(
+        kind="For",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("target", Child(target)),
+            ("iter", Child(iter_handle)),
+            ("body", Children(body)),
+            ("orelse", Children(orelse)),
+        ),
+    )
 
 
 def _try_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
@@ -1252,12 +1581,22 @@ def _try_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
             if j < len(ek) and _is_leaf(ek[j]) and ek[j].value == "as":
                 exc_name = ek[j + 1].value
             handler_body = _stmts(unit, kids[i + 2])
-            handlers.append(_fixed(
-                "ExceptHandler",
-                _span(unit, c).envelope(_span(unit, kids[i + 2])),
-                (("type_", MaybeChild(_h(unit, exc_type) if exc_type is not None else None)),
-                 ("name", SlotLeaf(exc_name)), ("body", Children(handler_body))),
-            ))
+            handlers.append(
+                _fixed(
+                    "ExceptHandler",
+                    _span(unit, c).envelope(_span(unit, kids[i + 2])),
+                    (
+                        (
+                            "type_",
+                            MaybeChild(
+                                _h(unit, exc_type) if exc_type is not None else None
+                            ),
+                        ),
+                        ("name", SlotLeaf(exc_name)),
+                        ("body", Children(handler_body)),
+                    ),
+                )
+            )
             i += 3
         elif c.type == "keyword" and c.value == "else":
             orelse = _stmts(unit, kids[i + 2])
@@ -1268,9 +1607,17 @@ def _try_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
         else:
             i += 1
     kind = "TryStar" if is_star else "Try"
-    return Description(kind=kind, raw_span=_span(unit, node), anchors=(),
-                        slots=(("body", Children(body)), ("handlers", Children(tuple(handlers))),
-                               ("orelse", Children(orelse)), ("finalbody", Children(finalbody))))
+    return Description(
+        kind=kind,
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("body", Children(body)),
+            ("handlers", Children(tuple(handlers))),
+            ("orelse", Children(orelse)),
+            ("finalbody", Children(finalbody)),
+        ),
+    )
 
 
 def _with_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
@@ -1282,14 +1629,31 @@ def _with_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
             ik = _kids(it)
             ctx = _h(unit, ik[0])
             var = _h(unit, ik[2]) if len(ik) > 2 else None
-            items.append(_fixed("WithItem", _span(unit, it),
-                                 (("context_expr", Child(ctx)), ("optional_vars", MaybeChild(var)))))
+            items.append(
+                _fixed(
+                    "WithItem",
+                    _span(unit, it),
+                    (("context_expr", Child(ctx)), ("optional_vars", MaybeChild(var))),
+                )
+            )
         else:
-            items.append(_fixed("WithItem", _span(unit, it),
-                                 (("context_expr", Child(_h(unit, it))), ("optional_vars", MaybeChild(None)))))
+            items.append(
+                _fixed(
+                    "WithItem",
+                    _span(unit, it),
+                    (
+                        ("context_expr", Child(_h(unit, it))),
+                        ("optional_vars", MaybeChild(None)),
+                    ),
+                )
+            )
     body = _stmts(unit, kids[-1])
-    return Description(kind="With", raw_span=_span(unit, node), anchors=(),
-                        slots=(("items", Children(tuple(items))), ("body", Children(body))))
+    return Description(
+        kind="With",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("items", Children(tuple(items))), ("body", Children(body))),
+    )
 
 
 def _funcdef(unit: SourceUnit, node: ParsoNode) -> Description:
@@ -1297,7 +1661,9 @@ def _funcdef(unit: SourceUnit, node: ParsoNode) -> Description:
     name = kids[1].value
     idx = 2
     if kids[idx].type in ("typeparams",):
-        idx += 1  # PEP 695 generic params: not further destructured (rare in this corpus)
+        idx += (
+            1  # PEP 695 generic params: not further destructured (rare in this corpus)
+        )
     params_node = kids[idx]
     idx += 1
     returns = None
@@ -1305,11 +1671,19 @@ def _funcdef(unit: SourceUnit, node: ParsoNode) -> Description:
         returns = kids[idx + 1]
         idx += 2
     body = _stmts(unit, kids[-1])
-    return Description(kind="FunctionDef", raw_span=_span(unit, node), anchors=(),
-                        slots=(("name", SlotLeaf(name)), ("params", Children(_flatten_params(unit, params_node))),
-                               ("body", Children(body)), ("decorators", Children(())),
-                               ("returns", MaybeChild(_h(unit, returns) if returns is not None else None)),
-                               ("type_params", Children(()))))
+    return Description(
+        kind="FunctionDef",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("name", SlotLeaf(name)),
+            ("params", Children(_flatten_params(unit, params_node))),
+            ("body", Children(body)),
+            ("decorators", Children(())),
+            ("returns", MaybeChild(_h(unit, returns) if returns is not None else None)),
+            ("type_params", Children(())),
+        ),
+    )
 
 
 def _classdef(unit: SourceUnit, node: ParsoNode) -> Description:
@@ -1320,14 +1694,27 @@ def _classdef(unit: SourceUnit, node: ParsoNode) -> Description:
     idx = 2
     if idx < len(kids) and _is_leaf(kids[idx]) and kids[idx].value == "(":
         if not (_is_leaf(kids[idx + 1]) and kids[idx + 1].value == ")"):
-            arglist_kids = _kids(kids[idx + 1]) if kids[idx + 1].type == "arglist" else [kids[idx + 1]]
+            arglist_kids = (
+                _kids(kids[idx + 1])
+                if kids[idx + 1].type == "arglist"
+                else [kids[idx + 1]]
+            )
             b, kw = _call_args(unit, arglist_kids)
             bases, keywords = tuple(b), tuple(kw)
     body = _stmts(unit, kids[-1])
-    return Description(kind="ClassDef", raw_span=_span(unit, node), anchors=(),
-                        slots=(("name", SlotLeaf(name)), ("bases", Children(bases)),
-                               ("keywords", Children(keywords)), ("body", Children(body)),
-                               ("decorators", Children(())), ("type_params", Children(()))))
+    return Description(
+        kind="ClassDef",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("name", SlotLeaf(name)),
+            ("bases", Children(bases)),
+            ("keywords", Children(keywords)),
+            ("body", Children(body)),
+            ("decorators", Children(())),
+            ("type_params", Children(())),
+        ),
+    )
 
 
 def _decorated(unit: SourceUnit, node: ParsoNode) -> Description:
@@ -1356,13 +1743,17 @@ def _async_stmt(unit: SourceUnit, node: ParsoNode) -> Description:
     span = _span(unit, node)
     if inner.type == "funcdef":
         base = _funcdef(unit, inner)
-        return Description(kind="AsyncFunctionDef", raw_span=span, anchors=(), slots=base.slots)
+        return Description(
+            kind="AsyncFunctionDef", raw_span=span, anchors=(), slots=base.slots
+        )
     if inner.type == "for_stmt":
         base = _for_stmt(unit, inner)
         return Description(kind="AsyncFor", raw_span=span, anchors=(), slots=base.slots)
     if inner.type == "with_stmt":
         base = _with_stmt(unit, inner)
-        return Description(kind="AsyncWith", raw_span=span, anchors=(), slots=base.slots)
+        return Description(
+            kind="AsyncWith", raw_span=span, anchors=(), slots=base.slots
+        )
     vocabulary_missing(
         owner="parso_adapter._async_stmt",
         observed=f"async_stmt wrapping {inner.type!r} not recognized",
@@ -1378,9 +1769,15 @@ def _lambdef(unit: SourceUnit, node: ParsoNode) -> Description:
     body_node = kids[-1]
     if len(kids) > 3:
         params_node = kids[1]
-    return Description(kind="Lambda", raw_span=_span(unit, node), anchors=(),
-                        slots=(("params", Children(_flatten_params(unit, params_node))),
-                               ("body", Child(_h(unit, body_node)))))
+    return Description(
+        kind="Lambda",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("params", Children(_flatten_params(unit, params_node))),
+            ("body", Child(_h(unit, body_node))),
+        ),
+    )
 
 
 def _ternary(unit: SourceUnit, node: ParsoNode) -> Description:
@@ -1388,20 +1785,38 @@ def _ternary(unit: SourceUnit, node: ParsoNode) -> Description:
     body = _h(unit, kids[0])
     test = _h(unit, kids[2])
     orelse = _h(unit, kids[4])
-    return Description(kind="IfExp", raw_span=_span(unit, node), anchors=(),
-                        slots=(("test", Child(test)), ("body", Child(body)), ("orelse", Child(orelse))))
+    return Description(
+        kind="IfExp",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("test", Child(test)), ("body", Child(body)), ("orelse", Child(orelse))),
+    )
 
 
 def _namedexpr(unit: SourceUnit, node: ParsoNode) -> Description:
     kids = _kids(node)
-    return Description(kind="NamedExpr", raw_span=_span(unit, node), anchors=(),
-                        slots=(("target", Child(_h(unit, kids[0]))), ("value", Child(_h(unit, kids[2])))))
+    return Description(
+        kind="NamedExpr",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("target", Child(_h(unit, kids[0]))),
+            ("value", Child(_h(unit, kids[2]))),
+        ),
+    )
 
 
 def _not_test(unit: SourceUnit, node: ParsoNode) -> Description:
     kids = _kids(node)
-    return Description(kind="UnaryOp", raw_span=_span(unit, node), anchors=(),
-                        slots=(("op", OpLeaf(operator_for("Not"))), ("operand", Child(_h(unit, kids[1])))))
+    return Description(
+        kind="UnaryOp",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("op", OpLeaf(operator_for("Not"))),
+            ("operand", Child(_h(unit, kids[1]))),
+        ),
+    )
 
 
 def _factor(unit: SourceUnit, node: ParsoNode) -> Description:
@@ -1414,22 +1829,41 @@ def _factor(unit: SourceUnit, node: ParsoNode) -> Description:
             requested="'+', '-', or '~'",
             fix="extend _UNARY_TOKEN deliberately",
         )
-    return Description(kind="UnaryOp", raw_span=_span(unit, node), anchors=(),
-                        slots=(("op", OpLeaf(operator_for(kind))), ("operand", Child(_h(unit, kids[1])))))
+    return Description(
+        kind="UnaryOp",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("op", OpLeaf(operator_for(kind))),
+            ("operand", Child(_h(unit, kids[1]))),
+        ),
+    )
 
 
 def _power(unit: SourceUnit, node: ParsoNode) -> Description:
     kids = _kids(node)
     left = _h(unit, kids[0])
     right = _h(unit, kids[2])
-    return Description(kind="BinOp", raw_span=_span(unit, node), anchors=(),
-                        slots=(("left", Child(left)), ("op", OpLeaf(operator_for("Pow"))), ("right", Child(right))))
+    return Description(
+        kind="BinOp",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("left", Child(left)),
+            ("op", OpLeaf(operator_for("Pow"))),
+            ("right", Child(right)),
+        ),
+    )
 
 
 def _star_expr(unit: SourceUnit, node: ParsoNode) -> Description:
     kids = _kids(node)
-    return Description(kind="Starred", raw_span=_span(unit, node), anchors=(),
-                        slots=(("value", Child(_h(unit, kids[1]))),))
+    return Description(
+        kind="Starred",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("value", Child(_h(unit, kids[1]))),),
+    )
 
 
 def _atom_expr(unit: SourceUnit, node: ParsoNode) -> Description:
@@ -1444,7 +1878,9 @@ def _atom_expr(unit: SourceUnit, node: ParsoNode) -> Description:
 
 def _bare_tuple_node(unit: SourceUnit, node: ParsoNode) -> Description:
     elts = _strip_commas(_kids(node))
-    return _bare_tuple(unit, elts, _span(unit, node)).describe()  # note: overridden below for envelope
+    return _bare_tuple(
+        unit, elts, _span(unit, node)
+    ).describe()  # note: overridden below for envelope
 
 
 _DISPATCH = {
@@ -1472,8 +1908,9 @@ _DISPATCH = {
     "sync_comp_for": _comprehension,
     "fstring_expr": _describe_fstring_expr,
     "strings": lambda u, n: _join_string_pieces(u, _kids(n)).describe(),
-    "fstring": lambda u, n: _fixed("JoinedStr", _span(u, n),
-                                    (("values", Children(tuple(_fstring_values(u, n)))),)).describe(),
+    "fstring": lambda u, n: _fixed(
+        "JoinedStr", _span(u, n), (("values", Children(tuple(_fstring_values(u, n)))),)
+    ).describe(),
     "expr_stmt": _expr_stmt,
     "return_stmt": _return_stmt,
     "yield_expr": _yield_expr,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/tree_sitter_python_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/tree_sitter_python_adapter.py
@@ -108,7 +108,7 @@ def _fields(node: TSNode, name: str) -> List[TSNode]:
 
 def _text(unit: SourceUnit, node: TSNode) -> str:
     span = _span(unit, node)
-    return unit.source[span.start:span.end]
+    return unit.source[span.start : span.end]
 
 
 class _Handle(BackendNode):
@@ -138,9 +138,15 @@ class _Fixed(BackendNode):
         return self._desc
 
 
-def _fixed(kind: str, raw_span: Optional[Span], slots: Tuple[Tuple[str, Slot], ...],
-           anchors: Tuple[Span, ...] = ()) -> _Fixed:
-    return _Fixed(Description(kind=kind, raw_span=raw_span, anchors=anchors, slots=slots))
+def _fixed(
+    kind: str,
+    raw_span: Optional[Span],
+    slots: Tuple[Tuple[str, Slot], ...],
+    anchors: Tuple[Span, ...] = (),
+) -> _Fixed:
+    return _Fixed(
+        Description(kind=kind, raw_span=raw_span, anchors=anchors, slots=slots)
+    )
 
 
 def _h(unit: SourceUnit, node: Optional[TSNode]) -> Optional[BackendNode]:
@@ -148,15 +154,34 @@ def _h(unit: SourceUnit, node: Optional[TSNode]) -> Optional[BackendNode]:
 
 
 _BIN_TOKEN = {
-    "+": "Add", "-": "Sub", "*": "Mult", "@": "MatMult", "/": "Div",
-    "%": "Mod", "**": "Pow", "<<": "LShift", ">>": "RShift", "|": "BitOr",
-    "^": "BitXor", "&": "BitAnd", "//": "FloorDiv",
+    "+": "Add",
+    "-": "Sub",
+    "*": "Mult",
+    "@": "MatMult",
+    "/": "Div",
+    "%": "Mod",
+    "**": "Pow",
+    "<<": "LShift",
+    ">>": "RShift",
+    "|": "BitOr",
+    "^": "BitXor",
+    "&": "BitAnd",
+    "//": "FloorDiv",
 }
 _AUG_TOKEN = {k + "=": v for k, v in _BIN_TOKEN.items()}
 _UNARY_TOKEN = {"+": "UAdd", "-": "USub", "~": "Invert"}
 _CMP_TOKEN = {
-    "<": "Lt", ">": "Gt", "==": "Eq", ">=": "GtE", "<=": "LtE", "!=": "NotEq",
-    "<>": "NotEq", "in": "In", "not in": "NotIn", "is": "Is", "is not": "IsNot",
+    "<": "Lt",
+    ">": "Gt",
+    "==": "Eq",
+    ">=": "GtE",
+    "<=": "LtE",
+    "!=": "NotEq",
+    "<>": "NotEq",
+    "in": "In",
+    "not in": "NotIn",
+    "is": "Is",
+    "is not": "IsNot",
 }
 
 
@@ -164,8 +189,12 @@ def _bool_kind(node_type: str) -> str:
     return {"and": "And", "or": "Or"}[node_type]
 
 
-def _bare_tuple(unit: SourceUnit, elts: Sequence[TSNode], raw_span: Optional[Span]) -> BackendNode:
-    return _fixed("Tuple", raw_span, (("elts", Children(tuple(_h(unit, e) for e in elts))),))
+def _bare_tuple(
+    unit: SourceUnit, elts: Sequence[TSNode], raw_span: Optional[Span]
+) -> BackendNode:
+    return _fixed(
+        "Tuple", raw_span, (("elts", Children(tuple(_h(unit, e) for e in elts))),)
+    )
 
 
 def _pattern_list_targets(unit: SourceUnit, node: TSNode) -> BackendNode:
@@ -176,7 +205,11 @@ def _pattern_list_targets(unit: SourceUnit, node: TSNode) -> BackendNode:
     elts = _named(node)
     if len(elts) == 1:
         return _target_handle(unit, elts[0])
-    return _fixed("Tuple", None, (("elts", Children(tuple(_target_handle(unit, e) for e in elts))),))
+    return _fixed(
+        "Tuple",
+        None,
+        (("elts", Children(tuple(_target_handle(unit, e) for e in elts))),),
+    )
 
 
 # --------------------------------------------------------------------------
@@ -200,8 +233,12 @@ def _block_stmts(unit: SourceUnit, node: Optional[TSNode]) -> Tuple[BackendNode,
 
 def _module(unit: SourceUnit, node: TSNode) -> Description:
     body = tuple(_h(unit, c) for c in _named(node) if c.type != "comment")
-    return Description(kind="Module", raw_span=Span(0, len(unit.source)), anchors=(),
-                        slots=(("body", Children(body)),))
+    return Description(
+        kind="Module",
+        raw_span=Span(0, len(unit.source)),
+        anchors=(),
+        slots=(("body", Children(body)),),
+    )
 
 
 def _expression_statement(unit: SourceUnit, node: TSNode) -> Description:
@@ -211,8 +248,12 @@ def _expression_statement(unit: SourceUnit, node: TSNode) -> Description:
     if len(kids) > 1:
         # `f(x), "msg"` in statement position: a bare tuple — the same
         # shape CPython's ast gives (Expr(Tuple)).
-        return Description(kind="Tuple", raw_span=_span(unit, node), anchors=(),
-                            slots=(("elts", Children(tuple(_h(unit, c) for c in kids))),))
+        return Description(
+            kind="Tuple",
+            raw_span=_span(unit, node),
+            anchors=(),
+            slots=(("elts", Children(tuple(_h(unit, c) for c in kids))),),
+        )
     vocabulary_missing(
         owner="tree_sitter_python_adapter._expression_statement",
         observed=f"expression_statement with {len(kids)} named children",
@@ -223,17 +264,28 @@ def _expression_statement(unit: SourceUnit, node: TSNode) -> Description:
 
 
 def _leaf_identifier(unit: SourceUnit, node: TSNode) -> Description:
-    return Description(kind="Name", raw_span=_span(unit, node), anchors=(),
-                        slots=(("id", SlotLeaf(_text(unit, node))),))
+    return Description(
+        kind="Name",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("id", SlotLeaf(_text(unit, node))),),
+    )
 
 
-def _fixed_constant(span: Span, value: object, literal_kind: Optional[str] = None) -> Description:
-    return Description(kind="Constant", raw_span=span, anchors=(),
-                        slots=(("value", SlotLeaf(value)), ("literal_kind", SlotLeaf(literal_kind))))
+def _fixed_constant(
+    span: Span, value: object, literal_kind: Optional[str] = None
+) -> Description:
+    return Description(
+        kind="Constant",
+        raw_span=span,
+        anchors=(),
+        slots=(("value", SlotLeaf(value)), ("literal_kind", SlotLeaf(literal_kind))),
+    )
 
 
 def _number(unit: SourceUnit, node: TSNode) -> Description:
     import ast as _pyast
+
     text = _text(unit, node)
     value = _pyast.literal_eval(text)
     return _fixed_constant(_span(unit, node), value)
@@ -247,6 +299,7 @@ def _string_like(unit: SourceUnit, node: TSNode) -> Description:
     if not interpolations:
         text = _text(unit, node)
         import ast as _pyast
+
         try:
             value = _pyast.literal_eval(text)
         except Exception:
@@ -267,8 +320,12 @@ def _string_like(unit: SourceUnit, node: TSNode) -> Description:
                 requested="string_content or interpolation",
                 fix="extend _string_like deliberately",
             )
-    return Description(kind="JoinedStr", raw_span=span, anchors=(),
-                        slots=(("values", Children(tuple(values))),))
+    return Description(
+        kind="JoinedStr",
+        raw_span=span,
+        anchors=(),
+        slots=(("values", Children(tuple(values))),),
+    )
 
 
 def _concatenated_string(unit: SourceUnit, node: TSNode) -> Description:
@@ -277,14 +334,17 @@ def _concatenated_string(unit: SourceUnit, node: TSNode) -> Description:
     start to the last's end (spec: including inter-piece whitespace)."""
     pieces = _named(node)
     span = Span(_span(unit, pieces[0]).start, _span(unit, pieces[-1]).end)
-    any_fstring = any(any(c.type == "interpolation" for c in p.children) for p in pieces)
+    any_fstring = any(
+        any(c.type == "interpolation" for c in p.children) for p in pieces
+    )
     if not any_fstring:
         import ast as _pyast
+
         text = "".join(_text(unit, p) for p in pieces)
         try:
             value = _pyast.literal_eval(text)
         except Exception:
-            value = unit.source[span.start:span.end]
+            value = unit.source[span.start : span.end]
         return _fixed_constant(span, value)
     values: List[BackendNode] = []
     for p in pieces:
@@ -295,12 +355,17 @@ def _concatenated_string(unit: SourceUnit, node: TSNode) -> Description:
                 values.append(_h(unit, c))
             elif c.type == "interpolation":
                 values.append(_interpolation(unit, c))
-    return Description(kind="JoinedStr", raw_span=span, anchors=(), slots=(("values", Children(tuple(values))),))
+    return Description(
+        kind="JoinedStr",
+        raw_span=span,
+        anchors=(),
+        slots=(("values", Children(tuple(values))),),
+    )
 
 
 def _string_content(unit: SourceUnit, node: TSNode) -> Description:
     span = _span(unit, node)
-    return _fixed_constant(span, unit.source[span.start:span.end])
+    return _fixed_constant(span, unit.source[span.start : span.end])
 
 
 def _interpolation(unit: SourceUnit, node: TSNode) -> BackendNode:
@@ -320,19 +385,30 @@ def _interpolation(unit: SourceUnit, node: TSNode) -> BackendNode:
                 spec_values.append(_interpolation_like(unit, c, inner))
             else:
                 spec_values.append(_h(unit, c))
-        format_spec = _fixed("JoinedStr", spec_span, (("values", Children(tuple(spec_values))),))
+        format_spec = _fixed(
+            "JoinedStr", spec_span, (("values", Children(tuple(spec_values))),)
+        )
     return _fixed(
         "FormattedValue",
         _span(unit, node),
-        (("value", Child(_h(unit, value))), ("conversion", SlotLeaf(conversion)),
-         ("format_spec", MaybeChild(format_spec))),
+        (
+            ("value", Child(_h(unit, value))),
+            ("conversion", SlotLeaf(conversion)),
+            ("format_spec", MaybeChild(format_spec)),
+        ),
     )
 
 
 def _interpolation_like(unit: SourceUnit, node: TSNode, inner: TSNode) -> BackendNode:
-    return _fixed("FormattedValue", _span(unit, node),
-                  (("value", Child(_h(unit, inner))), ("conversion", SlotLeaf(-1)),
-                   ("format_spec", MaybeChild(None))))
+    return _fixed(
+        "FormattedValue",
+        _span(unit, node),
+        (
+            ("value", Child(_h(unit, inner))),
+            ("conversion", SlotLeaf(-1)),
+            ("format_spec", MaybeChild(None)),
+        ),
+    )
 
 
 _SIMPLE_LEAF = {
@@ -360,24 +436,41 @@ def _binary_operator(unit: SourceUnit, node: TSNode) -> Description:
             requested="a known binary operator token",
             fix="extend _BIN_TOKEN deliberately",
         )
-    return Description(kind="BinOp", raw_span=_span(unit, node), anchors=(),
-                        slots=(("left", Child(_h(unit, left))), ("op", OpLeaf(operator_for(kind))),
-                               ("right", Child(_h(unit, right)))))
+    return Description(
+        kind="BinOp",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("left", Child(_h(unit, left))),
+            ("op", OpLeaf(operator_for(kind))),
+            ("right", Child(_h(unit, right))),
+        ),
+    )
 
 
 def _boolean_operator(unit: SourceUnit, node: TSNode) -> Description:
     kids = node.children
     op_type = next(c.type for c in kids if not c.is_named)
     values = _named(node)
-    return Description(kind="BoolOp", raw_span=_span(unit, node), anchors=(),
-                        slots=(("op", OpLeaf(operator_for(_bool_kind(op_type)))),
-                               ("values", Children(tuple(_h(unit, v) for v in values)))))
+    return Description(
+        kind="BoolOp",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("op", OpLeaf(operator_for(_bool_kind(op_type)))),
+            ("values", Children(tuple(_h(unit, v) for v in values))),
+        ),
+    )
 
 
 def _not_operator(unit: SourceUnit, node: TSNode) -> Description:
     arg = _field(node, "argument")
-    return Description(kind="UnaryOp", raw_span=_span(unit, node), anchors=(),
-                        slots=(("op", OpLeaf(operator_for("Not"))), ("operand", Child(_h(unit, arg)))))
+    return Description(
+        kind="UnaryOp",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("op", OpLeaf(operator_for("Not"))), ("operand", Child(_h(unit, arg)))),
+    )
 
 
 def _unary_operator(unit: SourceUnit, node: TSNode) -> Description:
@@ -391,8 +484,12 @@ def _unary_operator(unit: SourceUnit, node: TSNode) -> Description:
             requested="'+', '-', or '~'",
             fix="extend _UNARY_TOKEN deliberately",
         )
-    return Description(kind="UnaryOp", raw_span=_span(unit, node), anchors=(),
-                        slots=(("op", OpLeaf(operator_for(kind))), ("operand", Child(_h(unit, arg)))))
+    return Description(
+        kind="UnaryOp",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("op", OpLeaf(operator_for(kind))), ("operand", Child(_h(unit, arg)))),
+    )
 
 
 def _comparison_operator(unit: SourceUnit, node: TSNode) -> Description:
@@ -413,9 +510,16 @@ def _comparison_operator(unit: SourceUnit, node: TSNode) -> Description:
                 fix="extend _CMP_TOKEN deliberately",
             )
         ops.append(operator_for(kind))
-    return Description(kind="Compare", raw_span=_span(unit, node), anchors=(),
-                        slots=(("left", Child(_h(unit, left))), ("ops", OpsLeaf(tuple(ops))),
-                               ("comparators", Children(tuple(_h(unit, c) for c in comparators)))))
+    return Description(
+        kind="Compare",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("left", Child(_h(unit, left))),
+            ("ops", OpsLeaf(tuple(ops))),
+            ("comparators", Children(tuple(_h(unit, c) for c in comparators))),
+        ),
+    )
 
 
 # --------------------------------------------------------------------------
@@ -435,29 +539,64 @@ def _call(unit: SourceUnit, node: TSNode) -> Description:
             for c in _named(arglist):
                 if c.type == "list_splat":
                     inner = c.children[1]
-                    args.append(_fixed("Starred", _span(unit, c), (("value", Child(_h(unit, inner))),)))
+                    args.append(
+                        _fixed(
+                            "Starred",
+                            _span(unit, c),
+                            (("value", Child(_h(unit, inner))),),
+                        )
+                    )
                 elif c.type == "dictionary_splat":
                     inner = c.children[1]
-                    keywords.append(_fixed("Keyword", None,
-                                            (("arg", SlotLeaf(None)), ("value", Child(_h(unit, inner))))))
+                    keywords.append(
+                        _fixed(
+                            "Keyword",
+                            None,
+                            (
+                                ("arg", SlotLeaf(None)),
+                                ("value", Child(_h(unit, inner))),
+                            ),
+                        )
+                    )
                 elif c.type == "keyword_argument":
                     name_node = _field(c, "name")
                     value_node = _field(c, "value")
-                    keywords.append(_fixed("Keyword", _span(unit, c),
-                                            (("arg", SlotLeaf(_text(unit, name_node))),
-                                             ("value", Child(_h(unit, value_node))))))
+                    keywords.append(
+                        _fixed(
+                            "Keyword",
+                            _span(unit, c),
+                            (
+                                ("arg", SlotLeaf(_text(unit, name_node))),
+                                ("value", Child(_h(unit, value_node))),
+                            ),
+                        )
+                    )
                 else:
                     args.append(_h(unit, c))
-    return Description(kind="Call", raw_span=_span(unit, node), anchors=(),
-                        slots=(("func", Child(_h(unit, func))), ("args", Children(tuple(args))),
-                               ("keywords", Children(tuple(keywords)))))
+    return Description(
+        kind="Call",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("func", Child(_h(unit, func))),
+            ("args", Children(tuple(args))),
+            ("keywords", Children(tuple(keywords))),
+        ),
+    )
 
 
 def _attribute(unit: SourceUnit, node: TSNode) -> Description:
     value = _field(node, "object")
     attr = _field(node, "attribute")
-    return Description(kind="Attribute", raw_span=_span(unit, node), anchors=(),
-                        slots=(("value", Child(_h(unit, value))), ("attr", SlotLeaf(_text(unit, attr)))))
+    return Description(
+        kind="Attribute",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("value", Child(_h(unit, value))),
+            ("attr", SlotLeaf(_text(unit, attr))),
+        ),
+    )
 
 
 def _subscript(unit: SourceUnit, node: TSNode) -> Description:
@@ -468,8 +607,12 @@ def _subscript(unit: SourceUnit, node: TSNode) -> Description:
     else:
         elts = tuple(_one_subscript_item(unit, s) for s in subs)
         slice_handle = _fixed("Tuple", None, (("elts", Children(elts)),))
-    return Description(kind="Subscript", raw_span=_span(unit, node), anchors=(),
-                        slots=(("value", Child(_h(unit, value))), ("slice_", Child(slice_handle))))
+    return Description(
+        kind="Subscript",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("value", Child(_h(unit, value))), ("slice_", Child(slice_handle))),
+    )
 
 
 def _one_subscript_item(unit: SourceUnit, node: TSNode) -> BackendNode:
@@ -489,8 +632,11 @@ def _one_subscript_item(unit: SourceUnit, node: TSNode) -> BackendNode:
     def _maybe(seg: List[TSNode]) -> Slot:
         return MaybeChild(_h(unit, seg[0]) if seg else None)
 
-    return _fixed("Slice", _span(unit, node),
-                  (("lower", _maybe(lower)), ("upper", _maybe(upper)), ("step", _maybe(step))))
+    return _fixed(
+        "Slice",
+        _span(unit, node),
+        (("lower", _maybe(lower)), ("upper", _maybe(upper)), ("step", _maybe(step))),
+    )
 
 
 def _parenthesized_expression(unit: SourceUnit, node: TSNode) -> Description:
@@ -507,8 +653,12 @@ def _parenthesized_expression(unit: SourceUnit, node: TSNode) -> Description:
 
 def _tuple_expr(unit: SourceUnit, node: TSNode) -> Description:
     elts = [c for c in _named(node) if c.type != "comment"]
-    return Description(kind="Tuple", raw_span=_span(unit, node), anchors=(),
-                        slots=(("elts", Children(tuple(_h(unit, e) for e in elts))),))
+    return Description(
+        kind="Tuple",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("elts", Children(tuple(_h(unit, e) for e in elts))),),
+    )
 
 
 def _list_expr(unit: SourceUnit, node: TSNode) -> Description:
@@ -516,16 +666,27 @@ def _list_expr(unit: SourceUnit, node: TSNode) -> Description:
     for c in _named(node):
         if c.type == "list_splat":
             inner = c.children[1]
-            elts.append(_fixed("Starred", _span(unit, c), (("value", Child(_h(unit, inner))),)))
+            elts.append(
+                _fixed("Starred", _span(unit, c), (("value", Child(_h(unit, inner))),))
+            )
         else:
             elts.append(_h(unit, c))
-    return Description(kind="List", raw_span=_span(unit, node), anchors=(),
-                        slots=(("elts", Children(tuple(elts))),))
+    return Description(
+        kind="List",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("elts", Children(tuple(elts))),),
+    )
 
 
 def _set_expr(unit: SourceUnit, node: TSNode) -> Description:
     elts = tuple(_h(unit, c) for c in _named(node))
-    return Description(kind="Set", raw_span=_span(unit, node), anchors=(), slots=(("elts", Children(elts)),))
+    return Description(
+        kind="Set",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("elts", Children(elts)),),
+    )
 
 
 def _dictionary(unit: SourceUnit, node: TSNode) -> Description:
@@ -534,12 +695,25 @@ def _dictionary(unit: SourceUnit, node: TSNode) -> Description:
         if c.type == "pair":
             key = _field(c, "key")
             value = _field(c, "value")
-            items.append(_fixed("DictItem", _span(unit, c),
-                                 (("key", MaybeChild(_h(unit, key))), ("value", Child(_h(unit, value))))))
+            items.append(
+                _fixed(
+                    "DictItem",
+                    _span(unit, c),
+                    (
+                        ("key", MaybeChild(_h(unit, key))),
+                        ("value", Child(_h(unit, value))),
+                    ),
+                )
+            )
         elif c.type == "dictionary_splat":
             inner = c.children[1]
-            items.append(_fixed("DictItem", _span(unit, c),
-                                 (("key", MaybeChild(None)), ("value", Child(_h(unit, inner))))))
+            items.append(
+                _fixed(
+                    "DictItem",
+                    _span(unit, c),
+                    (("key", MaybeChild(None)), ("value", Child(_h(unit, inner)))),
+                )
+            )
         else:
             vocabulary_missing(
                 owner="tree_sitter_python_adapter._dictionary",
@@ -547,7 +721,12 @@ def _dictionary(unit: SourceUnit, node: TSNode) -> Description:
                 requested="pair or dictionary_splat",
                 fix="extend _dictionary deliberately",
             )
-    return Description(kind="Dict", raw_span=_span(unit, node), anchors=(), slots=(("items", Children(tuple(items))),))
+    return Description(
+        kind="Dict",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("items", Children(tuple(items))),),
+    )
 
 
 def _comprehension_clause(unit: SourceUnit, node: TSNode) -> Description:
@@ -556,13 +735,27 @@ def _comprehension_clause(unit: SourceUnit, node: TSNode) -> Description:
     left = _field(node, "left")
     right = _field(node, "right")
     is_async = any(not c.is_named and c.type == "async" for c in node.children)
-    target = _pattern_list_targets(unit, left) if left.type in ("pattern_list", "tuple_pattern") else _h(unit, left)
-    return Description(kind="Comprehension", raw_span=_span(unit, node), anchors=(),
-                        slots=(("target", Child(target)), ("iter", Child(_h(unit, right))),
-                               ("ifs", Children(())), ("is_async", SlotLeaf(is_async))))
+    target = (
+        _pattern_list_targets(unit, left)
+        if left.type in ("pattern_list", "tuple_pattern")
+        else _h(unit, left)
+    )
+    return Description(
+        kind="Comprehension",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("target", Child(target)),
+            ("iter", Child(_h(unit, right))),
+            ("ifs", Children(())),
+            ("is_async", SlotLeaf(is_async)),
+        ),
+    )
 
 
-def _comprehension_body(unit: SourceUnit, node: TSNode, elt_field: str) -> Tuple[BackendNode, Tuple[BackendNode, ...]]:
+def _comprehension_body(
+    unit: SourceUnit, node: TSNode, elt_field: str
+) -> Tuple[BackendNode, Tuple[BackendNode, ...]]:
     elt = _field(node, elt_field)
     generators: List[BackendNode] = []
     current_desc: Optional[Description] = None
@@ -582,26 +775,40 @@ def _comprehension_body(unit: SourceUnit, node: TSNode, elt_field: str) -> Tuple
 
 
 def _finish_clause(desc: Description, ifs: List[BackendNode]) -> BackendNode:
-    new_slots = tuple((n, Children(tuple(ifs))) if n == "ifs" else (n, s) for n, s in desc.slots)
+    new_slots = tuple(
+        (n, Children(tuple(ifs))) if n == "ifs" else (n, s) for n, s in desc.slots
+    )
     return _fixed(desc.kind, desc.raw_span, new_slots, desc.anchors)
 
 
 def _list_comprehension(unit: SourceUnit, node: TSNode) -> Description:
     elt, gens = _comprehension_body(unit, node, "body")
-    return Description(kind="ListComp", raw_span=_span(unit, node), anchors=(),
-                        slots=(("elt", Child(elt)), ("generators", Children(gens))))
+    return Description(
+        kind="ListComp",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("elt", Child(elt)), ("generators", Children(gens))),
+    )
 
 
 def _set_comprehension(unit: SourceUnit, node: TSNode) -> Description:
     elt, gens = _comprehension_body(unit, node, "body")
-    return Description(kind="SetComp", raw_span=_span(unit, node), anchors=(),
-                        slots=(("elt", Child(elt)), ("generators", Children(gens))))
+    return Description(
+        kind="SetComp",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("elt", Child(elt)), ("generators", Children(gens))),
+    )
 
 
 def _generator_expression(unit: SourceUnit, node: TSNode) -> Description:
     elt, gens = _comprehension_body(unit, node, "body")
-    return Description(kind="GeneratorExp", raw_span=_span(unit, node), anchors=(),
-                        slots=(("elt", Child(elt)), ("generators", Children(gens))))
+    return Description(
+        kind="GeneratorExp",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("elt", Child(elt)), ("generators", Children(gens))),
+    )
 
 
 def _dictionary_comprehension(unit: SourceUnit, node: TSNode) -> Description:
@@ -621,24 +828,42 @@ def _dictionary_comprehension(unit: SourceUnit, node: TSNode) -> Description:
             current_ifs.append(_h(unit, _named(c)[0]))
     if current_desc is not None:
         generators.append(_finish_clause(current_desc, current_ifs))
-    return Description(kind="DictComp", raw_span=_span(unit, node), anchors=(),
-                        slots=(("key", Child(_h(unit, key))), ("value", Child(_h(unit, value))),
-                               ("generators", Children(tuple(generators)))))
+    return Description(
+        kind="DictComp",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("key", Child(_h(unit, key))),
+            ("value", Child(_h(unit, value))),
+            ("generators", Children(tuple(generators))),
+        ),
+    )
 
 
 def _conditional_expression(unit: SourceUnit, node: TSNode) -> Description:
     named = _named(node)
     body, test, orelse = named[0], named[1], named[2]
-    return Description(kind="IfExp", raw_span=_span(unit, node), anchors=(),
-                        slots=(("test", Child(_h(unit, test))), ("body", Child(_h(unit, body))),
-                               ("orelse", Child(_h(unit, orelse)))))
+    return Description(
+        kind="IfExp",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("test", Child(_h(unit, test))),
+            ("body", Child(_h(unit, body))),
+            ("orelse", Child(_h(unit, orelse))),
+        ),
+    )
 
 
 def _named_expression(unit: SourceUnit, node: TSNode) -> Description:
     name = _field(node, "name")
     value = _field(node, "value")
-    return Description(kind="NamedExpr", raw_span=_span(unit, node), anchors=(),
-                        slots=(("target", Child(_h(unit, name))), ("value", Child(_h(unit, value)))))
+    return Description(
+        kind="NamedExpr",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("target", Child(_h(unit, name))), ("value", Child(_h(unit, value)))),
+    )
 
 
 def _yield_expr(unit: SourceUnit, node: TSNode) -> Description:
@@ -647,21 +872,43 @@ def _yield_expr(unit: SourceUnit, node: TSNode) -> Description:
     named = _named(node)
     span = _span(unit, node)
     if has_from:
-        return Description(kind="YieldFrom", raw_span=span, anchors=(), slots=(("value", Child(_h(unit, named[0]))),))
+        return Description(
+            kind="YieldFrom",
+            raw_span=span,
+            anchors=(),
+            slots=(("value", Child(_h(unit, named[0]))),),
+        )
     value = named[0] if named else None
-    return Description(kind="Yield", raw_span=span, anchors=(), slots=(("value", MaybeChild(_h(unit, value))),))
+    return Description(
+        kind="Yield",
+        raw_span=span,
+        anchors=(),
+        slots=(("value", MaybeChild(_h(unit, value))),),
+    )
 
 
 def _await_expr(unit: SourceUnit, node: TSNode) -> Description:
     value = _named(node)[0]
-    return Description(kind="Await", raw_span=_span(unit, node), anchors=(), slots=(("value", Child(_h(unit, value))),))
+    return Description(
+        kind="Await",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("value", Child(_h(unit, value))),),
+    )
 
 
 def _lambda(unit: SourceUnit, node: TSNode) -> Description:
     params_node = _field(node, "parameters")
     body = _field(node, "body")
-    return Description(kind="Lambda", raw_span=_span(unit, node), anchors=(),
-                        slots=(("params", Children(_flatten_params(unit, params_node))), ("body", Child(_h(unit, body)))))
+    return Description(
+        kind="Lambda",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("params", Children(_flatten_params(unit, params_node))),
+            ("body", Child(_h(unit, body))),
+        ),
+    )
 
 
 # --------------------------------------------------------------------------
@@ -669,7 +916,9 @@ def _lambda(unit: SourceUnit, node: TSNode) -> Description:
 # --------------------------------------------------------------------------
 
 
-def _flatten_params(unit: SourceUnit, node: Optional[TSNode]) -> Tuple[BackendNode, ...]:
+def _flatten_params(
+    unit: SourceUnit, node: Optional[TSNode]
+) -> Tuple[BackendNode, ...]:
     if node is None:
         return ()
     params: List[BackendNode] = []
@@ -693,38 +942,72 @@ def _flatten_params(unit: SourceUnit, node: Optional[TSNode]) -> Tuple[BackendNo
 
 def _retag(handle: BackendNode, kind: str) -> BackendNode:
     desc = handle.describe()
-    new_slots = tuple((n, SlotLeaf(kind)) if n == "param_kind" else (n, s) for n, s in desc.slots)
+    new_slots = tuple(
+        (n, SlotLeaf(kind)) if n == "param_kind" else (n, s) for n, s in desc.slots
+    )
     return _fixed(desc.kind, desc.raw_span, new_slots, desc.anchors)
 
 
 def _one_param(unit: SourceUnit, node: TSNode, after_star: bool) -> BackendNode:
     span = _span(unit, node)
     if node.type == "identifier":
-        return _fixed("Param", None,
-                       (("name", SlotLeaf(_text(unit, node))), ("annotation", MaybeChild(None)),
-                        ("default", MaybeChild(None)),
-                        ("param_kind", SlotLeaf("keyword_only" if after_star else "positional_or_keyword"))),
-                       anchors=(span,))
+        return _fixed(
+            "Param",
+            None,
+            (
+                ("name", SlotLeaf(_text(unit, node))),
+                ("annotation", MaybeChild(None)),
+                ("default", MaybeChild(None)),
+                (
+                    "param_kind",
+                    SlotLeaf("keyword_only" if after_star else "positional_or_keyword"),
+                ),
+            ),
+            anchors=(span,),
+        )
     if node.type == "list_splat_pattern":
         name_node = _named(node)[0]
-        return _fixed("Param", None,
-                       (("name", SlotLeaf(_text(unit, name_node))), ("annotation", MaybeChild(None)),
-                        ("default", MaybeChild(None)), ("param_kind", SlotLeaf("vararg"))),
-                       anchors=(_span(unit, name_node),))
+        return _fixed(
+            "Param",
+            None,
+            (
+                ("name", SlotLeaf(_text(unit, name_node))),
+                ("annotation", MaybeChild(None)),
+                ("default", MaybeChild(None)),
+                ("param_kind", SlotLeaf("vararg")),
+            ),
+            anchors=(_span(unit, name_node),),
+        )
     if node.type == "dictionary_splat_pattern":
         name_node = _named(node)[0]
-        return _fixed("Param", None,
-                       (("name", SlotLeaf(_text(unit, name_node))), ("annotation", MaybeChild(None)),
-                        ("default", MaybeChild(None)), ("param_kind", SlotLeaf("kwarg"))),
-                       anchors=(_span(unit, name_node),))
+        return _fixed(
+            "Param",
+            None,
+            (
+                ("name", SlotLeaf(_text(unit, name_node))),
+                ("annotation", MaybeChild(None)),
+                ("default", MaybeChild(None)),
+                ("param_kind", SlotLeaf("kwarg")),
+            ),
+            anchors=(_span(unit, name_node),),
+        )
     if node.type == "default_parameter":
         name_node = _field(node, "name")
         value_node = _field(node, "value")
-        return _fixed("Param", None,
-                       (("name", SlotLeaf(_text(unit, name_node))), ("annotation", MaybeChild(None)),
-                        ("default", MaybeChild(_h(unit, value_node))),
-                        ("param_kind", SlotLeaf("keyword_only" if after_star else "positional_or_keyword"))),
-                       anchors=(_span(unit, name_node),))
+        return _fixed(
+            "Param",
+            None,
+            (
+                ("name", SlotLeaf(_text(unit, name_node))),
+                ("annotation", MaybeChild(None)),
+                ("default", MaybeChild(_h(unit, value_node))),
+                (
+                    "param_kind",
+                    SlotLeaf("keyword_only" if after_star else "positional_or_keyword"),
+                ),
+            ),
+            anchors=(_span(unit, name_node),),
+        )
     if node.type == "typed_parameter":
         kids = list(node.children)
         name_node = kids[0]
@@ -738,21 +1021,35 @@ def _one_param(unit: SourceUnit, node: TSNode, after_star: bool) -> BackendNode:
             kind = "kwarg"
         elif after_star:
             kind = "keyword_only"
-        return _fixed("Param", None,
-                       (("name", SlotLeaf(_text(unit, name_node))),
-                        ("annotation", MaybeChild(_h(unit, annotation_node))),
-                        ("default", MaybeChild(None)), ("param_kind", SlotLeaf(kind))),
-                       anchors=(_span(unit, name_node),))
+        return _fixed(
+            "Param",
+            None,
+            (
+                ("name", SlotLeaf(_text(unit, name_node))),
+                ("annotation", MaybeChild(_h(unit, annotation_node))),
+                ("default", MaybeChild(None)),
+                ("param_kind", SlotLeaf(kind)),
+            ),
+            anchors=(_span(unit, name_node),),
+        )
     if node.type == "typed_default_parameter":
         name_node = _field(node, "name")
         annotation_node = _field(node, "type")
         value_node = _field(node, "value")
-        return _fixed("Param", None,
-                       (("name", SlotLeaf(_text(unit, name_node))),
-                        ("annotation", MaybeChild(_h(unit, annotation_node))),
-                        ("default", MaybeChild(_h(unit, value_node))),
-                        ("param_kind", SlotLeaf("keyword_only" if after_star else "positional_or_keyword"))),
-                       anchors=(_span(unit, name_node),))
+        return _fixed(
+            "Param",
+            None,
+            (
+                ("name", SlotLeaf(_text(unit, name_node))),
+                ("annotation", MaybeChild(_h(unit, annotation_node))),
+                ("default", MaybeChild(_h(unit, value_node))),
+                (
+                    "param_kind",
+                    SlotLeaf("keyword_only" if after_star else "positional_or_keyword"),
+                ),
+            ),
+            anchors=(_span(unit, name_node),),
+        )
     vocabulary_missing(
         owner="tree_sitter_python_adapter._one_param",
         observed=f"parameter shape {node.type!r} not recognized",
@@ -773,17 +1070,32 @@ def _assignment(unit: SourceUnit, node: TSNode) -> Description:
     type_node = _field(node, "type")
     span = _span(unit, node)
     if type_node is not None:
-        return Description(kind="AnnAssign", raw_span=span, anchors=(),
-                            slots=(("target", Child(_h(unit, left))), ("annotation", Child(_h(unit, type_node))),
-                                   ("value", MaybeChild(_h(unit, right))), ("simple", SlotLeaf(True))))
+        return Description(
+            kind="AnnAssign",
+            raw_span=span,
+            anchors=(),
+            slots=(
+                ("target", Child(_h(unit, left))),
+                ("annotation", Child(_h(unit, type_node))),
+                ("value", MaybeChild(_h(unit, right))),
+                ("simple", SlotLeaf(True)),
+            ),
+        )
     targets = [left]
     value_node = right
     while value_node is not None and value_node.type == "assignment":
         targets.append(_field(value_node, "left"))
         value_node = _field(value_node, "right")
     target_handles = tuple(_target_handle(unit, t) for t in targets)
-    return Description(kind="Assign", raw_span=span, anchors=(),
-                        slots=(("targets", Children(target_handles)), ("value", Child(_h(unit, value_node)))))
+    return Description(
+        kind="Assign",
+        raw_span=span,
+        anchors=(),
+        slots=(
+            ("targets", Children(target_handles)),
+            ("value", Child(_h(unit, value_node))),
+        ),
+    )
 
 
 def _target_handle(unit: SourceUnit, node: TSNode) -> BackendNode:
@@ -791,16 +1103,32 @@ def _target_handle(unit: SourceUnit, node: TSNode) -> BackendNode:
         elts = _named(node)
         if len(elts) == 1:
             return _target_handle(unit, elts[0])
-        return _fixed("Tuple", None, (("elts", Children(tuple(_target_handle(unit, e) for e in elts))),))
+        return _fixed(
+            "Tuple",
+            None,
+            (("elts", Children(tuple(_target_handle(unit, e) for e in elts))),),
+        )
     if node.type == "tuple_pattern":
         elts = _named(node)
-        return _fixed("Tuple", _span(unit, node), (("elts", Children(tuple(_target_handle(unit, e) for e in elts))),))
+        return _fixed(
+            "Tuple",
+            _span(unit, node),
+            (("elts", Children(tuple(_target_handle(unit, e) for e in elts))),),
+        )
     if node.type == "list_pattern":
         elts = _named(node)
-        return _fixed("List", _span(unit, node), (("elts", Children(tuple(_target_handle(unit, e) for e in elts))),))
+        return _fixed(
+            "List",
+            _span(unit, node),
+            (("elts", Children(tuple(_target_handle(unit, e) for e in elts))),),
+        )
     if node.type == "list_splat_pattern":
         inner = _named(node)[0]
-        return _fixed("Starred", _span(unit, node), (("value", Child(_target_handle(unit, inner))),))
+        return _fixed(
+            "Starred",
+            _span(unit, node),
+            (("value", Child(_target_handle(unit, inner))),),
+        )
     return _h(unit, node)
 
 
@@ -816,9 +1144,16 @@ def _augmented_assignment(unit: SourceUnit, node: TSNode) -> Description:
             requested="a known augmented assignment token",
             fix="extend _AUG_TOKEN deliberately",
         )
-    return Description(kind="AugAssign", raw_span=_span(unit, node), anchors=(),
-                        slots=(("target", Child(_h(unit, left))), ("op", OpLeaf(operator_for(kind))),
-                               ("value", Child(_h(unit, right)))))
+    return Description(
+        kind="AugAssign",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("target", Child(_h(unit, left))),
+            ("op", OpLeaf(operator_for(kind))),
+            ("value", Child(_h(unit, right))),
+        ),
+    )
 
 
 def _return_statement(unit: SourceUnit, node: TSNode) -> Description:
@@ -829,15 +1164,24 @@ def _return_statement(unit: SourceUnit, node: TSNode) -> Description:
             value = _bare_tuple(unit, named, None)
         else:
             value = _h(unit, named[0])
-    return Description(kind="Return", raw_span=_span(unit, node), anchors=(), slots=(("value", MaybeChild(value)),))
+    return Description(
+        kind="Return",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("value", MaybeChild(value)),),
+    )
 
 
 def _delete_statement(unit: SourceUnit, node: TSNode) -> Description:
     named = _named(node)
     inner = named[0]
     elts = _named(inner) if inner.type == "expression_list" else [inner]
-    return Description(kind="Delete", raw_span=_span(unit, node), anchors=(),
-                        slots=(("targets", Children(tuple(_h(unit, e) for e in elts))),))
+    return Description(
+        kind="Delete",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("targets", Children(tuple(_h(unit, e) for e in elts))),),
+    )
 
 
 def _raise_statement(unit: SourceUnit, node: TSNode) -> Description:
@@ -849,26 +1193,47 @@ def _raise_statement(unit: SourceUnit, node: TSNode) -> Description:
         exc_node = None
     elif named:
         exc_node = named[0]
-    return Description(kind="Raise", raw_span=_span(unit, node), anchors=(),
-                        slots=(("exc", MaybeChild(_h(unit, exc_node))), ("cause", MaybeChild(_h(unit, cause)))))
+    return Description(
+        kind="Raise",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("exc", MaybeChild(_h(unit, exc_node))),
+            ("cause", MaybeChild(_h(unit, cause))),
+        ),
+    )
 
 
 def _assert_statement(unit: SourceUnit, node: TSNode) -> Description:
     named = _named(node)
     test = named[0]
     msg = named[1] if len(named) > 1 else None
-    return Description(kind="Assert", raw_span=_span(unit, node), anchors=(),
-                        slots=(("test", Child(_h(unit, test))), ("msg", MaybeChild(_h(unit, msg)))))
+    return Description(
+        kind="Assert",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("test", Child(_h(unit, test))), ("msg", MaybeChild(_h(unit, msg)))),
+    )
 
 
 def _global_statement(unit: SourceUnit, node: TSNode) -> Description:
     names = tuple(_text(unit, c) for c in _named(node))
-    return Description(kind="Global", raw_span=_span(unit, node), anchors=(), slots=(("names", SlotLeaf(names)),))
+    return Description(
+        kind="Global",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("names", SlotLeaf(names)),),
+    )
 
 
 def _nonlocal_statement(unit: SourceUnit, node: TSNode) -> Description:
     names = tuple(_text(unit, c) for c in _named(node))
-    return Description(kind="Nonlocal", raw_span=_span(unit, node), anchors=(), slots=(("names", SlotLeaf(names)),))
+    return Description(
+        kind="Nonlocal",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("names", SlotLeaf(names)),),
+    )
 
 
 def _if_statement(unit: SourceUnit, node: TSNode) -> Description:
@@ -882,8 +1247,16 @@ def _if_statement(unit: SourceUnit, node: TSNode) -> Description:
         orelse = (_elif_handle(unit, alt),)
     else:  # else_clause
         orelse = _block_stmts(unit, _field(alt, "body"))
-    return Description(kind="If", raw_span=_span(unit, node), anchors=(),
-                        slots=(("test", Child(_h(unit, test))), ("body", Children(body)), ("orelse", Children(orelse))))
+    return Description(
+        kind="If",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("test", Child(_h(unit, test))),
+            ("body", Children(body)),
+            ("orelse", Children(orelse)),
+        ),
+    )
 
 
 def _elif_handle(unit: SourceUnit, node: TSNode) -> BackendNode:
@@ -896,8 +1269,15 @@ def _elif_handle(unit: SourceUnit, node: TSNode) -> BackendNode:
         orelse = (_elif_handle(unit, alt),)
     else:
         orelse = _block_stmts(unit, _field(alt, "body"))
-    return _fixed("If", _span(unit, node),
-                  (("test", Child(_h(unit, test))), ("body", Children(body)), ("orelse", Children(orelse))))
+    return _fixed(
+        "If",
+        _span(unit, node),
+        (
+            ("test", Child(_h(unit, test))),
+            ("body", Children(body)),
+            ("orelse", Children(orelse)),
+        ),
+    )
 
 
 def _while_statement(unit: SourceUnit, node: TSNode) -> Description:
@@ -905,8 +1285,16 @@ def _while_statement(unit: SourceUnit, node: TSNode) -> Description:
     body = _block_stmts(unit, _field(node, "body"))
     alt = _field(node, "alternative")
     orelse = _block_stmts(unit, _field(alt, "body")) if alt is not None else ()
-    return Description(kind="While", raw_span=_span(unit, node), anchors=(),
-                        slots=(("test", Child(_h(unit, test))), ("body", Children(body)), ("orelse", Children(orelse))))
+    return Description(
+        kind="While",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("test", Child(_h(unit, test))),
+            ("body", Children(body)),
+            ("orelse", Children(orelse)),
+        ),
+    )
 
 
 def _for_statement(unit: SourceUnit, node: TSNode) -> Description:
@@ -918,10 +1306,22 @@ def _for_statement(unit: SourceUnit, node: TSNode) -> Description:
     body = _block_stmts(unit, _field(node, "body"))
     alt = _field(node, "alternative")
     orelse = _block_stmts(unit, _field(alt, "body")) if alt is not None else ()
-    kind = "AsyncFor" if any(not c.is_named and c.type == "async" for c in node.children) else "For"
-    return Description(kind=kind, raw_span=_span(unit, node), anchors=(),
-                        slots=(("target", Child(target)), ("iter", Child(iter_handle)),
-                               ("body", Children(body)), ("orelse", Children(orelse))))
+    kind = (
+        "AsyncFor"
+        if any(not c.is_named and c.type == "async" for c in node.children)
+        else "For"
+    )
+    return Description(
+        kind=kind,
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("target", Child(target)),
+            ("iter", Child(iter_handle)),
+            ("body", Children(body)),
+            ("orelse", Children(orelse)),
+        ),
+    )
 
 
 def _with_statement(unit: SourceUnit, node: TSNode) -> Description:
@@ -941,28 +1341,65 @@ def _with_statement(unit: SourceUnit, node: TSNode) -> Description:
                     ctx = _named(c)[0]
                     alias = _field(c, "alias")
                     alias_inner = _named(alias)[0] if alias is not None else None
-                    items.append(_fixed("WithItem", _span(unit, c),
-                                         (("context_expr", Child(_h(unit, ctx))),
-                                          ("optional_vars", MaybeChild(_h(unit, alias_inner))))))
+                    items.append(
+                        _fixed(
+                            "WithItem",
+                            _span(unit, c),
+                            (
+                                ("context_expr", Child(_h(unit, ctx))),
+                                ("optional_vars", MaybeChild(_h(unit, alias_inner))),
+                            ),
+                        )
+                    )
                 else:
-                    items.append(_fixed("WithItem", _span(unit, c),
-                                         (("context_expr", Child(_h(unit, c))),
-                                          ("optional_vars", MaybeChild(None)))))
+                    items.append(
+                        _fixed(
+                            "WithItem",
+                            _span(unit, c),
+                            (
+                                ("context_expr", Child(_h(unit, c))),
+                                ("optional_vars", MaybeChild(None)),
+                            ),
+                        )
+                    )
             continue
         if value.type == "as_pattern":
             ctx = _named(value)[0]
             alias = _field(value, "alias")
             alias_inner = _named(alias)[0] if alias is not None else None
-            items.append(_fixed("WithItem", _span(unit, it),
-                                 (("context_expr", Child(_h(unit, ctx))),
-                                  ("optional_vars", MaybeChild(_h(unit, alias_inner))))))
+            items.append(
+                _fixed(
+                    "WithItem",
+                    _span(unit, it),
+                    (
+                        ("context_expr", Child(_h(unit, ctx))),
+                        ("optional_vars", MaybeChild(_h(unit, alias_inner))),
+                    ),
+                )
+            )
         else:
-            items.append(_fixed("WithItem", _span(unit, it),
-                                 (("context_expr", Child(_h(unit, value))), ("optional_vars", MaybeChild(None)))))
+            items.append(
+                _fixed(
+                    "WithItem",
+                    _span(unit, it),
+                    (
+                        ("context_expr", Child(_h(unit, value))),
+                        ("optional_vars", MaybeChild(None)),
+                    ),
+                )
+            )
     body = _block_stmts(unit, _field(node, "body"))
-    kind = "AsyncWith" if any(not c.is_named and c.type == "async" for c in node.children) else "With"
-    return Description(kind=kind, raw_span=_span(unit, node), anchors=(),
-                        slots=(("items", Children(tuple(items))), ("body", Children(body))))
+    kind = (
+        "AsyncWith"
+        if any(not c.is_named and c.type == "async" for c in node.children)
+        else "With"
+    )
+    return Description(
+        kind=kind,
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("items", Children(tuple(items))), ("body", Children(body))),
+    )
 
 
 def _try_statement(unit: SourceUnit, node: TSNode) -> Description:
@@ -982,23 +1419,43 @@ def _try_statement(unit: SourceUnit, node: TSNode) -> Description:
                 if value.type == "as_pattern":
                     exc_type = _named(value)[0]
                     alias = _field(value, "alias")
-                    exc_name = _text(unit, _named(alias)[0]) if alias is not None else None
+                    exc_name = (
+                        _text(unit, _named(alias)[0]) if alias is not None else None
+                    )
                 else:
                     exc_type = value
-            handler_body = _block_stmts(unit, next(k for k in c.children if k.type == "block"))
-            handlers.append(_fixed(
-                "ExceptHandler", _span(unit, c),
-                (("type_", MaybeChild(_h(unit, exc_type))), ("name", SlotLeaf(exc_name)),
-                 ("body", Children(handler_body))),
-            ))
+            handler_body = _block_stmts(
+                unit, next(k for k in c.children if k.type == "block")
+            )
+            handlers.append(
+                _fixed(
+                    "ExceptHandler",
+                    _span(unit, c),
+                    (
+                        ("type_", MaybeChild(_h(unit, exc_type))),
+                        ("name", SlotLeaf(exc_name)),
+                        ("body", Children(handler_body)),
+                    ),
+                )
+            )
         elif c.type == "else_clause":
             orelse = _block_stmts(unit, _field(c, "body"))
         elif c.type == "finally_clause":
-            finalbody = _block_stmts(unit, next(k for k in c.children if k.type == "block"))
+            finalbody = _block_stmts(
+                unit, next(k for k in c.children if k.type == "block")
+            )
     kind = "TryStar" if is_star else "Try"
-    return Description(kind=kind, raw_span=_span(unit, node), anchors=(),
-                        slots=(("body", Children(body)), ("handlers", Children(tuple(handlers))),
-                               ("orelse", Children(orelse)), ("finalbody", Children(finalbody))))
+    return Description(
+        kind=kind,
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("body", Children(body)),
+            ("handlers", Children(tuple(handlers))),
+            ("orelse", Children(orelse)),
+            ("finalbody", Children(finalbody)),
+        ),
+    )
 
 
 def _function_definition(unit: SourceUnit, node: TSNode) -> Description:
@@ -1006,11 +1463,24 @@ def _function_definition(unit: SourceUnit, node: TSNode) -> Description:
     params = _flatten_params(unit, _field(node, "parameters"))
     returns = _field(node, "return_type")
     body = _block_stmts(unit, _field(node, "body"))
-    kind = "AsyncFunctionDef" if any(not c.is_named and c.type == "async" for c in node.children) else "FunctionDef"
-    return Description(kind=kind, raw_span=_span(unit, node), anchors=(),
-                        slots=(("name", SlotLeaf(name)), ("params", Children(params)), ("body", Children(body)),
-                               ("decorators", Children(())),
-                               ("returns", MaybeChild(_h(unit, returns))), ("type_params", Children(()))))
+    kind = (
+        "AsyncFunctionDef"
+        if any(not c.is_named and c.type == "async" for c in node.children)
+        else "FunctionDef"
+    )
+    return Description(
+        kind=kind,
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("name", SlotLeaf(name)),
+            ("params", Children(params)),
+            ("body", Children(body)),
+            ("decorators", Children(())),
+            ("returns", MaybeChild(_h(unit, returns))),
+            ("type_params", Children(())),
+        ),
+    )
 
 
 def _class_definition(unit: SourceUnit, node: TSNode) -> Description:
@@ -1023,21 +1493,48 @@ def _class_definition(unit: SourceUnit, node: TSNode) -> Description:
             if c.type == "keyword_argument":
                 name_node = _field(c, "name")
                 value_node = _field(c, "value")
-                keywords.append(_fixed("Keyword", _span(unit, c),
-                                        (("arg", SlotLeaf(_text(unit, name_node))), ("value", Child(_h(unit, value_node))))))
+                keywords.append(
+                    _fixed(
+                        "Keyword",
+                        _span(unit, c),
+                        (
+                            ("arg", SlotLeaf(_text(unit, name_node))),
+                            ("value", Child(_h(unit, value_node))),
+                        ),
+                    )
+                )
             elif c.type == "list_splat":
                 inner = c.children[1]
-                bases.append(_fixed("Starred", _span(unit, c), (("value", Child(_h(unit, inner))),)))
+                bases.append(
+                    _fixed(
+                        "Starred", _span(unit, c), (("value", Child(_h(unit, inner))),)
+                    )
+                )
             elif c.type == "dictionary_splat":
                 inner = c.children[1]
-                keywords.append(_fixed("Keyword", None, (("arg", SlotLeaf(None)), ("value", Child(_h(unit, inner))))))
+                keywords.append(
+                    _fixed(
+                        "Keyword",
+                        None,
+                        (("arg", SlotLeaf(None)), ("value", Child(_h(unit, inner)))),
+                    )
+                )
             else:
                 bases.append(_h(unit, c))
     body = _block_stmts(unit, _field(node, "body"))
-    return Description(kind="ClassDef", raw_span=_span(unit, node), anchors=(),
-                        slots=(("name", SlotLeaf(name)), ("bases", Children(tuple(bases))),
-                               ("keywords", Children(tuple(keywords))), ("body", Children(body)),
-                               ("decorators", Children(())), ("type_params", Children(()))))
+    return Description(
+        kind="ClassDef",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("name", SlotLeaf(name)),
+            ("bases", Children(tuple(bases))),
+            ("keywords", Children(tuple(keywords))),
+            ("body", Children(body)),
+            ("decorators", Children(())),
+            ("type_params", Children(())),
+        ),
+    )
 
 
 def _decorated_definition(unit: SourceUnit, node: TSNode) -> Description:
@@ -1046,7 +1543,10 @@ def _decorated_definition(unit: SourceUnit, node: TSNode) -> Description:
     inner = _field(node, "definition")
     base = _describe(unit, inner)
     span = Span(_span(unit, node).start, base.raw_span.end)
-    new_slots = tuple((n, Children(dec_handles)) if n == "decorators" else (n, s) for n, s in base.slots)
+    new_slots = tuple(
+        (n, Children(dec_handles)) if n == "decorators" else (n, s)
+        for n, s in base.slots
+    )
     return Description(kind=base.kind, raw_span=span, anchors=(), slots=new_slots)
 
 
@@ -1056,16 +1556,31 @@ def _import_statement(unit: SourceUnit, node: TSNode) -> Description:
         if not c.is_named or c.type in _SKIP_TYPES:
             continue
         names.append(_import_alias(unit, c))
-    return Description(kind="Import", raw_span=_span(unit, node), anchors=(), slots=(("names", Children(tuple(names))),))
+    return Description(
+        kind="Import",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("names", Children(tuple(names))),),
+    )
 
 
 def _import_alias(unit: SourceUnit, node: TSNode) -> BackendNode:
     if node.type == "aliased_import":
         name_node = _field(node, "name")
         alias_node = _field(node, "alias")
-        return _fixed("ImportAlias", _span(unit, node),
-                      (("name", SlotLeaf(_dotted_str(unit, name_node))), ("asname", SlotLeaf(_text(unit, alias_node)))))
-    return _fixed("ImportAlias", _span(unit, node), (("name", SlotLeaf(_dotted_str(unit, node))), ("asname", SlotLeaf(None))))
+        return _fixed(
+            "ImportAlias",
+            _span(unit, node),
+            (
+                ("name", SlotLeaf(_dotted_str(unit, name_node))),
+                ("asname", SlotLeaf(_text(unit, alias_node))),
+            ),
+        )
+    return _fixed(
+        "ImportAlias",
+        _span(unit, node),
+        (("name", SlotLeaf(_dotted_str(unit, node))), ("asname", SlotLeaf(None))),
+    )
 
 
 def _dotted_str(unit: SourceUnit, node: TSNode) -> str:
@@ -1078,24 +1593,45 @@ def _import_from_statement(unit: SourceUnit, node: TSNode) -> Description:
     module: Optional[str] = None
     if module_node is not None:
         if module_node.type == "relative_import":
-            prefix = _field(module_node, None) if False else next(
-                (c for c in module_node.children if c.type == "import_prefix"), None
+            prefix = (
+                _field(module_node, None)
+                if False
+                else next(
+                    (c for c in module_node.children if c.type == "import_prefix"), None
+                )
             )
             if prefix is not None:
                 level = sum(1 for c in prefix.children if c.type == ".")
-            dotted = next((c for c in module_node.children if c.type == "dotted_name"), None)
+            dotted = next(
+                (c for c in module_node.children if c.type == "dotted_name"), None
+            )
             module = _text(unit, dotted) if dotted is not None else None
         else:
             module = _dotted_str(unit, module_node)
     names_nodes = _fields(node, "name")
-    star_node = next((c for c in node.children if not c.is_named and c.type == "*"), None)
+    star_node = next(
+        (c for c in node.children if not c.is_named and c.type == "*"), None
+    )
     if star_node is not None:
-        names = (_fixed("ImportAlias", _span(unit, star_node),
-                         (("name", SlotLeaf("*")), ("asname", SlotLeaf(None)))),)
+        names = (
+            _fixed(
+                "ImportAlias",
+                _span(unit, star_node),
+                (("name", SlotLeaf("*")), ("asname", SlotLeaf(None))),
+            ),
+        )
     else:
         names = tuple(_import_alias(unit, n) for n in names_nodes)
-    return Description(kind="ImportFrom", raw_span=_span(unit, node), anchors=(),
-                        slots=(("module", SlotLeaf(module)), ("names", Children(names)), ("level", SlotLeaf(level))))
+    return Description(
+        kind="ImportFrom",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("module", SlotLeaf(module)),
+            ("names", Children(names)),
+            ("level", SlotLeaf(level)),
+        ),
+    )
 
 
 def _dotted_name_expr(unit: SourceUnit, node: TSNode) -> BackendNode:
@@ -1108,7 +1644,11 @@ def _dotted_name_expr(unit: SourceUnit, node: TSNode) -> BackendNode:
     start = _span(unit, parts[0]).start
     for p in parts[1:]:
         end = _span(unit, p).end
-        acc = _fixed("Attribute", Span(start, end), (("value", Child(acc)), ("attr", SlotLeaf(_text(unit, p)))))
+        acc = _fixed(
+            "Attribute",
+            Span(start, end),
+            (("value", Child(acc)), ("attr", SlotLeaf(_text(unit, p)))),
+        )
     return acc
 
 
@@ -1123,9 +1663,17 @@ def _generic_type(unit: SourceUnit, node: TSNode) -> Description:
     if len(items) == 1:
         slice_handle = _one_subscript_item(unit, items[0])
     else:
-        slice_handle = _fixed("Tuple", None, (("elts", Children(tuple(_one_subscript_item(unit, i) for i in items))),))
-    return Description(kind="Subscript", raw_span=_span(unit, node), anchors=(),
-                        slots=(("value", Child(_h(unit, base))), ("slice_", Child(slice_handle))))
+        slice_handle = _fixed(
+            "Tuple",
+            None,
+            (("elts", Children(tuple(_one_subscript_item(unit, i) for i in items))),),
+        )
+    return Description(
+        kind="Subscript",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(("value", Child(_h(unit, base))), ("slice_", Child(slice_handle))),
+    )
 
 
 def _type_var(unit: SourceUnit, item: TSNode) -> BackendNode:
@@ -1135,14 +1683,24 @@ def _type_var(unit: SourceUnit, item: TSNode) -> BackendNode:
         name_node, bound_node = _named(inner)[0], _named(inner)[1]
         name_inner = _named(name_node)[0] if name_node.type == "type" else name_node
         bound_inner = _named(bound_node)[0] if bound_node.type == "type" else bound_node
-        return _fixed("TypeVar", _span(unit, inner),
-                       (("name", SlotLeaf(_text(unit, name_inner))),
-                        ("bound", MaybeChild(_h(unit, bound_inner))),
-                        ("default_value", MaybeChild(None))))
-    return _fixed("TypeVar", _span(unit, inner),
-                   (("name", SlotLeaf(_text(unit, inner))),
-                    ("bound", MaybeChild(None)),
-                    ("default_value", MaybeChild(None))))
+        return _fixed(
+            "TypeVar",
+            _span(unit, inner),
+            (
+                ("name", SlotLeaf(_text(unit, name_inner))),
+                ("bound", MaybeChild(_h(unit, bound_inner))),
+                ("default_value", MaybeChild(None)),
+            ),
+        )
+    return _fixed(
+        "TypeVar",
+        _span(unit, inner),
+        (
+            ("name", SlotLeaf(_text(unit, inner))),
+            ("bound", MaybeChild(None)),
+            ("default_value", MaybeChild(None)),
+        ),
+    )
 
 
 def _type_alias_statement(unit: SourceUnit, node: TSNode) -> Description:
@@ -1159,15 +1717,33 @@ def _type_alias_statement(unit: SourceUnit, node: TSNode) -> Description:
             if i.is_named and i.type not in _SKIP_TYPES
         )
         name_expr = base
-    return Description(kind="TypeAlias", raw_span=_span(unit, node), anchors=(),
-                        slots=(("name", Child(_h(unit, name_expr))), ("type_params", Children(type_params)),
-                               ("value", Child(_h(unit, _named(right)[0] if right.type == "type" else right)))))
+    return Description(
+        kind="TypeAlias",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("name", Child(_h(unit, name_expr))),
+            ("type_params", Children(type_params)),
+            (
+                "value",
+                Child(_h(unit, _named(right)[0] if right.type == "type" else right)),
+            ),
+        ),
+    )
 
 
 def _future_import_statement(unit: SourceUnit, node: TSNode) -> Description:
     names = tuple(_import_alias(unit, n) for n in _fields(node, "name"))
-    return Description(kind="ImportFrom", raw_span=_span(unit, node), anchors=(),
-                        slots=(("module", SlotLeaf("__future__")), ("names", Children(names)), ("level", SlotLeaf(0))))
+    return Description(
+        kind="ImportFrom",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("module", SlotLeaf("__future__")),
+            ("names", Children(names)),
+            ("level", SlotLeaf(0)),
+        ),
+    )
 
 
 def _match_statement(unit: SourceUnit, node: TSNode) -> Description:
@@ -1178,8 +1754,15 @@ def _match_statement(unit: SourceUnit, node: TSNode) -> Description:
         if c.type != "case_clause":
             continue
         cases.append(_case_clause(unit, c))
-    return Description(kind="Match", raw_span=_span(unit, node), anchors=(),
-                        slots=(("subject", Child(_h(unit, subject))), ("cases", Children(tuple(cases)))))
+    return Description(
+        kind="Match",
+        raw_span=_span(unit, node),
+        anchors=(),
+        slots=(
+            ("subject", Child(_h(unit, subject))),
+            ("cases", Children(tuple(cases))),
+        ),
+    )
 
 
 def _case_clause(unit: SourceUnit, node: TSNode) -> BackendNode:
@@ -1192,13 +1775,24 @@ def _case_clause(unit: SourceUnit, node: TSNode) -> BackendNode:
     if len(pattern_nodes) == 1:
         pattern = _pattern(unit, pattern_nodes[0])
     else:
-        pat_span = Span(_span(unit, pattern_nodes[0]).start, _span(unit, pattern_nodes[-1]).end)
-        pattern = _fixed("MatchSequence", pat_span,
-                          (("patterns", Children(tuple(_pattern(unit, p) for p in pattern_nodes))),))
+        pat_span = Span(
+            _span(unit, pattern_nodes[0]).start, _span(unit, pattern_nodes[-1]).end
+        )
+        pattern = _fixed(
+            "MatchSequence",
+            pat_span,
+            (("patterns", Children(tuple(_pattern(unit, p) for p in pattern_nodes))),),
+        )
     guard_cond = _named(guard)[0] if guard is not None else None
-    return _fixed("MatchCase", _span(unit, node),
-                  (("pattern", Child(pattern)), ("guard", MaybeChild(_h(unit, guard_cond))),
-                   ("body", Children(body))))
+    return _fixed(
+        "MatchCase",
+        _span(unit, node),
+        (
+            ("pattern", Child(pattern)),
+            ("guard", MaybeChild(_h(unit, guard_cond))),
+            ("body", Children(body)),
+        ),
+    )
 
 
 def _pattern(unit: SourceUnit, node: TSNode) -> BackendNode:
@@ -1206,16 +1800,38 @@ def _pattern(unit: SourceUnit, node: TSNode) -> BackendNode:
         inner = _named(node)
         if len(inner) == 1:
             return _pattern(unit, inner[0])
-        return _fixed("MatchSequence", _span(unit, node),
-                       (("patterns", Children(tuple(_pattern(unit, p) for p in inner))),))
+        return _fixed(
+            "MatchSequence",
+            _span(unit, node),
+            (("patterns", Children(tuple(_pattern(unit, p) for p in inner))),),
+        )
     span = _span(unit, node)
     if node.type == "_":
-        return _fixed("MatchAs", span, (("pattern", MaybeChild(None)), ("name", SlotLeaf(None))))
-    if node.type in ("integer", "float", "true", "false", "none", "string", "complex_pattern", "unary_operator",
-                      "concatenated_string"):
-        return _h(unit, node) if node.type != "true" and node.type != "false" and node.type != "none" else _Fixed(_SIMPLE_LEAF[node.type](unit, node))
+        return _fixed(
+            "MatchAs", span, (("pattern", MaybeChild(None)), ("name", SlotLeaf(None)))
+        )
+    if node.type in (
+        "integer",
+        "float",
+        "true",
+        "false",
+        "none",
+        "string",
+        "complex_pattern",
+        "unary_operator",
+        "concatenated_string",
+    ):
+        return (
+            _h(unit, node)
+            if node.type != "true" and node.type != "false" and node.type != "none"
+            else _Fixed(_SIMPLE_LEAF[node.type](unit, node))
+        )
     if node.type == "identifier":
-        return _fixed("MatchAs", span, (("pattern", MaybeChild(None)), ("name", SlotLeaf(_text(unit, node)))))
+        return _fixed(
+            "MatchAs",
+            span,
+            (("pattern", MaybeChild(None)), ("name", SlotLeaf(_text(unit, node)))),
+        )
     if node.type in ("dotted_name", "attribute"):
         return _fixed("MatchValue", span, (("value", Child(_h(unit, node))),))
     if node.type in ("list_pattern", "tuple_pattern"):
@@ -1234,8 +1850,17 @@ def _pattern(unit: SourceUnit, node: TSNode) -> BackendNode:
         tn = _fields(node, "alias")
         if tn:
             tgt = tn[0]
-            target_name = _text(unit, _named(tgt)[0] if tgt.type == "as_pattern_target" else tgt)
-        return _fixed("MatchAs", span, (("pattern", MaybeChild(_pattern(unit, inner))), ("name", SlotLeaf(target_name))))
+            target_name = _text(
+                unit, _named(tgt)[0] if tgt.type == "as_pattern_target" else tgt
+            )
+        return _fixed(
+            "MatchAs",
+            span,
+            (
+                ("pattern", MaybeChild(_pattern(unit, inner))),
+                ("name", SlotLeaf(target_name)),
+            ),
+        )
     if node.type == "union_pattern":
         items = [_pattern(unit, c) for c in _named(node)]
         return _fixed("MatchOr", span, (("patterns", Children(tuple(items))),))
@@ -1254,9 +1879,16 @@ def _pattern(unit: SourceUnit, node: TSNode) -> BackendNode:
                 kwd_patterns.append(_pattern_item(unit, kv))
             else:
                 positional.append(_pattern_item(unit, c))
-        return _fixed("MatchClass", span,
-                      (("cls_", Child(_h(unit, cls_node))), ("patterns", Children(tuple(positional))),
-                       ("kwd_attrs", SlotLeaf(tuple(kwd_attrs))), ("kwd_patterns", Children(tuple(kwd_patterns)))))
+        return _fixed(
+            "MatchClass",
+            span,
+            (
+                ("cls_", Child(_h(unit, cls_node))),
+                ("patterns", Children(tuple(positional))),
+                ("kwd_attrs", SlotLeaf(tuple(kwd_attrs))),
+                ("kwd_patterns", Children(tuple(kwd_patterns))),
+            ),
+        )
     if node.type == "dict_pattern":
         keys: List[BackendNode] = []
         patterns: List[BackendNode] = []
@@ -1282,8 +1914,15 @@ def _pattern(unit: SourceUnit, node: TSNode) -> BackendNode:
             keys.append(_h(unit, key_node))
             patterns.append(_pattern_item(unit, value_node))
             i = j + 1
-        return _fixed("MatchMapping", span,
-                      (("keys", Children(tuple(keys))), ("patterns", Children(tuple(patterns))), ("rest", SlotLeaf(rest))))
+        return _fixed(
+            "MatchMapping",
+            span,
+            (
+                ("keys", Children(tuple(keys))),
+                ("patterns", Children(tuple(patterns))),
+                ("rest", SlotLeaf(rest)),
+            ),
+        )
     vocabulary_missing(
         owner="tree_sitter_python_adapter._pattern",
         observed=f"case pattern shape {node.type!r} not recognized",
@@ -1351,9 +1990,15 @@ _DISPATCH = {
     "assert_statement": _assert_statement,
     "global_statement": _global_statement,
     "nonlocal_statement": _nonlocal_statement,
-    "pass_statement": lambda u, n: Description(kind="Pass", raw_span=_span(u, n), anchors=(), slots=()),
-    "break_statement": lambda u, n: Description(kind="Break", raw_span=_span(u, n), anchors=(), slots=()),
-    "continue_statement": lambda u, n: Description(kind="Continue", raw_span=_span(u, n), anchors=(), slots=()),
+    "pass_statement": lambda u, n: Description(
+        kind="Pass", raw_span=_span(u, n), anchors=(), slots=()
+    ),
+    "break_statement": lambda u, n: Description(
+        kind="Break", raw_span=_span(u, n), anchors=(), slots=()
+    ),
+    "continue_statement": lambda u, n: Description(
+        kind="Continue", raw_span=_span(u, n), anchors=(), slots=()
+    ),
     "if_statement": _if_statement,
     "while_statement": _while_statement,
     "for_statement": _for_statement,
@@ -1395,20 +2040,29 @@ _DISPATCH = {
     "dotted_name": lambda u, n: _dotted_name_expr(u, n).describe(),
     "generic_type": _generic_type,
     "splat_type": lambda u, n: Description(
-        kind="Starred", raw_span=_span(u, n), anchors=(),
+        kind="Starred",
+        raw_span=_span(u, n),
+        anchors=(),
         slots=(("value", Child(_h(u, _named(n)[0]))),),
     ),
     "list_splat": lambda u, n: Description(
-        kind="Starred", raw_span=_span(u, n), anchors=(),
+        kind="Starred",
+        raw_span=_span(u, n),
+        anchors=(),
         slots=(("value", Child(_h(u, _named(n)[0]))),),
     ),
     # PEP 604 `X | Y` written in annotation position parses as its own
     # 'union_type' node rather than a binary_operator (the '|' expression
     # form still goes through binary_operator/BinOp as usual) — same shape.
     "union_type": lambda u, n: Description(
-        kind="BinOp", raw_span=_span(u, n), anchors=(),
-        slots=(("left", Child(_h(u, _named(n)[0]))), ("op", OpLeaf(operator_for("BitOr"))),
-               ("right", Child(_h(u, _named(n)[1])))),
+        kind="BinOp",
+        raw_span=_span(u, n),
+        anchors=(),
+        slots=(
+            ("left", Child(_h(u, _named(n)[0]))),
+            ("op", OpLeaf(operator_for("BitOr"))),
+            ("right", Child(_h(u, _named(n)[1]))),
+        ),
     ),
 }
 

--- a/implementations/python/sugar-source-tree/tests/test_assign_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_targets.py
@@ -87,14 +87,24 @@ def test_mixed_chained_targets_stay_loud():
 
 
 def test_attribute_store_target_lifts_a_typed_red_effect():
-    entries = _fn("def A(o):\n    o.a = 1\n    return o\n").sugar().desugar().value.record.statements
+    entries = (
+        _fn("def A(o):\n    o.a = 1\n    return o\n")
+        .sugar()
+        .desugar()
+        .value.record.statements
+    )
     red = [e for e in entries if isinstance(e, Incomplete)]
     assert len(red) == 1
     assert isinstance(red[0].effect, AttributeStoreRuntimeEffect)
 
 
 def test_subscript_store_target_lifts_a_typed_red_effect():
-    entries = _fn("def A(xs):\n    xs[0] = 1\n    return xs\n").sugar().desugar().value.record.statements
+    entries = (
+        _fn("def A(xs):\n    xs[0] = 1\n    return xs\n")
+        .sugar()
+        .desugar()
+        .value.record.statements
+    )
     red = [e for e in entries if isinstance(e, Incomplete)]
     assert len(red) == 1
     assert isinstance(red[0].effect, SubscriptStoreRuntimeEffect)

--- a/implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py
+++ b/implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py
@@ -9,7 +9,11 @@ from sugar_lift_py_tests.floor import ReturnValue, TermValue, UniverseValue
 from sugar_lift_py_tests.ir import and_, make_var, not_, or_, py_truthy
 from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted, Incomplete
 from sugar_lift_python_source.source_oracle import path_source
-from sugar_source_tree.binding_state import BranchResultSlot, GuardedBinding, UnboundBinding
+from sugar_source_tree.binding_state import (
+    BranchResultSlot,
+    GuardedBinding,
+    UnboundBinding,
+)
 from sugar_source_tree.nodes import Node
 from sugar_source_tree.panic import BackendDefect, SugarNotWritten
 from sugar_source_tree.tree import SourceFile
@@ -193,9 +197,7 @@ def test_bound_augassign_control_remains_completed_value() -> None:
     out = _out("def f():\n x = 1\n x += 2\n return x\n")
     assert isinstance(out, Complete)
     returns = [
-        entry
-        for entry in out.value.record.statements
-        if isinstance(entry, ReturnValue)
+        entry for entry in out.value.record.statements if isinstance(entry, ReturnValue)
     ]
     assert returns[0].value == TermValue(3)
 
@@ -245,9 +247,7 @@ def test_try_exception_alias_is_tombstoned_after_handler() -> None:
 
 def test_try_uncaught_raise_remains_a_halted_face() -> None:
     out = _out(
-        "def f():\n"
-        " try:\n  raise TypeError\n"
-        " except ValueError:\n  pass\n"
+        "def f():\n" " try:\n  raise TypeError\n" " except ValueError:\n  pass\n"
     )
     assert isinstance(out, Incomplete)
     assert isinstance(out.effect, RaiseEffect)

--- a/implementations/python/sugar-source-tree/tests/test_comparison_operators.py
+++ b/implementations/python/sugar-source-tree/tests/test_comparison_operators.py
@@ -15,7 +15,12 @@ def _inv(src: str):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
         f.write(src)
         path = f.name
-    return next(SourceFile(path_source(path)).functions()).sugar().desugar().value.invs()[0]
+    return (
+        next(SourceFile(path_source(path)).functions())
+        .sugar()
+        .desugar()
+        .value.invs()[0]
+    )
 
 
 def test_not_equal_is_equals_negated():
@@ -37,7 +42,11 @@ def test_chained_comparison_conjoins_adjacent_pairs():
     assert inv.kind == "and"
     left, right = inv.operands
     assert left.name == "py.lt" and left.args[0].value == 0 and left.args[1].name == "z"
-    assert right.name == "py.lt" and right.args[0].name == "z" and right.args[1].value == 10
+    assert (
+        right.name == "py.lt"
+        and right.args[0].name == "z"
+        and right.args[1].value == 10
+    )
 
 
 def test_comparison_composes_inside_boolop():

--- a/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
+++ b/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
@@ -152,8 +152,7 @@ def test_nested_lambda_same_name_does_not_escape_comprehension_transform():
 
 def test_nested_symbolic_listcomp_builds_composed_lambda_binders():
     term = _out(
-        "def A(xs, ys, z):\n"
-        "    return [[f(x, y, z) for y in ys] for x in xs]\n"
+        "def A(xs, ys, z):\n" "    return [[f(x, y, z) for y in ys] for x in xs]\n"
     )
 
     assert term.name == "py.listcomp"
@@ -166,10 +165,7 @@ def test_nested_symbolic_listcomp_builds_composed_lambda_binders():
 
 
 def test_nested_comprehension_iterable_builds_without_flattening():
-    term = _out(
-        "def A(ys):\n"
-        "    return [f(x) for x in [g(y) for y in ys]]\n"
-    )
+    term = _out("def A(ys):\n" "    return [f(x) for x in [g(y) for y in ys]]\n")
 
     assert term.name == "py.listcomp"
     assert term.args[0].name == "py.listcomp"
@@ -179,10 +175,7 @@ def test_nested_comprehension_iterable_builds_without_flattening():
 
 
 def test_nested_generator_expression_retains_both_lazy_coordinates():
-    term = _out(
-        "def A(xs, ys):\n"
-        "    return ((f(x, y) for y in ys) for x in xs)\n"
-    )
+    term = _out("def A(xs, ys):\n" "    return ((f(x, y) for y in ys) for x in xs)\n")
 
     assert term.name == "py.generatorexp"
     assert term.args[1].param_name == "x"
@@ -223,8 +216,7 @@ def test_nested_arm_composes_already_built_comprehension_kinds(
 def test_nested_comprehension_does_not_admit_an_inner_filtered_gap():
     with pytest.raises(SugarNotWritten):
         _fn(
-            "def A(xs, ys):\n"
-            "    return [[y for y in ys if keep(y)] for x in xs]\n"
+            "def A(xs, ys):\n" "    return [[y for y in ys if keep(y)] for x in xs]\n"
         ).sugar()
 
 
@@ -241,11 +233,7 @@ def test_list_generator_nested_arm_does_not_widen_set_or_dict(source):
 
 
 def test_bound_target_masks_outer_same_spelling_and_keeps_call_coordinate():
-    term = _out(
-        "def A(xs):\n"
-        "    x = 999\n"
-        "    return [f(x) for x in xs]\n"
-    )
+    term = _out("def A(xs):\n" "    x = 999\n" "    return [f(x) for x in xs]\n")
     assert term.name == "py.listcomp"
     assert term.args[1].param_name == "x"
     assert term.args[1].body.name == "call:f"
@@ -353,9 +341,7 @@ def test_nested_comprehension_substitutes_outer_capture_before_building():
 
 def test_walrus_comprehension_substitutes_outer_capture_before_own_gap():
     fn = _fn(
-        "def A():\n"
-        "    value = 7\n"
-        "    return [(captured := value) for x in [1]]\n"
+        "def A():\n" "    value = 7\n" "    return [(captured := value) for x in [1]]\n"
     )
     expression = fn.substitute({}).body[-1].value
     assert expression.elt.value.value == 7
@@ -365,8 +351,6 @@ def test_walrus_comprehension_substitutes_outer_capture_before_own_gap():
 
 def test_existing_concrete_displays_keep_exact_terms():
     filtered = _out("def A():\n    return [x for x in [1, 2, 3] if x > 1]\n")
-    destructured = _out(
-        "def A():\n    return [a + b for a, b in [(1, 2), (3, 4)]]\n"
-    )
+    destructured = _out("def A():\n    return [a + b for a, b in [(1, 2), (3, 4)]]\n")
     assert filtered == ctor("array", [num(2), num(3)])
     assert destructured == ctor("array", [num(3), num(7)])

--- a/implementations/python/sugar-source-tree/tests/test_could_not_parse_twin.py
+++ b/implementations/python/sugar-source-tree/tests/test_could_not_parse_twin.py
@@ -72,8 +72,6 @@ def test_an_unparseable_file_produces_a_recorded_row_never_an_escaped_exception(
     )
 
     assert result.files == 1  # only fine.py parsed
-    could_not_parse = [
-        f for f in result.failures if f[1] == "backend_could_not_parse"
-    ]
+    could_not_parse = [f for f in result.failures if f[1] == "backend_could_not_parse"]
     assert len(could_not_parse) == 1
     assert could_not_parse[0][0] == "unparseable.py"

--- a/implementations/python/sugar-source-tree/tests/test_exit_builds.py
+++ b/implementations/python/sugar-source-tree/tests/test_exit_builds.py
@@ -55,9 +55,9 @@ def test_raise_name_points_at_the_built_value() -> None:
 
 
 def test_raise_constructor_carries_its_built_call_coordinate() -> None:
-    outcome = _statement(
-        "def A():\n    raise ValueError(7)\n", "Raise"
-    ).sugar().desugar()
+    outcome = (
+        _statement("def A():\n    raise ValueError(7)\n", "Raise").sugar().desugar()
+    )
 
     assert isinstance(outcome, Incomplete)
     raised = outcome.effect.raised_value
@@ -72,9 +72,11 @@ def test_unwritten_raised_child_stays_loud() -> None:
 
 
 def test_raise_from_carries_the_built_cause() -> None:
-    outcome = _statement(
-        "def A():\n    raise ValueError from KeyError\n", "Raise"
-    ).sugar().desugar()
+    outcome = (
+        _statement("def A():\n    raise ValueError from KeyError\n", "Raise")
+        .sugar()
+        .desugar()
+    )
 
     assert isinstance(outcome, Incomplete)
     assert outcome.effect.cause_value.to_term(owner="raise-cause").name == "KeyError"

--- a/implementations/python/sugar-source-tree/tests/test_for_unroll.py
+++ b/implementations/python/sugar-source-tree/tests/test_for_unroll.py
@@ -24,7 +24,9 @@ def _invs(src):
 
 
 def test_concrete_for_unrolls_the_body_per_element():
-    invs = _invs("def A(z):\n    for x in [1, 2, 3]:\n        assert x == z\n    return z\n")
+    invs = _invs(
+        "def A(z):\n    for x in [1, 2, 3]:\n        assert x == z\n    return z\n"
+    )
     assert len(invs) == 3
     assert [i.args[0].value for i in invs] == [1, 2, 3]  # x = each element
     assert all(i.name == "py.eq" and i.args[1].name == "z" for i in invs)
@@ -39,7 +41,9 @@ def test_symbolic_assert_only_loop_is_a_universal():
     # for x in xs: assert P(x)  over a symbolic (formal) xs is the degenerate
     # fold -- forall x. member(x, xs) -> P(x). The loop no longer sinks the
     # function; it emits its FOL universal.
-    inv = _invs("def A(z, xs):\n    for x in xs:\n        assert x == z\n    return z\n")[0]
+    inv = _invs(
+        "def A(z, xs):\n    for x in xs:\n        assert x == z\n    return z\n"
+    )[0]
     assert inv.kind == "forall"
     body = inv.body  # member(x, xs) -> (x == z)
     assert body.kind == "implies"
@@ -51,9 +55,14 @@ def test_symbolic_carried_accumulator_is_a_fold_coordinate():
     # t = 0; for x in xs: t = t + x; return t  over a symbolic xs is the fold:
     # the carried t rebinds to the coordinate py.fold.Add(0, xs) -- a reference
     # the dig resolves (the recurrence), the same shape as a recursion's call:f.
-    post = _fn(
-        "def A(xs):\n    total = 0\n    for x in xs:\n        total = total + x\n    return total\n"
-    ).sugar().desugar().value.post()
+    post = (
+        _fn(
+            "def A(xs):\n    total = 0\n    for x in xs:\n        total = total + x\n    return total\n"
+        )
+        .sugar()
+        .desugar()
+        .value.post()
+    )
     fold = post.args[1]
     assert fold.name == "call:py.fold.Add"
     assert fold.args[0].value == 0  # init
@@ -74,9 +83,14 @@ def test_loop_carried_accumulator_folds_over_a_concrete_iterable():
     # t = 0; for x in [1,2,3]: t = t + x; return t  -- the carried accumulator is
     # threaded through the unroll (t reads the previous iteration's value), so it
     # folds to 6. The `for` dissolved into block-threading; no loop-sugar.
-    post = _fn(
-        "def A():\n    t = 0\n    for x in [1, 2, 3]:\n        t = t + x\n    return t\n"
-    ).sugar().desugar().value.post()
+    post = (
+        _fn(
+            "def A():\n    t = 0\n    for x in [1, 2, 3]:\n        t = t + x\n    return t\n"
+        )
+        .sugar()
+        .desugar()
+        .value.post()
+    )
     assert post.args[1].value == 6  # out == 0+1+2+3
 
 
@@ -92,14 +106,18 @@ def test_tuple_target_destructures_the_concrete_element():
 def test_starred_target_stays_loud():
     # for a, *b -- a starred target does not destructure here; still loud.
     with pytest.raises(SugarNotWritten):
-        _fn("def A(z):\n    for a, *b in [(1, 2)]:\n        assert a == a\n    return z\n").sugar()
+        _fn(
+            "def A(z):\n    for a, *b in [(1, 2)]:\n        assert a == a\n    return z\n"
+        ).sugar()
 
 
 def test_arity_mismatch_stays_loud():
     # the target has two names, the element three -- not destructured, loud
     # (running it would be a ValueError; never bind a wrong shape).
     with pytest.raises(SugarNotWritten):
-        _fn("def A(z):\n    for a, b in [(1, 2, 3)]:\n        assert a == b\n    return z\n").sugar()
+        _fn(
+            "def A(z):\n    for a, b in [(1, 2, 3)]:\n        assert a == b\n    return z\n"
+        ).sugar()
 
 
 if __name__ == "__main__":
@@ -132,8 +150,13 @@ def test_jump_bearing_body_never_unrolls():
 def test_for_else_splices_after_the_unroll():
     # With no break possible (the jump-guard blocks jump-bearing bodies from
     # unrolling), the else ALWAYS runs: just more block, after the iterations.
-    post = _fn(
-        "def A():\n    t = 0\n    for x in [1, 2]:\n        t = t + x\n"
-        "    else:\n        t = t + 100\n    return t\n"
-    ).sugar().desugar().value.post()
+    post = (
+        _fn(
+            "def A():\n    t = 0\n    for x in [1, 2]:\n        t = t + x\n"
+            "    else:\n        t = t + 100\n    return t\n"
+        )
+        .sugar()
+        .desugar()
+        .value.post()
+    )
     assert post.args[1].value == 103

--- a/implementations/python/sugar-source-tree/tests/test_fragment.py
+++ b/implementations/python/sugar-source-tree/tests/test_fragment.py
@@ -19,11 +19,7 @@ from sugar_source_tree import (
 )
 
 SOURCE = (
-    "def f(a, b):\n"
-    "    total = a + b\n"
-    "    return total\n"
-    "\n"
-    "x = f(1, 2)\n"
+    "def f(a, b):\n" "    total = a + b\n" "    return total\n" "\n" "x = f(1, 2)\n"
 )
 
 

--- a/implementations/python/sugar-source-tree/tests/test_if_exp_and_phi_lift.py
+++ b/implementations/python/sugar-source-tree/tests/test_if_exp_and_phi_lift.py
@@ -22,7 +22,9 @@ def _post(src: str):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
         f.write(src)
         path = f.name
-    return next(SourceFile(path_source(path)).functions()).sugar().desugar().value.post()
+    return (
+        next(SourceFile(path_source(path)).functions()).sugar().desugar().value.post()
+    )
 
 
 def _no_py_conditional(post):
@@ -72,7 +74,9 @@ def test_phi_conditional_binding_lifts_end_to_end():
     # if c: x = 5 else: x = 6 ; return x
     # substitute rewrites `return x` to `return (5 if c else 6)`; the IfExp value
     # distributes to the same guarded post -- the phi is liftable, not a gap.
-    post = _post("def A(c):\n    if c:\n        x = 5\n    else:\n        x = 6\n    return x\n")
+    post = _post(
+        "def A(c):\n    if c:\n        x = 5\n    else:\n        x = 6\n    return x\n"
+    )
     _no_py_conditional(post)
     assert post.kind == "and"
     then_imp, else_imp = post.operands
@@ -87,4 +91,6 @@ if __name__ == "__main__":
     test_direct_ifexp_predicate_distributes()
     test_direct_ifexp_bare_truthiness_distributes()
     test_phi_conditional_binding_lifts_end_to_end()
-    print("ok: IfExp value distributes; phi lifts end-to-end; substitute is sole binder")
+    print(
+        "ok: IfExp value distributes; phi lifts end-to-end; substitute is sole binder"
+    )

--- a/implementations/python/sugar-source-tree/tests/test_if_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_if_sugar.py
@@ -37,7 +37,11 @@ def _return_of(fn):
 
 def test_if_else_assignment_becomes_a_phi():
     # if c: x = 5 else: x = 6 ; return x  ->  return (5 if c else 6)
-    ret = _return_of(_fn("def A(c):\n    if c:\n        x = 5\n    else:\n        x = 6\n    return x\n"))
+    ret = _return_of(
+        _fn(
+            "def A(c):\n    if c:\n        x = 5\n    else:\n        x = 6\n    return x\n"
+        )
+    )
     assert ret.value.kind == "IfExp"
     assert ret.value.test.kind == "BranchResultRef"
     assert ret.value.body.value == 5  # then arm
@@ -65,7 +69,9 @@ def test_one_armed_if_with_no_prior_is_an_honest_gap_not_a_guess():
 def test_the_phi_borrows_the_if_source_span():
     # The synthesized IfExp is a shadow that still addresses the if's source site
     # (the memento invariant survives rewriting).
-    fn = _fn("def A(c):\n    if c:\n        x = 5\n    else:\n        x = 6\n    return x\n")
+    fn = _fn(
+        "def A(c):\n    if c:\n        x = 5\n    else:\n        x = 6\n    return x\n"
+    )
     if_node = next(n for n in fn.walk() if n.kind == "If")
     phi = _return_of(fn).value
     assert phi.span == if_node.span
@@ -81,7 +87,9 @@ def _invs(fn):
 
 def test_guarded_assert_is_an_implication():
     # if z == 1: assert z == 1  ->  inv  (z == 1) -> (z == 1)
-    invs = _invs(_fn("def A(z):\n    if z == 1:\n        assert z == 1\n    return z\n"))
+    invs = _invs(
+        _fn("def A(z):\n    if z == 1:\n        assert z == 1\n    return z\n")
+    )
     assert len(invs) == 2
     guard = invs[-1]
     assert getattr(guard, "kind", None) == "implies", guard
@@ -94,7 +102,9 @@ def test_guarded_assert_is_an_implication():
 def test_guard_discriminates_condition_from_fact():
     # if z == 1: assert z == 2  ->  (z == 1) -> (z == 2): antecedent is the
     # CONDITION, consequent the FACT, and they are not conflated.
-    invs = _invs(_fn("def A(z):\n    if z == 1:\n        assert z == 2\n    return z\n"))
+    invs = _invs(
+        _fn("def A(z):\n    if z == 1:\n        assert z == 2\n    return z\n")
+    )
     ante, cons = invs[-1].operands
     # The antecedent is the authenticated branch-result coordinate; the fact
     # retains its original value.
@@ -110,7 +120,11 @@ def test_guarded_return_posts_both_faces():
     #   (z == 1 -> out == 10)  AND  (not(z == 1) -> out == 20)
     # The exiting branch posts under the guard; the fall-through tail posts under
     # its negation. No face is dropped.
-    uni = _fn("def A(z):\n    if z == 1:\n        return 10\n    return 20\n").sugar().desugar()
+    uni = (
+        _fn("def A(z):\n    if z == 1:\n        return 10\n    return 20\n")
+        .sugar()
+        .desugar()
+    )
     post = uni.value.post()
     assert post.kind == "and"
     then_imp, else_imp = post.operands
@@ -129,9 +143,13 @@ def test_guarded_raise_halts_its_branch_and_guards_the_tail():
     # the assert becomes  not(z == 1) -> (z == 2).
     from sugar_lift_py_tests.outcome import Completed, ExitSet, Halted
 
-    out = _fn(
-        "def A(z):\n    if z == 1:\n        raise ValueError\n    assert z == 2\n    return z\n"
-    ).sugar().desugar()
+    out = (
+        _fn(
+            "def A(z):\n    if z == 1:\n        raise ValueError\n    assert z == 2\n    return z\n"
+        )
+        .sugar()
+        .desugar()
+    )
     assert isinstance(out, ExitSet)
     completed = next(e for e in out.exits if isinstance(e, Completed))
     halted = next(e for e in out.exits if isinstance(e, Halted))

--- a/implementations/python/sugar-source-tree/tests/test_inert_statements.py
+++ b/implementations/python/sugar-source-tree/tests/test_inert_statements.py
@@ -72,4 +72,6 @@ if __name__ == "__main__":
     test_global_is_inert()
     test_nonlocal_is_inert()
     test_import_does_not_block_a_later_fact()
-    print("ok: import/importfrom/pass/global/nonlocal inert; effects still ride through")
+    print(
+        "ok: import/importfrom/pass/global/nonlocal inert; effects still ride through"
+    )

--- a/implementations/python/sugar-source-tree/tests/test_lambda_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_lambda_sugar.py
@@ -44,9 +44,7 @@ def test_lambda_body_changes_content_addressed_callable_identity():
 
 
 def test_lambda_parameter_masks_same_spelled_outer_binding():
-    expression = _return_expression(
-        "def A():\n    x = 7\n    return lambda x: x\n"
-    )
+    expression = _return_expression("def A():\n    x = 7\n    return lambda x: x\n")
     sugar = expression.sugar()
 
     assert sugar.formals == ("x",)
@@ -54,9 +52,7 @@ def test_lambda_parameter_masks_same_spelled_outer_binding():
 
 
 def test_lambda_captures_authenticated_outer_binding_while_masking_parameter():
-    expression = _return_expression(
-        "def A():\n    z = 7\n    return lambda x: x + z\n"
-    )
+    expression = _return_expression("def A():\n    z = 7\n    return lambda x: x + z\n")
     sugar = expression.sugar()
 
     assert sugar.formals == ("x",)
@@ -76,12 +72,22 @@ def test_lambda_rebinding_changes_constructed_capture():
 
 
 def test_nested_lambda_capture_rebinding_changes_opaque_coordinate():
-    first = _return_expression(
-        "def A():\n    z = 7\n    return lambda x: lambda x: x + z\n"
-    ).sugar().desugar().value
-    second = _return_expression(
-        "def A():\n    z = 8\n    return lambda x: lambda x: x + z\n"
-    ).sugar().desugar().value
+    first = (
+        _return_expression(
+            "def A():\n    z = 7\n    return lambda x: lambda x: x + z\n"
+        )
+        .sugar()
+        .desugar()
+        .value
+    )
+    second = (
+        _return_expression(
+            "def A():\n    z = 8\n    return lambda x: lambda x: x + z\n"
+        )
+        .sugar()
+        .desugar()
+        .value
+    )
 
     assert first.parameters == second.parameters == ("x",)
     assert first.to_term(owner="test") != second.to_term(owner="test")
@@ -124,9 +130,7 @@ def test_inline_lambda_call_constructs_callable_then_ordinary_computed_call():
 
 
 def test_lambda_coordinate_is_opaque_and_does_not_leak_nested_same_named_formals():
-    expression = _return_expression(
-        "def A(x):\n    return lambda x: lambda x: x\n"
-    )
+    expression = _return_expression("def A(x):\n    return lambda x: lambda x: x\n")
     outer = expression.sugar().desugar().value
 
     coordinate = outer.to_term(owner="test")
@@ -138,9 +142,7 @@ def test_lambda_coordinate_is_opaque_and_does_not_leak_nested_same_named_formals
 
 
 def test_parser_backed_lambda_with_unresolved_capture_stays_loud():
-    function = _function(
-        "def A():\n    z = 7\n    f = lambda x: x + z\n    return f\n"
-    )
+    function = _function("def A():\n    z = 7\n    f = lambda x: x + z\n    return f\n")
     parser_backed_lambda = function.body[1].value
 
     with pytest.raises(SugarNotWritten, match="Lambda.sugar"):
@@ -148,9 +150,12 @@ def test_parser_backed_lambda_with_unresolved_capture_stays_loud():
 
 
 def test_lambda_application_substitutes_the_formal_in_the_body_term():
-    callable_value = _return_expression(
-        "def A():\n    return lambda x: x + 1\n"
-    ).sugar().desugar().value
+    callable_value = (
+        _return_expression("def A():\n    return lambda x: x + 1\n")
+        .sugar()
+        .desugar()
+        .value
+    )
 
     applied = callable_value.apply(TermValue(7), None)
 

--- a/implementations/python/sugar-source-tree/tests/test_libcst_adapter.py
+++ b/implementations/python/sugar-source-tree/tests/test_libcst_adapter.py
@@ -27,7 +27,11 @@ from conftest import oracle_source_file
 from sugar_source_tree.backend import BackendCouldNotParse  # noqa: E402
 from sugar_source_tree.tree import SourceFile  # noqa: E402
 from sugar_source_tree.cpython_adapter import CPythonAstBackend  # noqa: E402
-from sugar_source_tree.libcst_adapter import LibCSTBackend, _describe, _Ctx  # noqa: E402
+from sugar_source_tree.libcst_adapter import (
+    LibCSTBackend,
+    _describe,
+    _Ctx,
+)  # noqa: E402
 from sugar_source_tree import nodes  # noqa: E402
 from sugar_source_tree.panic import SourceTreePanic  # noqa: E402
 
@@ -114,7 +118,9 @@ def test_param_span_includes_annotation_and_default():
 
 def test_comprehension_clause_starts_at_the_for_keyword():
     """LibCST's CompFor position starts at the preceding whitespace."""
-    assert segment_of("[i for i in xs if i]\n", nodes.Comprehension) == "for i in xs if i"
+    assert (
+        segment_of("[i for i in xs if i]\n", nodes.Comprehension) == "for i in xs if i"
+    )
 
 
 def test_async_comprehension_clause_starts_at_async():

--- a/implementations/python/sugar-source-tree/tests/test_match_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_match_sugar.py
@@ -64,10 +64,15 @@ def test_wildcard_guarded_by_all_negations():
 def test_capture_binds_the_subject():
     # case x: binds x = subject (the temporal half, via substitute). So a
     # `case 1: return 10; case x: return x` capture arm is `not(z==1) -> out==z`.
-    post = _fn(
-        "def A(z):\n    match z:\n        case 1:\n            return 10\n"
-        "        case x:\n            return x\n"
-    ).sugar().desugar().value.post()
+    post = (
+        _fn(
+            "def A(z):\n    match z:\n        case 1:\n            return 10\n"
+            "        case x:\n            return x\n"
+        )
+        .sugar()
+        .desugar()
+        .value.post()
+    )
     capture_arm = post.operands[1]  # the `case x:` implication
     assert capture_arm.operands[0].operands[0].kind == "not"  # guarded by not(z==1)
     assert capture_arm.operands[1].args[1].name == "z"  # out == z (x = subject)
@@ -75,12 +80,16 @@ def test_capture_binds_the_subject():
 
 def test_structural_pattern_stays_loud():
     with pytest.raises(SugarNotWritten):
-        _fn("def A(z):\n    match z:\n        case [a, b]:\n            return a\n").sugar()
+        _fn(
+            "def A(z):\n    match z:\n        case [a, b]:\n            return a\n"
+        ).sugar()
 
 
 def test_pattern_guard_stays_loud():
     with pytest.raises(SugarNotWritten):
-        _fn("def A(z):\n    match z:\n        case 1 if z > 0:\n            return z\n").sugar()
+        _fn(
+            "def A(z):\n    match z:\n        case 1 if z > 0:\n            return z\n"
+        ).sugar()
 
 
 def test_singleton_pattern_none_and_bool():

--- a/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
@@ -36,7 +36,12 @@ def test_method_chains_compose():
 
 
 def test_assert_consumes_the_coordinate():
-    inv = _fn("def A(s):\n    assert s.upper() == s\n    return s\n").sugar().desugar().value.invs()[0]
+    inv = (
+        _fn("def A(s):\n    assert s.upper() == s\n    return s\n")
+        .sugar()
+        .desugar()
+        .value.invs()[0]
+    )
     assert inv.name == "py.eq"
     assert inv.args[0].name == "call:upper"
 

--- a/implementations/python/sugar-source-tree/tests/test_raise_from_contract.py
+++ b/implementations/python/sugar-source-tree/tests/test_raise_from_contract.py
@@ -31,8 +31,7 @@ def _effect(source: str):
 
 def test_raise_from_constructs_exception_and_cause_on_the_halt_effect() -> None:
     effect = _effect(
-        "def f():\n"
-        "    raise ValueError('outer') from KeyError('inner')\n"
+        "def f():\n" "    raise ValueError('outer') from KeyError('inner')\n"
     )
 
     assert isinstance(effect.raised_value, CallSiteValue)
@@ -56,8 +55,7 @@ def test_explicit_from_none_is_a_constructed_none_cause() -> None:
 
 def test_unwritten_cause_expression_stays_loud_at_the_cause() -> None:
     node = _raise(
-        "async def f(cause):\n"
-        "    raise ValueError('outer') from (await cause)\n"
+        "async def f(cause):\n" "    raise ValueError('outer') from (await cause)\n"
     )
 
     with pytest.raises(SugarNotWritten, match=r"\[Await\.sugar\]"):

--- a/implementations/python/sugar-source-tree/tests/test_raise_from_measurement.py
+++ b/implementations/python/sugar-source-tree/tests/test_raise_from_measurement.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 from sugar_source_tree.panic import BackendDefect
 
-
 SCRIPT = (
     Path(__file__).parents[2]
     / "sugar-lift-py-tests"
@@ -44,8 +43,7 @@ def test_measurement_observes_raise_from_direct_residue_drained(tmp_path) -> Non
 
 def test_measurement_counts_unwritten_cause_descendant_as_blocked(tmp_path) -> None:
     (tmp_path / "blocked.py").write_text(
-        "async def blocked(cause):\n"
-        "    raise ValueError() from (await cause)\n",
+        "async def blocked(cause):\n" "    raise ValueError() from (await cause)\n",
         encoding="utf-8",
     )
 
@@ -57,14 +55,15 @@ def test_measurement_counts_unwritten_cause_descendant_as_blocked(tmp_path) -> N
 
 def test_blocked_classifier_walks_into_cause_not_up_to_parent() -> None:
     parsed = ast.parse(
-        "async def blocked(cause):\n"
-        "    raise ValueError() from (await cause)\n"
+        "async def blocked(cause):\n" "    raise ValueError() from (await cause)\n"
     )
     raise_node = next(node for node in ast.walk(parsed) if isinstance(node, ast.Raise))
     await_node = next(node for node in ast.walk(parsed) if isinstance(node, ast.Await))
     gap_sites = {("Await", await_node.lineno, await_node.col_offset)}
 
-    direct, blocked = _module().classify_raise_from([raise_node], gap_sites, ast.unparse(parsed))
+    direct, blocked = _module().classify_raise_from(
+        [raise_node], gap_sites, ast.unparse(parsed)
+    )
 
     assert direct == {}
     assert blocked == {"raise_from": 1}
@@ -109,9 +108,7 @@ def test_measurement_surfaces_planted_construction_panic(tmp_path, monkeypatch) 
 
 def test_measurement_is_red_when_direct_residue_remains() -> None:
     assert (
-        _module().exit_status(
-            {"direct": {"raise_from": 1}, "construction_panics": []}
-        )
+        _module().exit_status({"direct": {"raise_from": 1}, "construction_panics": []})
         == 1
     )
 

--- a/implementations/python/sugar-source-tree/tests/test_raise_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_raise_sugar.py
@@ -46,7 +46,9 @@ def test_exception_name_is_read_structurally():
     # raise E, raise E(...), raise mod.E, raise mod.E(...) all name E / mod.E,
     # independently of the normally built child carried by the exit.
     assert _effect("def A():\n    raise ValueError\n").exception_name == "ValueError"
-    assert _effect("def A():\n    raise ValueError('x')\n").exception_name == "ValueError"
+    assert (
+        _effect("def A():\n    raise ValueError('x')\n").exception_name == "ValueError"
+    )
     assert _effect("def A():\n    raise os.error\n").exception_name == "os.error"
     assert _effect("def A():\n    raise a.b.E(1)\n").exception_name == "a.b.E"
 

--- a/implementations/python/sugar-source-tree/tests/test_range_unroll.py
+++ b/implementations/python/sugar-source-tree/tests/test_range_unroll.py
@@ -24,13 +24,17 @@ def _invs(src):
 
 
 def test_range_stop_unrolls_the_body_per_element():
-    invs = _invs("def A(z):\n    for i in range(3):\n        assert i == z\n    return z\n")
+    invs = _invs(
+        "def A(z):\n    for i in range(3):\n        assert i == z\n    return z\n"
+    )
     assert len(invs) == 3
     assert [i.args[0].value for i in invs] == [0, 1, 2]
 
 
 def test_range_start_stop_unrolls_the_body_per_element():
-    invs = _invs("def A(z):\n    for i in range(2, 5):\n        assert i == z\n    return z\n")
+    invs = _invs(
+        "def A(z):\n    for i in range(2, 5):\n        assert i == z\n    return z\n"
+    )
     assert [i.args[0].value for i in invs] == [2, 3, 4]
 
 
@@ -42,24 +46,36 @@ def test_range_start_stop_step_unrolls_the_body_per_element():
 
 
 def test_empty_range_states_nothing():
-    invs = _invs("def A(z):\n    for i in range(0):\n        assert i == z\n    return z\n")
+    invs = _invs(
+        "def A(z):\n    for i in range(0):\n        assert i == z\n    return z\n"
+    )
     assert invs == ()
 
 
 def test_loop_carried_accumulator_folds_over_a_concrete_range():
     # t = 0; for i in range(4): t = t + i; return t  -- folds to 0+1+2+3 = 6.
-    post = _fn(
-        "def A():\n    t = 0\n    for i in range(4):\n        t = t + i\n    return t\n"
-    ).sugar().desugar().value.post()
+    post = (
+        _fn(
+            "def A():\n    t = 0\n    for i in range(4):\n        t = t + i\n    return t\n"
+        )
+        .sugar()
+        .desugar()
+        .value.post()
+    )
     assert post.args[1].value == 6
 
 
 def test_symbolic_range_bound_is_a_universal():
     # range(n) with symbolic n is not concrete, so the assert-only loop emits
     # its universal forall i. member(i, range(n)) -> P(i) -- not loud.
-    inv = _fn(
-        "def A(z, n):\n    for i in range(n):\n        assert i == z\n    return z\n"
-    ).sugar().desugar().value.invs()[0]
+    inv = (
+        _fn(
+            "def A(z, n):\n    for i in range(n):\n        assert i == z\n    return z\n"
+        )
+        .sugar()
+        .desugar()
+        .value.invs()[0]
+    )
     assert inv.kind == "forall"
 
 

--- a/implementations/python/sugar-source-tree/tests/test_roll_call.py
+++ b/implementations/python/sugar-source-tree/tests/test_roll_call.py
@@ -51,7 +51,10 @@ def test_identical_source_nodes_keep_distinct_roster_coordinates() -> None:
 
     functions = [entry for entry in report.roster if entry.kind == "FunctionDef"]
 
-    assert [(entry.start_line, entry.start_col) for entry in functions] == [(2, 4), (4, 4)]
+    assert [(entry.start_line, entry.start_col) for entry in functions] == [
+        (2, 4),
+        (4, 4),
+    ]
 
 
 def test_moment_zero_minority_is_the_whole_roster() -> None:

--- a/implementations/python/sugar-source-tree/tests/test_slice_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_slice_sugar.py
@@ -10,7 +10,13 @@ def _sub(src):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
         f.write(src)
         path = f.name
-    return next(SourceFile(path_source(path)).functions()).sugar().desugar().value.post().args[1]
+    return (
+        next(SourceFile(path_source(path)).functions())
+        .sugar()
+        .desugar()
+        .value.post()
+        .args[1]
+    )
 
 
 def test_full_slice():

--- a/implementations/python/sugar-source-tree/tests/test_starred_spread.py
+++ b/implementations/python/sugar-source-tree/tests/test_starred_spread.py
@@ -22,9 +22,7 @@ def _returned_term(expression: str):
     out = _function(f"def f(a, b, d):\n    return {expression}\n").sugar().desugar()
     assert isinstance(out, Complete)
     returns = [
-        entry
-        for entry in out.value.record.statements
-        if isinstance(entry, ReturnValue)
+        entry for entry in out.value.record.statements if isinstance(entry, ReturnValue)
     ]
     assert len(returns) == 1
     return returns[0].value.to_term(owner="starred-spread-test")

--- a/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
+++ b/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
@@ -54,12 +54,7 @@ def test_subscript_store_lifts_a_red_effect_and_the_block_continues():
 
 
 def test_subscript_store_post_out_equals_the_returned_value():
-    v = (
-        _fn("def A(xs, i, v):\n    xs[i] = v\n    return v\n")
-        .sugar()
-        .desugar()
-        .value
-    )
+    v = _fn("def A(xs, i, v):\n    xs[i] = v\n    return v\n").sugar().desugar().value
     post = v.post()
     assert post.name == "="
     assert post.args[0].name == "out"
@@ -88,9 +83,7 @@ def test_subscript_store_witness_names_the_index():
 
 
 def test_two_stores_in_one_block_both_lift_and_discriminate_by_target():
-    entries = _entries(
-        "def A(o, v, w):\n    o.a = v\n    o.b = w\n    return v\n"
-    )
+    entries = _entries("def A(o, v, w):\n    o.a = v\n    o.b = w\n    return v\n")
     red = [e for e in entries if isinstance(e, Incomplete)]
     assert len(red) == 2
     operands = {repr(e.effect.witness.runtime_operand.term) for e in red}

--- a/implementations/python/sugar-source-tree/tests/test_substitute_int_literal.py
+++ b/implementations/python/sugar-source-tree/tests/test_substitute_int_literal.py
@@ -47,7 +47,9 @@ def test_integer_literal_is_the_inert_terminus():
 
 def test_name_is_the_one_base_case_that_binds():
     binop = next(
-        n for n in _tree("def f(x):\n    return x + 5\n").root.walk() if n.kind == "BinOp"
+        n
+        for n in _tree("def f(x):\n    return x + 5\n").root.walk()
+        if n.kind == "BinOp"
     )
     three = _bind_target()
     name_x = binop.left  # capture once: the tree materializes a fresh node per access
@@ -60,7 +62,9 @@ def test_name_is_the_one_base_case_that_binds():
 
 def test_compound_just_recurses():
     binop = next(
-        n for n in _tree("def f(x):\n    return x + 5\n").root.walk() if n.kind == "BinOp"
+        n
+        for n in _tree("def f(x):\n    return x + 5\n").root.walk()
+        if n.kind == "BinOp"
     )
     rewritten = binop.substitute({"x": _bind_target()})
     assert rewritten is not binop  # rebuilt because a child changed
@@ -101,16 +105,22 @@ def test_binders_mask_their_bound_names():
     forfn = next(_tree("def f(xs):\n    for x in xs:\n        return x\n").functions())
     assert forfn.substitute({"x": _bind_target()}) is forfn
     # lambda z: z + 1 -- the parameter z is masked for the body.
-    lam = next(n for n in _tree("g = lambda z: z + z\n").root.walk() if n.kind == "Lambda")
+    lam = next(
+        n for n in _tree("g = lambda z: z + z\n").root.walk() if n.kind == "Lambda"
+    )
     substituted_lambda = lam.substitute({"z": _bind_target()})
     assert substituted_lambda is not lam  # shadow proves substitution ran
     assert substituted_lambda.body.left.id == "z"
     assert substituted_lambda.body.right.id == "z"
     # [i for i in xs] -- the comprehension loop var i is masked (no capture);
     # a free var in the element substitutes.
-    c1 = next(n for n in _tree("a = [i for i in xs]\n").root.walk() if n.kind == "ListComp")
+    c1 = next(
+        n for n in _tree("a = [i for i in xs]\n").root.walk() if n.kind == "ListComp"
+    )
     assert c1.substitute({"i": _bind_target()}) is c1
-    c2 = next(n for n in _tree("a = [y for i in xs]\n").root.walk() if n.kind == "ListComp")
+    c2 = next(
+        n for n in _tree("a = [y for i in xs]\n").root.walk() if n.kind == "ListComp"
+    )
     assert c2.substitute({"y": _bind_target()}).elt.value == 3
 
 

--- a/implementations/python/sugar-source-tree/tests/test_tree_sitter_adapter.py
+++ b/implementations/python/sugar-source-tree/tests/test_tree_sitter_adapter.py
@@ -55,7 +55,5 @@ def test_byte_vs_codepoint_columns_are_normalized():
     LibCST) — verify a non-ASCII prefix does not corrupt a later span."""
     source = 'x = "éü" + f(y)\n'
     root = _root(source, filename="unicode.py")
-    call_positions = [
-        n.segment() for n in root.walk() if type(n).__name__ == "Call"
-    ]
+    call_positions = [n.segment() for n in root.walk() if type(n).__name__ == "Call"]
     assert call_positions == ["f(y)"]

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -19,7 +19,12 @@ def _val(src):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
         f.write("import pytest\nimport contextlib\nimport tm\n" + src)
         path = f.name
-    return next(source_file_with_preconstruction(Path(path)).functions()).sugar().desugar().value
+    return (
+        next(source_file_with_preconstruction(Path(path)).functions())
+        .sugar()
+        .desugar()
+        .value
+    )
 
 
 def _fn(src):
@@ -170,8 +175,6 @@ def test_finally_reduces_on_uncaught_path():
     assert names == {"RuntimeError"}
 
 
-
-
 def test_finally_pass_restores_uncaught_raise():
     """Cleanup fall-through restores the incoming halt (ValueError survives)."""
     from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
@@ -251,9 +254,7 @@ def test_conditional_raise_both_exits_survive_through_finally():
     from sugar_lift_py_tests.floor.guarded_return import GuardedReturn
     from sugar_lift_py_tests.ir import not_
 
-    returns = [
-        e for e in v.record.contribution() if isinstance(e, GuardedReturn)
-    ]
+    returns = [e for e in v.record.contribution() if isinstance(e, GuardedReturn)]
     assert len(returns) == 2
     assert {entry.value.value for entry in returns} == {1, 2}
     assert returns[1].guards[0] == not_(returns[0].guards[0])
@@ -283,7 +284,9 @@ def test_conditional_raise_assign_paths_through_finally_no_residual_halt():
     post = v.post()
     assert post.kind == "and"
     assert {face.operands[1].args[1].value for face in post.operands} == {1, 2}
-    by_value = {face.operands[1].args[1].value: face.operands[0] for face in post.operands}
+    by_value = {
+        face.operands[1].args[1].value: face.operands[0] for face in post.operands
+    }
     assert by_value[2].name == "py.truthy"
     assert by_value[1].kind == "not"
 
@@ -304,7 +307,9 @@ def test_false_arm_conditional_raise_routes_with_reverse_polarity():
     assert _incompletes(v) == []
     post = v.post()
     assert post.kind == "and"
-    by_value = {face.operands[1].args[1].value: face.operands[0] for face in post.operands}
+    by_value = {
+        face.operands[1].args[1].value: face.operands[0] for face in post.operands
+    }
     assert by_value[1].name == "py.truthy"
     assert by_value[2].kind == "not"
 
@@ -334,15 +339,15 @@ def test_except_as_binds_matching_raise_witness_in_handler():
     typed = [
         inv
         for inv in v.invs()
-        if inv.name == "="
-        and getattr(inv.args[0], "name", None) == "effect_slot_type"
+        if inv.name == "=" and getattr(inv.args[0], "name", None) == "effect_slot_type"
     ]
-    assert typed, f"missing effect_slot_type in {[i.name for i in v.invs()]}: {v.invs()}"
+    assert (
+        typed
+    ), f"missing effect_slot_type in {[i.name for i in v.invs()]}: {v.invs()}"
     assert typed[0].args[1].value == "ValueError"
     # Witness identity is the slot itself (post), not a type-derived equation.
     assert not any(
-        inv.name == "="
-        and getattr(inv.args[0], "name", None) == "effect_slot_identity"
+        inv.name == "=" and getattr(inv.args[0], "name", None) == "effect_slot_identity"
         for inv in v.invs()
     )
     origins = [
@@ -417,8 +422,7 @@ def test_tuple_except_as_binds_the_matched_type_witness():
     typed = [
         inv
         for inv in v.invs()
-        if inv.name == "="
-        and getattr(inv.args[0], "name", None) == "effect_slot_type"
+        if inv.name == "=" and getattr(inv.args[0], "name", None) == "effect_slot_type"
     ]
     assert typed and typed[0].args[1].value == "ValueError"
 
@@ -475,7 +479,6 @@ def test_dotted_except_type_matches():
     assert v.post().args[1].name == "z"
 
 
-
 def test_two_raise_valueerror_sites_have_distinct_origins_same_type():
     """Two raise ValueError sites: equal type testimony, distinct origins."""
     v = _val(
@@ -493,8 +496,7 @@ def test_two_raise_valueerror_sites_have_distinct_origins_same_type():
     types = [
         inv.args[1].value
         for inv in v.invs()
-        if inv.name == "="
-        and getattr(inv.args[0], "name", None) == "effect_slot_type"
+        if inv.name == "=" and getattr(inv.args[0], "name", None) == "effect_slot_type"
     ]
     assert types.count("ValueError") >= 2
     origins = [

--- a/implementations/python/sugar-source-tree/tests/test_typed.py
+++ b/implementations/python/sugar-source-tree/tests/test_typed.py
@@ -11,15 +11,17 @@ from sugar_source_tree.spans import Span
 
 
 def test_every_constructed_node_is_typed():
-    root = oracle_source_file((
-        "import os\n"
-        "class C:\n"
-        "    def m(self, *a, **k):\n"
-        "        return {x: y for x, y in a if x}\n"
-        "async def g():\n"
-        "    async with open('f') as fh:\n"
-        "        await fh.read()\n"
-    )).root
+    root = oracle_source_file(
+        (
+            "import os\n"
+            "class C:\n"
+            "    def m(self, *a, **k):\n"
+            "        return {x: y for x, y in a if x}\n"
+            "async def g():\n"
+            "    async with open('f') as fh:\n"
+            "        await fh.read()\n"
+        )
+    ).root
     for node in root.walk():
         assert isinstance(node, Typed)
         assert node.resolve_type() is type(node)

--- a/implementations/python/sugar-source-tree/tests/test_unary_bool_attribute_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_unary_bool_attribute_sugar.py
@@ -37,7 +37,9 @@ def test_unary_minus_and_invert_emit_symbolic_ops():
 
 def test_not_is_truth_then_negate():
     # if not (z == 1): the guard is not(z == 1), so the body's fact rides under it.
-    invs = _invs("def A(z):\n    if not (z == 1):\n        assert z == z\n    return z\n")
+    invs = _invs(
+        "def A(z):\n    if not (z == 1):\n        assert z == z\n    return z\n"
+    )
     authentication = invs[0]
     observed = authentication.operands[0].operands[1]
     assert observed.kind == "not"

--- a/implementations/python/sugar-source-tree/tests/test_while_unroll.py
+++ b/implementations/python/sugar-source-tree/tests/test_while_unroll.py
@@ -26,29 +26,46 @@ def _out(src):
 
 def test_concrete_counter_unrolls():
     # i = 0; while i < 3: i = i + 1; return i  ->  out == 3
-    assert _out("def A():\n    i = 0\n    while i < 3:\n        i = i + 1\n    return i\n").value == 3
+    assert (
+        _out(
+            "def A():\n    i = 0\n    while i < 3:\n        i = i + 1\n    return i\n"
+        ).value
+        == 3
+    )
 
 
 def test_concrete_accumulator_unrolls():
     # sum 0..3 through a while: out == 6
-    assert _out(
-        "def A():\n    i = 0\n    t = 0\n    while i < 4:\n        t = t + i\n"
-        "        i = i + 1\n    return t\n"
-    ).value == 6
+    assert (
+        _out(
+            "def A():\n    i = 0\n    t = 0\n    while i < 4:\n        t = t + i\n"
+            "        i = i + 1\n    return t\n"
+        ).value
+        == 6
+    )
 
 
 def test_false_condition_skips_the_body():
-    assert _out("def A():\n    i = 5\n    while False:\n        i = 9\n    return i\n").value == 5
+    assert (
+        _out(
+            "def A():\n    i = 5\n    while False:\n        i = 9\n    return i\n"
+        ).value
+        == 5
+    )
 
 
 def test_while_true_stays_loud():
     with pytest.raises(SugarNotWritten):
-        _fn("def A():\n    i = 0\n    while True:\n        i = i + 1\n    return i\n").sugar()
+        _fn(
+            "def A():\n    i = 0\n    while True:\n        i = i + 1\n    return i\n"
+        ).sugar()
 
 
 def test_symbolic_condition_stays_loud():
     with pytest.raises(SugarNotWritten):
-        _fn("def A(n):\n    i = 0\n    while i < n:\n        i = i + 1\n    return i\n").sugar()
+        _fn(
+            "def A(n):\n    i = 0\n    while i < n:\n        i = i + 1\n    return i\n"
+        ).sugar()
 
 
 if __name__ == "__main__":

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -41,7 +41,9 @@ def _coordinate(node) -> SourceFragmentCoordinateV1:
 
 def _source_with_resolution(source_identity, resolution):
     first = SourceFile(source_identity)
-    with_node = next(node for node in first.nodes() if node.kind in {"With", "AsyncWith"})
+    with_node = next(
+        node for node in first.nodes() if node.kind in {"With", "AsyncWith"}
+    )
     use_site = _coordinate(with_node.items[0].context_expr)
     if callable(resolution):
         resolution = resolution(use_site)
@@ -80,7 +82,9 @@ def _function_sugar(source_identity, resolution):
     return next(source.functions()).sugar()
 
 
-def test_authenticated_ref_constructs_resource_once_and_binds_enter_result(tmp_path, monkeypatch):
+def test_authenticated_ref_constructs_resource_once_and_binds_enter_result(
+    tmp_path, monkeypatch
+):
     path = tmp_path / "consumer.py"
     path.write_text(
         "from dependency import manager\n"
@@ -108,7 +112,11 @@ def test_authenticated_ref_constructs_resource_once_and_binds_enter_result(tmp_p
         lambda *_: (_ for _ in ()).throw(AssertionError("source proof invoked")),
     )
     sugar = _function_sugar(path_source(str(path)), _resolved)
-    resource = next(statement for statement in sugar.statements if isinstance(statement, WithResourceSugar))
+    resource = next(
+        statement
+        for statement in sugar.statements
+        if isinstance(statement, WithResourceSugar)
+    )
     assert resource.contract_ref.member_cid == _cid("m")
     assert resource.contract_ref.payload_cid == _cid("p")
     assert resource.enter_slot_id == f"{resource.manager_slot_id}#enter_result"
@@ -128,7 +136,12 @@ def test_unresolved_ref_stays_typed_loud(tmp_path, monkeypatch):
     )
     from sugar_lift_python_source.source_oracle import path_source
     import sugar_lift_py_tests.exit_disposition_proof as source_proof
-    monkeypatch.setattr(source_proof, "prove_exit_disposition_from_manager_expr", lambda *_: pytest.fail("source proof invoked"))
+
+    monkeypatch.setattr(
+        source_proof,
+        "prove_exit_disposition_from_manager_expr",
+        lambda *_: pytest.fail("source proof invoked"),
+    )
 
     def unresolved(use_site):
         return ContextManagerResolutionGapV1(

--- a/implementations/python/sugar-source-tree/tests/with_resolution_fixture.py
+++ b/implementations/python/sugar-source-tree/tests/with_resolution_fixture.py
@@ -28,16 +28,18 @@ def source_file_with_preconstruction(path):
     resolutions = {}
     for row in _context_manager_demand_rows(path.parent):
         site = SourceFragmentCoordinateV1.decode(row["useSite"])
-        preimage = {key: row[key] for key in (
-            "useSite", "targetSymbol", "importSignature", "expectedKind"
-        )}
+        preimage = {
+            key: row[key]
+            for key in ("useSite", "targetSymbol", "importSignature", "expectedKind")
+        }
         resolutions[site] = ContextManagerResolutionGapV1(
-            _hash_json(preimage), site, row["targetSymbol"],
-            row["gapKind"] or "unresolved-symbol", (),
+            _hash_json(preimage),
+            site,
+            row["targetSymbol"],
+            row["gapKind"] or "unresolved-symbol",
+            (),
         )
-    refs = ResolvedContractRefsV1(
-        _cid("c"), _cid("t"), MappingProxyType(resolutions)
-    )
+    refs = ResolvedContractRefsV1(_cid("c"), _cid("t"), MappingProxyType(resolutions))
     return SourceFile(
         path_source(str(path)),
         construction_context=TreeConstructionContextV1(refs),

--- a/implementations/python/sugar-typed-recognition/src/sugar_typed_recognition/claim.py
+++ b/implementations/python/sugar-typed-recognition/src/sugar_typed_recognition/claim.py
@@ -147,7 +147,9 @@ def _operator_field_names(cls: type) -> Tuple[str, ...]:
     names: list[str] = []
     if is_dataclass(cls):
         for f in dataclass_fields(cls):
-            annotation = f.type if isinstance(f.type, str) else getattr(f.type, "__name__", "")
+            annotation = (
+                f.type if isinstance(f.type, str) else getattr(f.type, "__name__", "")
+            )
             if "Operator" in annotation:
                 names.append(f.name)
     result = tuple(names)

--- a/implementations/python/sugar-typed-recognition/tests/test_dispatch.py
+++ b/implementations/python/sugar-typed-recognition/tests/test_dispatch.py
@@ -134,9 +134,7 @@ def test_operands_are_already_typed_when_the_parent_is_recognized():
     finished children.
     """
     root = parse(
-        "def f(a, b):\n"
-        "    assert len(a) + b * 2\n"
-        "    return a.join(b)\n"
+        "def f(a, b):\n" "    assert len(a) + b * 2\n" "    return a.join(b)\n"
     )
     seen = 0
     for node in root.walk():
@@ -150,9 +148,11 @@ def test_nested_dispatch_resolves_at_every_level():
     root = parse("assert len(xs) + n * 2\n")
     catalog = default_catalog()
     resolved = {
-        type(n).__name__: catalog.resolve(
+        type(n)
+        .__name__: catalog.resolve(
             Role.STATEMENT if isinstance(n, (Assert, Return)) else Role.TERM, n
-        ).name()
+        )
+        .name()
         for n in root.walk()
         if isinstance(n, (Assert, BinOp, Call, Name))
     }

--- a/implementations/python/sugar-typed-recognition/tests/test_failure_arms.py
+++ b/implementations/python/sugar-typed-recognition/tests/test_failure_arms.py
@@ -52,9 +52,10 @@ def test_gap_when_no_claim_owns_the_operand_types():
 
 
 def test_gap_when_no_claim_accepts_the_shape_at_all():
-    site = only(parse("y = [1]\n"), __import__(
-        "sugar_node_membrane.nodes", fromlist=["List"]
-    ).List)
+    site = only(
+        parse("y = [1]\n"),
+        __import__("sugar_node_membrane.nodes", fromlist=["List"]).List,
+    )
     with pytest.raises(RecognitionPanic) as exc:
         default_catalog().resolve(Role.TERM, site)
     assert exc.value.arm is RecognitionArm.GAP
@@ -152,9 +153,10 @@ def test_ambiguity_is_the_soundness_guarantee_of_the_ported_disjointness():
     assert exc.value.arm is RecognitionArm.AMBIGUOUS
 
     # With the exclusion as ported, the same site resolves to exactly one.
-    assert TypedCatalog((PlainCallClaim, LenCallClaim)).resolve(
-        Role.TERM, site
-    ) is LenCallClaim
+    assert (
+        TypedCatalog((PlainCallClaim, LenCallClaim)).resolve(Role.TERM, site)
+        is LenCallClaim
+    )
 
 
 def test_the_ported_catalog_is_unambiguous_over_a_real_corpus():
@@ -266,6 +268,7 @@ def test_structural_absence_is_a_fact_not_a_missing():
 
 def test_a_kind_string_as_accepts_is_refused_at_class_creation():
     with pytest.raises(RecognitionPanic) as exc:
+
         class Stringly(TypedClaim):
             accepts = "Call"  # type: ignore[assignment]
             role = Role.TERM
@@ -301,8 +304,7 @@ def test_operator_fields_cover_every_operator_carrier():
         for f in dataclass_fields(cls):
             annotation = f.type if isinstance(f.type, str) else ""
             mentions_operator_class = any(
-                sub.__name__ in annotation
-                for sub in _all_subclasses(Operator)
+                sub.__name__ in annotation for sub in _all_subclasses(Operator)
             )
             if mentions_operator_class:
                 assert f.name in declared, (


### PR DESCRIPTION
Pure Black 26.5.1 fix-forward for the failing `core (Python format)` check.

- Exact CI scope: `implementations/python`
- Black reported and reformatted exactly 180 files
- Fresh `black --check implementations/python`: 679 files unchanged, exit 0
- `git diff --check`: clean

Pure formatting; merging immediately as authorized.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply Python formatting fixes across test and source files to pass core format check
> Applies purely cosmetic reformatting across a large number of Python source and test files to satisfy the project's core format checker. Changes include wrapping long lines with parentheses, collapsing multi-line expressions into single lines, reformatting dict/set literals, and adjusting function signature layouts. No logic, values, or behavior is altered in any file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7840243.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->