### PR TITLE
fix: Cut C uses sole runtime BindingEntryV1 for actuals and receiver state

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context/reduce_context.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context/reduce_context.py
@@ -32,7 +32,6 @@ class ReduceContext:
     # the attribute crashed the numpy/pandas package audit as unstructured exit=2
     # after opaque body dig started reducing vendor-bridged bodies.
     external_bridge_sink: Any = None
-    binding_coordinate_values: tuple[tuple[str, Any], ...] = ()
 
     @classmethod
     def root(
@@ -66,7 +65,6 @@ class ReduceContext:
             ),
             dig_sink=source.dig_sink,
             external_bridge_sink=getattr(source, "external_bridge_sink", None),
-            binding_coordinate_values=getattr(source, "binding_coordinate_values", ()),
         )
 
     def record_operation(
@@ -103,23 +101,4 @@ class ReduceContext:
             prefer_ground_module_bindings=self.prefer_ground_module_bindings,
             dig_sink=self.dig_sink,
             external_bridge_sink=self.external_bridge_sink,
-            binding_coordinate_values=self.binding_coordinate_values,
-        )
-
-    def with_binding_coordinate_values(self, values) -> "ReduceContext":
-        result = self.with_temporal(self.temporal)
-        result.binding_coordinate_values = tuple(values)
-        return result
-
-    def value_for_binding_coordinate(self, coordinate_cid: str):
-        for candidate, value in reversed(self.binding_coordinate_values):
-            if candidate == coordinate_cid:
-                return value
-        from sugar_source_tree.panic import SugarNotWritten
-
-        raise SugarNotWritten(
-            owner="ReduceContext.value_for_binding_coordinate",
-            observed=coordinate_cid,
-            requested="an authenticated formal-to-actual binding",
-            fix="bind the exact call occurrence before reducing its source body",
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -991,9 +991,7 @@ class CallSiteValue(FloorValue):
             return None
         from sugar_lift_py_tests.outcome import Incomplete, complete_value
 
-        reduce_ctx = _ctx_with_curried_args(
-            ctx, self.parameters, self.arg_values, self.formal_coordinate_cids
-        )
+        reduce_ctx = _ctx_with_curried_args(ctx, self.parameters, self.arg_values)
         active_demand = _ACTIVE_DIG_DEMAND.get()
         nested_budget = min(budget, _NESTED_DIG_DEMAND_BUDGET)
         if active_demand >= nested_budget:
@@ -1083,9 +1081,7 @@ class CallSiteValue(FloorValue):
             )
         from sugar_lift_py_tests.outcome import Incomplete, complete_value
 
-        reduce_ctx = _ctx_with_curried_args(
-            ctx, self.parameters, self.arg_values, self.formal_coordinate_cids
-        )
+        reduce_ctx = _ctx_with_curried_args(ctx, self.parameters, self.arg_values)
         outcome = _reduce_callsite_body(body, reduce_ctx, blame=self.target_name)
         if isinstance(outcome, Incomplete):
             _force_floor_gap(
@@ -1259,7 +1255,6 @@ def _ctx_with_curried_args(
     ctx: Any,
     parameters: tuple[str, ...],
     arg_values: tuple[FloorValue, ...],
-    formal_coordinate_cids: tuple[str, ...] = (),
 ):
     from sugar_lift_py_tests.temporal import curry_temporal
 
@@ -1270,10 +1265,4 @@ def _ctx_with_curried_args(
         owner="CallSiteValue.force_floor",
         blame="<callsite>",
     )
-    if formal_coordinate_cids:
-        if len(formal_coordinate_cids) != len(arg_values):
-            return result
-        result = result.with_binding_coordinate_values(
-            zip(formal_coordinate_cids, arg_values, strict=True)
-        )
     return result

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -32,43 +32,26 @@ class ClassDefinitionValue(FloorValue):
             symbol_kind="coordinate",
         )
 
-    def construct_receiver_state(self, actuals: tuple[object, ...]):
+    def construct_receiver_state_from_block(self, block, receiver_coordinate_cid):
         from sugar_lift_py_tests.floor import (
-            CallSiteValue,
             ObjectField,
             ObjectValue,
             ReceiverFieldStoreValue,
         )
         from sugar_lift_py_tests.ir import _term_content_cid, ctor, str_const
 
