### PR TITLE
Cut D: construct source manager __enter__/__exit__ through sole call frames (#6088)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -991,7 +991,12 @@ class CallSiteValue(FloorValue):
             return None
         from sugar_lift_py_tests.outcome import Incomplete, complete_value
 
-        reduce_ctx = _ctx_with_curried_args(ctx, self.parameters, self.arg_values)
+        reduce_ctx = _ctx_with_curried_args(
+            ctx,
+            self.parameters,
+            self.arg_values,
+            self.formal_coordinate_cids,
+        )
         active_demand = _ACTIVE_DIG_DEMAND.get()
         nested_budget = min(budget, _NESTED_DIG_DEMAND_BUDGET)
         if active_demand >= nested_budget:
@@ -1081,7 +1086,12 @@ class CallSiteValue(FloorValue):
             )
         from sugar_lift_py_tests.outcome import Incomplete, complete_value
 
-        reduce_ctx = _ctx_with_curried_args(ctx, self.parameters, self.arg_values)
+        reduce_ctx = _ctx_with_curried_args(
+            ctx,
+            self.parameters,
+            self.arg_values,
+            self.formal_coordinate_cids,
+        )
         outcome = _reduce_callsite_body(body, reduce_ctx, blame=self.target_name)
         if isinstance(outcome, Incomplete):
             _force_floor_gap(
@@ -1112,6 +1122,30 @@ class CallSiteValue(FloorValue):
                 arg_values=self.arg_values,
             )
         return floor
