### PR TITLE
Route contract expressions through typed construction

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/contract_expression.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/contract_expression.py
@@ -1,135 +1,65 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-"""Parse string contract expressions into IR formulas via ast.
+"""Construct embedded Python contract expressions through the source tree.
 
-Not a second SourceFragment. Source currency is one: sugar_source_tree
-SourceFragment, sealed only through the one SourceOracle. Contract
-strings are small formula text; they parse with the stdlib ast module.
+The CPython expression grammar stays below ``cpython_adapter``.  Above that
+boundary this module sees one typed ``Expression`` and follows the ordinary
+construction path: substitute, construct Sugar, reduce, then ask the resulting
+floor value for its Python truth predicate.  Unsupported or effectful shapes
+remain loud; there is no private formula evaluator.
 """
 
 from __future__ import annotations
 
-import ast
 import textwrap
 
-from .ir import (
-    Formula,
-    and_,
-    bool_const,
-    comparison_with_none_guard,
-    ctor,
-    eq,
-    make_var,
-    not_,
-    num,
-    or_,
-    str_const,
-)
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.backend import BackendCouldNotParse, materialize
+from sugar_source_tree.cpython_adapter import CPythonAstBackend
+from sugar_source_tree.nodes import Expression, SourceUnit
+
+from .context import ReduceContext
+from .floor import PredicateValue
+from .ir import Formula
+from .outcome import Complete
 
 
 def parse_contract_expression(expr: str, available_names: list[str]) -> Formula:
-    """Parse a string contract expression into a canonical IR formula."""
+    """Build one contract predicate through the sole Python construction path.
+
+    ``available_names`` describes the surrounding declaration's formals.  Name
+    nodes are deliberately left as ordinary free formals during substitution;
+    the declaration binder owns their scope when it installs this formula.
+    """
+    del available_names  # binder ownership is outside the expression body
     source = textwrap.dedent(expr).strip()
+    source_cid = blake3_512_of(source.encode("utf-8"))
     try:
-        tree = ast.parse(source, mode="eval")
+        unit = SourceUnit(
+            filename="<contract-expression>", source=source, source_cid=source_cid
+        )
     except SyntaxError as exc:
         raise ValueError(f"empty or invalid contract expression: {expr!r}") from exc
-    return _translate_expr(tree.body, available_names)
+    backend = CPythonAstBackend()
+    try:
+        node = materialize(unit, backend.expression(unit))
+    except BackendCouldNotParse as exc:
+        raise ValueError(f"empty or invalid contract expression: {expr!r}") from exc
+    if not isinstance(node, Expression):
+        raise ValueError(
+            f"contract expression adapter returned {type(node).__name__}, expected Expression"
+        )
 
-
-_COMPARE_OPS = {
-    ast.Eq: "=",
-    ast.NotEq: "≠",
-    ast.Lt: "<",
-    ast.LtE: "≤",
-    ast.Gt: ">",
-    ast.GtE: "≥",
-    ast.Is: "=",
-    ast.IsNot: "≠",
-}
-
-
-def _translate_expr(node: ast.AST, available_names: list[str]) -> Formula:
-    if isinstance(node, ast.BoolOp):
-        operands = [_translate_expr(value, available_names) for value in node.values]
-        if isinstance(node.op, ast.And):
-            return and_(operands)
-        if isinstance(node.op, ast.Or):
-            return or_(operands)
-        raise ValueError(f"unsupported bool op: {type(node.op).__name__}")
-
-    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
-        return not_(_translate_expr(node.operand, available_names))
-
-    if isinstance(node, ast.Compare):
-        if len(node.ops) != 1 or len(node.comparators) != 1:
-            raise ValueError("chained comparisons are not supported")
-        symbol = _COMPARE_OPS.get(type(node.ops[0]))
-        if symbol is None:
-            raise ValueError(f"unsupported comparison: {type(node.ops[0]).__name__}")
-        left = _translate_term(node.left, available_names)
-        right = _translate_term(node.comparators[0], available_names)
-        return comparison_with_none_guard(symbol, left, right)
-
-    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
-        left = _translate_term(node.left, available_names)
-        right = _translate_term(node.right, available_names)
-        term = ctor("+", [left, right])
-        return eq(term, term)
-
-    term = _translate_term(node, available_names)
-    return eq(term, bool_const(True))
-
-
-def _translate_term(node: ast.AST, available_names: list[str]):
-    if isinstance(node, ast.Name):
-        name = node.id
-        if name == "None":
-            return ctor("None", [])
-        if name == "True":
-            return bool_const(True)
-        if name == "False":
-            return bool_const(False)
-        return make_var(name)
-
-    if isinstance(node, ast.Constant):
-        value = node.value
-        if isinstance(value, bool):
-            return bool_const(value)
-        if isinstance(value, int):
-            return num(value)
-        if isinstance(value, str):
-            return str_const(value)
-        if value is None:
-            return ctor("None", [])
-        raise ValueError(f"unsupported constant: {type(value).__name__}")
-
-    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
-        if isinstance(node.operand, ast.Constant) and isinstance(
-            node.operand.value, int
-        ):
-            return num(-node.operand.value)
-        raise ValueError("unary minus only supported on integer literals")
-
-    if isinstance(node, ast.Call):
-        if not isinstance(node.func, ast.Name):
-            raise ValueError("only simple-name calls are supported")
-        arguments = [
-            _translate_term(argument, available_names) for argument in node.args
-        ]
-        return ctor(node.func.id, arguments)
-
-    if isinstance(node, ast.BinOp):
-        symbols = {
-            ast.Add: "+",
-            ast.Sub: "-",
-            ast.Mult: "*",
-            ast.Div: "/",
-        }
-        symbol = symbols.get(type(node.op))
-        if symbol is None:
-            raise ValueError(f"unsupported binary op: {type(node.op).__name__}")
-        left = _translate_term(node.left, available_names)
-        right = _translate_term(node.right, available_names)
-        return ctor(symbol, [left, right])
-
-    raise ValueError(f"unsupported expression: {type(node).__name__}")
+    constructed = node.substitute({}).sugar()
+    outcome = constructed.desugar(ReduceContext.root(owner="contract-expression"))
+    if not isinstance(outcome, Complete):
+        raise ValueError(
+            "contract expression did not complete through ordinary construction: "
+            f"{type(outcome).__name__}"
+        )
+    truth = outcome.value.truth(node.fragment)
+    if not isinstance(truth, Complete) or not isinstance(truth.value, PredicateValue):
+        raise ValueError(
+            "contract expression has no constructed truth predicate: "
+            f"{type(truth).__name__}"
+        )
+    return truth.value.formula

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -70,22 +70,14 @@ _ENUMERATION_ACTIVE = False
 _BOUND_CONTRACT_REFS = None
 _BOUND_CALL_CONTRACT_REFS = None
 def _context_manager_demand_rows(root: Path) -> List[Dict[str, Any]]:
-    """Enroll with-site import coordinates without constructing any Sugar.
+    """Enroll typed With occurrences without constructing any Sugar.
 
-    Enumeration is SourceOracle → SourceFile → typed Nodes only
-    (Import / ImportFrom / With / AsyncWith / Call / Name / Attribute).
-    No raw ``ast.parse`` / ``ast.walk`` side door.
+    Import authority is joined later from ``_call_contract_demand_rows`` at the
+    identical source coordinate.  This pass owns only the structural fact that
+    a typed WithItem exists; it never reconstructs imports from spellings.
     """
     from sugar_lift_python_source.source_oracle import SourceUnavailable
