### PR TITLE
drain: route import binding through typed source tree (#6115)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -7,7 +7,6 @@ the import-to-contract bridge protocol.
 
 from __future__ import annotations
 
-import ast
 import json
 from dataclasses import dataclass, field as dataclass_field
 from pathlib import Path
@@ -16,11 +15,15 @@ from typing import Any, Iterable
 from .canonicalizer import blake3_512_of, encode_jcs
 from .context_manager_contract import _json_value
 
+from sugar_source_tree.nodes import Expression, Module, Node, Statement
+from sugar_source_tree.tree import SourceFile
+
+
 class UnsupportedStatementGrammar(RuntimeError):
     pass
 
 
-AST_STATEMENT_TYPE_NAMES = frozenset(
+TYPED_STATEMENT_KINDS = frozenset(
     {
         "FunctionDef",
         "AsyncFunctionDef",
@@ -52,11 +55,6 @@ AST_STATEMENT_TYPE_NAMES = frozenset(
         "Continue",
     }
 )
-AST_STATEMENT_TYPES = frozenset(
-    statement for statement in ast.stmt.__subclasses__() if statement.__module__ == "ast"
-)
-if {statement.__name__ for statement in AST_STATEMENT_TYPES} != AST_STATEMENT_TYPE_NAMES:
-    raise UnsupportedStatementGrammar("unsupported running ast.stmt grammar")
 
 
 class UnsupportedStatementVariant(RuntimeError):
@@ -67,10 +65,13 @@ def _hash(value: Any) -> str:
     return blake3_512_of(encode_jcs(_json_value(value)).encode("utf-8"))
 
 
-def _site(source_cid: str, node: ast.AST) -> dict[str, Any]:
-    if not hasattr(node, "lineno"):
-        body = getattr(node, "body", ())
-        if not body:
+def _site(source_cid: str, node: Node) -> dict[str, Any]:
+    # Preserve the established module-scope coordinate: CPython's Module has
+    # no span, so its authenticated coordinate is the body extent rather than
+    # trailing whitespace at EOF.  The typed adapter's Module span includes
+    # that whitespace; projecting the typed body keeps existing CIDs stable.
+    if node.kind == "Module":
+        if not node.body:
             return {
                 "sourceCid": source_cid,
                 "startLine": 1,
@@ -78,19 +79,21 @@ def _site(source_cid: str, node: ast.AST) -> dict[str, Any]:
                 "endLine": 1,
                 "endCol": 0,
             }
+        end = node.body[-1].line_col_span()
         return {
             "sourceCid": source_cid,
             "startLine": 1,
             "startCol": 0,
-            "endLine": body[-1].end_lineno,
-            "endCol": body[-1].end_col_offset,
+            "endLine": end.end_line,
+            "endCol": end.end_col,
         }
+    span = node.line_col_span()
     return {
         "sourceCid": source_cid,
-        "startLine": node.lineno,
-        "startCol": node.col_offset,
-        "endLine": node.end_lineno,
-        "endCol": node.end_col_offset,
+        "startLine": span.start_line,
+        "startCol": span.start_col,
+        "endLine": span.end_line,
+        "endCol": span.end_col,
     }
 
 
@@ -210,12 +213,12 @@ def _join(*states: State) -> State:
     }
 
 
-def _bound_names(target: ast.AST) -> set[str]:
-    if isinstance(target, ast.Name):
+def _bound_names(target: Node) -> set[str]:
+    if target.kind == "Name":
         return {target.id}
-    if isinstance(target, (ast.Tuple, ast.List)):
+    if target.kind in ("Tuple", "List"):
         return set().union(*(_bound_names(item) for item in target.elts), set())
-    if isinstance(target, ast.Starred):
+    if target.kind == "Starred":
         return _bound_names(target.value)
     return set()
 
@@ -227,7 +230,7 @@ def module_name_for_path(root: Path, path: Path) -> str:
     return ".".join(parts)
 
 
-def _import_from_module(current: str, node: ast.ImportFrom) -> str | None:
+def _import_from_module(current: str, node: Node) -> str | None:
     if node.level == 0:
         return node.module
     package = current.split(".")
@@ -263,7 +266,7 @@ class _Pass:
         self.class_outer_states: dict[int, State] = {}
 
     def _state_only_statement(
-        self, node: ast.stmt, state: State, scope: ast.AST
+        self, node: Statement, state: State, scope: Node
     ) -> State:
         """Transfer one statement without enrolling any use-site testimony."""
         transfer = _Pass(
@@ -277,9 +280,9 @@ class _Pass:
 
     def _loop_entry(
         self,
-        node: ast.For | ast.AsyncFor | ast.While,
+        node: Statement,
         state: State,
-        scope: ast.AST,
+        scope: Node,
     ) -> State:
         """Least fixed point for definitions that can arrive on a back-edge."""
         entry = dict(state)
@@ -296,36 +299,30 @@ class _Pass:
                 return entry
             entry = widened
 
-    def expression(self, node: ast.AST | None, state: State, scope: ast.AST) -> None:
+    def expression(self, node: Node | None, state: State, scope: Node) -> None:
         if node is None:
             return
-        if isinstance(node, ast.Call):
+        if node.kind == "Call":
             self.expression(node.func, state, scope)
             for arg in node.args:
                 self.expression(arg, state, scope)
             for keyword in node.keywords:
                 self.expression(keyword.value, state, scope)
             if (
-                isinstance(node.func, (ast.Name, ast.Attribute))
-                and (isinstance(node.func, ast.Attribute) or not node.keywords)
-                and not any(isinstance(arg, ast.Starred) for arg in node.args)
+                node.func.kind in ("Name", "Attribute")
+                and (node.func.kind == "Attribute" or not node.keywords)
+                and not any(arg.kind == "Starred" for arg in node.args)
                 and not any(keyword.arg is None for keyword in node.keywords)
             ):
                 self._call(node, state, scope)
             return
-        if isinstance(node, ast.Lambda):
+        if node.kind == "Lambda":
             inner = dict(state)
-            for arg in (*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs):
-                inner[arg.arg] = frozenset({_NON_IMPORT})
-            if node.args.vararg:
-                inner[node.args.vararg.arg] = frozenset({_NON_IMPORT})
-            if node.args.kwarg:
-                inner[node.args.kwarg.arg] = frozenset({_NON_IMPORT})
+            for param in node.params:
+                inner[param.name] = frozenset({_NON_IMPORT})
             self.expression(node.body, inner, node)
             return
-        if isinstance(
-            node, (ast.ListComp, ast.SetComp, ast.GeneratorExp, ast.DictComp)
-        ):
+        if node.kind in ("ListComp", "SetComp", "GeneratorExp", "DictComp"):
             inner = dict(state)
             for generator in node.generators:
                 self.expression(generator.iter, inner, scope)
@@ -333,22 +330,21 @@ class _Pass:
                     inner[name] = frozenset({_NON_IMPORT})
                 for condition in generator.ifs:
                     self.expression(condition, inner, scope)
-            if isinstance(node, ast.DictComp):
+            if node.kind == "DictComp":
                 self.expression(node.key, inner, scope)
                 self.expression(node.value, inner, scope)
             else:
                 self.expression(node.elt, inner, scope)
             return
-        for child in ast.iter_child_nodes(node):
-            self.expression(child, state, scope)
+        for _, _, child in node.children():
+            if isinstance(child, Expression):
+                self.expression(child, state, scope)
 
-    def _call(self, node: ast.Call, state: State, scope: ast.AST) -> None:
-        if isinstance(node.func, ast.Name):
+    def _call(self, node: Node, state: State, scope: Node) -> None:
+        if node.func.kind == "Name":
             local_name = node.func.id
             exported_path: tuple[str, ...] = ()
-        elif isinstance(node.func, ast.Attribute) and isinstance(
-            node.func.value, ast.Name
-        ):
+        elif node.func.kind == "Attribute" and node.func.value.kind == "Name":
             local_name = node.func.value.id
             exported_path = (node.func.attr,)
         else:
@@ -356,7 +352,8 @@ class _Pass:
         reaching = state.get(local_name, frozenset({_UNBOUND}))
         imports = {value for value in reaching if isinstance(value, _ImportDef)}
         nonimports = reaching - imports
-        key = (node.lineno, node.col_offset, node.end_lineno, node.end_col_offset)
+        span = node.line_col_span()
+        key = (span.start_line, span.start_col, span.end_line, span.end_col)
         if len(imports) == 1 and not nonimports:
             binding = next(iter(imports))
             self.outcomes[key] = "authenticated-import-use"
@@ -393,16 +390,16 @@ class _Pass:
             self.outcomes[key] = "no-lexical-binding"
 
     def statements(
-        self, statements: Iterable[ast.stmt], state: State, scope: ast.AST
+        self, statements: Iterable[Statement], state: State, scope: Node
     ) -> State:
         state = dict(state)
         for statement in statements:
             state = self.statement(statement, state, scope)
         return state
 
-    def statement(self, node: ast.stmt, state: State, scope: ast.AST) -> State:
+    def statement(self, node: Statement, state: State, scope: Node) -> State:
         state = dict(state)
-        if isinstance(node, ast.ImportFrom):
+        if node.kind == "ImportFrom":
             module = _import_from_module(self.module_name, node)
             if module is None:
                 return state
@@ -438,7 +435,7 @@ class _Pass:
                     }
                 )
             return state
-        if isinstance(node, ast.Import):
+        if node.kind == "Import":
             for alias in node.names:
                 local = alias.asname or alias.name.split(".")[0]
                 payload = {
@@ -469,24 +466,23 @@ class _Pass:
                     }
                 )
             return state
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            for deco in node.decorator_list:
+        if node.kind in ("FunctionDef", "AsyncFunctionDef"):
+            for deco in node.decorators:
                 self.expression(deco, state, scope)
             for default in (
-                *node.args.defaults,
-                *(d for d in node.args.kw_defaults if d),
+                *(p.default for p in node.params if p.default is not None),
             ):
                 self.expression(default, state, scope)
