### PR TITLE
Add construction-invariant audit floor

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/construction_invariant_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_invariant_law.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+"""Closed construction-invariant auditor.
+
+This is a pre-review floor, not a semantic recognizer.  It detects structural
+shapes which have repeatedly admitted fabricated authority or a second
+construction path.  Every row names the replacement law; unknown source is an
+auditor error, never a zero.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+from typing import Iterable
+
+
+SELF_HASH = "SELF-HASHING-AS-AUTHORITY"
+NAME_GATE = "NAME-SPELLING-OVERLOAD-GATE"
+SECOND_PATH = "SECOND-CONSTRUCTION-PATH"
+NON_EXHAUSTIVE = "NON-EXHAUSTIVE-VARIANT-COVERAGE"
+FABRICATED = "FABRICATED-COMPLETION-FALLBACK"
+
+REQUIRED_FIX = {
+    SELF_HASH: (
+        "re-resolve against the authenticated artifact/graph and require "
+        "byte-identical equality; a self-hash is integrity, not authority"
+    ),
+    NAME_GATE: (
+        "resolve through an authenticated binding/contract coordinate; remove "
+        "vendor, spelling, manifest, and overload-name dispatch"
+    ),
+    SECOND_PATH: (
+        "delete the private evaluator and consume already-constructed Sugar/"
+        "call-frame/receiver-state testimony from the sole construction door"
+    ),
+    NON_EXHAUSTIVE: (
+        "use a closed typed union or an executable running-grammar coverage "
+        "audit, with every unknown variant returning a typed-loud outcome"
+    ),
+    FABRICATED: (
+        "preserve the opaque/symbolic face as typed-loud; never synthesize a "
+        "default value, None completion, benign catch-all, or dropped filter"
+    ),
+}
+
+
+@dataclass(frozen=True, order=True)
+class Finding:
+    path: str
+    line: int
+    column: int
+    violation_class: str
+    observed: str
+
+    @property
+    def required_fix(self) -> str:
+        return REQUIRED_FIX[self.violation_class]
+
+    def to_value(self) -> dict[str, object]:
+        return {
+            "path": self.path,
+            "line": self.line,
+            "column": self.column,
+            "class": self.violation_class,
+            "observed": self.observed,
+            "requiredFix": self.required_fix,
+        }
+
+
+_HASH_CALLS = {
+    "cid_of_json",
+    "canonical_json_cid",
+    "blake3_512_of",
+    "jcs_cid",
+    "hash",
+    "sha256",
+}
+_AUTHORITY_WORDS = (
+    "authenticated",
+    "resolved",
+    "contractref",
+    "contract_ref",
+    "constructed",
+    "authority",
+)
+_REVALIDATION_WORDS = (
+    "revalidate",
+    "reconstruct",
+    "re_resolve",
+    "resolve_import_binding",
+    "authenticate",
+    "from_graph",
+)
+_FORBIDDEN_SPELLING = re.compile(
+    r"(^|[.:/_-])(pytest|pandas|numpy|pyarrow|matplotlib|contextlib)([.:/_-]|$)",
+    re.IGNORECASE,
+)
+_FORBIDDEN_API_NAMES = {
+    "row_for_spelling",
+    "default_community_manifest",
+    "manifest_membrane",
+    "community_context_managers",
+    "overload_name",
+}
+_FLOOR_MAKERS = {
+    "FloorValue",
+    "TermValue",
+    "StringValue",
+    "NoneValue",
+    "TupleValue",
+    "DictValue",
+    "ObjectValue",
+    "ObjectField",
+    "GuardedValue",
+}
+_AST_STMT_NAMES = {
+    "FunctionDef",
+    "AsyncFunctionDef",
+    "ClassDef",
+    "Return",
+    "Delete",
+    "Assign",
+    "TypeAlias",
+    "AugAssign",
+    "AnnAssign",
+    "For",
+    "AsyncFor",
+    "While",
+    "If",
+    "With",
+    "AsyncWith",
+    "Match",
+    "Raise",
+    "Try",
+    "TryStar",
+    "Assert",
+    "Import",
+    "ImportFrom",
+    "Global",
+    "Nonlocal",
+    "Expr",
+    "Pass",
+    "Break",
+    "Continue",
+}
+
+
+def _name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _name(node.value)
+        return f"{base}.{node.attr}" if base else node.attr
+    return ""
+
+
+def _call_name(node: ast.AST) -> str:
+    return _name(node.func) if isinstance(node, ast.Call) else ""
+
+
+def _depends_on(node: ast.AST, names: set[str]) -> bool:
+    return any(isinstance(child, ast.Name) and child.id in names for child in ast.walk(node))
+
+
+def _finding(path: str, node: ast.AST, kind: str, observed: str) -> Finding:
+    return Finding(path, getattr(node, "lineno", 1), getattr(node, "col_offset", 0), kind, observed)
+
+
+def _function_parameters(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    args = node.args
+    return {
+        item.arg
+        for item in (
+            *args.posonlyargs,
+            *args.args,
+            *args.kwonlyargs,
+            *(() if args.vararg is None else (args.vararg,)),
+            *(() if args.kwarg is None else (args.kwarg,)),
+        )
+    }
+
+
+def _has_revalidation(function: ast.AST) -> bool:
+    for node in ast.walk(function):
+        if isinstance(node, ast.Call):
+            call = _call_name(node).lower().split(".")[-1]
+            if call in _REVALIDATION_WORDS or call.startswith(("revalidate_", "reconstruct_", "resolve_")):
+                return True
+        if isinstance(node, ast.Compare) and any(
+            isinstance(op, (ast.Eq, ast.NotEq)) for op in node.ops
+        ):
+            return True
+    return False
+
+
+def _self_hash_findings(tree: ast.Module, path: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for function in (
+        node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ):
+        parameters = _function_parameters(function)
+        hashes: dict[str, ast.Call] = {}
+        for node in ast.walk(function):
+            if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                continue
+            value = node.value
+            if not isinstance(value, ast.Call):
+                continue
+            call_tail = _call_name(value).split(".")[-1]
+            if call_tail not in _HASH_CALLS or not _depends_on(value, parameters):
+                continue
+            targets = node.targets if isinstance(node, ast.Assign) else (node.target,)
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    hashes[target.id] = value
+        if not hashes or _has_revalidation(function):
+            continue
+        for node in ast.walk(function):
+            if not isinstance(node, ast.Return) or not isinstance(node.value, ast.Call):
+                continue
+            sink = node.value
+            sink_name = _call_name(sink).lower().replace(".", "")
+            uses_hash = _depends_on(sink, set(hashes))
+            uses_input = _depends_on(sink, parameters)
+            has_cid_slot = any("cid" in keyword.arg.lower() for keyword in sink.keywords if keyword.arg)
+            authority_sink = any(word in sink_name for word in _AUTHORITY_WORDS)
+            if uses_hash and uses_input and (has_cid_slot or authority_sink):
+                findings.append(
+                    _finding(
+                        path,
+                        node,
+                        SELF_HASH,
+                        "caller-controlled preimage is self-hashed into an authority-bearing return",
+                    )
+                )
+                break
+    return findings
+
+
+def _is_gate_context(node: ast.Constant, parents: dict[ast.AST, ast.AST]) -> bool:
+    parent = parents.get(node)
+    if isinstance(parent, (ast.Compare, ast.Subscript, ast.Dict)):
+        return True
+    if isinstance(parent, ast.Call):
+        return _call_name(parent).endswith((".get", ".lookup", ".resolve", ".dispatch"))
+    if isinstance(parent, (ast.Tuple, ast.List, ast.Set)):
+        grand = parents.get(parent)
+        return isinstance(grand, (ast.Compare, ast.Dict, ast.Call))
+    return False
+
+
+def _name_gate_findings(tree: ast.Module, path: str) -> list[Finding]:
+    parents = {child: parent for parent in ast.walk(tree) for child in ast.iter_child_nodes(parent)}
+    findings: list[Finding] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr in _FORBIDDEN_API_NAMES:
+            findings.append(_finding(path, node, NAME_GATE, f"spelling authority API `{node.attr}`"))
+        elif isinstance(node, ast.Name) and node.id in _FORBIDDEN_API_NAMES:
+            findings.append(_finding(path, node, NAME_GATE, f"spelling authority name `{node.id}`"))
+        elif (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and (_FORBIDDEN_SPELLING.search(node.value) or "overload" in node.value.lower())
+            and _is_gate_context(node, parents)
+        ):
+            findings.append(_finding(path, node, NAME_GATE, f"semantic gate literal {node.value!r}"))
+    return findings
+
+
+def _ast_test_names(function: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Call) or _call_name(node) != "isinstance" or len(node.args) < 2:
+            continue
+        for candidate in ast.walk(node.args[1]):
+            if isinstance(candidate, ast.Attribute) and _name(candidate.value) == "ast":
+                names.add(candidate.attr)
+    return names
+
+
+def _second_path_findings(tree: ast.Module, path: str) -> list[Finding]:
+    if path.endswith(("sugar_source_tree/nodes.py", "sugar_lift_python_source/lifter.py")):
+        return []
+    findings: list[Finding] = []
+    for function in (
+        node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ):
+        ast_tests = _ast_test_names(function)
+        makers = {
+            _call_name(node).split(".")[-1]
+            for node in ast.walk(function)
+            if isinstance(node, ast.Call)
+        } & _FLOOR_MAKERS
+        if ast_tests and makers:
+            findings.append(
+                _finding(
+                    path,
+                    function,
+                    SECOND_PATH,
+                    f"private AST evaluator branches on {sorted(ast_tests)} and manufactures {sorted(makers)}",
+                )
+            )
+    return findings
+
+
+def _has_stmt_coverage_audit(tree: ast.Module) -> bool:
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if (
+            node.func.attr == "__subclasses__"
+            and isinstance(node.func.value, ast.Attribute)
+            and _name(node.func.value) == "ast.stmt"
+        ):
+            return True
+    return False
+
+
+def _terminal_loud(function: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    if not function.body:
+        return False
+    last = function.body[-1]
+    if isinstance(last, ast.Raise):
+        return True
+    if isinstance(last, ast.Return) and isinstance(last.value, ast.Call):
+        name = _call_name(last.value).lower()
+        return any(word in name for word in ("gap", "unsupported", "incomplete", "error"))
+    return False
+
+
+def _declares_statement_transfer(function: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Separate grammar transfers from helpers that incidentally inspect AST nodes."""
+
+    for argument in (*function.args.posonlyargs, *function.args.args, *function.args.kwonlyargs):
+        annotation = argument.annotation
+        if annotation is None:
+            continue
+        rendered = ast.unparse(annotation)
+        if "ast.stmt" in rendered or rendered in {"stmt", "Statement"}:
+            return True
+    return False
+
+
+def _non_exhaustive_findings(tree: ast.Module, path: str) -> list[Finding]:
+    coverage = _has_stmt_coverage_audit(tree)
+    findings: list[Finding] = []
+    for function in (
+        node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ):
+        if not _declares_statement_transfer(function):
+            continue
+        stmt_tests = _ast_test_names(function) & _AST_STMT_NAMES
+        if len(stmt_tests) >= 2 and (not coverage or not _terminal_loud(function)):
+            findings.append(
+                _finding(
+                    path,
+                    function,
+                    NON_EXHAUSTIVE,
+                    f"statement transfer handles {sorted(stmt_tests)} without both grammar audit and loud unknown arm",
+                )
+            )
+    return findings
+
+
+def _fabricated_findings(tree: ast.Module, path: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _call_name(node).split(".")[-1]
+        if name in {"Complete", "Completed"} and any(
+            isinstance(argument, ast.Constant) and argument.value is None
+            for argument in (*node.args, *(keyword.value for keyword in node.keywords))
+        ):
+            findings.append(
+                _finding(path, node, FABRICATED, "completion manufactures None as a fallback value")
+            )
+        if name in {"unwrap_or_default", "get_or_default"}:
+            findings.append(_finding(path, node, FABRICATED, f"benign default fallback `{name}`"))
+    return findings
+
+
+def scan_python_source(source: str, path: str) -> list[Finding]:
+    tree = ast.parse(source, filename=path)
+    findings = [
+        *_self_hash_findings(tree, path),
+        *_name_gate_findings(tree, path),
+        *_second_path_findings(tree, path),
+        *_non_exhaustive_findings(tree, path),
+        *_fabricated_findings(tree, path),
+    ]
+    return sorted(set(findings))
+
+
+_RUST_CATCH_ALL = re.compile(r"\b_\s*=>")
+_RUST_BENIGN_ARM = re.compile(
+    r"\b_\s*=>[^,;\n]*(?:Default::default|Outcome::Complete|Complete\s*\(\s*None|"
+    r"Completed\s*\(\s*None|Ok\s*\(\s*None)"
+)
+
+
+def scan_rust_source(source: str, path: str) -> list[Finding]:
+    findings: list[Finding] = []
+    lines = source.splitlines()
+    for index, line in enumerate(lines, 1):
+        match = _RUST_CATCH_ALL.search(line)
+        # Rust utility matches legitimately use `_ => None/false` for typed
+        # projections.  The invariant concerns a semantic outcome/default,
+        # so require the catch-all itself to manufacture that outcome.
+        if match and _RUST_BENIGN_ARM.search(line):
+            findings.append(Finding(path, index, match.start(), NON_EXHAUSTIVE, "Rust catch-all variant arm silently accepts an unknown variant"))
+            findings.append(Finding(path, index, match.start(), FABRICATED, "Rust catch-all manufactures a benign completion/default"))
+    return sorted(set(findings))
+
+
+def _default_roots(repo: Path) -> tuple[Path, ...]:
+    return (
+        repo / "implementations/python/sugar-source-tree/src",
+        repo / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar",
+        repo / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_contract.py",
+        repo / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py",
+        repo / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/call_contract_resolution.py",
+        repo / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py",
+        repo / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py",
+        repo / "implementations/python/sugar-lift-python-source/src",
+        repo / "implementations/rust/sugar-linker/src",
+        repo / "implementations/rust/sugar-compiler/src",
+        repo / "implementations/rust/sugar-proof-envelope/src",
+        repo / "implementations/rust/sugar-ir-types/src",
+    )
+
+
+def _source_files(roots: Iterable[Path]) -> list[Path]:
+    files: set[Path] = set()
+    for root in roots:
+        if root.is_file() and root.suffix in {".py", ".rs"}:
+            files.add(root)
+        elif root.is_dir():
+            files.update(path for path in root.rglob("*") if path.suffix in {".py", ".rs"})
+    return sorted(files)
+
+
+def scan_roots(roots: Iterable[Path], *, repo: Path | None = None) -> tuple[list[Finding], list[str]]:
+    base = (repo or Path.cwd()).resolve()
+    findings: list[Finding] = []
+    errors: list[str] = []
+    for path in _source_files(roots):
+        label = str(path.resolve().relative_to(base)) if path.resolve().is_relative_to(base) else str(path)
+        try:
+            source = path.read_text(encoding="utf-8")
+            findings.extend(scan_python_source(source, label) if path.suffix == ".py" else scan_rust_source(source, label))
+        except (OSError, UnicodeError, SyntaxError) as exc:
+            errors.append(f"{label}: {type(exc).__name__}: {exc}")
+    return sorted(set(findings)), sorted(errors)
+
+
+def format_report(findings: Iterable[Finding], errors: Iterable[str] = ()) -> str:
+    rows = list(findings)
+    error_rows = list(errors)
+    lines = []
+    for finding in rows:
+        lines.append(
+            f"{finding.path}:{finding.line}:{finding.column}: {finding.violation_class}: "
+            f"{finding.observed}; required fix: {finding.required_fix}"
+        )
+    lines.extend(f"AUDITOR-ERROR: {error}" for error in error_rows)
+    by_class = {kind: sum(row.violation_class == kind for row in rows) for kind in REQUIRED_FIX}
+    lines.append(f"R_construction_invariant_violations = {len(rows)}")
+    for kind, count in by_class.items():
+        lines.append(f"R_{kind.lower().replace('-', '_')} = {count}")
+    lines.append(f"R_auditor_errors = {len(error_rows)}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("roots", nargs="*", type=Path)
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--json", type=Path)
+    args = parser.parse_args()
+    repo = args.repo.resolve()
+    roots = tuple(path.resolve() for path in args.roots) or _default_roots(repo)
+    findings, errors = scan_roots(roots, repo=repo)
+    print(format_report(findings, errors))
+    if args.json is not None:
+        args.json.write_text(
+            json.dumps(
+                {
+                    "kind": "construction-invariant-audit",
+                    "R": len(findings),
+                    "auditorErrors": errors,
+                    "findings": [finding.to_value() for finding in findings],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    return 1 if findings or errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_invariant_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_invariant_law.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+
+
+_SCRIPT = (
+    Path(__file__).parents[1] / "scripts" / "construction_invariant_law.py"
+)
+_SPEC = importlib.util.spec_from_file_location("construction_invariant_law", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+LAW = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = LAW
+_SPEC.loader.exec_module(LAW)
+
+
+def _classes(source: str) -> set[str]:
+    return {finding.violation_class for finding in LAW.scan_python_source(source, "planted.py")}
+
+
+def test_each_reject_class_has_a_structural_planted_twin() -> None:
+    assert _classes(
+        """
+def decode(raw):
+    content_cid = cid_of_json(raw)
+    return AuthenticatedThing(raw=raw, cid=content_cid)
+"""
+    ) == {"SELF-HASHING-AS-AUTHORITY"}
+
+    assert _classes(
+        """
+def resolve(symbol):
+    if symbol == "pytest.raises":
+        return EffectBoundary()
+"""
+    ) == {"NAME-SPELLING-OVERLOAD-GATE"}
+
+    assert _classes(
+        """
+import ast
+def _expr(node):
+    if isinstance(node, ast.Constant):
+        return StringValue(node.value)
+    return ObjectValue("made", ())
+"""
+    ) == {"SECOND-CONSTRUCTION-PATH"}
+
+    assert _classes(
+        """
+import ast
+def transfer(statement: ast.stmt, state):
+    if isinstance(statement, ast.If):
+        return state
+    if isinstance(statement, ast.For):
+        return state
+    return state
+"""
+    ) == {"NON-EXHAUSTIVE-VARIANT-COVERAGE"}
+
+    assert _classes(
+        """
+def desugar(value):
+    if value is None:
+        return Complete(None)
+    return Complete(value)
+"""
+    ) == {"FABRICATED-COMPLETION-FALLBACK"}
+
+
+def test_discrimination_negatives_do_not_false_positive() -> None:
+    source = """
+import ast
+
+def checksum(payload):
+    return cid_of_json(payload)
+
+def decode(raw, graph):
+    reconstructed = graph.resolve(raw)
+    if reconstructed.to_value() != raw:
+        raise AuthenticationError("not byte-identical")
+    return ResolvedThing(reconstructed)
+
+def measure(node):
+    if isinstance(node, ast.Constant):
+        return type(node).__name__
+    return "other"
+
+STATEMENT_TYPES = frozenset(ast.stmt.__subclasses__())
+def transfer(statement, state):
+    if isinstance(statement, ast.If):
+        return state
+    raise UnsupportedStatement(type(statement).__name__)
+
+def desugar(value):
+    if value is None:
+        raise TypedGap("opaque")
+    return Complete(value)
+"""
+    assert LAW.scan_python_source(source, "clean.py") == []
+
+
+def test_rust_benign_catchall_and_default_fallback_are_loud() -> None:
+    source = """
+fn decode(value: Value) -> Outcome {
+    match value {
+        Value::Known(v) => Outcome::Complete(v),
+        _ => Outcome::Complete(Default::default()),
+    }
+}
+"""
+    findings = LAW.scan_rust_source(source, "planted.rs")
+    assert {finding.violation_class for finding in findings} == {
+        "FABRICATED-COMPLETION-FALLBACK",
+        "NON-EXHAUSTIVE-VARIANT-COVERAGE",
+    }
+
+
+def test_report_names_file_line_class_and_required_fix() -> None:
+    findings = LAW.scan_python_source(
+        'def resolve(name):\n    return TABLE.get(name, "pytest.raises")\n',
+        "construction/door.py",
+    )
+    rendered = LAW.format_report(findings)
+    assert "construction/door.py:2" in rendered
+    assert "NAME-SPELLING-OVERLOAD-GATE" in rendered
+    assert "required fix:" in rendered
+    assert "R_construction_invariant_violations = 1" in rendered
+
+
+def test_cli_is_red_on_a_planted_violation_and_green_on_clean_source(tmp_path: Path) -> None:
+    planted = tmp_path / "planted.py"
+    planted.write_text(
+        'def resolve(name):\n    return TABLE.get(name, "pytest.raises")\n',
+        encoding="utf-8",
+    )
+    red = subprocess.run(
+        [sys.executable, str(_SCRIPT), "--repo", str(tmp_path), str(planted)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert red.returncode == 1
+    assert "NAME-SPELLING-OVERLOAD-GATE" in red.stdout
+
+    planted.write_text("def identity(value):\n    return value\n", encoding="utf-8")
+    green = subprocess.run(
+        [sys.executable, str(_SCRIPT), "--repo", str(tmp_path), str(planted)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert green.returncode == 0
+    assert "R_construction_invariant_violations = 0" in green.stdout


### PR DESCRIPTION
## Summary
- add a reusable construction-path auditor for five recurring soundness reject classes
- report every finding with file:line, violation class, and required repair law
- add planted positive and clean discrimination twins, including executable red/green CLI behavior

## Current main measurement
- R_construction_invariant_violations = 14
- R_name_spelling_overload_gate = 7
- R_non_exhaustive_variant_coverage = 7
- R_self_hashing_as_authority = 0
- R_second_construction_path = 0
- R_fabricated_completion_fallback = 0
- R_auditor_errors = 0

The direct audit intentionally exits non-zero while R or auditor errors are nonzero. The pytest discrimination suite remains green and prevents the detector itself from becoming toothless.

## Validation
- PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src python3 -m pytest -q implementations/python/sugar-lift-py-tests/tests/test_construction_invariant_law.py --noconftest (5 passed)
- direct current-main audit: exit 1, R=14, auditor_errors=0
- python3 -m py_compile on auditor and tests
- git diff --check

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add construction-invariant audit script and CLI for Python and Rust sources
> - Adds [construction_invariant_law.py](https://github.com/TSavo/sugar/pull/6108/files#diff-d79f46df33c455d00e9bc928445c143d180473c1c04f28feb653ebd0ec45bf0a), a static analysis tool that scans Python and Rust source files for violations of construction invariants across five categories: `SELF-HASHING-AS-AUTHORITY`, `NAME-SPELLING-OVERLOAD-GATE`, `SECOND-CONSTRUCTION-PATH`, `NON-EXHAUSTIVE-VARIANT-COVERAGE`, and `FABRICATED-COMPLETION-FALLBACK`.
> - The Python scanner uses the `ast` module to detect patterns such as self-hashing inputs into authority-bearing returns, forbidden API names or gate-context literals, private AST evaluators branching on `ast.*` kinds, non-exhaustive statement-transfer functions, and manufactured benign defaults.
> - The Rust scanner uses regex to flag catch-all match arms that both accept unknown variants and produce benign outcomes on the same line.
> - Provides a CLI accepting source roots, a `--repo` flag for label normalization, and an optional `--json` output path; exits 1 if any findings or auditor errors are present.
> - Adds [test_construction_invariant_law.py](https://github.com/TSavo/sugar/pull/6108/files#diff-7631171dde05bd3d885d8d82ee6e6f41031aaf19b30c15147b4a40d3f90b91fe) with positive/negative detection tests, Rust scanner tests, report format tests, and a CLI integration test.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd05ebd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->