### PR TITLE
Route lifter definition/class collectors through typed tree

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py
@@ -2,16 +2,41 @@ from __future__ import annotations
 
 import ast
 import os
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Iterable
 
-from .canonical import cid_of_json
+from .canonical import blake3_512_of, cid_of_json
 from .value_pins import (
     ValuePin,
     mutable_global_pin_opacity_entry,
     scan_module_value_pins,
 )
+
+
+def _typed_tree():
+    """Lazy typed-tree import — lifter is still dual-body residual overall."""
+    tree_src = Path(__file__).resolve().parents[3] / "sugar-source-tree" / "src"
+    if tree_src.is_dir() and str(tree_src) not in sys.path:
+        sys.path.insert(0, str(tree_src))
+    from sugar_source_tree.backend import BackendCouldNotParse
+    from sugar_source_tree.nodes import (
+        AsyncFunctionDef,
+        ClassDef,
+        FunctionDef,
+        Node,
+    )
+    from sugar_source_tree.tree import SourceFile
+
+    return (
+        SourceFile,
+        BackendCouldNotParse,
+        FunctionDef,
+        AsyncFunctionDef,
+        ClassDef,
+        Node,
+    )
 from .ir import (
     Json,
     bool_const,
@@ -258,14 +283,17 @@ def lift_source(source: str, source_path: str) -> LiftResult:
         mutable_global_pin_opacity_entry(pin, source_path=source_path)
         for pin in pin_scan.mutable_global_pins
     )
-    class_shapes = _lift_class_shapes(tree, module_path)
-    collector = _DefinitionCollector(module_path)
-    collector.visit(tree)
+    class_shapes = _lift_class_shapes(
+        tree, module_path, source=source, source_path=source_path
+    )
+    definitions = _collect_definitions(
+        source, source_path, module_path, tree
+    )
     receiver_contexts = _receiver_contexts_by_method(class_shapes)
 
     body_terms: list[Json] = []
     contracts: list[Json] = []
