### PR TITLE
Route recensus panics through sanctioned audit collector

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/comprehension_iteration_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/comprehension_iteration_recensus.py
@@ -12,6 +12,9 @@ import signal
 import subprocess
 import sys
 import time
+from typing import Any, Callable
+
+from sugar_lift_py_tests.audit_only import collect_construction_panic
 
 
 class FileTimeout(Exception):
@@ -151,6 +154,20 @@ def _git_commit(root: Path) -> str:
     ).strip()
 
 
+def _collect_file_construction(
+    label: str, walker: Callable[[], Any]
+) -> tuple[Any | None, dict[str, Any] | None]:
+    value, gap = collect_construction_panic(label, walker)
+    if gap is None:
+        return value, None
+    return None, {
+        "file": label,
+        "type": "ConstructionPanic",
+        "message": gap.message,
+        "gap": gap.info,
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("corpus", type=Path)
@@ -174,6 +191,7 @@ def main() -> int:
     )
     direct_mechanisms: dict[str, Counter] = defaultdict(Counter)
     defects = []
+    construction_panics: list[dict[str, Any]] = []
     files_completed = 0
     started = time.time()
     target_kinds = (
@@ -197,13 +215,26 @@ def main() -> int:
                 if isinstance(node, target_kinds):
                     syntax[_syntax_coordinate(node, lines)] = _shape(node)
 
-            reporter = CollectingReporter()
-            source_file = SourceFile.from_path(str(path), reporter=reporter)
-            for function in source_file.functions():
-                try:
-                    function.sugar()
-                except SugarNotWritten:
-                    pass
+            def construct_file():
+                reporter = CollectingReporter()
+                source_file = SourceFile.from_path(str(path), reporter=reporter)
+                for function in source_file.functions():
+                    try:
+                        function.sugar()
+                    except SugarNotWritten:
+                        pass
+                return reporter
+
+            reporter, panic_row = _collect_file_construction(relative, construct_file)
+            if panic_row is not None:
+                construction_panics.append(panic_row)
+                print(
+                    f"[{index}/{len(files)}] CONSTRUCTION-PANIC {relative}: "
+                    f"{panic_row['message']}",
+                    flush=True,
+                )
+                continue
+            assert reporter is not None
 
             registered = {_coordinate(node) for node in reporter.registered}
             present = {_coordinate(node) for node in reporter.present}
@@ -232,9 +263,7 @@ def main() -> int:
                     f"direct-family={direct}",
                     flush=True,
                 )
-        except BaseException as exc:
-            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
-                raise
+        except Exception as exc:
             defects.append(
                 {"file": relative, "type": type(exc).__name__, "message": str(exc)}
             )
@@ -262,6 +291,8 @@ def main() -> int:
         "filesTotal": len(files),
         "filesCompleted": files_completed,
         "defects": defects,
+        "constructionPanics": construction_panics,
+        "R_construction_panics": len(construction_panics),
         "families": {
             family: dict(sorted(statuses.items()))
             for family, statuses in sorted(counts.items())
@@ -280,7 +311,7 @@ def main() -> int:
     print(rendered, flush=True)
     if args.json is not None:
         args.json.write_text(rendered + "\n")
-    return 1 if defects or files_completed != len(files) else 0
+    return 1 if defects or construction_panics or files_completed != len(files) else 0
 
 
 if __name__ == "__main__":

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -12,6 +12,9 @@ import signal
 import subprocess
 import sys
 import time
+from typing import Any, Callable
+
+from sugar_lift_py_tests.audit_only import collect_construction_panic
 
 
 class FileTimeout(Exception):
@@ -121,6 +124,20 @@ def _git_commit(root: Path) -> str:
     ).strip()
 
 
+def _collect_file_construction(
+    label: str, walker: Callable[[], Any]
+) -> tuple[Any | None, dict[str, Any] | None]:
+    value, gap = collect_construction_panic(label, walker)
+    if gap is None:
+        return value, None
+    return None, {
+        "file": label,
+        "type": "ConstructionPanic",
+        "message": gap.message,
+        "gap": gap.info,
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("corpus", type=Path)
@@ -139,6 +156,7 @@ def main() -> int:
     mechanisms: dict[str, Counter] = defaultdict(Counter)
     families = Counter()
     defects = []
+    construction_panics: list[dict[str, Any]] = []
     files_completed = 0
     functions_total = 0
     functions_clean = 0
@@ -157,15 +175,30 @@ def main() -> int:
                 if labels:
                     syntax[(type(node).__name__, node.lineno, node.col_offset)] = labels
 
-            reporter = CollectingReporter()
-            source_file = SourceFile.from_path(str(path), reporter=reporter)
-            for function in source_file.functions():
-                functions_total += 1
-                try:
-                    function.sugar()
-                    functions_clean += 1
-                except SugarNotWritten:
-                    pass
+            def construct_file():
+                nonlocal functions_total, functions_clean
+                reporter = CollectingReporter()
+                source_file = SourceFile.from_path(str(path), reporter=reporter)
+                for function in source_file.functions():
+                    functions_total += 1
+                    try:
+                        function.sugar()
+                        functions_clean += 1
+                    except SugarNotWritten:
+                        pass
+                return reporter
+
+            reporter, panic_row = _collect_file_construction(relative, construct_file)
+            if panic_row is not None:
+                construction_panics.append(panic_row)
+                families["ConstructionPanic"] += 1
+                print(
+                    f"[{index}/{len(files)}] CONSTRUCTION-PANIC {relative}: "
+                    f"{panic_row['message']}",
+                    flush=True,
+                )
+                continue
+            assert reporter is not None
 
             registered = {_coordinate(node) for node in reporter.registered}
             present = {_coordinate(node) for node in reporter.present}
@@ -199,9 +232,7 @@ def main() -> int:
                     f"direct-labelled={direct}",
                     flush=True,
                 )
