### PR TITLE
Drain dead source_tables dual path + typed __all__/reexport scans

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -385,7 +385,7 @@ def _cache_cardinalities() -> tuple[int, int]:
     source_entries = 0
     source_module = sys.modules.get("sugar_lift_python_source.source_tables")
     if source_module is not None:
-        for name in ("source_splitlines", "source_lines", "_parsed", "parsed_parents"):
+        for name in ("source_splitlines", "source_lines", "_parsed"):
             cached = getattr(source_module, name, None)
             if cached is not None and hasattr(cached, "cache_info"):
                 source_entries += cached.cache_info().currsize

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py
@@ -4,13 +4,35 @@ import ast
 import json
 import os
 import re
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
 
 from .ast_template import function_body_template, function_param_names
 from .canonical import blake3_512_of, cid_of_json, template_cid_of_json
-from .source_tables import parsed_tree
+
+
+def _typed_tree():
+    """Lazy typed-tree imports — avoid circular import with source_oracle."""
+    _tree_src = Path(__file__).resolve().parents[3] / "sugar-source-tree" / "src"
+    if _tree_src.is_dir() and str(_tree_src) not in sys.path:
+        sys.path.insert(0, str(_tree_src))
+    from sugar_source_tree.backend import BackendCouldNotParse
+    from sugar_source_tree.nodes import Assign, Constant, List, Name, Tuple_
+    from sugar_source_tree.nodes import ImportFrom as TypedImportFrom
+    from sugar_source_tree.tree import SourceFile
+
+    return (
+        SourceFile,
+        BackendCouldNotParse,
+        Assign,
+        Constant,
+        List,
+        Name,
+        Tuple_,
+        TypedImportFrom,
+    )
 
 Json = Any
 class UnsupportedStatementGrammar(RuntimeError):
@@ -306,30 +328,56 @@ def _module_file(root: Path, module: str) -> Path | None:
 
 
 def _literal_all_exports(root: Path, module: str) -> list[str]:
+    """Read ``__all__`` through the typed source tree — not raw ``ast.walk``.
+
+    Source enters once via SourceFile (adapter-backed). Semantic authority is
+    typed Assign/Name/Constant/List/Tuple nodes; foreign ast is not the door.
+    """
+    (
+        SourceFile,
+        BackendCouldNotParse,
+        Assign,
+        Constant,
+        List,
+        Name,
+        Tuple_,
+        _TypedImportFrom,
+    ) = _typed_tree()
     file_path = _module_file(root, module)
     if file_path is None:
         return []
     try:
         source = file_path.read_text(encoding="utf-8")
-        tree = ast.parse(source, filename=str(file_path))
-    except (OSError, SyntaxError):
+        source_file = SourceFile(
+            (
+                source,
+                str(file_path),
+                blake3_512_of(source.encode("utf-8")),
+            )
+        )
+    except (OSError, SyntaxError, BackendCouldNotParse, UnicodeError, ValueError):
         return []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Assign):
+    for node in source_file.root.walk():
+        if not isinstance(node, Assign):
             continue
         if not any(
-            isinstance(target, ast.Name) and target.id == "__all__"
-            for target in node.targets
+            isinstance(target, Name) and target.id == "__all__" for target in node.targets
         ):
             continue
-        try:
-            value = ast.literal_eval(node.value)
-        except (ValueError, SyntaxError):
+        value = node.value
+        if isinstance(value, (List, Tuple_)):
+            items: list[str] = []
+            for element in value.elts:
+                if not isinstance(element, Constant) or not isinstance(
+                    element.value, str
+                ):
+                    return []
+                items.append(element.value)
+            return items
+        if isinstance(value, Constant) and isinstance(value.value, (list, tuple)):
+            if all(isinstance(item, str) for item in value.value):
+                return list(value.value)
             return []
-        if isinstance(value, (list, tuple)) and all(
-            isinstance(item, str) for item in value
-        ):
-            return list(value)
         return []
     return []
 
