### PR TITLE
Cut B: source-visible call frames + ClassDef through the sole constructor (#6088)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -15,6 +15,7 @@ from .builder_state import BuilderState
 from .bv32_value import Bv32Value
 from .builtin_exception_class_value import BuiltinExceptionClassValue
 from .call_site_value import CallSiteValue
+from .class_definition_value import ClassDefinitionValue, ConstructedClassMethodV1
 from .curried_loop_scope import CurriedLoopBody, CurriedLoopScope
 from .class_value import ClassValue
 from .comprehension_value import ComprehensionValue

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -108,6 +108,7 @@ class CallSiteValue(FloorValue):
     authenticated_target_symbol: str | None = dataclass_field(
         default=None, compare=False
     )
+    source_call_frame_cid: str | None = dataclass_field(default=None, compare=False)
 
     def __hash__(self) -> int:
         """Hash the finite call coordinate, never the recursively-owned body.
@@ -1140,6 +1141,12 @@ def _reduce_callsite_body(
     *,
     blame: str,
 ):
+    from sugar_lift_py_tests.sugar.source_visible_function_body_sugar import (
+        SourceVisibleFunctionBodySugar,
+    )
+
+    if isinstance(body, SourceVisibleFunctionBodySugar):
+        return body.desugar(ctx)
     if isinstance(body, SugarBody):
         return body.reduce(ctx)
     if isinstance(body, FunctionBodyUniverse):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_source_tree.panic import SugarNotWritten
+
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class ConstructedClassMethodV1:
+    name: str
+    definition_fragment_cid: str
+    body: object = field(compare=False)
+
+
+@dataclass(frozen=True)
+class ClassDefinitionValue(FloorValue):
+    class_name: str
+    class_definition_cid: str
+    methods: tuple[ConstructedClassMethodV1, ...]
+    initializer: ConstructedClassMethodV1 | None
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:class-definition",
+            [str_const(self.class_definition_cid)],
+            symbol_kind="coordinate",
+        )
+
+    def construct_receiver_state(self, actuals: tuple[object, ...]):
+        del actuals
+        raise SugarNotWritten(
+            owner="ClassDefinitionValue.construct_receiver_state",
+            observed="awaiting-binding-coordinate",
+            requested="BindingCoordinateV1 receiver and field projections",
+            fix=(
+                "wire the shared scope-owner/binding-site/projection-path spine; "
+                "never infer receiver fields by name"
+            ),
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from sugar_lift_python_source.canonical import cid_of_json
+
+from .context_manager_resolution import SourceFragmentCoordinateV1
+
+
+@dataclass(frozen=True)
+class SourceVisibleCallFrameV1:
+    """A body constructed by FunctionDef through the ordinary tree door."""
+
+    source_identity_cid: str
+    definition_site: SourceFragmentCoordinateV1
+    definition_fragment_cid: str
+    parameters: tuple[str, ...]
+    body: object = field(compare=False)
+    frame_cid: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        preimage = {
+            "kind": "source-visible-call-frame",
+            "schemaVersion": "1",
+            "sourceIdentityCid": self.source_identity_cid,
+            "definitionSite": self.definition_site.wire(),
+            "definitionFragmentCid": self.definition_fragment_cid,
+            "parameters": list(self.parameters),
+        }
+        object.__setattr__(self, "frame_cid", cid_of_json(preimage))
+
+
+@dataclass(frozen=True)
+class AwaitingBindingCoordinateCallFrameV1:
+    """Typed boundary until the shared BindingCoordinateV1 spine lands."""
+
+    source_identity_cid: str
+    definition_site: SourceFragmentCoordinateV1
+    parameters: tuple[str, ...]
+    kind: Literal["awaiting-binding-coordinate"] = "awaiting-binding-coordinate"
+
+
+SourceCallFrameV1 = SourceVisibleCallFrameV1 | AwaitingBindingCoordinateCallFrameV1

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -35,6 +35,7 @@ class CallSiteSugar(Sugar):
     contract_ref: Any = dataclass_field(default=None, compare=False)
     contract_resolution_gap: str | None = dataclass_field(default=None, compare=False)
     exception_type_coordinate: Any = dataclass_field(default=None, compare=False)
+    source_call_frame: Any = dataclass_field(default=None, compare=False)
 
     @classmethod
     def witnesses(cls):
@@ -96,16 +97,58 @@ class CallSiteSugar(Sugar):
         )
         if self.contract_ref is not None:
             return self._collect_bridged(positional)
+        source_body = None
+        source_frame_cid = None
+        if self.source_call_frame is not None:
+            from sugar_lift_py_tests.source_call_frame import (
+                AwaitingBindingCoordinateCallFrameV1,
+                SourceVisibleCallFrameV1,
+            )
+            from sugar_source_tree.panic import SugarNotWritten
+
+            if isinstance(self.source_call_frame, AwaitingBindingCoordinateCallFrameV1):
+                raise SugarNotWritten(
+                    owner="CallSiteSugar.desugar",
+                    observed=self.source_call_frame.kind,
+                    requested="the shared BindingCoordinateV1 formal frame",
+                    fix=(
+                        "wire the shared formal binding coordinate into this "
+                        "already-constructed source body; never bind by name"
+                    ),
+                )
+            if not isinstance(self.source_call_frame, SourceVisibleCallFrameV1):
+                raise SugarNotWritten(
+                    owner="CallSiteSugar.desugar",
+                    observed=type(self.source_call_frame).__name__,
+                    requested="a closed SourceCallFrameV1 variant",
+                    fix="construct a typed source frame or keep the call loud",
+                )
+            if self.keywords or len(positional) != len(
+                self.source_call_frame.parameters
+            ):
+                raise SugarNotWritten(
+                    owner="CallSiteSugar.desugar",
+                    observed="source call-frame signature mismatch",
+                    requested="actuals matching the constructed source frame",
+                    fix="bind through the ordinary formal frame or keep the call loud",
+                )
+            source_body = self.source_call_frame.body
+            source_frame_cid = self.source_call_frame.frame_cid
         return Complete(
             CallSiteValue(
                 target_name=self.target_name,
                 arg_values=positional + tuple(value for _, value in kw_values),
-                parameters=(),
+                parameters=(
+                    self.source_call_frame.parameters
+                    if self.source_call_frame is not None
+                    else ()
+                ),
                 term=term,
-                body=None,  # the dig is CUED, not inlined here
+                body=source_body,
                 keyword_names=tuple(name for name, _ in kw_values),
                 site=self.site,
                 exception_type_coordinate=self.exception_type_coordinate,
+                source_call_frame_cid=source_frame_cid,
             )
         )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_py_tests.floor.class_definition_value import (
+    ClassDefinitionValue,
+    ConstructedClassMethodV1,
+)
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+
+@dataclass(frozen=True)
+class ClassDefinitionSugar(Sugar):
+    class_name: str
+    source_identity_cid: str
+    definition_fragment_cid: str
+    methods: tuple[ConstructedClassMethodV1, ...]
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="ClassDefinitionValue",
+            reason="class structure is source testimony, not a proposition",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        preimage = {
+            "kind": "python-class-definition",
+            "schemaVersion": "1",
+            "sourceIdentityCid": self.source_identity_cid,
+            "definitionFragmentCid": self.definition_fragment_cid,
+            "methods": [
+                {
+                    "name": method.name,
+                    "definitionFragmentCid": method.definition_fragment_cid,
+                }
+                for method in self.methods
+            ],
+        }
+        initializer = next(
+            (method for method in self.methods if method.name == "__init__"), None
+        )
+        return Complete(
+            ClassDefinitionValue(
+                self.class_name,
+                cid_of_json(preimage),
+                self.methods,
+                initializer,
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/source_visible_function_body_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/source_visible_function_body_sugar.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.outcome import Outcome
+from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_body
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+
+@dataclass(frozen=True)
+class SourceVisibleFunctionBodySugar(Sugar):
+    """Already-constructed statement Sugars for one source-visible call frame."""
+
+    statements: tuple[object, ...]
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="BlockValue",
+            reason="call-frame bodies project the ordinary constructed block",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        return reduce_body(self.statements)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1084,6 +1084,50 @@ class FunctionDef(Statement):
     type_params: Tuple[TypeParam, ...]
     _child_fields = ("decorators", "type_params", "params", "returns", "body")
 
+    def source_visible_call_frame(self):
+        """Construct this callable body through the ordinary node/Sugar door.
+
+        Parameterized frames require the shared BindingCoordinateV1 owner.  The
+        coordinate-free zero-parameter arm can already carry its exact body;
+        it is built from the same substituted statement nodes as `_construct_sugar`.
+        """
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+        )
+        from sugar_lift_py_tests.source_call_frame import (
+            AwaitingBindingCoordinateCallFrameV1,
+            SourceVisibleCallFrameV1,
+        )
+
+        span = self.line_col_span()
+        site = SourceFragmentCoordinateV1(
+            self.unit.source_cid,
+            span.start_line,
+            span.start_col,
+            span.end_line,
+            span.end_col,
+        )
+        parameters = tuple(param.name for param in self.params)
+        if parameters:
+            return AwaitingBindingCoordinateCallFrameV1(
+                self.unit.source_cid, site, parameters
+            )
+        from sugar_lift_py_tests.sugar.source_visible_function_body_sugar import (
+            SourceVisibleFunctionBodySugar,
+        )
+
+        substituted = self.substitute({})
+        body = SourceVisibleFunctionBodySugar(
+            tuple(statement.sugar() for statement in substituted.body), self.fragment
+        )
+        return SourceVisibleCallFrameV1(
+            source_identity_cid=self.unit.source_cid,
+            definition_site=site,
+            definition_fragment_cid=self.fragment.seal().cid,
+            parameters=(),
+            body=body,
+        )
+
     def substitute(self, scope):
         """The first MASKING node: a function opens a scope. Its parameters
         (and any PEP 695 type parameters) bind their names, and ONLY THE BODY
@@ -1245,6 +1289,44 @@ class ClassDef(Statement):
         if d:
             changed["body"] = new_body
         return self if not changed else rewrite(self, **changed)
+
+    def _construct_sugar(self):
+        """Construct source-visible class structure through child method Sugars.
+
+        Instantiation/receiver fields remain a typed coordinate gap in the
+        resulting floor value.  No class body is interpreted beside this door.
+        """
+        methods = tuple(item for item in self.body if isinstance(item, FunctionDef))
+        unsupported = tuple(
+            item for item in self.body if not isinstance(item, (FunctionDef, Pass))
+        )
+        if unsupported:
+            from sugar_source_tree.panic import SugarNotWritten
+
+            raise SugarNotWritten(
+                owner="ClassDef._construct_sugar",
+                observed=f"unsupported class member {unsupported[0].kind}",
+                requested="a total source-visible class member construction arm",
+                fix="add the member's ordinary node Sugar arm or keep the class loud",
+            )
+        from sugar_lift_py_tests.floor import ConstructedClassMethodV1
+        from sugar_lift_py_tests.sugar.class_definition_sugar import (
+            ClassDefinitionSugar,
+        )
+
+        constructed = tuple(
+            ConstructedClassMethodV1(
+                method.name, method.fragment.seal().cid, method.sugar()
+            )
+            for method in methods
+        )
+        return ClassDefinitionSugar(
+            class_name=self.name,
+            source_identity_cid=self.unit.source_cid,
+            definition_fragment_cid=self.fragment.seal().cid,
+            methods=constructed,
+            site=self.fragment,
+        )
 
 
 class Return(Statement):
@@ -4092,6 +4174,23 @@ class Call(Expression):
                 elif resolution is not None:
                     contract_ref = resolution
 
+            source_call_frame = None
+            frames = getattr(context, "source_call_frames", None)
+            if frames is not None:
+                from sugar_lift_py_tests.context_manager_resolution import (
+                    SourceFragmentCoordinateV1,
+                )
+
+                span = self.line_col_span()
+                coordinate = SourceFragmentCoordinateV1(
+                    self.unit.source_cid,
+                    span.start_line,
+                    span.start_col,
+                    span.end_line,
+                    span.end_col,
+                )
+                source_call_frame = frames.get(coordinate)
+
             return CallSiteSugar(
                 target_name=self.func.id,
                 args=tuple(a.sugar() for a in self.args),
@@ -4099,6 +4198,7 @@ class Call(Expression):
                 keywords=keyword_sugars,
                 contract_ref=contract_ref,
                 contract_resolution_gap=contract_resolution_gap,
+                source_call_frame=source_call_frame,
             )
         if isinstance(self.func, Attribute):
             from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.floor import BlockValue, CallSiteValue, ReturnValue, TermValue
+from sugar_lift_py_tests.outcome import Complete
+from sugar_source_tree.nodes import Call, ClassDef, FunctionDef
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _source_file(source: str, *, context=None) -> SourceFile:
+    from sugar_lift_python_source.canonical import blake3_512_of
+
+    return SourceFile(
+        (source, "renamed_fixture.py", blake3_512_of(source.encode("utf-8"))),
+        construction_context=context,
+    )
+
+
+def _coordinate(node) -> SourceFragmentCoordinateV1:
+    span = node.line_col_span()
+    return SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
+def test_source_visible_zero_parameter_call_carries_the_ordinary_body() -> None:
+    context = SimpleNamespace(source_call_frames={})
+    source = _source_file(
+        "def renamed_value():\n" "    return 7\n\n" "renamed_value()\n",
+        context=context,
+    )
+    function = next(node for node in source.nodes() if isinstance(node, FunctionDef))
+    call = next(node for node in source.nodes() if isinstance(node, Call))
+    frame = function.source_visible_call_frame()
+    context.source_call_frames[_coordinate(call)] = frame
+
+    outcome = call.sugar().desugar()
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, CallSiteValue)
+    assert outcome.value.body is frame.body
+    assert outcome.value.parameters == ()
+    assert frame.frame_cid.startswith("blake3-512:")
+    constructed = outcome.value.force_floor(
+        None, owner="source-visible-call-frame", project_callsite=False
+    )
+    assert isinstance(constructed, BlockValue)
+    assert len(constructed.statements) == 1
+    assert isinstance(constructed.statements[0], ReturnValue)
+    assert constructed.statements[0].value == TermValue(7)
+
+
+def test_parameterized_source_frame_stays_loud_until_binding_coordinate_lands() -> None:
+    context = SimpleNamespace(source_call_frames={})
+    source = _source_file(
+        "def renamed_identity(value):\n" "    return value\n\n" "renamed_identity(7)\n",
+        context=context,
+    )
+    function = next(node for node in source.nodes() if isinstance(node, FunctionDef))
+    call = next(node for node in source.nodes() if isinstance(node, Call))
+    context.source_call_frames[_coordinate(call)] = function.source_visible_call_frame()
+
+    with pytest.raises(SugarNotWritten, match="awaiting-binding-coordinate"):
+        call.sugar().desugar()
+
+
+def test_class_definition_constructs_methods_but_receiver_state_awaits_coordinate() -> (
+    None
+):
+    source = _source_file(
+        "class RenamedGuard:\n"
+        "    def __init__(self, expected):\n"
+        "        self.expected = expected\n\n"
+        "    def enter(self):\n"
+        "        return self\n"
+    )
+    class_node = next(node for node in source.nodes() if isinstance(node, ClassDef))
+
+    outcome = class_node.sugar().desugar()
+
+    assert isinstance(outcome, Complete)
+    assert outcome.value.class_name == "RenamedGuard"
+    assert tuple(method.name for method in outcome.value.methods) == (
+        "__init__",
+        "enter",
+    )
+    assert outcome.value.initializer is not None
+    assert outcome.value.class_definition_cid.startswith("blake3-512:")
+    with pytest.raises(SugarNotWritten, match="awaiting-binding-coordinate"):
+        outcome.value.construct_receiver_state(())
+
+
+def test_unknown_class_member_stays_typed_loud() -> None:
+    source = _source_file("class RenamedGuard:\n    state = make_state()\n")
+    class_node = next(node for node in source.nodes() if isinstance(node, ClassDef))
+
+    with pytest.raises(SugarNotWritten, match="unsupported class member Assign"):
+        class_node.sugar()


