### PR TITLE
feat: emit native pandas five-floor census summaries (#6125)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -157,6 +157,7 @@ def main() -> int:
     families = Counter()
     defects = []
     construction_panics: list[dict[str, Any]] = []
+    floor_rows: list[dict[str, Any]] = []
     files_completed = 0
     functions_total = 0
     functions_clean = 0
@@ -197,6 +198,12 @@ def main() -> int:
                     f"{panic_row['message']}",
                     flush=True,
                 )
+                floor_rows.append(
+                    {
+                        "file": f"{args.corpus.name}/{relative}",
+                        "category": "construction-panic",
+                    }
+                )
                 continue
             assert reporter is not None
 
@@ -225,6 +232,9 @@ def main() -> int:
                     if mechanism is not None:
                         mechanisms[label][mechanism] += 1
             files_completed += 1
+            floor_rows.append(
+                {"file": f"{args.corpus.name}/{relative}", "category": "completed"}
+            )
             if index % 100 == 0:
                 direct = sum(row["direct-loud"] for row in counts.values())
                 print(
@@ -240,6 +250,13 @@ def main() -> int:
                 f"[{index}/{len(files)}] DEFECT {type(exc).__name__} "
                 f"{relative}: {exc}",
                 flush=True,
+            )
+            floor_rows.append(
+                {
+                    "file": f"{args.corpus.name}/{relative}",
+                    "category": "unmeasurable",
+                    "reason": type(exc).__name__,
+                }
             )
         finally:
             signal.alarm(0)
@@ -270,6 +287,30 @@ def main() -> int:
         "elapsedSeconds": time.time() - started,
         "python": sys.version,
     }
+    from pandas_floor_summary import floor_summary
+
+    file_names = sorted(
+        f"{args.corpus.name}/{path.relative_to(args.corpus)}" for path in files
+    )
+    result["floorSummary"] = floor_summary(
+        floor="control-effect",
+        files=file_names,
+        rows=floor_rows,
+        totals={
+            "R_control_effect": result["R"],
+            "constructionPanics": len(construction_panics),
+            "unmeasurable": len(defects),
+        },
+        measured=(
+            not defects
+            and not construction_panics
+            and files_completed == len(files)
+        ),
+        unmeasurable_reasons=(
+            (["construction-panic"] if construction_panics else [])
+            + (["defect"] if defects else [])
+        ),
+    )
     rendered = json.dumps(result, indent=2)
     print("=== RESULT JSON ===", flush=True)
     print(rendered, flush=True)

--- a/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py
@@ -246,6 +246,7 @@ def _run_parent(args: argparse.Namespace) -> int:
     categories: Counter[str] = Counter()
     assertion_counts: Counter[str] = Counter()
     terminal_rows: list[dict[str, Any]] = []
+    floor_rows: list[dict[str, Any]] = []
     representatives: dict[str, list[str]] = defaultdict(list)
     construction_panic_rows: list[dict[str, Any]] = []
     effect_occurrence_counts: Counter[str] = Counter()
@@ -267,6 +268,7 @@ def _run_parent(args: argparse.Namespace) -> int:
         assertion_counts["assertions_total"] += assertion_count
         if assertion_count == 0:
             assertion_counts["files_without_assertions"] += 1
+            floor_rows.append({"file": rel, "category": "completed-no-assertions"})
             continue
         assertion_counts["files_with_assertions"] += 1
         command = [
@@ -308,6 +310,7 @@ def _run_parent(args: argparse.Namespace) -> int:
             )
 
         category = str(row["category"])
+        floor_rows.append({"file": rel, "category": category})
         categories[category] += 1
         if len(representatives[category]) < 10:
             representatives[category].append(rel)
@@ -410,6 +413,23 @@ def _run_parent(args: argparse.Namespace) -> int:
         "factory_walk_unclassified_shape_split": shape_split,
         "factory_walk_unclassified_rows": retained_loci,
     }
