### PR TITLE
drain: caller-parameter contracts via ContractConditionalConstruction (#6086)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import json
+from typing import Any
+
+from sugar_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs
+from sugar_lift_py_tests.context_manager_contract import _json_value
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.floor import FloorValue
+from sugar_lift_py_tests.ir import Formula, Term, formula_to_value, term_to_value
+
+
+def _json(value) -> Any:
+    return json.loads(encode_jcs(value))
+
+
+def _cid(value: Any) -> str:
+    return blake3_512_of(encode_jcs(_json_value(value)).encode("utf-8"))
+
+
+def source_coordinate(site) -> SourceFragmentCoordinateV1:
+    span = site.line_col_span
+    return SourceFragmentCoordinateV1(
+        site.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
+@dataclass(frozen=True)
+class ParameterContractDemandV1:
+    owner_source_identity_cid: str
+    formal_coordinate_cid: str
+    operation_site: SourceFragmentCoordinateV1
+    demanded_formula: Formula
+    candidate_cid: str
+    demand_cid: str
+    demanded_effect_bound: object | None = None
+    kind: str = "parameter-contract-demand"
+    schema_version: str = "1"
+
+    @classmethod
+    def mint(
+        cls,
+        *,
+        owner_source_identity_cid: str,
+        formal_coordinate_cid: str,
+        operation_site: SourceFragmentCoordinateV1,
+        demanded_formula: Formula,
+        candidate_cid: str,
+    ) -> "ParameterContractDemandV1":
+        preimage = {
+            "kind": "parameter-contract-demand",
+            "schemaVersion": "1",
+            "ownerSourceIdentityCid": owner_source_identity_cid,
+            "formalCoordinateCid": formal_coordinate_cid,
+            "operationSite": operation_site.wire(),
+            "demandedFormula": _json(formula_to_value(demanded_formula)),
+            "demandedEffectBound": None,
+            "candidateCid": candidate_cid,
+        }
+        return cls(
+            owner_source_identity_cid,
+            formal_coordinate_cid,
+            operation_site,
+            demanded_formula,
+            candidate_cid,
+            _cid(preimage),
+        )
+
+    def to_value(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "schemaVersion": self.schema_version,
+            "ownerSourceIdentityCid": self.owner_source_identity_cid,
+            "formalCoordinateCid": self.formal_coordinate_cid,
+            "operationSite": self.operation_site.wire(),
+            "demandedFormula": _json(formula_to_value(self.demanded_formula)),
+            "demandedEffectBound": None,
+            "candidateCid": self.candidate_cid,
+            "demandCid": self.demand_cid,
+        }
+
+
+@dataclass(frozen=True)
+class ContractConditionalConstructionV1:
+    source_node: SourceFragmentCoordinateV1
+    candidate: Term
+    candidate_cid: str
+    demand: ParameterContractDemandV1
+    value: FloorValue
+
+    @classmethod
+    def mint(
+        cls,
+        *,
+        site,
+        candidate: Term,
+        demand_formula: Formula,
+        value: FloorValue,
+        coordinate,
+    ):
+        source_node = source_coordinate(site)
+        candidate_preimage = {
+            "kind": "parameter-contract-candidate",
+            "schemaVersion": "1",
+            "sourceNode": source_node.wire(),
+            "candidate": _json(term_to_value(candidate)),
+        }
+        candidate_cid = _cid(candidate_preimage)
+        demand = ParameterContractDemandV1.mint(
+            owner_source_identity_cid=coordinate.owner_source_identity_cid,
+            formal_coordinate_cid=coordinate.coordinate_cid,
+            operation_site=source_node,
+            demanded_formula=demand_formula,
+            candidate_cid=candidate_cid,
+        )
+        return cls(source_node, candidate, candidate_cid, demand, value)
+
+    def and_then(self, step):
+        from sugar_lift_py_tests.outcome import Complete
+
+        following = step(self.value)
+        if isinstance(following, Complete):
+            return replace(self, value=following.value)
+        return following
+
+    def contribution(self):
+        return (self,)
+
+    def inv_contribution(self):
+        return self.value.inv_contribution()
+
+    def post_contribution(self):
+        return self.value.post_contribution()
+
+    def derived_post_contribution(self):
+        return self.value.derived_post_contribution()
+
+    def edge_contribution(self, source_name):
+        return self.value.edge_contribution(source_name)
+
+    def follow(self):
+        return self.value.follow_rest()
+
+    def extend_scope(self, ctx):
+        return self.value.extend_scope(ctx)
+
+    def to_value(self) -> dict[str, Any]:
+        return {
+            "kind": "contract-conditional-construction",
+            "schemaVersion": "1",
+            "sourceNode": self.source_node.wire(),
+            "candidate": _json(term_to_value(self.candidate)),
+            "candidateCid": self.candidate_cid,
+            "demand": self.demand.to_value(),
+        }
+
+
+@dataclass(frozen=True)
+class ValueOccurrenceCoordinateV1:
+    source: SourceFragmentCoordinateV1
+    occurrence_cid: str
+
+    @classmethod
+    def mint(cls, source: SourceFragmentCoordinateV1):
+        return cls(source, _cid({"kind": "value-occurrence", "source": source.wire()}))
+
+    def to_value(self):
+        return {"source": self.source.wire(), "occurrenceCid": self.occurrence_cid}
+
+    @classmethod
+    def from_value(cls, value):
+        if not isinstance(value, dict) or set(value) != {"source", "occurrenceCid"}:
+            raise ValueError("value occurrence requires an exact key set")
+        result = cls(
+            SourceFragmentCoordinateV1.decode(value["source"]), value["occurrenceCid"]
+        )
+        if result != cls.mint(result.source):
+            raise ValueError("value occurrence CID is stale")
+        return result
+
+
+@dataclass(frozen=True)
+class FormalActualBindingV1:
+    formal_coordinate_cid: str
+    actual_occurrence: ValueOccurrenceCoordinateV1
+    actual_term: Term
+    actual_contract_ref_cid: str | None = None
+
+    def to_value(self):
+        return {
+            "formalCoordinateCid": self.formal_coordinate_cid,
+            "actualOccurrence": self.actual_occurrence.to_value(),
+            "actualTerm": _json(term_to_value(self.actual_term)),
+            "actualContractRefCid": self.actual_contract_ref_cid,
+        }
+
+    @classmethod
+    def from_value(cls, value):
+        expected = {
+            "formalCoordinateCid",
+            "actualOccurrence",
+            "actualTerm",
+            "actualContractRefCid",
+        }
+        if not isinstance(value, dict) or set(value) != expected:
+            raise ValueError("formal actual binding requires an exact key set")
+        return cls(
+            value["formalCoordinateCid"],
+            ValueOccurrenceCoordinateV1.from_value(value["actualOccurrence"]),
+            _term_from_value(value["actualTerm"]),
+            value["actualContractRefCid"],
+        )
+
+
+@dataclass(frozen=True)
+class CallEdgeV2:
+    source_contract_cid: str
+    target_contract_cid: str
+    call_site: SourceFragmentCoordinateV1
+    formal_actual_bindings: tuple[FormalActualBindingV1, ...]
+    edge_cid: str
+
+    @classmethod
+    def mint(
+        cls,
+        *,
+        source_contract_cid,
+        target_contract_cid,
+        call_site,
+        formal_actual_bindings,
+    ):
+        coordinates = tuple(
+            binding.formal_coordinate_cid for binding in formal_actual_bindings
+        )
+        if len(set(coordinates)) != len(coordinates):
+            raise ValueError("CallEdgeV2 has a duplicate formal coordinate")
+        preimage = {
+            "kind": "call-edge",
+            "schemaVersion": "2",
+            "sourceContractCid": source_contract_cid,
+            "targetContractCid": target_contract_cid,
+            "callSite": call_site.wire(),
+            "formalActualBindings": [
+                binding.to_value() for binding in formal_actual_bindings
+            ],
+        }
+        return cls(
+            source_contract_cid,
+            target_contract_cid,
+            call_site,
+            tuple(formal_actual_bindings),
+            _cid(preimage),
+        )
+
+    def to_value(self):
+        return {
+            "kind": "call-edge",
+            "schemaVersion": "2",
+            "sourceContractCid": self.source_contract_cid,
+            "targetContractCid": self.target_contract_cid,
+            "callSite": self.call_site.wire(),
+            "formalActualBindings": [
+                binding.to_value() for binding in self.formal_actual_bindings
+            ],
+            "edgeCid": self.edge_cid,
+        }
+
+    @classmethod
+    def from_value(cls, value):
+        expected = {
+            "kind",
+            "schemaVersion",
+            "sourceContractCid",
+            "targetContractCid",
+            "callSite",
+            "formalActualBindings",
+            "edgeCid",
+        }
+        if not isinstance(value, dict) or set(value) != expected:
+            raise ValueError("CallEdgeV2 requires an exact key set")
+        if value["kind"] != "call-edge" or value["schemaVersion"] != "2":
+            raise ValueError("CallEdgeV2 has the wrong tag")
+        result = cls.mint(
+            source_contract_cid=value["sourceContractCid"],
+            target_contract_cid=value["targetContractCid"],
+            call_site=SourceFragmentCoordinateV1.decode(value["callSite"]),
+            formal_actual_bindings=tuple(
+                FormalActualBindingV1.from_value(item)
+                for item in value["formalActualBindings"]
+            ),
+        )
+        if result.edge_cid != value["edgeCid"]:
+            raise ValueError("CallEdgeV2 CID is stale")
+        return result
+
+
+def _term_from_value(value):
+    from sugar_lift_py_tests.ir import (
+        bool_const,
+        ctor,
+        make_var,
+        num,
+        real_lit,
+        str_const,
+    )
+
+    if not isinstance(value, dict):
+        raise ValueError("actual term must be a ProofIR term")
+    kind = value.get("kind")
+    if kind == "var" and set(value) == {"kind", "name"}:
+        return make_var(value["name"])
+    if kind == "ctor" and set(value) == {"kind", "name", "args"}:
+        return ctor(value["name"], [_term_from_value(item) for item in value["args"]])
+    if kind == "const" and set(value) == {"kind", "value", "sort"}:
+        sort = value["sort"].get("name") if isinstance(value["sort"], dict) else None
+        if sort == "Int" and type(value["value"]) is int:
+            return num(value["value"])
+        if sort == "Bool" and type(value["value"]) is bool:
+            return bool_const(value["value"])
+        if sort == "String" and isinstance(value["value"], str):
+            return str_const(value["value"])
+        if sort == "Real" and isinstance(value["value"], str):
+            return real_lit(value["value"])
+    raise ValueError("actual term shape is unsupported")

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -43,6 +43,7 @@ class SymbolicValue(FloorValue):
     """
 
     term: Term
+    formal_coordinate: object | None = None
 
     def python_isinstance(self, type_name: str, type_term, site):
         """Fold ground ``python:*`` data ctors against a named builtin type.
@@ -414,8 +415,24 @@ class SymbolicValue(FloorValue):
         return Complete(SymbolicValue(ctor("py.invert", [self.term])))
 
     def subscript(self, index, site):
-        # A symbolic receiver stays the py.subscript coordinate regardless of index.
-        return self.py_subscript_coordinate(index, site)
+        # A generic symbolic receiver stays the py.subscript coordinate. A
+        # declaration-owned formal emits that same candidate once, gated by
+        # the exact indexability demand for later linker discharge.
+        built = self.py_subscript_coordinate(index, site)
+        if self.formal_coordinate is None:
+            return built
+        from sugar_lift_py_tests.caller_parameter_contract import (
+            ContractConditionalConstructionV1,
+        )
+        from sugar_lift_py_tests.ir import atomic
+
+        return ContractConditionalConstructionV1.mint(
+            site=site,
+            candidate=built.value.to_term(owner=str(site)),
+            demand_formula=atomic("python:indexable", [self.term]),
+            value=built.value,
+            coordinate=self.formal_coordinate,
+        )
 
     def attribute(self, name, site):
         # A symbolic receiver stays the py.getattr coordinate: an opaque term

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/formal_parameter.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/formal_parameter.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from sugar_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs
+from sugar_lift_py_tests.context_manager_contract import _json_value
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.ir import PrimitiveSort
+
+ParameterKindV1 = Literal[
+    "positional-only",
+    "positional-or-keyword",
+    "variadic-positional",
+    "keyword-only",
+    "variadic-keyword",
+]
+
+
+def _cid(value: Any) -> str:
+    return blake3_512_of(encode_jcs(_json_value(value)).encode("utf-8"))
+
+
+@dataclass(frozen=True)
+class FormalParameterCoordinateV1:
+    owner_source_identity_cid: str
+    owner_definition_locus: SourceFragmentCoordinateV1
+    declaration_locus: SourceFragmentCoordinateV1
+    ordinal: int
+    parameter_kind: ParameterKindV1
+    declared_name: str
+    sort: PrimitiveSort
+    coordinate_cid: str
+    kind: str = "formal-parameter-coordinate"
+    schema_version: str = "1"
+
+    def __post_init__(self) -> None:
+        if not self.owner_source_identity_cid.startswith("blake3-512:"):
+            raise ValueError("formal owner requires a source identity CID")
+        if (
+            isinstance(self.ordinal, bool)
+            or not isinstance(self.ordinal, int)
+            or self.ordinal < 0
+        ):
+            raise ValueError("formal ordinal must be nonnegative")
+        if not self.declared_name:
+            raise ValueError("formal declared name must be nonempty")
+        if self.parameter_kind not in {
+            "positional-only",
+            "positional-or-keyword",
+            "variadic-positional",
+            "keyword-only",
+            "variadic-keyword",
+        }:
+            raise ValueError("formal parameter kind is unknown")
+        if self.sort != PrimitiveSort("Value"):
+            raise ValueError("formal sort is not the authenticated Python Value sort")
+        if self.coordinate_cid != _cid(self.preimage()):
+            raise ValueError("formal coordinate CID is stale")
+
+    @classmethod
+    def mint(
+        cls,
+        *,
+        owner_source_identity_cid: str,
+        owner_definition_locus: SourceFragmentCoordinateV1,
+        declaration_locus: SourceFragmentCoordinateV1,
+        ordinal: int,
+        parameter_kind: ParameterKindV1,
+        declared_name: str,
+        sort: PrimitiveSort,
+    ) -> "FormalParameterCoordinateV1":
+        fields = {
+            "kind": "formal-parameter-coordinate",
+            "schemaVersion": "1",
+            "ownerSourceIdentityCid": owner_source_identity_cid,
+            "ownerDefinitionLocus": owner_definition_locus.wire(),
+            "declarationLocus": declaration_locus.wire(),
+            "ordinal": ordinal,
+            "parameterKind": parameter_kind,
+            "declaredName": declared_name,
+            "sort": {"kind": "primitive", "name": sort.name},
+        }
+        return cls(
+            owner_source_identity_cid,
+            owner_definition_locus,
+            declaration_locus,
+            ordinal,
+            parameter_kind,
+            declared_name,
+            sort,
+            _cid(fields),
+        )
+
+    def preimage(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "schemaVersion": self.schema_version,
+            "ownerSourceIdentityCid": self.owner_source_identity_cid,
+            "ownerDefinitionLocus": self.owner_definition_locus.wire(),
+            "declarationLocus": self.declaration_locus.wire(),
+            "ordinal": self.ordinal,
+            "parameterKind": self.parameter_kind,
+            "declaredName": self.declared_name,
+            "sort": {"kind": "primitive", "name": self.sort.name},
+        }
+
+    def to_value(self) -> dict[str, Any]:
+        return {**self.preimage(), "coordinateCid": self.coordinate_cid}

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
@@ -928,6 +928,10 @@ class ContractDecl:
     out_binding: str = "out"
     evidence: Optional[EvidenceTerm] = None
     source_warrants: List[dict[str, Any]] = field(default_factory=list)
+    owner_source_identity_cid: Optional[str] = None
+    owner_definition_locus: Optional[dict[str, Any]] = None
+    formal_declarations: List[dict[str, Any]] = field(default_factory=list)
+    declared_parameter_demand_cids: List[str] = field(default_factory=list)
 
 
 # To-Value (canonicalizer Value tree) --------------------------------------
@@ -1583,6 +1587,36 @@ def contract_decl_to_value(d: ContractDecl) -> Value:
                 "sourceWarrants",
                 varr([_json_like_to_value(warrant) for warrant in d.source_warrants]),
             )
+        )
+    ownership = (
+        d.owner_source_identity_cid,
+        d.owner_definition_locus,
+        d.formal_declarations,
+        d.declared_parameter_demand_cids,
+    )
+    if any(item is not None and item != [] for item in ownership):
+        if (
+            d.owner_source_identity_cid is None
+            or d.owner_definition_locus is None
+            or not d.formal_declarations
+        ):
+            raise ValueError("formal ownership testimony must be complete")
+        pairs.extend(
+            [
+                ("ownerSourceIdentityCid", vstr(d.owner_source_identity_cid)),
+                (
+                    "ownerDefinitionLocus",
+                    _json_like_to_value(d.owner_definition_locus),
+                ),
+                (
+                    "formalDeclarations",
+                    _json_like_to_value(d.formal_declarations),
+                ),
+                (
+                    "declaredDemandCids",
+                    _json_like_to_value(d.declared_parameter_demand_cids),
+                ),
+            ]
         )
     return vobj(pairs)
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/__init__.py
@@ -5,9 +5,13 @@ from .complete_value import complete_value
 from .exit_set import Completed, ExitSet, Halted, outcome_to_exitset, true_guard
 from .incomplete import Incomplete
 from .outcome import Outcome