-    for info in collector.definitions:
+    for info in definitions:
         contract = _lift_function(
             info,
             source_path,
@@ -343,67 +371,220 @@ def lift_paths(workspace_root: str, source_paths: Iterable[str]) -> LiftResult:
     return result
 
 
-class _DefinitionCollector(ast.NodeVisitor):
-    def __init__(self, module_path: str):
-        self.module_path = module_path
-        self.scope: list[tuple[str, str]] = []
-        self.definitions: list[_FunctionInfo] = []
+def _dual_function_index(
+    tree: ast.Module,
+) -> dict[tuple[int, str], ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Index residual dual-body function nodes by (lineno, name) for body lifting.
 
-    def visit_ClassDef(self, node: ast.ClassDef) -> Any:
-        self.scope.append(("class", node.name))
-        for stmt in node.body:
-            self.visit(stmt)
-        self.scope.pop()
+    Manual stack — not ``ast.NodeVisitor`` / ``ast.walk``. Semantic authority for
+    *which* functions participate is the typed walk; this index only pairs the
+    dual-body payload residual body emitters still consume.
+    """
+    index: dict[tuple[int, str], ast.FunctionDef | ast.AsyncFunctionDef] = {}
+    stack: list[ast.AST] = [tree]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            index[(int(node.lineno), node.name)] = node
+        stack.extend(reversed(list(ast.iter_child_nodes(node))))
+    return index
 
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> Any:
-        self._record_function(node)
 
-    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> Any:
-        self._record_function(node)
+def _dual_class_index(tree: ast.Module) -> dict[tuple[int, str], ast.ClassDef]:
+    """Index residual dual-body class nodes by (lineno, name) for shape building."""
+    index: dict[tuple[int, str], ast.ClassDef] = {}
+    stack: list[ast.AST] = [tree]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, ast.ClassDef):
+            index[(int(node.lineno), node.name)] = node
+        stack.extend(reversed(list(ast.iter_child_nodes(node))))
+    return index
 
-    def _record_function(self, node: ast.AST) -> None:
-        assert isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-        qualname = _qualname(self.scope, node.name)
-        self.definitions.append(
-            _FunctionInfo(
-                node=node,
-                qualname=qualname,
-                fn_name=f"{self.module_path}.{qualname}",
-            )
+
+def _collect_definitions(
+    source: str,
+    source_path: str,
+    module_path: str,
+    tree: ast.Module,
+) -> list[_FunctionInfo]:
+    """Discover functions via SourceFile / typed Nodes.
+
+    SourceFile is the parse door for discovery. Scope / qualname rules match the
+    retired ``_DefinitionCollector`` NodeVisitor: enter class bodies with class
+    scope; record FunctionDef / AsyncFunctionDef and do NOT enter their bodies
+    (nested functions are not separate contracts here). Residual dual-body AST
+    nodes are paired by (lineno, name) until body emission drains.
+    """
+    (
+        SourceFile,
+        BackendCouldNotParse,
+        FunctionDef,
+        AsyncFunctionDef,
+        ClassDef,
+        Node,
+    ) = _typed_tree()
+    dual = _dual_function_index(tree)
+    try:
+        source_file = SourceFile(
+            (source, source_path, blake3_512_of(source.encode("utf-8")))
         )
+    except (SyntaxError, BackendCouldNotParse, UnicodeError, ValueError):
+        return _collect_definitions_dual(tree, module_path)
 
+    definitions: list[_FunctionInfo] = []
 
-class _ClassCollector(ast.NodeVisitor):
-    def __init__(self, module_path: str):
-        self.module_path = module_path
-        self.scope: list[tuple[str, str]] = []
-        self.classes: list[_ClassInfo] = []
-
-    def visit_ClassDef(self, node: ast.ClassDef) -> Any:
-        qualname = _qualname(self.scope, node.name)
-        self.classes.append(
-            _ClassInfo(
-                node=node,
-                qualname=qualname,
-                class_name=f"{self.module_path}.{qualname}",
+    def visit(node: Node, scope: list[tuple[str, str]]) -> None:
+        if isinstance(node, ClassDef):
+            nested = scope + [("class", node.name)]
+            for stmt in node.body:
+                visit(stmt, nested)
+            return
+        if isinstance(node, (FunctionDef, AsyncFunctionDef)):
+            qualname = _qualname(scope, node.name)
+            lineno = int(node.line_col_span().start_line)
+            dual_node = dual.get((lineno, node.name))
+            if dual_node is None:
+                raise RuntimeError(
+                    "typed/dual function pair missing for "
+                    f"{node.name!r} at line {lineno} in {source_path}"
+                )
+            definitions.append(
+                _FunctionInfo(
+                    node=dual_node,
+                    qualname=qualname,
+                    fn_name=f"{module_path}.{qualname}",
+                )
             )
+            return
+        for _, _, child in node.children():
+            visit(child, scope)
+
+    visit(source_file.root, [])
+    return definitions
+
+
+def _collect_definitions_dual(
+    tree: ast.Module, module_path: str
+) -> list[_FunctionInfo]:
+    """Residual dual-body discovery when SourceFile construction refuses."""
+    definitions: list[_FunctionInfo] = []
+
+    def visit(node: ast.AST, scope: list[tuple[str, str]]) -> None:
+        if isinstance(node, ast.ClassDef):
+            nested = scope + [("class", node.name)]
+            for stmt in node.body:
+                visit(stmt, nested)
+            return
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            qualname = _qualname(scope, node.name)
+            definitions.append(
+                _FunctionInfo(
+                    node=node,
+                    qualname=qualname,
+                    fn_name=f"{module_path}.{qualname}",
+                )
+            )
+            return
+        for child in ast.iter_child_nodes(node):
+            visit(child, scope)
+
+    visit(tree, [])
+    return definitions
+
+
+def _collect_classes(
+    source: str,
+    source_path: str,
+    module_path: str,
+    tree: ast.Module,
+) -> list[_ClassInfo]:
+    """Discover classes via SourceFile / typed Nodes.
+
+    Scope rules match the retired ``_ClassCollector`` NodeVisitor: record every
+    ClassDef; enter class bodies with class scope; enter function bodies with
+    function scope so nested classes under ``f.<locals>`` keep qualnames. Dual
+    ClassDef payload pairs by (lineno, name) for residual shape scanners.
+    """
+    (
+        SourceFile,
+        BackendCouldNotParse,
+        FunctionDef,
+        AsyncFunctionDef,
+        ClassDef,
+        Node,
+    ) = _typed_tree()
+    dual = _dual_class_index(tree)
+    try:
+        source_file = SourceFile(
+            (source, source_path, blake3_512_of(source.encode("utf-8")))
         )
-        self.scope.append(("class", node.name))
-        for stmt in node.body:
-            self.visit(stmt)
-        self.scope.pop()
+    except (SyntaxError, BackendCouldNotParse, UnicodeError, ValueError):
+        return _collect_classes_dual(tree, module_path)
 
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> Any:
-        self.scope.append(("function", node.name))
-        for stmt in node.body:
-            self.visit(stmt)
-        self.scope.pop()
+    classes: list[_ClassInfo] = []
 
-    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> Any:
-        self.scope.append(("function", node.name))
-        for stmt in node.body:
-            self.visit(stmt)
-        self.scope.pop()
+    def visit(node: Node, scope: list[tuple[str, str]]) -> None:
+        if isinstance(node, ClassDef):
+            qualname = _qualname(scope, node.name)
+            lineno = int(node.line_col_span().start_line)
+            dual_node = dual.get((lineno, node.name))
+            if dual_node is None:
+                raise RuntimeError(
+                    "typed/dual class pair missing for "
+                    f"{node.name!r} at line {lineno} in {source_path}"
+                )
+            classes.append(
+                _ClassInfo(
+                    node=dual_node,
+                    qualname=qualname,
+                    class_name=f"{module_path}.{qualname}",
+                )
+            )
+            nested = scope + [("class", node.name)]
+            for stmt in node.body:
+                visit(stmt, nested)
+            return
+        if isinstance(node, (FunctionDef, AsyncFunctionDef)):
+            nested = scope + [("function", node.name)]
+            for stmt in node.body:
+                visit(stmt, nested)
+            return
+        for _, _, child in node.children():
+            visit(child, scope)
+
+    visit(source_file.root, [])
+    return classes
+
+
+def _collect_classes_dual(tree: ast.Module, module_path: str) -> list[_ClassInfo]:
+    """Residual dual-body class discovery when SourceFile construction refuses."""
+    classes: list[_ClassInfo] = []
+
+    def visit(node: ast.AST, scope: list[tuple[str, str]]) -> None:
+        if isinstance(node, ast.ClassDef):
+            qualname = _qualname(scope, node.name)
+            classes.append(
+                _ClassInfo(
+                    node=node,
+                    qualname=qualname,
+                    class_name=f"{module_path}.{qualname}",
+                )
+            )
+            nested = scope + [("class", node.name)]
+            for stmt in node.body:
+                visit(stmt, nested)
+            return
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            nested = scope + [("function", node.name)]
+            for stmt in node.body:
+                visit(stmt, nested)
+            return
+        for child in ast.iter_child_nodes(node):
+            visit(child, scope)
+
+    visit(tree, [])
+    return classes
 
 
 class _MethodAttributeScanner(ast.NodeVisitor):
@@ -2079,14 +2260,19 @@ def _lift_function(
         return None
 
 
-def _lift_class_shapes(tree: ast.Module, module_path: str) -> list[Json]:
-    collector = _ClassCollector(module_path)
-    collector.visit(tree)
+def _lift_class_shapes(
+    tree: ast.Module,
+    module_path: str,
+    *,
+    source: str,
+    source_path: str,
+) -> list[Json]:
+    classes = _collect_classes(source, source_path, module_path, tree)
     shapes: list[Json] = []
     shapes_by_name: dict[str, Json] = {}
     setattr_override_by_name: dict[str, bool] = {}
 
-    for info in collector.classes:
+    for info in classes:
         shape, setattr_override_in_mro = _build_class_shape(
             info,
             shapes_by_name=shapes_by_name,

--- a/implementations/python/sugar-lift-python-source/tests/test_lifter.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_lifter.py
@@ -26,6 +26,10 @@ from sugar_lift_python_source.lifter import (
     _EffectSet,
     _Emitter,
     _UnsupportedSyntax,
+    _collect_classes,
+    _collect_classes_dual,
+    _collect_definitions,
+    _collect_definitions_dual,
     lift_source,
 )
 from sugar_lift_python_source.rpc import dispatch, initialize_result
@@ -6657,3 +6661,59 @@ def test_kit_declaration_returns_python_source_lift_surface() -> None:
         },
     ]
     assert result["residueCategories"] == []
+
+
+def test_definition_and_class_collectors_typed_dual_twins() -> None:
+    """Typed SourceFile discovery must match residual dual-body scope rules.
+
+    Scope twins the retired NodeVisitor collectors: class bodies prepend the
+    class name; nested classes under functions take ``f.<locals>``; nested
+    functions inside functions are not separate definitions.
+    """
+    source = """\
+def outer():
+    def nested():
+        return 1
+    class Inner:
+        def method(self):
+            return 2
+    return nested
+
+class Outer:
+    def method(self):
+        return 3
+    class Nested:
+        async def amethod(self):
+            return 4
+
+async def top_async():
+    pass
+"""
+    path = "collector_twins.py"
+    module_path = "collector_twins"
+    tree = ast.parse(source, filename=path)
+
+    typed_defs = _collect_definitions(source, path, module_path, tree)
+    dual_defs = _collect_definitions_dual(tree, module_path)
+    assert [(d.qualname, d.fn_name, d.node.name, d.node.lineno) for d in typed_defs] == [
+        (d.qualname, d.fn_name, d.node.name, d.node.lineno) for d in dual_defs
+    ]
+    assert [d.qualname for d in typed_defs] == [
+        "outer",
+        "Outer.method",
+        "Outer.Nested.amethod",
+        "top_async",
+    ]
+
+    typed_classes = _collect_classes(source, path, module_path, tree)
+    dual_classes = _collect_classes_dual(tree, module_path)
+    assert [
+        (c.qualname, c.class_name, c.node.name, c.node.lineno) for c in typed_classes
+    ] == [
+        (c.qualname, c.class_name, c.node.name, c.node.lineno) for c in dual_classes
+    ]
+    assert [c.qualname for c in typed_classes] == [
+        "outer.<locals>.Inner",
+        "Outer",
+        "Outer.Nested",
+    ]


### PR DESCRIPTION
## Summary
- Replace lifter `_DefinitionCollector` / `_ClassCollector` `ast.NodeVisitor` side doors with SourceFile → typed `FunctionDef`/`ClassDef` walks.
- Residual dual-body AST nodes still pair by `(lineno, name)` for body/shape emitters until that half drains (same output contracts).
- Twin regression locks scope/qualname parity (class methods, nested classes under `f.<locals>`, nested functions not separate defs).

## R
| Axis | Before | After |
|------|--------|-------|
| **R_construction_side_doors** | **32** | **28** |
| R_sole_path | 0 | 0 |
| R_ast_semantic_above_adapter | 24 | 20 |
| foreign_ast_import | 8 | 8 |

ΔR = **−4** (two visitor classes × base+class hits).

## Validation
- `bin/brun -- python scripts/construction_side_door_law.py` (from sugar-lift-py-tests)
- `bin/bpytest tests/test_lifter.py -k 'collector_twins or test_simple or test_function_with_return or test_class_shape'`

## Doctrine
Surgical dual-body drain only — not a full lifter rewrite. Sole-path floor held at 0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route definition and class collectors through typed tree in lifter
> - Replaces `_DefinitionCollector` and `_ClassCollector` AST visitor classes in [lifter.py](https://github.com/TSavo/sugar/pull/6136/files#diff-58a1f7c2bcc2b92168531c4fe9f19b1d610afb5225875219d7cd7581e055326c) with typed-first collectors (`_collect_definitions`, `_collect_classes`) that build a `SourceFile` from `sugar_source_tree` and pair typed nodes back to residual AST nodes by `(lineno, name)`.
> - Adds residual AST-only fallback collectors (`_collect_definitions_dual`, `_collect_classes_dual`) that mirror the old visitor logic when `sugar_source_tree` raises `BackendCouldNotParse` or similar exceptions.
> - A new `_typed_tree` helper lazily injects the `sugar-source-tree/src` directory into `sys.path` and imports typed node classes on first use.
> - Adds a test verifying typed and dual collectors produce identical qualnames on a snippet with nested functions, classes, and async methods.
> - Risk: pairing failures between typed and residual AST nodes now raise `RuntimeError`; missing typed dependencies raise `ImportError`, both of which are new failure modes in `lift_source`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5d5fb7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->