@@ -472,19 +520,38 @@ def _public_reexport_map(workspace_root: Path) -> dict[str, tuple[str, str]] | N
     mapping: dict[str, tuple[str, str]] = {}
     aliases: dict[str, str] = {}
     public_aliases: set[str] = set()
+    (
+        SourceFile,
+        BackendCouldNotParse,
+        _Assign,
+        _Constant,
+        _List,
+        _Name,
+        _Tuple_,
+        TypedImportFrom,
+    ) = _typed_tree()
+
     for current_file in sorted(root.rglob("*.py")):
         current_module = _module_name_for_package_file(root, current_file)
         if current_module is None:
             continue
         try:
             current_src = current_file.read_text(encoding="utf-8")
-            current_tree = parsed_tree(current_src, filename=str(current_file))
-        except (OSError, SyntaxError):
+            source_file = SourceFile(
+                (
+                    current_src,
+                    str(current_file),
+                    blake3_512_of(current_src.encode("utf-8")),
+                )
+            )
+        except (OSError, SyntaxError, BackendCouldNotParse, UnicodeError, ValueError):
             continue
-        for node in ast.walk(current_tree):
-            if not isinstance(node, ast.ImportFrom):
+        for node in source_file.root.walk():
+            if not isinstance(node, TypedImportFrom):
                 continue
-            target_module = _package_import_target(package, current_module, node)
+            # Typed ImportFrom exposes the same .level / .module fields the
+            # package-relative resolver reads — no foreign ast required.
+            target_module = _package_import_target(package, current_module, node)  # type: ignore[arg-type]
             if target_module is None:
                 continue
             for alias in node.names:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -12,12 +12,24 @@ from dataclasses import dataclass, field
 from email.parser import BytesParser
 import importlib.metadata
 from pathlib import Path, PurePosixPath
+import sys
 from types import MappingProxyType
 from typing import Any, Literal, Mapping
 
 from .canonical import blake3_512_of, cid_of_json
 from .source_oracle import SourceUnavailable, dependency_artifact_file
 from .source_tables import parsed_tree
+
+
+def _source_file_cls():
+    """Lazy SourceFile — avoid circular import with source_oracle/tree."""
+    _tree_src = Path(__file__).resolve().parents[3] / "sugar-source-tree" / "src"
+    if _tree_src.is_dir() and str(_tree_src) not in sys.path:
+        sys.path.insert(0, str(_tree_src))
+    from sugar_source_tree.backend import BackendCouldNotParse
+    from sugar_source_tree.tree import SourceFile
+
+    return SourceFile, BackendCouldNotParse
 
 
 class DependencyArtifactAuthenticationError(Exception):
@@ -443,10 +455,13 @@ class DependencyArtifactGraph:
             module_name = _module_name(relative)
             if module_name is None:
                 continue
+            SourceFile, BackendCouldNotParse = _source_file_cls()
             try:
                 source = content.decode("utf-8")
-                parsed_tree(source, str(path))
-            except (UnicodeError, SyntaxError) as exc:
+                # Parse gate through SourceFile (typed tree). Export resolution
+                # still uses residual parsed_tree until that scan is typed.
+                SourceFile((source, str(path), content_cid))
+            except (UnicodeError, SyntaxError, BackendCouldNotParse, ValueError) as exc:
                 raise DependencyArtifactAuthenticationError(
                     f"recorded Python module {module_name} is not parseable UTF-8 source"
                 ) from exc

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import ast
 import importlib.machinery
 import os
+import sys
 from collections import OrderedDict
 from pathlib import Path
 from typing import Any
