### PR TITLE
drain: Try routes authenticated exception identity via ExitSet

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py
@@ -1,0 +1,28 @@
+"""One authenticated exception matcher shared by Try and With."""
+
+from __future__ import annotations
+
+
+def matches_raise_effect(effect, expected) -> bool:
+    """Match by constructed exception coordinates and authenticated ancestry.
+
+    Exact identity is sufficient. When the raised type carries source-derived
+    MRO testimony, a handler coordinate may match an authenticated ancestor.
+    Missing identity is a construction gap; spelling never participates.
+    """
+    from sugar_source_tree.panic import SugarNotWritten
+
+    identity_reader = getattr(expected, "exception_type_identity", None)
+    expected_identity = identity_reader() if identity_reader is not None else None
+    raised_identity = getattr(effect, "exception_type_coordinate", None)
+    if expected_identity is None or raised_identity is None:
+        raise SugarNotWritten(
+            owner="matches_raise_effect",
+            observed="handler or raised exception lacks authenticated identity",
+            requested="authenticated exception-type identity on both operands",
+            fix="resolve both exception classes through their lexical coordinates",
+        )
+    if expected_identity == raised_identity:
+        return True
+    raised_mro = getattr(effect, "exception_type_mro", None)
+    return raised_mro is not None and expected_identity in raised_mro

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context/factory_build_context.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context/factory_build_context.py
@@ -69,6 +69,7 @@ class FactoryBuildContext:
     # Default False keeps top-level force_floor Incomplete on nested gaps so
     # ambient strip posts stay logo-safe (str.suffixof sorts).
     nested_external_bridge: bool = False
+    in_flight_effects: tuple[tuple[str, object], ...] = ()
 
     def __post_init__(self) -> None:
         if self.construction_audit_sink is None and self.audit_sink is not None:
@@ -101,4 +102,21 @@ class FactoryBuildContext:
             record_operation=self.record_operation,
             building=self.building,
             nested_external_bridge=self.nested_external_bridge,
+            in_flight_effects=self.in_flight_effects,
         )
+
+    def with_in_flight_effect(
+        self, slot_id: str, effect: object
+    ) -> "FactoryBuildContext":
+        from dataclasses import replace
+
+        return replace(
+            self,
+            in_flight_effects=(*self.in_flight_effects, (slot_id, effect)),
+        )
+
+    def in_flight_effect_for(self, slot_id: str):
+        for candidate_slot, effect in reversed(self.in_flight_effects):
+            if candidate_slot == slot_id:
+                return effect
+        return None

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context/reduce_context.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context/reduce_context.py
@@ -32,6 +32,7 @@ class ReduceContext:
     # the attribute crashed the numpy/pandas package audit as unstructured exit=2
     # after opaque body dig started reducing vendor-bridged bodies.
     external_bridge_sink: Any = None
+    in_flight_effects: tuple[tuple[str, object], ...] = ()
 
     @classmethod
     def root(
@@ -65,6 +66,7 @@ class ReduceContext:
             ),
             dig_sink=source.dig_sink,
             external_bridge_sink=getattr(source, "external_bridge_sink", None),
+            in_flight_effects=getattr(source, "in_flight_effects", ()),
         )
 
     def record_operation(
@@ -101,4 +103,29 @@ class ReduceContext:
             prefer_ground_module_bindings=self.prefer_ground_module_bindings,
             dig_sink=self.dig_sink,
             external_bridge_sink=self.external_bridge_sink,
+            in_flight_effects=self.in_flight_effects,
         )
+
+    def with_in_flight_effect(self, slot_id: str, effect: object) -> "ReduceContext":
+        return ReduceContext(
+            temporal=self.temporal,
+            module_temporal=self.module_temporal,
+            global_names=self.global_names,
+            nonlocal_names=self.nonlocal_names,
+            source_oracle=self.source_oracle,
+            proof_sink=self.proof_sink,
+            report_sink=self.report_sink,
+            construction_audit_sink=self.construction_audit_sink,
+            operation_log=self.operation_log,
+            module_rewrite_log=self.module_rewrite_log,
+            prefer_ground_module_bindings=self.prefer_ground_module_bindings,
+            dig_sink=self.dig_sink,
+            external_bridge_sink=self.external_bridge_sink,
+            in_flight_effects=(*self.in_flight_effects, (slot_id, effect)),
+        )
+
+    def in_flight_effect_for(self, slot_id: str):
+        for candidate_slot, effect in reversed(self.in_flight_effects):
+            if candidate_slot == slot_id:
+                return effect
+        return None

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/raise_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/raise_effect.py
@@ -11,6 +11,7 @@ class RaiseEffect:
     blame: str | None = None
     source_sha256: str | None = None
     exception_type_coordinate: Term | None = None
+    exception_type_mro: tuple[Term, ...] | None = None
     # Deterministic occurrence of THIS raise site (file:line:col). Distinct from
     # type name: two raise ValueError at different loci have different
     # occurrences. Never used as a fabricated "instance identity" from type alone.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/authenticated_exception_type_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/authenticated_exception_type_value.py
