### PR TITLE
foundation: publish runtime BindingEntryV1 carrier

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -1,7 +1,18 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, TypeAlias
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Any, Callable, TypeAlias
+
+from .binding_provenance import (
+    BindingCoordinateV1,
+    BindingEntryV1 as SealedBindingEntryV1,
+    BindingProvenanceGap,
+    BindingStateV1 as SealedBindingStateV1,
+    BoundBindingStateV1,
+    ConstructedValueTestimonyV1,
+    GuardedBindingStateV1,
+    UnboundBindingStateV1,
+)
 
 if TYPE_CHECKING:
     from sugar_source_tree.fragment import SourceFragment
@@ -33,11 +44,119 @@ class GuardedBinding:
 
 
 BindingState: TypeAlias = "Node | UnboundBinding | GuardedBinding"
-BindingMap: TypeAlias = dict[str, BindingState]
+
+
+class RuntimeBindingEntryGap(BindingProvenanceGap):
+    """A live binding cannot project into the authenticated sealed wire."""
+
+
+@dataclass(frozen=True)
+class BindingEntryV1:
+    """The sole runtime temporal binding carrier.
+
+    The live ``state`` is what substitution consumes.  ``sealed_state`` is its
+    pure-data projection; no live Node handle enters ``wire()``.
+    """
+
+    coordinate: BindingCoordinateV1
+    state: BindingState
+    sealed_state: SealedBindingStateV1 | None
+
+    @property
+    def constructed_value_testimony(self) -> ConstructedValueTestimonyV1 | None:
+        if isinstance(self.sealed_state, BoundBindingStateV1):
+            return self.sealed_state.testimony
+        return None
+
+    def with_testimony(
+        self, testimony: ConstructedValueTestimonyV1
+    ) -> "BindingEntryV1":
+        return replace(self, sealed_state=BoundBindingStateV1(testimony))
+
+    def wire(self) -> dict[str, Any]:
+        if self.sealed_state is None:
+            raise RuntimeBindingEntryGap(
+                "runtime binding state has no authenticated sealed projection"
+            )
+        if (
+            isinstance(self.sealed_state, BoundBindingStateV1)
+            and self.sealed_state.testimony is None
+        ):
+            raise RuntimeBindingEntryGap(
+                "constructed-value testimony unavailable"
+            )
+        # Decode the projection immediately: this authenticates coordinate and
+        # testimony CIDs by h=h(p), rather than trusting an in-memory dataclass.
+        return SealedBindingEntryV1.decode(
+            SealedBindingEntryV1(self.coordinate, self.sealed_state).wire()
+        ).wire()
+
+
+BindingMap: TypeAlias = dict[object, BindingEntryV1 | object]
+
+
+class RuntimeBindingEntryFactoryV1:
+    """The one function-scope minter for runtime binding occurrences."""
+
+    def __init__(self, scope_owner_cid: str) -> None:
+        self.scope_owner_cid = scope_owner_cid
+        self._ordinal = 0
+
+    def mint_entry(
+        self,
+        *,
+        binding_site: SourceFragment,
+        projection_path: tuple[str | int, ...],
+        state: BindingState,
+    ) -> BindingEntryV1:
+        ordinal = self._ordinal
+        self._ordinal += 1
+        return mint_runtime_binding_entry_v1(
+            scope_owner_cid=self.scope_owner_cid,
+            binding_site=binding_site,
+            projection_path=("occurrence", ordinal, *projection_path),
+            state=state,
+        )
+
+
+def mint_runtime_binding_entry_v1(
+    *,
+    scope_owner_cid: str,
+    binding_site: SourceFragment,
+    projection_path: tuple[str | int, ...],
+    state: BindingState,
+) -> BindingEntryV1:
+    """Mint one occurrence coordinate and keep its live state beside it."""
+    coordinate = BindingCoordinateV1.mint(
+        scope_owner_cid, binding_site, projection_path
+    )
+    if _is_node(state):
+        sealed_state: SealedBindingStateV1 | None = BoundBindingStateV1(None)
+    elif isinstance(state, UnboundBinding):
+        sealed_state = UnboundBindingStateV1(state.cause.seal().cid)
+    elif isinstance(state, GuardedBinding):
+        # Guard alternatives acquire state CIDs only after their projected
+        # entries are sealed.  Until then the runtime entry remains loud.
+        sealed_state = None
+    else:
+        raise RuntimeBindingEntryGap(
+            f"unknown runtime binding state {type(state).__name__}"
+        )
+    return BindingEntryV1(coordinate, state, sealed_state)
+
+
+def _is_node(value: object) -> bool:
+    from sugar_source_tree.nodes import Node
+
+    return isinstance(value, Node)
+
+
+def unwrap_binding_state(value: BindingEntryV1 | BindingState) -> BindingState:
+    return value.state if isinstance(value, BindingEntryV1) else value
 
 
 def binding_state_read_node(
-    state: BindingState,
+    state: BindingEntryV1 | BindingState,
     *,
     make_read: Callable[[UnboundBinding | GuardedBinding], Node],
 ) -> Node:
@@ -49,6 +168,7 @@ def binding_state_read_node(
     """
     from sugar_source_tree.nodes import Node
 
+    state = unwrap_binding_state(state)
     if isinstance(state, Node):
         return state
     if isinstance(state, (UnboundBinding, GuardedBinding)):
@@ -65,6 +185,8 @@ def join_binding_state(
 ) -> BindingState:
     from sugar_source_tree.nodes import Node
 
+    when_true = unwrap_binding_state(when_true)
+    when_false = unwrap_binding_state(when_false)
     if when_true is when_false or when_true == when_false:
         return when_true
     if isinstance(when_true, Node) and isinstance(when_false, Node):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -56,14 +56,17 @@ from .panic import (
 from .reporter import NULL_REPORTER, AuditReporter
 from .spans import LineColSpan, LineTable, Span
 from .binding_state import (
+    BindingEntryV1,
     BindingMap,
     BindingState,
     BranchResultSlot,
     GuardedBinding,
+    RuntimeBindingEntryFactoryV1,
     UnboundBinding,
     binding_state_read_node,
     branch_result_slot,
     join_binding_state,
+    unwrap_binding_state,
 )
 
 # Scope metadata travels beside temporal bindings under an unforgeable key.
@@ -71,12 +74,13 @@ from .binding_state import (
 # formal without substituting a fake value for that formal.
 _LEXICALLY_BOUND_NAMES = object()
 _FUNCTION_PARAMETERS = object()
+_BINDING_ENTRY_FACTORY = object()
 _MISSING = object()
 
 
 def _explicit_state(name: str, state, make_formal_ref):
     if name in state:
-        return state[name]
+        return unwrap_binding_state(state[name])
     if name in state.get(_FUNCTION_PARAMETERS, frozenset()):
         return make_formal_ref(name)
     return _MISSING
@@ -651,6 +655,52 @@ class Node(Typed):
         new_items, changed, _net = self._substitute_body_tracked(statements, scope)
         return new_items, changed
 
+    def _binding_entries(self, binding, scope: BindingMap):
+        if not binding:
+            return binding
+        factory = scope.get(_BINDING_ENTRY_FACTORY)
+        if not isinstance(factory, RuntimeBindingEntryFactoryV1):
+            # External/unit callers may substitute isolated expressions without
+            # opening a function binding scope.  They do not create a runtime
+            # BindingMap; production function substitution always has a factory.
+            return binding
+        wrapped = {}
+        for local_index, (name, state) in enumerate(binding.items()):
+            if isinstance(state, BindingEntryV1):
+                wrapped[name] = state
+                continue
+            site, path = self._binding_site_and_path(name, local_index)
+            wrapped[name] = factory.mint_entry(
+                binding_site=site,
+                projection_path=path,
+                state=state,
+            )
+        return wrapped
+
+    def _binding_site_and_path(self, name: str, ordinal: int):
+        candidates = []
+        targets = getattr(self, "targets", None)
+        if isinstance(targets, tuple):
+            for target_index, target in enumerate(targets):
+                for projection_index, node in enumerate(target.walk()):
+                    if isinstance(node, Name) and node.id == name:
+                        candidates.append(
+                            (
+                                node.fragment,
+                                ("targets", target_index, "projection", projection_index),
+                            )
+                        )
+        target = getattr(self, "target", None)
+        if isinstance(target, Node):
+            for projection_index, node in enumerate(target.walk()):
+                if isinstance(node, Name) and node.id == name:
+                    candidates.append(
+                        (node.fragment, ("target", "projection", projection_index))
+                    )
+        if ordinal < len(candidates):
+            return candidates[ordinal]
+        return self.fragment, ("constructed-projection", ordinal)
+
     def _substitute_body_tracked(self, statements: tuple, scope: BindingMap):
         """Substitute a statement sequence, THREADING each statement's binding:
         an assignment binds its name to its substituted rhs for the rest of the
@@ -688,6 +738,7 @@ class Node(Typed):
                 new_items.append(produced_stmt)
                 binding = produced_stmt.substitution_binding(scope)
                 if binding:
+                    binding = produced_stmt._binding_entries(binding, scope)
                     scope = {**scope, **binding}
                 # walrus bindings nested in the statement's expressions leak out
                 # to the enclosing block (their scope is the containing function).
@@ -695,9 +746,11 @@ class Node(Typed):
                     if node.kind == "NamedExpr":
                         wb = node.substitution_binding(scope)
                         if wb:
+                            wb = node._binding_entries(wb, scope)
                             scope = {**scope, **wb}
             if isinstance(new_stmt, _Splice) and new_stmt.bindings:
-                scope = {**scope, **new_stmt.bindings}
+                projected = stmt._binding_entries(new_stmt.bindings, scope)
+                scope = {**scope, **projected}
         net = {k: v for k, v in scope.items() if initial.get(k) is not v}
         return (tuple(new_items) if changed else statements), changed, net
 
@@ -1248,7 +1301,22 @@ class FunctionDef(Statement):
             with reduction_span(sugar="Substitute", role="temporal", site=where):
                 # Substitute the body against an empty scope: formals are masked
                 # (stay free -> symbolic), locals thread/inline, phis -> IfExps.
-                substituted = self.substitute({})
+                from sugar_lift_python_source.canonical import cid_of_json
+
+                scope_owner_cid = cid_of_json(
+                    {
+                        "kind": "binding-scope-owner",
+                        "schemaVersion": "1",
+                        "source": self.fragment.seal().to_dict(),
+                    }
+                )
+                substituted = self.substitute(
+                    {
+                        _BINDING_ENTRY_FACTORY: RuntimeBindingEntryFactoryV1(
+                            scope_owner_cid
+                        )
+                    }
+                )
             with reduction_span(sugar="Construct", role="construction", site=where):
                 bridge_source_symbol = None
                 context = self.unit.construction_context
@@ -1607,6 +1675,7 @@ class AugAssign(Statement):
             return None
         name = self.target.id
         old_state = scope.get(name, self.target)
+        old_state = unwrap_binding_state(old_state)
         old_read = binding_state_read_node(
             old_state,
             make_read=self.target._make_binding_read,
@@ -1904,6 +1973,7 @@ class For(Statement):
         init = scope.get(name.id)
         if init is None:
             return None  # no pre-loop value to seed the fold
+        init = unwrap_binding_state(init)
         op = value.op.kind
         fold = self._make_call(self._make_name(f"py.fold.{op}"), (init, self.iter))
         return {name.id: fold}
@@ -4465,6 +4535,7 @@ class Name(Expression):
         bound = scope.get(self.id, _MISSING)
         if bound is _MISSING:
             return self
+        bound = unwrap_binding_state(bound)
         if isinstance(bound, Node):
             return bound
         return self._make_binding_read(bound)
@@ -4532,6 +4603,7 @@ def _construct_binding_projection(state):
         UnboundProjection,
     )
 
+    state = unwrap_binding_state(state)
     if isinstance(state, Node):
         return state.sugar()
     if isinstance(state, UnboundBinding):

--- a/implementations/python/sugar-source-tree/tests/test_runtime_binding_entry_v1.py
+++ b/implementations/python/sugar-source-tree/tests/test_runtime_binding_entry_v1.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.binding_provenance import (
+    BindingEntryV1 as SealedBindingEntryV1,
+    ConstructedValueTestimonyV1,
+)
+from sugar_source_tree.binding_state import (
+    BindingEntryV1,
+    RuntimeBindingEntryFactoryV1,
+    RuntimeBindingEntryGap,
+)
+from sugar_source_tree.tree import SourceFile
+
+
+def _function(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(source)
+        path = handle.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _entry(source: str = "def arbitrary():\n    renamed = 1\n"):
+    function = _function(source)
+    assignment = next(node for node in function.walk() if node.kind == "Assign")
+    target = assignment.targets[0]
+    live_state = assignment.value
+    factory = RuntimeBindingEntryFactoryV1(
+        cid_of_json({"scope": function.fragment.seal().to_dict()})
+    )
+    entry = factory.mint_entry(
+        binding_site=target.fragment,
+        projection_path=("targets", 0),
+        state=live_state,
+    )
+    return assignment, live_state, entry
+
+
+def test_runtime_entry_keeps_live_node_and_projects_only_pure_wire():
+    assignment, live_state, entry = _entry()
+    assert entry.state is live_state
+    assert "renamed" not in entry.coordinate.preimage
+    with pytest.raises(RuntimeBindingEntryGap, match="testimony unavailable"):
+        entry.wire()
+
+    testimony = ConstructedValueTestimonyV1.mint(
+        assignment.value.fragment,
+        cid_of_json({"kind": "constructed-int", "value": 1}),
+    )
+    projected = entry.with_testimony(testimony).wire()
+    assert set(projected) == {"coordinate", "state"}
+    assert "state" in projected and "ref" not in repr(projected)
+    assert SealedBindingEntryV1.decode(projected).wire() == projected
+
+
+def test_projection_reauthenticates_coordinate_and_testimony_cids():
+    from dataclasses import replace
+
+    assignment, _live_state, entry = _entry()
+    testimony = ConstructedValueTestimonyV1.mint(
+        assignment.value.fragment, cid_of_json({"value": 1})
+    )
+    ready = entry.with_testimony(testimony)
+    with pytest.raises(ValueError, match="coordinate CID mismatch"):
+        replace(
+            ready,
+            coordinate=replace(ready.coordinate, cid="blake3-512:stale"),
+        ).wire()
+    with pytest.raises(ValueError, match="testimony CID mismatch"):
+        ready.with_testimony(
+            replace(testimony, cid="blake3-512:stale")
+        ).wire()
+
+
+def test_distinct_occurrences_borrowing_one_span_never_collide():
+    assignment, _live_state, _entry_one = _entry()
+    factory = RuntimeBindingEntryFactoryV1(
+        cid_of_json({"scope": assignment.fragment.seal().to_dict()})
+    )
+    first = factory.mint_entry(
+        binding_site=assignment.targets[0].fragment,
+        projection_path=("targets", 0),
+        state=assignment.value,
+    )
+    second = factory.mint_entry(
+        binding_site=assignment.targets[0].fragment,
+        projection_path=("targets", 0),
+        state=assignment.value,
+    )
+    assert first.coordinate.cid != second.coordinate.cid
+
+
+def test_runtime_binding_map_has_one_carrier_not_parallel_name_to_node_state():
+    assignment, live_state, entry = _entry()
+    bindings = {"renamed": entry}
+    assert bindings["renamed"] is entry
+    assert isinstance(bindings["renamed"], BindingEntryV1)
+    assert bindings["renamed"].state is live_state


### PR DESCRIPTION
## Outcome

Publishes the one runtime temporal-binding carrier shared by loop construction, object/place identity (#6126), and Cut C receiver state.

- `BindingEntryV1` keeps the live substituted `Node | UnboundBinding | GuardedBinding` beside its authenticated `BindingCoordinateV1`.
- `.wire()` projects only pure #6114 `BindingEntryV1` data and immediately decodes it again, enforcing h=h(p) for coordinate and constructed-value testimony CIDs.
- production function substitution uses one `RuntimeBindingEntryFactoryV1`; identifier strings remain lexical lookup keys only.
- `Name`, `AugAssign`, guarded joins, and the grandfathered fold unwrap that same runtime entry. There is no parallel name-to-Node map.
- unavailable constructed-value or guarded-state testimony remains a typed `RuntimeBindingEntryGap`.

This is deliberately the small carrier PR. It does **not** include `SubstitutionTraceV1`, LoopConstructionV1, loop effects, or the parked loop wire. Cut B (#6113) already provides the constructor arms these coordinates feed into. PR #2 will make the carrier load-bearing for trace/loops after this shared type lands.

## Twins

- live Node remains available to substitution while absent from the sealed wire
- Python sealed round-trip is byte-identical
- stale coordinate CID and stale testimony CID stay loud
- two binding occurrences borrowing one span mint distinct coordinates
- one lexical name maps to one runtime entry carrying both live state and coordinate; no parallel map
- renamed binding has no identifier in the coordinate preimage

## Validation

```text
PYTHONPATH=implementations/python/sugar-lift-python-source/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-source-tree/tests:implementations/python/sugar-lift-py-tests/src \
python3 -m pytest --noconftest -q \
  implementations/python/sugar-source-tree/tests/test_runtime_binding_entry_v1.py \
  implementations/python/sugar-source-tree/tests/test_binding_provenance_v1.py \
  implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py \
  implementations/python/sugar-source-tree/tests/test_branch_result_slot.py \
  implementations/python/sugar-source-tree/tests/test_assign_targets.py \
  implementations/python/sugar-source-tree/tests/test_for_unroll.py \
  implementations/python/sugar-source-tree/tests/test_while_unroll.py
# 56 passed
```

Broader source-tree run before the final rebase: 388 passed, 5 skipped, with only the known environment-specific pinned-golden mismatch.

No Rust wire changed: the projection is the already-merged #6114 closed Rust `BindingEntryV1` schema. Heavy Rust is therefore not re-entered by this Python runtime-only carrier PR.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish runtime `BindingEntryV1` carrier with provenance coordinates during function body substitution
> - Introduces `BindingEntryV1`, a frozen dataclass pairing a live `BindingState` with an optional sealed-state projection and a `BindingCoordinateV1`. Its `wire()` method re-encodes via `SealedBindingEntryV1` and raises `RuntimeBindingEntryGap` if sealed state or testimony is missing.
> - Adds `RuntimeBindingEntryFactoryV1` to mint uniquely-coordinated entries per binding occurrence, using an internal ordinal to produce deterministic projection paths.
> - `FunctionDef` substitution now injects a `RuntimeBindingEntryFactoryV1` into scope so bindings collected during block substitution become `BindingEntryV1` objects with provenance coordinates.
> - Adds `unwrap_binding_state` and updates `binding_state_read_node`, `join_binding_state`, `AugAssign`, `For`, `Name.substitute`, and `_construct_binding_projection` to transparently read through `BindingEntryV1` entries.
> - Risk: unknown `BindingState` subclasses passed to `mint_runtime_binding_entry_v1` now raise `RuntimeBindingEntryGap` instead of silently producing an entry.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c216827.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->