-    from sugar_source_tree.nodes import (
-        AsyncWith,
-        Attribute,
-        Call,
-        Import,
-        ImportFrom,
-        Name,
-        With,
-    )
+    from sugar_source_tree.nodes import AsyncWith, With
     from sugar_source_tree.tree import SourceFile, SourceTree
 
     rows: List[Dict[str, Any]] = []
@@ -94,35 +86,14 @@ def _context_manager_demand_rows(root: Path) -> List[Dict[str, Any]]:
             source_file = SourceFile.from_path(path)
         except SourceUnavailable:
             continue
-        imports: Dict[str, str] = {}
-        with_nodes: List[With | AsyncWith] = []
         for node in source_file.nodes():
-            if isinstance(node, ImportFrom) and node.module:
-                for alias in node.names:
-                    imports[alias.asname or alias.name] = f"{node.module}.{alias.name}"
-            elif isinstance(node, Import):
-                for alias in node.names:
-                    imports[alias.asname or alias.name.split(".")[0]] = alias.name
-            elif isinstance(node, (With, AsyncWith)):
-                with_nodes.append(node)
-        source_cid = source_file.unit.source_cid
-        for node in with_nodes:
+            if not isinstance(node, (With, AsyncWith)):
+                continue
             for item in node.items:
                 expression = item.context_expr