@@ -13,9 +13,13 @@ class AuthenticatedExceptionTypeValue(FloorValue):
 
     value: FloorValue
     identity: Term
+    mro: tuple[Term, ...] | None = None
 
     def to_term(self, *, owner: str):
         return self.value.to_term(owner=owner)
 
     def exception_type_identity(self) -> Term:
         return self.identity
+
+    def exception_type_mro(self) -> tuple[Term, ...] | None:
+        return self.mro

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -98,6 +98,9 @@ class CallSiteValue(FloorValue):
     exception_type_coordinate: Term | None = dataclass_field(
         default=None, compare=False
     )
+    exception_type_mro: tuple[Term, ...] | None = dataclass_field(
+        default=None, compare=False
+    )
     # Issued by a registered Call Sugar from an authenticated import target.
     # The target spelling alone never grants native behavior.
     native_shape: object | None = None
@@ -110,6 +113,9 @@ class CallSiteValue(FloorValue):
     )
     source_call_frame_cid: str | None = dataclass_field(default=None, compare=False)
     formal_coordinate_cids: tuple[str, ...] = dataclass_field(default=(), compare=False)
+
+    def exception_type_identity(self) -> Term | None:
+        return self.exception_type_coordinate
 
     def __hash__(self) -> int:
         """Hash the finite call coordinate, never the recursively-owned body.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/in_flight_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/in_flight_effect.py
@@ -1,0 +1,36 @@
+"""Explicit handler-owned in-flight effect context; never ambient state."""
+
+from __future__ import annotations
+
+
+def bind_in_flight_effect(ctx, slot_id: str, effect):
+    if ctx is None:
+        from sugar_lift_py_tests.context.reduce_context import ReduceContext
+
+        ctx = ReduceContext.root(owner="bind_in_flight_effect")
+    binder = getattr(ctx, "with_in_flight_effect", None)
+    if binder is None:
+        from sugar_source_tree.panic import SugarNotWritten
+
+        raise SugarNotWritten(
+            owner="bind_in_flight_effect",
+            observed="reduction context cannot carry authenticated in-flight effects",
+            requested="the shared ReduceContext/FactoryBuildContext effect slot",
+            fix="route handler reduction through the one effect context",
+        )
+    return binder(slot_id, effect)
+
+
+def resolve_in_flight_effect(ctx, slot_id: str):
+    reader = getattr(ctx, "in_flight_effect_for", None) if ctx is not None else None
+    effect = reader(slot_id) if reader is not None else None
+    if effect is None:
+        from sugar_source_tree.panic import SugarNotWritten
+
+        raise SugarNotWritten(
+            owner="resolve_in_flight_effect",
+            observed="bare raise has no authenticated in-flight effect testimony",
+            requested="the exact RaiseEffect bound by its matching handler slot",
+            fix="keep unowned or stale-slot bare raise loud",
+        )
+    return effect

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/authenticated_exception_type_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/authenticated_exception_type_sugar.py
@@ -9,6 +9,7 @@ from sugar_lift_py_tests.sugar.sugar_base import Sugar
 class AuthenticatedExceptionTypeSugar(Sugar):
     value: Sugar
     identity: object
+    mro: tuple | None = None
     site: object = dataclass_field(compare=False, default=None)
 
     @classmethod
@@ -31,6 +32,6 @@ class AuthenticatedExceptionTypeSugar(Sugar):
 
         return self.value.desugar(ctx).and_then(
             lambda value: Complete(
-                AuthenticatedExceptionTypeValue(value, self.identity)
+                AuthenticatedExceptionTypeValue(value, self.identity, self.mro)
             )
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -35,6 +35,7 @@ class CallSiteSugar(Sugar):
     contract_ref: Any = dataclass_field(default=None, compare=False)
     contract_resolution_gap: str | None = dataclass_field(default=None, compare=False)
     exception_type_coordinate: Any = dataclass_field(default=None, compare=False)
+    exception_type_mro: tuple | None = dataclass_field(default=None, compare=False)
     source_call_frame: Any = dataclass_field(default=None, compare=False)
 
     @classmethod
@@ -139,6 +140,7 @@ class CallSiteSugar(Sugar):
                 keyword_names=tuple(name for name, _ in kw_values),
                 site=self.site,
                 exception_type_coordinate=self.exception_type_coordinate,
+                exception_type_mro=self.exception_type_mro,
                 source_call_frame_cid=source_frame_cid,
                 formal_coordinate_cids=(),
             )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/raise_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/raise_sugar.py
@@ -25,10 +25,11 @@ class RaiseSugar(Sugar):
     or authenticates an exception value.
     """
 
-    exception: object
+    exception: object | None
     cause: object | None
     exception_name: str | None
     site: object = dataclass_field(compare=False)
+    in_flight_slot: str | None = None
 
     @classmethod
     def witnesses(cls):
@@ -54,7 +55,25 @@ class RaiseSugar(Sugar):
         )
         blame = f"{self.site.filename}:{self.site.line}:{self.site.col}"
 