-        except BaseException as exc:
-            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
-                raise
+        except Exception as exc:
             defects.append(
                 {"file": relative, "type": type(exc).__name__, "message": str(exc)}
             )
@@ -220,6 +251,8 @@ def main() -> int:
         "filesTotal": len(files),
         "filesCompleted": files_completed,
         "defects": defects,
+        "constructionPanics": construction_panics,
+        "R_construction_panics": len(construction_panics),
         "functionsTotal": functions_total,
         "functionsConstructClean": functions_clean,
         "constructs": {
@@ -242,7 +275,7 @@ def main() -> int:
     print(rendered, flush=True)
     if args.json is not None:
         args.json.write_text(rendered + "\n")
-    return 1 if defects or files_completed != len(files) else 0
+    return 1 if defects or construction_panics or files_completed != len(files) else 0
 
 
 if __name__ == "__main__":

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.gap.info import ConstructionGap
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _load(name: str):
+    path = _SCRIPTS / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    "script_name",
+    ("comprehension_iteration_recensus", "control_effect_recensus"),
+)
+def test_recensus_projects_construction_panic_as_a_loud_counted_gap(
+    script_name: str,
+) -> None:
+    module = _load(script_name)
+    panic = ConstructionPanic(
+        ConstructionGap(
+            owner="renamed-constructor",
+            blame="fixture.py:1:0",
+            observed="OpaqueValue",
+            requested="constructed value",
+            fix="implement the constructor",
+        )
+    )
+
+    def panic_walker():
+        raise panic
+
+    value, row = module._collect_file_construction("fixture.py", panic_walker)
+
+    assert value is None
+    assert row == {
+        "file": "fixture.py",
+        "type": "ConstructionPanic",
+        "message": panic.info.message,
+        "gap": panic.info.to_json(),
+    }


### PR DESCRIPTION
## Outcome

Restores the ConstructionPanic catch floor without weakening its law.

- routes comprehension_iteration_recensus.py and control_effect_recensus.py through audit_only.collect_construction_panic
- removes their broad BaseException catch-and-continue paths
- preserves each panic original ConstructionGap testimony in a loud row
- records R_construction_panics and keeps the census exit nonzero whenever a panic occurs
- adds a renamed-constructor discrimination twin for both scripts

## Verification

- 9 focused tests passed
- construction_panic_catch_law.py: R_construction_panic_catches_outside_audit = 0
- no ConstructionPanic/BaseException catch remains in either census script
- py_compile and git diff --check pass

No Rust changes or heavy local builds.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route recensus construction panics through a structured audit collector
> - Adds `_collect_file_construction` to [comprehension_iteration_recensus.py](https://github.com/TSavo/sugar/pull/6112/files#diff-b6639480959700852c37a7e20e475e3527c1077d734c344a61ec378e0d4ba81e) and [control_effect_recensus.py](https://github.com/TSavo/sugar/pull/6112/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d), which calls `collect_construction_panic` and returns a structured `ConstructionPanic` row instead of propagating the exception.
> - Both recensus scripts now log a `CONSTRUCTION-PANIC` line, append the panic to a `construction_panics` list, and include `constructionPanics`/`R_construction_panics` fields in the output JSON.
> - Exception handling is narrowed from `BaseException` to `Exception`; `KeyboardInterrupt`/`SystemExit` are no longer caught.
> - The exit code is now non-zero if any construction panics, defects, or incomplete files are present.
> - Adds a parametrized test in [test_recensus_panic_collection.py](https://github.com/TSavo/sugar/pull/6112/files#diff-4ae95f3eb7ec62a0f5b1b052a6ed60801932afc953bacaf26eec9dd5734617df) verifying `_collect_file_construction` returns the expected `(None, row)` structure on panic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 77c9c8d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->