### PR TITLE
Construct nested and starred display assignments

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1897,16 +1897,90 @@ class Assign(Statement):
         return rewrite(self, **changes)
 
     def _destructured_binding(self):
-        # `a, b = <display>` -- a single Tuple/List target of plain Names,
-        # destructured against the already-substituted rhs when it is a
-        # Tuple/List display of the same arity. Starred/nested targets, an
-        # arity mismatch, or a non-display rhs return None here (mirrors
-        # For._target_bindings_for -- the shared destructuring reader, called
-        # class-explicitly so it never depends on `self` being a For).
+        # Destructure only an already-constructed Tuple/List display.  This is
+        # structural projection, not an iterator guess: a symbolic/opaque RHS
+        # has no authenticated cardinality and therefore stays loud.
         target = self.targets[0]
         if not isinstance(target, (Tuple_, List)):
             return None
-        return For._target_bindings_for(self, target, self.value)
+        return self._destructure_display(target, self.value)
+
+    def _destructure_display(self, target, value):
+        if isinstance(target, Name):
+            return {target.id: value}
+        if not isinstance(target, (Tuple_, List)) or not isinstance(
+            value, (Tuple_, List)
+        ):
+            return None
+
+        starred = [
+            index for index, element in enumerate(target.elts) if isinstance(element, Starred)
+        ]
+        if len(starred) > 1:
+            return None
+        pairs = []
+        if not starred:
+            if len(target.elts) != len(value.elts):
+                return None
+            pairs = list(zip(target.elts, value.elts))
+        else:
+            star_index = starred[0]
+            suffix = len(target.elts) - star_index - 1
+            if len(value.elts) < len(target.elts) - 1:
+                return None
+            pairs.extend(zip(target.elts[:star_index], value.elts[:star_index]))
+            rest_end = len(value.elts) - suffix if suffix else len(value.elts)
+            rest = self._make_unpack_rest_list(value.elts[star_index:rest_end])
+            pairs.append((target.elts[star_index].value, rest))
+            if suffix:
+                pairs.extend(zip(target.elts[-suffix:], value.elts[-suffix:]))
+
+        bindings = {}
+        for child_target, child_value in pairs:
+            child = self._destructure_display(child_target, child_value)
+            if child is None:
+                return None
+            bindings.update(child)
+        return bindings
+
+    def _make_unpack_rest_list(self, elements):
+        """The starred target's real CPython list result, from real RHS children."""
+        from .backend import Children, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        return materialize(
+            self.unit,
+            ShadowNode(
+                "List",
+                self.span,
+                (("elts", Children(tuple(_handle_of(element) for element in elements))),),
+            ),
+            self.reporter,
+        )
+
+    def _binding_site_and_path(self, name: str, ordinal: int):
+        del ordinal
+        matches = []
+
+        def collect(target, path):
+            if isinstance(target, Name):
+                if target.id == name:
+                    matches.append((target.fragment, path))
+                return
+            if isinstance(target, Starred):
+                collect(target.value, (*path, "starred"))
+                return
+            if isinstance(target, (Tuple_, List)):
+                kind = "tuple" if isinstance(target, Tuple_) else "list"
+                for index, child in enumerate(target.elts):
+                    collect(child, (*path, kind, index))
+
+        for target_index, target in enumerate(self.targets):
+            collect(target, ("targets", target_index))
+        if matches:
+            # Repeated targets are legal; the final store is the live binding.
+            return matches[-1]
+        return super()._binding_site_and_path(name, 0)
 
     def substitution_binding(self, scope):
         # A single Name target binds its name to the already-substituted rhs.

--- a/implementations/python/sugar-source-tree/tests/test_assign_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_targets.py
@@ -57,14 +57,53 @@ def test_chained_assign_binds_every_target():
     assert post.args[1].value == 10
 
 
