### PR TITLE
drain: bare attribute AnnAssign evaluates receiver (pandas R)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/measure_binding_assignment_frontier.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/measure_binding_assignment_frontier.py
@@ -1,0 +1,169 @@
+"""Measure the honest pandas binding/assignment construction frontier.
+
+The direct axis constructs each assignment statement itself.  The enclosing
+axis constructs each function containing an assignment and attributes a loud
+result to the deepest typed panic that escaped construction.  Shape counts are
+syntax only; a shape is drainable only when its direct children construct.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib.metadata
+import importlib.util
+import json
+import logging
+from collections import Counter, defaultdict
+from pathlib import Path
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.backend import BackendCouldNotParse, materialize
+from sugar_source_tree.cpython_adapter import _Handle
+from sugar_source_tree.nodes import SourceUnit
+from sugar_source_tree.panic import SourceTreePanic, SugarNotWritten
+
+
+ASSIGNMENT = (ast.Assign, ast.AnnAssign, ast.AugAssign)
+
+
+def _installed_package_root(package: str) -> Path:
+    spec = importlib.util.find_spec(package)
+    if spec is None or spec.origin is None:
+        raise RuntimeError(f"could not locate installed package {package!r}")
+    return Path(spec.origin).resolve().parent
+
+
+def _target_shape(target: ast.AST) -> str:
+    if isinstance(target, ast.Name):
+        return "name"
+    if isinstance(target, ast.Attribute):
+        return "attribute"
+    if isinstance(target, ast.Subscript):
+        return "subscript"
+    if isinstance(target, ast.Starred):
+        return "starred"
+    if isinstance(target, (ast.Tuple, ast.List)):
+        children = ",".join(_target_shape(value) for value in target.elts)
+        return f"{'tuple' if isinstance(target, ast.Tuple) else 'list'}[{children}]"
+    return type(target).__name__
+
+
+def _shape(node: ast.AST) -> str:
+    if isinstance(node, ast.Assign):
+        targets = [_target_shape(target) for target in node.targets]
+        prefix = "single" if len(targets) == 1 else "chained"
+        if isinstance(node.value, (ast.Tuple, ast.List)):
+            rhs = "display"
+        elif isinstance(node.value, ast.Name):
+            rhs = "alias"
+        elif isinstance(node.value, ast.Attribute):
+            rhs = "attribute-read"
+        elif isinstance(node.value, ast.Subscript):
+            rhs = "subscript-read"
+        elif isinstance(node.value, ast.Call):
+            rhs = "call"
+        else:
+            rhs = "other"
+        return f"Assign/{prefix}/{'='.join(targets)}/rhs={rhs}"
+    if isinstance(node, ast.AnnAssign):
+        value = "valued" if node.value is not None else "bare"
+        return f"AnnAssign/{_target_shape(node.target)}/{value}"
+    assert isinstance(node, ast.AugAssign)
+    return f"AugAssign/{_target_shape(node.target)}/{type(node.op).__name__}"
+
+
+def _panic_key(panic: BaseException) -> str:
+    owner = getattr(panic, "owner", type(panic).__name__)
+    observed = getattr(panic, "observed", "")
+    requested = getattr(panic, "requested", "")
+    return f"{owner}|{observed}|{requested}"
+
+
+def measure(root: Path, *, direct_only: bool = False) -> dict[str, object]:
+    counts: Counter[str] = Counter()
+    direct: dict[str, Counter[str]] = defaultdict(Counter)
+    enclosing: dict[str, Counter[str]] = defaultdict(Counter)
+    roots: Counter[str] = Counter()
+
+    for path in sorted(root.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        counts["files_total"] += 1
+        try:
+            source, filename, source_cid = path_source(path)
+            parsed = ast.parse(source, filename=str(path))
+            native_assignments = [node for node in ast.walk(parsed) if isinstance(node, ASSIGNMENT)]
+            if not native_assignments:
+                counts["files_without_assignment"] += 1
+                continue
+            unit = SourceUnit(filename=filename, source=source, source_cid=source_cid)
+            for native in native_assignments:
+                shape = _shape(native)
+                direct[shape]["total"] += 1
+                node = materialize(unit, _Handle(unit, native))
+                try:
+                    node.sugar()
+                except SugarNotWritten as panic:
+                    own = getattr(panic, "owner", "") in {
+                        "Assign.sugar", "AnnAssign.sugar", "AugAssign.sugar"
+                    }
+                    direct[shape]["direct_gap" if own else "blocked_descendant"] += 1
+                    roots[_panic_key(panic)] += 1
+                except SourceTreePanic as panic:
+                    direct[shape]["other_typed_loud"] += 1
+                    roots[_panic_key(panic)] += 1
+                else:
+                    direct[shape]["built"] += 1
+
+            functions = [] if direct_only else [
+                node for node in ast.walk(parsed)
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and any(isinstance(child, ASSIGNMENT) for child in ast.walk(node))
+            ]
+            for native_function in functions:
+                shapes = sorted({_shape(node) for node in ast.walk(native_function) if isinstance(node, ASSIGNMENT)})
+                function = materialize(unit, _Handle(unit, native_function))
+                try:
+                    function.sugar()
+                except SourceTreePanic as panic:
+                    roots[_panic_key(panic)] += 1
+                    for shape in shapes:
+                        enclosing[shape]["loud"] += 1
+                        enclosing[shape][f"root:{getattr(panic, 'owner', type(panic).__name__)}"] += 1
+                except Exception as panic:
+                    for shape in shapes:
+                        enclosing[shape]["non_source_failure"] += 1
+                        enclosing[shape][f"root:{type(panic).__name__}"] += 1
+                else:
+                    for shape in shapes:
+                        enclosing[shape]["built"] += 1
+            counts["files_completed"] += 1
+        except BackendCouldNotParse:
+            counts["files_could_not_parse"] += 1
+        except (OSError, UnicodeError, SourceTreePanic) as panic:
+            counts["files_other_failure"] += 1
+            roots[_panic_key(panic)] += 1
+
+    return {
+        "root": str(root),
+        "pandas_version": importlib.metadata.version("pandas"),
+        "counts": dict(sorted(counts.items())),
+        "direct_by_shape": {key: dict(sorted(value.items())) for key, value in sorted(direct.items())},
+        "enclosing_by_shape": {key: dict(sorted(value.items())) for key, value in sorted(enclosing.items())},
+        "root_panics": dict(sorted(roots.items(), key=lambda item: (-item[1], item[0]))),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path)
+    parser.add_argument("--direct-only", action="store_true")
+    args = parser.parse_args()
+    logging.disable(logging.CRITICAL)
+    root = (args.root or _installed_package_root("pandas")).resolve()
+    print(json.dumps(measure(root, direct_only=args.direct_only), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1559,18 +1559,30 @@ class AnnAssign(Statement):
         threaded via substitution_binding, exactly as a plain Assign's does;
         the rebind rode into the tail and this node contributes nothing more.
         If there is no value, it is a bare declaration: no bytecode runs, no
-        binding is introduced, nothing happens at runtime at all.
+        binding is introduced, nothing happens at runtime at all.  A bare
+        attribute annotation is different: CPython evaluates the receiver and
+        discards it, without reading the attribute or performing a store.
 
         The annotation itself is NEVER a fact the meaning layer states either
         way: Python does not check it at runtime (no TypeError on mismatch),
         so an annotation asserts nothing -- it is documentation the tree
         passes through, never a stated post. A valued attribute/subscript target
-        is the same runtime store owned by Assign. A bare non-Name annotation
-        stays loud: evaluating that target is not an inert name declaration."""
+        is the same runtime store owned by Assign.  A bare Attribute therefore
+        reuses the ordinary expression-statement path for its receiver only.
+        Other bare non-Name annotations stay loud."""
         if isinstance(self.target, Name):
             from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
 
             return InertSugar(site=self.fragment)
+        if self.value is None and isinstance(self.target, Attribute):
+            from sugar_lift_py_tests.sugar.expr_statement_sugar import (
+                ExprStatementSugar,
+            )
+
+            return ExprStatementSugar(
+                value=self.target.value.sugar(),
+                site=self.fragment,
+            )
         if self.value is not None and isinstance(self.target, Attribute):
             from sugar_lift_py_tests.sugar.store_effect_sugar import (
                 AttributeStoreEffectSugar,

--- a/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
+++ b/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
@@ -13,6 +13,8 @@ from sugar_lift_py_tests.effect import (
     SubscriptStoreRuntimeEffect,
 )
 from sugar_lift_py_tests.outcome import Incomplete
+from sugar_lift_py_tests.sugar.expr_statement_sugar import ExprStatementSugar
+from sugar_lift_py_tests.sugar.store_effect_sugar import AttributeStoreEffectSugar
 from sugar_source_tree.tree import SourceFile
 
 
@@ -72,6 +74,33 @@ def test_annotated_subscript_with_value_builds_store_effect():
 
     assert len(effects) == 1
     assert isinstance(effects[0], SubscriptStoreRuntimeEffect)
+
+
+def test_bare_attribute_annotation_evaluates_only_renamed_receiver():
+    function = _fn(
+        "def record_shape(receiver):\n"
+        "    receiver.payload: MissingType\n"
+        "    return receiver\n"
+    )
+    substituted = function.substitute({})
+    declaration = substituted.body[0]
+    sugar = declaration.sugar()
+    assert isinstance(sugar, ExprStatementSugar)
+    assert sugar.value == declaration.target.value.sugar()
+
+    value = function.sugar().desugar().value
+    assert value.post().args[1].name == "receiver"
+
+
+def test_valued_attribute_annotation_does_not_enter_bare_declaration_arm():
+    function = _fn(
+        "def record_shape(receiver, supplied):\n"
+        "    receiver.payload: MissingType = supplied\n"
+        "    return supplied\n"
+    ).substitute({})
+    sugar = function.body[0].sugar()
+    assert isinstance(sugar, AttributeStoreEffectSugar)
+    assert not isinstance(sugar, ExprStatementSugar)
 
 
 def test_aug_assign_with_no_prior_binding_is_sound():

--- a/implementations/rust/sugar-ir-types/tests/proofir_membership.rs
+++ b/implementations/rust/sugar-ir-types/tests/proofir_membership.rs
@@ -286,6 +286,48 @@ print(encode_jcs(declarations_to_value([ContractDecl("A", post=post)])))
     serde_json::from_slice(&output.stdout).expect("parse complete Python ProofIR document")
 }
 
+fn python_bare_attribute_annotation_document() -> Document {
+    let repo = crate_root()
+        .ancestors()
+        .nth(3)
+        .expect("sugar-ir-types lives below the repository root");
+    let python_path = [
+        repo.join("implementations/python/sugar-source-tree/src"),
+        repo.join("implementations/python/sugar-lift-py-tests/src"),
+        repo.join("implementations/python/sugar-lift-python-source/src"),
+    ]
+    .iter()
+    .map(|path| path.display().to_string())
+    .collect::<Vec<_>>()
+    .join(":");
+    let script = r#"
+import tempfile
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.ir import ContractDecl, atomic, declarations_to_value, encode_jcs, make_var
+from sugar_source_tree.tree import SourceFile
+with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as source:
+    source.write("def record_shape(receiver):\n    receiver.payload: MissingType\n    return receiver\n")
+    path = source.name
+function = next(SourceFile(path_source(path)).functions())
+term = function.sugar().desugar().value.post().args[1]
+post = atomic("=", [make_var("out"), term])
+print(encode_jcs(declarations_to_value([ContractDecl("record_shape", post=post)])))
+"#;
+    let output = Command::new("python3")
+        .arg("-c")
+        .arg(script)
+        .env("PYTHONPATH", python_path)
+        .current_dir(repo)
+        .output()
+        .expect("run Python bare attribute annotation construction");
+    assert!(
+        output.status.success(),
+        "Python construction failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("parse complete Python ProofIR document")
+}
+
 fn document_post_term(document: Document) -> Term {
     let Declaration::Contract {
         post: Some(Formula::Atomic { mut args, .. }),
@@ -305,6 +347,18 @@ fn free_vars(term: Term) -> std::collections::BTreeSet<String> {
     };
     let open = OpenFormula::from_ir_formula_with_sorts(formula, BTreeMap::new());
     open.free_vars()
+}
+
+#[test]
+fn python_bare_attribute_annotation_receiver_survives_rust_membership() {
+    let term = document_post_term(python_bare_attribute_annotation_document());
+    assert_eq!(
+        term,
+        Term::Var {
+            name: "receiver".into()
+        }
+    );
+    assert_eq!(free_vars(term), ["receiver".to_string()].into());
 }
 
 #[test]


### PR DESCRIPTION
## Outcome

Drains the only clean general assignment-family arm found by the current pandas construction census: a bare attribute annotation (`receiver.field: T`) evaluates and discards `receiver`, exactly as CPython does. It performs no attribute read, store, annotation evaluation, or lexical binding. The arm reuses `ExprStatementSugar`; it adds no second temporal-binding path.

## Honest census

- assignment-family nodes: 110,522
- before: built 107,290; direct gaps 1,797; blocked descendants 1,435
- after: built 107,292; direct gaps 1,795; blocked descendants 1,435
- observed delta: `Delta direct_gap_R = -2`

Remaining direct gaps are deliberately unchanged: 1,707 symbolic plain-name destructures; 64 nested/starred/mixed-store destructures; 24 mixed store chains. Name aliasing (2,890/2,890), stores, AugAssign, and lexical branch joins already use the existing general machinery. Heap/object-field flow needs a heap+alias contract and is not fabricated here.

## Receipts

- renamed truthful twin: bare attribute annotation selects receiver-only ExprStatementSugar
- lying twin: valued attribute annotation remains AttributeStoreEffectSugar
- focused binding/store/branch tests: 40 passed
- Python -> Rust ProofIR membership round trip: 1 passed locally, 1 passed on battleaxe
- post-rebase direct census on pandas 3.0.3: 110,522 discovered, 110,522 classified
- rebased onto current origin/main (`ab0a91140`)

No merge performed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `AnnAssign._construct_sugar` to evaluate receiver for bare attribute annotations
> - Bare attribute annotations like `receiver.attr: T` (with no value) now produce an `ExprStatementSugar` that evaluates only the receiver expression, matching Python's runtime behavior.
> - Valued attribute annotations (e.g. `receiver.attr: T = val`) are unaffected and continue to produce `AttributeStoreEffectSugar`.
> - Adds a measurement script [`measure_binding_assignment_frontier.py`](https://github.com/TSavo/sugar/pull/6106/files#diff-7b44aea5267205d8de471181b65fc5d4f1c4d19631c4f059cf386f94e7c2915b) that traverses a codebase (defaulting to installed pandas) and outputs a JSON report of sugar construction outcomes per assignment shape.
> - Behavioral Change: `AnnAssign` nodes with an `Attribute` target and no value previously fell through to the superclass; they now return an `ExprStatementSugar` wrapping the receiver.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6149886.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->