+        if self.exception is None:
+            if self.in_flight_slot is None:
+                from sugar_source_tree.panic import SugarNotWritten
+
+                raise SugarNotWritten(
+                    owner="RaiseSugar.desugar",
+                    observed="bare raise lacks an authenticated in-flight effect slot",
+                    requested="the enclosing handler's effect-slot coordinate",
+                    fix="keep unowned bare raise loud",
+                )
+            from sugar_lift_py_tests.in_flight_effect import (
+                resolve_in_flight_effect,
+            )
+
+            return Incomplete(resolve_in_flight_effect(ctx, self.in_flight_slot))
+
         def halt(raised_value, cause_value=None):
+            identity_reader = getattr(raised_value, "exception_type_identity", None)
+            mro_reader = getattr(raised_value, "exception_type_mro", None)
             return Incomplete(
                 RaiseEffect(
                     exception_name=self.exception_name,
@@ -63,9 +82,14 @@ class RaiseSugar(Sugar):
                     # Occurrence is the raise site — not a type-level identity.
                     occurrence=blame,
                     exception_type_coordinate=(
-                        raised_value.exception_type_identity()
-                        if hasattr(raised_value, "exception_type_identity")
+                        identity_reader()
+                        if identity_reader is not None
                         else getattr(raised_value, "exception_type_coordinate", None)
+                    ),
+                    exception_type_mro=(
+                        mro_reader()
+                        if callable(mro_reader)
+                        else getattr(raised_value, "exception_type_mro", None)
                     ),
                     raised_value=raised_value,
                     cause_value=cause_value,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
@@ -23,7 +23,7 @@ from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 @dataclass(frozen=True)
 class TrySugar(Sugar):
-    """handlers: ((EffectMatcher|None, body_sugars, slot_id|None), ...)"""
+    """handlers: ((authenticated type Sugar|None, body_sugars, slot_id), ...)"""
 
     body: tuple
     handlers: tuple
@@ -59,20 +59,19 @@ class TrySugar(Sugar):
             reduce_block_to_exitset,
         )
 
-        del ctx
-
-        body_es = promote_raise_halts(reduce_block_to_exitset(self.body))
+        body_es = promote_raise_halts(reduce_block_to_exitset(self.body, ctx))
         pre_finally = _route_handlers_over_exits(
             body_es,
             self.handlers,
             self.orelse,
             site=self.site,
+            ctx=ctx,
         )
 
         if not self.finalbody:
             return exitset_to_outcome(pre_finally)
 
-        cleanup_es = reduce_block_to_exitset(self.finalbody)
+        cleanup_es = reduce_block_to_exitset(self.finalbody, ctx)
 
         def _cleanup():
             return cleanup_es
@@ -90,17 +89,28 @@ class TrySugar(Sugar):
         return exitset_to_outcome(after)
 
 
-def _effect_matches(effect, matcher) -> bool:
-    """Bare except (matcher is None) matches any raise; typed arms exact name."""
+def _effect_matches(effect, matcher, ctx=None) -> bool:
+    """Bare except matches any raise; typed arms use constructed identity."""
     from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.authenticated_exception_matching import (
+        matches_raise_effect,
+    )
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_source_tree.panic import SugarNotWritten
 
     if not isinstance(effect, RaiseEffect):
         return False
     if matcher is None:
         return True
-    if getattr(matcher, "kind", None) != "raise":
-        return False
-    return effect.exception_name == matcher.name
+    expected = matcher.desugar(ctx)
+    if not isinstance(expected, Complete):
+        raise SugarNotWritten(
+            owner="TrySugar._effect_matches",
+            observed="except type did not construct a completed type operand",
+            requested="an authenticated exception-type value",
+            fix="keep unresolved handler types loud",
+        )
+    return matches_raise_effect(effect, expected.value)
 
 
 def _binding_facts_for(slot_id, effect, site) -> tuple:
@@ -123,6 +133,7 @@ def _route_handlers_over_exits(
     orelse: tuple,
     *,
     site,
+    ctx=None,
 ):
     """Route each Halted raise through the first matching handler.
 
@@ -140,9 +151,14 @@ def _route_handlers_over_exits(
         if isinstance(exit_, Halted):
             matched = False
             for matcher, handler_body, slot_id in handlers:
-                if not _effect_matches(exit_.effect, matcher):
+                if not _effect_matches(exit_.effect, matcher, ctx):
                     continue
-                handler_es = reduce_block_to_exitset(handler_body)
+                from sugar_lift_py_tests.in_flight_effect import (
+                    bind_in_flight_effect,
+                )
+
+                handler_ctx = bind_in_flight_effect(ctx, slot_id, exit_.effect)
+                handler_es = reduce_block_to_exitset(handler_body, handler_ctx)
                 facts = _binding_facts_for(slot_id, exit_.effect, site)
                 if facts:
                     handler_es = _prepend_facts(handler_es, facts)
@@ -154,7 +170,7 @@ def _route_handlers_over_exits(
             continue
 
         if orelse:
-            else_es = reduce_block_to_exitset(orelse)
+            else_es = reduce_block_to_exitset(orelse, ctx)
 
             def _then_else(state):
                 return else_es.sequence(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
@@ -185,20 +185,12 @@ def _bind_real_actuals(signature, manager_value):
 def _matches_raise(effect, expected, pattern) -> bool:
     import re
 
-    from sugar_source_tree.panic import SugarNotWritten
+    from sugar_lift_py_tests.authenticated_exception_matching import (
+        matches_raise_effect,
+    )
 
-    identity_reader = getattr(expected, "exception_type_identity", None)
-    expected_identity = identity_reader() if identity_reader is not None else None
-    raised_identity = effect.exception_type_coordinate
-    if expected_identity is None or raised_identity is None:
-        raise SugarNotWritten(
-            owner="WithEffectBoundarySugar._matches_raise",
-            observed="expected or raised exception lacks authenticated identity",
-            requested="authenticated exception-type identity on both operands",
-            fix="resolve both exception classes through their lexical floor coordinates",
-        )
     raised = effect.raised_value
-    if expected_identity != raised_identity:
+    if not matches_raise_effect(effect, expected):
         return False
     if pattern is None:
         return True

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
@@ -77,7 +77,8 @@ def test_block_reduction_retains_complement_of_guarded_halt():
     effect = RaiseEffect(exception_name="ValueError")
 
     class GuardedHalt:
-        def desugar(self):
+        def desugar(self, ctx=None):
+            del ctx
             return Incomplete(effect).guarded(condition)
 
     exits = reduce_block_to_exitset((GuardedHalt(),))

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -83,9 +83,17 @@ _MISSING = object()
 @dataclass(frozen=True)
 class ControlConstructionContextV1:
     loop_targets: tuple[object, ...] = ()
+    exception_slots: tuple[str, ...] = ()
 
     def enter_loop(self, target: object) -> "ControlConstructionContextV1":
-        return ControlConstructionContextV1((*self.loop_targets, target))
+        return ControlConstructionContextV1(
+            (*self.loop_targets, target), self.exception_slots
+        )
+
+    def enter_exception(self, slot_id: str) -> "ControlConstructionContextV1":
+        return ControlConstructionContextV1(
+            self.loop_targets, (*self.exception_slots, slot_id)
+        )
 
     def nearest_loop_target(self):
         if not self.loop_targets:
@@ -93,6 +101,16 @@ class ControlConstructionContextV1:
 
             raise LoopWireError("loop-control occurrence has no enclosing loop")
         return self.loop_targets[-1]
+
+    def nearest_exception_slot(self) -> str:
+        if not self.exception_slots:
+            raise SugarNotWritten(
+                owner="ControlConstructionContextV1.nearest_exception_slot",
+                observed="bare raise has no authenticated in-flight exception slot",
+                requested="an enclosing except handler effect-slot coordinate",
+                fix="construct bare raise only inside the handler that owns its effect",
+            )
+        return self.exception_slots[-1]
 
 
 def _explicit_state(name: str, state):
@@ -105,7 +123,8 @@ def _explicit_state(name: str, state):
 class _ConditionalRaiseRoute:
     slot: BranchResultSlot
     raised_on_true: bool
-    exception_name: str
+    exception_identity: object | None
+    exception_mro: tuple | None
 
 
 _NESTED_COMPREHENSION_TEMPLATE = object()
@@ -325,6 +344,54 @@ class SourceUnit:
             )
         return None
 
+    def exception_type_mro(self, node: "Name"):
+        """Return the source-authenticated ancestry known for ``node``.
+
+        Builtin/imported identities authenticate the exact class. Source class
+        identities additionally carry every lexically resolved base coordinate.
+        A computed base or cycle leaves the testimony unavailable, never guessed.
+        """
+        identity = self.exception_type_identity(node)
+        if identity is None:
+            return None
+        module = self._require_typed_module("SourceUnit.exception_type_mro")
+        definitions = [
+            statement
+            for statement in module.body
+            if statement.kind == "ClassDef" and statement.name == node.id
+        ]
+        if len(definitions) != 1:
+            return (identity,)
+
+        result = [identity]
+        visiting: set[str] = set()
+
+        def append_definition(definition) -> bool:
+            if definition.name in visiting:
+                return False
+            visiting.add(definition.name)
+            for base in definition.bases:
+                if not isinstance(base, Name):
+                    return False
+                base_identity = self.exception_type_identity(base)
+                if base_identity is None:
+                    return False
+                if base_identity not in result:
+                    result.append(base_identity)
+                base_definitions = [
+                    candidate
+                    for candidate in module.body
+                    if candidate.kind == "ClassDef" and candidate.name == base.id
+                ]
+                if len(base_definitions) == 1 and not append_definition(
+                    base_definitions[0]
+                ):
+                    return False
+            visiting.remove(definition.name)
+            return True
+
+        return tuple(result) if append_definition(definitions[0]) else None
+
 
 class Typeable:
     """The interface: you may ask me for my node type.
@@ -448,6 +515,8 @@ class Node(Typed):
 
                 raise LoopWireError("loop node has no owned target coordinate")
             return self.control_context.enter_loop(self.owned_loop_target)
+        if isinstance(self, ExceptHandler) and field_name == "body":
+            return self.control_context.enter_exception(self._effect_slot_id())
         if isinstance(self, (FunctionDef, AsyncFunctionDef, ClassDef, Lambda)) and field_name == "body":
             return ControlConstructionContextV1()
         return self.control_context
@@ -663,10 +732,11 @@ class Node(Typed):
         )
 
     def _effect_slot_id(self) -> str:
