### PR TITLE
Route lambdas through source call frames

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/lambda_callable.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/lambda_callable.py
@@ -19,6 +19,7 @@ class LambdaCallable(FloorValue):
     parameters: tuple[str, ...]
     body: Any
     construction_identity: str
+    source_call_frame: Any = None
     default_values: tuple[Any, ...] = ()
     keyword_only_parameters: tuple[str, ...] = ()
     keyword_only_default_values: tuple[Any | None, ...] = ()
@@ -81,31 +82,31 @@ class LambdaCallable(FloorValue):
         )
 
     def apply(self, value: TermValue, ctx):
-        from sugar_lift_py_tests.outcome import Incomplete, complete_value
+        del ctx
+        from sugar_lift_py_tests.floor import CallSiteValue
+        from sugar_lift_py_tests.ir import ctor
+        from sugar_source_tree.panic import SugarNotWritten
 
-        if (
-            len(self.parameters) != 1
-            or self.keyword_only_parameters
-            or self.vararg_parameter is not None
-            or self.kwarg_parameter is not None
-        ):
-            raise TypeError(
-                "LambdaCallable.apply owns single-parameter apply only; "
-                f"got formals {self.parameters!r}, "
-                f"vararg={self.vararg_parameter!r}, "
-                f"kwarg={self.kwarg_parameter!r}"
+        frame = self.source_call_frame
+        if frame is None or len(self.parameters) != 1:
+            raise SugarNotWritten(
+                owner="LambdaCallable.apply",
+                observed="lambda has no single-actual source frame",
+                requested="the ordinary SourceCallFrameV1 call door",
+                fix="carry a source-visible frame or keep the callback loud",
             )
-        outcome = self.body.desugar(ctx)
-        if isinstance(outcome, Incomplete):
-            return outcome
-        result = complete_value(outcome, owner="LambdaCallable")
-        from sugar_lift_py_tests.floor import SymbolicValue
-        from sugar_lift_py_tests.ir import subst_var_in_term
-
-        return SymbolicValue(
-            subst_var_in_term(
-                result.to_term(owner="LambdaCallable.body"),
-                self.parameters[0],
-                value.to_term(owner="LambdaCallable.argument"),
-            )
+        return CallSiteValue(
+            target_name="py.call",
+            arg_values=(value,),
+            parameters=frame.parameters,
+            term=ctor(
+                "py.call",
+                [
+                    self.to_term(owner="LambdaCallable"),
+                    value.to_term(owner="LambdaCallable"),
+                ],
+            ),
+            body=frame.body,
+            source_call_frame_cid=frame.frame_cid,
+            formal_coordinate_cids=tuple(item.cid for item in frame.formal_coordinates),
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/computed_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/computed_call_sugar.py
@@ -30,6 +30,7 @@ class ComputedCallSugar(Sugar):
     args: tuple  # the argument sugars, in source order
     site: object = dataclass_field(compare=False)
     keywords: tuple = ()  # (name or explicit "**", sugar), source order
+    source_call_frame: object | None = dataclass_field(default=None, compare=False)
 
     @classmethod
     def witnesses(cls):
@@ -87,6 +88,44 @@ class ComputedCallSugar(Sugar):
             + keyword_terms,
             symbol_kind="coordinate",
         )
+        frame = self.source_call_frame
+        if frame is not None:
+            from sugar_lift_py_tests.source_call_frame import (
+                SourceCallBindingGap,
+                SourceVisibleCallFrameV1,
+            )
+            from sugar_source_tree.panic import SugarNotWritten
+
+            if not isinstance(frame, SourceVisibleCallFrameV1):
+                raise SugarNotWritten(
+                    owner="ComputedCallSugar.desugar",
+                    observed=type(frame).__name__,
+                    requested="a closed SourceCallFrameV1 variant",
+                    fix="construct a typed source frame or keep the call loud",
+                )
+            try:
+                positional = frame.bind_actuals(positional, kw_values, ctx)
+            except SourceCallBindingGap as exc:
+                raise SugarNotWritten(
+                    owner="ComputedCallSugar.desugar",
+                    observed=str(exc),
+                    requested="actuals matching the authenticated lambda signature",
+                    fix="supply real actuals/defaults or keep the lambda call loud",
+                ) from exc
+            return Complete(
+                CallSiteValue(
+                    target_name="py.call",
+                    arg_values=positional,
+                    parameters=frame.parameters,
+                    term=term,
+                    body=frame.body,
+                    site=self.site,
+                    source_call_frame_cid=frame.frame_cid,
+                    formal_coordinate_cids=tuple(
+                        item.cid for item in frame.formal_coordinates
+                    ),
+                )
+            )
         return Complete(
             CallSiteValue(
                 target_name="py.call",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/lambda_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/lambda_sugar.py
@@ -15,6 +15,7 @@ class LambdaSugar(Sugar):
 
     formals: tuple[str, ...]
     body: Sugar
+    source_call_frame: object
     site: object = dataclass_field(compare=False)
 
     @classmethod
@@ -40,5 +41,6 @@ class LambdaSugar(Sugar):
                 parameters=self.formals,
                 body=self.body,
                 construction_identity=construction_identity,
+                source_call_frame=self.source_call_frame,
             )
         )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4128,24 +4128,85 @@ class Lambda(Expression):
         # is the construction-time testimony that capture substitution ran.
         return rewrite(self, params=new_params, body=new_body)
 
-    def _construct_sugar(self):
-        """Construct only plain positional-or-keyword expression lambdas.
+    def source_visible_call_frame(self):
+        """Project the lambda through the ordinary source-call-frame door."""
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+        )
+        from sugar_lift_py_tests.source_call_frame import SourceVisibleCallFrameV1
+        from sugar_source_tree.binding_provenance import BindingCoordinateV1
 
-        Every other binding role remains loud.  The body constructs through its
-        own node so an unsupported child preserves that child's exact panic.
-        """
+        span = self.line_col_span()
+        site = SourceFragmentCoordinateV1(
+            self.unit.source_cid,
+            span.start_line,
+            span.start_col,
+            span.end_line,
+            span.end_col,
+        )
+        owner_cid = self.fragment.seal().cid
+        coordinates = tuple(
+            BindingCoordinateV1.mint(owner_cid, param.fragment, ("formal", index))
+            for index, param in enumerate(self.params)
+        )
+        formal_scope = {
+            param.name: self._make_coordinate_ref(param, coordinate)
+            for param, coordinate in zip(self.params, coordinates, strict=True)
+        }
+        return SourceVisibleCallFrameV1(
+            source_identity_cid=self.unit.source_cid,
+            definition_site=site,
+            definition_fragment_cid=owner_cid,
+            parameters=tuple(param.name for param in self.params),
+            formal_coordinates=coordinates,
+            parameter_kinds=tuple(param.param_kind for param in self.params),
+            default_sugars=tuple(
+                param.default.sugar() if param.default is not None else None
+                for param in self.params
+            ),
+            default_nodes=tuple(param.default for param in self.params),
+            default_fragments=tuple(
+                param.default.fragment if param.default is not None else None
+                for param in self.params
+            ),
+            default_fragment_cids=tuple(
+                param.default.fragment.seal().cid if param.default is not None else None
+                for param in self.params
+            ),
+            body=self._source_visible_body(formal_scope),
+            owner=self,
+        )
+
+    def _source_visible_body(self, scope):
+        from sugar_lift_py_tests.sugar.return_sugar import ReturnSugar
+        from sugar_lift_py_tests.sugar.source_visible_function_body_sugar import (
+            SourceVisibleFunctionBodySugar,
+        )
+
+        body = self.body.substitute(scope)
+        return SourceVisibleFunctionBodySugar(
+            (ReturnSugar(value=body.sugar(), site=self.fragment),), self.fragment
+        )
+
+    def _make_coordinate_ref(self, param: "Param", coordinate) -> "Node":
+        from .backend import Leaf, materialize
         from .shadow import ShadowNode
 
-        if (
-            not isinstance(self.ref, ShadowNode)
-            or len(self.params) != 1
-            or any(
-                param.param_kind != "positional_or_keyword"
-                or param.default is not None
-                or param.annotation is not None
-                for param in self.params
-            )
-        ):
+        return materialize(
+            self.unit,
+            ShadowNode(
+                "BindingCoordinateRef",
+                param.span,
+                (("coordinate", Leaf(coordinate)),),
+            ),
+            self.reporter,
+        )
+
+    def _construct_sugar(self):
+        """Construct an expression lambda carrying its ordinary source frame."""
+        from .shadow import ShadowNode
+
+        if not isinstance(self.ref, ShadowNode):
             return super()._construct_sugar()
 
         from sugar_lift_py_tests.sugar.lambda_sugar import LambdaSugar
@@ -4153,6 +4214,7 @@ class Lambda(Expression):
         return LambdaSugar(
             formals=tuple(param.name for param in self.params),
             body=self.body.sugar(),
+            source_call_frame=self.source_visible_call_frame(),
             site=self.fragment,
         )
 
@@ -4873,7 +4935,10 @@ class Call(Expression):
                 TreeConstructionContextV1,
             )
 
-            if isinstance(context, TreeConstructionContextV1) and context.source_call_frames:
+            if (
+                isinstance(context, TreeConstructionContextV1)
+                and context.source_call_frames
+            ):
                 span = self.line_col_span()
                 coordinate = SourceFragmentCoordinateV1(
                     self.unit.source_cid,
@@ -4922,11 +4987,29 @@ class Call(Expression):
             )
         from sugar_lift_py_tests.sugar.computed_call_sugar import ComputedCallSugar
 
+        source_call_frame = None
+        if isinstance(self.func, Lambda):
+            from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+
+            if any(keyword.arg is None for keyword in self.keywords):
+                raise SourceCallBindingGap(
+                    "spread keyword requires typed variadic projection"
+                )
+            source_call_frame = self.func.source_visible_call_frame().bind_node_actuals(
+                self.args,
+                tuple(
+                    (keyword.arg, keyword.value)
+                    for keyword in self.keywords
+                    if keyword.arg is not None
+                ),
+            )
+
         return ComputedCallSugar(
             callee=self.func.sugar(),
             args=tuple(a.sugar() for a in self.args),
             site=self.fragment,
             keywords=keyword_sugars,
+            source_call_frame=source_call_frame,
         )
 
     @staticmethod

--- a/implementations/python/sugar-source-tree/tests/test_lambda_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_lambda_sugar.py
@@ -2,8 +2,15 @@
 
 import pytest
 
-from sugar_lift_py_tests.floor import SymbolicValue, TermValue
-from sugar_lift_py_tests.ir import ctor, num, str_const
+from sugar_lift_py_tests.floor import (
+    BlockValue,
+    DictValue,
+    ReturnValue,
+    StringValue,
+    TermValue,
+    TupleValue,
+)
+from sugar_lift_py_tests.ir import str_const
 from sugar_lift_py_tests.proofir.formulas import _free_vars_in_ir_term
 from sugar_source_tree.panic import SugarNotWritten
 
@@ -105,9 +112,34 @@ def test_nested_lambda_capture_rebinding_changes_opaque_coordinate():
         "def A():\n    return lambda x, y: x\n",
     ],
 )
