### PR TITLE
drain: ground filtered SetComp/DictComp construction

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/comprehension_iteration_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/comprehension_iteration_recensus.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Measure pandas comprehension/iteration construction without hiding residue."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from collections import Counter, defaultdict
+import json
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import time
+
+
+class FileTimeout(Exception):
+    pass
+
+
+def _timeout(_signum, _frame):
+    raise FileTimeout("per-file construction timeout")
+
+
+def _coordinate(node) -> tuple[str, int, int]:
+    span = node.line_col_span()
+    return node.kind, span.start_line, span.start_col
+
+
+def _syntax_coordinate(node: ast.AST, lines: list[str]) -> tuple[str, int, int]:
+    line = node.lineno
+    byte_col = node.col_offset
+    prefix = lines[line - 1].encode("utf-8")[:byte_col]
+    return type(node).__name__, line, len(prefix.decode("utf-8"))
+
+
+def _contains(node: ast.AST, kinds: tuple[type[ast.AST], ...]) -> bool:
+    return any(
+        isinstance(child, kinds) for child in ast.walk(node) if child is not node
+    )
+
+
+def _contains_or_is(node: ast.AST, kinds: tuple[type[ast.AST], ...]) -> bool:
+    return any(isinstance(child, kinds) for child in ast.walk(node))
+
+
+def _iteration_evidence(iterables: list[ast.expr]) -> str:
+    """Classify syntax-authenticated finite iteration vs a protocol obligation.
+
+    Only list/tuple displays carry their complete element sequence in this AST.
+    A call spelled ``range`` is deliberately not authenticated here: it may be
+    rebound, and the construction pass owns that lexical decision.
+    """
+    if all(isinstance(iterable, (ast.List, ast.Tuple)) for iterable in iterables):
+        return "literal-finite-iteration-evidence"
+    return "iterator-protocol-and-exhaustion-required"
+
+
+def _comprehension_shape(node: ast.AST) -> tuple[str, tuple[str, ...]]:
+    generators = node.generators
+    roots = [generator.iter for generator in generators]
+    if isinstance(node, ast.DictComp):
+        roots.extend((node.key, node.value))
+    else:
+        roots.append(node.elt)
+
+    flags = []
+    if any(generator.is_async for generator in generators):
+        flags.append("async-clause")
+    if any(generator.ifs for generator in generators):
+        flags.append("filter")
+    if len(generators) > 1:
+        flags.append("multiple-generators")
+    if any(not isinstance(generator.target, ast.Name) for generator in generators):
+        flags.append("non-name-target")
+    if any(_contains_or_is(root, (ast.NamedExpr,)) for root in roots):
+        flags.append("named-expression")
+    comprehension_kinds = (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)
+    if any(_contains_or_is(root, comprehension_kinds) for root in roots):
+        flags.append("nested-comprehension")
+    if not flags:
+        flags.append("single-simple-coordinate")
+
+    priority = (
+        "async-clause",
+        "filter",
+        "multiple-generators",
+        "non-name-target",
+        "named-expression",
+        "nested-comprehension",
+        "single-simple-coordinate",
+    )
+    primary = next(label for label in priority if label in flags)
+    flags.append(_iteration_evidence([generator.iter for generator in generators]))
+    return primary, tuple(flags)
+
+
+def _for_shape(node: ast.For | ast.AsyncFor) -> tuple[str, tuple[str, ...]]:
+    flags = []
+    if isinstance(node, ast.AsyncFor):
+        flags.append("async-iteration")
+    if node.orelse:
+        flags.append("else")
+    if not isinstance(node.target, ast.Name):
+        flags.append("non-name-target")
+    if _contains(node, (ast.Break, ast.Continue)):
+        flags.append("loop-control")
+
+    binding_kinds = (ast.Assign, ast.AnnAssign, ast.AugAssign, ast.NamedExpr)
+    has_binding = any(
+        isinstance(descendant, binding_kinds)
+        for statement in node.body
+        for descendant in ast.walk(statement)
+    )
+    has_fact = any(
+        not any(
+            isinstance(descendant, binding_kinds) for descendant in ast.walk(statement)
+        )
+        for statement in node.body
+    )
+    if has_binding and has_fact:
+        flags.append("mixed-accumulator-facts")
+    elif has_binding:
+        flags.append("fold-body")
+    else:
+        flags.append("fact-body")
+
+    priority = (
+        "async-iteration",
+        "loop-control",
+        "else",
+        "non-name-target",
+        "mixed-accumulator-facts",
+        "fold-body",
+        "fact-body",
+    )
+    primary = next(label for label in priority if label in flags)
+    flags.append(_iteration_evidence([node.iter]))
+    return primary, tuple(flags)
+
+
+def _shape(node: ast.AST) -> tuple[str, tuple[str, ...]]:
+    if isinstance(node, (ast.For, ast.AsyncFor)):
+        return _for_shape(node)
+    return _comprehension_shape(node)
+
+
+def _git_commit(root: Path) -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("corpus", type=Path)
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--timeout", type=int, default=180)
+    parser.add_argument("--json", type=Path)
+    args = parser.parse_args()
+
+    from sugar_source_tree.panic import SugarNotWritten
+    from sugar_source_tree.reporter import CollectingReporter
+    from sugar_source_tree.tree import SourceFile
+
+    files = sorted(args.corpus.rglob("*.py"))
+    signal.signal(signal.SIGALRM, _timeout)
+    counts: dict[str, Counter] = defaultdict(Counter)
+    primary_shapes: dict[str, dict[str, Counter]] = defaultdict(
+        lambda: defaultdict(Counter)
+    )
+    shape_axes: dict[str, dict[str, Counter]] = defaultdict(
+        lambda: defaultdict(Counter)
+    )
+    direct_mechanisms: dict[str, Counter] = defaultdict(Counter)
+    defects = []
+    files_completed = 0
+    started = time.time()
+    target_kinds = (
+        ast.ListComp,
+        ast.SetComp,
+        ast.DictComp,
+        ast.GeneratorExp,
+        ast.For,
+        ast.AsyncFor,
+    )
+
+    for index, path in enumerate(files, 1):
+        relative = str(path.relative_to(args.corpus))
+        try:
+            signal.alarm(args.timeout)
+            source = path.read_text(encoding="utf-8", errors="replace")
+            tree = ast.parse(source, filename=str(path))
+            lines = source.splitlines()
+            syntax = {}
+            for node in ast.walk(tree):
+                if isinstance(node, target_kinds):
+                    syntax[_syntax_coordinate(node, lines)] = _shape(node)
+
+            reporter = CollectingReporter()
+            source_file = SourceFile.from_path(str(path), reporter=reporter)
+            for function in source_file.functions():
+                try:
+                    function.sugar()
+                except SugarNotWritten:
+                    pass
+
+            registered = {_coordinate(node) for node in reporter.registered}
+            present = {_coordinate(node) for node in reporter.present}
+            gaps = {_coordinate(node): panic for node, panic in reporter.gaps}
+            for key, (primary, axes) in syntax.items():
+                family = key[0]
+                if key in gaps:
+                    status = "direct-loud"
+                    direct_mechanisms[family][type(gaps[key]).__name__] += 1
+                elif key in present:
+                    status = "built"
+                elif key in registered:
+                    status = "blocked-descendant"
+                else:
+                    status = "unregistered"
+                counts[family][status] += 1
+                primary_shapes[family][primary][status] += 1
+                for axis in axes:
+                    shape_axes[family][axis][status] += 1
+
+            files_completed += 1
+            if index % 100 == 0:
+                direct = sum(row["direct-loud"] for row in counts.values())
+                print(
+                    f"[{index}/{len(files)}] completed={files_completed} "
+                    f"direct-family={direct}",
+                    flush=True,
+                )
+        except BaseException as exc:
+            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                raise
+            defects.append(
+                {"file": relative, "type": type(exc).__name__, "message": str(exc)}
+            )
+            print(
+                f"[{index}/{len(files)}] DEFECT {type(exc).__name__} "
+                f"{relative}: {exc}",
+                flush=True,
+            )
+        finally:
+            signal.alarm(0)
+
+    def render_nested(rows):
+        return {
+            family: {
+                shape: dict(sorted(statuses.items()))
+                for shape, statuses in sorted(shapes.items())
+            }
+            for family, shapes in sorted(rows.items())
+        }
+
+    result = {
+        "kind": "comprehension-iteration-construction-recensus",
+        "commit": _git_commit(args.repo),
+        "corpus": str(args.corpus),
+        "filesTotal": len(files),
+        "filesCompleted": files_completed,
+        "defects": defects,
+        "families": {
+            family: dict(sorted(statuses.items()))
+            for family, statuses in sorted(counts.items())
+        },
+        "primaryShapes": render_nested(primary_shapes),
+        "overlappingShapeAxes": render_nested(shape_axes),
+        "directGapMechanisms": {
+            family: dict(sorted(rows.items(), key=lambda item: (-item[1], item[0])))
+            for family, rows in sorted(direct_mechanisms.items())
+        },
+        "elapsedSeconds": time.time() - started,
+        "python": sys.version,
+    }
+    rendered = json.dumps(result, indent=2)
+    print("=== RESULT JSON ===", flush=True)
+    print(rendered, flush=True)
+    if args.json is not None:
+        args.json.write_text(rendered + "\n")
+    return 1 if defects or files_completed != len(files) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3534,18 +3534,29 @@ class ListComp(Expression):
             if bindings is None:
                 return None
             inner = {**scope, **bindings}