-        """Deterministic slot identity from this binding site's source extent.
+        """Content-addressed slot identity from this binding occurrence.
 
-        No process identity fallback. If a stable span cannot be produced,
-        stay loud — do not invent a nondeterministic coordinate.
+        The preimage pins the source, fragment, and occurrence span. Re-resolving
+        the same source occurrence is byte-identical; equal text at another
+        occurrence cannot collide. No process identity fallback exists.
         """
         try:
             lc = self.line_col_span()
@@ -677,9 +747,21 @@ class Node(Typed):
                 requested="a deterministic file:line:col extent for the binding site",
                 fix="ensure the adapter anchors this node; never invent a process-local identity",
             ) from exc
-        return (
-            f"{self.unit.filename}:{lc.start_line}:{lc.start_col}:"
-            f"{lc.end_line}:{lc.end_col}"
+        from sugar_lift_python_source.canonical import cid_of_json
+
+        memento = self.fragment.seal()
+        return cid_of_json(
+            {
+                "kind": "python-effect-slot-v1",
+                "sourceCid": memento.source_cid,
+                "fragmentCid": memento.cid,
+                "span": {
+                    "startLine": lc.start_line,
+                    "startCol": lc.start_col,
+                    "endLine": lc.end_line,
+                    "endCol": lc.end_col,
+                },
+            }
         )
 
     def _make_effect_ref(self, slot_id: str) -> "Node":
@@ -3259,7 +3341,7 @@ class With(Statement):
             args = list(manager_sugar.args)
             position = actual_location[1]
             args[position] = AuthenticatedExceptionTypeSugar(
-                args[position], identity, actual.fragment
+                args[position], identity, site=actual.fragment
             )
             return replace(manager_sugar, args=tuple(args))
         keywords_sugar = list(manager_sugar.keywords)
@@ -3267,7 +3349,9 @@ class With(Statement):
             if name == actual_location[1]:
                 keywords_sugar[position] = (
                     name,
-                    AuthenticatedExceptionTypeSugar(sugar, identity, actual.fragment),
+                    AuthenticatedExceptionTypeSugar(
+                        sugar, identity, site=actual.fragment
+                    ),
                 )
                 break
         return replace(manager_sugar, keywords=tuple(keywords_sugar))
@@ -3392,9 +3476,15 @@ class Raise(Statement):
     def _construct_sugar(self):
         """Build exception and explicit cause children for the halt effect."""
         if self.exc is None:
-            # Re-raise needs authenticated active-exception context. It remains
-            # outside this arm rather than fabricating an exception operand.
-            return super()._construct_sugar()
+            from sugar_lift_py_tests.sugar.raise_sugar import RaiseSugar
+
+            return RaiseSugar(
+                exception=None,
+                cause=None,
+                exception_name=None,
+                site=self.fragment,
+                in_flight_slot=self.control_context.nearest_exception_slot(),
+            )
         from sugar_lift_py_tests.sugar.raise_sugar import RaiseSugar
         from dataclasses import replace
 
@@ -3404,19 +3494,24 @@ class Raise(Statement):
         from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
 
         identity = None
+        mro = None
         if isinstance(self.exc, Call) and isinstance(self.exc.func, Name):
             identity = self.unit.exception_type_identity(self.exc.func)
+            mro = self.unit.exception_type_mro(self.exc.func)
         elif isinstance(self.exc, Name):
             identity = self.unit.exception_type_identity(self.exc)
+            mro = self.unit.exception_type_mro(self.exc)
 
         exception_sugar = self.exc.sugar()
         if identity is not None and isinstance(exception_sugar, CallSiteSugar):
             exception_sugar = replace(
-                exception_sugar, exception_type_coordinate=identity
+                exception_sugar,
+                exception_type_coordinate=identity,
+                exception_type_mro=mro,
             )
         elif identity is not None:
             exception_sugar = AuthenticatedExceptionTypeSugar(
-                exception_sugar, identity, self.exc.fragment
+                exception_sugar, identity, mro, self.exc.fragment
             )
 
         return RaiseSugar(
@@ -3491,16 +3586,20 @@ class Try(Statement):
         if any(new is not old for new, old in zip(new_handlers, self.handlers)):
             changed["handlers"] = tuple(new_handlers)
 
-        unconditional = self._unconditional_raise_name(self.body)
+        unconditional = self._unconditional_raise_testimony(self.body)
         conditional = self._conditional_raise(self.body)
         completion_nets = []
         if unconditional is None:
             completion_nets.append(body_completion)
         for handler, handler_net in zip(self.handlers, handler_nets):
             if unconditional is not None:
-                include = self._handler_matches(handler, unconditional)
+                include = self._handler_matches(handler, *unconditional)
             elif conditional is not None:
-                include = self._handler_matches(handler, conditional.exception_name)
+                include = self._handler_matches(
+                    handler,
+                    conditional.exception_identity,
+                    conditional.exception_mro,
+                )
             else:
                 include = True
             if include:
@@ -3522,50 +3621,67 @@ class Try(Statement):
         node = self if not changed else rewrite(self, **changed)
         return _Splice((node,), merged) if merged else node
 
-    @staticmethod
-    def _handler_matches(handler, exception_name: str) -> bool:
+    def _handler_matches(self, handler, exception_identity, exception_mro) -> bool:
         if handler.type_ is None:
+            return True
+        if exception_identity is None:
             return True
         nodes = (
             handler.type_.elts
             if isinstance(handler.type_, Tuple_)
             else (handler.type_,)
         )
-        return any(Try._except_type_name(node) == exception_name for node in nodes)
+        for node in nodes:
+            if not isinstance(node, Name):
+                continue
+            handler_identity = self.unit.exception_type_identity(node)
+            if handler_identity == exception_identity or (
+                exception_mro is not None and handler_identity in exception_mro
+            ):
+                return True
+        return False
 
-    @staticmethod
-    def _unconditional_raise_name(statements):
+    def _unconditional_raise_testimony(self, statements):
         for statement in statements:
             if isinstance(statement, Raise):
-                return statement._exception_name()
+                node = statement.exc
+                if isinstance(node, Call):
+                    node = node.func
+                if not isinstance(node, Name):
+                    return (None, None)
+                return (
+                    self.unit.exception_type_identity(node),
+                    self.unit.exception_type_mro(node),
+                )
             if isinstance(statement, Return):
                 return None
             if isinstance(statement, If):
-                left = Try._unconditional_raise_name(statement.body)
-                right = Try._unconditional_raise_name(statement.orelse)
+                left = self._unconditional_raise_testimony(statement.body)
+                right = self._unconditional_raise_testimony(statement.orelse)
                 if left is not None and left == right:
                     return left
             # The first ordinary statement can complete, so continue scanning.
         return None
 
-    @staticmethod
-    def _conditional_raise(statements):
+    def _conditional_raise(self, statements):
         for statement in statements:
             if not isinstance(statement, If):
                 continue
-            left = Try._unconditional_raise_name(statement.body)
-            right = Try._unconditional_raise_name(statement.orelse)
+            left = self._unconditional_raise_testimony(statement.body)
+            right = self._unconditional_raise_testimony(statement.orelse)
             if left is not None and right is None:
                 return _ConditionalRaiseRoute(
                     slot=branch_result_slot(statement.test),
                     raised_on_true=True,
-                    exception_name=left,
+                    exception_identity=left[0],
+                    exception_mro=left[1],
                 )
             if right is not None and left is None:
                 return _ConditionalRaiseRoute(
                     slot=branch_result_slot(statement.test),
                     raised_on_true=False,
-                    exception_name=right,
+                    exception_identity=right[0],
+                    exception_mro=right[1],
                 )
         return None
 
@@ -3616,33 +3732,13 @@ class Try(Statement):
     def _make_branch_result_ref(self, slot):
         return If._make_branch_result_ref(self, slot)
 
-    @staticmethod
-    def _except_type_name(type_node):
-        """Structural exception type name off an ``except E`` clause: bare
-        ``Name`` -> ``"E"``, dotted ``Attribute`` chain -> ``"mod.E"``. Same
-        walk as ``Raise._exception_name`` (no desugar, no factory). Tuple types,
-        bare ``except:``, and exotic expressions return ``None`` so the sugar
-        stays LOUD rather than inventing a matcher."""
-        if type_node is None:
-            return None
-        node = type_node
-        parts = []
-        while node is not None and node.kind == "Attribute":
-            parts.append(node.attr)
-            node = node.value
-        if node is not None and node.kind == "Name":
-            parts.append(node.id)
-        if not parts:
-            return None
-        return ".".join(reversed(parts))
-
     def _construct_sugar(self):
         """`try: body (except E: handler)+ [else] [finally]` -- the STRUCTURAL