-                target = None
-                if isinstance(expression, Call):
-                    callee = expression.func
-                    if isinstance(callee, Name):
-                        target = imports.get(callee.id)
-                    elif isinstance(callee, Attribute) and isinstance(
-                        callee.value, Name
-                    ):
-                        base = imports.get(callee.value.id)
-                        if base:
-                            target = f"{base}.{callee.attr}"
                 span = expression.line_col_span()
                 coordinate = {
-                    "sourceCid": source_cid,
+                    "sourceCid": source_file.unit.source_cid,
                     "startLine": span.start_line,
                     "startCol": span.start_col,
                     "endLine": span.end_line,
@@ -133,10 +104,10 @@ def _context_manager_demand_rows(root: Path) -> List[Dict[str, Any]]:
                         "schemaVersion": "1",
                         "kind": "context-manager-demand",
                         "useSite": coordinate,
-                        "targetSymbol": target,
+                        "targetSymbol": None,
                         "importSignature": {"parameters": []},
                         "expectedKind": "context-manager-contract",
-                        "gapKind": None if target else "runtime-selected",
+                        "gapKind": "runtime-selected",
                     }
                 )
     return rows

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
@@ -110,7 +110,7 @@ def test_malformed_table_cid_and_unsorted_ambiguity_are_loud():
         decode_resolved_contract_refs(ambiguous)
 
 
-def test_demand_enrollment_uses_import_coordinate_without_sugar_or_target_source(
+def test_demand_enrollment_uses_typed_with_coordinate_without_spelling_authority(
     tmp_path, monkeypatch
 ):
     consumer = tmp_path / "consumer.py"
@@ -131,8 +131,11 @@ def test_demand_enrollment_uses_import_coordinate_without_sugar_or_target_source
     )
     rows = lift_rpc._context_manager_demand_rows(tmp_path)
     assert len(rows) == 1
-    assert rows[0]["targetSymbol"] == "dependency_that_is_not_present.manager"
-    assert rows[0]["gapKind"] is None
+    # This structural pass never infers authority from the alias spelling.
+    # _preconstruction_demand_rows joins the separately authenticated lexical
+    # ImportBinding at this exact coordinate.
+    assert rows[0]["targetSymbol"] is None
+    assert rows[0]["gapKind"] == "runtime-selected"
     assert rows[0]["useSite"]["sourceCid"].startswith("blake3-512:")
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_contract_expression_construction_path.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_contract_expression_construction_path.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.contract_expression import parse_contract_expression
+
+
+def test_renamed_contract_expression_uses_ordinary_call_and_formal_construction():
+    formula = parse_contract_expression(
+        "arbitrary_constructor(arbitrary_formal)", ["arbitrary_formal"]
+    )
+
+    # A renamed, non-vendor callee follows the ordinary CallSiteSugar path.
+    # The old private evaluator emitted an unrelated ctor named only by the
+    # parsed spelling; the sole path emits the native call coordinate.
+    rendered = repr(formula)
+    assert "call:arbitrary_constructor" in rendered
+    assert "arbitrary_formal" in rendered
+    assert "py.truthy" in rendered
+
+
+def test_malformed_contract_expression_stays_loud():
+    with pytest.raises(ValueError, match="empty or invalid contract expression"):
+        parse_contract_expression("arbitrary_formal +", ["arbitrary_formal"])

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/cpython_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/cpython_adapter.py
@@ -420,3 +420,19 @@ class CPythonAstBackend(Backend):
                 backend=self.name, file=unit.filename, reason=str(err)
             ) from err
         return _Handle(unit, tree)
+
+    def expression(self, unit: SourceUnit) -> BackendNode:
+        """Parse one expression through the same backend vocabulary.
+
+        This is the adapter boundary for embedded Python expression surfaces.
+        The caller still materializes the returned handle into the ordinary
+        typed ``Expression`` graph before substitution or construction; raw
+        CPython nodes never cross this method.
+        """
+        try:
+            tree = ast.parse(unit.source, filename=unit.filename, mode="eval")
+        except (SyntaxError, ValueError) as err:
+            raise BackendCouldNotParse(
+                backend=self.name, file=unit.filename, reason=str(err)
+            ) from err
+        return _Handle(unit, tree.body)

--- a/implementations/python/sugar-source-tree/tests/with_resolution_fixture.py
+++ b/implementations/python/sugar-source-tree/tests/with_resolution_fixture.py
@@ -13,7 +13,7 @@ from sugar_lift_py_tests.context_manager_resolution import (
     TreeConstructionContextV1,
     _hash_json,
 )
