### PR TITLE
Cut C extension: construct renamed manager protocol bodies (#6088)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -125,6 +125,10 @@ class CallSiteSugar(Sugar):
                 ) from exc
             source_body = self.source_call_frame.body
             source_frame_cid = self.source_call_frame.frame_cid
+            # bind_actuals returned the complete formal-ordered tuple,
+            # including keyword/default actuals. They must not be appended a
+            # second time below.
+            kw_values = ()
         return Complete(
             CallSiteValue(
                 target_name=self.target_name,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
@@ -40,6 +40,18 @@ def predicate_formula(value, site):
         )
     formula = getattr(truth.value, "formula", None)
     if formula is None:
+        from sugar_lift_py_tests.outcome.exit_set import false_guard, true_guard
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        if isinstance(truth.value, TrueBoolLiteralSugar):
+            return true_guard()
+        if isinstance(truth.value, FalseBoolLiteralSugar):
+            return false_guard()
         raise NotImplementedError(
             f"condition folded without a symbolic formula: {type(value).__name__}"
         )

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -29,11 +29,13 @@ from sugar_source_tree.nodes import Call, Constant
 from sugar_source_tree.tree import SourceFile
 
 
-def _distribution(root: Path, source: str) -> importlib.metadata.Distribution:
+def _distribution(
+    root: Path, source: str, *, exported: str = "make_guard"
+) -> importlib.metadata.Distribution:
     package = root / "arbitrary"
     package.mkdir()
     (package / "__init__.py").write_text(
-        "from arbitrary.manager import make_guard\n", encoding="utf-8"
+        f"from arbitrary.manager import {exported}\n", encoding="utf-8"
     )
     (package / "manager.py").write_text(source, encoding="utf-8")
     metadata = root / "arbitrary_dist-1.0.dist-info"
@@ -55,9 +57,11 @@ def _distribution(root: Path, source: str) -> importlib.metadata.Distribution:
     return importlib.metadata.Distribution.at(metadata)
 
 
-def _resolved(root: Path, source: str):
-    graph = DependencyArtifactGraph.authenticate(_distribution(root, source))
-    consumer = "import arbitrary\narbitrary.make_guard(23)\n"
+def _resolved(root: Path, source: str, *, exported: str = "make_guard"):
+    graph = DependencyArtifactGraph.authenticate(
+        _distribution(root, source, exported=exported)
+    )
+    consumer = f"import arbitrary\narbitrary.{exported}(23)\n"
     path = root / "consumer.py"
     path.write_text(consumer, encoding="utf-8")
     source_cid = blake3_512_of(consumer.encode())
@@ -294,3 +298,27 @@ def test_source_factory_default_gets_authenticated_binding_testimony(tmp_path):
         entry.constructed_value_testimony is not None
         for entry in behavior.formal_actual_bindings
     )
+
+
+def test_merged_renamed_some_guard_factory_constructs_through_sole_door(tmp_path):
+    fixture = (
+        Path(__file__).parents[2]
+        / "sugar-lift-py-tests/tests/fixtures/with_source_derivation"
+        / "arbitrary_manager_module.py"
+    )
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path, fixture.read_text(encoding="utf-8"), exported="some_manager"
+    )
+
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    assert behavior.receiver_state.class_name == "SomeGuard"
+    assert behavior.receiver_state.has_method("__enter__")
+    assert behavior.receiver_state.has_method("__exit__")
+    protocol = construct_manager_protocol(behavior, exit_face_id="fixture-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+    assert protocol.enter_outcome() is not None
+    assert protocol.exit_outcome() is not None


### PR DESCRIPTION
## Slice

The merged #6101 `some_manager` fixture now constructs its `SomeGuard` object and both `__enter__`/`__exit__` outcomes through Cut C+D's ordinary source frames.

General fixes exposed by that red twin:

- after `SourceVisibleCallFrameV1.bind_actuals` produces the complete formal-ordered tuple, keyword values are no longer appended a second time
- the shared `predicate_formula` now projects the existing exact True/False floor variants to true/false guards, rather than erroring on a ground branch

No manager/package names occur in production code. Installed `pytest.raises` remains typed-loud at `ManagerConstructionGapV1(kind="opaque-call-target", detail="set")` pending the separate opaque-builtin witness mechanism.

## Evidence

```
focused Cut C/D + ExitSet: 12 passed
R_construction_invariant_violations = 0
R_second_construction_path = 0
R_non_exhaustive_variant_coverage = 0
R_name_spelling_overload_gate = 0
R_fabricated_completion_fallback = 0
R_auditor_errors = 0
R_construction_side_doors = 0
R_ast_semantic_above_adapter = 0
```

Stacked on #6147. Do not merge without focused constructor audit.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct renamed manager protocol bodies with class fields, docstrings, and factory prefixes
> - `ClassDef._construct_sugar` now extracts docstrings, class-level assignments, annotated assignments, and decorator/annotation CIDs into `ClassDefinitionSugar`, replacing previous `SugarNotWritten` errors for those members.
> - `ClassDefinitionSugar.desugar` and `ClassDefinitionValue` propagate the new `class_fields`, `docstring_cid`, `annotation_cids`, and `decorator_cids` through to the constructed `ObjectValue`.
> - `construct_manager_behavior` now mints authenticated `ConstructedValueTestimony` for default/keyword parameters and captures pre-return statements as `factory_prefix` recorded in `ConstructedManagerBehaviorV1`.
> - `MethodCallSugar._collect_kwargs` executes source-visible object method calls without keywords directly via `receiver.call_method_value`; keyword usage on such methods raises `SugarNotWritten`.
> - `predicate_formula` maps literal `True`/`False` conditions to `true_guard()`/`false_guard()` without requiring a symbolic formula.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f88bdcb.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->