### PR TITLE
Cut C extension: authenticated local-base MRO method projection (#6088)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -154,6 +154,10 @@ class TreeConstructionContextV1:
     # Mutable frame table held by reference; the context object itself is frozen.
     source_call_frames: dict = field(default_factory=dict)
     source_derived_contract_refs: dict = field(default_factory=dict)
+    # Runtime-only, prebound class-base Sugar children keyed by the exact
+    # subclass definition coordinate.  These are never serialized; the class
+    # definition projects their sealed CIDs into its own preimage.
+    source_class_bases: dict = field(default_factory=dict)
 
     @classmethod
     def for_source_call_construction(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -32,6 +32,7 @@ class ClassDefinitionValue(FloorValue):
     docstring_cid: str | None = None
     annotation_cids: tuple[str, ...] = ()
     decorator_cids: tuple[str, ...] = ()
+    base_classes: tuple["ClassDefinitionValue", ...] = ()
 
     def to_term(self, *, owner: str):
         del owner
@@ -103,6 +104,14 @@ class ClassDefinitionValue(FloorValue):
     def _object_methods(self):
         from sugar_lift_py_tests.floor import ObjectMethodValue
 
+        # ObjectValue searches from the end, so emit the reversed C3 lookup
+        # tail before this class's methods.  A base method is retained with its
+        # original authenticated source frame; nothing is reconstructed here.
+        inherited = tuple(
+            method
+            for base in reversed(self._c3_tail())
+            for method in base.methods
+        )
         return tuple(
             ObjectMethodValue(
                 method.name,
@@ -114,5 +123,34 @@ class ClassDefinitionValue(FloorValue):
                     for coordinate in method.source_call_frame.formal_coordinates
                 ),
             )
-            for method in self.methods
+            for method in (*inherited, *self.methods)
         )
+
+    def _c3_tail(self) -> tuple["ClassDefinitionValue", ...]:
+        if not self.base_classes:
+            return ()
+        sequences = [list((base, *base._c3_tail())) for base in self.base_classes]
+        sequences.append(list(self.base_classes))
+        result = []
+        while any(sequences):
+            sequences = [sequence for sequence in sequences if sequence]
+            candidate = next(
+                (
+                    sequence[0]
+                    for sequence in sequences
+                    if not any(sequence[0] in other[1:] for other in sequences)
+                ),
+                None,
+            )
+            if candidate is None:
+                raise SugarNotWritten(
+                    owner="ClassDefinitionValue._c3_tail",
+                    observed="inconsistent authenticated local base order",
+                    requested="one valid C3 linearization",
+                    fix="keep inconsistent or dynamic inheritance loud",
+                )
+            result.append(candidate)
+            for sequence in sequences:
+                if sequence and sequence[0] == candidate:
+                    sequence.pop(0)
+        return tuple(result)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
@@ -23,6 +23,8 @@ class ClassDefinitionSugar(Sugar):
     docstring_cid: str | None
     annotation_cids: tuple[str, ...]
     decorator_cids: tuple[str, ...]
+    base_sugars: tuple[Sugar, ...]
+    base_fragment_cids: tuple[str, ...]
     site: object = field(compare=False)
 
     @classmethod
@@ -58,6 +60,10 @@ class ClassDefinitionSugar(Sugar):
             "docstringCid": self.docstring_cid,
             "annotationCids": list(self.annotation_cids),
             "decoratorCids": list(self.decorator_cids),
+            "baseDefinitionCids": [
+                base.class_definition_cid for base in self.base_sugars
+            ],
+            "baseFragmentCids": list(self.base_fragment_cids),
         }
 
     @property
@@ -68,6 +74,21 @@ class ClassDefinitionSugar(Sugar):
         from sugar_lift_py_tests.floor import ObjectField
 
         class_fields = []
+        base_values = []
+        for base in self.base_sugars:
+            outcome = base.desugar(ctx)
+            if not isinstance(outcome, Complete) or not isinstance(
+                outcome.value, ClassDefinitionValue
+            ):
+                from sugar_source_tree.panic import SugarNotWritten
+
+                raise SugarNotWritten(
+                    owner="ClassDefinitionSugar.desugar",
+                    observed="class base did not construct to ClassDefinitionValue",
+                    requested="one authenticated source-visible base definition",
+                    fix="keep dynamic or opaque inheritance loud",
+                )
+            base_values.append(outcome.value)
         for item in self.fields:
             outcome = item.value_sugar.desugar(ctx)
             if not isinstance(outcome, Complete):
@@ -93,5 +114,6 @@ class ClassDefinitionSugar(Sugar):
                 self.docstring_cid,
                 self.annotation_cids,
                 self.decorator_cids,
+                tuple(base_values),
             )
         )

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -135,6 +135,22 @@ def construct_manager_behavior(
             )
 
     frames: dict[str, object] = {}