+
+    def reduce_source_outcome(self, ctx: Any = None):
+        """Reduce this already-constructed source body without floor projection.
+
+        Context-manager protocol construction needs the body's complete
+        ExitSet, including method halts.  This uses the identical explicit call
+        frame/curry path as ``force_floor`` and never reconstructs source.
+        """
+        if self.body is None or len(self.parameters) != len(self.arg_values):
+            _force_floor_gap(
+                owner="CallSiteValue.reduce_source_outcome",
+                target_name=self.target_name,
+                observed="missing body or callsite arity mismatch",
+                fix="retain the source-visible call frame or keep the call loud",
+            )
+        reduce_ctx = _ctx_with_curried_args(
+            ctx,
+            self.parameters,
+            self.arg_values,
+            self.formal_coordinate_cids,
+        )
+        return _reduce_callsite_body(
+            self.body, reduce_ctx, blame=self.target_name
+        )
 
 
 def force_floor(
@@ -1255,6 +1289,7 @@ def _ctx_with_curried_args(
     ctx: Any,
     parameters: tuple[str, ...],
     arg_values: tuple[FloorValue, ...],
+    formal_coordinate_cids: tuple[str, ...] = (),
 ):
     from sugar_lift_py_tests.temporal import curry_temporal
 
@@ -1265,4 +1300,14 @@ def _ctx_with_curried_args(
         owner="CallSiteValue.force_floor",
         blame="<callsite>",
     )
+    if formal_coordinate_cids:
+        if len(formal_coordinate_cids) != len(arg_values):
+            return result
+        result = curry_temporal(
+            result,
+            formal_coordinate_cids,
+            arg_values,
+            owner="CallSiteValue.force_floor formal coordinates",
+            blame="<callsite-coordinate>",
+        )
     return result

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -35,6 +35,7 @@ class ClassDefinitionValue(FloorValue):
     def construct_receiver_state_from_block(self, block, receiver_coordinate_cid):
         from sugar_lift_py_tests.floor import (
             ObjectField,
+            ObjectMethodValue,
             ObjectValue,
             ReceiverFieldStoreValue,
         )
@@ -43,6 +44,7 @@ class ClassDefinitionValue(FloorValue):
         receiver = ObjectValue(
             self.class_name,
             (),
+            methods=self._object_methods(),
             identity=receiver_coordinate_cid or self.class_definition_cid,
         )
         if block is None:
@@ -81,5 +83,23 @@ class ClassDefinitionValue(FloorValue):
         return ObjectValue(
             self.class_name,
             ordered,
+            methods=self._object_methods(),
             identity=_term_content_cid(identity_term),
+        )
+
+    def _object_methods(self):
+        from sugar_lift_py_tests.floor import ObjectMethodValue
+
+        return tuple(
+            ObjectMethodValue(
+                method.name,
+                method.source_call_frame.parameters,
+                method.source_call_frame.body,
+                method.source_call_frame.frame_cid,
+                tuple(
+                    coordinate.cid
+                    for coordinate in method.source_call_frame.formal_coordinates
+                ),
+            )
+            for method in self.methods
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_method_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_method_value.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sugar_lift_py_tests.sugar_body import SugarBody
+
+if TYPE_CHECKING:
+    from sugar_lift_py_tests.sugar.sugar_base import Sugar
 
 from .floor_value import FloorValue
 
@@ -16,8 +19,12 @@ class ObjectMethodValue(FloorValue):
     # is the open membrane here, matching FactoryBuildResult.sugar, since a
     # method body's reduction shape varies with the SugarRole it was built
     # under and is not known at this seam.
-    body: SugarBody[Any]
+    body: SugarBody[Any] | Sugar
+    source_call_frame_cid: str | None = None
+    formal_coordinate_cids: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
-        if not isinstance(self.body, SugarBody):
-            raise TypeError("ObjectMethodValue body must be factory-built")
+        from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+        if not isinstance(self.body, (SugarBody, Sugar)):
+            raise TypeError("ObjectMethodValue body must be constructor-built")

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
@@ -110,6 +110,15 @@ class ObjectValue(FloorValue):
             [str_const(self.class_name), str_const(self.identity)],
         )
 
+    def attribute(self, name, site):
+        """Project an exact field from this constructed receiver state."""
+        for field in reversed(self.fields):
+            if field.name == name:
+                from sugar_lift_py_tests.outcome import Complete
+
+                return Complete(field.value)
+        return super().attribute(name, site)
+
     def attribute_assign_with(
         self, operation: AttributeMutationOperation, ctx: FactoryBuildContext | None
     ) -> Outcome:
@@ -361,7 +370,6 @@ class ObjectValue(FloorValue):
         from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
         from sugar_lift_py_tests.ir import ctor
         from sugar_lift_py_tests.outcome import Complete
-        from sugar_lift_py_tests.sugar.floor_terms import floor_to_term
 
         for method in reversed(self.methods):
             if method.name != name:
@@ -389,7 +397,7 @@ class ObjectValue(FloorValue):
             target_name = f"{self.class_name}.{name}"
             arg_values = (self, *arguments)
             arg_terms = [
-                floor_to_term(value, owner=f"{owner} method argument")
+                value.to_term(owner=f"{owner} method argument")
                 for value in arg_values
             ]
             call_value = CallSiteValue(
@@ -402,6 +410,8 @@ class ObjectValue(FloorValue):
                     symbol_kind="contract-target",
                 ),
                 body=method.body,
+                source_call_frame_cid=method.source_call_frame_cid,
+                formal_coordinate_cids=method.formal_coordinate_cids,
             )
             if not any(
                 isinstance(value, (SymbolicValue, CallSiteValue))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -258,6 +258,50 @@ class ExitSet(Generic[T]):
                     exits.append(Halted(guard, incoming.effect, incoming.state))
         return ExitSet(tuple(exits)).normalize()
 
+    def and_exit_truthiness(self, exit_es: "ExitSet[object]", *, site: object):
+        """Run a source-constructed ``__exit__`` and retain both truth faces.
+
+        This is the source-derived counterpart of contract-selected
+        ``and_exit``.  A completed exit result is interpreted only through the
+        ordinary Python truth predicate.  On an incoming halt, truth consumes
+        the effect and falsity restores that exact effect; neither face is
+        discarded.
+        """
+        from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
+
+        exits: list[Exit[object]] = []
+        for incoming in self.exits:
+            for ex in exit_es.exits:
+                guard = _and_guards(incoming.guard, ex.guard)
+                if isinstance(ex, Halted):
+                    exits.append(Halted(guard, ex.effect, ex.state))
+                    continue
+                if isinstance(incoming, Completed):
+                    exits.append(Completed(guard, incoming.value))
+                    continue
+                from sugar_lift_py_tests.floor import TermValue
+
+                if isinstance(ex.value, TermValue) and type(ex.value.value) is bool:
+                    truth = true_guard() if ex.value.value else false_guard()
+                else:
+                    truth = predicate_formula(ex.value, site)
+                falsity = (
+                    false_guard()
+                    if _is_true(truth)
+                    else true_guard() if _is_false(truth) else not_(truth)
+                )
+                exits.append(
+                    Completed(_and_guards(guard, truth), incoming.state)
+                )
+                exits.append(
+                    Halted(
+                        _and_guards(guard, falsity),
+                        incoming.effect,
+                        incoming.state,
+                    )
+                )
+        return ExitSet(tuple(exits)).normalize()
+
     def collapse(self):
         """Return the old linear Outcome only for one unconditional exit."""
         normalized = self.normalize()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binding_coordinate_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binding_coordinate_ref_sugar.py
@@ -22,6 +22,12 @@ class BindingCoordinateRefSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
+        if ctx is not None and hasattr(ctx, "temporal"):
+            value = ctx.temporal.value_if_bound(self.coordinate.cid)
+            if value is not None:
+                from sugar_lift_py_tests.outcome import Complete
+
+                return Complete(value)
         from sugar_source_tree.panic import SugarNotWritten
 
         raise SugarNotWritten(

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_constructed_exit_truthiness.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_constructed_exit_truthiness.py
@@ -1,0 +1,45 @@
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.floor import SymbolicValue, TermValue
+from sugar_lift_py_tests.ir import ctor, not_
+from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted, true_guard
+from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
+
+
+def test_source_constructed_exit_retains_suppressed_and_unsuppressed_faces():
+    original = RaiseEffect(TermValue("boom"), None, None)
+    incoming = ExitSet.halted(original, state=TermValue("before-exit"))
+    result = SymbolicValue(ctor("fixture:exit-result", []))
+
+    routed = incoming.and_exit_truthiness(
+        ExitSet.completed(result), site="renamed-fixture"
+    )
+
+    truth = predicate_formula(result, "renamed-fixture")
+    assert routed.exits == (
+        Completed(truth, TermValue("before-exit")),
+        Halted(not_(truth), original, TermValue("before-exit")),
+    )
+
+
+def test_source_constructed_false_exit_restores_original_effect():
+    original = RaiseEffect(TermValue("boom"), None, None)
+    incoming = ExitSet.halted(original, state=TermValue("before-exit"))
+
+    routed = incoming.and_exit_truthiness(
+        ExitSet.completed(TermValue(False)), site="renamed-fixture"
+    )
+
+    assert routed.exits == (
+        Halted(true_guard(), original, TermValue("before-exit")),
+    )
+
+
+def test_source_constructed_exit_runs_on_non_exception_transfer():
+    body_result = TermValue("return-break-or-continue")
+    incoming = ExitSet.completed(body_result)
+
+    routed = incoming.and_exit_truthiness(
+        ExitSet.completed(TermValue(True)), site="renamed-fixture"
+    )
+
+    assert routed.exits == (Completed(true_guard(), body_result),)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -191,7 +191,6 @@ def construct_manager_behavior(
         ),
         body=frame.body,
         source_call_frame_cid=frame.frame_cid,
-        formal_coordinate_cids=(),
     )
     result = call.force_floor(
         None, owner="construct_manager_behavior", project_callsite=False

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
@@ -1,0 +1,125 @@
+"""Cut D: construct source-visible context-manager protocol methods once."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from sugar_lift_py_tests.floor import CallSiteValue
+from sugar_lift_py_tests.floor.manager_coordinate import (
+    ExitTracebackCoordinate,
+    ExitTypeCoordinate,
+    ExitValueCoordinate,
+)
+from sugar_lift_py_tests.outcome import Complete
+
+from .canonical import cid_of_json
+from .manager_construction import ConstructedManagerBehaviorV1
+
+
+@dataclass(frozen=True)
+class ConstructedManagerProtocolV1:
+    manager_construction_cid: str
+    protocol_construction_cid: str
+    enter_call: CallSiteValue = field(compare=False)
+    exit_call: CallSiteValue = field(compare=False)
+    enter_frame_cid: str
+    exit_frame_cid: str
+    exit_face_id: str
+
+    @property
+    def preimage(self):
+        return {
+            "kind": "constructed-manager-protocol",
+            "schemaVersion": "1",
+            "managerConstructionCid": self.manager_construction_cid,
+            "enterFrameCid": self.enter_frame_cid,
+            "exitFrameCid": self.exit_frame_cid,
+            "exitFaceId": self.exit_face_id,
+        }
+
+    def __post_init__(self) -> None:
+        if cid_of_json(self.preimage) != self.protocol_construction_cid:
+            raise ValueError("manager protocol CID does not match its preimage")
+
+    def enter_outcome(self, ctx: object = None):
+        return self.enter_call.reduce_source_outcome(ctx)
+
+    def exit_outcome(self, ctx: object = None):
+        return self.exit_call.reduce_source_outcome(ctx)
+
+
+@dataclass(frozen=True)
+class ManagerProtocolConstructionGapV1:
+    kind: Literal["enter-missing", "exit-missing", "method-construction"]
+    manager_construction_cid: str
+    detail: str
+
+
+def construct_manager_protocol(
+    behavior: ConstructedManagerBehaviorV1,
+    *,
+    exit_face_id: str,
+) -> ConstructedManagerProtocolV1 | ManagerProtocolConstructionGapV1:
+    """Project ``__enter__``/``__exit__`` from Cut C's exact receiver.
+
+    Method bodies were constructed by ``FunctionDef`` and retained by the
+    class-construction arm.  This function only binds the constructed receiver
+    and the typed exit-face operands to those bodies.
+    """
+    receiver = behavior.receiver_state
+    if not receiver.has_method("__enter__"):
+        return ManagerProtocolConstructionGapV1(
+            "enter-missing", behavior.manager_construction_cid, "source-visible method"
+        )
+    if not receiver.has_method("__exit__"):
+        return ManagerProtocolConstructionGapV1(
+            "exit-missing", behavior.manager_construction_cid, "source-visible method"
+        )
+    enter = receiver.call_method_value(
+        "__enter__", (), owner="construct_manager_protocol", blame=exit_face_id
+    )
+    exit_ = receiver.call_method_value(
+        "__exit__",
+        (
+            ExitTypeCoordinate(exit_face_id, None),
+            ExitValueCoordinate(exit_face_id, None),
+            ExitTracebackCoordinate(exit_face_id, None),
+        ),
+        owner="construct_manager_protocol",
+        blame=exit_face_id,
+    )
+    if not isinstance(enter, Complete) or not isinstance(enter.value, CallSiteValue):
+        return ManagerProtocolConstructionGapV1(
+            "method-construction", behavior.manager_construction_cid, "__enter__"
+        )
+    if not isinstance(exit_, Complete) or not isinstance(exit_.value, CallSiteValue):
+        return ManagerProtocolConstructionGapV1(
+            "method-construction", behavior.manager_construction_cid, "__exit__"
+        )
+    enter_frame_cid = _method_frame_cid(receiver, "__enter__")
+    exit_frame_cid = _method_frame_cid(receiver, "__exit__")
+    preimage = {
+        "kind": "constructed-manager-protocol",
+        "schemaVersion": "1",
+        "managerConstructionCid": behavior.manager_construction_cid,
+        "enterFrameCid": enter_frame_cid,
+        "exitFrameCid": exit_frame_cid,
+        "exitFaceId": exit_face_id,
+    }
+    return ConstructedManagerProtocolV1(
+        behavior.manager_construction_cid,
+        cid_of_json(preimage),
+        enter.value,
+        exit_.value,
+        enter_frame_cid,
+        exit_frame_cid,
+        exit_face_id,
+    )
+
+
+def _method_frame_cid(receiver, name: str) -> str:
+    method = next(item for item in reversed(receiver.methods) if item.name == name)
+    if method.source_call_frame_cid is None:
+        raise ValueError("source-visible method has no authenticated call frame")
+    return method.source_call_frame_cid

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -4,7 +4,7 @@ import csv
 import importlib.metadata
 from pathlib import Path
 
-from sugar_lift_py_tests.floor import TermValue
+from sugar_lift_py_tests.floor import BlockValue, ReturnValue, TermValue
 from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.dependency_artifact import (
@@ -17,6 +17,11 @@ from sugar_lift_python_source.manager_construction import (
     ConstructedManagerBehaviorV1,
     ManagerConstructionGapV1,
     construct_manager_behavior,
+)
+from sugar_lift_python_source.manager_protocol_construction import (
+    ConstructedManagerProtocolV1,
+    ManagerProtocolConstructionGapV1,
+    construct_manager_protocol,
 )
 from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
 from sugar_source_tree.binding_state import BindingEntryV1
@@ -113,3 +118,92 @@ def test_opaque_source_call_stays_typed_loud(tmp_path):
 
     assert isinstance(result, ManagerConstructionGapV1)
     assert result.kind == "opaque-call-target"
+
+
+def test_renamed_manager_protocol_retains_ordinary_method_call_frames(tmp_path):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class ArbitraryGuard:\n"
+        "    def __init__(self, marker):\n"
+        "        self.marker = marker\n\n"
+        "    def __enter__(self):\n"
+        "        return self.marker\n\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return self.marker\n\n"
+        "def make_guard(marker):\n"
+        "    return ArbitraryGuard(marker)\n",
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+
+    protocol = construct_manager_protocol(behavior, exit_face_id="fixture-face")
+
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+    assert protocol.enter_call.body is not None
+    assert protocol.exit_call.body is not None
+    assert protocol.enter_frame_cid.startswith("blake3-512:")
+    assert protocol.exit_frame_cid.startswith("blake3-512:")
+    assert protocol.protocol_construction_cid.startswith("blake3-512:")
+    assert protocol.enter_call.formal_coordinate_cids
+    enter_block = protocol.enter_call.force_floor(
+        None, owner="renamed enter", project_callsite=False
+    )
+    exit_block = protocol.exit_call.force_floor(
+        None, owner="renamed exit", project_callsite=False
+    )
+    assert isinstance(enter_block, BlockValue)
+    assert isinstance(exit_block, BlockValue)
+    assert enter_block.statements == (ReturnValue(actual.value),)
+    assert exit_block.statements == (ReturnValue(actual.value),)
+
+
+def test_manager_missing_source_protocol_method_stays_typed_loud(tmp_path):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class ArbitraryObject:\n"
+        "    def __init__(self, marker):\n"
+        "        self.marker = marker\n\n"
+        "def make_guard(marker):\n"
+        "    return ArbitraryObject(marker)\n",
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+
+    protocol = construct_manager_protocol(behavior, exit_face_id="fixture-face")
+
+    assert isinstance(protocol, ManagerProtocolConstructionGapV1)
+    assert protocol.kind == "enter-missing"
+
+
+def test_renamed_enter_and_exit_halts_remain_method_exitsets(tmp_path):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class ArbitraryFailingGuard:\n"
+        "    def __init__(self, marker):\n"
+        "        self.marker = marker\n\n"
+        "    def __enter__(self):\n"
+        "        raise ValueError('enter')\n\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        raise TypeError('exit')\n\n"
+        "def make_guard(marker):\n"
+        "    return ArbitraryFailingGuard(marker)\n",
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    protocol = construct_manager_protocol(behavior, exit_face_id="fixture-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+
+    from sugar_lift_py_tests.outcome import ExitSet, Halted, outcome_to_exitset
+
+    enter = outcome_to_exitset(protocol.enter_outcome())
+    exit_ = outcome_to_exitset(protocol.exit_outcome())
+    assert isinstance(enter, ExitSet)
+    assert isinstance(exit_, ExitSet)
+    assert all(isinstance(face, Halted) for face in enter.exits)
+    assert all(isinstance(face, Halted) for face in exit_.exits)


### PR DESCRIPTION
## Outcome

Constructs source-visible context-manager `__enter__` and `__exit__` from Cut C's exact `ConstructedManagerBehaviorV1`, through the ordinary `FunctionDef`/`SourceVisibleCallFrameV1`/`CallSiteValue` door.

- constructed receiver state retains its already-built class method frames
- actual receiver and protocol arguments curry under authenticated `BindingCoordinateV1` formal coordinates
- `__enter__` and parametric `__exit__(manager, exc_type, exc, tb)` preserve their full source-body outcomes
- source-derived exit truthiness retains both suppression and original-effect faces
- missing protocol source remains a typed `ManagerProtocolConstructionGapV1`
- no manager/package spelling and no private AST evaluator

## Instruments

Focused twins:

```
8 passed in 1.05s
```

Construction invariant:

```
R_construction_invariant_violations = 0
R_self_hashing_as_authority = 0
R_name_spelling_overload_gate = 0
R_second_construction_path = 0
R_non_exhaustive_variant_coverage = 0
R_fabricated_completion_fallback = 0
R_auditor_errors = 0
```

Side-door floor is unchanged from the stacked baseline:

```
R_construction_side_doors = 1
R_sole_path_construction_side_doors = 0
R_foreign_ast_import = 1  # existing dependency_artifact.py finding
R_ast_semantic_above_adapter = 0
R_dual_old_lifter = 0
auditor_errors = 0
```

Source-tree sweep: `389 passed, 5 skipped`; one backend-fingerprint golden mismatch in `test_corpus.py` is unrelated to this diff. Python-source sweep progressed through `420 passed` before an unrelated long-running tail was interrupted at 117s.

## Delta / next edge

Predicted direct delta for Cut D alone: `0` (producer testimony only). It unlocks Cut E's derived immutable CM summary and With binding; that is the path into the measured 5,454-site With/manager residual.

Stacked on #6139. Do not merge until the base lands and the focused architecture review confirms the sole-path boundary.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct source manager `__enter__`/`__exit__` through sole call frames
> - Adds `construct_manager_protocol` in [manager_protocol_construction.py](https://github.com/TSavo/sugar/pull/6144/files#diff-bdbfb97c4a5209dd6ce8e2b561f5dde22cdb35bce955d8d781c7c1e72ff11700) that inspects a constructed manager behavior for `__enter__`/`__exit__`, reduces each to a `CallSiteValue`, and returns a `ConstructedManagerProtocolV1` or a structured `ManagerProtocolConstructionGapV1` on failure.
> - Extends `SourceVisibleCallFrameV1` with `bind_node_actuals`, which binds real AST node actuals to formal parameters and asks the owning unit for a body, returning a new frame with runtime binding entries.
> - Adds `ClassDef._source_visible_body` and updates `ClassConstructorBodySugar` so class constructor desugaring builds receiver state from an initializer block and a receiver coordinate CID, removing the previous reliance on formal parameter actuals.
> - Removes `binding_coordinate_values` from `ReduceContext` and replaces coordinate binding in `_ctx_with_curried_args` with `curry_temporal` semantics.
> - Adds `ExitSet.and_exit_truthiness` to split control flow based on the truthiness of another exit set, with guard propagation and effect preservation.
> - Risk: `ReduceContext.with_binding_coordinate_values` and `value_for_binding_coordinate` are deleted; any callers outside this PR will break at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6586c70.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->