+from sugar_lift_py_tests.caller_parameter_contract import (
+    ContractConditionalConstructionV1,
+)
 
 __all__ = [
     "Complete",
+    "ContractConditionalConstructionV1",
     "Completed",
     "ExitSet",
     "Halted",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/outcome.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/outcome.py
@@ -3,5 +3,8 @@ from __future__ import annotations
 from .complete import Complete
 from .incomplete import Incomplete
 from .exit_set import ExitSet
+from sugar_lift_py_tests.caller_parameter_contract import (
+    ContractConditionalConstructionV1,
+)
 
-Outcome = Complete | Incomplete | ExitSet
+Outcome = Complete | Incomplete | ExitSet | ContractConditionalConstructionV1

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/formal_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/formal_ref_sugar.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.floor import SymbolicValue
+from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+from sugar_lift_py_tests.ir import make_var
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class FormalRefSugar(Sugar):
+    coordinate: FormalParameterCoordinateV1
+    site: object = field(compare=False)
+
+    @property
+    def name(self) -> str:
+        """Projection-compatible spelling; identity remains the coordinate."""
+        return self.coordinate.declared_name
+
+    @classmethod
+    def witnesses(cls):
+        from sugar_lift_py_tests.sugar.name_sugar import NameSugar
+
+        return NameSugar.witnesses()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        return Complete(
+            SymbolicValue(
+                make_var(self.coordinate.declared_name),
+                formal_coordinate=self.coordinate,
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/tests/test_caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_caller_parameter_contract.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import (
+    CallEdgeV2,
+    FormalActualBindingV1,
+    ValueOccurrenceCoordinateV1,
+)
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.canonicalizer import encode_jcs
+from sugar_lift_py_tests.floor import TermValue
+from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+from sugar_lift_py_tests.ir import (
+    ContractDecl,
+    PrimitiveSort,
+    contract_decl_to_value,
+    term_to_value,
+)
+
+
+def _site(source: str, start: int, end: int) -> SourceFragmentCoordinateV1:
+    return SourceFragmentCoordinateV1(source, 1, start, 1, end)
+
+
+def test_call_edge_v2_has_only_ordered_coordinate_bindings() -> None:
+    source = "blake3-512:" + "11" * 64
+    call_site = _site(source, 0, 12)
+    occurrence = ValueOccurrenceCoordinateV1.mint(_site(source, 5, 6))
+    binding = FormalActualBindingV1(
+        formal_coordinate_cid="blake3-512:" + "22" * 64,
+        actual_occurrence=occurrence,
+        actual_term=TermValue(3).to_term(owner="test"),
+    )
+    edge = CallEdgeV2.mint(
+        source_contract_cid="blake3-512:" + "33" * 64,
+        target_contract_cid="blake3-512:" + "44" * 64,
+        call_site=call_site,
+        formal_actual_bindings=(binding,),
+    )
+
+    wire = edge.to_value()
+    assert "formalActualBindings" in wire
+    assert "formalActuals" not in wire
+    assert CallEdgeV2.from_value(wire) == edge
+
+    malformed = {**wire, "formalActuals": {"x": term_to_value(binding.actual_term)}}
+    with pytest.raises(ValueError, match="exact key set"):
+        CallEdgeV2.from_value(malformed)
+
+
+def test_duplicate_formal_coordinate_is_loud() -> None:
+    source = "blake3-512:" + "55" * 64
+    occurrence = ValueOccurrenceCoordinateV1.mint(_site(source, 3, 4))
+    binding = FormalActualBindingV1(
+        "blake3-512:" + "66" * 64,
+        occurrence,
+        TermValue(1).to_term(owner="test"),
+    )
+    with pytest.raises(ValueError, match="duplicate formal"):
+        CallEdgeV2.mint(
+            source_contract_cid="blake3-512:" + "77" * 64,
+            target_contract_cid="blake3-512:" + "88" * 64,
+            call_site=_site(source, 0, 9),
+            formal_actual_bindings=(binding, binding),
+        )
+
+
+def test_contract_decl_content_addresses_formal_ownership_testimony() -> None:
+    source = "blake3-512:" + "99" * 64
+    owner = _site(source, 0, 10)
+    declaration = _site(source, 4, 6)
+    coordinate = FormalParameterCoordinateV1.mint(
+        owner_source_identity_cid=source,
+        owner_definition_locus=owner,
+        declaration_locus=declaration,
+        ordinal=0,
+        parameter_kind="positional-or-keyword",
+        declared_name="xs",
+        sort=PrimitiveSort("Value"),
+    )
+    value = json.loads(
+        encode_jcs(
+            contract_decl_to_value(
+                ContractDecl(
+                    "consume",
+                    owner_source_identity_cid=source,
+                    owner_definition_locus=owner.wire(),
+                    formal_declarations=[coordinate.to_value()],
+                )
+            )
+        )
+    )
+    assert value["ownerSourceIdentityCid"] == source
+    assert value["ownerDefinitionLocus"] == owner.wire()
+    assert value["formalDeclarations"] == [coordinate.to_value()]

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -28,6 +28,8 @@ from sugar_lift_py_tests.ir import encode_jcs, term_to_value
 from .canonical import cid_of_json
 from .dependency_artifact import DependencyArtifactGraph, ResolvedPythonObjectV1
 from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+from sugar_lift_py_tests.ir import PrimitiveSort
 from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
 
 
@@ -56,14 +58,6 @@ class ConstructedCallActualV1:
             raise ManagerConstructionAuthenticationError(
                 "constructed keyword actual requires a nonempty keyword"
             )
-
-
-@dataclass(frozen=True)
-class FormalParameterCoordinateV1:
-    definition_cid: str
-    parameter_index: int
-    formal_name: str
-    passing: str
 
 
 @dataclass(frozen=True)
@@ -444,8 +438,31 @@ def _bind(definition, positional, keywords, skip_first=False):
                         default_nodes[parameter.name], definition.source_cid
                     ),
                 )
-        coordinate = FormalParameterCoordinateV1(
-            definition.cid, index, parameter.name, parameter.kind.name
+        declaration_node = next(
+            argument
+            for argument in (
+                *node.args.posonlyargs,
+                *node.args.args,
+                *((node.args.vararg,) if node.args.vararg else ()),
+                *node.args.kwonlyargs,
+                *((node.args.kwarg,) if node.args.kwarg else ()),
+            )
+            if argument.arg == parameter.name
+        )
+        coordinate = FormalParameterCoordinateV1.mint(
+            owner_source_identity_cid=definition.source_cid,
+            owner_definition_locus=_node_occurrence(node, definition.source_cid),
+            declaration_locus=_node_occurrence(declaration_node, definition.source_cid),
+            ordinal=index,
+            parameter_kind={
+                inspect.Parameter.POSITIONAL_ONLY: "positional-only",
+                inspect.Parameter.POSITIONAL_OR_KEYWORD: "positional-or-keyword",
+                inspect.Parameter.VAR_POSITIONAL: "variadic-positional",
+                inspect.Parameter.KEYWORD_ONLY: "keyword-only",
+                inspect.Parameter.VAR_KEYWORD: "variadic-keyword",
+            }[parameter.kind],
+            declared_name=parameter.name,
+            sort=PrimitiveSort("Value"),
         )
         binding = FormalActualBindingV1(
             coordinate, parameter.name, value, provenance, occurrences
@@ -549,7 +566,7 @@ def _object_value(value):
 
 def _binding_value(binding):
     return {
-        "formal": binding.coordinate.__dict__,
+        "formal": binding.coordinate.to_value(),
         "actual": _floor_value(binding.actual),
         "provenance": binding.provenance,
         "actualOccurrences": [item.wire() for item in binding.actual_occurrences],

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -70,15 +70,12 @@ from .binding_state import (
 # It lets recognition distinguish a builtin spelling from a lexically bound
 # formal without substituting a fake value for that formal.
 _LEXICALLY_BOUND_NAMES = object()
-_FUNCTION_PARAMETERS = object()
 _MISSING = object()
 
 
-def _explicit_state(name: str, state, make_formal_ref):
+def _explicit_state(name: str, state):
     if name in state:
         return state[name]
-    if name in state.get(_FUNCTION_PARAMETERS, frozenset()):
-        return make_formal_ref(name)
     return _MISSING
 
 
@@ -1108,13 +1105,17 @@ class FunctionDef(Statement):
             {k: v for k, v in scope.items() if k not in bound} if bound else scope
         )
         inherited_bound = scope.get(_LEXICALLY_BOUND_NAMES, frozenset())
+        formal_refs = {
+            parameter.name: self._make_parameter_ref(parameter, ordinal)
+            for ordinal, parameter in enumerate(self.params)
+        }
         body_scope = {
             **body_scope,
+            **formal_refs,
             **{
                 name: UnboundBinding(name=name, cause=self.fragment) for name in locals_
             },
             _LEXICALLY_BOUND_NAMES: frozenset(inherited_bound) | bound | locals_,
-            _FUNCTION_PARAMETERS: parameters,
         }
 
         changed: dict[str, object] = {}
@@ -1132,6 +1133,58 @@ class FunctionDef(Statement):
         if not changed:
             return self
         return rewrite(self, **changed)
+
+    def _make_parameter_ref(self, parameter: Param, ordinal: int) -> "Node":
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+        )
+        from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+        from sugar_lift_py_tests.ir import PrimitiveSort
+
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        kind = {
+            "positional_only": "positional-only",
+            "positional_or_keyword": "positional-or-keyword",
+            "vararg": "variadic-positional",
+            "keyword_only": "keyword-only",
+            "kwarg": "variadic-keyword",
+        }.get(parameter.param_kind)
+        if kind is None:
+            from .panic import BackendDefect
+
+            raise BackendDefect(
+                owner="FunctionDef._make_parameter_ref",
+                observed=parameter.param_kind,
+                requested="one canonical Python parameter kind",
+                fix="repair the backend parameter-kind projection",
+            )
+
+        def coordinate(node: Node) -> SourceFragmentCoordinateV1:
+            span = node.line_col_span()
+            return SourceFragmentCoordinateV1(
+                node.unit.source_cid,
+                span.start_line,
+                span.start_col,
+                span.end_line,
+                span.end_col,
+            )
+
+        formal = FormalParameterCoordinateV1.mint(
+            owner_source_identity_cid=self.unit.source_cid,
+            owner_definition_locus=coordinate(self),
+            declaration_locus=coordinate(parameter),
+            ordinal=ordinal,
+            parameter_kind=kind,
+            declared_name=parameter.name,
+            sort=PrimitiveSort("Value"),
+        )
+        return materialize(
+            self.unit,
+            ShadowNode("FormalRef", parameter.span, (("coordinate", Leaf(formal)),)),
+            self.reporter,
+        )
 
     def _construct_sugar(self):
         """`def <name>(<formals>): <body>` constructs FunctionUniverseSugar WITH
@@ -1278,11 +1331,7 @@ class Delete(Statement):
         operations = []
         for target in self.targets:
             if isinstance(target, Name):
-                prior = _explicit_state(
-                    target.id,
-                    current,
-                    lambda name: self._make_formal_ref(name, target.span),
-                )
+                prior = _explicit_state(target.id, current)
                 if prior is _MISSING:
                     prior = UnboundBinding(name=target.id, cause=target.fragment)
                 operation = self._make_delete_name(target.id, prior, target.span)
@@ -1301,16 +1350,6 @@ class Delete(Statement):
                 )
             operations.append(operation)
         return operations[0] if len(operations) == 1 else _Splice(tuple(operations))
-
-    def _make_formal_ref(self, name: str, span: Span) -> "Node":
-        from .backend import Leaf, materialize
-        from .shadow import ShadowNode
-
-        return materialize(
-            self.unit,
-            ShadowNode("FormalRef", span, (("name", Leaf(name)),)),
-            self.reporter,
-        )
 
     def _make_delete_name(
         self, name: str, prior: BindingState, span: Span | None = None
@@ -2091,11 +2130,7 @@ class If(Statement):
         phis = []
         availability: BindingMap = {}
         for name in sorted(names):
-            incoming = _explicit_state(
-                name,
-                scope,
-                lambda spelling: self._make_formal_ref(spelling),
-            )
+            incoming = _explicit_state(name, scope)
             then_val = then_net.get(name, incoming)
             else_val = else_net.get(name, incoming)
             if then_val is _MISSING or else_val is _MISSING:
@@ -2127,16 +2162,6 @@ class If(Statement):
                 desc.raw_span or self.span,
                 (*desc.slots, ("branch_result_slot_id", Leaf(slot.slot_id))),
             ),
-            self.reporter,
-        )
-
-    def _make_formal_ref(self, name: str) -> "Node":
-        from .backend import Leaf, materialize
-        from .shadow import ShadowNode
-
-        return materialize(
-            self.unit,
-            ShadowNode("FormalRef", self.span, (("name", Leaf(name)),)),
             self.reporter,
         )
 
@@ -2614,7 +2639,9 @@ class Raise(Statement):
         while node is not None and node.kind == "Attribute":  # mod.sub.E
             parts.append(node.attr)
             node = node.value
-        if node is not None and node.kind == "Name":
+        if isinstance(node, FormalRef):
+            parts.append(node.coordinate.declared_name)
+        elif node is not None and node.kind == "Name":
             parts.append(node.id)
         if not parts:
             return None
@@ -2814,10 +2841,7 @@ class Try(Statement):
         names = set().union(*(net.keys() for net in nets))
         merged: BindingMap = {}
         for name in sorted(names):
-            states = [
-                net.get(name, _explicit_state(name, scope, self._make_formal_ref))
-                for net in nets
-            ]
+            states = [net.get(name, _explicit_state(name, scope)) for net in nets]
             if any(state is _MISSING for state in states):
                 continue
             if all(state is states[0] or state == states[0] for state in states[1:]):
@@ -2840,16 +2864,6 @@ class Try(Statement):
             if all(isinstance(state, UnboundBinding) for state in states):
                 merged[name] = states[0]
         return merged
-
-    def _make_formal_ref(self, name: str) -> "Node":
-        from .backend import Leaf, materialize
-        from .shadow import ShadowNode
-
-        return materialize(
-            self.unit,
-            ShadowNode("FormalRef", self.span, (("name", Leaf(name)),)),
-            self.reporter,
-        )
 
     def _make_ifexp(self, test, body, orelse):
         return If._make_ifexp(self, test, body, orelse)
@@ -4015,7 +4029,11 @@ class Call(Expression):
             callee_name = self._spread_callee_name(self.func)
             return SpreadCallSugar(
                 callee_name=callee_name,
-                callee=(None if isinstance(self.func, Name) else self.func.sugar()),
+                callee=(
+                    None
+                    if isinstance(self.func, (Name, FormalRef))
+                    else self.func.sugar()
+                ),
                 arguments=arguments,
                 site=self.fragment,
             )
@@ -4024,7 +4042,7 @@ class Call(Expression):
             (kw.arg if kw.arg is not None else "**", kw.value.sugar())
             for kw in self.keywords
         )
-        if isinstance(self.func, Name):
+        if isinstance(self.func, (Name, FormalRef)):
             from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
 
             contract_ref = None
@@ -4067,7 +4085,11 @@ class Call(Expression):
                     contract_ref = resolution
 
             return CallSiteSugar(
-                target_name=self.func.id,
+                target_name=(
+                    self.func.id
+                    if isinstance(self.func, Name)
+                    else self.func.coordinate.declared_name
+                ),
                 args=tuple(a.sugar() for a in self.args),
                 site=self.fragment,
                 keywords=keyword_sugars,
@@ -4102,6 +4124,8 @@ class Call(Expression):
         """
         if isinstance(callee, Name):
             return callee.id
+        if isinstance(callee, FormalRef):
+            return callee.coordinate.declared_name
         if isinstance(callee, Attribute):
             base = Call._spread_callee_name(callee.value)
             return f"{base}.{callee.attr}" if base is not None else None
@@ -4329,18 +4353,18 @@ class Name(Expression):
 
 
 class FormalRef(Expression):
-    """A lazily materialized formal used only when availability becomes explicit."""
+    """The one authenticated coordinate-bearing reference for a declaration."""
 
-    name: str
+    coordinate: object
 
     def substitute(self, scope):
         del scope
         return self
 
     def _construct_sugar(self):
-        from sugar_lift_py_tests.sugar.name_sugar import NameSugar
+        from sugar_lift_py_tests.sugar.formal_ref_sugar import FormalRefSugar
 
-        return NameSugar(name=self.name, site=self.fragment)
+        return FormalRefSugar(coordinate=self.coordinate, site=self.fragment)
 
 
 class BranchResultRef(Expression):

--- a/implementations/python/sugar-source-tree/tests/test_formal_parameter_coordinate.py
+++ b/implementations/python/sugar-source-tree/tests/test_formal_parameter_coordinate.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _function(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(source)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def test_two_parameter_reads_share_one_authenticated_coordinate() -> None:
+    function = _function("def consume(xs):\n return xs[0] + xs[1]\n")
+    substituted = function.substitute({})
+    refs = [node for node in substituted.walk() if node.kind == "FormalRef"]
+
+    assert len(refs) == 2
+    assert refs[0].coordinate is refs[1].coordinate
+    assert refs[0].coordinate.coordinate_cid == refs[1].coordinate.coordinate_cid
+    assert refs[0].coordinate.ordinal == 0
+    assert refs[0].coordinate.declared_name == "xs"
+    assert refs[0].coordinate.owner_source_identity_cid == function.unit.source_cid
+
+
+def test_reassignment_replaces_formal_coordinate_for_later_reads() -> None:
+    function = _function("def consume(xs):\n first = xs\n xs = 3\n return xs\n")
+    substituted = function.substitute({})
+    refs = [node for node in substituted.walk() if node.kind == "FormalRef"]
+    returns = [node for node in substituted.walk() if node.kind == "Return"]
+
+    assert len(refs) == 1
+    assert returns[0].value.kind == "Constant"
+    assert returns[0].value.value == 3
+
+
+def test_owner_or_ordinal_changes_formal_coordinate_identity() -> None:
+    left = _function("def consume(x, y):\n return x\n").substitute({})
+    right = _function("def consume(x, y):\n return y\n").substitute({})
+    left_ref = next(node for node in left.walk() if node.kind == "FormalRef")
+    right_ref = next(node for node in right.walk() if node.kind == "FormalRef")
+
+    assert left_ref.coordinate.ordinal == 0
+    assert right_ref.coordinate.ordinal == 1
+    assert left_ref.coordinate.coordinate_cid != right_ref.coordinate.coordinate_cid

--- a/implementations/python/sugar-source-tree/tests/test_parameter_contract_conditional.py
+++ b/implementations/python/sugar-source-tree/tests/test_parameter_contract_conditional.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import tempfile
+
+from sugar_lift_py_tests.caller_parameter_contract import (
+    ContractConditionalConstructionV1,
+)
+from sugar_lift_py_tests.floor import UniverseValue
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _out(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(source)
+        path = f.name
+    return next(SourceFile(path_source(path)).functions()).sugar().desugar()
+
+
+def test_symbolic_parameter_subscript_constructs_one_pending_candidate() -> None:
+    out = _out("def consume(xs):\n return xs[0]\n")
+
+    assert isinstance(out, Complete)
+    assert isinstance(out.value, UniverseValue)
+    pending = [
+        row
+        for row in out.value.record.statements
+        if isinstance(row, ContractConditionalConstructionV1)
+    ]
+    assert len(pending) == 1
+    conditional = pending[0]
+    assert conditional.demand.formal_coordinate_cid
+    assert conditional.demand.candidate_cid == conditional.candidate_cid
+    assert conditional.demand.demand_cid
+    assert conditional.candidate_cid

--- a/implementations/python/sugar-source-tree/tests/test_substitute_int_literal.py
+++ b/implementations/python/sugar-source-tree/tests/test_substitute_int_literal.py
@@ -75,9 +75,12 @@ def test_compound_just_recurses():
 
 def test_function_masks_its_parameter():
     # def f(x): return x -- the parameter x is HELD OUT of the body's scope, so
-    # an outer x cannot capture it. The function comes back unchanged.
+    # an outer x cannot capture it. The body read becomes its authenticated
+    # declaration-owned FormalRef rather than retaining a generic Name.
     fx = next(_tree("def f(x):\n    return x\n").functions())
-    assert fx.substitute({"x": _bind_target()}) is fx
+    substituted = fx.substitute({"x": _bind_target()})
+    ref = next(node for node in substituted.walk() if node.kind == "FormalRef")
+    assert ref.coordinate.declared_name == "x"
     # def g(): return x -- no parameter shadows it, so the FREE x DOES substitute.
     g = next(_tree("def g():\n    return x\n").functions())
     gsub = g.substitute({"x": _bind_target()})
@@ -101,9 +104,11 @@ def test_a_block_threads_its_assignments():
 
 def test_binders_mask_their_bound_names():
     # for x in xs: return x -- the loop target x is masked for the body, so an
-    # outer x cannot capture it; the loop comes back unchanged.
+    # outer x cannot capture it; the parameter read is coordinate-bearing.
     forfn = next(_tree("def f(xs):\n    for x in xs:\n        return x\n").functions())
-    assert forfn.substitute({"x": _bind_target()}) is forfn
+    substituted = forfn.substitute({"x": _bind_target()})
+    ref = next(node for node in substituted.walk() if node.kind == "FormalRef")
+    assert ref.coordinate.declared_name == "xs"
     # lambda z: z + 1 -- the parameter z is masked for the body.
     lam = next(
         n for n in _tree("g = lambda z: z + z\n").root.walk() if n.kind == "Lambda"

--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -1758,6 +1758,7 @@ dependencies = [
 name = "sugar-linker"
 version = "0.0.1"
 dependencies = [
+ "libsugar",
  "serde",
  "serde_json",
  "sugar-canonicalizer",

--- a/implementations/rust/sugar-linker/Cargo.toml
+++ b/implementations/rust/sugar-linker/Cargo.toml
@@ -21,5 +21,6 @@ sugar-ir-compiler = { path = "../sugar-ir-compiler" }
 sugar-ir-compiler-smt-lib = { path = "../sugar-ir-compiler-smt-lib" }
 sugar-claim-envelope = { path = "../sugar-claim-envelope" }
 sugar-proof-envelope = { path = "../sugar-proof-envelope" }
+libsugar = { path = "../libsugar" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/implementations/rust/sugar-linker/src/caller_parameter.rs
+++ b/implementations/rust/sugar-linker/src/caller_parameter.rs
@@ -1,0 +1,395 @@
+use std::collections::BTreeSet;
+
+use libsugar::wp::substitute_in_formula;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as Json;
+use sugar_ir_types::{IrFormula, IrTerm, Sort};
+
+use crate::{canonical_json_cid, Cid};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SourceFragmentCoordinateV1 {
+    pub source_cid: Cid,
+    pub start_line: usize,
+    pub start_col: usize,
+    pub end_line: usize,
+    pub end_col: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct FormalParameterCoordinateV1 {
+    pub kind: String,
+    pub schema_version: String,
+    pub owner_source_identity_cid: Cid,
+    pub owner_definition_locus: SourceFragmentCoordinateV1,
+    pub declaration_locus: SourceFragmentCoordinateV1,
+    pub ordinal: usize,
+    pub parameter_kind: ParameterKindV1,
+    pub declared_name: String,
+    pub sort: Sort,
+    pub coordinate_cid: Cid,
+}
+
+impl FormalParameterCoordinateV1 {
+    pub fn preimage(&self) -> Json {
+        serde_json::json!({
+            "kind": self.kind,
+            "schemaVersion": self.schema_version,
+            "ownerSourceIdentityCid": self.owner_source_identity_cid,
+            "ownerDefinitionLocus": self.owner_definition_locus,
+            "declarationLocus": self.declaration_locus,
+            "ordinal": self.ordinal,
+            "parameterKind": self.parameter_kind,
+            "declaredName": self.declared_name,
+            "sort": self.sort,
+        })
+    }
+
+    pub fn validate(&self) -> Result<(), ParameterResolutionGapV1> {
+        if self.kind != "formal-parameter-coordinate"
+            || self.schema_version != "1"
+            || canonical_json_cid(&self.preimage()) != self.coordinate_cid
+        {
+            return Err(ParameterResolutionGapV1::StaleFormalCoordinate);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ParameterKindV1 {
+    #[serde(rename = "positional-only")]
+    PositionalOnly,
+    #[serde(rename = "positional-or-keyword")]
+    PositionalOrKeyword,
+    #[serde(rename = "variadic-positional")]
+    VariadicPositional,
+    #[serde(rename = "keyword-only")]
+    KeywordOnly,
+    #[serde(rename = "variadic-keyword")]
+    VariadicKeyword,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct FormalParameterDeclarationV1 {
+    pub coordinate: FormalParameterCoordinateV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ParameterOwnedContractV1 {
+    pub contract_cid: Cid,
+    pub semantic_decl: Json,
+    pub owner_source_identity_cid: Cid,
+    pub owner_definition_locus: SourceFragmentCoordinateV1,
+    pub formal_declarations: Vec<FormalParameterDeclarationV1>,
+    pub formal_sorts: Vec<Sort>,
+    #[serde(default)]
+    pub declared_demand_cids: BTreeSet<Cid>,
+}
+
+impl ParameterOwnedContractV1 {
+    pub fn validate(&self) -> Result<(), ParameterResolutionGapV1> {
+        if canonical_json_cid(&self.semantic_decl) != self.contract_cid {
+            return Err(ParameterResolutionGapV1::StaleContract);
+        }
+        let owner = self
+            .semantic_decl
+            .get("ownerSourceIdentityCid")
+            .and_then(Json::as_str);
+        if owner != Some(self.owner_source_identity_cid.as_str())
+            || self.semantic_decl.get("ownerDefinitionLocus")
+                != Some(&serde_json::to_value(&self.owner_definition_locus).unwrap())
+            || self.semantic_decl.get("formalDeclarations")
+                != Some(&serde_json::to_value(&self.formal_declarations).unwrap())
+            || self.semantic_decl.get("declaredDemandCids")
+                != Some(&serde_json::to_value(&self.declared_demand_cids).unwrap())
+        {
+            return Err(ParameterResolutionGapV1::MissingFormalOwnershipTestimony);
+        }
+        if self.formal_declarations.len() != self.formal_sorts.len() {
+            return Err(ParameterResolutionGapV1::FormalSortMismatch);
+        }
+        for (ordinal, (declaration, sort)) in self
+            .formal_declarations
+            .iter()
+            .zip(&self.formal_sorts)
+            .enumerate()
+        {
+            declaration.coordinate.validate()?;
+            let coordinate = &declaration.coordinate;
+            if coordinate.ordinal != ordinal {
+                return Err(ParameterResolutionGapV1::FormalOrdinalMismatch);
+            }
+            if coordinate.owner_source_identity_cid != self.owner_source_identity_cid
+                || coordinate.owner_definition_locus != self.owner_definition_locus
+            {
+                return Err(ParameterResolutionGapV1::FormalCoordinateMismatch);
+            }
+            if &coordinate.sort != sort {
+                return Err(ParameterResolutionGapV1::FormalSortMismatch);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ValueOccurrenceCoordinateV1 {
+    pub source: SourceFragmentCoordinateV1,
+    pub occurrence_cid: Cid,
+}
+
+impl ValueOccurrenceCoordinateV1 {
+    pub fn validate(&self) -> Result<(), ParameterResolutionGapV1> {
+        let preimage = serde_json::json!({"kind": "value-occurrence", "source": self.source});
+        if canonical_json_cid(&preimage) != self.occurrence_cid {
+            return Err(ParameterResolutionGapV1::UnauthenticatedActualOccurrence);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct FormalActualBindingV1 {
+    pub formal_coordinate_cid: Cid,
+    pub actual_occurrence: ValueOccurrenceCoordinateV1,
+    pub actual_term: IrTerm,
+    pub actual_contract_ref_cid: Option<Cid>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CallEdgeV2 {
+    pub kind: String,
+    pub schema_version: String,
+    pub source_contract_cid: Cid,
+    pub target_contract_cid: Cid,
+    pub call_site: SourceFragmentCoordinateV1,
+    pub formal_actual_bindings: Vec<FormalActualBindingV1>,
+    pub edge_cid: Cid,
+}
+
+impl CallEdgeV2 {
+    pub fn preimage(&self) -> Json {
+        serde_json::json!({
+            "kind": self.kind,
+            "schemaVersion": self.schema_version,
+            "sourceContractCid": self.source_contract_cid,
+            "targetContractCid": self.target_contract_cid,
+            "callSite": self.call_site,
+            "formalActualBindings": self.formal_actual_bindings,
+        })
+    }
+
+    pub fn validate_against(
+        &self,
+        contract: &ParameterOwnedContractV1,
+    ) -> Result<(), ParameterResolutionGapV1> {
+        if self.kind != "call-edge"
+            || self.schema_version != "2"
+            || canonical_json_cid(&self.preimage()) != self.edge_cid
+        {
+            return Err(ParameterResolutionGapV1::StaleCallEdge);
+        }
+        contract.validate()?;
+        if self.target_contract_cid != contract.contract_cid {
+            return Err(ParameterResolutionGapV1::StaleContract);
+        }
+        let mut seen = BTreeSet::new();
+        for binding in &self.formal_actual_bindings {
+            if !seen.insert(binding.formal_coordinate_cid.clone()) {
+                return Err(ParameterResolutionGapV1::FormalCoordinateMismatch);
+            }
+            binding.actual_occurrence.validate()?;
+            if binding.actual_occurrence.source.source_cid != self.call_site.source_cid {
+                return Err(ParameterResolutionGapV1::UnauthenticatedActualOccurrence);
+            }
+            if binding.actual_contract_ref_cid.is_some() {
+                return Err(ParameterResolutionGapV1::UnauthenticatedActualContractRef);
+            }
+            let Some(declaration) = contract
+                .formal_declarations
+                .iter()
+                .find(|item| item.coordinate.coordinate_cid == binding.formal_coordinate_cid)
+            else {
+                return Err(ParameterResolutionGapV1::FormalCoordinateMismatch);
+            };
+            if declaration.coordinate.ordinal >= contract.formal_declarations.len() {
+                return Err(ParameterResolutionGapV1::FormalOrdinalMismatch);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ParameterContractDemandV1 {
+    pub kind: String,
+    pub schema_version: String,
+    pub owner_source_identity_cid: Cid,
+    pub formal_coordinate_cid: Cid,
+    pub operation_site: SourceFragmentCoordinateV1,
+    pub demanded_formula: IrFormula,
+    pub demanded_effect_bound: Option<Json>,
+    pub candidate_cid: Cid,
+    pub demand_cid: Cid,
+}
+
+impl ParameterContractDemandV1 {
+    pub fn preimage(&self) -> Json {
+        serde_json::json!({
+            "kind": self.kind,
+            "schemaVersion": self.schema_version,
+            "ownerSourceIdentityCid": self.owner_source_identity_cid,
+            "formalCoordinateCid": self.formal_coordinate_cid,
+            "operationSite": self.operation_site,
+            "demandedFormula": self.demanded_formula,
+            "demandedEffectBound": self.demanded_effect_bound,
+            "candidateCid": self.candidate_cid,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ContractConditionalConstructionV1 {
+    pub kind: String,
+    pub schema_version: String,
+    pub source_node: SourceFragmentCoordinateV1,
+    pub candidate: IrTerm,
+    pub candidate_cid: Cid,
+    pub demand: ParameterContractDemandV1,
+}
+
+impl ContractConditionalConstructionV1 {
+    pub fn validate(&self) -> Result<(), ParameterResolutionGapV1> {
+        let candidate_preimage = serde_json::json!({
+            "kind": "parameter-contract-candidate",
+            "schemaVersion": "1",
+            "sourceNode": self.source_node,
+            "candidate": self.candidate,
+        });
+        if self.kind != "contract-conditional-construction"
+            || self.schema_version != "1"
+            || canonical_json_cid(&candidate_preimage) != self.candidate_cid
+            || self.demand.candidate_cid != self.candidate_cid
+            || canonical_json_cid(&self.demand.preimage()) != self.demand.demand_cid
+        {
+            return Err(ParameterResolutionGapV1::StaleCandidateOrDemand);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AuthenticatedCallerV1 {
+    pub caller_contract_cid: Cid,
+    pub caller_contract_decl: Json,
+    pub edge: CallEdgeV2,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ClosedCallerUniverseV1 {
+    pub closed: bool,
+    pub has_external_callers: bool,
+    pub callers: Vec<AuthenticatedCallerV1>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParameterContractResolutionV1 {
+    pub demand_cid: Cid,
+    pub candidate_cid: Cid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParameterResolutionGapV1 {
+    MissingFormalOwnershipTestimony,
+    FormalCoordinateMismatch,
+    FormalOrdinalMismatch,
+    FormalSortMismatch,
+    UnauthenticatedActualOccurrence,
+    UnauthenticatedActualContractRef,
+    StaleFormalCoordinate,
+    StaleContract,
+    StaleCallEdge,
+    StaleCandidateOrDemand,
+    NoIncomingCaller,
+    OpenCallerUniverse,
+    DisagreeingCallers,
+}
+
+pub fn discharge_parameter_candidate(
+    candidate: &ContractConditionalConstructionV1,
+    callee: &ParameterOwnedContractV1,
+    universe: &ClosedCallerUniverseV1,
+) -> Result<ParameterContractResolutionV1, ParameterResolutionGapV1> {
+    candidate.validate()?;
+    callee.validate()?;
+    if candidate.demand.owner_source_identity_cid != callee.owner_source_identity_cid
+        || !callee
+            .formal_declarations
+            .iter()
+            .any(|item| item.coordinate.coordinate_cid == candidate.demand.formal_coordinate_cid)
+    {
+        return Err(ParameterResolutionGapV1::FormalCoordinateMismatch);
+    }
+    if callee
+        .declared_demand_cids
+        .contains(&candidate.demand.demand_cid)
+    {
+        return Ok(ParameterContractResolutionV1 {
+            demand_cid: candidate.demand.demand_cid.clone(),
+            candidate_cid: candidate.candidate_cid.clone(),
+        });
+    }
+    if !universe.closed || universe.has_external_callers {
+        return Err(ParameterResolutionGapV1::OpenCallerUniverse);
+    }
+    if universe.callers.is_empty() {
+        return Err(ParameterResolutionGapV1::NoIncomingCaller);
+    }
+    for caller in &universe.callers {
+        caller.edge.validate_against(callee)?;
+        if caller.caller_contract_cid != caller.edge.source_contract_cid
+            || canonical_json_cid(&caller.caller_contract_decl) != caller.caller_contract_cid
+        {
+            return Err(ParameterResolutionGapV1::DisagreeingCallers);
+        }
+        let Some(binding) = caller.edge.formal_actual_bindings.iter().find(|binding| {
+            binding.formal_coordinate_cid == candidate.demand.formal_coordinate_cid
+        }) else {
+            return Err(ParameterResolutionGapV1::FormalCoordinateMismatch);
+        };
+        let Some(declaration) = callee.formal_declarations.iter().find(|declaration| {
+            declaration.coordinate.coordinate_cid == candidate.demand.formal_coordinate_cid
+        }) else {
+            return Err(ParameterResolutionGapV1::FormalCoordinateMismatch);
+        };
+        let instantiated = substitute_in_formula(
+            candidate.demand.demanded_formula.clone(),
+            &declaration.coordinate.declared_name,
+            &binding.actual_term,
+        );
+        let proved = caller
+            .caller_contract_decl
+            .get("provedFormulas")
+            .and_then(Json::as_array)
+            .ok_or(ParameterResolutionGapV1::DisagreeingCallers)?;
+        if !proved.contains(&serde_json::to_value(instantiated).unwrap()) {
+            return Err(ParameterResolutionGapV1::DisagreeingCallers);
+        }
+    }
+    Ok(ParameterContractResolutionV1 {
+        demand_cid: candidate.demand.demand_cid.clone(),
+        candidate_cid: candidate.candidate_cid.clone(),
+    })
+}

--- a/implementations/rust/sugar-linker/src/lib.rs
+++ b/implementations/rust/sugar-linker/src/lib.rs
@@ -55,6 +55,8 @@ use sugar_proof_envelope::{
 use sugar_verifier::solvers::{run_plan, SolverHandle, SolverPlan, SolverSeat};
 use sugar_verifier::types::ObligationVerdict;
 
+pub mod caller_parameter;
+
 /// The typed locus of a call site, per `ir-formal-grammar.md` (`Locus`).
 ///
 /// Replaces the free-form `serde_json::Value` that the call-site slot used to

--- a/implementations/rust/sugar-linker/tests/caller_parameter_contract.rs
+++ b/implementations/rust/sugar-linker/tests/caller_parameter_contract.rs
@@ -1,0 +1,289 @@
+use std::collections::BTreeSet;
+
+use serde_json::json;
+use sugar_ir_types::{IrFormula, IrTerm, Sort};
+use sugar_linker::caller_parameter::{
+    discharge_parameter_candidate, AuthenticatedCallerV1, CallEdgeV2, ClosedCallerUniverseV1,
+    ContractConditionalConstructionV1, FormalActualBindingV1, FormalParameterCoordinateV1,
+    FormalParameterDeclarationV1, ParameterContractDemandV1, ParameterKindV1,
+    ParameterOwnedContractV1, ParameterResolutionGapV1, SourceFragmentCoordinateV1,
+    ValueOccurrenceCoordinateV1,
+};
+use sugar_linker::{canonical_json_cid, Cid};
+
+fn value_sort() -> Sort {
+    Sort::Primitive {
+        name: "Value".into(),
+    }
+}
+
+fn locus(source_cid: &Cid, line: usize) -> SourceFragmentCoordinateV1 {
+    SourceFragmentCoordinateV1 {
+        source_cid: source_cid.clone(),
+        start_line: line,
+        start_col: 0,
+        end_line: line,
+        end_col: 1,
+    }
+}
+
+struct Fixture {
+    contract: ParameterOwnedContractV1,
+    candidate: ContractConditionalConstructionV1,
+    edge: CallEdgeV2,
+    caller_contract_decl: serde_json::Value,
+}
+
+fn fixture() -> Fixture {
+    let source_cid = canonical_json_cid(&json!({"source": "def consume(xs): return xs[0]"}));
+    let owner_locus = locus(&source_cid, 1);
+    let declaration_locus = locus(&source_cid, 1);
+    let mut coordinate = FormalParameterCoordinateV1 {
+        kind: "formal-parameter-coordinate".into(),
+        schema_version: "1".into(),
+        owner_source_identity_cid: source_cid.clone(),
+        owner_definition_locus: owner_locus.clone(),
+        declaration_locus,
+        ordinal: 0,
+        parameter_kind: ParameterKindV1::PositionalOrKeyword,
+        declared_name: "xs".into(),
+        sort: value_sort(),
+        coordinate_cid: Cid::from("pending"),
+    };
+    coordinate.coordinate_cid = canonical_json_cid(&coordinate.preimage());
+    let declarations = vec![FormalParameterDeclarationV1 {
+        coordinate: coordinate.clone(),
+    }];
+    let semantic_decl = json!({
+        "ownerSourceIdentityCid": source_cid,
+        "ownerDefinitionLocus": owner_locus,
+        "formalDeclarations": declarations,
+        "declaredDemandCids": [],
+    });
+    let contract_cid = canonical_json_cid(&semantic_decl);
+    let contract = ParameterOwnedContractV1 {
+        contract_cid: contract_cid.clone(),
+        semantic_decl,
+        owner_source_identity_cid: source_cid.clone(),
+        owner_definition_locus: owner_locus.clone(),
+        formal_declarations: declarations,
+        formal_sorts: vec![value_sort()],
+        declared_demand_cids: BTreeSet::new(),
+    };
+
+    let source_node = locus(&source_cid, 1);
+    let candidate_term = IrTerm::Ctor {
+        name: "python:getitem".into(),
+        args: vec![
+            IrTerm::Var { name: "xs".into() },
+            IrTerm::Const {
+                value: json!(0),
+                sort: Sort::Primitive { name: "Int".into() },
+            },
+        ],
+    };
+    let candidate_cid = canonical_json_cid(&json!({
+        "kind": "parameter-contract-candidate",
+        "schemaVersion": "1",
+        "sourceNode": source_node,
+        "candidate": candidate_term,
+    }));
+    let mut demand = ParameterContractDemandV1 {
+        kind: "parameter-contract-demand".into(),
+        schema_version: "1".into(),
+        owner_source_identity_cid: source_cid.clone(),
+        formal_coordinate_cid: coordinate.coordinate_cid.clone(),
+        operation_site: source_node.clone(),
+        demanded_formula: IrFormula::Atomic {
+            name: "python:indexable".into(),
+            args: vec![IrTerm::Var { name: "xs".into() }],
+        },
+        demanded_effect_bound: None,
+        candidate_cid: candidate_cid.clone(),
+        demand_cid: Cid::from("pending"),
+    };
+    demand.demand_cid = canonical_json_cid(&demand.preimage());
+    let candidate = ContractConditionalConstructionV1 {
+        kind: "contract-conditional-construction".into(),
+        schema_version: "1".into(),
+        source_node,
+        candidate: candidate_term,
+        candidate_cid,
+        demand,
+    };
+
+    let call_site = locus(&source_cid, 20);
+    let actual_source = locus(&source_cid, 20);
+    let mut occurrence = ValueOccurrenceCoordinateV1 {
+        source: actual_source,
+        occurrence_cid: Cid::from("pending"),
+    };
+    occurrence.occurrence_cid = canonical_json_cid(&json!({
+        "kind": "value-occurrence",
+        "source": occurrence.source,
+    }));
+    let binding = FormalActualBindingV1 {
+        formal_coordinate_cid: coordinate.coordinate_cid,
+        actual_occurrence: occurrence,
+        actual_term: IrTerm::Ctor {
+            name: "python:list".into(),
+            args: vec![],
+        },
+        actual_contract_ref_cid: None,
+    };
+    let proved_formula = IrFormula::Atomic {
+        name: "python:indexable".into(),
+        args: vec![binding.actual_term.clone()],
+    };
+    let caller_contract_decl = json!({
+        "provedFormulas": [proved_formula],
+    });
+    let caller_contract_cid = canonical_json_cid(&caller_contract_decl);
+    let mut edge = CallEdgeV2 {
+        kind: "call-edge".into(),
+        schema_version: "2".into(),
+        source_contract_cid: caller_contract_cid,
+        target_contract_cid: contract_cid,
+        call_site,
+        formal_actual_bindings: vec![binding],
+        edge_cid: Cid::from("pending"),
+    };
+    edge.edge_cid = canonical_json_cid(&edge.preimage());
+    Fixture {
+        contract,
+        candidate,
+        edge,
+        caller_contract_decl,
+    }
+}
+
+#[test]
+fn one_authenticated_caller_discharge_preserves_candidate_identity() {
+    let f = fixture();
+    let candidate_wire = serde_json::to_value(&f.candidate).unwrap();
+    let candidate_round_trip: ContractConditionalConstructionV1 =
+        serde_json::from_value(candidate_wire).unwrap();
+    assert_eq!(candidate_round_trip, f.candidate);
+    candidate_round_trip.validate().unwrap();
+    let universe = ClosedCallerUniverseV1 {
+        closed: true,
+        has_external_callers: false,
+        callers: vec![AuthenticatedCallerV1 {
+            caller_contract_cid: f.edge.source_contract_cid.clone(),
+            caller_contract_decl: f.caller_contract_decl,
+            edge: f.edge,
+        }],
+    };
+    let resolved = discharge_parameter_candidate(&f.candidate, &f.contract, &universe)
+        .expect("the authenticated caller proves the exact demand");
+    assert_eq!(resolved.candidate_cid, f.candidate.candidate_cid);
+    assert_eq!(resolved.demand_cid, f.candidate.demand.demand_cid);
+}
+
+#[test]
+fn declared_formal_contract_discharges_without_caller_specialization() {
+    let mut f = fixture();
+    f.contract
+        .declared_demand_cids
+        .insert(f.candidate.demand.demand_cid.clone());
+    f.contract.semantic_decl["declaredDemandCids"] =
+        serde_json::to_value(&f.contract.declared_demand_cids).unwrap();
+    f.contract.contract_cid = canonical_json_cid(&f.contract.semantic_decl);
+    let resolved = discharge_parameter_candidate(
+        &f.candidate,
+        &f.contract,
+        &ClosedCallerUniverseV1 {
+            closed: false,
+            has_external_callers: true,
+            callers: vec![],
+        },
+    )
+    .expect("the callee's own declared formal contract is authoritative");
+    assert_eq!(resolved.candidate_cid, f.candidate.candidate_cid);
+}
+
+#[test]
+fn disagreeing_callers_do_not_globally_specialize_the_callee() {
+    let f = fixture();
+    let proving = AuthenticatedCallerV1 {
+        caller_contract_cid: f.edge.source_contract_cid.clone(),
+        caller_contract_decl: f.caller_contract_decl,
+        edge: f.edge.clone(),
+    };
+    let disagreeing_decl = json!({"provedFormulas": []});
+    let disagreeing_cid = canonical_json_cid(&disagreeing_decl);
+    let mut disagreeing_edge = proving.edge.clone();
+    disagreeing_edge.source_contract_cid = disagreeing_cid.clone();
+    disagreeing_edge.edge_cid = canonical_json_cid(&disagreeing_edge.preimage());
+    let disagreeing = AuthenticatedCallerV1 {
+        caller_contract_cid: disagreeing_cid,
+        caller_contract_decl: disagreeing_decl,
+        edge: disagreeing_edge,
+    };
+    let gap = discharge_parameter_candidate(
+        &f.candidate,
+        &f.contract,
+        &ClosedCallerUniverseV1 {
+            closed: true,
+            has_external_callers: false,
+            callers: vec![proving, disagreeing],
+        },
+    )
+    .unwrap_err();
+    assert_eq!(gap, ParameterResolutionGapV1::DisagreeingCallers);
+}
+
+#[test]
+fn external_caller_universe_stays_loud() {
+    let f = fixture();
+    let gap = discharge_parameter_candidate(
+        &f.candidate,
+        &f.contract,
+        &ClosedCallerUniverseV1 {
+            closed: false,
+            has_external_callers: true,
+            callers: vec![],
+        },
+    )
+    .unwrap_err();
+    assert_eq!(gap, ParameterResolutionGapV1::OpenCallerUniverse);
+}
+
+#[test]
+fn entry_point_without_authenticated_callers_stays_loud() {
+    let f = fixture();
+    let gap = discharge_parameter_candidate(
+        &f.candidate,
+        &f.contract,
+        &ClosedCallerUniverseV1 {
+            closed: true,
+            has_external_callers: false,
+            callers: vec![],
+        },
+    )
+    .unwrap_err();
+    assert_eq!(gap, ParameterResolutionGapV1::NoIncomingCaller);
+}
+
+#[test]
+fn stale_formal_identity_is_not_accepted_by_name() {
+    let mut f = fixture();
+    f.edge.formal_actual_bindings[0].formal_coordinate_cid =
+        canonical_json_cid(&json!({"sameSpelling": "xs", "differentOwner": true}));
+    f.edge.edge_cid = canonical_json_cid(&f.edge.preimage());
+    let gap = f.edge.validate_against(&f.contract).unwrap_err();
+    assert_eq!(gap, ParameterResolutionGapV1::FormalCoordinateMismatch);
+}
+
+#[test]
+fn unverified_actual_contract_reference_stays_loud() {
+    let mut f = fixture();
+    f.edge.formal_actual_bindings[0].actual_contract_ref_cid =
+        Some(canonical_json_cid(&json!({"unverified": true})));
+    f.edge.edge_cid = canonical_json_cid(&f.edge.preimage());
+    let gap = f.edge.validate_against(&f.contract).unwrap_err();
+    assert_eq!(
+        gap,
+        ParameterResolutionGapV1::UnauthenticatedActualContractRef
+    );
+}


### PR DESCRIPTION
## Outcome

First caller-parameter slice: declaration-owned FormalParameterCoordinateV1 on FormalRef, one construction into ContractConditionalConstructionV1, ordered CallEdgeV2 formalActualBindings, and Rust discharge only from the callee declaration or the common exact formula testified by every caller in a closed universe.

## Instruments

- one construction / stable candidate+demand CID twin
- declared-contract and one closed authenticated caller discharge twins
- disagreeing callers, external/entry-point callers, stale coordinate, and unauthenticated actual-contract refs stay typed gaps
- existing projection shapes remain compatible

## Receipts

- focused Python: 10 passed
- source-tree + manager sweep under local Python 3.14: 376 passed, 5 skipped; one interpreter-specific pinned corpus golden mismatch
- Rust sugar-linker caller_parameter_contract: 7 passed locally
- battleaxe receipt running in background with the workspace manifest path

## R accounting

The authoritative pandas caller-parameter bucket is approximately 863. This PR establishes the first exact subscript/indexability candidate and discharge path; the honest observed pandas delta is reported after the background corpus instrument, with pending/unresolved demands remaining loud.

Stacked on Cut C #6104; do not merge before its base.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add caller-parameter contract infrastructure via `ContractConditionalConstructionV1`
> - Introduces `FormalParameterCoordinateV1` (Python and Rust) as an authenticated, CID-stamped identity for each formal parameter, replacing ad-hoc placeholder dataclasses.
> - Adds `ContractConditionalConstructionV1`, a new `Outcome` type representing a pending construction conditional on a parameter contract demand, produced when a `SymbolicValue` tied to a formal parameter is subscripted.
> - Adds `CallEdgeV2`, `ParameterContractDemandV1`, `ValueOccurrenceCoordinateV1`, and `FormalActualBindingV1` as authenticated wire structures on both sides, with CID-freshness validation raising `ValueError` on stale or malformed inputs.
> - Implements `discharge_parameter_candidate` in Rust ([caller_parameter.rs](https://github.com/TSavo/sugar/pull/6110/files#diff-bea66b4dd42a61e343e8ddf6ac0ed1b2b4c8b92dd2262f122e00e2838b797a71)), which resolves a demanded formula by substituting actual terms from call edges and verifying the instantiated formula appears in `provedFormulas`.
> - `FunctionDef.substitute` now injects one `FormalRef` node per parameter carrying the authenticated coordinate; all reads share the same identity rather than being reconstructed independently.
> - Risk: serialized binding wire format under `'formal'` changes from a raw `__dict__` to the canonical `coordinate.to_value()` shape, which is a breaking change for any consumer reading that field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c6ed72f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->