-        sibling of with-raises. A typed clause contributes one exact router
-        matcher per bare/dotted type (including each element of a tuple); a
-        bare clause contributes the widest raise matcher. Exotic type
-        expressions and empty tuples stay loud. ``except*`` lives on TryStar
-        and stays loud there.
+        sibling of with-raises. A typed clause contributes one constructed,
+        authenticated exception coordinate per Name element of a tuple; a bare
+        clause contributes the widest raise matcher. Unresolved/dotted/computed
+        type expressions and empty tuples stay loud. ``except*`` lives on
+        TryStar and stays loud there.
 
         ``except <type> as <name>``: substitute already rewrote loads of
         ``name`` to ``EffectRef(slot)`` inside the handler. Routing
@@ -3663,12 +3759,11 @@ class Try(Statement):
                 site=self.fragment,
             )
 
-        from sugar_lift_py_tests.context_manager_contract import EffectMatcher
-
         handler_specs = []
         for handler in self.handlers:
-            # slot_id for authentication when this arm has `as` (substitute site).
-            slot_id = handler._effect_slot_id() if handler.name else None
+            # Every handler owns an effect slot. ``as e`` projects it; a bare
+            # re-raise cites the same slot even without a lexical target.
+            slot_id = handler._effect_slot_id()
             body_sugars = tuple(stmt.sugar() for stmt in handler.body)
             if handler.type_ is None:
                 handler_specs.append((None, body_sugars, slot_id))
