### PR TITLE
Cut A: SourceOracle authenticates dependency artifacts → ResolvedPythonObjectV1 (#6088)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import ast
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field as dataclass_field
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -59,6 +59,93 @@ class _ImportDef:
 class _ModuleFunctionDef:
     target_symbol: str
     definition_site: tuple[int, int, int, int]
+
+
+_IMPORT_AUTHORITY = object()
+
+
+@dataclass(frozen=True)
+class ImportBindingV1:
+    """A final-checked #6090 import binding, never a caller-owned mapping."""
+
+    value: dict[str, Any]
+    cid: str
+    _authority: object = dataclass_field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self._authority is not _IMPORT_AUTHORITY:
+            raise ValueError("ImportBindingV1 was not minted by the lexical pass")
+        if self.value.get("kind") != "python-import-binding":
+            raise ValueError("ImportBindingV1 requires a python-import-binding")
+        if _hash(self.value) != self.cid:
+            raise ValueError("ImportBindingV1 CID does not match its preimage")
+
+    def to_value(self) -> dict[str, Any]:
+        return json.loads(encode_jcs(_json_value(self.value)))
+
+
+@dataclass(frozen=True)
+class AuthenticatedImportUseV1:
+    """The final lexical-pass receipt consumed by source-artifact resolution."""
+
+    import_binding: ImportBindingV1
+    target_symbol: str
+    use: dict[str, Any]
+    demand: dict[str, Any]
+    root: Path = dataclass_field(repr=False, compare=False)
+    path: Path = dataclass_field(repr=False, compare=False)
+    source: str = dataclass_field(repr=False, compare=False)
+    source_cid: str = dataclass_field(repr=False, compare=False)
+    module_identities: dict[str, dict[str, Any]] = dataclass_field(
+        repr=False, compare=False
+    )
+    _authority: object = dataclass_field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self._authority is not _IMPORT_AUTHORITY:
+            raise ValueError(
+                "AuthenticatedImportUseV1 was not minted by the lexical pass"
+            )
+        if blake3_512_of(self.source.encode("utf-8")) != self.source_cid:
+            raise ValueError("authenticated import-use source CID is stale")
+        if self.use.get("kind") != "authenticated-import-use":
+            raise ValueError("authenticated import use has the wrong kind")
+        use_without_cid = {
+            key: value for key, value in self.use.items() if key != "cid"
+        }
+        if self.use.get("cid") != _hash(use_without_cid):
+            raise ValueError("authenticated import-use CID does not match its preimage")
+        if self.use.get("importBindingCid") != self.import_binding.cid:
+            raise ValueError("authenticated import use cites another binding")
+        for key, value in (
+            ("authenticatedImportUse", self.use),
+            ("importBinding", self.import_binding.to_value()),
+            ("targetSymbol", self.target_symbol),
+            ("importBindingCid", self.import_binding.cid),
+        ):
+            if self.demand.get(key) != value:
+                raise ValueError(f"authenticated demand has stale {key}")
+
+    def revalidate(self) -> None:
+        """Re-run #6090 and demand byte identity at the resolution door."""
+        rows, outcomes = authenticated_import_uses(
+            self.root,
+            self.path,
+            self.source,
+            self.source_cid,
+            module_identities=self.module_identities,
+        )
+        site = self.use["useSite"]
+        key = (
+            site["startLine"],
+            site["startCol"],
+            site["endLine"],
+            site["endCol"],
+        )
+        if outcomes.get(key) != "authenticated-import-use" or self.demand not in rows:
+            raise ValueError(
+                "authenticated import use is not byte-identical to lexical revalidation"
+            )
 
 
 _NON_IMPORT = "non-import"
@@ -572,6 +659,40 @@ def authenticated_import_uses(
     )
     runner.statements(module.body, {}, module)
     return runner.rows, runner.outcomes
+
+
+def authenticated_import_use_receipts(
+    root: Path,
+    path: Path,
+    source: str,
+    source_cid: str,
+    module_identities: dict[str, dict[str, Any]] | None = None,
+) -> tuple[list[AuthenticatedImportUseV1], dict[tuple[int, int, int, int], str]]:
+    """Return typed, final-checked receipts from the sole lexical pass."""
+    rows, outcomes = authenticated_import_uses(
+        root, path, source, source_cid, module_identities=module_identities
+    )
+    receipts: list[AuthenticatedImportUseV1] = []
+    for row in rows:
+        binding_value = row["importBinding"]
+        binding = ImportBindingV1(
+            binding_value, row["importBindingCid"], _IMPORT_AUTHORITY
+        )
+        receipts.append(
+            AuthenticatedImportUseV1(
+                import_binding=binding,
+                target_symbol=row["targetSymbol"],
+                use=row["authenticatedImportUse"],
+                demand=row,
+                root=root,
+                path=path,
+                source=source,
+                source_cid=source_cid,
+                module_identities=dict(module_identities or {}),
+                _authority=_IMPORT_AUTHORITY,
+            )
+        )
+    return receipts, outcomes
 
 
 def authenticated_module_exports(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -1,0 +1,765 @@
+"""Authenticated installed Python artifacts and static object resolution.
+
+This module is a preconstruction boundary.  It reads distribution-recorded
+files once, content-addresses them, and resolves only source-visible static
+imports and re-exports.  It never imports or executes a target module.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+from email.parser import BytesParser
+import importlib.metadata
+from pathlib import Path, PurePosixPath
+from types import MappingProxyType
+from typing import Any, Literal, Mapping
+
+from .canonical import blake3_512_of, cid_of_json
+from .source_oracle import SourceUnavailable, dependency_artifact_file
+from .source_tables import parsed_tree
+
+
+class DependencyArtifactAuthenticationError(Exception):
+    """The selected installed artifact cannot be authenticated exactly."""
+
+
+@dataclass(frozen=True)
+class AuthenticatedArtifactFileV1:
+    source_seat: str
+    content_cid: str
+    content: bytes = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if blake3_512_of(self.content) != self.content_cid:
+            raise DependencyArtifactAuthenticationError(
+                "artifact file CID does not match its retained bytes"
+            )
+
+
+@dataclass(frozen=True)
+class AuthenticatedModuleSourceV1:
+    module_name: str
+    source_seat: str
+    source_cid: str
+    source: str = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if blake3_512_of(self.source.encode("utf-8")) != self.source_cid:
+            raise DependencyArtifactAuthenticationError(
+                "module source CID does not match its retained source"
+            )
+
+
+@dataclass(frozen=True)
+class DefinitionCoordinateV1:
+    name: str
+    kind: Literal["function", "class", "import"]
+    source_cid: str
+    start_line: int
+    start_col: int
+    end_line: int
+    end_col: int
+    fragment_cid: str
+
+    def __post_init__(self) -> None:
+        _string(self.name, "definition name")
+        if self.kind not in {"function", "class", "import"}:
+            raise ValueError("definition coordinate has unknown kind")
+        _cid(self.source_cid, "definition sourceCid")
+        for value, label in (
+            (self.start_line, "startLine"),
+            (self.start_col, "startCol"),
+            (self.end_line, "endLine"),
+            (self.end_col, "endCol"),
+        ):
+            _nonnegative_int(value, label)
+        _cid(self.fragment_cid, "definition fragmentCid")
+
+    def to_value(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "sourceCid": self.source_cid,
+            "startLine": self.start_line,
+            "startCol": self.start_col,
+            "endLine": self.end_line,
+            "endCol": self.end_col,
+            "fragmentCid": self.fragment_cid,
+        }
+
+    @classmethod
+    def from_value(cls, value: Any) -> "DefinitionCoordinateV1":
+        _require_exact_keys(
+            value,
+            {
+                "name",
+                "kind",
+                "sourceCid",
+                "startLine",
+                "startCol",
+                "endLine",
+                "endCol",
+                "fragmentCid",
+            },
+            "definition coordinate",
+        )
+        if value["kind"] not in {"function", "class", "import"}:
+            raise ValueError("definition coordinate has unknown kind")
+        return cls(
+            name=_string(value["name"], "definition name"),
+            kind=value["kind"],
+            source_cid=_cid(value["sourceCid"], "definition sourceCid"),
+            start_line=_nonnegative_int(value["startLine"], "startLine"),
+            start_col=_nonnegative_int(value["startCol"], "startCol"),
+            end_line=_nonnegative_int(value["endLine"], "endLine"),
+            end_col=_nonnegative_int(value["endCol"], "endCol"),
+            fragment_cid=_cid(value["fragmentCid"], "definition fragmentCid"),
+        )
+
+
+@dataclass(frozen=True)
+class ReexportWarrantV1:
+    from_module: str
+    from_source_cid: str
+    to_module: str
+    to_source_cid: str
+    exported_name: str
+    imported_name: str
+    definition: DefinitionCoordinateV1
+    cid: str = ""
+
+    def __post_init__(self) -> None:
+        if self.definition.kind != "import":
+            raise ValueError("re-export warrant must cite an import definition")
+        if self.definition.source_cid != self.from_source_cid:
+            raise ValueError("re-export definition is not in its from-module source")
+        expected = cid_of_json(self._preimage())
+        if self.cid and self.cid != expected:
+            raise ValueError("re-export warrant CID does not match its preimage")
+        object.__setattr__(self, "cid", expected)
+
+    def _preimage(self) -> dict[str, Any]:
+        return {
+            "kind": "python-static-reexport-warrant",
+            "schemaVersion": "1",
+            "fromModule": self.from_module,
+            "fromSourceCid": self.from_source_cid,
+            "toModule": self.to_module,
+            "toSourceCid": self.to_source_cid,
+            "exportedName": self.exported_name,
+            "importedName": self.imported_name,
+            "definition": self.definition.to_value(),
+        }
+
+    def to_value(self) -> dict[str, Any]:
+        return {**self._preimage(), "cid": self.cid}
+
+    @classmethod
+    def from_value(cls, value: Any) -> "ReexportWarrantV1":
+        _require_exact_keys(
+            value,
+            {
+                "kind",
+                "schemaVersion",
+                "fromModule",
+                "fromSourceCid",
+                "toModule",
+                "toSourceCid",
+                "exportedName",
+                "importedName",
+                "definition",
+                "cid",
+            },
+            "re-export warrant",
+        )
+        if (
+            value["kind"] != "python-static-reexport-warrant"
+            or value["schemaVersion"] != "1"
+        ):
+            raise ValueError("unsupported re-export warrant")
+        return cls(
+            from_module=_string(value["fromModule"], "fromModule"),
+            from_source_cid=_cid(value["fromSourceCid"], "fromSourceCid"),
+            to_module=_string(value["toModule"], "toModule"),
+            to_source_cid=_cid(value["toSourceCid"], "toSourceCid"),
+            exported_name=_string(value["exportedName"], "exportedName"),
+            imported_name=_string(value["importedName"], "importedName"),
+            definition=DefinitionCoordinateV1.from_value(value["definition"]),
+            cid=_cid(value["cid"], "warrant cid"),
+        )
+
+
+@dataclass(frozen=True)
+class ResolvedPythonObjectV1:
+    distribution_artifact_cid: str
+    import_binding_cid: str
+    module_name: str
+    source_cid: str
+    reexport_warrants: tuple[ReexportWarrantV1, ...]
+    definition: DefinitionCoordinateV1
+    cid: str = ""
+
+    def __post_init__(self) -> None:
+        if self.definition.kind not in {"function", "class"}:
+            raise ValueError(
+                "resolved Python object must name a callable or class definition"
+            )
+        if self.definition.source_cid != self.source_cid:
+            raise ValueError("resolved definition is not in the resolved module source")
+        for left, right in zip(
+            self.reexport_warrants,
+            self.reexport_warrants[1:],
+            strict=False,
+        ):
+            if (
+                left.to_module != right.from_module
+                or left.to_source_cid != right.from_source_cid
+            ):
+                raise ValueError("re-export warrants do not form one source chain")
+        if self.reexport_warrants:
+            last = self.reexport_warrants[-1]
+            if (
+                last.to_module != self.module_name
+                or last.to_source_cid != self.source_cid
+            ):
+                raise ValueError(
+                    "re-export warrants do not reach the resolved definition"
+                )
+        expected = cid_of_json(self._preimage())
+        if self.cid and self.cid != expected:
+            raise ValueError("resolved Python object CID does not match its preimage")
+        object.__setattr__(self, "cid", expected)
+
+    def _preimage(self) -> dict[str, Any]:
+        return {
+            "kind": "resolved-python-object",
+            "schemaVersion": "1",
+            "distributionArtifactCid": self.distribution_artifact_cid,
+            "importBindingCid": self.import_binding_cid,
+            "moduleName": self.module_name,
+            "sourceCid": self.source_cid,
+            "reexportWarrants": [item.to_value() for item in self.reexport_warrants],
+            "definition": self.definition.to_value(),
+        }
+
+    def to_value(self) -> dict[str, Any]:
+        return {**self._preimage(), "cid": self.cid}
+
+    @classmethod
+    def from_value(cls, value: Any) -> "ResolvedPythonObjectV1":
+        _require_exact_keys(
+            value,
+            {
+                "kind",
+                "schemaVersion",
+                "distributionArtifactCid",
+                "importBindingCid",
+                "moduleName",
+                "sourceCid",
+                "reexportWarrants",
+                "definition",
+                "cid",
+            },
+            "resolved Python object",
+        )
+        if value["kind"] != "resolved-python-object" or value["schemaVersion"] != "1":
+            raise ValueError("unsupported resolved Python object")
+        warrants = value["reexportWarrants"]
+        if not isinstance(warrants, list):
+            raise ValueError("reexportWarrants must be a list")
+        return cls(
+            distribution_artifact_cid=_cid(
+                value["distributionArtifactCid"], "distributionArtifactCid"
+            ),
+            import_binding_cid=_cid(value["importBindingCid"], "importBindingCid"),
+            module_name=_string(value["moduleName"], "moduleName"),
+            source_cid=_cid(value["sourceCid"], "sourceCid"),
+            reexport_warrants=tuple(
+                ReexportWarrantV1.from_value(item) for item in warrants
+            ),
+            definition=DefinitionCoordinateV1.from_value(value["definition"]),
+            cid=_cid(value["cid"], "resolved object cid"),
+        )
+
+
+@dataclass(frozen=True)
+class PythonObjectResolutionGapV1:
+    kind: Literal[
+        "malformed-import-binding",
+        "artifact-module-absent",
+        "target-outside-binding",
+        "dynamic-export",
+        "ambiguous-static-export",
+        "static-export-absent",
+        "opaque-source",
+        "reexport-cycle",
+    ]
+    import_binding_cid: str
+    distribution_artifact_cid: str
+    module_name: str
+    exported_name: str
+
+
+PythonObjectResolutionV1 = ResolvedPythonObjectV1 | PythonObjectResolutionGapV1
+
+
+@dataclass(frozen=True)
+class DependencyArtifactGraph:
+    distribution_name: str
+    distribution_version: str
+    distribution_artifact_cid: str
+    files: tuple[AuthenticatedArtifactFileV1, ...]
+    modules: Mapping[str, AuthenticatedModuleSourceV1]
+
+    def __post_init__(self) -> None:
+        metadata_files = [
+            item
+            for item in self.files
+            if item.source_seat.endswith(".dist-info/METADATA")
+        ]
+        if len(metadata_files) != 1:
+            raise DependencyArtifactAuthenticationError(
+                "distribution graph must retain one METADATA preimage"
+            )
+        metadata = BytesParser().parsebytes(metadata_files[0].content)
+        if (
+            metadata.get("Name") != self.distribution_name
+            or metadata.get("Version") != self.distribution_version
+        ):
+            raise DependencyArtifactAuthenticationError(
+                "distribution identity does not match its METADATA preimage"
+            )
+        records = [
+            {"path": item.source_seat, "contentCid": item.content_cid}
+            for item in self.files
+        ]
+        if records != sorted(records, key=lambda item: item["path"]):
+            raise DependencyArtifactAuthenticationError(
+                "artifact files must be canonically ordered"
+            )
+        expected = cid_of_json(
+            {
+                "kind": "python-dependency-artifact",
+                "schemaVersion": "1",
+                "distributionName": self.distribution_name,
+                "distributionVersion": self.distribution_version,
+                "files": records,
+            }
+        )
+        if expected != self.distribution_artifact_cid:
+            raise DependencyArtifactAuthenticationError(
+                "distribution artifact CID does not match its file preimage"
+            )
+        files_by_seat = {item.source_seat: item for item in self.files}
+        if len(files_by_seat) != len(self.files):
+            raise DependencyArtifactAuthenticationError(
+                "distribution artifact contains duplicate file seats"
+            )
+        for module_name, module in self.modules.items():
+            recorded = files_by_seat.get(module.source_seat)
+            if (
+                module_name != module.module_name
+                or recorded is None
+                or recorded.content_cid != module.source_cid
+            ):
+                raise DependencyArtifactAuthenticationError(
+                    "module source is not projected from the artifact file manifest"
+                )
+
+    @classmethod
+    def authenticate(
+        cls, distribution: importlib.metadata.Distribution
+    ) -> "DependencyArtifactGraph":
+        """Hash every recorded installed file and publish authenticated modules."""
+        files = distribution.files
+        if files is None:
+            raise DependencyArtifactAuthenticationError(
+                "installed distribution has no recorded file manifest"
+            )
+        authenticated_files: list[AuthenticatedArtifactFileV1] = []
+        modules: dict[str, AuthenticatedModuleSourceV1] = {}
+        for recorded in sorted(files, key=lambda item: str(item)):
+            relative = PurePosixPath(str(recorded))
+            if relative.is_absolute():
+                raise DependencyArtifactAuthenticationError(
+                    "distribution manifest contains an absolute file seat"
+                )
+            path = Path(distribution.locate_file(recorded))
+            try:
+                content, _seat, content_cid = dependency_artifact_file(str(path))
+            except SourceUnavailable as exc:
+                raise DependencyArtifactAuthenticationError(
+                    f"cannot read recorded distribution file {relative}"
+                ) from exc
+            authenticated_files.append(
+                AuthenticatedArtifactFileV1(
+                    source_seat=relative.as_posix(),
+                    content_cid=content_cid,
+                    content=content,
+                )
+            )
+            module_name = _module_name(relative)
+            if module_name is None:
+                continue
+            try:
+                source = content.decode("utf-8")
+                parsed_tree(source, str(path))
+            except (UnicodeError, SyntaxError) as exc:
+                raise DependencyArtifactAuthenticationError(
+                    f"recorded Python module {module_name} is not parseable UTF-8 source"
+                ) from exc
+            if module_name in modules:
+                raise DependencyArtifactAuthenticationError(
+                    f"distribution contains duplicate module seat {module_name}"
+                )
+            modules[module_name] = AuthenticatedModuleSourceV1(
+                module_name=module_name,
+                source_seat=relative.as_posix(),
+                source_cid=content_cid,
+                source=source,
+            )
+        metadata_files = [
+            item
+            for item in authenticated_files
+            if item.source_seat.endswith(".dist-info/METADATA")
+        ]
+        if len(metadata_files) != 1:
+            raise DependencyArtifactAuthenticationError(
+                "installed distribution must contain one recorded METADATA file"
+            )
+        metadata = BytesParser().parsebytes(metadata_files[0].content)
+        name = metadata.get("Name")
+        version = metadata.get("Version")
+        if not isinstance(name, str) or not name or not version:
+            raise DependencyArtifactAuthenticationError(
+                "installed distribution lacks name or version metadata"
+            )
+        preimage = {
+            "kind": "python-dependency-artifact",
+            "schemaVersion": "1",
+            "distributionName": name,
+            "distributionVersion": version,
+            "files": [
+                {"path": item.source_seat, "contentCid": item.content_cid}
+                for item in authenticated_files
+            ],
+        }
+        return cls(
+            distribution_name=name,
+            distribution_version=version,
+            distribution_artifact_cid=cid_of_json(preimage),
+            files=tuple(authenticated_files),
+            modules=MappingProxyType(modules),
+        )
+
+
+def resolve_import_binding(
+    import_binding: Mapping[str, Any],
+    *,
+    target_symbol: str,
+    graph: DependencyArtifactGraph,
+) -> PythonObjectResolutionV1:
+    """Resolve an existing ImportBinding through one authenticated artifact."""
+    binding_value = dict(import_binding)
+    binding_cid = cid_of_json(binding_value)
+    try:
+        module_name, bound_path, authenticated_source_cid = _binding_target(
+            binding_value
+        )
+    except (KeyError, TypeError, ValueError):
+        return _gap("malformed-import-binding", binding_cid, graph, "", target_symbol)
+    prefix = "python:"
+    if not target_symbol.startswith(prefix):
+        return _gap(
+            "target-outside-binding", binding_cid, graph, module_name, target_symbol
+        )
+    requested = target_symbol[len(prefix) :].split(".")
+    module = graph.modules.get(module_name)
+    if (
+        authenticated_source_cid is not None
+        and module is not None
+        and module.source_cid != authenticated_source_cid
+    ):
+        return _gap("opaque-source", binding_cid, graph, module_name, target_symbol)
+    base = module_name.split(".")
+    bound = list(bound_path)
+    if bound:
+        expected = base + bound
+        if requested != expected or len(bound) != 1:
+            return _gap(
+                "target-outside-binding",
+                binding_cid,
+                graph,
+                module_name,
+                target_symbol,
+            )
+        exported_name = bound[0]
+    elif requested[: len(base)] == base and len(requested) == len(base) + 1:
+        exported_name = requested[-1]
+    else:
+        return _gap(
+            "target-outside-binding", binding_cid, graph, module_name, target_symbol
+        )
+    return _resolve_export(
+        graph,
+        binding_cid,
+        module_name,
+        exported_name,
+        (),
+        frozenset(),
+    )
+
+
+def _resolve_export(
+    graph: DependencyArtifactGraph,
+    binding_cid: str,
+    module_name: str,
+    exported_name: str,
+    warrants: tuple[ReexportWarrantV1, ...],
+    seen: frozenset[tuple[str, str]],
+) -> PythonObjectResolutionV1:
+    key = (module_name, exported_name)
+    if key in seen:
+        return _gap("reexport-cycle", binding_cid, graph, module_name, exported_name)
+    module = graph.modules.get(module_name)
+    if module is None:
+        return _gap(
+            "artifact-module-absent", binding_cid, graph, module_name, exported_name
+        )
+    tree = parsed_tree(module.source, module.source_seat)
+    candidates: list[ast.AST] = []
+    imports: list[tuple[ast.ImportFrom, ast.alias]] = []
+    aliases: list[ast.Name] = []
+    dynamic = False
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if node.name == "__getattr__":
+                dynamic = True
+            if node.name == exported_name:
+                candidates.append(node)
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if (alias.asname or alias.name) == exported_name:
+                    imports.append((node, alias))
+        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if (
+                isinstance(target, ast.Name)
+                and target.id == exported_name
+                and isinstance(node.value, ast.Name)
+            ):
+                aliases.append(node.value)
+    runtime_candidates = [node for node in candidates if not _is_overload(node)]
+    if runtime_candidates:
+        candidates = runtime_candidates
+    count = len(candidates) + len(imports) + len(aliases)
+    if count > 1:
+        return _gap(
+            "ambiguous-static-export", binding_cid, graph, module_name, exported_name
+        )
+    if candidates:
+        definition = _definition(module, candidates[0])
+        return ResolvedPythonObjectV1(
+            distribution_artifact_cid=graph.distribution_artifact_cid,
+            import_binding_cid=binding_cid,
+            module_name=module_name,
+            source_cid=module.source_cid,
+            reexport_warrants=warrants,
+            definition=definition,
+        )
+    if imports:
+        node, alias = imports[0]
+        target_module = _absolute_import(module_name, module.source_seat, node)
+        if target_module is None:
+            return _gap("opaque-source", binding_cid, graph, module_name, exported_name)
+        target = graph.modules.get(target_module)
+        if target is None:
+            return _gap(
+                "artifact-module-absent",
+                binding_cid,
+                graph,
+                target_module,
+                alias.name,
+            )
+        warrant = ReexportWarrantV1(
+            from_module=module_name,
+            from_source_cid=module.source_cid,
+            to_module=target_module,
+            to_source_cid=target.source_cid,
+            exported_name=exported_name,
+            imported_name=alias.name,
+            definition=_import_coordinate(module, node, exported_name),
+        )
+        return _resolve_export(
+            graph,
+            binding_cid,
+            target_module,
+            alias.name,
+            (*warrants, warrant),
+            seen | {key},
+        )
+    if aliases:
+        return _resolve_export(
+            graph,
+            binding_cid,
+            module_name,
+            aliases[0].id,
+            warrants,
+            seen | {key},
+        )
+    return _gap(
+        "dynamic-export" if dynamic else "static-export-absent",
+        binding_cid,
+        graph,
+        module_name,
+        exported_name,
+    )
+
+
+def _definition(
+    module: AuthenticatedModuleSourceV1, node: ast.AST
+) -> DefinitionCoordinateV1:
+    segment = ast.get_source_segment(module.source, node)
+    if segment is None:
+        raise DependencyArtifactAuthenticationError(
+            "definition source segment is unavailable"
+        )
+    kind: Literal["function", "class"] = (
+        "class" if isinstance(node, ast.ClassDef) else "function"
+    )
+    return DefinitionCoordinateV1(
+        name=node.name,
+        kind=kind,
+        source_cid=module.source_cid,
+        start_line=node.lineno,
+        start_col=node.col_offset,
+        end_line=node.end_lineno,
+        end_col=node.end_col_offset,
+        fragment_cid=blake3_512_of(segment.encode("utf-8")),
+    )
+
+
+def _import_coordinate(
+    module: AuthenticatedModuleSourceV1,
+    node: ast.ImportFrom,
+    exported_name: str,
+) -> DefinitionCoordinateV1:
+    segment = ast.get_source_segment(module.source, node)
+    if segment is None:
+        raise DependencyArtifactAuthenticationError(
+            "re-export source segment is unavailable"
+        )
+    return DefinitionCoordinateV1(
+        name=exported_name,
+        kind="import",
+        source_cid=module.source_cid,
+        start_line=node.lineno,
+        start_col=node.col_offset,
+        end_line=node.end_lineno,
+        end_col=node.end_col_offset,
+        fragment_cid=blake3_512_of(segment.encode("utf-8")),
+    )
+
+
+def _binding_target(
+    value: Mapping[str, Any],
+) -> tuple[str, tuple[str, ...], str | None]:
+    if value["kind"] != "python-import-binding" or value["schemaVersion"] != "1":
+        raise ValueError("unsupported import binding")
+    target = value["target"]
+    identity = target["moduleIdentity"]
+    if identity["kind"] == "unavailable-python-module":
+        module_name = identity["name"]
+        source_cid = None
+    elif identity["kind"] == "authenticated-python-module":
+        module_name = identity["moduleName"]
+        source_cid = _cid(identity["sourceCid"], "module identity sourceCid")
+    else:
+        raise ValueError("unsupported module identity")
+    path = target["exportedPath"]
+    if not isinstance(path, list) or not all(
+        isinstance(item, str) and item for item in path
+    ):
+        raise ValueError("invalid exported path")
+    return _string(module_name, "module name"), tuple(path), source_cid
+
+
+def _absolute_import(
+    current_module: str, source_seat: str, node: ast.ImportFrom
+) -> str | None:
+    if node.level == 0:
+        return node.module
+    package = current_module.split(".")
+    if not source_seat.endswith("/__init__.py"):
+        package.pop()
+    ascend = node.level - 1
+    if ascend > len(package):
+        return None
+    base = package[: len(package) - ascend]
+    if node.module:
+        base.extend(node.module.split("."))
+    return ".".join(base) or None
+
+
+def _is_overload(node: ast.AST) -> bool:
+    decorators = getattr(node, "decorator_list", ())
+    for decorator in decorators:
+        if isinstance(decorator, ast.Name) and decorator.id == "overload":
+            return True
+        if isinstance(decorator, ast.Attribute) and decorator.attr == "overload":
+            return True
+    return False
+
+
+def _module_name(path: PurePosixPath) -> str | None:
+    if path.suffix != ".py":
+        return None
+    parts = list(path.with_suffix("").parts)
+    if any(part.endswith(".dist-info") or part.endswith(".data") for part in parts):
+        return None
+    if parts[-1] == "__init__":
+        parts.pop()
+    if not parts or not all(part.isidentifier() for part in parts):
+        return None
+    return ".".join(parts)
+
+
+def _gap(
+    kind: Any,
+    binding_cid: str,
+    graph: DependencyArtifactGraph,
+    module_name: str,
+    exported_name: str,
+) -> PythonObjectResolutionGapV1:
+    return PythonObjectResolutionGapV1(
+        kind=kind,
+        import_binding_cid=binding_cid,
+        distribution_artifact_cid=graph.distribution_artifact_cid,
+        module_name=module_name,
+        exported_name=exported_name,
+    )
+
+
+def _require_exact_keys(value: Any, expected: set[str], label: str) -> None:
+    if not isinstance(value, dict) or set(value) != expected:
+        raise ValueError(f"{label} has an invalid key set")
+
+
+def _string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a nonempty string")
+    return value
+
+
+def _cid(value: Any, label: str) -> str:
+    value = _string(value, label)
+    if not value.startswith("blake3-512:"):
+        raise ValueError(f"{label} must be a content CID")
+    return value
+
+
+def _nonnegative_int(value: Any, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(f"{label} must be a nonnegative integer")
+    return value

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -24,6 +24,9 @@ class DependencyArtifactAuthenticationError(Exception):
     """The selected installed artifact cannot be authenticated exactly."""
 
 
+_ARTIFACT_INTAKE_AUTHORITY = object()
+
+
 @dataclass(frozen=True)
 class AuthenticatedArtifactFileV1:
     source_seat: str
@@ -247,7 +250,18 @@ class ResolvedPythonObjectV1:
         return {**self._preimage(), "cid": self.cid}
 
     @classmethod
-    def from_value(cls, value: Any) -> "ResolvedPythonObjectV1":
+    def from_value(
+        cls,
+        value: Any,
+        *,
+        graph: "DependencyArtifactGraph",
+        authenticated_use: Any,
+    ) -> "ResolvedPythonObjectV1":
+        """Authenticate wire input by re-resolving every cited preimage.
+
+        Parsing and recomputing this object's outer CID is insufficient: an
+        invented but self-consistent payload is not artifact authentication.
+        """
         _require_exact_keys(
             value,
             {
@@ -268,7 +282,12 @@ class ResolvedPythonObjectV1:
         warrants = value["reexportWarrants"]
         if not isinstance(warrants, list):
             raise ValueError("reexportWarrants must be a list")
-        return cls(
+        revalidated = resolve_import_binding(authenticated_use, graph=graph)
+        if not isinstance(revalidated, cls) or revalidated.to_value() != value:
+            raise DependencyArtifactAuthenticationError(
+                "resolved object is not byte-identical to artifact re-resolution"
+            )
+        decoded = cls(
             distribution_artifact_cid=_cid(
                 value["distributionArtifactCid"], "distributionArtifactCid"
             ),
@@ -281,6 +300,11 @@ class ResolvedPythonObjectV1:
             definition=DefinitionCoordinateV1.from_value(value["definition"]),
             cid=_cid(value["cid"], "resolved object cid"),
         )
+        if decoded != revalidated:
+            raise DependencyArtifactAuthenticationError(
+                "decoded resolved object differs from its authenticated preimage"
+            )
+        return revalidated
 
 
 @dataclass(frozen=True)
@@ -311,8 +335,13 @@ class DependencyArtifactGraph:
     distribution_artifact_cid: str
     files: tuple[AuthenticatedArtifactFileV1, ...]
     modules: Mapping[str, AuthenticatedModuleSourceV1]
+    _intake_authority: object = field(repr=False, compare=False)
 
     def __post_init__(self) -> None:
+        if self._intake_authority is not _ARTIFACT_INTAKE_AUTHORITY:
+            raise DependencyArtifactAuthenticationError(
+                "dependency artifact graph was not minted by SourceOracle intake"
+            )
         metadata_files = [
             item
             for item in self.files
@@ -360,12 +389,23 @@ class DependencyArtifactGraph:
             recorded = files_by_seat.get(module.source_seat)
             if (
                 module_name != module.module_name
+                or module_name != _module_name(PurePosixPath(module.source_seat))
                 or recorded is None
                 or recorded.content_cid != module.source_cid
             ):
                 raise DependencyArtifactAuthenticationError(
                     "module source is not projected from the artifact file manifest"
                 )
+        expected_modules = {
+            name
+            for item in self.files
+            for name in [_module_name(PurePosixPath(item.source_seat))]
+            if name is not None
+        }
+        if set(self.modules) != expected_modules:
+            raise DependencyArtifactAuthenticationError(
+                "artifact module projection is incomplete or contains invented modules"
+            )
 
     @classmethod
     def authenticate(
@@ -451,18 +491,35 @@ class DependencyArtifactGraph:
             distribution_artifact_cid=cid_of_json(preimage),
             files=tuple(authenticated_files),
             modules=MappingProxyType(modules),
+            _intake_authority=_ARTIFACT_INTAKE_AUTHORITY,
         )
 
 
 def resolve_import_binding(
-    import_binding: Mapping[str, Any],
+    authenticated_use: Any,
     *,
-    target_symbol: str,
     graph: DependencyArtifactGraph,
 ) -> PythonObjectResolutionV1:
-    """Resolve an existing ImportBinding through one authenticated artifact."""
-    binding_value = dict(import_binding)
+    """Resolve a final-checked #6090 import use through one artifact graph."""
+    from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
+
+    if not isinstance(authenticated_use, AuthenticatedImportUseV1):
+        raise DependencyArtifactAuthenticationError(
+            "source resolution requires AuthenticatedImportUseV1"
+        )
+    try:
+        authenticated_use.revalidate()
+    except ValueError as exc:
+        raise DependencyArtifactAuthenticationError(
+            "authenticated import use failed lexical revalidation"
+        ) from exc
+    binding_value = authenticated_use.import_binding.to_value()
+    target_symbol = authenticated_use.target_symbol
     binding_cid = cid_of_json(binding_value)
+    if binding_cid != authenticated_use.import_binding.cid:
+        raise DependencyArtifactAuthenticationError(
+            "authenticated import binding differs from its final-checked preimage"
+        )
     try:
         module_name, bound_path, authenticated_source_cid = _binding_target(
             binding_value
@@ -528,38 +585,59 @@ def _resolve_export(
             "artifact-module-absent", binding_cid, graph, module_name, exported_name
         )
     tree = parsed_tree(module.source, module.source_seat)
-    candidates: list[ast.AST] = []
-    imports: list[tuple[ast.ImportFrom, ast.alias]] = []
-    aliases: list[ast.Name] = []
-    dynamic = False
+    binding: tuple[str, Any] | None = None
+    dynamic_getattr = False
     for node in tree.body:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
             if node.name == "__getattr__":
-                dynamic = True
+                dynamic_getattr = True
             if node.name == exported_name:
-                candidates.append(node)
+                binding = (
+                    ("definition", node)
+                    if not node.decorator_list
+                    else ("dynamic", node)
+                )
         elif isinstance(node, ast.ImportFrom):
             for alias in node.names:
                 if (alias.asname or alias.name) == exported_name:
-                    imports.append((node, alias))
-        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
-            target = node.targets[0]
-            if (
-                isinstance(target, ast.Name)
-                and target.id == exported_name
+                    binding = ("import", (node, alias))
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if (alias.asname or alias.name.split(".")[0]) == exported_name:
+                    binding = ("dynamic", node)
+        elif isinstance(node, ast.Assign) and any(
+            _target_binds(target, exported_name) for target in node.targets
+        ):
+            binding = (
+                ("alias", node.value)
+                if len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)
                 and isinstance(node.value, ast.Name)
-            ):
-                aliases.append(node.value)
-    runtime_candidates = [node for node in candidates if not _is_overload(node)]
-    if runtime_candidates:
-        candidates = runtime_candidates
-    count = len(candidates) + len(imports) + len(aliases)
-    if count > 1:
-        return _gap(
-            "ambiguous-static-export", binding_cid, graph, module_name, exported_name
-        )
-    if candidates:
-        definition = _definition(module, candidates[0])
+                else ("dynamic", node)
+            )
+        elif isinstance(node, ast.AnnAssign) and _target_binds(
+            node.target, exported_name
+        ):
+            if node.value is not None:
+                binding = (
+                    ("alias", node.value)
+                    if isinstance(node.target, ast.Name)
+                    and isinstance(node.value, ast.Name)
+                    else ("dynamic", node)
+                )
+        elif isinstance(node, ast.AugAssign) and _target_binds(
+            node.target, exported_name
+        ):
+            binding = ("dynamic", node)
+        elif isinstance(node, (ast.If, ast.For, ast.AsyncFor, ast.While, ast.Try)):
+            if _compound_binds(node, exported_name):
+                binding = ("dynamic", node)
+        elif isinstance(node, ast.Delete) and any(
+            _target_binds(target, exported_name) for target in node.targets
+        ):
+            binding = None
+    if binding is not None and binding[0] == "definition":
+        definition = _definition(module, binding[1])
         return ResolvedPythonObjectV1(
             distribution_artifact_cid=graph.distribution_artifact_cid,
             import_binding_cid=binding_cid,
@@ -568,8 +646,8 @@ def _resolve_export(
             reexport_warrants=warrants,
             definition=definition,
         )
-    if imports:
-        node, alias = imports[0]
+    if binding is not None and binding[0] == "import":
+        node, alias = binding[1]
         target_module = _absolute_import(module_name, module.source_seat, node)
         if target_module is None:
             return _gap("opaque-source", binding_cid, graph, module_name, exported_name)
@@ -599,17 +677,21 @@ def _resolve_export(
             (*warrants, warrant),
             seen | {key},
         )
-    if aliases:
+    if binding is not None and binding[0] == "alias":
         return _resolve_export(
             graph,
             binding_cid,
             module_name,
-            aliases[0].id,
+            binding[1].id,
             warrants,
             seen | {key},
         )
     return _gap(
-        "dynamic-export" if dynamic else "static-export-absent",
+        (
+            "dynamic-export"
+            if dynamic_getattr or (binding is not None and binding[0] == "dynamic")
+            else "static-export-absent"
+        ),
         binding_cid,
         graph,
         module_name,
@@ -702,14 +784,57 @@ def _absolute_import(
     return ".".join(base) or None
 
 
-def _is_overload(node: ast.AST) -> bool:
-    decorators = getattr(node, "decorator_list", ())
-    for decorator in decorators:
-        if isinstance(decorator, ast.Name) and decorator.id == "overload":
-            return True
-        if isinstance(decorator, ast.Attribute) and decorator.attr == "overload":
-            return True
+def _target_binds(target: ast.AST, name: str) -> bool:
+    if isinstance(target, ast.Name):
+        return target.id == name
+    if isinstance(target, (ast.Tuple, ast.List)):
+        return any(_target_binds(item, name) for item in target.elts)
+    if isinstance(target, ast.Starred):
+        return _target_binds(target.value, name)
     return False
+
+
+def _compound_binds(statement: ast.stmt, name: str) -> bool:
+    """Conservatively identify a conditional/runtime-selected rebinding."""
+
+    class BindingVisitor(ast.NodeVisitor):
+        found = False
+
+        def visit_Name(self, node: ast.Name) -> None:
+            if isinstance(node.ctx, (ast.Store, ast.Del)) and node.id == name:
+                self.found = True
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            if node.name == name:
+                self.found = True
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            if node.name == name:
+                self.found = True
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            if node.name == name:
+                self.found = True
+
+        def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+            if any((alias.asname or alias.name) == name for alias in node.names):
+                self.found = True
+
+        def visit_Import(self, node: ast.Import) -> None:
+            if any(
+                (alias.asname or alias.name.split(".")[0]) == name
+                for alias in node.names
+            ):
+                self.found = True
+
+        def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+            if node.name == name:
+                self.found = True
+            self.generic_visit(node)
+
+    visitor = BindingVisitor()
+    visitor.visit(statement)
+    return visitor.found
 
 
 def _module_name(path: PurePosixPath) -> str | None:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -817,14 +817,42 @@ def export_statement_coverage() -> tuple[list[str], list[str]]:
 
 def _export_block(statements, name, initial):
     state = initial
-    for statement in statements:
+    for index, statement in enumerate(statements):
+        if _statement_contains_module_init_raise(statement) and _suite_binds_export(
+            statements[index + 1 :], name
+        ):
+            # A later binding is control-dependent on whether this exceptional
+            # prefix completes.  In particular, a With/AsyncWith exit may
+            # suppress the exception while skipping the remainder of its
+            # suite.  Selecting that later textual binding would authenticate
+            # an unreachable definition.
+            return ("dynamic", statement)
         state = _export_statement(statement, name, state)
     return state
 
 
+def _suite_binds_export(statements, name: str) -> bool:
+    marker = object()
+    return _export_block(statements, name, marker) is not marker
+
+
+def _statement_contains_module_init_raise(statement: ast.AST) -> bool:
+    stack: list[ast.AST] = [statement]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, ast.Raise):
+            return True
+        if node is not statement and isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+        ):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+    return False
+
+
 def _export_statement(statement: ast.stmt, name: str, state):
     if type(statement) not in (_EXPORT_SIMPLE_STATEMENTS | _EXPORT_COMPOUND_STATEMENTS):
-        return ("unsupported", type(statement).__name__)
+        return _unsupported_export_statement(statement)
     if _statement_walrus_binds(statement, name):
         state = ("dynamic", statement)
     if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
@@ -940,7 +968,13 @@ def _export_statement(statement: ast.stmt, name: str, state):
         iterated = _export_block(statement.body, name, iterated)
         iterated = _export_block(statement.orelse, name, iterated)
         return _join_export_states((state, iterated), statement)
-    return state
+    if type(statement) in _EXPORT_SIMPLE_STATEMENTS:
+        return state
+    return _unsupported_export_statement(statement)
+
+
+def _unsupported_export_statement(statement: ast.AST):
+    return ("unsupported", type(statement).__name__)
 
 
 def _join_export_states(states, locus):
@@ -962,7 +996,7 @@ def _pattern_binds(pattern: ast.pattern, name: str) -> bool:
     )
 
 
-def _statement_walrus_binds(statement: ast.stmt, name: str) -> bool:
+def _statement_walrus_binds(statement: ast.AST, name: str) -> bool:
     """Find module-scope named expressions without entering nested scopes/suites."""
     stack = list(ast.iter_child_nodes(statement))
     while stack:
@@ -979,7 +1013,7 @@ def _statement_walrus_binds(statement: ast.stmt, name: str) -> bool:
     return False
 
 
-def _cannot_raise_during_module_init(statement: ast.stmt) -> bool:
+def _cannot_raise_during_module_init(statement: ast.AST) -> bool:
     if isinstance(statement, ast.Pass):
         return True
     if not isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -314,6 +314,7 @@ class PythonObjectResolutionGapV1:
         "artifact-module-absent",
         "target-outside-binding",
         "dynamic-export",
+        "unsupported-statement",
         "ambiguous-static-export",
         "static-export-absent",
         "opaque-source",
@@ -585,57 +586,12 @@ def _resolve_export(
             "artifact-module-absent", binding_cid, graph, module_name, exported_name
         )
     tree = parsed_tree(module.source, module.source_seat)
-    binding: tuple[str, Any] | None = None
-    dynamic_getattr = False
-    for node in tree.body:
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            if node.name == "__getattr__":
-                dynamic_getattr = True
-            if node.name == exported_name:
-                binding = (
-                    ("definition", node)
-                    if not node.decorator_list
-                    else ("dynamic", node)
-                )
-        elif isinstance(node, ast.ImportFrom):
-            for alias in node.names:
-                if (alias.asname or alias.name) == exported_name:
-                    binding = ("import", (node, alias))
-        elif isinstance(node, ast.Import):
-            for alias in node.names:
-                if (alias.asname or alias.name.split(".")[0]) == exported_name:
-                    binding = ("dynamic", node)
-        elif isinstance(node, ast.Assign) and any(
-            _target_binds(target, exported_name) for target in node.targets
-        ):
-            binding = (
-                ("alias", node.value)
-                if len(node.targets) == 1
-                and isinstance(node.targets[0], ast.Name)
-                and isinstance(node.value, ast.Name)
-                else ("dynamic", node)
-            )
-        elif isinstance(node, ast.AnnAssign) and _target_binds(
-            node.target, exported_name
-        ):
-            if node.value is not None:
-                binding = (
-                    ("alias", node.value)
-                    if isinstance(node.target, ast.Name)
-                    and isinstance(node.value, ast.Name)
-                    else ("dynamic", node)
-                )
-        elif isinstance(node, ast.AugAssign) and _target_binds(
-            node.target, exported_name
-        ):
-            binding = ("dynamic", node)
-        elif isinstance(node, (ast.If, ast.For, ast.AsyncFor, ast.While, ast.Try)):
-            if _compound_binds(node, exported_name):
-                binding = ("dynamic", node)
-        elif isinstance(node, ast.Delete) and any(
-            _target_binds(target, exported_name) for target in node.targets
-        ):
-            binding = None
+    binding = _export_block(tree.body, exported_name, None)
+    dynamic_getattr = any(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "__getattr__"
+        for node in tree.body
+    )
     if binding is not None and binding[0] == "definition":
         definition = _definition(module, binding[1])
         return ResolvedPythonObjectV1(
@@ -685,6 +641,14 @@ def _resolve_export(
             binding[1].id,
             warrants,
             seen | {key},
+        )
+    if binding is not None and binding[0] == "unsupported":
+        return _gap(
+            "unsupported-statement",
+            binding_cid,
+            graph,
+            module_name,
+            exported_name,
         )
     return _gap(
         (
@@ -794,47 +758,248 @@ def _target_binds(target: ast.AST, name: str) -> bool:
     return False
 
 
-def _compound_binds(statement: ast.stmt, name: str) -> bool:
-    """Conservatively identify a conditional/runtime-selected rebinding."""
+_TYPE_ALIAS = getattr(ast, "TypeAlias", None)
+_TRY_TYPES = tuple(
+    kind for kind in (ast.Try, getattr(ast, "TryStar", None)) if kind is not None
+)
 
-    class BindingVisitor(ast.NodeVisitor):
-        found = False
+_EXPORT_SIMPLE_STATEMENTS = frozenset(
+    kind
+    for kind in (
+        ast.Assign,
+        ast.AnnAssign,
+        ast.AugAssign,
+        ast.Delete,
+        ast.Import,
+        ast.ImportFrom,
+        ast.FunctionDef,
+        ast.AsyncFunctionDef,
+        ast.ClassDef,
+        ast.Expr,
+        ast.Return,
+        ast.Raise,
+        ast.Assert,
+        ast.Pass,
+        ast.Break,
+        ast.Continue,
+        ast.Global,
+        ast.Nonlocal,
+        _TYPE_ALIAS,
+    )
+    if kind is not None
+)
+_EXPORT_COMPOUND_STATEMENTS = frozenset(
+    kind
+    for kind in (
+        ast.If,
+        ast.For,
+        ast.AsyncFor,
+        ast.While,
+        ast.With,
+        ast.AsyncWith,
+        ast.Try,
+        getattr(ast, "TryStar", None),
+        ast.Match,
+    )
+    if kind is not None
+)
 
-        def visit_Name(self, node: ast.Name) -> None:
-            if isinstance(node.ctx, (ast.Store, ast.Del)) and node.id == name:
-                self.found = True
 
-        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-            if node.name == name:
-                self.found = True
+def export_statement_coverage() -> tuple[list[str], list[str]]:
+    """Audit that every running-interpreter statement has one transfer arm."""
+    grammar = frozenset(ast.stmt.__subclasses__())
+    declared = _EXPORT_SIMPLE_STATEMENTS | _EXPORT_COMPOUND_STATEMENTS
+    return (
+        sorted(kind.__name__ for kind in grammar - declared),
+        sorted(kind.__name__ for kind in declared - grammar),
+    )
 
-        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
-            if node.name == name:
-                self.found = True
 
-        def visit_ClassDef(self, node: ast.ClassDef) -> None:
-            if node.name == name:
-                self.found = True
+def _export_block(statements, name, initial):
+    state = initial
+    for statement in statements:
+        state = _export_statement(statement, name, state)
+    return state
 
-        def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-            if any((alias.asname or alias.name) == name for alias in node.names):
-                self.found = True
 
-        def visit_Import(self, node: ast.Import) -> None:
+def _export_statement(statement: ast.stmt, name: str, state):
+    if type(statement) not in (_EXPORT_SIMPLE_STATEMENTS | _EXPORT_COMPOUND_STATEMENTS):
+        return ("unsupported", type(statement).__name__)
+    if _statement_walrus_binds(statement, name):
+        state = ("dynamic", statement)
+    if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        if statement.name != name:
+            return state
+        return (
+            ("definition", statement)
+            if not statement.decorator_list
+            else ("dynamic", statement)
+        )
+    if isinstance(statement, ast.ImportFrom):
+        for alias in statement.names:
+            if (alias.asname or alias.name) == name:
+                state = ("import", (statement, alias))
+        return state
+    if isinstance(statement, ast.Import):
+        return (
+            ("dynamic", statement)
             if any(
                 (alias.asname or alias.name.split(".")[0]) == name
-                for alias in node.names
+                for alias in statement.names
+            )
+            else state
+        )
+    if isinstance(statement, ast.Assign):
+        if not any(_target_binds(target, name) for target in statement.targets):
+            return state
+        if (
+            len(statement.targets) == 1
+            and isinstance(statement.targets[0], ast.Name)
+            and isinstance(statement.value, ast.Name)
+        ):
+            return ("alias", statement.value)
+        return ("dynamic", statement)
+    if isinstance(statement, ast.AnnAssign):
+        if statement.value is None or not _target_binds(statement.target, name):
+            return state
+        if isinstance(statement.target, ast.Name) and isinstance(
+            statement.value, ast.Name
+        ):
+            return ("alias", statement.value)
+        return ("dynamic", statement)
+    if isinstance(statement, ast.AugAssign):
+        return (
+            ("dynamic", statement) if _target_binds(statement.target, name) else state
+        )
+    if isinstance(statement, ast.Delete):
+        return (
+            None
+            if any(_target_binds(target, name) for target in statement.targets)
+            else state
+        )
+    if _TYPE_ALIAS is not None and isinstance(statement, _TYPE_ALIAS):
+        return (
+            ("dynamic", statement)
+            if isinstance(statement.name, ast.Name) and statement.name.id == name
+            else state
+        )
+    if isinstance(statement, (ast.With, ast.AsyncWith)):
+        for item in statement.items:
+            if item.optional_vars is not None and _target_binds(
+                item.optional_vars, name
             ):
-                self.found = True
+                state = ("dynamic", statement)
+        return _export_block(statement.body, name, state)
+    if isinstance(statement, ast.Match):
+        outputs = [
+            _export_block(
+                case.body,
+                name,
+                ("dynamic", statement) if _pattern_binds(case.pattern, name) else state,
+            )
+            for case in statement.cases
+        ]
+        exhaustive = (
+            bool(statement.cases)
+            and isinstance(statement.cases[-1].pattern, ast.MatchAs)
+            and statement.cases[-1].pattern.pattern is None
+            and statement.cases[-1].guard is None
+        )
+        if not exhaustive:
+            outputs.append(state)
+        return _join_export_states(outputs, statement)
+    if isinstance(statement, _TRY_TYPES):
+        completed = _export_block(statement.body, name, state)
+        completed = _export_block(statement.orelse, name, completed)
+        # A suite containing only definition/pass statements cannot raise while
+        # binding the export; its handlers are unreachable on successful module
+        # construction. Other try bodies retain every handler edge.
+        outputs = [completed]
+        if not all(_cannot_raise_during_module_init(item) for item in statement.body):
+            for handler in statement.handlers:
+                handler_state = (
+                    ("dynamic", statement) if handler.name == name else state
+                )
+                outputs.append(_export_block(handler.body, name, handler_state))
+        joined = _join_export_states(outputs, statement)
+        return _export_block(statement.finalbody, name, joined)
+    if isinstance(statement, ast.If):
+        return _join_export_states(
+            (
+                _export_block(statement.body, name, state),
+                _export_block(statement.orelse, name, state),
+            ),
+            statement,
+        )
+    if isinstance(statement, (ast.For, ast.AsyncFor, ast.While)):
+        iterated = state
+        if isinstance(statement, (ast.For, ast.AsyncFor)) and _target_binds(
+            statement.target, name
+        ):
+            iterated = ("dynamic", statement)
+        iterated = _export_block(statement.body, name, iterated)
+        iterated = _export_block(statement.orelse, name, iterated)
+        return _join_export_states((state, iterated), statement)
+    return state
 
-        def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
-            if node.name == name:
-                self.found = True
-            self.generic_visit(node)
 
-    visitor = BindingVisitor()
-    visitor.visit(statement)
-    return visitor.found
+def _join_export_states(states, locus):
+    states = tuple(states)
+    if states and all(state == states[0] for state in states[1:]):
+        return states[0]
+    return ("dynamic", locus)
+
+
+def _pattern_binds(pattern: ast.pattern, name: str) -> bool:
+    if isinstance(pattern, (ast.MatchAs, ast.MatchStar)) and pattern.name == name:
+        return True
+    if isinstance(pattern, ast.MatchMapping) and pattern.rest == name:
+        return True
+    return any(
+        _pattern_binds(child, name)
+        for child in ast.iter_child_nodes(pattern)
+        if isinstance(child, ast.pattern)
+    )
+
+
+def _statement_walrus_binds(statement: ast.stmt, name: str) -> bool:
+    """Find module-scope named expressions without entering nested scopes/suites."""
+    stack = list(ast.iter_child_nodes(statement))
+    while stack:
+        node = stack.pop()
+        if isinstance(node, ast.stmt):
+            continue
+        if isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+        ):
+            continue
+        if isinstance(node, ast.NamedExpr) and _target_binds(node.target, name):
+            return True
+        stack.extend(ast.iter_child_nodes(node))
+    return False
+
+
+def _cannot_raise_during_module_init(statement: ast.stmt) -> bool:
+    if isinstance(statement, ast.Pass):
+        return True
+    if not isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return False
+    arguments = statement.args
+    parameters = (
+        *arguments.posonlyargs,
+        *arguments.args,
+        *arguments.kwonlyargs,
+        *(() if arguments.vararg is None else (arguments.vararg,)),
+        *(() if arguments.kwarg is None else (arguments.kwarg,)),
+    )
+    return not (
+        statement.decorator_list
+        or arguments.defaults
+        or any(default is not None for default in arguments.kw_defaults)
+        or statement.returns is not None
+        or any(parameter.annotation is not None for parameter in parameters)
+        or getattr(statement, "type_params", ())
+    )
 
 
 def _module_name(path: PurePosixPath) -> str | None:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
@@ -148,6 +148,23 @@ def path_source(path: str) -> tuple[str, str, str]:
     return (source, str(path), blake3_512_of(source.encode("utf-8")))
 
 
+def dependency_artifact_file(path: str) -> tuple[bytes, str, str]:
+    """Mint one recorded dependency file as ``(bytes, seat, content CID)``.
+
+    The dependency artifact graph supplies the seat; this door only reads and
+    content-addresses it.  It performs no module lookup, import, or execution.
+    Binary files are admitted because a distribution artifact authenticates
+    every recorded byte, not only Python source files.
+    """
+    try:
+        content = Path(path).read_bytes()
+    except (OSError, ValueError) as exc:
+        raise SourceUnavailable(
+            f"cannot read dependency artifact file `{path}`: {exc}"
+        ) from exc
+    return content, str(path), blake3_512_of(content)
+
+
 def resolve_span_memento(
     memento: dict[str, Any], project_root: str | None = None
 ) -> dict[str, Any]:

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -354,6 +354,28 @@ def test_compound_statement_later_definition_is_the_authenticated_export(
     assert result.definition.start_line != 1
 
 
+def test_with_suppressible_exceptional_prefix_does_not_authenticate_unreachable_export(
+    tmp_path: Path,
+) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        _install_distribution(
+            tmp_path,
+            package_source="from example_pkg.implementation import build\n",
+            implementation_source=(
+                "def build(value):\n    return 'old'\n"
+                "with suppresses_exceptions():\n"
+                "    raise RuntimeError()\n"
+                "    def build(value):\n        return 'new'\n"
+            ),
+        )
+    )
+
+    result = resolve_import_binding(_demand(tmp_path), graph=graph)
+
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
 def test_export_transfer_exhaustively_classifies_running_ast_statement_grammar() -> (
     None
 ):

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -19,6 +19,7 @@ from sugar_lift_python_source.dependency_artifact import (
     PythonObjectResolutionGapV1,
     ResolvedPythonObjectV1,
     resolve_import_binding,
+    export_statement_coverage,
 )
 from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
 
@@ -308,3 +309,54 @@ def test_later_non_name_assignment_makes_export_dynamic(tmp_path: Path) -> None:
 
     assert isinstance(result, PythonObjectResolutionGapV1)
     assert result.kind == "dynamic-export"
+
+
+@pytest.mark.parametrize(
+    ("implementation", "expected_line"),
+    (
+        (
+            "def build(value):\n    return 'old'\n"
+            "with object():\n"
+            "    def build(value):\n        return value\n",
+            4,
+        ),
+        (
+            "def build(value):\n    return 'old'\n"
+            "match 1:\n"
+            "    case _:\n"
+            "        def build(value):\n            return value\n",
+            5,
+        ),
+        (
+            "def build(value):\n    return 'old'\n"
+            "try:\n"
+            "    def build(value):\n        return value\n"
+            "except* Exception:\n    pass\n",
+            4,
+        ),
+    ),
+    ids=("with", "match", "try-star"),
+)
+def test_compound_statement_later_definition_is_the_authenticated_export(
+    tmp_path: Path, implementation: str, expected_line: int
+) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        _install_distribution(
+            tmp_path,
+            package_source="from example_pkg.implementation import build\n",
+            implementation_source=implementation,
+        )
+    )
+    result = resolve_import_binding(_demand(tmp_path), graph=graph)
+
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.definition.start_line == expected_line
+    assert result.definition.start_line != 1
+
+
+def test_export_transfer_exhaustively_classifies_running_ast_statement_grammar() -> (
+    None
+):
+    missing, extra = export_statement_coverage()
+    assert missing == []
+    assert extra == []

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+from __future__ import annotations
+
+import csv
+from dataclasses import replace
+import importlib.metadata
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+from sugar_lift_python_source.dependency_artifact import (
+    DependencyArtifactAuthenticationError,
+    DependencyArtifactGraph,
+    PythonObjectResolutionGapV1,
+    ResolvedPythonObjectV1,
+    resolve_import_binding,
+)
+from sugar_lift_python_source.canonical import blake3_512_of
+
+
+def _install_distribution(
+    root: Path, *, package_source: str, implementation_source: str
+) -> importlib.metadata.Distribution:
+    package = root / "example_pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text(package_source, encoding="utf-8")
+    (package / "implementation.py").write_text(implementation_source, encoding="utf-8")
+    metadata = root / "example_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: example-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    (metadata / "top_level.txt").write_text("example_pkg\n", encoding="utf-8")
+    recorded = (
+        "example_pkg/__init__.py",
+        "example_pkg/implementation.py",
+        "example_dist-1.0.dist-info/METADATA",
+        "example_dist-1.0.dist-info/top_level.txt",
+        "example_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for path in recorded:
+            writer.writerow((path, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _demand(
+    root: Path, source: str = "import example_pkg\nexample_pkg.build(1)\n"
+) -> dict[str, object]:
+    from sugar_lift_py_tests.import_binding import authenticated_import_uses
+
+    path = root / "consumer.py"
+    path.write_text(source, encoding="utf-8")
+    source_cid = blake3_512_of(source.encode("utf-8"))
+    rows, outcomes = authenticated_import_uses(
+        root, path, source, source_cid, module_identities={}
+    )
+    assert set(outcomes.values()) == {"authenticated-import-use"}
+    return next(item for item in rows if item["kind"] == "call-contract-demand")
+
+
+def test_static_reexport_resolves_to_content_addressed_definition_without_import(
+    tmp_path: Path,
+) -> None:
+    distribution = _install_distribution(
+        tmp_path,
+        package_source=(
+            "from example_pkg.implementation import build\n"
+            "raise RuntimeError('module execution is forbidden')\n"
+        ),
+        implementation_source="def build(value):\n    return value\n",
+    )
+    sys.modules.pop("example_pkg", None)
+    sys.modules.pop("example_pkg.implementation", None)
+
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    demand = _demand(tmp_path)
+    result = resolve_import_binding(
+        demand["importBinding"], target_symbol=demand["targetSymbol"], graph=graph
+    )
+
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.distribution_artifact_cid == graph.distribution_artifact_cid
+    assert result.module_name == "example_pkg.implementation"
+    assert result.source_cid == graph.modules[result.module_name].source_cid
+    assert result.definition.kind == "function"
+    assert result.definition.name == "build"
+    assert result.definition.source_cid == result.source_cid
+    assert len(result.reexport_warrants) == 1
+    assert result.reexport_warrants[0].from_module == "example_pkg"
+    assert result.reexport_warrants[0].to_module == "example_pkg.implementation"
+    assert result.cid.startswith("blake3-512:")
+    assert "example_pkg" not in sys.modules
+    assert "example_pkg.implementation" not in sys.modules
+
+
+def test_resolved_python_object_round_trips_with_identical_cid(tmp_path: Path) -> None:
+    distribution = _install_distribution(
+        tmp_path,
+        package_source="from example_pkg.implementation import build\n",
+        implementation_source="class build:\n    pass\n",
+    )
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    demand = _demand(tmp_path, "from example_pkg import build as make\nmake(1)\n")
+    result = resolve_import_binding(
+        demand["importBinding"], target_symbol=demand["targetSymbol"], graph=graph
+    )
+    assert isinstance(result, ResolvedPythonObjectV1)
+
+    encoded = json.loads(json.dumps(result.to_value(), sort_keys=True))
+    decoded = ResolvedPythonObjectV1.from_value(encoded)
+
+    assert decoded == result
+    assert decoded.cid == result.cid
+    assert decoded.definition.kind == "class"
+
+
+def test_dynamic_export_stays_a_typed_loud_gap(tmp_path: Path) -> None:
+    distribution = _install_distribution(
+        tmp_path,
+        package_source=("def __getattr__(name):\n" "    return object()\n"),
+        implementation_source="def build(value):\n    return value\n",
+    )
+    graph = DependencyArtifactGraph.authenticate(distribution)
+
+    demand = _demand(tmp_path)
+    result = resolve_import_binding(
+        demand["importBinding"], target_symbol=demand["targetSymbol"], graph=graph
+    )
+
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+    assert result.import_binding_cid.startswith("blake3-512:")
+    assert result.distribution_artifact_cid == graph.distribution_artifact_cid
+
+
+def test_real_pytest_reexport_resolves_without_manager_name_recognition(
+    tmp_path: Path,
+) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        importlib.metadata.distribution("pytest")
+    )
+    demand = _demand(tmp_path, "import pytest\npytest.raises(ValueError)\n")
+
+    result = resolve_import_binding(
+        demand["importBinding"], target_symbol=demand["targetSymbol"], graph=graph
+    )
+
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.definition.name == "raises"
+    assert result.definition.kind == "function"
+    assert result.module_name != "pytest"
+    assert result.reexport_warrants
+    assert result.definition.source_cid == result.source_cid
+
+
+def test_fabricated_artifact_file_wrapper_is_loud(tmp_path: Path) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        _install_distribution(
+            tmp_path,
+            package_source="from example_pkg.implementation import build\n",
+            implementation_source="def build(value):\n    return value\n",
+        )
+    )
+
+    with pytest.raises(DependencyArtifactAuthenticationError):
+        replace(graph.files[0], content=b"forged bytes")

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -7,17 +7,20 @@ import importlib.metadata
 import json
 from pathlib import Path
 import sys
+from types import MappingProxyType
 
 import pytest
+from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
 
 from sugar_lift_python_source.dependency_artifact import (
     DependencyArtifactAuthenticationError,
     DependencyArtifactGraph,
+    AuthenticatedModuleSourceV1,
     PythonObjectResolutionGapV1,
     ResolvedPythonObjectV1,
     resolve_import_binding,
 )
-from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
 
 
 def _install_distribution(
@@ -50,17 +53,18 @@ def _install_distribution(
 
 def _demand(
     root: Path, source: str = "import example_pkg\nexample_pkg.build(1)\n"
-) -> dict[str, object]:
-    from sugar_lift_py_tests.import_binding import authenticated_import_uses
+) -> AuthenticatedImportUseV1:
+    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
 
     path = root / "consumer.py"
     path.write_text(source, encoding="utf-8")
     source_cid = blake3_512_of(source.encode("utf-8"))
-    rows, outcomes = authenticated_import_uses(
+    receipts, outcomes = authenticated_import_use_receipts(
         root, path, source, source_cid, module_identities={}
     )
     assert set(outcomes.values()) == {"authenticated-import-use"}
-    return next(item for item in rows if item["kind"] == "call-contract-demand")
+    assert len(receipts) == 1
+    return receipts[0]
 
 
 def test_static_reexport_resolves_to_content_addressed_definition_without_import(
@@ -79,9 +83,7 @@ def test_static_reexport_resolves_to_content_addressed_definition_without_import
 
     graph = DependencyArtifactGraph.authenticate(distribution)
     demand = _demand(tmp_path)
-    result = resolve_import_binding(
-        demand["importBinding"], target_symbol=demand["targetSymbol"], graph=graph
-    )
+    result = resolve_import_binding(demand, graph=graph)
 
     assert isinstance(result, ResolvedPythonObjectV1)
     assert result.distribution_artifact_cid == graph.distribution_artifact_cid
@@ -106,13 +108,13 @@ def test_resolved_python_object_round_trips_with_identical_cid(tmp_path: Path) -
     )
     graph = DependencyArtifactGraph.authenticate(distribution)
     demand = _demand(tmp_path, "from example_pkg import build as make\nmake(1)\n")
-    result = resolve_import_binding(
-        demand["importBinding"], target_symbol=demand["targetSymbol"], graph=graph
-    )
+    result = resolve_import_binding(demand, graph=graph)
     assert isinstance(result, ResolvedPythonObjectV1)
 
     encoded = json.loads(json.dumps(result.to_value(), sort_keys=True))
-    decoded = ResolvedPythonObjectV1.from_value(encoded)
+    decoded = ResolvedPythonObjectV1.from_value(
+        encoded, graph=graph, authenticated_use=demand
+    )
 
     assert decoded == result
     assert decoded.cid == result.cid
@@ -128,9 +130,7 @@ def test_dynamic_export_stays_a_typed_loud_gap(tmp_path: Path) -> None:
     graph = DependencyArtifactGraph.authenticate(distribution)
 
     demand = _demand(tmp_path)
-    result = resolve_import_binding(
-        demand["importBinding"], target_symbol=demand["targetSymbol"], graph=graph
-    )
+    result = resolve_import_binding(demand, graph=graph)
 
     assert isinstance(result, PythonObjectResolutionGapV1)
     assert result.kind == "dynamic-export"
@@ -146,9 +146,7 @@ def test_real_pytest_reexport_resolves_without_manager_name_recognition(
     )
     demand = _demand(tmp_path, "import pytest\npytest.raises(ValueError)\n")
 
-    result = resolve_import_binding(
-        demand["importBinding"], target_symbol=demand["targetSymbol"], graph=graph
-    )
+    result = resolve_import_binding(demand, graph=graph)
 
     assert isinstance(result, ResolvedPythonObjectV1)
     assert result.definition.name == "raises"
@@ -169,3 +167,144 @@ def test_fabricated_artifact_file_wrapper_is_loud(tmp_path: Path) -> None:
 
     with pytest.raises(DependencyArtifactAuthenticationError):
         replace(graph.files[0], content=b"forged bytes")
+
+
+def test_recorded_source_seat_cannot_be_relabelled_as_invented_module(
+    tmp_path: Path,
+) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        _install_distribution(
+            tmp_path,
+            package_source="from example_pkg.implementation import build\n",
+            implementation_source="def build(value):\n    return value\n",
+        )
+    )
+    real = graph.modules["example_pkg.implementation"]
+    invented = AuthenticatedModuleSourceV1(
+        module_name="invented.module",
+        source_seat=real.source_seat,
+        source_cid=real.source_cid,
+        source=real.source,
+    )
+
+    with pytest.raises(
+        DependencyArtifactAuthenticationError,
+        match="module source is not projected",
+    ):
+        replace(graph, modules=MappingProxyType({"invented.module": invented}))
+
+
+def test_fabricated_import_binding_mapping_is_rejected_at_resolution_door(
+    tmp_path: Path,
+) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        _install_distribution(
+            tmp_path,
+            package_source="from example_pkg.implementation import build\n",
+            implementation_source="def build(value):\n    return value\n",
+        )
+    )
+    fabricated = _demand(tmp_path).import_binding.to_value()
+
+    with pytest.raises(
+        DependencyArtifactAuthenticationError,
+        match="AuthenticatedImportUseV1",
+    ):
+        resolve_import_binding(fabricated, graph=graph)
+
+
+def test_final_checked_import_use_rejects_fabricated_definition_coordinate(
+    tmp_path: Path,
+) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        _install_distribution(
+            tmp_path,
+            package_source="from example_pkg.implementation import build\n",
+            implementation_source="def build(value):\n    return value\n",
+        )
+    )
+    receipt = _demand(tmp_path)
+    binding_value = receipt.import_binding.to_value()
+    binding_value["definitionSite"]["startLine"] = 999
+    binding_cid = cid_of_json(binding_value)
+    forged_binding = replace(
+        receipt.import_binding, value=binding_value, cid=binding_cid
+    )
+    use = dict(receipt.use)
+    use["importBindingCid"] = binding_cid
+    use["cid"] = cid_of_json({key: value for key, value in use.items() if key != "cid"})
+    demand = dict(receipt.demand)
+    demand["importBinding"] = binding_value
+    demand["importBindingCid"] = binding_cid
+    demand["authenticatedImportUse"] = use
+    forged_receipt = replace(
+        receipt,
+        import_binding=forged_binding,
+        use=use,
+        demand=demand,
+    )
+
+    with pytest.raises(
+        DependencyArtifactAuthenticationError,
+        match="lexical revalidation",
+    ):
+        resolve_import_binding(forged_receipt, graph=graph)
+
+
+def test_recomputed_outer_cid_cannot_authenticate_invented_resolved_artifact(
+    tmp_path: Path,
+) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        _install_distribution(
+            tmp_path,
+            package_source="from example_pkg.implementation import build\n",
+            implementation_source="def build(value):\n    return value\n",
+        )
+    )
+    demand = _demand(tmp_path)
+    resolved = resolve_import_binding(demand, graph=graph)
+    assert isinstance(resolved, ResolvedPythonObjectV1)
+    forged = resolved.to_value()
+    forged["moduleName"] = "invented.module"
+    forged["cid"] = cid_of_json(
+        {key: value for key, value in forged.items() if key != "cid"}
+    )
+
+    with pytest.raises(
+        DependencyArtifactAuthenticationError,
+        match="byte-identical",
+    ):
+        ResolvedPythonObjectV1.from_value(forged, graph=graph, authenticated_use=demand)
+
+
+def test_final_reaching_definition_wins_without_decorator_name_recognition(
+    tmp_path: Path,
+) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        _install_distribution(
+            tmp_path,
+            package_source="from example_pkg.implementation import build\n",
+            implementation_source=(
+                "def build(value):\n    return 'typing-only'\n\n"
+                "def build(value):\n    return value\n"
+            ),
+        )
+    )
+    resolved = resolve_import_binding(_demand(tmp_path), graph=graph)
+
+    assert isinstance(resolved, ResolvedPythonObjectV1)
+    assert resolved.definition.start_line == 4
+
+
+def test_later_non_name_assignment_makes_export_dynamic(tmp_path: Path) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        _install_distribution(
+            tmp_path,
+            package_source="from example_pkg.implementation import build\n",
+            implementation_source="def build(value):\n    return value\nbuild = 42\n",
+        )
+    )
+    result = resolve_import_binding(_demand(tmp_path), graph=graph)
+
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"


