### PR TITLE
feat: authenticated object field flow through temporal bindings

### DIFF
--- a/docs/audits/object-field-flow-acceptance-requirements.md
+++ b/docs/audits/object-field-flow-acceptance-requirements.md
@@ -74,6 +74,11 @@ generic fallback value.
   distinct identities and do not collide.
 - `authenticated-alias`: a plain assignment alias shares the authenticated
   identity, so a store through one name is visible through the other.
+- `version-flow`: a read before a later alias mutation remains the earlier
+  immutable value while a read after the mutation observes the new version,
+  including through a second authenticated alias.
+- `distinct-version-flow`: alternating stores through aliases of two distinct
+  construction occurrences never cross-link their version chains.
 - `symbolic-receiver`: no identity can be minted from a formal/symbolic
   receiver; the flow remains typed-loud.
 - `opaque-mutation`: a call without an authenticated frame contract may mutate

--- a/implementations/python/sugar-lift-py-tests/scripts/measure_binding_assignment_frontier.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/measure_binding_assignment_frontier.py
@@ -18,6 +18,7 @@ from collections import Counter, defaultdict
 from pathlib import Path
 
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_source_tree.backend import BackendCouldNotParse, materialize
 from sugar_source_tree.cpython_adapter import _Handle
 from sugar_source_tree.nodes import SourceUnit
@@ -80,10 +81,66 @@ def _panic_key(panic: BaseException) -> str:
     return f"{owner}|{observed}|{requested}"
 
 
-def measure(root: Path, *, direct_only: bool = False) -> dict[str, object]:
+def _plain_class_names(module: ast.Module) -> frozenset[str]:
+    forbidden = {
+        "__new__", "__getattr__", "__getattribute__", "__setattr__",
+        "__delattr__", "__getitem__", "__setitem__", "__delitem__",
+    }
+    return frozenset(
+        node.name
+        for node in module.body
+        if isinstance(node, ast.ClassDef)
+        and not node.bases
+        and not node.keywords
+        and not node.decorator_list
+        and all(isinstance(member, (ast.Pass, ast.FunctionDef)) for member in node.body)
+        and all(
+            not isinstance(member, ast.FunctionDef)
+            or (member.name not in forbidden and not member.decorator_list)
+            for member in node.body
+        )
+    )
+
+
+def _has_object_field_candidate(
+    function: ast.AST, plain_class_names: frozenset[str]
+) -> bool:
+    """Structural measurement label, never construction authority."""
+    constructed_names = {
+        target.id
+        for node in ast.walk(function)
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and (
+            isinstance(node.value, (ast.Dict, ast.List))
+            or (
+                isinstance(node.value, ast.Call)
+                and isinstance(node.value.func, ast.Name)
+                and node.value.func.id in plain_class_names
+            )
+        )
+        for target in node.targets
+    }
+    return any(
+        isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], (ast.Attribute, ast.Subscript))
+        and isinstance(node.targets[0].value, ast.Name)
+        and node.targets[0].value.id in constructed_names
+        for node in ast.walk(function)
+    )
+
+
+def measure(
+    root: Path, *, direct_only: bool = False, object_field_only: bool = False
+) -> dict[str, object]:
     counts: Counter[str] = Counter()
     direct: dict[str, Counter[str]] = defaultdict(Counter)
     enclosing: dict[str, Counter[str]] = defaultdict(Counter)
+    enclosing_functions: Counter[str] = Counter()
+    object_field_enclosing: Counter[str] = Counter()
+    object_field_rows: list[dict[str, object]] = []
     roots: Counter[str] = Counter()
 
     for path in sorted(root.rglob("*.py")):
@@ -93,12 +150,13 @@ def measure(root: Path, *, direct_only: bool = False) -> dict[str, object]:
         try:
             source, filename, source_cid = path_source(path)
             parsed = ast.parse(source, filename=str(path))
+            plain_class_names = _plain_class_names(parsed)
             native_assignments = [node for node in ast.walk(parsed) if isinstance(node, ASSIGNMENT)]
             if not native_assignments:
                 counts["files_without_assignment"] += 1
                 continue
             unit = SourceUnit(filename=filename, source=source, source_cid=source_cid)
-            for native in native_assignments:
+            for native in (() if object_field_only else native_assignments):
                 shape = _shape(native)
                 direct[shape]["total"] += 1
                 node = materialize(unit, _Handle(unit, native))
@@ -113,6 +171,9 @@ def measure(root: Path, *, direct_only: bool = False) -> dict[str, object]:
                 except SourceTreePanic as panic:
                     direct[shape]["other_typed_loud"] += 1
                     roots[_panic_key(panic)] += 1
+                except ConstructionPanic as panic:
+                    direct[shape]["construction_panic"] += 1
+                    roots[_panic_key(panic)] += 1
                 else:
                     direct[shape]["built"] += 1
 
@@ -120,22 +181,74 @@ def measure(root: Path, *, direct_only: bool = False) -> dict[str, object]:
                 node for node in ast.walk(parsed)
                 if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
                 and any(isinstance(child, ASSIGNMENT) for child in ast.walk(node))
+                and (
+                    not object_field_only
+                    or _has_object_field_candidate(node, plain_class_names)
+                )
             ]
             for native_function in functions:
+                enclosing_functions["total"] += 1
+                object_field_candidate = _has_object_field_candidate(
+                    native_function, plain_class_names
+                )
+                if object_field_candidate:
+                    object_field_enclosing["total"] += 1
+                row = {
+                    "path": str(path.relative_to(root)),
+                    "line": native_function.lineno,
+                    "function": native_function.name,
+                }
                 shapes = sorted({_shape(node) for node in ast.walk(native_function) if isinstance(node, ASSIGNMENT)})
                 function = materialize(unit, _Handle(unit, native_function))
                 try:
                     function.sugar()
                 except SourceTreePanic as panic:
+                    enclosing_functions["typed_loud"] += 1
+                    if object_field_candidate:
+                        object_field_enclosing["typed_loud"] += 1
+                        object_field_rows.append(
+                            {**row, "status": "typed_loud", "error": str(panic)}
+                        )
                     roots[_panic_key(panic)] += 1
                     for shape in shapes:
                         enclosing[shape]["loud"] += 1
                         enclosing[shape][f"root:{getattr(panic, 'owner', type(panic).__name__)}"] += 1
+                except ConstructionPanic as panic:
+                    enclosing_functions["construction_panic"] += 1
+                    if object_field_candidate:
+                        object_field_enclosing["construction_panic"] += 1
+                        object_field_rows.append(
+                            {
+                                **row,
+                                "status": "construction_panic",
+                                "error": str(panic),
+                            }
+                        )
+                    roots[_panic_key(panic)] += 1
+                    for shape in shapes:
+                        enclosing[shape]["construction_panic"] += 1
+                        enclosing[shape][
+                            f"root:{getattr(panic, 'owner', type(panic).__name__)}"
+                        ] += 1
                 except Exception as panic:
+                    enclosing_functions["non_source_failure"] += 1
+                    if object_field_candidate:
+                        object_field_enclosing["non_source_failure"] += 1
+                        object_field_rows.append(
+                            {
+                                **row,
+                                "status": "non_source_failure",
+                                "error": f"{type(panic).__name__}: {panic}",
+                            }
+                        )
                     for shape in shapes:
                         enclosing[shape]["non_source_failure"] += 1
                         enclosing[shape][f"root:{type(panic).__name__}"] += 1
                 else:
+                    enclosing_functions["built"] += 1
+                    if object_field_candidate:
+                        object_field_enclosing["built"] += 1
+                        object_field_rows.append({**row, "status": "built"})
                     for shape in shapes:
                         enclosing[shape]["built"] += 1
             counts["files_completed"] += 1
@@ -151,6 +264,9 @@ def measure(root: Path, *, direct_only: bool = False) -> dict[str, object]:
         "counts": dict(sorted(counts.items())),
         "direct_by_shape": {key: dict(sorted(value.items())) for key, value in sorted(direct.items())},
         "enclosing_by_shape": {key: dict(sorted(value.items())) for key, value in sorted(enclosing.items())},
+        "enclosing_functions": dict(sorted(enclosing_functions.items())),
+        "object_field_enclosing": dict(sorted(object_field_enclosing.items())),
+        "object_field_rows": object_field_rows,
         "root_panics": dict(sorted(roots.items(), key=lambda item: (-item[1], item[0]))),
     }
 
@@ -159,10 +275,21 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--root", type=Path)
     parser.add_argument("--direct-only", action="store_true")