@@ -3682,14 +3777,28 @@ class Try(Statement):
             if not type_nodes:
                 return super()._construct_sugar()  # empty tuple: no honest matcher
             for type_node in type_nodes:
-                type_name = self._except_type_name(type_node)
-                if type_name is None:
-                    return (
-                        super()._construct_sugar()
-                    )  # exotic tuple elt/type -- stay loud
+                if not isinstance(type_node, Name):
+                    return super()._construct_sugar()
+                identity = self.unit.exception_type_identity(type_node)
+                if identity is None:
+                    raise SugarNotWritten(
+                        owner="Try._construct_sugar",
+                        observed="typed except handler lacks authenticated exception identity",
+                        requested="a constructed exception-type coordinate",
+                        fix="resolve the handler type lexically or keep the try loud",
+                    )
+                from sugar_lift_py_tests.sugar.authenticated_exception_type_sugar import (
+                    AuthenticatedExceptionTypeSugar,
+                )
+
                 handler_specs.append(
                     (
-                        EffectMatcher(kind="raise", name=type_name),
+                        AuthenticatedExceptionTypeSugar(
+                            type_node.sugar(),
+                            identity,
+                            self.unit.exception_type_mro(type_node),
+                            type_node.fragment,
+                        ),
                         body_sugars,
                         slot_id,
                     )

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -109,6 +109,158 @@ def test_except_valueerror_does_catch_valueerror():
     assert v.post().args[1].name == "z"
 
 
+def test_renamed_handler_and_raise_match_by_authenticated_identity():
+    """Different lexical spellings for one builtin identity still match."""
+    v = _val(
+        "from builtins import ValueError as Raised\n"
+        "from builtins import ValueError as Caught\n"
+        "def A(z):\n"
+        "    try:\n"
+        "        raise Raised\n"
+        "    except Caught:\n"
+        "        pass\n"
+        "    return z\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+def test_source_subclass_matches_authenticated_base_coordinate():
+    """A source-derived MRO, not a spelling relation, proves the catch."""
+    v = _val(
+        "class RootFault(Exception):\n"
+        "    pass\n"
+        "class LeafFault(RootFault):\n"
+        "    pass\n"
+        "def A(z):\n"
+        "    try:\n"
+        "        raise LeafFault\n"
+        "    except RootFault:\n"
+        "        pass\n"
+        "    return z\n"
+    )
+    assert _incompletes(v) == []
+    assert v.post().args[1].name == "z"
+
+
+def test_source_unrelated_handler_propagates_by_authenticated_mro():
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    v = _val(
+        "class RootFault(Exception):\n"
+        "    pass\n"
+        "class LeafFault(RootFault):\n"
+        "    pass\n"
+        "class OtherFault(Exception):\n"
+        "    pass\n"
+        "def A(z):\n"
+        "    try:\n"
+        "        raise LeafFault\n"
+        "    except OtherFault:\n"
+        "        pass\n"
+        "    return z\n"
+    )
+    reds = _incompletes(v)
+    assert len(reds) == 1
+    assert isinstance(reds[0].effect, RaiseEffect)
+
+
+def test_same_spelling_unresolved_handler_identity_stays_loud():
+    """A formal named E is not exception authority on either side."""
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(E):\n"
+            "    try:\n"
+            "        raise E\n"
+            "    except E:\n"
+            "        pass\n"
+        ).sugar()
+
+
+def test_unresolved_raised_identity_stays_loud_at_the_router():
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(E):\n"
+            "    try:\n"
+            "        raise E\n"
+            "    except ValueError:\n"
+            "        pass\n"
+        ).sugar().desugar()
+
+
+def test_bare_reraise_reemits_the_exact_inflight_raise():
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    out = (
+        _fn(
+            "def A():\n"
+            "    try:\n"
+            "        raise ValueError\n"
+            "    except ValueError:\n"
+            "        raise\n"
+        )
+        .sugar()
+        .desugar()
+    )
+    assert isinstance(out, Incomplete)
+    assert isinstance(out.effect, RaiseEffect)
+    assert out.effect.exception_type_coordinate is not None
+    assert out.effect.exception_name == "ValueError"
+    assert out.effect.occurrence.endswith(":6:8")
+
+
+def test_nested_bare_reraise_uses_the_nearest_handler_slot():
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    out = (
+        _fn(
+            "def A():\n"
+            "    try:\n"
+            "        raise ValueError\n"
+            "    except ValueError:\n"
+            "        try:\n"
+            "            raise KeyError\n"
+            "        except KeyError:\n"
+            "            raise\n"
+        )
+        .sugar()
+        .desugar()
+    )
+    if isinstance(out, Incomplete):
+        effects = (out.effect,)
+    else:
+        effects = tuple(
+            entry.effect
+            for entry in out.value.record.contribution()
+            if isinstance(entry, Incomplete)
+        )
+    assert len(effects) == 1
+    assert isinstance(effects[0], RaiseEffect)
+    assert effects[0].exception_name == "KeyError"
+    assert effects[0].occurrence.endswith(":9:12")
+
+
+def test_handler_effect_slots_are_content_addressed_occurrences():
+    fn = _fn(
+        "def A():\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError:\n"
+        "        pass\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError:\n"
+        "        pass\n"
+    )
+    handlers = [node for node in fn.walk() if node.kind == "ExceptHandler"]
+    slots = [handler._effect_slot_id() for handler in handlers]
+    assert all(slot.startswith("blake3-512:") for slot in slots)
+    assert slots[0] != slots[1]
+    assert slots == [handler._effect_slot_id() for handler in handlers]
+
+
 def test_else_runs_when_body_is_raise_free():
     # Body with no observed raise reduces else; the else return is the exit.
     v = _val(
@@ -464,19 +616,18 @@ def test_non_name_except_type_stays_loud():
         ).sugar()
 
 
