### PR TITLE
Drain construction invariant floor to zero

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -16,6 +16,52 @@ from typing import Any, Iterable
 from .canonicalizer import blake3_512_of, encode_jcs
 from .context_manager_contract import _json_value
 
+class UnsupportedStatementGrammar(RuntimeError):
+    pass
+
+
+AST_STATEMENT_TYPE_NAMES = frozenset(
+    {
+        "FunctionDef",
+        "AsyncFunctionDef",
+        "ClassDef",
+        "Return",
+        "Delete",
+        "Assign",
+        "TypeAlias",
+        "AugAssign",
+        "AnnAssign",
+        "For",
+        "AsyncFor",
+        "While",
+        "If",
+        "With",
+        "AsyncWith",
+        "Match",
+        "Raise",
+        "Try",
+        "TryStar",
+        "Assert",
+        "Import",
+        "ImportFrom",
+        "Global",
+        "Nonlocal",
+        "Expr",
+        "Pass",
+        "Break",
+        "Continue",
+    }
+)
+AST_STATEMENT_TYPES = frozenset(
+    statement for statement in ast.stmt.__subclasses__() if statement.__module__ == "ast"
+)
+if {statement.__name__ for statement in AST_STATEMENT_TYPES} != AST_STATEMENT_TYPE_NAMES:
+    raise UnsupportedStatementGrammar("unsupported running ast.stmt grammar")
+
+
+class UnsupportedStatementVariant(RuntimeError):
+    pass
+
 
 def _hash(value: Any) -> str:
     return blake3_512_of(encode_jcs(_json_value(value)).encode("utf-8"))
@@ -445,10 +491,12 @@ class _Pass:
                 for name in _bound_names(target):
                     state[name] = frozenset({_UNBOUND})
             return state
-        for child in ast.iter_child_nodes(node):
-            if isinstance(child, ast.expr):
-                self.expression(child, state, scope)
-        return state
+        if type(node) in AST_STATEMENT_TYPES:
+            for child in ast.iter_child_nodes(node):
+                if isinstance(child, ast.expr):
+                    self.expression(child, state, scope)
+            return state
+        raise UnsupportedStatementVariant(type(node).__name__)
 
 
 def _function_locals(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:

--- a/implementations/python/sugar-lift-py-tests/tests/test_import_binding_statement_totality.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_import_binding_statement_totality.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from sugar_lift_py_tests import import_binding
+
+
+class RenamedFutureStatement(ast.stmt):
+    _fields: tuple[str, ...] = ()
+
+
+def test_import_binding_transfer_rejects_future_statement_variants_loudly() -> None:
+    transfer = import_binding._Pass(
+        source_cid="blake3-512:" + "0" * 128,
+        module_name="fixture",
+        module_identities={},
+    )
+    scope = ast.parse("pass")
+
+    with pytest.raises(import_binding.UnsupportedStatementVariant):
+        transfer.statement(RenamedFutureStatement(), {}, scope)
+
+
+def test_import_binding_statement_partition_matches_running_grammar() -> None:
+    running = frozenset(
+        statement for statement in ast.stmt.__subclasses__() if statement.__module__ == "ast"
+    )
+    assert import_binding.AST_STATEMENT_TYPES == running
+    assert import_binding.AST_STATEMENT_TYPE_NAMES == {item.__name__ for item in running}
+    assert issubclass(import_binding.UnsupportedStatementGrammar, RuntimeError)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/ast_template.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/ast_template.py
@@ -5,6 +5,52 @@ from typing import Any
 
 Json = Any
 
+class UnsupportedStatementGrammar(RuntimeError):
+    pass
+
+
+AST_STATEMENT_TYPE_NAMES = frozenset(
+    {
+        "FunctionDef",
+        "AsyncFunctionDef",
+        "ClassDef",
+        "Return",
+        "Delete",
+        "Assign",
+        "TypeAlias",
+        "AugAssign",
+        "AnnAssign",
+        "For",
+        "AsyncFor",
+        "While",
+        "If",
+        "With",
+        "AsyncWith",
+        "Match",
+        "Raise",
+        "Try",
+        "TryStar",
+        "Assert",
+        "Import",
+        "ImportFrom",
+        "Global",
+        "Nonlocal",
+        "Expr",
+        "Pass",
+        "Break",
+        "Continue",
+    }
+)
+AST_STATEMENT_TYPES = frozenset(
+    statement for statement in ast.stmt.__subclasses__() if statement.__module__ == "ast"
+)
+if {statement.__name__ for statement in AST_STATEMENT_TYPES} != AST_STATEMENT_TYPE_NAMES:
+    raise UnsupportedStatementGrammar("unsupported running ast.stmt grammar")
+
+
+class UnsupportedStatementVariant(RuntimeError):
+    pass
+
 
 def function_param_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
     return [arg.arg for arg in _ordered_signature_args(node.args)]
@@ -58,7 +104,9 @@ def stmt_to_template(stmt: ast.stmt, params: list[str]) -> Json:
             },
             "trailing_semi": False,
         }