-def test_unsupported_lambda_parameter_roles_stay_sugar_not_written(source):
-    with pytest.raises(SugarNotWritten, match="Lambda.sugar"):
-        _return_expression(source).sugar()
+def test_lambda_parameter_roles_use_the_source_call_frame(source):
+    sugar = _return_expression(source).sugar()
+
+    assert sugar.source_call_frame is not None
+    assert sugar.source_call_frame.parameters == sugar.formals
+
+
+@pytest.mark.parametrize(
+    ("expression", "expected"),
+    [
+        ("(lambda x=3: x + 1)()", TermValue(4)),
+        ("(lambda *xs: xs)(1, 2)", TupleValue((TermValue(1), TermValue(2)))),
+        (
+            "(lambda **kw: kw)(renamed=7)",
+            DictValue(((StringValue("renamed"), TermValue(7)),)),
+        ),
+        ("(lambda *, x: x)(x=9)", TermValue(9)),
+        ("(lambda x, /: x)(9)", TermValue(9)),
+        ("(lambda: 1)()", TermValue(1)),
+    ],
+)
+def test_lambda_signature_roles_bind_through_the_shared_frame(expression, expected):
+    call = _return_expression(f"def A():\n    return {expression}\n")
+    reduced = call.sugar().desugar().value.force_floor(
+        None, owner="lambda-signature-twin"
+    )
+
+    assert reduced.statements[0].value == expected
 
 
 def test_lambda_preserves_child_panic_role():
