### PR TITLE
Kill second-parse authority in SourceUnit identity

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -111,6 +111,9 @@ class SourceUnit:
     line_table: LineTable = field(init=False, default=None)  # type: ignore[assignment]
     module_bound_names: frozenset[str] = field(init=False, default_factory=frozenset)
     module_symtable: object = field(init=False, default=None)
+    # Bound by SourceFile after the backend materializes the Module — the sole
+    # structural authority for module-body identity. Never a second parse.
+    typed_module: object = field(init=False, default=None)
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "line_table", LineTable(self.source))
@@ -126,6 +129,27 @@ class SourceUnit:
                 if symbol.is_assigned() or symbol.is_imported() or symbol.is_namespace()
             ),
         )
+        object.__setattr__(self, "typed_module", None)
+
+    def bind_typed_module(self, module: "Module") -> None:
+        """Attach the already-materialized Module root (SourceFile only)."""
+        object.__setattr__(self, "typed_module", module)
+
+    def _require_typed_module(self, owner: str) -> "Module":
+        module = self.typed_module
+        if module is None:
+            raise SourceTreePanic(
+                owner=owner,
+                observed="typed Module is not bound on this SourceUnit",
+                requested=(
+                    "the SourceFile-materialized Module as structural authority"
+                ),
+                fix=(
+                    "construct through SourceFile so the typed tree is bound "
+                    "before module-level identity queries"
+                ),
+            )
+        return module  # type: ignore[return-value]
 
     def function_symtable(self, name: str, lineno: int):
         matches = []
@@ -153,16 +177,22 @@ class SourceUnit:
         return matches[0]
 
     def is_module_level_function(self, name: str, lineno: int) -> bool:
-        """Whether this exact definition occupies an importable module slot."""
-        import ast
+        """Whether this exact definition occupies an importable module slot.
 
-        module = ast.parse(self.source, filename=self.filename)
-        return any(
-            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-            and node.name == name
-            and node.lineno == lineno
-            for node in module.body
-        )
+        Authority is the already-materialized typed Module body (direct
+        ``FunctionDef`` / ``AsyncFunctionDef`` children only) — never a second
+        parse of the source text as semantic authority.
+        """
+        module = self._require_typed_module("SourceUnit.is_module_level_function")
+        for statement in module.body:
+            if statement.kind not in ("FunctionDef", "AsyncFunctionDef"):
+                continue
+            if (
+                statement.name == name
+                and statement.line_col_span().start_line == lineno
+            ):
+                return True
+        return False
 
     def exception_type_identity(self, node: "Name"):
         """Return the authenticated exception-class coordinate reaching ``node``.
@@ -171,27 +201,33 @@ class SourceUnit:
         an exact ``from builtins import ...`` binding, or one source class
         definition.  Ambiguous, reassigned, parameter, and computed bindings
         have no identity coordinate and therefore stay loud at the consumer.
-        """
-        import ast
 