-            verdicts = []
-            for guard in gen.ifs:
-                new_guard, changed = self._substitute_field(guard, inner)
-                verdict = While._ground_truth(self, new_guard if changed else guard)
-                if verdict is None:
-                    return None
-                verdicts.append(verdict)
-            if not all(verdicts):
+            filters_pass = ListComp._ground_filters_pass(self, gen.ifs, inner)
+            if filters_pass is None:
+                return None
+            if not filters_pass:
                 continue
             new_elt, _d = self._substitute_field(self.elt, inner)
             results.append(new_elt if _d else self.elt)
         return ListComp._make_list(self, tuple(results))
+
+    def _ground_filters_pass(self, filters, scope) -> "Optional[bool]":
+        """The conjunction of constructed ground filters, or no testimony.
+
+        Every comprehension kind shares this reader. A symbolic guard yields
+        ``None`` so the enclosing node stays loud; no guard verdict is guessed.
+        """
+        verdicts = []
+        for guard in filters:
+            new_guard, changed = self._substitute_field(guard, scope)
+            verdict = While._ground_truth(self, new_guard if changed else guard)
+            if verdict is None:
+                return None
+            verdicts.append(verdict)
+        return all(verdicts)
 
     def _contains_forbidden_shape(self, roots: tuple) -> bool:
         """True for a nested comprehension or walrus in this comprehension."""