-from sugar_lift_py_tests.lift_rpc import _context_manager_demand_rows
+from sugar_lift_py_tests.lift_rpc import _preconstruction_demand_rows
 from sugar_source_tree.tree import SourceFile
 
 
@@ -26,7 +26,9 @@ def source_file_with_preconstruction(path):
     shutil.copyfile(path, isolated)
     path = isolated
     resolutions = {}
-    for row in _context_manager_demand_rows(path.parent):
+    for row in _preconstruction_demand_rows(path.parent):
+        if row.get("kind") != "context-manager-demand":
+            continue
         site = SourceFragmentCoordinateV1.decode(row["useSite"])
         preimage = {
             key: row[key]


### PR DESCRIPTION
## Summary

- delete the private raw-AST contract-expression evaluator
- parse embedded expressions only below `CPythonAstBackend`, then materialize a typed `Expression`, substitute, construct its ordinary Sugar, reduce, and project its truth predicate
- make the structural With-demand pass enumerate typed nodes only and leave all import authority to the authenticated preconstruction call-demand join
- remove the file-wide spelling map that had landed in the parallel `lift_rpc` slice

## Measured floor delta

Current `origin/main` at `8a3aa1b22`:

```text
R_construction_side_doors = 9
R_ast_semantic_above_adapter = 9
auditor_errors = 0
```

This branch:

```text
R_construction_side_doors = 7
R_ast_semantic_above_adapter = 7
auditor_errors = 0
```

So this slice's live delta is exactly **-2**. The four `lift_rpc.py` raw-AST findings in the original six-site assignment were independently drained by merged PR #6118 while this branch was in progress; this branch preserves that drain and removes its file-wide spelling-derived authority map. The seven remaining rows are all in `import_binding.py`, outside this slice's ownership.

## Verification

```text
89 passed
377 passed, 5 skipped  (sugar-source-tree, excluding the pinned corpus golden)
CONSTRUCTION-SIDE-DOOR SELF-TEST GREEN
R_construction_invariant_violations = 0
R_self_hashing_as_authority = 0
R_name_spelling_overload_gate = 0
R_second_construction_path = 0
R_non_exhaustive_variant_coverage = 0
R_fabricated_completion_fallback = 0
R_auditor_errors = 0
```

The pinned corpus golden test also fails identically on clean `origin/main` under local CPython 3.14, so it is inherited and unrelated to this slice. No heavy Rust build was run locally.

## Discrimination

- renamed/non-vendor contract callee constructs the ordinary `call:arbitrary_constructor` coordinate with its real formal operand
- malformed embedded expression stays loud
- structural With enrollment carries no target spelling; the authenticated lexical ImportBinding join supplies identity later


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route contract expressions through the Sugar typed construction pipeline
> - Rewrites [`parse_contract_expression`](https://github.com/TSavo/sugar/pull/6122/files#diff-01eba5fd670c4b7bc41f2c59017e5018f857ade4e45e2c6b91d5ef4ccafdf6f5) to use the standard Sugar construction path (substitute → sugar → desugar) instead of a bespoke `ast`-based translator with custom operator maps and per-node translation code.
> - Adds `CPythonAstBackend.expression` in [`cpython_adapter.py`](https://github.com/TSavo/sugar/pull/6122/files#diff-86f6cdc4253cb2663574c3b352f66a7b8d09accf15875cf6d70c7d5516f43f1f) to parse a `SourceUnit` as a single expression via `ast.parse(mode='eval')`, translating parse errors into `BackendCouldNotParse`.
> - Updates `_context_manager_demand_rows` in [`lift_rpc.py`](https://github.com/TSavo/sugar/pull/6122/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) so demand rows set `targetSymbol` to `None` and `gapKind` to `'runtime-selected'`, deferring import authority resolution to a later join.
> - Behavioral Change: `parse_contract_expression` now raises `ValueError` for non-expression nodes, incomplete construction, or missing truth predicates, in addition to the existing parse failure case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a57819b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contract expressions now support embedded Python expression parsing and ordinary call-based construction.
  * Invalid contract expressions now produce clear validation errors.
  * Context-manager demand records use typed use-site coordinates with runtime-selected targets.

* **Bug Fixes**
  * Prevented import aliases or spelling from incorrectly determining context-manager targets.

* **Tests**
  * Added coverage for contract-expression rendering, malformed expressions, and updated context-manager resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->