-def test_starred_target_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A():\n    a, *b = (1, 2, 3)\n    return a\n").sugar()
+def test_starred_target_binds_real_prefix_rest_and_suffix_values():
+    post = _post(
+        "def A():\n"
+        "    a, *rest, z = (1, 2, 3, 4)\n"
+        "    return a + rest[0] + rest[1] + z\n"
+    )
+    assert post.args[1].value == 10
 
 
-def test_nested_tuple_target_stays_loud():
-    with pytest.raises(SugarNotWritten):
-        _fn("def A():\n    (a, b), c = (1, 2), 3\n    return c\n").sugar()
+def test_nested_tuple_target_binds_each_structural_projection():
+    post = _post(
+        "def A():\n"
+        "    (a, (b, c)), d = (1, (2, 3)), 4\n"
+        "    return a + b + c + d\n"
+    )
+    assert post.args[1].value == 10
+
+
+def test_nested_tuple_projection_pairing_discriminates():
+    left = _post(
+        "def A():\n    (a, (b, c)) = (1, (2, 4))\n    return b - c\n"
+    ).args[1].value
+    right = _post(
+        "def A():\n    (a, (b, c)) = (1, (4, 2))\n    return b - c\n"
+    ).args[1].value
+    assert (left, right) == (-2, 2)
+
+
+def test_nested_and_starred_targets_use_one_runtime_binding_entry_model():
+    function = _fn(
+        "def arbitrary():\n"
+        "    (a, (b, *rest)), z = (1, (2, 3, 4)), 5\n"
+        "    return a + b + rest[0] + rest[1] + z\n"
+    )
+    trace = function.sugar().substitution_trace
+    first = trace.records[0]
+    entries = dict(first.post_bindings)
+    assert set(entries) == {"a", "b", "rest", "z"}
+    assert len({entry.coordinate.cid for entry in entries.values()}) == 4
+    paths = {
+        name: tuple(entry.coordinate.preimage["projectionPath"])
+        for name, entry in entries.items()
+    }
+    assert paths["a"][-4:] == ("tuple", 0, "tuple", 0)
+    assert paths["b"][-4:] == ("tuple", 1, "tuple", 0)
+    assert paths["rest"][-1] == "starred"
+    assert paths["z"][-2:] == ("tuple", 1)
 
 
 def test_arity_mismatch_stays_loud():


### PR DESCRIPTION
## What changed

- Recursively destructures already-constructed tuple/list displays through the sole runtime BindingEntryV1 substitution path.
- Supports nested tuple/list targets and one starred target; the starred rest is a real constructed list of RHS children.
- Mints distinct structural BindingCoordinateV1 projection paths for every bound target.
- Keeps symbolic/non-display RHS and arity mismatches typed-loud; introduces no unpack-projection coordinate or second binding model.

## Boundary

- Does not touch authenticated plain-object field state owned by #6126.
- Does not admit symbolic or opaque iterable unpacking.

## Validation

- Focused Assign/binding suite: 35 passed.
- Construction-invariant violations: R=0 on every axis.
- Construction side doors: R=0.
- Sugar calls in desugar: R=0.

Pandas delta is being measured on battleaxe and will be posted before this draft is marked ready.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add nested and starred destructuring support to `Assign` display assignments
> - `Assign._destructured_binding` now delegates to a new recursive helper `_destructure_display` instead of `For._target_bindings_for`, enabling structural projection over `Tuple`/`List` displays with nested patterns and starred targets.
> - `_destructure_display` handles arity validation, prefix/suffix pairing for starred targets, and recursive merging of child bindings, bailing out on non-structural cases.
> - `_make_unpack_rest_list` materializes a CPython-style list node for the starred rest elements using `backend.materialize`.
> - `_binding_site_and_path` records each bound name's structural position as a `projectionPath` encoding `('tuple'/'list', index)` steps and `'starred'` markers.
> - Tests in [test_assign_targets.py](https://github.com/TSavo/sugar/pull/6151/files#diff-91153c1ff8e699049c64744bb1af84de90ecb151910a727b2cab71174096e3cd) are updated from expecting `SugarNotWritten` errors to asserting concrete computed values for nested and starred patterns.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c18f5ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->