### PR TITLE
Hold sole-path construction side-door floor at R=0

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/construction_side_door_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_side_door_law.py
@@ -14,8 +14,10 @@ parser objects.
 
 This instrument names every current construction-path side door. There is no
 baseline, threshold, or allowlist. Exit 1 while R > 0. Prefer larger honest
-red over hollow green. Do not allowlist remaining offenders (including
-``import_binding`` / ``contract_expression``) — they stay red until killed.
+red over hollow green. Sole-path packages (``sugar-lift-py-tests`` construction
+and ``sugar-source-tree`` above adapters) must stay at R=0. Dual-body residual
+under ``sugar-lift-python-source`` stays named and red until that body is
+retired or routed through the sole path — do not allowlist it.
 
 Measure axes (combined R; every offender named by class):
 
@@ -506,6 +508,22 @@ def scan_roots(roots: Sequence[Path]) -> list[SideDoorOffender]:
     return sorted(offenders, key=lambda r: (r.path, r.line, r.kind, r.expression))
 
 
+def sole_path_roots(repo: Path | None = None) -> list[Path]:
+    """Sole construction packages only (no dual-body parasite).
+
+    R on these roots must stay 0: meaning is tree + prebound refs only.
+    """
+    kit = Path(__file__).resolve().parents[1]
+    py = kit.parent
+    if repo is not None:
+        py = (repo / "implementations" / "python").resolve()
+        kit = py / "sugar-lift-py-tests"
+    return [
+        kit / "src" / "sugar_lift_py_tests",
+        py / "sugar-source-tree" / "src" / "sugar_source_tree",
+    ]
+
+
 def default_production_roots(repo: Path | None = None) -> list[Path]:
     """Production construction packages on the sole path (and its parasites).
 
@@ -519,8 +537,7 @@ def default_production_roots(repo: Path | None = None) -> list[Path]:
         py = (repo / "implementations" / "python").resolve()
         kit = py / "sugar-lift-py-tests"
     return [
-        kit / "src" / "sugar_lift_py_tests",
-        py / "sugar-source-tree" / "src" / "sugar_source_tree",
+        *sole_path_roots(repo),
         py / "sugar-lift-python-source" / "src" / "sugar_lift_python_source",
     ]
 
@@ -740,23 +757,39 @@ def main(argv: Sequence[str] | None = None) -> int:
     r = r_construction_side_doors(offenders)
     err = r_auditor_errors(offenders)
     axes = r_by_axis(offenders)
+    # Always remeasure sole-path packages so dual-body residual cannot mask a
+    # sole-path reintroduction (or a hollow green on the real construction path).
+    sole_offenders = scan_roots(sole_path_roots(args.repo))
+    sole_r = r_construction_side_doors(sole_offenders)
+    sole_err = r_auditor_errors(sole_offenders)
     summary = {
         "instrument": "R_construction_side_doors",
         "ok": r == 0 and err == 0,
         "R_construction_side_doors": r,
+        "R_sole_path_construction_side_doors": sole_r,
         "R_membrane_admission": axes["membrane-admission"],
         "R_foreign_ast_import": axes["foreign-ast-import"],
         "R_ast_semantic_above_adapter": axes["ast-semantic-above-adapter"],
         "R_dual_old_lifter": axes["dual-old-lifter"],
         "auditor_errors": err,
+        "sole_path_auditor_errors": sole_err,
         "offenders": offenders_to_jsonable(
             [row for row in offenders if row.kind in _SIDE_DOOR_KINDS]
         ),
     }
+    if sole_r > 0 or sole_err > 0:
+        print(
+            "CONSTRUCTION-SIDE-DOOR LAW SOLE-PATH RED: "
+            f"R_sole_path={sole_r}"
+            + (f"; sole_path_auditor_errors={sole_err}" if sole_err else "")
+            + " (sole path must stay tree + prebound refs only)"
+        )
+        print(format_report(sole_offenders))
     if r > 0 or err > 0:
         print(
             "CONSTRUCTION-SIDE-DOOR LAW RED: "
             f"R={r}"
+            f" sole_path={sole_r}"
             f" membrane={axes['membrane-admission']}"
             f" foreign_ast_import={axes['foreign-ast-import']}"
             f" ast_above_adapter={axes['ast-semantic-above-adapter']}"
@@ -765,10 +798,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         print(format_report(offenders))
         print(json.dumps(summary))
+        # Sole-path reintroduction is worse than dual-body residual alone.
+        return 1
+    if sole_r > 0 or sole_err > 0:
+        print(json.dumps(summary))
         return 1
     print(
         "CONSTRUCTION-SIDE-DOOR LAW GREEN: R_construction_side_doors = 0 "
-        "(meaning is tree + prebound refs only)"
+        f"(sole_path={sole_r}; meaning is tree + prebound refs only)"
     )
     print(json.dumps(summary))
     return 0

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_side_door_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_side_door_law.py
@@ -2,9 +2,9 @@
 
 Green only when meaning is tree + prebound authenticated contract refs only.
 This suite proves the instrument discriminates planted twins, stays quiet on
-clean trees / adapters, and reports live-repository R > 0 while offenders
-remain. It does not fix, delete, or allowlist production doors — including
-import_binding / contract_expression foreign-ast imports.
+clean trees / adapters, holds sole-path packages at R=0, and keeps the live
+default scan red while dual-body residual remains under sugar-lift-python-
+source. It does not allowlist dual-body doors.
 """
 
 from __future__ import annotations
