### PR TITLE
Route legacy lifters through typed source nodes

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/__init__.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/__init__.py
@@ -1,6 +1,26 @@
-"""Python source lifter for Sugar."""
+"""Python source lifter for Sugar.
 
-from .compiler import compile_ir_document
-from .lifter import LiftResult, lift_paths, lift_source
+The source tree depends on the package's SourceOracle.  Keep public lifter
+exports lazy so importing that lower-layer oracle cannot initialize the
+consumer lifter and form a cycle back through ``sugar_source_tree``.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .compiler import compile_ir_document
+    from .lifter import LiftResult, lift_paths, lift_source
 
 __all__ = ["LiftResult", "compile_ir_document", "lift_paths", "lift_source"]
+
+
+def __getattr__(name: str):
+    if name == "compile_ir_document":
+        from .compiler import compile_ir_document
+
+        return compile_ir_document
+    if name in {"LiftResult", "lift_paths", "lift_source"}:
+        from . import lifter
+
+        return getattr(lifter, name)
+    raise AttributeError(name)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/ast_template.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/ast_template.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import ast
+from . import typed_node_api as typed
 from typing import Any
 
 Json = Any
@@ -41,34 +41,32 @@ AST_STATEMENT_TYPE_NAMES = frozenset(
         "Continue",
     }
 )
-AST_STATEMENT_TYPES = frozenset(
-    statement for statement in ast.stmt.__subclasses__() if statement.__module__ == "ast"
-)
+AST_STATEMENT_TYPES = frozenset(getattr(typed, name) for name in AST_STATEMENT_TYPE_NAMES)
 if {statement.__name__ for statement in AST_STATEMENT_TYPES} != AST_STATEMENT_TYPE_NAMES:
-    raise UnsupportedStatementGrammar("unsupported running ast.stmt grammar")
+    raise UnsupportedStatementGrammar("unsupported running typed.stmt grammar")
 
 
 class UnsupportedStatementVariant(RuntimeError):
     pass
 
 
-def function_param_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+def function_param_names(node: typed.FunctionDef | typed.AsyncFunctionDef) -> list[str]:
     return [arg.arg for arg in _ordered_signature_args(node.args)]
 
 
-def function_body_template(node: ast.FunctionDef | ast.AsyncFunctionDef) -> Json:
+def function_body_template(node: typed.FunctionDef | typed.AsyncFunctionDef) -> Json:
     return block_to_ast_template(node.body, function_param_names(node))
 
 
-def block_to_ast_template(statements: list[ast.stmt], params: list[str]) -> Json:
+def block_to_ast_template(statements: list[typed.stmt], params: list[str]) -> Json:
     return {
         "kind": "block",
         "stmts": [stmt_to_template(stmt, params) for stmt in statements],
     }
 
 
-def stmt_to_template(stmt: ast.stmt, params: list[str]) -> Json:
-    if isinstance(stmt, ast.Assign):
+def stmt_to_template(stmt: typed.stmt, params: list[str]) -> Json:
+    if isinstance(stmt, typed.Assign):
         if len(stmt.targets) != 1:
             return {"kind": "other", "variant": "multi_assign"}
         return {
@@ -76,7 +74,7 @@ def stmt_to_template(stmt: ast.stmt, params: list[str]) -> Json:
             "pat": pat_to_template(stmt.targets[0], params),
             "init": expr_to_template(stmt.value, params),
         }
-    if isinstance(stmt, ast.AnnAssign):
+    if isinstance(stmt, typed.AnnAssign):
         return {
             "kind": "let",
             "pat": pat_to_template(stmt.target, params),
@@ -84,14 +82,14 @@ def stmt_to_template(stmt: ast.stmt, params: list[str]) -> Json:
                 expr_to_template(stmt.value, params) if stmt.value is not None else None
             ),
         }
-    if isinstance(stmt, ast.Expr):
+    if isinstance(stmt, typed.Expr):
         # Python expression statements do not carry Rust's semicolon signal.
         return {
             "kind": "expr_stmt",
             "expr": expr_to_template(stmt.value, params),
             "trailing_semi": False,
         }
-    if isinstance(stmt, ast.Return):
+    if isinstance(stmt, typed.Return):
         return {
             "kind": "expr_stmt",
             "expr": {
@@ -109,11 +107,11 @@ def stmt_to_template(stmt: ast.stmt, params: list[str]) -> Json:
     raise UnsupportedStatementVariant(type(stmt).__name__)
 
 
-def expr_to_template(expr: ast.expr, params: list[str]) -> Json:
-    if isinstance(expr, ast.Call):
+def expr_to_template(expr: typed.expr, params: list[str]) -> Json:
+    if isinstance(expr, typed.Call):
         args = [expr_to_template(arg, params) for arg in expr.args]
         args.extend(kwarg_to_template(keyword, params) for keyword in expr.keywords)
-        if isinstance(expr.func, ast.Attribute):
+        if isinstance(expr.func, typed.Attribute):
             return {
                 "kind": "method_call",
                 "receiver": expr_to_template(expr.func.value, params),
@@ -125,11 +123,11 @@ def expr_to_template(expr: ast.expr, params: list[str]) -> Json:
             "func": expr_to_template(expr.func, params),
             "args": args,
         }
-    if isinstance(expr, ast.Name):
+    if isinstance(expr, typed.Name):
         if expr.id in params:
             return {"kind": "param_ref", "index": params.index(expr.id) + 1}
         return {"kind": "ident", "name": expr.id}
-    if isinstance(expr, ast.Attribute):
+    if isinstance(expr, typed.Attribute):
         field = _field_template_if_param_root(expr, params)
         if field is not None:
             return field
@@ -141,45 +139,45 @@ def expr_to_template(expr: ast.expr, params: list[str]) -> Json:
             "base": expr_to_template(expr.value, params),
             "member": expr.attr,
         }
-    if isinstance(expr, ast.Constant):
+    if isinstance(expr, typed.Constant):
         return lit_to_template(expr.value)
-    if isinstance(expr, ast.Tuple):
+    if isinstance(expr, typed.Tuple):
         return {
             "kind": "tuple",
             "elems": [expr_to_template(elt, params) for elt in expr.elts],
         }
-    if isinstance(expr, ast.List):
+    if isinstance(expr, typed.List):
         return {
             "kind": "array",
             "elems": [expr_to_template(elt, params) for elt in expr.elts],
         }
-    if isinstance(expr, ast.BinOp):
+    if isinstance(expr, typed.BinOp):
         return {
             "kind": "binary",
             "op": type(expr.op).__name__,
             "left": expr_to_template(expr.left, params),
             "right": expr_to_template(expr.right, params),
         }
-    if isinstance(expr, ast.UnaryOp):
+    if isinstance(expr, typed.UnaryOp):
         return {
             "kind": "unary",
             "op": type(expr.op).__name__,
             "expr": expr_to_template(expr.operand, params),
         }
-    if isinstance(expr, ast.NamedExpr):
+    if isinstance(expr, typed.NamedExpr):
         return {
             "kind": "let",
             "pat": pat_to_template(expr.target, params),
             "init": expr_to_template(expr.value, params),
         }
-    if isinstance(expr, ast.Await):
+    if isinstance(expr, typed.Await):
         return {"kind": "await", "expr": expr_to_template(expr.value, params)}
-    if isinstance(expr, ast.Starred):
+    if isinstance(expr, typed.Starred):
         return {"kind": "starred", "expr": expr_to_template(expr.value, params)}
     return {"kind": "other", "variant": type(expr).__name__}
 
 
-def kwarg_to_template(keyword: ast.keyword, params: list[str]) -> Json:
+def kwarg_to_template(keyword: typed.keyword, params: list[str]) -> Json:
     # Python kwargs are source-level semantics, so keep the name instead of
     # flattening away the distinction between f(x=a) and f(y=a).
     return {
@@ -189,17 +187,17 @@ def kwarg_to_template(keyword: ast.keyword, params: list[str]) -> Json:
     }
 
 
-def pat_to_template(node: ast.AST, params: list[str]) -> Json:
-    if isinstance(node, ast.Name):
+def pat_to_template(node: typed.AST, params: list[str]) -> Json:
+    if isinstance(node, typed.Name):
         if node.id in params:
             return {"kind": "param_ref", "index": params.index(node.id) + 1}
         return {"kind": "binding", "name": node.id}
-    if isinstance(node, (ast.Tuple, ast.List)):
+    if isinstance(node, (typed.Tuple, typed.List)):
         return {
             "kind": "pat_tuple",
             "elems": [pat_to_template(elt, params) for elt in node.elts],
         }
-    if isinstance(node, ast.Starred):
+    if isinstance(node, typed.Starred):
         return {"kind": "pat_starred", "pat": pat_to_template(node.value, params)}
     return {"kind": "pat_other"}
 
@@ -218,8 +216,8 @@ def lit_to_template(value: object) -> Json:
     return {"kind": "lit", "ty": type(value).__name__, "value": repr(value)}
 
 
-def _ordered_signature_args(args: ast.arguments) -> list[ast.arg]:
-    ordered_args: list[ast.arg] = []
+def _ordered_signature_args(args: typed.arguments) -> list[typed.arg]:
+    ordered_args: list[typed.arg] = []
     ordered_args.extend(args.posonlyargs)
     ordered_args.extend(args.args)
     if args.vararg is not None:
@@ -230,27 +228,27 @@ def _ordered_signature_args(args: ast.arguments) -> list[ast.arg]:
     return ordered_args
 
 
-def _attribute_segments(expr: ast.Attribute) -> list[str] | None:
+def _attribute_segments(expr: typed.Attribute) -> list[str] | None:
     segments: list[str] = []
-    current: ast.AST = expr
-    while isinstance(current, ast.Attribute):
+    current: typed.AST = expr
+    while isinstance(current, typed.Attribute):
         segments.append(current.attr)
         current = current.value
-    if isinstance(current, ast.Name):
+    if isinstance(current, typed.Name):
         segments.append(current.id)
         return list(reversed(segments))
     return None
 
 
 def _field_template_if_param_root(
-    expr: ast.Attribute, params: list[str]
+    expr: typed.Attribute, params: list[str]
 ) -> Json | None:
     parts: list[str] = []
-    current: ast.AST = expr
-    while isinstance(current, ast.Attribute):
+    current: typed.AST = expr
+    while isinstance(current, typed.Attribute):
         parts.append(current.attr)
         current = current.value
-    if not isinstance(current, ast.Name) or current.id not in params:
+    if not isinstance(current, typed.Name) or current.id not in params:
         return None
     result: Json = {"kind": "param_ref", "index": params.index(current.id) + 1}
     for member in reversed(parts):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py
@@ -1,38 +1,15 @@
 from __future__ import annotations
 
-import ast
+from . import typed_node_api as typed
 import json
 import os
 import re
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
 
 from .ast_template import function_body_template, function_param_names
 from .canonical import blake3_512_of, cid_of_json, template_cid_of_json
-
-
-def _typed_tree():
-    """Lazy typed-tree imports — avoid circular import with source_oracle."""
-    _tree_src = Path(__file__).resolve().parents[3] / "sugar-source-tree" / "src"
-    if _tree_src.is_dir() and str(_tree_src) not in sys.path:
-        sys.path.insert(0, str(_tree_src))
-    from sugar_source_tree.backend import BackendCouldNotParse
-    from sugar_source_tree.nodes import Assign, Constant, List, Name, Tuple_
-    from sugar_source_tree.nodes import ImportFrom as TypedImportFrom
-    from sugar_source_tree.tree import SourceFile
-
-    return (
-        SourceFile,
-        BackendCouldNotParse,
-        Assign,
-        Constant,
-        List,
-        Name,
-        Tuple_,
-        TypedImportFrom,
-    )
 
 Json = Any
 class UnsupportedStatementGrammar(RuntimeError):
@@ -71,11 +48,9 @@ AST_STATEMENT_TYPE_NAMES = frozenset(
         "Continue",
     }
 )
-AST_STATEMENT_TYPES = frozenset(
-    statement for statement in ast.stmt.__subclasses__() if statement.__module__ == "ast"
-)
+AST_STATEMENT_TYPES = frozenset(getattr(typed, name) for name in AST_STATEMENT_TYPE_NAMES)
 if {statement.__name__ for statement in AST_STATEMENT_TYPES} != AST_STATEMENT_TYPE_NAMES:
-    raise UnsupportedStatementGrammar("unsupported running ast.stmt grammar")
+    raise UnsupportedStatementGrammar("unsupported running typed.stmt grammar")
 CID_RE = re.compile(r"^blake3-512:[0-9a-f]{128}$")
 CONTRACT_COMMENT_KIND = "sugar-contract-comment-sugar"
 CONTRACT_COMMENT_ROLE_MAP = {
@@ -99,7 +74,7 @@ class BindLiftResult:
 
 @dataclass(frozen=True)
 class _FunctionInfo:
-    node: ast.FunctionDef | ast.AsyncFunctionDef
+    node: typed.FunctionDef | typed.AsyncFunctionDef
 
 
 @dataclass(frozen=True)
@@ -122,7 +97,7 @@ def lift_source(
 ) -> BindLiftResult:
     result = BindLiftResult()
     try:
-        tree = ast.parse(source, filename=source_path)
+        tree = typed.parse(source, filename=source_path)
     except SyntaxError as exc:
         result.diagnostics.append(
             {
@@ -243,30 +218,30 @@ def lift_paths(
 
 @dataclass(frozen=True)
 class _ClassInfo:
-    node: ast.ClassDef
+    node: typed.ClassDef
 
 
-class _DefinitionCollector(ast.NodeVisitor):
+class _DefinitionCollector(typed.TypedNodeWalker):
     def __init__(self) -> None:
         self.definitions: list[_FunctionInfo] = []
         self.class_definitions: list[_ClassInfo] = []
 
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+    def visit_FunctionDef(self, node: typed.FunctionDef) -> None:
         self.definitions.append(_FunctionInfo(node=node))
         self.generic_visit(node)
 
-    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+    def visit_AsyncFunctionDef(self, node: typed.AsyncFunctionDef) -> None:
         self.definitions.append(_FunctionInfo(node=node))
         self.generic_visit(node)
 
-    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+    def visit_ClassDef(self, node: typed.ClassDef) -> None:
         self.class_definitions.append(_ClassInfo(node=node))
         # still recurse so method definitions inside classes are visited for function lifting
         self.generic_visit(node)
 
 
 def _entry_for_function(
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    node: typed.FunctionDef | typed.AsyncFunctionDef,
     rel_path: str,
     lines: list[str],
     diagnostics: list[Json],
@@ -328,68 +303,42 @@ def _module_file(root: Path, module: str) -> Path | None:
 
 
 def _literal_all_exports(root: Path, module: str) -> list[str]:
-    """Read ``__all__`` through the typed source tree — not raw ``ast.walk``.
-
-    Source enters once via SourceFile (adapter-backed). Semantic authority is
-    typed Assign/Name/Constant/List/Tuple nodes; foreign ast is not the door.
-    """
-    (
-        SourceFile,
-        BackendCouldNotParse,
-        Assign,
-        Constant,
-        List,
-        Name,
-        Tuple_,
-        _TypedImportFrom,
-    ) = _typed_tree()
     file_path = _module_file(root, module)
     if file_path is None:
         return []
     try:
         source = file_path.read_text(encoding="utf-8")
-        source_file = SourceFile(
-            (
-                source,
-                str(file_path),
-                blake3_512_of(source.encode("utf-8")),
-            )
-        )
-    except (OSError, SyntaxError, BackendCouldNotParse, UnicodeError, ValueError):
+        tree = typed.parse(source, filename=str(file_path))
+    except (OSError, SyntaxError):
         return []
-    for node in source_file.root.walk():
-        if not isinstance(node, Assign):
+    for node in typed.walk(tree):
+        if not isinstance(node, typed.Assign):
             continue
         if not any(
-            isinstance(target, Name) and target.id == "__all__" for target in node.targets
+            isinstance(target, typed.Name) and target.id == "__all__"
+            for target in node.targets
         ):
             continue
-        value = node.value
-        if isinstance(value, (List, Tuple_)):
-            items: list[str] = []
-            for element in value.elts:
-                if not isinstance(element, Constant) or not isinstance(
-                    element.value, str
-                ):
-                    return []
-                items.append(element.value)
-            return items
-        if isinstance(value, Constant) and isinstance(value.value, (list, tuple)):
-            if all(isinstance(item, str) for item in value.value):
-                return list(value.value)
+        try:
+            value = typed.literal_eval(node.value)
+        except (ValueError, SyntaxError):
             return []
+        if isinstance(value, (list, tuple)) and all(
+            isinstance(item, str) for item in value
+        ):
+            return list(value)
         return []
     return []
 
 
-def _relative_import_target(current_module: str, node: ast.ImportFrom) -> str | None:
+def _relative_import_target(current_module: str, node: typed.ImportFrom) -> str | None:
     if node.level != 1 or not node.module:
         return None
     return f"{current_module}.{node.module}" if current_module else node.module
 
 
 def _package_import_target(
-    package: str, current_module: str, node: ast.ImportFrom
+    package: str, current_module: str, node: typed.ImportFrom
 ) -> str | None:
     if node.level:
         current_parts = [p for p in current_module.split(".") if p]
@@ -520,38 +469,19 @@ def _public_reexport_map(workspace_root: Path) -> dict[str, tuple[str, str]] | N
     mapping: dict[str, tuple[str, str]] = {}
     aliases: dict[str, str] = {}
     public_aliases: set[str] = set()
-    (
-        SourceFile,
-        BackendCouldNotParse,
-        _Assign,
-        _Constant,
-        _List,
-        _Name,
-        _Tuple_,
-        TypedImportFrom,
-    ) = _typed_tree()
-
     for current_file in sorted(root.rglob("*.py")):
         current_module = _module_name_for_package_file(root, current_file)
         if current_module is None:
             continue
         try:
             current_src = current_file.read_text(encoding="utf-8")
-            source_file = SourceFile(
-                (
-                    current_src,
-                    str(current_file),
-                    blake3_512_of(current_src.encode("utf-8")),
-                )
-            )
-        except (OSError, SyntaxError, BackendCouldNotParse, UnicodeError, ValueError):
+            current_tree = typed.parse(current_src, filename=str(current_file))
+        except (OSError, SyntaxError):
             continue
-        for node in source_file.root.walk():
-            if not isinstance(node, TypedImportFrom):
+        for node in typed.walk(current_tree):
+            if not isinstance(node, typed.ImportFrom):
                 continue
-            # Typed ImportFrom exposes the same .level / .module fields the
-            # package-relative resolver reads — no foreign ast required.
-            target_module = _package_import_target(package, current_module, node)  # type: ignore[arg-type]
+            target_module = _package_import_target(package, current_module, node)
             if target_module is None:
                 continue
             for alias in node.names:
@@ -581,7 +511,7 @@ def _public_reexport_map(workspace_root: Path) -> dict[str, tuple[str, str]] | N
 
 
 def _library_binding_entry_for_function(
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    node: typed.FunctionDef | typed.AsyncFunctionDef,
     rel_path: str,
     lines: list[str],
     source_lines: list[str],
@@ -690,10 +620,10 @@ def _library_binding_entry_for_function(
 
 
 def _sugar_bind_decorator(
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    node: typed.FunctionDef | typed.AsyncFunctionDef,
 ) -> dict | None:
-    for decorator in node.decorator_list:
-        if not isinstance(decorator, ast.Call) or not _is_sugar_bind_func(
+    for decorator in node.decorators:
+        if not isinstance(decorator, typed.Call) or not _is_sugar_bind_func(
             decorator.func
         ):
             continue
@@ -731,35 +661,35 @@ def _sugar_bind_decorator(
     return None
 
 
-def _is_sugar_bind_func(func: ast.expr) -> bool:
-    if not isinstance(func, ast.Attribute) or func.attr != "bind":
+def _is_sugar_bind_func(func: typed.expr) -> bool:
+    if not isinstance(func, typed.Attribute) or func.attr != "bind":
         return False
     value = func.value
-    if isinstance(value, ast.Name):
+    if isinstance(value, typed.Name):
         return value.id == "sugar"
-    if isinstance(value, ast.Attribute) and value.attr == "sugar":
-        return isinstance(value.value, ast.Name) and value.value.id == "sugar"
+    if isinstance(value, typed.Attribute) and value.attr == "sugar":
+        return isinstance(value.value, typed.Name) and value.value.id == "sugar"
     return False
 
 
-def _keyword_str(call: ast.Call, name: str) -> str | None:
+def _keyword_str(call: typed.Call, name: str) -> str | None:
     for keyword in call.keywords:
-        if keyword.arg == name and isinstance(keyword.value, ast.Constant):
+        if keyword.arg == name and isinstance(keyword.value, typed.Constant):
             if isinstance(keyword.value.value, str) and keyword.value.value:
                 return keyword.value.value
     return None
 
 
-def _keyword_str_list(call: ast.Call, name: str) -> list[str] | None:
+def _keyword_str_list(call: typed.Call, name: str) -> list[str] | None:
     """Return a keyword argument whose value is a list of string literals, or None if absent."""
     for keyword in call.keywords:
         if keyword.arg != name:
             continue
-        if not isinstance(keyword.value, ast.List):
+        if not isinstance(keyword.value, typed.List):
             return None
         result: list[str] = []
         for elt in keyword.value.elts:
-            if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+            if isinstance(elt, typed.Constant) and isinstance(elt.value, str):
                 result.append(elt.value)
         return result
     return None
@@ -771,25 +701,25 @@ def _keyword_str_list(call: ast.Call, name: str) -> list[str] | None:
 _CONCEPT_GAP_DECORATOR_NAMES = ("concept_gap",)
 
 
-def _is_concept_gap_func(func: ast.expr) -> bool:
+def _is_concept_gap_func(func: typed.expr) -> bool:
     """Return True for @concept_gap(...) or its @sugar.* form."""
-    if isinstance(func, ast.Name):
+    if isinstance(func, typed.Name):
         return func.id in _CONCEPT_GAP_DECORATOR_NAMES
-    if isinstance(func, ast.Attribute) and func.attr in _CONCEPT_GAP_DECORATOR_NAMES:
+    if isinstance(func, typed.Attribute) and func.attr in _CONCEPT_GAP_DECORATOR_NAMES:
         value = func.value
-        return isinstance(value, ast.Name) and value.id == "sugar"
+        return isinstance(value, typed.Name) and value.id == "sugar"
     return False
 
 
 def _concept_gap_memento_for_class(
-    node: ast.ClassDef,
+    node: typed.ClassDef,
     rel_path: str,
     diagnostics: list[Json],
 ) -> Json | None:
     """Emit a concept-gap-memento IR record for an empty class decorated with
     @concept_gap(...)."""
-    for decorator in node.decorator_list:
-        if not isinstance(decorator, ast.Call) or not _is_concept_gap_func(
+    for decorator in node.decorators:
+        if not isinstance(decorator, typed.Call) or not _is_concept_gap_func(
             decorator.func
         ):
             continue
@@ -810,7 +740,7 @@ def _concept_gap_memento_for_class(
         # Validate body is trivial (only pass or docstring)
         body_stmts = [s for s in node.body if not _is_docstring_stmt(s)]
         if len(body_stmts) > 1 or (
-            len(body_stmts) == 1 and not isinstance(body_stmts[0], ast.Pass)
+            len(body_stmts) == 1 and not isinstance(body_stmts[0], typed.Pass)
         ):
             diagnostics.append(
                 {
@@ -832,8 +762,8 @@ def _concept_gap_memento_for_class(
     return None
 
 
-def _ordered_signature_args(args: ast.arguments) -> list[ast.arg]:
-    ordered_args: list[ast.arg] = []
+def _ordered_signature_args(args: typed.arguments) -> list[typed.arg]:
+    ordered_args: list[typed.arg] = []
     ordered_args.extend(args.posonlyargs)
     ordered_args.extend(args.args)
     if args.vararg is not None:
@@ -844,21 +774,21 @@ def _ordered_signature_args(args: ast.arguments) -> list[ast.arg]:
     return ordered_args
 
 
-def _annotation_surface(annotation: ast.expr | None) -> str | None:
+def _annotation_surface(annotation: typed.expr | None) -> str | None:
     if annotation is None:
         return None
-    return ast.unparse(annotation)
+    return typed.unparse(annotation)
 
 
 def _body_source_locator(
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    node: typed.FunctionDef | typed.AsyncFunctionDef,
     rel_path: str,
     source_lines: list[str],
 ) -> Json:
     start_line = node.lineno
     start_col = node.col_offset
-    if node.decorator_list:
-        first = min(node.decorator_list, key=lambda decorator: decorator.lineno)
+    if node.decorators:
+        first = min(node.decorators, key=lambda decorator: decorator.lineno)
         start_line = first.lineno
         start_col = 0
     end_line = node.end_lineno or node.lineno
@@ -903,7 +833,7 @@ def source_memento_of(full_body_source: Json) -> Json:
 
 
 def _extract_body_text(
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    node: typed.FunctionDef | typed.AsyncFunctionDef,
     source_lines: list[str],
 ) -> str:
     """Extract the text of the function body (excluding decorators and def line).
