### PR TITLE
Cut C extension: route inter-method calls through source frames (#6088)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
@@ -67,6 +67,25 @@ class MethodCallSugar(Sugar):
                     receiver, tuple(rest), kw_values + ((name, value),), positional, ctx
                 )
             )
+        from sugar_lift_py_tests.floor import ObjectValue
+
+        if isinstance(receiver, ObjectValue):
+            if kw_values:
+                from sugar_source_tree.panic import SugarNotWritten
+
+                raise SugarNotWritten(
+                    owner="MethodCallSugar._collect_kwargs",
+                    observed="source-visible object method called with keywords",
+                    requested="keyword binding through its SourceVisibleCallFrameV1",
+                    fix="extend the sole method call frame binder; never drop keywords",
+                )
+            return receiver.call_method_value(
+                self.name,
+                positional,
+                owner="MethodCallSugar",
+                blame=self.site,
+                ctx=ctx,
+            )
         from sugar_lift_py_tests.floor import CallSiteValue
         from sugar_lift_py_tests.ir import ctor, str_const
 

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -4,7 +4,7 @@ import csv
 import importlib.metadata
 from pathlib import Path
 
-from sugar_lift_py_tests.floor import BlockValue, ReturnValue, TermValue
+from sugar_lift_py_tests.floor import BlockValue, CallSiteValue, ReturnValue, TermValue
 from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.dependency_artifact import (
@@ -237,3 +237,37 @@ def test_fixture_manager_class_bodies_construct_docstrings_and_class_fields():
     assert type(fields["claimed_suppression"]).__name__ == "TrueBoolLiteralSugar"
     assert observation.annotation_cids
     assert observation.decorator_cids
+
+
+def test_renamed_manager_inter_method_call_uses_constructed_method_frame(tmp_path):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class RenamedGuard:\n"
+        "    def __init__(self, marker):\n"
+        "        self.marker = marker\n\n"
+        "    def project(self):\n"
+        "        return self.marker\n\n"
+        "    def __enter__(self):\n"
+        "        return self.project()\n\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n\n"
+        "def make_guard(marker):\n"
+        "    return RenamedGuard(marker)\n",
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    protocol = construct_manager_protocol(behavior, exit_face_id="fixture-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+
+    enter_block = protocol.enter_call.force_floor(
+        None, owner="inter-method enter", project_callsite=False
+    )
+    assert isinstance(enter_block, BlockValue)
+    returned = enter_block.statements[0]
+    assert isinstance(returned, ReturnValue)
+    assert isinstance(returned.value, CallSiteValue)
+    helper_block = returned.value.force_floor(None, owner="inter-method")
+    assert isinstance(helper_block, BlockValue)
+    assert helper_block.statements == (ReturnValue(actual.value),)


### PR DESCRIPTION
## Slice

When ordinary `MethodCallSugar` has an exact constructed `ObjectValue`, it now delegates to that object's retained source-visible method frame. The receiver and positional actuals flow through the existing `CallSiteValue`/`BindingCoordinateV1` call door; no method AST is reinterpreted.

Keyword method calls remain typed-loud until `SourceVisibleCallFrameV1` keyword binding is threaded at this seam. Opaque receivers retain the existing uninterpreted call coordinate.

## Evidence

A renamed `RenamedGuard.__enter__ -> self.project() -> self.marker` twin constructs and reduces through both authenticated method frames to the exact constructed receiver field.

```
sole-path manager tests: 7 passed
R_construction_invariant_violations = 0
R_second_construction_path = 0
R_non_exhaustive_variant_coverage = 0
R_name_spelling_overload_gate = 0
R_fabricated_completion_fallback = 0
R_auditor_errors = 0
R_construction_side_doors = 0
R_ast_semantic_above_adapter = 0
```

Stacked on #6145. Do not merge without the focused constructor audit.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route inter-method calls through source frames when receiver is an ObjectValue
> - Method call desugaring in [`MethodCallSugar._collect_kwargs`](https://github.com/TSavo/sugar/pull/6146/files#diff-1a6a1e058898693a04db89a8dda185ad15e19277c08fb04e58876c1736c68088) now dispatches through `receiver.call_method_value` when the receiver is an `ObjectValue`, instead of always producing a `CallSiteValue`.
> - `ClassDef._construct_sugar` in [`nodes.py`](https://github.com/TSavo/sugar/pull/6146/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now extracts class-level docstrings, simple assignments, and annotated assignments, constructing `ConstructedClassFieldV1` entries and including them in `ClassDefinitionSugar`.
> - `ClassDefinitionValue` is extended with `class_fields`, `docstring_cid`, `annotation_cids`, and `decorator_cids`; `ObjectValue`s produced from it now carry `class_fields`.
> - Keyword arguments are rejected with `SugarNotWritten` when the receiver is an `ObjectValue`.
> - Behavioral Change: desugaring a class definition now fails loudly if any class field value sugar does not complete.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ebc0d0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->