### PR TITLE
Construct name augmented assignment read op store

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/augassign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/augassign_sugar.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import _call_pair
+
+
+@dataclass(frozen=True)
+class AugAssignSugar(Sugar):
+    """The already-constructed read-op-store value of a lexical AugAssign."""
+
+    operation: Sugar
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        prefix = "def A(renamed):\n    renamed += 2\n    return renamed\n\n"
+        return _call_pair(
+            name="augassign_read_op_store",
+            owner_sugar=cls.__name__,
+            truthful=prefix + "def test_a():\n    assert A(3) == 5\n",
+            lying=prefix + "def test_a():\n    assert A(3) == 3\n",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.outcome import Complete
+
+        # Evaluate the read-op child for its real effects, then discard its
+        # ordinary value: the lexical store is already carried by BindingEntryV1.
+        # Incomplete/Halted faces bypass this continuation and remain loud.
+        return self.operation.desugar(ctx).and_then(
+            lambda _value: Complete(BlockValue((), can_fall_through=True))
+        )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2130,13 +2130,38 @@ class AugAssign(Statement):
         from .shadow import rewrite
 
         new_value, d = self._substitute_field(self.value, scope)
-        return self if not d else rewrite(self, value=new_value)
+        rewritten = self if not d else rewrite(self, value=new_value)
+        if not isinstance(rewritten.target, Name):
+            return rewritten
+        name = rewritten.target.id
+        old_state = unwrap_binding_state(scope.get(name, rewritten.target))
+        old_read = binding_state_read_node(
+            old_state,
+            make_read=rewritten.target._make_binding_read,
+        )
+        operation = rewritten._make_binop(old_read, rewritten.op, rewritten.value)
+        from .backend import Child, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        desc = rewritten.ref.describe()
+        return materialize(
+            self.unit,
+            ShadowNode(
+                desc.kind,
+                desc.raw_span or self.span,
+                (*desc.slots, ("operation", Child(_handle_of(operation)))),
+            ),
+            self.reporter,
+        )
 
     def substitution_binding(self, scope):
         # `x OP= e` rebinds x to `x OP e`, reading the OLD x from the scope
         # (or the target itself if x was free). Only a plain Name target binds.
         if not isinstance(self.target, Name):
             return None
+        operation = getattr(self, "operation", None)
+        if isinstance(operation, Node):
+            return {self.target.id: operation}
         name = self.target.id
         old_state = scope.get(name, self.target)
         old_state = unwrap_binding_state(old_state)
@@ -2156,9 +2181,15 @@ class AugAssign(Statement):
         targets are runtime stores rather than lexical bindings, so they reuse
         Assign's typed attribute/subscript store effects."""
         if isinstance(self.target, Name):
-            from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+            from sugar_lift_py_tests.sugar.augassign_sugar import AugAssignSugar
 
-            return InertSugar(site=self.fragment)
+            operation = getattr(self, "operation", None)
+            if not isinstance(operation, Node):
+                return super()._construct_sugar()
+            return AugAssignSugar(
+                operation=operation.sugar(),
+                site=self.fragment,
+            )
         if isinstance(self.target, Attribute):
             from sugar_lift_py_tests.sugar.store_effect_sugar import (
                 AttributeStoreEffectSugar,

--- a/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
+++ b/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
@@ -14,6 +14,8 @@ from sugar_lift_py_tests.effect import (
 )
 from sugar_lift_py_tests.outcome import Incomplete
 from sugar_lift_py_tests.sugar.expr_statement_sugar import ExprStatementSugar
+from sugar_lift_py_tests.sugar.augassign_sugar import AugAssignSugar
+from sugar_lift_py_tests.sugar.binop_sugar import BinOpSugar
 from sugar_lift_py_tests.sugar.store_effect_sugar import AttributeStoreEffectSugar
 from sugar_source_tree.tree import SourceFile
 
@@ -41,6 +43,34 @@ def test_aug_assign_rebinds_and_is_inert():
     v = _fn("def A():\n    t = 0\n    t += 2\n    return t\n").sugar().desugar().value
     assert v.invs() == ()
     assert v.post().args[1].value == 2
+
+
+def test_name_augassign_constructs_explicit_read_op_store_child():
+    function = _fn("def arbitrary():\n    renamed = 1\n    renamed += 2\n")
+    substituted = function.substitute({})
+    sugar = substituted.body[1].sugar()
+    assert isinstance(sugar, AugAssignSugar)
+    assert isinstance(sugar.operation, BinOpSugar)
+    assert sugar.operation.op_kind == "Add"
+
+
+def test_name_augassign_reads_the_guarded_join_not_a_last_writer():
+    function = _fn(
+        "def arbitrary(condition):\n"
+        "    renamed = 1\n"
+        "    if condition:\n"
+        "        renamed = 2\n"
+        "    renamed += 3\n"
+        "    return renamed\n"
+    )
+    substituted = function.substitute({})
+    sugar = next(
+        statement.sugar()
+        for statement in substituted.body
+        if statement.kind == "AugAssign"
+    )
+    assert isinstance(sugar, AugAssignSugar)
+    assert type(sugar.operation.left).__name__ == "IfExpSugar"
 
 
 def _red_effects(source):


### PR DESCRIPTION
## What changed

- Makes a plain-name AugAssign own an explicit constructed read-op child instead of an inert statement.
- Threads that same operation through the sole runtime BindingEntryV1 binding.
- Evaluates the operation for effects, discards only its completed expression value, and preserves Incomplete/Halted faces.
- Reads a guarded branch join through the existing IfExp/GuardedBinding projection rather than choosing a writer.

Attribute/subscript AugAssign remains on the store surface owned by 6634. Unsupported target grammar remains typed-loud.

## Validation

- Focused AugAssign/branch/binding suite: 33 passed.
- Construction-invariant violations: R=0 on every axis.
- Construction side doors: R=0.
- Sugar calls in desugar: R=0.

Pandas base/head delta will be measured on battleaxe before this draft is marked ready.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct explicit read-op-store child node for Name-target `AugAssign`
> - `AugAssign.substitute` now materializes an explicit `operation` child node representing the `old_read op value` binop expression when the target is a `Name`, attaching it via a `ShadowNode` ref.
> - `AugAssign.substitution_binding` binds the target name to this precomputed `operation` node when available, avoiding redundant binop reconstruction.
> - `AugAssign._construct_sugar` returns `AugAssignSugar` (with the operation's sugar and site fragment) instead of an inert sugar when the `operation` child exists.
> - `AugAssignSugar.desugar` evaluates the operation child for effects and returns a fall-through `BlockValue`, replacing previously inert behavior.
> - Two new tests in [test_annassign_augassign.py](https://github.com/TSavo/sugar/pull/6154/files#diff-30ccfa310e23bca737065f9008a2cc5abfe0aa5c4cc93f778912a95faa683c35) verify the explicit child is a `BinOpSugar` with `Add`, and that the read source is a guarded join (`IfExpSugar`) rather than the last writer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c8f237.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->