+    from pandas_floor_summary import floor_summary
+
+    all_files = sorted(
+        f"{package}/{path.relative_to(root).as_posix()}"
+        for package, root, path in paths
+    )
+    fatal_r = sum(
+        count for category, count in categories.items() if category != "completed"
+    )
+    report["floorSummary"] = floor_summary(
+        floor="fatal-triage",
+        files=all_files,
+        rows=floor_rows,
+        totals={"R_fatal_triage": fatal_r, **dict(categories)},
+        measured=len(floor_rows) == len(all_files),
+        unmeasurable_reasons=(),
+    )
     if args.compact and r_unclassified > COMPACT_LOCUS_LIMIT:
         report["factory_walk_unclassified_rows_truncated"] = True
         report["factory_walk_unclassified_rows_retained"] = COMPACT_LOCUS_LIMIT

--- a/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
@@ -48,6 +48,7 @@ class AuditSummary(NamedTuple):
     timeouts: int
     non_native_red: int
     offenders: tuple[NativeCrashOffender, ...]
+    rows: tuple[ChildResult, ...]
 
 
 def native_crash_offender(
@@ -200,6 +201,7 @@ def audit_paths(
         timeouts=sum(row.category == "timeout" for row in rows),
         non_native_red=sum(row.category == "non-native-red" for row in rows),
         offenders=offenders,
+        rows=tuple(rows),
     )
 
 
@@ -232,6 +234,7 @@ def main() -> int:
     )
     parser.add_argument("--child-file", type=Path)
     parser.add_argument("--child-rel")
+    parser.add_argument("--json", type=Path)
     args = parser.parse_args()
 
     if args.child_file or args.child_rel:
@@ -260,6 +263,32 @@ def main() -> int:
         file_timeout=args.file_timeout,
         workers=max(1, args.workers),
     )
