### PR TITLE
test: object-identity / object-field-flow acceptance twins

### DIFF
--- a/docs/audits/object-field-flow-acceptance-requirements.md
+++ b/docs/audits/object-field-flow-acceptance-requirements.md
@@ -1,0 +1,86 @@
+# Object identity and object-field-flow acceptance requirements
+
+This note scopes the construction substrate required by the acceptance matrix in
+`implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/`.
+It deliberately specifies obligations, not a production representation.
+
+## Required authority
+
+An object occurrence needs a content-addressed identity whose CID is derived
+from its authenticated construction testimony and construction locus. The
+identity law is `h = h(p)`: equal authenticated construction preimages produce
+the same identity and different construction occurrences produce different
+identities. A source spelling, a variable name, a class name, or a symbolic
+receiver is not an identity preimage.
+
+A field place is the typed pair of an authenticated object identity and a field
+selector. The selector participates in the place CID, but its spelling alone
+grants no object authority. A field version additionally commits to the prior
+field version, the constructed stored value, and the exact store occurrence.
+This prevents two stores or two independently constructed objects from sharing
+an accidental identity hub.
+
+## One temporal model
+
+Object identities and field versions must be values carried by the existing
+source-tree substitution and `BindingState` flow. A name binding may carry an
+authenticated object identity just as it carries any other constructed node.
+An assignment alias copies that identity through the ordinary binding update;
+there is no ambient heap table, global name map, desugar-time scope, or second
+binding resolver.
+
+Branching uses the existing guarded state. A field version available on only
+one completion face must remain guarded on that face; a read after the join may
+project it only under the corresponding guard. A halted face contributes no
+store to later state.
+
+## Alias and descriptor obligations
+
+`alias = original` shares an identity only when the RHS construction already
+carries authenticated object identity. Calls, imports without resolved
+construction testimony, symbolic parameters, and other opaque projections do
+not establish alias equivalence.
+
+Before a store can become a field version, construction must establish the
+applicable descriptor/`__setattr__` behavior. A data descriptor, dynamic
+`__setattr__`, monkey patch, or unresolved class contract can redirect or reject
+the store; those cases remain typed-loud. A later read likewise requires
+authenticated lookup behavior compatible with the stored place. The model may
+not replace Python descriptor semantics with a plain dictionary assumption.
+
+An opaque call that can receive the object invalidates knowledge of mutable
+fields unless the call contract proves the relevant frame condition. It is
+unsound to retain a pre-call field value merely because the variable spelling
+did not change.
+
+## Total outcome
+
+For every attempted object-field projection, construction has exactly two
+outcomes:
+
+1. an authenticated object/place identity and field version threaded through
+   the existing temporal binding state; or
+2. a typed construction gap naming the missing identity, alias, descriptor, or
+   frame testimony.
+
+There is no fabricated completion, name/vendor dispatch, ambient state, or
+generic fallback value.
+
+## Acceptance matrix
+
+- `store-then-read`: the later read observes the constructed stored value;
+  truthful is SAT and the lying twin is UNSAT.
+- `distinct-objects`: two construction occurrences of the same class retain
+  distinct identities and do not collide.
+- `authenticated-alias`: a plain assignment alias shares the authenticated
+  identity, so a store through one name is visible through the other.
+- `symbolic-receiver`: no identity can be minted from a formal/symbolic
+  receiver; the flow remains typed-loud.
+- `opaque-mutation`: a call without an authenticated frame contract may mutate
+  the object; a later field read remains typed-loud.
+- `opaque-alias`: an opaque function result does not inherit its argument's
+  identity; reading through it remains typed-loud.
+
+Every case has a renamed structural twin. The fixture audit rejects imports,
+ambient binding declarations, stringly reflection, and type/name inspection so
+no passing implementation can justify itself with a vendor or spelling gate.

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/authenticated_alias.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/authenticated_alias.py
@@ -1,0 +1,34 @@
+class Parcel:
+    pass
+
+
+def truthful():
+    original = Parcel()
+    alias = original
+    original.payload = 7
+    assert alias.payload == 7
+
+
+def lying():
+    original = Parcel()
+    alias = original
+    original.payload = 7
+    assert alias.payload == 8
+
+
+class Capsule:
+    pass
+
+
+def renamed_truthful():
+    source = Capsule()
+    echo = source
+    source.marker = 7
+    assert echo.marker == 7
+
+
+def renamed_lying():
+    source = Capsule()
+    echo = source
+    source.marker = 7
+    assert echo.marker == 8

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/distinct_objects.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/distinct_objects.py
@@ -1,0 +1,38 @@
+class Parcel:
+    pass
+
+
+def truthful():
+    left = Parcel()
+    right = Parcel()
+    left.payload = 7
+    right.payload = 11
+    assert (left.payload, right.payload) == (7, 11)
+
+
+def lying():
+    left = Parcel()
+    right = Parcel()
+    left.payload = 7
+    right.payload = 11
+    assert (left.payload, right.payload) == (11, 11)
+
+
+class Capsule:
+    pass
+
+
+def renamed_truthful():
+    first = Capsule()
+    second = Capsule()
+    first.marker = 7
+    second.marker = 11
+    assert (first.marker, second.marker) == (7, 11)
+
+
+def renamed_lying():
+    first = Capsule()
+    second = Capsule()
+    first.marker = 7
+    second.marker = 11
+    assert (first.marker, second.marker) == (11, 11)

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/opaque_alias.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/opaque_alias.py
@@ -1,0 +1,20 @@
+class Parcel:
+    pass
+
+
+def read_through_opaque_alias(alias_factory):
+    original = Parcel()
+    alias = alias_factory(original)
+    original.payload = 7
+    return alias.payload
+
+
+class Capsule:
+    pass
+
+
+def renamed_read_through_opaque_alias(project):
+    source = Capsule()
+    echo = project(source)
+    source.marker = 7
+    return echo.marker

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/opaque_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/opaque_mutation.py
@@ -1,0 +1,20 @@
+class Parcel:
+    pass
+
+
+def read_after_opaque_mutation(mutator):
+    item = Parcel()
+    item.payload = 7
+    mutator(item)
+    return item.payload
+
+
+class Capsule:
+    pass
+
+
+def renamed_read_after_opaque_mutation(transform):
+    vessel = Capsule()
+    vessel.marker = 7
+    transform(vessel)
+    return vessel.marker

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/store_then_read.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/store_then_read.py
@@ -1,0 +1,30 @@
+class Parcel:
+    pass
+
+
+def truthful():
+    item = Parcel()
+    item.payload = 7
+    assert item.payload == 7
+
+
+def lying():
+    item = Parcel()
+    item.payload = 7
+    assert item.payload == 8
+
+
+class Capsule:
+    pass
+
+
+def renamed_truthful():
+    vessel = Capsule()
+    vessel.marker = 7
+    assert vessel.marker == 7
+
+
+def renamed_lying():
+    vessel = Capsule()
+    vessel.marker = 7
+    assert vessel.marker == 8

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/symbolic_receiver.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/symbolic_receiver.py
@@ -1,0 +1,8 @@
+def read_after_store(receiver, supplied):
+    receiver.payload = supplied
+    return receiver.payload
+
+
+def renamed_read_after_store(container, offered):
+    container.marker = offered
+    return container.marker

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/verdict_matrix.json
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/verdict_matrix.json
@@ -1,0 +1,59 @@
+{
+  "schema": "object-field-flow-acceptance-v1",
+  "cases": [
+    {
+      "id": "store-then-read",
+      "file": "store_then_read.py",
+      "canonical": {"truthful": "truthful", "lying": "lying"},
+      "renamed": {"truthful": "renamed_truthful", "lying": "renamed_lying"},
+      "current": "typed-loud",
+      "target": {"truthful": "sat", "lying": "unsat"},
+      "requires": ["content-addressed-object-identity", "field-version-threading"]
+    },
+    {
+      "id": "distinct-objects",
+      "file": "distinct_objects.py",
+      "canonical": {"truthful": "truthful", "lying": "lying"},
+      "renamed": {"truthful": "renamed_truthful", "lying": "renamed_lying"},
+      "current": "typed-loud",
+      "target": {"truthful": "sat", "lying": "unsat"},
+      "requires": ["construction-occurrence-discrimination", "no-spelling-identity"]
+    },
+    {
+      "id": "authenticated-alias",
+      "file": "authenticated_alias.py",
+      "canonical": {"truthful": "truthful", "lying": "lying"},
+      "renamed": {"truthful": "renamed_truthful", "lying": "renamed_lying"},
+      "current": "typed-loud",
+      "target": {"truthful": "sat", "lying": "unsat"},
+      "requires": ["authenticated-alias-equivalence", "single-temporal-binding-model"]
+    },
+    {
+      "id": "symbolic-receiver",
+      "file": "symbolic_receiver.py",
+      "canonical": "read_after_store",
+      "renamed": "renamed_read_after_store",
+      "current": "typed-loud",
+      "target": "typed-loud",
+      "requires": ["no-symbolic-receiver-identity", "no-fabricated-state"]
+    },
+    {
+      "id": "opaque-mutation",
+      "file": "opaque_mutation.py",
+      "canonical": "read_after_opaque_mutation",
+      "renamed": "renamed_read_after_opaque_mutation",
+      "current": "typed-loud",
+      "target": "typed-loud",
+      "requires": ["opaque-call-invalidates-field-knowledge", "no-fabricated-state"]
+    },
+    {
+      "id": "opaque-alias",
+      "file": "opaque_alias.py",
+      "canonical": "read_through_opaque_alias",
+      "renamed": "renamed_read_through_opaque_alias",
+      "current": "typed-loud",
+      "target": "typed-loud",
+      "requires": ["alias-requires-construction-testimony", "no-fabricated-state"]
+    }
+  ]
+}

