### PR TITLE
Finish bind_lifter: drop DefinitionCollector for typed.walk

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py
@@ -109,14 +109,13 @@ def lift_source(
         )
         return result
 
-    collector = _DefinitionCollector()
-    collector.visit(tree)
+    definitions, class_definitions = _collect_definitions(tree)
     lines = source.splitlines()
     source_lines = source.splitlines(keepends=True)
     rel_path = source_path.replace(os.sep, "/")
     emit_bind = layer in ("library-bindings", "all")
     emit_general = layer == "all"
-    for info in collector.definitions:
+    for info in definitions:
         try:
             if emit_bind:
                 entry = _library_binding_entry_for_function(
@@ -145,7 +144,7 @@ def lift_source(
                 }
             )
     if emit_bind:
-        for cls_info in collector.class_definitions:
+        for cls_info in class_definitions:
             entry = _concept_gap_memento_for_class(
                 cls_info.node, rel_path, result.diagnostics
             )
@@ -221,23 +220,18 @@ class _ClassInfo:
     node: typed.ClassDef
 
 
-class _DefinitionCollector(typed.TypedNodeWalker):
-    def __init__(self) -> None:
-        self.definitions: list[_FunctionInfo] = []
-        self.class_definitions: list[_ClassInfo] = []
-
-    def visit_FunctionDef(self, node: typed.FunctionDef) -> None:
-        self.definitions.append(_FunctionInfo(node=node))
-        self.generic_visit(node)
-
-    def visit_AsyncFunctionDef(self, node: typed.AsyncFunctionDef) -> None:
-        self.definitions.append(_FunctionInfo(node=node))
-        self.generic_visit(node)
-
-    def visit_ClassDef(self, node: typed.ClassDef) -> None:
-        self.class_definitions.append(_ClassInfo(node=node))
-        # still recurse so method definitions inside classes are visited for function lifting
-        self.generic_visit(node)
+def _collect_definitions(
+    tree: typed.Module,
+) -> tuple[list[_FunctionInfo], list[_ClassInfo]]:
+    """Collect functions/classes via typed.walk — no visitor side door."""
+    definitions: list[_FunctionInfo] = []
+    class_definitions: list[_ClassInfo] = []
+    for node in typed.walk(tree):
+        if isinstance(node, (typed.FunctionDef, typed.AsyncFunctionDef)):
+            definitions.append(_FunctionInfo(node=node))
+        elif isinstance(node, typed.ClassDef):
+            class_definitions.append(_ClassInfo(node=node))
+    return definitions, class_definitions
 
 
 def _entry_for_function(


### PR DESCRIPTION
## Summary
- Finish bind_lifter residual side-door work: remove `_DefinitionCollector(typed.TypedNodeWalker)`.
- Collect function/class definitions via `typed.walk` over SourceFile modules.
- `import ast` / `ast.parse` already drained onto `typed_node_api.parse` (#6134); this closes the remaining DefinitionCollector locus.
- Preserve bind RPC behavior.

## ΔR
| Axis | Value |
|---|---|
| `R_construction_side_doors` | **1** (held; only `dependency_artifact` remains) |
| `R_sole_path_construction_side_doors` | **0** (held) |
| bind_lifter instrumented side-door loci | **0** |

## Validation
```bash
cd implementations/python/sugar-lift-python-source
../../../bin/brun -- python -m pytest tests/test_bind_lifter.py -q
# 58 passed

cd implementations/python/sugar-lift-py-tests
../../../bin/brun -- python scripts/construction_side_door_law.py
# R=1 sole_path=0
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `_DefinitionCollector` with `typed.walk` in `bind_lifter`
> Removes the `_DefinitionCollector` visitor class from [bind_lifter.py](https://github.com/TSavo/sugar/pull/6141/files#diff-2d1544de1ff27adb0b95a4be7fdb157e9565af85beed277481deadec84eb2292) and replaces it with a new `_collect_definitions` helper that iterates `typed.walk(tree)` directly. The returned `(definitions, class_definitions)` tuple is destructured in `lift_source`, keeping all downstream IR and diagnostic logic unchanged. Behavioral Change: collected node ordering now follows `typed.walk` traversal order rather than the previous visitor's pre-order traversal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3674ca8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->