### PR TITLE
Cut C: interprocedural manager-factory + returned-object construction (#6088)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context/reduce_context.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context/reduce_context.py
@@ -32,6 +32,7 @@ class ReduceContext:
     # the attribute crashed the numpy/pandas package audit as unstructured exit=2
     # after opaque body dig started reducing vendor-bridged bodies.
     external_bridge_sink: Any = None
+    binding_coordinate_values: tuple[tuple[str, Any], ...] = ()
 
     @classmethod
     def root(
@@ -65,6 +66,7 @@ class ReduceContext:
             ),
             dig_sink=source.dig_sink,
             external_bridge_sink=getattr(source, "external_bridge_sink", None),
+            binding_coordinate_values=getattr(source, "binding_coordinate_values", ()),
         )
 
     def record_operation(
@@ -101,4 +103,23 @@ class ReduceContext:
             prefer_ground_module_bindings=self.prefer_ground_module_bindings,
             dig_sink=self.dig_sink,
             external_bridge_sink=self.external_bridge_sink,
+            binding_coordinate_values=self.binding_coordinate_values,
+        )
+
+    def with_binding_coordinate_values(self, values) -> "ReduceContext":
+        result = self.with_temporal(self.temporal)
+        result.binding_coordinate_values = tuple(values)
+        return result
+
+    def value_for_binding_coordinate(self, coordinate_cid: str):
+        for candidate, value in reversed(self.binding_coordinate_values):
+            if candidate == coordinate_cid:
+                return value
+        from sugar_source_tree.panic import SugarNotWritten
+
+        raise SugarNotWritten(
+            owner="ReduceContext.value_for_binding_coordinate",
+            observed=coordinate_cid,
+            requested="an authenticated formal-to-actual binding",
+            fix="bind the exact call occurrence before reducing its source body",
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Any, Mapping
 
@@ -111,11 +111,54 @@ class ResolvedContractRefsV1:
             ) from exc
 
 
+# Placeholder table for construction that does not enroll context-manager
+# demands (e.g. sole-path manager-factory construction). With.require still
+# fails closed when a use-site is absent.
+_EMPTY_CONTRACT_TABLE_CID = "blake3-512:" + ("00" * 64)
+
+
+def empty_resolved_contract_refs() -> ResolvedContractRefsV1:
+    from types import MappingProxyType
+
+    return ResolvedContractRefsV1(
+        catalog_cid=_EMPTY_CONTRACT_TABLE_CID,
+        table_cid=_EMPTY_CONTRACT_TABLE_CID,
+        by_use_site=MappingProxyType({}),
+    )
+
+
 @dataclass(frozen=True)
 class TreeConstructionContextV1:
+    """Explicit tree construction handle — the only non-Sugar construction currency.
+
+    - ``contract_refs``: prebound With resolutions (empty table is valid; missing
+      use-sites stay loud via ``require``).
+    - ``source_call_frames``: prebound ordinary source-call frames keyed by
+      use-site coordinate string; mutated only by the sole-path scheduler that
+      owns the handle, never ambient process state.
+    """
+
     contract_refs: ResolvedContractRefsV1
     call_contract_refs: object | None = None
     workspace_root: str | None = None
