### PR TITLE
Cut C extension: authenticate defaults and preserve manager-factory prefix (#6088)

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Literal
 
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
@@ -48,6 +48,8 @@ class ConstructedManagerBehaviorV1:
     receiver_state_cid: str
     formal_actual_bindings: tuple[BindingEntryV1, ...]
     source_call_frame_cid: str
+    factory_prefix: tuple[FloorValue, ...] = field(default=(), compare=False)
+    factory_prefix_cids: tuple[str, ...] = ()
 
     @property
     def preimage(self):
@@ -60,6 +62,7 @@ class ConstructedManagerBehaviorV1:
                 item.wire() for item in self.formal_actual_bindings
             ],
             "sourceCallFrameCid": self.source_call_frame_cid,
+            "factoryPrefixCids": list(self.factory_prefix_cids),
         }
 
     def __post_init__(self) -> None:
@@ -173,11 +176,21 @@ def construct_manager_behavior(
         frame = frame.bind_node_actuals(
             tuple(item.node for item in actuals),
             tuple((name, item.node) for name, item in keyword_actuals),
-            testimonies=tuple(
-                item.testimony
-                for item in (*actuals, *(item for _, item in keyword_actuals))
-            ),
         )
+        supplied = {
+            id(item.node): item.testimony
+            for item in (*actuals, *(item for _, item in keyword_actuals))
+        }
+        authenticated_entries = []
+        for entry, value in zip(frame.runtime_entries, values, strict=True):
+            testimony = supplied.get(id(entry.state))
+            if testimony is None:
+                testimony = ConstructedValueTestimonyV1.mint(
+                    entry.state.fragment,
+                    _term_content_cid(value.to_term(owner=resolved.cid)),
+                )
+            authenticated_entries.append(entry.with_testimony(testimony))
+        frame = replace(frame, runtime_entries=tuple(authenticated_entries))
     except SourceCallBindingGap as exc:
         return ManagerConstructionGapV1("call-binding", resolved.cid, str(exc))
     call = CallSiteValue(
@@ -195,12 +208,12 @@ def construct_manager_behavior(
     result = call.force_floor(
         None, owner="construct_manager_behavior", project_callsite=False
     )
-    if (
-        isinstance(result, BlockValue)
-        and len(result.statements) == 1
-        and isinstance(result.statements[0], ReturnValue)
+    factory_prefix: tuple[FloorValue, ...] = ()
+    if isinstance(result, BlockValue) and result.statements and isinstance(
+        result.statements[-1], ReturnValue
     ):
-        returned = result.statements[0].value
+        factory_prefix = result.statements[:-1]
+        returned = result.statements[-1].value
         if isinstance(returned, CallSiteValue):
             result = returned.force_floor(
                 None, owner="construct_manager_behavior returned object"
@@ -212,6 +225,10 @@ def construct_manager_behavior(
             "non-manager-result", resolved.cid, type(result).__name__
         )
     bindings = frame.runtime_entries
+    prefix_cids = tuple(
+        _term_content_cid(item.to_term(owner=resolved.cid))
+        for item in factory_prefix
+    )
     preimage = {
         "kind": "constructed-manager-behavior",
         "schemaVersion": "1",
@@ -219,6 +236,7 @@ def construct_manager_behavior(
         "receiverStateCid": result.identity,
         "formalActualBindings": [item.wire() for item in bindings],
         "sourceCallFrameCid": frame.frame_cid,
+        "factoryPrefixCids": list(prefix_cids),
     }
     return ConstructedManagerBehaviorV1(
         resolved.cid,
@@ -227,6 +245,8 @@ def construct_manager_behavior(
         result.identity,
         bindings,
         frame.frame_cid,
+        factory_prefix,
+        prefix_cids,
     )
 
 

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -271,3 +271,26 @@ def test_renamed_manager_inter_method_call_uses_constructed_method_frame(tmp_pat
     helper_block = returned.value.force_floor(None, owner="inter-method")
     assert isinstance(helper_block, BlockValue)
     assert helper_block.statements == (ReturnValue(actual.value),)
+
+
+def test_source_factory_default_gets_authenticated_binding_testimony(tmp_path):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class DefaultedGuard:\n"
+        "    def __init__(self, marker, enabled):\n"
+        "        self.marker = marker\n"
+        "        self.enabled = enabled\n\n"
+        "def make_guard(marker, *, enabled=False):\n"
+        "    return DefaultedGuard(marker, enabled)\n",
+    )
+
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    assert len(behavior.formal_actual_bindings) == 2
+    assert all(
+        entry.constructed_value_testimony is not None
+        for entry in behavior.formal_actual_bindings
+    )


### PR DESCRIPTION
## Slice

Completes two ordinary source-call-frame obligations exposed by the renamed manager factory:

- omitted source defaults now receive `ConstructedValueTestimonyV1` from their exact default-node fragment and constructed semantic value; caller-supplied actuals retain their original occurrence testimony
- a manager factory block with completed prefix statements plus a terminal return preserves that prefix in `ConstructedManagerBehaviorV1`, with every prefix term CID in the manager-construction preimage

No prefix statement is silently dropped, and no default value is synthesized.

## Evidence

```
sole-path manager tests: 8 passed
R_construction_invariant_violations = 0
R_second_construction_path = 0
R_non_exhaustive_variant_coverage = 0
R_name_spelling_overload_gate = 0
R_fabricated_completion_fallback = 0
R_auditor_errors = 0
R_construction_side_doors = 0
R_ast_semantic_above_adapter = 0
```

Stacked on #6146. Do not merge without focused constructor audit.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add authenticate defaults and factory prefix preservation to manager behavior construction
> - `construct_manager_behavior` now authenticates all formal-actual bindings by attaching testimonies, minting default `ConstructedValueTestimonyV1` instances when none are supplied.
> - Pre-return statements in a manager block are captured as a `factory_prefix` and stored (with their CIDs) on `ConstructedManagerBehaviorV1` and its canonical preimage.
> - `ClassDef` sugar construction now extracts docstrings, class-level fields (from assignments and annotated assignments), and decorator/annotation CIDs from Python source.
> - Method calls on source-visible `ObjectValue` receivers now dispatch directly via `call_method_value` instead of producing a `CallSiteValue`, and reject keyword arguments with `SugarNotWritten`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized af1f8b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->