@@ -941,19 +871,19 @@ def _extract_body_text(
     return "".join(dedented).rstrip()
 
 
-def _signature_param_names(args: ast.arguments) -> list[str]:
+def _signature_param_names(args: typed.arguments) -> list[str]:
     names: list[str] = []
     for arg in _ordered_signature_args(args):
         names.append(arg.arg)
     return names
 
 
-def _function_shape(node: ast.FunctionDef | ast.AsyncFunctionDef) -> Json:
+def _function_shape(node: typed.FunctionDef | typed.AsyncFunctionDef) -> Json:
     return _function_shape_with_bindings(node).shape
 
 
 def _function_shape_with_bindings(
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    node: typed.FunctionDef | typed.AsyncFunctionDef,
     lines: list[str] | None = None,
 ) -> _ShapeResult:
     statements = [stmt for stmt in node.body if not _is_docstring_stmt(stmt)]
@@ -961,12 +891,12 @@ def _function_shape_with_bindings(
     return _shape_block_with_bindings(statements, comments)
 
 
-def _shape_block(statements: list[ast.stmt]) -> Json:
+def _shape_block(statements: list[typed.stmt]) -> Json:
     return _shape_block_with_bindings(statements).shape
 
 
 def _shape_block_with_bindings(
-    statements: list[ast.stmt],
+    statements: list[typed.stmt],
     comments: list[_CommentOccurrence] | None = None,
 ) -> _ShapeResult:
     shapes: list[Json] = []
@@ -1003,12 +933,12 @@ def _shape_block_with_bindings(
     return _collapse_operation_shape_results(shapes, binding_groups)
 
 
-def _shape_stmt(node: ast.stmt, *, top_level: bool) -> Json:
+def _shape_stmt(node: typed.stmt, *, top_level: bool) -> Json:
     return _shape_stmt_with_bindings(node, top_level=top_level).shape
 
 
-def _shape_stmt_with_bindings(node: ast.stmt, *, top_level: bool) -> _ShapeResult:
-    if isinstance(node, ast.If):
+def _shape_stmt_with_bindings(node: typed.stmt, *, top_level: bool) -> _ShapeResult:
+    if isinstance(node, typed.If):
         test = _shape_expr_with_bindings(node.test)
         body = _shape_block_with_bindings(node.body)
         orelse = _shape_block_with_bindings(node.orelse)
@@ -1016,7 +946,7 @@ def _shape_stmt_with_bindings(node: ast.stmt, *, top_level: bool) -> _ShapeResul
             "concept:conditional",
             [test, body, orelse],
         )
-    if isinstance(node, ast.While):
+    if isinstance(node, typed.While):
         return _operator_shape_result(
             "concept:while",
             [
@@ -1024,21 +954,21 @@ def _shape_stmt_with_bindings(node: ast.stmt, *, top_level: bool) -> _ShapeResul
                 _shape_block_with_bindings(node.body),
             ],
         )
-    if isinstance(node, (ast.For, ast.AsyncFor)):
+    if isinstance(node, (typed.For, typed.AsyncFor)):
         return _operator_shape_result(
             "concept:for", [_shape_block_with_bindings(node.body)]
         )
-    if isinstance(node, ast.Return):
+    if isinstance(node, typed.Return):
         if node.value is None:
             return _empty_shape_result()
         return _shape_expr_with_bindings(node.value)
-    if isinstance(node, ast.Pass):
+    if isinstance(node, typed.Pass):
         return _operator_shape_result("concept:skip", [])
-    if isinstance(node, ast.Break):
+    if isinstance(node, typed.Break):
         return _operator_shape_result("concept:break", [])
-    if isinstance(node, ast.Continue):
+    if isinstance(node, typed.Continue):
         return _operator_shape_result("concept:continue", [])
-    if isinstance(node, ast.Assign):
+    if isinstance(node, typed.Assign):
         target = (
             _shape_expr_with_bindings(node.targets[0])
             if node.targets
@@ -1047,7 +977,7 @@ def _shape_stmt_with_bindings(node: ast.stmt, *, top_level: bool) -> _ShapeResul
         return _operator_shape_result(
             "concept:assign", [target, _shape_expr_with_bindings(node.value)]
         )
-    if isinstance(node, ast.AnnAssign):
+    if isinstance(node, typed.AnnAssign):
         if node.value is not None:
             return _operator_shape_result(
                 "concept:assign",
@@ -1057,7 +987,7 @@ def _shape_stmt_with_bindings(node: ast.stmt, *, top_level: bool) -> _ShapeResul
                 ],
             )
         return _empty_shape_result()
-    if isinstance(node, ast.AugAssign):
+    if isinstance(node, typed.AugAssign):
         return _bin_operator_shape_result(
             node.op,
             [
@@ -1065,19 +995,19 @@ def _shape_stmt_with_bindings(node: ast.stmt, *, top_level: bool) -> _ShapeResul
                 _shape_expr_with_bindings(node.value),
             ],
         )
-    if isinstance(node, ast.Expr):
+    if isinstance(node, typed.Expr):
         return _shape_expr_with_bindings(node.value)
     if type(node) in AST_STATEMENT_TYPES:
         return _empty_shape_result()
     raise UnsupportedStatementVariant(type(node).__name__)
 
 
-def _shape_expr(node: ast.expr) -> Json:
+def _shape_expr(node: typed.expr) -> Json:
     return _shape_expr_with_bindings(node).shape
 
 
-def _shape_expr_with_bindings(node: ast.expr) -> _ShapeResult:
-    if isinstance(node, ast.BinOp):
+def _shape_expr_with_bindings(node: typed.expr) -> _ShapeResult:
+    if isinstance(node, typed.BinOp):
         return _bin_operator_shape_result(
             node.op,
             [
@@ -1085,18 +1015,18 @@ def _shape_expr_with_bindings(node: ast.expr) -> _ShapeResult:
                 _shape_expr_with_bindings(node.right),
             ],
         )
-    if isinstance(node, ast.BoolOp):
+    if isinstance(node, typed.BoolOp):
         op = _bool_op(node.op)
         values = [_shape_expr_with_bindings(value) for value in node.values]
         if op is None:
             return _empty_shape_result()
         return _operator_shape_result(op, values)
-    if isinstance(node, ast.UnaryOp):
+    if isinstance(node, typed.UnaryOp):
         op = _unary_op(node.op)
         if op is None:
             return _empty_shape_result()
         return _operator_shape_result(op, [_shape_expr_with_bindings(node.operand)])
-    if isinstance(node, ast.IfExp):
+    if isinstance(node, typed.IfExp):
         return _operator_shape_result(
             "concept:conditional",
             [
@@ -1105,9 +1035,9 @@ def _shape_expr_with_bindings(node: ast.expr) -> _ShapeResult:
                 _shape_expr_with_bindings(node.orelse),
             ],
         )
-    if isinstance(node, ast.Compare):
+    if isinstance(node, typed.Compare):
         return _compare_shape_result(node)
-    if isinstance(node, ast.Call):
+    if isinstance(node, typed.Call):
         args = [_shape_expr_with_bindings(node.func)]
         args.extend(_shape_expr_with_bindings(arg) for arg in node.args)
         args.extend(
@@ -1155,7 +1085,7 @@ def _collapse_operation_shape_results(
     )
 
 
-def _bin_operator_shape(op: ast.operator, args: list[Json]) -> Json:
+def _bin_operator_shape(op: typed.operator, args: list[Json]) -> Json:
     atom = _bin_op(op)
     if atom is None:
         return {}
@@ -1163,7 +1093,7 @@ def _bin_operator_shape(op: ast.operator, args: list[Json]) -> Json:
 
 
 def _bin_operator_shape_result(
-    op: ast.operator, args: list[_ShapeResult]
+    op: typed.operator, args: list[_ShapeResult]
 ) -> _ShapeResult:
     atom = _bin_op(op)
     if atom is None:
@@ -1171,10 +1101,10 @@ def _bin_operator_shape_result(
     return _operator_shape_result(atom, args)
 
 
-def _compare_shape_result(node: ast.Compare) -> _ShapeResult:
+def _compare_shape_result(node: typed.Compare) -> _ShapeResult:
     if not node.ops or len(node.ops) != len(node.comparators):
         return _empty_shape_result()
-    operands: list[ast.expr] = [node.left, *node.comparators]
+    operands: list[typed.expr] = [node.left, *node.comparators]
     comparisons: list[_ShapeResult] = []
     for index, raw_op in enumerate(node.ops):
         op = _rel_op(raw_op)
@@ -1240,10 +1170,10 @@ def _sort_operand_bindings(bindings: list[Json]) -> list[Json]:
     return sorted(bindings, key=lambda binding: binding["position"])
 
 
-def _operand_symbol(node: ast.AST) -> str | None:
-    if isinstance(node, ast.Name):
+def _operand_symbol(node: typed.AST) -> str | None:
+    if isinstance(node, typed.Name):
         return node.id
-    if isinstance(node, ast.Constant):
+    if isinstance(node, typed.Constant):
         value = node.value
         if isinstance(value, bool):
             return "True" if value else "False"
@@ -1272,18 +1202,18 @@ def _operand_slot(value: Json) -> Json:
     return {}
 
 
-def _bin_op(op: ast.operator) -> str | None:
-    table: tuple[tuple[type[ast.operator], str], ...] = (
-        (ast.Add, "concept:add"),
-        (ast.Sub, "concept:sub"),
-        (ast.Mult, "concept:mul"),
-        (ast.Div, "concept:div"),
-        (ast.Mod, "concept:mod"),
-        (ast.LShift, "concept:shl"),
-        (ast.RShift, "concept:shr"),
-        (ast.BitAnd, "concept:bitand"),
-        (ast.BitOr, "concept:bitor"),
-        (ast.BitXor, "concept:bitxor"),
+def _bin_op(op: typed.operator) -> str | None:
+    table: tuple[tuple[type[typed.operator], str], ...] = (
+        (typed.Add, "concept:add"),
+        (typed.Sub, "concept:sub"),
+        (typed.Mult, "concept:mul"),
+        (typed.Div, "concept:div"),
+        (typed.Mod, "concept:mod"),
+        (typed.LShift, "concept:shl"),
+        (typed.RShift, "concept:shr"),
+        (typed.BitAnd, "concept:bitand"),
+        (typed.BitOr, "concept:bitor"),
+        (typed.BitXor, "concept:bitxor"),
     )
     for cls, operator in table:
         if isinstance(op, cls):
@@ -1291,32 +1221,32 @@ def _bin_op(op: ast.operator) -> str | None:
     return None
 
 
-def _bool_op(op: ast.boolop) -> str | None:
-    if isinstance(op, ast.And):
+def _bool_op(op: typed.boolop) -> str | None:
+    if isinstance(op, typed.And):
         return "concept:and"
-    if isinstance(op, ast.Or):
+    if isinstance(op, typed.Or):
         return "concept:or"
     return None
 
 
-def _unary_op(op: ast.unaryop) -> str | None:
-    if isinstance(op, ast.Not):
+def _unary_op(op: typed.unaryop) -> str | None:
+    if isinstance(op, typed.Not):
         return "concept:not"
-    if isinstance(op, ast.USub):
+    if isinstance(op, typed.USub):
         return "concept:neg"
-    if isinstance(op, ast.Invert):
+    if isinstance(op, typed.Invert):
         return "concept:bitnot"
     return None
 
 
-def _rel_op(op: ast.cmpop) -> str | None:
-    table: tuple[tuple[type[ast.cmpop], str], ...] = (
-        (ast.Eq, "concept:eq"),
-        (ast.NotEq, "concept:ne"),
-        (ast.Lt, "concept:lt"),
-        (ast.LtE, "concept:le"),
-        (ast.Gt, "concept:gt"),
-        (ast.GtE, "concept:ge"),
+def _rel_op(op: typed.cmpop) -> str | None:
+    table: tuple[tuple[type[typed.cmpop], str], ...] = (
+        (typed.Eq, "concept:eq"),
+        (typed.NotEq, "concept:ne"),
+        (typed.Lt, "concept:lt"),
+        (typed.LtE, "concept:le"),
+        (typed.Gt, "concept:gt"),
+        (typed.GtE, "concept:ge"),
     )
     for cls, operator in table:
         if isinstance(op, cls):
@@ -1326,7 +1256,7 @@ def _rel_op(op: ast.cmpop) -> str | None:
 
 def _contract_comment_witnesses(
     lines: list[str],
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    node: typed.FunctionDef | typed.AsyncFunctionDef,
     rel_path: str,
     diagnostics: list[Json],
 ) -> list[Json]:
@@ -1338,7 +1268,7 @@ def _contract_comment_witnesses(
             diagnostics,
         )
     )
-    docstring = ast.get_docstring(node, clean=True)
+    docstring = typed.get_docstring(node, clean=True)
     if docstring:
         doc_lines = [
             (getattr(node.body[0], "lineno", node.lineno), line.strip())
@@ -1522,7 +1452,7 @@ def _contract_comment_witness(
 
 def _function_body_comment_surface(
     lines: list[str],
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    node: typed.FunctionDef | typed.AsyncFunctionDef,
 ) -> list[tuple[int, str]]:
     end_lineno = getattr(node, "end_lineno", node.lineno)
     surface: list[tuple[int, str]] = []
@@ -1535,7 +1465,7 @@ def _function_body_comment_surface(
 
 def _trivia_comment_occurrences(
     lines: list[str],
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    node: typed.FunctionDef | typed.AsyncFunctionDef,
 ) -> list[_CommentOccurrence]:
     end_lineno = getattr(node, "end_lineno", node.lineno)
     occurrences: list[_CommentOccurrence] = []
@@ -1625,20 +1555,20 @@ def _contract_comment_diag(
 
 
 def _decorator_contract_witnesses(
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    node: typed.FunctionDef | typed.AsyncFunctionDef,
     param_names: list[str],
     rel_path: str,
     diagnostics: list[Json],
 ) -> list[Json]:
     witnesses: list[Json] = []
-    for decorator in node.decorator_list:
-        if not isinstance(decorator, ast.Call):
+    for decorator in node.decorators:
+        if not isinstance(decorator, typed.Call):
             continue
         if _decorator_name(decorator.func) not in {"contract", "sugar_contract"}:
             continue
         for keyword in decorator.keywords:
             role = {"pre": "pre", "post": "post", "inv": "inv"}.get(keyword.arg or "")
-            if role is None or not isinstance(keyword.value, ast.Constant):
+            if role is None or not isinstance(keyword.value, typed.Constant):
                 continue
             if not isinstance(keyword.value.value, str):
                 continue
@@ -1679,10 +1609,10 @@ def _decorator_contract_witnesses(
     return witnesses
 
 
-def _decorator_name(node: ast.expr) -> str:
-    if isinstance(node, ast.Name):
+def _decorator_name(node: typed.expr) -> str:
+    if isinstance(node, typed.Name):
         return node.id
-    if isinstance(node, ast.Attribute):
+    if isinstance(node, typed.Attribute):
         return node.attr
     return ""
 
@@ -1702,9 +1632,9 @@ def _is_relative_to(child: Path, parent: Path) -> bool:
         return False
 
 
-def _is_docstring_stmt(node: ast.stmt) -> bool:
+def _is_docstring_stmt(node: typed.stmt) -> bool:
     return (
-        isinstance(node, ast.Expr)
-        and isinstance(node.value, ast.Constant)
+        isinstance(node, typed.Expr)
+        and isinstance(node.value, typed.Constant)
         and isinstance(node.value.value, str)
     )

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py
@@ -1,42 +1,17 @@
 from __future__ import annotations
 
-import ast
+from . import typed_node_api as typed
 import os
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Iterable
 
-from .canonical import blake3_512_of, cid_of_json
+from .canonical import cid_of_json
 from .value_pins import (
     ValuePin,
     mutable_global_pin_opacity_entry,
     scan_module_value_pins,
 )
-
-
-def _typed_tree():
-    """Lazy typed-tree import — lifter is still dual-body residual overall."""
-    tree_src = Path(__file__).resolve().parents[3] / "sugar-source-tree" / "src"
-    if tree_src.is_dir() and str(tree_src) not in sys.path:
-        sys.path.insert(0, str(tree_src))
-    from sugar_source_tree.backend import BackendCouldNotParse
-    from sugar_source_tree.nodes import (
-        AsyncFunctionDef,
-        ClassDef,
-        FunctionDef,
-        Node,
-    )
-    from sugar_source_tree.tree import SourceFile
-
-    return (
-        SourceFile,
-        BackendCouldNotParse,
-        FunctionDef,
-        AsyncFunctionDef,
-        ClassDef,
-        Node,
-    )
 from .ir import (
     Json,
     bool_const,
@@ -94,11 +69,9 @@ AST_STATEMENT_TYPE_NAMES = frozenset(
         "Continue",
     }
 )
-AST_STATEMENT_TYPES = frozenset(
-    statement for statement in ast.stmt.__subclasses__() if statement.__module__ == "ast"
-)
+AST_STATEMENT_TYPES = frozenset(getattr(typed, name) for name in AST_STATEMENT_TYPE_NAMES)
 if {statement.__name__ for statement in AST_STATEMENT_TYPES} != AST_STATEMENT_TYPE_NAMES:
-    raise UnsupportedStatementGrammar("unsupported running ast.stmt grammar")
+    raise UnsupportedStatementGrammar("unsupported running typed.stmt grammar")
 RUNTIME_FAILURE_SITE_CONCEPT = "concept:panic-freedom.leaf.runtime-failure-site"
 CLASS_SHAPE_ASSUMPTIONS = [
     "presence-guaranteed-assuming-standard-construction-via-__init__",
@@ -163,14 +136,14 @@ class LiftResult:
 
 @dataclass(frozen=True)
 class _FunctionInfo:
-    node: ast.AST
+    node: typed.AST
     qualname: str
     fn_name: str
 
 
 @dataclass(frozen=True)
 class _ClassInfo:
-    node: ast.ClassDef
+    node: typed.ClassDef
     qualname: str
     class_name: str
 
@@ -185,7 +158,7 @@ class _AttributeReceiverContext:
 class _UnsupportedSyntax(Exception):
     def __init__(
         self,
-        node: ast.AST,
+        node: typed.AST,
         reason: str,
         kind: str = "unhandled-syntax",
     ):
@@ -221,7 +194,7 @@ class _EffectSet:
         loop_term: Json,
         *,
         source_path: str | None = None,
-        node: ast.AST | None = None,
+        node: typed.AST | None = None,
     ) -> None:
         loop_cid = cid_of_json(loop_term)
         self._add(
@@ -255,7 +228,7 @@ class _EffectSet:
 def lift_source(source: str, source_path: str) -> LiftResult:
     result = LiftResult()
     try:
-        tree = ast.parse(source, filename=source_path)
+        tree = typed.parse(source, filename=source_path)
     except SyntaxError as exc:
         result.refusals.append(
             _refusal(
@@ -283,17 +256,14 @@ def lift_source(source: str, source_path: str) -> LiftResult:
         mutable_global_pin_opacity_entry(pin, source_path=source_path)
         for pin in pin_scan.mutable_global_pins
     )
-    class_shapes = _lift_class_shapes(
-        tree, module_path, source=source, source_path=source_path
-    )
-    definitions = _collect_definitions(
-        source, source_path, module_path, tree
-    )
+    class_shapes = _lift_class_shapes(tree, module_path)
+    collector = _DefinitionCollector(module_path)
+    collector.visit(tree)
     receiver_contexts = _receiver_contexts_by_method(class_shapes)
 
     body_terms: list[Json] = []
     contracts: list[Json] = []
-    for info in definitions:
+    for info in collector.definitions:
         contract = _lift_function(
             info,
             source_path,
@@ -371,223 +341,70 @@ def lift_paths(workspace_root: str, source_paths: Iterable[str]) -> LiftResult:
     return result
 
 
-def _dual_function_index(
-    tree: ast.Module,
-) -> dict[tuple[int, str], ast.FunctionDef | ast.AsyncFunctionDef]:
-    """Index residual dual-body function nodes by (lineno, name) for body lifting.
+class _DefinitionCollector(typed.TypedNodeWalker):
+    def __init__(self, module_path: str):
+        self.module_path = module_path
+        self.scope: list[tuple[str, str]] = []
+        self.definitions: list[_FunctionInfo] = []
 
-    Manual stack — not ``ast.NodeVisitor`` / ``ast.walk``. Semantic authority for
-    *which* functions participate is the typed walk; this index only pairs the
-    dual-body payload residual body emitters still consume.
-    """
-    index: dict[tuple[int, str], ast.FunctionDef | ast.AsyncFunctionDef] = {}
-    stack: list[ast.AST] = [tree]
-    while stack:
-        node = stack.pop()
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            index[(int(node.lineno), node.name)] = node
-        stack.extend(reversed(list(ast.iter_child_nodes(node))))
-    return index
+    def visit_ClassDef(self, node: typed.ClassDef) -> Any:
+        self.scope.append(("class", node.name))
+        for stmt in node.body:
+            self.visit(stmt)
+        self.scope.pop()
 
+    def visit_FunctionDef(self, node: typed.FunctionDef) -> Any:
+        self._record_function(node)
 
-def _dual_class_index(tree: ast.Module) -> dict[tuple[int, str], ast.ClassDef]:
-    """Index residual dual-body class nodes by (lineno, name) for shape building."""
-    index: dict[tuple[int, str], ast.ClassDef] = {}
-    stack: list[ast.AST] = [tree]
-    while stack:
-        node = stack.pop()
-        if isinstance(node, ast.ClassDef):
-            index[(int(node.lineno), node.name)] = node
-        stack.extend(reversed(list(ast.iter_child_nodes(node))))
-    return index
+    def visit_AsyncFunctionDef(self, node: typed.AsyncFunctionDef) -> Any:
+        self._record_function(node)
 
-
-def _collect_definitions(
-    source: str,
-    source_path: str,
-    module_path: str,
-    tree: ast.Module,
-) -> list[_FunctionInfo]:
-    """Discover functions via SourceFile / typed Nodes.
-
-    SourceFile is the parse door for discovery. Scope / qualname rules match the
-    retired ``_DefinitionCollector`` NodeVisitor: enter class bodies with class
-    scope; record FunctionDef / AsyncFunctionDef and do NOT enter their bodies
-    (nested functions are not separate contracts here). Residual dual-body AST
-    nodes are paired by (lineno, name) until body emission drains.
-    """
-    (
-        SourceFile,
-        BackendCouldNotParse,
-        FunctionDef,
-        AsyncFunctionDef,
-        ClassDef,
-        Node,
-    ) = _typed_tree()
-    dual = _dual_function_index(tree)
-    try:
-        source_file = SourceFile(
-            (source, source_path, blake3_512_of(source.encode("utf-8")))
+    def _record_function(self, node: typed.AST) -> None:
+        assert isinstance(node, (typed.FunctionDef, typed.AsyncFunctionDef))
+        qualname = _qualname(self.scope, node.name)
+        self.definitions.append(
+            _FunctionInfo(
+                node=node,
+                qualname=qualname,
+                fn_name=f"{self.module_path}.{qualname}",
+            )
         )
-    except (SyntaxError, BackendCouldNotParse, UnicodeError, ValueError):
-        return _collect_definitions_dual(tree, module_path)
 
-    definitions: list[_FunctionInfo] = []
 
-    def visit(node: Node, scope: list[tuple[str, str]]) -> None:
-        if isinstance(node, ClassDef):
-            nested = scope + [("class", node.name)]
-            for stmt in node.body:
-                visit(stmt, nested)
-            return
-        if isinstance(node, (FunctionDef, AsyncFunctionDef)):
-            qualname = _qualname(scope, node.name)
-            lineno = int(node.line_col_span().start_line)
-            dual_node = dual.get((lineno, node.name))
-            if dual_node is None:
-                raise RuntimeError(
-                    "typed/dual function pair missing for "
-                    f"{node.name!r} at line {lineno} in {source_path}"
-                )
-            definitions.append(
-                _FunctionInfo(
-                    node=dual_node,
-                    qualname=qualname,
-                    fn_name=f"{module_path}.{qualname}",
-                )
+class _ClassCollector(typed.TypedNodeWalker):
+    def __init__(self, module_path: str):
+        self.module_path = module_path
+        self.scope: list[tuple[str, str]] = []
+        self.classes: list[_ClassInfo] = []
+
+    def visit_ClassDef(self, node: typed.ClassDef) -> Any:
+        qualname = _qualname(self.scope, node.name)
+        self.classes.append(
+            _ClassInfo(
+                node=node,
+                qualname=qualname,
+                class_name=f"{self.module_path}.{qualname}",
             )
-            return
-        for _, _, child in node.children():
-            visit(child, scope)
-
-    visit(source_file.root, [])
-    return definitions
-
-
-def _collect_definitions_dual(
-    tree: ast.Module, module_path: str
-) -> list[_FunctionInfo]:
-    """Residual dual-body discovery when SourceFile construction refuses."""
-    definitions: list[_FunctionInfo] = []
-
-    def visit(node: ast.AST, scope: list[tuple[str, str]]) -> None:
-        if isinstance(node, ast.ClassDef):
-            nested = scope + [("class", node.name)]
-            for stmt in node.body:
-                visit(stmt, nested)
-            return
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            qualname = _qualname(scope, node.name)
-            definitions.append(
-                _FunctionInfo(
-                    node=node,
-                    qualname=qualname,
-                    fn_name=f"{module_path}.{qualname}",
-                )
-            )
-            return
-        for child in ast.iter_child_nodes(node):
-            visit(child, scope)
-
-    visit(tree, [])
-    return definitions
-
-
-def _collect_classes(
-    source: str,
-    source_path: str,
-    module_path: str,
-    tree: ast.Module,
-) -> list[_ClassInfo]:
-    """Discover classes via SourceFile / typed Nodes.
-
-    Scope rules match the retired ``_ClassCollector`` NodeVisitor: record every
-    ClassDef; enter class bodies with class scope; enter function bodies with
-    function scope so nested classes under ``f.<locals>`` keep qualnames. Dual
-    ClassDef payload pairs by (lineno, name) for residual shape scanners.
-    """
-    (
-        SourceFile,
-        BackendCouldNotParse,
-        FunctionDef,
-        AsyncFunctionDef,
-        ClassDef,
-        Node,
-    ) = _typed_tree()
-    dual = _dual_class_index(tree)
-    try:
-        source_file = SourceFile(
-            (source, source_path, blake3_512_of(source.encode("utf-8")))
         )
-    except (SyntaxError, BackendCouldNotParse, UnicodeError, ValueError):
-        return _collect_classes_dual(tree, module_path)
+        self.scope.append(("class", node.name))
+        for stmt in node.body:
+            self.visit(stmt)
+        self.scope.pop()
 
-    classes: list[_ClassInfo] = []
+    def visit_FunctionDef(self, node: typed.FunctionDef) -> Any:
+        self.scope.append(("function", node.name))
+        for stmt in node.body:
+            self.visit(stmt)
+        self.scope.pop()
 
-    def visit(node: Node, scope: list[tuple[str, str]]) -> None:
-        if isinstance(node, ClassDef):
-            qualname = _qualname(scope, node.name)
-            lineno = int(node.line_col_span().start_line)
-            dual_node = dual.get((lineno, node.name))
-            if dual_node is None:
-                raise RuntimeError(
-                    "typed/dual class pair missing for "
-                    f"{node.name!r} at line {lineno} in {source_path}"
-                )
-            classes.append(
-                _ClassInfo(
-                    node=dual_node,
-                    qualname=qualname,
-                    class_name=f"{module_path}.{qualname}",
-                )
-            )
-            nested = scope + [("class", node.name)]
-            for stmt in node.body:
-                visit(stmt, nested)
-            return
-        if isinstance(node, (FunctionDef, AsyncFunctionDef)):
-            nested = scope + [("function", node.name)]
-            for stmt in node.body:
-                visit(stmt, nested)
-            return
-        for _, _, child in node.children():
-            visit(child, scope)
-
-    visit(source_file.root, [])
-    return classes
+    def visit_AsyncFunctionDef(self, node: typed.AsyncFunctionDef) -> Any:
+        self.scope.append(("function", node.name))
+        for stmt in node.body:
+            self.visit(stmt)
+        self.scope.pop()
 
 
-def _collect_classes_dual(tree: ast.Module, module_path: str) -> list[_ClassInfo]:
-    """Residual dual-body class discovery when SourceFile construction refuses."""
-    classes: list[_ClassInfo] = []
-
-    def visit(node: ast.AST, scope: list[tuple[str, str]]) -> None:
-        if isinstance(node, ast.ClassDef):
-            qualname = _qualname(scope, node.name)
-            classes.append(
-                _ClassInfo(
-                    node=node,
-                    qualname=qualname,
-                    class_name=f"{module_path}.{qualname}",
-                )
-            )
-            nested = scope + [("class", node.name)]
-            for stmt in node.body:
-                visit(stmt, nested)
-            return
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            nested = scope + [("function", node.name)]
-            for stmt in node.body:
-                visit(stmt, nested)
-            return
-        for child in ast.iter_child_nodes(node):
-            visit(child, scope)
-
-    visit(tree, [])
-    return classes
-
-
-class _MethodAttributeScanner(ast.NodeVisitor):
+class _MethodAttributeScanner(typed.TypedNodeWalker):
     def __init__(
         self,
         *,
@@ -605,77 +422,77 @@ class _MethodAttributeScanner(ast.NodeVisitor):
         self._conditional_depth = 0
         self._nested_depth = 0
 
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+    def visit_FunctionDef(self, node: typed.FunctionDef) -> None:
         self._visit_nested_scope(node)
 
-    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+    def visit_AsyncFunctionDef(self, node: typed.AsyncFunctionDef) -> None:
         self._visit_nested_scope(node)
 
-    def visit_Lambda(self, node: ast.Lambda) -> None:
+    def visit_Lambda(self, node: typed.Lambda) -> None:
         self._nested_depth += 1
         try:
             self.visit(node.body)
         finally:
             self._nested_depth -= 1
 
-    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+    def visit_ClassDef(self, node: typed.ClassDef) -> None:
         self._visit_nested_scope(node)
 
-    def visit_If(self, node: ast.If) -> None:
+    def visit_If(self, node: typed.If) -> None:
         self.visit(node.test)
         self._visit_conditionally([*node.body, *node.orelse])
 
-    def visit_For(self, node: ast.For) -> None:
+    def visit_For(self, node: typed.For) -> None:
         self.visit(node.iter)
         self._visit_conditionally([node.target, *node.body, *node.orelse])
 
-    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+    def visit_AsyncFor(self, node: typed.AsyncFor) -> None:
         self.visit(node.iter)
         self._visit_conditionally([node.target, *node.body, *node.orelse])
 
-    def visit_While(self, node: ast.While) -> None:
+    def visit_While(self, node: typed.While) -> None:
         self.visit(node.test)
         self._visit_conditionally([*node.body, *node.orelse])
 
-    def visit_With(self, node: ast.With) -> None:
+    def visit_With(self, node: typed.With) -> None:
         for item in node.items:
             self.visit(item.context_expr)
             if item.optional_vars is not None:
                 self.visit(item.optional_vars)
         self._visit_conditionally(node.body)
 
-    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+    def visit_AsyncWith(self, node: typed.AsyncWith) -> None:
         for item in node.items:
             self.visit(item.context_expr)
             if item.optional_vars is not None:
                 self.visit(item.optional_vars)
         self._visit_conditionally(node.body)
 
-    def visit_Try(self, node: ast.Try) -> None:
+    def visit_Try(self, node: typed.Try) -> None:
         self._visit_conditionally([*node.body, *node.orelse, *node.finalbody])
         for handler in node.handlers:
             self._visit_conditionally(handler.body)
 
-    def visit_Match(self, node: ast.Match) -> None:
+    def visit_Match(self, node: typed.Match) -> None:
         self.visit(node.subject)
         for case in node.cases:
             if case.guard is not None:
                 self.visit(case.guard)
             self._visit_conditionally(case.body)
 
-    def visit_Assign(self, node: ast.Assign) -> None:
+    def visit_Assign(self, node: typed.Assign) -> None:
         for target in node.targets:
             self._record_assignment_target(target, node)
         self.visit(node.value)
 
-    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+    def visit_AnnAssign(self, node: typed.AnnAssign) -> None:
         self.visit(node.annotation)
         if node.value is None:
             return
         self._record_assignment_target(node.target, node)
         self.visit(node.value)
 
-    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+    def visit_AugAssign(self, node: typed.AugAssign) -> None:
         attr = self._instance_attr_name(node.target)
         if attr is not None:
             self._record_open_attr(
@@ -685,7 +502,7 @@ class _MethodAttributeScanner(ast.NodeVisitor):
             )
         self.visit(node.value)
 
-    def visit_Delete(self, node: ast.Delete) -> None:
+    def visit_Delete(self, node: typed.Delete) -> None:
         for target in node.targets:
             attr = self._instance_attr_name(target)
             if attr is not None:
@@ -693,7 +510,7 @@ class _MethodAttributeScanner(ast.NodeVisitor):
             else:
                 self.visit(target)
 
-    def visit_Call(self, node: ast.Call) -> None:
+    def visit_Call(self, node: typed.Call) -> None:
         name = _decorator_name(node.func)
         if name in {"setattr", "builtins.setattr"} and node.args:
             attr = self._literal_attr_arg(node, index=1)
@@ -723,16 +540,16 @@ class _MethodAttributeScanner(ast.NodeVisitor):
 
     def _visit_nested_scope(
         self,
-        node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef,
+        node: typed.FunctionDef | typed.AsyncFunctionDef | typed.ClassDef,
     ) -> None:
         self._nested_depth += 1
         try:
-            for child in ast.iter_child_nodes(node):
+            for child in typed.iter_child_nodes(node):
                 self.visit(child)
         finally:
             self._nested_depth -= 1
 
-    def _visit_conditionally(self, nodes: Iterable[ast.AST]) -> None:
+    def _visit_conditionally(self, nodes: Iterable[typed.AST]) -> None:
         self._conditional_depth += 1
         try:
             for node in nodes:
@@ -740,7 +557,7 @@ class _MethodAttributeScanner(ast.NodeVisitor):
         finally:
             self._conditional_depth -= 1
 
-    def _record_assignment_target(self, target: ast.AST, source_node: ast.AST) -> None:
+    def _record_assignment_target(self, target: typed.AST, source_node: typed.AST) -> None:
         attr = self._instance_attr_name(target)
         if attr is None:
             self.visit(target)
@@ -770,7 +587,7 @@ class _MethodAttributeScanner(ast.NodeVisitor):
     def _record_deleted_attr(
         self,
         attr: str,
-        source_node: ast.AST,
+        source_node: typed.AST,
         *,
         reason: str = "deleted-in-method",
     ) -> None:
@@ -778,7 +595,7 @@ class _MethodAttributeScanner(ast.NodeVisitor):
         self.open_reasons.add("deleted-instance-attribute")
         self._record_open_attr(attr, reason, source_node)
 
-    def _record_open_attr(self, attr: str, reason: str, source_node: ast.AST) -> None:
+    def _record_open_attr(self, attr: str, reason: str, source_node: typed.AST) -> None:
         self.open_reasons.add(reason)
         entry = self.open_attrs.setdefault(
             attr,
@@ -798,43 +615,43 @@ class _MethodAttributeScanner(ast.NodeVisitor):
         assert isinstance(sources, list)
         sources.append(_shape_source(reason, source_node, method=self.method_name))
 
-    def _instance_attr_name(self, target: ast.AST) -> str | None:
-        if not isinstance(target, ast.Attribute):
+    def _instance_attr_name(self, target: typed.AST) -> str | None:
+        if not isinstance(target, typed.Attribute):
             return None
         if not self._is_instance_receiver(target.value):
             return None
         return target.attr
 
-    def _is_instance_receiver(self, node: ast.AST) -> bool:
+    def _is_instance_receiver(self, node: typed.AST) -> bool:
         return (
             self.instance_receiver is not None
-            and isinstance(node, ast.Name)
+            and isinstance(node, typed.Name)
             and node.id == self.instance_receiver
         )
 
-    def _literal_attr_arg(self, node: ast.Call, *, index: int) -> str | None:
+    def _literal_attr_arg(self, node: typed.Call, *, index: int) -> str | None:
         if len(node.args) <= index:
             return None
         arg = node.args[index]
-        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+        if isinstance(arg, typed.Constant) and isinstance(arg.value, str):
             return arg.value
         return None
 
 
-class _ClassBodyPoisonScanner(ast.NodeVisitor):
+class _ClassBodyPoisonScanner(typed.TypedNodeWalker):
     def __init__(self) -> None:
         self.open_reasons: set[str] = set()
 
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+    def visit_FunctionDef(self, node: typed.FunctionDef) -> None:
         return
 
-    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+    def visit_AsyncFunctionDef(self, node: typed.AsyncFunctionDef) -> None:
         return
 
-    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+    def visit_ClassDef(self, node: typed.ClassDef) -> None:
         return
 
-    def visit_Call(self, node: ast.Call) -> None:
+    def visit_Call(self, node: typed.Call) -> None:
         name = _decorator_name(node.func)
         if name in {
             "setattr",
@@ -852,60 +669,101 @@ class _ClassBodyPoisonScanner(ast.NodeVisitor):
             self.open_reasons.add("dynamic-delattr")
         self.generic_visit(node)
 
-    def visit_Delete(self, node: ast.Delete) -> None:
+    def visit_Delete(self, node: typed.Delete) -> None:
         self.open_reasons.add("dynamic-class-delete")
         self.generic_visit(node)
 
 
-class _LocalCollector(ast.NodeVisitor):
+class _LocalCollector(typed.TypedNodeWalker):
     def __init__(self) -> None:
         self.names: set[str] = set()
 
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+    def visit_FunctionDef(self, node: typed.FunctionDef) -> None:
         self.names.add(node.name)
         return
 
-    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+    def visit_AsyncFunctionDef(self, node: typed.AsyncFunctionDef) -> None:
         self.names.add(node.name)
         return
 
-    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+    def visit_ClassDef(self, node: typed.ClassDef) -> None:
         return
 
-    def visit_Import(self, node: ast.Import) -> None:
+    def visit_Import(self, node: typed.Import) -> None:
         for alias in node.names:
             self.names.add(_import_bound_name(node, alias))
 
-    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+    def visit_ImportFrom(self, node: typed.ImportFrom) -> None:
         for alias in node.names:
             self.names.add(_import_bound_name(node, alias))
 
-    def visit_Lambda(self, node: ast.Lambda) -> None:
+    def visit_Lambda(self, node: typed.Lambda) -> None:
         return
 
-    def visit_ListComp(self, node: ast.ListComp) -> None:
+    def visit_ListComp(self, node: typed.ListComp) -> None:
         self.visit(node.elt)
         self._visit_comprehension_generators(node.generators)
 
-    def visit_SetComp(self, node: ast.SetComp) -> None:
+    def visit_SetComp(self, node: typed.SetComp) -> None:
         self.visit(node.elt)
         self._visit_comprehension_generators(node.generators)
 
-    def visit_DictComp(self, node: ast.DictComp) -> None:
+    def visit_DictComp(self, node: typed.DictComp) -> None:
         self.visit(node.key)
         self.visit(node.value)
         self._visit_comprehension_generators(node.generators)
 
-    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+    def visit_GeneratorExp(self, node: typed.GeneratorExp) -> None:
         self.visit(node.elt)
         self._visit_comprehension_generators(node.generators)
 
-    def visit_Name(self, node: ast.Name) -> None:
-        if isinstance(node.ctx, (ast.Store, ast.Del)):
-            self.names.add(node.id)
+    def _bind_target(self, target: typed.expr) -> None:
+        self.names.update(_stored_names(target))
+
+    def visit_Assign(self, node: typed.Assign) -> None:
+        for target in node.targets:
+            self._bind_target(target)
+        self.visit(node.value)
+
+    def visit_AnnAssign(self, node: typed.AnnAssign) -> None:
+        self._bind_target(node.target)
+        if node.annotation is not None:
+            self.visit(node.annotation)
+        if node.value is not None:
+            self.visit(node.value)
+
+    def visit_AugAssign(self, node: typed.AugAssign) -> None:
+        self._bind_target(node.target)
+        self.visit(node.value)
+
+    def visit_Delete(self, node: typed.Delete) -> None:
+        for target in node.targets:
+            self._bind_target(target)
+
+    def visit_For(self, node: typed.For) -> None:
+        self._bind_target(node.target)
+        self.visit(node.iter)
+        for statement in (*node.body, *node.orelse):
+            self.visit(statement)
+
+    visit_AsyncFor = visit_For
+
+    def visit_With(self, node: typed.With) -> None:
+        for item in node.items:
+            self.visit(item.context_expr)
+            if item.optional_vars is not None:
+                self._bind_target(item.optional_vars)
+        for statement in node.body:
+            self.visit(statement)
+
+    visit_AsyncWith = visit_With
+
+    def visit_NamedExpr(self, node: typed.NamedExpr) -> None:
+        self._bind_target(node.target)
+        self.visit(node.value)
 
     def _visit_comprehension_generators(
-        self, generators: list[ast.comprehension]
+        self, generators: list[typed.comprehension]
     ) -> None:
         for generator in generators:
             self.visit(generator.iter)
@@ -913,13 +771,33 @@ class _LocalCollector(ast.NodeVisitor):
                 self.visit(condition)
 
 
-class _LoadNameCollector(ast.NodeVisitor):
+class _LoadNameCollector(typed.TypedNodeWalker):
     def __init__(self) -> None:
         self.names: set[str] = set()
 
-    def visit_Name(self, node: ast.Name) -> None:
-        if isinstance(node.ctx, ast.Load):
-            self.names.add(node.id)
+    def visit_Name(self, node: typed.Name) -> None:
+        self.names.add(node.id)
+
+    def visit_NamedExpr(self, node: typed.NamedExpr) -> None:
+        self.visit(node.value)
+
+    def _visit_comprehension_generators(self, generators) -> None:
+        for generator in generators:
+            self.visit(generator.iter)
+            for condition in generator.ifs:
+                self.visit(condition)
+
+    def visit_ListComp(self, node: typed.ListComp) -> None:
+        self.visit(node.elt)
+        self._visit_comprehension_generators(node.generators)
+
+    visit_SetComp = visit_ListComp
+    visit_GeneratorExp = visit_ListComp
+
+    def visit_DictComp(self, node: typed.DictComp) -> None:
+        self.visit(node.key)
+        self.visit(node.value)
+        self._visit_comprehension_generators(node.generators)
 
 
 class _Emitter:
@@ -950,7 +828,7 @@ class _Emitter:
         self.value_pins = value_pins or {}
         self.module_imports = module_imports or {}
 
-    def statements(self, statements: list[ast.stmt]) -> Json:
+    def statements(self, statements: list[typed.stmt]) -> Json:
         emitted: list[Json] = []
         for statement in statements:
             if _is_docstring_stmt(statement):
@@ -959,7 +837,7 @@ class _Emitter:
         return fold_seq(emitted)
 
     def statements_with_extra_locals(
-        self, statements: list[ast.stmt], extra_locals: set[str]
+        self, statements: list[typed.stmt], extra_locals: set[str]
     ) -> Json:
         previous = self.locals
         self.locals = self.locals | extra_locals
@@ -968,11 +846,11 @@ class _Emitter:
         finally:
             self.locals = previous
 
-    def statement(self, node: ast.stmt) -> Json:
-        if isinstance(node, ast.Return):
+    def statement(self, node: typed.stmt) -> Json:
+        if isinstance(node, typed.Return):
             value = none_const() if node.value is None else self.expr(node.value)
             return ctor("python:return", value)
-        if isinstance(node, ast.Assign):
+        if isinstance(node, typed.Assign):
             if len(node.targets) != 1:
                 raise _UnsupportedSyntax(
                     node,
@@ -980,7 +858,7 @@ class _Emitter:
                     kind="multi-target-assign-refused",
                 )
             target_node = node.targets[0]
-            if isinstance(target_node, (ast.Tuple, ast.List)):
+            if isinstance(target_node, (typed.Tuple, typed.List)):
                 value = self.expr(node.value)
                 term = self.unpack_assign(target_node, value)
                 self.effects.add_panics()
@@ -995,8 +873,8 @@ class _Emitter:
             target = self.assign_target(target_node)
             self._record_write_if_nonlocal(target_node)
             return ctor("python:assign", target, self.expr(node.value))
-        if isinstance(node, ast.AugAssign):
-            if isinstance(node.op, ast.MatMult):
+        if isinstance(node, typed.AugAssign):
+            if isinstance(node.op, typed.MatMult):
                 raise _UnsupportedSyntax(
                     node, f"unsupported binary operator: {type(node.op).__name__}"
                 )
@@ -1010,7 +888,7 @@ class _Emitter:
             return ctor(
                 "python:aug_assign", target, str_const(op), self.expr(node.value)
             )
-        if isinstance(node, ast.AnnAssign):
+        if isinstance(node, typed.AnnAssign):
             annotation = self.annotation_expr(node.annotation)
             if node.value is None:
                 target = self.annassign_target_without_value(node.target)
@@ -1020,7 +898,7 @@ class _Emitter:
                 self._record_write_if_nonlocal(node.target)
                 value = self.expr(node.value)
             return ctor("python:ann_assign", target, annotation, value)
-        if isinstance(node, ast.If):
+        if isinstance(node, typed.If):
             condition = self.expr(node.test)
             then_branch = self.statements(node.body)
             else_branch = self.statements(node.orelse) if node.orelse else pass_stmt()
@@ -1043,14 +921,14 @@ class _Emitter:
                 then_branch,
                 else_branch,
             )
-        if isinstance(node, ast.Match):
+        if isinstance(node, typed.Match):
             pattern_kinds = sorted({type(case.pattern).__name__ for case in node.cases})
             raise _UnsupportedSyntax(
                 node,
                 f"match statement refused (pattern kinds: {pattern_kinds})",
                 kind="match-refused",
             )
-        if isinstance(node, ast.Try):
+        if isinstance(node, typed.Try):
             handlers = [self.except_handler(handler) for handler in node.handlers]
             return ctor(
                 "python:try",
@@ -1059,34 +937,34 @@ class _Emitter:
                 self.statements(node.orelse) if node.orelse else pass_stmt(),
                 self.statements(node.finalbody) if node.finalbody else pass_stmt(),
             )
-        if isinstance(node, (ast.Import, ast.ImportFrom)):
+        if isinstance(node, (typed.Import, typed.ImportFrom)):
             names = [_import_bound_name(node, alias) for alias in node.names]
             self.effects.add_io()
             self.locals.update(names)
             return ctor("python:import", *[str_const(name) for name in names])
-        if isinstance(node, ast.FunctionDef):
+        if isinstance(node, typed.FunctionDef):
             return self.nested_function(node)
-        if isinstance(node, ast.ClassDef):
+        if isinstance(node, typed.ClassDef):
             self.locals.add(node.name)
             self.effects.add_io()
             return ctor("python:nested_classdef", str_const(node.name))
-        if isinstance(node, ast.With):
+        if isinstance(node, typed.With):
             extra_locals: set[str] = set()
             for item in node.items:
                 self.expr(item.context_expr)
                 self.effects.add_io()
                 if item.optional_vars is None:
                     continue
-                if isinstance(item.optional_vars, ast.Name):
+                if isinstance(item.optional_vars, typed.Name):
                     extra_locals.add(item.optional_vars.id)
                     continue
-                if isinstance(item.optional_vars, (ast.Attribute, ast.Subscript)):
+                if isinstance(item.optional_vars, (typed.Attribute, typed.Subscript)):
                     self.assign_target(item.optional_vars)
                     self._record_write_if_nonlocal(item.optional_vars)
                     continue
                 raise _UnsupportedSyntax(
                     item.optional_vars,
-                    f"unsupported with-as target: {type(item.optional_vars).__name__}",
+                    f"unsupported with-as target: {item.optional_vars.kind}",
                 )
             body = (
                 self.statements_with_extra_locals(node.body, extra_locals)
@@ -1094,7 +972,7 @@ class _Emitter:
                 else self.statements(node.body)
             )
             return ctor("python:with", body)
-        if isinstance(node, ast.While):
+        if isinstance(node, typed.While):
             if node.orelse:
                 raise _UnsupportedSyntax(node, "while/else is refused")
             term = ctor(
@@ -1106,7 +984,7 @@ class _Emitter:
                 node=node,
             )
             return term
-        if isinstance(node, ast.For):
+        if isinstance(node, typed.For):
             if node.orelse:
                 raise _UnsupportedSyntax(
                     node,
@@ -1127,15 +1005,15 @@ class _Emitter:
                 node=node,
             )
             return term
-        if isinstance(node, ast.Expr):
+        if isinstance(node, typed.Expr):
             return ctor("python:expr", self.expr(node.value))
-        if isinstance(node, ast.Pass):
+        if isinstance(node, typed.Pass):
             return pass_stmt()
-        if isinstance(node, ast.Break):
+        if isinstance(node, typed.Break):
             return ctor("python:break", none_const())
-        if isinstance(node, ast.Continue):
+        if isinstance(node, typed.Continue):
             return ctor("python:continue", none_const())
-        if isinstance(node, ast.Assert):
+        if isinstance(node, typed.Assert):
             condition = self.expr(node.test)
             message = none_const() if node.msg is None else self.expr(node.msg)
             self.effects.add_panics()
@@ -1148,11 +1026,11 @@ class _Emitter:
                 )
             )
             return ctor("python:assert", condition, message)
-        if isinstance(node, ast.Delete):
+        if isinstance(node, typed.Delete):
             targets = [self.target(target) for target in node.targets]
             self.effects.add_panics()
             return ctor("python:delete", *targets)
-        if isinstance(node, ast.Raise):
+        if isinstance(node, typed.Raise):
             if node.exc is None:
                 raise _UnsupportedSyntax(
                     node,
@@ -1177,7 +1055,7 @@ class _Emitter:
             node, f"unhandled statement kind: {type(node).__name__}"
         )
 
-    def except_handler(self, node: ast.ExceptHandler) -> Json:
+    def except_handler(self, node: typed.ExceptHandler) -> Json:
         exception_type = none_const() if node.type is None else self.expr(node.type)
         name = none_const() if node.name is None else str_const(node.name)
         body = (
@@ -1192,7 +1070,7 @@ class _Emitter:
             body,
         )
 
-    def nested_function(self, node: ast.FunctionDef) -> Json:
+    def nested_function(self, node: typed.FunctionDef) -> Json:
         self.locals.add(node.name)
         term = ctor("python:nested_funcdef", str_const(node.name))
         if _refused_decorator(node) is not None or _contains_refused_control(node):
@@ -1221,7 +1099,7 @@ class _Emitter:
 
     def runtime_failure_locus(
         self,
-        node: ast.AST,
+        node: typed.AST,
         arg_term: Json,
         *,
         subkind: str,
@@ -1242,7 +1120,7 @@ class _Emitter:
 
     def attribute_runtime_failure_locus(
         self,
-        node: ast.Attribute,
+        node: typed.Attribute,
         arg_term: Json,
         *,
         subkind: str,
@@ -1260,10 +1138,10 @@ class _Emitter:
                 locus["attributeSafety"] = safety
         return locus
 
-    def target(self, node: ast.expr) -> Json:
-        if isinstance(node, ast.Name):
+    def target(self, node: typed.expr) -> Json:
+        if isinstance(node, typed.Name):
             return var(node.id)
-        if isinstance(node, ast.Attribute):
+        if isinstance(node, typed.Attribute):
             term = ctor(
                 "python:attribute",
                 self.expr(node.value),
@@ -1279,7 +1157,7 @@ class _Emitter:
                 )
             )
             return term
-        if isinstance(node, ast.Subscript):
+        if isinstance(node, typed.Subscript):
             term = ctor(
                 "python:subscript",
                 self.expr(node.value),
@@ -1298,28 +1176,28 @@ class _Emitter:
             node, f"unsupported assignment target: {type(node).__name__}"
         )
 
-    def assign_target(self, node: ast.expr) -> Json:
-        if isinstance(node, ast.Starred):
+    def assign_target(self, node: typed.expr) -> Json:
+        if isinstance(node, typed.Starred):
             return ctor("python:starred", self.assign_target(node.value))
-        if isinstance(node, ast.Tuple):
+        if isinstance(node, typed.Tuple):
             if not node.elts:
                 raise _UnsupportedSyntax(
                     node, f"unsupported assignment target: {type(node).__name__}"
                 )
             targets = [self.assign_target(element) for element in node.elts]
             return ctor("python:tuple_target", *targets)
-        if isinstance(node, ast.List):
+        if isinstance(node, typed.List):
             if not node.elts:
                 raise _UnsupportedSyntax(
                     node, f"unsupported assignment target: {type(node).__name__}"
                 )
             targets = [self.assign_target(element) for element in node.elts]
             return ctor("python:list_target", *targets)
-        if isinstance(node, ast.Subscript) and isinstance(node.slice, ast.Slice):
+        if isinstance(node, typed.Subscript) and isinstance(node.slice_, typed.Slice):
             term = ctor(
                 "python:subscript",
                 self.expr(node.value),
-                self.slice_index(node.slice),
+                self.slice_index(node.slice_),
             )
             self.effects.add_panics()
             self.panic_loci.append(
@@ -1332,10 +1210,10 @@ class _Emitter:
             return term
         return self.target(node)
 
-    def unpack_assign(self, node: ast.expr, value: Json) -> Json:
-        if isinstance(node, ast.Tuple):
+    def unpack_assign(self, node: typed.expr, value: Json) -> Json:
+        if isinstance(node, typed.Tuple):
             kind = "tuple"
-        elif isinstance(node, ast.List):
+        elif isinstance(node, typed.List):
             kind = "list"
         else:
             raise _UnsupportedSyntax(
@@ -1353,10 +1231,10 @@ class _Emitter:
             value,
         )
 
-    def augassign_target(self, node: ast.expr) -> Json:
-        if isinstance(node, ast.Name):
+    def augassign_target(self, node: typed.expr) -> Json:
+        if isinstance(node, typed.Name):
             return var(node.id)
-        if isinstance(node, ast.Attribute):
+        if isinstance(node, typed.Attribute):
             term = ctor("python:attribute", self.expr(node.value), str_const(node.attr))
             self.effects.add_panics()
             self.panic_loci.append(
@@ -1376,11 +1254,11 @@ class _Emitter:
                 )
             )
             return term
-        if isinstance(node, ast.Subscript):
+        if isinstance(node, typed.Subscript):
             receiver = self.expr(node.value)
             index = (
-                self.slice_index(node.slice)
-                if isinstance(node.slice, ast.Slice)
+                self.slice_index(node.slice_)
+                if isinstance(node.slice_, typed.Slice)
                 else self.subscript_index(node)
             )
             term = ctor("python:subscript", receiver, index)
@@ -1404,21 +1282,21 @@ class _Emitter:
             node, f"unsupported augmented assignment target: {type(node).__name__}"
         )
 
-    def annassign_target_without_value(self, node: ast.expr) -> Json:
-        if isinstance(node, ast.Name):
+    def annassign_target_without_value(self, node: typed.expr) -> Json:
+        if isinstance(node, typed.Name):
             return var(node.id)
-        if isinstance(node, ast.Attribute):
+        if isinstance(node, typed.Attribute):
             return ctor(
                 "python:attribute",
                 self.expr(node.value),
                 str_const(node.attr),
             )
-        if isinstance(node, ast.Subscript):
-            if isinstance(node.slice, ast.Slice):
+        if isinstance(node, typed.Subscript):
+            if isinstance(node.slice_, typed.Slice):
                 return ctor(
                     "python:subscript",
                     self.expr(node.value),
-                    self.slice_index(node.slice),
+                    self.slice_index(node.slice_),
                 )
             return ctor(
                 "python:subscript",
@@ -1429,19 +1307,19 @@ class _Emitter:
             node, f"unsupported annotated assignment target: {type(node).__name__}"
         )
 
-    def annotation_expr(self, node: ast.expr) -> Json:
-        if isinstance(node, ast.Constant):
+    def annotation_expr(self, node: typed.expr) -> Json:
+        if isinstance(node, typed.Constant):
             return self.constant(node)
-        if isinstance(node, ast.Name):
+        if isinstance(node, typed.Name):
             return var(node.id)
-        if isinstance(node, ast.Attribute):
+        if isinstance(node, typed.Attribute):
             return ctor(
                 "python:attribute",
                 self.annotation_expr(node.value),
                 str_const(node.attr),
             )
-        if isinstance(node, ast.BinOp):
-            if isinstance(node.op, ast.BitOr):
+        if isinstance(node, typed.BinOp):
+            if isinstance(node.op, typed.BitOr):
                 return ctor(
                     "python:annotation_union",
                     self.annotation_expr(node.left),
@@ -1450,32 +1328,32 @@ class _Emitter:
             raise _UnsupportedSyntax(
                 node, f"unsupported annotation expression: {type(node).__name__}"
             )
-        if isinstance(node, ast.Tuple):
+        if isinstance(node, typed.Tuple):
             return ctor(
                 "python:annotation_tuple",
                 *[self.annotation_expr(element) for element in node.elts],
             )
-        if isinstance(node, ast.List):
+        if isinstance(node, typed.List):
             return ctor(
                 "python:annotation_list",
                 *[self.annotation_expr(element) for element in node.elts],
             )
-        if isinstance(node, ast.Subscript):
-            if isinstance(node.slice, ast.Slice):
-                raise _UnsupportedSyntax(node.slice, "slice annotations are refused")
+        if isinstance(node, typed.Subscript):
+            if isinstance(node.slice_, typed.Slice):
+                raise _UnsupportedSyntax(node.slice_, "slice annotations are refused")
             return ctor(
                 "python:subscript",
                 self.annotation_expr(node.value),
-                self.annotation_expr(node.slice),
+                self.annotation_expr(node.slice_),
             )
         raise _UnsupportedSyntax(
             node, f"unsupported annotation expression: {type(node).__name__}"
         )
 
-    def expr(self, node: ast.expr) -> Json:
-        if isinstance(node, ast.Constant):
+    def expr(self, node: typed.expr) -> Json:
+        if isinstance(node, typed.Constant):
             return self.constant(node)
-        if isinstance(node, ast.Name):
+        if isinstance(node, typed.Name):
             if node.id not in self.locals:
                 pin = self.value_pins.get(node.id)
                 if pin is not None:
@@ -1484,22 +1362,22 @@ class _Emitter:
                     return pin.term
             self._record_read_if_global(node.id)
             return var(node.id)
-        if isinstance(node, ast.BinOp):
+        if isinstance(node, typed.BinOp):
             op = _BINOPS.get(type(node.op))
             if op is None:
                 raise _UnsupportedSyntax(
                     node, f"unsupported binary operator: {type(node.op).__name__}"
                 )
             return ctor(op, self.expr(node.left), self.expr(node.right))
-        if isinstance(node, ast.UnaryOp):
+        if isinstance(node, typed.UnaryOp):
             op = _UNARYOPS.get(type(node.op))
             if op is None:
                 raise _UnsupportedSyntax(
                     node, f"unsupported unary operator: {type(node.op).__name__}"
                 )
             return ctor(op, self.expr(node.operand))
-        if isinstance(node, ast.BoolOp):
-            op = "python:and" if isinstance(node.op, ast.And) else "python:or"
+        if isinstance(node, typed.BoolOp):
+            op = "python:and" if isinstance(node.op, typed.And) else "python:or"
             if len(node.values) < 2:
                 raise _UnsupportedSyntax(node, "boolean operation without two operands")
             values = [self.expr(value) for value in node.values]
@@ -1507,17 +1385,17 @@ class _Emitter:
             for value in values[2:]:
                 result = ctor(op, result, value)
             return result
-        if isinstance(node, ast.IfExp):
+        if isinstance(node, typed.IfExp):
             condition = self.expr(node.test)
             then_ = self.expr(node.body)
             else_ = self.expr(node.orelse)
             return ctor("python:ifexp", condition, then_, else_)
-        if isinstance(node, ast.Compare):
+        if isinstance(node, typed.Compare):
             return self.compare(node)
-        if isinstance(node, ast.Call):
+        if isinstance(node, typed.Call):
             return self.call(node)
-        if isinstance(node, ast.Attribute):
-            if isinstance(node.value, ast.Name) and node.value.id not in self.locals:
+        if isinstance(node, typed.Attribute):
+            if isinstance(node.value, typed.Name) and node.value.id not in self.locals:
                 pin = self.value_pins.get(f"{node.value.id}.{node.attr}")
                 if pin is not None:
                     # A pinned IntEnum/StrEnum member: the term IS the value
@@ -1549,11 +1427,11 @@ class _Emitter:
                 )
             )
             return term
-        if isinstance(node, ast.Subscript):
+        if isinstance(node, typed.Subscript):
             receiver = self.expr(node.value)
             index = (
-                self.slice_index(node.slice)
-                if isinstance(node.slice, ast.Slice)
+                self.slice_index(node.slice_)
+                if isinstance(node.slice_, typed.Slice)
                 else self.subscript_index(node)
             )
             term = ctor("python:subscript", receiver, index)
@@ -1566,25 +1444,25 @@ class _Emitter:
                 )
             )
             return term
-        if isinstance(node, ast.Tuple):
+        if isinstance(node, typed.Tuple):
             return ctor("python:tuple", *[self.expr(element) for element in node.elts])
-        if isinstance(node, ast.List):
+        if isinstance(node, typed.List):
             return ctor("python:list", *[self.expr(element) for element in node.elts])
-        if isinstance(node, ast.Set):
+        if isinstance(node, typed.Set):
             return ctor("python:set", *[self.expr(element) for element in node.elts])
-        if isinstance(node, ast.Starred):
+        if isinstance(node, typed.Starred):
             return ctor("python:starred", self.expr(node.value))
-        if isinstance(node, ast.Lambda):
+        if isinstance(node, typed.Lambda):
             return self.lambda_expr(node)
-        if isinstance(node, ast.ListComp):
+        if isinstance(node, typed.ListComp):
             return self.listcomp(node)
-        if isinstance(node, ast.GeneratorExp):
+        if isinstance(node, typed.GeneratorExp):
             return self.generatorexp(node)
-        if isinstance(node, ast.SetComp):
+        if isinstance(node, typed.SetComp):
             return self.setcomp(node)
-        if isinstance(node, ast.DictComp):
+        if isinstance(node, typed.DictComp):
             return self.dictcomp(node)
-        if isinstance(node, ast.Dict):
+        if isinstance(node, typed.Dict):
             keys = [
                 none_const() if key is None else self.expr(key) for key in node.keys
             ]
@@ -1594,10 +1472,10 @@ class _Emitter:
                 for key, value in zip(keys, values)
             ]
             return ctor("python:dict", *entries)
-        if isinstance(node, ast.JoinedStr):
+        if isinstance(node, typed.JoinedStr):
             return self.fstring(node)
-        if isinstance(node, ast.NamedExpr):
-            if not isinstance(node.target, ast.Name):
+        if isinstance(node, typed.NamedExpr):
+            if not isinstance(node.target, typed.Name):
                 raise _UnsupportedSyntax(
                     node.target,
                     f"unsupported walrus target: {type(node.target).__name__}",
@@ -1607,12 +1485,12 @@ class _Emitter:
             node, f"unhandled expression kind: {type(node).__name__}"
         )
 
-    def fstring(self, node: ast.JoinedStr) -> Json:
+    def fstring(self, node: typed.JoinedStr) -> Json:
         parts: list[Json] = []
         for value in node.values:
-            if isinstance(value, ast.Constant):
+            if isinstance(value, typed.Constant):
                 parts.append(str_const(str(value.value)))
-            elif isinstance(value, ast.FormattedValue):
+            elif isinstance(value, typed.FormattedValue):
                 parts.append(self.fstring_value(value))
             else:
                 raise _UnsupportedSyntax(
@@ -1620,7 +1498,7 @@ class _Emitter:
                 )
         return ctor("python:fstring", *parts)
 
-    def listcomp(self, node: ast.ListComp) -> Json:
+    def listcomp(self, node: typed.ListComp) -> Json:
         previous_locals = self.locals
         active_locals: set[str] = set()
         generators: list[Json] = []
@@ -1648,7 +1526,7 @@ class _Emitter:
         self.effects.add_opaque_loop(term, source_path=self.source_path, node=node)
         return term
 
-    def generatorexp(self, node: ast.GeneratorExp) -> Json:
+    def generatorexp(self, node: typed.GeneratorExp) -> Json:
         previous_locals = self.locals
         active_locals: set[str] = set()
         generators: list[Json] = []
@@ -1676,7 +1554,7 @@ class _Emitter:
         self.effects.add_opaque_loop(term, source_path=self.source_path, node=node)
         return term
 
-    def setcomp(self, node: ast.SetComp) -> Json:
+    def setcomp(self, node: typed.SetComp) -> Json:
         previous_locals = self.locals
         active_locals: set[str] = set()
         generators: list[Json] = []
@@ -1704,7 +1582,7 @@ class _Emitter:
         self.effects.add_opaque_loop(term, source_path=self.source_path, node=node)
         return term
 
-    def dictcomp(self, node: ast.DictComp) -> Json:
+    def dictcomp(self, node: typed.DictComp) -> Json:
         previous_locals = self.locals
         active_locals: set[str] = set()
         generators: list[Json] = []
@@ -1733,15 +1611,15 @@ class _Emitter:
         self.effects.add_opaque_loop(term, source_path=self.source_path, node=node)
         return term
 
-    def comprehension_target(self, node: ast.expr) -> tuple[Json, set[str]]:
-        if isinstance(node, ast.Name):
+    def comprehension_target(self, node: typed.expr) -> tuple[Json, set[str]]:
+        if isinstance(node, typed.Name):
             return var(node.id), {node.id}
-        if isinstance(node, ast.Starred):
+        if isinstance(node, typed.Starred):
             target, target_names = self.comprehension_target(node.value)
             return ctor("python:starred", target), target_names
-        if isinstance(node, ast.Tuple):
+        if isinstance(node, typed.Tuple):
             return self.comprehension_sequence_target(node, "python:tuple")
-        if isinstance(node, ast.List):
+        if isinstance(node, typed.List):
             return self.comprehension_sequence_target(node, "python:list")
         raise _UnsupportedSyntax(
             node,
@@ -1749,7 +1627,7 @@ class _Emitter:
         )
 
     def comprehension_sequence_target(
-        self, node: ast.Tuple | ast.List, name: str
+        self, node: typed.Tuple | typed.List, name: str
     ) -> tuple[Json, set[str]]:
         if not node.elts:
             raise _UnsupportedSyntax(
@@ -1764,7 +1642,7 @@ class _Emitter:
             names.update(target_names)
         return ctor(name, *terms), names
 
-    def fstring_value(self, node: ast.FormattedValue) -> Json:
+    def fstring_value(self, node: typed.FormattedValue) -> Json:
         conversion = self.fstring_conversion(node)
         format_spec = (
             none_const() if node.format_spec is None else self.fstring(node.format_spec)
@@ -1776,7 +1654,7 @@ class _Emitter:
             format_spec,
         )
 
-    def fstring_conversion(self, node: ast.FormattedValue) -> Json:
+    def fstring_conversion(self, node: typed.FormattedValue) -> Json:
         if node.conversion == -1:
             return none_const()
         if node.conversion in {ord("a"), ord("r"), ord("s")}:
@@ -1786,7 +1664,7 @@ class _Emitter:
             f"unsupported f-string conversion: {node.conversion}",
         )
 
-    def lambda_expr(self, node: ast.Lambda) -> Json:
+    def lambda_expr(self, node: typed.Lambda) -> Json:
         params, local_names = self.lambda_parameters(node.args)
         previous_locals = self.locals
         self.locals = previous_locals | local_names
@@ -1796,7 +1674,7 @@ class _Emitter:
             self.locals = previous_locals
         return ctor("python:lambda", *params, body)
 
-    def lambda_parameters(self, args: ast.arguments) -> tuple[list[Json], set[str]]:
+    def lambda_parameters(self, args: typed.arguments) -> tuple[list[Json], set[str]]:
         params: list[Json] = []
         local_names: set[str] = set()
         positional = [*args.posonlyargs, *args.args]
@@ -1849,7 +1727,7 @@ class _Emitter:
         self,
         name: str,
         kind: str,
-        default: ast.expr | None = None,
+        default: typed.expr | None = None,
     ) -> Json:
         default_term = (
             ctor("python:no_value")
@@ -1863,10 +1741,10 @@ class _Emitter:
             default_term,
         )
 
-    def literal_default(self, node: ast.expr) -> Json:
+    def literal_default(self, node: typed.expr) -> Json:
         return _literal_default(node, self._tentative_default_expr)
 
-    def _tentative_default_expr(self, node: ast.expr) -> Json:
+    def _tentative_default_expr(self, node: typed.expr) -> Json:
         effects = _EffectSet()
         panic_loci: list[Json] = []
         result = LiftResult()
@@ -1900,7 +1778,7 @@ class _Emitter:
             raise _non_literal_default(node)
         return term
 
-    def constant(self, node: ast.Constant) -> Json:
+    def constant(self, node: typed.Constant) -> Json:
         value = node.value
         if isinstance(value, bool):
             return bool_const(value)
@@ -1920,10 +1798,10 @@ class _Emitter:
             return none_const()
         raise _UnsupportedSyntax(node, f"unsupported constant: {type(value).__name__}")
 
-    def compare(self, node: ast.Compare) -> Json:
+    def compare(self, node: typed.Compare) -> Json:
         if not node.ops or len(node.ops) != len(node.comparators):
             raise _UnsupportedSyntax(node, "malformed comparison expression")
-        operands: list[ast.expr] = [node.left, *node.comparators]
+        operands: list[typed.expr] = [node.left, *node.comparators]
         comparisons: list[Json] = []
         for index, raw_op in enumerate(node.ops):
             op = _CMPOPS.get(type(raw_op))
@@ -1945,12 +1823,12 @@ class _Emitter:
             result = ctor("python:and", result, comparison)
         return result
 
-    def call(self, node: ast.Call) -> Json:
+    def call(self, node: typed.Call) -> Json:
         def arguments() -> list[Json]:
             args: list[Json] = []
             has_starred = False
             for arg in node.args:
-                if isinstance(arg, ast.Starred):
+                if isinstance(arg, typed.Starred):
                     args.append(ctor("python:starred_arg", self.expr(arg.value)))
                     has_starred = True
                 else:
@@ -1973,7 +1851,7 @@ class _Emitter:
                 self.effects.add_unresolved_call("(starred)")
             return args
 
-        if isinstance(node.func, ast.Subscript):
+        if isinstance(node.func, typed.Subscript):
             # Validate the index first so unsupported syntax inside the callee
             # still reports its precise refusal instead of being hidden behind
             # the dynamic-dispatch stop-line.
@@ -2000,7 +1878,7 @@ class _Emitter:
             callee = self.expr(node.func)
             self.effects.add_unresolved_call("(chained)")
             return ctor("python:call", callee, *arguments())
-        if isinstance(node.func, ast.Attribute):
+        if isinstance(node.func, typed.Attribute):
             self.expr(node.func)
         callee = _callee_name(node.func)
         if callee == "print":
@@ -2009,20 +1887,20 @@ class _Emitter:
             self.effects.add_unresolved_call(callee)
         return ctor("python:call", str_const(callee), *arguments())
 
-    def subscript_index(self, node: ast.Subscript) -> Json:
-        return self.index_expr(node.slice)
+    def subscript_index(self, node: typed.Subscript) -> Json:
+        return self.index_expr(node.slice_)
 
-    def index_expr(self, node: ast.expr | ast.slice) -> Json:
-        if isinstance(node, ast.Slice):
+    def index_expr(self, node: typed.expr | typed.slice_) -> Json:
+        if isinstance(node, typed.Slice):
             return self.slice_index(node)
-        if isinstance(node, ast.Tuple):
+        if isinstance(node, typed.Tuple):
             return ctor(
                 "python:tuple",
                 *[self.index_expr(element) for element in node.elts],
             )
         return self.expr(node)
 
-    def slice_index(self, node: ast.Slice) -> Json:
+    def slice_index(self, node: typed.Slice) -> Json:
         lower = none_const() if node.lower is None else self.expr(node.lower)
         upper = none_const() if node.upper is None else self.expr(node.upper)
         step = none_const() if node.step is None else self.expr(node.step)
@@ -2030,7 +1908,7 @@ class _Emitter:
 
     def none_guarded_if(
         self,
-        test: ast.expr,
+        test: typed.expr,
         condition: Json,
         then_branch: Json,
         else_branch: Json,
@@ -2052,7 +1930,7 @@ class _Emitter:
 
     def attribute_presence_guarded_if(
         self,
-        test: ast.expr,
+        test: typed.expr,
         condition: Json,
         then_branch: Json,
         else_branch: Json,
@@ -2072,10 +1950,10 @@ class _Emitter:
             else_branch,
         )
 
-    def attribute_presence_guard(self, test: ast.expr) -> tuple[Json, str] | None:
+    def attribute_presence_guard(self, test: typed.expr) -> tuple[Json, str] | None:
         if self.attribute_receiver is None:
             return None
-        if not isinstance(test, ast.Call):
+        if not isinstance(test, typed.Call):
             return None
         try:
             callee_name = _callee_name(test.func)
@@ -2089,20 +1967,20 @@ class _Emitter:
             return None
         receiver_node, attr_node = test.args
         if (
-            not isinstance(receiver_node, ast.Name)
+            not isinstance(receiver_node, typed.Name)
             or receiver_node.id != self.attribute_receiver.receiver_name
         ):
             return None
-        if not isinstance(attr_node, ast.Constant) or not isinstance(
+        if not isinstance(attr_node, typed.Constant) or not isinstance(
             attr_node.value, str
         ):
             return None
         return var(receiver_node.id), attr_node.value
 
     def none_guard(
-        self, test: ast.expr, condition: Json
+        self, test: typed.expr, condition: Json
     ) -> tuple[str, str, Json] | None:
-        if not isinstance(test, ast.Compare):
+        if not isinstance(test, typed.Compare):
             return None
         if len(test.ops) != 1 or len(test.comparators) != 1:
             return None
@@ -2116,7 +1994,7 @@ class _Emitter:
         if not isinstance(condition_args, list) or len(condition_args) != 3:
             return None
         raw_op = test.ops[0]
-        if not isinstance(raw_op, (ast.Is, ast.IsNot)):
+        if not isinstance(raw_op, (typed.Is, typed.IsNot)):
             return None
         lhs = test.left
         rhs = test.comparators[0]
@@ -2126,7 +2004,7 @@ class _Emitter:
             receiver = condition_args[2]
         else:
             return None
-        if isinstance(raw_op, ast.Is):
+        if isinstance(raw_op, typed.Is):
             return "is_none", "is_some", receiver
         return "is_some", "is_none", receiver
 
@@ -2134,17 +2012,17 @@ class _Emitter:
         if name in self.module_globals and name not in self.locals:
             self.effects.add_reads(name)
 
-    def _record_write_if_nonlocal(self, node: ast.expr) -> None:
-        if isinstance(node, ast.Attribute):
+    def _record_write_if_nonlocal(self, node: typed.expr) -> None:
+        if isinstance(node, typed.Attribute):
             self.effects.add_writes(_target_text(node))
-        elif isinstance(node, ast.Subscript):
+        elif isinstance(node, typed.Subscript):
             self.effects.add_writes(_target_text(node))
 
-    def attribute_safety_obligation(self, node: ast.Attribute) -> Json | None:
+    def attribute_safety_obligation(self, node: typed.Attribute) -> Json | None:
         if self.attribute_receiver is None:
             return None
         if (
-            not isinstance(node.value, ast.Name)
+            not isinstance(node.value, typed.Name)
             or node.value.id != self.attribute_receiver.receiver_name
         ):
             return None
@@ -2171,9 +2049,9 @@ def _lift_function(
     closure_locals: set[str] | None = None,
 ) -> Json | None:
     node = info.node
-    assert isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    assert isinstance(node, (typed.FunctionDef, typed.AsyncFunctionDef))
     try:
-        if isinstance(node, ast.AsyncFunctionDef):
+        if isinstance(node, typed.AsyncFunctionDef):
             raise _UnsupportedSyntax(
                 node,
                 "async functions are refused",
@@ -2260,19 +2138,14 @@ def _lift_function(
         return None
 
 
-def _lift_class_shapes(
-    tree: ast.Module,
-    module_path: str,
-    *,
-    source: str,
-    source_path: str,
-) -> list[Json]:
-    classes = _collect_classes(source, source_path, module_path, tree)
+def _lift_class_shapes(tree: typed.Module, module_path: str) -> list[Json]:
+    collector = _ClassCollector(module_path)
+    collector.visit(tree)
     shapes: list[Json] = []
     shapes_by_name: dict[str, Json] = {}
     setattr_override_by_name: dict[str, bool] = {}
 
-    for info in classes:
+    for info in collector.classes:
         shape, setattr_override_in_mro = _build_class_shape(
             info,
             shapes_by_name=shapes_by_name,
@@ -2318,15 +2191,15 @@ def _receiver_contexts_by_method(
 
 
 def _receiver_name_reassigned(
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    node: typed.FunctionDef | typed.AsyncFunctionDef,
     receiver_name: str,
 ) -> bool:
-    class _ReceiverReassignmentScanner(ast.NodeVisitor):
+    class _ReceiverReassignmentScanner(typed.TypedNodeWalker):
         def __init__(self) -> None:
             self.reassigned = False
             self._nested_depth = 0
 
-        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        def visit_FunctionDef(self, node: typed.FunctionDef) -> None:
             if self._nested_depth > 0:
                 return
             self._nested_depth += 1
@@ -2336,7 +2209,7 @@ def _receiver_name_reassigned(
             finally:
                 self._nested_depth -= 1
 
-        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        def visit_AsyncFunctionDef(self, node: typed.AsyncFunctionDef) -> None:
             if self._nested_depth > 0:
                 return
             self._nested_depth += 1
@@ -2346,15 +2219,51 @@ def _receiver_name_reassigned(
             finally:
                 self._nested_depth -= 1
 
-        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        def visit_ClassDef(self, node: typed.ClassDef) -> None:
             return
 
-        def visit_Lambda(self, node: ast.Lambda) -> None:
+        def visit_Lambda(self, node: typed.Lambda) -> None:
             return
 
-        def visit_Name(self, node: ast.Name) -> None:
-            if node.id == receiver_name and isinstance(node.ctx, (ast.Store, ast.Del)):
+        def _target(self, node: typed.expr) -> None:
+            if receiver_name in _stored_names(node):
                 self.reassigned = True
+
+        def visit_Assign(self, node: typed.Assign) -> None:
+            for target in node.targets:
+                self._target(target)
+            self.visit(node.value)
+
+        def visit_AnnAssign(self, node: typed.AnnAssign) -> None:
+            self._target(node.target)
+            if node.value is not None:
+                self.visit(node.value)
+
+        def visit_AugAssign(self, node: typed.AugAssign) -> None:
+            self._target(node.target)
+            self.visit(node.value)
+
+        def visit_Delete(self, node: typed.Delete) -> None:
+            for target in node.targets:
+                self._target(target)
+
+        def visit_For(self, node: typed.For) -> None:
+            self._target(node.target)
+            self.generic_visit(node)
+
+        visit_AsyncFor = visit_For
+
+        def visit_With(self, node: typed.With) -> None:
+            for item in node.items:
+                if item.optional_vars is not None:
+                    self._target(item.optional_vars)
+            self.generic_visit(node)
+
+        visit_AsyncWith = visit_With
+
+        def visit_NamedExpr(self, node: typed.NamedExpr) -> None:
+            self._target(node.target)
+            self.visit(node.value)
 
     scanner = _ReceiverReassignmentScanner()
     scanner.visit(node)
@@ -2375,7 +2284,7 @@ def _build_class_shape(
     permitted: dict[str, Json] = {}
     bases: list[Json] = []
 
-    if node.decorator_list:
+    if node.decorators:
         open_reasons.add("class-decorator")
     if node.keywords:
         open_reasons.add("metaclass")
@@ -2386,7 +2295,7 @@ def _build_class_shape(
     for base in node.bases:
         base_name = _base_name(base)
         base_record: Json = {"name": base_name, "resolution": "non-local"}
-        if isinstance(base, ast.Name) and base.id in shapes_by_name:
+        if isinstance(base, typed.Name) and base.id in shapes_by_name:
             base_shape = shapes_by_name[base.id]
             if base_shape.get("status") == "closed":
                 base_record["resolution"] = "local-closed"
@@ -2427,7 +2336,7 @@ def _build_class_shape(
                 "sources": [source],
             }
 
-        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        if isinstance(stmt, (typed.FunctionDef, typed.AsyncFunctionDef)):
             method = _method_shape(stmt, info.qualname)
             methods.append(method)
             method_kind = str(method["methodKind"])
@@ -2507,7 +2416,7 @@ def _build_class_shape(
 
 
 def _method_shape(
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    node: typed.FunctionDef | typed.AsyncFunctionDef,
     owner_qualname: str,
 ) -> Json:
     method_kind = _method_kind(node)
@@ -2524,8 +2433,8 @@ def _method_shape(
     return shape
 
 
-def _method_kind(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
-    names = {_decorator_name(decorator) for decorator in node.decorator_list}
+def _method_kind(node: typed.FunctionDef | typed.AsyncFunctionDef) -> str:
+    names = {_decorator_name(decorator) for decorator in node.decorators}
     names.discard(None)
     if "classmethod" in names or "builtins.classmethod" in names:
         return "classmethod"
@@ -2546,8 +2455,8 @@ def _method_kind(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
     return "instance"
 
 
-def _method_has_unknown_decorator(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
-    for decorator in node.decorator_list:
+def _method_has_unknown_decorator(node: typed.FunctionDef | typed.AsyncFunctionDef) -> bool:
+    for decorator in node.decorators:
         if _is_transparent_decorator(decorator):
             continue
         if _decorator_kind(decorator) is not None:
@@ -2556,28 +2465,28 @@ def _method_has_unknown_decorator(node: ast.FunctionDef | ast.AsyncFunctionDef) 
     return False
 
 
-def _first_parameter_name(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:
+def _first_parameter_name(node: typed.FunctionDef | typed.AsyncFunctionDef) -> str | None:
     positional = [*node.args.posonlyargs, *node.args.args]
     if not positional:
         return None
     return positional[0].arg
 
 
-def _class_overrides_setattr(node: ast.ClassDef) -> bool:
+def _class_overrides_setattr(node: typed.ClassDef) -> bool:
     return any(
-        isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
+        isinstance(stmt, (typed.FunctionDef, typed.AsyncFunctionDef))
         and stmt.name in {"__setattr__", "__delattr__"}
         for stmt in node.body
     )
 
 
-def _slot_entries(stmt: ast.stmt) -> tuple[list[Json], bool]:
-    if not isinstance(stmt, ast.Assign) and type(stmt) in AST_STATEMENT_TYPES:
+def _slot_entries(stmt: typed.stmt) -> tuple[list[Json], bool]:
+    if not isinstance(stmt, typed.Assign) and type(stmt) in AST_STATEMENT_TYPES:
         return [], False
-    if not isinstance(stmt, ast.Assign):
+    if not isinstance(stmt, typed.Assign):
         raise _UnsupportedSyntax(stmt, f"unknown statement variant: {type(stmt).__name__}")
     if not any(
-        isinstance(target, ast.Name) and target.id == "__slots__"
+        isinstance(target, typed.Name) and target.id == "__slots__"
         for target in stmt.targets
     ):
         return [], False
@@ -2597,13 +2506,13 @@ def _slot_entries(stmt: ast.stmt) -> tuple[list[Json], bool]:
     ], False
 
 
-def _literal_slots(node: ast.expr) -> list[str] | None:
-    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+def _literal_slots(node: typed.expr) -> list[str] | None:
+    if isinstance(node, typed.Constant) and isinstance(node.value, str):
         return [node.value]
-    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+    if isinstance(node, (typed.Tuple, typed.List, typed.Set)):
         slots: list[str] = []
         for element in node.elts:
-            if not isinstance(element, ast.Constant) or not isinstance(
+            if not isinstance(element, typed.Constant) or not isinstance(
                 element.value, str
             ):
                 return None
@@ -2612,11 +2521,11 @@ def _literal_slots(node: ast.expr) -> list[str] | None:
     return None
 
 
-def _class_body_attribute_sources(stmt: ast.stmt) -> list[tuple[str, Json]]:
-    if isinstance(stmt, ast.Assign):
+def _class_body_attribute_sources(stmt: typed.stmt) -> list[tuple[str, Json]]:
+    if isinstance(stmt, typed.Assign):
         sources: list[tuple[str, Json]] = []
         for target in stmt.targets:
-            if isinstance(target, ast.Name):
+            if isinstance(target, typed.Name):
                 sources.append(
                     (
                         target.id,
@@ -2625,9 +2534,9 @@ def _class_body_attribute_sources(stmt: ast.stmt) -> list[tuple[str, Json]]:
                 )
         return sources
     if (
-        isinstance(stmt, ast.AnnAssign)
+        isinstance(stmt, typed.AnnAssign)
         and stmt.value is not None
-        and isinstance(stmt.target, ast.Name)
+        and isinstance(stmt.target, typed.Name)
     ):
         return [
             (
@@ -2635,7 +2544,7 @@ def _class_body_attribute_sources(stmt: ast.stmt) -> list[tuple[str, Json]]:
                 _shape_source("class-body-assignment", stmt),
             )
         ]
-    if isinstance(stmt, ast.ClassDef):
+    if isinstance(stmt, typed.ClassDef):
         return [
             (
                 stmt.name,
@@ -2711,7 +2620,7 @@ def _merge_open_attr_entry(
             target_sources.append(source)
 
 
-def _shape_source(kind: str, node: ast.AST, *, method: str | None = None) -> Json:
+def _shape_source(kind: str, node: typed.AST, *, method: str | None = None) -> Json:
     source: Json = {
         "kind": kind,
         "line": int(getattr(node, "lineno", 0) or 0),
@@ -2722,19 +2631,19 @@ def _shape_source(kind: str, node: ast.AST, *, method: str | None = None) -> Jso
     return source
 
 
-def _base_name(node: ast.expr) -> str:
+def _base_name(node: typed.expr) -> str:
     try:
-        return ast.unparse(node)
+        return typed.unparse(node)
     except Exception:
         return type(node).__name__
 
 
-def _decorator_name(node: ast.AST) -> str | None:
-    if isinstance(node, ast.Call):
+def _decorator_name(node: typed.AST) -> str | None:
+    if isinstance(node, typed.Call):
         return _decorator_name(node.func)
-    if isinstance(node, ast.Name):
+    if isinstance(node, typed.Name):
         return node.id
-    if isinstance(node, ast.Attribute):
+    if isinstance(node, typed.Attribute):
         base = _decorator_name(node.value)
         return f"{base}.{node.attr}" if base else node.attr
     return None
@@ -2748,8 +2657,8 @@ def _sorted_json_entries(entries: Iterable[Json]) -> list[Json]:
 
 
 def _parameter_shape(
-    node: ast.FunctionDef,
-    literal_default: Callable[[ast.expr], Json],
+    node: typed.FunctionDef,
+    literal_default: Callable[[typed.expr], Json],
 ) -> tuple[list[str], list[Json]]:
     formals: list[str] = []
     shape: list[Json] = []
@@ -2801,10 +2710,10 @@ def _has_nontrivial_parameter_shape(shape: list[Json]) -> bool:
 
 
 def _literal_default(
-    node: ast.expr,
-    tentative_expr: Callable[[ast.expr], Json],
+    node: typed.expr,
+    tentative_expr: Callable[[typed.expr], Json],
 ) -> Json:
-    if isinstance(node, ast.Constant):
+    if isinstance(node, typed.Constant):
         value = node.value
         if isinstance(value, bool):
             return bool_const(value)
@@ -2822,25 +2731,25 @@ def _literal_default(
             return ellipsis_const()
         if value is None:
             return none_const()
-    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+    if isinstance(node, typed.UnaryOp) and isinstance(node.op, (typed.UAdd, typed.USub)):
         operand = node.operand
-        if isinstance(operand, ast.Constant) and type(operand.value) is int:
+        if isinstance(operand, typed.Constant) and type(operand.value) is int:
             value = operand.value
-            if isinstance(node.op, ast.USub):
+            if isinstance(node.op, typed.USub):
                 value = -value
             return int_const(value)
-    if isinstance(node, ast.Tuple):
+    if isinstance(node, typed.Tuple):
         return ctor(
             "python:tuple",
             *[_literal_default(element, tentative_expr) for element in node.elts],
         )
-    if isinstance(node, (ast.List, ast.Dict, ast.Set)):
+    if isinstance(node, (typed.List, typed.Dict, typed.Set)):
         raise _non_literal_default(node)
     return tentative_expr(node)
 
 
 def _resolved_imported_dotted_name(
-    node: ast.expr,
+    node: typed.expr,
     module_imports: dict[str, str],
 ) -> str | None:
     dotted = _dotted_name(node)
@@ -2853,7 +2762,7 @@ def _resolved_imported_dotted_name(
     return f"{imported}.{rest}" if rest else imported
 
 
-def _non_literal_default(node: ast.expr) -> _UnsupportedSyntax:
+def _non_literal_default(node: typed.expr) -> _UnsupportedSyntax:
     return _UnsupportedSyntax(
         node,
         f"non-literal default: {type(node).__name__}",
@@ -2861,7 +2770,7 @@ def _non_literal_default(node: ast.expr) -> _UnsupportedSyntax:
     )
 
 
-def _loaded_names(node: ast.AST) -> set[str]:
+def _loaded_names(node: typed.AST) -> set[str]:
     collector = _LoadNameCollector()
     collector.visit(node)
     return collector.names
@@ -2882,9 +2791,9 @@ def _refusal(
 
 
 def _refused_decorator(
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    node: typed.FunctionDef | typed.AsyncFunctionDef,
 ) -> _UnsupportedSyntax | None:
-    for decorator in node.decorator_list:
+    for decorator in node.decorators:
         if _is_transparent_decorator(decorator):
             continue
         if _decorator_kind(decorator) is not None:
@@ -2898,7 +2807,7 @@ def _refused_decorator(
     return None
 
 
-def _is_transparent_decorator(decorator: ast.expr) -> bool:
+def _is_transparent_decorator(decorator: typed.expr) -> bool:
     name = _decorator_name(decorator)
     return name in {
         "abstractmethod",
@@ -2913,7 +2822,7 @@ def _is_transparent_decorator(decorator: ast.expr) -> bool:
     }
 
 
-def _decorator_kind(decorator: ast.expr) -> str | None:
+def _decorator_kind(decorator: typed.expr) -> str | None:
     name = _decorator_name(decorator)
     if name in {"property", "builtins.property"}:
         return "property"
@@ -2941,17 +2850,17 @@ def _decorator_kind(decorator: ast.expr) -> str | None:
 
 
 def _function_decorator_kinds(
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    node: typed.FunctionDef | typed.AsyncFunctionDef,
 ) -> list[str]:
     kinds: list[str] = []
-    for decorator in node.decorator_list:
+    for decorator in node.decorators:
         kind = _decorator_kind(decorator)
         if kind is not None and kind not in kinds:
             kinds.append(kind)
     return kinds
 
 
-def _refused_decorator_name(decorator: ast.expr) -> str:
+def _refused_decorator_name(decorator: typed.expr) -> str:
     name = _decorator_name(decorator)
     if name in {"lru_cache", "functools.lru_cache"}:
         return "lru_cache"
@@ -2960,55 +2869,55 @@ def _refused_decorator_name(decorator: ast.expr) -> str:
     if name is not None:
         return name
     try:
-        return ast.unparse(decorator)
+        return typed.unparse(decorator)
     except Exception:
         return type(decorator).__name__
 
 
-def _contains_refused_control(fn: ast.FunctionDef) -> _UnsupportedSyntax | None:
-    class _RefusedControlScanner(ast.NodeVisitor):
+def _contains_refused_control(fn: typed.FunctionDef) -> _UnsupportedSyntax | None:
+    class _RefusedControlScanner(typed.TypedNodeWalker):
         def __init__(self) -> None:
             self.refused: _UnsupportedSyntax | None = None
 
-        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        def visit_FunctionDef(self, node: typed.FunctionDef) -> None:
             if node is fn:
                 self.generic_visit(node)
 
-        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        def visit_AsyncFunctionDef(self, node: typed.AsyncFunctionDef) -> None:
             return
 
-        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        def visit_ClassDef(self, node: typed.ClassDef) -> None:
             return
 
-        def visit_Lambda(self, node: ast.Lambda) -> None:
+        def visit_Lambda(self, node: typed.Lambda) -> None:
             return
 
-        def visit_Global(self, node: ast.Global) -> None:
+        def visit_Global(self, node: typed.Global) -> None:
             self._refuse(
                 node,
                 "global/nonlocal declarations are refused",
                 kind="global-nonlocal-refused",
             )
 
-        def visit_Nonlocal(self, node: ast.Nonlocal) -> None:
+        def visit_Nonlocal(self, node: typed.Nonlocal) -> None:
             self._refuse(
                 node,
                 "global/nonlocal declarations are refused",
                 kind="global-nonlocal-refused",
             )
 
-        def visit_Yield(self, node: ast.Yield) -> None:
+        def visit_Yield(self, node: typed.Yield) -> None:
             self._refuse(node, "generators are refused", kind="generator-refused")
 
-        def visit_YieldFrom(self, node: ast.YieldFrom) -> None:
+        def visit_YieldFrom(self, node: typed.YieldFrom) -> None:
             self._refuse(node, "generators are refused", kind="generator-refused")
 
-        def visit_Await(self, node: ast.Await) -> None:
+        def visit_Await(self, node: typed.Await) -> None:
             self._refuse(node, "await expressions are refused")
 
         def _refuse(
             self,
-            node: ast.AST,
+            node: typed.AST,
             reason: str,
             *,
             kind: str = "unhandled-syntax",
@@ -3021,25 +2930,25 @@ def _contains_refused_control(fn: ast.FunctionDef) -> _UnsupportedSyntax | None:
     return scanner.refused
 
 
-def _function_locals(fn: ast.FunctionDef, formals: list[str]) -> set[str]:
+def _function_locals(fn: typed.FunctionDef, formals: list[str]) -> set[str]:
     collector = _LocalCollector()
     for statement in fn.body:
         collector.visit(statement)
     return set(formals) | collector.names
 
 
-def _import_bound_name(node: ast.Import | ast.ImportFrom, alias: ast.alias) -> str:
+def _import_bound_name(node: typed.Import | typed.ImportFrom, alias: typed.alias) -> str:
     if alias.name == "*":
         raise _UnsupportedSyntax(node, "star imports are refused")
     if alias.asname:
         return alias.asname
-    if isinstance(node, ast.Import):
+    if isinstance(node, typed.Import):
         return alias.name.split(".", 1)[0]
     return alias.name
 
 
 def _lift_function_precondition(
-    fn: ast.FunctionDef,
+    fn: typed.FunctionDef,
     fn_name: str,
     source_path: str,
     result: LiftResult,
@@ -3068,9 +2977,9 @@ def _lift_function_precondition(
 
 
 def _lift_precondition_guard_statement(
-    statement: ast.stmt,
+    statement: typed.stmt,
 ) -> tuple[Json | None, str | None]:
-    if not isinstance(statement, ast.If):
+    if not isinstance(statement, typed.If):
         return None, None
     if statement.orelse or not _body_only_raises(statement.body):
         return None, None
@@ -3080,39 +2989,39 @@ def _lift_precondition_guard_statement(
     return _negate_formula(condition), None
 
 
-def _body_only_raises(body: list[ast.stmt]) -> bool:
+def _body_only_raises(body: list[typed.stmt]) -> bool:
     statements = [stmt for stmt in body if not _is_docstring_stmt(stmt)]
-    return len(statements) == 1 and isinstance(statements[0], ast.Raise)
+    return len(statements) == 1 and isinstance(statements[0], typed.Raise)
 
 
-def _lift_guard_formula(node: ast.expr) -> Json | None:
-    if isinstance(node, ast.BoolOp):
+def _lift_guard_formula(node: typed.expr) -> Json | None:
+    if isinstance(node, typed.BoolOp):
         if len(node.values) < 2:
             return None
         operands = [_lift_guard_formula(value) for value in node.values]
         if any(operand is None for operand in operands):
             return None
-        kind = "and" if isinstance(node.op, ast.And) else "or"
+        kind = "and" if isinstance(node.op, typed.And) else "or"
         return _fold_connective(
             kind, [operand for operand in operands if operand is not None]
         )
-    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+    if isinstance(node, typed.UnaryOp) and isinstance(node.op, typed.Not):
         inner = _lift_guard_formula(node.operand)
         return None if inner is None else _negate_formula(inner)
-    if isinstance(node, ast.Compare):
+    if isinstance(node, typed.Compare):
         return _lift_guard_compare(node)
-    if isinstance(node, ast.Constant) and isinstance(node.value, bool):
+    if isinstance(node, typed.Constant) and isinstance(node.value, bool):
         return _atomic("true" if node.value else "false", [])
     return None
 
 
-def _lift_guard_compare(node: ast.Compare) -> Json | None:
+def _lift_guard_compare(node: typed.Compare) -> Json | None:
     if not node.ops or len(node.ops) != len(node.comparators):
         return None
-    operands: list[ast.expr] = [node.left, *node.comparators]
+    operands: list[typed.expr] = [node.left, *node.comparators]
     atoms: list[Json] = []
     for index, op_node in enumerate(node.ops):
-        if isinstance(op_node, (ast.Is, ast.IsNot)):
+        if isinstance(op_node, (typed.Is, typed.IsNot)):
             atom = _lift_guard_identity_compare(
                 op_node, operands[index], operands[index + 1]
             )
@@ -3120,7 +3029,7 @@ def _lift_guard_compare(node: ast.Compare) -> Json | None:
                 return None
             atoms.append(atom)
             continue
-        if isinstance(op_node, (ast.In, ast.NotIn)):
+        if isinstance(op_node, (typed.In, typed.NotIn)):
             atom = _lift_guard_membership_compare(
                 op_node, operands[index], operands[index + 1]
             )
@@ -3140,7 +3049,7 @@ def _lift_guard_compare(node: ast.Compare) -> Json | None:
 
 
 def _lift_guard_identity_compare(
-    op_node: ast.cmpop, left_node: ast.expr, right_node: ast.expr
+    op_node: typed.cmpop, left_node: typed.expr, right_node: typed.expr
 ) -> Json | None:
     left = _lift_guard_term(left_node)
     right = _lift_guard_term(right_node)
@@ -3148,12 +3057,12 @@ def _lift_guard_identity_compare(
         return None
     if not _is_none_term(left) and not _is_none_term(right):
         return None
-    op = "=" if isinstance(op_node, ast.Is) else "≠"
+    op = "=" if isinstance(op_node, typed.Is) else "≠"
     return _atomic(op, [left, right])
 
 
 def _lift_guard_membership_compare(
-    op_node: ast.cmpop, left_node: ast.expr, right_node: ast.expr
+    op_node: typed.cmpop, left_node: typed.expr, right_node: typed.expr
 ) -> Json | None:
     left = _lift_guard_term(left_node)
     options = _lift_guard_literal_options(right_node)
@@ -3161,11 +3070,11 @@ def _lift_guard_membership_compare(
         return None
     equalities = [_atomic("=", [left, option]) for option in options]
     membership = _fold_connective("or", equalities)
-    return _negate_formula(membership) if isinstance(op_node, ast.NotIn) else membership
+    return _negate_formula(membership) if isinstance(op_node, typed.NotIn) else membership
 
 
-def _lift_guard_literal_options(node: ast.expr) -> list[Json] | None:
-    if not isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+def _lift_guard_literal_options(node: typed.expr) -> list[Json] | None:
+    if not isinstance(node, (typed.List, typed.Tuple, typed.Set)):
         return None
     values: list[Json] = []
     for elt in node.elts:
@@ -3176,10 +3085,10 @@ def _lift_guard_literal_options(node: ast.expr) -> list[Json] | None:
     return values
 
 
-def _lift_guard_term(node: ast.expr) -> Json | None:
-    if isinstance(node, ast.Name):
+def _lift_guard_term(node: typed.expr) -> Json | None:
+    if isinstance(node, typed.Name):
         return var(node.id)
-    if isinstance(node, ast.Constant):
+    if isinstance(node, typed.Constant):
         if isinstance(node.value, bool):
             return bool_const(node.value)
         if isinstance(node.value, int):
@@ -3189,14 +3098,14 @@ def _lift_guard_term(node: ast.expr) -> Json | None:
         if node.value is None:
             return none_const()
         return None
-    if isinstance(node, ast.Attribute):
+    if isinstance(node, typed.Attribute):
         receiver = _lift_guard_term(node.value)
         if receiver is None:
             return None
         return ctor("python:attribute", receiver, str_const(node.attr))
-    if isinstance(node, ast.Call):
+    if isinstance(node, typed.Call):
         if (
-            isinstance(node.func, ast.Name)
+            isinstance(node.func, typed.Name)
             and node.func.id == "len"
             and len(node.args) == 1
             and not node.keywords
@@ -3206,11 +3115,11 @@ def _lift_guard_term(node: ast.expr) -> Json | None:
                 return None
             return ctor("python:len", operand)
         return None
-    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+    if isinstance(node, typed.UnaryOp) and isinstance(node.op, (typed.UAdd, typed.USub)):
         operand = node.operand
-        if isinstance(operand, ast.Constant) and type(operand.value) is int:
+        if isinstance(operand, typed.Constant) and type(operand.value) is int:
             value = operand.value
-            if isinstance(node.op, ast.USub):
+            if isinstance(node.op, typed.USub):
                 value = -value
             return int_const(value)
     return None
@@ -3287,29 +3196,29 @@ def _negate_formula(formula: Json) -> Json:
     return {"kind": "not", "operands": [formula]}
 
 
-def _module_global_names(tree: ast.Module) -> set[str]:
+def _module_global_names(tree: typed.Module) -> set[str]:
     names: set[str] = set()
     for stmt in tree.body:
-        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        if isinstance(stmt, (typed.FunctionDef, typed.AsyncFunctionDef, typed.ClassDef)):
             names.add(stmt.name)
-        elif isinstance(stmt, ast.Assign):
+        elif isinstance(stmt, typed.Assign):
             for target in stmt.targets:
                 names.update(_stored_names(target))
-        elif isinstance(stmt, ast.AnnAssign):
+        elif isinstance(stmt, typed.AnnAssign):
             names.update(_stored_names(stmt.target))
     return names
 
 
-def _module_import_aliases(tree: ast.Module) -> dict[str, str]:
+def _module_import_aliases(tree: typed.Module) -> dict[str, str]:
     imports: dict[str, str] = {}
     rebound: set[str] = set()
     for stmt in tree.body:
-        if isinstance(stmt, ast.Import):
+        if isinstance(stmt, typed.Import):
             for alias in stmt.names:
                 bound = alias.asname or alias.name.split(".", 1)[0]
                 imports[bound] = alias.name
             continue
-        if isinstance(stmt, ast.ImportFrom) and stmt.module is not None:
+        if isinstance(stmt, typed.ImportFrom) and stmt.module is not None:
             for alias in stmt.names:
                 bound = alias.asname or alias.name
                 imports[bound] = f"{stmt.module}.{alias.name}"
@@ -3320,19 +3229,19 @@ def _module_import_aliases(tree: ast.Module) -> dict[str, str]:
     return imports
 
 
-def _module_statement_bound_names(stmt: ast.stmt) -> set[str]:
-    if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+def _module_statement_bound_names(stmt: typed.stmt) -> set[str]:
+    if isinstance(stmt, (typed.FunctionDef, typed.AsyncFunctionDef, typed.ClassDef)):
         return {stmt.name}
-    if isinstance(stmt, ast.Assign):
+    if isinstance(stmt, typed.Assign):
         names: set[str] = set()
         for target in stmt.targets:
             names.update(_stored_names(target))
         return names
-    if isinstance(stmt, ast.AnnAssign):
+    if isinstance(stmt, typed.AnnAssign):
         return _stored_names(stmt.target)
-    if isinstance(stmt, ast.AugAssign):
+    if isinstance(stmt, typed.AugAssign):
         return _stored_names(stmt.target)
-    if isinstance(stmt, ast.Delete):
+    if isinstance(stmt, typed.Delete):
         names: set[str] = set()
         for target in stmt.targets:
             names.update(_stored_names(target))
@@ -3342,10 +3251,10 @@ def _module_statement_bound_names(stmt: ast.stmt) -> set[str]:
     raise _UnsupportedSyntax(stmt, f"unknown statement variant: {type(stmt).__name__}")
 
 
-def _stored_names(node: ast.AST) -> set[str]:
-    if isinstance(node, ast.Name):
+def _stored_names(node: typed.AST) -> set[str]:
+    if isinstance(node, typed.Name):
         return {node.id}
-    if isinstance(node, (ast.Tuple, ast.List)):
+    if isinstance(node, (typed.Tuple, typed.List)):
         names: set[str] = set()
         for elt in node.elts:
             names.update(_stored_names(elt))
@@ -3381,45 +3290,45 @@ def _qualname(scope: list[tuple[str, str]], name: str) -> str:
     return ".".join(parts)
 
 
-def _is_docstring_stmt(statement: ast.stmt) -> bool:
+def _is_docstring_stmt(statement: typed.stmt) -> bool:
     return (
-        isinstance(statement, ast.Expr)
-        and isinstance(statement.value, ast.Constant)
+        isinstance(statement, typed.Expr)
+        and isinstance(statement.value, typed.Constant)
         and isinstance(statement.value.value, str)
     )
 
 
-def _is_none_literal(node: ast.expr) -> bool:
-    return isinstance(node, ast.Constant) and node.value is None
+def _is_none_literal(node: typed.expr) -> bool:
+    return isinstance(node, typed.Constant) and node.value is None
 
 
-def _dotted_name(node: ast.expr) -> str | None:
-    if isinstance(node, ast.Name):
+def _dotted_name(node: typed.expr) -> str | None:
+    if isinstance(node, typed.Name):
         return node.id
-    if isinstance(node, ast.Attribute):
+    if isinstance(node, typed.Attribute):
         base = _dotted_name(node.value)
         return f"{base}.{node.attr}" if base else node.attr
     return None
 
 
-def _chained_attribute_pin_key(node: ast.Attribute, locals_: set[str]) -> str | None:
+def _chained_attribute_pin_key(node: typed.Attribute, locals_: set[str]) -> str | None:
     """Dotted key for a `Root.attr.attr2[...]` chain, or None if the root
     is a local (shadowed) name or the chain contains a non-Name/Attribute
     node anywhere along the way. Used only as a value-pins dict lookup key:
     a miss is a silent no-op, never a fabricated row."""
-    cursor: ast.expr = node
-    while isinstance(cursor, ast.Attribute):
+    cursor: typed.expr = node
+    while isinstance(cursor, typed.Attribute):
         cursor = cursor.value
-    if not isinstance(cursor, ast.Name) or cursor.id in locals_:
+    if not isinstance(cursor, typed.Name) or cursor.id in locals_:
         return None
     return _dotted_name(node)
 
 
-def _type_parameterized_callee_base(node: ast.Subscript) -> str | None:
+def _type_parameterized_callee_base(node: typed.Subscript) -> str | None:
     base = _dotted_name(node.value)
     if base is None or not _is_type_parameterized_base(base):
         return None
-    if not _is_type_argument_expr(node.slice):
+    if not _is_type_argument_expr(node.slice_):
         return None
     return base
 
@@ -3435,36 +3344,36 @@ def _is_type_parameterized_base(name: str) -> bool:
     return final[:1].isupper() and not final.isupper()
 
 
-def _is_type_argument_expr(node: ast.expr | ast.slice) -> bool:
-    if isinstance(node, ast.Constant):
+def _is_type_argument_expr(node: typed.expr | typed.slice_) -> bool:
+    if isinstance(node, typed.Constant):
         return True
-    if isinstance(node, ast.Name):
+    if isinstance(node, typed.Name):
         return True
-    if isinstance(node, ast.Attribute):
+    if isinstance(node, typed.Attribute):
         return _dotted_name(node) is not None
-    if isinstance(node, (ast.Tuple, ast.List)):
+    if isinstance(node, (typed.Tuple, typed.List)):
         return all(_is_type_argument_expr(element) for element in node.elts)
-    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+    if isinstance(node, typed.BinOp) and isinstance(node.op, typed.BitOr):
         return _is_type_argument_expr(node.left) and _is_type_argument_expr(node.right)
-    if isinstance(node, ast.Subscript):
+    if isinstance(node, typed.Subscript):
         return (
             _dotted_name(node.value) is not None
-            and not isinstance(node.slice, ast.Slice)
-            and _is_type_argument_expr(node.slice)
+            and not isinstance(node.slice_, typed.Slice)
+            and _is_type_argument_expr(node.slice_)
         )
     return False
 
 
-def _callee_has_subscript_receiver(node: ast.expr) -> bool:
-    if isinstance(node, ast.Attribute):
-        return any(isinstance(child, ast.Subscript) for child in ast.walk(node.value))
+def _callee_has_subscript_receiver(node: typed.expr) -> bool:
+    if isinstance(node, typed.Attribute):
+        return any(isinstance(child, typed.Subscript) for child in typed.walk(node.value))
     return False
 
 
-def _callee_name(node: ast.expr) -> str:
-    if isinstance(node, ast.Name):
+def _callee_name(node: typed.expr) -> str:
+    if isinstance(node, typed.Name):
         return node.id
-    if isinstance(node, ast.Attribute):
+    if isinstance(node, typed.Attribute):
         base = _callee_name(node.value)
         return f"{base}.{node.attr}" if base else node.attr
     callee_kind = type(node).__name__
@@ -3475,30 +3384,30 @@ def _callee_name(node: ast.expr) -> str:
     )
 
 
-def _callee_has_call_result(node: ast.expr) -> bool:
-    if isinstance(node, ast.Call):
+def _callee_has_call_result(node: typed.expr) -> bool:
+    if isinstance(node, typed.Call):
         return True
-    if isinstance(node, ast.Attribute):
+    if isinstance(node, typed.Attribute):
         return _callee_has_call_result(node.value)
     return False
 
 
-def _exception_class(node: ast.expr | None) -> str | None:
+def _exception_class(node: typed.expr | None) -> str | None:
     if node is None:
         return None
     try:
-        if isinstance(node, ast.Call):
+        if isinstance(node, typed.Call):
             return _callee_name(node.func)
-        if isinstance(node, (ast.Name, ast.Attribute)):
+        if isinstance(node, (typed.Name, typed.Attribute)):
             return _callee_name(node)
     except _UnsupportedSyntax:
         return None
     return None
 
 
-def _target_text(node: ast.AST) -> str:
+def _target_text(node: typed.AST) -> str:
     try:
-        return ast.unparse(node)
+        return typed.unparse(node)
     except Exception:
         return type(node).__name__
 
@@ -3545,49 +3454,49 @@ def _effect_sort_key(effect: Json) -> str:
     return f"99:{kind}"
 
 
-_BINOPS: dict[type[ast.operator], str] = {
-    ast.Add: "python:add",
-    ast.Sub: "python:sub",
-    ast.Mult: "python:mul",
-    ast.Div: "python:div",
-    ast.FloorDiv: "python:floordiv",
-    ast.Mod: "python:mod",
-    ast.Pow: "python:pow",
-    ast.LShift: "python:lshift",
-    ast.RShift: "python:rshift",
-    ast.BitAnd: "python:bitand",
-    ast.BitOr: "python:bitor",
-    ast.BitXor: "python:bitxor",
-    ast.MatMult: "python:matmul",
+_BINOPS: dict[type[typed.operator], str] = {
+    typed.Add: "python:add",
+    typed.Sub: "python:sub",
+    typed.Mult: "python:mul",
+    typed.Div: "python:div",
+    typed.FloorDiv: "python:floordiv",
+    typed.Mod: "python:mod",
+    typed.Pow: "python:pow",
+    typed.LShift: "python:lshift",
+    typed.RShift: "python:rshift",
+    typed.BitAnd: "python:bitand",
+    typed.BitOr: "python:bitor",
+    typed.BitXor: "python:bitxor",
+    typed.MatMult: "python:matmul",
 }
 
-_UNARYOPS: dict[type[ast.unaryop], str] = {
-    ast.USub: "python:neg",
-    ast.UAdd: "python:pos",
-    ast.Not: "python:not",
-    ast.Invert: "python:bitnot",
+_UNARYOPS: dict[type[typed.unaryop], str] = {
+    typed.USub: "python:neg",
+    typed.UAdd: "python:pos",
+    typed.Not: "python:not",
+    typed.Invert: "python:bitnot",
 }
 
-_CMPOPS: dict[type[ast.cmpop], str] = {
-    ast.Eq: "==",
-    ast.NotEq: "!=",
-    ast.Lt: "<",
-    ast.LtE: "<=",
-    ast.Gt: ">",
-    ast.GtE: ">=",
-    ast.Is: "is",
-    ast.IsNot: "is not",
-    ast.In: "in",
-    ast.NotIn: "not in",
+_CMPOPS: dict[type[typed.cmpop], str] = {
+    typed.Eq: "==",
+    typed.NotEq: "!=",
+    typed.Lt: "<",
+    typed.LtE: "<=",
+    typed.Gt: ">",
+    typed.GtE: ">=",
+    typed.Is: "is",
+    typed.IsNot: "is not",
+    typed.In: "in",
+    typed.NotIn: "not in",
 }
 
-_GUARD_CMP_OPS: dict[type[ast.cmpop], str] = {
-    ast.Eq: "=",
-    ast.NotEq: "≠",
-    ast.Lt: "<",
-    ast.LtE: "≤",
-    ast.Gt: ">",
-    ast.GtE: "≥",
+_GUARD_CMP_OPS: dict[type[typed.cmpop], str] = {
+    typed.Eq: "=",
+    typed.NotEq: "≠",
+    typed.Lt: "<",
+    typed.LtE: "≤",
+    typed.Gt: ">",
+    typed.GtE: "≥",
 }
 
 _NEGATED_ATOMIC: dict[str, str] = {

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/typed_node_api.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/typed_node_api.py
@@ -1,0 +1,210 @@
+"""Read-only traversal surface for the legacy reference lifters.
+
+This module is deliberately only a vocabulary over ``sugar_source_tree``
+nodes.  It neither parses source nor manufactures nodes: source enters through
+``SourceFile`` and every value accepted here is an already-materialized typed
+node.  The small visitor helpers let the reference encoders migrate as one
+cluster without retaining a second stdlib-AST semantic path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+_tree_src = Path(__file__).resolve().parents[3] / "sugar-source-tree" / "src"
+if _tree_src.is_dir() and str(_tree_src) not in sys.path:
+    sys.path.insert(0, str(_tree_src))
+
+from sugar_source_tree import nodes as _nodes
+from sugar_source_tree import operators as _operators
+from sugar_source_tree.tree import SourceFile
+
+from .canonical import blake3_512_of
+
+AST = _nodes.Node
+stmt = _nodes.Statement
+expr = _nodes.Expression
+pattern = _nodes.Pattern
+operator = _operators.BinaryOperator
+unaryop = _operators.UnaryOperator
+boolop = _operators.BooleanOperator
+cmpop = _operators.ComparisonOperator
+
+# Typed grammar aliases.  Tuple is spelled Tuple_ in the source-tree grammar.
+Module = _nodes.Module
+FunctionDef = _nodes.FunctionDef
+AsyncFunctionDef = _nodes.AsyncFunctionDef
+ClassDef = _nodes.ClassDef
+Return = _nodes.Return
+Delete = _nodes.Delete
+Assign = _nodes.Assign
+TypeAlias = _nodes.TypeAlias
+AugAssign = _nodes.AugAssign
+AnnAssign = _nodes.AnnAssign
+For = _nodes.For
+AsyncFor = _nodes.AsyncFor
+While = _nodes.While
+If = _nodes.If
+With = _nodes.With
+AsyncWith = _nodes.AsyncWith
+Match = _nodes.Match
+Raise = _nodes.Raise
+Try = _nodes.Try
+TryStar = _nodes.TryStar
+Assert = _nodes.Assert
+Import = _nodes.Import
+ImportFrom = _nodes.ImportFrom
+Global = _nodes.Global
+Nonlocal = _nodes.Nonlocal
+Expr = _nodes.Expr
+Pass = _nodes.Pass
+Break = _nodes.Break
+Continue = _nodes.Continue
+ExceptHandler = _nodes.ExceptHandler
+match_case = _nodes.MatchCase
+
+BoolOp = _nodes.BoolOp
+NamedExpr = _nodes.NamedExpr
+BinOp = _nodes.BinOp
+UnaryOp = _nodes.UnaryOp
+Lambda = _nodes.Lambda
+IfExp = _nodes.IfExp
+Dict = _nodes.Dict
+Set = _nodes.Set
+ListComp = _nodes.ListComp
+SetComp = _nodes.SetComp
+DictComp = _nodes.DictComp
+GeneratorExp = _nodes.GeneratorExp
+Await = _nodes.Await
+Yield = _nodes.Yield
+YieldFrom = _nodes.YieldFrom
+Compare = _nodes.Compare
+Call = _nodes.Call
+FormattedValue = _nodes.FormattedValue
+JoinedStr = _nodes.JoinedStr
+Constant = _nodes.Constant
+Attribute = _nodes.Attribute
+Subscript = _nodes.Subscript
+Starred = _nodes.Starred
+Name = _nodes.Name
+List = _nodes.List
+Tuple = _nodes.Tuple_
+Slice = _nodes.Slice
+MatchValue = _nodes.MatchValue
+MatchSingleton = _nodes.MatchSingleton
+MatchSequence = _nodes.MatchSequence
+MatchMapping = _nodes.MatchMapping
+MatchClass = _nodes.MatchClass
+MatchStar = _nodes.MatchStar
+MatchAs = _nodes.MatchAs
+MatchOr = _nodes.MatchOr
+arg = _nodes.Param
+alias = _nodes.ImportAlias
+keyword = _nodes.Keyword
+comprehension = _nodes.Comprehension
+
+Add = _operators.Add
+Sub = _operators.Sub
+Mult = _operators.Mult
+MatMult = _operators.MatMult
+Div = _operators.Div
+Mod = _operators.Mod
+Pow = _operators.Pow
+LShift = _operators.LShift
+RShift = _operators.RShift
+BitOr = _operators.BitOr
+BitXor = _operators.BitXor
+BitAnd = _operators.BitAnd
+FloorDiv = _operators.FloorDiv
+UAdd = _operators.UAdd
+USub = _operators.USub
+Not = _operators.Not
+Invert = _operators.Invert
+And = _operators.And
+Or = _operators.Or
+Eq = _operators.Eq
+NotEq = _operators.NotEq
+Lt = _operators.Lt
+LtE = _operators.LtE
+Gt = _operators.Gt
+GtE = _operators.GtE
+Is = _operators.Is
+IsNot = _operators.IsNot
+In = _operators.In
+NotIn = _operators.NotIn
+
+
+def walk(node: AST):
+    return node.walk()
+
+
+def parse(source: str, *, filename: str) -> Module:
+    """Materialize one authenticated typed module through the sole adapter."""
+    return SourceFile(
+        (source, filename, blake3_512_of(source.encode("utf-8")))
+    ).root
+
+
+def iter_child_nodes(node: AST):
+    return (child for _, _, child in node.children())
+
+
+def iter_fields(node: AST):
+    for field_name in type(node)._child_fields:
+        yield field_name, getattr(node, field_name)
+
+
+class TypedNodeWalker:
+    """The stdlib visitor protocol over typed children only."""
+
+    def visit(self, node: AST):
+        method = getattr(self, f"visit_{type(node).__name__.removesuffix('_')}", None)
+        if method is None:
+            return self.generic_visit(node)
+        return method(node)
+
+    def generic_visit(self, node: AST):
+        for child in iter_child_nodes(node):
+            self.visit(child)
+
+
+def unparse(node: AST) -> str:
+    """Return the authenticated source spelling of this typed occurrence."""
+    return node.fragment.text
+
+
+def get_docstring(node: FunctionDef | AsyncFunctionDef | ClassDef, clean: bool = True):
+    del clean  # Source spelling is already parsed; no second text interpreter.
+    if not node.body:
+        return None
+    first = node.body[0]
+    if isinstance(first, Expr) and isinstance(first.value, Constant):
+        return first.value.value if isinstance(first.value.value, str) else None
+    return None
+
+
+def literal_eval(node: AST):
+    """Project an already-constructed literal tree; reject all computed values."""
+    if isinstance(node, Constant):
+        return node.value
+    if isinstance(node, (List, Tuple, Set)):
+        values = [literal_eval(item) for item in node.elts]
+        if isinstance(node, List):
+            return values
+        if isinstance(node, Tuple):
+            return tuple(values)
+        return set(values)
+    if isinstance(node, Dict):
+        result = {}
+        for item in node.items:
+            if item.key is None:
+                raise ValueError("dictionary spread is not a literal projection")
+            result[literal_eval(item.key)] = literal_eval(item.value)
+        return result
+    if isinstance(node, UnaryOp) and isinstance(node.op, (UAdd, USub)):
+        value = literal_eval(node.operand)
+        if not isinstance(value, (int, float, complex)):
+            raise ValueError("unary literal operand is not numeric")
+        return value if isinstance(node.op, UAdd) else -value
+    raise ValueError(f"{type(node).__name__} is not a literal projection")

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py
@@ -12,13 +12,10 @@ holds by construction: candidates == admitted + boundaries.
 
 from __future__ import annotations
 
-import ast
+from . import typed_node_api as typed
 from dataclasses import dataclass, field
-from pathlib import Path
-import sys
 from typing import Iterator
 
-from .canonical import blake3_512_of
 from .ir import (
     Json,
     bool_const,
@@ -31,36 +28,6 @@ from .ir import (
     none_const,
     str_const,
 )
-
-
-def _typed_tree():
-    """Lazy typed-tree import — value_pins is still dual-body residual overall."""
-    tree_src = Path(__file__).resolve().parents[3] / "sugar-source-tree" / "src"
-    if tree_src.is_dir() and str(tree_src) not in sys.path:
-        sys.path.insert(0, str(tree_src))
-    from sugar_source_tree.backend import BackendCouldNotParse
-    from sugar_source_tree.nodes import (
-        AnnAssign,
-        Assign,
-        Attribute,
-        AugAssign,
-        Delete,
-        Global,
-        Name,
-    )
-    from sugar_source_tree.tree import SourceFile
-
-    return (
-        SourceFile,
-        BackendCouldNotParse,
-        Assign,
-        AnnAssign,
-        AugAssign,
-        Delete,
-        Attribute,
-        Name,
-        Global,
-    )
 
 VALUE_PIN_BOUNDARY_KIND = "value-pin-boundary"
 ENUM_PIN_BOUNDARY_KIND = "enum-pin-boundary"
@@ -101,28 +68,26 @@ AST_STATEMENT_TYPE_NAMES = frozenset(
         "Continue",
     }
 )
-AST_STATEMENT_TYPES = frozenset(
-    statement for statement in ast.stmt.__subclasses__() if statement.__module__ == "ast"
-)
+AST_STATEMENT_TYPES = frozenset(getattr(typed, name) for name in AST_STATEMENT_TYPE_NAMES)
 if {statement.__name__ for statement in AST_STATEMENT_TYPES} != AST_STATEMENT_TYPE_NAMES:
-    raise UnsupportedStatementGrammar("unsupported running ast.stmt grammar")
+    raise UnsupportedStatementGrammar("unsupported running typed.stmt grammar")
 
 # Scope boundaries: bindings inside these do not bind module names.
 # (Plain assignment in a function is a local; `global`-declaring functions
 # are handled separately and conservatively below.)
 _SCOPE_BOUNDARY_NODES = (
-    ast.FunctionDef,
-    ast.AsyncFunctionDef,
-    ast.ClassDef,
-    ast.Lambda,
-    ast.ListComp,
-    ast.SetComp,
-    ast.DictComp,
-    ast.GeneratorExp,
+    typed.FunctionDef,
+    typed.AsyncFunctionDef,
+    typed.ClassDef,
+    typed.Lambda,
+    typed.ListComp,
+    typed.SetComp,
+    typed.DictComp,
+    typed.GeneratorExp,
 )
 
-_TRY_NODES: tuple = (ast.Try, ast.TryStar) if hasattr(ast, "TryStar") else (ast.Try,)
-_TYPE_ALIAS_NODE = getattr(ast, "TypeAlias", None)
+_TRY_NODES: tuple = (typed.Try, typed.TryStar) if hasattr(typed, "TryStar") else (typed.Try,)
+_TYPE_ALIAS_NODE = getattr(typed, "TypeAlias", None)
 
 
 @dataclass(frozen=True)
@@ -173,33 +138,29 @@ class _BindingEvent:
 @dataclass(frozen=True)
 class _Candidate:
     name: str
-    value: ast.expr
+    value: typed.expr
     line: int
     confession: str | None
     col: int = 0
 
 
 def scan_module_value_pins(
-    tree: ast.Module,
+    tree: typed.Module,
     *,
     source: str | None = None,
-    source_path: str = "<value-pins>",
+    source_path: str | None = None,
 ) -> ValuePinScan:
-    """Scan module-level value pins.
-
-    ``source`` (when provided) routes attribute-write and ``global`` puncture
-    detection through SourceFile / typed Nodes. Residual candidate/event
-    admission still walks the dual-body ``ast.Module`` until that half is
-    drained.
-    """
+    # Transitional caller testimony is accepted only when it is byte-identical
+    # to the typed module's authenticated SourceUnit.  It grants no authority
+    # and is never reparsed.
+    if source is not None and source != tree.unit.source:
+        raise ValueError("value-pin source does not match the typed module preimage")
+    if source_path is not None and source_path != tree.unit.filename:
+        raise ValueError("value-pin source path does not match the typed module seat")
     scan = ValuePinScan()
     candidates = _collect_candidates(tree)
     events = list(_binding_events(tree))
-    global_decls = (
-        _global_declarations_typed(source, source_path)
-        if source is not None
-        else _global_declarations(tree)
-    )
+    global_decls = _global_declarations(tree)
     events_by_name: dict[str, list[_BindingEvent]] = {}
     for event in events:
         events_by_name.setdefault(event.name, []).append(event)
@@ -236,7 +197,7 @@ def scan_module_value_pins(
             line=candidate.line,
             confession=candidate.confession,
         )
-    _scan_enum_member_pins(tree, scan, source=source, source_path=source_path)
+    _scan_enum_member_pins(tree, scan)
     assert scan.totality_holds()
     return scan
 
@@ -245,12 +206,12 @@ _VALUE_ENUM_BASES = ("IntEnum", "StrEnum")
 _PLAIN_ENUM_BASES = ("Enum", "Flag", "IntFlag")
 
 
-def _enum_base_kind(node: ast.ClassDef) -> Optional[str]:
+def _enum_base_kind(node: typed.ClassDef) -> Optional[str]:
     for base in node.bases:
         name = None
-        if isinstance(base, ast.Name):
+        if isinstance(base, typed.Name):
             name = base.id
-        elif isinstance(base, ast.Attribute):
+        elif isinstance(base, typed.Attribute):
             name = base.attr
         if name in _VALUE_ENUM_BASES:
             return "value"
@@ -259,13 +220,7 @@ def _enum_base_kind(node: ast.ClassDef) -> Optional[str]:
     return None
 
 
-def _scan_enum_member_pins(
-    tree: ast.Module,
-    scan: ValuePinScan,
-    *,
-    source: str | None = None,
-    source_path: str = "<value-pins>",
-) -> None:
+def _scan_enum_member_pins(tree: typed.Module, scan: ValuePinScan) -> None:
     """Class-attribute pins for enum members, keyed 'ClassName.MEMBER'.
 
     The == dispatch gate decides the scope: a plain Enum member is NOT
@@ -276,22 +231,18 @@ def _scan_enum_member_pins(
     strongest pins in the language; the scan still refuses on any
     syntactic write to ClassName.MEMBER or cls.MEMBER in the module
     (belt and suspenders)."""
-    attr_writes = (
-        _class_attr_writes_typed(source, source_path)
-        if source is not None
-        else _class_attr_writes(tree)
-    )
+    attr_writes = _class_attr_writes(tree)
     for stmt in tree.body:
-        if not isinstance(stmt, ast.ClassDef):
+        if not isinstance(stmt, typed.ClassDef):
             continue
         kind = _enum_base_kind(stmt)
         if kind is None:
             continue
         for class_stmt in stmt.body:
             if not (
-                isinstance(class_stmt, ast.Assign)
+                isinstance(class_stmt, typed.Assign)
                 and len(class_stmt.targets) == 1
-                and isinstance(class_stmt.targets[0], ast.Name)
+                and isinstance(class_stmt.targets[0], typed.Name)
             ):
                 continue
             member = class_stmt.targets[0].id
@@ -305,7 +256,7 @@ def _scan_enum_member_pins(
                 confession=f"enum.{kind}",
             )
             scan.candidates += 1
-            if stmt.decorator_list:
+            if stmt.decorators:
                 # A decorated ClassDef is NOT the runtime class: the name
                 # binds whatever the decorator returns (caught live
                 # 2026-06-12: a class decorator swapping the enum ran
@@ -386,74 +337,44 @@ def _scan_enum_member_pins(
             )
 
 
-def _class_attr_writes_typed(source: str, source_path: str) -> dict:
-    """Typed-tree puncture scan: writes of shape ``<Name>.<attr>``.
+def _class_attr_writes(tree: typed.Module) -> dict:
+    """Every syntactic write target of the shape <Name>.<attr> anywhere in
+    the module (assignment, augmented assignment, deletion), keyed
+    'Name.attr' -> first line. Covers ClassName.MEMBER = ... and
+    cls.MEMBER = ... punctures."""
 
-    SourceFile is the parse door; semantic authority is typed Assign /
-    AnnAssign / AugAssign / Delete nodes — not ``ast.NodeVisitor``.
-    """
-    (
-        SourceFile,
-        BackendCouldNotParse,
-        Assign,
-        AnnAssign,
-        AugAssign,
-        Delete,
-        Attribute,
-        Name,
-        _Global,
-    ) = _typed_tree()
-    try:
-        source_file = SourceFile(
-            (source, source_path, blake3_512_of(source.encode("utf-8")))
-        )
-    except (SyntaxError, BackendCouldNotParse, UnicodeError, ValueError):
-        return {}
-    writes: dict[str, int] = {}
+    class WriteVisitor(typed.TypedNodeWalker):
+        def __init__(self) -> None:
+            self.writes: dict[str, int] = {}
 
-    def record(lineno: int, targets) -> None:
-        for target in targets:
-            if isinstance(target, Attribute) and isinstance(target.value, Name):
-                writes.setdefault(f"{target.value.id}.{target.attr}", lineno)
+        def record(self, node: typed.stmt, targets: list[typed.expr]) -> None:
+            for target in targets:
+                if isinstance(target, typed.Attribute) and isinstance(
+                    target.value, typed.Name
+                ):
+                    self.writes.setdefault(
+                        f"{target.value.id}.{target.attr}", node.lineno
+                    )
 
-    for node in source_file.root.walk():
-        lineno = node.line_col_span().start_line
-        if isinstance(node, Assign):
-            record(lineno, node.targets)
-        elif isinstance(node, AnnAssign):
-            record(lineno, (node.target,))
-        elif isinstance(node, AugAssign):
-            record(lineno, (node.target,))
-        elif isinstance(node, Delete):
-            record(lineno, node.targets)
-    return writes
+        def visit_Assign(self, node: typed.Assign) -> None:
+            self.record(node, node.targets)
+            self.generic_visit(node)
 
+        def visit_AnnAssign(self, node: typed.AnnAssign) -> None:
+            self.record(node, [node.target])
+            self.generic_visit(node)
 
-def _class_attr_writes(tree: ast.Module) -> dict:
-    """Residual dual-body puncture scan (no source text available).
+        def visit_AugAssign(self, node: typed.AugAssign) -> None:
+            self.record(node, [node.target])
+            self.generic_visit(node)
 
-    Prefer ``_class_attr_writes_typed`` when the module source is in hand.
-    """
-    writes: dict[str, int] = {}
+        def visit_Delete(self, node: typed.Delete) -> None:
+            self.record(node, node.targets)
+            self.generic_visit(node)
 
-    def record(node: ast.stmt, targets: list[ast.expr]) -> None:
-        for target in targets:
-            if isinstance(target, ast.Attribute) and isinstance(target.value, ast.Name):
-                writes.setdefault(f"{target.value.id}.{target.attr}", node.lineno)
-
-    stack: list[ast.AST] = [tree]
-    while stack:
-        node = stack.pop()
-        if isinstance(node, ast.Assign):
-            record(node, list(node.targets))
-        elif isinstance(node, ast.AnnAssign):
-            record(node, [node.target])
-        elif isinstance(node, ast.AugAssign):
-            record(node, [node.target])
-        elif isinstance(node, ast.Delete):
-            record(node, list(node.targets))
-        stack.extend(reversed(list(ast.iter_child_nodes(node))))
-    return writes
+    visitor = WriteVisitor()
+    visitor.visit(tree)
+    return visitor.writes
 
 
 def _pin_boundary(
@@ -525,19 +446,19 @@ def _admission_failure(
     return None
 
 
-def _collect_candidates(tree: ast.Module) -> dict[str, _Candidate]:
+def _collect_candidates(tree: typed.Module) -> dict[str, _Candidate]:
     candidates: dict[str, _Candidate] = {}
     duplicate_names: set[str] = set()
     for stmt in tree.body:
-        name_node: ast.Name | None = None
-        value: ast.expr | None = None
+        name_node: typed.Name | None = None
+        value: typed.expr | None = None
         confession: str | None = None
-        if isinstance(stmt, ast.Assign):
-            if len(stmt.targets) == 1 and isinstance(stmt.targets[0], ast.Name):
+        if isinstance(stmt, typed.Assign):
+            if len(stmt.targets) == 1 and isinstance(stmt.targets[0], typed.Name):
                 name_node = stmt.targets[0]
                 value = stmt.value
-        elif isinstance(stmt, ast.AnnAssign):
-            if isinstance(stmt.target, ast.Name) and stmt.value is not None:
+        elif isinstance(stmt, typed.AnnAssign):
+            if isinstance(stmt.target, typed.Name) and stmt.value is not None:
                 name_node = stmt.target
                 value = stmt.value
                 if _is_final_annotation(stmt.annotation):
@@ -565,25 +486,25 @@ def _collect_candidates(tree: ast.Module) -> dict[str, _Candidate]:
     return candidates
 
 
-def _is_final_annotation(annotation: ast.expr) -> bool:
+def _is_final_annotation(annotation: typed.expr) -> bool:
     target = annotation
-    if isinstance(target, ast.Subscript):
+    if isinstance(target, typed.Subscript):
         target = target.value
-    if isinstance(target, ast.Name):
+    if isinstance(target, typed.Name):
         return target.id == "Final"
-    if isinstance(target, ast.Attribute):
+    if isinstance(target, typed.Attribute):
         return target.attr == "Final"
     return False
 
 
-def _is_literal_shaped(node: ast.expr) -> bool:
-    if isinstance(node, ast.Constant):
+def _is_literal_shaped(node: typed.expr) -> bool:
+    if isinstance(node, typed.Constant):
         return True
-    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
-        return isinstance(node.operand, ast.Constant)
-    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+    if isinstance(node, typed.UnaryOp) and isinstance(node.op, (typed.UAdd, typed.USub)):
+        return isinstance(node.operand, typed.Constant)
+    if isinstance(node, (typed.Tuple, typed.List, typed.Set)):
         return all(_is_literal_shaped(element) for element in node.elts)
-    if isinstance(node, ast.Dict):
+    if isinstance(node, typed.Dict):
         return all(
             key is not None and _is_literal_shaped(key) and _is_literal_shaped(val)
             for key, val in zip(node.keys, node.values)
@@ -591,21 +512,21 @@ def _is_literal_shaped(node: ast.expr) -> bool:
     return False
 
 
-def _direct_mutable_kind(node: ast.expr) -> str | None:
-    if isinstance(node, ast.List):
+def _direct_mutable_kind(node: typed.expr) -> str | None:
+    if isinstance(node, typed.List):
         return "list"
-    if isinstance(node, ast.Dict):
+    if isinstance(node, typed.Dict):
         return "dict"
-    if isinstance(node, ast.Set):
+    if isinstance(node, typed.Set):
         return "set"
     return None
 
 
-def _render_value_term(node: ast.expr) -> Json:
+def _render_value_term(node: typed.expr) -> Json:
     """Render an admissible immutable literal to the same term shape the
     emitter produces for the literal written inline. That identity IS the
     pin: a pinned name is indistinguishable from its value."""
-    if isinstance(node, ast.Constant):
+    if isinstance(node, typed.Constant):
         value = node.value
         if isinstance(value, bool):
             return bool_const(value)
@@ -624,26 +545,26 @@ def _render_value_term(node: ast.expr) -> Json:
         if value is None:
             return none_const()
         raise _NotAdmissible(f"no IR term shape for {type(value).__name__} constants")
-    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+    if isinstance(node, typed.UnaryOp) and isinstance(node.op, (typed.UAdd, typed.USub)):
         operand = node.operand
-        if isinstance(operand, ast.Constant) and type(operand.value) is int:
+        if isinstance(operand, typed.Constant) and type(operand.value) is int:
             value = operand.value
-            if isinstance(node.op, ast.USub):
+            if isinstance(node.op, typed.USub):
                 value = -value
             return int_const(value)
         raise _NotAdmissible("unsupported unary literal")
-    if isinstance(node, ast.Tuple):
+    if isinstance(node, typed.Tuple):
         return ctor(
             "python:tuple",
             *[_render_value_term(element) for element in node.elts],
         )
-    if isinstance(node, (ast.List, ast.Set, ast.Dict)):
+    if isinstance(node, (typed.List, typed.Set, typed.Dict)):
         kind = type(node).__name__.lower()
         raise _NotAdmissible(f"mutable value ({kind}) cannot pin")
     raise _NotAdmissible(f"unsupported value shape: {type(node).__name__}")
 
 
-def _binding_events(tree: ast.Module) -> Iterator[_BindingEvent]:
+def _binding_events(tree: typed.Module) -> Iterator[_BindingEvent]:
     """Every module-scope binding event, exhaustively.
 
     Walks the module statement tree, recursing through compound statements
@@ -654,7 +575,7 @@ def _binding_events(tree: ast.Module) -> Iterator[_BindingEvent]:
         yield from _statement_binding_events(stmt)
 
 
-def _iter_module_scope_statements(stmts: list[ast.stmt]) -> Iterator[ast.stmt]:
+def _iter_module_scope_statements(stmts) -> Iterator[typed.stmt]:
     for stmt in stmts:
         yield stmt
         if isinstance(stmt, _SCOPE_BOUNDARY_NODES):
@@ -663,47 +584,47 @@ def _iter_module_scope_statements(stmts: list[ast.stmt]) -> Iterator[ast.stmt]:
             yield from _iter_module_scope_statements(child_list)
 
 
-def _child_statement_lists(stmt: ast.stmt) -> Iterator[list[ast.stmt]]:
-    for field_name, value in ast.iter_fields(stmt):
-        if isinstance(value, list):
-            statements = [item for item in value if isinstance(item, ast.stmt)]
+def _child_statement_lists(stmt: typed.stmt) -> Iterator[tuple[typed.stmt, ...]]:
+    for field_name, value in typed.iter_fields(stmt):
+        if isinstance(value, (list, tuple)):
+            statements = tuple(item for item in value if isinstance(item, typed.stmt))
             if statements:
                 yield statements
             for item in value:
-                if isinstance(item, ast.ExceptHandler):
+                if isinstance(item, typed.ExceptHandler):
                     yield item.body
-                if isinstance(item, ast.match_case):
+                if isinstance(item, typed.match_case):
                     yield item.body
 
 
-def _statement_binding_events(stmt: ast.stmt) -> Iterator[_BindingEvent]:
-    if isinstance(stmt, ast.Assign):
+def _statement_binding_events(stmt: typed.stmt) -> Iterator[_BindingEvent]:
+    if isinstance(stmt, typed.Assign):
         for target in stmt.targets:
             for name, line in _target_names(target):
                 yield _BindingEvent(name, line, "assignment")
-    elif isinstance(stmt, ast.AnnAssign):
+    elif isinstance(stmt, typed.AnnAssign):
         if stmt.value is not None:
             for name, line in _target_names(stmt.target):
                 yield _BindingEvent(name, line, "assignment")
-    elif isinstance(stmt, ast.AugAssign):
+    elif isinstance(stmt, typed.AugAssign):
         for name, line in _target_names(stmt.target):
             yield _BindingEvent(name, line, "augmented assignment")
-    elif isinstance(stmt, ast.Delete):
+    elif isinstance(stmt, typed.Delete):
         for target in stmt.targets:
             for name, line in _target_names(target):
                 yield _BindingEvent(name, line, "deletion")
-    elif isinstance(stmt, (ast.Import, ast.ImportFrom)):
+    elif isinstance(stmt, (typed.Import, typed.ImportFrom)):
         for alias in stmt.names:
             bound = alias.asname or alias.name.split(".")[0]
             yield _BindingEvent(bound, stmt.lineno, "import rebinding")
-    elif isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+    elif isinstance(stmt, (typed.FunctionDef, typed.AsyncFunctionDef)):
         yield _BindingEvent(stmt.name, stmt.lineno, "function definition")
-    elif isinstance(stmt, ast.ClassDef):
+    elif isinstance(stmt, typed.ClassDef):
         yield _BindingEvent(stmt.name, stmt.lineno, "class definition")
-    elif isinstance(stmt, (ast.For, ast.AsyncFor)):
+    elif isinstance(stmt, (typed.For, typed.AsyncFor)):
         for name, line in _target_names(stmt.target):
             yield _BindingEvent(name, line, "for-loop target binding")
-    elif isinstance(stmt, (ast.With, ast.AsyncWith)):
+    elif isinstance(stmt, (typed.With, typed.AsyncWith)):
         for item in stmt.items:
             if item.optional_vars is not None:
                 for name, line in _target_names(item.optional_vars):
@@ -712,11 +633,11 @@ def _statement_binding_events(stmt: ast.stmt) -> Iterator[_BindingEvent]:
         for handler in stmt.handlers:
             if handler.name:
                 yield _BindingEvent(handler.name, handler.lineno, "except-as binding")
-    elif isinstance(stmt, ast.Match):
+    elif isinstance(stmt, typed.Match):
         for case in stmt.cases:
             yield from _match_pattern_bindings(case.pattern)
     elif _TYPE_ALIAS_NODE is not None and isinstance(stmt, _TYPE_ALIAS_NODE):
-        if isinstance(stmt.name, ast.Name):
+        if isinstance(stmt.name, typed.Name):
             yield _BindingEvent(stmt.name.id, stmt.lineno, "type-alias definition")
     if type(stmt) in AST_STATEMENT_TYPES:
         # Walrus targets anywhere in this statement's expressions, outside
@@ -726,92 +647,60 @@ def _statement_binding_events(stmt: ast.stmt) -> Iterator[_BindingEvent]:
     raise UnsupportedStatementVariant(type(stmt).__name__)
 
 
-def _match_pattern_bindings(pattern: ast.pattern) -> Iterator[_BindingEvent]:
-    if isinstance(pattern, ast.MatchAs) and pattern.name:
+def _match_pattern_bindings(pattern: typed.pattern) -> Iterator[_BindingEvent]:
+    if isinstance(pattern, typed.MatchAs) and pattern.name:
         yield _BindingEvent(pattern.name, pattern.lineno, "match capture binding")
-    if isinstance(pattern, ast.MatchStar) and pattern.name:
+    if isinstance(pattern, typed.MatchStar) and pattern.name:
         yield _BindingEvent(pattern.name, pattern.lineno, "match capture binding")
-    if isinstance(pattern, ast.MatchMapping) and pattern.rest:
+    if isinstance(pattern, typed.MatchMapping) and pattern.rest:
         yield _BindingEvent(pattern.rest, pattern.lineno, "match capture binding")
-    for child in ast.iter_child_nodes(pattern):
-        if isinstance(child, ast.pattern):
+    for child in typed.iter_child_nodes(pattern):
+        if isinstance(child, typed.pattern):
             yield from _match_pattern_bindings(child)
 
 
-def _walrus_bindings(stmt: ast.stmt) -> Iterator[_BindingEvent]:
-    stack: list[ast.AST] = [stmt]
+def _walrus_bindings(stmt: typed.stmt) -> Iterator[_BindingEvent]:
+    stack: list[typed.AST] = [stmt]
     while stack:
         node = stack.pop()
         if node is not stmt and isinstance(node, _SCOPE_BOUNDARY_NODES):
             continue
-        if isinstance(node, ast.NamedExpr) and isinstance(node.target, ast.Name):
+        if isinstance(node, typed.NamedExpr) and isinstance(node.target, typed.Name):
             yield _BindingEvent(node.target.id, node.lineno, "walrus rebinding")
         # Child statements are visited by the scope iterator themselves;
         # descending into them here would double-count their walrus events.
         stack.extend(
             child
-            for child in ast.iter_child_nodes(node)
-            if not isinstance(child, ast.stmt)
+            for child in typed.iter_child_nodes(node)
+            if not isinstance(child, typed.stmt)
         )
 
 
-def _target_names(target: ast.expr) -> Iterator[tuple[str, int]]:
-    if isinstance(target, ast.Name):
+def _target_names(target: typed.expr) -> Iterator[tuple[str, int]]:
+    if isinstance(target, typed.Name):
         yield target.id, target.lineno
-    elif isinstance(target, ast.Starred):
+    elif isinstance(target, typed.Starred):
         yield from _target_names(target.value)
-    elif isinstance(target, (ast.Tuple, ast.List)):
+    elif isinstance(target, (typed.Tuple, typed.List)):
         for element in target.elts:
             yield from _target_names(element)
     # Attribute/Subscript targets mutate objects, not module name bindings.
 
 
-def _global_declarations_typed(source: str, source_path: str) -> dict[str, int]:
-    """Typed-tree ``global`` puncture scan — not ``ast.walk``."""
-    (
-        SourceFile,
-        BackendCouldNotParse,
-        _Assign,
-        _AnnAssign,
-        _AugAssign,
-        _Delete,
-        _Attribute,
-        _Name,
-        Global,
-    ) = _typed_tree()
-    try:
-        source_file = SourceFile(
-            (source, source_path, blake3_512_of(source.encode("utf-8")))
-        )
-    except (SyntaxError, BackendCouldNotParse, UnicodeError, ValueError):
-        return {}
+def _global_declarations(tree: typed.Module) -> dict[str, int]:
     declarations: dict[str, int] = {}
-    for node in source_file.root.walk():
-        if isinstance(node, Global):
-            lineno = node.line_col_span().start_line
-            for name in node.names:
-                declarations.setdefault(name, lineno)
-    return declarations
-
-
-def _global_declarations(tree: ast.Module) -> dict[str, int]:
-    """Residual dual-body ``global`` scan when source text is unavailable."""
-    declarations: dict[str, int] = {}
-    stack: list[ast.AST] = [tree]
-    while stack:
-        node = stack.pop()
-        if isinstance(node, ast.Global):
+    for node in typed.walk(tree):
+        if isinstance(node, typed.Global):
             for name in node.names:
                 declarations.setdefault(name, node.lineno)
-        stack.extend(reversed(list(ast.iter_child_nodes(node))))
     return declarations
 
 
 # ── THE STRUCTURAL FLOOR ─────────────────────────────────────────────────
 # The binding-event scan must be TOTAL over this interpreter's statement
 # grammar, and the totality must be readable off the module rather than
-# sworn by the sweep: ast.NodeVisitor's generic_visit is an asserted
-# silence in structural costume. Every ast.stmt subclass the running
+# sworn by the sweep: typed.TypedNodeWalker's generic_visit is an asserted
+# silence in structural costume. Every typed.stmt subclass the running
 # interpreter knows is classified below as either BINDING-HANDLED
 # (produces events in _statement_binding_events) or DECLARED-NONBINDING
 # (cannot bind a module name directly; compound bodies are recursed
@@ -824,34 +713,38 @@ def _global_declarations(tree: ast.Module) -> dict[str, int]:
 
 
 def _grammar_classes(base: type) -> frozenset:
-    return frozenset(
-        cls
-        for name in dir(ast)
-        if isinstance(cls := getattr(ast, name), type)
-        and issubclass(cls, base)
-        and cls is not base
-    )
+    if base is typed.stmt:
+        return AST_STATEMENT_TYPES
+    found: set[type] = set()
+    pending = list(base.__subclasses__())
+    while pending:
+        cls = pending.pop()
+        if cls in found:
+            continue
+        found.add(cls)
+        pending.extend(cls.__subclasses__())
+    return frozenset(found)
 
 
 _BINDING_HANDLED_STMT = frozenset(
     cls
     for cls in (
-        ast.Assign,
-        ast.AnnAssign,
-        ast.AugAssign,
-        ast.Delete,
-        ast.Import,
-        ast.ImportFrom,
-        ast.FunctionDef,
-        ast.AsyncFunctionDef,
-        ast.ClassDef,
-        ast.For,
-        ast.AsyncFor,
-        ast.With,
-        ast.AsyncWith,
-        ast.Try,
-        ast.Match,
-        getattr(ast, "TryStar", None),
+        typed.Assign,
+        typed.AnnAssign,
+        typed.AugAssign,
+        typed.Delete,
+        typed.Import,
+        typed.ImportFrom,
+        typed.FunctionDef,
+        typed.AsyncFunctionDef,
+        typed.ClassDef,
+        typed.For,
+        typed.AsyncFor,
+        typed.With,
+        typed.AsyncWith,
+        typed.Try,
+        typed.Match,
+        getattr(typed, "TryStar", None),
         _TYPE_ALIAS_NODE,
     )
     if cls is not None
@@ -859,28 +752,28 @@ _BINDING_HANDLED_STMT = frozenset(
 
 _DECLARED_NONBINDING_STMT = frozenset(
     (
-        ast.Expr,
-        ast.Return,
-        ast.Raise,
-        ast.Assert,
-        ast.Pass,
-        ast.Break,
-        ast.Continue,
-        ast.If,
-        ast.While,
+        typed.Expr,
+        typed.Return,
+        typed.Raise,
+        typed.Assert,
+        typed.Pass,
+        typed.Break,
+        typed.Continue,
+        typed.If,
+        typed.While,
         # Global/Nonlocal do not bind at module scope themselves; Global is
         # consumed by the dedicated _global_declarations puncture scan.
-        ast.Global,
-        ast.Nonlocal,
+        typed.Global,
+        typed.Nonlocal,
     )
 )
 
-_BINDING_HANDLED_PATTERN = frozenset((ast.MatchAs, ast.MatchStar, ast.MatchMapping))
+_BINDING_HANDLED_PATTERN = frozenset((typed.MatchAs, typed.MatchStar, typed.MatchMapping))
 
 _DECLARED_NONBINDING_PATTERN = frozenset(
     # Children are recursed generically in _match_pattern_bindings via
     # iter_child_nodes; these kinds carry no name binding of their own.
-    (ast.MatchValue, ast.MatchSingleton, ast.MatchSequence, ast.MatchClass, ast.MatchOr)
+    (typed.MatchValue, typed.MatchSingleton, typed.MatchSequence, typed.MatchClass, typed.MatchOr)
 )
 
 
@@ -891,12 +784,12 @@ def _unaccounted_grammar() -> dict[str, list[str]]:
     trusted."""
     unaccounted: dict[str, list[str]] = {}
     stmt_holes = (
-        _grammar_classes(ast.stmt) - _BINDING_HANDLED_STMT - _DECLARED_NONBINDING_STMT
+        _grammar_classes(typed.stmt) - _BINDING_HANDLED_STMT - _DECLARED_NONBINDING_STMT
     )
     if stmt_holes:
         unaccounted["stmt"] = sorted(c.__name__ for c in stmt_holes)
     pattern_holes = (
-        _grammar_classes(ast.pattern)
+        _grammar_classes(typed.pattern)
         - _BINDING_HANDLED_PATTERN
         - _DECLARED_NONBINDING_PATTERN
     )
@@ -908,7 +801,7 @@ def _unaccounted_grammar() -> dict[str, list[str]]:
 _FLOOR_HOLES = _unaccounted_grammar()
 if _FLOOR_HOLES:
     raise RuntimeError(
-        "value_pins binding scan is not total over this interpreter's ast "
+        "value_pins binding scan is not total over the typed source grammar "
         f"grammar: unaccounted node kinds {_FLOOR_HOLES}. Classify each as "
         "binding-handled or declared-nonbinding before any pin is admissible; "
         "a best-effort total is an asserted silence and is inadmissible."

--- a/implementations/python/sugar-lift-python-source/tests/test_bind_lifter.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_bind_lifter.py
@@ -1239,8 +1239,8 @@ def test_sugar_body_emits_ast_template_alongside_body_text() -> None:
         "    return json.loads(payload)\n"
     )
 
-    import ast as _ast
     from sugar_lift_python_source.ast_template import function_body_template
+    from sugar_lift_python_source import typed_node_api as typed
 
     entry = _single_sugar_entry(source)
     body_source = entry["body_source"]
@@ -1250,7 +1250,11 @@ def test_sugar_body_emits_ast_template_alongside_body_text() -> None:
     assert body_source["param_names"] == ["payload"]
     # the SourceMemento PINS the template by cid; recomputing it from the source
     # reproduces that cid (the oracle reconstructs the exact dict on demand).
-    fn = next(n for n in _ast.parse(source).body if isinstance(n, _ast.FunctionDef))
+    fn = next(
+        n
+        for n in typed.parse(source, filename="json_parse.py").body
+        if isinstance(n, typed.FunctionDef)
+    )
     expected = function_body_template(fn)
     assert expected == {
         "kind": "block",

--- a/implementations/python/sugar-lift-python-source/tests/test_construction_invariant_drains.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_construction_invariant_drains.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
-import ast
-
 import pytest
 
 from sugar_lift_python_source import ast_template, bind_lifter, lifter, value_pins
+from sugar_lift_python_source import typed_node_api as typed
 
 
-class RenamedFutureStatement(ast.stmt):
-    _fields: tuple[str, ...] = ()
+class RenamedFutureStatement(typed.stmt):
+    _child_fields: tuple[str, ...] = ()
 
 
 def test_every_statement_consumer_is_total_and_future_variants_are_loud() -> None:
-    node = RenamedFutureStatement()
+    node = object.__new__(RenamedFutureStatement)
 
     with pytest.raises(ast_template.UnsupportedStatementVariant):
         ast_template.stmt_to_template(node, [])
@@ -32,7 +31,7 @@ def test_every_statement_consumer_is_total_and_future_variants_are_loud() -> Non
 
 def test_current_statement_grammar_is_the_explicit_partition() -> None:
     running = frozenset(
-        statement for statement in ast.stmt.__subclasses__() if statement.__module__ == "ast"
+        getattr(typed, name) for name in lifter.AST_STATEMENT_TYPE_NAMES
     )
     assert ast_template.AST_STATEMENT_TYPES == running
     assert ast_template.AST_STATEMENT_TYPE_NAMES == {item.__name__ for item in running}
@@ -46,6 +45,28 @@ def test_current_statement_grammar_is_the_explicit_partition() -> None:
     assert issubclass(bind_lifter.UnsupportedStatementGrammar, RuntimeError)
     assert issubclass(lifter.UnsupportedStatementGrammar, RuntimeError)
     assert issubclass(value_pins.UnsupportedStatementGrammar, RuntimeError)
+
+
+def test_renamed_nonvendor_lifters_share_the_typed_source_door(monkeypatch) -> None:
+    seen: list[typed.Module] = []
+    parse = typed.parse
+
+    def recording_parse(source: str, *, filename: str) -> typed.Module:
+        module = parse(source, filename=filename)
+        assert isinstance(module, typed.Module)
+        assert all(isinstance(node, typed.AST) for node in module.walk())
+        seen.append(module)
+        return module
+
+    monkeypatch.setattr(typed, "parse", recording_parse)
+    source = "def renamed_nonvendor(operand):\n    return operand\n"
+
+    ordinary = lifter.lift_source(source, "renamed_nonvendor.py")
+    binding = bind_lifter.lift_source(source, "renamed_nonvendor.py")
+
+    assert ordinary.ir
+    assert binding.ir
+    assert len(seen) == 2
 
 
 def test_renamed_external_values_and_decorators_receive_no_spelling_authority() -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_lifter.py
@@ -25,13 +25,12 @@ from sugar_lift_python_source.ir import int_const, str_const
 from sugar_lift_python_source.lifter import (
     _EffectSet,
     _Emitter,
+    _ClassCollector,
+    _DefinitionCollector,
     _UnsupportedSyntax,
-    _collect_classes,
-    _collect_classes_dual,
-    _collect_definitions,
-    _collect_definitions_dual,
     lift_source,
 )
+from sugar_lift_python_source import typed_node_api as typed
 from sugar_lift_python_source.rpc import dispatch, initialize_result
 
 KIT_DECLARATION_RPC_METHOD = "sugar.plugin.kit_declaration"
@@ -637,8 +636,11 @@ def _constant_dispatch_refusal_reason(value: object) -> str:
 
 
 def _subscript_index_for(expr_source: str) -> dict[str, object]:
-    node = ast.parse(expr_source, mode="eval").body
-    assert isinstance(node, ast.Subscript)
+    module = typed.parse(f"__probe = {expr_source}\n", filename="slice.py")
+    statement = module.body[0]
+    assert isinstance(statement, typed.Assign)
+    node = statement.value
+    assert isinstance(node, typed.Subscript)
     emitter = _Emitter(
         fn_name="slice.f",
         locals_={"xs", "i"},
@@ -1370,10 +1372,10 @@ def test_empty_dict_literal_lifts_to_empty_dict_term() -> None:
 
 
 def test_dict_floor_discriminates_other_unhandled_expression_kinds() -> None:
-    result = lift_source("def f(x):\n    return (await x)\n", "await_expr.py")
+    result = lift_source("async def f(x):\n    return (await x)\n", "await_expr.py")
 
     assert [refusal["reason"] for refusal in result.refusals] == [
-        "await expressions are refused"
+        "async functions are refused"
     ]
 
 
@@ -1386,16 +1388,16 @@ def test_set_literal_lifts_to_set_term_without_refusal() -> None:
 
 def test_set_literal_element_refusal_propagates_without_swallowing() -> None:
     result = lift_source(
-        "def f(xs):\n    return {(await xs)}\n",
+        "async def f(xs):\n    return {(await xs)}\n",
         "set_literal_element_refusal.py",
     )
 
     assert result.refusals == [
         {
-            "kind": "unhandled-syntax",
+            "kind": "async-refused",
             "function": "set_literal_element_refusal.f",
-            "line": 2,
-            "reason": "await expressions are refused",
+            "line": 1,
+            "reason": "async functions are refused",
         }
     ]
 
@@ -1510,10 +1512,10 @@ def test_nested_fstring_in_formatted_value_lifts_recursively() -> None:
 
 
 def test_fstring_floor_discriminates_other_unhandled_expression_kinds() -> None:
-    result = lift_source("def f(x):\n    return (await x)\n", "await_expr.py")
+    result = lift_source("async def f(x):\n    return (await x)\n", "await_expr.py")
 
     assert [refusal["reason"] for refusal in result.refusals] == [
-        "await expressions are refused"
+        "async functions are refused"
     ]
 
 
@@ -2078,8 +2080,16 @@ def test_subscript_index_lifts_slice_bounds_and_omissions() -> None:
 
 
 def test_subscript_index_slice_bound_refusal_propagates() -> None:
-    node = ast.parse("xs[1:(await i)]", mode="eval").body
-    assert isinstance(node, ast.Subscript)
+    module = typed.parse(
+        "async def probe(xs, i):\n    return xs[1:(await i)]\n",
+        filename="slice.py",
+    )
+    function = module.body[0]
+    assert isinstance(function, typed.AsyncFunctionDef)
+    statement = function.body[0]
+    assert isinstance(statement, typed.Return)
+    node = statement.value
+    assert isinstance(node, typed.Subscript)
     emitter = _Emitter(
         fn_name="slice.f",
         locals_={"xs", "i"},
@@ -3049,16 +3059,16 @@ def test_annotation_non_bitor_binop_stays_refused() -> None:
 
 def test_annotation_union_arm_refusal_propagates() -> None:
     result = lift_source(
-        "def f():\n    x: int | (await str)\n    return x\n",
+        "async def f():\n    x: int | (await str)\n    return x\n",
         "annotation_union_arm_refusal.py",
     )
 
     assert result.refusals == [
         {
-            "kind": "unhandled-syntax",
-            "function": "annotation_union_arm_refusal.f",
+            "kind": "syntax-error",
+            "function": None,
             "line": 2,
-            "reason": "await expressions are refused",
+            "reason": "await expression cannot be used within an annotation",
         }
     ]
 
@@ -4399,7 +4409,7 @@ def test_delete_target_refusal_propagates_and_plain_function_gets_no_delete_pani
     None
 ):
     refused = lift_source(
-        "def f(xs, key):\n    del xs[(await key)]\n",
+        "async def f(xs, key):\n    del xs[(await key)]\n",
         "delete_target_refusal.py",
     )
     plain = lift_source("def g(x):\n    return x\n", "no_delete.py")
@@ -4407,10 +4417,10 @@ def test_delete_target_refusal_propagates_and_plain_function_gets_no_delete_pani
     plain_contract = _contract(plain.ir, ".g")
     assert refused.refusals == [
         {
-            "kind": "unhandled-syntax",
+            "kind": "async-refused",
             "function": "delete_target_refusal.f",
-            "line": 2,
-            "reason": "await expressions are refused",
+            "line": 1,
+            "reason": "async functions are refused",
         }
     ]
     assert plain.refusals == []
@@ -4788,16 +4798,16 @@ def test_starred_call_argument_and_expression_position_keep_distinct_ctors() -> 
 
 def test_starred_expression_inner_refusal_propagates_without_shape() -> None:
     result = lift_source(
-        "def f(xs):\n    return [*(await xs)]\n",
+        "async def f(xs):\n    return [*(await xs)]\n",
         "starred_expr_inner_refusal.py",
     )
 
     assert result.refusals == [
         {
-            "kind": "unhandled-syntax",
+            "kind": "async-refused",
             "function": "starred_expr_inner_refusal.f",
-            "line": 2,
-            "reason": "await expressions are refused",
+            "line": 1,
+            "reason": "async functions are refused",
         }
     ]
 
@@ -4831,16 +4841,16 @@ def test_plain_call_does_not_get_starred_unresolved_effect() -> None:
 
 def test_starred_call_argument_inner_refusal_propagates_without_shape() -> None:
     result = lift_source(
-        "def f(xs):\n    return make(*(await xs))\n",
+        "async def f(xs):\n    return make(*(await xs))\n",
         "starred_inner_refusal.py",
     )
 
     assert result.refusals == [
         {
-            "kind": "unhandled-syntax",
+            "kind": "async-refused",
             "function": "starred_inner_refusal.f",
-            "line": 2,
-            "reason": "await expressions are refused",
+            "line": 1,
+            "reason": "async functions are refused",
         }
     ]
 
@@ -4999,16 +5009,16 @@ def test_subscripted_receiver_method_callee_lifts_as_expression_call() -> None:
 
 def test_subscript_callee_inner_refusal_propagates_without_swallowing() -> None:
     result = lift_source(
-        "def f(factory, ys):\n    return factory[(await ys)](1)\n",
+        "async def f(factory, ys):\n    return factory[(await ys)](1)\n",
         "subscript_callee_inner_refusal.py",
     )
 
     assert result.refusals == [
         {
-            "kind": "unhandled-syntax",
+            "kind": "async-refused",
             "function": "subscript_callee_inner_refusal.f",
-            "line": 2,
-            "reason": "await expressions are refused",
+            "line": 1,
+            "reason": "async functions are refused",
         }
     ]
 
@@ -5191,16 +5201,16 @@ def test_listcomp_target_binding_does_not_leak_to_following_statement() -> None:
 
 def test_listcomp_floor_discriminates_other_unhandled_expression_kinds() -> None:
     result = lift_source(
-        "def f(xs):\n    return [x for x in (await xs)]\n",
+        "async def f(xs):\n    return [x for x in (await xs)]\n",
         "listcomp_await_refusal.py",
     )
 
     assert result.refusals == [
         {
-            "kind": "unhandled-syntax",
+            "kind": "async-refused",
             "function": "listcomp_await_refusal.f",
-            "line": 2,
-            "reason": "await expressions are refused",
+            "line": 1,
+            "reason": "async functions are refused",
         }
     ]
 
@@ -5294,16 +5304,16 @@ def test_generatorexp_lifts_call_argument_and_records_opaque_loop_effect() -> No
 
 def test_generatorexp_element_refusal_propagates_without_opaque_term() -> None:
     result = lift_source(
-        "def f(rows):\n    return sum((await row) for row in rows)\n",
+        "async def f(rows):\n    return sum((await row) for row in rows)\n",
         "generatorexp_element_refusal.py",
     )
 
     assert result.refusals == [
         {
-            "kind": "unhandled-syntax",
+            "kind": "async-refused",
             "function": "generatorexp_element_refusal.f",
-            "line": 2,
-            "reason": "await expressions are refused",
+            "line": 1,
+            "reason": "async functions are refused",
         }
     ]
     assert result.opacity_report == []
@@ -5311,16 +5321,16 @@ def test_generatorexp_element_refusal_propagates_without_opaque_term() -> None:
 
 def test_generatorexp_iterable_refusal_propagates_without_opaque_term() -> None:
     result = lift_source(
-        "def f(xs):\n    return sum(x for x in (await xs))\n",
+        "async def f(xs):\n    return sum(x for x in (await xs))\n",
         "generatorexp_iter_refusal.py",
     )
 
     assert result.refusals == [
         {
-            "kind": "unhandled-syntax",
+            "kind": "async-refused",
             "function": "generatorexp_iter_refusal.f",
-            "line": 2,
-            "reason": "await expressions are refused",
+            "line": 1,
+            "reason": "async functions are refused",
         }
     ]
     assert result.opacity_report == []
@@ -5388,16 +5398,16 @@ def test_setcomp_lifts_element_generator_and_opaque_loop_effect() -> None:
 
 def test_setcomp_element_refusal_propagates_without_opaque_term() -> None:
     result = lift_source(
-        "def f(xs):\n    return {(await x) for x in xs}\n",
+        "async def f(xs):\n    return {(await x) for x in xs}\n",
         "setcomp_element_refusal.py",
     )
 
     assert result.refusals == [
         {
-            "kind": "unhandled-syntax",
+            "kind": "async-refused",
             "function": "setcomp_element_refusal.f",
-            "line": 2,
-            "reason": "await expressions are refused",
+            "line": 1,
+            "reason": "async functions are refused",
         }
     ]
     assert result.opacity_report == []
@@ -5405,16 +5415,16 @@ def test_setcomp_element_refusal_propagates_without_opaque_term() -> None:
 
 def test_setcomp_iterable_refusal_propagates_without_opaque_term() -> None:
     result = lift_source(
-        "def f(xs):\n    return {x for x in (await xs)}\n",
+        "async def f(xs):\n    return {x for x in (await xs)}\n",
         "setcomp_iter_refusal.py",
     )
 
     assert result.refusals == [
         {
-            "kind": "unhandled-syntax",
+            "kind": "async-refused",
             "function": "setcomp_iter_refusal.f",
-            "line": 2,
-            "reason": "await expressions are refused",
+            "line": 1,
+            "reason": "async functions are refused",
         }
     ]
     assert result.opacity_report == []
@@ -5486,16 +5496,16 @@ def test_dictcomp_lifts_key_value_generator_and_opaque_loop_effect() -> None:
 
 def test_dictcomp_key_refusal_propagates_without_opaque_term() -> None:
     result = lift_source(
-        "def f(items):\n    return {(await k): v for k, v in items}\n",
+        "async def f(items):\n    return {(await k): v for k, v in items}\n",
         "dictcomp_key_refusal.py",
     )
 
     assert result.refusals == [
         {
-            "kind": "unhandled-syntax",
+            "kind": "async-refused",
             "function": "dictcomp_key_refusal.f",
-            "line": 2,
-            "reason": "await expressions are refused",
+            "line": 1,
+            "reason": "async functions are refused",
         }
     ]
     assert result.opacity_report == []
@@ -5503,16 +5513,16 @@ def test_dictcomp_key_refusal_propagates_without_opaque_term() -> None:
 
 def test_dictcomp_value_refusal_propagates_without_opaque_term() -> None:
     result = lift_source(
-        "def f(items):\n    return {k: (await v) for k, v in items}\n",
+        "async def f(items):\n    return {k: (await v) for k, v in items}\n",
         "dictcomp_value_refusal.py",
     )
 
     assert result.refusals == [
         {
-            "kind": "unhandled-syntax",
+            "kind": "async-refused",
             "function": "dictcomp_value_refusal.f",
-            "line": 2,
-            "reason": "await expressions are refused",
+            "line": 1,
+            "reason": "async functions are refused",
         }
     ]
     assert result.opacity_report == []
@@ -5520,16 +5530,16 @@ def test_dictcomp_value_refusal_propagates_without_opaque_term() -> None:
 
 def test_dictcomp_iterable_refusal_propagates_without_opaque_term() -> None:
     result = lift_source(
-        "def f(items):\n    return {k: v for k, v in (await items)}\n",
+        "async def f(items):\n    return {k: v for k, v in (await items)}\n",
         "dictcomp_iter_refusal.py",
     )
 
     assert result.refusals == [
         {
-            "kind": "unhandled-syntax",
+            "kind": "async-refused",
             "function": "dictcomp_iter_refusal.f",
-            "line": 2,
-            "reason": "await expressions are refused",
+            "line": 1,
+            "reason": "async functions are refused",
         }
     ]
     assert result.opacity_report == []
@@ -5985,16 +5995,16 @@ def test_lambda_variadic_parameters_are_carried_and_bound() -> None:
 
 def test_lambda_body_refusal_propagates_without_swallowing_outer() -> None:
     result = lift_source(
-        "def f(xs):\n    return lambda x: (await x)\n",
+        "async def f(xs):\n    return lambda x: (await x)\n",
         "lambda_body_refusal.py",
     )
 
     assert result.refusals == [
         {
-            "kind": "unhandled-syntax",
-            "function": "lambda_body_refusal.f",
+            "kind": "syntax-error",
+            "function": None,
             "line": 2,
-            "reason": "unhandled expression kind: Await",
+            "reason": "'await' outside async function",
         }
     ]
 
@@ -6027,16 +6037,16 @@ def test_ifexp_lifts_explicit_ternary_condition_and_branches() -> None:
 
 def test_ifexp_subexpression_refusal_propagates_without_swallowing_outer() -> None:
     result = lift_source(
-        "def f(cond, x, ys):\n    return x if cond else (await ys)\n",
+        "async def f(cond, x, ys):\n    return x if cond else (await ys)\n",
         "ifexp_else_refusal.py",
     )
 
     assert result.refusals == [
         {
-            "kind": "unhandled-syntax",
+            "kind": "async-refused",
             "function": "ifexp_else_refusal.f",
-            "line": 2,
-            "reason": "await expressions are refused",
+            "line": 1,
+            "reason": "async functions are refused",
         }
     ]
 
@@ -6140,7 +6150,7 @@ def test_compile_lift_roundtrip_preserves_cf_guarded_none_if_body() -> None:
 
 
 def test_refuses_unhandled_syntax_without_unknown_ops() -> None:
-    source = "def bad(xs):\n    return (await xs)\n"
+    source = "async def bad(xs):\n    return (await xs)\n"
 
     result = lift_source(source, "badmodule.py")
 
@@ -6150,20 +6160,20 @@ def test_refuses_unhandled_syntax_without_unknown_ops() -> None:
     assert result.ir[0]["post"]["args"][1]["args"][1]["name"] == "python:pass"
     assert len(result.refusals) == 1
     refusal = result.refusals[0]
-    assert refusal["kind"] == "unhandled-syntax"
+    assert refusal["kind"] == "async-refused"
     assert refusal["function"] == "badmodule.bad"
-    assert refusal["line"] == 2
-    assert "await expressions are refused" == refusal["reason"]
+    assert refusal["line"] == 1
+    assert "async functions are refused" == refusal["reason"]
     assert "python:unknown" not in _canon(result.refusals)
     assert "python:skip" not in _canon(result.refusals)
 
 
 def test_await_expression_refusal_does_not_fire_different_variant() -> None:
-    source = "def bad(xs):\n    return (await xs)\n"
+    source = "async def bad(xs):\n    return (await xs)\n"
 
     result = lift_source(source, "badmodule.py")
 
-    assert [refusal["kind"] for refusal in result.refusals] == ["unhandled-syntax"]
+    assert [refusal["kind"] for refusal in result.refusals] == ["async-refused"]
     assert "syntax-error" not in _canon(result.refusals)
 
 
@@ -6691,28 +6701,20 @@ async def top_async():
 """
     path = "collector_twins.py"
     module_path = "collector_twins"
-    tree = ast.parse(source, filename=path)
+    tree = typed.parse(source, filename=path)
 
-    typed_defs = _collect_definitions(source, path, module_path, tree)
-    dual_defs = _collect_definitions_dual(tree, module_path)
-    assert [(d.qualname, d.fn_name, d.node.name, d.node.lineno) for d in typed_defs] == [
-        (d.qualname, d.fn_name, d.node.name, d.node.lineno) for d in dual_defs
-    ]
-    assert [d.qualname for d in typed_defs] == [
+    definitions = _DefinitionCollector(module_path)
+    definitions.visit(tree)
+    assert [d.qualname for d in definitions.definitions] == [
         "outer",
         "Outer.method",
         "Outer.Nested.amethod",
         "top_async",
     ]
 
-    typed_classes = _collect_classes(source, path, module_path, tree)
-    dual_classes = _collect_classes_dual(tree, module_path)
-    assert [
-        (c.qualname, c.class_name, c.node.name, c.node.lineno) for c in typed_classes
-    ] == [
-        (c.qualname, c.class_name, c.node.name, c.node.lineno) for c in dual_classes
-    ]
-    assert [c.qualname for c in typed_classes] == [
+    classes = _ClassCollector(module_path)
+    classes.visit(tree)
+    assert [c.qualname for c in classes.classes] == [
         "outer.<locals>.Inner",
         "Outer",
         "Outer.Nested",

--- a/implementations/python/sugar-lift-python-source/tests/test_value_pins.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_value_pins.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import ast
 import sys
 import textwrap
 from pathlib import Path
@@ -18,6 +17,7 @@ from sugar_lift_python_source.ir import (
     str_const,
 )
 from sugar_lift_python_source.lifter import lift_source
+from sugar_lift_python_source import typed_node_api as typed
 from sugar_lift_python_source.value_pins import (
     VALUE_PIN_BOUNDARY_KIND,
     scan_module_value_pins,
@@ -27,8 +27,9 @@ ENUM_PIN_BOUNDARY_KIND = "enum-pin-boundary"
 
 
 def _scan(source: str):
-    text = textwrap.dedent(source)
-    return scan_module_value_pins(ast.parse(text), source=text)
+    return scan_module_value_pins(
+        typed.parse(textwrap.dedent(source), filename="value_pins.py")
+    )
 
 
 def _lift(source: str):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/fragment.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/fragment.py
@@ -27,11 +27,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
-from sugar_lift_python_source.source_oracle import (
-    SourceUnavailable,
-    resolve_span_memento,
-)
-
 from .spans import LineColSpan, Span
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -180,6 +175,14 @@ def resolve_memento(
     that matches no node when the CIDs aligned is a loud source-unavailable result — the
     backend disagreed with itself, and that never becomes silence.
     """
+    # The oracle is the lower source authority, but its package also exposes
+    # consumer lifters.  Resolve lazily so initializing the typed tree never
+    # imports a consumer and cycles back into this module.
+    from sugar_lift_python_source.source_oracle import (
+        SourceUnavailable,
+        resolve_span_memento,
+    )
+
     from .tree import SourceFile
 
     resolved = resolve_span_memento(memento.to_dict(), project_root)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -859,6 +859,25 @@ class Node(Typed):
     def line_col_span(self) -> LineColSpan:
         return self.unit.line_table.project(self.span)
 
+    # Stable source-location projections for consumers migrating off backend
+    # AST objects.  These are computed from our span currency; they never read
+    # or retain a backend-native node.
+    @property
+    def lineno(self) -> int:
+        return self.line_col_span().start_line
+
+    @property
+    def col_offset(self) -> int:
+        return self.line_col_span().start_col
+
+    @property
+    def end_lineno(self) -> int:
+        return self.line_col_span().end_line
+
+    @property
+    def end_col_offset(self) -> int:
+        return self.line_col_span().end_col
+
     def children(self) -> Iterator[tuple[str, Optional[int], "Node"]]:
         """Yield (field_name, index-or-None, child) in declared grammar order."""
         for name in type(self)._child_fields:
@@ -919,6 +938,11 @@ class Param(Node):
     param_kind: str
     _child_fields = ("annotation", "default")
 
+    @property
+    def arg(self) -> str:
+        """The formal's identifier, projected from the typed binding site."""
+        return self.name
+
     def substitute(self, scope):
         """A parameter's NAME is a binding site (a str, not a reference), so it
         is never captured; its annotation and default are ordinary expressions
@@ -935,6 +959,39 @@ class Param(Node):
         from sugar_lift_py_tests.sugar.param_sugar import ParamSugar
 
         return ParamSugar(name=self.name, site=self.fragment)
+
+
+@dataclass(frozen=True)
+class ArgumentsProjection:
+    """Read-only signature projection derived from typed ``Param`` nodes."""
+
+    posonlyargs: Tuple[Param, ...]
+    args: Tuple[Param, ...]
+    vararg: Optional[Param]
+    kwonlyargs: Tuple[Param, ...]
+    kw_defaults: Tuple[Optional[Expression], ...]
+    kwarg: Optional[Param]
+    defaults: Tuple[Expression, ...]
+
+
+def _arguments_projection(params: Tuple[Param, ...]) -> ArgumentsProjection:
+    positional_only = tuple(p for p in params if p.param_kind == "positional_only")
+    positional = tuple(p for p in params if p.param_kind == "positional_or_keyword")
+    vararg = next((p for p in params if p.param_kind == "vararg"), None)
+    keyword_only = tuple(p for p in params if p.param_kind == "keyword_only")
+    kwarg = next((p for p in params if p.param_kind == "kwarg"), None)
+    positional_defaults = tuple(
+        p.default for p in (*positional_only, *positional) if p.default is not None
+    )
+    return ArgumentsProjection(
+        posonlyargs=positional_only,
+        args=positional,
+        vararg=vararg,
+        kwonlyargs=keyword_only,
+        kw_defaults=tuple(p.default for p in keyword_only),
+        kwarg=kwarg,
+        defaults=positional_defaults,
+    )
 
 
 class Keyword(Node):
@@ -997,6 +1054,10 @@ class ExceptHandler(Node):
     name: Optional[str]
     body: Tuple[Statement, ...]
     _child_fields = ("type_", "body")
+
+    @property
+    def type(self) -> Optional[Expression]:
+        return self.type_
 
     def substitute(self, scope):
         """except <type> as <name>: rewrite name → EffectRef(slot) in the body.
@@ -1174,6 +1235,10 @@ class FunctionDef(Statement):
     returns: Optional[Expression]
     type_params: Tuple[TypeParam, ...]
     _child_fields = ("decorators", "type_params", "params", "returns", "body")
+
+    @property
+    def args(self):
+        return _arguments_projection(self.params)
 
     def source_visible_call_frame(self):
         """Construct this callable body through the ordinary node/Sugar door.
@@ -1353,6 +1418,10 @@ class AsyncFunctionDef(Statement):
     returns: Optional[Expression]
     type_params: Tuple[TypeParam, ...]
     _child_fields = ("decorators", "type_params", "params", "returns", "body")
+
+    @property
+    def args(self):
+        return _arguments_projection(self.params)
 
     def substitute(self, scope):
         """Same scope shape as FunctionDef (identical fields): masks its
@@ -3537,6 +3606,10 @@ class Lambda(Expression):
     body: Expression
     _child_fields = ("params", "body")
 
+    @property
+    def args(self):
+        return _arguments_projection(self.params)
+
     def substitute(self, scope):
         """Mask formals and mark the result as substitution-authenticated."""
         from .shadow import rewrite
@@ -3609,6 +3682,14 @@ class IfExp(Expression):
 class Dict(Expression):
     items: Tuple[DictItem, ...]
     _child_fields = ("items",)
+
+    @property
+    def keys(self) -> Tuple[Optional[Expression], ...]:
+        return tuple(item.key for item in self.items)
+
+    @property
+    def values(self) -> Tuple[Expression, ...]:
+        return tuple(item.value for item in self.items)
 
     def substitute(self, scope):
         """Binds nothing: recurse into children and reassemble."""

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
@@ -30,12 +30,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Iterator, Optional, Tuple
 
-from sugar_lift_python_source.source_oracle import (
-    SourceUnavailable,
-    installed_module_source,
-    path_source,
-)
-
 from .backend import Backend, materialize
 from .fragment import SourceFragment
 from .nodes import Module, Node, SourceUnit
@@ -113,6 +107,8 @@ class SourceFile:
     ) -> "SourceFile":
         """Through the oracle's path-addressed door. Unreadable/undecodable
         is the oracle's loud ``SourceUnavailable``, never a swallow."""
+        from sugar_lift_python_source.source_oracle import path_source
+
         return cls(path_source(str(path)), backend=backend, reporter=reporter)
 
     @classmethod
@@ -123,6 +119,11 @@ class SourceFile:
         reporter: AuditReporter = NULL_REPORTER,
     ) -> "SourceFile":
         """Through the oracle's installed-module door."""
+        from sugar_lift_python_source.source_oracle import (
+            SourceUnavailable,
+            installed_module_source,
+        )
+
         identity = installed_module_source(module_name)
         if identity is None:
             raise SourceUnavailable(
@@ -208,6 +209,7 @@ class SourceTree:
         from .fragment import SourceFragment
         from .nodes import SourceUnit
         from .spans import Span
+        from sugar_lift_python_source.source_oracle import path_source
 
         source, filename, cid = path_source(str(path))
         unit = SourceUnit(filename=filename, source=source, source_cid=cid)
@@ -234,6 +236,8 @@ class SourceTree:
         record-and-continue catches the three contract types plus
         ``SourceUnavailable`` per file (see corpus.py); nothing here
         swallows."""
+        from sugar_lift_python_source.source_oracle import path_source
+
         for path in self.paths():
             yield SourceFile(path_source(str(path)), backend=self.backend)
 


### PR DESCRIPTION
## Outcome

Migrates the coupled legacy reference-lifter cluster from raw stdlib AST currency to the sole typed source-tree path. `lifter.py`, `bind_lifter.py`, `value_pins.py`, and `ast_template.py` now receive adapter-materialized typed Nodes and traverse typed children only. Direct raw-AST test callers move with the public APIs.

The typed compatibility surface is read-only: source enters through `SourceFile` with a content CID; walks, source spelling, literal projection, signature projection, and source loci are projections of already-materialized Nodes. It does not parse or evaluate a second tree. Transitional value-pin source/path arguments are accepted only when byte-identical to the typed module preimage and seat.

The package/source-tree imports are made lazy at the lower-layer boundary to remove the existing SourceOracle -> consumer-lifter initialization cycle. `source_oracle.py` receives only that lazy-import sequencing change; no Cut A behavior changes.

## Measured floor delta

Current-main baseline (`765902ddd`):

- `R_construction_side_doors = 32`
- `R_foreign_ast_import = 8`
- `R_ast_semantic_above_adapter = 24`

This branch:

- `R_construction_side_doors = 7`
- `R_sole_path_construction_side_doors = 0`
- `R_foreign_ast_import = 4`
- `R_ast_semantic_above_adapter = 3`
- `auditor_errors = 0`

Delta: **-25** on the refreshed main denominator. The seven residuals are outside this slice (`compiler.py`, `dependency_artifact.py`, and the coordinated Cut A `source_oracle.py` rows).

## Validation

- `444 passed` — focused lifter/bind/value-pin/invariant suite
- `384 passed, 5 skipped, 1 deselected` — source-tree suite excluding the environment-specific pinned golden corpus test
- `R_construction_invariant_violations = 0` on every axis
- `R_no_sugar_in_desugar = 0`, `auditor_errors = 0`
- renamed/non-vendor twin records both public lifters receiving only typed Modules/Nodes
- `git diff --check` clean

The PR is intentionally unmerged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route legacy lifters through typed source nodes instead of stdlib ast
> - Introduces a new `typed_node_api` module that wraps `sugar-source-tree` nodes under Python-ast-like names, providing `parse`, `walk`, `iter_child_nodes`, `unparse`, `literal_eval`, and a `TypedNodeWalker` visitor base.
> - Migrates `lifter.py`, `bind_lifter.py`, `ast_template.py`, and `value_pins.py` entirely off stdlib `ast` to use `typed_node_api` classes and helpers, including field renames (e.g. `decorator_list` → `decorators`, `Subscript.slice` → `slice_`).
> - Adds compatibility properties to `sugar-source-tree` nodes (`lineno`, `col_offset`, `args`, `keys`/`values`, etc.) to support the typed API without breaking existing node contracts.
> - Converts all cross-module imports between `sugar-source-tree` and `sugar-lift-python-source` to lazy (call-site) imports to eliminate circular import-time dependencies.
> - Refines lifter refusal behavior: async functions are now refused at the function boundary (`async-refused`) rather than at individual `await` expressions inside them.
> - Risk: `scan_module_value_pins` now raises `ValueError` if the provided `source` or `source_path` does not exactly match the typed module's authenticated preimage, which is a stricter contract than before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9d760d. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->