@@ -35,6 +36,17 @@ from .ast_template import (
 from .bind_lifter import _body_source_locator
 from .canonical import blake3_512_of, template_cid_of_json
 from .source_tables import parsed_tree, source_segment, source_splitlines
+
+
+def _source_file_cls():
+    """Lazy SourceFile import — tree imports this module for path_source."""
+    _tree_src = Path(__file__).resolve().parents[3] / "sugar-source-tree" / "src"
+    if _tree_src.is_dir() and str(_tree_src) not in sys.path:
+        sys.path.insert(0, str(_tree_src))
+    from sugar_source_tree.backend import BackendCouldNotParse
+    from sugar_source_tree.tree import SourceFile
+
+    return SourceFile, BackendCouldNotParse
 
 
 class SourceUnavailable(Exception):
@@ -60,7 +72,8 @@ def installed_module_source(
 
     The returned identity is ``(source, filename, content CID)``.  Callers may
     derive views from it, but must not independently discover/read/parse the
-    module.  Content-keyed ``parsed_tree`` then owns the one parsed AST.
+    module.  ``SourceFile`` is the parse gate; residual dual-path consumers
+    may still re-parse for template recompute until those paths are drained.
 
     Successful answers partition by authenticated source CID and source seat.
     Discovery re-reads installed bytes so content drift and late appearance
@@ -106,10 +119,13 @@ def installed_module_source(
         return cached
 
     # Parse before publishing a successful oracle answer. Syntax failures are
-    # not cached as completed source.
+    # not cached as completed source. SourceFile is the sole parse door —
+    # adapters own foreign grammar; this layer only admits successfully typed
+    # modules into the oracle cache.
+    SourceFile, BackendCouldNotParse = _source_file_cls()
     try:
-        parsed_tree(source, origin)
-    except SyntaxError:
+        SourceFile((source, origin, source_cid))
+    except (SyntaxError, BackendCouldNotParse, UnicodeError, ValueError):
         return None
 
     result = (source, origin, source_cid)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_tables.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_tables.py
@@ -23,18 +23,13 @@ from __future__ import annotations
 
 import ast
 import functools
-import symtable
 
 __all__ = [
     "SOURCE_TABLE_CAPACITY",
-    "locate_parsed_node",
-    "parsed_locus_index",
-    "parsed_parents",
     "parsed_tree",
     "source_lines",
     "source_segment",
     "source_splitlines",
-    "source_symtable",
 ]
 
 # Align with install-source index capacity (install_source_dig): hot working
@@ -96,78 +91,11 @@ def parsed_tree(source: str, filename: str = "<unknown>") -> ast.Module:
 
     Raises SyntaxError exactly as `ast.parse` does (the raise recurs on every
     call for the same source; failures are not cached).
+
+    Dual-path residual: production construction should enter through
+    ``SourceFile`` / typed Nodes. Remaining callers (bind_lifter / source_oracle
+    template recompute / dependency_artifact export scan) still pin this table
+    until those paths are drained. Parent maps, locus indexes, and symtable
+    caches that had no production callers were deleted rather than rewritten.
     """
     return _parsed(source, filename)
-
-
-@functools.lru_cache(maxsize=SOURCE_TABLE_CAPACITY)
-def parsed_parents(source: str) -> "tuple[ast.Module, dict[ast.AST, ast.AST]] | None":
-    """The parsed tree plus its child->parent map, or None on a syntax error.
-
-    One parse and one walk per source; every ancestor query over the same
-    module shares the same table.
-    """
-    try:
-        tree = parsed_tree(source)
-    except SyntaxError:
-        return None
-    parents = {
-        child: parent
-        for parent in ast.walk(tree)
-        for child in ast.iter_child_nodes(parent)
-    }
-    return tree, parents
-
-
-@functools.lru_cache(maxsize=SOURCE_TABLE_CAPACITY)
-def parsed_locus_index(
-    source: str,
-) -> "dict[tuple[type, int, int], ast.AST] | None":
-    """Map ``(type(node), lineno, col_offset)`` → node for one source.
-
-    Call-site recognizers re-resolve a SourceFragment's locus against the
-    content-keyed parse. A full ``ast.walk`` per site is O(module × sites) and
-    dominated factory.select wall on large modules (BuiltinCalleeUniverseSugar
-    / visible_declarations). One index walk per source is the replacement.
-    """
-    try:
-        tree = parsed_tree(source)
-    except SyntaxError:
-        return None
-    index: dict[tuple[type, int, int], ast.AST] = {}
-    for node in ast.walk(tree):
-        lineno = getattr(node, "lineno", None)
-        col = getattr(node, "col_offset", None)
-        if lineno is None or col is None:
-            continue
-        index[(type(node), int(lineno), int(col))] = node
-    return index
-
-
-def locate_parsed_node(
-    source: str,
-    node_type: type,
-    line: int,
-    col: int,
-) -> ast.AST | None:
-    """O(1) locus lookup against the content-keyed index (None if missing)."""
-    index = parsed_locus_index(source)
-    if index is None:
-        return None
-    return index.get((node_type, int(line), int(col)))
-
-
-@functools.lru_cache(maxsize=SOURCE_TABLE_CAPACITY)
-def source_symtable(source: str) -> "symtable.SymbolTable | None":
-    """Content-keyed ``symtable.symtable`` for one module source.
-
-    ``lexical_function_bindings`` re-enters symbol-table construction for every
-    Call site during factory.select. A full re-parse per site is O(module ×
-    sites) and dominated residual wall after parsed_locus_index drained the
-    AST-walk half of the same path. One table per source is the replacement;
-    failures are not cached (SyntaxError returns None each call).
-    """
-    try:
-        return symtable.symtable(source, "<unknown>", "exec")
-    except SyntaxError:
-        return None

--- a/implementations/python/sugar-lift-python-source/tests/test_source_tables.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_tables.py
@@ -8,14 +8,10 @@ import ast
 from sugar_lift_python_source import source_tables
 from sugar_lift_python_source.source_tables import (
     SOURCE_TABLE_CAPACITY,
-    locate_parsed_node,
-    parsed_locus_index,
-    parsed_parents,
     parsed_tree,
     source_lines,
     source_segment,
     source_splitlines,
-    source_symtable,
 )
 
 
@@ -29,9 +25,6 @@ def test_source_tables_are_lru_bounded_not_unbounded() -> None:
     for fn in (
         source_splitlines,
         source_lines,
-        parsed_parents,
-        parsed_locus_index,
-        source_symtable,
     ):
         info = fn.cache_info()
         # lru_cache exposes maxsize; None would mean unbounded.
@@ -47,9 +40,6 @@ def test_tables_evict_past_capacity_without_losing_semantics() -> None:
     source_splitlines.cache_clear()
     source_lines.cache_clear()
     source_tables._parsed.cache_clear()
-    parsed_parents.cache_clear()
-    parsed_locus_index.cache_clear()
-    source_symtable.cache_clear()
 
     n = SOURCE_TABLE_CAPACITY + 8
     bodies = [f"x_{i} = {i}\n" for i in range(n)]
@@ -58,33 +48,17 @@ def test_tables_evict_past_capacity_without_losing_semantics() -> None:
         assert source_lines(body) == tuple(ast._splitlines_no_ff(body))
         tree = parsed_tree(body)
         assert isinstance(tree, ast.Module)
-        parents = parsed_parents(body)
-        assert parents is not None
-        assert isinstance(parents[0], ast.Module)
-        index = parsed_locus_index(body)
-        assert index is not None
-        table = source_symtable(body)
-        assert table is not None
 
     # Oldest entries may be gone; re-query still correct (recompute path).
     first = bodies[0]
     assert source_splitlines(first) == tuple(first.splitlines(keepends=True))
     assert source_lines(first) == tuple(ast._splitlines_no_ff(first))
     assert parsed_tree(first).body[0].targets[0].id == "x_0"  # type: ignore[attr-defined]
-    assign = parsed_tree(first).body[0]
-    assert (
-        locate_parsed_node(first, type(assign), assign.lineno, assign.col_offset)
-        is assign
-    )
-    assert source_symtable(first) is not None
 
     # Cache never grows past capacity.
     assert source_splitlines.cache_info().currsize <= SOURCE_TABLE_CAPACITY
     assert source_lines.cache_info().currsize <= SOURCE_TABLE_CAPACITY
     assert source_tables._parsed.cache_info().currsize <= SOURCE_TABLE_CAPACITY
-    assert parsed_parents.cache_info().currsize <= SOURCE_TABLE_CAPACITY
-    assert parsed_locus_index.cache_info().currsize <= SOURCE_TABLE_CAPACITY
-    assert source_symtable.cache_info().currsize <= SOURCE_TABLE_CAPACITY
 
 
 def test_source_segment_still_uses_line_table() -> None:
@@ -95,3 +69,14 @@ def test_source_segment_still_uses_line_table() -> None:
     segment = source_segment(source, fn)
     assert segment is not None
     assert "def f()" in segment
+
+
+def test_dead_dual_path_tables_are_gone() -> None:
+    """Parent / locus / symtable caches had no production callers — deleted."""
+    for name in (
+        "parsed_parents",
+        "parsed_locus_index",
+        "locate_parsed_node",
+        "source_symtable",
+    ):
+        assert not hasattr(source_tables, name), name


### PR DESCRIPTION
## Summary
- Delete production-dead dual-path tables (`parsed_parents`, `parsed_locus_index`, `locate_parsed_node`, `source_symtable`) — no production callers; tests pin their absence.
- Route bind_lifter `__all__` and public re-export discovery through `SourceFile` / typed Nodes (kill `ast.parse` + `ast.walk` on those paths).
- Gate `installed_module_source` and dependency-artifact module intake parse through `SourceFile` (lazy import to avoid oracle↔tree cycle).
- Residual dual body remains in lifter/bind_lifter collectors, value_pins, source_oracle resolve walks, source_tables.parsed_tree, compiler, ast_template.

## R trajectory
- Before: **R=40** (foreign_ast=8, ast_above_adapter=32, sole_path=0)
- After: **R=35** (foreign_ast=8, ast_above_adapter=27, sole_path=0)
- ΔR = −5

## Validation
- `bin/brun -- python implementations/python/sugar-lift-py-tests/scripts/construction_side_door_law.py`
- `bin/bpytest` test_source_tables, test_source_oracle, test_bind_lifter, test_construction_side_door_law (88 passed)

## Doctrine
Prefer delete dead dual path over rewrite. Construction: materialize once, dispatch. Red remains honorable on residual dual body.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove dead `source_tables` APIs and migrate `__all__`/re-export scans to typed AST
> - Deletes `parsed_parents`, `parsed_locus_index`, `locate_parsed_node`, and `source_symtable` from [`source_tables.py`](https://github.com/TSavo/sugar/pull/6129/files#diff-ebd3cc1a0454697bef411fbe60c0f33cb960b7317e4d7b3c4cd9eb5acf45abd3); a new test asserts these names are gone.
> - Rewrites `__all__` extraction in [`bind_lifter.py`](https://github.com/TSavo/sugar/pull/6129/files#diff-2d1544de1ff27adb0b95a4be7fdb157e9565af85beed277481deadec84eb2292) and re-export scanning to use typed `SourceFile`/`TypedImportFrom` nodes instead of `ast.parse`; files that fail typed parsing now yield empty results.
> - Replaces `parsed_tree` syntax-validation gates in [`dependency_artifact.py`](https://github.com/TSavo/sugar/pull/6129/files#diff-153692407653e4eda2c94b6899d612575f4b0f569fd4ee8a0ac674aef4e90464) and [`source_oracle.py`](https://github.com/TSavo/sugar/pull/6129/files#diff-46c211dd48cf8b40814f36939afc72cfd9d8d750d36f6572af9c9e02ba22ea6f) with typed `SourceFile` construction, broadening rejection to cover `BackendCouldNotParse` and `ValueError`.
> - Typed tree imports are deferred via `_typed_tree`/`_source_file_cls` helpers that patch `sys.path` lazily to avoid circular imports.
> - Risk: any external caller of the removed `source_tables` APIs will fail at attribute access; modules rejected by the new typed parser gate that previously passed `ast.parse` will now be excluded from caches and dependency graphs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f6e063.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->