-            if isinstance(scope, ast.Module):
+            if scope.kind == "Module":
                 state[node.name] = frozenset(
                     {
                         _ModuleFunctionDef(
                             f"python:{self.module_name}.{node.name}",
                             (
-                                node.lineno,
-                                node.col_offset,
-                                node.end_lineno,
-                                node.end_col_offset,
+                                node.line_col_span().start_line,
+                                node.line_col_span().start_col,
+                                node.line_col_span().end_line,
+                                node.line_col_span().end_col,
                             ),
                         )
                     }
@@ -497,25 +493,21 @@ class _Pass:
                 return state
             inner = dict(
                 self.class_outer_states.get(id(scope), state)
-                if isinstance(scope, ast.ClassDef)
+                if scope.kind == "ClassDef"
                 else state
             )
             local_names = _function_locals(node)
             for name in local_names:
                 inner[name] = frozenset({_UNBOUND})
-            for arg in (*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs):
-                inner[arg.arg] = frozenset({_NON_IMPORT})
-            if node.args.vararg:
-                inner[node.args.vararg.arg] = frozenset({_NON_IMPORT})
-            if node.args.kwarg:
-                inner[node.args.kwarg.arg] = frozenset({_NON_IMPORT})
+            for param in node.params:
+                inner[param.name] = frozenset({_NON_IMPORT})
             globals_, _nonlocals = _function_declarations(node)
             for name in globals_:
                 inner[name] = self.module_state.get(name, frozenset({_UNBOUND}))
             self.statements(node.body, inner, node)
             return state
-        if isinstance(node, ast.ClassDef):
-            for expr in (*node.decorator_list, *node.bases):
+        if node.kind == "ClassDef":
+            for expr in (*node.decorators, *node.bases):
                 self.expression(expr, state, scope)
             state[node.name] = frozenset({_NON_IMPORT})
             if not self.analyze_nested:
@@ -523,21 +515,21 @@ class _Pass:
             self.class_outer_states[id(node)] = dict(state)
             self.statements(node.body, dict(state), node)
             return state
-        if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign, ast.NamedExpr)):
+        if node.kind in ("Assign", "AnnAssign", "AugAssign", "NamedExpr"):
             value = getattr(node, "value", None)
             self.expression(value, state, scope)
