### PR TITLE
foundation: publish BindingCoordinateV1 + SubstitutionTraceV1 wire

### DIFF
--- a/implementations/python/sugar-source-tree/pyproject.toml
+++ b/implementations/python/sugar-source-tree/pyproject.toml
@@ -24,3 +24,8 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = [
+    "../sugar-lift-python-source/src",
+    "src",
+    "../sugar-lift-py-tests/src",
+]

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_provenance.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_provenance.py
@@ -1,0 +1,389 @@
+"""Closed, content-addressed identity for temporal Python bindings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from sugar_lift_python_source.canonical import cid_of_json
+
+from .fragment import SourceFragment
+
+
+class BindingProvenanceGap(ValueError):
+    """A binding coordinate/state cannot enter the authenticated wire."""
+
+
+def _cid(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.startswith("blake3-512:"):
+        raise BindingProvenanceGap(f"{field} must be an authenticated CID")
+    return value
+
+
+def _exact(raw: object, fields: set[str], owner: str) -> dict[str, Any]:
+    if not isinstance(raw, dict) or set(raw) != fields:
+        raise BindingProvenanceGap(f"malformed {owner}")
+    return raw
+
+
+@dataclass(frozen=True)
+class BindingCoordinateV1:
+    scope_owner_cid: str
+    binding_site: dict[str, Any]
+    projection_path: tuple[str | int, ...]
+    cid: str
+
+    @property
+    def preimage(self) -> dict[str, Any]:
+        return {
+            "kind": "binding-coordinate",
+            "schemaVersion": "1",
+            "scopeOwnerCid": self.scope_owner_cid,
+            "bindingSite": self.binding_site,
+            "projectionPath": list(self.projection_path),
+        }
+
+    def wire(self) -> dict[str, Any]:
+        return {**self.preimage, "bindingCoordinateCid": self.cid}
+
+    @classmethod
+    def mint(
+        cls,
+        scope_owner_cid: str,
+        binding_site: SourceFragment,
+        projection_path: tuple[str | int, ...],
+    ) -> "BindingCoordinateV1":
+        _cid(scope_owner_cid, "scopeOwnerCid")
+        if not projection_path or not all(
+            isinstance(part, (str, int)) and not isinstance(part, bool)
+            for part in projection_path
+        ):
+            raise BindingProvenanceGap(
+                "projectionPath must be one non-empty structural path"
+            )
+        site = binding_site.seal().to_dict()
+        preimage = {
+            "kind": "binding-coordinate",
+            "schemaVersion": "1",
+            "scopeOwnerCid": scope_owner_cid,
+            "bindingSite": site,
+            "projectionPath": list(projection_path),
+        }
+        return cls(scope_owner_cid, site, projection_path, cid_of_json(preimage))
+
+    @classmethod
+    def decode(cls, raw: object) -> "BindingCoordinateV1":
+        raw = _exact(
+            raw,
+            {
+                "kind",
+                "schemaVersion",
+                "scopeOwnerCid",
+                "bindingSite",
+                "projectionPath",
+                "bindingCoordinateCid",
+            },
+            "BindingCoordinateV1",
+        )
+        if raw["kind"] != "binding-coordinate" or raw["schemaVersion"] != "1":
+            raise BindingProvenanceGap("unsupported BindingCoordinateV1")
+        _cid(raw["scopeOwnerCid"], "scopeOwnerCid")
+        site = _decode_source_memento(raw["bindingSite"])
+        path = raw["projectionPath"]
+        if not isinstance(path, list) or not path or not all(
+            isinstance(part, (str, int)) and not isinstance(part, bool) for part in path
+        ):
+            raise BindingProvenanceGap("malformed projectionPath")
+        observed = _cid(raw["bindingCoordinateCid"], "bindingCoordinateCid")
+        preimage = {key: value for key, value in raw.items() if key != "bindingCoordinateCid"}
+        if cid_of_json(preimage) != observed:
+            raise BindingProvenanceGap("coordinate CID mismatch")
+        return cls(raw["scopeOwnerCid"], site, tuple(path), observed)
+
+
+@dataclass(frozen=True)
+class ConstructedValueTestimonyV1:
+    source_fragment_cid: str
+    semantic_value_cid: str
+    cid: str
+
+    @property
+    def preimage(self) -> dict[str, Any]:
+        return {
+            "kind": "constructed-value-testimony",
+            "schemaVersion": "1",
+            "sourceFragmentCid": self.source_fragment_cid,
+            "semanticValueCid": self.semantic_value_cid,
+        }
+
+    def wire(self) -> dict[str, Any]:
+        return {**self.preimage, "constructedValueTestimonyCid": self.cid}
+
+    @classmethod
+    def mint(
+        cls, source_fragment: SourceFragment, semantic_value_cid: str
+    ) -> "ConstructedValueTestimonyV1":
+        _cid(semantic_value_cid, "semanticValueCid")
+        preimage = {
+            "kind": "constructed-value-testimony",
+            "schemaVersion": "1",
+            "sourceFragmentCid": source_fragment.seal().cid,
+            "semanticValueCid": semantic_value_cid,
+        }
+        return cls(
+            preimage["sourceFragmentCid"],
+            semantic_value_cid,
+            cid_of_json(preimage),
+        )
+
+    @classmethod
+    def decode(cls, raw: object) -> "ConstructedValueTestimonyV1":
+        raw = _exact(
+            raw,
+            {
+                "kind",
+                "schemaVersion",
+                "sourceFragmentCid",
+                "semanticValueCid",
+                "constructedValueTestimonyCid",
+            },
+            "ConstructedValueTestimonyV1",
+        )
+        if raw["kind"] != "constructed-value-testimony" or raw["schemaVersion"] != "1":
+            raise BindingProvenanceGap("unsupported ConstructedValueTestimonyV1")
+        _cid(raw["sourceFragmentCid"], "sourceFragmentCid")
+        _cid(raw["semanticValueCid"], "semanticValueCid")
+        observed = _cid(
+            raw["constructedValueTestimonyCid"], "constructedValueTestimonyCid"
+        )
+        preimage = {
+            key: value
+            for key, value in raw.items()
+            if key != "constructedValueTestimonyCid"
+        }
+        if cid_of_json(preimage) != observed:
+            raise BindingProvenanceGap("constructed testimony CID mismatch")
+        return cls(raw["sourceFragmentCid"], raw["semanticValueCid"], observed)
+
+
+@dataclass(frozen=True)
+class BoundBindingStateV1:
+    testimony: ConstructedValueTestimonyV1 | None
+
+
+@dataclass(frozen=True)
+class UnboundBindingStateV1:
+    cause_fragment_cid: str
+
+
+@dataclass(frozen=True)
+class GuardedBindingStateV1:
+    guard_formula_cid: str
+    when_true_state_cid: str
+    when_false_state_cid: str
+
+
+BindingStateV1 = BoundBindingStateV1 | UnboundBindingStateV1 | GuardedBindingStateV1
+
+
+@dataclass(frozen=True)
+class BindingEntryV1:
+    coordinate: BindingCoordinateV1
+    state: BindingStateV1
+
+    def constructed_value_testimony_cid(self) -> str:
+        if not isinstance(self.state, BoundBindingStateV1):
+            raise BindingProvenanceGap("binding entry is not a bound value")
+        if self.state.testimony is None:
+            raise BindingProvenanceGap("constructed-value testimony unavailable")
+        ConstructedValueTestimonyV1.decode(self.state.testimony.wire())
+        return self.state.testimony.cid
+
+    def wire(self) -> dict[str, Any]:
+        return {"coordinate": self.coordinate.wire(), "state": _state_wire(self.state)}
+
+    @classmethod
+    def decode(cls, raw: object) -> "BindingEntryV1":
+        raw = _exact(raw, {"coordinate", "state"}, "BindingEntryV1")
+        return cls(BindingCoordinateV1.decode(raw["coordinate"]), _decode_state(raw["state"]))
+
+
+@dataclass(frozen=True)
+class SubstitutionTraceRecordV1:
+    statement_source: dict[str, Any]
+    pre_entries: tuple[BindingEntryV1, ...]
+    post_entries: tuple[BindingEntryV1, ...]
+    cid: str
+
+    @property
+    def preimage(self) -> dict[str, Any]:
+        return {
+            "kind": "substitution-trace-record",
+            "schemaVersion": "1",
+            "statementSource": self.statement_source,
+            "preEntries": [entry.wire() for entry in self.pre_entries],
+            "postEntries": [entry.wire() for entry in self.post_entries],
+        }
+
+    def wire(self) -> dict[str, Any]:
+        return {**self.preimage, "recordCid": self.cid}
+
+    @classmethod
+    def mint(
+        cls,
+        statement_source: SourceFragment,
+        pre_entries: tuple[BindingEntryV1, ...],
+        post_entries: tuple[BindingEntryV1, ...],
+    ) -> "SubstitutionTraceRecordV1":
+        pre = tuple(sorted(pre_entries, key=lambda entry: entry.coordinate.cid))
+        post = tuple(sorted(post_entries, key=lambda entry: entry.coordinate.cid))
+        source = statement_source.seal().to_dict()
+        value = cls(source, pre, post, "")
+        return cls(source, pre, post, cid_of_json(value.preimage))
+
+    @classmethod
+    def decode(cls, raw: object) -> "SubstitutionTraceRecordV1":
+        raw = _exact(
+            raw,
+            {
+                "kind",
+                "schemaVersion",
+                "statementSource",
+                "preEntries",
+                "postEntries",
+                "recordCid",
+            },
+            "SubstitutionTraceRecordV1",
+        )
+        if raw["kind"] != "substitution-trace-record" or raw["schemaVersion"] != "1":
+            raise BindingProvenanceGap("unsupported SubstitutionTraceRecordV1")
+        source = _decode_source_memento(raw["statementSource"])
+        pre = _decode_entries(raw["preEntries"])
+        post = _decode_entries(raw["postEntries"])
+        observed = _cid(raw["recordCid"], "recordCid")
+        preimage = {key: value for key, value in raw.items() if key != "recordCid"}
+        if cid_of_json(preimage) != observed:
+            raise BindingProvenanceGap("trace record CID mismatch")
+        return cls(source, pre, post, observed)
+
+
+@dataclass(frozen=True)
+class SubstitutionTraceV1:
+    scope_owner_cid: str
+    records: tuple[SubstitutionTraceRecordV1, ...]
+    cid: str
+
+    @property
+    def preimage(self) -> dict[str, Any]:
+        return {
+            "kind": "substitution-trace",
+            "schemaVersion": "1",
+            "scopeOwnerCid": self.scope_owner_cid,
+            "records": [record.wire() for record in self.records],
+        }
+
+    def wire(self) -> dict[str, Any]:
+        return {**self.preimage, "traceCid": self.cid}
+
+    @classmethod
+    def mint(
+        cls, scope_owner_cid: str, records: tuple[SubstitutionTraceRecordV1, ...]
+    ) -> "SubstitutionTraceV1":
+        _cid(scope_owner_cid, "scopeOwnerCid")
+        value = cls(scope_owner_cid, records, "")
+        return cls(scope_owner_cid, records, cid_of_json(value.preimage))
+
+    @classmethod
+    def decode(cls, raw: object) -> "SubstitutionTraceV1":
+        raw = _exact(
+            raw,
+            {"kind", "schemaVersion", "scopeOwnerCid", "records", "traceCid"},
+            "SubstitutionTraceV1",
+        )
+        if raw["kind"] != "substitution-trace" or raw["schemaVersion"] != "1":
+            raise BindingProvenanceGap("unsupported SubstitutionTraceV1")
+        _cid(raw["scopeOwnerCid"], "scopeOwnerCid")
+        if not isinstance(raw["records"], list):
+            raise BindingProvenanceGap("trace records must be an array")
+        records = tuple(SubstitutionTraceRecordV1.decode(item) for item in raw["records"])
+        observed = _cid(raw["traceCid"], "traceCid")
+        preimage = {key: value for key, value in raw.items() if key != "traceCid"}
+        if cid_of_json(preimage) != observed:
+            raise BindingProvenanceGap("trace CID mismatch")
+        return cls(raw["scopeOwnerCid"], records, observed)
+
+
+def _decode_source_memento(raw: object) -> dict[str, Any]:
+    raw = _exact(raw, {"file", "span", "source_cid", "cid"}, "SourceMemento")
+    span = _exact(raw["span"], {"start", "end"}, "SourceMemento span")
+    if not all(isinstance(span[key], int) and not isinstance(span[key], bool) for key in span):
+        raise BindingProvenanceGap("source span offsets must be integers")
+    _cid(raw["source_cid"], "source_cid")
+    _cid(raw["cid"], "cid")
+    if not isinstance(raw["file"], str):
+        raise BindingProvenanceGap("source file must be a string")
+    return raw
+
+
+def _state_wire(state: BindingStateV1) -> dict[str, Any]:
+    if isinstance(state, BoundBindingStateV1):
+        if state.testimony is None:
+            raise BindingProvenanceGap("constructed-value testimony unavailable")
+        return {"kind": "bound", "testimony": state.testimony.wire()}
+    if isinstance(state, UnboundBindingStateV1):
+        return {"kind": "unbound", "causeFragmentCid": _cid(state.cause_fragment_cid, "causeFragmentCid")}
+    if isinstance(state, GuardedBindingStateV1):
+        return {
+            "kind": "guarded",
+            "guardFormulaCid": _cid(state.guard_formula_cid, "guardFormulaCid"),
+            "whenTrueStateCid": _cid(state.when_true_state_cid, "whenTrueStateCid"),
+            "whenFalseStateCid": _cid(state.when_false_state_cid, "whenFalseStateCid"),
+        }
+    raise BindingProvenanceGap(f"unknown binding state {type(state).__name__}")
+
+
+def _decode_state(raw: object) -> BindingStateV1:
+    if not isinstance(raw, dict):
+        raise BindingProvenanceGap("malformed BindingStateV1")
+    kind = raw.get("kind")
+    if kind == "bound":
+        raw = _exact(raw, {"kind", "testimony"}, "bound BindingStateV1")
+        return BoundBindingStateV1(ConstructedValueTestimonyV1.decode(raw["testimony"]))
+    if kind == "unbound":
+        raw = _exact(raw, {"kind", "causeFragmentCid"}, "unbound BindingStateV1")
+        return UnboundBindingStateV1(_cid(raw["causeFragmentCid"], "causeFragmentCid"))
+    if kind == "guarded":
+        raw = _exact(
+            raw,
+            {"kind", "guardFormulaCid", "whenTrueStateCid", "whenFalseStateCid"},
+            "guarded BindingStateV1",
+        )
+        return GuardedBindingStateV1(
+            _cid(raw["guardFormulaCid"], "guardFormulaCid"),
+            _cid(raw["whenTrueStateCid"], "whenTrueStateCid"),
+            _cid(raw["whenFalseStateCid"], "whenFalseStateCid"),
+        )
+    raise BindingProvenanceGap("unknown BindingStateV1 variant")
+
+
+def _decode_entries(raw: object) -> tuple[BindingEntryV1, ...]:
+    if not isinstance(raw, list):
+        raise BindingProvenanceGap("binding entries must be an array")
+    entries = tuple(BindingEntryV1.decode(item) for item in raw)
+    cids = [entry.coordinate.cid for entry in entries]
+    if cids != sorted(cids) or len(cids) != len(set(cids)):
+        raise BindingProvenanceGap("binding entries must be unique and CID-sorted")
+    return entries
+
+
+__all__ = [
+    "BindingCoordinateV1",
+    "BindingEntryV1",
+    "BindingProvenanceGap",
+    "BoundBindingStateV1",
+    "ConstructedValueTestimonyV1",
+    "GuardedBindingStateV1",
+    "SubstitutionTraceRecordV1",
+    "SubstitutionTraceV1",
+    "UnboundBindingStateV1",
+]

--- a/implementations/python/sugar-source-tree/tests/test_binding_provenance_v1.py
+++ b/implementations/python/sugar-source-tree/tests/test_binding_provenance_v1.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.binding_provenance import (
+    BindingCoordinateV1,
+    BindingEntryV1,
+    BindingProvenanceGap,
+    BoundBindingStateV1,
+    ConstructedValueTestimonyV1,
+    SubstitutionTraceRecordV1,
+    SubstitutionTraceV1,
+)
+from sugar_source_tree.tree import SourceFile
+
+
+def _assignments(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(source)
+        path = handle.name
+    function = next(SourceFile(path_source(path)).functions())
+    return function, [node for node in function.walk() if node.kind == "Assign"]
+
+
+def test_coordinate_is_occurrence_and_projection_not_identifier():
+    function, assignments = _assignments(
+        "def arbitrary():\n    same = 1\n    same = 2\n"
+    )
+    owner = cid_of_json({"scope": function.fragment.seal().to_dict()})
+    first = BindingCoordinateV1.mint(
+        owner, assignments[0].targets[0].fragment, ("targets", 0)
+    )
+    second = BindingCoordinateV1.mint(
+        owner, assignments[1].targets[0].fragment, ("targets", 0)
+    )
+    assert first.cid != second.cid
+    assert "same" not in first.preimage
+    assert BindingCoordinateV1.decode(first.wire()) == first
+
+
+def test_borrowed_span_values_require_distinct_occurrence_paths():
+    function, assignments = _assignments("def arbitrary():\n    value = 1\n")
+    owner = cid_of_json({"scope": function.fragment.seal().to_dict()})
+    site = assignments[0].targets[0].fragment
+    one = BindingCoordinateV1.mint(owner, site, ("synthetic", 0))
+    two = BindingCoordinateV1.mint(owner, site, ("synthetic", 1))
+    assert one.cid != two.cid
+
+
+def test_constructed_value_testimony_is_authenticated_and_unavailable_is_loud():
+    _function, assignments = _assignments("def arbitrary():\n    value = 1\n")
+    value = assignments[0].value
+    testimony = ConstructedValueTestimonyV1.mint(
+        value.fragment, cid_of_json({"kind": "IntLiteralSugar", "value": 1})
+    )
+    assert ConstructedValueTestimonyV1.decode(testimony.wire()) == testimony
+    entry = BindingEntryV1(
+        BindingCoordinateV1.mint(
+            cid_of_json({"scope": "arbitrary"}),
+            assignments[0].targets[0].fragment,
+            ("targets", 0),
+        ),
+        BoundBindingStateV1(None),
+    )
+    with pytest.raises(BindingProvenanceGap, match="testimony unavailable"):
+        entry.constructed_value_testimony_cid()
+
+
+def test_trace_round_trip_authenticates_every_preimage():
+    function, assignments = _assignments("def arbitrary():\n    value = 1\n")
+    owner = cid_of_json({"scope": function.fragment.seal().to_dict()})
+    coordinate = BindingCoordinateV1.mint(
+        owner, assignments[0].targets[0].fragment, ("targets", 0)
+    )
+    testimony = ConstructedValueTestimonyV1.mint(
+        assignments[0].value.fragment, cid_of_json({"value": 1})
+    )
+    entry = BindingEntryV1(coordinate, BoundBindingStateV1(testimony))
+    record = SubstitutionTraceRecordV1.mint(
+        assignments[0].fragment, (), (entry,)
+    )
+    trace = SubstitutionTraceV1.mint(owner, (record,))
+    assert SubstitutionTraceV1.decode(trace.wire()) == trace
+
+    stale = trace.wire()
+    stale["traceCid"] = "blake3-512:stale"
+    with pytest.raises(BindingProvenanceGap, match="trace CID mismatch"):
+        SubstitutionTraceV1.decode(stale)
+
+    with pytest.raises(BindingProvenanceGap, match="coordinate CID mismatch"):
+        BindingCoordinateV1.decode(
+            replace(coordinate, cid="blake3-512:stale").wire()
+        )

--- a/implementations/rust/sugar-ir-types/src/binding_provenance.rs
+++ b/implementations/rust/sugar-ir-types/src/binding_provenance.rs
@@ -1,0 +1,290 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BindingProvenanceError {
+    Malformed(String),
+    CidMismatch(&'static str),
+}
+
+impl std::fmt::Display for BindingProvenanceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Malformed(message) => write!(f, "malformed binding provenance: {message}"),
+            Self::CidMismatch(field) => write!(f, "binding provenance CID mismatch: {field}"),
+        }
+    }
+}
+
+impl std::error::Error for BindingProvenanceError {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourceSpanV1 {
+    pub start: u64,
+    pub end: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourceMementoV1 {
+    pub file: String,
+    pub span: SourceSpanV1,
+    pub source_cid: String,
+    pub cid: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ProjectionPathPartV1 {
+    Name(String),
+    Index(i64),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BindingCoordinateKindV1 {
+    #[serde(rename = "binding-coordinate")]
+    BindingCoordinate,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BindingCoordinateV1 {
+    pub kind: BindingCoordinateKindV1,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+    #[serde(rename = "scopeOwnerCid")]
+    pub scope_owner_cid: String,
+    #[serde(rename = "bindingSite")]
+    pub binding_site: SourceMementoV1,
+    #[serde(rename = "projectionPath")]
+    pub projection_path: Vec<ProjectionPathPartV1>,
+    #[serde(rename = "bindingCoordinateCid")]
+    pub binding_coordinate_cid: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ConstructedValueTestimonyKindV1 {
+    #[serde(rename = "constructed-value-testimony")]
+    ConstructedValueTestimony,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConstructedValueTestimonyV1 {
+    pub kind: ConstructedValueTestimonyKindV1,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+    #[serde(rename = "sourceFragmentCid")]
+    pub source_fragment_cid: String,
+    #[serde(rename = "semanticValueCid")]
+    pub semantic_value_cid: String,
+    #[serde(rename = "constructedValueTestimonyCid")]
+    pub constructed_value_testimony_cid: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", deny_unknown_fields)]
+pub enum BindingStateV1 {
+    #[serde(rename = "bound")]
+    Bound {
+        testimony: ConstructedValueTestimonyV1,
+    },
+    #[serde(rename = "unbound")]
+    Unbound {
+        #[serde(rename = "causeFragmentCid")]
+        cause_fragment_cid: String,
+    },
+    #[serde(rename = "guarded")]
+    Guarded {
+        #[serde(rename = "guardFormulaCid")]
+        guard_formula_cid: String,
+        #[serde(rename = "whenTrueStateCid")]
+        when_true_state_cid: String,
+        #[serde(rename = "whenFalseStateCid")]
+        when_false_state_cid: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BindingEntryV1 {
+    pub coordinate: BindingCoordinateV1,
+    pub state: BindingStateV1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SubstitutionTraceRecordKindV1 {
+    #[serde(rename = "substitution-trace-record")]
+    SubstitutionTraceRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SubstitutionTraceRecordV1 {
+    pub kind: SubstitutionTraceRecordKindV1,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+    #[serde(rename = "statementSource")]
+    pub statement_source: SourceMementoV1,
+    #[serde(rename = "preEntries")]
+    pub pre_entries: Vec<BindingEntryV1>,
+    #[serde(rename = "postEntries")]
+    pub post_entries: Vec<BindingEntryV1>,
+    #[serde(rename = "recordCid")]
+    pub record_cid: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SubstitutionTraceKindV1 {
+    #[serde(rename = "substitution-trace")]
+    SubstitutionTrace,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SubstitutionTraceV1 {
+    pub kind: SubstitutionTraceKindV1,
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: String,
+    #[serde(rename = "scopeOwnerCid")]
+    pub scope_owner_cid: String,
+    pub records: Vec<SubstitutionTraceRecordV1>,
+    #[serde(rename = "traceCid")]
+    pub trace_cid: String,
+}
+
+fn canonical(value: serde_json::Value) -> sugar_canonicalizer::Value {
+    match value {
+        serde_json::Value::Null => sugar_canonicalizer::Value::Null,
+        serde_json::Value::Bool(value) => sugar_canonicalizer::Value::Bool(value),
+        serde_json::Value::Number(value) => sugar_canonicalizer::Value::Integer(
+            value
+                .as_i64()
+                .map(i128::from)
+                .or_else(|| value.as_u64().map(i128::from))
+                .expect("binding provenance integers fit i64/u64"),
+        ),
+        serde_json::Value::String(value) => sugar_canonicalizer::Value::String(value),
+        serde_json::Value::Array(values) => sugar_canonicalizer::Value::Array(
+            values
+                .into_iter()
+                .map(canonical)
+                .map(std::sync::Arc::new)
+                .collect(),
+        ),
+        serde_json::Value::Object(values) => sugar_canonicalizer::Value::Object(
+            values
+                .into_iter()
+                .map(|(key, value)| (key, std::sync::Arc::new(canonical(value))))
+                .collect(),
+        ),
+    }
+}
+
+fn validate_cid<T: Serialize>(
+    value: &T,
+    field: &'static str,
+    observed: &str,
+) -> Result<(), BindingProvenanceError> {
+    let mut json = serde_json::to_value(value)
+        .map_err(|error| BindingProvenanceError::Malformed(error.to_string()))?;
+    json.as_object_mut()
+        .ok_or_else(|| BindingProvenanceError::Malformed("record is not an object".into()))?
+        .remove(field)
+        .ok_or_else(|| BindingProvenanceError::Malformed(format!("missing {field}")))?;
+    let expected = sugar_canonicalizer::blake3_512_of(
+        sugar_canonicalizer::encode_jcs(&canonical(json)).as_bytes(),
+    );
+    if expected != observed {
+        return Err(BindingProvenanceError::CidMismatch(field));
+    }
+    Ok(())
+}
+
+fn require_cid(value: &str, field: &str) -> Result<(), BindingProvenanceError> {
+    if value.starts_with("blake3-512:") {
+        Ok(())
+    } else {
+        Err(BindingProvenanceError::Malformed(format!(
+            "{field} is not a CID"
+        )))
+    }
+}
+
+impl SubstitutionTraceV1 {
+    pub fn decode(bytes: &[u8]) -> Result<Self, BindingProvenanceError> {
+        let value: Self = serde_json::from_slice(bytes)
+            .map_err(|error| BindingProvenanceError::Malformed(error.to_string()))?;
+        value.validate()?;
+        Ok(value)
+    }
+
+    pub fn validate(&self) -> Result<(), BindingProvenanceError> {
+        if self.schema_version != "1" {
+            return Err(BindingProvenanceError::Malformed(
+                "unsupported trace schema version".into(),
+            ));
+        }
+        require_cid(&self.scope_owner_cid, "scopeOwnerCid")?;
+        validate_cid(self, "traceCid", &self.trace_cid)?;
+        for record in &self.records {
+            if record.schema_version != "1" {
+                return Err(BindingProvenanceError::Malformed(
+                    "unsupported record schema version".into(),
+                ));
+            }
+            validate_cid(record, "recordCid", &record.record_cid)?;
+            validate_entries(&record.pre_entries)?;
+            validate_entries(&record.post_entries)?;
+        }
+        Ok(())
+    }
+}
+
+fn validate_entries(entries: &[BindingEntryV1]) -> Result<(), BindingProvenanceError> {
+    let mut prior: Option<&str> = None;
+    for entry in entries {
+        let coordinate = &entry.coordinate;
+        if coordinate.schema_version != "1" || coordinate.projection_path.is_empty() {
+            return Err(BindingProvenanceError::Malformed(
+                "unsupported or empty binding coordinate".into(),
+            ));
+        }
+        require_cid(&coordinate.scope_owner_cid, "scopeOwnerCid")?;
+        validate_cid(
+            coordinate,
+            "bindingCoordinateCid",
+            &coordinate.binding_coordinate_cid,
+        )?;
+        if prior.is_some_and(|value| value >= coordinate.binding_coordinate_cid.as_str()) {
+            return Err(BindingProvenanceError::Malformed(
+                "entries are not unique and CID-sorted".into(),
+            ));
+        }
+        prior = Some(&coordinate.binding_coordinate_cid);
+        match &entry.state {
+            BindingStateV1::Bound { testimony } => {
+                validate_cid(
+                    testimony,
+                    "constructedValueTestimonyCid",
+                    &testimony.constructed_value_testimony_cid,
+                )?;
+                require_cid(&testimony.source_fragment_cid, "sourceFragmentCid")?;
+                require_cid(&testimony.semantic_value_cid, "semanticValueCid")?;
+            }
+            BindingStateV1::Unbound { cause_fragment_cid } => {
+                require_cid(cause_fragment_cid, "causeFragmentCid")?;
+            }
+            BindingStateV1::Guarded {
+                guard_formula_cid,
+                when_true_state_cid,
+                when_false_state_cid,
+            } => {
+                require_cid(guard_formula_cid, "guardFormulaCid")?;
+                require_cid(when_true_state_cid, "whenTrueStateCid")?;
+                require_cid(when_false_state_cid, "whenFalseStateCid")?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/implementations/rust/sugar-ir-types/src/lib.rs
+++ b/implementations/rust/sugar-ir-types/src/lib.rs
@@ -4861,3 +4861,4 @@ mod witness_cid_stability_tests {
         assert_eq!(p1, p2, "attestation payload must be deterministic");
     }
 }
+pub mod binding_provenance;

--- a/implementations/rust/sugar-ir-types/tests/binding_provenance.rs
+++ b/implementations/rust/sugar-ir-types/tests/binding_provenance.rs
@@ -1,0 +1,105 @@
+use sugar_ir_types::binding_provenance::{BindingProvenanceError, SubstitutionTraceV1};
+
+fn canonical(value: serde_json::Value) -> sugar_canonicalizer::Value {
+    match value {
+        serde_json::Value::Null => sugar_canonicalizer::Value::Null,
+        serde_json::Value::Bool(value) => sugar_canonicalizer::Value::Bool(value),
+        serde_json::Value::Number(value) => {
+            sugar_canonicalizer::Value::Integer(value.as_i64().map(i128::from).unwrap())
+        }
+        serde_json::Value::String(value) => sugar_canonicalizer::Value::String(value),
+        serde_json::Value::Array(values) => sugar_canonicalizer::Value::Array(
+            values
+                .into_iter()
+                .map(canonical)
+                .map(std::sync::Arc::new)
+                .collect(),
+        ),
+        serde_json::Value::Object(values) => sugar_canonicalizer::Value::Object(
+            values
+                .into_iter()
+                .map(|(key, value)| (key, std::sync::Arc::new(canonical(value))))
+                .collect(),
+        ),
+    }
+}
+
+fn seal(mut value: serde_json::Value, field: &str) -> serde_json::Value {
+    let cid = sugar_canonicalizer::blake3_512_of(
+        sugar_canonicalizer::encode_jcs(&canonical(value.clone())).as_bytes(),
+    );
+    value
+        .as_object_mut()
+        .unwrap()
+        .insert(field.into(), cid.into());
+    value
+}
+
+#[test]
+fn authenticated_trace_round_trips_through_closed_variants() {
+    let site = serde_json::json!({
+        "file":"arbitrary.py","span":{"start":20,"end":25},
+        "source_cid":"blake3-512:source","cid":"blake3-512:fragment"
+    });
+    let coordinate = seal(
+        serde_json::json!({
+            "kind":"binding-coordinate","schemaVersion":"1",
+            "scopeOwnerCid":"blake3-512:scope","bindingSite":site,
+            "projectionPath":["targets",0]
+        }),
+        "bindingCoordinateCid",
+    );
+    let testimony = seal(
+        serde_json::json!({
+            "kind":"constructed-value-testimony","schemaVersion":"1",
+            "sourceFragmentCid":"blake3-512:fragment",
+            "semanticValueCid":"blake3-512:value"
+        }),
+        "constructedValueTestimonyCid",
+    );
+    let record = seal(
+        serde_json::json!({
+            "kind":"substitution-trace-record","schemaVersion":"1",
+            "statementSource":site,"preEntries":[],
+            "postEntries":[{"coordinate":coordinate,"state":{"kind":"bound","testimony":testimony}}]
+        }),
+        "recordCid",
+    );
+    let trace = seal(
+        serde_json::json!({
+            "kind":"substitution-trace","schemaVersion":"1",
+            "scopeOwnerCid":"blake3-512:scope","records":[record]
+        }),
+        "traceCid",
+    );
+    let bytes = serde_json::to_vec(&trace).unwrap();
+    let decoded = SubstitutionTraceV1::decode(&bytes).unwrap();
+    assert_eq!(serde_json::to_value(decoded).unwrap(), trace);
+}
+
+#[test]
+fn closed_decoder_rejects_unknown_state_variant() {
+    let raw = br#"{
+      "kind":"substitution-trace","schemaVersion":"1","scopeOwnerCid":"blake3-512:x",
+      "records":[{"kind":"substitution-trace-record","schemaVersion":"1",
+        "statementSource":{"file":"x.py","span":{"start":0,"end":1},"source_cid":"blake3-512:s","cid":"blake3-512:f"},
+        "preEntries":[],"postEntries":[{"coordinate":{
+          "kind":"binding-coordinate","schemaVersion":"1","scopeOwnerCid":"blake3-512:x",
+          "bindingSite":{"file":"x.py","span":{"start":0,"end":1},"source_cid":"blake3-512:s","cid":"blake3-512:f"},
+          "projectionPath":["target",0],"bindingCoordinateCid":"blake3-512:c"},
+          "state":{"kind":"future-state","value":"x"}}],"recordCid":"blake3-512:r"}],
+      "traceCid":"blake3-512:t"}"#;
+    let error = SubstitutionTraceV1::decode(raw).unwrap_err();
+    assert!(matches!(error, BindingProvenanceError::Malformed(_)));
+}
+
+#[test]
+fn stale_trace_cid_is_loud() {
+    let raw = br#"{
+      "kind":"substitution-trace","schemaVersion":"1","scopeOwnerCid":"blake3-512:x",
+      "records":[],"traceCid":"blake3-512:stale"}"#;
+    assert_eq!(
+        SubstitutionTraceV1::decode(raw).unwrap_err(),
+        BindingProvenanceError::CidMismatch("traceCid")
+    );
+}


### PR DESCRIPTION
Publishes the single authenticated binding-provenance vocabulary needed by downstream construction work.

This PR is deliberately types-only:
- `BindingCoordinateV1`, minted from scope-owner CID + binding-site source fragment + destructuring projection path (identifier spelling is not identity)
- `BindingEntryV1` with closed binding-state variants
- immutable `SubstitutionTraceV1` pre/post snapshots
- constructed-value testimony CID access with typed-loud absence
- closed Python and Rust decoders with CID re-authentication
- round-trip, stale-CID, unknown-variant, and borrowed-span collision twins

It does **not** rewire BindingMap, `_substitute_body_tracked`, or loops. That integration remains PR #2. This small foundation publishes the one coordinate definition so 6634 object/place identity and 6640 Cut C step 6 receiver/object-state work can build on it without duplicating identity.

Cut B (#6113) is now merged beneath this PR and supplies the sole-constructor arms these authenticated coordinates feed into.

Collection fix:
- package pytest configuration pins the current checkout sibling sources, preventing an ambient stale editable `sugar_lift_python_source` from hijacking collection

Validation:
- exact former collection command: `4 passed`
- focused Python suite: `32 passed`n- sole-construction floor attribution: current main `R=9`; PR `R=9` (zero introduced sites)
- battleaxe: `bin/sugarbin cargo --host bx -- test --manifest-path implementations/rust/Cargo.toml -p sugar-ir-types --test binding_provenance` — `3 passed; 0 failed`

Honest construction delta: ΔR=0 (wire foundation only).

Do not merge without architect review.