+    if args.json is not None:
+        from pandas_floor_summary import floor_summary, relative_files, write_json
+
+        files = relative_files(paths, args.repo_root)
+        payload = floor_summary(
+            floor="native-crash",
+            files=files,
+            rows=[
+                {
+                    "file": row.file,
+                    "category": row.category,
+                    "returncode": row.returncode,
+                    "signal": row.offender.signal if row.offender else None,
+                }
+                for row in summary.rows
+            ],
+            totals={
+                "R_native_crashes": len(summary.offenders),
+                "completed": summary.completed,
+                "nonNativeRed": summary.non_native_red,
+                "timeouts": summary.timeouts,
+            },
+            measured=summary.timeouts == 0,
+            unmeasurable_reasons=("timeout",) if summary.timeouts else (),
+        )
+        write_json(args.json, payload)
     print(
         "NATIVE-CRASH SURFACE: "
         f"discovered={summary.discovered} completed={summary.completed} "

--- a/implementations/python/sugar-lift-py-tests/scripts/pandas_floor_summary.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/pandas_floor_summary.py
@@ -1,0 +1,58 @@
+"""Native, conserved JSON testimony for installed-corpus floor measurements."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA = "pandas-floor-summary-v1"
+
+
+def relative_files(paths: Sequence[Path], root: Path) -> list[str]:
+    return sorted(path.resolve().relative_to(root.resolve()).as_posix() for path in paths)
+
+
+def corpus_cid(files: Sequence[str]) -> str:
+    preimage = json.dumps(list(files), separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(preimage.encode("utf-8")).hexdigest()
+
+
+def floor_summary(
+    *,
+    floor: str,
+    files: Sequence[str],
+    rows: Sequence[Mapping[str, Any]],
+    totals: Mapping[str, int],
+    measured: bool,
+    unmeasurable_reasons: Sequence[str] = (),
+) -> dict[str, Any]:
+    ordered_files = sorted(files)
+    ordered_rows = sorted((dict(row) for row in rows), key=lambda row: str(row["file"]))
+    if not ordered_files:
+        raise ValueError("a floor summary requires a non-empty measured corpus")
+    if [str(row["file"]) for row in ordered_rows] != ordered_files:
+        raise ValueError("floor rows must account for every corpus file exactly once")
+    reasons = sorted(set(unmeasurable_reasons))
+    if measured and reasons:
+        raise ValueError("a measured floor cannot carry unmeasurable reasons")
+    return {
+        "kind": SCHEMA,
+        "floor": floor,
+        "measurement": "measured" if measured else "unmeasurable",
+        "unmeasurableReasons": reasons,
+        "corpus": {
+            "files": ordered_files,
+            "filesTotal": len(ordered_files),
+            "manifestCid": corpus_cid(ordered_files),
+        },
+        "rows": ordered_rows,
+        "totals": dict(sorted(totals.items())),
+    }
+
+
+def write_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/implementations/python/sugar-lift-py-tests/scripts/reconcile_pandas_floors.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/reconcile_pandas_floors.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Reconcile five native pandas floor reports without interpreting absence as zero."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from pandas_floor_summary import SCHEMA, write_json
+
+FLOORS = ("control-effect", "fatal-triage", "silent", "native-crash", "timeout")
+
+
+def _summary(raw: Mapping[str, Any]) -> Mapping[str, Any]:
+    nested = raw.get("floorSummary")
+    return nested if isinstance(nested, Mapping) else raw
+
+
+def reconcile(reports: Mapping[str, Mapping[str, Any]]) -> dict[str, Any]:
+    missing = sorted(set(FLOORS) - set(reports))
+    errors: list[str] = [f"missing floor: {name}" for name in missing]
+    summaries: dict[str, Mapping[str, Any]] = {}
+    for name in FLOORS:
+        if name not in reports:
+            continue
+        row = _summary(reports[name])
+        summaries[name] = row
+        if row.get("kind") != SCHEMA:
+            errors.append(f"{name}: wrong or absent native schema")
+        if row.get("floor") != name:
+            errors.append(f"{name}: floor identity mismatch")
+        if row.get("measurement") != "measured":
+            errors.append(f"{name}: measurement is not complete")
+        corpus = row.get("corpus")
+        rows = row.get("rows")
+        if not isinstance(corpus, Mapping) or not isinstance(rows, list):
+            errors.append(f"{name}: absent corpus or per-site rows")
+            continue
+        files = corpus.get("files")
+        if not isinstance(files, list) or not files:
+            errors.append(f"{name}: empty corpus is not a measured zero")
+        elif len(rows) != len(files):
+            errors.append(f"{name}: per-site row conservation failure")
+    manifests = {
+        str(row.get("corpus", {}).get("manifestCid"))
+        for row in summaries.values()
+        if isinstance(row.get("corpus"), Mapping)
+    }
+    if len(manifests) != 1 or "None" in manifests:
+        errors.append("five floors do not name one identical corpus manifest")
+    totals = {
+        name: dict(row.get("totals", {}))
+        for name, row in summaries.items()
+        if isinstance(row.get("totals"), Mapping)
+    }
+    r_total = sum(
+        value
+        for floor_totals in totals.values()
+        for key, value in floor_totals.items()
+        if key.startswith("R_") and isinstance(value, int)
+    )
+    return {
+        "kind": "pandas-validated-summary-v1",
+        "measurement": "measured" if not errors else "unmeasurable",
+        "corpusManifestCid": next(iter(manifests)) if len(manifests) == 1 else None,
+        "floors": totals,
+        "R_total": r_total,
+        "verdict": "green" if not errors and r_total == 0 else "red",
+        "errors": errors,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    for floor in FLOORS:
+        parser.add_argument("--" + floor, type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=Path("validated-summary.json"))
+    args = parser.parse_args()
+    reports = {
+        floor: json.loads(getattr(args, floor.replace("-", "_")).read_text(encoding="utf-8"))
+        for floor in FLOORS
+    }
+    result = reconcile(reports)
+    write_json(args.output, result)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["verdict"] == "green" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
@@ -38,6 +38,7 @@ class AuditSummary(NamedTuple):
     non_native_red: int
     native_crashes: int
     offenders: tuple[SilentOffender, ...]
+    rows: tuple[ChildResult, ...]
 
 
 def _roll_call_keys(audit: Mapping[str, Any]) -> set[tuple[str, int, int, str]]:
@@ -242,6 +243,7 @@ def audit_paths(
         non_native_red=sum(row.category == "non-native-red" for row in rows),
         native_crashes=sum(row.category == "native-crash" for row in rows),
         offenders=offenders,
+        rows=tuple(rows),
     )
 
 
@@ -285,6 +287,7 @@ def main() -> int:
     )
     parser.add_argument("--child-file", type=Path)
     parser.add_argument("--child-rel")
+    parser.add_argument("--json", type=Path)
     args = parser.parse_args()
 
     if args.child_file or args.child_rel:
@@ -304,6 +307,37 @@ def main() -> int:
         file_timeout=args.file_timeout,
         workers=max(1, args.workers),
     )
+    incomplete = tuple(
+        sorted({row.category for row in summary.rows if row.category != "completed"})
+    )
+    if args.json is not None:
+        from pandas_floor_summary import floor_summary, relative_files, write_json
+
+        files = relative_files(paths, args.repo_root)
+        payload = floor_summary(
+            floor="silent",
+            files=files,
+            rows=[
+                {
+                    "file": row.file,
+                    "category": row.category,
+                    "silentLoci": [offender._asdict() for offender in row.offenders],
+                    "silentCount": r_silent(row.offenders),
+                }
+                for row in summary.rows
+            ],
+            totals={
+                "R_silent": r_silent(summary.offenders),
+                "completed": summary.completed,
+                "constructionPanics": summary.construction_panics,
+                "nativeCrashes": summary.native_crashes,
+                "nonNativeRed": summary.non_native_red,
+                "timeouts": summary.timeouts,
+            },
+            measured=not incomplete,
+            unmeasurable_reasons=incomplete,
+        )
+        write_json(args.json, payload)
     print(
         "SILENT SURFACE: "
         f"files_discovered={summary.discovered} files_completed={summary.completed} "
@@ -312,6 +346,12 @@ def main() -> int:
         f"non_native_red={summary.non_native_red} "
         f"native_crashes={summary.native_crashes} timeouts={summary.timeouts}"
     )
+    if incomplete:
+        print(
+            "SILENT ZERO-TOLERANCE RED: measurement incomplete: "
+            + ", ".join(incomplete)
+        )
+        return 1
     if summary.offenders:
         print("SILENT ZERO-TOLERANCE RED")
         print(format_report(summary.offenders))

--- a/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
@@ -34,6 +34,11 @@ class ChildResult(NamedTuple):
     offender: TimeoutOffender | None
 
 
+class AuditSummary(NamedTuple):
+    rows: tuple[ChildResult, ...]
+    offenders: tuple[TimeoutOffender, ...]
+
+
 def timeout_offender(*, file: str, timeout_seconds: float) -> TimeoutOffender:
     return TimeoutOffender(file, timeout_seconds)
 
@@ -104,6 +109,24 @@ def _run_child(path: Path, rel: str) -> int:
     return run_production_lift_child(path, rel)
 
 
+def audit_paths(
+    paths: Sequence[Path], *, root: Path, file_timeout: int, workers: int
+) -> AuditSummary:
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        rows = tuple(
+            executor.map(
+                lambda path: _run_isolated(
+                    path, root=root, file_timeout=file_timeout
+                ),
+                sorted(paths),
+            )
+        )
+    return AuditSummary(
+        rows=rows,
+        offenders=tuple(row.offender for row in rows if row.offender is not None),
+    )
+
+
 def main() -> int:
     for stream in (sys.stdout, sys.stderr):
         try:
@@ -122,6 +145,7 @@ def main() -> int:
     )
     parser.add_argument("--child-file", type=Path)
     parser.add_argument("--child-rel")
+    parser.add_argument("--json", type=Path)
     args = parser.parse_args()
     if args.child_file or args.child_rel:
         if args.child_file is None or args.child_rel is None:
@@ -142,16 +166,40 @@ def main() -> int:
     except ValueError as error:
         print(f"TIMEOUT ZERO-TOLERANCE RED: {error}")
         return 1
-    with ThreadPoolExecutor(max_workers=max(1, args.workers)) as executor:
-        rows = list(
-            executor.map(
-                lambda path: _run_isolated(
-                    path, root=args.repo_root, file_timeout=args.file_timeout
-                ),
-                paths,
-            )
+    summary = audit_paths(
+        paths,
+        root=args.repo_root,
+        file_timeout=args.file_timeout,
+        workers=max(1, args.workers),
+    )
+    rows = summary.rows
+    offenders = summary.offenders
+    if args.json is not None:
+        from pandas_floor_summary import floor_summary, relative_files, write_json
+
+        files = relative_files(paths, args.repo_root)
+        payload = floor_summary(
+            floor="timeout",
+            files=files,
+            rows=[
+                {
+                    "file": row.file,
+                    "category": row.category,
+                    "timeoutSeconds": (
+                        row.offender.timeout_seconds if row.offender else None
+                    ),
+                }
+                for row in rows
+            ],
+            totals={
+                "R_timeouts": len(offenders),
+                "completed": sum(row.category == "completed" for row in rows),
+                "nativeCrashes": sum(row.category == "native-crash" for row in rows),
+                "nonNativeRed": sum(row.category == "non-native-red" for row in rows),
+            },
+            measured=True,
         )
-    offenders = tuple(row.offender for row in rows if row.offender is not None)
+        write_json(args.json, payload)
     print(
         "TIMEOUT SURFACE: "
         f"discovered={len(rows)} "

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_floor_summary.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_floor_summary.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+SUMMARY = _load("pandas_floor_summary")
+RECONCILE = _load("reconcile_pandas_floors")
+
+
+def _floor(name: str, *, r: int = 0, measured: bool = True) -> dict:
+    return SUMMARY.floor_summary(
+        floor=name,
+        files=["renamed/pkg/non_vendor.py"],
+        rows=[{"file": "renamed/pkg/non_vendor.py", "category": "completed"}],
+        totals={f"R_{name.replace('-', '_')}": r},
+        measured=measured,
+        unmeasurable_reasons=() if measured else ("planted-terminal",),
+    )
+
+
+def test_five_measured_native_floors_reconcile_on_identical_corpus() -> None:
+    reports = {name: _floor(name) for name in RECONCILE.FLOORS}
+
+    result = RECONCILE.reconcile(reports)
+
+    assert result["measurement"] == "measured"
+    assert result["verdict"] == "green"
+    assert result["errors"] == []
+    assert set(result["floors"]) == set(RECONCILE.FLOORS)
+
+
+def test_absent_floor_is_loud_not_an_implicit_zero() -> None:
+    reports = {name: _floor(name) for name in RECONCILE.FLOORS if name != "silent"}
+
+    result = RECONCILE.reconcile(reports)
+
+    assert result["measurement"] == "unmeasurable"
+    assert "missing floor: silent" in result["errors"]
+
+
+def test_unmeasurable_terminal_is_loud_even_when_reported_r_is_zero() -> None:
+    reports = {name: _floor(name) for name in RECONCILE.FLOORS}
+    reports["silent"] = _floor("silent", r=0, measured=False)
+
+    result = RECONCILE.reconcile(reports)
+
+    assert result["measurement"] == "unmeasurable"
+    assert "silent: measurement is not complete" in result["errors"]
+
+
+def test_measured_nonzero_floor_is_still_a_red_verdict() -> None:
+    reports = {name: _floor(name) for name in RECONCILE.FLOORS}
+    reports["timeout"] = _floor("timeout", r=1)
+
+    result = RECONCILE.reconcile(reports)
+
+    assert result["measurement"] == "measured"
+    assert result["R_total"] == 1
+    assert result["verdict"] == "red"
+
+
+def test_per_site_conservation_rejects_a_lying_summary() -> None:
+    with pytest.raises(ValueError, match="account for every corpus file"):
+        SUMMARY.floor_summary(
+            floor="timeout",
+            files=["renamed/a.py", "renamed/b.py"],
+            rows=[{"file": "renamed/a.py", "category": "completed"}],
+            totals={"R_timeouts": 0},
+            measured=True,
+        )
+
+
+def test_different_corpus_identity_cannot_reconcile() -> None:
+    reports = {name: _floor(name) for name in RECONCILE.FLOORS}
+    reports["timeout"] = SUMMARY.floor_summary(
+        floor="timeout",
+        files=["renamed/other.py"],
+        rows=[{"file": "renamed/other.py", "category": "completed"}],
+        totals={"R_timeouts": 0},
+        measured=True,
+    )
+
+    result = RECONCILE.reconcile(reports)
+
+    assert result["measurement"] == "unmeasurable"
+    assert "five floors do not name one identical corpus manifest" in result["errors"]


### PR DESCRIPTION
Closes #6125

Adds native per-site JSON summaries for silent, native-crash, and timeout floors, gives the existing control-effect and fatal-triage reports the same conserved corpus envelope, and reconciles all five into `validated-summary.json`.

The reconciler distinguishes measured/nonzero from unmeasurable and rejects absent floors, empty corpora, incomplete per-site rows, and corpus-manifest disagreement. Panics/crashes/timeouts remain loud terminal rows.

R axis: makes R_silent, R_native_crashes, and R_timeouts machine-measurable.
Predicted epsilon: measurement-only; no construction R change.
Floors preserved: no panic swallowing; absent measurement is never zero.

Verification: `bin/bpytest -q implementations/python/sugar-lift-py-tests/tests/test_pandas_floor_summary.py implementations/python/sugar-lift-py-tests/tests/test_native_crash_zero_tolerance.py implementations/python/sugar-lift-py-tests/tests/test_timeout_zero_tolerance.py implementations/python/sugar-lift-py-tests/tests/test_silent_zero_tolerance.py --noconftest`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native pandas five-floor census summaries to zero-tolerance audit scripts
> - Adds a new [`pandas_floor_summary.py`](https://github.com/TSavo/sugar/pull/6137/files#diff-20080c9bd7db218747d4a9cf7d36694accc28da99b9e01b62ecdbb3cc81748ba) module that assembles and validates canonical per-file floor summary dicts, computes corpus manifest CIDs, and writes sorted JSON output.
> - Updates `control_effect_recensus.py`, `corpus_fatal_triage.py`, `native_crash_zero_tolerance.py`, `silent_zero_tolerance.py`, and `timeout_zero_tolerance.py` to collect per-file rows and emit a `floorSummary` JSON object (optionally via `--json` flag).
> - Adds [`reconcile_pandas_floors.py`](https://github.com/TSavo/sugar/pull/6137/files#diff-d207b2d96fdb3bee448a2319eaeb4ecfbd25044d76a77ade5f95dd4f6c967a31), a CLI that validates all five floor reports share the same corpus, are all measured, and computes a summed `R_total`; exits nonzero on red verdict or validation errors.
> - Adds [`test_pandas_floor_summary.py`](https://github.com/TSavo/sugar/pull/6137/files#diff-8d411bb57db2ace48f7740c95cd13cd8ffba6466ae1dd1eee016e64c642de471) covering reconciliation success, missing floors, unmeasurable terminals, and corpus identity mismatches.
> - Behavioral Change: `silent_zero_tolerance.py` now exits with code 1 when any file is not `completed`, even if there are no silent offenders.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39bd34c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->