### PR TITLE
Add R_foreign_ast_import to construction side-door law

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/construction_side_door_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_side_door_law.py
@@ -8,9 +8,14 @@ Construction IS correctness. The sole path is:
 Prebound authenticated contract refs may enter as construction context.
 **Green only when meaning is tree + prebound refs only.**
 
+Currency above adapters is only BackendNode / our Node / SourceFragment /
+prebound contract refs — never stdlib ``ast.AST``, never libcst nodes, never
+parser objects.
+
 This instrument names every current construction-path side door. There is no
 baseline, threshold, or allowlist. Exit 1 while R > 0. Prefer larger honest
-red over hollow green.
+red over hollow green. Do not allowlist remaining offenders (including
+``import_binding`` / ``contract_expression``) — they stay red until killed.
 
 Measure axes (combined R; every offender named by class):
 
@@ -18,21 +23,28 @@ Measure axes (combined R; every offender named by class):
    meaning via spelling membrane, ``community_context_managers.json``,
    ``contract_for_manager`` / ``default_community_manifest`` /
    ``manifest_membrane`` / ``row_for_spelling`` (or equivalent).
-2. **ast-semantic-above-adapter** — production code outside ``*_adapter.py``
-   using ``import ast`` / ``ast.parse`` / ``ast.walk`` / ``ast.NodeVisitor``
-   for semantic resolve/admit. Adapters may use ast. Scripts/audit/idd may
-   use ast only when they never feed construction (excluded by scan root).
-3. **dual-old-lifter** (optional axis) — production enumerate path still
-   imports the old ``lifter`` / ``bind_lifter`` construction door.
+2. **foreign-ast-import** — any ``import ast`` / ``from ast`` in production
+   packages outside ``*_adapter*.py`` under sugar-source-tree, sugar-lift-py-
+   tests (construction path; idd/audit_only excluded only as non-construction
+   audit surfaces), and sugar-lift-python-source while that body still feeds
+   lift_rpc / production. Each file with a foreign ast import is an offender
+   locus so R tells the truth about finishing construction.
+3. **ast-semantic-above-adapter** — production code outside ``*_adapter*.py``
+   using ``ast.parse`` / ``ast.walk`` / ``ast.NodeVisitor`` for semantic
+   resolve/admit after a foreign import. Adapters may use ast.
+4. **dual-old-lifter** — production enumerate path still imports the old
+   ``lifter`` / ``bind_lifter`` construction door.
 