@@ -3676,11 +3687,7 @@ class SetComp(Expression):
         ):
             return None
         gen = self.generators[0]
-        if (
-            gen.is_async
-            or gen.ifs
-            or ListComp._contains_forbidden_shape(self, (gen.iter,))
-        ):
+        if gen.is_async or ListComp._contains_forbidden_shape(self, (gen.iter,)):
             return None
         new_iter, changed = self._substitute_field(gen.iter, scope)
         iterable = new_iter if changed else gen.iter
@@ -3695,7 +3702,13 @@ class SetComp(Expression):
             bindings = For._target_bindings_for(self, gen.target, element)
             if bindings is None:
                 return None
-            new_elt, changed = self._substitute_field(self.elt, {**scope, **bindings})
+            inner = {**scope, **bindings}
+            filters_pass = ListComp._ground_filters_pass(self, gen.ifs, inner)
+            if filters_pass is None:
+                return None
+            if not filters_pass:
+                continue
+            new_elt, changed = self._substitute_field(self.elt, inner)
             result = new_elt if changed else self.elt
             key = ListComp._ground_hash_key(self, result)
             if key is None:
@@ -3766,11 +3779,7 @@ class DictComp(Expression):
         ):
             return None
         gen = self.generators[0]
-        if (
-            gen.is_async
-            or gen.ifs
-            or ListComp._contains_forbidden_shape(self, (gen.iter,))
-        ):
+        if gen.is_async or ListComp._contains_forbidden_shape(self, (gen.iter,)):
             return None
         new_iter, changed = self._substitute_field(gen.iter, scope)
         iterable = new_iter if changed else gen.iter
