### PR TITLE
test: loop-construction acceptance twins (break/continue/else/symbolic)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/loop_construction/arbitrary_iteration_module.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/loop_construction/arbitrary_iteration_module.py
@@ -1,0 +1,151 @@
+"""Source-structural semantic oracle for loop-construction acceptance."""
+
+
+def continue_backedge():
+    head = []
+    tail = []
+    post = 0
+    for item in (0, 1, 2, 3):
+        head.append(item)
+        post = item + 1
+        if item % 2 == 0:
+            continue
+        tail.append(item)
+    return {"head": tuple(head), "tail": tuple(tail), "post": post}
+
+
+def break_exit():
+    visited = []
+    completed_tail = []
+    post = -1
+    for item in (0, 1, 2, 3, 4):
+        visited.append(item)
+        post = item
+        if item == 2:
+            break
+        completed_tail.append(item)
+    return {
+        "visited": tuple(visited),
+        "completed_tail": tuple(completed_tail),
+        "post": post,
+    }
+
+
+def for_else_exhaustion():
+    events = []
+    for item in (0, 1):
+        events.append(f"body:{item}")
+    else:
+        events.append("else")
+    return tuple(events)
+
+
+def for_else_break():
+    events = []
+    for item in (0, 1, 2):
+        events.append(f"body:{item}")
+        if item == 1:
+            break
+    else:
+        events.append("else")
+    return tuple(events)
+
+
+def while_else_exhaustion():
+    events = []
+    item = 0
+    while item < 2:
+        events.append(f"body:{item}")
+        item += 1
+    else:
+        events.append("else")
+    return tuple(events)
+
+
+def while_else_break():
+    events = []
+    item = 0
+    while item < 3:
+        events.append(f"body:{item}")
+        if item == 1:
+            break
+        item += 1
+    else:
+        events.append("else")
+    return tuple(events)
+
+
+def nested_break():
+    events = []
+    for outer in (0, 1):
+        events.append(("outer", outer))
+        for inner in (0, 1):
+            events.append(("inner", outer, inner))
+            break
+        events.append(("after-inner", outer))
+    events.append(("outer-complete",))
+    return tuple(events)
+
+
+def nested_continue():
+    events = []
+    for outer in (0, 1):
+        for inner in (0, 1):
+            events.append(("head", outer, inner))
+            if inner == 0:
+                continue
+            events.append(("tail", outer, inner))
+        events.append(("after-inner", outer))
+    return tuple(events)
+
+
+def concrete_bounded():
+    trace = []
+    state = 0
+    for item in (1, 2, 3, 4):
+        state += item
+        trace.append((item - 1, state))
+    return tuple(trace)
+
+
+def symbolic_break(items, stop):
+    visited = []
+    stopped = False
+    for item in items:
+        visited.append(item)
+        if item == stop:
+            stopped = True
+            break
+    return {"visited": tuple(visited), "stopped": stopped}
+
+
+def symbolic_break_lying(items, stop):
+    result = symbolic_break(items, stop)
+    assert result["visited"] == tuple(items)
+    return result
+
+
+def guarded_break_join(should_break):
+    visited = []
+    tail = []
+    post = -1
+    for item in (0, 1, 2):
+        visited.append(item)
+        post = item
+        if should_break and item == 1:
+            break
+        tail.append(item)
+    return {"visited": tuple(visited), "tail": tuple(tail), "post": post}
+
+
+def guarded_continue_join(should_continue):
+    visited = []
+    tail = []
+    post = 0
+    for item in (0, 1, 2):
+        visited.append(item)
+        post = item + 1
+        if should_continue and item == 1:
+            continue
+        tail.append(item)
+    return {"visited": tuple(visited), "tail": tuple(tail), "post": post}

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/loop_construction/cases.json
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/loop_construction/cases.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": 1,
+  "moduleGraph": ["arbitrary_iteration_module.py"],
+  "authority": "source-structure-only",
+  "cases": [
+    {
+      "case": "continue_backedge",
+      "construct": "Continue",
+      "loopKind": "For",
+      "constructionVerdict": "typed-continue-to-owning-loop-backedge",
+      "stateRule": "tail-after-continue-is-not-in-the-continued-face",
+      "truthfulVerdict": "head-all-tail-odd-post-four",
+      "lyingVerdict": "continued-tail-runs",
+      "lyingDisposition": "reject"
+    },
+    {
+      "case": "break_exit",
+      "construct": "Break",
+      "loopKind": "For",
+      "constructionVerdict": "typed-break-to-owning-loop-exit",
+      "stateRule": "break-state-excludes-unvisited-elements-and-skipped-tail",
+      "truthfulVerdict": "visited-zero-one-two-post-two",
+      "lyingVerdict": "facts-for-unvisited-elements",
+      "lyingDisposition": "reject"
+    },
+    {
+      "case": "for_else_exhaustion",
+      "construct": "LoopElse",
+      "loopKind": "For",
+      "constructionVerdict": "normal-exhaustion-runs-else",
+      "truthfulVerdict": "else-runs",
+      "lyingVerdict": "else-skipped",
+      "lyingDisposition": "reject"
+    },
+    {
+      "case": "for_else_break",
+      "construct": "LoopElse",
+      "loopKind": "For",
+      "constructionVerdict": "break-suppresses-else",
+      "truthfulVerdict": "else-skipped",
+      "lyingVerdict": "else-runs-after-break",
+      "lyingDisposition": "reject"
+    },
+    {
+      "case": "while_else_exhaustion",
+      "construct": "LoopElse",
+      "loopKind": "While",
+      "constructionVerdict": "normal-exhaustion-runs-else",
+      "truthfulVerdict": "else-runs",
+      "lyingVerdict": "else-skipped",
+      "lyingDisposition": "reject"
+    },
+    {
+      "case": "while_else_break",
+      "construct": "LoopElse",
+      "loopKind": "While",
+      "constructionVerdict": "break-suppresses-else",
+      "truthfulVerdict": "else-skipped",
+      "lyingVerdict": "else-runs-after-break",
+      "lyingDisposition": "reject"
+    },
+    {
+      "case": "nested_break",
+      "construct": "Break",
+      "loopKind": "NestedFor",
+      "constructionVerdict": "nearest-loop-alone-consumes-break",
+      "truthfulVerdict": "outer-loop-completes",
+      "lyingVerdict": "outer-loop-consumes-inner-break",
+      "lyingDisposition": "reject"
+    },
+    {
+      "case": "nested_continue",
+      "construct": "Continue",
+      "loopKind": "NestedFor",
+      "constructionVerdict": "nearest-loop-alone-consumes-continue",
+      "truthfulVerdict": "outer-tail-runs-after-inner-exhaustion",
+      "lyingVerdict": "outer-loop-consumes-inner-continue",
+      "lyingDisposition": "reject"
+    },
+    {
+      "case": "concrete_bounded",
+      "construct": "IterationState",
+      "loopKind": "For",
+      "constructionVerdict": "bounded-unroll-with-one-state-transition-per-element",
+      "truthfulVerdict": "states-one-three-six-ten",
+      "lyingVerdict": "iterations-share-one-post-state",
+      "lyingDisposition": "reject"
+    },
+    {
+      "case": "symbolic_break",
+      "lyingFunction": "symbolic_break_lying",
+      "construct": "OpaqueLoop",
+      "loopKind": "For",
+      "constructionVerdict": "opaque-loop-with-typed-break-obligation",
+      "stateRule": "no-whole-iterable-universal-after-reachable-break",
+      "truthfulVerdict": "prefix-through-stop-only",
+      "lyingVerdict": "universal-over-entire-iterable",
+      "lyingDisposition": "typed-loud"
+    },
+    {
+      "case": "guarded_break_join",
+      "construct": "GuardedExitJoin",
+      "loopKind": "For",
+      "constructionVerdict": "exitset-joins-break-and-exhaustion-faces",
+      "stateRule": "each-guard-retains-its-own-exact-state",
+      "truthfulVerdict": "break-face-post-one-exhaustion-face-post-two",
+      "lyingVerdict": "one-state-used-for-both-guards",
+      "lyingDisposition": "reject"
+    },
+    {
+      "case": "guarded_continue_join",
+      "construct": "GuardedExitJoin",
+      "loopKind": "For",
+      "constructionVerdict": "exitset-routes-continue-face-to-backedge",
+      "stateRule": "continued-face-omits-skipped-tail-and-rejoins-next-iteration",
+      "truthfulVerdict": "guarded-tail-omits-one-only",
+      "lyingVerdict": "continued-face-carries-skipped-tail",
+      "lyingDisposition": "reject"
+    }
+  ]
+}

