### PR TITLE
Cut C: interprocedural manager-factory + returned-object construction (#6088)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import ast
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field as dataclass_field
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -59,6 +59,93 @@ class _ImportDef:
 class _ModuleFunctionDef:
     target_symbol: str
     definition_site: tuple[int, int, int, int]
+
+
+_IMPORT_AUTHORITY = object()
+
+
+@dataclass(frozen=True)
+class ImportBindingV1:
+    """A final-checked #6090 import binding, never a caller-owned mapping."""
+
+    value: dict[str, Any]
+    cid: str
+    _authority: object = dataclass_field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self._authority is not _IMPORT_AUTHORITY:
+            raise ValueError("ImportBindingV1 was not minted by the lexical pass")
+        if self.value.get("kind") != "python-import-binding":
+            raise ValueError("ImportBindingV1 requires a python-import-binding")
+        if _hash(self.value) != self.cid:
+            raise ValueError("ImportBindingV1 CID does not match its preimage")
+
+    def to_value(self) -> dict[str, Any]:
+        return json.loads(encode_jcs(_json_value(self.value)))
+
+
+@dataclass(frozen=True)
+class AuthenticatedImportUseV1:
+    """The final lexical-pass receipt consumed by source-artifact resolution."""
+
+    import_binding: ImportBindingV1
+    target_symbol: str
+    use: dict[str, Any]
+    demand: dict[str, Any]
+    root: Path = dataclass_field(repr=False, compare=False)
+    path: Path = dataclass_field(repr=False, compare=False)
+    source: str = dataclass_field(repr=False, compare=False)
+    source_cid: str = dataclass_field(repr=False, compare=False)
+    module_identities: dict[str, dict[str, Any]] = dataclass_field(
+        repr=False, compare=False
+    )
+    _authority: object = dataclass_field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self._authority is not _IMPORT_AUTHORITY:
+            raise ValueError(
+                "AuthenticatedImportUseV1 was not minted by the lexical pass"
+            )
+        if blake3_512_of(self.source.encode("utf-8")) != self.source_cid:
+            raise ValueError("authenticated import-use source CID is stale")
+        if self.use.get("kind") != "authenticated-import-use":
+            raise ValueError("authenticated import use has the wrong kind")
+        use_without_cid = {
+            key: value for key, value in self.use.items() if key != "cid"
+        }
+        if self.use.get("cid") != _hash(use_without_cid):
+            raise ValueError("authenticated import-use CID does not match its preimage")
+        if self.use.get("importBindingCid") != self.import_binding.cid:
+            raise ValueError("authenticated import use cites another binding")
+        for key, value in (
+            ("authenticatedImportUse", self.use),
+            ("importBinding", self.import_binding.to_value()),
+            ("targetSymbol", self.target_symbol),
+            ("importBindingCid", self.import_binding.cid),
+        ):
+            if self.demand.get(key) != value:
+                raise ValueError(f"authenticated demand has stale {key}")
+
+    def revalidate(self) -> None:
+        """Re-run #6090 and demand byte identity at the resolution door."""
+        rows, outcomes = authenticated_import_uses(
+            self.root,
+            self.path,
+            self.source,
+            self.source_cid,
+            module_identities=self.module_identities,
+        )
+        site = self.use["useSite"]
+        key = (
+            site["startLine"],
+            site["startCol"],
+            site["endLine"],
+            site["endCol"],
+        )
+        if outcomes.get(key) != "authenticated-import-use" or self.demand not in rows:
+            raise ValueError(
+                "authenticated import use is not byte-identical to lexical revalidation"
+            )
 
 
 _NON_IMPORT = "non-import"
@@ -572,6 +659,40 @@ def authenticated_import_uses(
     )
     runner.statements(module.body, {}, module)
     return runner.rows, runner.outcomes
+
+
+def authenticated_import_use_receipts(
+    root: Path,
+    path: Path,
+    source: str,
+    source_cid: str,
+    module_identities: dict[str, dict[str, Any]] | None = None,
+) -> tuple[list[AuthenticatedImportUseV1], dict[tuple[int, int, int, int], str]]:
+    """Return typed, final-checked receipts from the sole lexical pass."""
+    rows, outcomes = authenticated_import_uses(
+        root, path, source, source_cid, module_identities=module_identities
+    )
+    receipts: list[AuthenticatedImportUseV1] = []
+    for row in rows:
+        binding_value = row["importBinding"]
+        binding = ImportBindingV1(
+            binding_value, row["importBindingCid"], _IMPORT_AUTHORITY
+        )
+        receipts.append(
+            AuthenticatedImportUseV1(
+                import_binding=binding,
+                target_symbol=row["targetSymbol"],
+                use=row["authenticatedImportUse"],
+                demand=row,
+                root=root,
+                path=path,
+                source=source,
+                source_cid=source_cid,
+                module_identities=dict(module_identities or {}),
+                _authority=_IMPORT_AUTHORITY,
+            )
+        )
+    return receipts, outcomes
 
 
 def authenticated_module_exports(

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/arbitrary_manager_module.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/arbitrary_manager_module.py
@@ -1,0 +1,125 @@
+"""Arbitrarily renamed context managers for source-derivation acceptance."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+class ExpectedError(Exception):
+    pass
+
+
+class OtherError(Exception):
+    pass
+
+
+class ExpectationNotMet(Exception):
+    pass
+
+
+class EnterFailure(Exception):
+    pass
+
+
+class ExitFailure(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class ObservationSlot:
+    label: str
+
+
+events: list[tuple[Any, ...]] = []
+manager_evaluations = 0
+
+
+def reset_observations() -> None:
+    global manager_evaluations
+    events.clear()
+    manager_evaluations = 0
+
+
+class SomeGuard:
+    """An expectation boundary whose behavior is entirely visible in source."""
+
+    def __init__(
+        self,
+        expected_exception: type[BaseException],
+        *,
+        fail_enter: bool = False,
+        fail_exit: bool = False,
+    ) -> None:
+        self.expected_exception = expected_exception
+        self.fail_enter = fail_enter
+        self.fail_exit = fail_exit
+        self.observation = ObservationSlot("matched-exception")
+
+    def __enter__(self) -> ObservationSlot:
+        events.append(("enter", self.expected_exception))
+        if self.fail_enter:
+            raise EnterFailure("enter failed")
+        return self.observation
+
+    def __exit__(self, effect_type, effect, traceback) -> bool:
+        events.append(("exit", effect_type, effect, traceback))
+        if self.fail_exit:
+            raise ExitFailure("exit failed")
+        if effect_type is None:
+            raise ExpectationNotMet("expected effect was absent")
+        return issubclass(effect_type, self.expected_exception)
+
+
+def some_manager(
+    expected_exception: type[BaseException],
+    *,
+    fail_enter: bool = False,
+    fail_exit: bool = False,
+) -> SomeGuard:
+    global manager_evaluations
+    manager_evaluations += 1
+    events.append(("manager", expected_exception))
+    return SomeGuard(
+        expected_exception,
+        fail_enter=fail_enter,
+        fail_exit=fail_exit,
+    )
+
+
+class SomeResource:
+    """A source-visible ProtocolResource which never suppresses effects."""
+
+    def __init__(self) -> None:
+        self.value = ObservationSlot("resource-value")
+
+    def __enter__(self) -> ObservationSlot:
+        events.append(("resource-enter",))
+        return self.value
+
+    def __exit__(self, effect_type, effect, traceback) -> bool:
+        events.append(("resource-exit", effect_type, effect, traceback))
+        return False
+
+
+def some_resource() -> SomeResource:
+    events.append(("resource-manager",))
+    return SomeResource()
+
+
+class LyingGuard:
+    """A claim cannot override the source-visible NeverSuppresses behavior."""
+
+    claimed_suppression = True
+
+    def __enter__(self) -> ObservationSlot:
+        events.append(("lying-enter",))
+        return ObservationSlot("lying-value")
+
+    def __exit__(self, effect_type, effect, traceback) -> bool:
+        events.append(("lying-exit", effect_type, effect, traceback))
+        return False
+
+
+def lying_manager() -> LyingGuard:
+    return LyingGuard()

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/arbitrary_native_module.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/arbitrary_native_module.py
@@ -1,0 +1,7 @@
+"""Renamed wrapper around a native manager whose protocol source is unavailable."""
+
+from _thread import allocate_lock
+
+
+def some_manager():
+    return allocate_lock()

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/cases.json
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/cases.json
@@ -1,0 +1,52 @@
+{
+  "schemaVersion": 1,
+  "moduleGraph": [
+    "arbitrary_manager_module.py",
+    "arbitrary_native_module.py",
+    "consumer_cases.py"
+  ],
+  "consumerModule": "consumer_cases",
+  "expectedContracts": {
+    "arbitrary_manager_module.some_manager": {
+      "semanticVerb": "EffectBoundary",
+      "mode": "Expects",
+      "effectKind": "Raise",
+      "expectedTypeOperand": {"kind": "formal-argument", "position": 0},
+      "binding": "observation-slot",
+      "exitDisposition": "matching-effect-only"
+    },
+    "arbitrary_manager_module.some_resource": {
+      "semanticVerb": "ProtocolResource",
+      "enter": "total-result-projection",
+      "exit": "total",
+      "exitDisposition": "NeverSuppresses",
+      "binding": "simple-name"
+    },
+    "arbitrary_manager_module.lying_manager": {
+      "semanticVerb": "ProtocolResource",
+      "enter": "total-result-projection",
+      "exit": "total",
+      "exitDisposition": "NeverSuppresses",
+      "claimMustBeIgnored": "LyingGuard.claimed_suppression"
+    },
+    "arbitrary_native_module.some_manager": {
+      "semanticVerb": "Gap",
+      "gapKind": "source-unavailable"
+    }
+  },
+  "cases": [
+    {"function": "normal", "semanticVerb": "EffectBoundary", "verdict": "expectation-not-met"},
+    {"function": "raised_unsuppressed", "semanticVerb": "EffectBoundary", "verdict": "propagates"},
+    {"function": "raised_suppressed", "semanticVerb": "EffectBoundary", "verdict": "consumed"},
+    {"function": "exit_fails", "semanticVerb": "EffectBoundary", "verdict": "exit-failure-supersedes"},
+    {"function": "enter_fails", "semanticVerb": "EffectBoundary", "verdict": "enter-failure-skips-body"},
+    {"function": "returns_from_body", "semanticVerb": "EffectBoundary", "verdict": "exit-runs-on-return"},
+    {"function": "breaks_from_body", "semanticVerb": "EffectBoundary", "verdict": "exit-runs-on-break"},
+    {"function": "continues_from_body", "semanticVerb": "EffectBoundary", "verdict": "exit-runs-on-continue"},
+    {"function": "manager_evaluated_once", "semanticVerb": "EffectBoundary", "verdict": "manager-evaluated-once"},
+    {"function": "protocol_resource", "semanticVerb": "ProtocolResource", "verdict": "completed"},
+    {"function": "protocol_resource_does_not_suppress", "semanticVerb": "ProtocolResource", "verdict": "propagates"},
+    {"function": "lying_claim_does_not_suppress", "semanticVerb": "ProtocolResource", "verdict": "source-never-suppresses"},
+    {"function": "opaque_native", "semanticVerb": "Gap", "verdict": "typed-loud-source-unavailable"}
+  ]
+}

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/consumer_cases.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/with_source_derivation/consumer_cases.py
@@ -1,0 +1,74 @@
+"""Consumers for the source-derived context-manager acceptance truth-set."""
+
+from __future__ import annotations
+
+import arbitrary_manager_module as m
+import arbitrary_native_module as n
+
+
+def normal():
+    with m.some_manager(m.ExpectedError):
+        pass
+
+
+def raised_unsuppressed():
+    with m.some_manager(m.ExpectedError):
+        raise m.OtherError("other")
+
+
+def raised_suppressed():
+    with m.some_manager(m.ExpectedError) as observation_slot:
+        assert observation_slot.label == "matched-exception"
+        raise m.ExpectedError("expected")
+
+
+def exit_fails():
+    with m.some_manager(m.ExpectedError, fail_exit=True):
+        raise m.ExpectedError("body failure")
+
+
+def enter_fails(body_observation):
+    with m.some_manager(m.ExpectedError, fail_enter=True):
+        body_observation.append("entered")
+
+
+def returns_from_body():
+    with m.some_manager(m.ExpectedError):
+        return "body return"
+
+
+def breaks_from_body():
+    for _ in range(1):
+        with m.some_manager(m.ExpectedError):
+            break
+
+
+def continues_from_body():
+    for _ in range(1):
+        with m.some_manager(m.ExpectedError):
+            continue
+
+
+def manager_evaluated_once():
+    with m.some_manager(m.ExpectedError):
+        raise m.ExpectedError("expected")
+
+
+def protocol_resource():
+    with m.some_resource() as resource:
+        return resource
+
+
+def protocol_resource_does_not_suppress():
+    with m.some_resource():
+        raise m.OtherError("resource body failure")
+
+
+def lying_claim_does_not_suppress():
+    with m.lying_manager():
+        raise m.ExpectedError("claim must not grant suppression")
+
+
+def opaque_native():
+    with n.some_manager():
+        pass

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_source_derivation_fixture.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_source_derivation_fixture.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+FIXTURES = Path(__file__).parent / "fixtures" / "with_source_derivation"
+EXPECTED_CASES = {
+    "normal",
+    "raised_unsuppressed",
+    "raised_suppressed",
+    "exit_fails",
+    "enter_fails",
+    "returns_from_body",
+    "breaks_from_body",
+    "continues_from_body",
+    "manager_evaluated_once",
+    "protocol_resource",
+    "protocol_resource_does_not_suppress",
+    "lying_claim_does_not_suppress",
+    "opaque_native",
+}
+
+
+@pytest.fixture
+def fixture_modules(monkeypatch):
+    monkeypatch.syspath_prepend(str(FIXTURES))
+    for name in (
+        "consumer_cases",
+        "arbitrary_manager_module",
+        "arbitrary_native_module",
+    ):
+        sys.modules.pop(name, None)
+    managers = importlib.import_module("arbitrary_manager_module")
+    consumers = importlib.import_module("consumer_cases")
+    managers.reset_observations()
+    return managers, consumers
+
+
+def test_truth_set_is_complete_and_contains_no_vendor_enrollment():
+    manifest = json.loads((FIXTURES / "cases.json").read_text())
+    assert manifest["schemaVersion"] == 1
+    assert {case["function"] for case in manifest["cases"]} == EXPECTED_CASES
+    assert {case["semanticVerb"] for case in manifest["cases"]} == {
+        "EffectBoundary",
+        "ProtocolResource",
+        "Gap",
+    }
+    assert manifest["expectedContracts"] == {
+        "arbitrary_manager_module.some_manager": {
+            "semanticVerb": "EffectBoundary",
+            "mode": "Expects",
+            "effectKind": "Raise",
+            "expectedTypeOperand": {"kind": "formal-argument", "position": 0},
+            "binding": "observation-slot",
+            "exitDisposition": "matching-effect-only",
+        },
+        "arbitrary_manager_module.some_resource": {
+            "semanticVerb": "ProtocolResource",
+            "enter": "total-result-projection",
+            "exit": "total",
+            "exitDisposition": "NeverSuppresses",
+            "binding": "simple-name",
+        },
+        "arbitrary_manager_module.lying_manager": {
+            "semanticVerb": "ProtocolResource",
+            "enter": "total-result-projection",
+            "exit": "total",
+            "exitDisposition": "NeverSuppresses",
+            "claimMustBeIgnored": "LyingGuard.claimed_suppression",
+        },
+        "arbitrary_native_module.some_manager": {
+            "semanticVerb": "Gap",
+            "gapKind": "source-unavailable",
+        },
+    }
+
+    consumer = ast.parse((FIXTURES / "consumer_cases.py").read_text())
+    imports = [node for node in consumer.body if isinstance(node, ast.Import)]
+    assert [(alias.name, alias.asname) for node in imports for alias in node.names] == [
+        ("arbitrary_manager_module", "m"),
+        ("arbitrary_native_module", "n"),
+    ]
+    with_functions = {
+        node.name
+        for node in consumer.body
+        if isinstance(node, ast.FunctionDef)
+        and any(isinstance(child, ast.With) for child in ast.walk(node))
+    }
+    assert with_functions == EXPECTED_CASES
+
+    fixture_text = "\n".join(path.read_text() for path in sorted(FIXTURES.glob("*.py")))
+    for forbidden in (
+        "pytest",
+        "pandas",
+        "vendor",
+        "provider",
+        "enrollment",
+        "catalog",
+    ):
+        assert forbidden not in fixture_text
+
+
+def test_effect_boundary_normal_completion_is_expectation_not_met(fixture_modules):
+    managers, consumers = fixture_modules
+    with pytest.raises(managers.ExpectationNotMet):
+        consumers.normal()
+
+
+def test_effect_boundary_matching_and_nonmatching_effects(fixture_modules):
+    managers, consumers = fixture_modules
+    consumers.raised_suppressed()
+    with pytest.raises(managers.OtherError):
+        consumers.raised_unsuppressed()
+
+
+def test_exit_failure_supersedes_body_failure(fixture_modules):
+    managers, consumers = fixture_modules
+    with pytest.raises(managers.ExitFailure) as raised:
+        consumers.exit_fails()
+    assert isinstance(raised.value.__context__, managers.ExpectedError)
+
+
+def test_enter_failure_skips_body(fixture_modules):
+    managers, consumers = fixture_modules
+    body_observation = []
+    with pytest.raises(managers.EnterFailure):
+        consumers.enter_fails(body_observation)
+    assert body_observation == []
+    assert [event[0] for event in managers.events] == ["manager", "enter"]
+
+
+@pytest.mark.parametrize(
+    "function_name",
+    ["returns_from_body", "breaks_from_body", "continues_from_body"],
+)
+def test_exit_runs_on_non_exception_control_transfer(fixture_modules, function_name):
+    managers, consumers = fixture_modules
+    with pytest.raises(managers.ExpectationNotMet):
+        getattr(consumers, function_name)()
+    assert [event[0] for event in managers.events] == ["manager", "enter", "exit"]
+    assert managers.events[-1][1:] == (None, None, None)
+
+
+def test_manager_expression_is_evaluated_once(fixture_modules):
+    managers, consumers = fixture_modules
+    consumers.manager_evaluated_once()
+    assert managers.manager_evaluations == 1
+    assert [event[0] for event in managers.events] == ["manager", "enter", "exit"]
+
+
+def test_protocol_resource_returns_enter_value_and_never_suppresses(fixture_modules):
+    managers, consumers = fixture_modules
+    resource = consumers.protocol_resource()
+    assert resource.label == "resource-value"
+    with pytest.raises(managers.OtherError):
+        consumers.protocol_resource_does_not_suppress()
+    assert [event[0] for event in managers.events] == [
+        "resource-manager",
+        "resource-enter",
+        "resource-exit",
+        "resource-manager",
+        "resource-enter",
+        "resource-exit",
+    ]
+
+
+def test_lying_suppression_claim_cannot_override_source(fixture_modules):
+    managers, consumers = fixture_modules
+    assert managers.LyingGuard.claimed_suppression is True
+    with pytest.raises(managers.ExpectedError):
+        consumers.lying_claim_does_not_suppress()
+    assert managers.events[-1][0] == "lying-exit"
+
+
+def test_opaque_native_manager_remains_typed_loud():
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.panic import SugarNotWritten
+    from sugar_source_tree.tree import SourceFile
+
+    source = SourceFile(path_source(str(FIXTURES / "consumer_cases.py")))
+    function = next(item for item in source.functions() if item.name == "opaque_native")
+    with pytest.raises(SugarNotWritten) as caught:
+        function.sugar()
+    assert type(caught.value).__name__ == "RuntimeSelectedContextManager"

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -1,0 +1,765 @@
+"""Authenticated installed Python artifacts and static object resolution.
+
+This module is a preconstruction boundary.  It reads distribution-recorded
+files once, content-addresses them, and resolves only source-visible static
+imports and re-exports.  It never imports or executes a target module.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+from email.parser import BytesParser
+import importlib.metadata
+from pathlib import Path, PurePosixPath
+from types import MappingProxyType
+from typing import Any, Literal, Mapping
+
+from .canonical import blake3_512_of, cid_of_json
+from .source_oracle import SourceUnavailable, dependency_artifact_file
+from .source_tables import parsed_tree
+
+
+class DependencyArtifactAuthenticationError(Exception):
+    """The selected installed artifact cannot be authenticated exactly."""
+
+
+@dataclass(frozen=True)
+class AuthenticatedArtifactFileV1:
+    source_seat: str
+    content_cid: str
+    content: bytes = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if blake3_512_of(self.content) != self.content_cid:
+            raise DependencyArtifactAuthenticationError(
+                "artifact file CID does not match its retained bytes"
+            )
+
+
+@dataclass(frozen=True)
+class AuthenticatedModuleSourceV1:
+    module_name: str
+    source_seat: str
+    source_cid: str
+    source: str = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if blake3_512_of(self.source.encode("utf-8")) != self.source_cid:
+            raise DependencyArtifactAuthenticationError(
+                "module source CID does not match its retained source"
+            )
+
+
+@dataclass(frozen=True)
+class DefinitionCoordinateV1:
+    name: str
+    kind: Literal["function", "class", "import"]
+    source_cid: str
+    start_line: int
+    start_col: int
+    end_line: int
+    end_col: int
+    fragment_cid: str
+
+    def __post_init__(self) -> None:
+        _string(self.name, "definition name")
+        if self.kind not in {"function", "class", "import"}:
+            raise ValueError("definition coordinate has unknown kind")
+        _cid(self.source_cid, "definition sourceCid")
+        for value, label in (
+            (self.start_line, "startLine"),
+            (self.start_col, "startCol"),
+            (self.end_line, "endLine"),
+            (self.end_col, "endCol"),
+        ):
+            _nonnegative_int(value, label)
+        _cid(self.fragment_cid, "definition fragmentCid")
+
+    def to_value(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "sourceCid": self.source_cid,
+            "startLine": self.start_line,
+            "startCol": self.start_col,
+            "endLine": self.end_line,
+            "endCol": self.end_col,
+            "fragmentCid": self.fragment_cid,
+        }
+
+    @classmethod
+    def from_value(cls, value: Any) -> "DefinitionCoordinateV1":
+        _require_exact_keys(
+            value,
+            {
+                "name",
+                "kind",
+                "sourceCid",
+                "startLine",
+                "startCol",
+                "endLine",
+                "endCol",
+                "fragmentCid",
+            },
+            "definition coordinate",
+        )
+        if value["kind"] not in {"function", "class", "import"}:
+            raise ValueError("definition coordinate has unknown kind")
+        return cls(
+            name=_string(value["name"], "definition name"),
+            kind=value["kind"],
+            source_cid=_cid(value["sourceCid"], "definition sourceCid"),
+            start_line=_nonnegative_int(value["startLine"], "startLine"),
+            start_col=_nonnegative_int(value["startCol"], "startCol"),
+            end_line=_nonnegative_int(value["endLine"], "endLine"),
+            end_col=_nonnegative_int(value["endCol"], "endCol"),
+            fragment_cid=_cid(value["fragmentCid"], "definition fragmentCid"),
+        )
+
+
+@dataclass(frozen=True)
+class ReexportWarrantV1:
+    from_module: str
+    from_source_cid: str
+    to_module: str
+    to_source_cid: str
+    exported_name: str
+    imported_name: str
+    definition: DefinitionCoordinateV1
+    cid: str = ""
+
+    def __post_init__(self) -> None:
+        if self.definition.kind != "import":
+            raise ValueError("re-export warrant must cite an import definition")
+        if self.definition.source_cid != self.from_source_cid:
+            raise ValueError("re-export definition is not in its from-module source")
+        expected = cid_of_json(self._preimage())
+        if self.cid and self.cid != expected:
+            raise ValueError("re-export warrant CID does not match its preimage")
+        object.__setattr__(self, "cid", expected)
+
+    def _preimage(self) -> dict[str, Any]:
+        return {
+            "kind": "python-static-reexport-warrant",
+            "schemaVersion": "1",
+            "fromModule": self.from_module,
+            "fromSourceCid": self.from_source_cid,
+            "toModule": self.to_module,
+            "toSourceCid": self.to_source_cid,
+            "exportedName": self.exported_name,
+            "importedName": self.imported_name,
+            "definition": self.definition.to_value(),
+        }
+
+    def to_value(self) -> dict[str, Any]:
+        return {**self._preimage(), "cid": self.cid}
+
+    @classmethod
+    def from_value(cls, value: Any) -> "ReexportWarrantV1":
+        _require_exact_keys(
+            value,
+            {
+                "kind",
+                "schemaVersion",
+                "fromModule",
+                "fromSourceCid",
+                "toModule",
+                "toSourceCid",
+                "exportedName",
+                "importedName",
+                "definition",
+                "cid",
+            },
+            "re-export warrant",
+        )
+        if (
+            value["kind"] != "python-static-reexport-warrant"
+            or value["schemaVersion"] != "1"
+        ):
+            raise ValueError("unsupported re-export warrant")
+        return cls(
+            from_module=_string(value["fromModule"], "fromModule"),
+            from_source_cid=_cid(value["fromSourceCid"], "fromSourceCid"),
+            to_module=_string(value["toModule"], "toModule"),
+            to_source_cid=_cid(value["toSourceCid"], "toSourceCid"),
+            exported_name=_string(value["exportedName"], "exportedName"),
+            imported_name=_string(value["importedName"], "importedName"),
+            definition=DefinitionCoordinateV1.from_value(value["definition"]),
+            cid=_cid(value["cid"], "warrant cid"),
+        )
+
+
+@dataclass(frozen=True)
+class ResolvedPythonObjectV1:
+    distribution_artifact_cid: str
+    import_binding_cid: str
+    module_name: str
+    source_cid: str
+    reexport_warrants: tuple[ReexportWarrantV1, ...]
+    definition: DefinitionCoordinateV1
+    cid: str = ""
+
+    def __post_init__(self) -> None:
+        if self.definition.kind not in {"function", "class"}:
+            raise ValueError(
+                "resolved Python object must name a callable or class definition"
+            )
+        if self.definition.source_cid != self.source_cid:
+            raise ValueError("resolved definition is not in the resolved module source")
+        for left, right in zip(
+            self.reexport_warrants,
+            self.reexport_warrants[1:],
+            strict=False,
+        ):
+            if (
+                left.to_module != right.from_module
+                or left.to_source_cid != right.from_source_cid
+            ):
+                raise ValueError("re-export warrants do not form one source chain")
+        if self.reexport_warrants:
+            last = self.reexport_warrants[-1]
+            if (
+                last.to_module != self.module_name
+                or last.to_source_cid != self.source_cid
+            ):
+                raise ValueError(
+                    "re-export warrants do not reach the resolved definition"
+                )
+        expected = cid_of_json(self._preimage())
+        if self.cid and self.cid != expected:
+            raise ValueError("resolved Python object CID does not match its preimage")
+        object.__setattr__(self, "cid", expected)
+
+    def _preimage(self) -> dict[str, Any]:
+        return {
+            "kind": "resolved-python-object",
+            "schemaVersion": "1",
+            "distributionArtifactCid": self.distribution_artifact_cid,
+            "importBindingCid": self.import_binding_cid,
+            "moduleName": self.module_name,
+            "sourceCid": self.source_cid,
+            "reexportWarrants": [item.to_value() for item in self.reexport_warrants],
+            "definition": self.definition.to_value(),
+        }
+
+    def to_value(self) -> dict[str, Any]:
+        return {**self._preimage(), "cid": self.cid}
+
+    @classmethod
+    def from_value(cls, value: Any) -> "ResolvedPythonObjectV1":
+        _require_exact_keys(
+            value,
+            {
+                "kind",
+                "schemaVersion",
+                "distributionArtifactCid",
+                "importBindingCid",
+                "moduleName",
+                "sourceCid",
+                "reexportWarrants",
+                "definition",
+                "cid",
+            },
+            "resolved Python object",
+        )
+        if value["kind"] != "resolved-python-object" or value["schemaVersion"] != "1":
+            raise ValueError("unsupported resolved Python object")
+        warrants = value["reexportWarrants"]
+        if not isinstance(warrants, list):
+            raise ValueError("reexportWarrants must be a list")
+        return cls(
+            distribution_artifact_cid=_cid(
+                value["distributionArtifactCid"], "distributionArtifactCid"
+            ),
+            import_binding_cid=_cid(value["importBindingCid"], "importBindingCid"),
+            module_name=_string(value["moduleName"], "moduleName"),
+            source_cid=_cid(value["sourceCid"], "sourceCid"),
+            reexport_warrants=tuple(
+                ReexportWarrantV1.from_value(item) for item in warrants
+            ),
+            definition=DefinitionCoordinateV1.from_value(value["definition"]),
+            cid=_cid(value["cid"], "resolved object cid"),
+        )
+
+
+@dataclass(frozen=True)
+class PythonObjectResolutionGapV1:
+    kind: Literal[
+        "malformed-import-binding",
+        "artifact-module-absent",
+        "target-outside-binding",
+        "dynamic-export",
+        "ambiguous-static-export",
+        "static-export-absent",
+        "opaque-source",
+        "reexport-cycle",
+    ]
+    import_binding_cid: str
+    distribution_artifact_cid: str
+    module_name: str
+    exported_name: str
+
+
+PythonObjectResolutionV1 = ResolvedPythonObjectV1 | PythonObjectResolutionGapV1
+
+
+@dataclass(frozen=True)
+class DependencyArtifactGraph:
+    distribution_name: str
+    distribution_version: str
+    distribution_artifact_cid: str
+    files: tuple[AuthenticatedArtifactFileV1, ...]
+    modules: Mapping[str, AuthenticatedModuleSourceV1]
+
+    def __post_init__(self) -> None:
+        metadata_files = [
+            item
+            for item in self.files
+            if item.source_seat.endswith(".dist-info/METADATA")
+        ]
+        if len(metadata_files) != 1:
+            raise DependencyArtifactAuthenticationError(
+                "distribution graph must retain one METADATA preimage"
+            )
+        metadata = BytesParser().parsebytes(metadata_files[0].content)
+        if (
+            metadata.get("Name") != self.distribution_name
+            or metadata.get("Version") != self.distribution_version
+        ):
+            raise DependencyArtifactAuthenticationError(
+                "distribution identity does not match its METADATA preimage"
+            )
+        records = [
+            {"path": item.source_seat, "contentCid": item.content_cid}
+            for item in self.files
+        ]
+        if records != sorted(records, key=lambda item: item["path"]):
+            raise DependencyArtifactAuthenticationError(
+                "artifact files must be canonically ordered"
+            )
+        expected = cid_of_json(
+            {
+                "kind": "python-dependency-artifact",
+                "schemaVersion": "1",
+                "distributionName": self.distribution_name,
+                "distributionVersion": self.distribution_version,
+                "files": records,
+            }
+        )
+        if expected != self.distribution_artifact_cid:
+            raise DependencyArtifactAuthenticationError(
+                "distribution artifact CID does not match its file preimage"
+            )
+        files_by_seat = {item.source_seat: item for item in self.files}
+        if len(files_by_seat) != len(self.files):
+            raise DependencyArtifactAuthenticationError(
+                "distribution artifact contains duplicate file seats"
+            )
+        for module_name, module in self.modules.items():
+            recorded = files_by_seat.get(module.source_seat)
+            if (
+                module_name != module.module_name
+                or recorded is None
+                or recorded.content_cid != module.source_cid
+            ):
+                raise DependencyArtifactAuthenticationError(
+                    "module source is not projected from the artifact file manifest"
+                )
+
+    @classmethod
+    def authenticate(
+        cls, distribution: importlib.metadata.Distribution
+    ) -> "DependencyArtifactGraph":
+        """Hash every recorded installed file and publish authenticated modules."""
+        files = distribution.files
+        if files is None:
+            raise DependencyArtifactAuthenticationError(
+                "installed distribution has no recorded file manifest"
+            )
+        authenticated_files: list[AuthenticatedArtifactFileV1] = []
+        modules: dict[str, AuthenticatedModuleSourceV1] = {}
+        for recorded in sorted(files, key=lambda item: str(item)):
+            relative = PurePosixPath(str(recorded))
+            if relative.is_absolute():
+                raise DependencyArtifactAuthenticationError(
+                    "distribution manifest contains an absolute file seat"
+                )
+            path = Path(distribution.locate_file(recorded))
+            try:
+                content, _seat, content_cid = dependency_artifact_file(str(path))
+            except SourceUnavailable as exc:
+                raise DependencyArtifactAuthenticationError(
+                    f"cannot read recorded distribution file {relative}"
+                ) from exc
+            authenticated_files.append(
+                AuthenticatedArtifactFileV1(
+                    source_seat=relative.as_posix(),
+                    content_cid=content_cid,
+                    content=content,
+                )
+            )
+            module_name = _module_name(relative)
+            if module_name is None:
+                continue
+            try:
+                source = content.decode("utf-8")
+                parsed_tree(source, str(path))
+            except (UnicodeError, SyntaxError) as exc:
+                raise DependencyArtifactAuthenticationError(
+                    f"recorded Python module {module_name} is not parseable UTF-8 source"
+                ) from exc
+            if module_name in modules:
+                raise DependencyArtifactAuthenticationError(
+                    f"distribution contains duplicate module seat {module_name}"
+                )
+            modules[module_name] = AuthenticatedModuleSourceV1(
+                module_name=module_name,
+                source_seat=relative.as_posix(),
+                source_cid=content_cid,
+                source=source,
+            )
+        metadata_files = [
+            item
+            for item in authenticated_files
+            if item.source_seat.endswith(".dist-info/METADATA")
+        ]
+        if len(metadata_files) != 1:
+            raise DependencyArtifactAuthenticationError(
+                "installed distribution must contain one recorded METADATA file"
+            )
+        metadata = BytesParser().parsebytes(metadata_files[0].content)
+        name = metadata.get("Name")
+        version = metadata.get("Version")
+        if not isinstance(name, str) or not name or not version:
+            raise DependencyArtifactAuthenticationError(
+                "installed distribution lacks name or version metadata"
+            )
+        preimage = {
+            "kind": "python-dependency-artifact",
+            "schemaVersion": "1",
+            "distributionName": name,
+            "distributionVersion": version,
+            "files": [
+                {"path": item.source_seat, "contentCid": item.content_cid}
+                for item in authenticated_files
+            ],
+        }
+        return cls(
+            distribution_name=name,
+            distribution_version=version,
+            distribution_artifact_cid=cid_of_json(preimage),
+            files=tuple(authenticated_files),
+            modules=MappingProxyType(modules),
+        )
+
+
+def resolve_import_binding(
+    import_binding: Mapping[str, Any],
+    *,
+    target_symbol: str,
+    graph: DependencyArtifactGraph,
+) -> PythonObjectResolutionV1:
+    """Resolve an existing ImportBinding through one authenticated artifact."""
+    binding_value = dict(import_binding)
+    binding_cid = cid_of_json(binding_value)
+    try:
+        module_name, bound_path, authenticated_source_cid = _binding_target(
+            binding_value
+        )
+    except (KeyError, TypeError, ValueError):
+        return _gap("malformed-import-binding", binding_cid, graph, "", target_symbol)
+    prefix = "python:"
+    if not target_symbol.startswith(prefix):
+        return _gap(
+            "target-outside-binding", binding_cid, graph, module_name, target_symbol
+        )
+    requested = target_symbol[len(prefix) :].split(".")
+    module = graph.modules.get(module_name)
+    if (
+        authenticated_source_cid is not None
+        and module is not None
+        and module.source_cid != authenticated_source_cid
+    ):
+        return _gap("opaque-source", binding_cid, graph, module_name, target_symbol)
+    base = module_name.split(".")
+    bound = list(bound_path)
+    if bound:
+        expected = base + bound
+        if requested != expected or len(bound) != 1:
+            return _gap(
+                "target-outside-binding",
+                binding_cid,
+                graph,
+                module_name,
+                target_symbol,
+            )
+        exported_name = bound[0]
+    elif requested[: len(base)] == base and len(requested) == len(base) + 1:
+        exported_name = requested[-1]
+    else:
+        return _gap(
+            "target-outside-binding", binding_cid, graph, module_name, target_symbol
+        )
+    return _resolve_export(
+        graph,
+        binding_cid,
+        module_name,
+        exported_name,
+        (),
+        frozenset(),
+    )
+
+
+def _resolve_export(
+    graph: DependencyArtifactGraph,
+    binding_cid: str,
+    module_name: str,
+    exported_name: str,
+    warrants: tuple[ReexportWarrantV1, ...],
+    seen: frozenset[tuple[str, str]],
+) -> PythonObjectResolutionV1:
+    key = (module_name, exported_name)
+    if key in seen:
+        return _gap("reexport-cycle", binding_cid, graph, module_name, exported_name)
+    module = graph.modules.get(module_name)
+    if module is None:
+        return _gap(
+            "artifact-module-absent", binding_cid, graph, module_name, exported_name
+        )
+    tree = parsed_tree(module.source, module.source_seat)
+    candidates: list[ast.AST] = []
+    imports: list[tuple[ast.ImportFrom, ast.alias]] = []
+    aliases: list[ast.Name] = []
+    dynamic = False
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if node.name == "__getattr__":
+                dynamic = True
+            if node.name == exported_name:
+                candidates.append(node)
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if (alias.asname or alias.name) == exported_name:
+                    imports.append((node, alias))
+        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if (
+                isinstance(target, ast.Name)
+                and target.id == exported_name
+                and isinstance(node.value, ast.Name)
+            ):
+                aliases.append(node.value)
+    runtime_candidates = [node for node in candidates if not _is_overload(node)]
+    if runtime_candidates:
+        candidates = runtime_candidates
+    count = len(candidates) + len(imports) + len(aliases)
+    if count > 1:
+        return _gap(
+            "ambiguous-static-export", binding_cid, graph, module_name, exported_name
+        )
+    if candidates:
+        definition = _definition(module, candidates[0])
+        return ResolvedPythonObjectV1(
+            distribution_artifact_cid=graph.distribution_artifact_cid,
+            import_binding_cid=binding_cid,
+            module_name=module_name,
+            source_cid=module.source_cid,
+            reexport_warrants=warrants,
+            definition=definition,
+        )
+    if imports:
+        node, alias = imports[0]
+        target_module = _absolute_import(module_name, module.source_seat, node)
+        if target_module is None:
+            return _gap("opaque-source", binding_cid, graph, module_name, exported_name)
+        target = graph.modules.get(target_module)
+        if target is None:
+            return _gap(
+                "artifact-module-absent",
+                binding_cid,
+                graph,
+                target_module,
+                alias.name,
+            )
+        warrant = ReexportWarrantV1(
+            from_module=module_name,
+            from_source_cid=module.source_cid,
+            to_module=target_module,
+            to_source_cid=target.source_cid,
+            exported_name=exported_name,
+            imported_name=alias.name,
+            definition=_import_coordinate(module, node, exported_name),
+        )
+        return _resolve_export(
+            graph,
+            binding_cid,
+            target_module,
+            alias.name,
+            (*warrants, warrant),
+            seen | {key},
+        )
+    if aliases:
+        return _resolve_export(
+            graph,
+            binding_cid,
+            module_name,
+            aliases[0].id,
+            warrants,
+            seen | {key},
+        )
+    return _gap(
+        "dynamic-export" if dynamic else "static-export-absent",
+        binding_cid,
+        graph,
+        module_name,
+        exported_name,
+    )
+
+
+def _definition(
+    module: AuthenticatedModuleSourceV1, node: ast.AST
+) -> DefinitionCoordinateV1:
+    segment = ast.get_source_segment(module.source, node)
+    if segment is None:
+        raise DependencyArtifactAuthenticationError(
+            "definition source segment is unavailable"
+        )
+    kind: Literal["function", "class"] = (
+        "class" if isinstance(node, ast.ClassDef) else "function"
+    )
+    return DefinitionCoordinateV1(
+        name=node.name,
+        kind=kind,
+        source_cid=module.source_cid,
+        start_line=node.lineno,
+        start_col=node.col_offset,
+        end_line=node.end_lineno,
+        end_col=node.end_col_offset,
+        fragment_cid=blake3_512_of(segment.encode("utf-8")),
+    )
+
+
+def _import_coordinate(
+    module: AuthenticatedModuleSourceV1,
+    node: ast.ImportFrom,
+    exported_name: str,
+) -> DefinitionCoordinateV1:
+    segment = ast.get_source_segment(module.source, node)
+    if segment is None:
+        raise DependencyArtifactAuthenticationError(
+            "re-export source segment is unavailable"
+        )
+    return DefinitionCoordinateV1(
+        name=exported_name,
+        kind="import",
+        source_cid=module.source_cid,
+        start_line=node.lineno,
+        start_col=node.col_offset,
+        end_line=node.end_lineno,
+        end_col=node.end_col_offset,
+        fragment_cid=blake3_512_of(segment.encode("utf-8")),
+    )
+
+
+def _binding_target(
+    value: Mapping[str, Any],
+) -> tuple[str, tuple[str, ...], str | None]:
+    if value["kind"] != "python-import-binding" or value["schemaVersion"] != "1":
+        raise ValueError("unsupported import binding")
+    target = value["target"]
+    identity = target["moduleIdentity"]
+    if identity["kind"] == "unavailable-python-module":
+        module_name = identity["name"]
+        source_cid = None
+    elif identity["kind"] == "authenticated-python-module":
+        module_name = identity["moduleName"]
+        source_cid = _cid(identity["sourceCid"], "module identity sourceCid")
+    else:
+        raise ValueError("unsupported module identity")
+    path = target["exportedPath"]
+    if not isinstance(path, list) or not all(
+        isinstance(item, str) and item for item in path
+    ):
+        raise ValueError("invalid exported path")
+    return _string(module_name, "module name"), tuple(path), source_cid
+
+
+def _absolute_import(
+    current_module: str, source_seat: str, node: ast.ImportFrom
+) -> str | None:
+    if node.level == 0:
+        return node.module
+    package = current_module.split(".")
+    if not source_seat.endswith("/__init__.py"):
+        package.pop()
+    ascend = node.level - 1
+    if ascend > len(package):
+        return None
+    base = package[: len(package) - ascend]
+    if node.module:
+        base.extend(node.module.split("."))
+    return ".".join(base) or None
+
+
+def _is_overload(node: ast.AST) -> bool:
+    decorators = getattr(node, "decorator_list", ())
+    for decorator in decorators:
+        if isinstance(decorator, ast.Name) and decorator.id == "overload":
+            return True
+        if isinstance(decorator, ast.Attribute) and decorator.attr == "overload":
+            return True
+    return False
+
+
+def _module_name(path: PurePosixPath) -> str | None:
+    if path.suffix != ".py":
+        return None
+    parts = list(path.with_suffix("").parts)
+    if any(part.endswith(".dist-info") or part.endswith(".data") for part in parts):
+        return None
+    if parts[-1] == "__init__":
+        parts.pop()
+    if not parts or not all(part.isidentifier() for part in parts):
+        return None
+    return ".".join(parts)
+
+
+def _gap(
+    kind: Any,
+    binding_cid: str,
+    graph: DependencyArtifactGraph,
+    module_name: str,
+    exported_name: str,
+) -> PythonObjectResolutionGapV1:
+    return PythonObjectResolutionGapV1(
+        kind=kind,
+        import_binding_cid=binding_cid,
+        distribution_artifact_cid=graph.distribution_artifact_cid,
+        module_name=module_name,
+        exported_name=exported_name,
+    )
+
+
+def _require_exact_keys(value: Any, expected: set[str], label: str) -> None:
+    if not isinstance(value, dict) or set(value) != expected:
+        raise ValueError(f"{label} has an invalid key set")
+
+
+def _string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a nonempty string")
+    return value
+
+
+def _cid(value: Any, label: str) -> str:
+    value = _string(value, label)
+    if not value.startswith("blake3-512:"):
+        raise ValueError(f"{label} must be a content CID")
+    return value
+
+
+def _nonnegative_int(value: Any, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(f"{label} must be a nonnegative integer")
+    return value

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -24,6 +24,9 @@ class DependencyArtifactAuthenticationError(Exception):
     """The selected installed artifact cannot be authenticated exactly."""
 
 
+_ARTIFACT_INTAKE_AUTHORITY = object()
+
+
 @dataclass(frozen=True)
 class AuthenticatedArtifactFileV1:
     source_seat: str
@@ -247,7 +250,18 @@ class ResolvedPythonObjectV1:
         return {**self._preimage(), "cid": self.cid}
 
     @classmethod
-    def from_value(cls, value: Any) -> "ResolvedPythonObjectV1":
+    def from_value(
+        cls,
+        value: Any,
+        *,
+        graph: "DependencyArtifactGraph",
+        authenticated_use: Any,
+    ) -> "ResolvedPythonObjectV1":
+        """Authenticate wire input by re-resolving every cited preimage.
+
+        Parsing and recomputing this object's outer CID is insufficient: an
+        invented but self-consistent payload is not artifact authentication.
+        """
         _require_exact_keys(
             value,
             {
@@ -268,7 +282,12 @@ class ResolvedPythonObjectV1:
         warrants = value["reexportWarrants"]
         if not isinstance(warrants, list):
             raise ValueError("reexportWarrants must be a list")
-        return cls(
+        revalidated = resolve_import_binding(authenticated_use, graph=graph)
+        if not isinstance(revalidated, cls) or revalidated.to_value() != value:
+            raise DependencyArtifactAuthenticationError(
+                "resolved object is not byte-identical to artifact re-resolution"
+            )
+        decoded = cls(
             distribution_artifact_cid=_cid(
                 value["distributionArtifactCid"], "distributionArtifactCid"
             ),
@@ -281,6 +300,11 @@ class ResolvedPythonObjectV1:
             definition=DefinitionCoordinateV1.from_value(value["definition"]),
             cid=_cid(value["cid"], "resolved object cid"),
         )
+        if decoded != revalidated:
+            raise DependencyArtifactAuthenticationError(
+                "decoded resolved object differs from its authenticated preimage"
+            )
+        return revalidated
 
 
 @dataclass(frozen=True)
@@ -311,8 +335,13 @@ class DependencyArtifactGraph:
     distribution_artifact_cid: str
     files: tuple[AuthenticatedArtifactFileV1, ...]
     modules: Mapping[str, AuthenticatedModuleSourceV1]
+    _intake_authority: object = field(repr=False, compare=False)
 
     def __post_init__(self) -> None:
+        if self._intake_authority is not _ARTIFACT_INTAKE_AUTHORITY:
+            raise DependencyArtifactAuthenticationError(
+                "dependency artifact graph was not minted by SourceOracle intake"
+            )
         metadata_files = [
             item
             for item in self.files
@@ -360,12 +389,23 @@ class DependencyArtifactGraph:
             recorded = files_by_seat.get(module.source_seat)
             if (
                 module_name != module.module_name
+                or module_name != _module_name(PurePosixPath(module.source_seat))
                 or recorded is None
                 or recorded.content_cid != module.source_cid
             ):
                 raise DependencyArtifactAuthenticationError(
                     "module source is not projected from the artifact file manifest"
                 )
+        expected_modules = {
+            name
+            for item in self.files
+            for name in [_module_name(PurePosixPath(item.source_seat))]
+            if name is not None
+        }
+        if set(self.modules) != expected_modules:
+            raise DependencyArtifactAuthenticationError(
+                "artifact module projection is incomplete or contains invented modules"
+            )
 
     @classmethod
     def authenticate(
@@ -451,18 +491,35 @@ class DependencyArtifactGraph:
             distribution_artifact_cid=cid_of_json(preimage),
             files=tuple(authenticated_files),
             modules=MappingProxyType(modules),
+            _intake_authority=_ARTIFACT_INTAKE_AUTHORITY,
         )
 
 
 def resolve_import_binding(
-    import_binding: Mapping[str, Any],
+    authenticated_use: Any,
     *,
-    target_symbol: str,
     graph: DependencyArtifactGraph,
 ) -> PythonObjectResolutionV1:
-    """Resolve an existing ImportBinding through one authenticated artifact."""
-    binding_value = dict(import_binding)
+    """Resolve a final-checked #6090 import use through one artifact graph."""
+    from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
+
+    if not isinstance(authenticated_use, AuthenticatedImportUseV1):
+        raise DependencyArtifactAuthenticationError(
+            "source resolution requires AuthenticatedImportUseV1"
+        )
+    try:
+        authenticated_use.revalidate()
+    except ValueError as exc:
+        raise DependencyArtifactAuthenticationError(
+            "authenticated import use failed lexical revalidation"
+        ) from exc
+    binding_value = authenticated_use.import_binding.to_value()
+    target_symbol = authenticated_use.target_symbol
     binding_cid = cid_of_json(binding_value)
+    if binding_cid != authenticated_use.import_binding.cid:
+        raise DependencyArtifactAuthenticationError(
+            "authenticated import binding differs from its final-checked preimage"
+        )
     try:
         module_name, bound_path, authenticated_source_cid = _binding_target(
             binding_value
@@ -528,38 +585,59 @@ def _resolve_export(
             "artifact-module-absent", binding_cid, graph, module_name, exported_name
         )
     tree = parsed_tree(module.source, module.source_seat)
-    candidates: list[ast.AST] = []
-    imports: list[tuple[ast.ImportFrom, ast.alias]] = []
-    aliases: list[ast.Name] = []
-    dynamic = False
+    binding: tuple[str, Any] | None = None
+    dynamic_getattr = False
     for node in tree.body:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
             if node.name == "__getattr__":
-                dynamic = True
+                dynamic_getattr = True
             if node.name == exported_name:
-                candidates.append(node)
+                binding = (
+                    ("definition", node)
+                    if not node.decorator_list
+                    else ("dynamic", node)
+                )
         elif isinstance(node, ast.ImportFrom):
             for alias in node.names:
                 if (alias.asname or alias.name) == exported_name:
-                    imports.append((node, alias))
-        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
-            target = node.targets[0]
-            if (
-                isinstance(target, ast.Name)
-                and target.id == exported_name
+                    binding = ("import", (node, alias))
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if (alias.asname or alias.name.split(".")[0]) == exported_name:
+                    binding = ("dynamic", node)
+        elif isinstance(node, ast.Assign) and any(
+            _target_binds(target, exported_name) for target in node.targets
+        ):
+            binding = (
+                ("alias", node.value)
+                if len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)
                 and isinstance(node.value, ast.Name)
-            ):
-                aliases.append(node.value)
-    runtime_candidates = [node for node in candidates if not _is_overload(node)]
-    if runtime_candidates:
-        candidates = runtime_candidates
-    count = len(candidates) + len(imports) + len(aliases)
-    if count > 1:
-        return _gap(
-            "ambiguous-static-export", binding_cid, graph, module_name, exported_name
-        )
-    if candidates:
-        definition = _definition(module, candidates[0])
+                else ("dynamic", node)
+            )
+        elif isinstance(node, ast.AnnAssign) and _target_binds(
+            node.target, exported_name
+        ):
+            if node.value is not None:
+                binding = (
+                    ("alias", node.value)
+                    if isinstance(node.target, ast.Name)
+                    and isinstance(node.value, ast.Name)
+                    else ("dynamic", node)
+                )
+        elif isinstance(node, ast.AugAssign) and _target_binds(
+            node.target, exported_name
+        ):
+            binding = ("dynamic", node)
+        elif isinstance(node, (ast.If, ast.For, ast.AsyncFor, ast.While, ast.Try)):
+            if _compound_binds(node, exported_name):
+                binding = ("dynamic", node)
+        elif isinstance(node, ast.Delete) and any(
+            _target_binds(target, exported_name) for target in node.targets
+        ):
+            binding = None
+    if binding is not None and binding[0] == "definition":
+        definition = _definition(module, binding[1])
         return ResolvedPythonObjectV1(
             distribution_artifact_cid=graph.distribution_artifact_cid,
             import_binding_cid=binding_cid,
@@ -568,8 +646,8 @@ def _resolve_export(
             reexport_warrants=warrants,
             definition=definition,
         )
-    if imports:
-        node, alias = imports[0]
+    if binding is not None and binding[0] == "import":
+        node, alias = binding[1]
         target_module = _absolute_import(module_name, module.source_seat, node)
         if target_module is None:
             return _gap("opaque-source", binding_cid, graph, module_name, exported_name)
@@ -599,17 +677,21 @@ def _resolve_export(
             (*warrants, warrant),
             seen | {key},
         )
-    if aliases:
+    if binding is not None and binding[0] == "alias":
         return _resolve_export(
             graph,
             binding_cid,
             module_name,
-            aliases[0].id,
+            binding[1].id,
             warrants,
             seen | {key},
         )
     return _gap(
-        "dynamic-export" if dynamic else "static-export-absent",
+        (
+            "dynamic-export"
+            if dynamic_getattr or (binding is not None and binding[0] == "dynamic")
+            else "static-export-absent"
+        ),
         binding_cid,
         graph,
         module_name,
@@ -702,14 +784,57 @@ def _absolute_import(
     return ".".join(base) or None
 
 
-def _is_overload(node: ast.AST) -> bool:
-    decorators = getattr(node, "decorator_list", ())
-    for decorator in decorators:
-        if isinstance(decorator, ast.Name) and decorator.id == "overload":
-            return True
-        if isinstance(decorator, ast.Attribute) and decorator.attr == "overload":
-            return True
+def _target_binds(target: ast.AST, name: str) -> bool:
+    if isinstance(target, ast.Name):
+        return target.id == name
+    if isinstance(target, (ast.Tuple, ast.List)):
+        return any(_target_binds(item, name) for item in target.elts)
+    if isinstance(target, ast.Starred):
+        return _target_binds(target.value, name)
     return False
+
+
+def _compound_binds(statement: ast.stmt, name: str) -> bool:
+    """Conservatively identify a conditional/runtime-selected rebinding."""
+
+    class BindingVisitor(ast.NodeVisitor):
+        found = False
+
+        def visit_Name(self, node: ast.Name) -> None:
+            if isinstance(node.ctx, (ast.Store, ast.Del)) and node.id == name:
+                self.found = True
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            if node.name == name:
+                self.found = True
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            if node.name == name:
+                self.found = True
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            if node.name == name:
+                self.found = True
+
+        def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+            if any((alias.asname or alias.name) == name for alias in node.names):
+                self.found = True
+
+        def visit_Import(self, node: ast.Import) -> None:
+            if any(
+                (alias.asname or alias.name.split(".")[0]) == name
+                for alias in node.names
+            ):
+                self.found = True
+
+        def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+            if node.name == name:
+                self.found = True
+            self.generic_visit(node)
+
+    visitor = BindingVisitor()
+    visitor.visit(statement)
+    return visitor.found
 
 
 def _module_name(path: PurePosixPath) -> str | None:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -314,6 +314,7 @@ class PythonObjectResolutionGapV1:
         "artifact-module-absent",
         "target-outside-binding",
         "dynamic-export",
+        "unsupported-statement",
         "ambiguous-static-export",
         "static-export-absent",
         "opaque-source",
@@ -585,57 +586,12 @@ def _resolve_export(
             "artifact-module-absent", binding_cid, graph, module_name, exported_name
         )
     tree = parsed_tree(module.source, module.source_seat)
-    binding: tuple[str, Any] | None = None
-    dynamic_getattr = False
-    for node in tree.body:
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            if node.name == "__getattr__":
-                dynamic_getattr = True
-            if node.name == exported_name:
-                binding = (
-                    ("definition", node)
-                    if not node.decorator_list
-                    else ("dynamic", node)
-                )
-        elif isinstance(node, ast.ImportFrom):
-            for alias in node.names:
-                if (alias.asname or alias.name) == exported_name:
-                    binding = ("import", (node, alias))
-        elif isinstance(node, ast.Import):
-            for alias in node.names:
-                if (alias.asname or alias.name.split(".")[0]) == exported_name:
-                    binding = ("dynamic", node)
-        elif isinstance(node, ast.Assign) and any(
-            _target_binds(target, exported_name) for target in node.targets
-        ):
-            binding = (
-                ("alias", node.value)
-                if len(node.targets) == 1
-                and isinstance(node.targets[0], ast.Name)
-                and isinstance(node.value, ast.Name)
-                else ("dynamic", node)
-            )
-        elif isinstance(node, ast.AnnAssign) and _target_binds(
-            node.target, exported_name
-        ):
-            if node.value is not None:
-                binding = (
-                    ("alias", node.value)
-                    if isinstance(node.target, ast.Name)
-                    and isinstance(node.value, ast.Name)
-                    else ("dynamic", node)
-                )
-        elif isinstance(node, ast.AugAssign) and _target_binds(
-            node.target, exported_name
-        ):
-            binding = ("dynamic", node)
-        elif isinstance(node, (ast.If, ast.For, ast.AsyncFor, ast.While, ast.Try)):
-            if _compound_binds(node, exported_name):
-                binding = ("dynamic", node)
-        elif isinstance(node, ast.Delete) and any(
-            _target_binds(target, exported_name) for target in node.targets
-        ):
-            binding = None
+    binding = _export_block(tree.body, exported_name, None)
+    dynamic_getattr = any(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "__getattr__"
+        for node in tree.body
+    )
     if binding is not None and binding[0] == "definition":
         definition = _definition(module, binding[1])
         return ResolvedPythonObjectV1(
@@ -685,6 +641,14 @@ def _resolve_export(
             binding[1].id,
             warrants,
             seen | {key},
+        )
+    if binding is not None and binding[0] == "unsupported":
+        return _gap(
+            "unsupported-statement",
+            binding_cid,
+            graph,
+            module_name,
+            exported_name,
         )
     return _gap(
         (
@@ -794,47 +758,248 @@ def _target_binds(target: ast.AST, name: str) -> bool:
     return False
 
 
-def _compound_binds(statement: ast.stmt, name: str) -> bool:
-    """Conservatively identify a conditional/runtime-selected rebinding."""
+_TYPE_ALIAS = getattr(ast, "TypeAlias", None)
+_TRY_TYPES = tuple(
+    kind for kind in (ast.Try, getattr(ast, "TryStar", None)) if kind is not None
+)
 
-    class BindingVisitor(ast.NodeVisitor):
-        found = False
+_EXPORT_SIMPLE_STATEMENTS = frozenset(
+    kind
+    for kind in (
+        ast.Assign,
+        ast.AnnAssign,
+        ast.AugAssign,
+        ast.Delete,
+        ast.Import,
+        ast.ImportFrom,
+        ast.FunctionDef,
+        ast.AsyncFunctionDef,
+        ast.ClassDef,
+        ast.Expr,
+        ast.Return,
+        ast.Raise,
+        ast.Assert,
+        ast.Pass,
+        ast.Break,
+        ast.Continue,
+        ast.Global,
+        ast.Nonlocal,
+        _TYPE_ALIAS,
+    )
+    if kind is not None
+)
+_EXPORT_COMPOUND_STATEMENTS = frozenset(
+    kind
+    for kind in (
+        ast.If,
+        ast.For,
+        ast.AsyncFor,
+        ast.While,
+        ast.With,
+        ast.AsyncWith,
+        ast.Try,
+        getattr(ast, "TryStar", None),
+        ast.Match,
+    )
+    if kind is not None
+)
 
-        def visit_Name(self, node: ast.Name) -> None:
-            if isinstance(node.ctx, (ast.Store, ast.Del)) and node.id == name:
-                self.found = True
 
-        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-            if node.name == name:
-                self.found = True
+def export_statement_coverage() -> tuple[list[str], list[str]]:
+    """Audit that every running-interpreter statement has one transfer arm."""
+    grammar = frozenset(ast.stmt.__subclasses__())
+    declared = _EXPORT_SIMPLE_STATEMENTS | _EXPORT_COMPOUND_STATEMENTS
+    return (
+        sorted(kind.__name__ for kind in grammar - declared),
+        sorted(kind.__name__ for kind in declared - grammar),
+    )
 
-        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
-            if node.name == name:
-                self.found = True
 
-        def visit_ClassDef(self, node: ast.ClassDef) -> None:
-            if node.name == name:
-                self.found = True
+def _export_block(statements, name, initial):
+    state = initial
+    for statement in statements:
+        state = _export_statement(statement, name, state)
+    return state
 
-        def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-            if any((alias.asname or alias.name) == name for alias in node.names):
-                self.found = True
 
-        def visit_Import(self, node: ast.Import) -> None:
+def _export_statement(statement: ast.stmt, name: str, state):
+    if type(statement) not in (_EXPORT_SIMPLE_STATEMENTS | _EXPORT_COMPOUND_STATEMENTS):
+        return ("unsupported", type(statement).__name__)
+    if _statement_walrus_binds(statement, name):
+        state = ("dynamic", statement)
+    if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        if statement.name != name:
+            return state
+        return (
+            ("definition", statement)
+            if not statement.decorator_list
+            else ("dynamic", statement)
+        )
+    if isinstance(statement, ast.ImportFrom):
+        for alias in statement.names:
+            if (alias.asname or alias.name) == name:
+                state = ("import", (statement, alias))
+        return state
+    if isinstance(statement, ast.Import):
+        return (
+            ("dynamic", statement)
             if any(
                 (alias.asname or alias.name.split(".")[0]) == name
-                for alias in node.names
+                for alias in statement.names
+            )
+            else state
+        )
+    if isinstance(statement, ast.Assign):
+        if not any(_target_binds(target, name) for target in statement.targets):
+            return state
+        if (
+            len(statement.targets) == 1
+            and isinstance(statement.targets[0], ast.Name)
+            and isinstance(statement.value, ast.Name)
+        ):
+            return ("alias", statement.value)
+        return ("dynamic", statement)
+    if isinstance(statement, ast.AnnAssign):
+        if statement.value is None or not _target_binds(statement.target, name):
+            return state
+        if isinstance(statement.target, ast.Name) and isinstance(
+            statement.value, ast.Name
+        ):
+            return ("alias", statement.value)
+        return ("dynamic", statement)
+    if isinstance(statement, ast.AugAssign):
+        return (
+            ("dynamic", statement) if _target_binds(statement.target, name) else state
+        )
+    if isinstance(statement, ast.Delete):
+        return (
+            None
+            if any(_target_binds(target, name) for target in statement.targets)
+            else state
+        )
+    if _TYPE_ALIAS is not None and isinstance(statement, _TYPE_ALIAS):
+        return (
+            ("dynamic", statement)
+            if isinstance(statement.name, ast.Name) and statement.name.id == name
+            else state
+        )
+    if isinstance(statement, (ast.With, ast.AsyncWith)):
+        for item in statement.items:
+            if item.optional_vars is not None and _target_binds(
+                item.optional_vars, name
             ):
-                self.found = True
+                state = ("dynamic", statement)
+        return _export_block(statement.body, name, state)
+    if isinstance(statement, ast.Match):
+        outputs = [
+            _export_block(
+                case.body,
+                name,
+                ("dynamic", statement) if _pattern_binds(case.pattern, name) else state,
+            )
+            for case in statement.cases
+        ]
+        exhaustive = (
+            bool(statement.cases)
+            and isinstance(statement.cases[-1].pattern, ast.MatchAs)
+            and statement.cases[-1].pattern.pattern is None
+            and statement.cases[-1].guard is None
+        )
+        if not exhaustive:
+            outputs.append(state)
+        return _join_export_states(outputs, statement)
+    if isinstance(statement, _TRY_TYPES):
+        completed = _export_block(statement.body, name, state)
+        completed = _export_block(statement.orelse, name, completed)
+        # A suite containing only definition/pass statements cannot raise while
+        # binding the export; its handlers are unreachable on successful module
+        # construction. Other try bodies retain every handler edge.
+        outputs = [completed]
+        if not all(_cannot_raise_during_module_init(item) for item in statement.body):
+            for handler in statement.handlers:
+                handler_state = (
+                    ("dynamic", statement) if handler.name == name else state
+                )
+                outputs.append(_export_block(handler.body, name, handler_state))
+        joined = _join_export_states(outputs, statement)
+        return _export_block(statement.finalbody, name, joined)
+    if isinstance(statement, ast.If):
+        return _join_export_states(
+            (
+                _export_block(statement.body, name, state),
+                _export_block(statement.orelse, name, state),
+            ),
+            statement,
+        )
+    if isinstance(statement, (ast.For, ast.AsyncFor, ast.While)):
+        iterated = state
+        if isinstance(statement, (ast.For, ast.AsyncFor)) and _target_binds(
+            statement.target, name
+        ):
+            iterated = ("dynamic", statement)
+        iterated = _export_block(statement.body, name, iterated)
+        iterated = _export_block(statement.orelse, name, iterated)
+        return _join_export_states((state, iterated), statement)
+    return state
 
-        def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
-            if node.name == name:
-                self.found = True
-            self.generic_visit(node)
 
-    visitor = BindingVisitor()
-    visitor.visit(statement)
-    return visitor.found
+def _join_export_states(states, locus):
+    states = tuple(states)
+    if states and all(state == states[0] for state in states[1:]):
+        return states[0]
+    return ("dynamic", locus)
+
+
+def _pattern_binds(pattern: ast.pattern, name: str) -> bool:
+    if isinstance(pattern, (ast.MatchAs, ast.MatchStar)) and pattern.name == name:
+        return True
+    if isinstance(pattern, ast.MatchMapping) and pattern.rest == name:
+        return True
+    return any(
+        _pattern_binds(child, name)
+        for child in ast.iter_child_nodes(pattern)
+        if isinstance(child, ast.pattern)
+    )
+
+
+def _statement_walrus_binds(statement: ast.stmt, name: str) -> bool:
+    """Find module-scope named expressions without entering nested scopes/suites."""
+    stack = list(ast.iter_child_nodes(statement))
+    while stack:
+        node = stack.pop()
+        if isinstance(node, ast.stmt):
+            continue
+        if isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+        ):
+            continue
+        if isinstance(node, ast.NamedExpr) and _target_binds(node.target, name):
+            return True
+        stack.extend(ast.iter_child_nodes(node))
+    return False
+
+
+def _cannot_raise_during_module_init(statement: ast.stmt) -> bool:
+    if isinstance(statement, ast.Pass):
+        return True
+    if not isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return False
+    arguments = statement.args
+    parameters = (
+        *arguments.posonlyargs,
+        *arguments.args,
+        *arguments.kwonlyargs,
+        *(() if arguments.vararg is None else (arguments.vararg,)),
+        *(() if arguments.kwarg is None else (arguments.kwarg,)),
+    )
+    return not (
+        statement.decorator_list
+        or arguments.defaults
+        or any(default is not None for default in arguments.kw_defaults)
+        or statement.returns is not None
+        or any(parameter.annotation is not None for parameter in parameters)
+        or getattr(statement, "type_params", ())
+    )
 
 
 def _module_name(path: PurePosixPath) -> str | None:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -20,16 +20,42 @@ from sugar_lift_py_tests.floor import (
     ObjectField,
     ObjectValue,
     StringValue,
-    SymbolicValue,
     TermValue,
     TupleValue,
 )
-from sugar_lift_py_tests.ir import ctor, encode_jcs, str_const, term_to_value
-from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
-from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+from sugar_lift_py_tests.ir import encode_jcs, term_to_value
 
 from .canonical import cid_of_json
 from .dependency_artifact import DependencyArtifactGraph, ResolvedPythonObjectV1
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
+
+
+class ManagerConstructionAuthenticationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class ConstructedCallActualV1:
+    occurrence: SourceFragmentCoordinateV1
+    value: FloorValue = field(compare=False)
+    keyword: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.occurrence, SourceFragmentCoordinateV1):
+            raise ManagerConstructionAuthenticationError(
+                "constructed actual requires a source occurrence"
+            )
+        if not isinstance(self.value, FloorValue):
+            raise ManagerConstructionAuthenticationError(
+                "constructed actual requires an already-constructed floor value"
+            )
+        if self.keyword is not None and (
+            not isinstance(self.keyword, str) or not self.keyword
+        ):
+            raise ManagerConstructionAuthenticationError(
+                "constructed keyword actual requires a nonempty keyword"
+            )
 
 
 @dataclass(frozen=True)
@@ -46,6 +72,7 @@ class FormalActualBindingV1:
     formal_name: str
     actual: FloorValue = field(compare=False)
     provenance: Literal["actual", "default", "variadic"]
+    actual_occurrences: tuple[SourceFragmentCoordinateV1, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -58,7 +85,9 @@ class ConstructedCallFrameV1:
 @dataclass(frozen=True)
 class ConstructedManagerBehaviorV1:
     resolved_object_cid: str
+    manager_call_occurrence: SourceFragmentCoordinateV1
     manager_construction_cid: str
+    returned_object_cid: str
     receiver_state: ObjectValue = field(compare=False)
     receiver_state_cid: str
     formal_actuals: tuple[FormalActualBindingV1, ...] = field(compare=False)
@@ -75,6 +104,8 @@ class ConstructedManagerBehaviorV1:
             "kind": "python-manager-construction",
             "schemaVersion": "1",
             "resolvedObjectCid": self.resolved_object_cid,
+            "managerCallOccurrence": self.manager_call_occurrence.wire(),
+            "returnedObjectCid": self.returned_object_cid,
             "receiverStateCid": self.receiver_state_cid,
             "formalActuals": [_binding_value(item) for item in self.formal_actuals],
             "callFrames": [frame.__dict__ for frame in self.call_frames],
@@ -85,11 +116,44 @@ class ConstructedManagerBehaviorV1:
             "kind": "constructed-manager-behavior",
             "schemaVersion": "1",
             "resolvedObjectCid": self.resolved_object_cid,
+            "managerCallOccurrence": self.manager_call_occurrence.wire(),
             "managerConstructionCid": self.manager_construction_cid,
+            "returnedObjectCid": self.returned_object_cid,
+            "receiverState": _object_value(self.receiver_state),
             "receiverStateCid": self.receiver_state_cid,
             "callFrames": [frame.__dict__ for frame in self.call_frames],
             "formalActuals": [_binding_value(item) for item in self.formal_actuals],
         }
+
+    @classmethod
+    def from_value(
+        cls,
+        value: Any,
+        *,
+        resolved: ResolvedPythonObjectV1,
+        graph: DependencyArtifactGraph,
+        authenticated_use: AuthenticatedImportUseV1,
+        manager_call_occurrence: SourceFragmentCoordinateV1,
+        positional_actuals: tuple[ConstructedCallActualV1, ...],
+        keyword_actuals: tuple[ConstructedCallActualV1, ...] = (),
+    ) -> "ConstructedManagerBehaviorV1":
+        reconstructed = construct_manager_behavior(
+            resolved,
+            graph=graph,
+            authenticated_use=authenticated_use,
+            manager_call_occurrence=manager_call_occurrence,
+            positional_actuals=positional_actuals,
+            keyword_actuals=keyword_actuals,
+        )
+        if not isinstance(reconstructed, cls):
+            raise ManagerConstructionAuthenticationError(
+                "manager construction cannot be revalidated"
+            )
+        if not isinstance(value, dict) or value != reconstructed.to_value():
+            raise ManagerConstructionAuthenticationError(
+                "decoded manager construction is not byte-identical to reconstruction"
+            )
+        return reconstructed
 
 
 @dataclass(frozen=True)
@@ -142,9 +206,46 @@ def construct_manager_behavior(
     resolved: ResolvedPythonObjectV1,
     *,
     graph: DependencyArtifactGraph,
-    positional_actuals: tuple[FloorValue, ...],
-    keyword_actuals: tuple[tuple[str, FloorValue], ...] = (),
+    authenticated_use: AuthenticatedImportUseV1,
+    manager_call_occurrence: SourceFragmentCoordinateV1,
+    positional_actuals: tuple[ConstructedCallActualV1, ...],
+    keyword_actuals: tuple[ConstructedCallActualV1, ...] = (),
 ) -> ConstructedManagerBehaviorV1 | ManagerConstructionGapV1:
+    if not isinstance(authenticated_use, AuthenticatedImportUseV1):
+        return ManagerConstructionGapV1(
+            "call-binding", resolved.cid, "authenticated import use"
+        )
+    try:
+        authenticated_use.revalidate()
+    except ValueError:
+        return ManagerConstructionGapV1(
+            "call-binding", resolved.cid, "stale authenticated import use"
+        )
+    if authenticated_use.import_binding.cid != resolved.import_binding_cid:
+        return ManagerConstructionGapV1(
+            "call-binding", resolved.cid, "import binding CID"
+        )
+    if not isinstance(
+        manager_call_occurrence, SourceFragmentCoordinateV1
+    ) or manager_call_occurrence != SourceFragmentCoordinateV1.decode(
+        authenticated_use.use["useSite"]
+    ):
+        return ManagerConstructionGapV1(
+            "call-binding", resolved.cid, "manager call occurrence"
+        )
+    if any(actual.keyword is not None for actual in positional_actuals) or any(
+        actual.keyword is None for actual in keyword_actuals
+    ):
+        return ManagerConstructionGapV1(
+            "call-binding", resolved.cid, "actual occurrence role"
+        )
+    if any(
+        actual.occurrence.source_cid != authenticated_use.source_cid
+        for actual in (*positional_actuals, *keyword_actuals)
+    ):
+        return ManagerConstructionGapV1(
+            "call-binding", resolved.cid, "actual occurrence source CID"
+        )
     if graph.distribution_artifact_cid != resolved.distribution_artifact_cid:
         return ManagerConstructionGapV1(
             "artifact-mismatch", resolved.cid, "artifact CID"
@@ -175,17 +276,29 @@ def construct_manager_behavior(
         )
     state = _object_value(invocation.value)
     state_cid = cid_of_json(state)
+    returned_object_cid = cid_of_json(
+        {
+            "kind": "constructed-python-object",
+            "managerCallOccurrence": manager_call_occurrence.wire(),
+            "typeDefinitionCid": invocation.value.identity,
+            "receiverStateCid": state_cid,
+        }
+    )
     preimage = {
         "kind": "python-manager-construction",
         "schemaVersion": "1",
         "resolvedObjectCid": resolved.cid,
+        "managerCallOccurrence": manager_call_occurrence.wire(),
+        "returnedObjectCid": returned_object_cid,
         "receiverStateCid": state_cid,
         "formalActuals": [_binding_value(item) for item in invocation.bindings],
         "callFrames": [frame.__dict__ for frame in invocation.frames],
     }
     return ConstructedManagerBehaviorV1(
         resolved.cid,
+        manager_call_occurrence,
         cid_of_json(preimage),
+        returned_object_cid,
         invocation.value,
         state_cid,
         invocation.bindings,
@@ -251,6 +364,11 @@ def _bind(definition, positional, keywords, skip_first=False):
         raw = raw[1:]
     parameters: list[inspect.Parameter] = []
     defaults = [None] * (len(raw) - len(node.args.defaults)) + list(node.args.defaults)
+    default_nodes = {
+        argument.arg: default
+        for argument, default in zip(raw, defaults, strict=True)
+        if default is not None
+    }
     for index, (argument, default) in enumerate(zip(raw, defaults, strict=True)):
         kind = (
             inspect.Parameter.POSITIONAL_ONLY
@@ -273,6 +391,8 @@ def _bind(definition, positional, keywords, skip_first=False):
     for argument, default in zip(
         node.args.kwonlyargs, node.args.kw_defaults, strict=True
     ):
+        if default is not None:
+            default_nodes[argument.arg] = default
         parameters.append(
             inspect.Parameter(
                 argument.arg,
@@ -288,7 +408,9 @@ def _bind(definition, positional, keywords, skip_first=False):
         )
     signature = inspect.Signature(parameters)
     try:
-        bound = signature.bind(*positional, **dict(keywords))
+        bound = signature.bind(
+            *positional, **{actual.keyword: actual for actual in keywords}
+        )
     except TypeError as exc:
         raise _Gap("call-binding", str(exc)) from exc
     supplied = set(bound.arguments)
@@ -296,19 +418,38 @@ def _bind(definition, positional, keywords, skip_first=False):
     result = []
     env = {}
     for index, parameter in enumerate(parameters):
-        value = bound.arguments[parameter.name]
+        supplied_value = bound.arguments[parameter.name]
+        occurrences = ()
         if parameter.kind is inspect.Parameter.VAR_POSITIONAL:
-            value = TupleValue(tuple(value))
+            occurrences = tuple(item.occurrence for item in supplied_value)
+            value = TupleValue(tuple(item.value for item in supplied_value))
             provenance = "variadic"
         elif parameter.kind is inspect.Parameter.VAR_KEYWORD:
-            value = DictValue(tuple((StringValue(k), v) for k, v in value.items()))
+            occurrences = tuple(item.occurrence for item in supplied_value.values())
+            value = DictValue(
+                tuple(
+                    (StringValue(k), item.value) for k, item in supplied_value.items()
+                )
+            )
             provenance = "variadic"
         else:
             provenance = "actual" if parameter.name in supplied else "default"
+            if provenance == "actual":
+                occurrences = (supplied_value.occurrence,)
+                value = supplied_value.value
+            else:
+                value = supplied_value
+                occurrences = (
+                    _node_occurrence(
+                        default_nodes[parameter.name], definition.source_cid
+                    ),
+                )
         coordinate = FormalParameterCoordinateV1(
             definition.cid, index, parameter.name, parameter.kind.name
         )
-        binding = FormalActualBindingV1(coordinate, parameter.name, value, provenance)
+        binding = FormalActualBindingV1(
+            coordinate, parameter.name, value, provenance, occurrences
+        )
         result.append(binding)
         env[parameter.name] = value
     return tuple(result), env
@@ -332,10 +473,19 @@ def _expr(node, env, definitions):
                 frames = (*frames, *nested)
                 if not isinstance(value, TupleValue):
                     raise _Gap("call-binding", "* value")
-                positional.extend(value.elements)
+                positional.extend(
+                    ConstructedCallActualV1(
+                        _node_occurrence(item, callee.source_cid), element
+                    )
+                    for element in value.elements
+                )
                 continue
             value, nested = _expr(item, env, definitions)
-            positional.append(value)
+            positional.append(
+                ConstructedCallActualV1(
+                    _node_occurrence(item, callee.source_cid), value
+                )
+            )
             frames = (*frames, *nested)
         keywords = []
         for item in node.keywords:
@@ -345,12 +495,22 @@ def _expr(node, env, definitions):
                 if not isinstance(value, DictValue):
                     raise _Gap("call-binding", "** value")
                 keywords.extend(
-                    (key.value, entry)
+                    ConstructedCallActualV1(
+                        _node_occurrence(item.value, callee.source_cid),
+                        entry,
+                        keyword=key.value,
+                    )
                     for key, entry in value.entries
                     if isinstance(key, StringValue)
                 )
             else:
-                keywords.append((item.arg, value))
+                keywords.append(
+                    ConstructedCallActualV1(
+                        _node_occurrence(item.value, callee.source_cid),
+                        value,
+                        keyword=item.arg,
+                    )
+                )
         called = _invoke(callee, tuple(positional), tuple(keywords), definitions)
         return called.value, (*frames, *called.frames)
     raise _Gap("unsupported-source", type(node).__name__)
@@ -361,9 +521,9 @@ def _literal(node):
     if value is None:
         return NoneValue()
     if value is True:
-        return TrueBoolLiteralSugar(None)
+        return TermValue(True)
     if value is False:
-        return FalseBoolLiteralSugar(None)
+        return TermValue(False)
     if isinstance(value, int):
         return TermValue(value)
     if isinstance(value, str):
@@ -392,6 +552,7 @@ def _binding_value(binding):
         "formal": binding.coordinate.__dict__,
         "actual": _floor_value(binding.actual),
         "provenance": binding.provenance,
+        "actualOccurrences": [item.wire() for item in binding.actual_occurrences],
     }
 
 
@@ -414,4 +575,14 @@ def _coordinate_cid(resolved):
             "endLine": coordinate.end_line,
             "endColumn": coordinate.end_col,
         }
+    )
+
+
+def _node_occurrence(node: ast.AST, source_cid: str) -> SourceFragmentCoordinateV1:
+    return SourceFragmentCoordinateV1(
+        source_cid,
+        node.lineno,
+        node.col_offset,
+        node.end_lineno,
+        node.end_col_offset,
     )

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1,0 +1,417 @@
+"""Cut C: ordinary authenticated Python factory construction.
+
+The constructor consumes only Cut A graph objects and already-constructed
+actuals. Unsupported control flow or opaque calls produce typed gaps; no host
+module is imported or executed.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+import inspect
+import json
+from typing import Any, Literal
+
+from sugar_lift_py_tests.floor import (
+    DictValue,
+    FloorValue,
+    NoneValue,
+    ObjectField,
+    ObjectValue,
+    StringValue,
+    SymbolicValue,
+    TermValue,
+    TupleValue,
+)
+from sugar_lift_py_tests.ir import ctor, encode_jcs, str_const, term_to_value
+from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+from .canonical import cid_of_json
+from .dependency_artifact import DependencyArtifactGraph, ResolvedPythonObjectV1
+
+
+@dataclass(frozen=True)
+class FormalParameterCoordinateV1:
+    definition_cid: str
+    parameter_index: int
+    formal_name: str
+    passing: str
+
+
+@dataclass(frozen=True)
+class FormalActualBindingV1:
+    coordinate: FormalParameterCoordinateV1
+    formal_name: str
+    actual: FloorValue = field(compare=False)
+    provenance: Literal["actual", "default", "variadic"]
+
+
+@dataclass(frozen=True)
+class ConstructedCallFrameV1:
+    definition_name: str
+    definition_cid: str
+    formal_actual_cid: str
+
+
+@dataclass(frozen=True)
+class ConstructedManagerBehaviorV1:
+    resolved_object_cid: str
+    manager_construction_cid: str
+    receiver_state: ObjectValue = field(compare=False)
+    receiver_state_cid: str
+    formal_actuals: tuple[FormalActualBindingV1, ...] = field(compare=False)
+    call_frames: tuple[ConstructedCallFrameV1, ...]
+
+    def __post_init__(self) -> None:
+        if cid_of_json(_object_value(self.receiver_state)) != self.receiver_state_cid:
+            raise ValueError("receiver state CID does not match constructed fields")
+        if cid_of_json(self._construction_preimage()) != self.manager_construction_cid:
+            raise ValueError("manager construction CID does not match its preimage")
+
+    def _construction_preimage(self) -> dict[str, Any]:
+        return {
+            "kind": "python-manager-construction",
+            "schemaVersion": "1",
+            "resolvedObjectCid": self.resolved_object_cid,
+            "receiverStateCid": self.receiver_state_cid,
+            "formalActuals": [_binding_value(item) for item in self.formal_actuals],
+            "callFrames": [frame.__dict__ for frame in self.call_frames],
+        }
+
+    def to_value(self) -> dict[str, Any]:
+        return {
+            "kind": "constructed-manager-behavior",
+            "schemaVersion": "1",
+            "resolvedObjectCid": self.resolved_object_cid,
+            "managerConstructionCid": self.manager_construction_cid,
+            "receiverStateCid": self.receiver_state_cid,
+            "callFrames": [frame.__dict__ for frame in self.call_frames],
+            "formalActuals": [_binding_value(item) for item in self.formal_actuals],
+        }
+
+
+@dataclass(frozen=True)
+class ManagerConstructionGapV1:
+    kind: Literal[
+        "artifact-mismatch",
+        "definition-missing",
+        "call-binding",
+        "unsupported-source",
+        "opaque-call-target",
+        "non-manager-result",
+    ]
+    resolved_object_cid: str
+    detail: str
+
+
+class _Gap(Exception):
+    def __init__(self, kind: str, detail: str):
+        self.kind = kind
+        self.detail = detail
+
+
+@dataclass(frozen=True)
+class _Definition:
+    node: ast.FunctionDef | ast.ClassDef
+    source_cid: str
+
+    @property
+    def cid(self) -> str:
+        return cid_of_json(
+            {
+                "sourceCid": self.source_cid,
+                "name": self.node.name,
+                "line": self.node.lineno,
+                "column": self.node.col_offset,
+                "endLine": self.node.end_lineno,
+                "endColumn": self.node.end_col_offset,
+            }
+        )
+
+
+@dataclass(frozen=True)
+class _Invocation:
+    value: FloorValue
+    bindings: tuple[FormalActualBindingV1, ...]
+    frames: tuple[ConstructedCallFrameV1, ...]
+
+
+def construct_manager_behavior(
+    resolved: ResolvedPythonObjectV1,
+    *,
+    graph: DependencyArtifactGraph,
+    positional_actuals: tuple[FloorValue, ...],
+    keyword_actuals: tuple[tuple[str, FloorValue], ...] = (),
+) -> ConstructedManagerBehaviorV1 | ManagerConstructionGapV1:
+    if graph.distribution_artifact_cid != resolved.distribution_artifact_cid:
+        return ManagerConstructionGapV1(
+            "artifact-mismatch", resolved.cid, "artifact CID"
+        )
+    module = graph.modules.get(resolved.module_name)
+    if module is None or module.source_cid != resolved.source_cid:
+        return ManagerConstructionGapV1("artifact-mismatch", resolved.cid, "source CID")
+    tree = ast.parse(module.source, filename=module.source_seat)
+    definitions = {
+        node.name: _Definition(node, module.source_cid)
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.ClassDef))
+    }
+    definition = definitions.get(resolved.definition.name)
+    if definition is None or definition.cid != _coordinate_cid(resolved):
+        return ManagerConstructionGapV1(
+            "definition-missing", resolved.cid, "coordinate"
+        )
+    try:
+        invocation = _invoke(
+            definition, positional_actuals, keyword_actuals, definitions
+        )
+    except _Gap as gap:
+        return ManagerConstructionGapV1(gap.kind, resolved.cid, gap.detail)
+    if not isinstance(invocation.value, ObjectValue):
+        return ManagerConstructionGapV1(
+            "non-manager-result", resolved.cid, "not object"
+        )
+    state = _object_value(invocation.value)
+    state_cid = cid_of_json(state)
+    preimage = {
+        "kind": "python-manager-construction",
+        "schemaVersion": "1",
+        "resolvedObjectCid": resolved.cid,
+        "receiverStateCid": state_cid,
+        "formalActuals": [_binding_value(item) for item in invocation.bindings],
+        "callFrames": [frame.__dict__ for frame in invocation.frames],
+    }
+    return ConstructedManagerBehaviorV1(
+        resolved.cid,
+        cid_of_json(preimage),
+        invocation.value,
+        state_cid,
+        invocation.bindings,
+        invocation.frames,
+    )
+
+
+def _invoke(definition, positional, keywords, definitions) -> _Invocation:
+    if isinstance(definition.node, ast.ClassDef):
+        return _construct_class(definition, positional, keywords, definitions)
+    bindings, env = _bind(definition, positional, keywords)
+    env.update(definitions)
+    frames = [_frame(definition, bindings)]
+    for statement in definition.node.body:
+        if isinstance(statement, ast.Return) and statement.value is not None:
+            value, nested = _expr(statement.value, env, definitions)
+            return _Invocation(value, bindings, (*frames, *nested))
+        if isinstance(statement, (ast.Global, ast.Nonlocal)):
+            continue
+        raise _Gap("unsupported-source", type(statement).__name__)
+    raise _Gap("unsupported-source", "function has no value return")
+
+
+def _construct_class(definition, positional, keywords, definitions) -> _Invocation:
+    init = next(
+        (
+            item
+            for item in definition.node.body
+            if isinstance(item, ast.FunctionDef) and item.name == "__init__"
+        ),
+        None,
+    )
+    if init is None or definition.node.decorator_list:
+        raise _Gap("opaque-call-target", "class construction is dynamic")
+    init_def = _Definition(init, definition.source_cid)
+    bindings, env = _bind(init_def, positional, keywords, skip_first=True)
+    env.update(definitions)
+    fields: list[ObjectField] = []
+    frames = [_frame(init_def, bindings)]
+    for statement in init.body:
+        if not (isinstance(statement, ast.Assign) and len(statement.targets) == 1):
+            raise _Gap("unsupported-source", type(statement).__name__)
+        target = statement.targets[0]
+        if not (
+            isinstance(target, ast.Attribute)
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "self"
+        ):
+            raise _Gap("unsupported-source", "constructor target")
+        value, nested = _expr(statement.value, env, definitions)
+        fields.append(ObjectField(target.attr, value))
+        frames.extend(nested)
+    receiver = ObjectValue(definition.node.name, tuple(fields), identity=definition.cid)
+    return _Invocation(receiver, bindings, tuple(frames))
+
+
+def _bind(definition, positional, keywords, skip_first=False):
+    node = definition.node
+    if not isinstance(node, ast.FunctionDef):
+        raise _Gap("call-binding", "not function")
+    raw = [*node.args.posonlyargs, *node.args.args]
+    if skip_first:
+        raw = raw[1:]
+    parameters: list[inspect.Parameter] = []
+    defaults = [None] * (len(raw) - len(node.args.defaults)) + list(node.args.defaults)
+    for index, (argument, default) in enumerate(zip(raw, defaults, strict=True)):
+        kind = (
+            inspect.Parameter.POSITIONAL_ONLY
+            if index < len(node.args.posonlyargs)
+            else inspect.Parameter.POSITIONAL_OR_KEYWORD
+        )
+        parameters.append(
+            inspect.Parameter(
+                argument.arg,
+                kind,
+                default=(
+                    inspect.Parameter.empty if default is None else _literal(default)
+                ),
+            )
+        )
+    if node.args.vararg:
+        parameters.append(
+            inspect.Parameter(node.args.vararg.arg, inspect.Parameter.VAR_POSITIONAL)
+        )
+    for argument, default in zip(
+        node.args.kwonlyargs, node.args.kw_defaults, strict=True
+    ):
+        parameters.append(
+            inspect.Parameter(
+                argument.arg,
+                inspect.Parameter.KEYWORD_ONLY,
+                default=(
+                    inspect.Parameter.empty if default is None else _literal(default)
+                ),
+            )
+        )
+    if node.args.kwarg:
+        parameters.append(
+            inspect.Parameter(node.args.kwarg.arg, inspect.Parameter.VAR_KEYWORD)
+        )
+    signature = inspect.Signature(parameters)
+    try:
+        bound = signature.bind(*positional, **dict(keywords))
+    except TypeError as exc:
+        raise _Gap("call-binding", str(exc)) from exc
+    supplied = set(bound.arguments)
+    bound.apply_defaults()
+    result = []
+    env = {}
+    for index, parameter in enumerate(parameters):
+        value = bound.arguments[parameter.name]
+        if parameter.kind is inspect.Parameter.VAR_POSITIONAL:
+            value = TupleValue(tuple(value))
+            provenance = "variadic"
+        elif parameter.kind is inspect.Parameter.VAR_KEYWORD:
+            value = DictValue(tuple((StringValue(k), v) for k, v in value.items()))
+            provenance = "variadic"
+        else:
+            provenance = "actual" if parameter.name in supplied else "default"
+        coordinate = FormalParameterCoordinateV1(
+            definition.cid, index, parameter.name, parameter.kind.name
+        )
+        binding = FormalActualBindingV1(coordinate, parameter.name, value, provenance)
+        result.append(binding)
+        env[parameter.name] = value
+    return tuple(result), env
+
+
+def _expr(node, env, definitions):
+    if isinstance(node, ast.Name):
+        if node.id not in env:
+            raise _Gap("opaque-call-target", node.id)
+        return env[node.id], ()
+    if isinstance(node, ast.Constant):
+        return _literal(node), ()
+    if isinstance(node, ast.Call):
+        callee, frames = _expr(node.func, env, definitions)
+        if not isinstance(callee, _Definition):
+            raise _Gap("opaque-call-target", "call target")
+        positional = []
+        for item in node.args:
+            if isinstance(item, ast.Starred):
+                value, nested = _expr(item.value, env, definitions)
+                frames = (*frames, *nested)
+                if not isinstance(value, TupleValue):
+                    raise _Gap("call-binding", "* value")
+                positional.extend(value.elements)
+                continue
+            value, nested = _expr(item, env, definitions)
+            positional.append(value)
+            frames = (*frames, *nested)
+        keywords = []
+        for item in node.keywords:
+            value, nested = _expr(item.value, env, definitions)
+            frames = (*frames, *nested)
+            if item.arg is None:
+                if not isinstance(value, DictValue):
+                    raise _Gap("call-binding", "** value")
+                keywords.extend(
+                    (key.value, entry)
+                    for key, entry in value.entries
+                    if isinstance(key, StringValue)
+                )
+            else:
+                keywords.append((item.arg, value))
+        called = _invoke(callee, tuple(positional), tuple(keywords), definitions)
+        return called.value, (*frames, *called.frames)
+    raise _Gap("unsupported-source", type(node).__name__)
+
+
+def _literal(node):
+    value = node.value
+    if value is None:
+        return NoneValue()
+    if value is True:
+        return TrueBoolLiteralSugar(None)
+    if value is False:
+        return FalseBoolLiteralSugar(None)
+    if isinstance(value, int):
+        return TermValue(value)
+    if isinstance(value, str):
+        return StringValue(value)
+    raise _Gap("unsupported-source", "literal")
+
+
+def _floor_value(value):
+    if isinstance(value, ObjectValue):
+        return _object_value(value)
+    return json.loads(encode_jcs(term_to_value(value.to_term(owner="Cut C"))))
+
+
+def _object_value(value):
+    return {
+        "typeDefinitionCid": value.identity,
+        "fields": [
+            {"name": item.name, "value": _floor_value(item.value)}
+            for item in value.fields
+        ],
+    }
+
+
+def _binding_value(binding):
+    return {
+        "formal": binding.coordinate.__dict__,
+        "actual": _floor_value(binding.actual),
+        "provenance": binding.provenance,
+    }
+
+
+def _frame(definition, bindings):
+    return ConstructedCallFrameV1(
+        definition.node.name,
+        definition.cid,
+        cid_of_json([_binding_value(item) for item in bindings]),
+    )
+
+
+def _coordinate_cid(resolved):
+    coordinate = resolved.definition
+    return cid_of_json(
+        {
+            "sourceCid": coordinate.source_cid,
+            "name": coordinate.name,
+            "line": coordinate.start_line,
+            "column": coordinate.start_col,
+            "endLine": coordinate.end_line,
+            "endColumn": coordinate.end_col,
+        }
+    )

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
@@ -148,6 +148,23 @@ def path_source(path: str) -> tuple[str, str, str]:
     return (source, str(path), blake3_512_of(source.encode("utf-8")))
 
 
+def dependency_artifact_file(path: str) -> tuple[bytes, str, str]:
+    """Mint one recorded dependency file as ``(bytes, seat, content CID)``.
+
+    The dependency artifact graph supplies the seat; this door only reads and
+    content-addresses it.  It performs no module lookup, import, or execution.
+    Binary files are admitted because a distribution artifact authenticates
+    every recorded byte, not only Python source files.
+    """
+    try:
+        content = Path(path).read_bytes()
+    except (OSError, ValueError) as exc:
+        raise SourceUnavailable(
+            f"cannot read dependency artifact file `{path}`: {exc}"
+        ) from exc
+    return content, str(path), blake3_512_of(content)
+
+
 def resolve_span_memento(
     memento: dict[str, Any], project_root: str | None = None
 ) -> dict[str, Any]:

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -19,6 +19,7 @@ from sugar_lift_python_source.dependency_artifact import (
     PythonObjectResolutionGapV1,
     ResolvedPythonObjectV1,
     resolve_import_binding,
+    export_statement_coverage,
 )
 from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
 
@@ -308,3 +309,54 @@ def test_later_non_name_assignment_makes_export_dynamic(tmp_path: Path) -> None:
 
     assert isinstance(result, PythonObjectResolutionGapV1)
     assert result.kind == "dynamic-export"
+
+
+@pytest.mark.parametrize(
+    ("implementation", "expected_line"),
+    (
+        (
+            "def build(value):\n    return 'old'\n"
+            "with object():\n"
+            "    def build(value):\n        return value\n",
+            4,
+        ),
+        (
+            "def build(value):\n    return 'old'\n"
+            "match 1:\n"
+            "    case _:\n"
+            "        def build(value):\n            return value\n",
+            5,
+        ),
+        (
+            "def build(value):\n    return 'old'\n"
+            "try:\n"
+            "    def build(value):\n        return value\n"
+            "except* Exception:\n    pass\n",
+            4,
+        ),
+    ),
+    ids=("with", "match", "try-star"),
+)
+def test_compound_statement_later_definition_is_the_authenticated_export(
+    tmp_path: Path, implementation: str, expected_line: int
+) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        _install_distribution(
+            tmp_path,
+            package_source="from example_pkg.implementation import build\n",
+            implementation_source=implementation,
+        )
+    )
+    result = resolve_import_binding(_demand(tmp_path), graph=graph)
+
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.definition.start_line == expected_line
+    assert result.definition.start_line != 1
+
+
+def test_export_transfer_exhaustively_classifies_running_ast_statement_grammar() -> (
+    None
+):
+    missing, extra = export_statement_coverage()
+    assert missing == []
+    assert extra == []

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+from __future__ import annotations
+
+import csv
+from dataclasses import replace
+import importlib.metadata
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+from sugar_lift_python_source.dependency_artifact import (
+    DependencyArtifactAuthenticationError,
+    DependencyArtifactGraph,
+    PythonObjectResolutionGapV1,
+    ResolvedPythonObjectV1,
+    resolve_import_binding,
+)
+from sugar_lift_python_source.canonical import blake3_512_of
+
+
+def _install_distribution(
+    root: Path, *, package_source: str, implementation_source: str
+) -> importlib.metadata.Distribution:
+    package = root / "example_pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text(package_source, encoding="utf-8")
+    (package / "implementation.py").write_text(implementation_source, encoding="utf-8")
+    metadata = root / "example_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: example-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    (metadata / "top_level.txt").write_text("example_pkg\n", encoding="utf-8")
+    recorded = (
+        "example_pkg/__init__.py",
+        "example_pkg/implementation.py",
+        "example_dist-1.0.dist-info/METADATA",
+        "example_dist-1.0.dist-info/top_level.txt",
+        "example_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for path in recorded:
+            writer.writerow((path, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _demand(
+    root: Path, source: str = "import example_pkg\nexample_pkg.build(1)\n"
+) -> dict[str, object]:
+    from sugar_lift_py_tests.import_binding import authenticated_import_uses
+
+    path = root / "consumer.py"
+    path.write_text(source, encoding="utf-8")
+    source_cid = blake3_512_of(source.encode("utf-8"))
+    rows, outcomes = authenticated_import_uses(
+        root, path, source, source_cid, module_identities={}
+    )
+    assert set(outcomes.values()) == {"authenticated-import-use"}
+    return next(item for item in rows if item["kind"] == "call-contract-demand")
+
+
+def test_static_reexport_resolves_to_content_addressed_definition_without_import(
+    tmp_path: Path,
+) -> None:
+    distribution = _install_distribution(
+        tmp_path,
+        package_source=(
+            "from example_pkg.implementation import build\n"
+            "raise RuntimeError('module execution is forbidden')\n"
+        ),
+        implementation_source="def build(value):\n    return value\n",
+    )
+    sys.modules.pop("example_pkg", None)
+    sys.modules.pop("example_pkg.implementation", None)
+
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    demand = _demand(tmp_path)
+    result = resolve_import_binding(
+        demand["importBinding"], target_symbol=demand["targetSymbol"], graph=graph
+    )
+
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.distribution_artifact_cid == graph.distribution_artifact_cid
+    assert result.module_name == "example_pkg.implementation"
+    assert result.source_cid == graph.modules[result.module_name].source_cid
+    assert result.definition.kind == "function"
+    assert result.definition.name == "build"
+    assert result.definition.source_cid == result.source_cid
+    assert len(result.reexport_warrants) == 1
+    assert result.reexport_warrants[0].from_module == "example_pkg"
+    assert result.reexport_warrants[0].to_module == "example_pkg.implementation"
+    assert result.cid.startswith("blake3-512:")
+    assert "example_pkg" not in sys.modules
+    assert "example_pkg.implementation" not in sys.modules
+
+
+def test_resolved_python_object_round_trips_with_identical_cid(tmp_path: Path) -> None:
+    distribution = _install_distribution(
+        tmp_path,
+        package_source="from example_pkg.implementation import build\n",
+        implementation_source="class build:\n    pass\n",
+    )
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    demand = _demand(tmp_path, "from example_pkg import build as make\nmake(1)\n")
+    result = resolve_import_binding(
+        demand["importBinding"], target_symbol=demand["targetSymbol"], graph=graph
+    )
+    assert isinstance(result, ResolvedPythonObjectV1)
+
+    encoded = json.loads(json.dumps(result.to_value(), sort_keys=True))
+    decoded = ResolvedPythonObjectV1.from_value(encoded)
+
+    assert decoded == result
+    assert decoded.cid == result.cid
+    assert decoded.definition.kind == "class"
+
+
+def test_dynamic_export_stays_a_typed_loud_gap(tmp_path: Path) -> None:
+    distribution = _install_distribution(
+        tmp_path,
+        package_source=("def __getattr__(name):\n" "    return object()\n"),
+        implementation_source="def build(value):\n    return value\n",
+    )
+    graph = DependencyArtifactGraph.authenticate(distribution)
+
+    demand = _demand(tmp_path)
+    result = resolve_import_binding(
+        demand["importBinding"], target_symbol=demand["targetSymbol"], graph=graph
+    )
+
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+    assert result.import_binding_cid.startswith("blake3-512:")
+    assert result.distribution_artifact_cid == graph.distribution_artifact_cid
+
+
+def test_real_pytest_reexport_resolves_without_manager_name_recognition(
+    tmp_path: Path,
+) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        importlib.metadata.distribution("pytest")
+    )
+    demand = _demand(tmp_path, "import pytest\npytest.raises(ValueError)\n")
+
+    result = resolve_import_binding(
+        demand["importBinding"], target_symbol=demand["targetSymbol"], graph=graph
+    )
+
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.definition.name == "raises"
+    assert result.definition.kind == "function"
+    assert result.module_name != "pytest"
+    assert result.reexport_warrants
+    assert result.definition.source_cid == result.source_cid
+
+
+def test_fabricated_artifact_file_wrapper_is_loud(tmp_path: Path) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        _install_distribution(
+            tmp_path,
+            package_source="from example_pkg.implementation import build\n",
+            implementation_source="def build(value):\n    return value\n",
+        )
+    )
+
+    with pytest.raises(DependencyArtifactAuthenticationError):
+        replace(graph.files[0], content=b"forged bytes")

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -7,17 +7,20 @@ import importlib.metadata
 import json
 from pathlib import Path
 import sys
+from types import MappingProxyType
 
 import pytest
+from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
 
 from sugar_lift_python_source.dependency_artifact import (
     DependencyArtifactAuthenticationError,
     DependencyArtifactGraph,
+    AuthenticatedModuleSourceV1,
     PythonObjectResolutionGapV1,
     ResolvedPythonObjectV1,
     resolve_import_binding,
 )
-from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
 
 
 def _install_distribution(
@@ -50,17 +53,18 @@ def _install_distribution(
 
 def _demand(
     root: Path, source: str = "import example_pkg\nexample_pkg.build(1)\n"
-) -> dict[str, object]:
-    from sugar_lift_py_tests.import_binding import authenticated_import_uses
+) -> AuthenticatedImportUseV1:
+    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
 
     path = root / "consumer.py"
     path.write_text(source, encoding="utf-8")
     source_cid = blake3_512_of(source.encode("utf-8"))
-    rows, outcomes = authenticated_import_uses(
+    receipts, outcomes = authenticated_import_use_receipts(
         root, path, source, source_cid, module_identities={}
     )
     assert set(outcomes.values()) == {"authenticated-import-use"}
-    return next(item for item in rows if item["kind"] == "call-contract-demand")
+    assert len(receipts) == 1
+    return receipts[0]
 
 
 def test_static_reexport_resolves_to_content_addressed_definition_without_import(
@@ -79,9 +83,7 @@ def test_static_reexport_resolves_to_content_addressed_definition_without_import
 
     graph = DependencyArtifactGraph.authenticate(distribution)
     demand = _demand(tmp_path)
-    result = resolve_import_binding(
-        demand["importBinding"], target_symbol=demand["targetSymbol"], graph=graph
-    )
+    result = resolve_import_binding(demand, graph=graph)
 
     assert isinstance(result, ResolvedPythonObjectV1)
     assert result.distribution_artifact_cid == graph.distribution_artifact_cid
@@ -106,13 +108,13 @@ def test_resolved_python_object_round_trips_with_identical_cid(tmp_path: Path) -
     )
     graph = DependencyArtifactGraph.authenticate(distribution)
     demand = _demand(tmp_path, "from example_pkg import build as make\nmake(1)\n")
-    result = resolve_import_binding(
-        demand["importBinding"], target_symbol=demand["targetSymbol"], graph=graph
-    )
+    result = resolve_import_binding(demand, graph=graph)
     assert isinstance(result, ResolvedPythonObjectV1)
 
     encoded = json.loads(json.dumps(result.to_value(), sort_keys=True))
-    decoded = ResolvedPythonObjectV1.from_value(encoded)
+    decoded = ResolvedPythonObjectV1.from_value(
+        encoded, graph=graph, authenticated_use=demand
+    )
 
     assert decoded == result
     assert decoded.cid == result.cid
@@ -128,9 +130,7 @@ def test_dynamic_export_stays_a_typed_loud_gap(tmp_path: Path) -> None:
     graph = DependencyArtifactGraph.authenticate(distribution)
 
     demand = _demand(tmp_path)
-    result = resolve_import_binding(
-        demand["importBinding"], target_symbol=demand["targetSymbol"], graph=graph
-    )
+    result = resolve_import_binding(demand, graph=graph)
 
     assert isinstance(result, PythonObjectResolutionGapV1)
     assert result.kind == "dynamic-export"
@@ -146,9 +146,7 @@ def test_real_pytest_reexport_resolves_without_manager_name_recognition(
     )
     demand = _demand(tmp_path, "import pytest\npytest.raises(ValueError)\n")
 
-    result = resolve_import_binding(
-        demand["importBinding"], target_symbol=demand["targetSymbol"], graph=graph
-    )
+    result = resolve_import_binding(demand, graph=graph)
 
     assert isinstance(result, ResolvedPythonObjectV1)
     assert result.definition.name == "raises"
@@ -169,3 +167,144 @@ def test_fabricated_artifact_file_wrapper_is_loud(tmp_path: Path) -> None:
 
     with pytest.raises(DependencyArtifactAuthenticationError):
         replace(graph.files[0], content=b"forged bytes")
+
+
+def test_recorded_source_seat_cannot_be_relabelled_as_invented_module(
+    tmp_path: Path,
+) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        _install_distribution(
+            tmp_path,
+            package_source="from example_pkg.implementation import build\n",
+            implementation_source="def build(value):\n    return value\n",
+        )
+    )
+    real = graph.modules["example_pkg.implementation"]
+    invented = AuthenticatedModuleSourceV1(
+        module_name="invented.module",
+        source_seat=real.source_seat,
+        source_cid=real.source_cid,
+        source=real.source,
+    )
+
+    with pytest.raises(
+        DependencyArtifactAuthenticationError,
+        match="module source is not projected",
+    ):
+        replace(graph, modules=MappingProxyType({"invented.module": invented}))
+
+
+def test_fabricated_import_binding_mapping_is_rejected_at_resolution_door(
+    tmp_path: Path,
+) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        _install_distribution(
+            tmp_path,
+            package_source="from example_pkg.implementation import build\n",
+            implementation_source="def build(value):\n    return value\n",
+        )
+    )
+    fabricated = _demand(tmp_path).import_binding.to_value()
+
+    with pytest.raises(
+        DependencyArtifactAuthenticationError,
+        match="AuthenticatedImportUseV1",
+    ):
+        resolve_import_binding(fabricated, graph=graph)
+
+
+def test_final_checked_import_use_rejects_fabricated_definition_coordinate(
+    tmp_path: Path,
+) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        _install_distribution(
+            tmp_path,
+            package_source="from example_pkg.implementation import build\n",
+            implementation_source="def build(value):\n    return value\n",
+        )
+    )
+    receipt = _demand(tmp_path)
+    binding_value = receipt.import_binding.to_value()
+    binding_value["definitionSite"]["startLine"] = 999
+    binding_cid = cid_of_json(binding_value)
+    forged_binding = replace(
+        receipt.import_binding, value=binding_value, cid=binding_cid
+    )
+    use = dict(receipt.use)
+    use["importBindingCid"] = binding_cid
+    use["cid"] = cid_of_json({key: value for key, value in use.items() if key != "cid"})
+    demand = dict(receipt.demand)
+    demand["importBinding"] = binding_value
+    demand["importBindingCid"] = binding_cid
+    demand["authenticatedImportUse"] = use
+    forged_receipt = replace(
+        receipt,
+        import_binding=forged_binding,
+        use=use,
+        demand=demand,
+    )
+
+    with pytest.raises(
+        DependencyArtifactAuthenticationError,
+        match="lexical revalidation",
+    ):
+        resolve_import_binding(forged_receipt, graph=graph)
+
+
+def test_recomputed_outer_cid_cannot_authenticate_invented_resolved_artifact(
+    tmp_path: Path,
+) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        _install_distribution(
+            tmp_path,
+            package_source="from example_pkg.implementation import build\n",
+            implementation_source="def build(value):\n    return value\n",
+        )
+    )
+    demand = _demand(tmp_path)
+    resolved = resolve_import_binding(demand, graph=graph)
+    assert isinstance(resolved, ResolvedPythonObjectV1)
+    forged = resolved.to_value()
+    forged["moduleName"] = "invented.module"
+    forged["cid"] = cid_of_json(
+        {key: value for key, value in forged.items() if key != "cid"}
+    )
+
+    with pytest.raises(
+        DependencyArtifactAuthenticationError,
+        match="byte-identical",
+    ):
+        ResolvedPythonObjectV1.from_value(forged, graph=graph, authenticated_use=demand)
+
+
+def test_final_reaching_definition_wins_without_decorator_name_recognition(
+    tmp_path: Path,
+) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        _install_distribution(
+            tmp_path,
+            package_source="from example_pkg.implementation import build\n",
+            implementation_source=(
+                "def build(value):\n    return 'typing-only'\n\n"
+                "def build(value):\n    return value\n"
+            ),
+        )
+    )
+    resolved = resolve_import_binding(_demand(tmp_path), graph=graph)
+
+    assert isinstance(resolved, ResolvedPythonObjectV1)
+    assert resolved.definition.start_line == 4
+
+
+def test_later_non_name_assignment_makes_export_dynamic(tmp_path: Path) -> None:
+    graph = DependencyArtifactGraph.authenticate(
+        _install_distribution(
+            tmp_path,
+            package_source="from example_pkg.implementation import build\n",
+            implementation_source="def build(value):\n    return value\nbuild = 42\n",
+        )
+    )
+    result = resolve_import_binding(_demand(tmp_path), graph=graph)
+
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"

--- a/implementations/python/sugar-lift-python-source/tests/test_manager_factory_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_manager_factory_construction.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import replace
+import importlib.metadata
+import json
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.floor import ObjectValue, SymbolicValue
+from sugar_lift_py_tests.ir import ctor, str_const
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.dependency_artifact import (
+    DependencyArtifactGraph,
+    ResolvedPythonObjectV1,
+    resolve_import_binding,
+)
+from sugar_lift_python_source.manager_construction import (
+    ConstructedManagerBehaviorV1,
+    ManagerConstructionGapV1,
+    construct_manager_behavior,
+)
+
+
+def _installed(root: Path, source: str) -> importlib.metadata.Distribution:
+    package = root / "arbitrary"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        "from arbitrary.manager import some_manager\n", encoding="utf-8"
+    )
+    (package / "manager.py").write_text(source, encoding="utf-8")
+    metadata = root / "arbitrary_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: arbitrary-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    files = (
+        "arbitrary/__init__.py",
+        "arbitrary/manager.py",
+        "arbitrary_dist-1.0.dist-info/METADATA",
+        "arbitrary_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for file in files:
+            writer.writerow((file, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _resolved(root: Path, source: str):
+    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+
+    graph = DependencyArtifactGraph.authenticate(_installed(root, source))
+    consumer_source = "import arbitrary\narbitrary.some_manager(ExpectedError)\n"
+    path = root / "consumer.py"
+    path.write_text(consumer_source, encoding="utf-8")
+    receipts, _ = authenticated_import_use_receipts(
+        root,
+        path,
+        consumer_source,
+        blake3_512_of(consumer_source.encode()),
+    )
+    resolved = resolve_import_binding(receipts[0], graph=graph)
+    assert isinstance(resolved, ResolvedPythonObjectV1)
+    return graph, resolved
+
+
+SOURCE = """
+class SomeGuard:
+    def __init__(self, expected, *, match=None, **observations):
+        self.expected = expected
+        self.match = match
+        self.observations = observations
+
+def helper(expected, *labels, match=None, **observations):
+    return SomeGuard(expected, match=match, **observations)
+
+def some_manager(expected, *labels, match=None, **observations):
+    return helper(expected, *labels, match=match, **observations)
+"""
+
+
+def test_renamed_factory_constructs_receiver_state_defaults_variadics_and_helpers(
+    tmp_path,
+):
+    graph, resolved = _resolved(tmp_path, SOURCE)
+    expected = SymbolicValue(ctor("python:type", [str_const("fixture.Expected")]))
+    result = construct_manager_behavior(
+        resolved,
+        graph=graph,
+        positional_actuals=(expected, SymbolicValue(str_const("real-label"))),
+        keyword_actuals=(("label", SymbolicValue(str_const("real-entry"))),),
+    )
+
+    assert isinstance(result, ConstructedManagerBehaviorV1)
+    assert isinstance(result.receiver_state, ObjectValue)
+    fields = {field.name: field.value for field in result.receiver_state.fields}
+    assert fields["expected"] is expected
+    assert fields["match"].to_term(owner="test").name == "None"
+    assert result.call_frames[1].definition_name == "helper"
+    assert result.formal_actuals[-1].formal_name == "observations"
+    assert result.manager_construction_cid.startswith("blake3-512:")
+    assert (
+        json.loads(json.dumps(result.to_value(), sort_keys=True)) == result.to_value()
+    )
+
+    with pytest.raises(ValueError, match="manager construction CID"):
+        replace(result, manager_construction_cid="blake3-512:" + "00" * 64)
+
+
+def test_opaque_factory_stays_typed_loud(tmp_path):
+    graph, resolved = _resolved(
+        tmp_path, "def some_manager(value):\n    return len(value)\n"
+    )
+    result = construct_manager_behavior(
+        resolved,
+        graph=graph,
+        positional_actuals=(SymbolicValue(str_const("value")),),
+    )
+    assert isinstance(result, ManagerConstructionGapV1)
+    assert result.kind == "opaque-call-target"

--- a/implementations/python/sugar-lift-python-source/tests/test_manager_factory_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_manager_factory_construction.py
@@ -17,10 +17,13 @@ from sugar_lift_python_source.dependency_artifact import (
     resolve_import_binding,
 )
 from sugar_lift_python_source.manager_construction import (
+    ConstructedCallActualV1,
     ConstructedManagerBehaviorV1,
+    ManagerConstructionAuthenticationError,
     ManagerConstructionGapV1,
     construct_manager_behavior,
 )
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
 
 
 def _installed(root: Path, source: str) -> importlib.metadata.Distribution:
@@ -64,7 +67,7 @@ def _resolved(root: Path, source: str):
     )
     resolved = resolve_import_binding(receipts[0], graph=graph)
     assert isinstance(resolved, ResolvedPythonObjectV1)
-    return graph, resolved
+    return graph, resolved, receipts[0]
 
 
 SOURCE = """
@@ -85,13 +88,38 @@ def some_manager(expected, *labels, match=None, **observations):
 def test_renamed_factory_constructs_receiver_state_defaults_variadics_and_helpers(
     tmp_path,
 ):
-    graph, resolved = _resolved(tmp_path, SOURCE)
+    graph, resolved, authenticated_use = _resolved(tmp_path, SOURCE)
     expected = SymbolicValue(ctor("python:type", [str_const("fixture.Expected")]))
+    call_site = SourceFragmentCoordinateV1.decode(authenticated_use.use["useSite"])
+    expected_occurrence = SourceFragmentCoordinateV1(
+        authenticated_use.source_cid, 2, 23, 2, 36
+    )
+    label_occurrence = SourceFragmentCoordinateV1(
+        authenticated_use.source_cid, 2, 38, 2, 50
+    )
+    entry_occurrence = SourceFragmentCoordinateV1(
+        authenticated_use.source_cid, 2, 58, 2, 70
+    )
+    positional_actuals = (
+        ConstructedCallActualV1(expected_occurrence, expected),
+        ConstructedCallActualV1(
+            label_occurrence, SymbolicValue(str_const("real-label"))
+        ),
+    )
+    keyword_actuals = (
+        ConstructedCallActualV1(
+            entry_occurrence,
+            SymbolicValue(str_const("real-entry")),
+            keyword="label",
+        ),
+    )
     result = construct_manager_behavior(
         resolved,
         graph=graph,
-        positional_actuals=(expected, SymbolicValue(str_const("real-label"))),
-        keyword_actuals=(("label", SymbolicValue(str_const("real-entry"))),),
+        authenticated_use=authenticated_use,
+        manager_call_occurrence=call_site,
+        positional_actuals=positional_actuals,
+        keyword_actuals=keyword_actuals,
     )
 
     assert isinstance(result, ConstructedManagerBehaviorV1)
@@ -102,22 +130,89 @@ def test_renamed_factory_constructs_receiver_state_defaults_variadics_and_helper
     assert result.call_frames[1].definition_name == "helper"
     assert result.formal_actuals[-1].formal_name == "observations"
     assert result.manager_construction_cid.startswith("blake3-512:")
+    encoded = json.loads(json.dumps(result.to_value(), sort_keys=True))
     assert (
-        json.loads(json.dumps(result.to_value(), sort_keys=True)) == result.to_value()
+        ConstructedManagerBehaviorV1.from_value(
+            encoded,
+            resolved=resolved,
+            graph=graph,
+            authenticated_use=authenticated_use,
+            manager_call_occurrence=call_site,
+            positional_actuals=positional_actuals,
+            keyword_actuals=keyword_actuals,
+        )
+        == result
     )
+    assert result.manager_call_occurrence == call_site
+    assert result.returned_object_cid.startswith("blake3-512:")
+    assert result.formal_actuals[0].actual_occurrences == (expected_occurrence,)
+    assert result.formal_actuals[2].provenance == "default"
+    assert len(result.formal_actuals[2].actual_occurrences) == 1
+    assert result.formal_actuals[1].provenance == "variadic"
+    assert result.formal_actuals[1].actual_occurrences == (label_occurrence,)
+
+    forged = dict(encoded)
+    forged["receiverStateCid"] = "blake3-512:" + "01" * 64
+    with pytest.raises(ManagerConstructionAuthenticationError, match="byte-identical"):
+        ConstructedManagerBehaviorV1.from_value(
+            forged,
+            resolved=resolved,
+            graph=graph,
+            authenticated_use=authenticated_use,
+            manager_call_occurrence=call_site,
+            positional_actuals=positional_actuals,
+            keyword_actuals=keyword_actuals,
+        )
 
     with pytest.raises(ValueError, match="manager construction CID"):
         replace(result, manager_construction_cid="blake3-512:" + "00" * 64)
 
 
 def test_opaque_factory_stays_typed_loud(tmp_path):
-    graph, resolved = _resolved(
+    graph, resolved, authenticated_use = _resolved(
         tmp_path, "def some_manager(value):\n    return len(value)\n"
     )
     result = construct_manager_behavior(
         resolved,
         graph=graph,
-        positional_actuals=(SymbolicValue(str_const("value")),),
+        authenticated_use=authenticated_use,
+        manager_call_occurrence=SourceFragmentCoordinateV1.decode(
+            authenticated_use.use["useSite"]
+        ),
+        positional_actuals=(
+            ConstructedCallActualV1(
+                SourceFragmentCoordinateV1(authenticated_use.source_cid, 2, 13, 2, 18),
+                SymbolicValue(str_const("value")),
+            ),
+        ),
     )
     assert isinstance(result, ManagerConstructionGapV1)
     assert result.kind == "opaque-call-target"
+
+
+def test_fabricated_or_stale_actual_occurrence_is_loud(tmp_path):
+    with pytest.raises(
+        ManagerConstructionAuthenticationError, match="already-constructed"
+    ):
+        ConstructedCallActualV1(
+            SourceFragmentCoordinateV1("blake3-512:" + "00" * 64, 1, 0, 1, 1),
+            object(),
+        )
+
+    graph, resolved, authenticated_use = _resolved(tmp_path, SOURCE)
+    result = construct_manager_behavior(
+        resolved,
+        graph=graph,
+        authenticated_use=authenticated_use,
+        manager_call_occurrence=SourceFragmentCoordinateV1(
+            "blake3-512:" + "11" * 64, 1, 0, 1, 30
+        ),
+        positional_actuals=(
+            ConstructedCallActualV1(
+                SourceFragmentCoordinateV1("blake3-512:" + "22" * 64, 1, 13, 1, 20),
+                SymbolicValue(str_const("value")),
+            ),
+        ),
+    )
+    assert isinstance(result, ManagerConstructionGapV1)
+    assert result.kind == "call-binding"


### PR DESCRIPTION
## Cut C

Constructs an authenticated resolved Python manager factory through source-visible calls into a content-addressed returned object and receiver state. The producer emits `ConstructedManagerBehaviorV1` for Cuts D/E with:

- authenticated manager call occurrence and constructed operand occurrences
- complete formal/actual bindings, including defaults and variadic provenance
- transitive call-frame testimony for source-visible helpers and constructors
- per-call returned-object CID, receiver-state CID, and manager-construction CID
- decode by reconstruction from Cut A's authenticated graph/import-use receipt and byte-identical comparison

No manager/package spelling, module import/execution, provider path, or source read occurs during construction. Unsupported/native/dynamic call targets remain `ManagerConstructionGapV1`.

## Focused evidence

- Cut C + Cut A + SourceOracle + call-resolution + renamed #6101 acceptance fixtures: 66 passed
- forged raw value, stale operand occurrence, mutated receiver-state receipt: loud
- renamed helper/default/`*args`/`**kwargs` factory: returns the exact constructed expected-type child in receiver state
- opaque `len` factory: typed `opaque-call-target` gap

Predicted epsilon: unlocks Cut D protocol construction and general imported-call/caller-parameter work; this PR does not summarize `__enter__`/`__exit__` or change With.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add interprocedural manager-factory construction and source-derivation test fixtures
> - Adds [manager_construction.py](https://github.com/TSavo/sugar/pull/6104/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1), which reconstructs and authenticates context manager factory invocations from source AST and artifact data, returning a CID-verifiable `ConstructedManagerBehaviorV1` or a typed `ManagerConstructionGapV1` on failure.
> - Supports binding of positional, keyword, variadic, and default arguments; evaluates a restricted expression subset to reconstruct receiver state from `__init__` attribute assignments.
> - Adds test fixtures in `with_source_derivation/` (manager/resource/guard classes, factory functions, consumer cases, and a `cases.json` manifest) to exercise suppression, enter/exit failures, non-exception control transfers, and opaque native managers.
> - Adds test suites validating end-to-end construction, CID round-trips, tampering detection, and typed gaps for opaque or unauthenticated call targets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8b9b05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->