### PR TITLE
Cut C extension: construct class-body testimony for source managers (#6088)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -15,7 +15,11 @@ from .builder_state import BuilderState
 from .bv32_value import Bv32Value
 from .builtin_exception_class_value import BuiltinExceptionClassValue
 from .call_site_value import CallSiteValue
-from .class_definition_value import ClassDefinitionValue, ConstructedClassMethodV1
+from .class_definition_value import (
+    ClassDefinitionValue,
+    ConstructedClassFieldV1,
+    ConstructedClassMethodV1,
+)
 from .curried_loop_scope import CurriedLoopBody, CurriedLoopScope
 from .class_value import ClassValue
 from .comprehension_value import ComprehensionValue

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -16,11 +16,22 @@ class ConstructedClassMethodV1:
 
 
 @dataclass(frozen=True)
+class ConstructedClassFieldV1:
+    name: str
+    definition_fragment_cid: str
+    value_sugar: object = field(compare=False)
+
+
+@dataclass(frozen=True)
 class ClassDefinitionValue(FloorValue):
     class_name: str
     class_definition_cid: str
     methods: tuple[ConstructedClassMethodV1, ...]
     initializer: ConstructedClassMethodV1 | None
+    class_fields: tuple[object, ...] = ()
+    docstring_cid: str | None = None
+    annotation_cids: tuple[str, ...] = ()
+    decorator_cids: tuple[str, ...] = ()
 
     def to_term(self, *, owner: str):
         del owner
@@ -45,6 +56,7 @@ class ClassDefinitionValue(FloorValue):
             self.class_name,
             (),
             methods=self._object_methods(),
+            class_fields=self.class_fields,
             identity=receiver_coordinate_cid or self.class_definition_cid,
         )
         if block is None:
@@ -84,6 +96,7 @@ class ClassDefinitionValue(FloorValue):
             self.class_name,
             ordered,
             methods=self._object_methods(),
+            class_fields=self.class_fields,
             identity=_term_content_cid(identity_term),
         )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from sugar_lift_python_source.canonical import cid_of_json
 from sugar_lift_py_tests.floor.class_definition_value import (
     ClassDefinitionValue,
+    ConstructedClassFieldV1,
     ConstructedClassMethodV1,
 )
 from sugar_lift_py_tests.outcome import Complete, Outcome
@@ -18,6 +19,10 @@ class ClassDefinitionSugar(Sugar):
     source_identity_cid: str
     definition_fragment_cid: str
     methods: tuple[ConstructedClassMethodV1, ...]
+    fields: tuple[ConstructedClassFieldV1, ...]
+    docstring_cid: str | None
+    annotation_cids: tuple[str, ...]
+    decorator_cids: tuple[str, ...]
     site: object = field(compare=False)
 
     @classmethod
@@ -43,6 +48,16 @@ class ClassDefinitionSugar(Sugar):
                 }
                 for method in self.methods
             ],
+            "fields": [
+                {
+                    "name": item.name,
+                    "definitionFragmentCid": item.definition_fragment_cid,
+                }
+                for item in self.fields
+            ],
+            "docstringCid": self.docstring_cid,
+            "annotationCids": list(self.annotation_cids),
+            "decoratorCids": list(self.decorator_cids),
         }
 
     @property
@@ -50,7 +65,21 @@ class ClassDefinitionSugar(Sugar):
         return cid_of_json(self.preimage)
 
     def desugar(self, ctx: object = None) -> Outcome:
-        del ctx
+        from sugar_lift_py_tests.floor import ObjectField
+
+        class_fields = []
+        for item in self.fields:
+            outcome = item.value_sugar.desugar(ctx)
+            if not isinstance(outcome, Complete):
+                from sugar_source_tree.panic import SugarNotWritten
+
+                raise SugarNotWritten(
+                    owner="ClassDefinitionSugar.desugar",
+                    observed=f"class field {item.name} did not construct completely",
+                    requested="one exact constructed class-field value",
+                    fix="keep effectful or unresolved class initializers loud",
+                )
+            class_fields.append(ObjectField(item.name, outcome.value))
         initializer = next(
             (method for method in self.methods if method.name == "__init__"), None
         )
@@ -60,5 +89,9 @@ class ClassDefinitionSugar(Sugar):
                 self.class_definition_cid,
                 self.methods,
                 initializer,
+                tuple(class_fields),
+                self.docstring_cid,
+                self.annotation_cids,
+                self.decorator_cids,
             )
         )

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -207,3 +207,33 @@ def test_renamed_enter_and_exit_halts_remain_method_exitsets(tmp_path):
     assert isinstance(exit_, ExitSet)
     assert all(isinstance(face, Halted) for face in enter.exits)
     assert all(isinstance(face, Halted) for face in exit_.exits)