+    # Mutable frame table held by reference; the context object itself is frozen.
+    source_call_frames: dict = field(default_factory=dict)
+
+    @classmethod
+    def for_source_call_construction(
+        cls,
+        *,
+        source_call_frames: dict | None = None,
+        call_contract_refs: object | None = None,
+        workspace_root: str | None = None,
+    ) -> "TreeConstructionContextV1":
+        """Construction context for sole-path source-call frames without CM enrollment."""
+        return cls(
+            contract_refs=empty_resolved_contract_refs(),
+            call_contract_refs=call_contract_refs,
+            workspace_root=workspace_root,
+            source_call_frames={} if source_call_frames is None else source_call_frames,
+        )
 
 
 _GAP_KINDS = frozenset(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -57,6 +57,7 @@ from .none_value import NoneValue
 from .object_field import ObjectField
 from .object_method_value import ObjectMethodValue
 from .object_value import ObjectValue
+from .receiver_field_store_value import ReceiverFieldStoreValue
 from .opaque_op_callsite import OpaqueOpCallsite
 from .predicate_value import PredicateValue
 from .raise_value import RaiseValue
@@ -123,6 +124,7 @@ REGISTERED_FLOOR_TYPES: tuple[type[FloorDispatchSurface], ...] = (
     PredicateValue,
     RaiseValue,
     RaisesWithValue,
+    ReceiverFieldStoreValue,
     ReturnValue,
     ScopeRebind,
     SequenceConstructor,
@@ -195,6 +197,7 @@ __all__ = [
     "ObjectField",
     "ObjectMethodValue",
     "ObjectValue",
+    "ReceiverFieldStoreValue",
     "OpaqueOpCallsite",
     "PredicateValue",
     "RaiseValue",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -109,6 +109,7 @@ class CallSiteValue(FloorValue):
         default=None, compare=False
     )
     source_call_frame_cid: str | None = dataclass_field(default=None, compare=False)
+    formal_coordinate_cids: tuple[str, ...] = dataclass_field(default=(), compare=False)
 
     def __hash__(self) -> int:
         """Hash the finite call coordinate, never the recursively-owned body.
@@ -990,7 +991,9 @@ class CallSiteValue(FloorValue):
             return None
         from sugar_lift_py_tests.outcome import Incomplete, complete_value
 
-        reduce_ctx = _ctx_with_curried_args(ctx, self.parameters, self.arg_values)
+        reduce_ctx = _ctx_with_curried_args(
+            ctx, self.parameters, self.arg_values, self.formal_coordinate_cids
+        )
         active_demand = _ACTIVE_DIG_DEMAND.get()
         nested_budget = min(budget, _NESTED_DIG_DEMAND_BUDGET)
         if active_demand >= nested_budget:
@@ -1080,7 +1083,9 @@ class CallSiteValue(FloorValue):
             )
         from sugar_lift_py_tests.outcome import Incomplete, complete_value
 
-        reduce_ctx = _ctx_with_curried_args(ctx, self.parameters, self.arg_values)
+        reduce_ctx = _ctx_with_curried_args(
+            ctx, self.parameters, self.arg_values, self.formal_coordinate_cids
+        )
         outcome = _reduce_callsite_body(body, reduce_ctx, blame=self.target_name)
         if isinstance(outcome, Incomplete):
             _force_floor_gap(
@@ -1144,8 +1149,13 @@ def _reduce_callsite_body(
     from sugar_lift_py_tests.sugar.source_visible_function_body_sugar import (
         SourceVisibleFunctionBodySugar,
     )
+    from sugar_lift_py_tests.sugar.class_constructor_body_sugar import (
+        ClassConstructorBodySugar,
+    )
 
     if isinstance(body, SourceVisibleFunctionBodySugar):
+        return body.desugar(ctx)
+    if isinstance(body, ClassConstructorBodySugar):
         return body.desugar(ctx)
     if isinstance(body, SugarBody):
         return body.reduce(ctx)
@@ -1157,7 +1167,7 @@ def _reduce_callsite_body(
         owner="CallSiteValue.force_floor",
         target_name=blame,
         observed=type(body).__name__,
-        fix="carry a SugarBody or FunctionBodyUniverse before demanding a callsite floor",
+        fix="carry a closed ordinary source-body variant before demanding a callsite floor",
     )
 
 
@@ -1249,13 +1259,21 @@ def _ctx_with_curried_args(
     ctx: Any,
     parameters: tuple[str, ...],
     arg_values: tuple[FloorValue, ...],
+    formal_coordinate_cids: tuple[str, ...] = (),
 ):
     from sugar_lift_py_tests.temporal import curry_temporal
 
-    return curry_temporal(
+    result = curry_temporal(
         ctx,
         parameters,
         arg_values,
         owner="CallSiteValue.force_floor",
         blame="<callsite>",
     )
+    if formal_coordinate_cids:
+        if len(formal_coordinate_cids) != len(arg_values):
+            return result
+        result = result.with_binding_coordinate_values(
+            zip(formal_coordinate_cids, arg_values, strict=True)
+        )
+    return result

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -12,6 +12,7 @@ class ConstructedClassMethodV1:
     name: str
     definition_fragment_cid: str
     body: object = field(compare=False)
+    source_call_frame: object = field(compare=False)
 
 
 @dataclass(frozen=True)
@@ -32,13 +33,70 @@ class ClassDefinitionValue(FloorValue):
         )
 
     def construct_receiver_state(self, actuals: tuple[object, ...]):
-        del actuals
-        raise SugarNotWritten(
-            owner="ClassDefinitionValue.construct_receiver_state",
-            observed="awaiting-binding-coordinate",
-            requested="BindingCoordinateV1 receiver and field projections",
-            fix=(
-                "wire the shared scope-owner/binding-site/projection-path spine; "
-                "never infer receiver fields by name"
+        from sugar_lift_py_tests.floor import (
+            CallSiteValue,
+            ObjectField,
+            ObjectValue,
+            ReceiverFieldStoreValue,
+        )
+        from sugar_lift_py_tests.ir import _term_content_cid, ctor, str_const
+
+        receiver = ObjectValue(self.class_name, (), identity=self.class_definition_cid)
+        if self.initializer is None:
+            return receiver
+        frame = self.initializer.source_call_frame
+        values = (receiver, *actuals)
+        call = CallSiteValue(
+            target_name="python:source-class-init",
+            arg_values=values,
+            parameters=frame.parameters,
+            term=ctor(
+                "python:source-class-init",
+                [str_const(self.class_definition_cid)],
+                symbol_kind="coordinate",
             ),
+            body=frame.body,
+            source_call_frame_cid=frame.frame_cid,
+            formal_coordinate_cids=tuple(item.cid for item in frame.formal_coordinates),
+        )
+        block = call.force_floor(
+            None,
+            owner="ClassDefinitionValue.construct_receiver_state",
+            project_callsite=False,
+        )
+        fields: dict[str, object] = {}
+        for statement in block.statements:
+            if not isinstance(statement, ReceiverFieldStoreValue):
+                continue
+            if statement.receiver != receiver:
+                raise SugarNotWritten(
+                    owner="ClassDefinitionValue.construct_receiver_state",
+                    observed="receiver coordinate mismatch",
+                    requested="stores projected from this exact constructed receiver",
+                    fix="preserve BindingCoordinateV1 through initializer reduction",
+                )
+            fields[statement.attr] = statement.value
+        ordered = tuple(
+            ObjectField(name, value) for name, value in sorted(fields.items())
+        )
+        identity_term = ctor(
+            "python:constructed-object-state",
+            [
+                str_const(self.class_definition_cid),
+                *(
+                    ctor(
+                        "python:field",
+                        [
+                            str_const(field.name),
+                            field.value.to_term(owner=self.class_definition_cid),
+                        ],
+                    )
+                    for field in ordered
+                ),
+            ],
+        )
+        return ObjectValue(
+            self.class_name,
+            ordered,
+            identity=_term_content_cid(identity_term),
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_field_store_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_field_store_value.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class ReceiverFieldStoreValue(FloorValue):
+    receiver: FloorValue
+    attr: str
+    value: FloorValue
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:receiver-field-store",
+            [
+                self.receiver.to_term(owner=owner),
+                str_const(self.attr),
+                self.value.to_term(owner=owner),
+            ],
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal
-
 from sugar_lift_python_source.canonical import cid_of_json
+from sugar_source_tree.binding_provenance import BindingCoordinateV1
 
 from .context_manager_resolution import SourceFragmentCoordinateV1
 
@@ -16,6 +15,11 @@ class SourceVisibleCallFrameV1:
     definition_site: SourceFragmentCoordinateV1
     definition_fragment_cid: str
     parameters: tuple[str, ...]
+    formal_coordinates: tuple[BindingCoordinateV1, ...]
+    parameter_kinds: tuple[str, ...]
+    default_sugars: tuple[object | None, ...] = field(compare=False)
+    default_fragments: tuple[object | None, ...] = field(compare=False)
+    default_fragment_cids: tuple[str | None, ...]
     body: object = field(compare=False)
     frame_cid: str = field(init=False)
 
@@ -27,18 +31,68 @@ class SourceVisibleCallFrameV1:
             "definitionSite": self.definition_site.wire(),
             "definitionFragmentCid": self.definition_fragment_cid,
             "parameters": list(self.parameters),
+            "formalCoordinates": [item.wire() for item in self.formal_coordinates],
+            "parameterKinds": list(self.parameter_kinds),
+            "defaultFragmentCids": list(self.default_fragment_cids),
         }
         object.__setattr__(self, "frame_cid", cid_of_json(preimage))
 
+    def bind_actuals(self, positional: tuple, keywords: tuple, ctx=None) -> tuple:
+        from sugar_lift_py_tests.floor import DictValue, StringValue, TupleValue
 
-@dataclass(frozen=True)
-class AwaitingBindingCoordinateCallFrameV1:
-    """Typed boundary until the shared BindingCoordinateV1 spine lands."""
+        remaining = list(positional)
+        named = dict(keywords)
+        if len(named) != len(keywords):
+            raise SourceCallBindingGap("duplicate keyword actual")
+        bound = []
+        for index, (name, kind, default) in enumerate(
+            zip(
+                self.parameters,
+                self.parameter_kinds,
+                self.default_sugars,
+                strict=True,
+            )
+        ):
+            if kind == "vararg":
+                bound.append(TupleValue(tuple(remaining)))
+                remaining.clear()
+                continue
+            if kind == "kwarg":
+                bound.append(
+                    DictValue(
+                        tuple((StringValue(key), value) for key, value in named.items())
+                    )
+                )
+                named.clear()
+                continue
+            value = None
+            present = False
+            if kind in {"positional_only", "positional_or_keyword"} and remaining:
+                value = remaining.pop(0)
+                present = True
+                if name in named:
+                    raise SourceCallBindingGap("formal received positional and keyword")
+            elif kind != "positional_only" and name in named:
+                value = named.pop(name)
+                present = True
+            if not present and default is not None:
+                from sugar_lift_py_tests.outcome import Complete
 
-    source_identity_cid: str
-    definition_site: SourceFragmentCoordinateV1
-    parameters: tuple[str, ...]
-    kind: Literal["awaiting-binding-coordinate"] = "awaiting-binding-coordinate"
+                outcome = default.desugar(ctx)
+                if not isinstance(outcome, Complete):
+                    raise SourceCallBindingGap("default did not construct completely")
+                value = outcome.value
+                present = True
+            if not present:
+                raise SourceCallBindingGap(f"missing required formal {index}")
+            bound.append(value)
+        if remaining or named:
+            raise SourceCallBindingGap("unconsumed call actual")
+        return tuple(bound)
 
 
-SourceCallFrameV1 = SourceVisibleCallFrameV1 | AwaitingBindingCoordinateCallFrameV1
+class SourceCallBindingGap(ValueError):
+    pass
+
+
+SourceCallFrameV1 = SourceVisibleCallFrameV1

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binding_coordinate_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binding_coordinate_ref_sugar.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class BindingCoordinateRefSugar(Sugar):
+    coordinate: object
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="FloorValue",
+            reason="a formal projection reuses its authenticated constructed actual",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        if ctx is None:
+            from sugar_source_tree.panic import SugarNotWritten
+
+            raise SugarNotWritten(
+                owner="BindingCoordinateRefSugar.desugar",
+                observed="missing source-call binding frame",
+                requested="the exact constructed actual for this BindingCoordinateV1",
+                fix="reduce the source body through its authenticated call frame",
+            )
+        return Complete(ctx.value_for_binding_coordinate(self.coordinate.cid))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -100,22 +100,9 @@ class CallSiteSugar(Sugar):
         source_body = None
         source_frame_cid = None
         if self.source_call_frame is not None:
-            from sugar_lift_py_tests.source_call_frame import (
-                AwaitingBindingCoordinateCallFrameV1,
-                SourceVisibleCallFrameV1,
-            )
+            from sugar_lift_py_tests.source_call_frame import SourceVisibleCallFrameV1
             from sugar_source_tree.panic import SugarNotWritten
 
-            if isinstance(self.source_call_frame, AwaitingBindingCoordinateCallFrameV1):
-                raise SugarNotWritten(
-                    owner="CallSiteSugar.desugar",
-                    observed=self.source_call_frame.kind,
-                    requested="the shared BindingCoordinateV1 formal frame",
-                    fix=(
-                        "wire the shared formal binding coordinate into this "
-                        "already-constructed source body; never bind by name"
-                    ),
-                )
             if not isinstance(self.source_call_frame, SourceVisibleCallFrameV1):
                 raise SugarNotWritten(
                     owner="CallSiteSugar.desugar",
@@ -123,15 +110,19 @@ class CallSiteSugar(Sugar):
                     requested="a closed SourceCallFrameV1 variant",
                     fix="construct a typed source frame or keep the call loud",
                 )
-            if self.keywords or len(positional) != len(
-                self.source_call_frame.parameters
-            ):
+            from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+
+            try:
+                positional = self.source_call_frame.bind_actuals(
+                    positional, kw_values, ctx
+                )
+            except SourceCallBindingGap as exc:
                 raise SugarNotWritten(
                     owner="CallSiteSugar.desugar",
-                    observed="source call-frame signature mismatch",
-                    requested="actuals matching the constructed source frame",
-                    fix="bind through the ordinary formal frame or keep the call loud",
-                )
+                    observed=str(exc),
+                    requested="actuals matching the authenticated source signature",
+                    fix="supply a real actual/default/variadic occurrence or keep loud",
+                ) from exc
             source_body = self.source_call_frame.body
             source_frame_cid = self.source_call_frame.frame_cid
         return Complete(
@@ -149,6 +140,13 @@ class CallSiteSugar(Sugar):
                 site=self.site,
                 exception_type_coordinate=self.exception_type_coordinate,
                 source_call_frame_cid=source_frame_cid,
+                formal_coordinate_cids=(
+                    tuple(
+                        item.cid for item in self.source_call_frame.formal_coordinates
+                    )
+                    if self.source_call_frame is not None
+                    else ()
+                ),
             )
         )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_constructor_body_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_constructor_body_sugar.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class ClassConstructorBodySugar(Sugar):
+    definition: Sugar
+    formal_coordinates: tuple[object, ...]
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="ObjectValue",
+            reason="a class call projects its ordinary definition and initializer",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        if ctx is None:
+            from sugar_source_tree.panic import SugarNotWritten
+
+            raise SugarNotWritten(
+                owner="ClassConstructorBodySugar.desugar",
+                observed="missing source-call binding frame",
+                requested="coordinate-bound class constructor actuals",
+                fix="reduce the class call through its SourceVisibleCallFrameV1",
+            )
+        actuals = tuple(
+            ctx.value_for_binding_coordinate(item.cid)
+            for item in self.formal_coordinates
+        )
+        return self.definition.desugar(ctx).and_then(
+            lambda value: Complete(value.construct_receiver_state(actuals))
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
@@ -39,6 +39,7 @@ class ClassDefinitionSugar(Sugar):
                 {
                     "name": method.name,
                     "definitionFragmentCid": method.definition_fragment_cid,
+                    "sourceCallFrameCid": method.source_call_frame.frame_cid,
                 }
                 for method in self.methods
             ],

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -42,7 +42,9 @@ class _ReducedBlock:
     transforms: tuple = ()
 
 
-def reduce_block_to_exitset(statements: tuple) -> ExitSet[_ReducedBlock]:
+def reduce_block_to_exitset(
+    statements: tuple, ctx: object = None
+) -> ExitSet[_ReducedBlock]:
     """Reduce a suite to guarded exits before the linear compatibility view."""
     exits = ExitSet.completed(
         _ReducedBlock(entries=(), can_fall_through=True, fall_through=())
@@ -51,7 +53,7 @@ def reduce_block_to_exitset(statements: tuple) -> ExitSet[_ReducedBlock]:
     for index, head in enumerate(statements):
 
         def reduce_next(state: _ReducedBlock) -> ExitSet[_ReducedBlock]:
-            outcome = head.desugar()
+            outcome = head.desugar(ctx)
             from sugar_lift_py_tests.floor.guarded_faces import GuardedFaces
 
             if (
@@ -164,9 +166,9 @@ def reduce_block_to_exitset(statements: tuple) -> ExitSet[_ReducedBlock]:
     return exits
 
 
-def reduce_statements(statements: tuple):
+def reduce_statements(statements: tuple, ctx: object = None):
     """Return the legacy tuple only after ExitSet proves one unconditional exit."""
-    collapsed = reduce_block_to_exitset(statements).collapse()
+    collapsed = reduce_block_to_exitset(statements, ctx).collapse()
     if isinstance(collapsed, Incomplete):
         return ((collapsed,), False, ())
     if not isinstance(collapsed, Complete):
@@ -175,7 +177,7 @@ def reduce_statements(statements: tuple):
     return state.entries, state.can_fall_through, state.fall_through
 
 
-def reduce_body(statements: tuple):
+def reduce_body(statements: tuple, ctx: object = None):
     """Reduce a function body to ONE Outcome, preserving Complete/Incomplete.
 
     A body that reduces to a value is `Complete(BlockValue(record))` -- the
@@ -187,7 +189,7 @@ def reduce_body(statements: tuple):
     always Complete -- the distinction is carried structurally for the sugars
     (calls, unsupported statements) that will.
     """
-    exits = reduce_block_to_exitset(statements)
+    exits = reduce_block_to_exitset(statements, ctx)
     collapsed = exits.collapse()
     if isinstance(collapsed, Incomplete):
         return collapsed

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/receiver_field_store_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/receiver_field_store_sugar.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class ReceiverFieldStoreSugar(Sugar):
+    receiver: Sugar
+    value: Sugar
+    attr: str
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="ReceiverFieldStoreValue",
+            reason="initializer state is testimony from already-constructed children",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.receiver_field_store_value import (
+            ReceiverFieldStoreValue,
+        )
+
+        return self.receiver.desugar(ctx).and_then(
+            lambda receiver: self.value.desugar(ctx).and_then(
+                lambda value: Complete(
+                    ReceiverFieldStoreValue(receiver, self.attr, value)
+                )
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/source_visible_function_body_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/source_visible_function_body_sugar.py
@@ -24,5 +24,4 @@ class SourceVisibleFunctionBodySugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        del ctx
-        return reduce_body(self.statements)
+        return reduce_body(self.statements, ctx)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from types import SimpleNamespace
 from typing import Literal
 
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.floor import (
     BlockValue,
     CallSiteValue,
@@ -101,7 +101,7 @@ def construct_manager_behavior(
             "artifact-mismatch", resolved.cid, "module source CID"
         )
 
-    context = SimpleNamespace(source_call_frames={})
+    context = TreeConstructionContextV1.for_source_call_construction()
     source_file = SourceFile(
         (module.source, module.source_seat, module.source_cid),
         construction_context=context,

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1,0 +1,292 @@
+"""Cut C: project authenticated external source through the sole constructor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Literal
+
+from sugar_lift_py_tests.floor import (
+    BlockValue,
+    CallSiteValue,
+    FloorValue,
+    ObjectValue,
+    ReturnValue,
+)
+from sugar_lift_py_tests.ir import _term_content_cid, ctor
+from sugar_source_tree.binding_provenance import (
+    BindingEntryV1,
+    BoundBindingStateV1,
+    ConstructedValueTestimonyV1,
+)
+from sugar_source_tree.nodes import Call, ClassDef, FunctionDef, Name, Node
+from sugar_source_tree.tree import SourceFile
+from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+
+from .canonical import cid_of_json
+from .dependency_artifact import DependencyArtifactGraph, ResolvedPythonObjectV1
+
+
+@dataclass(frozen=True)
+class ConstructedCallActualV1:
+    value: FloorValue = field(compare=False)
+    testimony: ConstructedValueTestimonyV1
+
+    def __post_init__(self) -> None:
+        observed = _term_content_cid(
+            self.value.to_term(owner="ConstructedCallActualV1")
+        )
+        if observed != self.testimony.semantic_value_cid:
+            raise ValueError("constructed actual does not match its source testimony")
+
+
+@dataclass(frozen=True)
+class ConstructedManagerBehaviorV1:
+    resolved_object_cid: str
+    manager_construction_cid: str
+    receiver_state: ObjectValue = field(compare=False)
+    receiver_state_cid: str
+    formal_actual_bindings: tuple[BindingEntryV1, ...]
+    source_call_frame_cid: str
+
+    @property
+    def preimage(self):
+        return {
+            "kind": "constructed-manager-behavior",
+            "schemaVersion": "1",
+            "resolvedObjectCid": self.resolved_object_cid,
+            "receiverStateCid": self.receiver_state_cid,
+            "formalActualBindings": [
+                item.wire() for item in self.formal_actual_bindings
+            ],
+            "sourceCallFrameCid": self.source_call_frame_cid,
+        }
+
+    def __post_init__(self) -> None:
+        if self.receiver_state.identity != self.receiver_state_cid:
+            raise ValueError("receiver state CID does not match ordinary construction")
+        if cid_of_json(self.preimage) != self.manager_construction_cid:
+            raise ValueError("manager construction CID does not match its preimage")
+
+
+@dataclass(frozen=True)
+class ManagerConstructionGapV1:
+    kind: Literal[
+        "artifact-mismatch",
+        "definition-missing",
+        "opaque-call-target",
+        "non-manager-result",
+        "call-binding",
+    ]
+    resolved_object_cid: str
+    detail: str
+
+
+def construct_manager_behavior(
+    resolved: ResolvedPythonObjectV1,
+    *,
+    graph: DependencyArtifactGraph,
+    actuals: tuple[ConstructedCallActualV1, ...],
+    keyword_actuals: tuple[tuple[str, ConstructedCallActualV1], ...] = (),
+    call_site: object | None = None,
+) -> ConstructedManagerBehaviorV1 | ManagerConstructionGapV1:
+    """Construct one resolved callable through SourceFile -> Node -> Sugar only."""
+    if graph.distribution_artifact_cid != resolved.distribution_artifact_cid:
+        return ManagerConstructionGapV1(
+            "artifact-mismatch", resolved.cid, "distribution artifact CID"
+        )
+    module = graph.modules.get(resolved.module_name)
+    if module is None or module.source_cid != resolved.source_cid:
+        return ManagerConstructionGapV1(
+            "artifact-mismatch", resolved.cid, "module source CID"
+        )
+
+    context = SimpleNamespace(source_call_frames={})
+    source_file = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=context,
+    )
+    definitions = tuple(
+        item
+        for item in source_file.root.body
+        if isinstance(item, (FunctionDef, ClassDef))
+    )
+    target = next(
+        (item for item in definitions if _matches_definition(item, resolved)), None
+    )
+    if target is None:
+        return ManagerConstructionGapV1(
+            "definition-missing", resolved.cid, "resolved definition coordinate"
+        )
+
+    definition_names = {item.name for item in definitions}
+    if isinstance(target, FunctionDef):
+        opaque = tuple(
+            call.func.id
+            for call in _local_named_calls(target)
+            if call.func.id not in definition_names
+        )
+        if opaque:
+            return ManagerConstructionGapV1(
+                "opaque-call-target", resolved.cid, opaque[0]
+            )
+
+    frames: dict[str, object] = {}
+    for item in definitions:
+        if isinstance(item, ClassDef):
+            frames[item.name] = item.source_visible_constructor_frame()
+
+    pending = [item for item in definitions if isinstance(item, FunctionDef)]
+    while pending:
+        progressed = False
+        for function in tuple(pending):
+            local_calls = tuple(_local_named_calls(function))
+            unresolved = tuple(
+                call.func.id
+                for call in local_calls
+                if call.func.id in definition_names and call.func.id not in frames
+            )
+            if unresolved:
+                continue
+            for call in local_calls:
+                frame = frames.get(call.func.id)
+                if frame is not None:
+                    context.source_call_frames[_call_coordinate(call)] = frame
+            frames[function.name] = function.source_visible_call_frame()
+            pending.remove(function)
+            progressed = True
+        if not progressed:
+            return ManagerConstructionGapV1(
+                "opaque-call-target", resolved.cid, "recursive source call graph"
+            )
+
+    frame = frames.get(target.name)
+    if frame is None:
+        return ManagerConstructionGapV1(
+            "definition-missing", resolved.cid, "ordinary source call frame"
+        )
+    try:
+        values = frame.bind_actuals(
+            tuple(item.value for item in actuals),
+            tuple((name, item.value) for name, item in keyword_actuals),
+        )
+    except SourceCallBindingGap as exc:
+        return ManagerConstructionGapV1("call-binding", resolved.cid, str(exc))
+    call = CallSiteValue(
+        target_name="python:resolved-source-call",
+        arg_values=values,
+        parameters=frame.parameters,
+        term=ctor(
+            "python:resolved-source-call",
+            [item.to_term(owner=resolved.cid) for item in values],
+            symbol_kind="coordinate",
+        ),
+        body=frame.body,
+        source_call_frame_cid=frame.frame_cid,
+        formal_coordinate_cids=tuple(item.cid for item in frame.formal_coordinates),
+    )
+    result = call.force_floor(
+        None, owner="construct_manager_behavior", project_callsite=False
+    )
+    if (
+        isinstance(result, BlockValue)
+        and len(result.statements) == 1
+        and isinstance(result.statements[0], ReturnValue)
+    ):
+        returned = result.statements[0].value
+        if isinstance(returned, CallSiteValue):
+            result = returned.force_floor(
+                None, owner="construct_manager_behavior returned object"
+            )
+        else:
+            result = returned
+    if not isinstance(result, ObjectValue):
+        return ManagerConstructionGapV1(
+            "non-manager-result", resolved.cid, type(result).__name__
+        )
+    original_actuals = (*actuals, *(item for _, item in keyword_actuals))
+    used: set[int] = set()
+    bindings = []
+    for index, (coordinate, value) in enumerate(
+        zip(frame.formal_coordinates, values, strict=True)
+    ):
+        testimony = None
+        for actual_index, actual in enumerate(original_actuals):
+            if actual_index not in used and actual.value is value:
+                testimony = actual.testimony
+                used.add(actual_index)
+                break
+        if testimony is None:
+            fragment = frame.default_fragments[index]
+            if fragment is None and frame.parameter_kinds[index] in {"vararg", "kwarg"}:
+                fragment = call_site
+            if fragment is None:
+                return ManagerConstructionGapV1(
+                    "call-binding", resolved.cid, "constructed binding testimony absent"
+                )
+            testimony = ConstructedValueTestimonyV1.mint(
+                fragment,
+                _term_content_cid(value.to_term(owner=resolved.cid)),
+            )
+        bindings.append(BindingEntryV1(coordinate, BoundBindingStateV1(testimony)))
+    bindings = tuple(bindings)
+    preimage = {
+        "kind": "constructed-manager-behavior",
+        "schemaVersion": "1",
+        "resolvedObjectCid": resolved.cid,
+        "receiverStateCid": result.identity,
+        "formalActualBindings": [item.wire() for item in bindings],
+        "sourceCallFrameCid": frame.frame_cid,
+    }
+    return ConstructedManagerBehaviorV1(
+        resolved.cid,
+        cid_of_json(preimage),
+        result,
+        result.identity,
+        bindings,
+        frame.frame_cid,
+    )
+
+
+def _matches_definition(node: Node, resolved: ResolvedPythonObjectV1) -> bool:
+    span = node.line_col_span()
+    definition = resolved.definition
+    return (
+        (
+            (isinstance(node, FunctionDef) and definition.kind == "function")
+            or (isinstance(node, ClassDef) and definition.kind == "class")
+        )
+        and node.fragment.seal().cid == definition.fragment_cid
+        and node.unit.source_cid == definition.source_cid
+        and span.start_line == definition.start_line
+        and span.start_col == definition.start_col
+        and span.end_line == definition.end_line
+        and span.end_col == definition.end_col
+    )
+
+
+def _local_named_calls(function: FunctionDef):
+    stack = list(reversed(function.body))
+    while stack:
+        node = stack.pop()
+        if isinstance(node, (FunctionDef, ClassDef)):
+            continue
+        if isinstance(node, Call) and isinstance(node.func, Name):
+            yield node
+        children = [child for _, _, child in node.children()]
+        stack.extend(reversed(children))
+
+
+def _call_coordinate(call: Call):
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
+
+    span = call.line_col_span()
+    return SourceFragmentCoordinateV1(
+        call.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+from pathlib import Path
+
+from sugar_lift_py_tests.floor import TermValue
+from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.dependency_artifact import (
+    DependencyArtifactGraph,
+    ResolvedPythonObjectV1,
+    resolve_import_binding,
+)
+from sugar_lift_python_source.manager_construction import (
+    ConstructedCallActualV1,
+    ConstructedManagerBehaviorV1,
+    ManagerConstructionGapV1,
+    construct_manager_behavior,
+)
+from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
+from sugar_source_tree.nodes import Call, Constant
+from sugar_source_tree.tree import SourceFile
+
+
+def _distribution(root: Path, source: str) -> importlib.metadata.Distribution:
+    package = root / "arbitrary"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        "from arbitrary.manager import make_guard\n", encoding="utf-8"
+    )
+    (package / "manager.py").write_text(source, encoding="utf-8")
+    metadata = root / "arbitrary_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: arbitrary-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    files = (
+        "arbitrary/__init__.py",
+        "arbitrary/manager.py",
+        "arbitrary_dist-1.0.dist-info/METADATA",
+        "arbitrary_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for file in files:
+            writer.writerow((file, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _resolved(root: Path, source: str):
+    graph = DependencyArtifactGraph.authenticate(_distribution(root, source))
+    consumer = "import arbitrary\narbitrary.make_guard(23)\n"
+    path = root / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    source_cid = blake3_512_of(consumer.encode())
+    receipts, _ = authenticated_import_use_receipts(root, path, consumer, source_cid)
+    resolved = resolve_import_binding(receipts[0], graph=graph)
+    assert isinstance(resolved, ResolvedPythonObjectV1)
+    source_file = SourceFile((consumer, str(path), source_cid))
+    call = next(item for item in source_file.nodes() if isinstance(item, Call))
+    literal = next(item for item in call.args if isinstance(item, Constant))
+    actual = TermValue(23)
+    # Testimony uses the canonical term address, never repr spelling.
+    from sugar_lift_py_tests.ir import _term_content_cid
+
+    testimony = ConstructedValueTestimonyV1.mint(
+        literal.fragment, _term_content_cid(actual.to_term(owner="test"))
+    )
+    return graph, resolved, ConstructedCallActualV1(actual, testimony), call.fragment
+
+
+def test_renamed_factory_constructs_returned_receiver_state_through_one_door(tmp_path):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class UnprivilegedGuard:\n"
+        "    def __init__(self, expected):\n"
+        "        self.expected = expected\n\n"
+        "def make_guard(expected):\n"
+        "    return UnprivilegedGuard(expected)\n",
+    )
+
+    result = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    assert isinstance(result, ConstructedManagerBehaviorV1)
+    fields = {field.name: field.value for field in result.receiver_state.fields}
+    assert fields == {"expected": actual.value}
+    assert result.formal_actual_bindings[0].coordinate.projection_path == ("formal", 0)
+    assert result.manager_construction_cid.startswith("blake3-512:")
+
+
+def test_opaque_source_call_stays_typed_loud(tmp_path):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path, "def make_guard(expected):\n    return len(expected)\n"
+    )
+
+    result = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    assert isinstance(result, ManagerConstructionGapV1)
+    assert result.kind == "opaque-call-target"

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4385,12 +4385,12 @@ class Call(Expression):
                     contract_ref = resolution
 
             source_call_frame = None
-            frames = getattr(context, "source_call_frames", None)
-            if frames is not None:
-                from sugar_lift_py_tests.context_manager_resolution import (
-                    SourceFragmentCoordinateV1,
-                )
+            from sugar_lift_py_tests.context_manager_resolution import (
+                SourceFragmentCoordinateV1,
+                TreeConstructionContextV1,
+            )
 
+            if isinstance(context, TreeConstructionContextV1) and context.source_call_frames:
                 span = self.line_col_span()
                 coordinate = SourceFragmentCoordinateV1(
                     self.unit.source_cid,
@@ -4399,7 +4399,7 @@ class Call(Expression):
                     span.end_line,
                     span.end_col,
                 )
-                source_call_frame = frames.get(coordinate)
+                source_call_frame = context.source_call_frames.get(coordinate)
 
             return CallSiteSugar(
                 target_name=self.func.id,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -226,12 +226,8 @@ class SourceUnit:
             if start <= (span.start_line, span.start_col) <= end:
                 containing.append(candidate)
         if containing:
-            owner = max(
-                containing, key=lambda value: value.line_col_span().start_line
-            )
-            table = self.function_symtable(
-                owner.name, owner.line_col_span().start_line
-            )
+            owner = max(containing, key=lambda value: value.line_col_span().start_line)
+            table = self.function_symtable(owner.name, owner.line_col_span().start_line)
             try:
                 symbol = table.lookup(node.id)
             except KeyError:
@@ -257,11 +253,7 @@ class SourceUnit:
                 if statement.name == node.id:
                     bindings.append(("other",))
             elif kind in ("Assign", "AnnAssign", "AugAssign"):
-                targets = (
-                    statement.targets
-                    if kind == "Assign"
-                    else (statement.target,)
-                )
+                targets = statement.targets if kind == "Assign" else (statement.target,)
                 if any(
                     isinstance(target, Name) and target.id == node.id
                     for target in targets
@@ -1185,10 +1177,8 @@ class FunctionDef(Statement):
         from sugar_lift_py_tests.context_manager_resolution import (
             SourceFragmentCoordinateV1,
         )
-        from sugar_lift_py_tests.source_call_frame import (
-            AwaitingBindingCoordinateCallFrameV1,
-            SourceVisibleCallFrameV1,
-        )
+        from sugar_lift_py_tests.source_call_frame import SourceVisibleCallFrameV1
+        from sugar_source_tree.binding_provenance import BindingCoordinateV1
 
         span = self.line_col_span()
         site = SourceFragmentCoordinateV1(
@@ -1199,24 +1189,57 @@ class FunctionDef(Statement):
             span.end_col,
         )
         parameters = tuple(param.name for param in self.params)
-        if parameters:
-            return AwaitingBindingCoordinateCallFrameV1(
-                self.unit.source_cid, site, parameters
-            )
+        owner_cid = self.fragment.seal().cid
+        coordinates = tuple(
+            BindingCoordinateV1.mint(owner_cid, param.fragment, ("formal", index))
+            for index, param in enumerate(self.params)
+        )
+        formal_scope = {
+            param.name: self._make_coordinate_ref(param, coordinate)
+            for param, coordinate in zip(self.params, coordinates, strict=True)
+        }
         from sugar_lift_py_tests.sugar.source_visible_function_body_sugar import (
             SourceVisibleFunctionBodySugar,
         )
 
-        substituted = self.substitute({})
+        substituted_body, _ = self._substitute_body(self.body, formal_scope)
         body = SourceVisibleFunctionBodySugar(
-            tuple(statement.sugar() for statement in substituted.body), self.fragment
+            tuple(statement.sugar() for statement in substituted_body), self.fragment
         )
         return SourceVisibleCallFrameV1(
             source_identity_cid=self.unit.source_cid,
             definition_site=site,
             definition_fragment_cid=self.fragment.seal().cid,
-            parameters=(),
+            parameters=parameters,
+            formal_coordinates=coordinates,
+            parameter_kinds=tuple(param.param_kind for param in self.params),
+            default_sugars=tuple(
+                param.default.sugar() if param.default is not None else None
+                for param in self.params
+            ),
+            default_fragments=tuple(
+                param.default.fragment if param.default is not None else None
+                for param in self.params
+            ),
+            default_fragment_cids=tuple(
+                param.default.fragment.seal().cid if param.default is not None else None
+                for param in self.params
+            ),
             body=body,
+        )
+
+    def _make_coordinate_ref(self, param: "Param", coordinate) -> "Node":
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        return materialize(
+            self.unit,
+            ShadowNode(
+                "BindingCoordinateRef",
+                param.span,
+                (("coordinate", Leaf(coordinate)),),
+            ),
+            self.reporter,
         )
 
     def substitute(self, scope):
@@ -1422,7 +1445,10 @@ class ClassDef(Statement):
 
         constructed = tuple(
             ConstructedClassMethodV1(
-                method.name, method.fragment.seal().cid, method.sugar()
+                method.name,
+                method.fragment.seal().cid,
+                method.sugar(),
+                method.source_visible_call_frame(),
             )
             for method in methods
         )
@@ -1432,6 +1458,65 @@ class ClassDef(Statement):
             definition_fragment_cid=self.fragment.seal().cid,
             methods=constructed,
             site=self.fragment,
+        )
+
+    def source_visible_constructor_frame(self):
+        """The class call projected through its already-constructed definition."""
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+        )
+        from sugar_lift_py_tests.source_call_frame import SourceVisibleCallFrameV1
+        from sugar_lift_py_tests.sugar.class_constructor_body_sugar import (
+            ClassConstructorBodySugar,
+        )
+        from sugar_source_tree.binding_provenance import BindingCoordinateV1
+
+        initializer = next(
+            (
+                item
+                for item in self.body
+                if isinstance(item, FunctionDef) and item.name == "__init__"
+            ),
+            None,
+        )
+        params = () if initializer is None else initializer.params[1:]
+        owner_cid = self.fragment.seal().cid
+        coordinates = tuple(
+            BindingCoordinateV1.mint(owner_cid, param.fragment, ("formal", index))
+            for index, param in enumerate(params)
+        )
+        span = self.line_col_span()
+        site = SourceFragmentCoordinateV1(
+            self.unit.source_cid,
+            span.start_line,
+            span.start_col,
+            span.end_line,
+            span.end_col,
+        )
+        return SourceVisibleCallFrameV1(
+            source_identity_cid=self.unit.source_cid,
+            definition_site=site,
+            definition_fragment_cid=owner_cid,
+            parameters=tuple(param.name for param in params),
+            formal_coordinates=coordinates,
+            parameter_kinds=tuple(param.param_kind for param in params),
+            default_sugars=tuple(
+                param.default.sugar() if param.default is not None else None
+                for param in params
+            ),
+            default_fragments=tuple(
+                param.default.fragment if param.default is not None else None
+                for param in params
+            ),
+            default_fragment_cids=tuple(
+                param.default.fragment.seal().cid if param.default is not None else None
+                for param in params
+            ),
+            body=ClassConstructorBodySugar(
+                definition=self.sugar(),
+                formal_coordinates=coordinates,
+                site=self.fragment,
+            ),
         )
 
 
@@ -1561,9 +1646,15 @@ class Assign(Statement):
         from .shadow import rewrite
 
         new_value, changed = self._substitute_field(self.value, scope)
-        if not changed:
+        changes = {"value": new_value} if changed else {}
+        if len(self.targets) == 1 and isinstance(self.targets[0], Attribute):
+            target = self.targets[0]
+            receiver, receiver_changed = self._substitute_field(target.value, scope)
+            if receiver_changed:
+                changes["targets"] = (rewrite(target, value=receiver),)
+        if not changes:
             return self
-        return rewrite(self, value=new_value)
+        return rewrite(self, **changes)
 
     def _destructured_binding(self):
         # `a, b = <display>` -- a single Tuple/List target of plain Names,
@@ -1631,6 +1722,17 @@ class Assign(Statement):
             )
 
         if len(self.targets) == 1 and isinstance(self.targets[0], Attribute):