@@ -181,42 +181,72 @@ def test_default_roots_include_lift_python_source() -> None:
     assert "sugar_lift_python_source" in names
 
 
-def test_live_repository_is_red_while_offenders_remain() -> None:
-    """Instrument runs on production roots; main stays RED while R > 0."""
+def test_sole_path_roots_exclude_dual_body() -> None:
+    sole = _SCANNER.sole_path_roots()
+    names = [p.name for p in sole]
+    assert "sugar_lift_py_tests" in names
+    assert "sugar_source_tree" in names
+    assert "sugar_lift_python_source" not in names
+
+
+def test_sole_path_packages_are_green() -> None:
+    """Post-#6120/#6122/#6123: sole path is tree + prebound refs only."""
+    roots = _SCANNER.sole_path_roots()
+    offenders = _SCANNER.scan_roots(roots)
+    r = _SCANNER.r_construction_side_doors(offenders)
+    err = _SCANNER.r_auditor_errors(offenders)
+    assert err == 0, _SCANNER.format_report(offenders)
+    assert r == 0, (
+        "sole-path packages must stay at R=0; residual:\n"
+        + _SCANNER.format_report(offenders)
+    )
+    # Drained sole-path modules must not reintroduce foreign ast.
+    sole_foreign = [
+        row
+        for row in offenders
+        if row.kind == "foreign-ast-import"
+        and (
+            "import_binding" in row.path
+            or "contract_expression" in row.path
+            or "verify_dialect" in row.path
+        )
+    ]
+    assert sole_foreign == []
+
+
+def test_live_repository_is_red_while_dual_body_residual_remains() -> None:
+    """Default roots stay RED while dual-body sugar-lift-python-source has debt."""
     roots = _SCANNER.default_production_roots()
     offenders = _SCANNER.scan_roots(roots)
     r = _SCANNER.r_construction_side_doors(offenders)
     err = _SCANNER.r_auditor_errors(offenders)
     axes = _SCANNER.r_by_axis(offenders)
 
-    # Honest red: named side doors still on the construction path.
     assert err == 0, _SCANNER.format_report(offenders)
     assert r > 0, (
-        "expected live construction-path side doors (foreign ast import and/or "
-        "ast above adapter and/or membrane admission); instrument must stay red "
-        "until sole path is tree + prebound refs only"
+        "expected dual-body residual under sugar-lift-python-source; default "
+        "scan must stay red until that construction body is retired or routed "
+        "through the sole path"
     )
-    # Foreign-ast-import axis must name real debt (import_binding /
-    # contract_expression and dual construction body under lift-python-source).
     assert axes["foreign-ast-import"] > 0, (
-        "R_foreign_ast_import must stay red until no production package above "
-        "adapters imports stdlib ast"
+        "R_foreign_ast_import must stay red while dual-body packages above "
+        "adapters still import stdlib ast"
     )
     foreign_paths = {
         row.path
         for row in offenders
         if row.kind == "foreign-ast-import"
     }