-        receiver = ObjectValue(self.class_name, (), identity=self.class_definition_cid)
-        if self.initializer is None:
+        receiver = ObjectValue(
+            self.class_name,
+            (),
+            identity=receiver_coordinate_cid or self.class_definition_cid,
+        )
+        if block is None:
             return receiver
-        frame = self.initializer.source_call_frame
-        values = (receiver, *actuals)
-        call = CallSiteValue(
-            target_name="python:source-class-init",
-            arg_values=values,
-            parameters=frame.parameters,
-            term=ctor(
-                "python:source-class-init",
-                [str_const(self.class_definition_cid)],
-                symbol_kind="coordinate",
-            ),
-            body=frame.body,
-            source_call_frame_cid=frame.frame_cid,
-            formal_coordinate_cids=tuple(item.cid for item in frame.formal_coordinates),
-        )
-        block = call.force_floor(
-            None,
-            owner="ClassDefinitionValue.construct_receiver_state",
-            project_callsite=False,
-        )
         fields: dict[str, object] = {}
         for statement in block.statements:
             if not isinstance(statement, ReceiverFieldStoreValue):
                 continue
-            if statement.receiver != receiver:
+            if statement.receiver.identity != receiver.identity:
                 raise SugarNotWritten(
                     owner="ClassDefinitionValue.construct_receiver_state",
                     observed="receiver coordinate mismatch",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from sugar_lift_python_source.canonical import cid_of_json
 from sugar_source_tree.binding_provenance import BindingCoordinateV1
+from sugar_source_tree.binding_provenance import BoundBindingStateV1
+from sugar_source_tree.binding_state import BindingEntryV1
 
 from .context_manager_resolution import SourceFragmentCoordinateV1
 
@@ -18,9 +20,14 @@ class SourceVisibleCallFrameV1:
     formal_coordinates: tuple[BindingCoordinateV1, ...]
     parameter_kinds: tuple[str, ...]
     default_sugars: tuple[object | None, ...] = field(compare=False)
+    default_nodes: tuple[object | None, ...] = field(compare=False)
     default_fragments: tuple[object | None, ...] = field(compare=False)
     default_fragment_cids: tuple[str | None, ...]
     body: object = field(compare=False)
+    owner: object = field(compare=False, repr=False)
+    runtime_entries: tuple[BindingEntryV1, ...] = field(
+        default=(), compare=False, repr=False
+    )
     frame_cid: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -89,6 +96,123 @@ class SourceVisibleCallFrameV1:
         if remaining or named:
             raise SourceCallBindingGap("unconsumed call actual")
         return tuple(bound)
+
+    def bind_node_actuals(
+        self,
+        positional: tuple,
+        keywords: tuple,
+        testimonies: tuple[object | None, ...] | None = None,
+    ) -> "SourceVisibleCallFrameV1":
+        """Substitute real typed actual Nodes before constructing body Sugars."""
+        remaining = list(positional)
+        named = dict(keywords)
+        if len(named) != len(keywords):
+            raise SourceCallBindingGap("duplicate keyword actual")
+        bound = []
+        for index, (name, kind, default) in enumerate(
+            zip(
+                self.parameters,
+                self.parameter_kinds,
+                self.default_nodes,
+                strict=True,
+            )
+        ):
+            if kind == "vararg":
+                bound.append(self._tuple_node(tuple(remaining)))
+                remaining.clear()
+                continue
+            if kind == "kwarg":
+                bound.append(self._dict_node(tuple(named.items())))
+                named.clear()
+                continue
+            value = None
+            present = False
+            if kind in {"positional_only", "positional_or_keyword"} and remaining:
+                value = remaining.pop(0)
+                present = True
+                if name in named:
+                    raise SourceCallBindingGap("formal received positional and keyword")
+            elif kind != "positional_only" and name in named:
+                value = named.pop(name)
+                present = True
+            if not present and default is not None:
+                value = default
+                present = True
+            if not present:
+                raise SourceCallBindingGap(f"missing required formal {index}")
+            bound.append(value)
+        if remaining or named:
+            raise SourceCallBindingGap("unconsumed call actual")
+
+        supplied_testimonies = testimonies or (None,) * len(bound)
+        if len(supplied_testimonies) != len(bound):
+            raise SourceCallBindingGap("formal testimony arity mismatch")
+        entries = tuple(
+            BindingEntryV1(
+                coordinate,
+                node,
+                BoundBindingStateV1(testimony),
+            )
+            for coordinate, node, testimony in zip(
+                self.formal_coordinates, bound, supplied_testimonies, strict=True
+            )
+        )
+        scope = dict(zip(self.parameters, entries, strict=True))
+        body = self.owner._source_visible_body(scope)
+        return replace(self, body=body, runtime_entries=entries)
+
+    def _tuple_node(self, values: tuple):
+        from sugar_source_tree.backend import Children, materialize
+        from sugar_source_tree.shadow import ShadowNode, _handle_of
+
+        return materialize(
+            self.owner.unit,
+            ShadowNode(
+                "Tuple",
+                self.owner.span,
+                (("elts", Children(tuple(_handle_of(value) for value in values))),),
+            ),
+            self.owner.reporter,
+        )
+
+    def _dict_node(self, values: tuple[tuple[str, object], ...]):
+        from sugar_source_tree.backend import Child, Children, Leaf, materialize
+        from sugar_source_tree.shadow import ShadowNode, _handle_of
+
+        items = []
+        for key, value in values:
+            key_node = materialize(
+                self.owner.unit,
+                ShadowNode(
+                    "Constant",
+                    self.owner.span,
+                    (("value", Leaf(key)),),
+                ),
+                self.owner.reporter,
+            )
+            items.append(
+                materialize(
+                    self.owner.unit,
+                    ShadowNode(
+                        "DictItem",
+                        self.owner.span,
+                        (
+                            ("key", Child(_handle_of(key_node))),
+                            ("value", Child(_handle_of(value))),
+                        ),
+                    ),
+                    self.owner.reporter,
+                )
+            )
+        return materialize(
+            self.owner.unit,
+            ShadowNode(
+                "Dict",
+                self.owner.span,
+                (("items", Children(tuple(_handle_of(item) for item in items))),),
+            ),
+            self.owner.reporter,
+        )
 
 
 class SourceCallBindingGap(ValueError):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binding_coordinate_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binding_coordinate_ref_sugar.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.outcome import Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 
 
@@ -22,13 +22,11 @@ class BindingCoordinateRefSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        if ctx is None:
-            from sugar_source_tree.panic import SugarNotWritten
+        from sugar_source_tree.panic import SugarNotWritten
 
-            raise SugarNotWritten(
-                owner="BindingCoordinateRefSugar.desugar",
-                observed="missing source-call binding frame",
-                requested="the exact constructed actual for this BindingCoordinateV1",
-                fix="reduce the source body through its authenticated call frame",
-            )
-        return Complete(ctx.value_for_binding_coordinate(self.coordinate.cid))
+        raise SugarNotWritten(
+            owner="BindingCoordinateRefSugar.desugar",
+            observed="unspecialized source-call formal",
+            requested="runtime BindingEntryV1 substitution before Sugar construction",
+            fix="bind the exact typed actual Node through SourceVisibleCallFrameV1",
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -140,13 +140,7 @@ class CallSiteSugar(Sugar):
                 site=self.site,
                 exception_type_coordinate=self.exception_type_coordinate,
                 source_call_frame_cid=source_frame_cid,
-                formal_coordinate_cids=(
-                    tuple(
-                        item.cid for item in self.source_call_frame.formal_coordinates
-                    )
-                    if self.source_call_frame is not None
-                    else ()
-                ),
+                formal_coordinate_cids=(),
             )
         )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_constructor_body_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_constructor_body_sugar.py