### PR DESCRIPTION
## What

Extends the existing tree -> Sugar construction door, without adding an AST evaluator:

- `FunctionDef.source_visible_call_frame()` constructs a zero-parameter source-visible body from the same substituted statement nodes/Sugars used by ordinary construction.
- `Call` selects a preconstructed frame only by the exact call-site `SourceFragmentCoordinateV1`; `CallSiteSugar` carries that body and its content CID into `CallSiteValue`.
- `ClassDef._construct_sugar()` constructs class structure and method bodies through each child `FunctionDef.sugar()`; `__init__` is recorded as the initializer structural member.
- Parameterized formal binding and receiver/field state remain typed-loud as `awaiting-binding-coordinate` until 7341's shared `BindingCoordinateV1` spine lands. No names are used as binding identity.
- Unknown class-member and call-frame variants are typed-loud.

All emitted frame/class CIDs hash complete source/definition preimages. There is no manager/package recognition and no private `_invoke/_bind/_expr/_construct_class` evaluator.

## Construction floor

```text
R_construction_invariant_violations = 0
R_self_hashing_as_authority = 0
R_name_spelling_overload_gate = 0
R_second_construction_path = 0
R_non_exhaustive_variant_coverage = 0
R_fabricated_completion_fallback = 0
R_auditor_errors = 0
```