### PR DESCRIPTION
## Outcome

Introduces Cut A of the general context-manager derivation path:

```text
SourceOracle-recorded bytes
→ content-addressed DependencyArtifactGraph
→ existing #6090 ImportBinding
→ static re-export warrants
→ ResolvedPythonObjectV1 definition coordinate
```

This contains no provider-kit/catalog authority and no manager-name semantic dispatch. It stops before constructing manager calls or `__enter__`/`__exit__`.

## Authentication boundary

- hashes every file recorded by the selected installed distribution;
- retains and rechecks the exact bytes behind every file/module CID;
- binds distribution name/version to the retained `METADATA` preimage;
- maps only authenticated `.py` implementation seats into the module graph;
- parses static definitions/re-exports without importing or executing modules;
- validates `ResolvedPythonObjectV1` and every re-export warrant by recomputed canonical CID;
- dynamic, ambiguous, absent, cyclic, malformed, and opaque resolution shapes remain typed gaps.

## Evidence

Focused command:

```text
PYTHONPATH=implementations/python/sugar-lift-python-source/src:implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src \
python3 -m pytest -q \
  implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py \
  implementations/python/sugar-lift-python-source/tests/test_source_oracle.py \
  --noconftest
```

Result: `17 passed`.

Twins include:

- #6090's real ImportBinding resolving a static import/re-export chain;
- real `import pytest; pytest.raises(...)` resolving generically to the authenticated installed `raises` function definition;
- a package whose `__init__.py` would raise if executed, proving resolution performs no module execution;
- dynamic `__getattr__` export remains `PythonObjectResolutionGapV1(kind="dynamic-export")`;
- forged retained bytes fail `DependencyArtifactAuthenticationError`;
- `ResolvedPythonObjectV1` JSON round-trip preserves the exact CID.