@@ -9,7 +9,8 @@ from sugar_lift_py_tests.sugar.sugar_base import Sugar
 @dataclass(frozen=True)
 class ClassConstructorBodySugar(Sugar):
     definition: Sugar
-    formal_coordinates: tuple[object, ...]
+    initializer_body: Sugar | None
+    receiver_coordinate_cid: str | None
     site: object = field(compare=False)
 
     @classmethod
@@ -23,19 +24,36 @@ class ClassConstructorBodySugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        if ctx is None:
-            from sugar_source_tree.panic import SugarNotWritten
+        def construct(value):
+            if self.initializer_body is None:
+                return Complete(
+                    value.construct_receiver_state_from_block(
+                        None, self.receiver_coordinate_cid
+                    )
+                )
+            from sugar_lift_py_tests.floor import CallSiteValue
+            from sugar_lift_py_tests.ir import ctor, str_const
 
-            raise SugarNotWritten(
-                owner="ClassConstructorBodySugar.desugar",
-                observed="missing source-call binding frame",
-                requested="coordinate-bound class constructor actuals",
-                fix="reduce the class call through its SourceVisibleCallFrameV1",
+            call = CallSiteValue(
+                target_name="python:source-class-init",
+                arg_values=(),
+                parameters=(),
+                term=ctor(
+                    "python:source-class-init",
+                    [str_const(value.class_definition_cid)],
+                    symbol_kind="coordinate",
+                ),
+                body=self.initializer_body,
             )
-        actuals = tuple(
-            ctx.value_for_binding_coordinate(item.cid)
-            for item in self.formal_coordinates
-        )
-        return self.definition.desugar(ctx).and_then(
-            lambda value: Complete(value.construct_receiver_state(actuals))
-        )
+            block = call.force_floor(
+                ctx,
+                owner="ClassConstructorBodySugar.desugar",
+                project_callsite=False,
+            )
+            return Complete(
+                value.construct_receiver_state_from_block(
+                    block, self.receiver_coordinate_cid
+                )
+            )
+
+        return self.definition.desugar(ctx).and_then(construct)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
@@ -28,9 +28,9 @@ class ClassDefinitionSugar(Sugar):
             reason="class structure is source testimony, not a proposition",
         )
 