+
+
+def test_fixture_manager_class_bodies_construct_docstrings_and_class_fields():
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.nodes import ClassDef
+
+    fixture = (
+        Path(__file__).parents[2]
+        / "sugar-lift-py-tests/tests/fixtures/with_source_derivation"
+        / "arbitrary_manager_module.py"
+    )
+    source = SourceFile(path_source(str(fixture)))
+    classes = {
+        item.name: item
+        for item in source.root.body
+        if isinstance(item, ClassDef)
+    }
+
+    some_guard = classes["SomeGuard"].sugar().desugar().value
+    some_resource = classes["SomeResource"].sugar().desugar().value
+    lying_guard = classes["LyingGuard"].sugar().desugar().value
+    observation = classes["ObservationSlot"].sugar().desugar().value
+
+    assert some_guard.docstring_cid.startswith("blake3-512:")
+    assert some_resource.docstring_cid.startswith("blake3-512:")
+    assert lying_guard.docstring_cid.startswith("blake3-512:")
+    fields = {field.name: field.value for field in lying_guard.class_fields}
+    assert type(fields["claimed_suppression"]).__name__ == "TrueBoolLiteralSugar"
+    assert observation.annotation_cids
+    assert observation.decorator_cids

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1603,8 +1603,45 @@ class ClassDef(Statement):
         resulting floor value.  No class body is interpreted beside this door.
         """
         methods = tuple(item for item in self.body if isinstance(item, FunctionDef))
+        docstring_cid = None
+        if self.body:
+            first = self.body[0]
+            if (
+                isinstance(first, Expr)
+                and isinstance(first.value, Constant)
+                and isinstance(first.value.value, str)
+            ):
+                docstring_cid = first.fragment.seal().cid
+        class_assignments = tuple(
+            (item.targets[0].id, item.value, item.fragment)
+            for item in self.body
+            if isinstance(item, Assign)
+            and len(item.targets) == 1
+            and isinstance(item.targets[0], Name)
+        )
+        annotated_assignments = tuple(
+            item
+            for item in self.body
+            if isinstance(item, AnnAssign) and isinstance(item.target, Name)
+        )
         unsupported = tuple(
-            item for item in self.body if not isinstance(item, (FunctionDef, Pass))
+            item
+            for index, item in enumerate(self.body)
+            if not isinstance(item, (FunctionDef, Pass))
+            and not (
+                index == 0
+                and isinstance(item, Expr)
+                and isinstance(item.value, Constant)
+                and isinstance(item.value.value, str)
+            )
+            and not (
+                isinstance(item, Assign)
+                and len(item.targets) == 1
+                and isinstance(item.targets[0], Name)
+            )
+            and not (
+                isinstance(item, AnnAssign) and isinstance(item.target, Name)
+            )
         )
         if unsupported:
             from sugar_source_tree.panic import SugarNotWritten
@@ -1615,7 +1652,10 @@ class ClassDef(Statement):
                 requested="a total source-visible class member construction arm",
                 fix="add the member's ordinary node Sugar arm or keep the class loud",
             )
-        from sugar_lift_py_tests.floor import ConstructedClassMethodV1
+        from sugar_lift_py_tests.floor import (
+            ConstructedClassFieldV1,
+            ConstructedClassMethodV1,
+        )
         from sugar_lift_py_tests.sugar.class_definition_sugar import (
             ClassDefinitionSugar,
         )
@@ -1629,11 +1669,35 @@ class ClassDef(Statement):
             )
             for method in methods
         )
+        fields = tuple(
+            ConstructedClassFieldV1(
+                name,
+                fragment.seal().cid,
+                value.sugar(),
+            )
+            for name, value, fragment in class_assignments
+        ) + tuple(
+            ConstructedClassFieldV1(
+                item.target.id,
+                item.fragment.seal().cid,
+                item.value.sugar(),
+            )
+            for item in annotated_assignments
+            if item.value is not None
+        )
         return ClassDefinitionSugar(
             class_name=self.name,
             source_identity_cid=self.unit.source_cid,
             definition_fragment_cid=self.fragment.seal().cid,
             methods=constructed,
+            fields=fields,
+            docstring_cid=docstring_cid,
+            annotation_cids=tuple(
+                item.fragment.seal().cid for item in annotated_assignments
+            ),
+            decorator_cids=tuple(
+                item.fragment.seal().cid for item in self.decorators
+            ),
             site=self.fragment,
         )
 


### PR DESCRIPTION
## Slice

Extends the existing `ClassDef -> ClassDefinitionSugar` construction door for the source-manager class-body roles exercised by the merged #6101 renamed fixture:

- authenticated class docstring coordinate
- exact simple class-field assignments, with their value Sugars constructed by the ordinary child door
- annotation statement coordinates
- decorator source coordinates
- existing source-visible method call frames remain unchanged
- every other class-body grammar shape remains typed-loud

This is structural testimony only. It does not fabricate decorator effects (for example a generated dataclass initializer), interpret AST, or recognize a manager/package name.

## Evidence

```
sole-path manager tests: 6 passed
R_construction_invariant_violations = 0
R_second_construction_path = 0
R_non_exhaustive_variant_coverage = 0
R_name_spelling_overload_gate = 0
R_fabricated_completion_fallback = 0
R_auditor_errors = 0
R_construction_side_doors = 0
R_ast_semantic_above_adapter = 0
```

The renamed fixture's `SomeGuard`, `SomeResource`, `LyingGuard`, and annotated/decorated `ObservationSlot` class structures construct through this door. Method/base traversal and decorator application remain later Cut C-extension slices; Cut E remains projection-only after those land.

Do not merge without the focused constructor audit.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add class-body testimony construction for source managers including fields, docstrings, and decorator CIDs
> - Extends `ClassDef._construct_sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/6145/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to extract docstring CID, annotation CIDs, decorator CIDs, and class fields from simple (`Assign`) and annotated (`AnnAssign`) assignments in class bodies.
> - Introduces `ConstructedClassFieldV1` dataclass to represent individual class fields, and adds `class_fields` plus metadata CID attributes to `ClassDefinitionValue` and `ClassDefinitionSugar`.
> - `ClassDefinitionSugar.desugar()` now desugars each field's value sugar and raises `SugarNotWritten` if any field fails to fully construct.
> - Adds a test in [test_sole_path_manager_construction.py](https://github.com/TSavo/sugar/pull/6145/files#diff-66a8978c573ce822d1d2e242f2e0761e4bcdf509d2513e27a73b8692656b2477) that verifies docstring CIDs, class fields, annotation CIDs, and decorator CIDs are populated after desugaring fixture classes.
> - Behavioral Change: class body members matching `Assign` or `AnnAssign` patterns no longer trigger `SugarNotWritten`; they are now collected as fields instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ced22e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->