Predicted leverage: foundational only; `ΔR_with = 0` in Cut A. Cuts C/D consume this object to construct and summarize manager behavior.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ResolvedPythonObjectV1` and `DependencyArtifactGraph` to authenticate dependency artifact resolution
> - Adds `DependencyArtifactGraph` in [dependency_artifact.py](https://github.com/TSavo/sugar/pull/6100/files#diff-153692407653e4eda2c94b6899d612575f4b0f569fd4ee8a0ac674aef4e90464) that authenticates an installed distribution's files and module sources via content-addressed (blake3-512) CIDs, rejecting invalid distributions at construction time.
> - Adds `ResolvedPythonObjectV1`, `ReexportWarrantV1`, and `DefinitionCoordinateV1` as immutable, content-addressed records representing the result of resolving a Python object through a static re-export chain.
> - Adds `resolve_import_binding` which accepts a validated `AuthenticatedImportUseV1` and a `DependencyArtifactGraph`, walks the module AST to resolve exports, and returns either a `ResolvedPythonObjectV1` or a typed `PythonObjectResolutionGapV1` describing why resolution failed.
> - Adds `AuthenticatedImportUseV1` and `ImportBindingV1` in [import_binding.py](https://github.com/TSavo/sugar/pull/6100/files#diff-7ed90ea16c2ad4ca10c3dc0d09d9e32172d598701588b5f8b3e08040e56bab4a) as authority-gated receipts that revalidate byte-identical lexical state at consumption time.
> - Risk: `ResolvedPythonObjectV1.from_value()` re-resolves against the artifact graph and raises `DependencyArtifactAuthenticationError` on any structural mismatch, making deserialization non-trivial.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcbee75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->