@@ -3786,6 +3795,11 @@ class DictComp(Expression):
             if bindings is None:
                 return None
             inner = {**scope, **bindings}
+            filters_pass = ListComp._ground_filters_pass(self, gen.ifs, inner)
+            if filters_pass is None:
+                return None
+            if not filters_pass:
+                continue
             key, key_changed = self._substitute_field(self.key, inner)
             value, value_changed = self._substitute_field(self.value, inner)
             result_key = key if key_changed else self.key

--- a/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
+++ b/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
@@ -53,10 +53,40 @@ def test_dictcomp_over_concrete_range_dissolves():
     ]
 
 
+def test_filtered_dictcomp_keeps_only_ground_true_entries():
+    term = _out(
+        "def A():\n"
+        "    return {item: item + 10 for item in [0, 1, 2, 3] if item % 2 == 0}\n"
+    )
+    assert term.name == "python:dict"
+    assert [(item.args[0].value, item.args[1].value) for item in term.args] == [
+        (0, 10),
+        (2, 12),
+    ]
+
+
 def test_setcomp_over_concrete_range_dissolves():
     term = _out("def A():\n    return {x + 1 for x in range(3)}\n")
     assert term.name == "python:set"
     assert [arg.value for arg in term.args] == [1, 2, 3]
+
+
+def test_filtered_setcomp_keeps_only_ground_true_members():
+    term = _out("def A():\n" "    return {item for item in [0, 1, 2, 3] if item > 1}\n")
+    assert term.name == "python:set"
+    assert [arg.value for arg in term.args] == [2, 3]
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "{item for item in [0, 1, 2, 3] if keep(item)}",
+        "{item: item + 10 for item in [0, 1, 2, 3] if keep(item)}",
+    ],
+)
+def test_filtered_set_and_dict_do_not_fabricate_symbolic_guard_verdict(source):
+    with pytest.raises(SugarNotWritten):
+        _fn(f"def A(keep):\n    return {source}\n").sugar()
 
 
 def test_setcomp_preserves_duplicate_elimination():

--- a/implementations/rust/sugar-ir-types/tests/proofir_membership.rs
+++ b/implementations/rust/sugar-ir-types/tests/proofir_membership.rs
@@ -424,6 +424,40 @@ fn python_generator_expression_stays_lazy_after_rust_parse() {
 }
 
 #[test]