--- a/implementations/python/sugar-lift-py-tests/tests/test_loop_construction_acceptance_fixture.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_loop_construction_acceptance_fixture.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+FIXTURES = Path(__file__).parent / "fixtures" / "loop_construction"
+EXPECTED_CASES = {
+    "continue_backedge",
+    "break_exit",
+    "for_else_exhaustion",
+    "for_else_break",
+    "while_else_exhaustion",
+    "while_else_break",
+    "nested_break",
+    "nested_continue",
+    "concrete_bounded",
+    "symbolic_break",
+    "guarded_break_join",
+    "guarded_continue_join",
+}
+
+
+@pytest.fixture
+def loops(monkeypatch):
+    monkeypatch.syspath_prepend(str(FIXTURES))
+    sys.modules.pop("arbitrary_iteration_module", None)
+    return importlib.import_module("arbitrary_iteration_module")
+
+
+def _matrix():
+    return json.loads((FIXTURES / "cases.json").read_text())
+
+
+def test_truth_set_is_complete_and_structural():
+    manifest = _matrix()
+    assert manifest["schemaVersion"] == 1
+    assert manifest["moduleGraph"] == ["arbitrary_iteration_module.py"]
+    assert {case["case"] for case in manifest["cases"]} == EXPECTED_CASES
+    required_case_fields = {
+        "case",
+        "construct",
+        "loopKind",
+        "constructionVerdict",
+        "truthfulVerdict",
+        "lyingVerdict",
+        "lyingDisposition",
+    }
+    assert all(required_case_fields <= case.keys() for case in manifest["cases"])
+    assert all(
+        case["truthfulVerdict"] != case["lyingVerdict"]
+        for case in manifest["cases"]
+    )
+    assert all(
+        case["lyingDisposition"] in {"reject", "typed-loud"}
+        for case in manifest["cases"]
+    )
+
+    source_path = FIXTURES / "arbitrary_iteration_module.py"
+    source_text = source_path.read_text()
+    tree = ast.parse(source_text)
+    functions = {
+        node.name: node for node in tree.body if isinstance(node, ast.FunctionDef)
+    }
+    assert EXPECTED_CASES <= functions.keys()
+    assert any(isinstance(node, ast.For) for node in ast.walk(tree))
+    assert any(isinstance(node, ast.While) for node in ast.walk(tree))
+    assert any(isinstance(node, ast.Break) for node in ast.walk(tree))
+    assert any(isinstance(node, ast.Continue) for node in ast.walk(tree))
+
+    combined = source_text + json.dumps(manifest, sort_keys=True)
+    for forbidden in (
+        "pytest",
+        "pandas",
+        "numpy",
+        "vendor",
+        "provider",
+        "enrollment",
+        "catalog",
+    ):
+        assert forbidden not in combined.lower()
+
+
+def test_continue_routes_to_backedge_and_skips_tail(loops):
+    actual = loops.continue_backedge()
+    assert actual == {
+        "head": (0, 1, 2, 3),
+        "tail": (1, 3),
+        "post": 4,
+    }
+    assert actual != {"head": (0, 1, 2, 3), "tail": (0, 1, 2, 3), "post": 4}
+
+
+def test_break_exit_state_excludes_unvisited_elements(loops):
+    actual = loops.break_exit()
+    assert actual == {
+        "visited": (0, 1, 2),
+        "completed_tail": (0, 1),
+        "post": 2,
+    }
+    assert actual != {
+        "visited": (0, 1, 2, 3, 4),
+        "completed_tail": (0, 1, 3, 4),
+        "post": 4,
+    }
+
+
+@pytest.mark.parametrize(
+    ("function_name", "expected"),
+    [
+        ("for_else_exhaustion", ("body:0", "body:1", "else")),
+        ("for_else_break", ("body:0", "body:1")),
+        ("while_else_exhaustion", ("body:0", "body:1", "else")),
+        ("while_else_break", ("body:0", "body:1")),
+    ],
+)
+def test_loop_else_runs_only_on_normal_exhaustion(loops, function_name, expected):
+    assert getattr(loops, function_name)() == expected
+
+
+def test_nested_break_targets_nearest_loop(loops):
+    actual = loops.nested_break()
+    assert actual == (
+        ("outer", 0),
+        ("inner", 0, 0),
+        ("after-inner", 0),
+        ("outer", 1),
+        ("inner", 1, 0),
+        ("after-inner", 1),
+        ("outer-complete",),
+    )
+
+
+def test_nested_continue_targets_nearest_loop(loops):
+    actual = loops.nested_continue()
+    assert actual == (
+        ("head", 0, 0),
+        ("head", 0, 1),
+        ("tail", 0, 1),
+        ("after-inner", 0),
+        ("head", 1, 0),
+        ("head", 1, 1),
+        ("tail", 1, 1),
+        ("after-inner", 1),
+    )
+
+
+def test_concrete_bounded_loop_threads_exact_iteration_state(loops):
+    assert loops.concrete_bounded() == (
+        (0, 1),
+        (1, 3),
+        (2, 6),
+        (3, 10),
+    )
+
+
+def test_symbolic_break_runtime_twin_rejects_whole_iterable_claim(loops):
+    actual = loops.symbolic_break((2, 4, 7, 9), 7)
+    assert actual == {"visited": (2, 4, 7), "stopped": True}
+    assert actual["visited"] != (2, 4, 7, 9)
+    with pytest.raises(AssertionError):
+        loops.symbolic_break_lying((2, 4, 7, 9), 7)
+    case = next(case for case in _matrix()["cases"] if case["case"] == "symbolic_break")
+    assert case["lyingFunction"] == "symbolic_break_lying"
+    assert case["constructionVerdict"] == "opaque-loop-with-typed-break-obligation"
+    assert case["lyingVerdict"] == "universal-over-entire-iterable"
+    assert case["lyingDisposition"] == "typed-loud"
+
+
+@pytest.mark.parametrize("guard", [False, True])
+def test_guarded_break_join_preserves_guarded_state(loops, guard):
+    expected = (
+        {"visited": (0, 1, 2), "tail": (0, 1, 2), "post": 2}
+        if not guard
+        else {"visited": (0, 1), "tail": (0,), "post": 1}
+    )
+    assert loops.guarded_break_join(guard) == expected
+
+
+@pytest.mark.parametrize("guard", [False, True])
+def test_guarded_continue_join_preserves_guarded_state(loops, guard):
+    expected = (
+        {"visited": (0, 1, 2), "tail": (0, 1, 2), "post": 3}
+        if not guard
+        else {"visited": (0, 1, 2), "tail": (0, 2), "post": 3}
+    )
+    assert loops.guarded_continue_join(guard) == expected


### PR DESCRIPTION
## Outcome

Adds an implementation-independent, renamed source-structural truth-set for the pending typed loop construction. The machine-readable matrix and executable CPython oracle twins cover continue back-edges, break exits, For/While else, nearest nested-loop ownership, bounded per-iteration state, symbolic opaque-loop obligations, and guarded ExitSet joins.

The symbolic lying twin explicitly rejects whole-iterable universal facts after a reachable break. The fixture contains no vendor/provider/catalog/enrollment vocabulary and changes no production code.

## Validation

- `PYTHONPATH="implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src:implementations/python/sugar-lift-py-tests/src" python3 -m pytest --noconftest implementations/python/sugar-lift-py-tests/tests/test_loop_construction_acceptance_fixture.py implementations/python/sugar-lift-py-tests/tests/test_exit_set.py -q` — 37 passed
- `git diff origin/main...HEAD --check`

Non-draft acceptance gate only. Do not merge until architect review.