### PR TITLE
Enroll CM demand via SourceFile/typed Nodes, kill raw ast

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import ast
 import collections
 import dataclasses
 import gc
@@ -71,47 +70,63 @@ _ENUMERATION_ACTIVE = False
 _BOUND_CONTRACT_REFS = None
 _BOUND_CALL_CONTRACT_REFS = None
 def _context_manager_demand_rows(root: Path) -> List[Dict[str, Any]]:
-    """Enroll with-site import coordinates without constructing any Sugar."""
-    from sugar_lift_python_source.source_oracle import SourceUnavailable, path_source
-    from sugar_source_tree.tree import SourceTree
+    """Enroll with-site import coordinates without constructing any Sugar.
+
+    Enumeration is SourceOracle → SourceFile → typed Nodes only
+    (Import / ImportFrom / With / AsyncWith / Call / Name / Attribute).
+    No raw ``ast.parse`` / ``ast.walk`` side door.
+    """
+    from sugar_lift_python_source.source_oracle import SourceUnavailable
+    from sugar_source_tree.nodes import (
+        AsyncWith,
+        Attribute,
+        Call,
+        Import,
+        ImportFrom,
+        Name,
+        With,
+    )
+    from sugar_source_tree.tree import SourceFile, SourceTree
 
     rows: List[Dict[str, Any]] = []
     for path in SourceTree(root).paths():
         try:
-            source, _filename, source_cid = path_source(str(path))
+            source_file = SourceFile.from_path(path)
         except SourceUnavailable:
             continue
-        module = ast.parse(source, filename=str(path))
         imports: Dict[str, str] = {}
-        for node in ast.walk(module):
-            if isinstance(node, ast.ImportFrom) and node.module:
+        with_nodes: List[With | AsyncWith] = []
+        for node in source_file.nodes():
+            if isinstance(node, ImportFrom) and node.module:
                 for alias in node.names:
                     imports[alias.asname or alias.name] = f"{node.module}.{alias.name}"
-            elif isinstance(node, ast.Import):
+            elif isinstance(node, Import):
                 for alias in node.names:
                     imports[alias.asname or alias.name.split(".")[0]] = alias.name
-        for node in ast.walk(module):
-            if not isinstance(node, (ast.With, ast.AsyncWith)):
-                continue
+            elif isinstance(node, (With, AsyncWith)):
+                with_nodes.append(node)
+        source_cid = source_file.unit.source_cid
+        for node in with_nodes:
             for item in node.items:
                 expression = item.context_expr
                 target = None
-                if isinstance(expression, ast.Call):
+                if isinstance(expression, Call):
                     callee = expression.func
-                    if isinstance(callee, ast.Name):
+                    if isinstance(callee, Name):
                         target = imports.get(callee.id)
-                    elif isinstance(callee, ast.Attribute) and isinstance(
-                        callee.value, ast.Name
+                    elif isinstance(callee, Attribute) and isinstance(
+                        callee.value, Name
                     ):
                         base = imports.get(callee.value.id)
                         if base:
                             target = f"{base}.{callee.attr}"
+                span = expression.line_col_span()
                 coordinate = {
                     "sourceCid": source_cid,
-                    "startLine": expression.lineno,
-                    "startCol": expression.col_offset,
-                    "endLine": expression.end_lineno,
-                    "endCol": expression.end_col_offset,
+                    "startLine": span.start_line,
+                    "startCol": span.start_col,
+                    "endLine": span.end_line,
+                    "endCol": span.end_col,
                 }
                 rows.append(
                     {


### PR DESCRIPTION
## Summary
- Rewrite `lift_rpc._context_manager_demand_rows` to enumerate with-sites and import bindings via `SourceFile` / typed Nodes only (`Import`, `ImportFrom`, `With`, `AsyncWith`, `Call`, `Name`, `Attribute`).
- Remove all `import ast` / `ast.parse` / `ast.walk` from `lift_rpc.py` (last remaining use was this demand enrollment side door).
- Same demand-row schema; still non-constructing (does not call `With.sugar`).

## Validation
```
bin/bpytest tests/test_context_manager_resolution.py::test_demand_enrollment_uses_import_coordinate_without_sugar_or_target_source
bin/bpytest tests/test_call_contract_resolution.py -k 'demand or preconstruction or with_manager or shadowed_local'
# 4 passed
```

## Side-door ΔR (expected)
`R_construction_side_doors` should drop by 4 lift_rpc offenders (import + parse + 2× walk).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `ast.parse`/`ast.walk` with typed `SourceFile` nodes in `_context_manager_demand_rows`
> - Rewrites `_context_manager_demand_rows` in [lift_rpc.py](https://github.com/TSavo/sugar/pull/6118/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) to use `SourceFile.from_path` and `SourceFile.nodes()` instead of `ast.parse`/`ast.walk`.
> - Node matching now uses typed classes (`Import`, `ImportFrom`, `With`, `AsyncWith`, `Call`, `Name`, `Attribute`) from `sugar_source_tree.nodes`.
> - Source coordinates are derived from `expression.line_col_span()` instead of raw `lineno`/`col_offset` attributes, and `sourceCid` now comes from `SourceFile.unit.source_cid`.
> - Removes the top-level `import ast` since no stdlib AST usage remains.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ac715a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->