+            if isinstance(self.targets[0].value, BindingCoordinateRef):
+                from sugar_lift_py_tests.sugar.receiver_field_store_sugar import (
+                    ReceiverFieldStoreSugar,
+                )
+
+                return ReceiverFieldStoreSugar(
+                    receiver=self.targets[0].value.sugar(),
+                    value=self.value.sugar(),
+                    attr=self.targets[0].attr,
+                    site=self.fragment,
+                )
             from sugar_lift_py_tests.sugar.store_effect_sugar import (
                 AttributeStoreEffectSugar,
             )
@@ -4576,6 +4678,23 @@ class FormalRef(Expression):
         from sugar_lift_py_tests.sugar.name_sugar import NameSugar
 
         return NameSugar(name=self.name, site=self.fragment)
+
+
+class BindingCoordinateRef(Expression):
+    """Projection of one authenticated formal binding in a source call frame."""
+
+    coordinate: object
+
+    def substitute(self, scope):
+        del scope
+        return self
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.binding_coordinate_ref_sugar import (
+            BindingCoordinateRefSugar,
+        )
+
+        return BindingCoordinateRefSugar(self.coordinate, self.fragment)
 
 
 class BranchResultRef(Expression):

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -5,7 +5,15 @@ from types import SimpleNamespace
 import pytest
 
 from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
