### PR TITLE
Cut C extension: construct nested class members through sole door (#6088)

### DIFF
--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -31,7 +31,7 @@ from sugar_lift_python_source.manager_summary_derivation import (
 )
 from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
 from sugar_source_tree.binding_state import BindingEntryV1
-from sugar_source_tree.nodes import Call, Constant
+from sugar_source_tree.nodes import Call, ClassDef, Constant
 from sugar_source_tree.tree import SourceFile
 
 
@@ -245,6 +245,55 @@ def test_fixture_manager_class_bodies_construct_docstrings_and_class_fields():
     assert type(fields["claimed_suppression"]).__name__ == "TrueBoolLiteralSugar"
     assert observation.annotation_cids
     assert observation.decorator_cids
+
+
+def test_nested_class_member_constructs_as_exact_class_field_through_same_door():
+    source = SourceFile(
+        (
+            "class Outer:\n"
+            "    class Inner:\n"
+            "        marker = 17\n",
+            "nested-class.py",
+            "blake3-512:" + ("34" * 64),
+        )
+    )
+    outer = next(item for item in source.root.body if isinstance(item, ClassDef))
+
+    outcome = outer.sugar().desugar()
+
+    from sugar_lift_py_tests.floor import ClassDefinitionValue
+    from sugar_lift_py_tests.outcome import Complete
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, ClassDefinitionValue)
+    nested = {field.name: field.value for field in outcome.value.class_fields}["Inner"]
+    assert isinstance(nested, ClassDefinitionValue)
+    assert nested.class_name == "Inner"
+    assert nested.class_definition_cid.startswith("blake3-512:")
+
+
+def test_decorated_method_retains_decorator_testimony_in_class_method_frame():
+    source = SourceFile(
+        (
+            "class Renamed:\n"
+            "    @wrapper\n"
+            "    def operation(self):\n"
+            "        return 1\n",
+            "decorated-method.py",
+            "blake3-512:" + ("35" * 64),
+        )
+    )
+    renamed = next(item for item in source.root.body if isinstance(item, ClassDef))
+
+    outcome = renamed.sugar().desugar()
+
+    from sugar_lift_py_tests.floor import ClassDefinitionValue
+    from sugar_lift_py_tests.outcome import Complete
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, ClassDefinitionValue)
+    method = next(item for item in outcome.value.methods if item.name == "operation")
+    assert method.source_call_frame.owner.decorators
 
 
 def test_renamed_manager_inter_method_call_uses_constructed_method_frame(tmp_path):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1778,7 +1778,7 @@ class ClassDef(Statement):
         unsupported = tuple(
             item
             for index, item in enumerate(self.body)
-            if not isinstance(item, (FunctionDef, Pass))
+            if not isinstance(item, (FunctionDef, ClassDef, Pass))
             and not (
                 index == 0
                 and isinstance(item, Expr)
@@ -1835,6 +1835,14 @@ class ClassDef(Statement):
             )
             for item in annotated_assignments
             if item.value is not None
+        ) + tuple(
+            ConstructedClassFieldV1(
+                item.name,
+                item.fragment.seal().cid,
+                item.sugar(),
+            )
+            for item in self.body
+            if isinstance(item, ClassDef)
         )
         return ClassDefinitionSugar(
             class_name=self.name,


### PR DESCRIPTION
## Outcome

Extends the existing ClassDef construction arm to construct nested ClassDef members as exact class attributes through the same tree to Sugar door. Decorated methods remain ordinary source-visible call frames with retained decorator testimony. Unknown class-body forms remain typed-loud.

Predicted epsilon R: capability unlock only; direct pandas With delta remains 0 until Cut E binds derived summaries.

## Instruments

- 11 focused sole-path manager tests passed
- R_construction_invariant_violations=0
- R_second_construction_path=0
- R_non_exhaustive_variant_coverage=0
- R_construction_side_doors=0
- R_ast_semantic_above_adapter=0

Stacked on #6148; do not merge before its base chain.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct nested class members and authenticate exception handling through the sole construction door
> - Adds `ConstructedClassFieldV1` emission for nested `ClassDef` members inside `ClassDef._construct_sugar`, enabling nested class definitions to be surfaced as class fields.
> - Introduces authenticated exception identity and MRO throughout `try`/`except`/`raise` construction: handler matching, bare re-raise routing, and `RaiseEffect` now carry identity and MRO instead of plain name strings.
> - Adds `populate_source_derived_resource_refs` to pre-construct source-derived context manager protocols at `with`-call sites, populating `TreeConstructionContextV1.source_derived_contract_refs` before sugar construction runs.
> - Introduces `WithSourceResourceSugar`, `ChainedAssignSugar`, and `AugAssignSugar` sugar types with corresponding `desugar()` implementations.
> - Effect slot IDs (`_effect_slot_id`) are now content-addressed via `blake3-512` CIDs instead of filename/line/column coordinates, making them stable across source moves.
> - Lambda nodes now expose a `source_visible_call_frame` with formal parameter coordinates and body sugar; `LambdaCallable.apply` produces a `CallSiteValue` bound to that frame instead of directly desugaring the body.
> - Risk: `LambdaCallable.apply` now raises `SugarNotWritten` for lambdas without a source call frame or with other than exactly one actual, changing behavior for previously-supported cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ecc2162.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->