### PR TITLE
Route verify signatures through typed source tree

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_dialect.py
@@ -31,11 +31,30 @@ refusal.
 
 from __future__ import annotations
 
-import ast
 from dataclasses import dataclass
+from pathlib import Path
+import sys
 from typing import Any
 
-from .source_tables import parsed_tree
+# The verify plugin is also launched directly from this package's ``src``
+# directory.  Put the sibling typed-tree package on that process's import path
+# before loading it; source still enters only through SourceFile below.
+_tree_src = Path(__file__).resolve().parents[3] / "sugar-source-tree" / "src"
+if _tree_src.is_dir() and str(_tree_src) not in sys.path:
+    sys.path.insert(0, str(_tree_src))
+
+from sugar_source_tree.backend import BackendCouldNotParse
+from sugar_source_tree.nodes import (
+    AsyncFunctionDef,
+    ClassDef,
+    Expression,
+    FunctionDef,
+    Name,
+    Node,
+)
+from sugar_source_tree.tree import SourceFile
+
+from .canonical import blake3_512_of
 
 Json = dict[str, Any]
 
@@ -125,29 +144,37 @@ def collect_int_signatures(source: str, module_path: str = "") -> dict[str, _Sor
     lookup by bare leaf name would collide them."""
     out: dict[str, _Sorts] = {}
     try:
-        tree = parsed_tree(source)
-    except SyntaxError:
+        source_file = SourceFile(
+            (
+                source,
+                "<verify-dialect>",
+                blake3_512_of(source.encode("utf-8")),
+            )
+        )
+    except (SyntaxError, BackendCouldNotParse):
         return out
 
-    def visit(node: ast.AST, scope: list[tuple[str, str]]) -> None:
-        for child in ast.iter_child_nodes(node):
-            if isinstance(child, ast.ClassDef):
+    def visit(node: Node, scope: list[tuple[str, str]]) -> None:
+        for _, _, child in node.children():
+            if isinstance(child, ClassDef):
                 visit(child, scope + [("class", child.name)])
-            elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            elif isinstance(child, (FunctionDef, AsyncFunctionDef)):
                 qualname = _qualified_name(scope, child.name)
                 key = f"{module_path}.{qualname}" if module_path else qualname
                 formal_sorts: dict[str, str] = {}
-                for arg in child.args.args:
-                    sort = _sort_for_annotation(arg.annotation)
+                for param in child.params:
+                    if param.param_kind != "positional_or_keyword":
+                        continue
+                    sort = _sort_for_annotation(param.annotation)
                     if sort is not None:
-                        formal_sorts[arg.arg] = sort
+                        formal_sorts[param.name] = sort
                 return_sort = _sort_for_annotation(child.returns)
                 out[key] = _Sorts(formal_sorts=formal_sorts, return_sort=return_sort)
                 visit(child, scope + [("function", child.name)])
             else:
                 visit(child, scope)
 
-    visit(tree, [])
+    visit(source_file.root, [])
     return out
 
 
@@ -164,10 +191,10 @@ def _qualified_name(scope: list[tuple[str, str]], name: str) -> str:
     return ".".join(parts)
 
 
-def _sort_for_annotation(annotation: ast.expr | None) -> str | None:
+def _sort_for_annotation(annotation: Expression | None) -> str | None:
     if annotation is None:
         return None
-    if isinstance(annotation, ast.Name):
+    if isinstance(annotation, Name):
         if annotation.id in _INT_ANNOTATIONS:
             return "Int"
         if annotation.id in _BOOL_ANNOTATIONS:

--- a/implementations/python/sugar-lift-python-source/tests/test_verify_dialect.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_verify_dialect.py
@@ -559,6 +559,20 @@ def test_collect_int_signatures_keys_methods_by_qualified_name_not_bare_leaf():
     assert sorts["B.compute"].formal_sorts == {"y": "Int"}
 
 
+def test_collect_signatures_uses_typed_source_tree_not_raw_parser():
+    import sugar_lift_python_source.verify_dialect as verify_dialect
+
+    assert not hasattr(verify_dialect, "parsed_tree")
+
+    sorts = verify_dialect.collect_int_signatures(
+        "class Renamed:\n"
+        "    def arbitrary(self, value: int) -> str:\n"
+        "        return str(value)\n"
+    )
+    assert sorts["Renamed.arbitrary"].formal_sorts == {"value": "Int"}
+    assert sorts["Renamed.arbitrary"].return_sort == "String"
+
+
 def test_lift_workspace_resolves_nested_functions_sharing_a_leaf_name():
     """End-to-end regression for #3819: two nested `helper` closures (in
     different outer functions) share only their bare leaf name. Under


### PR DESCRIPTION
## Summary

- replace `verify_dialect.collect_int_signatures` raw `ast` traversal with `SourceFile` and typed source-tree nodes
- preserve qualified class/nested-function signatures and the existing positional-or-keyword annotation policy
- keep malformed source loud/empty exactly as before through typed backend parse failure
- add a renamed/non-vendor discrimination twin proving the collector has no `parsed_tree` side door

## Measured floor delta

Current main `bde946684`: `R_construction_side_doors=53`.

This branch: `R_construction_side_doors=52`, comprising `R_foreign_ast_import=11`, `R_ast_semantic_above_adapter=41`, `auditor_errors=0`.

Exact slice delta: **-1**.

## Verification

```text
42 passed (test_verify_dialect.py)
R_construction_invariant_violations = 0
R_self_hashing_as_authority = 0
R_name_spelling_overload_gate = 0
R_second_construction_path = 0
R_non_exhaustive_variant_coverage = 0
R_fabricated_completion_fallback = 0
R_auditor_errors = 0
```

No Rust build was run locally.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route `collect_int_signatures` through typed `sugar_source_tree` instead of raw AST
> - Replaces `ast`-based parsing in `collect_int_signatures` with a `sugar_source_tree.tree.SourceFile`, using typed node types (`ClassDef`, `FunctionDef`, `AsyncFunctionDef`) and a typed param model for traversal.
> - `_sort_for_annotation` now accepts `sugar_source_tree.nodes.Expression` instead of `ast.expr`, with `isinstance` checks updated to `sugar_source_tree.nodes.Name`.
> - Only `positional_or_keyword` parameters are recorded as sorts; the function returns an empty dict on `SyntaxError` or `BackendCouldNotParse`.
> - At import time, the module conditionally prepends the sibling `sugar-source-tree/src` directory to `sys.path` when present.
> - A new test in [test_verify_dialect.py](https://github.com/TSavo/sugar/pull/6123/files#diff-50c0d73f9afbc4bd0ec43606837bc110ffe83de8865e44ebe8272849beb4cc79) asserts that `parsed_tree` is absent and that `collect_int_signatures` extracts `Int`/`String` sorts correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd78e0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->