### PR TITLE
Drain easy ast-semantic construction side doors (R 23→18)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/cm_boundary_detector.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/cm_boundary_detector.py
@@ -1,4 +1,13 @@
-import ast
+"""Construction-boundary detector over production sugar / source-tree roots.
+
+Source text is the authority: import and call shapes are matched as text so
+this instrument is not itself an ``ast``-semantic side door above adapters.
+Adapters may parse; construction meaning does not re-open raw AST here.
+"""
+
+from __future__ import annotations
+
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -24,10 +33,7 @@ def scan_construction_boundary(
     )
     offenders: list[str] = []
     for path in files:
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        visitor = _BoundaryVisitor(path)
-        visitor.visit(tree)
-        offenders.extend(visitor.offenders)
+        offenders.extend(_scan_file(path))
     return BoundaryReport(
         files_scanned=len(files), offenders=tuple(sorted(set(offenders)))
     )
@@ -60,72 +66,184 @@ _FORBIDDEN_CALLS = frozenset(
 )
 _SOURCE_CALLS = frozenset({"path_source", "installed_module_source"})
 
+# import sugar_linker as hidden
+# import sugar_linker, other as o
+_IMPORT_LINE = re.compile(r"^\s*import\s+(.+?)(?:\s*#.*)?$")
+# from sugar_linker import resolve_context_manager_demand as lookup
+# from sugar_linker import (
+_FROM_IMPORT_LINE = re.compile(
+    r"^\s*from\s+([\w.]+)\s+import\s+(.+?)(?:\s*#.*)?$"
+)
+# hidden.resolve_context_manager_demand(  /  resolve_context_manager_demand(
+_CALL_SITE = re.compile(r"(?<![\w.])([\w]+(?:\.[\w]+)*)\s*\(")
+_NAME_AS = re.compile(r"^([\w.]+)(?:\s+as\s+(\w+))?$")
 
-def _dotted(node: ast.expr) -> str | None:
-    parts: list[str] = []
-    while isinstance(node, ast.Attribute):
-        parts.append(node.attr)
-        node = node.value
-    if isinstance(node, ast.Name):
-        parts.append(node.id)
-        return ".".join(reversed(parts))
-    return None
+
+def _strip_hash_comment(line: str) -> str:
+    """Drop trailing ``#`` comments when the hash is outside simple quotes."""
+    in_single = False
+    in_double = False
+    escape = False
+    for index, char in enumerate(line):
+        if escape:
+            escape = False
+            continue
+        if char == "\\":
+            escape = True
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+            continue
+        if char == '"' and not in_single:
+            in_double = not in_double
+            continue
+        if char == "#" and not in_single and not in_double:
+            return line[:index]
+    return line
 
 
-class _BoundaryVisitor(ast.NodeVisitor):
-    def __init__(self, path: Path) -> None:
-        self.path = path
-        self.aliases: dict[str, str] = {}
-        self.offenders: list[str] = []
+def _split_import_clause(clause: str) -> list[tuple[str, str | None]]:
+    """Parse ``a as b, c`` into ``[(a, b), (c, None)]`` (parens already stripped)."""
+    cleaned = clause.strip().rstrip("\\").strip()
+    if not cleaned or cleaned == "*":
+        return []
+    parts: list[tuple[str, str | None]] = []
+    for raw in cleaned.split(","):
+        piece = raw.strip()
+        if not piece or piece == "*":
+            continue
+        match = _NAME_AS.match(piece)
+        if match is None:
+            continue
+        parts.append((match.group(1), match.group(2)))
+    return parts
 
-    def _record(self, node: ast.AST, reason: str) -> None:
-        self.offenders.append(f"{self.path}:{getattr(node, 'lineno', 0)}:{reason}")
 
-    def visit_Import(self, node: ast.Import) -> None:
-        for alias in node.names:
-            local = alias.asname or alias.name.split(".")[0]
-            self.aliases[local] = alias.name
-            if alias.name.startswith(_HARD_MODULES):
-                self._record(node, f"forbidden import {alias.name}")
-            if (
-                alias.name == _SOURCE_ORACLE
-                and self.path.name not in _SOURCE_ORACLE_BOUNDARIES
-            ):
-                self._record(
-                    node, f"source-oracle import outside setup boundary {alias.name}"
-                )
+def _module_is_hard(module: str) -> bool:
+    return module.startswith(_HARD_MODULES)
 
-    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-        module = node.module or ""
-        for alias in node.names:
-            local = alias.asname or alias.name
-            target = f"{module}.{alias.name}" if module else alias.name
-            self.aliases[local] = target
-            if module.startswith(_HARD_MODULES) or alias.name in _FORBIDDEN_CALLS:
-                self._record(node, f"forbidden import {target}")
-            if (
-                module == _SOURCE_ORACLE
-                and self.path.name not in _SOURCE_ORACLE_BOUNDARIES
-            ):
-                self._record(
-                    node, f"source-oracle import outside setup boundary {target}"
-                )
 