-from sugar_lift_py_tests.floor import BlockValue, CallSiteValue, ReturnValue, TermValue
+from sugar_lift_py_tests.floor import (
+    BlockValue,
+    CallSiteValue,
+    DictValue,
+    ReturnValue,
+    StringValue,
+    TermValue,
+    TupleValue,
+)
 from sugar_lift_py_tests.outcome import Complete
 from sugar_source_tree.nodes import Call, ClassDef, FunctionDef
 from sugar_source_tree.panic import SugarNotWritten
@@ -59,7 +67,7 @@ def test_source_visible_zero_parameter_call_carries_the_ordinary_body() -> None:
     assert constructed.statements[0].value == TermValue(7)
 
 
-def test_parameterized_source_frame_stays_loud_until_binding_coordinate_lands() -> None:
+def test_parameterized_source_frame_projects_the_exact_actual_by_coordinate() -> None:
     context = SimpleNamespace(source_call_frames={})
     source = _source_file(
         "def renamed_identity(value):\n" "    return value\n\n" "renamed_identity(7)\n",
@@ -69,8 +77,21 @@ def test_parameterized_source_frame_stays_loud_until_binding_coordinate_lands() 
     call = next(node for node in source.nodes() if isinstance(node, Call))
     context.source_call_frames[_coordinate(call)] = function.source_visible_call_frame()
 
-    with pytest.raises(SugarNotWritten, match="awaiting-binding-coordinate"):
-        call.sugar().desugar()
+    frame = function.source_visible_call_frame()
+    context.source_call_frames[_coordinate(call)] = frame
+
+    outcome = call.sugar().desugar()
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, CallSiteValue)
+    assert len(frame.formal_coordinates) == 1
+    assert frame.formal_coordinates[0].projection_path == ("formal", 0)
+    constructed = outcome.value.force_floor(
+        None, owner="coordinate-source-visible-call-frame", project_callsite=False
+    )
+    assert isinstance(constructed, BlockValue)
+    assert isinstance(constructed.statements[0], ReturnValue)
+    assert constructed.statements[0].value == TermValue(7)
 
 
 def test_class_definition_constructs_methods_but_receiver_state_awaits_coordinate() -> (
@@ -95,8 +116,50 @@ def test_class_definition_constructs_methods_but_receiver_state_awaits_coordinat
     )
     assert outcome.value.initializer is not None
     assert outcome.value.class_definition_cid.startswith("blake3-512:")