-def test_dotted_except_type_matches():
-    # Dotted Name exception types are in the tractable core (same structural
-    # walk as raise's exception_name).
-    v = _val(
-        "def A(z):\n"
-        "    try:\n"
-        "        raise os.error\n"
-        "    except os.error:\n"
-        "        pass\n"
-        "    return z\n"
-    )
-    assert _incompletes(v) == []
-    assert v.post().args[1].name == "z"
+def test_dotted_except_without_authenticated_import_identity_stays_loud():
+    # Equal dotted spelling is not exception authority. The import-binding
+    # bridge must eventually provide a coordinate; until then this is loud.
+    with pytest.raises(SugarNotWritten):
+        _fn(
+            "def A(z):\n"
+            "    try:\n"
+            "        raise os.error\n"
+            "    except os.error:\n"
+            "        pass\n"
+            "    return z\n"
+        ).sugar()
 
 
 def test_two_raise_valueerror_sites_have_distinct_origins_same_type():


### PR DESCRIPTION
## Outcome

Routes `TrySugar` through the same authenticated exception-type coordinate matcher used by With EffectBoundary construction. This removes the latent `exception_name == matcher.name` construction side door.

Typed handlers now consume a `RaiseEffect` only when constructed identity matches exactly or the raised type's source-authenticated MRO contains the handler identity. Missing handler/raised identity remains a loud `SugarNotWritten` gap.