-    def desugar(self, ctx: object = None) -> Outcome:
-        del ctx
-        preimage = {
+    @property
+    def preimage(self):
+        return {
             "kind": "python-class-definition",
             "schemaVersion": "1",
             "sourceIdentityCid": self.source_identity_cid,
@@ -44,13 +44,20 @@ class ClassDefinitionSugar(Sugar):
                 for method in self.methods
             ],
         }
+
+    @property
+    def class_definition_cid(self) -> str:
+        return cid_of_json(self.preimage)
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
         initializer = next(
             (method for method in self.methods if method.name == "__init__"), None
         )
         return Complete(
             ClassDefinitionValue(
                 self.class_name,
-                cid_of_json(preimage),
+                self.class_definition_cid,
                 self.methods,
                 initializer,
             )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructed_receiver_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructed_receiver_ref_sugar.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.floor import ObjectValue
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class ConstructedReceiverRefSugar(Sugar):
+    class_name: str
+    binding_coordinate_cid: str
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="ObjectValue",
+            reason="a class call constructs its receiver from the authenticated class definition",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        return Complete(
+            ObjectValue(self.class_name, (), identity=self.binding_coordinate_cid)
+        )

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -15,10 +15,9 @@ from sugar_lift_py_tests.floor import (
 )
 from sugar_lift_py_tests.ir import _term_content_cid, ctor
 from sugar_source_tree.binding_provenance import (
-    BindingEntryV1,
-    BoundBindingStateV1,
     ConstructedValueTestimonyV1,
 )
+from sugar_source_tree.binding_state import BindingEntryV1
 from sugar_source_tree.nodes import Call, ClassDef, FunctionDef, Name, Node
 from sugar_source_tree.tree import SourceFile
 from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
@@ -29,6 +28,7 @@ from .dependency_artifact import DependencyArtifactGraph, ResolvedPythonObjectV1
 
 @dataclass(frozen=True)
 class ConstructedCallActualV1:
+    node: Node = field(compare=False)
     value: FloorValue = field(compare=False)
     testimony: ConstructedValueTestimonyV1
 
@@ -170,6 +170,14 @@ def construct_manager_behavior(
             tuple(item.value for item in actuals),
             tuple((name, item.value) for name, item in keyword_actuals),
         )
+        frame = frame.bind_node_actuals(
+            tuple(item.node for item in actuals),
+            tuple((name, item.node) for name, item in keyword_actuals),
+            testimonies=tuple(
+                item.testimony
+                for item in (*actuals, *(item for _, item in keyword_actuals))
+            ),
+        )
     except SourceCallBindingGap as exc:
         return ManagerConstructionGapV1("call-binding", resolved.cid, str(exc))
     call = CallSiteValue(
@@ -183,7 +191,7 @@ def construct_manager_behavior(
         ),
         body=frame.body,
         source_call_frame_cid=frame.frame_cid,
-        formal_coordinate_cids=tuple(item.cid for item in frame.formal_coordinates),
+        formal_coordinate_cids=(),
     )
     result = call.force_floor(
         None, owner="construct_manager_behavior", project_callsite=False
@@ -204,32 +212,7 @@ def construct_manager_behavior(
         return ManagerConstructionGapV1(
             "non-manager-result", resolved.cid, type(result).__name__
         )
-    original_actuals = (*actuals, *(item for _, item in keyword_actuals))
-    used: set[int] = set()
-    bindings = []
-    for index, (coordinate, value) in enumerate(
-        zip(frame.formal_coordinates, values, strict=True)
-    ):
-        testimony = None
-        for actual_index, actual in enumerate(original_actuals):
-            if actual_index not in used and actual.value is value:
-                testimony = actual.testimony
-                used.add(actual_index)
-                break
-        if testimony is None:
-            fragment = frame.default_fragments[index]
-            if fragment is None and frame.parameter_kinds[index] in {"vararg", "kwarg"}:
-                fragment = call_site
-            if fragment is None:
-                return ManagerConstructionGapV1(
-                    "call-binding", resolved.cid, "constructed binding testimony absent"
-                )
-            testimony = ConstructedValueTestimonyV1.mint(
-                fragment,
-                _term_content_cid(value.to_term(owner=resolved.cid)),
-            )
-        bindings.append(BindingEntryV1(coordinate, BoundBindingStateV1(testimony)))
-    bindings = tuple(bindings)
+    bindings = frame.runtime_entries
     preimage = {
         "kind": "constructed-manager-behavior",
         "schemaVersion": "1",

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -19,6 +19,7 @@ from sugar_lift_python_source.manager_construction import (
     construct_manager_behavior,
 )
 from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
+from sugar_source_tree.binding_state import BindingEntryV1
 from sugar_source_tree.nodes import Call, Constant
 from sugar_source_tree.tree import SourceFile
 
@@ -68,7 +69,12 @@ def _resolved(root: Path, source: str):
     testimony = ConstructedValueTestimonyV1.mint(
         literal.fragment, _term_content_cid(actual.to_term(owner="test"))
     )
-    return graph, resolved, ConstructedCallActualV1(actual, testimony), call.fragment
+    return (
+        graph,
+        resolved,
+        ConstructedCallActualV1(literal, actual, testimony),
+        call.fragment,
+    )
 
 
 def test_renamed_factory_constructs_returned_receiver_state_through_one_door(tmp_path):
@@ -88,7 +94,11 @@ def test_renamed_factory_constructs_returned_receiver_state_through_one_door(tmp
     assert isinstance(result, ConstructedManagerBehaviorV1)
     fields = {field.name: field.value for field in result.receiver_state.fields}
     assert fields == {"expected": actual.value}
-    assert result.formal_actual_bindings[0].coordinate.projection_path == ("formal", 0)
+    entry = result.formal_actual_bindings[0]
+    assert isinstance(entry, BindingEntryV1)
+    assert entry.state is actual.node
+    assert entry.coordinate.projection_path == ("formal", 0)
+    assert "node" not in repr(entry.wire()).lower()
     assert result.manager_construction_cid.startswith("blake3-512:")
 
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1282,6 +1282,7 @@ class FunctionDef(Statement):
                 param.default.sugar() if param.default is not None else None
                 for param in self.params
             ),
+            default_nodes=tuple(param.default for param in self.params),
             default_fragments=tuple(
                 param.default.fragment if param.default is not None else None
                 for param in self.params
@@ -1291,6 +1292,17 @@ class FunctionDef(Statement):
                 for param in self.params
             ),
             body=body,
+            owner=self,
+        )
+
+    def _source_visible_body(self, scope):
+        from sugar_lift_py_tests.sugar.source_visible_function_body_sugar import (
+            SourceVisibleFunctionBodySugar,
+        )
+
+        substituted_body, _ = self._substitute_body(self.body, scope)
+        return SourceVisibleFunctionBodySugar(
+            tuple(statement.sugar() for statement in substituted_body), self.fragment
         )
 
     def _make_coordinate_ref(self, param: "Param", coordinate) -> "Node":
@@ -1573,6 +1585,7 @@ class ClassDef(Statement):
                 param.default.sugar() if param.default is not None else None
                 for param in params
             ),
+            default_nodes=tuple(param.default for param in params),
             default_fragments=tuple(
                 param.default.fragment if param.default is not None else None
                 for param in params
@@ -1583,9 +1596,71 @@ class ClassDef(Statement):
             ),
             body=ClassConstructorBodySugar(
                 definition=self.sugar(),
-                formal_coordinates=coordinates,
+                initializer_body=None,
+                receiver_coordinate_cid=None,
                 site=self.fragment,
             ),
+            owner=self,
+        )
+
+    def _source_visible_body(self, scope):
+        from sugar_lift_py_tests.sugar.class_constructor_body_sugar import (
+            ClassConstructorBodySugar,
+        )
+        from sugar_source_tree.binding_provenance import (
+            BindingCoordinateV1,
+            BoundBindingStateV1,
+        )
+        from sugar_source_tree.binding_state import BindingEntryV1
+
+        initializer = next(
+            (
+                item
+                for item in self.body
+                if isinstance(item, FunctionDef) and item.name == "__init__"
+            ),
+            None,
+        )
+        initializer_body = None
+        receiver_coordinate_cid = None
+        if initializer is not None:
+            receiver_param = initializer.params[0]
+            coordinate = BindingCoordinateV1.mint(
+                self.fragment.seal().cid,
+                receiver_param.fragment,
+                ("receiver", 0),
+            )
+            receiver = self._make_constructed_receiver_ref(coordinate.cid)
+            receiver_coordinate_cid = coordinate.cid
+            initializer_scope = {
+                receiver_param.name: BindingEntryV1(
+                    coordinate, receiver, BoundBindingStateV1(None)
+                ),
+                **scope,
+            }
+            initializer_body = initializer._source_visible_body(initializer_scope)
+        return ClassConstructorBodySugar(
+            definition=self.sugar(),
+            initializer_body=initializer_body,
+            receiver_coordinate_cid=receiver_coordinate_cid,
+            site=self.fragment,
+        )
+
+    def _make_constructed_receiver_ref(self, receiver_coordinate_cid):
+        from .backend import Leaf, materialize
+        from .shadow import ShadowNode
+
+        return materialize(
+            self.unit,
+            ShadowNode(
+                "ConstructedReceiverRef",
+                self.span,
+                (
+                    ("class_name", Leaf(self.name)),
+                    ("binding_coordinate_cid", Leaf(receiver_coordinate_cid)),
+                ),
+            ),
+            self.reporter,
         )
 
 
@@ -1791,7 +1866,10 @@ class Assign(Statement):
             )
 
         if len(self.targets) == 1 and isinstance(self.targets[0], Attribute):