Command:

```text
python3 implementations/python/sugar-lift-py-tests/scripts/construction_invariant_law.py
```

## Tests

- Focused constructor, Call, With-contract, call-contract, and invariant twins: `50 passed`.
- Full source-tree: `376 passed, 5 skipped, 1 failed`; the sole failure is the pre-existing `test_pinned_golden_corpus_reproduces_byte_identically` fixture/golden byte mismatch, and this PR does not touch either file.
- Black over all nine changed/new Python files: unchanged.

Twins prove a renamed zero-parameter source function carries and reduces its exact ordinary body; a renamed parameterized function stays `awaiting-binding-coordinate`; a renamed class constructs method/initializer structure; receiver state and an unknown class member remain loud.

Predicted Epsilon: `R_second_construction_path = 0`, `R_non_exhaustive_variant_coverage = 0` (stable); this is coordinate-independent constructor plumbing, not a pandas census drain yet.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add source-visible call frames and ClassDef sugar through the sole constructor
> - Introduces `SourceVisibleCallFrameV1` and `AwaitingBindingCoordinateCallFrameV1` in [`source_call_frame.py`](https://github.com/TSavo/sugar/pull/6113/files#diff-46ed9299504763bf181346656eb60c3f3f7782237167304b1201599c48319ab6); zero-parameter functions produce a closed frame with a deterministic `frame_cid`, while parameterized functions return an awaiting-binding-coordinate frame.
> - Extends `CallSiteSugar.desugar` to accept a `source_call_frame`, embedding the source body and formal parameter names into `CallSiteValue`; raises `SugarNotWritten` on arity mismatches or awaiting-binding-coordinate frames.
> - Adds `ClassDefinitionSugar` and `ClassDefinitionValue` to desugar Python `ClassDef` nodes into a floor value with a deterministic `class_definition_cid` and an optional `__init__` reference; unsupported class members raise `SugarNotWritten`.
> - Adds `SourceVisibleFunctionBodySugar` so a call frame's body can be reduced through the existing floor reduction pipeline.
> - Risk: `ClassDefinitionValue.construct_receiver_state` unconditionally raises `SugarNotWritten` (awaiting binding coordinate), so class instantiation is not yet usable at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab38022.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->