-Self-test (``--self-test``) plants both membrane and ast twins and proves
-clean trees stay quiet. Live scan prints JSON with R and named offenders.
+Self-test (``--self-test``) plants membrane, foreign-ast-import, and
+ast-semantic twins and proves clean trees / adapters stay quiet. Live scan
+prints JSON with R and named offenders.
 """
 
 from __future__ import annotations
 
 import argparse
 import ast
+import fnmatch
 import json
 import sys
 import tempfile
@@ -81,7 +93,7 @@ _SIDE_DOOR_KINDS = frozenset(
     {
         "membrane-admission-api",
         "membrane-spelling-manifest",
-        "ast-semantic-import",
+        "foreign-ast-import",
         "ast-semantic-parse",
         "ast-semantic-walk",
         "ast-semantic-visitor",
@@ -100,7 +112,9 @@ _SKIP_DIR_NAMES = frozenset(
     }
 )
 
-_ADAPTER_SUFFIX = "_adapter.py"
+# Adapters may hold foreign parser objects. Match *_adapter*.py (not only
+# the trailing _adapter.py form) so tree_sitter_python_adapter etc. stay free.
+_ADAPTER_GLOB = "*_adapter*.py"
 
 
 def _rel_path(root: Path, path: Path) -> str:
@@ -128,7 +142,7 @@ def _qualified_name(node: ast.AST) -> str:
 
 
 def _is_adapter_path(path: Path) -> bool:
-    return path.name.endswith(_ADAPTER_SUFFIX)
+    return fnmatch.fnmatch(path.name, _ADAPTER_GLOB)
 
 
 def _should_skip_dir(path: Path) -> bool:
@@ -222,13 +236,16 @@ def _membrane_name_hits(node: ast.AST) -> list[tuple[str, str]]:
     return hits
 
 
-def _ast_semantic_hits(node: ast.AST) -> list[tuple[str, str]]:
-    """Return (kind-suffix, expression) for semantic-ast loci on this node."""
-    hits: list[tuple[str, str]] = []
+def _foreign_ast_import_expression(node: ast.AST) -> str | None:
+    """Return the import expression when node is import-ast / from-ast."""
     if _import_is_ast(node):
-        hits.append(("import", _safe_unparse(node)))
-        return hits
+        return _safe_unparse(node)
+    return None
 
+
+def _ast_semantic_hits(node: ast.AST) -> list[tuple[str, str]]:
+    """Return (kind-suffix, expression) for semantic-ast use (not the import)."""
+    hits: list[tuple[str, str]] = []
     if isinstance(node, ast.Call):
         func = node.func
         if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
@@ -325,8 +342,24 @@ def scan_file(path: Path, *, rel: str) -> list[SideDoorOffender]:
                     )
                 )
 
-            # --- ast semantic above adapter ---
+            # --- foreign ast import / ast semantic above adapter ---
             if not is_adapter:
+                foreign_import = _foreign_ast_import_expression(node)
+                if foreign_import is not None:
+                    offenders.append(
+                        SideDoorOffender(
+                            path=rel,
+                            line=getattr(node, "lineno", 0) or 0,
+                            kind="foreign-ast-import",
+                            axis="foreign-ast-import",
+                            expression=foreign_import,
+                            note=(
+                                "currency above adapters is BackendNode / our Node / "
+                                "SourceFragment / prebound contract refs only — never "
+                                "stdlib ast; keep import ast behind *_adapter*.py"
+                            ),
+                        )
+                    )
                 for marker, expression in _ast_semantic_hits(node):
                     kind = f"ast-semantic-{marker}"
                     offenders.append(
@@ -474,7 +507,11 @@ def scan_roots(roots: Sequence[Path]) -> list[SideDoorOffender]:
 
 
 def default_production_roots(repo: Path | None = None) -> list[Path]:
-    """Production construction packages on the sole path (and its parasites)."""
+    """Production construction packages on the sole path (and its parasites).
+
+    Includes sugar-lift-python-source while that package still feeds lift_rpc /
+    production construction so every foreign-ast import there is named.
+    """
     kit = Path(__file__).resolve().parents[1]
     py = kit.parent
     # kit = .../sugar-lift-py-tests; py = .../python
@@ -484,6 +521,7 @@ def default_production_roots(repo: Path | None = None) -> list[Path]:
     return [
         kit / "src" / "sugar_lift_py_tests",
         py / "sugar-source-tree" / "src" / "sugar_source_tree",
+        py / "sugar-lift-python-source" / "src" / "sugar_lift_python_source",
     ]
 
 
@@ -498,6 +536,7 @@ def r_auditor_errors(offenders: Sequence[SideDoorOffender]) -> int:
 def r_by_axis(offenders: Sequence[SideDoorOffender]) -> dict[str, int]:
     axes = {
         "membrane-admission": 0,
+        "foreign-ast-import": 0,
         "ast-semantic-above-adapter": 0,
         "dual-old-lifter": 0,
     }
@@ -513,6 +552,7 @@ def format_report(offenders: Sequence[SideDoorOffender]) -> str:
     lines = [
         f"R_construction_side_doors = {r}",
         f"R_membrane_admission = {axes['membrane-admission']}",
+        f"R_foreign_ast_import = {axes['foreign-ast-import']}",
         f"R_ast_semantic_above_adapter = {axes['ast-semantic-above-adapter']}",
         f"R_dual_old_lifter = {axes['dual-old-lifter']}",
         f"auditor_errors = {r_auditor_errors(offenders)}",
@@ -546,7 +586,7 @@ def offenders_to_jsonable(offenders: Sequence[SideDoorOffender]) -> list[dict[st
 
 
 def discrimination_self_test() -> bool:
-    """Planted membrane + ast twins trip; clean trees stay quiet."""
+    """Planted membrane + foreign-ast + ast-semantic twins trip; clean stays quiet."""
     membrane_plant = '''
 from sugar_lift_py_tests.manifest_membrane import contract_for_manager
 
@@ -568,6 +608,12 @@ def resolve_exit(source: str):
             return node
     return None
 '''
+    from_ast_plant = '''
+from ast import parse, walk, NodeVisitor
+
+def resolve(source: str):
+    return parse(source)
+'''
     dual_plant = '''
 from sugar_lift_python_source.lifter import lift_source
 
@@ -584,39 +630,54 @@ def sugar_from_tree(node, prebound_refs):
         root.mkdir()
         (root / "membrane_door.py").write_text(membrane_plant, encoding="utf-8")
         (root / "ast_door.py").write_text(ast_plant, encoding="utf-8")
+        (root / "from_ast_door.py").write_text(from_ast_plant, encoding="utf-8")
         # dual-old-lifter only fires on enumerate-path basenames
         (root / "lift_rpc.py").write_text(dual_plant, encoding="utf-8")
         (root / "clean.py").write_text(clean, encoding="utf-8")
-        # adapter may use ast — must not trip
+        # adapter may use ast — must not trip (including *_adapter*.py form)
         (root / "cpython_adapter.py").write_text(
             "import ast\n\ndef parse(src):\n    return ast.parse(src)\n",
+            encoding="utf-8",
+        )
+        (root / "tree_sitter_python_adapter.py").write_text(
+            "import ast as _pyast\n\ndef parse(src):\n    return _pyast.parse(src)\n",
             encoding="utf-8",
         )
         planted = scan_roots((root,))
         r = r_construction_side_doors(planted)
         kinds = {row.kind for row in planted}
         axes = {row.axis for row in planted if row.kind in _SIDE_DOOR_KINDS}
+        axis_counts = r_by_axis(planted)
         clean_only = scan_file(root / "clean.py", rel="pkg/clean.py")
         adapter_only = scan_file(
             root / "cpython_adapter.py", rel="pkg/cpython_adapter.py"
         )
-        adapter_ast = [
-            row for row in adapter_only if row.kind.startswith("ast-semantic-")
+        adapter_mid = scan_file(
+            root / "tree_sitter_python_adapter.py",
+            rel="pkg/tree_sitter_python_adapter.py",
+        )
+        adapter_foreign = [
+            row
+            for row in adapter_only + adapter_mid
+            if row.kind == "foreign-ast-import"
+            or row.kind.startswith("ast-semantic-")
         ]
     return (
-        r >= 3
+        r >= 4
         and "membrane-admission-api" in kinds
         and "membrane-spelling-manifest" in kinds
-        and "ast-semantic-import" in kinds
+        and "foreign-ast-import" in kinds
         and "ast-semantic-parse" in kinds
         and "ast-semantic-walk" in kinds
         and "ast-semantic-visitor" in kinds
         and "dual-old-lifter" in kinds
         and "membrane-admission" in axes
+        and "foreign-ast-import" in axes
         and "ast-semantic-above-adapter" in axes
         and "dual-old-lifter" in axes
+        and axis_counts["foreign-ast-import"] >= 2  # import ast + from ast
         and r_construction_side_doors(clean_only) == 0
-        and adapter_ast == []
+        and adapter_foreign == []
         and r_auditor_errors(planted) == 0
     )
 
@@ -684,6 +745,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "ok": r == 0 and err == 0,
         "R_construction_side_doors": r,
         "R_membrane_admission": axes["membrane-admission"],
+        "R_foreign_ast_import": axes["foreign-ast-import"],
         "R_ast_semantic_above_adapter": axes["ast-semantic-above-adapter"],
         "R_dual_old_lifter": axes["dual-old-lifter"],
         "auditor_errors": err,
@@ -696,6 +758,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             "CONSTRUCTION-SIDE-DOOR LAW RED: "
             f"R={r}"
             f" membrane={axes['membrane-admission']}"
+            f" foreign_ast_import={axes['foreign-ast-import']}"
             f" ast_above_adapter={axes['ast-semantic-above-adapter']}"
             f" dual_old_lifter={axes['dual-old-lifter']}"
             + (f"; auditor_errors={err}" if err else "")

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_side_door_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_side_door_law.py
@@ -3,7 +3,8 @@
 Green only when meaning is tree + prebound authenticated contract refs only.
 This suite proves the instrument discriminates planted twins, stays quiet on
 clean trees / adapters, and reports live-repository R > 0 while offenders
-remain. It does not fix, delete, or allowlist production doors.
+remain. It does not fix, delete, or allowlist production doors — including
+import_binding / contract_expression foreign-ast imports.
 """
 
 from __future__ import annotations
