### PR TITLE
Sequence chained assignments through runtime bindings

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
-from sugar_lift_py_tests.sugar.witnesses import _call_pair
+from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing, _call_pair
 
 
 @dataclass(frozen=True)
@@ -82,3 +82,34 @@ class MultiAssignSugar(Sugar):
         from sugar_lift_py_tests.floor.block_value import BlockValue
 
         return Complete(BlockValue((), can_fall_through=True))
+
+
+@dataclass(frozen=True)
+class ChainedAssignSugar(Sugar):
+    """One evaluated RHS distributed left-to-right across names and stores."""
+
+    bindings: tuple
+    stores: tuple
+    value: object
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="typed store effect",
+            reason="mixed chained stores stay red while lexical bindings continue",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_body
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.outcome import Complete
+
+        return self.value.desugar(ctx).and_then(
+            lambda _value: (
+                reduce_body(self.stores, ctx)
+                if self.stores
+                else Complete(BlockValue((), can_fall_through=True))
+            )
+        )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2196,8 +2196,10 @@ class Assign(Statement):
             if isinstance(target, Name):
                 return {target.id: self.value}
             return self._destructured_binding()
-        if all(isinstance(t, Name) for t in self.targets):
-            return {t.id: self.value for t in self.targets}
+        if all(isinstance(t, (Name, Attribute, Subscript)) for t in self.targets):
+            # Store targets do not bind lexical names, but they also do not
+            # erase the Name targets in the same left-to-right assignment.
+            return {t.id: self.value for t in self.targets if isinstance(t, Name)}
         return None
 
     def _construct_sugar(self):
@@ -2229,10 +2231,54 @@ class Assign(Statement):
             )
 
         if len(self.targets) > 1 and all(isinstance(t, Name) for t in self.targets):
-            from sugar_lift_py_tests.sugar.assign_sugar import MultiAssignSugar
+            from sugar_lift_py_tests.sugar.assign_sugar import ChainedAssignSugar
 
-            return MultiAssignSugar(
-                bindings=tuple((t.id, self.value.sugar()) for t in self.targets),
+            value_sugar = self.value.sugar()
+            return ChainedAssignSugar(
+                bindings=tuple((t.id, value_sugar) for t in self.targets),
+                stores=(),
+                value=value_sugar,
+                site=self.fragment,
+            )
+
+        if len(self.targets) > 1 and all(
+            isinstance(t, (Name, Attribute, Subscript)) for t in self.targets
+        ):
+            from sugar_lift_py_tests.sugar.assign_sugar import ChainedAssignSugar
+
+            value_sugar = self.value.sugar()
+            stores = []
+            for target in self.targets:
+                if isinstance(target, Attribute):
+                    from sugar_lift_py_tests.sugar.store_effect_sugar import (
+                        AttributeStoreEffectSugar,
+                    )
+
+                    stores.append(
+                        AttributeStoreEffectSugar(
+                            attr=target.attr,
+                            site=target.fragment,
+                        )
+                    )
+                elif isinstance(target, Subscript):
+                    from sugar_lift_py_tests.sugar.store_effect_sugar import (
+                        SubscriptStoreEffectSugar,
+                    )
+
+                    stores.append(
+                        SubscriptStoreEffectSugar(
+                            index_text=target.slice_.fragment.text,
+                            site=target.fragment,
+                        )
+                    )
+            return ChainedAssignSugar(
+                bindings=tuple(
+                    (target.id, value_sugar)
+                    for target in self.targets
+                    if isinstance(target, Name)
+                ),
+                stores=tuple(stores),
+                value=value_sugar,
                 site=self.fragment,
             )
 

--- a/implementations/python/sugar-source-tree/tests/test_assign_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_targets.py
@@ -66,6 +66,56 @@ def test_starred_target_binds_real_prefix_rest_and_suffix_values():
     assert post.args[1].value == 10
 
 
+def test_chained_assign_constructs_one_rhs_sugar_for_every_binding():
+    function = _fn("def arbitrary():\n    renamed = other = 5\n")
+    assignment = next(node for node in function.walk() if node.kind == "Assign")
+    sugar = assignment.sugar()
+    assert sugar.bindings[0][1] is sugar.bindings[1][1]
+
+
+def test_chained_names_receive_distinct_runtime_binding_coordinates():
+    function = _fn(
+        "def arbitrary():\n    renamed = other = 5\n    return renamed + other\n"
+    )
+    trace = function.sugar().substitution_trace
+    entries = dict(trace.records[0].post_bindings)
+    assert (
+        entries["renamed"].state.fragment.seal().cid
+        == entries["other"].state.fragment.seal().cid
+    )
+    assert entries["renamed"].coordinate.cid != entries["other"].coordinate.cid
+
+
+def test_mixed_chain_sequences_existing_store_obligation_and_name_binding():
+    entries = (
+        _fn("def arbitrary(o):\n    renamed = o.field = 5\n    return renamed\n")
+        .sugar()
+        .desugar()
+        .value.record.statements
+    )
+    red = [entry for entry in entries if isinstance(entry, Incomplete)]
+    assert len(red) == 1
+    assert isinstance(red[0].effect, AttributeStoreRuntimeEffect)
+
+
+def test_mixed_chain_preserves_each_store_face_in_source_order():
+    entries = (
+        _fn(
+            "def arbitrary(o, xs):\n"
+            "    renamed = o.field = xs[0] = 7\n"
+            "    return renamed\n"
+        )
+        .sugar()
+        .desugar()
+        .value.record.statements
+    )
+    red = [entry for entry in entries if isinstance(entry, Incomplete)]
+    assert [type(entry.effect) for entry in red] == [
+        AttributeStoreRuntimeEffect,
+        SubscriptStoreRuntimeEffect,
+    ]
+
+
 def test_nested_tuple_target_binds_each_structural_projection():
     post = _post(
         "def A():\n"


### PR DESCRIPTION
## What changed

- Constructs the RHS Sugar exactly once for chained Name assignment and shares that exact constructed child across every binding.
- Gives every chained Name its own runtime BindingEntryV1 / BindingCoordinateV1 while preserving one RHS source occurrence.
- Allows mixed Name/Attribute/Subscript chains to retain lexical bindings and sequence the existing store obligations in source order.
- Adds no attribute/subscript implementation; those Sugars remain owned by #6126/6634.

## Sound boundary

- Only Name, Attribute, and Subscript chain targets are admitted. Other target grammar remains loud.
- No ambient heap, second binder, name dispatch, or invented store value.

## Validation

- Focused Assign/binding suite: 37 passed.
- Construction-invariant violations: R=0 on every axis.
- Construction side doors: R=0.
- Sugar calls in desugar: R=0.

Pandas base/head delta will be measured on battleaxe before this draft is marked ready.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sequence chained assignments through a single RHS evaluation with ordered store effects
> - Introduces `ChainedAssignSugar` in [assign_sugar.py](https://github.com/TSavo/sugar/pull/6153/files#diff-03621f315f50e3e14d3638f63ee1c5f9f6c21ff7d8ae223847006d4bd4ad6f32) to desugar chained assignments by evaluating the RHS once, then executing attribute/subscript store effects in source order.
> - Updates `Assign._construct_sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/6153/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to emit `ChainedAssignSugar` for both name-only chains and mixed chains (names with attribute/subscript targets).
> - In mixed chains, only `Name` targets produce lexical bindings; `Attribute` and `Subscript` targets are captured as ordered store effects instead of suppressing name bindings.
> - Behavioral Change: name-only chained assignments previously produced `MultiAssignSugar`; they now produce `ChainedAssignSugar` with empty stores.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f2664d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->