+    parser.add_argument("--object-field-only", action="store_true")
     args = parser.parse_args()
     logging.disable(logging.CRITICAL)
     root = (args.root or _installed_package_root("pandas")).resolve()
-    print(json.dumps(measure(root, direct_only=args.direct_only), indent=2, sort_keys=True))
+    print(
+        json.dumps(
+            measure(
+                root,
+                direct_only=args.direct_only,
+                object_field_only=args.object_field_only,
+            ),
+            indent=2,
+            sort_keys=True,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/place_assign_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/place_assign_value.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class PlaceAssignValue(FloorValue):
+    receiver: FloorValue
+    selector_kind: str
+    selector: object
+    value: FloorValue
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        receiver = self.receiver.to_term(owner=owner)
+        if self.selector_kind == "attribute":
+            target = ctor(
+                "python:attribute",
+                [receiver, str_const(self.selector)],
+            )
+        elif self.selector_kind == "subscript":
+            target = ctor(
+                "python:subscript",
+                [receiver, self.selector.to_term(owner=owner)],
+            )
+        else:
+            raise ValueError(f"unknown place selector kind {self.selector_kind!r}")
+        return ctor(
+            "python:assign",
+            [target, self.value.to_term(owner=owner)],
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructed_object_place_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructed_object_place_sugar.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class ConstructedObjectPlaceSugar(Sugar):
+    value: object = field(compare=False)
+    testimony: object
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="FloorValue",
+            reason="projects one already-constructed value from authenticated testimony",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        from sugar_lift_py_tests.ir import _term_content_cid
+        from sugar_source_tree.binding_provenance import BindingProvenanceGap
+
+        observed = _term_content_cid(
+            self.value.to_term(owner="ConstructedObjectPlaceSugar")
+        )
+        if observed != self.testimony.semantic_value_cid:
+            raise BindingProvenanceGap("constructed object projection mismatch")
+        return Complete(self.value)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/place_assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/place_assign_sugar.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class PlaceAssignSugar(Sugar):
+    receiver: Sugar
+    selector_kind: str
+    selector: str | Sugar
+    value: Sugar
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="PlaceAssignValue",
+            reason="authenticated place store mirrors the Python reference assignment",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.place_assign_value import PlaceAssignValue
+
+        def with_receiver(receiver):
+            def with_value(value):
+                if self.selector_kind == "attribute":
+                    return Complete(
+                        PlaceAssignValue(
+                            receiver, "attribute", self.selector, value
+                        )
+                    )
+                if self.selector_kind != "subscript" or not isinstance(
+                    self.selector, Sugar
+                ):
+                    raise ValueError("typed place selector mismatch")
+                return self.selector.desugar(ctx).and_then(
+                    lambda selector: Complete(
+                        PlaceAssignValue(
+                            receiver, "subscript", selector, value
+                        )
+                    )
+                )
+
+            return self.value.desugar(ctx).and_then(with_value)
+
+        return self.receiver.desugar(ctx).and_then(with_receiver)

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/distinct_version_flow.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/distinct_version_flow.py
@@ -1,0 +1,72 @@
+class Parcel:
+    pass
+
+
+def truthful():
+    left = Parcel()
+    right = Parcel()
+    left_alias = left
+    right_alias = right
+    left.payload = 2
+    right.payload = 5
+    left_before = left_alias.payload
+    right_before = right_alias.payload
+    left_alias.payload = 11
+    right_alias.payload = 17
+    assert (left_before, right_before, left.payload, right.payload) == (2, 5, 11, 17)
+
+
+def lying():
+    left = Parcel()
+    right = Parcel()
+    left_alias = left
+    right_alias = right
+    left.payload = 2
+    right.payload = 5
+    left_before = left_alias.payload
+    right_before = right_alias.payload
+    left_alias.payload = 11
+    right_alias.payload = 17
+    assert (left_before, right_before, left.payload, right.payload) == (5, 2, 17, 11)
+
+
+class Capsule:
+    pass
+
+
+def renamed_truthful():
+    first = Capsule()
+    second = Capsule()
+    first_echo = first
+    second_echo = second
+    first.marker = 2
+    second.marker = 5
+    first_earlier = first_echo.marker
+    second_earlier = second_echo.marker
+    first_echo.marker = 11
+    second_echo.marker = 17
+    assert (first_earlier, second_earlier, first.marker, second.marker) == (
+        2,
+        5,
+        11,
+        17,
+    )
+
+
+def renamed_lying():
+    first = Capsule()
+    second = Capsule()
+    first_echo = first
+    second_echo = second
+    first.marker = 2
+    second.marker = 5
+    first_earlier = first_echo.marker
+    second_earlier = second_echo.marker
+    first_echo.marker = 11
+    second_echo.marker = 17
+    assert (first_earlier, second_earlier, first.marker, second.marker) == (
+        5,
+        2,
+        17,
+        11,
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/subscript_store_read.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/subscript_store_read.py
@@ -1,0 +1,22 @@
+def truthful():
+    parcel = {}
+    parcel[2] = 7
+    assert parcel[2] == 7
+
+
+def lying():
+    parcel = {}
+    parcel[2] = 7
+    assert parcel[2] == 8
+
+
+def renamed_truthful():
+    capsule = {}
+    capsule[2] = 7
+    assert capsule[2] == 7
+
+
+def renamed_lying():
+    capsule = {}
+    capsule[2] = 7
+    assert capsule[2] == 8

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/verdict_matrix.json
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/verdict_matrix.json
@@ -29,6 +29,24 @@
       "requires": ["authenticated-alias-equivalence", "single-temporal-binding-model"]
     },
     {
+      "id": "version-flow",
+      "file": "version_flow.py",
+      "canonical": {"truthful": "truthful", "lying": "lying"},
+      "renamed": {"truthful": "renamed_truthful", "lying": "renamed_lying"},
+      "current": "typed-loud",
+      "target": {"truthful": "sat", "lying": "unsat"},
+      "requires": ["immutable-field-version-chain", "authenticated-alias-equivalence", "read-snapshot-stability"]
+    },
+    {
+      "id": "distinct-version-flow",
+      "file": "distinct_version_flow.py",
+      "canonical": {"truthful": "truthful", "lying": "lying"},
+      "renamed": {"truthful": "renamed_truthful", "lying": "renamed_lying"},
+      "current": "typed-loud",
+      "target": {"truthful": "sat", "lying": "unsat"},
+      "requires": ["construction-occurrence-discrimination", "immutable-field-version-chain", "no-cross-object-version-collision"]
+    },
+    {
       "id": "symbolic-receiver",
       "file": "symbolic_receiver.py",
       "canonical": "read_after_store",

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/verdict_matrix.json
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/verdict_matrix.json
@@ -47,6 +47,15 @@
       "requires": ["construction-occurrence-discrimination", "immutable-field-version-chain", "no-cross-object-version-collision"]
     },
     {
+      "id": "subscript-store-read",
+      "file": "subscript_store_read.py",
+      "canonical": {"truthful": "truthful", "lying": "lying"},
+      "renamed": {"truthful": "renamed_truthful", "lying": "renamed_lying"},
+      "current": "typed-loud",
+      "target": {"truthful": "sat", "lying": "unsat"},
+      "requires": ["typed-subscript-selector", "immutable-field-version-chain", "single-temporal-binding-model"]
+    },
+    {
       "id": "symbolic-receiver",
       "file": "symbolic_receiver.py",
       "canonical": "read_after_store",

--- a/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/version_flow.py
+++ b/implementations/python/sugar-lift-py-tests/tests/fixtures/object_field_flow/version_flow.py
@@ -1,0 +1,50 @@
+class Parcel:
+    pass
+
+
+def truthful():
+    original = Parcel()
+    original.payload = 3
+    before = original.payload
+    alias = original
+    second_alias = alias
+    alias.payload = 8
+    after = second_alias.payload
+    assert (before, after) == (3, 8)
+
+
+def lying():
+    original = Parcel()
+    original.payload = 3
+    before = original.payload
+    alias = original
+    second_alias = alias
+    alias.payload = 8
+    after = second_alias.payload
+    assert (before, after) == (8, 3)
+
+
+class Capsule:
+    pass
+
+
+def renamed_truthful():
+    source = Capsule()
+    source.marker = 3
+    earlier = source.marker
+    echo = source
+    echo_again = echo
+    echo.marker = 8
+    later = echo_again.marker
+    assert (earlier, later) == (3, 8)
+
+
+def renamed_lying():
+    source = Capsule()
+    source.marker = 3
+    earlier = source.marker
+    echo = source
+    echo_again = echo
+    echo.marker = 8
+    later = echo_again.marker
+    assert (earlier, later) == (8, 3)

--- a/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
@@ -13,6 +13,11 @@ from sugar_lift_py_tests.effect.runtime_effect import RuntimeEffect
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.panic import SourceTreePanic
+from sugar_source_tree.binding_provenance import BindingProvenanceGap
+from sugar_source_tree.binding_state import SubstitutionTraceBuilderV1
+from sugar_source_tree.nodes import _SUBSTITUTION_TRACE_BUILDER
+from sugar_source_tree.backend import Child, Children, Leaf, materialize
+from sugar_source_tree.shadow import ShadowNode, _handle_of
 from sugar_source_tree.tree import SourceFile
 
 
@@ -24,6 +29,7 @@ POSITIVE_IDS = {
     "authenticated-alias",
     "version-flow",
     "distinct-version-flow",
+    "subscript-store-read",
 }
 LOUD_IDS = {"symbolic-receiver", "opaque-mutation", "opaque-alias"}
 FORBIDDEN_MECHANISM_CALLS = {"getattr", "setattr", "hasattr", "id", "type", "isinstance"}
@@ -95,7 +101,7 @@ def test_verdict_matrix_is_closed_and_names_every_required_invariant():
     assert MATRIX["schema"] == "object-field-flow-acceptance-v1"
     cases = MATRIX["cases"]
     assert {case["id"] for case in cases} == POSITIVE_IDS | LOUD_IDS
-    assert len(cases) == 8
+    assert len(cases) == 9
     requirements = {item for case in cases for item in case["requires"]}
     assert {
         "content-addressed-object-identity",
@@ -105,6 +111,7 @@ def test_verdict_matrix_is_closed_and_names_every_required_invariant():
         "immutable-field-version-chain",
         "read-snapshot-stability",
         "no-cross-object-version-collision",
+        "typed-subscript-selector",
         "single-temporal-binding-model",
         "no-symbolic-receiver-identity",
         "opaque-call-invalidates-field-knowledge",
@@ -162,10 +169,6 @@ def test_fixtures_are_renamed_structural_twins_without_name_or_vendor_authority(
     [case for case in MATRIX["cases"] if case["id"] in POSITIVE_IDS],
     ids=lambda case: case["id"],
 )
-@pytest.mark.xfail(
-    strict=True,
-    reason="acceptance red: construction-authoritative object/place identity is not implemented",
-)
 def test_positive_object_field_flow_acceptance_is_not_typed_loud(case):
     path = FIXTURES / case["file"]
     for names in (case["canonical"], case["renamed"]):
@@ -184,3 +187,269 @@ def test_unauthenticated_object_field_flow_stays_typed_loud(case):
     for function_name in (case["canonical"], case["renamed"]):
         result = _outcome_or_panic(path, function_name)
         assert _is_typed_loud(result), result
+
+
+def _object_states(path: Path, function_name: str):
+    function = _functions(path)[function_name]
+    owner = function.fragment.seal().cid
+    substituted = function.substitute(
+        {_SUBSTITUTION_TRACE_BUILDER: SubstitutionTraceBuilderV1(owner)}
+    )
+    return [
+        node for node in substituted.walk() if node.kind == "ObjectPlaceStateV1"
+    ]
+
+
+def test_object_and_field_versions_reresolve_and_distinct_objects_do_not_collide():
+    first = _object_states(FIXTURES / "version_flow.py", "truthful")
+    second = _object_states(FIXTURES / "version_flow.py", "truthful")
+    assert first and second
+    assert first[-1].object_identity_cid == second[-1].object_identity_cid
+    assert first[-1].version_cids == second[-1].version_cids
+    first[-1].validate_identity()
+    second[-1].validate_identity()
+
+    distinct = _object_states(FIXTURES / "distinct_version_flow.py", "truthful")
+    identities = {state.object_identity_cid for state in distinct}
+    coordinates = {state.owner_coordinate.cid for state in distinct}
+    assert len(identities) == 2
+    assert len(coordinates) == 2
+
+
+def test_a_type_name_does_not_admit_a_lying_object_identity():
+    state = _object_states(FIXTURES / "store_then_read.py", "truthful")[0]
+    forged = _forge_state(state, object_identity_cid="blake3-512:stale")
+    with pytest.raises(BindingProvenanceGap, match="object place identity CID mismatch"):
+        forged.validate_identity()
+
+
+def test_unmatched_field_version_is_loud_before_projection():
+    state = next(
+        state
+        for state in _object_states(FIXTURES / "store_then_read.py", "truthful")
+        if state.selectors
+    )
+    forged = _forge_state(
+        state,
+        version_cids=("blake3-512:stale", *state.version_cids[1:]),
+    )
+    with pytest.raises(BindingProvenanceGap, match="field version CID mismatch"):
+        forged.field(state.selectors[0])
+
+
+def test_branch_join_projects_both_authenticated_field_faces(tmp_path):
+    path = tmp_path / "both_faces.py"
+    path.write_text(
+        "class Vessel:\n    pass\n\n"
+        "def both_faces():\n"
+        "    flag = True\n"
+        "    item = Vessel()\n"
+        "    if flag:\n"
+        "        item.payload = 3\n"
+        "    else:\n"
+        "        item.payload = 8\n"
+        "    return item.payload\n"
+    )
+    function = _functions(path)["both_faces"]
+    substituted = function.substitute(
+        {
+            _SUBSTITUTION_TRACE_BUILDER: SubstitutionTraceBuilderV1(
+                function.fragment.seal().cid
+            )
+        }
+    )
+    returned = next(node for node in substituted.walk() if node.kind == "Return")
+    assert returned.value.kind == "IfExp"
+    assert returned.value.body.kind == "ConstructedValueProjectionV1"
+    assert returned.value.body.base.kind == "Constant"
+    assert returned.value.orelse.kind == "ConstructedValueProjectionV1"
+    assert returned.value.orelse.base.kind == "Constant"
+
+
+def test_branch_join_with_one_unproved_field_face_stays_loud(tmp_path):
+    path = tmp_path / "missing_face.py"
+    path.write_text(
+        "class Vessel:\n    pass\n\n"
+        "def missing_face():\n"
+        "    flag = True\n"
+        "    item = Vessel()\n"
+        "    if flag:\n"
+        "        item.payload = 3\n"
+        "    return item.payload\n"
+    )
+    function = _functions(path)["missing_face"]
+    substituted = function.substitute(
+        {
+            _SUBSTITUTION_TRACE_BUILDER: SubstitutionTraceBuilderV1(
+                function.fragment.seal().cid
+            )
+        }
+    )
+    returned = next(node for node in substituted.walk() if node.kind == "Return")
+    assert returned.value.kind == "Attribute"
+
+
+def test_authenticated_subscript_store_mirrors_reference_assign_target_shape():
+    from sugar_lift_py_tests.floor.place_assign_value import PlaceAssignValue
+
+    outcome = _functions(FIXTURES / "subscript_store_read.py")["truthful"].sugar().desugar()
+    statements = outcome.value.record.statements
+    store = next(item for item in statements if isinstance(item, PlaceAssignValue))
+    term = store.to_term(owner="subscript-reference-shape")
+    assert term.name == "python:assign"
+    assert term.args[0].name == "python:subscript"
+    assert len(term.args[0].args) == 2
+
+
+def test_unknown_place_selector_kind_is_typed_loud():
+    from sugar_lift_py_tests.floor.place_assign_value import PlaceAssignValue
+    from sugar_lift_py_tests.floor import TermValue
+
+    malformed = PlaceAssignValue(TermValue(1), "future-selector", 0, TermValue(2))
+    with pytest.raises(ValueError, match="unknown place selector kind"):
+        malformed.to_term(owner="lying-selector")
+
+
+@pytest.mark.parametrize(
+    "member",
+    [
+        "def __setattr__(self, name, value):\n        pass",
+        "@property\n    def payload(self):\n        return 1",
+    ],
+    ids=("dynamic-setattr", "descriptor"),
+)
+def test_custom_dispatch_never_acquires_plain_place_authority(tmp_path, member):
+    path = tmp_path / "dispatch.py"
+    path.write_text(
+        "class Vessel:\n    "
+        + member
+        + "\n\ndef boundary():\n    item = Vessel()\n"
+        "    item.payload = 7\n    return item.payload\n"
+    )
+    assert _is_typed_loud(_outcome_or_panic(path, "boundary"))
+
+
+def test_custom_setitem_receiver_stays_loud(tmp_path):
+    path = tmp_path / "setitem.py"
+    path.write_text(
+        "class Vessel:\n"
+        "    def __setitem__(self, key, value):\n"
+        "        pass\n\n"
+        "def boundary():\n"
+        "    item = Vessel()\n"
+        "    item[0] = 7\n"
+        "    return item[0]\n"
+    )
+    assert _is_typed_loud(_outcome_or_panic(path, "boundary"))
+
+
+def test_plain_object_without_setitem_stays_loud(tmp_path):
+    path = tmp_path / "plain_object_subscript.py"
+    path.write_text(
+        "class Vessel:\n    pass\n\n"
+        "def boundary():\n"
+        "    item = Vessel()\n"
+        "    item[0] = 7\n"
+        "    return item[0]\n"
+    )
+    assert _is_typed_loud(_outcome_or_panic(path, "boundary"))
+
+
+def test_out_of_range_list_store_stays_loud(tmp_path):
+    path = tmp_path / "out_of_range_list.py"
+    path.write_text(
+        "def boundary():\n"
+        "    item = []\n"
+        "    item[0] = 7\n"
+        "    return item[0]\n"
+    )
+    assert _is_typed_loud(_outcome_or_panic(path, "boundary"))
+
+
+def test_object_occurrence_constructs_once_then_projects_testimony(monkeypatch):
+    from sugar_source_tree.nodes import Call
+
+    original = Call._construct_sugar
+    constructions = 0
+
+    def counted(self):
+        nonlocal constructions
+        constructions += 1
+        return original(self)
+
+    monkeypatch.setattr(Call, "_construct_sugar", counted)
+    outcome = _outcome_or_panic(FIXTURES / "store_then_read.py", "truthful")
+    assert not _is_typed_loud(outcome)
+    assert constructions == 1
+
+
+def test_stored_expression_constructs_once_then_projects_testimony(
+    tmp_path, monkeypatch
+):
+    from sugar_source_tree.nodes import BinOp
+
+    path = tmp_path / "stored_call_once.py"
+    path.write_text(
+        "class Vessel:\n    pass\n\n"
+        "def boundary():\n"
+        "    item = Vessel()\n"
+        "    item.payload = 3 + 4\n"
+        "    return item.payload\n"
+    )
+    original = BinOp._construct_sugar
+    constructions = 0
+
+    def counted(self):
+        nonlocal constructions
+        constructions += 1
+        return original(self)
+
+    monkeypatch.setattr(BinOp, "_construct_sugar", counted)
+    outcome = _outcome_or_panic(path, "boundary")
+    assert not _is_typed_loud(outcome)
+    assert constructions == 1
+
+
+def _forge_state(state, **overrides):
+    values = {
+        "owner_coordinate": state.owner_coordinate,
+        "class_definition_cid": state.class_definition_cid,
+        "construction_testimony": state.construction_testimony,
+        "constructed_value": state.constructed_value,
+        "object_identity_cid": state.object_identity_cid,
+        "base": state.base,
+        "selectors": state.selectors,
+        "values": state.values,
+        "value_testimonies": state.value_testimonies,
+        "version_cids": state.version_cids,
+        "prior_version_cids": state.prior_version_cids,
+        "store_occurrence_cids": state.store_occurrence_cids,
+        "invalidated_by_opaque_call": state.invalidated_by_opaque_call,
+    }
+    values.update(overrides)
+    return materialize(
+        state.unit,
+        ShadowNode(
+            "ObjectPlaceStateV1",
+            state.span,
+            (
+                ("owner_coordinate", Leaf(values["owner_coordinate"])),
+                ("class_definition_cid", Leaf(values["class_definition_cid"])),
+                ("construction_testimony", Leaf(values["construction_testimony"])),
+                ("constructed_value", Leaf(values["constructed_value"])),
+                ("object_identity_cid", Leaf(values["object_identity_cid"])),
+                ("base", Child(_handle_of(values["base"]))),
+                ("selectors", Leaf(values["selectors"])),
+                (
+                    "values",
+                    Children(tuple(_handle_of(item) for item in values["values"])),
+                ),
+                ("value_testimonies", Leaf(values["value_testimonies"])),
+                ("version_cids", Leaf(values["version_cids"])),
+                ("prior_version_cids", Leaf(values["prior_version_cids"])),
+                ("store_occurrence_cids", Leaf(values["store_occurrence_cids"])),
+                ("invalidated_by_opaque_call", Leaf(values["invalidated_by_opaque_call"])),
+            ),
+        ),
+        state.reporter,
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_object_field_flow_acceptance.py
@@ -18,7 +18,13 @@ from sugar_source_tree.tree import SourceFile
 
 FIXTURES = Path(__file__).parent / "fixtures" / "object_field_flow"
 MATRIX = json.loads((FIXTURES / "verdict_matrix.json").read_text())
-POSITIVE_IDS = {"store-then-read", "distinct-objects", "authenticated-alias"}
+POSITIVE_IDS = {
+    "store-then-read",
+    "distinct-objects",
+    "authenticated-alias",
+    "version-flow",
+    "distinct-version-flow",
+}
 LOUD_IDS = {"symbolic-receiver", "opaque-mutation", "opaque-alias"}
 FORBIDDEN_MECHANISM_CALLS = {"getattr", "setattr", "hasattr", "id", "type", "isinstance"}
 
@@ -89,13 +95,16 @@ def test_verdict_matrix_is_closed_and_names_every_required_invariant():
     assert MATRIX["schema"] == "object-field-flow-acceptance-v1"
     cases = MATRIX["cases"]
     assert {case["id"] for case in cases} == POSITIVE_IDS | LOUD_IDS
-    assert len(cases) == 6
+    assert len(cases) == 8
     requirements = {item for case in cases for item in case["requires"]}
     assert {
         "content-addressed-object-identity",
         "construction-occurrence-discrimination",
         "no-spelling-identity",
         "authenticated-alias-equivalence",
+        "immutable-field-version-chain",
+        "read-snapshot-stability",
+        "no-cross-object-version-collision",
         "single-temporal-binding-model",
         "no-symbolic-receiver-identity",
         "opaque-call-invalidates-field-knowledge",

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -33,7 +33,7 @@ the backend contract stays read-only.
 from __future__ import annotations
 
 import symtable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, ClassVar, Iterator, Optional, Tuple
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -152,6 +152,8 @@ class SourceUnit:
     # Bound by SourceFile after the backend materializes the Module — the sole
     # structural authority for module-body identity. Never a second parse.
     typed_module: object = field(init=False, default=None)
+    module_direct_bindings: object = field(init=False, default=None)
+    function_nodes: Tuple[object, ...] = field(init=False, default=())
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "line_table", LineTable(self.source))
@@ -168,10 +170,30 @@ class SourceUnit:
             ),
         )
         object.__setattr__(self, "typed_module", None)
+        object.__setattr__(self, "module_direct_bindings", None)
+        object.__setattr__(self, "function_nodes", ())
 
     def bind_typed_module(self, module: "Module") -> None:
         """Attach the already-materialized Module root (SourceFile only)."""
         object.__setattr__(self, "typed_module", module)
+        bindings = {}
+        for statement in module.body:
+            for name in self._module_statement_bound_names(statement):
+                bindings.setdefault(name, []).append(statement)
+        object.__setattr__(
+            self,
+            "module_direct_bindings",
+            {name: tuple(items) for name, items in bindings.items()},
+        )
+        object.__setattr__(
+            self,
+            "function_nodes",
+            tuple(
+                node
+                for node in module.walk()
+                if isinstance(node, (FunctionDef, AsyncFunctionDef))
+            ),
+        )
 
     def loop_target_coordinate_for_loop(self, owner: "Node"):
         from sugar_lift_py_tests.context_manager_resolution import (
@@ -251,6 +273,107 @@ class SourceUnit:
             ):
                 return True
         return False
+
+    def plain_source_class_for_call(self, call: "Call") -> "ClassDef | None":
+        """Resolve one descriptor-free source class at an exact call use-site.
+
+        Spelling is only the lexical lookup key.  Authority is the unique typed
+        module binding plus the use-site's CPython scope classification.  A
+        local/free/nonlocal shadow, competing module binding, custom allocation,
+        descriptor, or dynamic attribute hook keeps the call unauthenticated.
+        """
+        if not isinstance(call.func, Name):
+            return None
+        # A directly materialized Call/Assign still owns its ordinary sugar.
+        # Absence of the SourceFile-bound module means only that class identity
+        # cannot be authenticated here; it must not revoke the existing call
+        # construction path.
+        module = self.typed_module
+        if module is None:
+            return None
+        span = call.line_col_span()
+        containing = []
+        for candidate in self.function_nodes:
+            owner_span = candidate.line_col_span()
+            if (
+                (owner_span.start_line, owner_span.start_col)
+                <= (span.start_line, span.start_col)
+                <= (owner_span.end_line, owner_span.end_col)
+            ):
+                containing.append(candidate)
+        if containing:
+            owner = max(
+                containing, key=lambda item: item.line_col_span().start_line
+            )
+            table = self.function_symtable(
+                owner.name, owner.line_col_span().start_line
+            )
+            try:
+                symbol = table.lookup(call.func.id)
+            except KeyError:
+                symbol = None
+            if symbol is not None and (
+                symbol.is_parameter()
+                or symbol.is_local()
+                or symbol.is_free()
+                or symbol.is_nonlocal()
+            ):
+                return None
+
+        bindings = (self.module_direct_bindings or {}).get(call.func.id, ())
+        if len(bindings) != 1 or not isinstance(bindings[0], ClassDef):
+            return None
+        definition = bindings[0]
+        forbidden_methods = {
+            "__new__",
+            "__getattr__",
+            "__getattribute__",
+            "__setattr__",
+            "__delattr__",
+            "__getitem__",
+            "__setitem__",
+            "__delitem__",
+        }
+        if (
+            definition.bases
+            or definition.keywords
+            or definition.decorators
+            or definition.type_params
+            or any(
+                not isinstance(member, (Pass, FunctionDef))
+                for member in definition.body
+            )
+            or any(
+                isinstance(member, FunctionDef)
+                and (member.name in forbidden_methods or member.decorators)
+                for member in definition.body
+            )
+        ):
+            return None
+        return definition
+
+    @staticmethod
+    def _module_statement_bound_names(statement: "Node") -> set[str]:
+        if isinstance(statement, (FunctionDef, AsyncFunctionDef, ClassDef)):
+            return {statement.name}
+        if isinstance(statement, (Assign, AnnAssign, AugAssign)):
+            targets = (
+                statement.targets
+                if isinstance(statement, Assign)
+                else (statement.target,)
+            )
+            return {
+                node.id
+                for target in targets
+                for node in target.walk()
+                if isinstance(node, Name)
+            }
+        if statement.kind in ("Import", "ImportFrom"):
+            return {
+                alias.asname or alias.name.split(".", 1)[0]
+                for alias in statement.names
+            }
+        return set()
 
     def exception_type_identity(self, node: "Name"):
         """Return the authenticated exception-class coordinate reaching ``node``.
@@ -656,6 +779,41 @@ class Node(Typed):
         so its value is already rewritten against the scope that stood before it."""
         return None
 
+    def refine_binding_entries(
+        self, binding: BindingMap, scope: BindingMap
+    ) -> BindingMap:
+        """Refine freshly minted entries without creating another binding map."""
+        del scope
+        return binding
+
+    def post_binding_statement(self, binding: BindingMap) -> "Node":
+        """Project a store's post-version into its substituted target."""
+        del binding
+        return self
+
+    def post_binding_scope(self, scope: BindingMap) -> BindingMap:
+        """Apply statement-owned invalidations to the one temporal map."""
+        exposed = {
+            state.object_identity_cid
+            for call in self.walk()
+            if isinstance(call, Call)
+            for state in call.exposed_object_places()
+        }
+        if not exposed:
+            return scope
+        replacements = {}
+        for name, entry in scope.items():
+            if (
+                isinstance(name, str)
+                and isinstance(entry, BindingEntryV1)
+                and isinstance(entry.state, ObjectPlaceStateV1)
+                and entry.state.object_identity_cid in exposed
+            ):
+                replacements[name] = replace(
+                    entry, state=entry.state.invalidate(self.fragment)
+                )
+        return {**scope, **replacements}
+
     def _make_binop(self, left: "Node", op, right: "Node") -> "Node":
         """Construct a fresh BinOp node ``<left> <op> <right>`` as a shadow that
         borrows this node's span (so it still addresses this source site). Used
@@ -877,6 +1035,12 @@ class Node(Typed):
                 binding = produced_stmt.substitution_binding(scope)
                 if binding:
                     binding = produced_stmt._binding_entries(binding, scope)
+                    binding = produced_stmt.refine_binding_entries(binding, scope)
+                    post_binding = produced_stmt.post_binding_statement(binding)
+                    if post_binding is not produced_stmt:
+                        produced_stmt = post_binding
+                        new_items[-1] = produced_stmt
+                        changed = True
                     scope = {**scope, **binding}
                 # walrus bindings nested in the statement's expressions leak out
                 # to the enclosing block (their scope is the containing function).
@@ -886,6 +1050,7 @@ class Node(Typed):
                         if wb:
                             wb = node._binding_entries(wb, scope)
                             scope = {**scope, **wb}
+                scope = produced_stmt.post_binding_scope(scope)
             if isinstance(new_stmt, _Splice) and new_stmt.bindings:
                 projected = stmt._binding_entries(new_stmt.bindings, scope)
                 scope = {**scope, **projected}
@@ -2109,7 +2274,9 @@ class Assign(Statement):
 
         new_value, changed = self._substitute_field(self.value, scope)
         changes = {"value": new_value} if changed else {}
-        if len(self.targets) == 1 and isinstance(self.targets[0], Attribute):
+        if len(self.targets) == 1 and isinstance(
+            self.targets[0], (Attribute, Subscript)
+        ):
             target = self.targets[0]
             receiver, receiver_changed = self._substitute_field(target.value, scope)
             if receiver_changed:
@@ -2216,12 +2383,204 @@ class Assign(Statement):
             target = self.targets[0]
             if isinstance(target, Name):
                 return {target.id: self.value}
+            if isinstance(target, Attribute) and isinstance(
+                target.value, ObjectPlaceStateV1
+            ):
+                updated = target.value.with_attribute_store(
+                    target.attr, self.value, self.fragment
+                )
+                if updated is None:
+                    return None
+                return {
+                    name: replace(entry, state=updated)
+                    for name, entry in scope.items()
+                    if isinstance(name, str)
+                    and isinstance(entry, BindingEntryV1)
+                    and isinstance(entry.state, ObjectPlaceStateV1)
+                    and entry.state.object_identity_cid
+                    == target.value.object_identity_cid
+                }
+            if isinstance(target, Subscript) and isinstance(
+                target.value, ObjectPlaceStateV1
+            ):
+                updated = target.value.with_subscript_store(
+                    target.slice_, self.value, self.fragment
+                )
+                if updated is None:
+                    return None
+                return {
+                    name: replace(entry, state=updated)
+                    for name, entry in scope.items()
+                    if isinstance(name, str)
+                    and isinstance(entry, BindingEntryV1)
+                    and isinstance(entry.state, ObjectPlaceStateV1)
+                    and entry.state.object_identity_cid
+                    == target.value.object_identity_cid
+                }
             return self._destructured_binding()
         if all(isinstance(t, (Name, Attribute, Subscript)) for t in self.targets):
             # Store targets do not bind lexical names, but they also do not
             # erase the Name targets in the same left-to-right assignment.
             return {t.id: self.value for t in self.targets if isinstance(t, Name)}
         return None
+
+    def refine_binding_entries(self, binding, scope):
+        del scope
+        if len(self.targets) != 1 or not isinstance(self.targets[0], Name):
+            return binding
+        entry = binding.get(self.targets[0].id)
+        if not isinstance(entry, BindingEntryV1):
+            return binding
+        if isinstance(entry.state, ObjectPlaceStateV1):
+            return {
+                **binding,
+                self.targets[0].id: replace(
+                    entry.with_testimony(entry.state.construction_testimony),
+                    state=entry.state,
+                ),
+            }
+        state = self._object_place_state(entry)
+        if state is None:
+            return binding
+        return {
+            **binding,
+            self.targets[0].id: replace(
+                entry.with_testimony(state.construction_testimony), state=state
+            ),
+        }
+
+    def _object_place_state(self, entry: BindingEntryV1):
+        definition = None
+        if isinstance(self.value, Call):
+            definition = self.unit.plain_source_class_for_call(self.value)
+            if definition is None:
+                return None
+        elif not isinstance(self.value, (Dict, List)):
+            return None
+        constructed = self._constructed_floor_value(self.value)
+        if constructed is None:
+            return None
+        floor_value, testimony = constructed
+        from sugar_lift_python_source.canonical import cid_of_json
+        if definition is not None:
+            from sugar_lift_py_tests.floor import ObjectValue
+            from sugar_lift_py_tests.outcome import Complete
+
+            if not isinstance(floor_value, ObjectValue):
+                return None
+            class_outcome = definition.sugar().desugar()
+            if not isinstance(class_outcome, Complete):
+                return None
+            class_definition_cid = class_outcome.value.class_definition_cid
+        else:
+            class_definition_cid = cid_of_json(
+                {
+                    "kind": "python-builtin-container-grammar",
+                    "schemaVersion": "1",
+                    "grammarKind": self.value.kind,
+                }
+            )
+        from .backend import Child, Children, Leaf, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        preimage = {
+            "kind": "python-object-place-identity",
+            "schemaVersion": "1",
+            "ownerBindingCoordinate": entry.coordinate.wire(),
+            "classDefinitionCid": class_definition_cid,
+            "constructionTestimony": testimony.wire(),
+            "constructionOccurrenceCid": self.value.fragment.seal().cid,
+        }
+        return materialize(
+            self.unit,
+            ShadowNode(
+                "ObjectPlaceStateV1",
+                self.targets[0].span,
+                (
+                    ("owner_coordinate", Leaf(entry.coordinate)),
+                    ("class_definition_cid", Leaf(class_definition_cid)),
+                    ("construction_testimony", Leaf(testimony)),
+                    ("constructed_value", Leaf(floor_value)),
+                    ("object_identity_cid", Leaf(cid_of_json(preimage))),
+                    ("base", Child(_handle_of(self.value))),
+                    ("selectors", Leaf(())),
+                    ("values", Children(())),
+                    ("value_testimonies", Leaf(())),
+                    ("version_cids", Leaf(())),
+                    ("prior_version_cids", Leaf(())),
+                    ("store_occurrence_cids", Leaf(())),
+                    ("invalidated_by_opaque_call", Leaf(False)),
+                ),
+            ),
+            self.reporter,
+        )
+
+    @staticmethod
+    def _constructed_floor_value(value):
+        from sugar_lift_py_tests.floor import CallSiteValue
+        from sugar_lift_py_tests.ir import _term_content_cid
+        from sugar_lift_py_tests.outcome import Complete
+        from .binding_provenance import ConstructedValueTestimonyV1
+
+        outcome = value.sugar().desugar()
+        if not isinstance(outcome, Complete):
+            return None
+        constructed = outcome.value
+        if isinstance(constructed, CallSiteValue):
+            constructed = constructed.force_floor(
+                None,
+                owner="Assign._constructed_floor_value",
+                project_callsite=False,
+            )
+        term = constructed.to_term(owner="Assign._constructed_floor_value")
+        testimony = ConstructedValueTestimonyV1.mint(
+            value.fragment, _term_content_cid(term)
+        )
+        return constructed, testimony
+
+    def post_binding_statement(self, binding):
+        if len(self.targets) == 1 and isinstance(self.targets[0], Name):
+            entry = binding.get(self.targets[0].id)
+            if isinstance(entry, BindingEntryV1) and isinstance(
+                entry.state, ObjectPlaceStateV1
+            ):
+                from .shadow import rewrite
+
+                return rewrite(self, value=entry.state)
+        if len(self.targets) != 1 or not isinstance(
+            self.targets[0], (Attribute, Subscript)
+        ):
+            return self
+        prior = self.targets[0].value
+        if not isinstance(prior, ObjectPlaceStateV1):
+            return self
+        updated = next(
+            (
+                entry.state
+                for entry in binding.values()
+                if isinstance(entry, BindingEntryV1)
+                and isinstance(entry.state, ObjectPlaceStateV1)
+                and entry.state.object_identity_cid == prior.object_identity_cid
+            ),
+            None,
+        )
+        if updated is None:
+            return self
+        from .shadow import rewrite
+
+        target = self.targets[0]
+        projected = (
+            updated.attribute_field(target.attr)
+            if isinstance(target, Attribute)
+            else updated.subscript_field(target.slice_)
+        )
+        if projected is None:
+            return self
+        return rewrite(
+            self,
+            targets=(rewrite(target, value=updated),),
+            value=projected,
+        )
 
     def _construct_sugar(self):
         """`<name> = <rhs>` constructs AssignSugar WITH the rhs's sugar (held as
@@ -2304,6 +2663,18 @@ class Assign(Statement):
             )
 
         if len(self.targets) == 1 and isinstance(self.targets[0], Attribute):
+            if isinstance(self.targets[0].value, ObjectPlaceStateV1):
+                from sugar_lift_py_tests.sugar.place_assign_sugar import (
+                    PlaceAssignSugar,
+                )
+
+                return PlaceAssignSugar(
+                    receiver=self.targets[0].value.sugar(),
+                    selector_kind="attribute",
+                    selector=self.targets[0].attr,
+                    value=self.value.sugar(),
+                    site=self.fragment,
+                )
             if isinstance(
                 self.targets[0].value,
                 (BindingCoordinateRef, ConstructedReceiverRef),
@@ -2328,6 +2699,18 @@ class Assign(Statement):
             )
 
         if len(self.targets) == 1 and isinstance(self.targets[0], Subscript):
+            if isinstance(self.targets[0].value, ObjectPlaceStateV1):
+                from sugar_lift_py_tests.sugar.place_assign_sugar import (
+                    PlaceAssignSugar,
+                )
+
+                return PlaceAssignSugar(
+                    receiver=self.targets[0].value.sugar(),
+                    selector_kind="subscript",
+                    selector=self.targets[0].slice_.sugar(),
+                    value=self.value.sugar(),
+                    site=self.fragment,
+                )
             from sugar_lift_py_tests.sugar.store_effect_sugar import (
                 SubscriptStoreEffectSugar,
             )
@@ -5151,6 +5534,19 @@ class Call(Expression):
             return func.value
         return None
 
+    def exposed_object_places(self) -> tuple["ObjectPlaceStateV1", ...]:
+        """Object states crossing this call without a frame-condition proof."""
+        roots = list(self.args) + [keyword.value for keyword in self.keywords]
+        receiver = self.receiver()
+        if receiver is not None:
+            roots.append(receiver)
+        seen = {}
+        for root in roots:
+            for node in root.walk():
+                if isinstance(node, ObjectPlaceStateV1):
+                    seen[node.object_identity_cid] = node
+        return tuple(seen.values())
+
     def _construct_sugar(self):
         """A call constructs its callee's sugar WITH the argument sugars.
         `<name>(<args>)` -> CallSiteSugar, the call-site coordinate (THE DIG
@@ -5275,6 +5671,28 @@ class Call(Expression):
                             for keyword in self.keywords
                             if keyword.arg is not None
                         ),
+                    )
+
+            if source_call_frame is None:
+                definition = self.unit.plain_source_class_for_call(self)
+                if definition is not None:
+                    from sugar_lift_py_tests.source_call_frame import (
+                        SourceCallBindingGap,
+                    )
+
+                    if any(keyword.arg is None for keyword in self.keywords):
+                        raise SourceCallBindingGap(
+                            "spread keyword requires typed variadic projection"
+                        )
+                    source_call_frame = (
+                        definition.source_visible_constructor_frame().bind_node_actuals(
+                            self.args,
+                            tuple(
+                                (keyword.arg, keyword.value)
+                                for keyword in self.keywords
+                                if keyword.arg is not None
+                            ),
+                        )
                     )
 
             return CallSiteSugar(
@@ -5471,6 +5889,348 @@ class Constant(Expression):
         return super()._construct_sugar()  # every literal kind is now converted
 
 
+class ObjectPlaceStateV1(Expression):
+    """Immutable field versions carried only inside runtime BindingEntryV1.
+
+    This is a constructed Node value, not a binding resolver or heap.  Its sole
+    identity source is the owning entry's BindingCoordinateV1.  If it escapes
+    the attribute store/read projections, its base value constructs normally.
+    """
+
+    owner_coordinate: object
+    class_definition_cid: str
+    construction_testimony: object
+    constructed_value: object
+    object_identity_cid: str
+    base: Expression
+    selectors: Tuple[object, ...]
+    values: Tuple[Expression, ...]
+    value_testimonies: Tuple[object, ...]
+    version_cids: Tuple[str, ...]
+    prior_version_cids: Tuple[Optional[str], ...]
+    store_occurrence_cids: Tuple[str, ...]
+    invalidated_by_opaque_call: bool
+    _child_fields = ("base", "values")
+
+    def substitute(self, scope):
+        del scope
+        return self
+
+    def _construct_sugar(self):
+        self.validate_identity()
+        from sugar_lift_py_tests.sugar.constructed_object_place_sugar import (
+            ConstructedObjectPlaceSugar,
+        )
+
+        return ConstructedObjectPlaceSugar(
+            self.constructed_value,
+            self.construction_testimony,
+            self.fragment,
+        )
+
+    def validate_identity(self) -> None:
+        from sugar_lift_python_source.canonical import cid_of_json
+        from .binding_provenance import (
+            BindingCoordinateV1,
+            BindingProvenanceGap,
+            ConstructedValueTestimonyV1,
+        )
+
+        BindingCoordinateV1.decode(self.owner_coordinate.wire())
+        ConstructedValueTestimonyV1.decode(self.construction_testimony.wire())
+        from sugar_lift_py_tests.ir import _term_content_cid
+
+        observed = _term_content_cid(
+            self.constructed_value.to_term(owner="ObjectPlaceStateV1")
+        )
+        if observed != self.construction_testimony.semantic_value_cid:
+            raise BindingProvenanceGap("object construction testimony mismatch")
+        expected = cid_of_json(
+            {
+                "kind": "python-object-place-identity",
+                "schemaVersion": "1",
+                "ownerBindingCoordinate": self.owner_coordinate.wire(),
+                "classDefinitionCid": self.class_definition_cid,
+                "constructionTestimony": self.construction_testimony.wire(),
+                "constructionOccurrenceCid": self.base.fragment.seal().cid,
+            }
+        )
+        if expected != self.object_identity_cid:
+            raise BindingProvenanceGap("object place identity CID mismatch")
+
+    def version(self, selector) -> Optional[str]:
+        try:
+            return self.version_cids[self.selectors.index(selector)]
+        except ValueError:
+            return None
+
+    def with_attribute_store(self, name, value, occurrence):
+        from .object_place import AttributePlaceSelectorV1
+
+        return self._with_store(
+            AttributePlaceSelectorV1(name), value, occurrence
+        )
+
+    def with_subscript_store(self, index, value, occurrence):
+        resolved = self._subscript_selector(index)
+        if resolved is None:
+            return None
+        selector, index_value = resolved
+        from sugar_lift_py_tests.floor.dict_value import DictValue
+        from sugar_lift_py_tests.floor.list_value import ListValue
+        from sugar_lift_py_tests.outcome import Complete
+
+        if type(self.constructed_value) not in (DictValue, ListValue):
+            return None
+        value_construction = Assign._constructed_floor_value(value)
+        if value_construction is None:
+            return None
+        value_floor, _testimony = value_construction
+        if not isinstance(
+            self.constructed_value.setitem(index_value, value_floor, occurrence),
+            Complete,
+        ):
+            return None
+        return self._with_store(
+            selector, value, occurrence, constructed=value_construction
+        )
+
+    def _with_store(self, selector, value, occurrence, *, constructed=None):
+        self.validate_identity()
+        from .object_place import validate_place_selector
+
+        validate_place_selector(selector)
+        constructed = constructed or Assign._constructed_floor_value(value)
+        if constructed is None:
+            return None
+        floor_value, testimony = constructed
+        projected = ConstructedValueProjectionV1.create(
+            value, floor_value, testimony
+        )
+        from sugar_lift_python_source.canonical import cid_of_json
+
+        prior = self.version(selector)
+        occurrence_cid = occurrence.seal().cid
+        preimage = {
+            "kind": "python-object-place-version",
+            "schemaVersion": "1",
+            "ownerBindingCoordinate": self.owner_coordinate.wire(),
+            "objectIdentityCid": self.object_identity_cid,
+            "classDefinitionCid": self.class_definition_cid,
+            "selector": selector.wire(),
+            "priorVersionCid": prior,
+            "constructedValueTestimony": testimony.wire(),
+            "storeOccurrenceCid": occurrence_cid,
+        }
+        selectors = list(self.selectors)
+        values = list(self.values)
+        testimonies = list(self.value_testimonies)
+        versions = list(self.version_cids)
+        priors = list(self.prior_version_cids)
+        occurrences = list(self.store_occurrence_cids)
+        if selector in selectors:
+            index = selectors.index(selector)
+            values[index] = projected
+            testimonies[index] = testimony
+            versions[index] = cid_of_json(preimage)
+            priors[index] = prior
+            occurrences[index] = occurrence_cid
+        else:
+            selectors.append(selector)
+            values.append(projected)
+            testimonies.append(testimony)
+            versions.append(cid_of_json(preimage))
+            priors.append(prior)
+            occurrences.append(occurrence_cid)
+        return self._replace_state(
+            span=occurrence.node.span,
+            selectors=tuple(selectors),
+            values=tuple(values),
+            value_testimonies=tuple(testimonies),
+            version_cids=tuple(versions),
+            prior_version_cids=tuple(priors),
+            store_occurrence_cids=tuple(occurrences),
+            invalidated=False,
+        )
+
+    def attribute_field(self, name: str):
+        from .object_place import AttributePlaceSelectorV1
+
+        return self.field(AttributePlaceSelectorV1(name))
+
+    def subscript_field(self, index):
+        from sugar_lift_py_tests.floor.dict_value import DictValue
+        from sugar_lift_py_tests.floor.list_value import ListValue
+
+        if type(self.constructed_value) not in (DictValue, ListValue):
+            return None
+        resolved = self._subscript_selector(index)
+        selector = None if resolved is None else resolved[0]
+        return None if selector is None else self.field(selector)
+
+    def field(self, selector):
+        self.validate_identity()
+        from .object_place import validate_place_selector
+
+        validate_place_selector(selector)
+        if self.invalidated_by_opaque_call:
+            return None
+        try:
+            index = self.selectors.index(selector)
+        except ValueError:
+            return None
+        from sugar_lift_python_source.canonical import cid_of_json
+        from .binding_provenance import (
+            BindingProvenanceGap,
+            ConstructedValueTestimonyV1,
+        )
+
+        testimony = self.value_testimonies[index]
+        ConstructedValueTestimonyV1.decode(testimony.wire())
+        projected = self.values[index]
+        if not isinstance(projected, ConstructedValueProjectionV1):
+            raise BindingProvenanceGap("field value lacks constructed projection")
+        projected.validate_testimony()
+        if projected.construction_testimony != testimony:
+            raise BindingProvenanceGap("field value testimony mismatch")
+        expected = cid_of_json(
+            {
+                "kind": "python-object-place-version",
+                "schemaVersion": "1",
+                "ownerBindingCoordinate": self.owner_coordinate.wire(),
+                "objectIdentityCid": self.object_identity_cid,
+                "classDefinitionCid": self.class_definition_cid,
+                "selector": selector.wire(),
+                "priorVersionCid": self.prior_version_cids[index],
+                "constructedValueTestimony": testimony.wire(),
+                "storeOccurrenceCid": self.store_occurrence_cids[index],
+            }
+        )
+        if expected != self.version_cids[index]:
+            raise BindingProvenanceGap("field version CID mismatch")
+        return projected
+
+    @staticmethod
+    def _subscript_selector(index):
+        constructed = Assign._constructed_floor_value(index)
+        if constructed is None:
+            return None
+        value, testimony = constructed
+        from .object_place import SubscriptPlaceSelectorV1
+
+        return SubscriptPlaceSelectorV1(testimony.semantic_value_cid), value
+
+    def invalidate(self, occurrence):
+        self.validate_identity()
+        return self._replace_state(
+            span=occurrence.node.span,
+            selectors=self.selectors,
+            values=self.values,
+            value_testimonies=self.value_testimonies,
+            version_cids=self.version_cids,
+            prior_version_cids=self.prior_version_cids,
+            store_occurrence_cids=self.store_occurrence_cids,
+            invalidated=True,
+        )
+
+    def _replace_state(
+        self,
+        *,
+        span,
+        selectors,
+        values,
+        value_testimonies,
+        version_cids,
+        prior_version_cids,
+        store_occurrence_cids,
+        invalidated,
+    ):
+        from .backend import Child, Children, Leaf, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        return materialize(
+            self.unit,
+            ShadowNode(
+                "ObjectPlaceStateV1",
+                span,
+                (
+                    ("owner_coordinate", Leaf(self.owner_coordinate)),
+                    ("class_definition_cid", Leaf(self.class_definition_cid)),
+                    ("construction_testimony", Leaf(self.construction_testimony)),
+                    ("constructed_value", Leaf(self.constructed_value)),
+                    ("object_identity_cid", Leaf(self.object_identity_cid)),
+                    ("base", Child(_handle_of(self.base))),
+                    ("selectors", Leaf(selectors)),
+                    ("values", Children(tuple(_handle_of(item) for item in values))),
+                    ("value_testimonies", Leaf(value_testimonies)),
+                    ("version_cids", Leaf(version_cids)),
+                    ("prior_version_cids", Leaf(prior_version_cids)),
+                    ("store_occurrence_cids", Leaf(store_occurrence_cids)),
+                    ("invalidated_by_opaque_call", Leaf(invalidated)),
+                ),
+            ),
+            self.reporter,
+        )
+
+
+class ConstructedValueProjectionV1(Expression):
+    """A source value already constructed once and sealed by its testimony."""
+
+    constructed_value: object
+    construction_testimony: object
+    base: Expression
+    _child_fields = ("base",)
+
+    @classmethod
+    def create(cls, base, constructed_value, testimony):
+        from .backend import Child, Leaf, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        return materialize(
+            base.unit,
+            ShadowNode(
+                "ConstructedValueProjectionV1",
+                base.span,
+                (
+                    ("constructed_value", Leaf(constructed_value)),
+                    ("construction_testimony", Leaf(testimony)),
+                    ("base", Child(_handle_of(base))),
+                ),
+            ),
+            base.reporter,
+        )
+
+    def substitute(self, scope):
+        del scope
+        return self
+
+    def validate_testimony(self):
+        from .binding_provenance import (
+            BindingProvenanceGap,
+            ConstructedValueTestimonyV1,
+        )
+        from sugar_lift_py_tests.ir import _term_content_cid
+
+        ConstructedValueTestimonyV1.decode(self.construction_testimony.wire())
+        observed = _term_content_cid(
+            self.constructed_value.to_term(owner="ConstructedValueProjectionV1")
+        )
+        if observed != self.construction_testimony.semantic_value_cid:
+            raise BindingProvenanceGap("constructed field testimony mismatch")
+
+    def _construct_sugar(self):
+        self.validate_testimony()
+        from sugar_lift_py_tests.sugar.constructed_object_place_sugar import (
+            ConstructedObjectPlaceSugar,
+        )
+
+        return ConstructedObjectPlaceSugar(
+            self.constructed_value,
+            self.construction_testimony,
+            self.fragment,
+        )
+
+
 class Attribute(Expression):
     value: Expression
     attr: str
@@ -5486,8 +6246,28 @@ class Attribute(Expression):
         )
 
     def substitute(self, scope):
-        """Binds nothing: recurse into children and reassemble."""
-        return self._substitute_children(scope)
+        """Project only from a construction-authenticated object place."""
+        from .shadow import rewrite
+
+        receiver, changed = self._substitute_field(self.value, scope)
+        if (
+            isinstance(receiver, IfExp)
+            and isinstance(receiver.body, ObjectPlaceStateV1)
+            and isinstance(receiver.orelse, ObjectPlaceStateV1)
+            and receiver.body.object_identity_cid
+            == receiver.orelse.object_identity_cid
+        ):
+            when_true = receiver.body.attribute_field(self.attr)
+            when_false = receiver.orelse.attribute_field(self.attr)
+            if when_true is not None and when_false is not None:
+                return rewrite(
+                    receiver, body=when_true, orelse=when_false
+                )
+        if isinstance(receiver, ObjectPlaceStateV1):
+            projected = receiver.attribute_field(self.attr)
+            if projected is not None:
+                return projected
+        return self if not changed else rewrite(self, value=receiver)
 
 
 class Subscript(Expression):
@@ -5497,7 +6277,17 @@ class Subscript(Expression):
 
     def substitute(self, scope):
         """`<value>[<slice>]` binds nothing: recurse into receiver and index."""
-        return self._substitute_children(scope)
+        from .shadow import rewrite
+
+        receiver, receiver_changed = self._substitute_field(self.value, scope)
+        index, index_changed = self._substitute_field(self.slice_, scope)
+        if isinstance(receiver, ObjectPlaceStateV1):
+            projected = receiver.subscript_field(index)
+            if projected is not None:
+                return projected
+        if not receiver_changed and not index_changed:
+            return self
+        return rewrite(self, value=receiver, slice_=index)
 
     def _construct_sugar(self):
         """`<value>[<slice_>]` constructs SubscriptSugar WITH the receiver's and

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/object_place.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/object_place.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_python_source.canonical import cid_of_json
+
+
+@dataclass(frozen=True)
+class AttributePlaceSelectorV1:
+    name: str
+    cid: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "cid", cid_of_json(self.preimage))
+
+    @property
+    def preimage(self):
+        return {
+            "kind": "attribute-place-selector",
+            "schemaVersion": "1",
+            "name": self.name,
+        }
+
+    def wire(self):
+        return {**self.preimage, "cid": self.cid}
+
+
+@dataclass(frozen=True)
+class SubscriptPlaceSelectorV1:
+    index_term_cid: str
+    cid: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "cid", cid_of_json(self.preimage))
+
+    @property
+    def preimage(self):
+        return {
+            "kind": "subscript-place-selector",
+            "schemaVersion": "1",
+            "indexTermCid": self.index_term_cid,
+        }
+
+    def wire(self):
+        return {**self.preimage, "cid": self.cid}
+
+
+PlaceSelectorV1 = AttributePlaceSelectorV1 | SubscriptPlaceSelectorV1
+
+
+def validate_place_selector(selector: PlaceSelectorV1) -> None:
+    if not isinstance(selector, (AttributePlaceSelectorV1, SubscriptPlaceSelectorV1)):
+        raise TypeError(f"unknown place selector {type(selector).__name__}")
+    if cid_of_json(selector.preimage) != selector.cid:
+        raise ValueError("place selector CID mismatch")


### PR DESCRIPTION
## Status: draft — honest pandas measurement is non-bankable

The construction model and acceptance twins are implemented, but this branch must not merge in its current form. The current-main pandas measurement found no object-field drain and found existing enclosing constructions that become loud.

## Implemented foundation

- derives object/place identity exclusively from runtime `BindingEntryV1` owner coordinates plus constructed-value testimony
- threads immutable attribute/subscript versions through the one temporal binding map, including authenticated aliases and both branch faces
- revalidates content-addressed object/value/version testimony and rejects forged CIDs
- emits Python-reference `python:assign` attribute/subscript targets
- invalidates field knowledge at opaque calls; symbolic receivers, opaque aliases, custom descriptors, invalid subscript stores remain loud
- constructs object occurrences and stored RHS expressions exactly once, then projects sealed testimony

## Exact pandas receipt (pandas 3.0.3, 1,421 files)

The identical `--object-field-only` instrument found 134 candidate enclosing functions:

| Transition | Count |
|---|---:|
| typed-loud → typed-loud | 55 |
| typed-loud → construction panic | 30 |
| typed-loud → non-typed failure | 4 |
| built → built | 28 |
| built → construction panic | 16 |
| built → non-typed failure | 1 |
| typed-loud → built | **0** |

Honest ΔR = 0. Seventeen previously built enclosing functions regress, so this is not a mergeable drain. The per-site rows are emitted in `object_field_rows`; panics are counted as loud rather than swallowed.

## Focused evidence

- object-field plus existing binding/Assign tests: 95 passed
- construction side-door law: every axis R=0
- direct Assign census: byte-identical base/head (109,017 sites; zero changed rows on the pre-latest snapshot)
- battleaxe Rust attempt was blocked first by the shared Cargo lock and then by SSH multiplex contention; no Rust green is claimed

## Next decision

Keep as foundation draft or narrow only after a construction-authoritative object class in pandas produces a real typed-loud → built transition without any built regression. Do not merge this head.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add authenticated object field flow tracking through temporal bindings
> - Introduces `ObjectPlaceStateV1`, a new expression class in [`nodes.py`](https://github.com/TSavo/sugar/pull/6126/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) that tracks versioned, content-addressed field state for constructed objects (dicts, lists, or simple classes) across assignments.
> - Attribute and subscript stores on authenticated object places now update versioned state in scope; subsequent reads substitute to `ConstructedValueProjectionV1` with testimony validation instead of generic expressions.
> - Adds `PlaceAssignSugar` and `ConstructedObjectPlaceSugar` to desugar authenticated place stores and projections, verifying testimony and raising `BindingProvenanceGap` on mismatch.
> - Adds `object_place.py` with content-addressed `AttributePlaceSelectorV1` and `SubscriptPlaceSelectorV1` used for identity and version records.
> - Expands the acceptance test matrix with `version-flow`, `distinct-version-flow`, and `subscript-store-read` cases covering pre/post-mutation reads, cross-object alias isolation, and dictionary subscript stores.
> - Risk: opaque calls now invalidate tracked field state for any object place that crosses the call boundary, which is a new behavioral constraint on scope.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4f81fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->