@@ -54,6 +55,26 @@ MANIFEST = "community_context_managers.json"
     assert _SCANNER.r_construction_side_doors(offenders) >= 2
 
 
+def test_planted_foreign_ast_import_trips_floor(tmp_path: Path) -> None:
+    pkg = tmp_path / "sugar_lift_py_tests"
+    pkg.mkdir()
+    (pkg / "import_binding.py").write_text(
+        "import ast\n\ndef f():\n    return ast.parse('x')\n",
+        encoding="utf-8",
+    )
+    (pkg / "contract_expression.py").write_text(
+        "from ast import parse\n\ndef g(s):\n    return parse(s, mode='eval')\n",
+        encoding="utf-8",
+    )
+    offenders = _SCANNER.scan_roots((pkg,))
+    foreign = [row for row in offenders if row.kind == "foreign-ast-import"]
+    assert len(foreign) >= 2
+    assert all(row.axis == "foreign-ast-import" for row in foreign)
+    assert _SCANNER.r_by_axis(offenders)["foreign-ast-import"] >= 2
+    assert any("import ast" in row.expression for row in foreign)
+    assert any("from ast" in row.expression for row in foreign)
+
+
 def test_planted_ast_semantic_above_adapter_trips_floor(tmp_path: Path) -> None:
     pkg = tmp_path / "sugar_lift_py_tests"
     pkg.mkdir()