-    with pytest.raises(SugarNotWritten, match="awaiting-binding-coordinate"):
-        outcome.value.construct_receiver_state(())
+    receiver = outcome.value.construct_receiver_state((TermValue(11),))
+
+    assert receiver.class_name == "RenamedGuard"
+    assert {field.name: field.value for field in receiver.fields} == {
+        "expected": TermValue(11)
+    }
+    assert receiver.identity.startswith("blake3-512:")
+
+
+def test_source_frame_binds_constructed_defaults_and_variadics() -> None:
+    context = SimpleNamespace(source_call_frames={})
+    source = _source_file(
+        "def renamed_default(value=9):\n"
+        "    return value\n\n"
+        "def renamed_variadic(first, *rest, **options):\n"
+        "    return rest\n\n"
+        "renamed_default()\n"
+        "renamed_variadic(1, 2, 3, label=4)\n",
+        context=context,
+    )
+    functions = {
+        node.name: node for node in source.nodes() if isinstance(node, FunctionDef)
+    }
+    calls = [node for node in source.nodes() if isinstance(node, Call)]
+    context.source_call_frames[_coordinate(calls[0])] = functions[
+        "renamed_default"
+    ].source_visible_call_frame()
+    context.source_call_frames[_coordinate(calls[1])] = functions[
+        "renamed_variadic"
+    ].source_visible_call_frame()
+
+    default_call = calls[0].sugar().desugar().value
+    default_block = default_call.force_floor(
+        None, owner="default-call-frame", project_callsite=False
+    )
+    assert default_block.statements[0].value == TermValue(9)
+
+    variadic_call = calls[1].sugar().desugar().value
+    assert isinstance(variadic_call.arg_values[1], TupleValue)
+    assert variadic_call.arg_values[1].elements == (TermValue(2), TermValue(3))
+    assert isinstance(variadic_call.arg_values[2], DictValue)
+    assert variadic_call.arg_values[2].entries == (
+        (StringValue("label"), TermValue(4)),
+    )
 
 
 def test_unknown_class_member_stays_typed_loud() -> None:

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import pytest
 
