### PR TITLE
Drain source_oracle/source_tables dual-body AST cancer

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py
@@ -20,7 +20,6 @@
 
 from __future__ import annotations
 
-import ast
 import importlib.machinery
 import os
 import sys
@@ -28,6 +27,7 @@ from collections import OrderedDict
 from pathlib import Path
 from typing import Any
 
+from . import typed_node_api as typed
 from .ast_template import (
     expr_to_template,
     function_param_names,
@@ -35,7 +35,7 @@ from .ast_template import (
 )
 from .bind_lifter import _body_source_locator
 from .canonical import blake3_512_of, template_cid_of_json
-from .source_tables import parsed_tree, source_segment, source_splitlines
+from .source_tables import source_segment, source_splitlines
 
 
 def _source_file_cls():
@@ -261,12 +261,18 @@ def resolve_source_memento(
         source = path.read_text(encoding="utf-8")
     except OSError as exc:
         raise SourceUnavailable(f"cannot read source `{path}`: {exc}") from exc
+
+    source_cid = blake3_512_of(source.encode("utf-8"))
+    # SourceFile / typed Nodes are the sole recompute path: locate, body text,
+    # and template projection all speak typed currency (bind_lifter/ast_template
+    # already drain onto typed Nodes).
+    SourceFile, BackendCouldNotParse = _source_file_cls()
     try:
-        tree = parsed_tree(source, filename=str(path))
-    except SyntaxError as exc:
+        source_file = SourceFile((source, str(path), source_cid))
+    except (SyntaxError, BackendCouldNotParse, UnicodeError, ValueError) as exc:
         raise SourceUnavailable(f"cannot parse source `{path}`: {exc}") from exc
 
-    node = _locate_function(tree, function_name, span)
+    node = _locate_function(source_file, function_name, span)
     if node is None:
         raise SourceUnavailable(
             f"source function `{function_name}` not found in `{file}` near line "
@@ -316,13 +322,76 @@ def resolve_source_memento(
     }
 
 
+def _span_of(node: typed.AST) -> dict[str, int]:
+    return {
+        "start_line": node.lineno,
+        "start_col": node.col_offset,
+        "end_line": node.end_lineno,
+        "end_col": node.end_col_offset,
+    }
+
+
+def _locate_function(
+    source_file: Any,
+    function_name: Any,
+    span: dict[str, Any],
+) -> typed.FunctionDef | typed.AsyncFunctionDef | None:
+    """Find the typed FunctionDef matching the memento's name (and span)."""
+    start = span.get("start_line")
+    function_leaf = (
+        function_name.rsplit(".", 1)[-1] if isinstance(function_name, str) else None
+    )
+    matches = [
+        n
+        for n in source_file.functions()
+        if isinstance(n, (typed.FunctionDef, typed.AsyncFunctionDef))
+        and (
+            function_name is None or n.name == function_name or n.name == function_leaf
+        )
+    ]
+    if not matches:
+        return None
+    if isinstance(start, int) and len(matches) > 1:
+        for n in matches:
+            n_start = min((d.lineno for d in n.decorators), default=n.lineno)
+            if n_start <= start <= (n.end_lineno or n.lineno):
+                return n
+    return matches[0]
+
+
+def _locate_spanned_node(
+    fn: typed.FunctionDef | typed.AsyncFunctionDef,
+    span: dict[str, Any],
+    source_kind: str,
+) -> typed.AST | None:
+    if source_kind == "python.ast-stmt":
+        node_type: type = typed.stmt
+    elif source_kind == "python.ast-expr":
+        node_type = typed.expr
+    else:
+        return None
+    wanted = {
+        "start_line": span.get("start_line"),
+        "start_col": span.get("start_col"),
+        "end_line": span.get("end_line"),
+        "end_col": span.get("end_col"),
+    }
+    for node in fn.walk():
+        if not isinstance(node, node_type):
+            continue
+        if _span_of(node) == wanted:
+            return node
+    return None
+
+
 def _node_source_locator(
-    fn: ast.FunctionDef | ast.AsyncFunctionDef,
+    fn: typed.FunctionDef | typed.AsyncFunctionDef,
     rel_path: str,
     source: str,
     span: dict[str, Any],
     source_kind: str,
 ) -> dict[str, Any]:
+    """Statement/expression recompute through typed Nodes only."""
     node = _locate_spanned_node(fn, span, source_kind)
     if node is None:
         raise SourceUnavailable(
@@ -335,9 +404,9 @@ def _node_source_locator(
             f"{source_kind} source node in `{rel_path}` had no source segment"
         )
     params = function_param_names(fn)
-    if isinstance(node, ast.stmt):
+    if isinstance(node, typed.stmt):
         ast_template = stmt_to_template(node, params)
-    elif isinstance(node, ast.expr):
+    elif isinstance(node, typed.expr):
         ast_template = expr_to_template(node, params)
     else:
         raise SourceUnavailable(f"unsupported source node kind `{type(node).__name__}`")
@@ -349,40 +418,6 @@ def _node_source_locator(
         "param_names": params,
         "ast_template": ast_template,
         "body_text": body_text,
-    }
-
-
-def _locate_spanned_node(
-    fn: ast.FunctionDef | ast.AsyncFunctionDef,
-    span: dict[str, Any],
-    source_kind: str,
-) -> ast.AST | None:
-    node_type: type[ast.AST]
-    if source_kind == "python.ast-stmt":
-        node_type = ast.stmt
-    elif source_kind == "python.ast-expr":
-        node_type = ast.expr
-    else:
-        return None
-    for node in ast.walk(fn):
-        if not isinstance(node, node_type):
-            continue
-        if _span_of(node) == {
-            "start_line": span.get("start_line"),
-            "start_col": span.get("start_col"),
-            "end_line": span.get("end_line"),
-            "end_col": span.get("end_col"),
-        }:
-            return node
-    return None
-
-
-def _span_of(node: ast.AST) -> dict[str, int]:
-    return {
-        "start_line": getattr(node, "lineno"),
-        "start_col": getattr(node, "col_offset"),
-        "end_line": getattr(node, "end_lineno"),
-        "end_col": getattr(node, "end_col_offset"),
     }
 
 
@@ -451,29 +486,4 @@ def importlib_library_dir(library_tag: str) -> str | None:
     return str(Path(origin).parent) if origin else None
 
 
-def _locate_function(
-    tree: ast.AST,
-    function_name: Any,
-    span: dict[str, Any],
-) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
-    """Find the FunctionDef matching the memento's name (and span when ambiguous)."""
-    start = span.get("start_line")
-    function_leaf = (
-        function_name.rsplit(".", 1)[-1] if isinstance(function_name, str) else None
-    )
-    matches = [
-        n
-        for n in ast.walk(tree)
-        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
-        and (
-            function_name is None or n.name == function_name or n.name == function_leaf
-        )
-    ]
-    if not matches:
-        return None
-    if isinstance(start, int) and len(matches) > 1:
-        for n in matches:
-            n_start = min((d.lineno for d in n.decorator_list), default=n.lineno)
-            if n_start <= start <= (n.end_lineno or n.lineno):
-                return n
-    return matches[0]
+

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_tables.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_tables.py
@@ -1,15 +1,17 @@
-"""The one API for reading source text through the AST: table-backed, idempotent.
+"""The one API for reading source text through line tables: table-backed, idempotent.
 
-Every consumer that needs a node's source segment, a module's line table, or a
-parsed tree goes through these functions. Each is an idempotent recompute keyed
-by the source CONTENT, so behind the scenes it is a build-once in-memory table
-and an O(1) lookup on every subsequent request -- callers never know different.
+Every consumer that needs a node's source segment or a module's line table goes
+through these functions. Each is an idempotent recompute keyed by the source
+CONTENT, so behind the scenes it is a build-once in-memory table and an O(1)
+lookup on every subsequent request -- callers never know different.
 Keying by content (never by path) preserves drift semantics exactly: changed
 source is a new key and recomputes; identical source never re-derives.
 
-`ast.get_source_segment` re-splits the entire source on every call and callers
-that re-`ast.parse` per query are quadratic across a module's nodes; these
-tables are why neither ever appears outside this module.
+Stdlib parse / foreign AST currency does NOT live here. Residual dual-body
+consumers that still need a content-keyed ``ast.Module`` enter through
+``source_tables_adapter.parsed_tree``. Production construction enters through
+``SourceFile`` / typed Nodes. Parent maps, locus indexes, and symtable caches
+that had no production callers were deleted rather than rewritten.
 
 Process-lifetime bound: tables use a finite LRU (SOURCE_TABLE_CAPACITY), not
 `maxsize=None`. A resident lift generation walks many modules; unbounded
@@ -21,8 +23,13 @@ docs/analysis/ci-whack-a-mole-course-2026-07-15.md.
 
 from __future__ import annotations
 
-import ast
 import functools
+import re
+from typing import Any, Protocol
+
+# Re-export residual dual parse for callers that still pin it; the adapter
+# owns the foreign ``ast`` import so this module stays construction-clean.
+from .source_tables_adapter import SOURCE_TABLE_CAPACITY, parsed_tree
 
 __all__ = [
     "SOURCE_TABLE_CAPACITY",
@@ -32,9 +39,20 @@ __all__ = [
     "source_splitlines",
 ]
 
-# Align with install-source index capacity (install_source_dig): hot working
-# set of modules in one generation, not the whole corpus forever.
-SOURCE_TABLE_CAPACITY = 64
+
+# Mirror of CPython ``ast._splitlines_no_ff``: form feeds do not break lines,
+# so offsets agree with parser node positions. Kept local so this module never
+# imports foreign ``ast`` currency.
+_LINE_PATTERN = re.compile(r"(.*?(?:\r\n|\n|\r|$))")
+
+
+class _Positioned(Protocol):
+    """Duck shape for source-segment lookup — typed Node or residual dual AST."""
+
+    lineno: int
+    col_offset: int
+    end_lineno: int | None
+    end_col_offset: int | None
 
 
 @functools.lru_cache(maxsize=SOURCE_TABLE_CAPACITY)
@@ -52,17 +70,21 @@ def source_splitlines(source: str) -> tuple[str, ...]:
 def source_lines(source: str) -> tuple[str, ...]:
     """The module's line table (line ends kept), split once per source.
 
-    Mirrors the parser's own line splitting (`ast._splitlines_no_ff`): form
-    feeds do not break lines, so offsets agree with node positions.
+    Mirrors the parser's own line splitting (form feeds do not break lines),
+    so offsets agree with node positions.
     """
-    return tuple(ast._splitlines_no_ff(source))
+    lines: list[str] = []
+    for match in _LINE_PATTERN.finditer(source):
+        lines.append(match[0])
+    return tuple(lines)
 
 
-def source_segment(source: str, node: ast.AST) -> str | None:
+def source_segment(source: str, node: Any) -> str | None:
     """`ast.get_source_segment` semantics as a lookup against the line table.
 
     Returns None when position information is missing, exactly as the stdlib
     does. Column offsets are byte offsets into the UTF-8 encoding of each line.
+    Accepts any positioned node (typed Node attrs or residual dual AST).
     """
     try:
         if node.end_lineno is None or node.end_col_offset is None:
@@ -79,23 +101,3 @@ def source_segment(source: str, node: ast.AST) -> str | None:
     first = lines[lineno].encode()[col_offset:].decode()
     last = lines[end_lineno].encode()[:end_col_offset].decode()
     return "".join((first, *lines[lineno + 1 : end_lineno], last))
-
-
-@functools.lru_cache(maxsize=SOURCE_TABLE_CAPACITY)
-def _parsed(source: str, filename: str) -> ast.Module:
-    return ast.parse(source, filename=filename)
-
-
-def parsed_tree(source: str, filename: str = "<unknown>") -> ast.Module:
-    """The parsed module, one parse per (source, filename).
-
-    Raises SyntaxError exactly as `ast.parse` does (the raise recurs on every
-    call for the same source; failures are not cached).
-
-    Dual-path residual: production construction should enter through
-    ``SourceFile`` / typed Nodes. Remaining callers (bind_lifter / source_oracle
-    template recompute / dependency_artifact export scan) still pin this table
-    until those paths are drained. Parent maps, locus indexes, and symtable
-    caches that had no production callers were deleted rather than rewritten.
-    """
-    return _parsed(source, filename)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_tables_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_tables_adapter.py
@@ -1,0 +1,31 @@
+"""Stdlib-AST parse adapter for residual dual-body consumers.
+
+Production sole path enters through ``SourceFile`` / typed Nodes. The only
+remaining dual-body pin of a content-keyed stdlib ``ast.Module`` is
+``dependency_artifact`` export scan — foreign ``ast`` currency lives HERE
+(the ``*_adapter*`` boundary) and nowhere in the public line-table module.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+
+# Align with install-source / public source_tables capacity: hot working set
+# of modules in one generation, not the whole corpus forever.
+SOURCE_TABLE_CAPACITY = 64
+
+
+@functools.lru_cache(maxsize=SOURCE_TABLE_CAPACITY)
+def _parsed(source: str, filename: str) -> ast.Module:
+    return ast.parse(source, filename=filename)
+
+
+def parsed_tree(source: str, filename: str = "<unknown>") -> ast.Module:
+    """Content-keyed stdlib parse for residual dual-body consumers only.
+
+    Raises SyntaxError exactly as ``ast.parse`` does (the raise recurs on every
+    call for the same source; failures are not cached). Production construction
+    must not take this door — ``SourceFile`` is the sole parse gate.
+    """
+    return _parsed(source, filename)

--- a/implementations/python/sugar-lift-python-source/tests/test_source_oracle.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_oracle.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-import ast
 import os
 from pathlib import Path
 import sys
 
 import pytest
 
+from sugar_lift_python_source import typed_node_api as typed
 from sugar_lift_python_source.bind_lifter import (
     _body_source_locator,
     lift_source,
@@ -142,8 +142,13 @@ def test_oracle_resolves_dotted_method_envelope_name(tmp_path: Path) -> None:
     path = tmp_path / rel
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(src, encoding="utf-8")
-    tree = ast.parse(src, filename=rel)
-    fn = next(n for n in ast.walk(tree) if getattr(n, "name", "") == "get_signature")
+    tree = typed.parse(src, filename=rel)
+    fn = next(
+        n
+        for n in typed.walk(tree)
+        if isinstance(n, (typed.FunctionDef, typed.AsyncFunctionDef))
+        and n.name == "get_signature"
+    )
     full = _body_source_locator(fn, rel, src.splitlines(keepends=True))
     memento = dict(source_memento_of(full))
     memento["source_function_name"] = "Algo.get_signature"
@@ -164,8 +169,9 @@ def test_oracle_resolves_statement_memento_exactly(tmp_path: Path) -> None:
     path = tmp_path / rel
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(src, encoding="utf-8")
-    tree = ast.parse(src, filename=rel)
+    tree = typed.parse(src, filename=rel)
     fn = tree.body[0]
+    assert isinstance(fn, typed.FunctionDef)
     stmt = fn.body[0]
     source = "assert [1, 2, 3].map(lambda x: x + 1) == [2, 3, 4]"
     template = stmt_to_template(stmt, function_param_names(fn))

--- a/implementations/python/sugar-lift-python-source/tests/test_source_tables.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_tables.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import ast
 
 from sugar_lift_python_source import source_tables
+from sugar_lift_python_source import source_tables_adapter
 from sugar_lift_python_source.source_tables import (
     SOURCE_TABLE_CAPACITY,
     parsed_tree,
@@ -18,6 +19,7 @@ from sugar_lift_python_source.source_tables import (
 def test_capacity_is_finite_and_positive() -> None:
     assert SOURCE_TABLE_CAPACITY > 0
     assert SOURCE_TABLE_CAPACITY == 64
+    assert source_tables_adapter.SOURCE_TABLE_CAPACITY == SOURCE_TABLE_CAPACITY
 
 
 def test_source_tables_are_lru_bounded_not_unbounded() -> None:
@@ -30,8 +32,8 @@ def test_source_tables_are_lru_bounded_not_unbounded() -> None:
         # lru_cache exposes maxsize; None would mean unbounded.
         assert info.maxsize is not None, f"{fn.__name__} must be bounded"
         assert info.maxsize == SOURCE_TABLE_CAPACITY
-    # _parsed is wrapped only via parsed_tree; check the private table.
-    assert source_tables._parsed.cache_info().maxsize == SOURCE_TABLE_CAPACITY
+    # Dual residual parse lives on the adapter, still content-keyed LRU.
+    assert source_tables_adapter._parsed.cache_info().maxsize == SOURCE_TABLE_CAPACITY
 
 
 def test_tables_evict_past_capacity_without_losing_semantics() -> None:
@@ -39,7 +41,7 @@ def test_tables_evict_past_capacity_without_losing_semantics() -> None:
     # Clear so the test owns the cache population.
     source_splitlines.cache_clear()
     source_lines.cache_clear()
-    source_tables._parsed.cache_clear()
+    source_tables_adapter._parsed.cache_clear()
 
     n = SOURCE_TABLE_CAPACITY + 8
     bodies = [f"x_{i} = {i}\n" for i in range(n)]
@@ -58,7 +60,7 @@ def test_tables_evict_past_capacity_without_losing_semantics() -> None:
     # Cache never grows past capacity.
     assert source_splitlines.cache_info().currsize <= SOURCE_TABLE_CAPACITY
     assert source_lines.cache_info().currsize <= SOURCE_TABLE_CAPACITY
-    assert source_tables._parsed.cache_info().currsize <= SOURCE_TABLE_CAPACITY
+    assert source_tables_adapter._parsed.cache_info().currsize <= SOURCE_TABLE_CAPACITY
 
 
 def test_source_segment_still_uses_line_table() -> None:
@@ -69,6 +71,32 @@ def test_source_segment_still_uses_line_table() -> None:
     segment = source_segment(source, fn)
     assert segment is not None
     assert "def f()" in segment
+
+
+def test_source_lines_matches_parser_split_including_form_feed() -> None:
+    """Form feed must NOT break a line — matches ast._splitlines_no_ff."""
+    source = "a = 1\x0cb = 2\nc = 3\n"
+    assert source_lines(source) == tuple(ast._splitlines_no_ff(source))
+    # str.splitlines would split on form feed; our table must not.
+    assert any("\x0c" in line for line in source_lines(source))
+
+
+def test_public_source_tables_module_has_no_foreign_ast_import() -> None:
+    """Construction currency: line tables never import stdlib ast."""
+    text = (
+        __import__("pathlib")
+        .Path(source_tables.__file__)
+        .read_text(encoding="utf-8")
+    )
+    tree = ast.parse(text)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            assert not any(
+                alias.name == "ast" or alias.name.startswith("ast.")
+                for alias in node.names
+            )
+        if isinstance(node, ast.ImportFrom):
+            assert not (node.module and node.module.split(".", 1)[0] == "ast")
 
 
 def test_dead_dual_path_tables_are_gone() -> None:


### PR DESCRIPTION
## Outcome

Drain dual-body AST cancer in `source_tables` / `source_oracle` (leaf_assertions + value_pins WriteVisitor already clean on main).

- **source_oracle**: `resolve_source_memento` enters through `SourceFile` / typed Nodes end-to-end (locate, body text, template recompute). Kill `import ast` + both `ast.walk` offenders.
- **source_tables**: pure line tables (no foreign `ast`). Residual content-keyed stdlib parse lives in `source_tables_adapter` for `dependency_artifact` only.
- leaf_assertions / value_pins WriteVisitor: already drained prior; no further change needed.

## Instrument receipt

Baseline (origin/main `ca5cf449`):
- `R_construction_side_doors = 6`
- `R_sole_path_construction_side_doors = 0`
- offenders: source_oracle (import + 2×walk), source_tables (import + parse), dependency_artifact (import)

After:
- `R_construction_side_doors = 1`
- `R_sole_path_construction_side_doors = 0`
- `R_foreign_ast_import = 1` (dependency_artifact only)
- `R_ast_semantic_above_adapter = 0`
- `auditor_errors = 0`

**ΔR = −5** (oracle −3, tables −2). Sole path held at 0.

## Validation

```
bin/brun -- python scripts/construction_side_door_law.py
# R=1 sole_path=0

bin/brun --env PYTHONPATH -- env PYTHONPATH=src:../sugar-source-tree/src:../sugar-lift-py-tests/src \
  python -m pytest tests/test_source_tables.py tests/test_source_oracle.py -q
# 19 passed
```

lifter.py / bind_lifter.py left to other agents (already typed via #6134).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove stdlib `ast` dependency from `source_oracle` and `source_tables` in favor of typed-node API
> - Replaces all `ast`-based parsing, walking, and node inspection in [`source_oracle.py`](https://github.com/TSavo/sugar/pull/6140/files#diff-46c211dd48cf8b40814f36939afc72cfd9d8d750d36f6572af9c9e02ba22ea6f) and [`source_tables.py`](https://github.com/TSavo/sugar/pull/6140/files#diff-ebd3cc1a0454697bef411fbe60c0f33cb960b7317e4d7b3c4cd9eb5acf45abd3) with the typed-node API (`typed_node_api`).
> - Extracts the remaining `ast` usage (cache and `parsed_tree`) into a new [`source_tables_adapter.py`](https://github.com/TSavo/sugar/pull/6140/files#diff-4941c39efd9fd9fceccd6797df1801012d2a86689b279d6fbb029ee94a8b26da), keeping the public `source_tables` module free of direct `ast` imports (enforced by a new test).
> - `source_lines` now uses a compiled regex instead of `ast._splitlines_no_ff`, preserving identical form-feed-safe line-splitting behavior.
> - `source_segment` now accepts any node exposing position attributes, not just `ast.AST` nodes.
> - `resolve_source_memento` now catches `BackendCouldNotParse`, `UnicodeError`, and `ValueError` in addition to `SyntaxError` when parsing source files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bad4cc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->