Bare `raise` is represented by a content-addressed handler-owned in-flight-effect slot. Handler construction binds the exact incoming `RaiseEffect`; bare re-raise resolves and re-emits that occurrence. A missing slot stays loud.

The stale ExitSet test double was also updated for the current `desugar(ctx)` interface.

## Honest pandas census

Matched detached battleaxe runs, Python 3.12.3, installed pandas corpus:

- base: 1,415/1,415 files, 0 defects/timeouts, `R=7,937`
- head: 1,415/1,415 files, 0 defects/timeouts, `R=7,905`
- net: `Delta R=-32`
- `Raise`: 52 -> 0 (drain 52)
- `Try`: 0 -> 24 (24 honest false-green exposures now loud)
- other newly exposed/deeper movement: `For +1`; `With -2`, `Assign -2`, `Yield -1`

Function-clean coverage moves 19,673/27,707 to 19,670/27,707 because the 24 authenticated-identity gaps are no longer hidden by the spelling gate.

## Twins

- renamed aliases with one authenticated identity consume
- source-derived subclass MRO consumes; unrelated identity propagates
- same spelling without authenticated identity stays loud
- nested bare re-raise resolves the nearest handler slot and re-emits the exact incoming effect
- handler-slot CIDs are stable on re-resolution and distinct across occurrences

## Verification

- focused Try + ExitSet: `54 passed`
- broad source-tree base/head comparison: head `402 passed, 5 skipped, 12 failed`; base `394 passed, 5 skipped, 12 failed` (the same 12 current-main failures; +8 passing twins)
- construction side-door law: `R_construction_side_doors=0`, all axes and auditor errors zero
- `git diff --check`

No Rust wire changed in this lane; all behavior uses the existing Python ExitSet/EffectBoundary production router.

Architect review requested for authenticated identity/MRO ownership and the in-flight effect slot.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route try/except handlers via authenticated exception identity and MRO in ExitSet
> - `except` handlers now match raised exceptions using authenticated identity and MRO rather than structural name strings, so renamed imports and subclass relationships resolve correctly.
> - Bare `re-raise` (bare `raise` inside an `except` body) now re-emits the exact in-flight `RaiseEffect` from the nearest enclosing handler slot, preserving occurrence and name.
> - Effect slot IDs for `except` handlers are now content-addressed (blake3-512) coordinates derived from source/fragment/span, making them stable across re-resolution.
> - `ReduceContext` and `FactoryBuildContext` gain `in_flight_effects` to carry matched `RaiseEffect` values through reductions; `bind_in_flight_effect` and `resolve_in_flight_effect` provide the API for handlers and bare raise.
> - Behavioral Change: unresolved handler or raised exception identities now raise `SugarNotWritten` loudly rather than silently failing to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cbb85b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->