-            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            targets = node.targets if node.kind == "Assign" else [node.target]
             for target in targets:
                 for name in _bound_names(target):
                     state[name] = frozenset({_NON_IMPORT})
             return state
-        if isinstance(node, ast.If):
+        if node.kind == "If":
             self.expression(node.test, state, scope)
             return _join(
                 self.statements(node.body, state, scope),
                 self.statements(node.orelse, state, scope),
             )
-        if isinstance(node, (ast.For, ast.AsyncFor, ast.While)):
+        if node.kind in ("For", "AsyncFor", "While"):
             self.expression(getattr(node, "iter", None), state, scope)
             body_in = self._loop_entry(node, state, scope)
             self.expression(getattr(node, "test", None), body_in, scope)
@@ -550,7 +542,7 @@ class _Pass:
                 body,
                 self.statements(node.orelse, _join(state, body), scope),
             )
-        if isinstance(node, ast.Try):
+        if node.kind in ("Try", "TryStar"):
             exceptional_prefixes = [dict(state)]
             prefix = dict(state)
             for statement in node.body:
@@ -566,110 +558,103 @@ class _Pass:
             joined = _join(*paths)
             joined = self.statements(node.orelse, joined, scope)
             return self.statements(node.finalbody, joined, scope)
-        if isinstance(node, (ast.With, ast.AsyncWith)):
+        if node.kind in ("With", "AsyncWith"):
             for item in node.items:
                 self.expression(item.context_expr, state, scope)
                 if item.optional_vars:
                     for name in _bound_names(item.optional_vars):
                         state[name] = frozenset({_NON_IMPORT})
             return self.statements(node.body, state, scope)