--- a/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import ast
+import copy
+import json
+from pathlib import Path
+import runpy
+
+import pytest
+
+from sugar_lift_py_tests.outcome import Incomplete
+from sugar_lift_py_tests.effect.runtime_effect import RuntimeEffect
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.panic import SourceTreePanic
+from sugar_source_tree.tree import SourceFile
+
+
+FIXTURES = Path(__file__).parent / "fixtures" / "object_field_flow"
+MATRIX = json.loads((FIXTURES / "verdict_matrix.json").read_text())
+POSITIVE_IDS = {"store-then-read", "distinct-objects", "authenticated-alias"}
+LOUD_IDS = {"symbolic-receiver", "opaque-mutation", "opaque-alias"}
+FORBIDDEN_MECHANISM_CALLS = {"getattr", "setattr", "hasattr", "id", "type", "isinstance"}
+
+
+def _functions(path: Path):
+    return {function.name: function for function in SourceFile(path_source(path)).functions()}
+
+
+def _outcome_or_panic(path: Path, function_name: str):
+    try:
+        return _functions(path)[function_name].sugar().desugar()
+    except (ConstructionPanic, SourceTreePanic) as panic:
+        return panic
+
+
+def _is_typed_loud(result) -> bool:
+    if isinstance(result, (ConstructionPanic, Incomplete, SourceTreePanic)):
+        return True
+    value = getattr(result, "value", None)
+    record = getattr(value, "record", None)
+    statements = getattr(record, "statements", ())
+    return any(
+        isinstance(statement, RuntimeEffect)
+        or (
+            isinstance(statement, Incomplete)
+            and isinstance(statement.effect, RuntimeEffect)
+        )
+        for statement in statements
+    )
+
+
+class _RoleNormalizer(ast.NodeTransformer):
+    def __init__(self):
+        self.names: dict[str, str] = {}
+        self.attrs: dict[str, str] = {}
+
+    def _name(self, spelling: str) -> str:
+        return self.names.setdefault(spelling, f"name{len(self.names)}")
+
+    def visit_FunctionDef(self, node):
+        node.name = "function"
+        return self.generic_visit(node)
+
+    def visit_arg(self, node):
+        node.arg = self._name(node.arg)
+        return self.generic_visit(node)
+
+    def visit_Name(self, node):
+        node.id = self._name(node.id)
+        return self.generic_visit(node)
+
+    def visit_Attribute(self, node):
+        node.attr = self.attrs.setdefault(node.attr, f"field{len(self.attrs)}")
+        return self.generic_visit(node)
+
+
+def _normalized_function(module: ast.Module, name: str) -> str:
+    function = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+    normalized = _RoleNormalizer().visit(copy.deepcopy(function))
+    return ast.dump(ast.fix_missing_locations(normalized), include_attributes=False)
+
+
+def test_verdict_matrix_is_closed_and_names_every_required_invariant():
+    assert MATRIX["schema"] == "object-field-flow-acceptance-v1"
+    cases = MATRIX["cases"]
+    assert {case["id"] for case in cases} == POSITIVE_IDS | LOUD_IDS
+    assert len(cases) == 6
+    requirements = {item for case in cases for item in case["requires"]}
+    assert {
+        "content-addressed-object-identity",
+        "construction-occurrence-discrimination",
+        "no-spelling-identity",
+        "authenticated-alias-equivalence",
+        "single-temporal-binding-model",
+        "no-symbolic-receiver-identity",
+        "opaque-call-invalidates-field-knowledge",
+        "alias-requires-construction-testimony",
+        "no-fabricated-state",
+    } <= requirements
+
+
+@pytest.mark.parametrize(
+    "case",
+    [case for case in MATRIX["cases"] if case["id"] in POSITIVE_IDS],
+    ids=lambda case: case["id"],
+)
+def test_python_reference_discriminates_truthful_and_lying_twins(case):
+    namespace = runpy.run_path(FIXTURES / case["file"])
+    for names in (case["canonical"], case["renamed"]):
+        namespace[names["truthful"]]()
+        with pytest.raises(AssertionError):
+            namespace[names["lying"]]()
+
+
+@pytest.mark.parametrize("case", MATRIX["cases"], ids=lambda case: case["id"])
+def test_fixtures_are_renamed_structural_twins_without_name_or_vendor_authority(case):
+    path = FIXTURES / case["file"]
+    source = path.read_text()
+    module = ast.parse(source, filename=str(path))
+    assert not any(
+        isinstance(node, (ast.Import, ast.ImportFrom, ast.Global, ast.Nonlocal))
+        for node in ast.walk(module)
+    )
+    called_names = {
+        node.func.id
+        for node in ast.walk(module)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert called_names.isdisjoint(FORBIDDEN_MECHANISM_CALLS)
+    assert not any(
+        isinstance(node, ast.Constant) and isinstance(node.value, str)
+        for node in ast.walk(module)
+    )
+
+    canonical = case["canonical"]
+    renamed = case["renamed"]
+    if isinstance(canonical, dict):
+        for verdict in ("truthful", "lying"):
+            assert _normalized_function(module, canonical[verdict]) == _normalized_function(
+                module, renamed[verdict]
+            )
+    else:
+        assert _normalized_function(module, canonical) == _normalized_function(module, renamed)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [case for case in MATRIX["cases"] if case["id"] in POSITIVE_IDS],
+    ids=lambda case: case["id"],
+)
+@pytest.mark.xfail(
+    strict=True,
+    reason="acceptance red: construction-authoritative object/place identity is not implemented",
+)
+def test_positive_object_field_flow_acceptance_is_not_typed_loud(case):
+    path = FIXTURES / case["file"]
+    for names in (case["canonical"], case["renamed"]):
+        for function_name in names.values():
+            result = _outcome_or_panic(path, function_name)
+            assert not _is_typed_loud(result), result
+
+
+@pytest.mark.parametrize(
+    "case",
+    [case for case in MATRIX["cases"] if case["id"] in LOUD_IDS],
+    ids=lambda case: case["id"],
+)
+def test_unauthenticated_object_field_flow_stays_typed_loud(case):
+    path = FIXTURES / case["file"]
+    for function_name in (case["canonical"], case["renamed"]):
+        result = _outcome_or_panic(path, function_name)
+        assert _is_typed_loud(result), result


### PR DESCRIPTION
## What

- Adds a closed, machine-readable object-field-flow verdict matrix.
- Adds renamed/non-vendor fixtures for store/read, distinct identities, authenticated aliases, symbolic receivers, opaque mutation, and opaque aliases.
- Adds executable AST-law, Python-reference discrimination, current loud-boundary, and strict future-acceptance tests.
- Files the construction-authoritative object/place identity requirements for architect design.

## Invariants pinned

- Object identity is content-addressed from authenticated construction testimony, never spelling.
- Aliases share identity only through the existing temporal binding path.
- Symbolic receivers, opaque aliases, and opaque mutation remain typed-loud.
- Descriptor and frame testimony are required before field state can propagate.
- No ambient heap or second binding resolver.

## Verification

- 13 passed, 3 xfailed. The three positive capabilities are intentionally strict acceptance-red until the production model exists.
- Fixture AST audit: zero imports, vendor spellings, stringly reflection, or type/name inspection.
- JSON verdict matrix validates.
- No production or Rust changes; battleaxe not applicable.