+fn concrete_filtered_set_and_dict_displays_survive_rust_parse() {
+    let set_term = document_post_term(python_comprehension_document(
+        "{item for item in [0, 1, 2, 3] if item > 1}",
+        "",
+    ));
+    let Term::Ctor {
+        name: set_name,
+        args: set_members,
+    } = &set_term
+    else {
+        panic!("filtered set comprehension must dissolve to a set display")
+    };
+    assert_eq!(set_name, "python:set");
+    assert_eq!(set_members.len(), 2);
+
+    let dict_term = document_post_term(python_comprehension_document(
+        "{item: item + 10 for item in [0, 1, 2, 3] if item % 2 == 0}",
+        "",
+    ));
+    let Term::Ctor {
+        name: dict_name,
+        args: dict_entries,
+    } = &dict_term
+    else {
+        panic!("filtered dict comprehension must dissolve to a dict display")
+    };
+    assert_eq!(dict_name, "python:dict");
+    assert_eq!(dict_entries.len(), 2);
+    assert!(dict_entries.iter().all(
+        |entry| matches!(entry, Term::Ctor { name, args } if name == "python:dict_entry" && args.len() == 2)
+    ));
+}
+
+#[test]
 fn nested_python_comprehension_lambdas_survive_rust_parse() {
     let term = document_post_term(python_comprehension_document(
         "[[f(x, y, z) for y in ys] for x in xs]",


### PR DESCRIPTION
## Outcome

Adds one clean general arm: concrete finite `SetComp` and `DictComp` filters now use the same constructed ground-filter reader already used by `ListComp`, then dissolve to their existing display semantics.

This is deliberately narrow:

- every iterable element is source-authenticated by the existing finite unroll reader
- every filter is substituted through the comprehension's temporal target binding
- every filter must have a constructed ground truth verdict
- an undecidable/symbolic filter remains a loud `SugarNotWritten` gap
- no filter coordinate, predicate spelling, iterator testimony, or value is invented

## Honest pandas movement

**Observed ΔR = 0.** The full 1,415-file pre/post census completed with zero defects. Pandas has 11 direct filtered `SetComp` sites and 11 direct filtered `DictComp` sites, but all require symbolic iterator/guard semantics; none satisfy this finite ground arm.

The census instrument is included because the current residue is now the useful result: filters, multiple generators, non-name targets, iterator/exhaustion obligations, and For mechanisms remain independently measurable rather than hidden behind root parents.

## Design boundaries found

- Symbolic filters need a guard/predicate member in the comprehension coordinate. Current `ComprehensionSugar` has only `(iterable, lambda)`.
- Multiple generators need flat-map/iteration composition. Nesting existing collection coordinates would fabricate nested collections rather than Python's flattened iteration.
- Iterator state/exhaustion needs typed `iter`/`next`/termination testimony; the current coordinate carries no such evidence.
- For non-name targets remain tied to typed unpack-binding semantics.

These shapes stay loud pending architect rulings.

## Twins

- truthful filtered SetComp preserves exactly the admitted members
- truthful filtered DictComp preserves exactly the admitted entries
- symbolic/lying filter twins remain loud for both kinds
- Python-produced display terms survive Rust parsing

## Validation

- pandas pre census: 1,415/1,415 files, 0 defects
- pandas post census: 1,415/1,415 files, 0 defects
- focused Python: 64 passed
- battleaxe focused Python + Rust command: status 0
- battleaxe Rust round-trip twin: 1 passed
- Python and Rust formatting checks
- `git diff --check`

The branch is rebased on current main. Architect review requested; do not merge without the semantic review.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ground filtered `SetComp` and `DictComp` construction to dissolve into displays
> - `SetComp._try_unroll_to_display` and `DictComp._try_unroll_to_display` now handle comprehensions with filter guards by evaluating each guard against a per-element scope using the new `ListComp._ground_filters_pass` helper.
> - Elements/pairs are included only when all filters ground to `true`; if any filter is non-ground (symbolic), unrolling aborts and raises `SugarNotWritten`.
> - A new corpus-scanning CLI script ([comprehension_iteration_recensus.py](https://github.com/TSavo/sugar/pull/6105/files#diff-b6639480959700852c37a7e20e475e3527c1077d734c344a61ec378e0d4ba81e)) walks Python files, attempts sugar construction for comprehensions and loops, and emits a JSON summary of results and defects.
> - Tests cover filtered dissolve for both set and dict comprehensions, non-ground guard rejection, and cross-language persistence via a new Rust parse test.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c140d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->