-    return {"kind": "other", "variant": type(stmt).__name__}
+    if type(stmt) in AST_STATEMENT_TYPES:
+        return {"kind": "other", "variant": type(stmt).__name__}
+    raise UnsupportedStatementVariant(type(stmt).__name__)
 
 
 def expr_to_template(expr: ast.expr, params: list[str]) -> Json:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py
@@ -13,6 +13,47 @@ from .canonical import blake3_512_of, cid_of_json, template_cid_of_json
 from .source_tables import parsed_tree
 
 Json = Any
+class UnsupportedStatementGrammar(RuntimeError):
+    pass
+
+
+AST_STATEMENT_TYPE_NAMES = frozenset(
+    {
+        "FunctionDef",
+        "AsyncFunctionDef",
+        "ClassDef",
+        "Return",
+        "Delete",
+        "Assign",
+        "TypeAlias",
+        "AugAssign",
+        "AnnAssign",
+        "For",
+        "AsyncFor",
+        "While",
+        "If",
+        "With",
+        "AsyncWith",
+        "Match",
+        "Raise",
+        "Try",
+        "TryStar",
+        "Assert",
+        "Import",
+        "ImportFrom",
+        "Global",
+        "Nonlocal",
+        "Expr",
+        "Pass",
+        "Break",
+        "Continue",
+    }
+)
+AST_STATEMENT_TYPES = frozenset(
+    statement for statement in ast.stmt.__subclasses__() if statement.__module__ == "ast"
+)
+if {statement.__name__ for statement in AST_STATEMENT_TYPES} != AST_STATEMENT_TYPE_NAMES:
+    raise UnsupportedStatementGrammar("unsupported running ast.stmt grammar")
 CID_RE = re.compile(r"^blake3-512:[0-9a-f]{128}$")
 CONTRACT_COMMENT_KIND = "sugar-contract-comment-sugar"
 CONTRACT_COMMENT_ROLE_MAP = {
@@ -22,6 +63,10 @@ CONTRACT_COMMENT_ROLE_MAP = {
     "throws": "throws",
     "observation": "observation",
 }
+
+
+class UnsupportedStatementVariant(RuntimeError):
+    pass
 
 
 @dataclass
@@ -955,7 +1000,9 @@ def _shape_stmt_with_bindings(node: ast.stmt, *, top_level: bool) -> _ShapeResul
         )
     if isinstance(node, ast.Expr):
         return _shape_expr_with_bindings(node.value)
-    return _empty_shape_result()
+    if type(node) in AST_STATEMENT_TYPES:
+        return _empty_shape_result()
+    raise UnsupportedStatementVariant(type(node).__name__)
 
 
 def _shape_expr(node: ast.expr) -> Json:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import ast
-import locale
 import os
-import pickle
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Iterable
@@ -35,6 +33,47 @@ from .ir import (
 )
 
 PANIC_FREEDOM_EFFECT_KIND = "panic-freedom"