-            if isinstance(self.targets[0].value, BindingCoordinateRef):
+            if isinstance(
+                self.targets[0].value,
+                (BindingCoordinateRef, ConstructedReceiverRef),
+            ):
                 from sugar_lift_py_tests.sugar.receiver_field_store_sugar import (
                     ReceiverFieldStoreSugar,
                 )
@@ -4481,6 +4559,23 @@ class Call(Expression):
                     span.end_col,
                 )
                 source_call_frame = context.source_call_frames.get(coordinate)
+                if source_call_frame is not None:
+                    from sugar_lift_py_tests.source_call_frame import (
+                        SourceCallBindingGap,
+                    )
+
+                    if any(keyword.arg is None for keyword in self.keywords):
+                        raise SourceCallBindingGap(
+                            "spread keyword requires typed variadic projection"
+                        )
+                    source_call_frame = source_call_frame.bind_node_actuals(
+                        self.args,
+                        tuple(
+                            (keyword.arg, keyword.value)
+                            for keyword in self.keywords
+                            if keyword.arg is not None
+                        ),
+                    )
 
             return CallSiteSugar(
                 target_name=self.func.id,
@@ -4776,6 +4871,25 @@ class BindingCoordinateRef(Expression):
         )
 
         return BindingCoordinateRefSugar(self.coordinate, self.fragment)