-    # Do not allowlist these — they must remain counted until killed.
-    assert any("import_binding" in p for p in foreign_paths)
-    assert any("contract_expression" in p for p in foreign_paths)
-    # Dual construction body still on the production path.
+    # Dual construction body still on the production path — do not allowlist.
     assert any("sugar_lift_python_source" in p for p in foreign_paths)
+    # Sole-path drained modules are not residual debt.
+    assert not any("import_binding" in p for p in foreign_paths)
+    assert not any("contract_expression" in p for p in foreign_paths)
 
-    # Every counted row must name a class and axis.
     debt = [row for row in offenders if row.kind in _SCANNER._SIDE_DOOR_KINDS]
     assert debt
     assert all(row.axis and row.kind for row in debt)
+    assert all("sugar_lift_python_source" in row.path for row in debt)
     assert (
         axes["foreign-ast-import"] > 0
         or axes["ast-semantic-above-adapter"] > 0
@@ -238,6 +268,7 @@ def test_main_json_reports_r_and_offenders(capsys) -> None:
     assert summary["instrument"] == "R_construction_side_doors"
     assert summary["ok"] is False
     assert summary["R_construction_side_doors"] > 0
+    assert summary["R_sole_path_construction_side_doors"] == 0
     assert summary["R_foreign_ast_import"] > 0
     assert isinstance(summary["offenders"], list)
     assert summary["offenders"]
@@ -245,6 +276,10 @@ def test_main_json_reports_r_and_offenders(capsys) -> None:
     assert "axis" in summary["offenders"][0]
     assert any(
         row["axis"] == "foreign-ast-import" for row in summary["offenders"]
+    )
+    assert all(
+        "sugar_lift_python_source" in row["path"]
+        for row in summary["offenders"]
     )
 
 


### PR DESCRIPTION
## What changed

After #6120/#6122/#6123 (and #6124 leaf_assertions), remeasured `construction_side_door_law`:

| Scope | R |
|-------|---|
| sole path (`sugar-lift-py-tests` + `sugar-source-tree` above adapters) | **0** |
| default roots (includes dual-body `sugar-lift-python-source`) | **40** |

No remaining ast semantic doors under sole-path packages. `import_binding` / `contract_expression` are drained. `idd/*` and `cm_boundary` text-only mentions are correctly non-offenders.

This PR is fix-forward + instrument strengthen (not a noise "already clean" PR):

- live test still hard-required drained `import_binding` / `contract_expression` as foreign-ast offenders → suite red on main after the kills
- add `sole_path_roots()` + `R_sole_path_construction_side_doors` so dual-body residual cannot mask sole-path reintroduction
- prove sole R=0; keep default scan red on dual-body only

## Evidence (brun / bpytest only)

```
CONSTRUCTION-SIDE-DOOR SELF-TEST GREEN
SOLE: R_construction_side_doors = 0, R_sole_path = 0
DEFAULT: R=40 sole_path=0 membrane=0 foreign_ast_import=8 ast_above_adapter=32 dual_old_lifter=0
test_construction_side_door_law.py: 13 passed
```

No production construction drain in this PR — sole path already clean; dual-body residual left for separate drain lanes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hold sole-path construction side-door floor at R=0 in the CLI and test suite
> - Adds `sole_path_roots()` to compute the sole-path package roots (`sugar_lift_py_tests`, `sugar_source_tree`), excluding `sugar_lift_python_source` which carries known dual-body residual debt.
> - CLI in [construction_side_door_law.py](https://github.com/TSavo/sugar/pull/6128/files#diff-d0802b809390201e77c1fe23d939072c8ceea0b8e6e6e23dac7b3ed921bf44be) now scans sole-path roots separately, adds `R_sole_path_construction_side_doors` and `sole_path_auditor_errors` to the JSON summary, and exits with status 1 if either sole-path or default roots are red.
> - New tests in [test_construction_side_door_law.py](https://github.com/TSavo/sugar/pull/6128/files#diff-b9d7a8f88c6552158bba81bbe137654a54328005c380d2e7f619573f562a04a3) enforce that sole-path packages stay at R=0 and that all current debt originates exclusively from `sugar_lift_python_source`.
> - Behavioral Change: exit code 1 is now also triggered when sole-path R>0 or auditor errors exist, even if the overall default-roots scan is green.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 817def6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->