-from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
 from sugar_lift_py_tests.floor import (
     BlockValue,
     CallSiteValue,
@@ -41,7 +42,7 @@ def _coordinate(node) -> SourceFragmentCoordinateV1:
 
 
 def test_source_visible_zero_parameter_call_carries_the_ordinary_body() -> None:
-    context = SimpleNamespace(source_call_frames={})
+    context = TreeConstructionContextV1.for_source_call_construction()
     source = _source_file(
         "def renamed_value():\n" "    return 7\n\n" "renamed_value()\n",
         context=context,
@@ -68,7 +69,7 @@ def test_source_visible_zero_parameter_call_carries_the_ordinary_body() -> None:
 
 
 def test_parameterized_source_frame_projects_the_exact_actual_by_coordinate() -> None:
-    context = SimpleNamespace(source_call_frames={})
+    context = TreeConstructionContextV1.for_source_call_construction()
     source = _source_file(
         "def renamed_identity(value):\n" "    return value\n\n" "renamed_identity(7)\n",
         context=context,
@@ -126,7 +127,7 @@ def test_class_definition_constructs_methods_but_receiver_state_awaits_coordinat
 
 
 def test_source_frame_binds_constructed_defaults_and_variadics() -> None:
-    context = SimpleNamespace(source_call_frames={})
+    context = TreeConstructionContextV1.for_source_call_construction()
     source = _source_file(
         "def renamed_default(value=9):\n"
         "    return value\n\n"


### PR DESCRIPTION
## Outcome

Extends the sole SourceOracle -> adapter -> typed Node -> substitution -> Sugar constructor to consume authenticated `ResolvedPythonObjectV1` definitions, bind source-call frames through `BindingCoordinateV1`, and summarize the returned manager object/receiver state as `ConstructedManagerBehaviorV1`.

No private AST interpreter, vendor/manager spelling, provider catalog, or module execution. Opaque source calls remain `ManagerConstructionGapV1`.

## Focused evidence

- 51 focused dependency-artifact / coordinate / constructor tests passed after rebase
- renamed factory returns an `ObjectValue` whose field is the exact constructed actual
- defaults, `*args`, and `**kwargs` bind from constructed children/real operands
- opaque source call twin remains typed-loud
- `R_construction_invariant_violations=0`
- `R_second_construction_path=0`
- `R_non_exhaustive_variant_coverage=0`
- stronger side-door baseline not increased by this PR (no raw AST added)

## Predicted leverage

Cut C itself authenticates manager construction but does not yet rewrite `With`; predicted immediate pandas `Delta R` is 0. It unlocks Cut D (`__enter__`/`__exit__` construction) and the closed CM summary/With projection over the measured 5,454-site manager bucket.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add interprocedural sole-path manager construction via `construct_manager_behavior`
> - Adds `construct_manager_behavior` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6127/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1), which authenticates resolved objects, binds actuals against formal parameters (including defaults and variadics), reduces the call and returned value to an `ObjectValue`, and returns a `ConstructedManagerBehaviorV1` or a structured `ManagerConstructionGapV1` on failure — all without context-manager enrollment.
> - `SourceVisibleCallFrameV1` in [source_call_frame.py](https://github.com/TSavo/sugar/pull/6127/files#diff-46ed9299504763bf181346656eb60c3f3f7782237167304b1201599c48319ab6) now carries formal `BindingCoordinateV1` entries, parameter kinds, and default metadata; the new `bind_actuals` method performs validated positional/keyword/variadic binding, raising `SourceCallBindingGap` on error.
> - `ClassDef.source_visible_constructor_frame` in [nodes.py](https://github.com/TSavo/sugar/pull/6127/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) builds a source-visible frame for class constructor calls, wrapping the `__init__` body in `ClassConstructorBodySugar` to construct receiver state via `ClassDefinitionValue.construct_receiver_state`.
> - Introduces new sugar/floor types — `BindingCoordinateRefSugar`, `ClassConstructorBodySugar`, `ReceiverFieldStoreSugar`, and `ReceiverFieldStoreValue` — to represent formal coordinate projections and receiver field stores as first-class values throughout the reduction pipeline.
> - `ReduceContext` now carries `binding_coordinate_values` so constructed actuals can be looked up by coordinate CID during block/body reduction.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d002834.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->