+
+
+class ConstructedReceiverRef(Expression):
+    """Typed projection of the receiver constructed by this exact class call."""
+
+    class_name: str
+    binding_coordinate_cid: str
+
+    def substitute(self, scope):
+        return self
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.constructed_receiver_ref_sugar import (
+            ConstructedReceiverRefSugar,
+        )
+
+        return ConstructedReceiverRefSugar(
+            self.class_name, self.binding_coordinate_cid, self.fragment
+        )
 
 
 class BranchResultRef(Expression):

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -56,7 +56,7 @@ def test_source_visible_zero_parameter_call_carries_the_ordinary_body() -> None:
 
     assert isinstance(outcome, Complete)
     assert isinstance(outcome.value, CallSiteValue)
-    assert outcome.value.body is frame.body
+    assert outcome.value.body == frame.body
     assert outcome.value.parameters == ()
     assert frame.frame_cid.startswith("blake3-512:")
     constructed = outcome.value.force_floor(
@@ -98,14 +98,21 @@ def test_parameterized_source_frame_projects_the_exact_actual_by_coordinate() ->
 def test_class_definition_constructs_methods_but_receiver_state_awaits_coordinate() -> (
     None
 ):
+    context = TreeConstructionContextV1.for_source_call_construction()
     source = _source_file(
         "class RenamedGuard:\n"
         "    def __init__(self, expected):\n"
         "        self.expected = expected\n\n"
         "    def enter(self):\n"
-        "        return self\n"
+        "        return self\n\n"
+        "RenamedGuard(11)\n",
+        context=context,
     )
     class_node = next(node for node in source.nodes() if isinstance(node, ClassDef))
+    call = next(node for node in source.nodes() if isinstance(node, Call))
+    context.source_call_frames[_coordinate(call)] = (
+        class_node.source_visible_constructor_frame()
+    )
 
     outcome = class_node.sugar().desugar()
 
@@ -117,7 +124,9 @@ def test_class_definition_constructs_methods_but_receiver_state_awaits_coordinat
     )
     assert outcome.value.initializer is not None
     assert outcome.value.class_definition_cid.startswith("blake3-512:")