+class UnsupportedStatementGrammar(RuntimeError):
+    pass
+
+
+AST_STATEMENT_TYPE_NAMES = frozenset(
+    {
+        "FunctionDef",
+        "AsyncFunctionDef",
+        "ClassDef",
+        "Return",
+        "Delete",
+        "Assign",
+        "TypeAlias",
+        "AugAssign",
+        "AnnAssign",
+        "For",
+        "AsyncFor",
+        "While",
+        "If",
+        "With",
+        "AsyncWith",
+        "Match",
+        "Raise",
+        "Try",
+        "TryStar",
+        "Assert",
+        "Import",
+        "ImportFrom",
+        "Global",
+        "Nonlocal",
+        "Expr",
+        "Pass",
+        "Break",
+        "Continue",
+    }
+)
+AST_STATEMENT_TYPES = frozenset(
+    statement for statement in ast.stmt.__subclasses__() if statement.__module__ == "ast"
+)
+if {statement.__name__ for statement in AST_STATEMENT_TYPES} != AST_STATEMENT_TYPE_NAMES:
+    raise UnsupportedStatementGrammar("unsupported running ast.stmt grammar")
 RUNTIME_FAILURE_SITE_CONCEPT = "concept:panic-freedom.leaf.runtime-failure-site"
 CLASS_SHAPE_ASSUMPTIONS = [
     "presence-guaranteed-assuming-standard-construction-via-__init__",
@@ -1647,9 +1686,6 @@ class _Emitter:
         return _literal_default(node, self._tentative_default_expr)
 
     def _tentative_default_expr(self, node: ast.expr) -> Json:
-        known_constant = _known_external_default_constant(node, self.module_imports)
-        if known_constant is not None:
-            return known_constant
         effects = _EffectSet()
         panic_loci: list[Json] = []
         result = LiftResult()
@@ -1965,8 +2001,6 @@ def _lift_function(
         refused_decorator = _refused_decorator(node)
         if refused_decorator is not None:
             raise refused_decorator
-        if _is_overload_stub(node):
-            return None
         decorator_kinds = _function_decorator_kinds(node)
         default_emitter = _Emitter(
             fn_name=info.fn_name,
@@ -2352,8 +2386,10 @@ def _class_overrides_setattr(node: ast.ClassDef) -> bool:
 
 
 def _slot_entries(stmt: ast.stmt) -> tuple[list[Json], bool]:
-    if not isinstance(stmt, ast.Assign):
+    if not isinstance(stmt, ast.Assign) and type(stmt) in AST_STATEMENT_TYPES:
         return [], False
+    if not isinstance(stmt, ast.Assign):
+        raise _UnsupportedSyntax(stmt, f"unknown statement variant: {type(stmt).__name__}")
     if not any(
         isinstance(target, ast.Name) and target.id == "__slots__"
         for target in stmt.targets
@@ -2420,7 +2456,9 @@ def _class_body_attribute_sources(stmt: ast.stmt) -> list[tuple[str, Json]]:
                 _shape_source("nested-class-definition", stmt),
             )
         ]
-    return []
+    if type(stmt) in AST_STATEMENT_TYPES:
+        return []
+    raise _UnsupportedSyntax(stmt, f"unknown statement variant: {type(stmt).__name__}")
 
 
 def _merge_open_attr(
@@ -2615,24 +2653,6 @@ def _literal_default(
     return tentative_expr(node)
 
 
-def _known_external_default_constant(
-    node: ast.expr,
-    module_imports: dict[str, str],
-) -> Json | None:
-    name = _resolved_imported_dotted_name(node, module_imports)
-    if name == "numpy.nan":
-        return float_const(float("nan"))
-    if name == "os.curdir":
-        return str_const(os.curdir)
-    if name == "pickle.HIGHEST_PROTOCOL":
-        return int_const(pickle.HIGHEST_PROTOCOL)
-    if name == "locale.LC_ALL":
-        return int_const(locale.LC_ALL)
-    if name == "_format_impl._MAX_HEADER_SIZE":
-        return int_const(10000)
-    return None
-
-
 def _resolved_imported_dotted_name(
     node: ast.expr,
     module_imports: dict[str, str],
@@ -2699,16 +2719,11 @@ def _is_transparent_decorator(decorator: ast.expr) -> bool:
         "abc.abstractmethod",
         "wraps",
         "functools.wraps",
-        "overload",
-        "typing.overload",
         "final",
         "typing.final",
         "deprecated",
         "typing.deprecated",
         "warnings.deprecated",
-        "set_module",
-        "numpy._utils.set_module",
-        "numpy._core.overrides.set_module",
     }
 
 
@@ -2762,26 +2777,6 @@ def _refused_decorator_name(decorator: ast.expr) -> str:
         return ast.unparse(decorator)
     except Exception:
         return type(decorator).__name__
-
-
-def _is_overload_stub(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
-    if not any(
-        _decorator_name(decorator) in {"overload", "typing.overload"}
-        for decorator in node.decorator_list
-    ):
-        return False
-    body = [stmt for stmt in node.body if not _is_docstring_stmt(stmt)]
-    if not body:
-        return True
-    return all(
-        isinstance(stmt, ast.Pass)
-        or (
-            isinstance(stmt, ast.Expr)
-            and isinstance(stmt.value, ast.Constant)
-            and stmt.value.value is Ellipsis
-        )
-        for stmt in body
-    )
 
 
 def _contains_refused_control(fn: ast.FunctionDef) -> _UnsupportedSyntax | None:
@@ -3156,7 +3151,9 @@ def _module_statement_bound_names(stmt: ast.stmt) -> set[str]:
         for target in stmt.targets:
             names.update(_stored_names(target))
         return names
-    return set()
+    if type(stmt) in AST_STATEMENT_TYPES:
+        return set()
+    raise _UnsupportedSyntax(stmt, f"unknown statement variant: {type(stmt).__name__}")
 
 
 def _stored_names(node: ast.AST) -> set[str]:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py
@@ -32,6 +32,47 @@ from .ir import (
 VALUE_PIN_BOUNDARY_KIND = "value-pin-boundary"
 ENUM_PIN_BOUNDARY_KIND = "enum-pin-boundary"
 FINAL_CONFESSION = "typing.Final"
+class UnsupportedStatementGrammar(RuntimeError):
+    pass
+
+
+AST_STATEMENT_TYPE_NAMES = frozenset(
+    {
+        "FunctionDef",
+        "AsyncFunctionDef",
+        "ClassDef",
+        "Return",
+        "Delete",
+        "Assign",
+        "TypeAlias",
+        "AugAssign",
+        "AnnAssign",
+        "For",
+        "AsyncFor",
+        "While",
+        "If",
+        "With",
+        "AsyncWith",
+        "Match",
+        "Raise",
+        "Try",
+        "TryStar",
+        "Assert",
+        "Import",
+        "ImportFrom",
+        "Global",
+        "Nonlocal",
+        "Expr",
+        "Pass",
+        "Break",
+        "Continue",
+    }
+)
+AST_STATEMENT_TYPES = frozenset(
+    statement for statement in ast.stmt.__subclasses__() if statement.__module__ == "ast"
+)
+if {statement.__name__ for statement in AST_STATEMENT_TYPES} != AST_STATEMENT_TYPE_NAMES:
+    raise UnsupportedStatementGrammar("unsupported running ast.stmt grammar")
 
 # Scope boundaries: bindings inside these do not bind module names.
 # (Plain assignment in a function is a local; `global`-declaring functions
@@ -83,6 +124,10 @@ class _NotAdmissible(Exception):
     def __init__(self, reason: str):
         self.reason = reason
         super().__init__(reason)
+
+
+class UnsupportedStatementVariant(RuntimeError):
+    pass
 
 
 @dataclass(frozen=True)
@@ -584,9 +629,12 @@ def _statement_binding_events(stmt: ast.stmt) -> Iterator[_BindingEvent]:
     elif _TYPE_ALIAS_NODE is not None and isinstance(stmt, _TYPE_ALIAS_NODE):
         if isinstance(stmt.name, ast.Name):
             yield _BindingEvent(stmt.name.id, stmt.lineno, "type-alias definition")
-    # Walrus targets anywhere in this statement's expressions, outside
-    # nested scopes, bind module names.
-    yield from _walrus_bindings(stmt)
+    if type(stmt) in AST_STATEMENT_TYPES:
+        # Walrus targets anywhere in this statement's expressions, outside
+        # nested scopes, bind module names.
+        yield from _walrus_bindings(stmt)
+        return
+    raise UnsupportedStatementVariant(type(stmt).__name__)
 
 
 def _match_pattern_bindings(pattern: ast.pattern) -> Iterator[_BindingEvent]:

--- a/implementations/python/sugar-lift-python-source/tests/test_construction_invariant_drains.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_construction_invariant_drains.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from sugar_lift_python_source import ast_template, bind_lifter, lifter, value_pins
+
+
+class RenamedFutureStatement(ast.stmt):
+    _fields: tuple[str, ...] = ()
+
+
+def test_every_statement_consumer_is_total_and_future_variants_are_loud() -> None:
+    node = RenamedFutureStatement()
+
+    with pytest.raises(ast_template.UnsupportedStatementVariant):
+        ast_template.stmt_to_template(node, [])
+    with pytest.raises(bind_lifter.UnsupportedStatementVariant):
+        bind_lifter._shape_stmt_with_bindings(node, top_level=False)
+    with pytest.raises(lifter._UnsupportedSyntax):
+        lifter._Emitter.statement(object.__new__(lifter._Emitter), node)
+    with pytest.raises(lifter._UnsupportedSyntax):
+        lifter._slot_entries(node)
+    with pytest.raises(lifter._UnsupportedSyntax):
+        lifter._class_body_attribute_sources(node)
+    with pytest.raises(lifter._UnsupportedSyntax):
+        lifter._module_statement_bound_names(node)
+    with pytest.raises(value_pins.UnsupportedStatementVariant):
+        list(value_pins._statement_binding_events(node))
+
+
+def test_current_statement_grammar_is_the_explicit_partition() -> None:
+    running = frozenset(
+        statement for statement in ast.stmt.__subclasses__() if statement.__module__ == "ast"
+    )
+    assert ast_template.AST_STATEMENT_TYPES == running
+    assert ast_template.AST_STATEMENT_TYPE_NAMES == {item.__name__ for item in running}
+    assert bind_lifter.AST_STATEMENT_TYPES == running
+    assert bind_lifter.AST_STATEMENT_TYPE_NAMES == {item.__name__ for item in running}
+    assert lifter.AST_STATEMENT_TYPES == running
+    assert lifter.AST_STATEMENT_TYPE_NAMES == {item.__name__ for item in running}
+    assert value_pins.AST_STATEMENT_TYPES == running
+    assert value_pins.AST_STATEMENT_TYPE_NAMES == {item.__name__ for item in running}
+    assert issubclass(ast_template.UnsupportedStatementGrammar, RuntimeError)
+    assert issubclass(bind_lifter.UnsupportedStatementGrammar, RuntimeError)
+    assert issubclass(lifter.UnsupportedStatementGrammar, RuntimeError)
+    assert issubclass(value_pins.UnsupportedStatementGrammar, RuntimeError)
+
+
+def test_renamed_external_values_and_decorators_receive_no_spelling_authority() -> None:
+    source = (
+        "import arbitrary_provider as provider\n"
+        "\n"
+        "@provider.transparent_looking\n"
+        "def f(value=provider.magic_constant):\n"
+        "    return value\n"
+    )
+
+    result = lifter.lift_source(source, "renamed_provider.py")
+
+    assert result.refusals
+    assert any(row["kind"] == "decorator-refused" for row in result.refusals)
+    assert not any(str(row.get("fnName", "")).endswith(".f") for row in result.ir)
+
+
+def test_decorator_spelling_never_confers_transparency_or_stub_authority() -> None:
+    source = (
+        "def overload(fn):\n"
+        "    return fn\n"
+        "\n"
+        "@overload\n"
+        "def f():\n"
+        "    ...\n"
+        "\n"
+        "def set_module(value):\n"
+        "    return lambda fn: fn\n"
+        "\n"
+        "@set_module('renamed-vendor')\n"
+        "def g():\n"
+        "    return 1\n"
+    )
+
+    result = lifter.lift_source(source, "spelling_is_not_authority.py")
+
+    refused = {row["function"] for row in result.refusals if row["kind"] == "decorator-refused"}
+    assert any(name and name.endswith(".f") for name in refused)
+    assert any(name and name.endswith(".g") for name in refused)
+    assert not any(
+        str(row.get("fnName", "")).endswith((".f", ".g")) for row in result.ir
+    )
+
+
+def test_import_alias_does_not_turn_external_default_into_a_literal() -> None:
+    source = "from numpy import nan as renamed\ndef f(value=renamed):\n    return value\n"
+
+    result = lifter.lift_source(source, "aliased_external_default.py")
+
+    assert any(row["kind"] == "non-literal-default" for row in result.refusals)

--- a/implementations/python/sugar-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_lifter.py
@@ -3867,7 +3867,7 @@ def test_liftable_nonliteral_defaults_roundtrip_stably() -> None:
     )
 
 
-def test_known_external_constant_defaults_lift_without_effects() -> None:
+def test_external_constant_defaults_have_no_spelling_authority() -> None:
     source = (
         "import numpy as np\n"
         "import os\n"
@@ -3879,29 +3879,11 @@ def test_known_external_constant_defaults_lift_without_effects() -> None:
 
     result = lift_source(source, "known_external_default.py")
 
-    assert result.refusals == []
-    contract = _contract(result.ir, ".f")
-    assert contract["effects"] == []
-    assert contract["parameterShape"] == [
-        {
-            "name": "missing",
-            "kind": "positional-or-keyword",
-            "default": _float_const(float("nan")),
-        },
-        {
-            "name": "dest",
-            "kind": "positional-or-keyword",
-            "default": _str_const("."),
-        },
-        {
-            "name": "protocol",
-            "kind": "positional-or-keyword",
-            "default": _int_const(pickle.HIGHEST_PROTOCOL),
-        },
-    ]
+    assert any(row["kind"] == "non-literal-default" for row in result.refusals)
+    assert not any(str(row.get("fnName", "")).endswith(".f") for row in result.ir)
 
 
-def test_known_imported_header_size_default_lifts_without_effects() -> None:
+def test_imported_named_default_stays_loud_without_authenticated_value() -> None:
     source = (
         "from _format_impl import _MAX_HEADER_SIZE\n"
         "\n"
@@ -3911,16 +3893,8 @@ def test_known_imported_header_size_default_lifts_without_effects() -> None:
 
     result = lift_source(source, "known_imported_header_size_default.py")
 
-    assert result.refusals == []
-    contract = _contract(result.ir, ".f")
-    assert contract["effects"] == []
-    assert contract["parameterShape"] == [
-        {
-            "name": "max_header_size",
-            "kind": "positional-or-keyword",
-            "default": _int_const(10000),
-        }
-    ]
+    assert any(row["kind"] == "non-literal-default" for row in result.refusals)
+    assert not any(str(row.get("fnName", "")).endswith(".f") for row in result.ir)
 
 
 def test_unknown_imported_name_default_remains_refused() -> None:
@@ -4496,7 +4470,7 @@ def test_transparent_wraps_final_and_deprecated_decorators_lift_body() -> None:
     assert "decoratorKinds" not in contract
 
 
-def test_transparent_set_module_decorator_lifts_body_without_marker() -> None:
+def test_set_module_spelling_does_not_confer_transparency() -> None:
     source = (
         "def set_module(module):\n"
         "    def decorator(func):\n"
@@ -4511,13 +4485,11 @@ def test_transparent_set_module_decorator_lifts_body_without_marker() -> None:
 
     result = lift_source(source, "set_module_decorator.py")
 
-    contract = _contract(result.ir, ".f")
-    assert result.refusals == []
-    assert _function_body(result, ".f") == _return(_var("x"))
-    assert "decoratorKinds" not in contract
+    assert any(row["kind"] == "decorator-refused" for row in result.refusals)
+    assert not any(str(row.get("fnName", "")).endswith(".f") for row in result.ir)
 
 
-def test_overload_stub_body_mints_no_contract_or_body_fact() -> None:
+def test_overload_spelling_does_not_confer_stub_authority() -> None:
     source = (
         "import typing\n"
         "\n"
@@ -4528,7 +4500,7 @@ def test_overload_stub_body_mints_no_contract_or_body_fact() -> None:
 
     result = lift_source(source, "overload_stub.py")
 
-    assert result.refusals == []
+    assert any(row["kind"] == "decorator-refused" for row in result.refusals)
     assert not any(str(item.get("fnName", "")).endswith(".f") for item in result.ir)
     source_body = _source_unit_contract(result.ir)["post"]["args"][1]["args"][1]
     assert source_body["name"] == "python:pass"


### PR DESCRIPTION
## Outcome

Drains the construction-invariant floor from R=14 to R=0 without changing or suppressing the auditor.

## Capability repairs

- removes spelling-authorized external default fabrication; imported/default values without authenticated testimony remain non-literal-default loud
- removes overload and set-module spelling authority; decorators without authenticated semantics remain decorator-refused loud
- closes every current ast.stmt consumer over an explicit grammar partition
- preserves existing behavior for every admitted current statement variant
- makes a future/unmodeled statement grammar or variant a typed loud error, never a neutral return

## Discrimination

- renamed provider/decorator and misleading overload/set-module twins prove spellings confer no authority
- aliased external-default twin proves imports do not fabricate literals
- RenamedFutureStatement twins exercise all seven statement consumers
- running-grammar identity twins pin the complete ast.stmt variant set

## Verification

- reference lifter focused suite: 412 passed
- resolver/auditor focused suite: 31 passed
- construction invariant audit: R_construction_invariant_violations=0, R_auditor_errors=0
- git diff --check

No Rust source changed; no local heavy Rust build was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Python statement handling to detect unsupported syntax instead of silently accepting or ignoring it.
  - Added clearer errors when the running Python grammar differs from supported syntax.
  - External constants used as defaults are now rejected unless they are recognized literals.
  - Decorator spelling no longer incorrectly grants special behavior; unsupported decorators are reported.
  - Overload-style stubs are now processed consistently during lifting.
  - Added support for `final` and `deprecated` decorator forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drain construction invariant floor to zero by raising on unknown AST statement variants
> - Adds `UnsupportedStatementGrammar` and `UnsupportedStatementVariant` errors across `ast_template`, `bind_lifter`, `lifter`, `value_pins`, and `import_binding`; each module now validates the running `ast.stmt` grammar at import time and raises loudly on unknown/non-CPython statement subclasses instead of silently ignoring them.
> - Removes `_known_external_default_constant`, so default argument spellings like `numpy.nan`, `os.curdir`, and `pickle.HIGHEST_PROTOCOL` are no longer folded to literal constants during lifting.
> - Removes `_is_overload_stub` and strips `overload`, `set_module`, and related names from the transparent-decorator whitelist; functions decorated with these are now processed normally and subject to decorator refusal logic.
> - New tests in `test_construction_invariant_drains.py` and `test_import_binding_statement_totality.py` assert totality over the current grammar and loudness on future variants.
> - Behavioral Change: external constant defaults and `overload`-decorated functions that previously produced IR or were silently skipped now result in refusals or no IR.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a9a141.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->