### PR TITLE
test: renamed source-derived context-manager acceptance twins

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/arbitrary_manager_module.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/arbitrary_manager_module.py
@@ -1,0 +1,125 @@
+"""Arbitrarily renamed context managers for source-derivation acceptance."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+class ExpectedError(Exception):
+    pass
+
+
+class OtherError(Exception):
+    pass
+
+
+class ExpectationNotMet(Exception):
+    pass
+
+
+class EnterFailure(Exception):
+    pass
+
+
+class ExitFailure(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class ObservationSlot:
+    label: str
+
+
+events: list[tuple[Any, ...]] = []
+manager_evaluations = 0
+
+
+def reset_observations() -> None:
+    global manager_evaluations
+    events.clear()
+    manager_evaluations = 0
+
+
+class SomeGuard:
+    """An expectation boundary whose behavior is entirely visible in source."""
+
+    def __init__(
+        self,
+        expected_exception: type[BaseException],
+        *,
+        fail_enter: bool = False,
+        fail_exit: bool = False,
+    ) -> None:
+        self.expected_exception = expected_exception
+        self.fail_enter = fail_enter
+        self.fail_exit = fail_exit
+        self.observation = ObservationSlot("matched-exception")
+
+    def __enter__(self) -> ObservationSlot:
+        events.append(("enter", self.expected_exception))
+        if self.fail_enter:
+            raise EnterFailure("enter failed")
+        return self.observation
+
+    def __exit__(self, effect_type, effect, traceback) -> bool:
+        events.append(("exit", effect_type, effect, traceback))
+        if self.fail_exit:
+            raise ExitFailure("exit failed")
+        if effect_type is None:
+            raise ExpectationNotMet("expected effect was absent")
+        return issubclass(effect_type, self.expected_exception)
+
+
+def some_manager(
+    expected_exception: type[BaseException],
+    *,
+    fail_enter: bool = False,
+    fail_exit: bool = False,
+) -> SomeGuard:
+    global manager_evaluations
+    manager_evaluations += 1
+    events.append(("manager", expected_exception))
+    return SomeGuard(
+        expected_exception,
+        fail_enter=fail_enter,
+        fail_exit=fail_exit,
+    )
+
+
+class SomeResource:
+    """A source-visible ProtocolResource which never suppresses effects."""
+
+    def __init__(self) -> None:
+        self.value = ObservationSlot("resource-value")
+
+    def __enter__(self) -> ObservationSlot:
+        events.append(("resource-enter",))
+        return self.value
+
+    def __exit__(self, effect_type, effect, traceback) -> bool:
+        events.append(("resource-exit", effect_type, effect, traceback))
+        return False
+
+
+def some_resource() -> SomeResource:
+    events.append(("resource-manager",))
+    return SomeResource()
+
+
+class LyingGuard:
+    """A claim cannot override the source-visible NeverSuppresses behavior."""
+
+    claimed_suppression = True
+
+    def __enter__(self) -> ObservationSlot:
+        events.append(("lying-enter",))
+        return ObservationSlot("lying-value")
+
+    def __exit__(self, effect_type, effect, traceback) -> bool:
+        events.append(("lying-exit", effect_type, effect, traceback))
+        return False
+
+
+def lying_manager() -> LyingGuard:
+    return LyingGuard()

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/arbitrary_native_module.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/arbitrary_native_module.py
@@ -1,0 +1,7 @@
+"""Renamed wrapper around a native manager whose protocol source is unavailable."""
+
+from _thread import allocate_lock
+
+
+def some_manager():
+    return allocate_lock()

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/cases.json
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/cases.json
@@ -1,0 +1,52 @@
+{
+  "schemaVersion": 1,
+  "moduleGraph": [
+    "arbitrary_manager_module.py",
+    "arbitrary_native_module.py",
+    "consumer_cases.py"
+  ],
+  "consumerModule": "consumer_cases",
+  "expectedContracts": {
+    "arbitrary_manager_module.some_manager": {
+      "semanticVerb": "EffectBoundary",
+      "mode": "Expects",
+      "effectKind": "Raise",
+      "expectedTypeOperand": {"kind": "formal-argument", "position": 0},
+      "binding": "observation-slot",
+      "exitDisposition": "matching-effect-only"
+    },
+    "arbitrary_manager_module.some_resource": {
+      "semanticVerb": "ProtocolResource",
+      "enter": "total-result-projection",
+      "exit": "total",
+      "exitDisposition": "NeverSuppresses",
+      "binding": "simple-name"
+    },
+    "arbitrary_manager_module.lying_manager": {
+      "semanticVerb": "ProtocolResource",
+      "enter": "total-result-projection",
+      "exit": "total",
+      "exitDisposition": "NeverSuppresses",
+      "claimMustBeIgnored": "LyingGuard.claimed_suppression"
+    },
+    "arbitrary_native_module.some_manager": {
+      "semanticVerb": "Gap",
+      "gapKind": "source-unavailable"
+    }
+  },
+  "cases": [
+    {"function": "normal", "semanticVerb": "EffectBoundary", "verdict": "expectation-not-met"},
+    {"function": "raised_unsuppressed", "semanticVerb": "EffectBoundary", "verdict": "propagates"},
+    {"function": "raised_suppressed", "semanticVerb": "EffectBoundary", "verdict": "consumed"},
+    {"function": "exit_fails", "semanticVerb": "EffectBoundary", "verdict": "exit-failure-supersedes"},
+    {"function": "enter_fails", "semanticVerb": "EffectBoundary", "verdict": "enter-failure-skips-body"},
+    {"function": "returns_from_body", "semanticVerb": "EffectBoundary", "verdict": "exit-runs-on-return"},
+    {"function": "breaks_from_body", "semanticVerb": "EffectBoundary", "verdict": "exit-runs-on-break"},
+    {"function": "continues_from_body", "semanticVerb": "EffectBoundary", "verdict": "exit-runs-on-continue"},
+    {"function": "manager_evaluated_once", "semanticVerb": "EffectBoundary", "verdict": "manager-evaluated-once"},
+    {"function": "protocol_resource", "semanticVerb": "ProtocolResource", "verdict": "completed"},
+    {"function": "protocol_resource_does_not_suppress", "semanticVerb": "ProtocolResource", "verdict": "propagates"},
+    {"function": "lying_claim_does_not_suppress", "semanticVerb": "ProtocolResource", "verdict": "source-never-suppresses"},
+    {"function": "opaque_native", "semanticVerb": "Gap", "verdict": "typed-loud-source-unavailable"}
+  ]
+}

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/consumer_cases.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/consumer_cases.py
@@ -1,0 +1,74 @@
+"""Consumers for the source-derived context-manager acceptance truth-set."""
+
+from __future__ import annotations
+
+import arbitrary_manager_module as m
+import arbitrary_native_module as n
+
+
+def normal():
+    with m.some_manager(m.ExpectedError):
+        pass
+
+
+def raised_unsuppressed():
+    with m.some_manager(m.ExpectedError):
+        raise m.OtherError("other")
+
+
+def raised_suppressed():
+    with m.some_manager(m.ExpectedError) as observation_slot:
+        assert observation_slot.label == "matched-exception"
+        raise m.ExpectedError("expected")
+
+
+def exit_fails():
+    with m.some_manager(m.ExpectedError, fail_exit=True):
+        raise m.ExpectedError("body failure")
+
+
+def enter_fails(body_observation):
+    with m.some_manager(m.ExpectedError, fail_enter=True):
+        body_observation.append("entered")
+
+
+def returns_from_body():
+    with m.some_manager(m.ExpectedError):
+        return "body return"
+
+
+def breaks_from_body():
+    for _ in range(1):
+        with m.some_manager(m.ExpectedError):
+            break
+
+
+def continues_from_body():
+    for _ in range(1):
+        with m.some_manager(m.ExpectedError):
+            continue
+
+
+def manager_evaluated_once():
+    with m.some_manager(m.ExpectedError):
+        raise m.ExpectedError("expected")
+
+
+def protocol_resource():
+    with m.some_resource() as resource:
+        return resource
+
+
+def protocol_resource_does_not_suppress():
+    with m.some_resource():
+        raise m.OtherError("resource body failure")
+
+
+def lying_claim_does_not_suppress():
+    with m.lying_manager():
+        raise m.ExpectedError("claim must not grant suppression")
+
+
+def opaque_native():
+    with n.some_manager():
+        pass

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_source_derivation_fixture.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_source_derivation_fixture.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+FIXTURES = Path(__file__).parent / "fixtures" / "with_source_derivation"
+EXPECTED_CASES = {
+    "normal",
+    "raised_unsuppressed",
+    "raised_suppressed",
+    "exit_fails",
+    "enter_fails",
+    "returns_from_body",
+    "breaks_from_body",
+    "continues_from_body",
+    "manager_evaluated_once",
+    "protocol_resource",
+    "protocol_resource_does_not_suppress",
+    "lying_claim_does_not_suppress",
+    "opaque_native",
+}
+
+
+@pytest.fixture
+def fixture_modules(monkeypatch):
+    monkeypatch.syspath_prepend(str(FIXTURES))
+    for name in (
+        "consumer_cases",
+        "arbitrary_manager_module",
+        "arbitrary_native_module",
+    ):
+        sys.modules.pop(name, None)
+    managers = importlib.import_module("arbitrary_manager_module")
+    consumers = importlib.import_module("consumer_cases")
+    managers.reset_observations()
+    return managers, consumers
+
+
+def test_truth_set_is_complete_and_contains_no_vendor_enrollment():
+    manifest = json.loads((FIXTURES / "cases.json").read_text())
+    assert manifest["schemaVersion"] == 1
+    assert {case["function"] for case in manifest["cases"]} == EXPECTED_CASES
+    assert {case["semanticVerb"] for case in manifest["cases"]} == {
+        "EffectBoundary",
+        "ProtocolResource",
+        "Gap",
+    }
+    assert manifest["expectedContracts"] == {
+        "arbitrary_manager_module.some_manager": {
+            "semanticVerb": "EffectBoundary",
+            "mode": "Expects",
+            "effectKind": "Raise",
+            "expectedTypeOperand": {"kind": "formal-argument", "position": 0},
+            "binding": "observation-slot",
+            "exitDisposition": "matching-effect-only",
+        },
+        "arbitrary_manager_module.some_resource": {
+            "semanticVerb": "ProtocolResource",
+            "enter": "total-result-projection",
+            "exit": "total",
+            "exitDisposition": "NeverSuppresses",
+            "binding": "simple-name",
+        },
+        "arbitrary_manager_module.lying_manager": {
+            "semanticVerb": "ProtocolResource",
+            "enter": "total-result-projection",
+            "exit": "total",
+            "exitDisposition": "NeverSuppresses",
+            "claimMustBeIgnored": "LyingGuard.claimed_suppression",
+        },
+        "arbitrary_native_module.some_manager": {
+            "semanticVerb": "Gap",
+            "gapKind": "source-unavailable",
+        },
+    }
+
+    consumer = ast.parse((FIXTURES / "consumer_cases.py").read_text())
+    imports = [node for node in consumer.body if isinstance(node, ast.Import)]
+    assert [(alias.name, alias.asname) for node in imports for alias in node.names] == [
+        ("arbitrary_manager_module", "m"),
+        ("arbitrary_native_module", "n"),
+    ]
+    with_functions = {
+        node.name
+        for node in consumer.body
+        if isinstance(node, ast.FunctionDef)
+        and any(isinstance(child, ast.With) for child in ast.walk(node))
+    }
+    assert with_functions == EXPECTED_CASES
+
+    fixture_text = "\n".join(path.read_text() for path in sorted(FIXTURES.glob("*.py")))
+    for forbidden in (
+        "pytest",
+        "pandas",
+        "vendor",
+        "provider",
+        "enrollment",
+        "catalog",
+    ):
+        assert forbidden not in fixture_text
+
+
+def test_effect_boundary_normal_completion_is_expectation_not_met(fixture_modules):
+    managers, consumers = fixture_modules
+    with pytest.raises(managers.ExpectationNotMet):
+        consumers.normal()
+
+
+def test_effect_boundary_matching_and_nonmatching_effects(fixture_modules):
+    managers, consumers = fixture_modules
+    consumers.raised_suppressed()
+    with pytest.raises(managers.OtherError):
+        consumers.raised_unsuppressed()
+
+
+def test_exit_failure_supersedes_body_failure(fixture_modules):
+    managers, consumers = fixture_modules
+    with pytest.raises(managers.ExitFailure) as raised:
+        consumers.exit_fails()
+    assert isinstance(raised.value.__context__, managers.ExpectedError)
+
+
+def test_enter_failure_skips_body(fixture_modules):
+    managers, consumers = fixture_modules
+    body_observation = []
+    with pytest.raises(managers.EnterFailure):
+        consumers.enter_fails(body_observation)
+    assert body_observation == []
+    assert [event[0] for event in managers.events] == ["manager", "enter"]
+
+
+@pytest.mark.parametrize(
+    "function_name",
+    ["returns_from_body", "breaks_from_body", "continues_from_body"],
+)
+def test_exit_runs_on_non_exception_control_transfer(fixture_modules, function_name):
+    managers, consumers = fixture_modules
+    with pytest.raises(managers.ExpectationNotMet):
+        getattr(consumers, function_name)()
+    assert [event[0] for event in managers.events] == ["manager", "enter", "exit"]
+    assert managers.events[-1][1:] == (None, None, None)
+
+
+def test_manager_expression_is_evaluated_once(fixture_modules):
+    managers, consumers = fixture_modules
+    consumers.manager_evaluated_once()
+    assert managers.manager_evaluations == 1
+    assert [event[0] for event in managers.events] == ["manager", "enter", "exit"]
+
+
+def test_protocol_resource_returns_enter_value_and_never_suppresses(fixture_modules):
+    managers, consumers = fixture_modules
+    resource = consumers.protocol_resource()
+    assert resource.label == "resource-value"
+    with pytest.raises(managers.OtherError):
+        consumers.protocol_resource_does_not_suppress()
+    assert [event[0] for event in managers.events] == [
+        "resource-manager",
+        "resource-enter",
+        "resource-exit",
+        "resource-manager",
+        "resource-enter",
+        "resource-exit",
+    ]
+
+
+def test_lying_suppression_claim_cannot_override_source(fixture_modules):
+    managers, consumers = fixture_modules
+    assert managers.LyingGuard.claimed_suppression is True
+    with pytest.raises(managers.ExpectedError):
+        consumers.lying_claim_does_not_suppress()
+    assert managers.events[-1][0] == "lying-exit"
+
+
+def test_opaque_native_manager_remains_typed_loud():
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.panic import SugarNotWritten
+    from sugar_source_tree.tree import SourceFile
+
+    source = SourceFile(path_source(str(FIXTURES / "consumer_cases.py")))
+    function = next(item for item in source.functions() if item.name == "opaque_native")
+    with pytest.raises(SugarNotWritten) as caught:
+        function.sugar()
+    assert type(caught.value).__name__ == "RuntimeSelectedContextManager"


### PR DESCRIPTION
## What

- Add an arbitrary renamed source module with EffectBoundary-shaped and ProtocolResource-shaped context managers.
- Add a renamed native manager which must remain typed-loud when source construction is unavailable.
- Add a machine-readable Cuts C-E verdict matrix covering normal, matched/unmatched effects, enter/exit failure, control transfers, exactly-once manager evaluation, and a lying suppression claim.
- Add executable CPython/SourceTree twins proving fixture semantics and the current opaque-manager loud boundary.

## Why

This is the name-independent first end-to-end acceptance truth-set for #6088. Cuts C-E must derive the declared contract shapes from authenticated source construction without provider enrollment, spelling tables, or name recognition.

## Validation

- Focused fixture, authenticated-With, and transport tests: 26 passed.
- Black check: 4 files unchanged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename source-derived context-manager acceptance test fixtures and add supporting test infrastructure
> - Adds [arbitrary_manager_module.py](https://github.com/TSavo/sugar/pull/6101/files#diff-85b6bcad98750b726003bdeb984ce1330c0d71786ef2030f3107859221017a41) with custom context managers (`SomeGuard`, `SomeResource`, `LyingGuard`), exception classes, and event-tracing globals for acceptance tests.
> - Adds [consumer_cases.py](https://github.com/TSavo/sugar/pull/6101/files#diff-b51a3b8c80efb6f113573423d632fa39cde1430c0e70af8f42923e41cec4b8ac) with 13 functions exercising `with`-statement semantics (suppression, enter/exit failures, control flow, native managers).
> - Adds [test_with_source_derivation_fixture.py](https://github.com/TSavo/sugar/pull/6101/files#diff-ba757a9e1bc0b30a9c2d08ea46108fe1ffe16543d212c9d644bd2b134a71f6c8) with parametrized pytest tests validating lifecycle events, suppression behavior, and `SugarNotWritten` for opaque native managers.
> - Each test reloads fixture modules and resets global event state via `reset_observations()` to ensure isolation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47d9ce1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->