-    receiver = outcome.value.construct_receiver_state((TermValue(11),))
+    receiver = call.sugar().desugar().value.force_floor(
+        None, owner="typed-class-call", project_callsite=False
+    )
 
     assert receiver.class_name == "RenamedGuard"
     assert {field.name: field.value for field in receiver.fields} == {


### PR DESCRIPTION
## Fix-forward after #6127

#6127's sole-constructor direction is retained. This removes its temporary second temporal model and wires the now-landed runtime binding carrier:

- formal actuals are exact typed Nodes held by runtime `BindingEntryV1`;
- constructed testimony seals each formal entry; manager CID preimages consume only `entry.wire()`;
- `ReduceContext.binding_coordinate_values` and its lookup API are deleted;
- source-call bodies substitute runtime entries before Sugar construction;
- receiver identity rides a `BindingCoordinateV1` through a typed receiver projection and ordinary initializer Sugar body;
- `TreeConstructionContextV1` remains the explicit construction-context boundary from the merged correction.

No Node handle enters the sealed wire. Unknown/unspecialized formals remain typed-loud.

## Evidence

Focused Python: `11 passed`.

Construction invariant:

```
R_construction_invariant_violations = 0
R_self_hashing_as_authority = 0
R_name_spelling_overload_gate = 0
R_second_construction_path = 0
R_non_exhaustive_variant_coverage = 0
R_fabricated_completion_fallback = 0
R_auditor_errors = 0
```

Side-door floor on current main and this head: no increase; head is:

```
R_construction_side_doors = 6
R_sole_path_construction_side_doors = 0
R_foreign_ast_import = 3
R_ast_semantic_above_adapter = 3
auditor_errors = 0
```

Full source-tree sweep before the final main rebase: `389 passed, 5 skipped`, plus the pre-existing pinned golden corpus mismatch.

Rust closed-wire round trip on battleaxe:

```
test result: ok. 3 passed; 0 failed
```

Do not merge without architect confirmation.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace runtime binding coordinate context with node-level binding in call frame and class constructor
> - `SourceVisibleCallFrameV1` gains `bind_node_actuals`, which produces `BindingEntryV1` entries pairing formal coordinates with actual AST nodes and stores them as `runtime_entries` on the frame, replacing post-hoc reconstruction of formal-actual bindings.
> - `ClassDef._source_visible_body` now specializes the constructor body with a typed receiver reference tied to a minted `BindingCoordinateV1`, enabling receiver-field store recognition during sugar construction.
> - `ConstructedReceiverRef` is a new AST node that desugars to `ConstructedReceiverRefSugar`, representing the typed projection of a constructed receiver during initializer body specialization.
> - `BindingCoordinateRefSugar.desugar` now always raises `SugarNotWritten`; binding coordinate substitution must happen before sugar construction rather than at desugar time via context lookup.
> - `ReduceContext` no longer carries binding coordinate values, and `_ctx_with_curried_args` no longer injects them; callers that previously relied on `value_for_binding_coordinate` or `with_binding_coordinate_values` will break.
> - Risk: Removes `formal_coordinate_cids` threading through `CallSiteValue` and `CallSiteSugar`; any code path that previously depended on context-carried binding coordinates will now error at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d652f49.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->