@@ -149,15 +181,47 @@ def test_parser_backed_lambda_with_unresolved_capture_stays_loud():
         parser_backed_lambda.sugar()
 
 
-def test_lambda_application_substitutes_the_formal_in_the_body_term():
-    callable_value = (
-        _return_expression("def A():\n    return lambda x: x + 1\n")
-        .sugar()
-        .desugar()
-        .value
+def test_lambda_application_uses_body_bearing_callsite_not_private_apply():
+    call = _return_expression("def A():\n    return (lambda x: x + 1)(7)\n")
+    value = call.sugar().desugar().value
+
+    assert value.body is not None
+    assert value.source_call_frame_cid is not None
+    assert len(value.formal_coordinate_cids) == 1
+    reduced = value.force_floor(None, owner="lambda-call-frame-twin")
+    assert isinstance(reduced, BlockValue)
+    assert isinstance(reduced.statements[0], ReturnValue)
+    assert reduced.statements[0].value == TermValue(8)
+
+
+def test_lambda_call_frame_binds_runtime_entries_for_each_formal():
+    call = _return_expression("def A():\n    return (lambda x, y: x + y)(7, 8)\n")
+    frame = call.sugar().source_call_frame
+
+    assert tuple(entry.coordinate.cid for entry in frame.runtime_entries) == tuple(
+        coordinate.cid for coordinate in frame.formal_coordinates
+    )
+    assert all(not hasattr(entry, "sugar") for entry in frame.runtime_entries)
+
+
+def test_source_visible_callback_reuses_function_call_frame_and_lambda_frame():
+    functions = list(
+        oracle_source_file(
+            "def apply(fn, value):\n"
+            "    return fn(value)\n\n"
+            "def A():\n"
+            "    return apply(lambda renamed: renamed + 1, 4)\n"
+        ).functions()
+    )
+    apply_function, caller = functions
+    outer_call = caller.body[-1].value.substitute({})
+    apply_frame = apply_function.source_visible_call_frame().bind_node_actuals(
+        outer_call.args, ()
     )
 
-    applied = callable_value.apply(TermValue(7), None)
+    callback_call = apply_frame.body.desugar().value.statements[0].value
+    reduced = callback_call.force_floor(None, owner="source-visible-callback-twin")
 
-    assert isinstance(applied, SymbolicValue)
-    assert applied.term == ctor("+", [num(7), num(1)])
+    assert callback_call.source_call_frame_cid is not None
+    assert isinstance(reduced.statements[0], ReturnValue)
+    assert reduced.statements[0].value == TermValue(5)


### PR DESCRIPTION
## What changed

- gives every substitution-authenticated Lambda a `SourceVisibleCallFrameV1`
- mints formal `BindingCoordinateV1` coordinates and binds actual Nodes through runtime `BindingEntryV1`
- represents a Lambda expression body as the ordinary constructed function-body/return Sugar
- routes immediate and source-visible callback invocation to a body-bearing `CallSiteValue`
- removes the private term-substitution evaluator from `LambdaCallable.apply`
- expands Lambda parameter roles through the shared call-frame binding rules

## Soundness boundary

This is the same FunctionDef/CallSiteValue construction door. It does not add a Lambda interpreter, ambient binding map, name gate, or desugar-time tree re-entry. Parser-backed/unresolved Lambda escapes remain loud. Native/opaque callback consumers receive no fabricated body testimony.

## Validation

- `26 passed` — focused Lambda twins, including renamed source-visible callback, exact forced result, defaults, positional-only, keyword-only, varargs, and kwargs
- `R_no_sugar_in_desugar = 0`
- `R_construction_side_doors = 0`
- `R_construction_invariant_violations = 0` on every axis
- source-tree sweep: `394 passed / 5 skipped`; 13 broader pending-parameter/stale-fixture reds remain outside the focused Lambda gate

## Delta

Draft pending the sequential base/head pandas census behind #6151, #6153, and #6154. The measured Lambda denominator is 58; this PR claims no Delta R until the census receipt lands.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route lambda expressions through source-visible call frames for body-bearing call sites
> - Adds `source_visible_call_frame()` to `nodes.Lambda` in [nodes.py](https://github.com/TSavo/sugar/pull/6156/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0), constructing a `SourceVisibleCallFrameV1` with minted `BindingCoordinateV1` instances for each formal parameter.
> - Updates `LambdaSugar`, `LambdaCallable`, and `ComputedCallSugar` to carry and propagate the source call frame through desugaring and application.
> - `LambdaCallable.apply` and `ComputedCallSugar.desugar` now return a body-bearing `CallSiteValue` instead of performing direct symbolic substitution; missing or mismatched frames raise `SugarNotWritten`.
> - Behavioral Change: lambda application now requires a `source_call_frame` with exactly one parameter; calls that previously substituted inline will now raise `SugarNotWritten` if the frame is absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d8a903.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->