+        Structural authority is the already-materialized typed Module plus the
+        unit's CPython ``symtable`` (function scope flags). No second parse.
+        """
         from sugar_lift_py_tests.ir import ctor, str_const
         from sugar_lift_py_tests.temporal.builtin_name_bindings import (
             BUILTIN_EXCEPTION_NAMES,
         )
 
-        parsed = ast.parse(self.source, filename=self.filename)
+        module = self._require_typed_module("SourceUnit.exception_type_identity")
         span = node.line_col_span()
         containing = []
-        for candidate in ast.walk(parsed):
-            if not isinstance(candidate, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        for candidate in module.walk():
+            if candidate.kind not in ("FunctionDef", "AsyncFunctionDef"):
                 continue
-            start = (candidate.lineno, candidate.col_offset)
-            end = (candidate.end_lineno, candidate.end_col_offset)
+            cspan = candidate.line_col_span()
+            start = (cspan.start_line, cspan.start_col)
+            end = (cspan.end_line, cspan.end_col)
             if start <= (span.start_line, span.start_col) <= end:
                 containing.append(candidate)
         if containing:
-            owner = max(containing, key=lambda value: value.lineno)
-            table = self.function_symtable(owner.name, owner.lineno)
+            owner = max(
+                containing, key=lambda value: value.line_col_span().start_line
+            )
+            table = self.function_symtable(
+                owner.name, owner.line_col_span().start_line
+            )
             try:
                 symbol = table.lookup(node.id)
             except KeyError:
@@ -205,24 +241,25 @@ class SourceUnit:
                 return None
 
         bindings = []
-        for statement in parsed.body:
-            if isinstance(statement, ast.ImportFrom):
+        for statement in module.body:
+            kind = statement.kind
+            if kind == "ImportFrom":
                 for alias in statement.names:
                     if (alias.asname or alias.name) == node.id:
                         bindings.append(("import", statement.module, alias.name))
-            elif isinstance(statement, ast.ClassDef) and statement.name == node.id:
+            elif kind == "ClassDef" and statement.name == node.id:
                 bindings.append(("class", statement))
-            elif isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            elif kind in ("FunctionDef", "AsyncFunctionDef"):
                 if statement.name == node.id:
                     bindings.append(("other",))
-            elif isinstance(statement, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+            elif kind in ("Assign", "AnnAssign", "AugAssign"):
                 targets = (
                     statement.targets
-                    if isinstance(statement, ast.Assign)
+                    if kind == "Assign"
                     else (statement.target,)
                 )
                 if any(
-                    isinstance(target, ast.Name) and target.id == node.id
+                    isinstance(target, Name) and target.id == node.id
                     for target in targets
                 ):
                     bindings.append(("other",))
@@ -246,9 +283,10 @@ class SourceUnit:
             )
         if binding[0] == "class":
             definition = binding[1]
+            lc = definition.line_col_span()
             coordinate = (
-                f"{self.source_cid}:{definition.lineno}:{definition.col_offset}:"
-                f"{definition.end_lineno}:{definition.end_col_offset}"
+                f"{self.source_cid}:{lc.start_line}:{lc.start_col}:"
+                f"{lc.end_line}:{lc.end_col}"
             )
             return ctor(
                 "python:exception_type_identity",

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
@@ -99,6 +99,10 @@ class SourceFile:
             )
             raise AssertionError("unreachable")
         self.root: Module = root
+        # Identity queries on SourceUnit (module-level function slots,
+        # exception-type lexical bindings) read this already-materialized
+        # Module — never a second source parse as semantic authority.
+        self.unit.bind_typed_module(root)
 
     @classmethod
     def from_path(

--- a/implementations/python/sugar-source-tree/tests/test_source_unit_identity_no_ast.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_unit_identity_no_ast.py
@@ -1,0 +1,180 @@
+"""SourceUnit module-level / exception-type identity without a second parser.
+
+``is_module_level_function`` and ``exception_type_identity`` must read the
+already-materialized typed Module + unit symtable — never a second standard
+library parse of the source text. Truthful arms pin the closed lexical
+coordinates; lying arms stay loud (``None`` / ``False``).
+"""
+
+from __future__ import annotations
+
+import ast as _stdlib_ast
+import tempfile
+from pathlib import Path
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _file(source: str) -> SourceFile:
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(source)
+        path = f.name
+    return SourceFile(path_source(path))
+
+
+def _raise_name(source: str, name: str | None = None):
+    sf = _file(source)
+    for node in sf.root.walk():
+        if node.kind != "Raise":
+            continue
+        exc = node.exc
+        if exc is None:
+            continue
+        if exc.kind == "Call":
+            exc = exc.func
+        if exc.kind == "Name" and (name is None or exc.id == name):
+            return sf, exc
+    raise AssertionError(f"no Raise Name {name!r} in source")
+
+
+def test_nodes_py_has_no_ast_import_or_parse():
+    """R: raw stdlib parse must not be semantic authority in SourceUnit."""
+    nodes_path = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "sugar_source_tree"
+        / "nodes.py"
+    )
+    tree = _stdlib_ast.parse(nodes_path.read_text(encoding="utf-8"))
+    for node in _stdlib_ast.walk(tree):
+        if isinstance(node, _stdlib_ast.Import):
+            assert all(alias.name != "ast" for alias in node.names)
+        if isinstance(node, _stdlib_ast.ImportFrom):
+            assert node.module != "ast"
+        if isinstance(node, _stdlib_ast.Attribute) and isinstance(
+            node.value, _stdlib_ast.Name
+        ):
+            if node.value.id == "ast":
+                assert node.attr not in ("parse", "walk")
+
+
+def test_module_level_function_truthful_and_lying():
+    sf = _file(
+        "def f():\n"
+        "    def nested():\n"
+        "        pass\n"
+        "    pass\n"
+        "async def g():\n"
+        "    pass\n"
+        "class C:\n"
+        "    def f(self):\n"
+        "        pass\n"
+        "if True:\n"
+        "    def conditional():\n"
+        "        pass\n"
+    )
+    unit = sf.unit
+    by_name_line = {
+        (fn.name, fn.line_col_span().start_line): fn for fn in sf.functions()
+    }
+
+    # Truthful: direct module-body defs occupy importable slots.
+    f_line = next(line for (name, line) in by_name_line if name == "f" and line < 5)
+    g_line = next(line for (name, line) in by_name_line if name == "g")
+    assert unit.is_module_level_function("f", f_line) is True
+    assert unit.is_module_level_function("g", g_line) is True
+
+    # Lying: nested, class method, and conditional-body defs do not.
+    nested_line = next(line for (name, line) in by_name_line if name == "nested")
+    method_line = next(
+        line for (name, line) in by_name_line if name == "f" and line > 5
+    )
+    conditional_line = next(
+        line for (name, line) in by_name_line if name == "conditional"
+    )
+    assert unit.is_module_level_function("nested", nested_line) is False
+    assert unit.is_module_level_function("f", method_line) is False
+    assert unit.is_module_level_function("conditional", conditional_line) is False
+    # Wrong line for a real module def is also false.
+    assert unit.is_module_level_function("f", f_line + 1) is False
+
+
+def test_exception_type_identity_truthful_arms():
+    # Builtin vocabulary, unbound at module level.
+    _sf, name = _raise_name("def A():\n    raise ValueError\n", "ValueError")
+    identity = _sf.unit.exception_type_identity(name)
+    assert identity is not None
+    assert identity.name == "python:exception_type_identity"
+    assert identity.args[0].value == "builtins"
+    assert identity.args[1].value == "ValueError"
+
+    # Exact from-builtins import (including alias).
+    _sf, name = _raise_name(
+        "from builtins import ValueError as VE\ndef A():\n    raise VE\n",
+        "VE",
+    )
+    identity = _sf.unit.exception_type_identity(name)
+    assert identity is not None
+    assert identity.args[0].value == "builtins"
+    assert identity.args[1].value == "ValueError"
+
+    # One source class definition → source-class coordinate.
+    sf, name = _raise_name(
+        "class MyErr(Exception):\n    pass\ndef A():\n    raise MyErr\n",
+        "MyErr",
+    )
+    identity = sf.unit.exception_type_identity(name)
+    assert identity is not None
+    assert identity.args[0].value == "source-class"
+    class_def = next(n for n in sf.root.walk() if n.kind == "ClassDef" and n.name == "MyErr")
+    lc = class_def.line_col_span()
+    expected = (
+        f"{sf.unit.source_cid}:{lc.start_line}:{lc.start_col}:"
+        f"{lc.end_line}:{lc.end_col}"
+    )
+    assert identity.args[1].value == expected
+
+
+def test_exception_type_identity_lying_arms_stay_loud():
+    # Parameter binding — no identity coordinate.
+    _sf, name = _raise_name("def A(ValueError):\n    raise ValueError\n", "ValueError")
+    assert _sf.unit.exception_type_identity(name) is None
+
+    # Local reassignment — no identity coordinate.
+    _sf, name = _raise_name(
+        "def A():\n    ValueError = KeyError\n    raise ValueError\n",
+        "ValueError",
+    )
+    assert _sf.unit.exception_type_identity(name) is None
+
+    # Module-level assignment shadow of a builtin name.
+    _sf, name = _raise_name(
+        "ValueError = KeyError\ndef A():\n    raise ValueError\n",
+        "ValueError",
+    )
+    assert _sf.unit.exception_type_identity(name) is None
+
+    # Non-builtins import is not a closed exception identity.
+    _sf, name = _raise_name(
+        "from elsewhere import TypeError\ndef A():\n    raise TypeError\n",
+        "TypeError",
+    )
+    assert _sf.unit.exception_type_identity(name) is None
+
+    # Ambiguous: two module-level bindings for the same name.
+    _sf, name = _raise_name(
+        "class E(Exception):\n    pass\n"
+        "class E(Exception):\n    pass\n"
+        "def A():\n    raise E\n",
+        "E",
+    )
+    assert _sf.unit.exception_type_identity(name) is None
+
+
+if __name__ == "__main__":
+    test_nodes_py_has_no_ast_import_or_parse()
+    test_module_level_function_truthful_and_lying()
+    test_exception_type_identity_truthful_arms()
+    test_exception_type_identity_lying_arms_stay_loud()
+    print("ok: source-unit identity without second-parser authority")


### PR DESCRIPTION
## Summary
- `SourceUnit.is_module_level_function` and `exception_type_identity` no longer re-parse source via stdlib `ast`.
- Authority is the already-materialized typed `Module` (bound by `SourceFile.bind_typed_module`) plus the unit's CPython `symtable` for function-scope flags.
- Behavior twins pin truthful/lying arms for module-level function slots and exception-type identity; an AST-structure instrument keeps `nodes.py` free of `ast` imports/calls.

## Validation
```
bin/bpytest implementations/python/sugar-source-tree/tests/test_source_unit_identity_no_ast.py -v
# 4 passed
bin/bpytest implementations/python/sugar-source-tree/tests/test_raise_sugar.py \
  implementations/python/sugar-source-tree/tests/test_exit_builds.py \
  implementations/python/sugar-source-tree/tests/test_source_unit_identity_no_ast.py -q
# 16 passed
```