+    # Prebind exact local base occurrences to already-owned class Sugars.  The
+    # ClassDef arm consumes these children through the ordinary door and seals
+    # their definition CIDs; dynamic/imported bases remain loud there.
+    reaching_classes: dict[str, ClassDef] = {}
+    for item in definitions:
+        if not isinstance(item, ClassDef):
+            continue
+        local_bases = []
+        for base in item.bases:
+            if not isinstance(base, Name) or base.id not in reaching_classes:
+                local_bases = []
+                break
+            local_bases.append(reaching_classes[base.id].sugar())
+        if local_bases and len(local_bases) == len(item.bases):
+            context.source_class_bases[item.fragment.seal().cid] = tuple(local_bases)
+        reaching_classes[item.name] = item
     for item in definitions:
         if isinstance(item, ClassDef):
             frames[item.name] = item.source_visible_constructor_frame()

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -296,6 +296,55 @@ def test_decorated_method_retains_decorator_testimony_in_class_method_frame():
     assert method.source_call_frame.owner.decorators
 
 
+def test_local_inherited_manager_methods_follow_authenticated_mro(tmp_path):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class Ancestor:\n"
+        "    def __init__(self, marker):\n"
+        "        self.marker = marker\n\n"
+        "    def __enter__(self):\n"
+        "        return self.marker\n\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n\n"
+        "class Descendant(Ancestor):\n"
+        "    def __init__(self, marker):\n"
+        "        self.marker = marker\n\n"
+        "def make_guard(marker):\n"
+        "    return Descendant(marker)\n",
+    )
+
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    assert behavior.receiver_state.has_method("__enter__")
+    assert behavior.receiver_state.has_method("__exit__")
+    protocol = construct_manager_protocol(behavior, exit_face_id="inherited-face")
+    assert isinstance(protocol, ConstructedManagerProtocolV1)
+    assert protocol.enter_outcome() is not None
+    assert protocol.exit_outcome() is not None
+
+
+def test_opaque_base_never_fabricates_inherited_manager_methods(tmp_path):
+    graph, resolved, actual, call_site = _resolved(
+        tmp_path,
+        "class Descendant(OpaqueAncestor):\n"
+        "    def __init__(self, marker):\n"
+        "        self.marker = marker\n\n"
+        "def make_guard(marker):\n"
+        "    return Descendant(marker)\n",
+    )
+    behavior = construct_manager_behavior(
+        resolved, graph=graph, actuals=(actual,), call_site=call_site
+    )
+
+    assert isinstance(behavior, ConstructedManagerBehaviorV1)
+    protocol = construct_manager_protocol(behavior, exit_face_id="opaque-base")
+    assert isinstance(protocol, ManagerProtocolConstructionGapV1)
+    assert protocol.kind == "enter-missing"
+
+
 def test_renamed_manager_inter_method_call_uses_constructed_method_frame(tmp_path):
     graph, resolved, actual, call_site = _resolved(
         tmp_path,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1844,6 +1844,17 @@ class ClassDef(Statement):
             for item in self.body
             if isinstance(item, ClassDef)
         )
+        base_sugars = ()
+        if self.bases:
+            context = self.unit.construction_context
+            table = (
+                getattr(context, "source_class_bases", None)
+                if context is not None
+                else None
+            )
+            base_sugars = () if table is None else table.get(
+                self.fragment.seal().cid, ()
+            )
         return ClassDefinitionSugar(
             class_name=self.name,
             source_identity_cid=self.unit.source_cid,
@@ -1857,6 +1868,8 @@ class ClassDef(Statement):
             decorator_cids=tuple(
                 item.fragment.seal().cid for item in self.decorators
             ),
+            base_sugars=base_sugars,
+            base_fragment_cids=tuple(base.fragment.seal().cid for base in self.bases),
             site=self.fragment,
         )
 


### PR DESCRIPTION
## Outcome

Prebinds exact local class-base occurrences in the explicit TreeConstructionContext and constructs inherited methods from their already-owned ClassDefinitionSugar children. ClassDefinitionValue uses C3 order for method projection. Opaque bases contribute only authenticated source-fragment testimony and never fabricate inherited methods; manager protocol lookup therefore remains typed-loud.

Predicted epsilon R: capability unlock only; direct pandas With delta remains 0 until Cut E summary binding.

## Instruments

- 13 focused sole-path manager tests passed
- local inherited __enter__/__exit__ twin passes
- opaque-base lying twin stays ManagerProtocolConstructionGapV1
- R_construction_invariant_violations=0
- R_second_construction_path=0
- R_non_exhaustive_variant_coverage=0
- R_construction_side_doors=0
- R_ast_semantic_above_adapter=0

Stacked on #6150; do not merge before its base chain.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add authenticated local-base MRO method projection to class definition sugar
> - `ClassDefinitionValue` now carries `base_classes` and computes C3 linearization via a new `_c3_tail` helper, emitting inherited methods from authenticated local bases in MRO order before the class's own methods during `ObjectValue` lookup.
> - `ClassDefinitionSugar` gains `base_sugars` and `base_fragment_cids` fields; desugaring validates that each base resolves to a `ClassDefinitionValue` and threads the results into the produced value.
> - `construct_manager_behavior` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6152/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) adds a prebinding pass that detects classes whose bases resolve to earlier local class definitions and stores their Sugars in `context.source_class_bases`.
> - `ClassDef.sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/6152/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now emits nested classes as `ConstructedClassFieldV1` fields and wires in authenticated base Sugars when present in `source_class_bases`.
> - Risk: classes with inconsistent base ordering will raise `SugarNotWritten`; dynamic or imported bases remain unbound and produce no inherited methods (enter-missing gap).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3cdbad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->