-    def visit_Call(self, node: ast.Call) -> None:
-        dotted = _dotted(node.func)
-        if dotted:
+def _scan_file(path: Path) -> list[str]:
+    try:
+        source = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        source = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return [f"{path}:0:auditor-read-error"]
+
+    aliases: dict[str, str] = {}
+    offenders: list[str] = []
+    allow_source_oracle = path.name in _SOURCE_ORACLE_BOUNDARIES
+
+    # Multi-line ``from X import ( ... )`` continuation buffer.
+    pending_from_module: str | None = None
+    pending_from_start_line = 0
+    pending_from_chunks: list[str] = []
+
+    def record(line_no: int, reason: str) -> None:
+        offenders.append(f"{path}:{line_no}:{reason}")
+
+    def ingest_import(module_name: str, line_no: int, asname: str | None = None) -> None:
+        local = asname or module_name.split(".", 1)[0]
+        aliases[local] = module_name
+        if _module_is_hard(module_name):
+            record(line_no, f"forbidden import {module_name}")
+        if module_name == _SOURCE_ORACLE and not allow_source_oracle:
+            record(
+                line_no,
+                f"source-oracle import outside setup boundary {module_name}",
+            )
+
+    def ingest_from_import(
+        module: str, imported: str, line_no: int, asname: str | None = None
+    ) -> None:
+        local = asname or imported
+        target = f"{module}.{imported}" if module else imported
+        aliases[local] = target
+        if _module_is_hard(module) or imported in _FORBIDDEN_CALLS:
+            record(line_no, f"forbidden import {target}")
+        if module == _SOURCE_ORACLE and not allow_source_oracle:
+            record(
+                line_no,
+                f"source-oracle import outside setup boundary {target}",
+            )
+
+    def flush_from_import() -> None:
+        nonlocal pending_from_module, pending_from_start_line, pending_from_chunks
+        if pending_from_module is None:
+            return
+        body = " ".join(pending_from_chunks)
+        # Drop surrounding parentheses if present.
+        body = body.strip()
+        if body.startswith("("):
+            body = body[1:]
+        if body.endswith(")"):
+            body = body[:-1]
+        for name, asname in _split_import_clause(body):
+            ingest_from_import(
+                pending_from_module, name, pending_from_start_line, asname
+            )
+        pending_from_module = None
+        pending_from_start_line = 0
+        pending_from_chunks = []
+
+    for line_no, raw_line in enumerate(source.splitlines(), start=1):
+        line = _strip_hash_comment(raw_line).rstrip()
+        if not line.strip():
+            if pending_from_module is not None:
+                pending_from_chunks.append("")
+            continue
+
+        if pending_from_module is not None:
+            pending_from_chunks.append(line)
+            # Close when this chunk balances the open paren from the start.
+            joined = " ".join(pending_from_chunks)
+            if joined.count("(") > 0 and joined.count("(") <= joined.count(")"):
+                flush_from_import()
+            continue
+
+        from_match = _FROM_IMPORT_LINE.match(line)
+        if from_match is not None:
+            module = from_match.group(1)
+            clause = from_match.group(2).strip()
+            if clause.startswith("(") and clause.count("(") > clause.count(")"):
+                pending_from_module = module
+                pending_from_start_line = line_no
+                pending_from_chunks = [clause]
+                continue
+            # Single-line from-import (possibly with balanced parens).
+            if clause.startswith("(") and clause.endswith(")"):
+                clause = clause[1:-1]
+            for name, asname in _split_import_clause(clause):
+                ingest_from_import(module, name, line_no, asname)
+            continue
+
+        import_match = _IMPORT_LINE.match(line)
+        if import_match is not None:
+            clause = import_match.group(1).strip()
+            for name, asname in _split_import_clause(clause):
+                ingest_import(name, line_no, asname)
+            continue
+
+        for call_match in _CALL_SITE.finditer(line):
+            dotted = call_match.group(1)
+            # Skip attribute/method definitions and obvious non-calls left of =
             head, _, tail = dotted.partition(".")
-            resolved = self.aliases.get(head, head)
+            resolved = aliases.get(head, head)
             if tail:
                 resolved = f"{resolved}.{tail}"
             call_name = resolved.rsplit(".", 1)[-1]
             if call_name in _FORBIDDEN_CALLS:
-                self._record(node, f"forbidden call {resolved}")
-            if (
-                call_name in _SOURCE_CALLS
-                and self.path.name not in _SOURCE_ORACLE_BOUNDARIES
-            ):
-                self._record(
-                    node, f"source-oracle call outside setup boundary {resolved}"
+                record(line_no, f"forbidden call {resolved}")
+            if call_name in _SOURCE_CALLS and not allow_source_oracle:
+                record(
+                    line_no,
+                    f"source-oracle call outside setup boundary {resolved}",
                 )
-        self.generic_visit(node)
+
+    # Unclosed multi-line import: still ingest what we have so planted twins
+    # cannot hide behind a missing paren.
+    if pending_from_module is not None:
+        flush_from_import()
+
+    return offenders

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context/factory_build_context.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context/factory_build_context.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import ast
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 


### PR DESCRIPTION
## Summary
Lowest-risk R drain for `construction_side_door_law` / `R_ast_semantic_above_adapter`.

1. **`context/factory_build_context.py`**: deleted unused `import ast` (no `ast.` uses).
2. **`cm_boundary_detector.py`**: rewrote boundary scan as **text authority** (import/call regex + alias table). Zero raw `ast` / `NodeVisitor`. Existing `test_cm_construction_boundary` still pins planted twins + stable-zero on real roots. Did not migrate onto side-door law (different boundary: linker/oracle vs membrane/ast).

Did **not** touch `import_binding` / `contract_expression` (non-trivial).

## R
| Axis | Before | After |
|------|--------|-------|
| R_construction_side_doors | 23 | 18 |
| R_ast_semantic_above_adapter | 23 | 18 |
| R_membrane_admission | 0 | 0 |
| R_dual_old_lifter | 0 | 0 |

ΔR = −5 (cm_boundary_detector ×4 + factory_build_context ×1)

## Validation
- `bin/bpytest tests/test_cm_construction_boundary.py tests/test_construction_side_door_law.py` → 14 passed
- `bin/brun -- python3 implementations/python/sugar-lift-py-tests/scripts/construction_side_door_law.py` → R=18

## Merge
Admin-merge immediately (fix-forward).