### PR TITLE
Wire construction_side_door_law into sole-construction CI

### DIFF
--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -144,3 +144,17 @@ jobs:
         run: >-
           python
           implementations/python/sugar-lift-py-tests/scripts/no_sugar_in_desugar_law.py
+      # Permanent construction-currency floor (#6115+#6121+#6128). Dual-body
+      # residual keeps main honestly red until sugar-lift-python-source is drained;
+      # sole-path R is reported in the same instrument and must stay 0.
+      - name: R_construction_side_doors discrimination
+        if: always()
+        run: >-
+          python -m pytest --noconftest
+          implementations/python/sugar-lift-py-tests/tests/test_construction_side_door_law.py
+          -q
+      - name: R_construction_side_doors = 0
+        if: always()
+        run: >-
+          python
+          implementations/python/sugar-lift-py-tests/scripts/construction_side_door_law.py

--- a/tests/test_python_sole_construction_ci.py
+++ b/tests/test_python_sole_construction_ci.py
@@ -22,6 +22,9 @@ AXIS_COMMANDS = {
     "R_finite_unfold_compact_gaps = 0": ("finite_unfold_compact_projection_law.py"),
     "R_source_via_execution = 0": "source_via_execution_law.py",
     "R_no_sugar_in_desugar = 0": "no_sugar_in_desugar_law.py",
+    # Whole-kit construction currency (adapters only may name stdlib ast).
+    # Live R includes dual-body sugar-lift-python-source residual — exit 1 until 0.
+    "R_construction_side_doors = 0": "construction_side_door_law.py",
 }
 
 


### PR DESCRIPTION
## Why

`construction_side_door_law.py` was a permanent floor in spirit but only a local script.
`factory-zero-tolerance.yml` never ran it, so sole-construction CI could green while the
whole-kit scan stayed red at dual-body residual (~35 raw-AST authorities under
`sugar-lift-python-source`).

## What

- CI: discrimination pytest + live `construction_side_door_law.py` with `if: always()`
- Binding test: require `R_construction_side_doors = 0` step invokes the law script

## Expected

Main sole-construction job becomes **honestly red** until dual-body R hits 0.
Sole-path R remains 0 and is reported by the same instrument (`R_sole_path_construction_side_doors`).

## Predicted Epsilon R

Instrument wiring only — no production offender delta. CI red is the measurement boundary.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire `construction_side_door_law` checks into sole-construction CI job
> Adds two always-running steps to the `sole-construction-floors` CI job in [factory-zero-tolerance.yml](.github/workflows/factory-zero-tolerance.yml): a pytest run against `test_construction_side_door_law.py` and a direct invocation of `construction_side_door_law.py`. Also registers the new `R_construction_side_doors = 0` axis in the `AXIS_COMMANDS` dict in [test_python_sole_construction_ci.py](https://github.com/TSavo/sugar/pull/6132/files#diff-b94b7a42638a5f3bf792d21deb778da5ee5b7f32e26a112cf32599b545b71fe0). Non-zero exits from either step will fail the job.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2ac74e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->