@@ -73,7 +94,7 @@ def prove(source: str):
     )
     offenders = _SCANNER.scan_roots((pkg,))
     kinds = {row.kind for row in offenders}
-    assert "ast-semantic-import" in kinds
+    assert "foreign-ast-import" in kinds
     assert "ast-semantic-parse" in kinds
     assert "ast-semantic-walk" in kinds
     assert "ast-semantic-visitor" in kinds
@@ -83,9 +104,14 @@ def prove(source: str):
         for row in offenders
         if row.kind.startswith("ast-semantic-")
     )
+    assert all(
+        row.axis == "foreign-ast-import"
+        for row in offenders
+        if row.kind == "foreign-ast-import"
+    )
 
 
-def test_adapter_ast_use_does_not_trip_ast_axis(tmp_path: Path) -> None:
+def test_adapter_ast_use_does_not_trip_foreign_or_semantic_axis(tmp_path: Path) -> None:
     pkg = tmp_path / "sugar_source_tree"
     pkg.mkdir()
     (pkg / "cpython_adapter.py").write_text(
@@ -97,9 +123,20 @@ def parse_unit(source, filename):
 """,
         encoding="utf-8",
     )
+    (pkg / "tree_sitter_python_adapter.py").write_text(
+        """
+import ast as _pyast
+
+def parse_unit(source, filename):
+    return _pyast.parse(source, filename=filename)
+""",
+        encoding="utf-8",
+    )
     offenders = _SCANNER.scan_roots((pkg,))
     assert [
-        row for row in offenders if row.kind.startswith("ast-semantic-")
+        row
+        for row in offenders
+        if row.kind == "foreign-ast-import" or row.kind.startswith("ast-semantic-")
     ] == []
 
 
@@ -136,6 +173,14 @@ def handle_enumerate(source, path):
     assert _SCANNER.r_by_axis(offenders)["dual-old-lifter"] >= 1
 
 
+def test_default_roots_include_lift_python_source() -> None:
+    roots = _SCANNER.default_production_roots()
+    names = [p.name for p in roots]
+    assert "sugar_lift_py_tests" in names
+    assert "sugar_source_tree" in names
+    assert "sugar_lift_python_source" in names
+
+
 def test_live_repository_is_red_while_offenders_remain() -> None:
     """Instrument runs on production roots; main stays RED while R > 0."""
     roots = _SCANNER.default_production_roots()
@@ -147,16 +192,34 @@ def test_live_repository_is_red_while_offenders_remain() -> None:
     # Honest red: named side doors still on the construction path.
     assert err == 0, _SCANNER.format_report(offenders)
     assert r > 0, (
-        "expected live construction-path side doors (ast above adapter and/or "
-        "membrane admission); instrument must stay red until sole path is "
-        "tree + prebound refs only"
+        "expected live construction-path side doors (foreign ast import and/or "
+        "ast above adapter and/or membrane admission); instrument must stay red "
+        "until sole path is tree + prebound refs only"
     )
+    # Foreign-ast-import axis must name real debt (import_binding /
+    # contract_expression and dual construction body under lift-python-source).
+    assert axes["foreign-ast-import"] > 0, (
+        "R_foreign_ast_import must stay red until no production package above "
+        "adapters imports stdlib ast"
+    )
+    foreign_paths = {
+        row.path
+        for row in offenders
+        if row.kind == "foreign-ast-import"
+    }
+    # Do not allowlist these — they must remain counted until killed.
+    assert any("import_binding" in p for p in foreign_paths)
+    assert any("contract_expression" in p for p in foreign_paths)
+    # Dual construction body still on the production path.
+    assert any("sugar_lift_python_source" in p for p in foreign_paths)
+
     # Every counted row must name a class and axis.
     debt = [row for row in offenders if row.kind in _SCANNER._SIDE_DOOR_KINDS]
     assert debt
     assert all(row.axis and row.kind for row in debt)
     assert (
-        axes["ast-semantic-above-adapter"] > 0
+        axes["foreign-ast-import"] > 0
+        or axes["ast-semantic-above-adapter"] > 0
         or axes["membrane-admission"] > 0
         or axes["dual-old-lifter"] > 0
     )
@@ -175,10 +238,14 @@ def test_main_json_reports_r_and_offenders(capsys) -> None:
     assert summary["instrument"] == "R_construction_side_doors"
     assert summary["ok"] is False
     assert summary["R_construction_side_doors"] > 0
+    assert summary["R_foreign_ast_import"] > 0
     assert isinstance(summary["offenders"], list)
     assert summary["offenders"]
     assert "kind" in summary["offenders"][0]
     assert "axis" in summary["offenders"][0]
+    assert any(
+        row["axis"] == "foreign-ast-import" for row in summary["offenders"]
+    )
 
 
 def test_missing_root_is_auditor_error_not_crash(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Extend permanent `construction_side_door_law` with **R_foreign_ast_import**: any `import ast` / `from ast` outside `*_adapter*.py` under sugar-source-tree, sugar-lift-py-tests, and sugar-lift-python-source (dual construction body still on the lift_rpc path).
- Keep existing membrane-admission / ast-semantic-above-adapter / dual-old-lifter axes; do **not** allowlist `import_binding` or `contract_expression`.
- Self-test + focused bpytest prove discrimination; live scan stays **exit 1** while R > 0.

## Live R (honest red)

| Axis | R |
|------|---|
| R_construction_side_doors | **53** |
| R_membrane_admission | 0 |
| R_foreign_ast_import | **12** |
| R_ast_semantic_above_adapter | 41 |
| R_dual_old_lifter | 0 |

Foreign-ast-import offenders: `import_binding.py`, `contract_expression.py`, plus 10 files under `sugar_lift_python_source` (ast_template, bind_lifter, compiler, dependency_artifact, leaf_assertions, lifter, source_oracle, source_tables, value_pins, verify_dialect). Adapters stay quiet.

## Validation

- `python3 .../construction_side_door_law.py --self-test` → GREEN
- `python3 .../construction_side_door_law.py` → RED exit 1, R=53
- `bin/bpytest tests/test_construction_side_door_law.py -v` → 11 passed

## Mission note

Instrument only — no production door kills. Remaining import_binding/contract_expression stay red until killed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `R_foreign_ast_import` axis to construction side-door law scanner
> - Introduces a new `foreign-ast-import` offender kind that flags `import ast` and `from ast ...` statements found outside adapter files, tracked under a dedicated `R_foreign_ast_import` axis in reports and JSON output.
> - Replaces the old `ast-semantic-import` classification for import-site nodes; semantic detection (parse/walk/visitor patterns, `NodeVisitor` inheritance) continues separately.
> - Broadens adapter file exemption from a suffix check to a glob match (`*_adapter*.py`) so files like `tree_sitter_python_adapter.py` are correctly exempted.
> - Adds `sugar-lift-python-source/src/sugar_lift_python_source` as a third default production scan root.
> - Expands the self-test and unit tests to validate detection, axis counts, adapter exemptions, and CLI JSON output for the new axis.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80b7234.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->