-        if isinstance(node, ast.Delete):
+        if node.kind == "Delete":
             for target in node.targets:
                 for name in _bound_names(target):
                     state[name] = frozenset({_UNBOUND})
             return state
-        if type(node) in AST_STATEMENT_TYPES:
-            for child in ast.iter_child_nodes(node):
-                if isinstance(child, ast.expr):
+        if node.kind in TYPED_STATEMENT_KINDS:
+            for _, _, child in node.children():
+                if isinstance(child, Expression):
                     self.expression(child, state, scope)
             return state
         raise UnsupportedStatementVariant(type(node).__name__)
 
 
-def _function_locals(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
-    class Collector(ast.NodeVisitor):
-        def __init__(self):
-            self.globals: set[str] = set()
-            self.nonlocals: set[str] = set()
-            self.names: set[str] = set()
+def _function_locals(node: Node) -> set[str]:
+    """Collect lexical bindings from the adapter's typed tree.
 
-        def visit_Global(self, child):
-            self.globals.update(child.names)
+    Nested scopes are barriers.  Binding sites are read from their typed roles;
+    identifier spelling is never treated as evidence that a read is a store.
+    """
+    globals_: set[str] = set()
+    nonlocals: set[str] = set()
+    names: set[str] = set()
 
-        def visit_Nonlocal(self, child):
-            self.nonlocals.update(child.names)
-
-        def visit_Import(self, child):
-            self.names.update(
+    def visit(child: Node, *, root: bool = False) -> None:
+        if child.kind in ("FunctionDef", "AsyncFunctionDef"):
+            if not root:
+                names.add(child.name)
+                return
+        elif child.kind == "ClassDef":
+            names.add(child.name)
+            return
+        elif child.kind == "Lambda":
+            return
+        if child.kind == "Global":
+            globals_.update(child.names)
+        elif child.kind == "Nonlocal":
+            nonlocals.update(child.names)
+        elif child.kind in ("Import", "ImportFrom"):
+            names.update(
                 alias.asname or alias.name.split(".")[0] for alias in child.names
             )
+        elif child.kind == "ExceptHandler" and child.name:
+            names.add(child.name)
+        elif child.kind == "Assign":
+            for target in child.targets:
+                names.update(_bound_names(target))
+        elif child.kind in ("AnnAssign", "AugAssign", "NamedExpr"):
+            names.update(_bound_names(child.target))
+        elif child.kind in ("For", "AsyncFor"):
+            names.update(_bound_names(child.target))
+        elif child.kind in ("With", "AsyncWith"):
+            for item in child.items:
+                if item.optional_vars is not None:
+                    names.update(_bound_names(item.optional_vars))
+        elif child.kind == "Delete":
+            for target in child.targets:
+                names.update(_bound_names(target))
+        for _, _, descendant in child.children():
+            visit(descendant)
 
-        visit_ImportFrom = visit_Import
+    visit(node, root=True)
+    return names - globals_ - nonlocals
 
-        def visit_Name(self, child):
-            if isinstance(child.ctx, (ast.Store, ast.Del)):
-                self.names.add(child.id)
 
-        def visit_FunctionDef(self, child):
-            if child is not node:
-                self.names.add(child.name)
-                return
-            for statement in child.body:
-                self.visit(statement)
+def _function_declarations(node: Node) -> tuple[set[str], set[str]]:
+    globals_: set[str] = set()
+    nonlocals: set[str] = set()
 
-        visit_AsyncFunctionDef = visit_FunctionDef
-
-        def visit_ClassDef(self, child):
-            self.names.add(child.name)
-
-        def visit_Lambda(self, child):
+    def visit(child: Node, *, root: bool = False) -> None:
+        if not root and child.kind in (
+            "FunctionDef",
+            "AsyncFunctionDef",
+            "ClassDef",
+            "Lambda",
+        ):
             return
+        if child.kind == "Global":
+            globals_.update(child.names)
+        elif child.kind == "Nonlocal":
+            nonlocals.update(child.names)
+        for _, _, descendant in child.children():
+            visit(descendant)
 
-        def visit_ExceptHandler(self, child):
-            if child.name:
-                self.names.add(child.name)
-            self.generic_visit(child)
-
-    collector = Collector()
-    collector.visit(node)
-    return collector.names - collector.globals - collector.nonlocals
-
-
-def _function_declarations(
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
-) -> tuple[set[str], set[str]]:
-    class Collector(ast.NodeVisitor):
-        def __init__(self):
-            self.globals: set[str] = set()
-            self.nonlocals: set[str] = set()
-
-        def visit_Global(self, child):
-            self.globals.update(child.names)
-
-        def visit_Nonlocal(self, child):
-            self.nonlocals.update(child.names)
-
-        def visit_FunctionDef(self, child):
-            if child is node:
-                for statement in child.body:
-                    self.visit(statement)
-
-        visit_AsyncFunctionDef = visit_FunctionDef
-
-        def visit_ClassDef(self, child):
-            return
-
-        def visit_Lambda(self, child):
-            return
-
-    collector = Collector()
-    collector.visit(node)
-    return collector.globals, collector.nonlocals
+    visit(node, root=True)
+    return globals_, nonlocals
 
 
 def _final_module_state(
     *,
-    module: ast.Module,
+    module: Module,
     source_cid: str,
     module_name: str,
     module_identities: dict[str, dict[str, Any]],
@@ -690,7 +675,7 @@ def authenticated_import_uses(
     source_cid: str,
     module_identities: dict[str, dict[str, Any]] | None = None,
 ) -> tuple[list[dict[str, Any]], dict[tuple[int, int, int, int], str]]:
-    module = ast.parse(source, filename=str(path))
+    module = SourceFile((source, str(path), source_cid)).root
     module_name = module_name_for_path(root, path)
     identities = module_identities or {}
     module_state = _final_module_state(
@@ -748,7 +733,7 @@ def authenticated_module_exports(
 ) -> list[dict[str, Any]]:
     """Source-authenticated module-slot declarations for the frozen catalog."""
     module_name = module_name_for_path(root, path)
-    module = ast.parse(source, filename=str(path))
+    module = SourceFile((source, str(path), source_cid)).root
     final_state = _final_module_state(
         module=module,
         source_cid=source_cid,

--- a/implementations/python/sugar-lift-py-tests/tests/test_import_binding_statement_totality.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_import_binding_statement_totality.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-import ast
-
 import pytest
 
 from sugar_lift_py_tests import import_binding
+from sugar_source_tree.tree import SourceFile
 
 
-class RenamedFutureStatement(ast.stmt):
-    _fields: tuple[str, ...] = ()
+class RenamedFutureStatement:
+    kind = "RenamedFutureStatement"
 
 
 def test_import_binding_transfer_rejects_future_statement_variants_loudly() -> None:
@@ -17,16 +16,44 @@ def test_import_binding_transfer_rejects_future_statement_variants_loudly() -> N
         module_name="fixture",
         module_identities={},
     )
-    scope = ast.parse("pass")
+    scope = SourceFile(("pass\n", "fixture.py", "blake3-512:" + "1" * 128)).root
 
     with pytest.raises(import_binding.UnsupportedStatementVariant):
         transfer.statement(RenamedFutureStatement(), {}, scope)
 
 
 def test_import_binding_statement_partition_matches_running_grammar() -> None:
-    running = frozenset(
-        statement for statement in ast.stmt.__subclasses__() if statement.__module__ == "ast"
-    )
-    assert import_binding.AST_STATEMENT_TYPES == running
-    assert import_binding.AST_STATEMENT_TYPE_NAMES == {item.__name__ for item in running}
+    # The adapter owns parser grammar totality.  This pass owns the typed-node
+    # statement vocabulary it consumes; a future typed kind reaches the loud
+    # arm above rather than silently acquiring lexical authority.
+    assert import_binding.TYPED_STATEMENT_KINDS == {
+        "FunctionDef",
+        "AsyncFunctionDef",
+        "ClassDef",
+        "Return",
+        "Delete",
+        "Assign",
+        "TypeAlias",
+        "AugAssign",
+        "AnnAssign",
+        "For",
+        "AsyncFor",
+        "While",
+        "If",
+        "With",
+        "AsyncWith",
+        "Match",
+        "Raise",
+        "Try",
+        "TryStar",
+        "Assert",
+        "Import",
+        "ImportFrom",
+        "Global",
+        "Nonlocal",
+        "Expr",
+        "Pass",
+        "Break",
+        "Continue",
+    }
     assert issubclass(import_binding.UnsupportedStatementGrammar, RuntimeError)


### PR DESCRIPTION
## What changed

- removed the raw `ast` parser and visitor authority from `import_binding.py`
- routed import def-use analysis through the authenticated source tuple, `SourceFile`, the backend adapter, and typed source-tree nodes
- preserved the existing lexical control-flow analysis for scope barriers, exceptional prefixes, loop back-edges, aliases, and re-exports
- kept module-scope coordinates byte-identical by projecting the typed body extent
- confirmed `factory_build_context.py` has no side-door site and left it unchanged

## Instrument receipts

- rebased `origin/main`: `R_ast_semantic_above_adapter = 9`
- this branch: `R_ast_semantic_above_adapter = 2`
- slice delta: `-7`; the two remaining rows are in separately-owned `contract_expression.py`
- `R_membrane_admission = 0`, `R_dual_old_lifter = 0`, `auditor_errors = 0`
- construction invariant auditor: zero on every axis

## Focused evidence

- 40/40 focused tests passed: import binding totality, call-contract resolution, side-door law, construction-invariant law
- old-vs-new demand rows/CIDs were byte-identical for 4/4 representative alias, nested-scope, try/loop, and re-export fixtures
- renamed/non-vendor alias twins and shadowing/ambiguous-flow discrimination twins remain green

Predicted epsilon: `Epsilon R_ast_semantic_above_adapter = -7`. No Rust code changed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route import binding analysis through typed `sugar_source_tree` nodes instead of CPython `ast`
> - Replaces all CPython `ast` parsing and node traversal in [import_binding.py](https://github.com/TSavo/sugar/pull/6120/files#diff-7ed90ea16c2ad4ca10c3dc0d09d9e32172d598701588b5f8b3e08040e56bab4a) with `sugar_source_tree` typed nodes, including expression, statement, and function-local analysis.
> - Replaces the import-time `ast`-subclass grammar validation with a curated `TYPED_STATEMENT_KINDS` set; an unknown typed kind now raises `UnsupportedStatementVariant`.
> - Extends `_function_locals` to collect bindings from imports, assignment/with/for/delete targets, and except handler names, which were previously missed.
> - Adds explicit support for `TryStar` in statement analysis.
> - Behavioral Change: module-level definition sites are now anchored to the body extent rather than trailing whitespace.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ec54a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->